### PR TITLE
fix: strip stray editable nodes from the terminal container

### DIFF
--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -14,6 +14,7 @@ import { pauseRenderLoop, resumeRenderLoop } from "@/lib/render-pause"
 import { patchRowPaint } from "@/lib/row-paint"
 import { isTextPasteChord, missingKeySequence } from "@/lib/term-keys"
 import { computeGrid } from "@/lib/term-fit"
+import { isStrayTerminalChild } from "@/lib/term-dom"
 import { countingCanvasFactory, instrumentRender, recordChunk } from "@/lib/term-perf"
 import { useSettings } from "@/lib/settings"
 import type { ResolvedTheme } from "@/lib/settings"
@@ -256,6 +257,23 @@ export function TerminalView({ sessionId, projectId, cwd, kind, visible }: Termi
         window.clearTimeout(refitTimer)
         resizeObserver.disconnect()
       })
+
+      // Remove nós editáveis parasitas que o WebKitGTK insere no container
+      // contenteditable do ghostty (paste de seleção primária por clique-do-meio
+      // no X11, drag-drop); eles furam o guard de beforeinput do ghostty e
+      // deslocam o canvas em fluxo, sobrando texto selecionável. Só o <canvas> +
+      // <textarea> do ghostty (já anexados no open() acima) podem viver aqui.
+      const domGuard = new MutationObserver((records) => {
+        for (const record of records) {
+          for (const node of record.addedNodes) {
+            if (isStrayTerminalChild(node)) {
+              ;(node as ChildNode).remove()
+            }
+          }
+        }
+      })
+      domGuard.observe(container, { childList: true })
+      cleanups.push(() => domGuard.disconnect())
 
       await Service.Start(sessionId, projectId, cwd, kind, term.cols, term.rows)
       if (visibleRef.current) {

--- a/frontend/src/lib/term-dom.test.ts
+++ b/frontend/src/lib/term-dom.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+import { isStrayTerminalChild } from "./term-dom"
+
+describe("isStrayTerminalChild", () => {
+  it("keeps the canvas + textarea ghostty owns", () => {
+    expect(isStrayTerminalChild({ nodeName: "CANVAS" })).toBe(false)
+    expect(isStrayTerminalChild({ nodeName: "TEXTAREA" })).toBe(false)
+  })
+
+  it("flags editable nodes WebKitGTK slips in (drop, middle-click)", () => {
+    expect(isStrayTerminalChild({ nodeName: "DIV" })).toBe(true)
+    expect(isStrayTerminalChild({ nodeName: "SPAN" })).toBe(true)
+    expect(isStrayTerminalChild({ nodeName: "BR" })).toBe(true)
+    // Middle-click primary-selection paste drops a bare text node.
+    expect(isStrayTerminalChild({ nodeName: "#text" })).toBe(true)
+  })
+})

--- a/frontend/src/lib/term-dom.ts
+++ b/frontend/src/lib/term-dom.ts
@@ -1,0 +1,10 @@
+// ghostty-web é dono de exatamente um <canvas> + um <textarea> escondido dentro
+// do seu container contenteditable. Qualquer outro nó é conteúdo editável que o
+// WebKitGTK inseriu por fora do guard de beforeinput do ghostty (paste de seleção
+// primária por clique-do-meio no X11, drag-drop) — ele empurra o canvas em fluxo
+// e fica selecionável. É parasita: remover.
+const OWNED_TERMINAL_NODES = new Set(["CANVAS", "TEXTAREA"])
+
+export function isStrayTerminalChild(node: Pick<Node, "nodeName">): boolean {
+  return !OWNED_TERMINAL_NODES.has(node.nodeName)
+}


### PR DESCRIPTION
## Problem

After a while of use, a blank space grows **before** the terminal and a **selectable blue strip** is left outside the Claude Code content.

## Cause

`ghostty-web@0.4.0` opens the terminal into a `contenteditable` container with the `<canvas>` in normal flow (`display:block`). It already blocks editing via `beforeinput → preventDefault`, but on the forced X11 backend (`GDK_BACKEND=x11`, `main.go`) two paths **bypass** that guard and insert an editable node straight into the DOM:

- **middle-click primary-selection paste**
- **text drag-drop**

Each node enters normal flow, pushes the canvas down (the gap), and — being real editable text — stays selectable (the blue strip). It accumulates with every middle-click. Nothing in the repo cleaned up non-canvas children of the container.

## Fix

A `MutationObserver` on the terminal container removes any added node other than the `<canvas>`/`<textarea>` ghostty owns (both appended in `open()`, before the observer attaches). Fix at the source, vector-agnostic — resolves gap + blue strip + accumulation at once, without touching the library contract.

- `frontend/src/lib/term-dom.ts` — pure `isStrayTerminalChild` predicate.
- `frontend/src/lib/term-dom.test.ts` — covers keep (canvas/textarea) vs remove (div/span/br/#text).
- `frontend/src/components/TerminalView.tsx` — observer in the setup effect, disconnect on cleanup.

The 1-line `removeAttribute("contenteditable")` alternative was dropped: it changes ghostty's contract with a risk of regressing input.

## Test plan

- [x] `cd frontend && pnpm test` — 195 pass (incl. `isStrayTerminalChild`).
- [x] `cd frontend && pnpm build` — `tsc` + `vite` clean.

## Note (out of scope)

Latent finding, **not** this bug: `settings.tsx:174` writes `document.documentElement.style.zoom` while the shell uses `100vh` (`App.tsx:20`); `zoom≠1` (accidental pinch/ctrl-wheel, persisted) mismatches the height and exposes a near-black background strip at the edge. Address only if reported.