### PR TITLE
feat: open terminal links in the browser on Ctrl/Cmd-click

### DIFF
--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -10,6 +10,7 @@ import { patchGlyphAtlas } from "@/lib/glyph-atlas"
 import { patchPooledGetLine } from "@/lib/getline-pool"
 import { patchScrollGate, patchScrollbackCache } from "@/lib/scrollback-perf"
 import { ensureTransport, onSessionData, sendInput } from "@/lib/term-transport"
+import { registerLinkOpening } from "@/lib/term-links"
 import { pauseRenderLoop, resumeRenderLoop } from "@/lib/render-pause"
 import { patchRowPaint } from "@/lib/row-paint"
 import { isTextPasteChord, missingKeySequence } from "@/lib/term-keys"
@@ -174,6 +175,7 @@ export function TerminalView({ sessionId, projectId, cwd, kind, visible }: Termi
       }
       patchPooledGetLine(term.wasmTerm)
       patchScrollbackCache(term)
+      registerLinkOpening(term)
       fitTerminal(term, container)
       termRef.current = term
       ensureTransport()

--- a/frontend/src/lib/term-links.test.ts
+++ b/frontend/src/lib/term-links.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { ILink } from "ghostty-web"
+import { Browser } from "@wailsio/runtime"
+import { openInBrowser } from "./term-links"
+
+vi.mock("@wailsio/runtime", () => ({ Browser: { OpenURL: vi.fn() } }))
+
+const openURL = vi.mocked(Browser.OpenURL)
+
+function makeLink(text = "https://example.com"): ILink {
+  return { text, range: {} as ILink["range"], activate: () => {} }
+}
+
+function click(overrides: Partial<MouseEvent> = {}): MouseEvent {
+  return { ctrlKey: false, metaKey: false, ...overrides } as MouseEvent
+}
+
+afterEach(() => openURL.mockClear())
+
+describe("openInBrowser", () => {
+  it("opens the URL in the OS browser on Ctrl-click", () => {
+    openInBrowser(makeLink()).activate(click({ ctrlKey: true }))
+    expect(openURL).toHaveBeenCalledWith("https://example.com")
+  })
+
+  it("opens on Cmd-click too", () => {
+    openInBrowser(makeLink("https://a.dev")).activate(click({ metaKey: true }))
+    expect(openURL).toHaveBeenCalledWith("https://a.dev")
+  })
+
+  it("does nothing on a plain click without a modifier", () => {
+    openInBrowser(makeLink()).activate(click())
+    expect(openURL).not.toHaveBeenCalled()
+  })
+
+  it("preserves the detected link's text and range", () => {
+    const link = makeLink("https://keep.me")
+    const wrapped = openInBrowser(link)
+    expect(wrapped.text).toBe(link.text)
+    expect(wrapped.range).toBe(link.range)
+  })
+})

--- a/frontend/src/lib/term-links.ts
+++ b/frontend/src/lib/term-links.ts
@@ -1,0 +1,36 @@
+import { Browser } from "@wailsio/runtime"
+import { OSC8LinkProvider, UrlRegexProvider } from "ghostty-web"
+import type { ILink, ILinkProvider, Terminal as Ghostty } from "ghostty-web"
+
+// registerLinkOpening wires ghostty-web's built-in link detection — OSC 8
+// hyperlinks and URL-regex matches — and opens a match in the user's real
+// browser on Ctrl/Cmd-click. Without this no provider is registered, so links
+// are never detected (no hover underline, no click). The built-in providers
+// detect the same links but open them with window.open, which the WebKitGTK
+// webview traps instead of handing to the desktop; Browser.OpenURL routes the
+// URL through Wails to the OS default browser.
+export function registerLinkOpening(term: Ghostty): void {
+  const detectors: ILinkProvider[] = [new OSC8LinkProvider(term), new UrlRegexProvider(term)]
+  for (const detector of detectors) {
+    term.registerLinkProvider({
+      provideLinks(y, callback) {
+        detector.provideLinks(y, (links) => callback(links?.map(openInBrowser)))
+      },
+      dispose: () => detector.dispose?.(),
+    })
+  }
+}
+
+// openInBrowser returns a copy of a detected link whose activation opens the URL
+// in the OS browser via Wails on Ctrl/Cmd-click, matching a real terminal's
+// modifier-click-to-open behaviour.
+export function openInBrowser(link: ILink): ILink {
+  return {
+    ...link,
+    activate: (event: MouseEvent) => {
+      if (event.ctrlKey || event.metaKey) {
+        void Browser.OpenURL(link.text)
+      }
+    },
+  }
+}


### PR DESCRIPTION
## Problem

URLs in terminal output (e.g. the PR link printed by `gh`) were inert — no
hover underline, and clicking them did nothing. Expected: `Ctrl/Cmd+click`
opens the link in the user's default browser.

## Root cause

`ghostty-web` ships link detection (`OSC8LinkProvider` for OSC 8 hyperlinks +
`UrlRegexProvider` for URL-regex matches) but **registers no provider by
default**. `TerminalView` never called `registerLinkProvider`, so no link was
ever detected — no hover, no activation.

On top of that, the built-in providers activate via `window.open`, which the
WebKitGTK webview traps instead of handing to the OS browser.

## Fix

New `frontend/src/lib/term-links.ts`:

- `registerLinkOpening(term)` registers both built-in providers, so links are
  detected and hover-underlined.
- Each detected link is wrapped so `Ctrl/Cmd+click` opens it through Wails'
  `Browser.OpenURL` (routes to the desktop default browser) instead of
  `window.open`.

Wired into `TerminalView` right after the other ghostty-web patches. Reuses
ghostty-web's own detection — no hand-rolled URL regex.

## Test plan

- [x] `pnpm exec vitest run` — full suite 197 pass / 0 fail
- [x] `term-links.test.ts` — Ctrl-click and Cmd-click open the URL, plain click
      is a no-op, link text/range preserved (4 tests)
- [x] `term-links.ts` type-checks standalone (providers accept the terminal)
- [x] `prettier --check` clean