### PR TITLE
fix: forward the mouse wheel as a scroll instead of arrow keys

### DIFF
--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -13,7 +13,12 @@ import { ensureTransport, onSessionData, sendInput } from "@/lib/term-transport"
 import { registerLinkOpening } from "@/lib/term-links"
 import { pauseRenderLoop, resumeRenderLoop } from "@/lib/render-pause"
 import { patchRowPaint } from "@/lib/row-paint"
-import { isTextPasteChord, missingKeySequence } from "@/lib/term-keys"
+import {
+  altScreenWheelSequence,
+  isTextPasteChord,
+  missingKeySequence,
+  sgrWheelSequence,
+} from "@/lib/term-keys"
 import { computeGrid } from "@/lib/term-fit"
 import { isStrayTerminalChild } from "@/lib/term-dom"
 import { countingCanvasFactory, instrumentRender, recordChunk } from "@/lib/term-perf"
@@ -78,6 +83,30 @@ function fitTerminal(term: Ghostty, container: HTMLElement): void {
   const grid = computeGrid(container.clientWidth, container.clientHeight, cell)
   if (grid && (grid.cols !== term.cols || grid.rows !== term.rows)) {
     term.resize(grid.cols, grid.rows)
+  }
+}
+
+// pointerCell maps a wheel/mouse event to the 1-based terminal cell under the
+// pointer, for the coordinates an SGR mouse report carries. Falls back to the
+// top-left cell when metrics aren't ready; clamps into the grid so the report
+// never names a cell outside it.
+function pointerCell(
+  event: WheelEvent,
+  container: HTMLElement,
+  renderer: Ghostty["renderer"],
+  cols: number,
+  rows: number,
+): { col: number; row: number } {
+  const cell = renderer?.getMetrics()
+  if (!cell) {
+    return { col: 1, row: 1 }
+  }
+  const rect = container.getBoundingClientRect()
+  const col = Math.floor((event.clientX - rect.left) / cell.width) + 1
+  const row = Math.floor((event.clientY - rect.top) / cell.height) + 1
+  return {
+    col: Math.max(1, Math.min(cols, col)),
+    row: Math.max(1, Math.min(rows, row)),
   }
 }
 
@@ -209,6 +238,35 @@ export function TerminalView({ sessionId, projectId, cwd, kind, visible }: Termi
           return false
         }
         writeInput(seq)
+        return true
+      })
+
+      // ghostty-web reports no mouse events, so its alt-screen emulation turns
+      // the wheel into arrow keys. When the app enabled mouse tracking with SGR
+      // encoding (Claude Code, htop, vim), forward a real wheel event so it
+      // scrolls by its own line increment (smooth, no arrow-key warning).
+      // Otherwise fall back to PgUp/PgDn in the alt screen, and let ghostty
+      // scroll its own scrollback viewport everywhere else. See term-keys.ts.
+      term.attachCustomWheelEventHandler((event) => {
+        const wasm = term.wasmTerm
+        if (!wasm) {
+          return false
+        }
+        if (wasm.hasMouseTracking() && wasm.getMode(1006, false)) {
+          const { col, row } = pointerCell(event, container, term.renderer, term.cols, term.rows)
+          const seq = sgrWheelSequence(event.deltaY, col, row)
+          if (seq) {
+            writeInput(seq)
+          }
+          return true
+        }
+        if (!wasm.isAlternateScreen()) {
+          return false
+        }
+        const seq = altScreenWheelSequence(event.deltaY)
+        if (seq) {
+          writeInput(seq)
+        }
         return true
       })
 

