### PR TITLE
feat: offer to resume a card's previous Claude session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Reopening a session card that ran Claude Code before the last restart now asks
+  whether to resume that conversation. Accepting spawns `claude --resume` on the
+  session id the `SessionStart` hook recorded, so the card picks up where it
+  stopped; declining starts an empty session as before. The prompt is asked once
+  per card, the first time it is opened after a restart, and never for a shell
+  card or one created in this run.
 - A project tab badges what its sessions are doing while you work elsewhere: a
   bell when one is blocked waiting on you, a spinner while one is running, a
   check when a turn finished. The active tab never badges — its cards already

--- a/docs/hooks/session-start.md
+++ b/docs/hooks/session-start.md
@@ -2,8 +2,9 @@
 
 Reports the Claude Code session id running inside a lich session's PTY, so lich
 can persist the link between its own session (the card) and Claude's session.
-That id is the key for later features that need to reach a session's transcript
-or resume it; nothing in the UI changes today.
+That id is what lets a restored card offer to resume the conversation it ran
+before the last restart, and the key for later features that need to reach a
+session's transcript.
 
 See [README.md](README.md) for the shared transport (`LICH_PORT` / `LICH_TOKEN`
 / `LICH_SESSION_ID`) and the client rules every hook follows.
@@ -42,6 +43,11 @@ holds the id of the Claude session currently in the card.
 - **Persistence** — `internal/store/mutations.go`, `Service.SetClaudeSession`:
   `UPDATE sessions SET claude_session_id`. Surfaced on `store.Session`
   (`claudeSessionId`) and returned by `LoadState`.
+- **Consumer** — the resume prompt. `LoadState` hydrates the id onto the
+  frontend session (`resumableSession` in `frontend/src/lib/sessions.ts`), and
+  the first time a restored card is opened `TerminalHost` asks before spawning:
+  accepting passes the id to `terminal.Start`, which spawns `claude --resume
+  <id>`.
 
 ## Known ceilings
 
@@ -50,9 +56,9 @@ holds the id of the Claude session currently in the card.
   dropped — not an error. In practice Claude's boot is slower than the local
   insert, so this is not observed; if it ever bites, retry from the hook or
   re-report on a later event.
-- **`claude_session_id` is stored, not surfaced.** No feature reads it yet; it
-  exists so future work (transcript access, resume, the `ai-title` naming hook)
-  has the link ready.
+- **A card without the plugin never offers a resume.** The id only exists
+  because this hook reported it, so the prompt is a plugin-gated feature: the
+  session simply starts fresh, as before.
 - **Not the transcript path.** The path is reconstructable from the id and cwd;
   storing it too is a contract change — add a field only when a feature needs
   it, per the versioning note in the README.

--- a/frontend/src/components/ConfirmDialog.tsx
+++ b/frontend/src/components/ConfirmDialog.tsx
@@ -15,6 +15,8 @@ interface ConfirmDialogProps {
   onCancel: () => void
   title: string
   description: ReactNode
+  /** Label of the dismiss button. Defaults to "Cancel". */
+  cancelLabel?: string
   /** The action buttons, rendered after the shared Cancel. */
   children: ReactNode
 }
