### PR TITLE
feat: Claude Code plugin integration (session state, auto-naming, git refresh, install/update)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Claude Code plugin integration. lich pairs with a companion Claude Code
+  plugin ([`omartelo/lich-plugin`](https://github.com/omartelo/lich-plugin)),
+  installed and updated from within the app: a one-click install modal when it
+  is missing, and an actionable toast when a newer plugin release ships. The
+  plugin reports session activity back over the existing loopback transport;
+  every contract is documented in `docs/hooks/`, which lich owns as the
+  canonical source and the plugin references.
+- Session cards reflect Claude Code state live — a spinner while Claude is
+  producing output, a check when the turn ends, and a bell when Claude is
+  blocked on you (a permission prompt or an idle input request). The bell also
+  raises an actionable toast that routes to the waiting session, reachable even
+  when it lives in a background project, and skipped for the session already on
+  screen. A stale indicator clears when the session ends or is `/clear`ed.
+- Sessions auto-name from Claude's own title. When Claude generates its session
+  summary (the `ai-title` shown in `claude --resume`), lich adopts it as the
+  card label — unless you have renamed the session, which always wins.
+- A session's git badge refreshes the moment Claude edits files, ahead of the
+  ~3s poll, so the diff counts and branch stay current without the lag. The
+  poll stays the baseline, so the badge works unchanged without the plugin.
+
 ### Changed
 
 - The Linux Arch package no longer hardcodes `pkgrel` in `nfpm.yaml`. nfpm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,9 @@ Deliberate limits and shortcuts, with the upgrade path when it matters:
 
 - **git status is polled every ~3 s** — one shared poller per repository path
   (`frontend/src/lib/git-status-store.ts`), no filesystem watch. Unchanged status short-circuits (same reference, zero
-  re-renders). Move to an fs watcher if the poll ever costs too much.
+  re-renders). The lich plugin's `session-touched` hook nudges an immediate refresh after Claude edits files
+  (`refreshGitStatus` in `frontend/src/lib/useGitStatus.ts`, driven from `docs/hooks/session-touched.md`), but the poll
+  stays the baseline so it works without the plugin. Move to an fs watcher if the poll ever costs too much.
 - **Persistence is hybrid**: UI preferences live in `localStorage` (`lich.*` keys), the workspace in SQLite (
   `<data-dir>/lich/lich.db`). Session order is not persisted, and closing a session does not delete its row (close ≠
   delete).

--- a/build/linux/nfpm/nfpm.yaml
+++ b/build/linux/nfpm/nfpm.yaml
@@ -7,8 +7,8 @@ name: "lich"
 arch: ${GOARCH}
 platform: "linux"
 # Follows the git tag via $VERSION (injected by build/linux/Taskfile.yml) — no manual bump.
-# ponytail: exact-tag releases yield clean semver; a dev build between tags carries the
-# git-describe suffix as-is. Sanitize in the Taskfile if that ever needs to be a valid pkgver.
+# Exact-tag releases yield clean semver; a dev build between tags carries the git-describe
+# suffix as-is. Sanitize in the Taskfile if that ever needs to be a valid pkgver.
 version: "${VERSION}"
 section: "default"
 priority: "extra"

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -1,0 +1,60 @@
+# Hook contracts
+
+lich observes and drives Claude Code sessions through **hooks**. Each hook is a
+small script that runs inside a session (shipped by the companion plugin
+[`omartelo/lich-plugin`](https://github.com/omartelo/lich-plugin)) and talks to
+lich over a shared local transport.
+
+This directory is the **canonical, contract-first source** for those hooks:
+
+- lich owns the **server side** of every contract — the transport, the
+  endpoint, and how the reported data reaches the UI. That side lives in this
+  repo and is documented here.
+- The plugin owns the **client side** — the hook scripts. The plugin does not
+  redefine the protocol; it references the contract documented here and
+  implements against it.
+
+Define the contract here first, then implement both sides against it.
+
+## Shared transport
+
+Every hook rides the same loopback channel lich already runs for terminal I/O
+(`internal/terminal/transport.go`). lich injects three variables into the
+environment of **every PTY it spawns**, inherited by `claude` and its hooks:
+
+| Var               | Purpose                     |
+|-------------------|-----------------------------|
+| `LICH_PORT`       | endpoint port (loopback)    |
+| `LICH_TOKEN`      | auth token (`?token=`)      |
+| `LICH_SESSION_ID` | target session/card id      |
+
+Outside lich these are absent, so every hook must no-op and exit 0 — the plugin
+stays safe to install globally.
+
+## Client rules (all hooks)
+
+- Missing env vars → no-op, exit 0.
+- Short timeout, errors swallowed, always exit 0. A hook must never block or
+  fail the user's turn.
+
+## Versioning
+
+- A change **within** an existing contract (a script tweak) is a plugin-only
+  release — no lich release needed.
+- A change **to** a contract (new endpoint, field, or accepted value) is a
+  breaking change: ship the lich server side first, then the plugin. Keep the
+  two in lockstep.
+
+## Adding a new hook
+
+1. Write its contract in this directory (transport is already shared; document
+   the endpoint, payload, accepted values, and event→action mapping).
+2. Implement the lich server side (endpoint handler + however the data reaches
+   the UI) with tests.
+3. In the plugin, add the hook script and point its doc at the contract here —
+   the contract is the single source of truth.
+
+## Contracts
+
+- [session-state.md](session-state.md) — a session's processing state
+  (`busy`/`done`) shown on its card.

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -58,3 +58,5 @@ stays safe to install globally.
 
 - [session-state.md](session-state.md) — a session's processing state
   (`busy`/`done`) shown on its card.
+- [session-start.md](session-start.md) — the Claude session id, persisted
+  against the lich session for later features.

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -60,3 +60,5 @@ stays safe to install globally.
   (`busy`/`done`) shown on its card.
 - [session-start.md](session-start.md) — the Claude session id, persisted
   against the lich session for later features.
+- [session-title.md](session-title.md) — Claude's auto-generated `ai-title`,
+  applied as the session card's label.

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -62,3 +62,5 @@ stays safe to install globally.
   against the lich session for later features.
 - [session-title.md](session-title.md) — Claude's auto-generated `ai-title`,
   applied as the session card's label.
+- [session-touched.md](session-touched.md) — a session changed files, so its
+  git status refreshes immediately instead of on the next poll.

--- a/docs/hooks/session-start.md
+++ b/docs/hooks/session-start.md
@@ -1,0 +1,58 @@
+# Contract: session start
+
+Reports the Claude Code session id running inside a lich session's PTY, so lich
+can persist the link between its own session (the card) and Claude's session.
+That id is the key for later features that need to reach a session's transcript
+or resume it; nothing in the UI changes today.
+
+See [README.md](README.md) for the shared transport (`LICH_PORT` / `LICH_TOKEN`
+/ `LICH_SESSION_ID`) and the client rules every hook follows.
+
+## Request
+
+```
+POST http://127.0.0.1:${LICH_PORT}/session-start?token=${LICH_TOKEN}
+Content-Type: application/json
+
+{"session_id": "<LICH_SESSION_ID>", "claude_session_id": "<claude session id>"}
+```
+
+- `session_id` — the lich card, from `LICH_SESSION_ID`.
+- `claude_session_id` — Claude Code's own session id, from the hook payload's
+  `session_id` field on stdin. Must be non-empty.
+
+Responses: `204` ok · `401` invalid token · `400` invalid body · `500` lich
+failed to persist.
+
+## Event → action mapping
+
+| Claude Code hook | action                                              |
+|------------------|-----------------------------------------------------|
+| `SessionStart`   | store `claude_session_id` on the lich session row   |
+
+`SessionStart` fires on startup, resume, `/clear` and compaction. A resume
+reports the resumed session's id and overwrites the stored value — lich always
+holds the id of the Claude session currently in the card.
+
+## lich server side
+
+- **Endpoint** — `internal/terminal/transport.go`, `transport.sessionStart`:
+  validates the token and body (`parseSessionStart`) on the same loopback
+  listener as terminal I/O, then forwards `(session_id, claude_session_id)`.
+- **Persistence** — `internal/store/mutations.go`, `Service.SetClaudeSession`:
+  `UPDATE sessions SET claude_session_id`. Surfaced on `store.Session`
+  (`claudeSessionId`) and returned by `LoadState`.
+
+## Known ceilings
+
+- **Start races persistence.** The hook can fire before lich has inserted the
+  session row (`AddSession`). The `UPDATE` then matches nothing and the id is
+  dropped — not an error. In practice Claude's boot is slower than the local
+  insert, so this is not observed; if it ever bites, retry from the hook or
+  re-report on a later event.
+- **`claude_session_id` is stored, not surfaced.** No feature reads it yet; it
+  exists so future work (transcript access, resume, the `ai-title` naming hook)
+  has the link ready.
+- **Not the transcript path.** The path is reconstructable from the id and cwd;
+  storing it too is a contract change — add a field only when a feature needs
+  it, per the versioning note in the README.

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -1,7 +1,8 @@
 # Contract: session state
 
 Reports a session's Claude Code processing state to lich so its card shows a
-spinner while Claude is working and a check when the turn ends.
+spinner while Claude is working, a check when the turn ends, and a bell when
+Claude is blocked on the user — plus a toast that routes to the waiting card.
 
 See [README.md](README.md) for the shared transport (`LICH_PORT` / `LICH_TOKEN`
 / `LICH_SESSION_ID`) and the client rules every hook follows.
@@ -15,16 +16,21 @@ Content-Type: application/json
 {"session_id": "<LICH_SESSION_ID>", "state": "<busy|done>"}
 ```
 
-States: only `busy` and `done`. lich rejects anything else.
+States: `busy`, `done`, `waiting`. lich rejects anything else.
 
 Responses: `204` ok · `401` invalid token · `400` invalid body.
 
 ## Event → state mapping
 
-| Claude Code hook   | state  |
-|--------------------|--------|
-| `UserPromptSubmit` | `busy` |
-| `Stop`             | `done` |
+| Claude Code hook   | state     |
+|--------------------|-----------|
+| `UserPromptSubmit` | `busy`    |
+| `Stop`             | `done`    |
+| `Notification`     | `waiting` |
+
+`Notification` fires when Claude needs a permission decision or has been idle
+waiting for input — both mean "your turn". A later `UserPromptSubmit` (busy) or
+`Stop` (done) clears it. lich shows a toast (see below) only for `waiting`.
 
 ## lich server side
 
@@ -34,16 +40,28 @@ Responses: `204` ok · `401` invalid token · `400` invalid body.
   the token and body (`parseHookRequest`) on the same loopback listener as
   terminal I/O, then forwards `(session_id, state)`.
 - **UI push** — `internal/terminal/terminal.go`: emits the Wails event
-  `session-status:<id>` with the state.
+  `session-status:<id>` with the state, and for `waiting` also the global
+  `session-attention` event (`{id}`).
 - **Render** — `frontend/src/components/sidebar/SessionCard.tsx`: subscribes to
-  that event and shows a spinner (`busy`) or check (`done`).
+  the per-session event and shows a spinner (`busy`), check (`done`) or bell
+  (`waiting`).
+- **Toast + route** — `frontend/src/lib/projects.tsx`: subscribes to the global
+  `session-attention` event and raises an actionable toast that navigates to the
+  session's card. It is global so a session in a background project (whose card
+  is not mounted) still surfaces; it is skipped for the session already focused.
 
 ## Known ceilings
 
 - `UserPromptSubmit` → busy, `Stop` → done. An interrupt (Esc) that skips `Stop`
   can leave a spinner until the next turn resets it.
 - Status is not retained by lich: a card that unmounts and remounts (switching
-  projects mid-run) misses the event and can strand a spinner. Fix path: keep
-  the last state per session in Go and hand it to the card on mount.
-- States limited to `busy`/`done`. Adding another (e.g. `waiting` from
-  `Notification`) is a contract change — see the versioning note in the README.
+  projects mid-run) misses the event and can strand a spinner — and, after the
+  toast routes you to a background session, its freshly mounted card shows no
+  bell because the `waiting` event already fired. Fix path: keep the last state
+  per session in Go and hand it to the card on mount.
+- The attention toast auto-dismisses on a timer (`ATTENTION_TOAST_MS`); it does
+  not clear when the session leaves `waiting` (user handled it in the terminal).
+  Fix path: track the toast id per session and dismiss it on the next
+  busy/done.
+- Adding another state beyond `busy`/`done`/`waiting` is a contract change — see
+  the versioning note in the README.

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -1,0 +1,49 @@
+# Contract: session state
+
+Reports a session's Claude Code processing state to lich so its card shows a
+spinner while Claude is working and a check when the turn ends.
+
+See [README.md](README.md) for the shared transport (`LICH_PORT` / `LICH_TOKEN`
+/ `LICH_SESSION_ID`) and the client rules every hook follows.
+
+## Request
+
+```
+POST http://127.0.0.1:${LICH_PORT}/hook?token=${LICH_TOKEN}
+Content-Type: application/json
+
+{"session_id": "<LICH_SESSION_ID>", "state": "<busy|done>"}
+```
+
+States: only `busy` and `done`. lich rejects anything else.
+
+Responses: `204` ok · `401` invalid token · `400` invalid body.
+
+## Event → state mapping
+
+| Claude Code hook   | state  |
+|--------------------|--------|
+| `UserPromptSubmit` | `busy` |
+| `Stop`             | `done` |
+
+## lich server side
+
+- **Env injection** — `internal/terminal/terminal.go`, `Service.sessionEnv`:
+  adds the three `LICH_*` vars to each PTY's environment.
+- **Endpoint** — `internal/terminal/transport.go`, `transport.hook`: validates
+  the token and body (`parseHookRequest`) on the same loopback listener as
+  terminal I/O, then forwards `(session_id, state)`.
+- **UI push** — `internal/terminal/terminal.go`: emits the Wails event
+  `session-status:<id>` with the state.
+- **Render** — `frontend/src/components/sidebar/SessionCard.tsx`: subscribes to
+  that event and shows a spinner (`busy`) or check (`done`).
+
+## Known ceilings
+
+- `UserPromptSubmit` → busy, `Stop` → done. An interrupt (Esc) that skips `Stop`
+  can leave a spinner until the next turn resets it.
+- Status is not retained by lich: a card that unmounts and remounts (switching
+  projects mid-run) misses the event and can strand a spinner. Fix path: keep
+  the last state per session in Go and hand it to the card on mount.
+- States limited to `busy`/`done`. Adding another (e.g. `waiting` from
+  `Notification`) is a contract change — see the versioning note in the README.

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -25,12 +25,19 @@ Responses: `204` ok · `401` invalid token · `400` invalid body.
 | Claude Code hook   | state     |
 |--------------------|-----------|
 | `UserPromptSubmit` | `busy`    |
-| `Stop`             | `done`    |
+| `PostToolUse`      | `busy`    |
 | `Notification`     | `waiting` |
+| `Stop`             | `done`    |
 
 `Notification` fires when Claude needs a permission decision or has been idle
-waiting for input — both mean "your turn". A later `UserPromptSubmit` (busy) or
-`Stop` (done) clears it. lich shows a toast (see below) only for `waiting`.
+waiting for input — both mean "your turn"; lich shows a toast (see below) only
+for `waiting`.
+
+`waiting` clears the moment Claude resumes. A typed reply raises
+`UserPromptSubmit`, but a **permission approval, plan approval or answered
+question does not** — those resume by running a tool, so `PostToolUse → busy` is
+what re-arms the spinner after them. Every tool re-reports `busy` (idempotent);
+`Stop → done` ends the turn.
 
 ## lich server side
 
@@ -63,5 +70,9 @@ waiting for input — both mean "your turn". A later `UserPromptSubmit` (busy) o
   not clear when the session leaves `waiting` (user handled it in the terminal).
   Fix path: track the toast id per session and dismiss it on the next
   busy/done.
+- `PostToolUse → busy` recovers from `waiting` only when Claude runs a tool. Deny
+  a permission and let Claude end the turn without another tool and the card
+  stays `waiting` until `Stop → done`. Rare, and it self-corrects on the next
+  turn.
 - Adding another state beyond `busy`/`done`/`waiting` is a contract change — see
   the versioning note in the README.

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -16,7 +16,7 @@ Content-Type: application/json
 {"session_id": "<LICH_SESSION_ID>", "state": "<busy|done>"}
 ```
 
-States: `busy`, `done`, `waiting`. lich rejects anything else.
+States: `busy`, `done`, `waiting`, `idle`. lich rejects anything else.
 
 Responses: `204` ok · `401` invalid token · `400` invalid body.
 
@@ -28,10 +28,15 @@ Responses: `204` ok · `401` invalid token · `400` invalid body.
 | `PostToolUse`      | `busy`    |
 | `Notification`     | `waiting` |
 | `Stop`             | `done`    |
+| `SessionEnd`       | `idle`    |
 
 `Notification` fires when Claude needs a permission decision or has been idle
 waiting for input — both mean "your turn"; lich shows a toast (see below) only
 for `waiting`.
+
+`SessionEnd → idle` clears the card's indicator (no spinner/check/bell). It
+fires when the Claude session ends or is reset, so a stale state does not linger
+on a dead session, and a `/clear` starts the next session with a clean card.
 
 `waiting` clears the moment Claude resumes. A typed reply raises
 `UserPromptSubmit`, but a **permission approval, plan approval or answered
@@ -51,7 +56,7 @@ what re-arms the spinner after them. Every tool re-reports `busy` (idempotent);
   `session-attention` event (`{id}`).
 - **Render** — `frontend/src/components/sidebar/SessionCard.tsx`: subscribes to
   the per-session event and shows a spinner (`busy`), check (`done`) or bell
-  (`waiting`).
+  (`waiting`); any other value, including `idle`, clears the indicator.
 - **Toast + route** — `frontend/src/lib/projects.tsx`: subscribes to the global
   `session-attention` event and raises an actionable toast that navigates to the
   session's card. It is global so a session in a background project (whose card
@@ -74,5 +79,5 @@ what re-arms the spinner after them. Every tool re-reports `busy` (idempotent);
   a permission and let Claude end the turn without another tool and the card
   stays `waiting` until `Stop → done`. Rare, and it self-corrects on the next
   turn.
-- Adding another state beyond `busy`/`done`/`waiting` is a contract change — see
-  the versioning note in the README.
+- Adding another state beyond `busy`/`done`/`waiting`/`idle` is a contract
+  change — see the versioning note in the README.

--- a/docs/hooks/session-title.md
+++ b/docs/hooks/session-title.md
@@ -1,0 +1,69 @@
+# Contract: session title
+
+Reports Claude Code's auto-generated session title (the `ai-title`) so lich can
+name the session card after it — the same short summary shown in
+`claude --resume`, instead of `Session 3`.
+
+See [README.md](README.md) for the shared transport (`LICH_PORT` / `LICH_TOKEN`
+/ `LICH_SESSION_ID`) and the client rules every hook follows.
+
+## Request
+
+```
+POST http://127.0.0.1:${LICH_PORT}/session-title?token=${LICH_TOKEN}
+Content-Type: application/json
+
+{"session_id": "<LICH_SESSION_ID>", "title": "<ai-title>"}
+```
+
+- `session_id` — the lich card, from `LICH_SESSION_ID`.
+- `title` — the latest `ai-title` for the session. lich trims it and rejects an
+  empty result.
+
+Responses: `204` ok · `401` invalid token · `400` invalid body · `500` lich
+failed to persist.
+
+## Event → action mapping
+
+| Claude Code hook | action                                              |
+|------------------|-----------------------------------------------------|
+| `Stop`           | set the session label to `title` (if still auto)    |
+
+The `ai-title` is an internal Haiku summary of the first prompt, written to the
+transcript **after** the first turn — so it does not exist at `SessionStart`.
+The `Stop` hook is the earliest reliable point: read the transcript path Claude
+Code passes on stdin and take the last `ai-title` line:
+
+```sh
+title=$(tac "$transcript_path" | grep -m1 '"type":"ai-title"' | jq -r '.aiTitle')
+```
+
+Send it on `Stop`. Re-sending on every `Stop` is fine — lich only applies it
+while the label is still automatic (see below), so a stable title is idempotent.
+
+## lich server side
+
+- **Endpoint** — `internal/terminal/transport.go`, `transport.sessionTitle`:
+  validates the token and body (`parseSessionTitle`), then forwards
+  `(session_id, title)`.
+- **Guarded write** — `internal/store/mutations.go`, `Service.SetSessionTitle`:
+  `UPDATE sessions SET label = ? WHERE id = ? AND label_auto = 1`. A user
+  `RenameSession` clears `label_auto`, so a manual name is never stomped.
+  Returns whether the label actually changed.
+- **Live update** — `internal/terminal/terminal.go`: when the label changed,
+  emits the global Wails event `session-title` (`{id, label}`);
+  `frontend/src/lib/projects.tsx` mirrors it into session state so the card
+  updates without a reload.
+
+## Known ceilings
+
+- **Only overwrites an automatic label.** Once the user renames a session, the
+  title stops applying to it — by design (option A). There is no "revert to
+  auto" today; renaming to the exact default does not re-arm it.
+- **`ai-title` is internal and undocumented.** Format (`{"type":"ai-title",
+  "aiTitle":...}` in the transcript jsonl) can change between Claude Code
+  versions. The hook must swallow extraction failures and no-op — session state
+  and the rest of lich keep working if it breaks.
+- **Reacts to the first prompt, not later pivots reliably.** Claude Code may or
+  may not refresh the `ai-title` mid-session; lich applies whatever the hook
+  last sent while the label is still auto.

--- a/docs/hooks/session-touched.md
+++ b/docs/hooks/session-touched.md
@@ -1,0 +1,59 @@
+# Contract: session touched
+
+Signals that a session likely changed files on disk, so lich refreshes that
+session's git status **immediately** instead of waiting for its steady poll. It
+is a latency optimization, not a source of truth: lich polls git every ~3s
+regardless, so a user without the plugin sees the same diff badge — just up to a
+poll interval later.
+
+See [README.md](README.md) for the shared transport (`LICH_PORT` / `LICH_TOKEN`
+/ `LICH_SESSION_ID`) and the client rules every hook follows.
+
+## Request
+
+```
+POST http://127.0.0.1:${LICH_PORT}/session-touched?token=${LICH_TOKEN}
+Content-Type: application/json
+
+{"session_id": "<LICH_SESSION_ID>"}
+```
+
+Responses: `204` ok · `401` invalid token · `400` invalid body.
+
+## Event → action mapping
+
+| Claude Code hook                        | action                        |
+|-----------------------------------------|-------------------------------|
+| `PostToolUse` (file-mutating tools)     | refresh the session's git status |
+
+Fire it from `PostToolUse` **only for tools that write to disk** — match
+`Edit`, `Write`, `NotebookEdit`, `Bash` (and any others that mutate files). Do
+**not** fire on read-only tools (`Read`, `Grep`, `Glob`): a git-status refresh
+per read would cost more than the poll it is meant to beat. The tool name is on
+the hook's stdin payload if a single script filters instead of per-tool matchers.
+
+## lich server side
+
+- **Endpoint** — `internal/terminal/transport.go`, `transport.sessionTouched`:
+  validates the token and body (`parseSessionTouched`), then forwards the
+  session id.
+- **UI push** — `internal/terminal/terminal.go`: emits the global Wails event
+  `session-touched` (`{id}`).
+- **Refresh** — `frontend/src/lib/projects.tsx`: resolves the session id to the
+  path its card watches (its worktree, else the project path) and calls
+  `refreshGitStatus(path)` (`frontend/src/lib/useGitStatus.ts`), which fetches
+  that path now, ahead of the poll tick. A no-op when no card watches the path
+  (the session lives in a background project), so it costs no git call.
+
+## Known ceilings
+
+- **Poll stays the baseline.** This never replaces the ~3s poll (see the git
+  status ceiling in the repo `CLAUDE.md`); it only front-runs it. Changes from
+  outside Claude (a shell session, an external editor) are still caught by the
+  poll, not this hook.
+- **No debounce.** A burst of edits fires one POST per tool, each an immediate
+  git fetch. Cheap and idempotent (unchanged status short-circuits re-renders),
+  but a trailing debounce could collapse bursts if it ever matters.
+- **Session id, not path.** The hook sends the session id and lich/the frontend
+  resolve the path, so a `cd` inside a Bash tool can't point the refresh at the
+  wrong repository.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,7 @@ import { FooterBar } from "@/components/FooterBar"
 import { Home } from "@/components/Home"
 import { Settings } from "@/components/settings/Settings"
 import { Toaster } from "@/components/ui/sonner"
+import { ClaudePluginGate } from "@/components/ClaudePluginGate"
 
 // Layout is persistent across navigation: the project tabs, session sidebar and
 // TerminalHost stay mounted while the Outlet swaps screens (Home, Settings) on
@@ -56,6 +57,7 @@ function App() {
           </Routes>
         </ProjectsProvider>
       </HashRouter>
+      <ClaudePluginGate />
       <Toaster />
     </SettingsProvider>
   )

--- a/frontend/src/components/ClaudePluginGate.tsx
+++ b/frontend/src/components/ClaudePluginGate.tsx
@@ -1,0 +1,125 @@
+import {useEffect, useRef, useState} from "react"
+import {toast} from "sonner"
+import {Button} from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
+  decidePluginAction,
+  INSTALL_DISMISSED_KEY,
+  UPDATE_DISMISSED_KEY,
+} from "@/lib/plugin-gate"
+import {Service as ClaudePlugin} from "../../bindings/github.com/omartelo/lich/internal/claudeplugin"
+
+const RESTART_HINT = "restart your Claude sessions to apply."
+
+// ClaudePluginGate checks on startup whether the lich Claude Code plugin is
+// installed and current. Missing → a one-click install modal; a newer release →
+// a non-blocking, actionable update toast. Plugin hooks only load in new Claude
+// sessions, so both actions remind the user to restart. Any failure is silent —
+// it must never block or break startup.
+export function ClaudePluginGate() {
+  const [installOpen, setInstallOpen] = useState(false)
+  const [installing, setInstalling] = useState(false)
+  // Guard React strict-mode's double effect: the check runs once per start.
+  const checked = useRef(false)
+
+  useEffect(() => {
+    if (checked.current) return
+    checked.current = true
+    void check()
+  }, [])
+
+  const check = async () => {
+    let action
+    try {
+      const status = await ClaudePlugin.Status()
+      action = decidePluginAction(
+        status,
+        localStorage.getItem(INSTALL_DISMISSED_KEY) === "1",
+        localStorage.getItem(UPDATE_DISMISSED_KEY),
+      )
+    } catch {
+      return
+    }
+    if (action.kind === "install") {
+      setInstallOpen(true)
+    } else if (action.kind === "update") {
+      promptUpdate(action.version)
+    }
+  }
+
+  const promptUpdate = (version: string) => {
+    toast(`lich plugin ${version} is available`, {
+      duration: Infinity,
+      action: {label: "Update", onClick: () => void runUpdate()},
+      cancel: {
+        label: "Later",
+        onClick: () => localStorage.setItem(UPDATE_DISMISSED_KEY, version),
+      },
+    })
+  }
+
+  const runUpdate = async () => {
+    const pending = toast.loading("Updating lich plugin…")
+    try {
+      await ClaudePlugin.Update()
+      toast.success(`Plugin updated — ${RESTART_HINT}`, {id: pending})
+    } catch (error) {
+      toast.error(`Update failed: ${errorMessage(error)}`, {id: pending})
+    }
+  }
+
+  const runInstall = async () => {
+    setInstalling(true)
+    try {
+      await ClaudePlugin.Install()
+      setInstallOpen(false)
+      toast.success(`Plugin installed — ${RESTART_HINT}`)
+    } catch (error) {
+      toast.error(`Install failed: ${errorMessage(error)}`)
+    } finally {
+      setInstalling(false)
+    }
+  }
+
+  const dismissForever = () => {
+    localStorage.setItem(INSTALL_DISMISSED_KEY, "1")
+    setInstallOpen(false)
+  }
+
+  return (
+    <Dialog open={installOpen} onOpenChange={(open) => !open && !installing && setInstallOpen(false)}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Enable the Claude Code integration</DialogTitle>
+          <DialogDescription>
+            Install the lich plugin for Claude Code to get the most out of lich.
+            It deepens the integration between your sessions and the app, and gains
+            new capabilities with each release.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={dismissForever} disabled={installing}>
+            Don't ask again
+          </Button>
+          <Button variant="ghost" onClick={() => setInstallOpen(false)} disabled={installing}>
+            Not now
+          </Button>
+          <Button onClick={() => void runInstall()} disabled={installing}>
+            {installing ? "Installing…" : "Install"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/frontend/src/components/ClaudePluginGate.tsx
+++ b/frontend/src/components/ClaudePluginGate.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog"
 import {
   decidePluginAction,
+  DISMISSED_FLAG,
   INSTALL_DISMISSED_KEY,
   UPDATE_DISMISSED_KEY,
 } from "@/lib/plugin-gate"
@@ -41,7 +42,7 @@ export function ClaudePluginGate() {
       const status = await ClaudePlugin.Status()
       action = decidePluginAction(
         status,
-        localStorage.getItem(INSTALL_DISMISSED_KEY) === "1",
+        localStorage.getItem(INSTALL_DISMISSED_KEY) === DISMISSED_FLAG,
         localStorage.getItem(UPDATE_DISMISSED_KEY),
       )
     } catch {
@@ -89,7 +90,7 @@ export function ClaudePluginGate() {
   }
 
   const dismissForever = () => {
-    localStorage.setItem(INSTALL_DISMISSED_KEY, "1")
+    localStorage.setItem(INSTALL_DISMISSED_KEY, DISMISSED_FLAG)
     setInstallOpen(false)
   }
 

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -1,7 +1,7 @@
 import {useEffect, useRef, useState} from "react"
 import type {KeyboardEvent} from "react"
 import {Events} from "@wailsio/runtime"
-import {Check, GitBranch, LoaderCircle, Pencil, X} from "lucide-react"
+import {Bell, Check, GitBranch, LoaderCircle, Pencil, X} from "lucide-react"
 import {cn} from "@/lib/utils"
 import {displayPath} from "@/lib/paths"
 import {type Session} from "@/lib/sessions"
@@ -24,8 +24,9 @@ interface SessionCardProps {
 }
 
 // Processing state reported by the lich Claude Code hook: a spinner while Claude
-// produces output, a check once its turn ends. null before the first report.
-type SessionStatus = "busy" | "done" | null
+// produces output, a check once its turn ends, a bell when it is blocked on the
+// user (permission prompt or idle input). null before the first report.
+type SessionStatus = "busy" | "done" | "waiting" | null
 const STATUS_EVENT_PREFIX = "session-status:"
 
 // SessionCard is one session entry: a card showing the session label, the
@@ -72,7 +73,9 @@ export function SessionCard({
   useEffect(() => {
     const off = Events.On(STATUS_EVENT_PREFIX + session.id, (event: {data: unknown}) => {
       const next = event.data
-      setStatus(next === "busy" || next === "done" ? next : null)
+      setStatus(
+        next === "busy" || next === "done" || next === "waiting" ? next : null,
+      )
     })
     return () => off()
   }, [session.id])
@@ -127,6 +130,9 @@ export function SessionCard({
                 )}
                 {status === "done" && (
                   <Check className="size-3 shrink-0 text-emerald-500"/>
+                )}
+                {status === "waiting" && (
+                  <Bell className="size-3 shrink-0 text-amber-500"/>
                 )}
                 <span className="truncate text-sm font-medium text-foreground">
                   {session.label}

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useRef, useState} from "react"
 import type {KeyboardEvent} from "react"
-import {GitBranch, Pencil, X} from "lucide-react"
+import {Events} from "@wailsio/runtime"
+import {Check, GitBranch, LoaderCircle, Pencil, X} from "lucide-react"
 import {cn} from "@/lib/utils"
 import {displayPath} from "@/lib/paths"
 import {type Session} from "@/lib/sessions"
@@ -22,6 +23,11 @@ interface SessionCardProps {
   onRename: (label: string) => void
 }
 
+// Processing state reported by the lich Claude Code hook: a spinner while Claude
+// produces output, a check once its turn ends. null before the first report.
+type SessionStatus = "busy" | "done" | null
+const STATUS_EVENT_PREFIX = "session-status:"
+
 // SessionCard is one session entry: a card showing the session label, the
 // session's working directory, and that directory's git branch with a diff
 // badge (when it is a repo), with a close button on hover.
@@ -36,6 +42,7 @@ export function SessionCard({
   const pathRef = useRef<HTMLSpanElement>(null)
   const [pathOverflow, setPathOverflow] = useState(false)
   const [editing, setEditing] = useState(false)
+  const [status, setStatus] = useState<SessionStatus>(null)
   // A worktree session lives in its own checkout: show that path and poll its
   // git status, so the badge reflects the worktree's branch, not the project's.
   const shownPath = session.path || path
@@ -57,6 +64,18 @@ export function SessionCard({
       setEditing(false)
     }
   }
+
+  // The card is always mounted for every listed session (unlike TerminalView,
+  // which only mounts once a session is viewed), so it is the reliable place to
+  // track status. A backend-retained last state would survive project switches;
+  // for now switching away mid-run can strand a spinner until the next turn.
+  useEffect(() => {
+    const off = Events.On(STATUS_EVENT_PREFIX + session.id, (event: {data: unknown}) => {
+      const next = event.data
+      setStatus(next === "busy" || next === "done" ? next : null)
+    })
+    return () => off()
+  }, [session.id])
 
   // Fade the left (path start) only when the tail can't fit, so a path that
   // fits keeps its "~" crisp — matching how terminals hint at hidden prefix.
@@ -102,9 +121,17 @@ export function SessionCard({
                 className="w-full rounded-sm bg-transparent pr-5 text-sm font-medium text-foreground outline-none ring-1 ring-accent-foreground/30"
               />
             ) : (
-              <span className="w-full truncate pr-5 text-sm font-medium text-foreground">
-              {session.label}
-            </span>
+              <span className="flex w-full min-w-0 items-center gap-1.5 pr-5">
+                {status === "busy" && (
+                  <LoaderCircle className="size-3 shrink-0 animate-spin text-muted-foreground"/>
+                )}
+                {status === "done" && (
+                  <Check className="size-3 shrink-0 text-emerald-500"/>
+                )}
+                <span className="truncate text-sm font-medium text-foreground">
+                  {session.label}
+                </span>
+              </span>
             )}
             {/* rtl anchors the tail (project folder) to the right so overflow is
               clipped on the left; the leading LRM keeps "~/" in logical order

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -25,7 +25,9 @@ interface SessionCardProps {
 
 // Processing state reported by the lich Claude Code hook: a spinner while Claude
 // produces output, a check once its turn ends, a bell when it is blocked on the
-// user (permission prompt or idle input). null before the first report.
+// user (permission prompt or idle input). null before the first report, and any
+// other value (the hook's "idle" on SessionEnd) clears back to null so a stale
+// indicator never lingers past a session or a /clear.
 type SessionStatus = "busy" | "done" | "waiting" | null
 const STATUS_EVENT_PREFIX = "session-status:"
 

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -5,6 +5,7 @@ import {Bell, Check, GitBranch, LoaderCircle, Pencil, X} from "lucide-react"
 import {cn} from "@/lib/utils"
 import {displayPath} from "@/lib/paths"
 import {type Session} from "@/lib/sessions"
+import {statusEventName, toSessionStatus, type SessionStatus} from "@/lib/session-events"
 import {useGitStatus} from "@/lib/useGitStatus"
 import {Tooltip, TooltipContent, TooltipTrigger} from "@/components/ui/tooltip"
 import {
@@ -23,14 +24,6 @@ interface SessionCardProps {
   onRename: (label: string) => void
 }
 
-// Processing state reported by the lich Claude Code hook: a spinner while Claude
-// produces output, a check once its turn ends, a bell when it is blocked on the
-// user (permission prompt or idle input). null before the first report, and any
-// other value (the hook's "idle" on SessionEnd) clears back to null so a stale
-// indicator never lingers past a session or a /clear.
-type SessionStatus = "busy" | "done" | "waiting" | null
-const STATUS_EVENT_PREFIX = "session-status:"
-
 // SessionCard is one session entry: a card showing the session label, the
 // session's working directory, and that directory's git branch with a diff
 // badge (when it is a repo), with a close button on hover.
@@ -45,7 +38,11 @@ export function SessionCard({
   const pathRef = useRef<HTMLSpanElement>(null)
   const [pathOverflow, setPathOverflow] = useState(false)
   const [editing, setEditing] = useState(false)
-  const [status, setStatus] = useState<SessionStatus>(null)
+  // Processing state reported by the lich Claude Code hook: a spinner while
+  // Claude produces output, a check once its turn ends, a bell when it is
+  // blocked on the user. null before the first report, and whenever the hook
+  // reports a state with no indicator (see toSessionStatus).
+  const [status, setStatus] = useState<SessionStatus | null>(null)
   // A worktree session lives in its own checkout: show that path and poll its
   // git status, so the badge reflects the worktree's branch, not the project's.
   const shownPath = session.path || path
@@ -73,11 +70,8 @@ export function SessionCard({
   // track status. A backend-retained last state would survive project switches;
   // for now switching away mid-run can strand a spinner until the next turn.
   useEffect(() => {
-    const off = Events.On(STATUS_EVENT_PREFIX + session.id, (event: {data: unknown}) => {
-      const next = event.data
-      setStatus(
-        next === "busy" || next === "done" || next === "waiting" ? next : null,
-      )
+    const off = Events.On(statusEventName(session.id), (event: {data: unknown}) => {
+      setStatus(toSessionStatus(event.data))
     })
     return () => off()
   }, [session.id])

--- a/frontend/src/lib/git-status-store.test.ts
+++ b/frontend/src/lib/git-status-store.test.ts
@@ -96,6 +96,31 @@ describe("createGitStatusStore", () => {
     expect(store.get("/repo")).toBeNull()
   })
 
+  it("refreshes a subscribed path immediately, ahead of the poll tick", async () => {
+    let files = 0
+    const fetch = vi.fn(async () => status(files))
+    const store = createGitStatusStore(fetch, POLL_MS)
+    const listener = vi.fn()
+    store.subscribe("/repo", listener)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fetch).toHaveBeenCalledTimes(1)
+
+    files = 7
+    store.refresh("/repo")
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(store.get("/repo")?.files).toBe(7)
+    expect(listener).toHaveBeenCalledTimes(2)
+  })
+
+  it("refresh is a no-op for a path no one subscribes to", async () => {
+    const fetch = vi.fn(async () => status(0))
+    const store = createGitStatusStore(fetch, POLL_MS)
+    store.refresh("/nobody-watches-this")
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
   it("drops an in-flight result after teardown", async () => {
     let resolve: (value: GitStatus | null) => void = () => {}
     const fetch = vi.fn(

--- a/frontend/src/lib/git-status-store.ts
+++ b/frontend/src/lib/git-status-store.ts
@@ -11,7 +11,9 @@ interface Entry {
   status: GitStatus | null
   listeners: Set<() => void>
   timer: ReturnType<typeof setInterval>
-  onVisible: () => void
+  // Fetches this path once, off the interval cadence. Reused for the
+  // visibilitychange re-fetch and the store's manual refresh(path).
+  refresh: () => void
 }
 
 const unchanged = (a: GitStatus | null, b: GitStatus | null): boolean =>
@@ -56,11 +58,11 @@ export function createGitStatusStore(fetch: GitStatusFetcher, pollMs: number) {
         status: null,
         listeners: new Set(),
         timer: setInterval(refresh, pollMs),
-        onVisible: refresh,
+        refresh,
       }
       entries.set(path, created)
       if (typeof document !== "undefined") {
-        document.addEventListener("visibilitychange", created.onVisible)
+        document.addEventListener("visibilitychange", created.refresh)
       }
       refresh()
       entry = created
@@ -73,7 +75,7 @@ export function createGitStatusStore(fetch: GitStatusFetcher, pollMs: number) {
       }
       clearInterval(entry.timer)
       if (typeof document !== "undefined") {
-        document.removeEventListener("visibilitychange", entry.onVisible)
+        document.removeEventListener("visibilitychange", entry.refresh)
       }
       entries.delete(path)
     }
@@ -82,5 +84,12 @@ export function createGitStatusStore(fetch: GitStatusFetcher, pollMs: number) {
   const get = (path: string): GitStatus | null =>
     entries.get(path)?.status ?? null
 
-  return {subscribe, get}
+  // refresh fetches a path now, ahead of its poll tick. A no-op when nothing is
+  // subscribed to that path (no card is showing it), so an event for a session
+  // in a background project costs no git call.
+  const refresh = (path: string): void => {
+    entries.get(path)?.refresh()
+  }
+
+  return {subscribe, get, refresh}
 }

--- a/frontend/src/lib/glyph-atlas.ts
+++ b/frontend/src/lib/glyph-atlas.ts
@@ -19,8 +19,8 @@ const FLAG_FAINT = 128
 const BLOCK_RANGE_START = 0x2580
 const BLOCK_RANGE_END = 0x259f
 
-// ponytail: whole-cache reset on overflow; an LRU only earns its keep if a
-// real session ever cycles >4096 live glyph+color combos.
+// Overflow resets the whole cache; an LRU only earns its keep if a real session
+// ever cycles >4096 live glyph+color combos.
 const MAX_SPRITES = 4096
 
 interface AtlasCell {

--- a/frontend/src/lib/plugin-gate.test.ts
+++ b/frontend/src/lib/plugin-gate.test.ts
@@ -1,0 +1,46 @@
+import {describe, expect, it} from "vitest"
+import {decidePluginAction} from "./plugin-gate"
+import type {Status} from "../../bindings/github.com/omartelo/lich/internal/claudeplugin"
+
+const status = (over: Partial<Status>): Status => ({
+  installed: false,
+  installedVersion: "",
+  latestVersion: "",
+  updateAvailable: false,
+  ...over,
+})
+
+describe("decidePluginAction", () => {
+  it("prompts install when not installed and not dismissed", () => {
+    expect(decidePluginAction(status({installed: false}), false, null)).toEqual({kind: "install"})
+  })
+
+  it("stays silent when not installed but dismissed forever", () => {
+    expect(decidePluginAction(status({installed: false}), true, null)).toEqual({kind: "none"})
+  })
+
+  it("prompts update when a newer version is available", () => {
+    const s = status({installed: true, updateAvailable: true, latestVersion: "0.0.2"})
+    expect(decidePluginAction(s, false, null)).toEqual({kind: "update", version: "0.0.2"})
+  })
+
+  it("skips update already dismissed for that exact version", () => {
+    const s = status({installed: true, updateAvailable: true, latestVersion: "0.0.2"})
+    expect(decidePluginAction(s, false, "0.0.2")).toEqual({kind: "none"})
+  })
+
+  it("re-prompts update when a newer version than the dismissed one appears", () => {
+    const s = status({installed: true, updateAvailable: true, latestVersion: "0.0.3"})
+    expect(decidePluginAction(s, false, "0.0.2")).toEqual({kind: "update", version: "0.0.3"})
+  })
+
+  it("stays silent when installed and up to date", () => {
+    const s = status({installed: true, updateAvailable: false, installedVersion: "0.0.2"})
+    expect(decidePluginAction(s, false, null)).toEqual({kind: "none"})
+  })
+
+  it("install dismissal does not suppress an update prompt", () => {
+    const s = status({installed: true, updateAvailable: true, latestVersion: "0.0.2"})
+    expect(decidePluginAction(s, true, null)).toEqual({kind: "update", version: "0.0.2"})
+  })
+})

--- a/frontend/src/lib/plugin-gate.ts
+++ b/frontend/src/lib/plugin-gate.ts
@@ -1,0 +1,30 @@
+// Startup decision for the lich Claude Code plugin: whether to prompt an
+// install, an update, or stay silent. Kept pure (no bindings, no storage) so it
+// is trivially testable; the component wires it to Status(), the dialog, and the
+// toast.
+
+import type {Status} from "../../bindings/github.com/omartelo/lich/internal/claudeplugin"
+
+export const INSTALL_DISMISSED_KEY = "lich.pluginInstallDismissed"
+export const UPDATE_DISMISSED_KEY = "lich.pluginUpdateDismissed"
+
+// PluginAction is what the gate should do: install prompt, update prompt (with
+// the target version), or nothing.
+export type PluginAction = {kind: "install"} | {kind: "update"; version: string} | {kind: "none"}
+
+// decidePluginAction resolves the startup prompt. Not installed and not
+// permanently dismissed → install. Installed with a newer release not yet
+// dismissed for that exact version → update. Otherwise nothing.
+export function decidePluginAction(
+  status: Status,
+  installDismissed: boolean,
+  updateDismissedVersion: string | null,
+): PluginAction {
+  if (!status.installed) {
+    return installDismissed ? {kind: "none"} : {kind: "install"}
+  }
+  if (status.updateAvailable && updateDismissedVersion !== status.latestVersion) {
+    return {kind: "update", version: status.latestVersion}
+  }
+  return {kind: "none"}
+}

--- a/frontend/src/lib/plugin-gate.ts
+++ b/frontend/src/lib/plugin-gate.ts
@@ -8,6 +8,10 @@ import type {Status} from "../../bindings/github.com/omartelo/lich/internal/clau
 export const INSTALL_DISMISSED_KEY = "lich.pluginInstallDismissed"
 export const UPDATE_DISMISSED_KEY = "lich.pluginUpdateDismissed"
 
+// Value stored under INSTALL_DISMISSED_KEY: the install prompt is dismissed for
+// good, unlike the update one which stores the version it was dismissed for.
+export const DISMISSED_FLAG = "1"
+
 // PluginAction is what the gate should do: install prompt, update prompt (with
 // the target version), or nothing.
 export type PluginAction = {kind: "install"} | {kind: "update"; version: string} | {kind: "none"}

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -1,6 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
 import type { ReactNode } from "react"
 import { Events } from "@wailsio/runtime"
+import { toast } from "sonner"
 import { useMatch, useNavigate } from "react-router-dom"
 import {
   Project,
@@ -71,6 +72,22 @@ function isTitleEvent(data: unknown): data is { id: string; label: string } {
   )
 }
 
+// Global event the backend emits when a session needs the user — a permission
+// prompt or an idle input request (see terminal.attentionEventName). Payload:
+// { id }. Drives the actionable toast that routes to the card.
+const ATTENTION_EVENT = "session-attention"
+
+// How long the "needs you" toast stays before auto-dismissing.
+const ATTENTION_TOAST_MS = 10_000
+
+function isAttentionEvent(data: unknown): data is { id: string } {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    typeof (data as { id?: unknown }).id === "string"
+  )
+}
+
 // buildSessionState rebuilds the in-memory session map from the persisted
 // projects returned by the store.
 function buildSessionState(loaded: StoreProject[]): SessionState {
@@ -103,6 +120,10 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
   sessionsRef.current = sessions
   const navigate = useNavigate()
   const activeProjectId = useMatch("/projects/:projectId")?.params.projectId
+  // Latest focused project id for the attention toast, read inside a once-only
+  // event subscription without re-subscribing on every navigation.
+  const activeProjectIdRef = useRef(activeProjectId)
+  activeProjectIdRef.current = activeProjectId
   const { hotkeys } = useSettings()
 
   const applyLoaded = useCallback((loaded: StoreProject[]) => {
@@ -245,6 +266,39 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     setSessions(next)
     void Store.SetActiveSession(projectId, sessionId)
   }, [])
+
+  // A session that needs the user (permission prompt or idle input) raises a
+  // global toast that routes to its card — reachable even when the session lives
+  // in a background project whose card is not mounted. Skipped for the session
+  // already in focus, where the terminal itself shows the prompt.
+  useEffect(() => {
+    const off = Events.On(ATTENTION_EVENT, (event: { data: unknown }) => {
+      if (!isAttentionEvent(event.data)) {
+        return
+      }
+      const { id } = event.data
+      const projectId = projectOfSession(sessionsRef.current, id)
+      if (!projectId) {
+        return
+      }
+      const project = sessionsRef.current[projectId]
+      if (projectId === activeProjectIdRef.current && project?.activeId === id) {
+        return
+      }
+      const label = project?.sessions.find((s) => s.id === id)?.label ?? "A session"
+      toast(`${label} needs your input`, {
+        duration: ATTENTION_TOAST_MS,
+        action: {
+          label: "Open",
+          onClick: () => {
+            navigate(`/projects/${projectId}`)
+            activateSession(projectId, id)
+          },
+        },
+      })
+    })
+    return () => off()
+  }, [navigate, activateSession])
 
   const renameSession = useCallback(
     (projectId: string, sessionId: string, label: string) => {

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
 import type { ReactNode } from "react"
+import { Events } from "@wailsio/runtime"
 import { useMatch, useNavigate } from "react-router-dom"
 import {
   Project,
@@ -11,6 +12,7 @@ import {
   activeSessionId,
   addSession,
   closeSession as removeSession,
+  projectOfSession,
   removeProject,
   renameSession as relabelSession,
   sessionsOf,
@@ -56,6 +58,19 @@ const toProject = (p: StoreProject): Project => ({
   path: p.path,
 })
 
+// Global event the backend emits when it auto-applies a session's ai-title as
+// its label (see terminal.titleEventName). Payload: { id, label }.
+const TITLE_EVENT = "session-title"
+
+function isTitleEvent(data: unknown): data is { id: string; label: string } {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    typeof (data as { id?: unknown }).id === "string" &&
+    typeof (data as { label?: unknown }).label === "string"
+  )
+}
+
 // buildSessionState rebuilds the in-memory session map from the persisted
 // projects returned by the store.
 function buildSessionState(loaded: StoreProject[]): SessionState {
@@ -99,6 +114,28 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     void Store.LoadState().then((loaded) => applyLoaded(loaded ?? []))
   }, [applyLoaded])
+
+  // The backend auto-applies the Claude ai-title as a session's label (only
+  // while the user has not renamed it) and emits this event with the change.
+  // Mirror it into local state so the card updates live; the store already
+  // persisted it, so this never writes back.
+  useEffect(() => {
+    const off = Events.On(TITLE_EVENT, (event: { data: unknown }) => {
+      if (!isTitleEvent(event.data)) {
+        return
+      }
+      const { id, label } = event.data
+      const projectId = projectOfSession(sessionsRef.current, id)
+      if (!projectId) {
+        return
+      }
+      const next = relabelSession(sessionsRef.current, projectId, id, label)
+      if (next !== sessionsRef.current) {
+        setSessions(next)
+      }
+    })
+    return () => off()
+  }, [])
 
   const openProject = useCallback(async () => {
     const picked = await ProjectService.Open()

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -21,6 +21,7 @@ import {
   type SessionKind,
   type SessionState,
 } from "./sessions"
+import { refreshGitStatus } from "./useGitStatus"
 import { isRecordingTarget, matchesCombo } from "./hotkeys"
 import { useSettings } from "./settings"
 
@@ -80,7 +81,13 @@ const ATTENTION_EVENT = "session-attention"
 // How long the "needs you" toast stays before auto-dismissing.
 const ATTENTION_TOAST_MS = 10_000
 
-function isAttentionEvent(data: unknown): data is { id: string } {
+// Global event the backend emits when a session likely changed files on disk
+// (see terminal.touchedEventName). Payload: { id }. Nudges an immediate
+// git-status refresh ahead of the steady poll.
+const TOUCHED_EVENT = "session-touched"
+
+// Both session-attention and session-touched carry only a session id.
+function isIdEvent(data: unknown): data is { id: string } {
   return (
     typeof data === "object" &&
     data !== null &&
@@ -118,6 +125,8 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
   const [sessions, setSessions] = useState<SessionState>({})
   const sessionsRef = useRef(sessions)
   sessionsRef.current = sessions
+  const projectsRef = useRef(projects)
+  projectsRef.current = projects
   const navigate = useNavigate()
   const activeProjectId = useMatch("/projects/:projectId")?.params.projectId
   // Latest focused project id for the attention toast, read inside a once-only
@@ -273,7 +282,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
   // already in focus, where the terminal itself shows the prompt.
   useEffect(() => {
     const off = Events.On(ATTENTION_EVENT, (event: { data: unknown }) => {
-      if (!isAttentionEvent(event.data)) {
+      if (!isIdEvent(event.data)) {
         return
       }
       const { id } = event.data
@@ -299,6 +308,32 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     })
     return () => off()
   }, [navigate, activateSession])
+
+  // A session that likely changed files on disk nudges an immediate git-status
+  // refresh for the path its card watches (its worktree, else the project's),
+  // ahead of the steady 3s poll. The poll still runs, so a user without the
+  // plugin keeps the same feedback — this only cuts the lag when the hook fires.
+  useEffect(() => {
+    const off = Events.On(TOUCHED_EVENT, (event: { data: unknown }) => {
+      if (!isIdEvent(event.data)) {
+        return
+      }
+      const { id } = event.data
+      const projectId = projectOfSession(sessionsRef.current, id)
+      if (!projectId) {
+        return
+      }
+      const session = sessionsRef.current[projectId]?.sessions.find(
+        (s) => s.id === id,
+      )
+      const project = projectsRef.current.find((p) => p.id === projectId)
+      const path = session?.path || project?.path
+      if (path) {
+        refreshGitStatus(path)
+      }
+    })
+    return () => off()
+  }, [])
 
   const renameSession = useCallback(
     (projectId: string, sessionId: string, label: string) => {

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -21,6 +21,14 @@ import {
   type SessionKind,
   type SessionState,
 } from "./sessions"
+import {
+  ATTENTION_EVENT,
+  isIdEvent,
+  isTitleEvent,
+  shouldToastAttention,
+  TITLE_EVENT,
+  TOUCHED_EVENT,
+} from "./session-events"
 import { refreshGitStatus } from "./useGitStatus"
 import { isRecordingTarget, matchesCombo } from "./hotkeys"
 import { useSettings } from "./settings"
@@ -60,40 +68,11 @@ const toProject = (p: StoreProject): Project => ({
   path: p.path,
 })
 
-// Global event the backend emits when it auto-applies a session's ai-title as
-// its label (see terminal.titleEventName). Payload: { id, label }.
-const TITLE_EVENT = "session-title"
-
-function isTitleEvent(data: unknown): data is { id: string; label: string } {
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    typeof (data as { id?: unknown }).id === "string" &&
-    typeof (data as { label?: unknown }).label === "string"
-  )
-}
-
-// Global event the backend emits when a session needs the user — a permission
-// prompt or an idle input request (see terminal.attentionEventName). Payload:
-// { id }. Drives the actionable toast that routes to the card.
-const ATTENTION_EVENT = "session-attention"
-
 // How long the "needs you" toast stays before auto-dismissing.
 const ATTENTION_TOAST_MS = 10_000
 
-// Global event the backend emits when a session likely changed files on disk
-// (see terminal.touchedEventName). Payload: { id }. Nudges an immediate
-// git-status refresh ahead of the steady poll.
-const TOUCHED_EVENT = "session-touched"
-
-// Both session-attention and session-touched carry only a session id.
-function isIdEvent(data: unknown): data is { id: string } {
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    typeof (data as { id?: unknown }).id === "string"
-  )
-}
+// Shown when a toasted session has no label to name it by.
+const UNLABELED_SESSION = "A session"
 
 // buildSessionState rebuilds the in-memory session map from the persisted
 // projects returned by the store.
@@ -286,15 +265,13 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
         return
       }
       const { id } = event.data
+      if (!shouldToastAttention(sessionsRef.current, id, activeProjectIdRef.current)) {
+        return
+      }
       const projectId = projectOfSession(sessionsRef.current, id)
-      if (!projectId) {
-        return
-      }
-      const project = sessionsRef.current[projectId]
-      if (projectId === activeProjectIdRef.current && project?.activeId === id) {
-        return
-      }
-      const label = project?.sessions.find((s) => s.id === id)?.label ?? "A session"
+      const label =
+        sessionsRef.current[projectId]?.sessions.find((s) => s.id === id)?.label ??
+        UNLABELED_SESSION
       toast(`${label} needs your input`, {
         duration: ATTENTION_TOAST_MS,
         action: {

--- a/frontend/src/lib/session-events.test.ts
+++ b/frontend/src/lib/session-events.test.ts
@@ -1,0 +1,116 @@
+import {describe, expect, it} from "vitest"
+import {
+  isIdEvent,
+  isTitleEvent,
+  shouldToastAttention,
+  statusEventName,
+  toSessionStatus,
+} from "./session-events"
+import {addSession, createProjectSessions, setActiveSession, type SessionState} from "./sessions"
+
+const ACTIVE = "project-active"
+const BACKGROUND = "project-background"
+
+// Two projects of two sessions each; "s2"/"b2" are the active session of their
+// project, mirroring the shape the provider reads on an attention event.
+function buildState(): SessionState {
+  let state: SessionState = {
+    [ACTIVE]: createProjectSessions("s1"),
+    [BACKGROUND]: createProjectSessions("b1"),
+  }
+  state = addSession(state, ACTIVE, "s2")
+  state = addSession(state, BACKGROUND, "b2")
+  return state
+}
+
+describe("statusEventName", () => {
+  it("suffixes the prefix with the session id", () => {
+    expect(statusEventName("abc")).toBe("session-status:abc")
+  })
+})
+
+describe("toSessionStatus", () => {
+  it("keeps each state the card renders an indicator for", () => {
+    expect(toSessionStatus("busy")).toBe("busy")
+    expect(toSessionStatus("done")).toBe("done")
+    expect(toSessionStatus("waiting")).toBe("waiting")
+  })
+
+  it("clears the indicator on the contract's idle", () => {
+    expect(toSessionStatus("idle")).toBeNull()
+  })
+
+  it("clears the indicator on an unknown state", () => {
+    expect(toSessionStatus("thinking")).toBeNull()
+    expect(toSessionStatus("")).toBeNull()
+  })
+
+  it("clears the indicator on a non-string payload", () => {
+    expect(toSessionStatus(undefined)).toBeNull()
+    expect(toSessionStatus(null)).toBeNull()
+    expect(toSessionStatus(42)).toBeNull()
+    expect(toSessionStatus({state: "busy"})).toBeNull()
+  })
+})
+
+describe("isIdEvent", () => {
+  it("accepts a payload carrying a string id", () => {
+    expect(isIdEvent({id: "s1"})).toBe(true)
+  })
+
+  it("rejects a missing, non-string or non-object payload", () => {
+    expect(isIdEvent({})).toBe(false)
+    expect(isIdEvent({id: 1})).toBe(false)
+    expect(isIdEvent(null)).toBe(false)
+    expect(isIdEvent("s1")).toBe(false)
+  })
+})
+
+describe("isTitleEvent", () => {
+  it("accepts a payload carrying a string id and label", () => {
+    expect(isTitleEvent({id: "s1", label: "build"})).toBe(true)
+  })
+
+  it("rejects a payload missing either half", () => {
+    expect(isTitleEvent({id: "s1"})).toBe(false)
+    expect(isTitleEvent({label: "build"})).toBe(false)
+    expect(isTitleEvent({id: "s1", label: 2})).toBe(false)
+    expect(isTitleEvent(null)).toBe(false)
+  })
+})
+
+describe("shouldToastAttention", () => {
+  it("stays silent for the session already in focus", () => {
+    expect(shouldToastAttention(buildState(), "s2", ACTIVE)).toBe(false)
+  })
+
+  it("toasts a background session of the active project", () => {
+    expect(shouldToastAttention(buildState(), "s1", ACTIVE)).toBe(true)
+  })
+
+  it("toasts the active session of a background project", () => {
+    expect(shouldToastAttention(buildState(), "b2", ACTIVE)).toBe(true)
+  })
+
+  it("toasts a background session of a background project", () => {
+    expect(shouldToastAttention(buildState(), "b1", ACTIVE)).toBe(true)
+  })
+
+  it("toasts every session while no project is focused", () => {
+    expect(shouldToastAttention(buildState(), "s2", undefined)).toBe(true)
+  })
+
+  it("toasts the previously focused session once focus moves away", () => {
+    const state = setActiveSession(buildState(), ACTIVE, "s1")
+    expect(shouldToastAttention(state, "s2", ACTIVE)).toBe(true)
+    expect(shouldToastAttention(state, "s1", ACTIVE)).toBe(false)
+  })
+
+  it("stays silent for a session no project holds", () => {
+    expect(shouldToastAttention(buildState(), "ghost", ACTIVE)).toBe(false)
+  })
+
+  it("stays silent for an empty state", () => {
+    expect(shouldToastAttention({}, "s1", ACTIVE)).toBe(false)
+  })
+})

--- a/frontend/src/lib/session-events.ts
+++ b/frontend/src/lib/session-events.ts
@@ -1,0 +1,80 @@
+// The frontend half of the session event contract (docs/hooks/): the names the
+// backend emits under, the narrowing of their untrusted payloads, and the rules
+// driven off them. The names are duplicated from internal/terminal/terminal.go —
+// unavoidable across the Go/TS boundary, so at least the TS side lives here
+// alone. Kept pure (no bindings, no React) so the provider and the card only
+// wire it up.
+
+import {projectOfSession, type SessionState} from "./sessions"
+
+// Per-session event carrying a session's Claude Code processing state (see
+// terminal.statusEventPrefix). Suffixed with the session id. Payload: the raw
+// state string.
+export const STATUS_EVENT_PREFIX = "session-status:"
+
+export const statusEventName = (sessionId: string): string =>
+  STATUS_EVENT_PREFIX + sessionId
+
+// Global event the backend emits when it auto-applies a session's ai-title as
+// its label (see terminal.titleEventName). Payload: { id, label }.
+export const TITLE_EVENT = "session-title"
+
+// Global event the backend emits when a session needs the user — a permission
+// prompt or an idle input request (see terminal.attentionEventName). Payload:
+// { id }.
+export const ATTENTION_EVENT = "session-attention"
+
+// Global event the backend emits when a session likely changed files on disk
+// (see terminal.touchedEventName). Payload: { id }.
+export const TOUCHED_EVENT = "session-touched"
+
+// The states a card renders an indicator for. The contract also defines "idle"
+// (SessionEnd), which maps to no indicator like any unknown value does.
+const RENDERED_STATUSES = ["busy", "done", "waiting"] as const
+
+export type SessionStatus = (typeof RENDERED_STATUSES)[number]
+
+// toSessionStatus narrows a status payload to the states the card renders. The
+// payload crosses a process boundary, so anything else — the contract's "idle",
+// a state from a newer plugin, a malformed value — yields null, which clears the
+// indicator rather than stranding a stale one.
+export function toSessionStatus(data: unknown): SessionStatus | null {
+  if (typeof data !== "string") {
+    return null
+  }
+  return (RENDERED_STATUSES as readonly string[]).includes(data)
+    ? (data as SessionStatus)
+    : null
+}
+
+// Both session-attention and session-touched carry only a session id.
+export function isIdEvent(data: unknown): data is {id: string} {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    typeof (data as {id?: unknown}).id === "string"
+  )
+}
+
+export function isTitleEvent(data: unknown): data is {id: string; label: string} {
+  return isIdEvent(data) && typeof (data as {label?: unknown}).label === "string"
+}
+
+// shouldToastAttention decides whether a session needing the user deserves the
+// global toast. The session already in focus (active session of the active
+// project) does not: its own terminal shows the prompt. Every other session
+// does, including one in a background project whose card is not even mounted.
+// An unknown session has nowhere to route, so it stays silent.
+export function shouldToastAttention(
+  state: SessionState,
+  sessionId: string,
+  activeProjectId: string | undefined,
+): boolean {
+  const projectId = projectOfSession(state, sessionId)
+  const project = state[projectId]
+  if (!project) {
+    return false
+  }
+  const focused = projectId === activeProjectId && project.activeId === sessionId
+  return !focused
+}

--- a/frontend/src/lib/sessions.test.ts
+++ b/frontend/src/lib/sessions.test.ts
@@ -4,6 +4,7 @@ import {
   addSession,
   closeSession,
   createProjectSessions,
+  projectOfSession,
   removeProject,
   renameSession,
   sessionsOf,
@@ -152,6 +153,17 @@ describe("renameSession", () => {
     const state = buildState(2)
     expect(renameSession(state, "nope", "s1", "x")).toBe(state)
     expect(renameSession(state, P, "ghost", "x")).toBe(state)
+  })
+})
+
+describe("projectOfSession", () => {
+  it("returns the id of the project owning the session", () => {
+    const state = buildState(3)
+    expect(projectOfSession(state, "s2")).toBe(P)
+  })
+
+  it("returns empty string when no project holds the session", () => {
+    expect(projectOfSession(buildState(2), "ghost")).toBe("")
   })
 })
 

--- a/frontend/src/lib/sessions.ts
+++ b/frontend/src/lib/sessions.ts
@@ -161,3 +161,15 @@ export function sessionsOf(state: SessionState, projectId: string): Session[] {
 export function activeSessionId(state: SessionState, projectId: string): string {
   return state[projectId]?.activeId ?? ""
 }
+
+// projectOfSession returns the id of the project owning a session, or "" when no
+// project holds it. Backend events (e.g. the auto ai-title) carry only a session
+// id, so the provider uses this to locate the project the reducer needs.
+export function projectOfSession(state: SessionState, sessionId: string): string {
+  for (const [projectId, project] of Object.entries(state)) {
+    if (project.sessions.some((s) => s.id === sessionId)) {
+      return projectId
+    }
+  }
+  return ""
+}

--- a/frontend/src/lib/term-fit.ts
+++ b/frontend/src/lib/term-fit.ts
@@ -3,9 +3,9 @@
 // permanent band between the terminal and the window. computeGrid divides the
 // full container instead, filling edge to edge. Only a sub-cell remainder is
 // left (< 1 cell, unavoidable: partial cells can't render), landing on the
-// right/bottom since the canvas is top-left anchored.
-// ponytail: the overlay scrollbar now paints over the last column while
-// scrolled; reserve a gutter again only if that ever bothers.
+// right/bottom since the canvas is top-left anchored. The trade: the overlay
+// scrollbar now paints over the last column while scrolled; reserve a gutter
+// again only if that ever bothers.
 
 export interface CellSize {
   width: number

--- a/frontend/src/lib/useGitStatus.ts
+++ b/frontend/src/lib/useGitStatus.ts
@@ -20,6 +20,13 @@ async function fetchGitStatus(path: string): Promise<GitStatus | null> {
 
 const store = createGitStatusStore(fetchGitStatus, GIT_POLL_MS)
 
+// refreshGitStatus fetches a path's git status immediately, ahead of its poll
+// tick — used by the session-touched hook signal to cut the up-to-3s lag on the
+// diff badge after Claude edits files. No-op when no card watches the path.
+export function refreshGitStatus(path: string): void {
+  store.refresh(path)
+}
+
 // useGitStatus subscribes to the shared per-path poller (see git-status-store):
 // all components watching the same directory share one fetch cycle, and an
 // unchanged status never re-renders them. Returns null until the first

--- a/internal/claudeplugin/claudeplugin.go
+++ b/internal/claudeplugin/claudeplugin.go
@@ -1,0 +1,225 @@
+// Package claudeplugin manages the lich companion plugin inside Claude Code:
+// whether it is installed, whether a newer release exists, and installing or
+// updating it. All mutations go through the `claude` CLI — the supported
+// interface — so lich never edits Claude Code's plugin state files by hand.
+package claudeplugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	marketplaceRepo = "omartelo/lich-plugin"
+	marketplaceName = "lich-plugin"
+	pluginName      = "lich"
+	// pluginKey is how Claude Code names the plugin everywhere: install target,
+	// update target, and key in installed_plugins.json.
+	pluginKey        = pluginName + "@" + marketplaceName
+	latestReleaseURL = "https://api.github.com/repos/" + marketplaceRepo + "/releases/latest"
+
+	// cmdTimeout bounds a `claude plugin` call; a marketplace add clones the
+	// repo, which the CLI itself caps at 120s.
+	cmdTimeout  = 130 * time.Second
+	httpTimeout = 5 * time.Second
+	bodyLimit   = 1 << 20
+)
+
+// BinResolver supplies the Claude Code binary to shell out to. The store
+// implements it; passing "" asks for the global binary.
+type BinResolver interface {
+	ClaudeBin(projectID string) string
+}
+
+// Service reports and manages the lich plugin's install state.
+type Service struct {
+	bins      BinResolver
+	http      *http.Client
+	configDir string
+}
+
+// New returns a service that shells out through bins and reads Claude Code's
+// plugin state from the resolved config directory.
+func New(bins BinResolver) *Service {
+	return &Service{
+		bins:      bins,
+		http:      &http.Client{Timeout: httpTimeout},
+		configDir: claudeConfigDir(),
+	}
+}
+
+// Status is the plugin's install/update state, reported to the frontend.
+type Status struct {
+	Installed        bool   `json:"installed"`
+	InstalledVersion string `json:"installedVersion"`
+	LatestVersion    string `json:"latestVersion"`
+	UpdateAvailable  bool   `json:"updateAvailable"`
+}
+
+// Status reports whether the plugin is installed and whether a newer release
+// exists. A failed network lookup leaves LatestVersion empty and never reports
+// an update — it must not block or break app startup.
+func (s *Service) Status() Status {
+	version, installed := s.installedVersion()
+	return computeStatus(installed, version, s.latestVersion())
+}
+
+// computeStatus is the pure decision: an update needs the plugin installed, a
+// known latest, and that latest to be strictly newer than what is installed.
+func computeStatus(installed bool, installedVer, latestVer string) Status {
+	return Status{
+		Installed:        installed,
+		InstalledVersion: installedVer,
+		LatestVersion:    latestVer,
+		UpdateAvailable:  installed && latestVer != "" && semverLess(installedVer, latestVer),
+	}
+}
+
+// Install adds the marketplace and installs the plugin at user scope.
+func (s *Service) Install() error {
+	// A repeat marketplace add errors ("already exists"); that is harmless —
+	// the install below is what matters, so only its error is surfaced.
+	_ = s.runClaude("plugin", "marketplace", "add", marketplaceRepo)
+	return s.runClaude("plugin", "install", pluginKey)
+}
+
+// Update pulls the latest released version. Claude Code applies it on the next
+// session (a restart is required, which the UI signals).
+func (s *Service) Update() error {
+	return s.runClaude("plugin", "update", pluginKey)
+}
+
+func (s *Service) runClaude(args ...string) error {
+	bin := s.bins.ClaudeBin("")
+	if bin == "" {
+		bin = "claude"
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), cmdTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, bin, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("claude %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// installedVersion reads the plugin's installed version from Claude Code's
+// plugin state, or ("", false) when absent or unreadable.
+func (s *Service) installedVersion() (string, bool) {
+	if s.configDir == "" {
+		return "", false
+	}
+	data, err := os.ReadFile(filepath.Join(s.configDir, "plugins", "installed_plugins.json"))
+	if err != nil {
+		return "", false
+	}
+	return parseInstalledVersion(data, pluginKey)
+}
+
+// parseInstalledVersion pulls the plugin's version out of installed_plugins.json,
+// preferring the user-scope install (how lich installs it) over any other.
+func parseInstalledVersion(data []byte, key string) (string, bool) {
+	var doc struct {
+		Plugins map[string][]struct {
+			Scope   string `json:"scope"`
+			Version string `json:"version"`
+		} `json:"plugins"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return "", false
+	}
+	entries := doc.Plugins[key]
+	for _, e := range entries {
+		if e.Scope == "user" && e.Version != "" {
+			return e.Version, true
+		}
+	}
+	for _, e := range entries {
+		if e.Version != "" {
+			return e.Version, true
+		}
+	}
+	return "", false
+}
+
+// latestVersion fetches the newest released version from GitHub, or "" on any
+// failure — the caller treats an empty result as "no update known".
+func (s *Service) latestVersion() string {
+	req, err := http.NewRequest(http.MethodGet, latestReleaseURL, nil)
+	if err != nil {
+		return ""
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "lich")
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return ""
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, bodyLimit))
+	if err != nil {
+		return ""
+	}
+	return parseLatestTag(data)
+}
+
+// parseLatestTag reads the release tag and normalizes it to a bare semver.
+func parseLatestTag(data []byte) string {
+	var doc struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.Unmarshal(data, &doc); err != nil {
+		return ""
+	}
+	return strings.TrimPrefix(doc.TagName, "v")
+}
+
+// semverLess reports whether version a is strictly older than b. Missing or
+// non-numeric components sort as 0 and pre-release/build suffixes are ignored —
+// the plugin releases plain vMAJOR.MINOR.PATCH tags.
+func semverLess(a, b string) bool {
+	pa, pb := parseSemver(a), parseSemver(b)
+	for i := range 3 {
+		if pa[i] != pb[i] {
+			return pa[i] < pb[i]
+		}
+	}
+	return false
+}
+
+func parseSemver(v string) [3]int {
+	v = strings.TrimPrefix(v, "v")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	var out [3]int
+	for i, part := range strings.SplitN(v, ".", 3) {
+		out[i], _ = strconv.Atoi(part)
+	}
+	return out
+}
+
+// claudeConfigDir resolves Claude Code's config directory: the CLAUDE_CONFIG_DIR
+// override, else ~/.claude.
+func claudeConfigDir() string {
+	if d := os.Getenv("CLAUDE_CONFIG_DIR"); d != "" {
+		return d
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".claude")
+}

--- a/internal/claudeplugin/claudeplugin.go
+++ b/internal/claudeplugin/claudeplugin.go
@@ -32,6 +32,10 @@ const (
 	cmdTimeout  = 130 * time.Second
 	httpTimeout = 5 * time.Second
 	bodyLimit   = 1 << 20
+
+	// Release ranks order a pre-release below the release of the same version.
+	preReleaseRank = 0
+	releaseRank    = 1
 )
 
 // BinResolver supplies the Claude Code binary to shell out to. The store
@@ -45,6 +49,9 @@ type Service struct {
 	bins      BinResolver
 	http      *http.Client
 	configDir string
+	// latestURL is the release endpoint to poll; a field so tests can point it
+	// at a local server.
+	latestURL string
 }
 
 // New returns a service that shells out through bins and reads Claude Code's
@@ -54,6 +61,7 @@ func New(bins BinResolver) *Service {
 		bins:      bins,
 		http:      &http.Client{Timeout: httpTimeout},
 		configDir: claudeConfigDir(),
+		latestURL: latestReleaseURL,
 	}
 }
 
@@ -154,7 +162,7 @@ func parseInstalledVersion(data []byte, key string) (string, bool) {
 // latestVersion fetches the newest released version from GitHub, or "" on any
 // failure — the caller treats an empty result as "no update known".
 func (s *Service) latestVersion() string {
-	req, err := http.NewRequest(http.MethodGet, latestReleaseURL, nil)
+	req, err := http.NewRequest(http.MethodGet, s.latestURL, nil)
 	if err != nil {
 		return ""
 	}
@@ -187,11 +195,17 @@ func parseLatestTag(data []byte) string {
 }
 
 // semverLess reports whether version a is strictly older than b. Missing or
-// non-numeric components sort as 0 and pre-release/build suffixes are ignored —
-// the plugin releases plain vMAJOR.MINOR.PATCH tags.
+// non-numeric components sort as 0, and a pre-release sorts before the release
+// it qualifies (SemVer §11: 1.0.0-rc1 < 1.0.0) — the plugin does ship rc tags,
+// so an install made during an rc window must still see the stable as an update.
+//
+// Two different pre-releases of the same version compare equal (rc.1 vs rc.2 is
+// not ordered): that would need identifier-wise comparison, and the update check
+// only ever weighs an install against GitHub's "latest" release, which never
+// resolves to a pre-release.
 func semverLess(a, b string) bool {
 	pa, pb := parseSemver(a), parseSemver(b)
-	for i := range 3 {
+	for i := range pa {
 		if pa[i] != pb[i] {
 			return pa[i] < pb[i]
 		}
@@ -199,12 +213,20 @@ func semverLess(a, b string) bool {
 	return false
 }
 
-func parseSemver(v string) [3]int {
+// parseSemver splits v into a comparable tuple: MAJOR, MINOR, PATCH, and a
+// release rank that keeps a pre-release below the release of the same version.
+func parseSemver(v string) [4]int {
 	v = strings.TrimPrefix(v, "v")
-	if i := strings.IndexAny(v, "-+"); i >= 0 {
+	// Build metadata carries no precedence (SemVer §10), so drop it before the
+	// pre-release check — "+" may legally precede nothing else.
+	if i := strings.IndexByte(v, '+'); i >= 0 {
 		v = v[:i]
 	}
-	var out [3]int
+	rank := releaseRank
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		v, rank = v[:i], preReleaseRank
+	}
+	out := [4]int{3: rank}
 	for i, part := range strings.SplitN(v, ".", 3) {
 		out[i], _ = strconv.Atoi(part)
 	}

--- a/internal/claudeplugin/claudeplugin_test.go
+++ b/internal/claudeplugin/claudeplugin_test.go
@@ -1,8 +1,12 @@
 package claudeplugin
 
 import (
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -86,8 +90,26 @@ func TestSemverLess(t *testing.T) {
 		{"1.0.0", "1.0.0", false},
 		{"1.2.0", "1.1.9", false},
 		{"v1.0.0", "v1.0.1", true},
-		{"1.0.0-rc1", "1.0.0", false},
 		{"1.0", "1.0.1", true},
+
+		// SemVer §11: a pre-release precedes the release it qualifies.
+		{"1.0.0-rc1", "1.0.0", true},
+		{"0.2.0-rc.3", "0.2.0", true},
+		{"v0.2.0-rc.3", "v0.2.0", true},
+		{"1.0.0", "1.0.0-rc1", false},
+		{"1.0.0-rc1", "1.0.1", true},
+		{"1.0.0-rc1", "0.9.9", false},
+		{"1.0.0-rc1", "1.0.0-rc1", false},
+
+		// Ordering between two distinct pre-releases is not resolved; they
+		// compare equal, so neither is "less" than the other.
+		{"1.0.0-rc1", "1.0.0-rc2", false},
+		{"1.0.0-rc2", "1.0.0-rc1", false},
+
+		// Build metadata carries no precedence (SemVer §10).
+		{"1.0.0+build.5", "1.0.0", false},
+		{"1.0.0", "1.0.0+build.5", false},
+		{"1.0.0-rc1+build.5", "1.0.0", true},
 	}
 	for _, tc := range tests {
 		if got := semverLess(tc.a, tc.b); got != tc.want {
@@ -109,6 +131,7 @@ func TestComputeStatus(t *testing.T) {
 		{"update available", true, "0.0.1", "0.0.2", true},
 		{"already latest", true, "0.0.2", "0.0.2", false},
 		{"installed newer than latest", true, "0.1.0", "0.0.2", false},
+		{"pre-release install sees the stable release", true, "0.2.0-rc.3", "0.2.0", true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -145,5 +168,153 @@ func TestInstalledVersionMissingFile(t *testing.T) {
 	s := &Service{configDir: t.TempDir()}
 	if ver, ok := s.installedVersion(); ok || ver != "" {
 		t.Fatalf("got (%q,%v), want empty/false for missing file", ver, ok)
+	}
+}
+
+func TestInstalledVersionNoConfigDir(t *testing.T) {
+	s := &Service{configDir: ""}
+	if ver, ok := s.installedVersion(); ok || ver != "" {
+		t.Fatalf("got (%q,%v), want empty/false without a config dir", ver, ok)
+	}
+}
+
+type stubBins struct{ bin string }
+
+func (s stubBins) ClaudeBin(string) string { return s.bin }
+
+func TestNewDefaults(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+
+	s := New(stubBins{bin: "claude"})
+	if s.latestURL != latestReleaseURL {
+		t.Errorf("latestURL = %q, want %q", s.latestURL, latestReleaseURL)
+	}
+	if s.http == nil || s.http.Timeout != httpTimeout {
+		t.Errorf("http client = %+v, want one with a %v timeout", s.http, httpTimeout)
+	}
+	if s.configDir != dir {
+		t.Errorf("configDir = %q, want %q", s.configDir, dir)
+	}
+	if s.bins == nil {
+		t.Error("bins = nil, want the resolver passed to New")
+	}
+}
+
+func TestClaudeConfigDir(t *testing.T) {
+	t.Run("env override wins", func(t *testing.T) {
+		t.Setenv("CLAUDE_CONFIG_DIR", "/custom/claude")
+		if got := claudeConfigDir(); got != "/custom/claude" {
+			t.Fatalf("claudeConfigDir() = %q, want %q", got, "/custom/claude")
+		}
+	})
+
+	t.Run("falls back to home", func(t *testing.T) {
+		t.Setenv("CLAUDE_CONFIG_DIR", "")
+		t.Setenv("HOME", "/home/someone")
+		if got := claudeConfigDir(); got != filepath.Join("/home/someone", ".claude") {
+			t.Fatalf("claudeConfigDir() = %q, want %q", got, "/home/someone/.claude")
+		}
+	})
+
+	t.Run("empty when home is unresolvable", func(t *testing.T) {
+		t.Setenv("CLAUDE_CONFIG_DIR", "")
+		t.Setenv("HOME", "")
+		if got := claudeConfigDir(); got != "" {
+			t.Fatalf("claudeConfigDir() = %q, want %q", got, "")
+		}
+	})
+}
+
+// serveBody starts a test server returning status/body and returns a Service
+// pointed at it.
+func serveBody(t *testing.T, status int, body string) *Service {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+	return &Service{http: srv.Client(), latestURL: srv.URL}
+}
+
+func TestLatestVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+		want   string
+	}{
+		{"tag with v prefix", http.StatusOK, `{"tag_name":"v0.2.0"}`, "0.2.0"},
+		{"pre-release tag", http.StatusOK, `{"tag_name":"v0.2.0-rc.3"}`, "0.2.0-rc.3"},
+		{"malformed json", http.StatusOK, `{"tag_name":`, ""},
+		{"not found", http.StatusNotFound, `{"message":"Not Found"}`, ""},
+		{"server error", http.StatusInternalServerError, ``, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := serveBody(t, tc.status, tc.body).latestVersion(); got != tc.want {
+				t.Fatalf("latestVersion() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestLatestVersionNetworkFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	s := &Service{http: srv.Client(), latestURL: srv.URL}
+	srv.Close()
+
+	if got := s.latestVersion(); got != "" {
+		t.Fatalf("latestVersion() = %q, want %q for an unreachable server", got, "")
+	}
+}
+
+func TestLatestVersionCapsBody(t *testing.T) {
+	// The tag is valid but padded past bodyLimit: the cap truncates the body
+	// mid-JSON, so a parse failure here is what proves the read is bounded.
+	body := `{"tag_name":"v9.9.9","body":"` + strings.Repeat("x", bodyLimit*2) + `"}`
+	if got := serveBody(t, http.StatusOK, body).latestVersion(); got != "" {
+		t.Fatalf("latestVersion() = %q, want %q — body read past bodyLimit", got, "")
+	}
+}
+
+func TestLatestVersionBadURL(t *testing.T) {
+	s := &Service{http: &http.Client{}, latestURL: "://not a url"}
+	if got := s.latestVersion(); got != "" {
+		t.Fatalf("latestVersion() = %q, want %q for an unbuildable request", got, "")
+	}
+}
+
+func TestStatus(t *testing.T) {
+	dir := t.TempDir()
+	pluginsDir := filepath.Join(dir, "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"plugins":{"lich@lich-plugin":[{"scope":"user","version":"0.2.0-rc.3"}]}}`
+	if err := os.WriteFile(filepath.Join(pluginsDir, "installed_plugins.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := serveBody(t, http.StatusOK, `{"tag_name":"v0.2.0"}`)
+	s.configDir = dir
+
+	want := Status{Installed: true, InstalledVersion: "0.2.0-rc.3", LatestVersion: "0.2.0", UpdateAvailable: true}
+	if got := s.Status(); got != want {
+		t.Fatalf("Status() = %+v, want %+v", got, want)
+	}
+}
+
+func TestStatusNotInstalled(t *testing.T) {
+	s := serveBody(t, http.StatusOK, `{"tag_name":"v0.2.0"}`)
+	s.configDir = t.TempDir()
+
+	got := s.Status()
+	if got.Installed || got.UpdateAvailable {
+		t.Fatalf("Status() = %+v, want not installed and no update", got)
+	}
+	if got.LatestVersion != "0.2.0" {
+		t.Fatalf("LatestVersion = %q, want %q", got.LatestVersion, "0.2.0")
 	}
 }

--- a/internal/claudeplugin/claudeplugin_test.go
+++ b/internal/claudeplugin/claudeplugin_test.go
@@ -1,0 +1,149 @@
+package claudeplugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseInstalledVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		json   string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "user scope",
+			json:   `{"plugins":{"lich@lich-plugin":[{"scope":"user","version":"0.0.1"}]}}`,
+			want:   "0.0.1",
+			wantOK: true,
+		},
+		{
+			name:   "prefers user over project",
+			json:   `{"plugins":{"lich@lich-plugin":[{"scope":"project","version":"9.9.9"},{"scope":"user","version":"0.0.1"}]}}`,
+			want:   "0.0.1",
+			wantOK: true,
+		},
+		{
+			name:   "falls back to any scope",
+			json:   `{"plugins":{"lich@lich-plugin":[{"scope":"project","version":"1.2.3"}]}}`,
+			want:   "1.2.3",
+			wantOK: true,
+		},
+		{
+			name:   "missing key",
+			json:   `{"plugins":{"other@mkt":[{"scope":"user","version":"1.0.0"}]}}`,
+			want:   "",
+			wantOK: false,
+		},
+		{
+			name:   "empty version ignored",
+			json:   `{"plugins":{"lich@lich-plugin":[{"scope":"user","version":""}]}}`,
+			want:   "",
+			wantOK: false,
+		},
+		{name: "malformed", json: `{`, want: "", wantOK: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parseInstalledVersion([]byte(tc.json), "lich@lich-plugin")
+			if got != tc.want || ok != tc.wantOK {
+				t.Fatalf("got (%q,%v), want (%q,%v)", got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestParseLatestTag(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want string
+	}{
+		{"v prefix", `{"tag_name":"v0.2.0"}`, "0.2.0"},
+		{"no prefix", `{"tag_name":"1.4.2"}`, "1.4.2"},
+		{"missing", `{"name":"x"}`, ""},
+		{"malformed", `not json`, ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := parseLatestTag([]byte(tc.json)); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSemverLess(t *testing.T) {
+	tests := []struct {
+		a, b string
+		want bool
+	}{
+		{"0.0.1", "0.0.2", true},
+		{"0.0.1", "0.1.0", true},
+		{"0.9.9", "1.0.0", true},
+		{"1.0.0", "1.0.0", false},
+		{"1.2.0", "1.1.9", false},
+		{"v1.0.0", "v1.0.1", true},
+		{"1.0.0-rc1", "1.0.0", false},
+		{"1.0", "1.0.1", true},
+	}
+	for _, tc := range tests {
+		if got := semverLess(tc.a, tc.b); got != tc.want {
+			t.Errorf("semverLess(%q,%q) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestComputeStatus(t *testing.T) {
+	tests := []struct {
+		name         string
+		installed    bool
+		installedVer string
+		latestVer    string
+		wantUpdate   bool
+	}{
+		{"not installed", false, "", "0.0.2", false},
+		{"installed, no latest known", true, "0.0.1", "", false},
+		{"update available", true, "0.0.1", "0.0.2", true},
+		{"already latest", true, "0.0.2", "0.0.2", false},
+		{"installed newer than latest", true, "0.1.0", "0.0.2", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeStatus(tc.installed, tc.installedVer, tc.latestVer)
+			if got.UpdateAvailable != tc.wantUpdate {
+				t.Fatalf("UpdateAvailable = %v, want %v", got.UpdateAvailable, tc.wantUpdate)
+			}
+			if got.Installed != tc.installed || got.InstalledVersion != tc.installedVer || got.LatestVersion != tc.latestVer {
+				t.Fatalf("status = %+v, mismatch on passthrough fields", got)
+			}
+		})
+	}
+}
+
+func TestInstalledVersionReadsConfigDir(t *testing.T) {
+	dir := t.TempDir()
+	pluginsDir := filepath.Join(dir, "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := `{"plugins":{"lich@lich-plugin":[{"scope":"user","version":"0.3.1"}]}}`
+	if err := os.WriteFile(filepath.Join(pluginsDir, "installed_plugins.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Service{configDir: dir}
+	ver, ok := s.installedVersion()
+	if !ok || ver != "0.3.1" {
+		t.Fatalf("got (%q,%v), want (0.3.1,true)", ver, ok)
+	}
+}
+
+func TestInstalledVersionMissingFile(t *testing.T) {
+	s := &Service{configDir: t.TempDir()}
+	if ver, ok := s.installedVersion(); ok || ver != "" {
+		t.Fatalf("got (%q,%v), want empty/false for missing file", ver, ok)
+	}
+}

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -80,6 +80,21 @@ func (s *Service) RenameSession(sessionID, label string) error {
 	return nil
 }
 
+// SetClaudeSession records the Claude Code session id running inside a lich
+// session's PTY, reported by the SessionStart hook. A session whose row does not
+// exist yet (the hook racing session persistence) matches nothing and is not an
+// error — the id is simply dropped, which is acceptable for the features it
+// backs. Re-reporting (e.g. after a resume) overwrites with the latest id.
+func (s *Service) SetClaudeSession(sessionID, claudeSessionID string) error {
+	if _, err := s.db.Exec(
+		`UPDATE sessions SET claude_session_id = ? WHERE id = ?`,
+		claudeSessionID, sessionID,
+	); err != nil {
+		return fmt.Errorf("set claude session: %w", err)
+	}
+	return nil
+}
+
 // SetActiveSession records which session is focused within a project.
 func (s *Service) SetActiveSession(projectID, sessionID string) error {
 	if _, err := s.db.Exec(

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -72,12 +72,37 @@ func (s *Service) DeleteSession(projectID, sessionID, activeID string) error {
 	})
 }
 
-// RenameSession updates a session's display label.
+// RenameSession updates a session's display label from an explicit user rename.
+// It clears label_auto so the automatic ai-title (SetSessionTitle) never stomps
+// a name the user chose.
 func (s *Service) RenameSession(sessionID, label string) error {
-	if _, err := s.db.Exec(`UPDATE sessions SET label = ? WHERE id = ?`, label, sessionID); err != nil {
+	if _, err := s.db.Exec(
+		`UPDATE sessions SET label = ?, label_auto = 0 WHERE id = ?`,
+		label, sessionID,
+	); err != nil {
 		return fmt.Errorf("rename session: %w", err)
 	}
 	return nil
+}
+
+// SetSessionTitle sets a session's label from the Claude Code ai-title reported
+// by the Stop hook, but only while the label is still automatic: a prior
+// RenameSession clears label_auto and makes this a no-op, so a user's own name
+// is never overwritten. Reports whether the label actually changed, so the
+// caller only pushes a UI update when it did.
+func (s *Service) SetSessionTitle(sessionID, title string) (bool, error) {
+	res, err := s.db.Exec(
+		`UPDATE sessions SET label = ? WHERE id = ? AND label_auto = 1`,
+		title, sessionID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("set session title: %w", err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("set session title rows: %w", err)
+	}
+	return n > 0, nil
 }
 
 // SetClaudeSession records the Claude Code session id running inside a lich

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,11 +32,12 @@ CREATE TABLE IF NOT EXISTS projects (
 );
 
 CREATE TABLE IF NOT EXISTS sessions (
-    id         TEXT NOT NULL PRIMARY KEY,
-    project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
-    label      TEXT NOT NULL,
-    kind       TEXT NOT NULL DEFAULT 'claude',
-    path       TEXT NOT NULL DEFAULT ''
+    id                TEXT NOT NULL PRIMARY KEY,
+    project_id        TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    label             TEXT NOT NULL,
+    kind              TEXT NOT NULL DEFAULT 'claude',
+    path              TEXT NOT NULL DEFAULT '',
+    claude_session_id TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
 
@@ -59,12 +60,16 @@ type Service struct {
 // Session is a persisted terminal session (metadata only). Kind selects what
 // the PTY runs: "claude" (Claude Code binary) or "shell" (the user's shell).
 // Path is the session's working directory when it lives in a git worktree;
-// empty means the project's own path.
+// empty means the project's own path. ClaudeSessionID is the id Claude Code
+// assigns its own session, reported by the SessionStart hook; empty until the
+// hook fires (or for shell sessions), it is the key for future features that
+// need to reach a session's transcript or resume it.
 type Session struct {
-	ID    string `json:"id"`
-	Label string `json:"label"`
-	Kind  string `json:"kind"`
-	Path  string `json:"path"`
+	ID              string `json:"id"`
+	Label           string `json:"label"`
+	Kind            string `json:"kind"`
+	Path            string `json:"path"`
+	ClaudeSessionID string `json:"claudeSessionId"`
 }
 
 // Project is a persisted project together with its restorable session state.
@@ -113,6 +118,7 @@ func open(path string) (*Service, error) {
 	migrations := []string{
 		`ALTER TABLE sessions ADD COLUMN kind TEXT NOT NULL DEFAULT 'claude'`,
 		`ALTER TABLE sessions ADD COLUMN path TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN claude_session_id TEXT NOT NULL DEFAULT ''`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.Exec(stmt); err != nil &&
@@ -183,7 +189,8 @@ func (s *Service) LoadState() ([]Project, error) {
 // sessionsOf returns a project's sessions in insertion order.
 func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	rows, err := s.db.Query(
-		`SELECT id, label, kind, path FROM sessions WHERE project_id = ? ORDER BY rowid`,
+		`SELECT id, label, kind, path, claude_session_id
+		   FROM sessions WHERE project_id = ? ORDER BY rowid`,
 		projectID,
 	)
 	if err != nil {
@@ -194,7 +201,7 @@ func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	sessions := []Session{}
 	for rows.Next() {
 		var sess Session
-		if err := rows.Scan(&sess.ID, &sess.Label, &sess.Kind, &sess.Path); err != nil {
+		if err := rows.Scan(&sess.ID, &sess.Label, &sess.Kind, &sess.Path, &sess.ClaudeSessionID); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}
 		sessions = append(sessions, sess)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -37,7 +37,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     label             TEXT NOT NULL,
     kind              TEXT NOT NULL DEFAULT 'claude',
     path              TEXT NOT NULL DEFAULT '',
-    claude_session_id TEXT NOT NULL DEFAULT ''
+    claude_session_id TEXT NOT NULL DEFAULT '',
+    label_auto        INTEGER NOT NULL DEFAULT 1
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
 
@@ -119,6 +120,7 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN kind TEXT NOT NULL DEFAULT 'claude'`,
 		`ALTER TABLE sessions ADD COLUMN path TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN claude_session_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN label_auto INTEGER NOT NULL DEFAULT 1`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.Exec(stmt); err != nil &&

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -99,6 +99,54 @@ func TestSessionKindPersistsAndDefaults(t *testing.T) {
 	}
 }
 
+// TestSetClaudeSessionPersistsAndDefaults proves the Claude session id survives
+// a reload, defaults to "" before the SessionStart hook reports it, and that a
+// re-report overwrites with the latest id.
+func TestSetClaudeSessionPersistsAndDefaults(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
+	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3)
+
+	if err := svc.SetClaudeSession("s1", "uuid-abc"); err != nil {
+		t.Fatalf("SetClaudeSession: %v", err)
+	}
+	// Re-report (e.g. after a resume) overwrites with the newest id.
+	if err := svc.SetClaudeSession("s1", "uuid-def"); err != nil {
+		t.Fatalf("SetClaudeSession re-report: %v", err)
+	}
+
+	sessions := mustLoadSessions(t, svc)
+	if sessions[0].ClaudeSessionID != "uuid-def" {
+		t.Errorf("s1 claude id = %q, want uuid-def", sessions[0].ClaudeSessionID)
+	}
+	if sessions[1].ClaudeSessionID != "" {
+		t.Errorf("s2 claude id = %q, want empty", sessions[1].ClaudeSessionID)
+	}
+}
+
+// TestSetClaudeSessionUnknownSessionNoop proves reporting for a session whose
+// row does not exist (the hook racing persistence) is not an error.
+func TestSetClaudeSessionUnknownSessionNoop(t *testing.T) {
+	svc := newTestStore(t)
+	if err := svc.SetClaudeSession("ghost", "uuid-x"); err != nil {
+		t.Errorf("SetClaudeSession unknown = %v, want nil", err)
+	}
+}
+
+// mustLoadSessions loads the single test project's sessions or fails.
+func mustLoadSessions(t *testing.T, svc *Service) []Session {
+	t.Helper()
+	projects, err := svc.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if len(projects) != 1 {
+		t.Fatalf("got %d projects, want 1", len(projects))
+	}
+	return projects[0].Sessions
+}
+
 func TestCloseProjectHidesButKeepsSessions(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
@@ -265,6 +313,7 @@ func TestOperationsOnClosedStoreReturnErrors(t *testing.T) {
 	assertErr("AddSession", svc.AddSession("p1", "s1", "Session 1", "", "", 2))
 	assertErr("DeleteSession", svc.DeleteSession("p1", "s1", ""))
 	assertErr("RenameSession", svc.RenameSession("s1", "x"))
+	assertErr("SetClaudeSession", svc.SetClaudeSession("s1", "uuid"))
 	assertErr("SetActiveSession", svc.SetActiveSession("p1", "s1"))
 	assertErr("SetSetting", svc.SetSetting("k", "", "v"))
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -215,6 +215,41 @@ func TestRenameAndActivateSession(t *testing.T) {
 	}
 }
 
+// TestSetSessionTitleRespectsManualRename proves the ai-title only sets the
+// label while it is still automatic: it applies to a fresh session, reports
+// that it changed, and no-ops (reporting false) once the user has renamed.
+func TestSetSessionTitleRespectsManualRename(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
+
+	applied, err := svc.SetSessionTitle("s1", "Fixing the auth bug")
+	if err != nil {
+		t.Fatalf("SetSessionTitle: %v", err)
+	}
+	if !applied {
+		t.Fatal("SetSessionTitle on an auto label = false, want true")
+	}
+	if got := mustLoadSessions(t, svc)[0].Label; got != "Fixing the auth bug" {
+		t.Errorf("label = %q, want the title", got)
+	}
+
+	// A user rename clears the auto flag; the next title must not stomp it.
+	if err := svc.RenameSession("s1", "my build"); err != nil {
+		t.Fatalf("RenameSession: %v", err)
+	}
+	applied, err = svc.SetSessionTitle("s1", "A different title")
+	if err != nil {
+		t.Fatalf("SetSessionTitle after rename: %v", err)
+	}
+	if applied {
+		t.Fatal("SetSessionTitle after a manual rename = true, want false")
+	}
+	if got := mustLoadSessions(t, svc)[0].Label; got != "my build" {
+		t.Errorf("manual label was stomped: %q", got)
+	}
+}
+
 func TestDatabasePath(t *testing.T) {
 	t.Setenv("LICH_DEV", "")
 	path, err := databasePath()
@@ -315,6 +350,9 @@ func TestOperationsOnClosedStoreReturnErrors(t *testing.T) {
 	assertErr("RenameSession", svc.RenameSession("s1", "x"))
 	assertErr("SetClaudeSession", svc.SetClaudeSession("s1", "uuid"))
 	assertErr("SetActiveSession", svc.SetActiveSession("p1", "s1"))
+	if _, err := svc.SetSessionTitle("s1", "x"); err == nil {
+		t.Error("SetSessionTitle on closed store = nil error, want error")
+	}
 	assertErr("SetSetting", svc.SetSetting("k", "", "v"))
 
 	if _, err := svc.GetSetting("k", ""); err == nil {

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -40,18 +40,20 @@ type session struct {
 	out  *coalescer
 }
 
-// BinResolver supplies the Claude Code binary path to spawn for a project. An
-// empty return spawns the default binary. The store implements it, reading the
-// per-project override or the global setting.
-type BinResolver interface {
+// Store is the persistence the terminal service depends on: the Claude Code
+// binary to spawn for a project (empty return spawns the default), and where to
+// record the Claude session id a PTY reports through the SessionStart hook. The
+// store implements both.
+type Store interface {
 	ClaudeBin(projectID string) string
+	SetClaudeSession(sessionID, claudeSessionID string) error
 }
 
 // Service manages PTY-backed shell sessions keyed by session ID.
 type Service struct {
 	mu       sync.Mutex
 	sessions map[string]*session
-	bins     BinResolver
+	store    Store
 	// env is the environment every spawned session inherits: the launch
 	// environment cleaned of AppImage runtime leakage (see childEnv), plus TERM.
 	env []string
@@ -61,18 +63,19 @@ type Service struct {
 }
 
 // New returns a ready-to-use terminal service that resolves the binary to spawn
-// through bins. env is the process environment to derive session environments
+// through store. env is the process environment to derive session environments
 // from — callers pass a snapshot taken before any os.Setenv tweaks (main.go
 // forces GDK_BACKEND on Linux) so those never leak into spawned shells.
-func New(bins BinResolver, env []string) *Service {
+func New(store Store, env []string) *Service {
 	s := &Service{
 		sessions: make(map[string]*session),
-		bins:     bins,
+		store:    store,
 		env:      append(childEnv(env), "TERM=xterm-256color"),
 	}
 	ws, err := newTransport(
 		func(id string, data []byte) { _ = s.writeBytes(id, data) },
 		func(id, state string) { application.Get().Event.Emit(statusEventPrefix+id, state) },
+		store.SetClaudeSession,
 	)
 	if err == nil {
 		s.ws = ws
@@ -240,7 +243,7 @@ func (s *Service) Start(id, projectID, cwd, kind string, cols, rows int) error {
 		cwd = home
 	}
 
-	cmd := exec.Command(resolveCommand(kind, s.bins.ClaudeBin(projectID), os.Getenv("SHELL")))
+	cmd := exec.Command(resolveCommand(kind, s.store.ClaudeBin(projectID), os.Getenv("SHELL")))
 	cmd.Dir = cwd
 	cmd.Env = s.sessionEnv(id)
 

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -31,7 +31,18 @@ const (
 	// ("busy"/"done"), reported by the lich hook running inside the PTY (see
 	// transport.hook and integrations/claude-plugin).
 	statusEventPrefix = "session-status:"
+	// titleEventName carries an auto-applied session label ({id, label}).
+	// Unlike the per-session events above, it is a single global event because
+	// the provider that owns session state consumes it centrally, not per card.
+	titleEventName = "session-title"
 )
+
+// titleEvent is the payload of titleEventName: the session whose label changed
+// and its new label.
+type titleEvent struct {
+	ID    string `json:"id"`
+	Label string `json:"label"`
+}
 
 // session is a single running PTY-backed shell.
 type session struct {
@@ -47,6 +58,7 @@ type session struct {
 type Store interface {
 	ClaudeBin(projectID string) string
 	SetClaudeSession(sessionID, claudeSessionID string) error
+	SetSessionTitle(sessionID, title string) (bool, error)
 }
 
 // Service manages PTY-backed shell sessions keyed by session ID.
@@ -76,6 +88,16 @@ func New(store Store, env []string) *Service {
 		func(id string, data []byte) { _ = s.writeBytes(id, data) },
 		func(id, state string) { application.Get().Event.Emit(statusEventPrefix+id, state) },
 		store.SetClaudeSession,
+		func(id, title string) error {
+			applied, err := store.SetSessionTitle(id, title)
+			if err != nil {
+				return err
+			}
+			if applied {
+				application.Get().Event.Emit(titleEventName, titleEvent{ID: id, Label: title})
+			}
+			return nil
+		},
 	)
 	if err == nil {
 		s.ws = ws

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -35,6 +35,11 @@ const (
 	// Unlike the per-session events above, it is a single global event because
 	// the provider that owns session state consumes it centrally, not per card.
 	titleEventName = "session-title"
+	// attentionEventName carries the id of a session that just needs the user
+	// (state "waiting"). It is global so the provider can toast and route to the
+	// card even when that session lives in a background project whose card is not
+	// mounted — the per-session status event alone cannot reach an unmounted card.
+	attentionEventName = "session-attention"
 )
 
 // titleEvent is the payload of titleEventName: the session whose label changed
@@ -42,6 +47,12 @@ const (
 type titleEvent struct {
 	ID    string `json:"id"`
 	Label string `json:"label"`
+}
+
+// attentionEvent is the payload of attentionEventName: the session needing the
+// user.
+type attentionEvent struct {
+	ID string `json:"id"`
 }
 
 // session is a single running PTY-backed shell.
@@ -86,7 +97,12 @@ func New(store Store, env []string) *Service {
 	}
 	ws, err := newTransport(
 		func(id string, data []byte) { _ = s.writeBytes(id, data) },
-		func(id, state string) { application.Get().Event.Emit(statusEventPrefix+id, state) },
+		func(id, state string) {
+			application.Get().Event.Emit(statusEventPrefix+id, state)
+			if state == statusWaiting {
+				application.Get().Event.Emit(attentionEventName, attentionEvent{ID: id})
+			}
+		},
 		store.SetClaudeSession,
 		func(id, title string) error {
 			applied, err := store.SetSessionTitle(id, title)

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -26,6 +27,10 @@ const (
 	dataEventPrefix = "terminal:data:"
 	// exitEventPrefix is emitted once when a session's shell process exits.
 	exitEventPrefix = "terminal:exit:"
+	// statusEventPrefix carries a session's Claude Code processing state
+	// ("busy"/"done"), reported by the lich hook running inside the PTY (see
+	// transport.hook and integrations/claude-plugin).
+	statusEventPrefix = "session-status:"
 )
 
 // session is a single running PTY-backed shell.
@@ -65,11 +70,33 @@ func New(bins BinResolver, env []string) *Service {
 		bins:     bins,
 		env:      append(childEnv(env), "TERM=xterm-256color"),
 	}
-	ws, err := newTransport(func(id string, data []byte) { _ = s.writeBytes(id, data) })
+	ws, err := newTransport(
+		func(id string, data []byte) { _ = s.writeBytes(id, data) },
+		func(id, state string) { application.Get().Event.Emit(statusEventPrefix+id, state) },
+	)
 	if err == nil {
 		s.ws = ws
 	}
 	return s
+}
+
+// sessionEnv is the environment for one PTY: the shared base plus the loopback
+// coordinates a Claude Code hook needs to report this session's status back to
+// lich. LICH_SESSION_ID is per-session, so this returns a fresh slice rather
+// than aliasing (and appending to) the shared s.env. When the transport failed
+// to start there is nowhere to report, so the base env is used unchanged — a
+// hook spawned in this PTY sees no LICH_PORT and no-ops.
+func (s *Service) sessionEnv(id string) []string {
+	if s.ws == nil {
+		return s.env
+	}
+	env := make([]string, len(s.env), len(s.env)+3)
+	copy(env, s.env)
+	return append(env,
+		"LICH_PORT="+strconv.Itoa(s.ws.port),
+		"LICH_TOKEN="+s.ws.token,
+		"LICH_SESSION_ID="+id,
+	)
 }
 
 // defaultBin is the Claude Code binary spawned when the user has not configured
@@ -215,7 +242,7 @@ func (s *Service) Start(id, projectID, cwd, kind string, cols, rows int) error {
 
 	cmd := exec.Command(resolveCommand(kind, s.bins.ClaudeBin(projectID), os.Getenv("SHELL")))
 	cmd.Dir = cwd
-	cmd.Env = s.env
+	cmd.Env = s.sessionEnv(id)
 
 	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)})
 	if err != nil {

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -28,8 +28,8 @@ const (
 	// exitEventPrefix is emitted once when a session's shell process exits.
 	exitEventPrefix = "terminal:exit:"
 	// statusEventPrefix carries a session's Claude Code processing state
-	// ("busy"/"done"), reported by the lich hook running inside the PTY (see
-	// transport.hook and integrations/claude-plugin).
+	// ("busy"/"done"/"waiting"/"idle"), reported by the lich hook running inside
+	// the PTY (see transport.hook and docs/hooks/session-state.md).
 	statusEventPrefix = "session-status:"
 	// titleEventName carries an auto-applied session label ({id, label}).
 	// Unlike the per-session events above, it is a single global event because

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -40,6 +40,9 @@ const (
 	// card even when that session lives in a background project whose card is not
 	// mounted — the per-session status event alone cannot reach an unmounted card.
 	attentionEventName = "session-attention"
+	// touchedEventName carries the id of a session that likely changed files on
+	// disk, nudging an immediate git-status refresh ahead of the steady poll.
+	touchedEventName = "session-touched"
 )
 
 // titleEvent is the payload of titleEventName: the session whose label changed
@@ -52,6 +55,12 @@ type titleEvent struct {
 // attentionEvent is the payload of attentionEventName: the session needing the
 // user.
 type attentionEvent struct {
+	ID string `json:"id"`
+}
+
+// touchedEvent is the payload of touchedEventName: the session whose files
+// likely changed.
+type touchedEvent struct {
 	ID string `json:"id"`
 }
 
@@ -113,6 +122,9 @@ func New(store Store, env []string) *Service {
 				application.Get().Event.Emit(titleEventName, titleEvent{ID: id, Label: title})
 			}
 			return nil
+		},
+		func(id string) {
+			application.Get().Event.Emit(touchedEventName, touchedEvent{ID: id})
 		},
 	)
 	if err == nil {

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -282,3 +282,36 @@ func TestPTYEcho(t *testing.T) {
 		t.Fatal("timed out reading PTY output")
 	}
 }
+
+// TestSessionEnvInjectsCoordinates proves a spawned PTY gets the loopback
+// coordinates a Claude Code hook needs, without aliasing the shared base env.
+func TestSessionEnvInjectsCoordinates(t *testing.T) {
+	s := &Service{env: []string{"A=1"}, ws: &transport{port: 4321, token: "tok"}}
+	env := s.sessionEnv("sess")
+
+	want := map[string]bool{
+		"A=1":                  true,
+		"LICH_PORT=4321":       true,
+		"LICH_TOKEN=tok":       true,
+		"LICH_SESSION_ID=sess": true,
+	}
+	for _, e := range env {
+		delete(want, e)
+	}
+	if len(want) != 0 {
+		t.Fatalf("missing env entries %v (got %v)", want, env)
+	}
+	if len(s.env) != 1 || s.env[0] != "A=1" {
+		t.Fatalf("shared base env was mutated: %v", s.env)
+	}
+}
+
+// TestSessionEnvNoTransport proves that without a transport there is nothing to
+// report to, so the base env is returned unchanged (the hook will no-op).
+func TestSessionEnvNoTransport(t *testing.T) {
+	s := &Service{env: []string{"A=1"}}
+	env := s.sessionEnv("sess")
+	if len(env) != 1 || env[0] != "A=1" {
+		t.Fatalf("expected base env unchanged, got %v", env)
+	}
+}

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -11,12 +11,13 @@ import (
 )
 
 // stubBins is a Store returning a fixed binary path, for tests that never
-// spawn. Its SetClaudeSession is a no-op — none of these tests exercise the
-// SessionStart path.
+// spawn. Its persistence methods are no-ops — none of these tests exercise the
+// SessionStart or ai-title paths.
 type stubBins struct{ bin string }
 
-func (s stubBins) ClaudeBin(string) string            { return s.bin }
-func (s stubBins) SetClaudeSession(_, _ string) error { return nil }
+func (s stubBins) ClaudeBin(string) string                   { return s.bin }
+func (s stubBins) SetClaudeSession(_, _ string) error        { return nil }
+func (s stubBins) SetSessionTitle(_, _ string) (bool, error) { return false, nil }
 
 // TestChildEnvStripsAppImageVars proves the AppImage runtime variables that break
 // mise/asdf shims are dropped while the real user environment is passed through.

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -10,10 +10,13 @@ import (
 	"github.com/creack/pty"
 )
 
-// stubBins is a BinResolver returning a fixed path, for tests that never spawn.
+// stubBins is a Store returning a fixed binary path, for tests that never
+// spawn. Its SetClaudeSession is a no-op — none of these tests exercise the
+// SessionStart path.
 type stubBins struct{ bin string }
 
-func (s stubBins) ClaudeBin(string) string { return s.bin }
+func (s stubBins) ClaudeBin(string) string            { return s.bin }
+func (s stubBins) SetClaudeSession(_, _ string) error { return nil }
 
 // TestChildEnvStripsAppImageVars proves the AppImage runtime variables that break
 // mise/asdf shims are dropped while the real user environment is passed through.

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -84,17 +85,20 @@ type transport struct {
 	input       func(id string, data []byte)
 	status      func(id, state string)
 	linkSession func(sessionID, claudeSessionID string) error
+	setTitle    func(sessionID, title string) error
 }
 
 // newTransport starts the listener on a random loopback port. input receives
 // decoded input frames (keyboard data for a session's PTY); status receives a
 // session's processing state reported by the Claude Code hook (see /hook);
 // linkSession records the Claude session id a PTY reports at start (see
-// /session-start).
+// /session-start); setTitle applies an auto-generated session label (see
+// /session-title).
 func newTransport(
 	input func(id string, data []byte),
 	status func(id, state string),
 	linkSession func(sessionID, claudeSessionID string) error,
+	setTitle func(sessionID, title string) error,
 ) (*transport, error) {
 	raw := make([]byte, tokenBytes)
 	if _, err := rand.Read(raw); err != nil {
@@ -110,11 +114,13 @@ func newTransport(
 		input:       input,
 		status:      status,
 		linkSession: linkSession,
+		setTitle:    setTitle,
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ws", t.handle)
 	mux.HandleFunc("/hook", t.hook)
 	mux.HandleFunc("/session-start", t.sessionStart)
+	mux.HandleFunc("/session-title", t.sessionTitle)
 	// ponytail: server and listener live for the process lifetime, like the
 	// PTY sessions they serve; add Shutdown if the app ever needs teardown.
 	go func() { _ = http.Serve(listener, mux) }()
@@ -225,6 +231,57 @@ func parseSessionStart(body []byte) (id, claudeID string, err error) {
 		return "", "", errors.New("session-start missing claude_session_id")
 	}
 	return req.SessionID, req.ClaudeSessionID, nil
+}
+
+// sessionTitle receives the ai-title POST from the Claude Code hook and applies
+// it as the session's label via the setTitle callback, which no-ops when the
+// user has renamed the session. A store failure is a 500; the hook ignores it.
+func (t *transport) sessionTitle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !t.authorized(r) {
+		http.Error(w, "invalid token", http.StatusUnauthorized)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, hookBodyLimit))
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+	id, title, err := parseSessionTitle(body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if t.setTitle != nil {
+		if err := t.setTitle(id, title); err != nil {
+			http.Error(w, "failed to set title", http.StatusInternalServerError)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// parseSessionTitle validates an ai-title POST body: the lich session id and a
+// non-empty title (trimmed, since the hook extracts it from a transcript line).
+func parseSessionTitle(body []byte) (id, title string, err error) {
+	var req struct {
+		SessionID string `json:"session_id"`
+		Title     string `json:"title"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return "", "", fmt.Errorf("invalid session-title body: %w", err)
+	}
+	if req.SessionID == "" {
+		return "", "", errors.New("session-title missing session_id")
+	}
+	title = strings.TrimSpace(req.Title)
+	if title == "" {
+		return "", "", errors.New("session-title missing title")
+	}
+	return req.SessionID, title, nil
 }
 
 // handle upgrades the single expected client. See authorized for the auth model.

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -5,8 +5,10 @@ import (
 	"crypto/rand"
 	"crypto/subtle"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"sync"
@@ -37,6 +39,13 @@ const (
 	wsReadLimit = 1 << 20
 	// tokenBytes is the size of the random connect token.
 	tokenBytes = 16
+	// hookBodyLimit bounds a status POST from the Claude Code hook; the payload
+	// is a tiny JSON object, so anything larger is malformed or hostile.
+	hookBodyLimit = 4 << 10
+	// statusBusy/statusDone are the only session states the hook may report:
+	// busy while Claude is producing output, done when its turn finishes.
+	statusBusy = "busy"
+	statusDone = "done"
 )
 
 // encodeFrame prefixes payload with the session id. The id must fit one byte
@@ -68,16 +77,18 @@ func decodeFrame(buf []byte) (string, []byte, error) {
 // transport is the local WebSocket endpoint. One client (the webview) is
 // expected; a new connection replaces the previous one.
 type transport struct {
-	mu    sync.Mutex
-	conn  *websocket.Conn
-	port  int
-	token string
-	input func(id string, data []byte)
+	mu     sync.Mutex
+	conn   *websocket.Conn
+	port   int
+	token  string
+	input  func(id string, data []byte)
+	status func(id, state string)
 }
 
 // newTransport starts the listener on a random loopback port. input receives
-// decoded input frames (keyboard data for a session's PTY).
-func newTransport(input func(id string, data []byte)) (*transport, error) {
+// decoded input frames (keyboard data for a session's PTY); status receives a
+// session's processing state reported by the Claude Code hook (see /hook).
+func newTransport(input func(id string, data []byte), status func(id, state string)) (*transport, error) {
 	raw := make([]byte, tokenBytes)
 	if _, err := rand.Read(raw); err != nil {
 		return nil, fmt.Errorf("failed to generate transport token: %w", err)
@@ -87,24 +98,78 @@ func newTransport(input func(id string, data []byte)) (*transport, error) {
 		return nil, fmt.Errorf("failed to listen for transport: %w", err)
 	}
 	t := &transport{
-		port:  listener.Addr().(*net.TCPAddr).Port,
-		token: hex.EncodeToString(raw),
-		input: input,
+		port:   listener.Addr().(*net.TCPAddr).Port,
+		token:  hex.EncodeToString(raw),
+		input:  input,
+		status: status,
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ws", t.handle)
+	mux.HandleFunc("/hook", t.hook)
 	// ponytail: server and listener live for the process lifetime, like the
 	// PTY sessions they serve; add Shutdown if the app ever needs teardown.
 	go func() { _ = http.Serve(listener, mux) }()
 	return t, nil
 }
 
-// handle upgrades the single expected client. The webview's origin is the
-// wails scheme (or the Vite dev server), never this listener's host, so the
-// origin check is skipped — the random token is the auth.
-func (t *transport) handle(w http.ResponseWriter, r *http.Request) {
+// authorized reports whether the request carries the transport's connect token.
+// The webview's origin is the wails scheme (or the Vite dev server), never this
+// listener's host, so the origin is not checked — the random token is the auth.
+func (t *transport) authorized(r *http.Request) bool {
 	provided := r.URL.Query().Get("token")
-	if subtle.ConstantTimeCompare([]byte(provided), []byte(t.token)) != 1 {
+	return subtle.ConstantTimeCompare([]byte(provided), []byte(t.token)) == 1
+}
+
+// hook receives a session status POST from the Claude Code hook running inside a
+// spawned PTY and forwards it to the frontend via the status callback.
+func (t *transport) hook(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !t.authorized(r) {
+		http.Error(w, "invalid token", http.StatusUnauthorized)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, hookBodyLimit))
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+	id, state, err := parseHookRequest(body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if t.status != nil {
+		t.status(id, state)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// parseHookRequest validates a status POST body: a session id and one of the
+// known states. It never trusts the payload — an unknown state is rejected so a
+// stray or hostile POST can't drive the UI into an undefined status.
+func parseHookRequest(body []byte) (id, state string, err error) {
+	var req struct {
+		SessionID string `json:"session_id"`
+		State     string `json:"state"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return "", "", fmt.Errorf("invalid hook body: %w", err)
+	}
+	if req.SessionID == "" {
+		return "", "", errors.New("hook missing session_id")
+	}
+	if req.State != statusBusy && req.State != statusDone {
+		return "", "", fmt.Errorf("hook has unknown state %q", req.State)
+	}
+	return req.SessionID, req.State, nil
+}
+
+// handle upgrades the single expected client. See authorized for the auth model.
+func (t *transport) handle(w http.ResponseWriter, r *http.Request) {
+	if !t.authorized(r) {
 		http.Error(w, "invalid token", http.StatusUnauthorized)
 		return
 	}

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -132,8 +132,8 @@ func newTransport(
 	mux.HandleFunc("/session-start", t.sessionStart)
 	mux.HandleFunc("/session-title", t.sessionTitle)
 	mux.HandleFunc("/session-touched", t.sessionTouched)
-	// ponytail: server and listener live for the process lifetime, like the
-	// PTY sessions they serve; add Shutdown if the app ever needs teardown.
+	// Server and listener live for the process lifetime, like the PTY sessions
+	// they serve; add Shutdown if the app ever needs teardown.
 	go func() { _ = http.Serve(listener, mux) }()
 	return t, nil
 }
@@ -146,9 +146,19 @@ func (t *transport) authorized(r *http.Request) bool {
 	return subtle.ConstantTimeCompare([]byte(provided), []byte(t.token)) == 1
 }
 
-// hook receives a session status POST from the Claude Code hook running inside a
-// spawned PTY and forwards it to the frontend via the status callback.
-func (t *transport) hook(w http.ResponseWriter, r *http.Request) {
+// servePost is the skeleton every hook endpoint shares: POST only, token
+// authenticated, body bounded to hookBodyLimit, parsed, applied, 204. A parse
+// failure is the caller's fault (400); an apply failure is ours (500). The hook
+// client ignores the response either way — the status codes exist so a failure
+// is visible to logs and tests rather than silently swallowed. It is a function
+// rather than a method on transport because Go methods cannot be generic.
+func servePost[T any](
+	t *transport,
+	w http.ResponseWriter,
+	r *http.Request,
+	parse func([]byte) (T, error),
+	apply func(T) error,
+) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		return
@@ -162,138 +172,131 @@ func (t *transport) hook(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "failed to read body", http.StatusBadRequest)
 		return
 	}
-	id, state, err := parseHookRequest(body)
+	parsed, err := parse(body)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	if t.status != nil {
-		t.status(id, state)
+	if err := apply(parsed); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+// hookRequest is a status POST body.
+type hookRequest struct {
+	SessionID string `json:"session_id"`
+	State     string `json:"state"`
+}
+
+// hook receives a session status POST from the Claude Code hook running inside a
+// spawned PTY and forwards it to the frontend via the status callback.
+func (t *transport) hook(w http.ResponseWriter, r *http.Request) {
+	servePost(t, w, r, parseHookRequest, func(req hookRequest) error {
+		if t.status != nil {
+			t.status(req.SessionID, req.State)
+		}
+		return nil
+	})
 }
 
 // parseHookRequest validates a status POST body: a session id and one of the
 // known states. It never trusts the payload — an unknown state is rejected so a
 // stray or hostile POST can't drive the UI into an undefined status.
-func parseHookRequest(body []byte) (id, state string, err error) {
-	var req struct {
-		SessionID string `json:"session_id"`
-		State     string `json:"state"`
-	}
+func parseHookRequest(body []byte) (hookRequest, error) {
+	var req hookRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		return "", "", fmt.Errorf("invalid hook body: %w", err)
+		return hookRequest{}, fmt.Errorf("invalid hook body: %w", err)
 	}
 	if req.SessionID == "" {
-		return "", "", errors.New("hook missing session_id")
+		return hookRequest{}, errors.New("hook missing session_id")
 	}
 	if req.State != statusBusy && req.State != statusDone &&
 		req.State != statusWaiting && req.State != statusIdle {
-		return "", "", fmt.Errorf("hook has unknown state %q", req.State)
+		return hookRequest{}, fmt.Errorf("hook has unknown state %q", req.State)
 	}
-	return req.SessionID, req.State, nil
+	return req, nil
+}
+
+// startRequest is a SessionStart POST body.
+type startRequest struct {
+	SessionID       string `json:"session_id"`
+	ClaudeSessionID string `json:"claude_session_id"`
 }
 
 // sessionStart receives the SessionStart POST from the Claude Code hook running
 // inside a spawned PTY and records the Claude session id against the lich
-// session via the linkSession callback. A store failure is a 500 so it surfaces
-// in logs; the hook ignores the response either way.
+// session via the linkSession callback.
 func (t *transport) sessionStart(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	if !t.authorized(r) {
-		http.Error(w, "invalid token", http.StatusUnauthorized)
-		return
-	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, hookBodyLimit))
-	if err != nil {
-		http.Error(w, "failed to read body", http.StatusBadRequest)
-		return
-	}
-	id, claudeID, err := parseSessionStart(body)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	if t.linkSession != nil {
-		if err := t.linkSession(id, claudeID); err != nil {
-			http.Error(w, "failed to record session", http.StatusInternalServerError)
-			return
+	servePost(t, w, r, parseSessionStart, func(req startRequest) error {
+		if t.linkSession == nil {
+			return nil
 		}
-	}
-	w.WriteHeader(http.StatusNoContent)
+		if err := t.linkSession(req.SessionID, req.ClaudeSessionID); err != nil {
+			return fmt.Errorf("failed to record session: %w", err)
+		}
+		return nil
+	})
 }
 
 // parseSessionStart validates a SessionStart POST body: the lich session id and
 // the non-empty Claude session id it is reporting. Both must be present.
-func parseSessionStart(body []byte) (id, claudeID string, err error) {
-	var req struct {
-		SessionID       string `json:"session_id"`
-		ClaudeSessionID string `json:"claude_session_id"`
-	}
+func parseSessionStart(body []byte) (startRequest, error) {
+	var req startRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		return "", "", fmt.Errorf("invalid session-start body: %w", err)
+		return startRequest{}, fmt.Errorf("invalid session-start body: %w", err)
 	}
 	if req.SessionID == "" {
-		return "", "", errors.New("session-start missing session_id")
+		return startRequest{}, errors.New("session-start missing session_id")
 	}
 	if req.ClaudeSessionID == "" {
-		return "", "", errors.New("session-start missing claude_session_id")
+		return startRequest{}, errors.New("session-start missing claude_session_id")
 	}
-	return req.SessionID, req.ClaudeSessionID, nil
+	return req, nil
+}
+
+// titleRequest is an ai-title POST body.
+type titleRequest struct {
+	SessionID string `json:"session_id"`
+	Title     string `json:"title"`
 }
 
 // sessionTitle receives the ai-title POST from the Claude Code hook and applies
 // it as the session's label via the setTitle callback, which no-ops when the
-// user has renamed the session. A store failure is a 500; the hook ignores it.
+// user has renamed the session.
 func (t *transport) sessionTitle(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	if !t.authorized(r) {
-		http.Error(w, "invalid token", http.StatusUnauthorized)
-		return
-	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, hookBodyLimit))
-	if err != nil {
-		http.Error(w, "failed to read body", http.StatusBadRequest)
-		return
-	}
-	id, title, err := parseSessionTitle(body)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	if t.setTitle != nil {
-		if err := t.setTitle(id, title); err != nil {
-			http.Error(w, "failed to set title", http.StatusInternalServerError)
-			return
+	servePost(t, w, r, parseSessionTitle, func(req titleRequest) error {
+		if t.setTitle == nil {
+			return nil
 		}
-	}
-	w.WriteHeader(http.StatusNoContent)
+		if err := t.setTitle(req.SessionID, req.Title); err != nil {
+			return fmt.Errorf("failed to set title: %w", err)
+		}
+		return nil
+	})
 }
 
 // parseSessionTitle validates an ai-title POST body: the lich session id and a
 // non-empty title (trimmed, since the hook extracts it from a transcript line).
-func parseSessionTitle(body []byte) (id, title string, err error) {
-	var req struct {
-		SessionID string `json:"session_id"`
-		Title     string `json:"title"`
-	}
+func parseSessionTitle(body []byte) (titleRequest, error) {
+	var req titleRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		return "", "", fmt.Errorf("invalid session-title body: %w", err)
+		return titleRequest{}, fmt.Errorf("invalid session-title body: %w", err)
 	}
 	if req.SessionID == "" {
-		return "", "", errors.New("session-title missing session_id")
+		return titleRequest{}, errors.New("session-title missing session_id")
 	}
-	title = strings.TrimSpace(req.Title)
-	if title == "" {
-		return "", "", errors.New("session-title missing title")
+	req.Title = strings.TrimSpace(req.Title)
+	if req.Title == "" {
+		return titleRequest{}, errors.New("session-title missing title")
 	}
-	return req.SessionID, title, nil
+	return req, nil
+}
+
+// touchedRequest is a touched POST body.
+type touchedRequest struct {
+	SessionID string `json:"session_id"`
 }
 
 // sessionTouched receives a POST from the Claude Code hook when a session likely
@@ -302,43 +305,25 @@ func parseSessionTitle(body []byte) (id, title string, err error) {
 // a best-effort latency optimization over the frontend's steady poll, so a
 // failure is harmless — the poll still catches the change.
 func (t *transport) sessionTouched(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	if !t.authorized(r) {
-		http.Error(w, "invalid token", http.StatusUnauthorized)
-		return
-	}
-	body, err := io.ReadAll(io.LimitReader(r.Body, hookBodyLimit))
-	if err != nil {
-		http.Error(w, "failed to read body", http.StatusBadRequest)
-		return
-	}
-	id, err := parseSessionTouched(body)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-	if t.touched != nil {
-		t.touched(id)
-	}
-	w.WriteHeader(http.StatusNoContent)
+	servePost(t, w, r, parseSessionTouched, func(req touchedRequest) error {
+		if t.touched != nil {
+			t.touched(req.SessionID)
+		}
+		return nil
+	})
 }
 
 // parseSessionTouched validates a touched POST body: just a non-empty lich
 // session id.
-func parseSessionTouched(body []byte) (id string, err error) {
-	var req struct {
-		SessionID string `json:"session_id"`
-	}
+func parseSessionTouched(body []byte) (touchedRequest, error) {
+	var req touchedRequest
 	if err := json.Unmarshal(body, &req); err != nil {
-		return "", fmt.Errorf("invalid session-touched body: %w", err)
+		return touchedRequest{}, fmt.Errorf("invalid session-touched body: %w", err)
 	}
 	if req.SessionID == "" {
-		return "", errors.New("session-touched missing session_id")
+		return touchedRequest{}, errors.New("session-touched missing session_id")
 	}
-	return req.SessionID, nil
+	return req, nil
 }
 
 // handle upgrades the single expected client. See authorized for the auth model.
@@ -395,9 +380,9 @@ func (t *transport) drop(conn *websocket.Conn) {
 
 // send delivers one session's output frame to the connected client. It
 // returns false — and drops the client on write failure — when the caller
-// should fall back to the event bridge.
-// ponytail: one mutex serializes writes for every session; per-session queues
-// only if a local loopback write ever measurably stalls.
+// should fall back to the event bridge. One mutex serializes writes for every
+// session; per-session queues only if a local loopback write ever measurably
+// stalls.
 func (t *transport) send(id string, data []byte) bool {
 	t.mu.Lock()
 	defer t.mu.Unlock()

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -77,18 +77,25 @@ func decodeFrame(buf []byte) (string, []byte, error) {
 // transport is the local WebSocket endpoint. One client (the webview) is
 // expected; a new connection replaces the previous one.
 type transport struct {
-	mu     sync.Mutex
-	conn   *websocket.Conn
-	port   int
-	token  string
-	input  func(id string, data []byte)
-	status func(id, state string)
+	mu          sync.Mutex
+	conn        *websocket.Conn
+	port        int
+	token       string
+	input       func(id string, data []byte)
+	status      func(id, state string)
+	linkSession func(sessionID, claudeSessionID string) error
 }
 
 // newTransport starts the listener on a random loopback port. input receives
 // decoded input frames (keyboard data for a session's PTY); status receives a
-// session's processing state reported by the Claude Code hook (see /hook).
-func newTransport(input func(id string, data []byte), status func(id, state string)) (*transport, error) {
+// session's processing state reported by the Claude Code hook (see /hook);
+// linkSession records the Claude session id a PTY reports at start (see
+// /session-start).
+func newTransport(
+	input func(id string, data []byte),
+	status func(id, state string),
+	linkSession func(sessionID, claudeSessionID string) error,
+) (*transport, error) {
 	raw := make([]byte, tokenBytes)
 	if _, err := rand.Read(raw); err != nil {
 		return nil, fmt.Errorf("failed to generate transport token: %w", err)
@@ -98,14 +105,16 @@ func newTransport(input func(id string, data []byte), status func(id, state stri
 		return nil, fmt.Errorf("failed to listen for transport: %w", err)
 	}
 	t := &transport{
-		port:   listener.Addr().(*net.TCPAddr).Port,
-		token:  hex.EncodeToString(raw),
-		input:  input,
-		status: status,
+		port:        listener.Addr().(*net.TCPAddr).Port,
+		token:       hex.EncodeToString(raw),
+		input:       input,
+		status:      status,
+		linkSession: linkSession,
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ws", t.handle)
 	mux.HandleFunc("/hook", t.hook)
+	mux.HandleFunc("/session-start", t.sessionStart)
 	// ponytail: server and listener live for the process lifetime, like the
 	// PTY sessions they serve; add Shutdown if the app ever needs teardown.
 	go func() { _ = http.Serve(listener, mux) }()
@@ -165,6 +174,57 @@ func parseHookRequest(body []byte) (id, state string, err error) {
 		return "", "", fmt.Errorf("hook has unknown state %q", req.State)
 	}
 	return req.SessionID, req.State, nil
+}
+
+// sessionStart receives the SessionStart POST from the Claude Code hook running
+// inside a spawned PTY and records the Claude session id against the lich
+// session via the linkSession callback. A store failure is a 500 so it surfaces
+// in logs; the hook ignores the response either way.
+func (t *transport) sessionStart(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !t.authorized(r) {
+		http.Error(w, "invalid token", http.StatusUnauthorized)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, hookBodyLimit))
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+	id, claudeID, err := parseSessionStart(body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if t.linkSession != nil {
+		if err := t.linkSession(id, claudeID); err != nil {
+			http.Error(w, "failed to record session", http.StatusInternalServerError)
+			return
+		}
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// parseSessionStart validates a SessionStart POST body: the lich session id and
+// the non-empty Claude session id it is reporting. Both must be present.
+func parseSessionStart(body []byte) (id, claudeID string, err error) {
+	var req struct {
+		SessionID       string `json:"session_id"`
+		ClaudeSessionID string `json:"claude_session_id"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return "", "", fmt.Errorf("invalid session-start body: %w", err)
+	}
+	if req.SessionID == "" {
+		return "", "", errors.New("session-start missing session_id")
+	}
+	if req.ClaudeSessionID == "" {
+		return "", "", errors.New("session-start missing claude_session_id")
+	}
+	return req.SessionID, req.ClaudeSessionID, nil
 }
 
 // handle upgrades the single expected client. See authorized for the auth model.

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -43,10 +43,13 @@ const (
 	// hookBodyLimit bounds a status POST from the Claude Code hook; the payload
 	// is a tiny JSON object, so anything larger is malformed or hostile.
 	hookBodyLimit = 4 << 10
-	// statusBusy/statusDone are the only session states the hook may report:
-	// busy while Claude is producing output, done when its turn finishes.
-	statusBusy = "busy"
-	statusDone = "done"
+	// statusBusy/statusDone/statusWaiting are the only session states the hook
+	// may report: busy while Claude is producing output, done when its turn
+	// finishes, waiting when Claude is blocked on the user (a permission prompt
+	// or an idle input request, from the Notification hook).
+	statusBusy    = "busy"
+	statusDone    = "done"
+	statusWaiting = "waiting"
 )
 
 // encodeFrame prefixes payload with the session id. The id must fit one byte
@@ -176,7 +179,7 @@ func parseHookRequest(body []byte) (id, state string, err error) {
 	if req.SessionID == "" {
 		return "", "", errors.New("hook missing session_id")
 	}
-	if req.State != statusBusy && req.State != statusDone {
+	if req.State != statusBusy && req.State != statusDone && req.State != statusWaiting {
 		return "", "", fmt.Errorf("hook has unknown state %q", req.State)
 	}
 	return req.SessionID, req.State, nil

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -43,13 +43,16 @@ const (
 	// hookBodyLimit bounds a status POST from the Claude Code hook; the payload
 	// is a tiny JSON object, so anything larger is malformed or hostile.
 	hookBodyLimit = 4 << 10
-	// statusBusy/statusDone/statusWaiting are the only session states the hook
-	// may report: busy while Claude is producing output, done when its turn
-	// finishes, waiting when Claude is blocked on the user (a permission prompt
-	// or an idle input request, from the Notification hook).
+	// These are the only session states the hook may report: busy while Claude
+	// is producing output, done when its turn finishes, waiting when Claude is
+	// blocked on the user (permission prompt or idle input, from Notification),
+	// and idle when the session ends (from SessionEnd) — idle clears the card's
+	// indicator so a stale spinner/check does not linger past a session or a
+	// /clear.
 	statusBusy    = "busy"
 	statusDone    = "done"
 	statusWaiting = "waiting"
+	statusIdle    = "idle"
 )
 
 // encodeFrame prefixes payload with the session id. The id must fit one byte
@@ -184,7 +187,8 @@ func parseHookRequest(body []byte) (id, state string, err error) {
 	if req.SessionID == "" {
 		return "", "", errors.New("hook missing session_id")
 	}
-	if req.State != statusBusy && req.State != statusDone && req.State != statusWaiting {
+	if req.State != statusBusy && req.State != statusDone &&
+		req.State != statusWaiting && req.State != statusIdle {
 		return "", "", fmt.Errorf("hook has unknown state %q", req.State)
 	}
 	return req.SessionID, req.State, nil

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -89,6 +89,7 @@ type transport struct {
 	status      func(id, state string)
 	linkSession func(sessionID, claudeSessionID string) error
 	setTitle    func(sessionID, title string) error
+	touched     func(sessionID string)
 }
 
 // newTransport starts the listener on a random loopback port. input receives
@@ -96,12 +97,14 @@ type transport struct {
 // session's processing state reported by the Claude Code hook (see /hook);
 // linkSession records the Claude session id a PTY reports at start (see
 // /session-start); setTitle applies an auto-generated session label (see
-// /session-title).
+// /session-title); touched signals a session likely changed files on disk (see
+// /session-touched).
 func newTransport(
 	input func(id string, data []byte),
 	status func(id, state string),
 	linkSession func(sessionID, claudeSessionID string) error,
 	setTitle func(sessionID, title string) error,
+	touched func(sessionID string),
 ) (*transport, error) {
 	raw := make([]byte, tokenBytes)
 	if _, err := rand.Read(raw); err != nil {
@@ -118,12 +121,14 @@ func newTransport(
 		status:      status,
 		linkSession: linkSession,
 		setTitle:    setTitle,
+		touched:     touched,
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ws", t.handle)
 	mux.HandleFunc("/hook", t.hook)
 	mux.HandleFunc("/session-start", t.sessionStart)
 	mux.HandleFunc("/session-title", t.sessionTitle)
+	mux.HandleFunc("/session-touched", t.sessionTouched)
 	// ponytail: server and listener live for the process lifetime, like the
 	// PTY sessions they serve; add Shutdown if the app ever needs teardown.
 	go func() { _ = http.Serve(listener, mux) }()
@@ -285,6 +290,51 @@ func parseSessionTitle(body []byte) (id, title string, err error) {
 		return "", "", errors.New("session-title missing title")
 	}
 	return req.SessionID, title, nil
+}
+
+// sessionTouched receives a POST from the Claude Code hook when a session likely
+// changed files on disk (a file-mutating tool ran) and forwards the session id
+// via the touched callback, which nudges an immediate git-status refresh. It is
+// a best-effort latency optimization over the frontend's steady poll, so a
+// failure is harmless — the poll still catches the change.
+func (t *transport) sessionTouched(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	if !t.authorized(r) {
+		http.Error(w, "invalid token", http.StatusUnauthorized)
+		return
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, hookBodyLimit))
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+	id, err := parseSessionTouched(body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if t.touched != nil {
+		t.touched(id)
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// parseSessionTouched validates a touched POST body: just a non-empty lich
+// session id.
+func parseSessionTouched(body []byte) (id string, err error) {
+	var req struct {
+		SessionID string `json:"session_id"`
+	}
+	if err := json.Unmarshal(body, &req); err != nil {
+		return "", fmt.Errorf("invalid session-touched body: %w", err)
+	}
+	if req.SessionID == "" {
+		return "", errors.New("session-touched missing session_id")
+	}
+	return req.SessionID, nil
 }
 
 // handle upgrades the single expected client. See authorized for the auth model.

--- a/internal/terminal/transport_test.go
+++ b/internal/terminal/transport_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -70,7 +72,7 @@ func dial(t *testing.T, tr *transport, token string) (*websocket.Conn, error) {
 }
 
 func TestTransportRejectsBadToken(t *testing.T) {
-	tr, err := newTransport(func(string, []byte) {})
+	tr, err := newTransport(func(string, []byte) {}, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -83,7 +85,7 @@ func TestTransportInputReachesService(t *testing.T) {
 	got := make(chan string, 1)
 	tr, err := newTransport(func(id string, data []byte) {
 		got <- id + ":" + string(data)
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -113,7 +115,7 @@ func TestTransportInputReachesService(t *testing.T) {
 }
 
 func TestTransportSendAndFallback(t *testing.T) {
-	tr, err := newTransport(func(string, []byte) {})
+	tr, err := newTransport(func(string, []byte) {}, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -147,6 +149,89 @@ func TestTransportSendAndFallback(t *testing.T) {
 	}
 	if id != "sess" || string(payload) != "output" {
 		t.Fatalf("got id=%q payload=%q", id, payload)
+	}
+}
+
+func TestParseHookRequest(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantID    string
+		wantState string
+		wantErr   bool
+	}{
+		{"busy", `{"session_id":"s1","state":"busy"}`, "s1", "busy", false},
+		{"done", `{"session_id":"s2","state":"done"}`, "s2", "done", false},
+		{"missing id", `{"state":"busy"}`, "", "", true},
+		{"unknown state", `{"session_id":"s1","state":"cooking"}`, "", "", true},
+		{"empty state", `{"session_id":"s1"}`, "", "", true},
+		{"bad json", `{`, "", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, state, err := parseHookRequest([]byte(tc.body))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.body)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id != tc.wantID || state != tc.wantState {
+				t.Fatalf("got (%q,%q), want (%q,%q)", id, state, tc.wantID, tc.wantState)
+			}
+		})
+	}
+}
+
+func TestHookForwardsStatus(t *testing.T) {
+	got := make(chan string, 1)
+	tr, err := newTransport(func(string, []byte) {}, func(id, state string) {
+		got <- id + ":" + state
+	})
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/hook?token=%s", tr.port, tr.token)
+	resp, err := http.Post(url, "application/json", strings.NewReader(`{"session_id":"sess","state":"busy"}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", resp.StatusCode)
+	}
+	select {
+	case v := <-got:
+		if v != "sess:busy" {
+			t.Fatalf("got %q", v)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("status never forwarded to the callback")
+	}
+}
+
+func TestHookRejectsBadToken(t *testing.T) {
+	fired := make(chan struct{}, 1)
+	tr, err := newTransport(func(string, []byte) {}, func(string, string) { fired <- struct{}{} })
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/hook?token=wrong", tr.port)
+	resp, err := http.Post(url, "application/json", strings.NewReader(`{"session_id":"s","state":"busy"}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+	select {
+	case <-fired:
+		t.Fatal("status callback fired despite a bad token")
+	case <-time.After(200 * time.Millisecond):
 	}
 }
 

--- a/internal/terminal/transport_test.go
+++ b/internal/terminal/transport_test.go
@@ -3,6 +3,7 @@ package terminal
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -171,7 +172,7 @@ func TestParseHookRequest(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			id, state, err := parseHookRequest([]byte(tc.body))
+			req, err := parseHookRequest([]byte(tc.body))
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error for %q", tc.body)
@@ -181,8 +182,8 @@ func TestParseHookRequest(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if id != tc.wantID || state != tc.wantState {
-				t.Fatalf("got (%q,%q), want (%q,%q)", id, state, tc.wantID, tc.wantState)
+			if req.SessionID != tc.wantID || req.State != tc.wantState {
+				t.Fatalf("got (%q,%q), want (%q,%q)", req.SessionID, req.State, tc.wantID, tc.wantState)
 			}
 		})
 	}
@@ -253,7 +254,7 @@ func TestParseSessionStart(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			id, claudeID, err := parseSessionStart([]byte(tc.body))
+			req, err := parseSessionStart([]byte(tc.body))
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error for %q", tc.body)
@@ -263,8 +264,9 @@ func TestParseSessionStart(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if id != tc.wantID || claudeID != tc.wantClaudeID {
-				t.Fatalf("got (%q,%q), want (%q,%q)", id, claudeID, tc.wantID, tc.wantClaudeID)
+			if req.SessionID != tc.wantID || req.ClaudeSessionID != tc.wantClaudeID {
+				t.Fatalf("got (%q,%q), want (%q,%q)",
+					req.SessionID, req.ClaudeSessionID, tc.wantID, tc.wantClaudeID)
 			}
 		})
 	}
@@ -342,7 +344,7 @@ func TestParseSessionTitle(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			id, title, err := parseSessionTitle([]byte(tc.body))
+			req, err := parseSessionTitle([]byte(tc.body))
 			if tc.wantErr {
 				if err == nil {
 					t.Fatalf("expected error for %q", tc.body)
@@ -352,8 +354,8 @@ func TestParseSessionTitle(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if id != tc.wantID || title != tc.wantTitle {
-				t.Fatalf("got (%q,%q), want (%q,%q)", id, title, tc.wantID, tc.wantTitle)
+			if req.SessionID != tc.wantID || req.Title != tc.wantTitle {
+				t.Fatalf("got (%q,%q), want (%q,%q)", req.SessionID, req.Title, tc.wantID, tc.wantTitle)
 			}
 		})
 	}
@@ -415,8 +417,8 @@ func TestSessionTitleRejectsBadToken(t *testing.T) {
 }
 
 func TestParseSessionTouched(t *testing.T) {
-	if id, err := parseSessionTouched([]byte(`{"session_id":"s1"}`)); err != nil || id != "s1" {
-		t.Fatalf("got (%q,%v), want (s1,nil)", id, err)
+	if req, err := parseSessionTouched([]byte(`{"session_id":"s1"}`)); err != nil || req.SessionID != "s1" {
+		t.Fatalf("got (%q,%v), want (s1,nil)", req.SessionID, err)
 	}
 	if _, err := parseSessionTouched([]byte(`{}`)); err == nil {
 		t.Fatal("expected error for missing session_id")
@@ -473,6 +475,158 @@ func TestSessionTouchedRejectsBadToken(t *testing.T) {
 	select {
 	case <-fired:
 		t.Fatal("touched callback fired despite a bad token")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// hookEndpoints is every hook endpoint paired with a body that parses cleanly.
+// They all share servePost, so the failure modes it owns are proved once across
+// the whole set instead of once per handler.
+var hookEndpoints = []struct {
+	path string
+	body string
+}{
+	{"/hook", `{"session_id":"s","state":"busy"}`},
+	{"/session-start", `{"session_id":"s","claude_session_id":"u"}`},
+	{"/session-title", `{"session_id":"s","title":"t"}`},
+	{"/session-touched", `{"session_id":"s"}`},
+}
+
+// newNilTransport starts a transport with every hook callback unset, the state
+// the app is in when a POST lands before the callbacks matter.
+func newNilTransport(t *testing.T) *transport {
+	t.Helper()
+	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+	return tr
+}
+
+func TestHookEndpointsRejectNonPost(t *testing.T) {
+	tr := newNilTransport(t)
+	for _, e := range hookEndpoints {
+		t.Run(e.path, func(t *testing.T) {
+			resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d%s?token=%s", tr.port, e.path, tr.token))
+			if err != nil {
+				t.Fatalf("get: %v", err)
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusMethodNotAllowed {
+				t.Fatalf("status = %d, want 405", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestHookEndpointsRejectInvalidJSON(t *testing.T) {
+	tr := newNilTransport(t)
+	for _, e := range hookEndpoints {
+		t.Run(e.path, func(t *testing.T) {
+			url := fmt.Sprintf("http://127.0.0.1:%d%s?token=%s", tr.port, e.path, tr.token)
+			resp, err := http.Post(url, "application/json", strings.NewReader(`{`))
+			if err != nil {
+				t.Fatalf("post: %v", err)
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestHookEndpointsWithNilCallbacks proves a valid POST is still accepted when
+// nothing is wired to receive it — the hook must never see an error for a
+// report lich simply has no use for.
+func TestHookEndpointsWithNilCallbacks(t *testing.T) {
+	tr := newNilTransport(t)
+	for _, e := range hookEndpoints {
+		t.Run(e.path, func(t *testing.T) {
+			url := fmt.Sprintf("http://127.0.0.1:%d%s?token=%s", tr.port, e.path, tr.token)
+			resp, err := http.Post(url, "application/json", strings.NewReader(e.body))
+			if err != nil {
+				t.Fatalf("post: %v", err)
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusNoContent {
+				t.Fatalf("status = %d, want 204", resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestStoreFailuresReport500 proves a persistence error reaches the response
+// rather than being swallowed. These are the only two hooks that write, and the
+// 500 is the sole signal that the write was lost.
+func TestStoreFailuresReport500(t *testing.T) {
+	boom := errors.New("store is down")
+	tests := []struct {
+		name string
+		path string
+		body string
+		tr   func() (*transport, error)
+	}{
+		{
+			name: "session-start link failure",
+			path: "/session-start",
+			body: `{"session_id":"s","claude_session_id":"u"}`,
+			tr: func() (*transport, error) {
+				return newTransport(func(string, []byte) {}, nil,
+					func(string, string) error { return boom }, nil, nil)
+			},
+		},
+		{
+			name: "session-title store failure",
+			path: "/session-title",
+			body: `{"session_id":"s","title":"t"}`,
+			tr: func() (*transport, error) {
+				return newTransport(func(string, []byte) {}, nil, nil,
+					func(string, string) error { return boom }, nil)
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tr, err := tc.tr()
+			if err != nil {
+				t.Fatalf("newTransport: %v", err)
+			}
+			url := fmt.Sprintf("http://127.0.0.1:%d%s?token=%s", tr.port, tc.path, tr.token)
+			resp, err := http.Post(url, "application/json", strings.NewReader(tc.body))
+			if err != nil {
+				t.Fatalf("post: %v", err)
+			}
+			_ = resp.Body.Close()
+			if resp.StatusCode != http.StatusInternalServerError {
+				t.Fatalf("status = %d, want 500", resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestHookBodyLimit proves an oversized body is truncated rather than read into
+// memory: the JSON is valid but padded past hookBodyLimit, so the cut lands
+// mid-document and the parse fails. Without the limit this would be a 204.
+func TestHookBodyLimit(t *testing.T) {
+	fired := make(chan struct{}, 1)
+	tr, err := newTransport(func(string, []byte) {}, func(string, string) { fired <- struct{}{} }, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+	padded := fmt.Sprintf(`{"pad":%q,"session_id":"s","state":"busy"}`, strings.Repeat("x", hookBodyLimit))
+	url := fmt.Sprintf("http://127.0.0.1:%d/hook?token=%s", tr.port, tr.token)
+	resp, err := http.Post(url, "application/json", strings.NewReader(padded))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (body should be cut mid-JSON)", resp.StatusCode)
+	}
+	select {
+	case <-fired:
+		t.Fatal("status callback fired on an oversized body")
 	case <-time.After(200 * time.Millisecond):
 	}
 }

--- a/internal/terminal/transport_test.go
+++ b/internal/terminal/transport_test.go
@@ -72,7 +72,7 @@ func dial(t *testing.T, tr *transport, token string) (*websocket.Conn, error) {
 }
 
 func TestTransportRejectsBadToken(t *testing.T) {
-	tr, err := newTransport(func(string, []byte) {}, nil)
+	tr, err := newTransport(func(string, []byte) {}, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestTransportInputReachesService(t *testing.T) {
 	got := make(chan string, 1)
 	tr, err := newTransport(func(id string, data []byte) {
 		got <- id + ":" + string(data)
-	}, nil)
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestTransportInputReachesService(t *testing.T) {
 }
 
 func TestTransportSendAndFallback(t *testing.T) {
-	tr, err := newTransport(func(string, []byte) {}, nil)
+	tr, err := newTransport(func(string, []byte) {}, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestHookForwardsStatus(t *testing.T) {
 	got := make(chan string, 1)
 	tr, err := newTransport(func(string, []byte) {}, func(id, state string) {
 		got <- id + ":" + state
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestHookForwardsStatus(t *testing.T) {
 
 func TestHookRejectsBadToken(t *testing.T) {
 	fired := make(chan struct{}, 1)
-	tr, err := newTransport(func(string, []byte) {}, func(string, string) { fired <- struct{}{} })
+	tr, err := newTransport(func(string, []byte) {}, func(string, string) { fired <- struct{}{} }, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -231,6 +231,94 @@ func TestHookRejectsBadToken(t *testing.T) {
 	select {
 	case <-fired:
 		t.Fatal("status callback fired despite a bad token")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestParseSessionStart(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         string
+		wantID       string
+		wantClaudeID string
+		wantErr      bool
+	}{
+		{"ok", `{"session_id":"s1","claude_session_id":"uuid-1"}`, "s1", "uuid-1", false},
+		{"missing session id", `{"claude_session_id":"uuid-1"}`, "", "", true},
+		{"missing claude id", `{"session_id":"s1"}`, "", "", true},
+		{"empty claude id", `{"session_id":"s1","claude_session_id":""}`, "", "", true},
+		{"bad json", `{`, "", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, claudeID, err := parseSessionStart([]byte(tc.body))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.body)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id != tc.wantID || claudeID != tc.wantClaudeID {
+				t.Fatalf("got (%q,%q), want (%q,%q)", id, claudeID, tc.wantID, tc.wantClaudeID)
+			}
+		})
+	}
+}
+
+func TestSessionStartLinksSession(t *testing.T) {
+	got := make(chan string, 1)
+	tr, err := newTransport(func(string, []byte) {}, nil, func(id, claudeID string) error {
+		got <- id + ":" + claudeID
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/session-start?token=%s", tr.port, tr.token)
+	resp, err := http.Post(url, "application/json",
+		strings.NewReader(`{"session_id":"sess","claude_session_id":"uuid-9"}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", resp.StatusCode)
+	}
+	select {
+	case v := <-got:
+		if v != "sess:uuid-9" {
+			t.Fatalf("got %q", v)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("session id never reached the callback")
+	}
+}
+
+func TestSessionStartRejectsBadToken(t *testing.T) {
+	fired := make(chan struct{}, 1)
+	tr, err := newTransport(func(string, []byte) {}, nil, func(string, string) error {
+		fired <- struct{}{}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/session-start?token=wrong", tr.port)
+	resp, err := http.Post(url, "application/json",
+		strings.NewReader(`{"session_id":"s","claude_session_id":"u"}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+	select {
+	case <-fired:
+		t.Fatal("link callback fired despite a bad token")
 	case <-time.After(200 * time.Millisecond):
 	}
 }

--- a/internal/terminal/transport_test.go
+++ b/internal/terminal/transport_test.go
@@ -162,6 +162,7 @@ func TestParseHookRequest(t *testing.T) {
 	}{
 		{"busy", `{"session_id":"s1","state":"busy"}`, "s1", "busy", false},
 		{"done", `{"session_id":"s2","state":"done"}`, "s2", "done", false},
+		{"waiting", `{"session_id":"s3","state":"waiting"}`, "s3", "waiting", false},
 		{"missing id", `{"state":"busy"}`, "", "", true},
 		{"unknown state", `{"session_id":"s1","state":"cooking"}`, "", "", true},
 		{"empty state", `{"session_id":"s1"}`, "", "", true},

--- a/internal/terminal/transport_test.go
+++ b/internal/terminal/transport_test.go
@@ -72,7 +72,7 @@ func dial(t *testing.T, tr *transport, token string) (*websocket.Conn, error) {
 }
 
 func TestTransportRejectsBadToken(t *testing.T) {
-	tr, err := newTransport(func(string, []byte) {}, nil, nil)
+	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestTransportInputReachesService(t *testing.T) {
 	got := make(chan string, 1)
 	tr, err := newTransport(func(id string, data []byte) {
 		got <- id + ":" + string(data)
-	}, nil, nil)
+	}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestTransportInputReachesService(t *testing.T) {
 }
 
 func TestTransportSendAndFallback(t *testing.T) {
-	tr, err := newTransport(func(string, []byte) {}, nil, nil)
+	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestHookForwardsStatus(t *testing.T) {
 	got := make(chan string, 1)
 	tr, err := newTransport(func(string, []byte) {}, func(id, state string) {
 		got <- id + ":" + state
-	}, nil)
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -215,7 +215,7 @@ func TestHookForwardsStatus(t *testing.T) {
 
 func TestHookRejectsBadToken(t *testing.T) {
 	fired := make(chan struct{}, 1)
-	tr, err := newTransport(func(string, []byte) {}, func(string, string) { fired <- struct{}{} }, nil)
+	tr, err := newTransport(func(string, []byte) {}, func(string, string) { fired <- struct{}{} }, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -273,7 +273,7 @@ func TestSessionStartLinksSession(t *testing.T) {
 	tr, err := newTransport(func(string, []byte) {}, nil, func(id, claudeID string) error {
 		got <- id + ":" + claudeID
 		return nil
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -302,7 +302,7 @@ func TestSessionStartRejectsBadToken(t *testing.T) {
 	tr, err := newTransport(func(string, []byte) {}, nil, func(string, string) error {
 		fired <- struct{}{}
 		return nil
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -319,6 +319,95 @@ func TestSessionStartRejectsBadToken(t *testing.T) {
 	select {
 	case <-fired:
 		t.Fatal("link callback fired despite a bad token")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestParseSessionTitle(t *testing.T) {
+	tests := []struct {
+		name      string
+		body      string
+		wantID    string
+		wantTitle string
+		wantErr   bool
+	}{
+		{"ok", `{"session_id":"s1","title":"Fixing auth"}`, "s1", "Fixing auth", false},
+		{"trims", `{"session_id":"s1","title":"  Fixing auth\n"}`, "s1", "Fixing auth", false},
+		{"missing session id", `{"title":"x"}`, "", "", true},
+		{"missing title", `{"session_id":"s1"}`, "", "", true},
+		{"blank title", `{"session_id":"s1","title":"   "}`, "", "", true},
+		{"bad json", `{`, "", "", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, title, err := parseSessionTitle([]byte(tc.body))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q", tc.body)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id != tc.wantID || title != tc.wantTitle {
+				t.Fatalf("got (%q,%q), want (%q,%q)", id, title, tc.wantID, tc.wantTitle)
+			}
+		})
+	}
+}
+
+func TestSessionTitleApplies(t *testing.T) {
+	got := make(chan string, 1)
+	tr, err := newTransport(func(string, []byte) {}, nil, nil, func(id, title string) error {
+		got <- id + ":" + title
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/session-title?token=%s", tr.port, tr.token)
+	resp, err := http.Post(url, "application/json",
+		strings.NewReader(`{"session_id":"sess","title":"Fixing auth"}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", resp.StatusCode)
+	}
+	select {
+	case v := <-got:
+		if v != "sess:Fixing auth" {
+			t.Fatalf("got %q", v)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("title never reached the callback")
+	}
+}
+
+func TestSessionTitleRejectsBadToken(t *testing.T) {
+	fired := make(chan struct{}, 1)
+	tr, err := newTransport(func(string, []byte) {}, nil, nil, func(string, string) error {
+		fired <- struct{}{}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/session-title?token=wrong", tr.port)
+	resp, err := http.Post(url, "application/json",
+		strings.NewReader(`{"session_id":"s","title":"x"}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+	select {
+	case <-fired:
+		t.Fatal("title callback fired despite a bad token")
 	case <-time.After(200 * time.Millisecond):
 	}
 }

--- a/internal/terminal/transport_test.go
+++ b/internal/terminal/transport_test.go
@@ -163,6 +163,7 @@ func TestParseHookRequest(t *testing.T) {
 		{"busy", `{"session_id":"s1","state":"busy"}`, "s1", "busy", false},
 		{"done", `{"session_id":"s2","state":"done"}`, "s2", "done", false},
 		{"waiting", `{"session_id":"s3","state":"waiting"}`, "s3", "waiting", false},
+		{"idle", `{"session_id":"s4","state":"idle"}`, "s4", "idle", false},
 		{"missing id", `{"state":"busy"}`, "", "", true},
 		{"unknown state", `{"session_id":"s1","state":"cooking"}`, "", "", true},
 		{"empty state", `{"session_id":"s1"}`, "", "", true},

--- a/internal/terminal/transport_test.go
+++ b/internal/terminal/transport_test.go
@@ -72,7 +72,7 @@ func dial(t *testing.T, tr *transport, token string) (*websocket.Conn, error) {
 }
 
 func TestTransportRejectsBadToken(t *testing.T) {
-	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil)
+	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestTransportInputReachesService(t *testing.T) {
 	got := make(chan string, 1)
 	tr, err := newTransport(func(id string, data []byte) {
 		got <- id + ":" + string(data)
-	}, nil, nil, nil)
+	}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestTransportInputReachesService(t *testing.T) {
 }
 
 func TestTransportSendAndFallback(t *testing.T) {
-	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil)
+	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -191,7 +191,7 @@ func TestHookForwardsStatus(t *testing.T) {
 	got := make(chan string, 1)
 	tr, err := newTransport(func(string, []byte) {}, func(id, state string) {
 		got <- id + ":" + state
-	}, nil, nil)
+	}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestHookForwardsStatus(t *testing.T) {
 
 func TestHookRejectsBadToken(t *testing.T) {
 	fired := make(chan struct{}, 1)
-	tr, err := newTransport(func(string, []byte) {}, func(string, string) { fired <- struct{}{} }, nil, nil)
+	tr, err := newTransport(func(string, []byte) {}, func(string, string) { fired <- struct{}{} }, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -274,7 +274,7 @@ func TestSessionStartLinksSession(t *testing.T) {
 	tr, err := newTransport(func(string, []byte) {}, nil, func(id, claudeID string) error {
 		got <- id + ":" + claudeID
 		return nil
-	}, nil)
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -303,7 +303,7 @@ func TestSessionStartRejectsBadToken(t *testing.T) {
 	tr, err := newTransport(func(string, []byte) {}, nil, func(string, string) error {
 		fired <- struct{}{}
 		return nil
-	}, nil)
+	}, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -363,7 +363,7 @@ func TestSessionTitleApplies(t *testing.T) {
 	tr, err := newTransport(func(string, []byte) {}, nil, nil, func(id, title string) error {
 		got <- id + ":" + title
 		return nil
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -392,7 +392,7 @@ func TestSessionTitleRejectsBadToken(t *testing.T) {
 	tr, err := newTransport(func(string, []byte) {}, nil, nil, func(string, string) error {
 		fired <- struct{}{}
 		return nil
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -409,6 +409,69 @@ func TestSessionTitleRejectsBadToken(t *testing.T) {
 	select {
 	case <-fired:
 		t.Fatal("title callback fired despite a bad token")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestParseSessionTouched(t *testing.T) {
+	if id, err := parseSessionTouched([]byte(`{"session_id":"s1"}`)); err != nil || id != "s1" {
+		t.Fatalf("got (%q,%v), want (s1,nil)", id, err)
+	}
+	if _, err := parseSessionTouched([]byte(`{}`)); err == nil {
+		t.Fatal("expected error for missing session_id")
+	}
+	if _, err := parseSessionTouched([]byte(`{`)); err == nil {
+		t.Fatal("expected error for bad json")
+	}
+}
+
+func TestSessionTouchedForwards(t *testing.T) {
+	got := make(chan string, 1)
+	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil, func(id string) {
+		got <- id
+	})
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/session-touched?token=%s", tr.port, tr.token)
+	resp, err := http.Post(url, "application/json", strings.NewReader(`{"session_id":"sess"}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", resp.StatusCode)
+	}
+	select {
+	case v := <-got:
+		if v != "sess" {
+			t.Fatalf("got %q", v)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("touched id never reached the callback")
+	}
+}
+
+func TestSessionTouchedRejectsBadToken(t *testing.T) {
+	fired := make(chan struct{}, 1)
+	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil, func(string) {
+		fired <- struct{}{}
+	})
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/session-touched?token=wrong", tr.port)
+	resp, err := http.Post(url, "application/json", strings.NewReader(`{"session_id":"s"}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+	select {
+	case <-fired:
+		t.Fatal("touched callback fired despite a bad token")
 	case <-time.After(200 * time.Millisecond):
 	}
 }

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"runtime"
 
+	"github.com/omartelo/lich/internal/claudeplugin"
 	"github.com/omartelo/lich/internal/fonts"
 	"github.com/omartelo/lich/internal/project"
 	"github.com/omartelo/lich/internal/store"
@@ -66,6 +67,7 @@ func main() {
 			application.NewService(terminal.New(db, env)),
 			application.NewService(fonts.New()),
 			application.NewService(project.New()),
+			application.NewService(claudeplugin.New(db)),
 			application.NewService(db),
 		},
 		Assets: application.AssetOptions{


### PR DESCRIPTION
lich ⇄ Claude Code plugin integration. Companion plugin: [omartelo/lich-plugin](https://github.com/omartelo/lich-plugin), versioned on its own SemVer. lich owns the server side of every contract; `docs/hooks/` is the canonical, contract-first source the plugin implements against.

## Shared transport

lich injects `LICH_PORT` / `LICH_TOKEN` / `LICH_SESSION_ID` into every spawned PTY, inherited by `claude` and its hooks. Each hook is a token-authed `POST` on the existing loopback transport (`internal/terminal/transport.go`). Outside lich the vars are absent, so every hook no-ops — the plugin stays safe to install globally.

## Contracts

**Session state** — `docs/hooks/session-state.md` (`cf69514`, `cc67df3`, `5f9853a`, `3614ea5`)
- `POST /hook {session_id, state}` — `busy` / `done` / `waiting` / `idle`, anything else rejected.
- Card shows a spinner (`busy` — UserPromptSubmit/PostToolUse), check (`done` — Stop), bell (`waiting` — Notification), or clears (`idle` — SessionEnd).
- `waiting` also raises a global, actionable toast that routes to the card — reachable even for a session in a background project, skipped for the focused one.
- `PostToolUse → busy` re-arms the spinner after a permission / plan / answer approval, which don't raise `UserPromptSubmit`.

**Session start** — `docs/hooks/session-start.md` (`a39d011`)
- `POST /session-start {session_id, claude_session_id}` — persists Claude's own session id on the session row, the link future features need to reach a transcript or resume.

**Session title** — `docs/hooks/session-title.md` (`3b9327a`)
- `POST /session-title {session_id, title}` — adopts Claude's `ai-title` as the card label while it is still automatic; a manual rename clears the auto flag and always wins. Live-updates via a `session-title` event.

**Session touched** — `docs/hooks/session-touched.md` (`4d1cd0d`)
- `POST /session-touched {session_id}` — on file-mutating tools, refreshes that session's git status immediately instead of waiting for the ~3s poll. The poll stays the baseline, so it works unchanged without the plugin.

**Install / update gate** — (`5aea90b`)
- `internal/claudeplugin` reports install state (`installed_plugins.json` + the latest GitHub release) and shells out to the `claude` CLI to install/update — never editing Claude Code's plugin state files by hand.
- Startup: a one-click install modal when the plugin is missing, and an actionable update toast when a newer release ships.
- Version comparison follows SemVer precedence: a pre-release sorts below the stable it precedes (§11), and build metadata carries no precedence (§10).

## Review pass

A review of the full branch landed these changes on top:

- **Fixed: a pre-release install never saw the stable update.** `parseSemver` stripped the `-rc.N` suffix, so `0.2.0-rc.3` and `0.2.0` compared equal and `UpdateAvailable` stayed false — anyone who installed during the rc window was stranded on it. The same `IndexAny(v, "-+")` also let build metadata affect precedence, against SemVer §10. Both split out and pinned by tests.
- **Deduplicated the four hook handlers.** `hook`, `sessionStart`, `sessionTitle` and `sessionTouched` each repeated the same skeleton (POST → token → bounded body → parse → apply → 204). They now share one generic `servePost`, which also made the status codes uniform.
- **Coverage** — `claudeplugin` 46.5% → 82.4% (`latestReleaseURL` became a `Service` field so `latestVersion` is reachable from `httptest`); `terminal` 76.2% → 81.9% (the handler sad paths — 405, 400, 500, nil-callback, oversized body — were entirely untested; only 204 and 401 were covered).
- **Frontend logic extracted to `lib/`.** The attention-toast suppression rule and the card's status narrowing were decision logic living in JSX, where this repo's test pattern (pure logic in `lib/`, no jsdom) could not reach them. Now in `lib/session-events.ts` with 17 tests.

## Test plan

- [x] `go test -race ./...` — 166 pass (6 packages), `go vet` clean, `gofmt` applied
- [x] `cd frontend && pnpm build` (tsc + vite) + `pnpm test` — 229 pass
- [x] Coverage per package: `claudeplugin` 82.4%, `terminal` 81.9%, `store` 85.5% — all over the 80% invariant
- [x] Manual: install modal + install; update toast on a newer plugin release (validated against a real `0.2.0-rc.1`)
- [x] Manual: spinner / check / bell / idle on the card; waiting toast routes across projects; spinner recovers after a permission / plan / answer
- [x] Manual: auto-title adopts Claude's title, a manual rename wins
- [x] Manual: git badge refreshes instantly on edits, poll fallback intact

## Known ceilings (documented in the contracts)

- Status isn't retained by lich: a card that unmounts and remounts mid-run (switching projects) misses the event and can strand a spinner or miss the bell.
- The attention toast auto-dismisses on a timer, not when the session leaves `waiting`.
- Deny a permission and let Claude end without another tool → the card stays `waiting` until `Stop`.
- `session-touched` has no debounce on edit bursts.
- Two distinct pre-releases of the same version (`rc.1` vs `rc.2`) compare equal. Exact §11 identifier-wise ordering is real code, and GitHub's `/releases/latest` never resolves to a pre-release, so the check only ever weighs an install against a stable.
- `claude_session_id` is captured and persisted but nothing reads it yet; it is the link the transcript/resume features will need.

## Follow-ups (not in this PR)

- Optional: cherry-pick `docs/hooks/` to `main` so the plugin session can read the contracts off the default branch.
