### PR TITLE
fix: hide PR badge once the PR is merged or closed

### DIFF
--- a/frontend/src/lib/usePullRequest.ts
+++ b/frontend/src/lib/usePullRequest.ts
@@ -6,12 +6,12 @@ export type {PullRequest}
 
 // usePullRequest resolves the open GitHub PR for a path's current branch via the
 // gh CLI. Unlike git status it is not polled: a PR is opened once and rarely
-// changes, and each lookup is a network round-trip. It refetches only when the
-// path or branch changes — enough to pick up a checkout or a freshly opened PR
-// on the next branch switch. Returns null while loading, on any error, or when
-// no PR exists, so the caller hides the badge. No poll: if a PR opened on the
-// current branch must appear without a branch switch, add a slow interval
-// (~30s) or a window-focus refetch.
+// changes, and each lookup is a network round-trip. It refetches when the path
+// or branch changes, and on window focus — so opening or merging a PR in the
+// browser is reflected the moment the user returns to lich, without a branch
+// switch. Returns null while loading, on any error, or when the branch has no
+// open PR (a merged or closed one is filtered server-side), so the caller hides
+// the badge.
 export function usePullRequest(path: string, branch: string): PullRequest | null {
   const [pr, setPr] = useState<PullRequest | null>(null)
   useEffect(() => {
@@ -20,15 +20,20 @@ export function usePullRequest(path: string, branch: string): PullRequest | null
       return
     }
     let alive = true
-    ProjectService.PullRequest(path)
-      .then((result) => {
-        if (alive) setPr(result)
-      })
-      .catch(() => {
-        if (alive) setPr(null)
-      })
+    const load = () => {
+      ProjectService.PullRequest(path)
+        .then((result) => {
+          if (alive) setPr(result)
+        })
+        .catch(() => {
+          if (alive) setPr(null)
+        })
+    }
+    load()
+    window.addEventListener("focus", load)
     return () => {
       alive = false
+      window.removeEventListener("focus", load)
     }
   }, [path, branch])
   return pr

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -71,10 +71,12 @@ func (s *Service) Branch(path string) string {
 }
 
 // PullRequest identifies the open GitHub pull request for a work tree's current
-// branch, as reported by the gh CLI.
+// branch, as reported by the gh CLI. State is one of gh's OPEN, CLOSED, MERGED;
+// only OPEN reaches the frontend (see parsePullRequest).
 type PullRequest struct {
 	Number int    `json:"number"`
 	URL    string `json:"url"`
+	State  string `json:"state"`
 }
 
 // prLookupTimeout caps the gh network call so a slow forge or hung auth prompt
@@ -88,7 +90,7 @@ const prLookupTimeout = 5 * time.Second
 func (s *Service) PullRequest(path string) *PullRequest {
 	ctx, cancel := context.WithTimeout(context.Background(), prLookupTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "gh", "pr", "view", "--json", "number,url")
+	cmd := exec.CommandContext(ctx, "gh", "pr", "view", "--json", "number,url,state")
 	cmd.Dir = path
 	out, err := cmd.Output()
 	if err != nil {
@@ -98,11 +100,15 @@ func (s *Service) PullRequest(path string) *PullRequest {
 }
 
 // parsePullRequest decodes gh's `pr view --json` output. It returns nil for
-// malformed JSON or a zero PR number (gh emits `{}` in some no-PR states), so a
-// bad payload hides the badge rather than showing "PR #0".
+// malformed JSON, a zero PR number (gh emits `{}` in some no-PR states), or a
+// non-OPEN state — gh reports the branch's PR even after it is merged or closed,
+// so without the state gate a merged PR would keep showing the badge.
 func parsePullRequest(out []byte) *PullRequest {
 	var pr PullRequest
-	if err := json.Unmarshal(out, &pr); err != nil || pr.Number == 0 || pr.URL == "" {
+	if err := json.Unmarshal(out, &pr); err != nil {
+		return nil
+	}
+	if pr.Number == 0 || pr.URL == "" || pr.State != "OPEN" {
 		return nil
 	}
 	return &pr

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -66,10 +66,13 @@ func TestParsePullRequest(t *testing.T) {
 		out  string
 		want *PullRequest
 	}{
-		{"valid", `{"number":7,"url":"https://github.com/o/r/pull/7"}`, &PullRequest{Number: 7, URL: "https://github.com/o/r/pull/7"}},
+		{"open", `{"number":7,"url":"https://github.com/o/r/pull/7","state":"OPEN"}`, &PullRequest{Number: 7, URL: "https://github.com/o/r/pull/7", State: "OPEN"}},
+		{"merged", `{"number":7,"url":"https://github.com/o/r/pull/7","state":"MERGED"}`, nil},
+		{"closed", `{"number":7,"url":"https://github.com/o/r/pull/7","state":"CLOSED"}`, nil},
+		{"missing state", `{"number":7,"url":"https://github.com/o/r/pull/7"}`, nil},
 		{"empty object", `{}`, nil},
-		{"zero number", `{"number":0,"url":"https://github.com/o/r/pull/0"}`, nil},
-		{"missing url", `{"number":7}`, nil},
+		{"zero number", `{"number":0,"url":"https://github.com/o/r/pull/0","state":"OPEN"}`, nil},
+		{"missing url", `{"number":7,"state":"OPEN"}`, nil},
 		{"malformed", `not json`, nil},
 		{"empty bytes", ``, nil},
 	}


### PR DESCRIPTION
## Problem

After merging a PR the footer badge stayed. Two causes:

1. **No state filter (root cause).** `gh pr view` reports the branch's PR in *any* state — `{"number":9,"state":"MERGED",...}`. We only requested `number,url`, so a merged or closed PR still rendered the badge.
2. **No refresh.** The lookup is not polled — it refetched only on path/branch change. Even with the filter, a merge done while sitting on the branch wouldn't clear until a branch switch.

## Fix

- **Backend:** request the `state` field (`gh pr view --json number,url,state`) and gate `parsePullRequest` on `state == "OPEN"`. Merged/closed/absent-state → `nil` → badge hidden.
- **Frontend:** `usePullRequest` also refetches on `window` focus, so opening or merging a PR in the browser is reflected the instant the user returns to lich.

## Test plan

- [x] `go test -race ./...` — 176 pass
- [x] `go vet ./...` clean, `gofmt` applied
- [x] `pnpm build` + `pnpm test` — 229 pass
- [x] `parsePullRequest` cases: open shows; merged / closed / missing-state hide
- [ ] Manual: merge the branch's PR in the browser → alt-tab back to lich → badge disappears