### PR TITLE
fix: stop TestTransportSendAndFallback racing the client registration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,21 @@ Non-negotiable rules. A violation means the work is not done.
 1. **Test coverage ≥ 80%.** Backend (Go) and frontend (React/TS). Without a test, the feature is not ready. Run the
    suite before marking any task done; if it fails, fix it first. OS/framework boundaries (the PTY, the Chromium
    launcher/zenity subprocesses, WebSocket wiring, the `main` bootstrap, xterm.js internals) are a documented
-   exception: cover the pure logic, never mock the framework just to inflate the number.
+   exception: cover the pure logic and leave the boundary itself alone (invariant 2 owns why).
 
-2. **Clean code.**
+2. **Tests answer to the contract, never the other way round.** A test earns its keep by failing when the product
+   breaks. Never weaken, skip, delete or rewrite one to buy a green run or a coverage number, and never mock the
+   framework to inflate it — a suite bought that way lies, and a lying suite is worse than a red one. A test may
+   change for exactly two reasons: the contract changed, or the test asserts something the contract never promised
+   (that is a broken test — name the real contract in the diff and say why the old assertion was wrong). "The
+   assertion was in my way" is not one of them. When in doubt, change the product, not the test.
+
+3. **A flake is a bug, and it has a root cause.** Never re-run CI until it goes green, never mark work done on a
+   suite that passes "most of the time", and never dismiss a failure as "unrelated" without proving it. Reproduce it
+   (`go test -count=200 -run TestX ./pkg/`), find the cause, fix that, and measure the failure rate before and after
+   — a fix you cannot show as a rate change is a guess.
+
+4. **Clean code.**
     - Small, focused functions (< 50 lines), one responsibility.
     - Cohesive files (200–400 lines typical, 800 max). Many small files > few large ones.
     - No deep nesting (> 4 levels) — use early returns.

--- a/internal/terminal/transport_test.go
+++ b/internal/terminal/transport_test.go
@@ -115,6 +115,29 @@ func TestTransportInputReachesService(t *testing.T) {
 	}
 }
 
+// sendWhenRegistered retries send until it reports a connected client, and says
+// whether it ever did.
+//
+// Dial returning only means the client read the handshake response: the server
+// registers the connection after websocket.Accept returns, in its own handler
+// goroutine, so send can still find no client for a moment. Production wants
+// exactly that — an unregistered client makes send report false and the output
+// falls back to the /events bridge — which leaves the window unobservable from
+// out here, and asserting on the first send is a coin flip. Frames dropped
+// before registration are the same fallback, so only the send that lands is
+// delivered to the client.
+func sendWhenRegistered(t *testing.T, tr *transport, id string, data []byte) bool {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if tr.send(id, data) {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return false
+}
+
 func TestTransportSendAndFallback(t *testing.T) {
 	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil, nil)
 	if err != nil {
@@ -129,10 +152,8 @@ func TestTransportSendAndFallback(t *testing.T) {
 		t.Fatalf("dial: %v", err)
 	}
 	defer func() { _ = conn.Close(websocket.StatusNormalClosure, "") }()
-	// The server registers the client during the handshake, so send is ready
-	// as soon as Dial returns.
-	if !tr.send("sess", []byte("output")) {
-		t.Fatal("send must succeed with a connected client")
+	if !sendWhenRegistered(t, tr, "sess", []byte("output")) {
+		t.Fatal("send never saw the connected client")
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)


### PR DESCRIPTION
## What

`TestTransportSendAndFallback` is a ~13% flake. It took the `v0.5.0` release workflow down — the tag is pushed, the run failed on this test, and no Release published.

## The race

The test asserted that `send()` reports a connected client the moment `Dial` returns, on this reasoning:

> // The server registers the client during the handshake, so send is ready
> // as soon as Dial returns.

That is wrong. `Dial` returns once the **client** reads the handshake response; the **server** registers the connection *after* `websocket.Accept` returns, in its own handler goroutine (`transport.handle`). The window between the two is real, and the assertion was a coin flip on which goroutine won.

## Why the test was the broken part, not the product

An unregistered client making `send()` report `false` is the designed contract, not a defect — output falls back to the `/events` bridge, slower but never broken, exactly as the ceilings in `CLAUDE.md` describe. The test asserted a scheduling coincidence the contract never promised.

So it now retries `send` until the client registers, and still fails (after 5s) if a connected client never receives the frame — which is the actual guarantee. Frames dropped before registration are the same documented fallback, so only the send that lands is delivered.

This is a fix to a test that asserted the wrong thing, **not** an assertion loosened to buy a green run. If it reads as the latter to you, say so and I'll revert.

## Invariants

The fix leans on two rules now recorded in `CLAUDE.md`:

- **Tests answer to the contract, never the other way round** — never bend one for a green run or a coverage number; a test changes only when the contract changed or when it asserts something the contract never promised.
- **A flake is a bug with a root cause** — reproduce and measure it, never re-run CI until it goes green.

Invariant 1 shed its "never mock the framework to inflate the number" tail, which invariant 2 now owns.

## Test plan

- [x] Reproduced: **29/200 failures (~14%)** on `5d8a0b8`, before the resume feature — pre-existing, not introduced by #14.
- [x] After the fix: **0/400**.
- [x] `go test -race ./...` — 202 pass; `-count=3` on `internal/terminal` clean; `go vet` clean; `gofmt` applied.
- [x] Audited the other `dial`/`send` call sites in the package: the input-frame test waits on a channel with a timeout (safe), and the no-client `send` assertion is deterministic. This was the only one.

## Note on v0.5.0

The `v0.5.0` tag is pushed at `2105819` and its workflow failed here, so nothing published. Re-running it would likely have gone green and left the flake alive — hence this PR first. How to land the release once this merges is worth a word before I touch the tag.