### PR TITLE
feat: open-PR badge in footer

### DIFF
--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -1,12 +1,14 @@
 import {useEffect, useState} from "react"
 import {useMatch} from "react-router-dom"
-import {FileText, GitBranch, Folder, Plus, Diff} from "lucide-react"
+import {Browser} from "@wailsio/runtime"
+import {FileText, GitBranch, Folder, Plus, Diff, GitPullRequestArrow} from "lucide-react"
 import {Service as ProjectService} from "../../bindings/github.com/omartelo/lich/internal/project"
 import {Service as TerminalService} from "../../bindings/github.com/omartelo/lich/internal/terminal"
 import {useProjects} from "@/lib/projects"
 import {activeSessionId, sessionsOf} from "@/lib/sessions"
 import {displayPath} from "@/lib/paths"
 import {useGitStatus} from "@/lib/useGitStatus"
+import {usePullRequest} from "@/lib/usePullRequest"
 import {
   Tooltip,
   TooltipContent,
@@ -47,6 +49,7 @@ export function FooterBar({diffOpen, onToggleDiff}: FooterBarProps) {
     : undefined
   const path = session?.path || projectPath
   const status = useGitStatus(path)
+  const pr = usePullRequest(path, status?.branch ?? "")
   const now = useNow()
 
   const attachFile = async () => {
@@ -106,6 +109,23 @@ export function FooterBar({diffOpen, onToggleDiff}: FooterBarProps) {
             )}
           </TooltipTrigger>
           <TooltipContent>Review changes</TooltipContent>
+        </Tooltip>
+      )}
+
+      {pr && (
+        <Tooltip>
+          <TooltipTrigger
+            render={
+              <button
+                type="button"
+                onClick={() => void Browser.OpenURL(pr.url)}
+                className="flex items-center gap-1.5 rounded-md border border-border bg-muted px-1.5 py-1 transition-colors hover:bg-accent hover:text-accent-foreground"
+              />
+            }
+          >
+            <GitPullRequestArrow className="size-3.5"/> PR #{pr.number}
+          </TooltipTrigger>
+          <TooltipContent>Open pull request on GitHub</TooltipContent>
         </Tooltip>
       )}
 

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -70,7 +70,7 @@ export function FooterBar({diffOpen, onToggleDiff}: FooterBarProps) {
               onClick={() => void attachFile()}
               disabled={!sessionId}
               aria-label="Attach file"
-              className="flex size-6 items-center justify-center rounded-md border border-border bg-muted text-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-40"
+              className="flex items-center justify-center rounded-md border border-border bg-muted p-1 text-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-40"
             />
           }
         >

--- a/frontend/src/lib/usePullRequest.ts
+++ b/frontend/src/lib/usePullRequest.ts
@@ -1,0 +1,35 @@
+import {useEffect, useState} from "react"
+import {Service as ProjectService} from "../../bindings/github.com/omartelo/lich/internal/project"
+import type {PullRequest} from "../../bindings/github.com/omartelo/lich/internal/project/models"
+
+export type {PullRequest}
+
+// usePullRequest resolves the open GitHub PR for a path's current branch via the
+// gh CLI. Unlike git status it is not polled: a PR is opened once and rarely
+// changes, and each lookup is a network round-trip. It refetches only when the
+// path or branch changes — enough to pick up a checkout or a freshly opened PR
+// on the next branch switch. Returns null while loading, on any error, or when
+// no PR exists, so the caller hides the badge. No poll: if a PR opened on the
+// current branch must appear without a branch switch, add a slow interval
+// (~30s) or a window-focus refetch.
+export function usePullRequest(path: string, branch: string): PullRequest | null {
+  const [pr, setPr] = useState<PullRequest | null>(null)
+  useEffect(() => {
+    if (!path) {
+      setPr(null)
+      return
+    }
+    let alive = true
+    ProjectService.PullRequest(path)
+      .then((result) => {
+        if (alive) setPr(result)
+      })
+      .catch(() => {
+        if (alive) setPr(null)
+      })
+    return () => {
+      alive = false
+    }
+  }, [path, branch])
+  return pr
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -6,14 +6,17 @@ package project
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/wailsapp/wails/v3/pkg/application"
 )
@@ -65,6 +68,44 @@ func (s *Service) Branch(path string) string {
 		return ""
 	}
 	return strings.TrimSpace(string(out))