--- a/frontend/src/lib/term-keys.test.ts
+++ b/frontend/src/lib/term-keys.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest"
-import { isTextPasteChord, missingKeySequence, type TermKeyState } from "./term-keys"
+import {
+  altScreenWheelSequence,
+  isTextPasteChord,
+  missingKeySequence,
+  sgrWheelSequence,
+  type TermKeyState,
+} from "./term-keys"
 
 const key = (over: Partial<TermKeyState>): TermKeyState => ({
   ctrlKey: false,
@@ -62,6 +68,18 @@ describe("missingKeySequence", () => {
     expect(isTextPasteChord(key({ ctrlKey: true, shiftKey: true, altKey: true, key: "V" }))).toBe(
       false,
     )
+  })
+
+  it("encodes the wheel as an SGR mouse report for mouse-tracking apps", () => {
+    expect(sgrWheelSequence(120, 4, 9)).toBe("\x1b[<65;4;9M") // down → button 65
+    expect(sgrWheelSequence(-3, 1, 1)).toBe("\x1b[<64;1;1M") // up → button 64
+    expect(sgrWheelSequence(0, 4, 9)).toBeNull() // pure horizontal wheel
+  })
+
+  it("maps the wheel to PgDn/PgUp in the alternate screen", () => {
+    expect(altScreenWheelSequence(120)).toBe("\x1b[6~") // down → PgDn
+    expect(altScreenWheelSequence(-3)).toBe("\x1b[5~") // up → PgUp
+    expect(altScreenWheelSequence(0)).toBeNull() // pure horizontal wheel
   })
 
   it("ignores AltGr composition", () => {

--- a/frontend/src/lib/term-keys.ts
+++ b/frontend/src/lib/term-keys.ts
@@ -55,6 +55,29 @@ export function missingKeySequence(event: TermKeyState): string | null {
   return null
 }
 
+// SGR mouse wheel report (DECSET 1006). Apps that turn on mouse tracking —
+// Claude Code, htop, vim with `mouse=a` — scroll on these by their own line
+// increment, which reads as smooth instead of a page jump. ghostty-web 0.4.0
+// reports no mouse events at all, so its alt-screen emulation turns the wheel
+// into arrow keys; forwarding this is what Claude Code actually asked for (and
+// why it warns about arrow keys). Button 64 = wheel up, 65 = down; press-only,
+// no release. col/row are the 1-based cell under the pointer. deltaY 0 (a pure
+// horizontal wheel) sends nothing.
+export function sgrWheelSequence(deltaY: number, col: number, row: number): string | null {
+  if (deltaY === 0) return null
+  const button = deltaY > 0 ? 65 : 64
+  return `\x1b[<${button};${col};${row}M`
+}
+
+// Fallback for TUIs without mouse tracking: in the alternate screen ghostty-web
+// still emulates the wheel as one arrow key per tick, which Claude Code rejects
+// as "arrow keys · use PgUp/PgDn to scroll". Page keys are what those TUIs
+// scroll their history with. deltaY > 0 → PgDn; upward → PgUp; 0 → nothing.
+export function altScreenWheelSequence(deltaY: number): string | null {
+  if (deltaY === 0) return null
+  return deltaY > 0 ? "\x1b[6~" : "\x1b[5~"
+}
+
 /**
  * Ctrl+Shift+V — the terminal-convention text-paste chord. Handled outside
  * missingKeySequence because pasting needs the async Wails clipboard read,


### PR DESCRIPTION
## Problem

Scrolling the mouse wheel over a session sent arrow keys to the backend instead of scrolling. Claude Code flagged it directly — **"Scroll wheel is sending arrow keys · use PgUp/PgDn to scroll"** — and the wheel could not navigate the transcript.

Root cause: ghostty-web 0.4.0 reports **no** mouse events at all, so its alternate-screen emulation turns each wheel tick into one arrow key (`CSI A`/`CSI B`). Any TUI that enables mouse tracking (Claude Code, htop, vim with `mouse=a`) receives arrows instead of the wheel report it asked for.

## Fix

The wheel handler is installed through ghostty's `attachCustomWheelEventHandler` escape hatch and branches in three layers:

1. **App has mouse tracking + SGR encoding (DECSET 1006)** → forward a real SGR wheel report (`\x1b[<64/65;col;row M`). The app scrolls by its own line increment — smooth, and the arrow-key warning is gone. This is what Claude Code actually requested.
2. **No mouse tracking, alternate screen** → send `PgUp`/`PgDn` so the TUI scrolls its history.
3. **Everywhere else** → return `false` and let ghostty scroll its own scrollback viewport.

Degrades safely: if an app has mouse tracking off, it lands on the PgUp/PgDn path (no regression).

## Notes

- Sequence builders (`sgrWheelSequence`, `altScreenWheelSequence`) are pure and unit-tested; pointer→cell coordinate mapping lives at the DOM boundary in `TerminalView` (framework boundary, coverage-exempt per the repo invariant).
- Only SGR (1006) encoding is forwarded. X10-encoded mouse tracking is not handled — add a `\x1b[M`-byte branch if a TUI ever falls through to PgUp/PgDn despite having mouse tracking on.

## Test plan

- [x] `pnpm test` — 201 pass (adds SGR + PgUp/PgDn direction cases in `term-keys.test.ts`)
- [x] `pnpm build` — tsc + vite clean
- [x] Manual: scroll wheel in a Claude Code session scrolls the transcript smoothly, no "arrow keys" warning
- [x] Manual: scroll wheel in a plain shell scrolls ghostty's scrollback