@@ -28,6 +30,7 @@ export function ConfirmDialog({
   onCancel,
   title,
   description,
+  cancelLabel = "Cancel",
   children,
 }: ConfirmDialogProps) {
   return (
@@ -41,7 +44,7 @@ export function ConfirmDialog({
         </DialogHeader>
         <DialogFooter>
           <Button variant="ghost" onClick={onCancel}>
-            Cancel
+            {cancelLabel}
           </Button>
           {children}
         </DialogFooter>

--- a/frontend/src/components/ResumeSessionDialog.tsx
+++ b/frontend/src/components/ResumeSessionDialog.tsx
@@ -1,0 +1,43 @@
+import { Button } from "@/components/ui/button"
+import { ConfirmDialog } from "@/components/ConfirmDialog"
+import type { Session } from "@/lib/sessions"
+
+interface ResumeSessionDialogProps {
+  /** The restored session about to spawn, or null when the dialog is hidden. */
+  session: Session | null
+  /** Spawn Claude Code fresh, leaving the previous conversation behind. */
+  onStartNew: () => void
+  /** Spawn Claude Code with --resume, continuing the previous conversation. */
+  onResume: () => void
+}
+
+// ResumeSessionDialog asks, the first time a restored card is opened, whether
+// its terminal should continue the Claude session it ran before the restart
+// (`--resume`) or start a new one. Dismissing is the same answer as "Start
+// new": the card has to end up with a terminal either way, and the spawn is
+// waiting on this.
+export function ResumeSessionDialog({
+  session,
+  onStartNew,
+  onResume,
+}: ResumeSessionDialogProps) {
+  return (
+    <ConfirmDialog
+      open={session !== null}
+      onCancel={onStartNew}
+      cancelLabel="Start new"
+      title="Resume previous session?"
+      description={
+        <>
+          <span className="font-medium">{session?.label}</span> left a Claude
+          Code session behind (
+          <span className="break-all font-mono">{session?.claudeSessionId}</span>
+          ). Resume it to pick the conversation up where it stopped, or start new
+          for an empty one.
+        </>
+      }
+    >
+      <Button onClick={onResume}>Resume</Button>
+    </ConfirmDialog>
+  )
+}

--- a/frontend/src/components/TerminalHost.tsx
+++ b/frontend/src/components/TerminalHost.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useMatch } from "react-router-dom"
 import { TerminalView } from "@/components/TerminalView"
+import { ResumeSessionDialog } from "@/components/ResumeSessionDialog"
 import { useProjects } from "@/lib/projects"
-import { activeSessionId, sessionsOf } from "@/lib/sessions"
+import { activeSessionId, resumableSession, sessionsOf } from "@/lib/sessions"
+import type { Session } from "@/lib/sessions"
 
 // TerminalHost keeps one persistent terminal per session, across every open
 // project, stacked in the same area. The router picks the active project and the
@@ -15,6 +17,10 @@ import { activeSessionId, sessionsOf } from "@/lib/sessions"
 // the session has first been viewed, not when its project loads. This keeps a
 // restore of many projects × sessions from spawning every PTY at launch. Once
 // spawned, a session stays mounted and running in the background.
+//
+// A restored session that ran Claude Code before the last restart carries that
+// Claude session's id, so its spawn waits on the resume prompt: the terminal is
+// mounted only once the user has said whether to continue that conversation.
 export function TerminalHost() {
   const { projects, sessions } = useProjects()
   const match = useMatch("/projects/:projectId")
@@ -28,14 +34,49 @@ export function TerminalHost() {
   // the set (ids are unique uuids, so closed sessions leave only harmless dead
   // entries), which keeps its terminal mounted after the user navigates away.
   const [spawned, setSpawned] = useState<Set<string>>(() => new Set())
+  // The session whose resume prompt is on screen, if any; its spawn waits here.
+  const [asking, setAsking] = useState<Session | null>(null)
+  // The Claude session each spawned session was told to resume, keyed by session
+  // id. Only the ones the user accepted land here; everything else spawns fresh.
+  const [resuming, setResuming] = useState<Record<string, string>>({})
+
+  // Read by the effect below without being dependencies of it: the decision is
+  // taken once per session id, and re-running it on an unrelated session or
+  // spawn change would re-prompt a session already answered.
+  const sessionsRef = useRef(sessions)
+  sessionsRef.current = sessions
+  const spawnedRef = useRef(spawned)
+  spawnedRef.current = spawned
+
   useEffect(() => {
-    if (!visibleSessionId) {
+    if (
+      !activeProjectId ||
+      !visibleSessionId ||
+      spawnedRef.current.has(visibleSessionId)
+    ) {
       return
     }
-    setSpawned((prev) =>
-      prev.has(visibleSessionId) ? prev : new Set(prev).add(visibleSessionId),
+    const resumable = resumableSession(
+      sessionsRef.current,
+      activeProjectId,
+      visibleSessionId,
     )
-  }, [visibleSessionId])
+    if (resumable) {
+      setAsking(resumable)
+      return
+    }
+    setSpawned((prev) => new Set(prev).add(visibleSessionId))
+  }, [activeProjectId, visibleSessionId])
+
+  // Answer the prompt and release the spawn: resume is the Claude session id to
+  // continue, or "" to start fresh.
+  const answerResume = (session: Session, resume: string) => {
+    setAsking(null)
+    if (resume) {
+      setResuming((prev) => ({ ...prev, [session.id]: resume }))
+    }
+    setSpawned((prev) => new Set(prev).add(session.id))
+  }
 
   return (
     <>
@@ -59,12 +100,20 @@ export function TerminalHost() {
                 projectId={project.id}
                 cwd={session.path || project.path}
                 kind={session.kind}
+                resume={resuming[session.id] ?? ""}
                 visible={visible}
               />
             </div>
           )
         })
       })}
+      <ResumeSessionDialog
+        session={asking}
+        onStartNew={() => asking && answerResume(asking, "")}
+        onResume={() =>
+          asking && answerResume(asking, asking.claudeSessionId ?? "")
+        }
+      />
     </>
   )
 }

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -101,6 +101,13 @@ export interface TerminalViewProps {
   projectId: string
   cwd: string
   kind: SessionKind
+  /**
+   * Claude session id to reopen (--resume) when the PTY spawns; "" starts
+   * fresh. Read once at mount: the host decides it before mounting us and it
+   * never changes for a given session, so it is deliberately not a dependency
+   * of the setup effect — a change there would kill and respawn the PTY.
+   */
+  resume: string
   visible: boolean
 }
 