+}
+
+// PullRequest identifies the open GitHub pull request for a work tree's current
+// branch, as reported by the gh CLI.
+type PullRequest struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
+}
+
+// prLookupTimeout caps the gh network call so a slow forge or hung auth prompt
+// never stalls the footer poll.
+const prLookupTimeout = 5 * time.Second
+
+// PullRequest returns the open pull request for the path's current branch, or nil
+// when there is none, gh is missing/unauthenticated, or the path is not a GitHub
+// repo. It shells out to `gh pr view`, which resolves the PR from the checked-out
+// branch. Any failure yields nil, matching Branch's "hide the segment" contract.
+func (s *Service) PullRequest(path string) *PullRequest {
+	ctx, cancel := context.WithTimeout(context.Background(), prLookupTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view", "--json", "number,url")
+	cmd.Dir = path
+	out, err := cmd.Output()
+	if err != nil {
+		return nil
+	}
+	return parsePullRequest(out)
+}
+
+// parsePullRequest decodes gh's `pr view --json` output. It returns nil for
+// malformed JSON or a zero PR number (gh emits `{}` in some no-PR states), so a
+// bad payload hides the badge rather than showing "PR #0".
+func parsePullRequest(out []byte) *PullRequest {
+	var pr PullRequest
+	if err := json.Unmarshal(out, &pr); err != nil || pr.Number == 0 || pr.URL == "" {
+		return nil
+	}
+	return &pr
 }
 
 // PickFile shows the native file picker and returns the chosen file path, or ""

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -57,6 +57,35 @@ func TestBranch(t *testing.T) {
 	}
 }
 
+// TestParsePullRequest proves the gh output decoder: a real PR yields its number
+// and URL, while malformed JSON, an empty object, and a PR missing its number or
+// URL all collapse to nil so the badge hides instead of showing garbage.
+func TestParsePullRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want *PullRequest
+	}{
+		{"valid", `{"number":7,"url":"https://github.com/o/r/pull/7"}`, &PullRequest{Number: 7, URL: "https://github.com/o/r/pull/7"}},
+		{"empty object", `{}`, nil},
+		{"zero number", `{"number":0,"url":"https://github.com/o/r/pull/0"}`, nil},
+		{"missing url", `{"number":7}`, nil},
+		{"malformed", `not json`, nil},
+		{"empty bytes", ``, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parsePullRequest([]byte(tt.out))
+			switch {
+			case tt.want == nil && got != nil:
+				t.Errorf("parsePullRequest(%q) = %+v, want nil", tt.out, got)
+			case tt.want != nil && (got == nil || *got != *tt.want):
+				t.Errorf("parsePullRequest(%q) = %+v, want %+v", tt.out, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestDiff proves Diff counts dirty files and added/deleted lines against HEAD,
 // and returns the zero value for clean repositories and non-repositories.
 func TestDiff(t *testing.T) {


### PR DESCRIPTION
## What

Adds a clickable **PR badge** to the footer status strip. When the active session's branch has an open GitHub pull request, the footer shows a `[<pr-icon> PR #N]` chip; clicking it opens the PR in the OS browser.

![badge](footer chip, same border+muted style as the diff toggle)

## How

- **Backend** (`internal/project/project.go`): new `PullRequest(path)` service method shells out to `gh pr view --json number,url` with `cmd.Dir = path` and a 5s context timeout. A pure `parsePullRequest` decoder returns `nil` for malformed JSON, an empty object, or a zero/urlless PR — so a bad payload hides the badge instead of rendering `PR #0`. Any failure (gh missing, unauthenticated, no PR, non-GitHub repo) yields `nil`, matching `Branch`'s "hide the segment" contract.
- **Frontend** (`usePullRequest.ts`): thin hook over the binding. **Not polled** — a PR is opened once and rarely changes, and each lookup is a network round-trip — so it refetches only when the path or branch changes.
- **`FooterBar.tsx`**: renders the chip only when a PR is present; the button opens `pr.url` via `Browser.OpenURL`.

## Known ceiling

No poll: a PR opened on the *current* branch appears on the next branch switch / remount, not instantly. Upgrade path (slow interval or window-focus refetch) noted in the hook comment.

## Test plan

- [x] `go test -race ./...` — 173 pass
- [x] `go vet ./...` clean, `gofmt` applied
- [x] `pnpm build` (tsc + vite) + `pnpm test` — 229 pass
- [x] `parsePullRequest` table test covers valid / empty / zero-number / missing-url / malformed / empty-bytes
- [ ] Manual: open repo with an active PR → badge shows, click opens browser; repo without PR / no gh → badge hidden