### PR TITLE
feat: keep session status in a store and badge project tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A project tab badges what its sessions are doing while you work elsewhere: a
+  bell when one is blocked waiting on you, a spinner while one is running, a
+  check when a turn finished. The active tab never badges — its cards already
+  say the same thing, per session. The check clears once the project has been on
+  screen; the bell and the spinner stay while they are true, so a tab you leave
+  mid-run keeps saying so.
+
+### Fixed
+
+- A session card kept its status indicator (spinner, check, bell) when its
+  project was not the one on screen. Switching projects mid-run unmounted the
+  card and dropped the state along with it, so coming back showed no spinner for
+  a session Claude was still working on; the state now lives in a store that
+  outlives the card. A session that starts needing your input while in the
+  background also shows its bell once the toast routes you to it.
+
 ## [0.4.0] - 2026-07-15
 
 ### Added

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -51,26 +51,37 @@ what re-arms the spinner after them. Every tool re-reports `busy` (idempotent);
 - **Endpoint** — `internal/terminal/transport.go`, `transport.hook`: validates
   the token and body (`parseHookRequest`) on the same loopback listener as
   terminal I/O, then forwards `(session_id, state)`.
-- **UI push** — `internal/terminal/terminal.go`: emits the app event
-  `session-status:<id>` with the state, and for `waiting` also the global
-  `session-attention` event (`{id}`).
-- **Render** — `frontend/src/components/sidebar/SessionCard.tsx`: subscribes to
-  the per-session event and shows a spinner (`busy`), check (`done`) or bell
+- **UI push** — `internal/terminal/terminal.go`: emits the global app event
+  `session-status` (`{id, state}`). Global rather than per-session because its
+  consumers outlive any one card.
+- **Store** — `frontend/src/lib/session-status-store.ts`: one subscription taken
+  at page load keeps the last state of every session, keyed by id. The card
+  cannot hold it: the sidebar only renders cards for the active project, so
+  switching projects unmounts them, and a status reported meanwhile would be lost.
+- **Render** — `frontend/src/components/sidebar/SessionCard.tsx`: reads the store
+  (`useSessionStatus`) and shows a spinner (`busy`), check (`done`) or bell
   (`waiting`); any other value, including `idle`, clears the indicator.
-- **Toast + route** — `frontend/src/lib/projects.tsx`: subscribes to the global
-  `session-attention` event and raises an actionable toast that navigates to the
-  session's card. It is global so a session in a background project (whose card
-  is not mounted) still surfaces; it is skipped for the session already focused.
+- **Tab badge** — `frontend/src/components/tabs/ProjectTab.tsx`: reduces a
+  project's sessions to one indicator (`useProjectStatus`, ranking `waiting` over
+  `busy` over `done`), shown only while the project is not the active one. A
+  `done` stops badging once the project has been on screen; `busy` and `waiting`
+  badge for as long as they hold, being live states rather than notifications.
+- **Toast + route** — `frontend/src/lib/projects.tsx`: raises an actionable toast
+  that navigates to the session's card when a report says `waiting`, skipped for
+  the session already focused. It reads the raw event rather than the store: the
+  store collapses a repeat state into no notification, which would swallow a
+  toast.
 
 ## Known ceilings
 
 - `UserPromptSubmit` → busy, `Stop` → done. An interrupt (Esc) that skips `Stop`
   can leave a spinner until the next turn resets it.
-- Status is not retained by lich: a card that unmounts and remounts (switching
-  projects mid-run) misses the event and can strand a spinner — and, after the
-  toast routes you to a background session, its freshly mounted card shows no
-  bell because the `waiting` event already fired. Fix path: keep the last state
-  per session in Go and hand it to the card on mount.
+- Status is retained in the page, not in Go: a reload starts the store empty, so
+  a session Claude is already working on shows no indicator until its next
+  report. The PTY is backend-owned and survives the reload, so it does keep
+  running. Same for the ~1s the `/events` socket takes to reconnect — the hub
+  drops what it emits with no client attached. Fix path: keep the last state per
+  session in Go and hand it to the store on connect.
 - The attention toast auto-dismisses on a timer (`ATTENTION_TOAST_MS`); it does
   not clear when the session leaves `waiting` (user handled it in the terminal).
   Fix path: track the toast id per session and dismiss it on the next

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -1,13 +1,12 @@
 import {useEffect, useRef, useState} from "react"
 import type {KeyboardEvent} from "react"
-import {onAppEvent} from "@/lib/app-events"
 import {Bell, Check, GitBranch, LoaderCircle, Pencil, X} from "lucide-react"
 import {useSortable} from "@dnd-kit/sortable"
 import {CSS} from "@dnd-kit/utilities"
 import {cn} from "@/lib/utils"
 import {displayPath} from "@/lib/paths"
 import {type Session} from "@/lib/sessions"