@@ -110,7 +117,14 @@ interface LiveTerminal {
   dispose(): void
 }
 
-export function TerminalView({ sessionId, projectId, cwd, kind, visible }: TerminalViewProps) {
+export function TerminalView({
+  sessionId,
+  projectId,
+  cwd,
+  kind,
+  resume,
+  visible,
+}: TerminalViewProps) {
   const { font, resolvedTerminalTheme } = useSettings()
   const containerRef = useRef<HTMLDivElement | null>(null)
   const liveRef = useRef<LiveTerminal | null>(null)
@@ -320,7 +334,7 @@ export function TerminalView({ sessionId, projectId, cwd, kind, visible }: Termi
         resizeObserver.disconnect()
       })
 
-      await Service.Start(sessionId, projectId, cwd, kind, live.term.cols, live.term.rows)
+      await Service.Start(sessionId, projectId, cwd, kind, resume, live.term.cols, live.term.rows)
       if (visibleRef.current) {
         live.term.focus()
       } else {

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -90,6 +90,7 @@ function buildSessionState(loaded: StoreProject[]): SessionState {
       label: s.label,
       kind: (s.kind === "shell" ? "shell" : "claude") as SessionKind,
       ...(s.path ? { path: s.path } : {}),
+      ...(s.claudeSessionId ? { claudeSessionId: s.claudeSessionId } : {}),
     }))
     state[p.id] = {
       sessions,

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -66,8 +66,16 @@ async function call<T>(method: string, args: unknown[]): Promise<T> {
 }
 
 export const Terminal = {
-  Start: (id: string, projectID: string, cwd: string, kind: string, cols: number, rows: number) =>
-    call<null>("terminal.Start", [id, projectID, cwd, kind, cols, rows]),
+  /** resume: a Claude session id to reopen (--resume); "" starts fresh. */
+  Start: (
+    id: string,
+    projectID: string,
+    cwd: string,
+    kind: string,
+    resume: string,
+    cols: number,
+    rows: number,
+  ) => call<null>("terminal.Start", [id, projectID, cwd, kind, resume, cols, rows]),
   Write: (id: string, data: string) => call<null>("terminal.Write", [id, data]),
   Resize: (id: string, cols: number, rows: number) =>
     call<null>("terminal.Resize", [id, cols, rows]),

--- a/frontend/src/lib/sessions.test.ts
+++ b/frontend/src/lib/sessions.test.ts
@@ -8,6 +8,7 @@ import {
   removeProject,
   renameSession,
   reorderSessions,
+  resumableSession,
   sessionsOf,
   setActiveSession,
   type SessionState,
@@ -23,6 +24,25 @@ function buildState(n: number): SessionState {
     state = addSession(state, P, `s${i}`)
   }
   return state
+}
+
+// withClaudeSession stamps a restored session's Claude session id onto the
+// state, the way hydration from the store does.
+function withClaudeSession(
+  state: SessionState,
+  sessionId: string,
+  claudeSessionId: string,
+  kind: "claude" | "shell" = "claude",
+): SessionState {
+  return {
+    ...state,
+    [P]: {
+      ...state[P],
+      sessions: state[P].sessions.map((s) =>
+        s.id === sessionId ? { ...s, kind, claudeSessionId } : s,
+      ),
+    },
+  }
 }
 
 describe("createProjectSessions", () => {
@@ -212,5 +232,34 @@ describe("reorderSessions", () => {
     const state = buildState(3)
     reorderSessions(state, P, ["s3", "s2", "s1"])
     expect(sessionsOf(state, P).map((s) => s.id)).toEqual(["s1", "s2", "s3"])
+  })
+})
+
+describe("resumableSession", () => {
+  it("returns a restored claude session carrying a claude session id", () => {
+    const state = withClaudeSession(buildState(2), "s1", "claude-abc")
+    expect(resumableSession(state, P, "s1")).toMatchObject({
+      id: "s1",
+      claudeSessionId: "claude-abc",
+    })
+  })
+
+  // A session created in this run has nothing to resume; only hydration from
+  // the store sets the id.
+  it("returns null for a session without a claude session id", () => {
+    expect(resumableSession(buildState(2), P, "s1")).toBeNull()
+  })
+
+  // Running Claude Code by hand inside a shell session lets the SessionStart
+  // hook stamp an id on its row — the shell still cannot reopen it.
+  it("returns null for a shell session even with a claude session id", () => {
+    const state = withClaudeSession(buildState(2), "s1", "claude-abc", "shell")
+    expect(resumableSession(state, P, "s1")).toBeNull()
+  })
+
+  it("returns null for unknown project and session ids", () => {
+    const state = withClaudeSession(buildState(2), "s1", "claude-abc")
+    expect(resumableSession(state, "nope", "s1")).toBeNull()
+    expect(resumableSession(state, P, "ghost")).toBeNull()
   })
 })

--- a/frontend/src/lib/sessions.ts
+++ b/frontend/src/lib/sessions.ts
@@ -19,6 +19,11 @@ export interface Session {
   // Working directory when the session lives in a git worktree; absent means
   // the project's own path.
   path?: string
+  // The Claude Code session this card ran before the last restart, reported by
+  // the SessionStart hook and read back on hydration. Only ever set by the
+  // store: a session created in this run has none, and the hook's later report
+  // is not mirrored here — a running session has nothing to resume.
+  claudeSessionId?: string
 }
 
 export interface ProjectSessions {
@@ -174,6 +179,23 @@ export function removeProject(
   const next = { ...state }
   delete next[projectId]
   return next
+}
+
+// resumableSession returns the session whose PTY should ask before it spawns,
+// because it carries the Claude session it ran before the last restart. Null for
+// everything with nothing to resume: unknown ids, sessions created in this run,
+// and shell sessions — whose shell cannot reopen a Claude session even when a
+// hand-run Claude Code left an id on their row.
+export function resumableSession(
+  state: SessionState,
+  projectId: string,
+  sessionId: string,
+): Session | null {
+  const session = state[projectId]?.sessions.find((s) => s.id === sessionId)
+  if (!session || session.kind !== "claude" || !session.claudeSessionId) {
+    return null
+  }
+  return session
 }
 
 export function sessionsOf(state: SessionState, projectId: string): Session[] {

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -195,6 +195,21 @@ func resolveBin(bin string) string {
 	return bin
 }
 
+// resumeFlag is the Claude Code flag that reopens an existing session by id.
+const resumeFlag = "--resume"
+
+// resumeArgs returns the arguments that reopen the Claude session resume names,
+// or nil when the session must start fresh. A "shell" session never resumes:
+// its PTY runs the user's shell, which knows nothing about --resume, and a
+// stray claude_session_id can land on its row when the user ran Claude Code by
+// hand inside it.
+func resumeArgs(kind, resume string) []string {
+	if kind == KindShell || resume == "" {
+		return nil
+	}
+	return []string{resumeFlag, resume}
+}
+
 // resolveCommand picks the binary a session runs: the user's shell for "shell"
 // sessions, otherwise the configured Claude Code binary.
 func resolveCommand(kind, bin, shellEnv string) string {
@@ -295,7 +310,12 @@ func scrubPathList(value, dir string) (string, bool) {
 // PTY sized to cols x rows and rooted at cwd, then streams its output to the
 // frontend. An empty cwd defaults to the user's home directory. Starting a
 // session that is already running is a no-op.
-func (s *Service) Start(id, projectID, cwd, kind string, cols, rows int) error {
+//
+// A non-empty resume is a Claude session id to reopen (`--resume`), which the
+// frontend passes after the user accepted the prompt to continue the session
+// this card ran before the last restart. An id Claude no longer knows fails in
+// the PTY like any other bad invocation — the user sees Claude's own error.
+func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -311,7 +331,10 @@ func (s *Service) Start(id, projectID, cwd, kind string, cols, rows int) error {
 		cwd = home
 	}
 
-	cmd := exec.Command(resolveCommand(kind, s.store.ClaudeBin(projectID), os.Getenv("SHELL")))
+	cmd := exec.Command(
+		resolveCommand(kind, s.store.ClaudeBin(projectID), os.Getenv("SHELL")),
+		resumeArgs(kind, resume)...,
+	)
 	cmd.Dir = cwd
 	cmd.Env = s.sessionEnv(id)
 

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -2,7 +2,10 @@ package terminal
 
 import (
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -224,11 +227,64 @@ func TestStartIsNoopWhenAlreadyRunning(t *testing.T) {
 	sess := spawnSession(t)
 	svc.sessions["s1"] = sess
 
-	if err := svc.Start("s1", "p1", "", "", 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", "", "", "", 80, 24); err != nil {
 		t.Errorf("Start(running) = %v, want nil", err)
 	}
 	if svc.sessions["s1"] != sess {
 		t.Error("Start replaced the running session")
+	}
+}
+
+// stayAliveBin writes a script that outlives Start, so the spawned session is
+// still in the map when the test inspects it. A binary that exits on an
+// unknown flag would race stream()'s cleanup.
+func stayAliveBin(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-claude")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nsleep 30\n"), 0o755); err != nil {
+		t.Fatalf("write stub bin: %v", err)
+	}
+	return path
+}
+
+// TestStartPassesResumeToTheProcess proves the resume id reaches the spawned
+// binary's argv — the wiring resumeArgs' unit test cannot see.
+func TestStartPassesResumeToTheProcess(t *testing.T) {
+	bin := stayAliveBin(t)
+	svc := New(stubBins{bin: bin}, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1") })
+
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "abc-123", 80, 24); err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+
+	svc.mu.Lock()
+	got := svc.sessions["s1"].cmd.Args
+	svc.mu.Unlock()
+
+	want := []string{bin, resumeFlag, "abc-123"}
+	if !slices.Equal(got, want) {
+		t.Errorf("spawned argv = %v, want %v", got, want)
+	}
+}
+
+// TestStartWithoutResumeSpawnsBare proves a session with no id to resume spawns
+// the binary alone, with no dangling flag.
+func TestStartWithoutResumeSpawnsBare(t *testing.T) {
+	bin := stayAliveBin(t)
+	svc := New(stubBins{bin: bin}, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1") })
+
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", 80, 24); err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+
+	svc.mu.Lock()
+	got := svc.sessions["s1"].cmd.Args
+	svc.mu.Unlock()
+
+	if !slices.Equal(got, []string{bin}) {
+		t.Errorf("spawned argv = %v, want %v", got, []string{bin})
 	}
 }
 
@@ -258,6 +314,28 @@ func TestResolveCommand(t *testing.T) {
 		if got := resolveCommand(tc.kind, tc.bin, tc.shell); got != tc.want {
 			t.Errorf("%s: resolveCommand(%q, %q, %q) = %q, want %q",
 				tc.name, tc.kind, tc.bin, tc.shell, got, tc.want)
+		}
+	}
+}
+
+// TestResumeArgs proves a Claude session resumes only when an id is given, and
+// that a shell session never grows a --resume flag its shell cannot parse.
+func TestResumeArgs(t *testing.T) {
+	cases := []struct {
+		name, kind, resume string
+		want               []string
+	}{
+		{"claude fresh", "claude", "", nil},
+		{"claude resume", "claude", "abc-123", []string{resumeFlag, "abc-123"}},
+		{"default kind resumes", "", "abc-123", []string{resumeFlag, "abc-123"}},
+		{"shell never resumes", KindShell, "abc-123", nil},
+		{"shell fresh", KindShell, "", nil},
+	}
+	for _, tc := range cases {
+		got := resumeArgs(tc.kind, tc.resume)
+		if !slices.Equal(got, tc.want) {
+			t.Errorf("%s: resumeArgs(%q, %q) = %v, want %v",
+				tc.name, tc.kind, tc.resume, got, tc.want)
 		}
 	}
 }


### PR DESCRIPTION
## What

The `SessionStart` hook has been recording each card's Claude session id since the plugin landed, with nothing reading it back — `docs/hooks/session-start.md` said as much under its ceilings. This gives it a consumer.

Reopening a restored card for the first time after a restart now asks whether to continue the Claude conversation it ran before:

- **Resume** → spawns `claude --resume <id>`, picking up where it stopped.
- **Start new** (or dismissing) → an empty session, exactly as before.

Asked once per card, on first view. Never for a card created in this run — it has no id — nor for a shell card.

## How

The spawn is gated on the answer in `TerminalHost`, which already owned the lazy-spawn gate: the `TerminalView` mounts only once the user has chosen, so the decision is taken once per card and the PTY is never respawned to apply it.

- `terminal.Start` takes a `resume` parameter; `resumeArgs(kind, resume)` builds `--resume <id>`.
- `sessions.ts` hydrates `claudeSessionId` from `LoadState`; `resumableSession()` decides who gets the prompt.
- `ResumeSessionDialog` is new, built on the existing `ConfirmDialog` (which gained a `cancelLabel`).

## Decisions worth a look

**Shell cards never resume, even carrying an id.** Not paranoia: run `claude` by hand inside a shell card and the `SessionStart` hook stamps that row, so a resume would spawn `$SHELL --resume <id>`. Guarded on both ends (`resumableSession`, `resumeArgs`) and tested.

**Dismissing starts a new session rather than doing nothing.** The card has to end up with a terminal either way, and the spawn is blocked waiting on the answer. The cost: declining lets the fresh session's `SessionStart` overwrite the stored id, so the old conversation leaves lich's view. It stays reachable through Claude's own `/resume` picker.

**An id Claude no longer knows** fails inside the PTY like any other bad invocation — the user sees Claude's own error, no special handling.

## Test plan

- [x] `go test -race ./...` — 202 pass; `go vet` clean; `gofmt` applied.
- [x] `pnpm test` — 207 pass; `pnpm build` (tsc + vite) clean.
- [x] `resumeArgs` unit-tested across kind × resume; `resumableSession` across restored / fresh / shell / unknown ids.
- [x] Real PTY spawn asserts the argv reaches the process — `resumeArgs` alone would not catch a broken `exec.Command` wiring.
- [x] Flag form confirmed against `claude --help` (`-r, --resume [value]`).
- [x] Resume and start-new both driven by hand in the running app.

The React wiring of the dialog itself (appears → answer → spawns) has no automated test: vitest here is node-env and only includes `*.test.ts`, so there's no component-test infra — the pure logic is covered, the click was verified by hand.

## Docs

`CHANGELOG.md` under Unreleased, and `docs/hooks/session-start.md` — the contract now names its consumer, and the "stored, not surfaced" ceiling is replaced by the real one: no plugin, no id, no prompt.