-import {statusEventName, toSessionStatus, type SessionStatus} from "@/lib/session-events"
+import {useSessionStatus} from "@/lib/useSessionStatus"
 import {useGitStatus} from "@/lib/useGitStatus"
 import {DiffStat} from "@/components/DiffStat"
 import {Tooltip, TooltipContent, TooltipTrigger} from "@/components/ui/tooltip"
@@ -46,7 +45,7 @@ export function SessionCard({
   // Claude produces output, a check once its turn ends, a bell when it is
   // blocked on the user. null before the first report, and whenever the hook
   // reports a state with no indicator (see toSessionStatus).
-  const [status, setStatus] = useState<SessionStatus | null>(null)
+  const status = useSessionStatus(session.id)
   // A worktree session lives in its own checkout: show that path and poll its
   // git status, so the badge reflects the worktree's branch, not the project's.
   const shownPath = session.path || path
@@ -78,17 +77,6 @@ export function SessionCard({
       setEditing(false)
     }
   }
-
-  // The card is always mounted for every listed session (unlike TerminalView,
-  // which only mounts once a session is viewed), so it is the reliable place to
-  // track status. A backend-retained last state would survive project switches;
-  // for now switching away mid-run can strand a spinner until the next turn.
-  useEffect(() => {
-    const off = onAppEvent(statusEventName(session.id), (data) => {
-      setStatus(toSessionStatus(data))
-    })
-    return () => off()
-  }, [session.id])
 
   // Fade the left (path start) only when the tail can't fit, so a path that
   // fits keeps its "~" crisp — matching how terminals hint at hidden prefix.

--- a/frontend/src/components/tabs/ProjectTab.tsx
+++ b/frontend/src/components/tabs/ProjectTab.tsx
@@ -1,21 +1,27 @@
 import { NavLink } from "react-router-dom"
-import { X } from "lucide-react"
+import { Bell, Check, LoaderCircle, X } from "lucide-react"
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
 import { cn } from "@/lib/utils"
+import { useProjectStatus } from "@/lib/useSessionStatus"
 import type { Project } from "@/lib/api-types"
 
 interface ProjectTabProps {
   project: Project
+  sessionIds: readonly string[]
   onClose: () => void
 }
 
 // ProjectTab is a browser-style tab: the project name, active underline, and a
 // close affordance that appears on hover. The tab is its own drag grip for
 // reordering the strip.
-export function ProjectTab({ project, onClose }: ProjectTabProps) {
+export function ProjectTab({ project, sessionIds, onClose }: ProjectTabProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: project.id })
+  // What the project's sessions are up to while you are looking elsewhere. The
+  // active tab never badges: its cards are already on screen saying the same
+  // thing, in more detail and per session.
+  const status = useProjectStatus(sessionIds)
 
   return (
     <div
@@ -35,18 +41,34 @@ export function ProjectTab({ project, onClose }: ProjectTabProps) {
           )
         }
       >
-        <span className="truncate">{project.name}</span>
-        <span
-          role="button"
-          aria-label={`Close ${project.name}`}
-          onClick={(event) => {
-            event.preventDefault()
-            onClose()
-          }}
-          className="flex size-4 shrink-0 items-center justify-center rounded opacity-0 transition-opacity hover:bg-foreground/15 group-hover:opacity-100"
-        >
-          <X className="size-3" />
-        </span>
+        {({ isActive }) => {
+          const badge = isActive ? null : status
+          return (
+            <>
+              {badge === "busy" && (
+                <LoaderCircle className="size-3 shrink-0 animate-spin" />
+              )}
+              {badge === "done" && (
+                <Check className="size-3 shrink-0 text-emerald-500" />
+              )}
+              {badge === "waiting" && (
+                <Bell className="size-3 shrink-0 text-amber-500" />
+              )}
+              <span className="truncate">{project.name}</span>
+              <span
+                role="button"
+                aria-label={`Close ${project.name}`}
+                onClick={(event) => {
+                  event.preventDefault()
+                  onClose()
+                }}
+                className="flex size-4 shrink-0 items-center justify-center rounded opacity-0 transition-opacity hover:bg-foreground/15 group-hover:opacity-100"
+              >
+                <X className="size-3" />
+              </span>
+            </>
+          )
+        }}
       </NavLink>
     </div>
   )

--- a/frontend/src/components/tabs/ProjectTabs.tsx
+++ b/frontend/src/components/tabs/ProjectTabs.tsx
@@ -5,13 +5,15 @@ import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortabl
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { useProjects } from "@/lib/projects"
+import { sessionsOf } from "@/lib/sessions"
 import { useSortableList } from "@/lib/use-sortable-list"
 import { ProjectTab } from "./ProjectTab"
 
 // ProjectTabs is the top strip: open projects as tabs (drag to reorder), a
 // button to open another, and settings pinned to the right.
 export function ProjectTabs() {
-  const { projects, openProject, closeProject, reorderProjects } = useProjects()
+  const { projects, sessions, openProject, closeProject, reorderProjects } =
+    useProjects()
   const ids = projects.map((project) => project.id)
   const { sensors, onDragEnd } = useSortableList(ids, reorderProjects)
 
@@ -28,6 +30,7 @@ export function ProjectTabs() {
               <ProjectTab
                 key={project.id}
                 project={project}
+                sessionIds={sessionsOf(sessions, project.id).map((s) => s.id)}
                 onClose={() => closeProject(project.id)}
               />
             ))}

--- a/frontend/src/lib/app-events.test.ts
+++ b/frontend/src/lib/app-events.test.ts
@@ -10,8 +10,11 @@ function registryWith(name: string, cb: Callback): Map<string, Set<Callback>> {
 describe("dispatchEnvelope", () => {
   it("routes the envelope data to the named handlers", () => {
     const cb = vi.fn()
-    dispatchEnvelope(registryWith("session-attention", cb), '{"name":"session-attention","data":{"id":"s1"}}')
-    expect(cb).toHaveBeenCalledWith({id: "s1"})
+    dispatchEnvelope(
+      registryWith("session-status", cb),
+      '{"name":"session-status","data":{"id":"s1","state":"busy"}}',
+    )
+    expect(cb).toHaveBeenCalledWith({id: "s1", state: "busy"})
   })
 
   it("delivers undefined data for payload-less events", () => {

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -21,14 +21,17 @@ import {
 } from "./sessions"
 import { applyOrder } from "./reorder"
 import {
-  ATTENTION_EVENT,
   isIdEvent,
+  isStatusEvent,
   isTitleEvent,
   shouldToastAttention,
+  STATUS_EVENT,
   TITLE_EVENT,
+  toSessionStatus,
   TOUCHED_EVENT,
 } from "./session-events"
 import { refreshGitStatus } from "./useGitStatus"
+import { markSessionSeen } from "./useSessionStatus"
 import { isRecordingTarget, matchesCombo } from "./hotkeys"
 import { useSettings } from "./settings"
 
@@ -261,9 +264,13 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
   // global toast that routes to its card — reachable even when the session lives
   // in a background project whose card is not mounted. Skipped for the session
   // already in focus, where the terminal itself shows the prompt.
+  //
+  // Driven off the raw event rather than the status store on purpose: the store
+  // collapses a repeat state into no notification, which would swallow the toast
+  // for a second waiting report. One toast per report is the contract here.
   useEffect(() => {
-    const off = onAppEvent(ATTENTION_EVENT, (data) => {
-      if (!isIdEvent(data)) {
+    const off = onAppEvent(STATUS_EVENT, (data) => {
+      if (!isStatusEvent(data) || toSessionStatus(data.state) !== "waiting") {
         return
       }
       const { id } = data
@@ -287,6 +294,24 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     })
     return () => off()
   }, [navigate, activateSession])
+
+  // Opening a project puts its cards on screen, so its sessions' statuses count
+  // as seen — and the cleanup marks them again on the way out, with the project
+  // being left. Without that second pass, a turn that finished while you sat in
+  // the project would badge the tab you just walked away from. A turn still
+  // running keeps its tab badged either way: only "done" reads this.
+  useEffect(() => {
+    if (!activeProjectId) {
+      return
+    }
+    const markSeen = () => {
+      for (const session of sessionsOf(sessionsRef.current, activeProjectId)) {
+        markSessionSeen(session.id)
+      }
+    }
+    markSeen()
+    return markSeen
+  }, [activeProjectId])
 
   // A session that likely changed files on disk nudges an immediate git-status
   // refresh for the path its card watches (its worktree, else the project's),

--- a/frontend/src/lib/session-events.test.ts
+++ b/frontend/src/lib/session-events.test.ts
@@ -1,9 +1,9 @@
 import {describe, expect, it} from "vitest"
 import {
   isIdEvent,
+  isStatusEvent,
   isTitleEvent,
   shouldToastAttention,
-  statusEventName,
   toSessionStatus,
 } from "./session-events"
 import {addSession, createProjectSessions, setActiveSession, type SessionState} from "./sessions"
@@ -23,9 +23,18 @@ function buildState(): SessionState {
   return state
 }
 
-describe("statusEventName", () => {
-  it("suffixes the prefix with the session id", () => {
-    expect(statusEventName("abc")).toBe("session-status:abc")
+describe("isStatusEvent", () => {
+  it("accepts a payload carrying an id and a state", () => {
+    expect(isStatusEvent({id: "abc", state: "busy"})).toBe(true)
+  })
+
+  it("rejects a payload missing either field or typed wrong", () => {
+    expect(isStatusEvent({id: "abc"})).toBe(false)
+    expect(isStatusEvent({state: "busy"})).toBe(false)
+    expect(isStatusEvent({id: "abc", state: 42})).toBe(false)
+    expect(isStatusEvent({id: 1, state: "busy"})).toBe(false)
+    expect(isStatusEvent(null)).toBe(false)
+    expect(isStatusEvent("busy")).toBe(false)
   })
 })
 

--- a/frontend/src/lib/session-events.ts
+++ b/frontend/src/lib/session-events.ts
@@ -7,22 +7,16 @@
 
 import {projectOfSession, type SessionState} from "./sessions"
 
-// Per-session event carrying a session's Claude Code processing state (see
-// terminal.statusEventPrefix). Suffixed with the session id. Payload: the raw
-// state string.
-export const STATUS_EVENT_PREFIX = "session-status:"
-
-export const statusEventName = (sessionId: string): string =>
-  STATUS_EVENT_PREFIX + sessionId
+// Global event carrying a session's Claude Code processing state (see
+// terminal.statusEventName). Payload: { id, state }. Global rather than
+// per-session so one subscription taken at load covers every session: a card is
+// only mounted while its project is active, and a name suffixed with the session
+// id can only reach a subscriber that exists when it is emitted.
+export const STATUS_EVENT = "session-status"
 
 // Global event the backend emits when it auto-applies a session's ai-title as
 // its label (see terminal.titleEventName). Payload: { id, label }.
 export const TITLE_EVENT = "session-title"
-
-// Global event the backend emits when a session needs the user — a permission
-// prompt or an idle input request (see terminal.attentionEventName). Payload:
-// { id }.
-export const ATTENTION_EVENT = "session-attention"
 
 // Global event the backend emits when a session likely changed files on disk
 // (see terminal.touchedEventName). Payload: { id }.
@@ -47,13 +41,17 @@ export function toSessionStatus(data: unknown): SessionStatus | null {
     : null
 }
 
-// Both session-attention and session-touched carry only a session id.
+// session-touched carries only a session id.
 export function isIdEvent(data: unknown): data is {id: string} {
   return (
     typeof data === "object" &&
     data !== null &&
     typeof (data as {id?: unknown}).id === "string"
   )
+}
+
+export function isStatusEvent(data: unknown): data is {id: string; state: string} {
+  return isIdEvent(data) && typeof (data as {state?: unknown}).state === "string"
 }
 
 export function isTitleEvent(data: unknown): data is {id: string; label: string} {

--- a/frontend/src/lib/session-status-store.test.ts
+++ b/frontend/src/lib/session-status-store.test.ts
@@ -1,0 +1,198 @@
+import {describe, expect, it, vi} from "vitest"
+import {createSessionStatusStore} from "./session-status-store"
+
+// A stand-in for the /events subscription: hands back an emit so a test can
+// drive the store the way the backend would.
+function fakeSource() {
+  let handler: (data: unknown) => void = () => {}
+  const source = vi.fn((h: (data: unknown) => void) => {
+    handler = h
+    return () => {}
+  })
+  return {source, emit: (data: unknown) => handler(data)}
+}
+
+const report = (id: string, state: string) => ({id, state})
+
+describe("createSessionStatusStore", () => {
+  it("subscribes to the source once at creation, before any listener", () => {
+    const {source} = fakeSource()
+    createSessionStatusStore(source)
+    expect(source).toHaveBeenCalledTimes(1)
+  })
+
+  it("records a status for a session nobody is subscribed to", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "busy"))
+    expect(store.get("s1")).toBe("busy")
+  })
+
+  // The regression: switching projects unmounts the card, which unsubscribes.
+  // The status — including one reported while it was away — must still be there
+  // when it comes back.
+  it("keeps the status across unsubscribe and resubscribe", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    const off = store.subscribe("s1", () => {})
+    emit(report("s1", "busy"))
+    off()
+    expect(store.get("s1")).toBe("busy")
+
+    const notify = vi.fn()
+    store.subscribe("s1", notify)
+    expect(store.get("s1")).toBe("busy")
+    emit(report("s1", "done"))
+    expect(store.get("s1")).toBe("done")
+    expect(notify).toHaveBeenCalledTimes(1)
+  })
+
+  it("applies a status reported while nothing was subscribed", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    const off = store.subscribe("s1", () => {})
+    off()
+    emit(report("s1", "waiting"))
+    expect(store.get("s1")).toBe("waiting")
+  })
+
+  it("notifies only the listeners of the session that changed", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    const first = vi.fn()
+    const second = vi.fn()
+    store.subscribe("s1", first)
+    store.subscribe("s2", second)
+    emit(report("s1", "busy"))
+    expect(first).toHaveBeenCalledTimes(1)
+    expect(second).not.toHaveBeenCalled()
+    expect(store.get("s2")).toBeNull()
+  })
+
+  it("skips the notify when the reported state repeats", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    const notify = vi.fn()
+    store.subscribe("s1", notify)
+    emit(report("s1", "busy"))
+    emit(report("s1", "busy"))
+    expect(notify).toHaveBeenCalledTimes(1)
+  })
+
+  it("clears the status on idle and on an unknown state", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "busy"))
+    emit(report("s1", "idle"))
+    expect(store.get("s1")).toBeNull()
+
+    emit(report("s2", "busy"))
+    emit(report("s2", "from-a-newer-plugin"))
+    expect(store.get("s2")).toBeNull()
+  })
+
+  it("ignores a malformed payload, keeping the previous status", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "busy"))
+    emit({id: "s1"})
+    emit({id: "s1", state: 42})
+    emit({state: "done"})
+    emit(null)
+    emit("busy")
+    expect(store.get("s1")).toBe("busy")
+  })
+
+  it("reports null for a session it has never heard of", () => {
+    const {source} = fakeSource()
+    const store = createSessionStatusStore(source)
+    expect(store.get("ghost")).toBeNull()
+  })
+})
+
+describe("pendingOf", () => {
+  it("badges nothing for a project with no reported session", () => {
+    const {source} = fakeSource()
+    const store = createSessionStatusStore(source)
+    expect(store.pendingOf([])).toBeNull()
+    expect(store.pendingOf(["ghost"])).toBeNull()
+  })
+
+  it("ranks waiting over busy over done", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "done"))
+    expect(store.pendingOf(["s1", "s2", "s3"])).toBe("done")
+    emit(report("s2", "busy"))
+    expect(store.pendingOf(["s1", "s2", "s3"])).toBe("busy")
+    emit(report("s3", "waiting"))
+    expect(store.pendingOf(["s1", "s2", "s3"])).toBe("waiting")
+  })
+
+  it("only counts the sessions of the project asked about", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("mine", "busy"))
+    emit(report("theirs", "waiting"))
+    expect(store.pendingOf(["mine"])).toBe("busy")
+  })
+
+  // Leaving a project marks its sessions seen, so the turn that finished while
+  // the user was in there does not badge the tab they just left.
+  it("drops a done once seen, and keeps live states regardless", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "done"))
+    store.markSeen("s1")
+    expect(store.pendingOf(["s1"])).toBeNull()
+    expect(store.get("s1")).toBe("done") // the card still shows its check
+
+    emit(report("s2", "busy"))
+    store.markSeen("s2")
+    expect(store.pendingOf(["s2"])).toBe("busy")
+
+    // A prompt left unanswered is still blocking after you walk away.
+    emit(report("s3", "waiting"))
+    store.markSeen("s3")
+    expect(store.pendingOf(["s3"])).toBe("waiting")
+  })
+
+  it("badges a done that lands after the session was marked seen", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "busy"))
+    store.markSeen("s1")
+    emit(report("s1", "done"))
+    expect(store.pendingOf(["s1"])).toBe("done")
+  })
+
+  it("notifies subscribers when a seen done stops badging", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    const notify = vi.fn()
+    store.subscribe("s1", notify)
+    emit(report("s1", "done"))
+    notify.mockClear()
+    store.markSeen("s1")
+    expect(notify).toHaveBeenCalledTimes(1)
+    store.markSeen("s1")
+    expect(notify).toHaveBeenCalledTimes(1) // already seen: nothing changed
+  })
+
+  it("does not notify when marking a live state seen", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    const notify = vi.fn()
+    store.subscribe("s1", notify)
+    emit(report("s1", "busy"))
+    notify.mockClear()
+    store.markSeen("s1")
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it("ignores markSeen for a session it has never heard of", () => {
+    const {source} = fakeSource()
+    const store = createSessionStatusStore(source)
+    expect(() => store.markSeen("ghost")).not.toThrow()
+  })
+})

--- a/frontend/src/lib/session-status-store.ts
+++ b/frontend/src/lib/session-status-store.ts
@@ -1,0 +1,118 @@
+import {
+  isStatusEvent,
+  toSessionStatus,
+  type SessionStatus,
+} from "./session-events"
+
+// A subscription to the global status event, injected so the store is testable
+// without standing up the /events socket. Returns its unsubscribe.
+export type StatusEventSource = (
+  handler: (data: unknown) => void,
+) => () => void
+
+interface Entry {
+  status: SessionStatus | null
+  // Whether the user has had a chance to see the current status, which only
+  // "done" cares about: it is the one state that persists with nothing running,
+  // so a finished turn would badge its project tab forever. "busy" and
+  // "waiting" are live — a tab left mid-run should keep saying so, and a
+  // permission prompt left unanswered is still blocking.
+  seen: boolean
+  listeners: Set<() => void>
+}
+
+// The tab badge of a project with several sessions. "waiting" wins because it
+// blocks the user, then "busy" because something is still running; "done" is
+// the leftover.
+const BADGE_PRIORITY = ["waiting", "busy", "done"] as const
+
+// createSessionStatusStore keeps the last reported status of every session,
+// keyed by session id, fed by one subscription taken at creation — before any
+// card mounts.
+//
+// The status cannot live in the card: SessionSidebar only renders cards for the
+// active project, so switching projects (or opening Home) unmounts every one of
+// them. A useState there died with the card and took its event listener with it,
+// so a status arriving while the card was unmounted was lost for good — coming
+// back to the project showed no spinner for a session Claude was still working
+// on. Entries therefore outlive their listeners: unsubscribing on unmount drops
+// the listener, never the status.
+export function createSessionStatusStore(source: StatusEventSource) {
+  const entries = new Map<string, Entry>()
+
+  const entryOf = (id: string): Entry => {
+    let entry = entries.get(id)
+    if (!entry) {
+      entry = {status: null, seen: false, listeners: new Set()}
+      entries.set(id, entry)
+    }
+    return entry
+  }
+
+  const notify = (entry: Entry): void => {
+    for (const listener of entry.listeners) {
+      listener()
+    }
+  }
+
+  source((data) => {
+    if (!isStatusEvent(data)) {
+      return
+    }
+    const entry = entryOf(data.id)
+    const next = toSessionStatus(data.state)
+    // The snapshot is a string union, so identity is free: bail on a repeat
+    // state and subscribers skip the re-render entirely.
+    if (entry.status === next) {
+      return
+    }
+    entry.status = next
+    // A fresh report is by definition unseen, whether or not the last one was.
+    entry.seen = false
+    notify(entry)
+  })
+
+  // markSeen records that a session's status has been on screen — its project
+  // was opened, or was open when the status arrived. Only a "done" changes
+  // appearance from it (see Entry.seen), so only that notifies.
+  const markSeen = (id: string): void => {
+    const entry = entries.get(id)
+    if (!entry || entry.seen) {
+      return
+    }
+    entry.seen = true
+    if (entry.status === "done") {
+      notify(entry)
+    }
+  }
+
+  // pendingOf reduces a project's sessions to the one status its tab should
+  // badge, or null when there is nothing to say. A seen "done" says nothing.
+  const pendingOf = (ids: readonly string[]): SessionStatus | null => {
+    const live = new Set<SessionStatus>()
+    for (const id of ids) {
+      const entry = entries.get(id)
+      if (!entry || entry.status === null) {
+        continue
+      }
+      if (entry.status === "done" && entry.seen) {
+        continue
+      }
+      live.add(entry.status)
+    }
+    return BADGE_PRIORITY.find((status) => live.has(status)) ?? null
+  }
+
+  const subscribe = (id: string, listener: () => void): (() => void) => {
+    const entry = entryOf(id)
+    entry.listeners.add(listener)
+    return () => {
+      entry.listeners.delete(listener)
+    }
+  }
+
+  const get = (id: string): SessionStatus | null =>
+    entries.get(id)?.status ?? null
+
+  return {subscribe, get, markSeen, pendingOf}
+}

--- a/frontend/src/lib/useSessionStatus.ts
+++ b/frontend/src/lib/useSessionStatus.ts
@@ -1,0 +1,52 @@
+import {useCallback, useSyncExternalStore} from "react"
+import {onAppEvent} from "./app-events"
+import {STATUS_EVENT, type SessionStatus} from "./session-events"
+import {createSessionStatusStore} from "./session-status-store"
+
+// Subscribed at import rather than on first use: that opens the /events socket
+// at page load, so a status reported before any card mounts still lands.
+const store = createSessionStatusStore((handler) =>
+  onAppEvent(STATUS_EVENT, handler),
+)
+
+// useSessionStatus reads a session's last reported Claude Code processing state
+// from the shared store (see session-status-store), which retains it across the
+// card's unmount. Returns null when nothing has been reported for the session,
+// and whenever the report maps to no indicator (see toSessionStatus).
+export function useSessionStatus(sessionId: string): SessionStatus | null {
+  const subscribe = useCallback(
+    (onChange: () => void) => store.subscribe(sessionId, onChange),
+    [sessionId],
+  )
+  return useSyncExternalStore(subscribe, () => store.get(sessionId))
+}
+
+// markSessionSeen records that a session's status has been on screen, so a
+// finished turn stops badging its project's tab. Called from the provider,
+// outside React's render.
+export function markSessionSeen(sessionId: string): void {
+  store.markSeen(sessionId)
+}
+
+// useProjectStatus reduces a project's sessions to the single status its tab
+// badges — what is happening in there while you are looking somewhere else.
+// The snapshot is a string union, so useSyncExternalStore is safe without
+// memoizing it: equal statuses are identical values.
+export function useProjectStatus(
+  sessionIds: readonly string[],
+): SessionStatus | null {
+  // sessionIds is a fresh array on every render of the tab strip; its contents
+  // are what actually matter to the subscription.
+  const key = sessionIds.join(",")
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const offs = sessionIds.map((id) => store.subscribe(id, onChange))
+      return () => offs.forEach((off) => off())
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [key],
+  )
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const snapshot = useCallback(() => store.pendingOf(sessionIds), [key])
+  return useSyncExternalStore(subscribe, snapshot)
+}

--- a/internal/events/hub.go
+++ b/internal/events/hub.go
@@ -1,5 +1,5 @@
-// Package events pushes app events (session status, attention, titles,
-// touched — anything the backend pushes to the UI) to the local WebSocket
+// Package events pushes app events (session status, titles, touched —
+// anything the backend pushes to the UI) to the local WebSocket
 // client on /events (see docs/chromium-shell.md). While no client is
 // connected events are dropped — the window owns the connection, so nobody
 // is listening anyway. It is also the delivery channel terminal I/O falls

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -20,9 +20,12 @@ import (
 	"github.com/omartelo/lich/internal/events"
 )
 
-// Event name prefixes. The concrete event carries the session ID as a suffix
-// (e.g. "terminal:data:home") so each frontend terminal subscribes only to its
-// own stream instead of filtering a global broadcast.
+// Event names. A terminal I/O event carries the session ID as a suffix (e.g.
+// "terminal:data:home") so each frontend terminal subscribes only to its own
+// stream instead of filtering a global broadcast. The session events below are
+// global and carry the id in their payload: their consumers outlive any one
+// card, and a per-session name can only reach a subscriber that exists when it
+// is emitted.
 const (
 	// dataEventPrefix carries base64-encoded PTY output. Output is base64-encoded
 	// because raw PTY bytes may split a multi-byte UTF-8 sequence mid-read, which
@@ -30,35 +33,31 @@ const (
 	dataEventPrefix = "terminal:data:"
 	// exitEventPrefix is emitted once when a session's shell process exits.
 	exitEventPrefix = "terminal:exit:"
-	// statusEventPrefix carries a session's Claude Code processing state
-	// ("busy"/"done"/"waiting"/"idle"), reported by the lich hook running inside
-	// the PTY (see transport.hook and docs/hooks/session-state.md).
-	statusEventPrefix = "session-status:"
+	// statusEventName carries a session's Claude Code processing state
+	// ({id, state} — "busy"/"done"/"waiting"/"idle"), reported by the lich hook
+	// running inside the PTY (see transport.hook and docs/hooks/session-state.md).
+	// The frontend keeps it in a store keyed by id (session-status-store.ts)
+	// rather than in the card, which is only mounted while its project is active.
+	statusEventName = "session-status"
 	// titleEventName carries an auto-applied session label ({id, label}).
-	// Unlike the per-session events above, it is a single global event because
-	// the provider that owns session state consumes it centrally, not per card.
 	titleEventName = "session-title"
-	// attentionEventName carries the id of a session that just needs the user
-	// (state "waiting"). It is global so the provider can toast and route to the
-	// card even when that session lives in a background project whose card is not
-	// mounted — the per-session status event alone cannot reach an unmounted card.
-	attentionEventName = "session-attention"
 	// touchedEventName carries the id of a session that likely changed files on
 	// disk, nudging an immediate git-status refresh ahead of the steady poll.
 	touchedEventName = "session-touched"
 )
+
+// statusEvent is the payload of statusEventName: the session whose Claude Code
+// processing state changed, and the new state.
+type statusEvent struct {
+	ID    string `json:"id"`
+	State string `json:"state"`
+}
 
 // titleEvent is the payload of titleEventName: the session whose label changed
 // and its new label.
 type titleEvent struct {
 	ID    string `json:"id"`
 	Label string `json:"label"`
-}
-
-// attentionEvent is the payload of attentionEventName: the session needing the
-// user.
-type attentionEvent struct {
-	ID string `json:"id"`
 }
 
 // touchedEvent is the payload of touchedEventName: the session whose files
@@ -114,10 +113,7 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 	ws, err := newTransport(
 		func(id string, data []byte) { _ = s.writeBytes(id, data) },
 		func(id, state string) {
-			hub.Emit(statusEventPrefix+id, state)
-			if state == statusWaiting {
-				hub.Emit(attentionEventName, attentionEvent{ID: id})
-			}
+			hub.Emit(statusEventName, statusEvent{ID: id, State: state})
 		},
 		store.SetClaudeSession,
 		func(id, title string) error {


### PR DESCRIPTION
## The bug

Prompt a session in project A, switch to B, come back: the spinner is gone, even though Claude is still working.

The status indicator lived in a `useState` inside `SessionCard`. `SessionSidebar` only renders cards for the *active* project, so switching projects unmounts every one of them — and going to Home or Settings unmounts the sidebar entirely, taking every card's status with it.

The second half is what made this more than a state-lifting problem: the `onAppEvent` subscription lived in the card too and left on cleanup. `app-events.ts` routes by exact name and drops what has no listener; the Go hub retains nothing. A status reported while the card was unmounted landed on nobody and was gone for good. A state library alone would not have fixed this — it would have faithfully preserved a value that never got updated.

The repo already knew: this was documented in `SessionCard.tsx`, `terminal.go`, and as a known ceiling in `docs/hooks/session-state.md`.

## The fix

Status moves to a module-level store keyed by session id (`session-status-store.ts`), fed by **one subscription taken at page load**, so it outlives any card and is never subscribed too late. This mirrors `git-status-store.ts`, the pattern already in the codebase — no new dependency, `useSyncExternalStore` (React 18) does the rest.

The backend event goes **global** (`session-status`, `{id, state}`) instead of per-session: a name suffixed with the session id can only reach a subscriber that exists when it is emitted. This aligns it with `session-title` and `session-touched`, which were already global.

That makes `session-attention` **redundant** — its own comment said it existed only because "the per-session status event alone cannot reach an unmounted card". Premise gone, event deleted (const, struct, conditional emit, and the TS constant). The Go side is a net deletion.

> The toast reads the **raw event**, not the store: the store collapses a repeat state into no notification, which would silently swallow a second `waiting` toast. Commented in place so nobody "optimizes" it later.

## The tab badge

A project tab now shows what its sessions are doing while you work elsewhere — bell (`waiting`) > spinner (`busy`) > check (`done`). The active tab never badges; its cards already say the same thing, per session.

Only `done` needs a notion of "seen". `busy` and `waiting` are live states that stay true on their own — leave a permission prompt unanswered and the bell correctly returns when you walk away. `done` is the one state that persists with nothing running, so without this every used project's tab would keep a permanent check.

Sessions are marked seen on **entering and on leaving** a project. Without that second pass, a turn that finished while you sat in the project would badge the tab you just walked away from. Since only `done` reads the flag, marking on the way out never clears the spinner of a project you left mid-run — which is the whole point of the feature.

## Bonus

Fixes the second ceiling documented in `session-state.md`: a session that starts waiting in a background project now shows its bell once the toast routes you to it. Previously the `waiting` event had already fired into the void.

## Contract

The `/hook` HTTP contract is untouched — the plugin still POSTs `{session_id, state}`. **No plugin release needed.**

## Test plan

- [x] `task test` — 203 frontend, Go incl. `-race`
- [x] `tsc` + `pnpm build`, `go vet`, `gofmt` clean
- [x] Regression test verified non-vacuous: mutating the store to the old behaviour (dropping the entry on unsubscribe) fails it with `expected null to be 'busy'` — the exact reported symptom
- [x] Manual: prompt in A → switch to B → back to A → **spinner still there**
- [x] Manual: same via Home/Settings (unmounts the whole sidebar)
- [x] Manual: `waiting` toast from a background project → "Open" → card shows the bell
- [x] Manual: tab badges — leave a project mid-run (spinner), let it finish (check), open it (clears), leave again (stays clear)
- [x] Manual: DevTools `/events` frames show `session-status` `{id,state}` and no `session-attention`

## Ceilings that remain

Status lives in the page, so a reload starts the store empty — the PTY is backend-owned and keeps running, and the indicator returns on the next report. Same for the ~1s `/events` reconnect window. Both are consistent with the reload ceiling already accepted in `CLAUDE.md`, and `session-state.md` records the fix path (retain in Go) if it ever matters.