### PR TITLE
feat: Windows port (experimental) — ConPTY terminal, Chrome/Edge discovery, parallel CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,8 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  # linux and windows build in parallel; release fans in and publishes.
+  linux:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -58,15 +59,98 @@ jobs:
       - name: Build Linux packages
         run: task package
 
-      - name: Assemble release assets
+      - name: Assemble Linux assets
         run: |
           cd bin
-          tag="${GITHUB_REF_NAME}"
+          # workflow_dispatch runs land here with a branch name; slashes would
+          # break the file names.
+          tag="${GITHUB_REF_NAME//\//-}"
           mv "lich.deb"             "lich-${tag}-amd64.deb"
           mv "lich.rpm"             "lich-${tag}-x86_64.rpm"
           mv "lich.pkg.tar.zst"     "lich-${tag}-x86_64.pkg.tar.zst"
           cp lich "lich-${tag}-linux-amd64"
-          sha256sum lich-${tag}-* > checksums.txt
+          ls -la lich-${tag}-*
+
+      - name: Upload Linux assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: lich-linux
+          path: bin/lich-*
+
+  windows:
+    runs-on: windows-latest
+    defaults:
+      run:
+        # bash (git-bash) keeps the steps byte-identical to the linux job's.
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: frontend/package.json
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install task
+        run: |
+          go install github.com/go-task/task/v3/cmd/task@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      # build:windows runs the frontend install+build dep, which go:embed
+      # needs before the backend suite can even compile — hence build first,
+      # tests right after. Frontend tests already gate the linux job; running
+      # them twice buys nothing.
+      - name: Build Windows binary
+        run: task build:windows
+
+      - name: Backend tests (windows)
+        run: go test ./...
+
+      - name: Assemble Windows assets
+        run: |
+          cd bin
+          tag="${GITHUB_REF_NAME//\//-}"
+          mv lich.exe "lich-${tag}-windows-amd64.exe"
+          ls -la lich-${tag}-*
+
+      - name: Upload Windows assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: lich-windows
+          path: bin/lich-*
+
+  release:
+    needs: [linux, windows]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout only for CHANGELOG.md — the notes come from it.
+      - uses: actions/checkout@v4
+
+      - name: Download build assets
+        uses: actions/download-artifact@v4
+        with:
+          path: bin
+          merge-multiple: true
+
+      - name: Checksums
+        run: |
+          cd bin
+          sha256sum lich-* > checksums.txt
           cat checksums.txt
 
       - name: Extract changelog notes
@@ -83,23 +167,10 @@ jobs:
           cat notes.md
 
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/v')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "$GITHUB_REF_NAME" \
-            bin/lich-${GITHUB_REF_NAME}-* bin/checksums.txt \
+            bin/lich-* bin/checksums.txt \
             --title "$GITHUB_REF_NAME" \
             --notes-file notes.md
-
-      - name: Upload workflow artifacts
-        if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
-        with:
-          name: lich-linux-packages
-          path: |
-            bin/*.deb
-            bin/*.rpm
-            bin/*.pkg.tar.zst
-            bin/lich
-            bin/checksums.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Experimental Windows build (`lich.exe`, `task build:windows`). Terminal
+  sessions run under ConPTY, the window opens in Chrome or Edge (found via
+  their conventional install paths), shell cards fall back to `COMSPEC`, and
+  npm's `claude.cmd` shim is spawned through `cmd.exe /c`. Releases now ship a
+  `windows-amd64.exe` asset built — and backend-tested — on a Windows runner
+  in parallel with the Linux packages.
+
 ## [0.5.0] - 2026-07-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,16 +5,20 @@
 `lich` is a **personal harness** — a desktop app whose Go backend serves an embedded React frontend to a system
 Chromium window in `--app` mode (no Electron, no webview toolkit; see `docs/chromium-shell.md` for the full decision
 record). It is shaped by the author's experience with and taste for other harnesses on the market; it is not a generic
-product, it is a bespoke tool. Linux-only.
+product, it is a bespoke tool. Linux first; an experimental Windows build ships alongside it (see Known Ceilings).
 
 ## Stack
 
 - **Backend**: Go 1.25, pure Go (CGO_ENABLED=0, fully static binary). Services exposed to the frontend over loopback
   HTTP RPC (`internal/rpc`) + WebSockets (terminal I/O in `internal/terminal/transport.go`, app events in
-  `internal/events`), all on one token-authenticated listener.
+  `internal/events`), all on one token-authenticated listener. OS-specific code is selected by build tags behind
+  small seams, never by runtime checks — the PTY is the model (`internal/terminal`'s `startPTY`: creack/pty on Unix,
+  ConPTY on Windows, where npm's `claude.cmd` shim runs through `cmd.exe /c`).
 - **Shell**: system Chromium-family browser launched in `--app` mode (`internal/chromium`), persistent profile under
-  `~/.config/lich/chromium-profile`. Window closed = app exit. Runtime needs: chromium/chrome on PATH, zenity for the
-  folder picker.
+  the user config dir (`~/.config/lich/chromium-profile`; `%AppData%\lich` on Windows). Window closed = app exit.
+  Runtime needs: a Chromium-family browser — chromium/chrome/brave on PATH on Linux, plus zenity for the folder
+  picker; chrome/edge/brave via their conventional install paths on Windows (picker is native win32, and Edge being
+  everywhere guarantees a window).
 - **Frontend**: React 18 + TypeScript + Vite. Terminal is xterm.js 6 + `@xterm/addon-webgl`. Service shapes are
   hand-owned in `frontend/src/lib/api-types.ts` (mirrors of the Go structs' JSON tags — keep in sync).
 - **Build/tasks**: [Task](https://taskfile.dev) — see Commands.
@@ -22,11 +26,12 @@ product, it is a bespoke tool. Linux-only.
 ## Commands
 
 ```bash
-task dev      # dev mode: Vite HMR + backend; separate DB, port and Chromium profile
-task build    # frontend build + static Go binary → bin/lich
-task run      # build + run
-task test     # go test ./... + frontend vitest
-task package  # .deb, .rpm, .pkg.tar.zst into bin/ (needs nfpm)
+task dev            # dev mode: Vite HMR + backend; separate DB, port and Chromium profile
+task build          # frontend build + static Go binary → bin/lich
+task build:windows  # cross-compiles bin/lich.exe (experimental)
+task run            # build + run
+task test           # go test ./... + frontend vitest
+task package        # .deb, .rpm, .pkg.tar.zst into bin/ (needs nfpm)
 ```
 
 Frontend in isolation: `cd frontend && pnpm run build` (runs `tsc` + `vite build`).
@@ -67,11 +72,13 @@ Non-negotiable rules. A violation means the work is not done.
 
 ## Release Checklist
 
-Releases are cut by pushing a `vX.Y.Z` tag. The `.github/workflows/release.yml` workflow runs the test suites, builds
-the frontend, then `task package` produces the Linux artifacts (`.deb`, `.rpm`, Arch `.pkg.tar.zst`, plus the raw
-static binary) and publishes a GitHub Release with a `checksums.txt`, taking the release notes from the
-matching `CHANGELOG.md` section. The binary is pure Go — the workflow needs no C toolchain; frontend build comes
-first because the backend `go:embed`s `frontend/dist`.
+Releases are cut by pushing a `vX.Y.Z` tag. The `.github/workflows/release.yml` workflow fans out into two parallel
+jobs — `linux` (frontend tests, backend tests, then `task package`: `.deb`, `.rpm`, Arch `.pkg.tar.zst`, plus the raw
+static binary) and `windows` (`task build:windows`, then the backend suite on a real Windows runner) — and a
+`release` job fans in, checksums every asset into one `checksums.txt` and publishes the GitHub Release, taking the
+notes from the matching `CHANGELOG.md` section. The binary is pure Go — no C toolchain anywhere; each job builds the
+frontend first because the backend `go:embed`s `frontend/dist`. A `workflow_dispatch` run from any branch exercises
+the whole pipeline (artifacts included) without publishing — use it to validate CI changes before a tag.
 
 The package version comes from the git tag: the Taskfile computes `VERSION` via `git describe` (env `VERSION`
 overrides) and injects it into `build/linux/nfpm/nfpm.yaml`.
@@ -116,3 +123,9 @@ Deliberate limits and shortcuts, with the upgrade path when it matters:
   mounts and by Ubuntu 24.04's AppArmor — plus ~200MB and owning Chromium security patches). Install formats are
   `.deb`/`.rpm`/`.pkg.tar.zst` (deps as Recommends; pacman has no Recommends, only optdepends) plus `install.sh`.
   If bundling ever matters, that's option 2 (CEF) of `docs/chromium-shell.md`, not an AppImage.
+- **Windows is experimental.** What holds it up: the backend suite runs on a Windows CI runner every release, and the
+  window/terminal path was smoke-tested by hand. What's missing: no installer or package (a bare unsigned `.exe`, so
+  SmartScreen warns — run it from a terminal, its console carries the logs), no Windows PTY tests
+  (`terminal_test.go` is `!windows`; conpty-backed spawn tests are the gap to close before the tag can narrow), and
+  the shell session is `COMSPEC`/cmd.exe — no PowerShell preference yet. The console subsystem build is deliberate
+  while the port is young: errors stay visible; `-H=windowsgui` is the flip when it stabilizes.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -24,6 +24,12 @@ tasks:
     cmds:
       - cmd: CGO_ENABLED=0 go build {{.GO_BUILD_FLAGS}} -o {{.BIN_DIR}}/{{.APP_NAME}} .
 
+  build:windows:
+    summary: Cross-compiles the Windows binary (experimental — untested runtime)
+    deps: [build:frontend]
+    cmds:
+      - cmd: CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build {{.GO_BUILD_FLAGS}} -o {{.BIN_DIR}}/{{.APP_NAME}}.exe .
+
   run:
     summary: Builds and runs the application
     deps: [build]

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,7 +1,8 @@
 version: '3'
 
 # lich is a pure-Go binary (no CGO) serving its embedded frontend to a system
-# Chromium --app window — see docs/chromium-shell.md. Linux-only.
+# Chromium --app window — see docs/chromium-shell.md. Linux first; an
+# experimental Windows build cross-compiles via build:windows.
 
 vars:
   APP_NAME: "lich"

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/omartelo/lich
 go 1.25.0
 
 require (
+	github.com/UserExistsError/conpty v0.1.4
 	github.com/coder/websocket v1.8.14
 	github.com/creack/pty v1.1.24
 	github.com/ncruces/zenity v0.10.14
+	golang.org/x/sys v0.47.0
 	modernc.org/sqlite v1.53.0
 )
 
@@ -21,7 +23,6 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/stretchr/testify v1.11.1 // indirect
 	golang.org/x/image v0.40.0 // indirect
-	golang.org/x/sys v0.44.0 // indirect
 	modernc.org/libc v1.73.4 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/UserExistsError/conpty v0.1.4 h1:+3FhJhiqhyEJa+K5qaK3/w6w+sN3Nh9O9VbJyBS02to=
+github.com/UserExistsError/conpty v0.1.4/go.mod h1:PDglKIkX3O/2xVk0MV9a6bCWxRmPVfxqZoTG/5sSd9I=
 github.com/akavel/rsrc v0.10.2 h1:Zxm8V5eI1hW4gGaYsJQUhxpjkENuG91ki8B4zCrvEsw=
 github.com/akavel/rsrc v0.10.2/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
@@ -44,8 +46,9 @@ golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
-golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/tools v0.45.0 h1:18qN3FAooORvApf5XjCXgsuayZOEtXf6JK18I3+ONa8=
 golang.org/x/tools v0.45.0/go.mod h1:LuUGqqaXcXMEFEruIVJVm5mgDD8vww/z/SR1gQ4uE/0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/chromium/candidates_unix.go
+++ b/internal/chromium/candidates_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package chromium
+
+// browserCandidates lists candidate binaries in preference order. Any
+// Chromium gives the same compositor; the preference only picks the most
+// conventional install. All bare names — Unix installs live on PATH.
+func browserCandidates() []string {
+	return []string{
+		"chromium",
+		"chromium-browser",
+		"google-chrome-stable",
+		"google-chrome",
+		"brave",
+	}
+}

--- a/internal/chromium/candidates_windows.go
+++ b/internal/chromium/candidates_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package chromium
+
+import "os"
+
+// browserCandidates lists candidate browsers in preference order. Windows
+// installs don't land on PATH, so the list is mostly absolute paths built
+// from the install-root environment variables (windowsBrowserCandidates in
+// chromium.go, where the logic stays testable from any OS).
+func browserCandidates() []string {
+	return windowsBrowserCandidates(os.Getenv)
+}

--- a/internal/chromium/chromium.go
+++ b/internal/chromium/chromium.go
@@ -11,26 +11,42 @@ import (
 	"os/exec"
 )
 
-// Candidate binaries, in preference order. Any Chromium gives the same
-// compositor; the preference only picks the most conventional install.
-var browserCandidates = []string{
-	"chromium",
-	"chromium-browser",
-	"google-chrome-stable",
-	"google-chrome",
-	"brave",
-}
-
-// FindBrowser returns the first Chromium-family binary on PATH. lookPath is
-// injectable for tests (production passes exec.LookPath).
+// FindBrowser returns the first Chromium-family binary that resolves, trying
+// this OS's candidates (candidates_unix.go / candidates_windows.go) in
+// preference order. lookPath is injectable for tests (production passes
+// exec.LookPath, which also accepts the absolute paths the Windows list uses).
 func FindBrowser(lookPath func(name string) (string, error)) (string, error) {
-	for _, name := range browserCandidates {
+	candidates := browserCandidates()
+	for _, name := range candidates {
 		if path, err := lookPath(name); err == nil {
 			return path, nil
 		}
 	}
-	return "", errors.New("no chromium-family browser found on PATH (tried " +
-		fmt.Sprint(browserCandidates) + "); install chromium")
+	return "", errors.New("no chromium-family browser found (tried " +
+		fmt.Sprint(candidates) + "); install chromium, chrome or edge")
+}
+
+// windowsBrowserCandidates builds the Windows candidate list: chrome, then
+// edge (present on every Windows), then brave, each under the install roots
+// Windows exposes as environment variables, with bare PATH names last.
+// Paths are joined with a literal backslash so the pure logic tests the same
+// on any OS. Kept out of the build-tagged file for exactly that reason.
+func windowsBrowserCandidates(getenv func(string) string) []string {
+	roots := []struct{ env, rel string }{
+		{"ProgramFiles", `Google\Chrome\Application\chrome.exe`},
+		{"ProgramFiles(x86)", `Google\Chrome\Application\chrome.exe`},
+		{"LocalAppData", `Google\Chrome\Application\chrome.exe`},
+		{"ProgramFiles(x86)", `Microsoft\Edge\Application\msedge.exe`},
+		{"ProgramFiles", `Microsoft\Edge\Application\msedge.exe`},
+		{"ProgramFiles", `BraveSoftware\Brave-Browser\Application\brave.exe`},
+	}
+	var out []string
+	for _, r := range roots {
+		if root := getenv(r.env); root != "" {
+			out = append(out, root+`\`+r.rel)
+		}
+	}
+	return append(out, "chrome", "msedge")
 }
 
 // Args builds the --app invocation. The dedicated user-data-dir is

--- a/internal/chromium/chromium_test.go
+++ b/internal/chromium/chromium_test.go
@@ -6,10 +6,18 @@ import (
 	"testing"
 )
 
+// TestFindBrowserPicksFirstHit proves missing candidates are skipped and
+// preference order decides among the installed ones — against whichever
+// candidate list this OS compiles in.
 func TestFindBrowserPicksFirstHit(t *testing.T) {
+	candidates := browserCandidates()
+	if len(candidates) < 2 {
+		t.Fatal("candidate list too short to prove ordering")
+	}
+	hits := map[string]bool{candidates[1]: true, candidates[len(candidates)-1]: true}
 	lookPath := func(name string) (string, error) {
-		if name == "google-chrome-stable" || name == "brave" {
-			return "/usr/bin/" + name, nil
+		if hits[name] {
+			return "/resolved/" + name, nil
 		}
 		return "", errors.New("not found")
 	}
@@ -17,8 +25,8 @@ func TestFindBrowserPicksFirstHit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindBrowser: %v", err)
 	}
-	if got != "/usr/bin/google-chrome-stable" {
-		t.Fatalf("want first candidate in preference order, got %q", got)
+	if want := "/resolved/" + candidates[1]; got != want {
+		t.Fatalf("FindBrowser = %q, want the earliest installed candidate %q", got, want)
 	}
 }
 

--- a/internal/chromium/chromium_test.go
+++ b/internal/chromium/chromium_test.go
@@ -29,6 +29,39 @@ func TestFindBrowserErrorsWhenNoneInstalled(t *testing.T) {
 	}
 }
 
+// TestWindowsBrowserCandidates proves the Windows list expands only the
+// install roots present in the environment, prefers chrome > edge > brave,
+// and always ends with the bare PATH names as a last resort.
+func TestWindowsBrowserCandidates(t *testing.T) {
+	env := map[string]string{
+		"ProgramFiles":      `C:\Program Files`,
+		"ProgramFiles(x86)": `C:\Program Files (x86)`,
+	}
+	got := windowsBrowserCandidates(func(k string) string { return env[k] })
+
+	want := []string{
+		`C:\Program Files\Google\Chrome\Application\chrome.exe`,
+		`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`,
+		`C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe`,
+		`C:\Program Files\Microsoft\Edge\Application\msedge.exe`,
+		`C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe`,
+		"chrome",
+		"msedge",
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("candidates = %v, want %v", got, want)
+	}
+}
+
+// TestWindowsBrowserCandidatesEmptyEnv proves a bare environment still leaves
+// the PATH names, so FindBrowser never iterates an empty list.
+func TestWindowsBrowserCandidatesEmptyEnv(t *testing.T) {
+	got := windowsBrowserCandidates(func(string) string { return "" })
+	if !slices.Equal(got, []string{"chrome", "msedge"}) {
+		t.Fatalf("candidates = %v, want PATH names only", got)
+	}
+}
+
 func TestArgs(t *testing.T) {
 	args := Args("http://127.0.0.1:47821/?token=x", "/home/u/.config/lich/chromium-profile", "lichdev", []string{"--ozone-platform=wayland"})
 	for _, want := range []string{

--- a/internal/claudeplugin/claudeplugin_test.go
+++ b/internal/claudeplugin/claudeplugin_test.go
@@ -211,7 +211,9 @@ func TestClaudeConfigDir(t *testing.T) {
 
 	t.Run("falls back to home", func(t *testing.T) {
 		t.Setenv("CLAUDE_CONFIG_DIR", "")
+		// os.UserHomeDir reads HOME on Unix and USERPROFILE on Windows.
 		t.Setenv("HOME", "/home/someone")
+		t.Setenv("USERPROFILE", "/home/someone")
 		if got := claudeConfigDir(); got != filepath.Join("/home/someone", ".claude") {
 			t.Fatalf("claudeConfigDir() = %q, want %q", got, "/home/someone/.claude")
 		}
@@ -220,6 +222,7 @@ func TestClaudeConfigDir(t *testing.T) {
 	t.Run("empty when home is unresolvable", func(t *testing.T) {
 		t.Setenv("CLAUDE_CONFIG_DIR", "")
 		t.Setenv("HOME", "")
+		t.Setenv("USERPROFILE", "")
 		if got := claudeConfigDir(); got != "" {
 			t.Fatalf("claudeConfigDir() = %q, want %q", got, "")
 		}

--- a/internal/project/worktree.go
+++ b/internal/project/worktree.go
@@ -101,7 +101,12 @@ func parseWorktreeBlock(block string) (Worktree, bool) {
 	for line := range strings.SplitSeq(block, "\n") {
 		switch {
 		case strings.HasPrefix(line, "worktree "):
-			wt.Path = strings.TrimPrefix(line, "worktree ")
+			// git prints forward slashes even on Windows; Clean folds the
+			// path into the platform's native form so it compares equal to
+			// the paths CreateWorktree builds with filepath.Join.
+			if p := strings.TrimPrefix(line, "worktree "); p != "" {
+				wt.Path = filepath.Clean(p)
+			}
 		case strings.HasPrefix(line, "branch refs/heads/"):
 			wt.Name = strings.TrimPrefix(line, "branch refs/heads/")
 		case line == "bare" || line == "detached":

--- a/internal/project/worktree_test.go
+++ b/internal/project/worktree_test.go
@@ -31,6 +31,10 @@ func initRepo(t *testing.T) (string, func(args ...string) string) {
 		}
 		return strings.TrimSpace(string(out))
 	}
+	// Byte-exact file content is part of the assertions (DiscardFile restores
+	// HEAD bytes); pin autocrlf so neither Git for Windows' default nor the
+	// machine's global config rewrites line endings on checkout.
+	git("config", "core.autocrlf", "false")
 	if err := os.WriteFile(filepath.Join(repo, "a.txt"), []byte("one\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
@@ -81,13 +85,29 @@ func TestListBranches(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListBranches after create: %v", err)
 	}
-	if len(got.Worktrees) != 1 || got.Worktrees[0] != (Worktree{Name: "resume-me", Path: wt.Path}) {
+	if len(got.Worktrees) != 1 {
+		t.Fatalf("Worktrees = %v, want one entry", got.Worktrees)
+	}
+	if got.Worktrees[0].Name != "resume-me" ||
+		canonPath(t, got.Worktrees[0].Path) != canonPath(t, wt.Path) {
 		t.Errorf("Worktrees = %v, want [{resume-me %s}]", got.Worktrees, wt.Path)
 	}
 
 	if _, err := svc.ListBranches(t.TempDir()); err == nil {
 		t.Error("ListBranches(non-repo) = nil error, want error")
 	}
+}
+
+// canonPath resolves platform aliasing — Windows 8.3 short names (the CI
+// runner's TEMP), symlinked temp dirs — so a path reported by git and one
+// built by Go compare equal when they name the same directory.
+func canonPath(t *testing.T, p string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return filepath.Clean(p)
+	}
+	return resolved
 }
 
 // TestParseWorktrees proves the porcelain parser skips the main worktree and
@@ -103,14 +123,15 @@ func TestParseWorktrees(t *testing.T) {
 			"main plus linked",
 			"worktree /repo\nHEAD abc\nbranch refs/heads/main\n\n" +
 				"worktree /wt/feat\nHEAD def\nbranch refs/heads/feat\n",
-			[]Worktree{{Name: "feat", Path: "/wt/feat"}},
+			// The parser folds paths into the platform's native form.
+			[]Worktree{{Name: "feat", Path: filepath.FromSlash("/wt/feat")}},
 		},
 		{
 			"detached and bare skipped",
 			"worktree /repo\nbare\n\n" +
 				"worktree /wt/pin\nHEAD abc\ndetached\n\n" +
 				"worktree /wt/ok\nHEAD def\nbranch refs/heads/ok\n",
-			[]Worktree{{Name: "ok", Path: "/wt/ok"}},
+			[]Worktree{{Name: "ok", Path: filepath.FromSlash("/wt/ok")}},
 		},
 		{"empty", "", []Worktree{}},
 	}

--- a/internal/terminal/pty.go
+++ b/internal/terminal/pty.go
@@ -1,0 +1,14 @@
+package terminal
+
+// ptyHandle is a running session's PTY end, the seam between the service and
+// the platform PTY API: Read streams the child's output, Write delivers
+// input, Resize changes the window size and Close hangs up. Each OS provides
+// startPTY plus an implementation of this interface (build tags select the
+// file, the Go idiom for OS-specific code) — terminal.go never touches a
+// platform PTY API directly.
+type ptyHandle interface {
+	Read(p []byte) (int, error)
+	Write(p []byte) (int, error)
+	Resize(cols, rows int) error
+	Close() error
+}

--- a/internal/terminal/pty.go
+++ b/internal/terminal/pty.go
@@ -1,14 +1,28 @@
 package terminal
 
+// ptySpec describes the child process a session's PTY runs. It carries
+// everything the platform needs to spawn: ConPTY has no exec.Cmd (CreateProcess
+// wants one command-line string plus explicit dir/env — see go#62708), so the
+// seam speaks in these primitives and each OS builds its own process from them.
+type ptySpec struct {
+	bin        string
+	args       []string
+	dir        string
+	env        []string
+	cols, rows int
+}
+
 // ptyHandle is a running session's PTY end, the seam between the service and
 // the platform PTY API: Read streams the child's output, Write delivers
-// input, Resize changes the window size and Close hangs up. Each OS provides
-// startPTY plus an implementation of this interface (build tags select the
-// file, the Go idiom for OS-specific code) — terminal.go never touches a
-// platform PTY API directly.
+// input, Resize changes the window size, Wait reaps the exited child and
+// Close hangs up and terminates it. Each OS provides startPTY(spec) plus an
+// implementation of this interface (build tags select the file, the Go idiom
+// for OS-specific code) — terminal.go never touches a platform PTY API
+// directly.
 type ptyHandle interface {
 	Read(p []byte) (int, error)
 	Write(p []byte) (int, error)
 	Resize(cols, rows int) error
+	Wait() error
 	Close() error
 }

--- a/internal/terminal/pty_unix.go
+++ b/internal/terminal/pty_unix.go
@@ -9,23 +9,38 @@ import (
 	"github.com/creack/pty"
 )
 
-// startPTY starts cmd attached to a fresh PTY sized cols x rows.
-func startPTY(cmd *exec.Cmd, cols, rows int) (ptyHandle, error) {
-	ptmx, err := pty.StartWithSize(cmd, winsize(cols, rows))
+// startPTY starts spec's child attached to a fresh PTY sized cols x rows.
+func startPTY(spec ptySpec) (ptyHandle, error) {
+	cmd := exec.Command(spec.bin, spec.args...)
+	cmd.Dir = spec.dir
+	cmd.Env = spec.env
+	ptmx, err := pty.StartWithSize(cmd, winsize(spec.cols, spec.rows))
 	if err != nil {
 		return nil, err
 	}
-	return &unixPTY{ptmx}, nil
+	return &unixPTY{File: ptmx, cmd: cmd}, nil
 }
 
-// unixPTY adds Resize to the PTY master file creack/pty returns, which
-// already carries Read/Write/Close.
+// unixPTY pairs the PTY master file creack/pty returns (which carries
+// Read/Write) with the child it drives: Wait reaps it after the master hits
+// EOF, and Close also kills it so hanging up ends the session.
 type unixPTY struct {
 	*os.File
+	cmd *exec.Cmd
 }
 
 func (p *unixPTY) Resize(cols, rows int) error {
 	return pty.Setsize(p.File, winsize(cols, rows))
+}
+
+func (p *unixPTY) Wait() error { return p.cmd.Wait() }
+
+func (p *unixPTY) Close() error {
+	err := p.File.Close()
+	if p.cmd.Process != nil {
+		_ = p.cmd.Process.Kill()
+	}
+	return err
 }
 
 func winsize(cols, rows int) *pty.Winsize {

--- a/internal/terminal/pty_unix.go
+++ b/internal/terminal/pty_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows
+
+package terminal
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/creack/pty"
+)
+
+// startPTY starts cmd attached to a fresh PTY sized cols x rows.
+func startPTY(cmd *exec.Cmd, cols, rows int) (ptyHandle, error) {
+	ptmx, err := pty.StartWithSize(cmd, winsize(cols, rows))
+	if err != nil {
+		return nil, err
+	}
+	return &unixPTY{ptmx}, nil
+}
+
+// unixPTY adds Resize to the PTY master file creack/pty returns, which
+// already carries Read/Write/Close.
+type unixPTY struct {
+	*os.File
+}
+
+func (p *unixPTY) Resize(cols, rows int) error {
+	return pty.Setsize(p.File, winsize(cols, rows))
+}
+
+func winsize(cols, rows int) *pty.Winsize {
+	return &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)}
+}

--- a/internal/terminal/pty_windows.go
+++ b/internal/terminal/pty_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package terminal
+
+import (
+	"errors"
+	"os/exec"
+)
+
+// startPTY is the Windows side of the PTY seam. ConPTY is the platform
+// primitive it must wrap; until that lands, the package compiles on Windows
+// and every session start fails with this error instead.
+func startPTY(_ *exec.Cmd, _, _ int) (ptyHandle, error) {
+	return nil, errors.New("terminal sessions need ConPTY support, not implemented yet")
+}

--- a/internal/terminal/pty_windows.go
+++ b/internal/terminal/pty_windows.go
@@ -3,13 +3,59 @@
 package terminal
 
 import (
-	"errors"
+	"context"
+	"fmt"
 	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/UserExistsError/conpty"
+	"golang.org/x/sys/windows"
 )
 
-// startPTY is the Windows side of the PTY seam. ConPTY is the platform
-// primitive it must wrap; until that lands, the package compiles on Windows
-// and every session start fails with this error instead.
-func startPTY(_ *exec.Cmd, _, _ int) (ptyHandle, error) {
-	return nil, errors.New("terminal sessions need ConPTY support, not implemented yet")
+// startPTY starts spec's child attached to a fresh ConPTY sized cols x rows.
+func startPTY(spec ptySpec) (ptyHandle, error) {
+	line, err := commandLine(spec.bin, spec.args)
+	if err != nil {
+		return nil, err
+	}
+	cpty, err := conpty.Start(
+		line,
+		conpty.ConPtyDimensions(spec.cols, spec.rows),
+		conpty.ConPtyWorkDir(spec.dir),
+		conpty.ConPtyEnv(spec.env),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &windowsPTY{cpty}, nil
+}
+
+// commandLine turns bin+args into the single quoted command line
+// CreateProcess expects. The binary goes through exec.LookPath because
+// CreateProcess resolves neither PATHEXT nor script wrappers — and npm ships
+// Claude Code as claude.cmd, which only cmd.exe can run.
+func commandLine(bin string, args []string) (string, error) {
+	path, err := exec.LookPath(bin)
+	if err != nil {
+		return "", fmt.Errorf("resolve %q: %w", bin, err)
+	}
+	argv := append([]string{path}, args...)
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".cmd", ".bat":
+		argv = append([]string{"cmd.exe", "/c"}, argv...)
+	}
+	return windows.ComposeCommandLine(argv), nil
+}
+
+// windowsPTY adapts a ConPTY to the seam. The embedded type already carries
+// Read, Write, Close (which terminates the child) and a same-shape Resize;
+// only Wait needs its context-and-exit-code signature narrowed.
+type windowsPTY struct {
+	*conpty.ConPty
+}
+
+func (p *windowsPTY) Wait() error {
+	_, err := p.ConPty.Wait(context.Background())
+	return err
 }

--- a/internal/terminal/shell_unix.go
+++ b/internal/terminal/shell_unix.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package terminal
+
+import "os"
+
+// defaultShell is spawned for "shell" sessions when the environment names none.
+const defaultShell = "/bin/sh"
+
+// userShell reads the user's shell from the environment, "" when unset.
+func userShell() string { return os.Getenv("SHELL") }

--- a/internal/terminal/shell_windows.go
+++ b/internal/terminal/shell_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+package terminal
+
+import "os"
+
+// defaultShell is spawned for "shell" sessions when the environment names none.
+const defaultShell = "cmd.exe"
+
+// userShell reads the user's shell from the environment, "" when unset.
+// Windows has no $SHELL; COMSPEC is the closest equivalent.
+func userShell() string { return os.Getenv("COMSPEC") }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/exec"
 	"strconv"
 	"strings"
 	"sync"
@@ -67,7 +66,6 @@ type touchedEvent struct {
 // session is a single running PTY-backed shell.
 type session struct {
 	pty ptyHandle
-	cmd *exec.Cmd
 	out *coalescer
 }
 
@@ -175,9 +173,6 @@ func (s *Service) sessionEnv(id string) []string {
 // defaultBin is the Claude Code binary spawned when the user has not configured
 // a custom path.
 const defaultBin = "claude"
-
-// defaultShell is spawned for "shell" sessions when $SHELL is unset.
-const defaultShell = "/bin/sh"
 
 // KindShell marks a session that runs the user's shell instead of Claude Code.
 const KindShell = "shell"
@@ -329,14 +324,14 @@ func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int)
 		cwd = home
 	}
 
-	cmd := exec.Command(
-		resolveCommand(kind, s.store.ClaudeBin(projectID), os.Getenv("SHELL")),
-		resumeArgs(kind, resume)...,
-	)
-	cmd.Dir = cwd
-	cmd.Env = s.sessionEnv(id)
-
-	p, err := startPTY(cmd, cols, rows)
+	p, err := startPTY(ptySpec{
+		bin:  resolveCommand(kind, s.store.ClaudeBin(projectID), userShell()),
+		args: resumeArgs(kind, resume),
+		dir:  cwd,
+		env:  s.sessionEnv(id),
+		cols: cols,
+		rows: rows,
+	})
 	if err != nil {
 		return fmt.Errorf("failed to start pty for %q: %w", id, err)
 	}
@@ -348,8 +343,8 @@ func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int)
 		encoded := base64.StdEncoding.EncodeToString(data)
 		s.hub.Emit(dataEventPrefix+id, encoded)
 	}, visibleFlushInterval, hiddenFlushInterval)
-	s.sessions[id] = &session{pty: p, cmd: cmd, out: out}
-	go s.stream(id, p, cmd, out)
+	s.sessions[id] = &session{pty: p, out: out}
+	go s.stream(id, p, out)
 	return nil
 }
 
@@ -357,7 +352,7 @@ func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int)
 // the process, drops the session and emits its exit event. Output goes through
 // the session's coalescer, which batches it on a short cadence while the
 // terminal is visible and a long one while it is hidden.
-func (s *Service) stream(id string, p ptyHandle, cmd *exec.Cmd, out *coalescer) {
+func (s *Service) stream(id string, p ptyHandle, out *coalescer) {
 	buf := make([]byte, readBufSize)
 	for {
 		n, err := p.Read(buf)
@@ -368,7 +363,7 @@ func (s *Service) stream(id string, p ptyHandle, cmd *exec.Cmd, out *coalescer) 
 			break
 		}
 	}
-	_ = cmd.Wait()
+	_ = p.Wait()
 	// Flush any batched output before the exit event so the frontend always
 	// sees the final bytes ahead of the exit banner.
 	out.Close()
@@ -436,11 +431,7 @@ func (s *Service) Close(id string) error {
 	if !ok {
 		return nil
 	}
-	err := sess.pty.Close()
-	if sess.cmd.Process != nil {
-		_ = sess.cmd.Process.Kill()
-	}
-	return err
+	return sess.pty.Close()
 }
 
 // ptyOf returns the PTY for a session, or nil if it is not running.

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -15,8 +15,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/creack/pty"
-
 	"github.com/omartelo/lich/internal/events"
 )
 
@@ -68,9 +66,9 @@ type touchedEvent struct {
 
 // session is a single running PTY-backed shell.
 type session struct {
-	ptmx *os.File
-	cmd  *exec.Cmd
-	out  *coalescer
+	pty ptyHandle
+	cmd *exec.Cmd
+	out *coalescer
 }
 
 // Store is the persistence the terminal service depends on: the Claude Code
@@ -338,7 +336,7 @@ func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int)
 	cmd.Dir = cwd
 	cmd.Env = s.sessionEnv(id)
 
-	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)})
+	p, err := startPTY(cmd, cols, rows)
 	if err != nil {
 		return fmt.Errorf("failed to start pty for %q: %w", id, err)
 	}
@@ -350,8 +348,8 @@ func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int)
 		encoded := base64.StdEncoding.EncodeToString(data)
 		s.hub.Emit(dataEventPrefix+id, encoded)
 	}, visibleFlushInterval, hiddenFlushInterval)
-	s.sessions[id] = &session{ptmx: ptmx, cmd: cmd, out: out}
-	go s.stream(id, ptmx, cmd, out)
+	s.sessions[id] = &session{pty: p, cmd: cmd, out: out}
+	go s.stream(id, p, cmd, out)
 	return nil
 }
 
@@ -359,10 +357,10 @@ func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int)
 // the process, drops the session and emits its exit event. Output goes through
 // the session's coalescer, which batches it on a short cadence while the
 // terminal is visible and a long one while it is hidden.
-func (s *Service) stream(id string, ptmx *os.File, cmd *exec.Cmd, out *coalescer) {
+func (s *Service) stream(id string, p ptyHandle, cmd *exec.Cmd, out *coalescer) {
 	buf := make([]byte, readBufSize)
 	for {
-		n, err := ptmx.Read(buf)
+		n, err := p.Read(buf)
 		if n > 0 {
 			out.Write(buf[:n])
 		}
@@ -376,7 +374,7 @@ func (s *Service) stream(id string, ptmx *os.File, cmd *exec.Cmd, out *coalescer
 	out.Close()
 
 	s.mu.Lock()
-	if current, ok := s.sessions[id]; ok && current.ptmx == ptmx {
+	if current, ok := s.sessions[id]; ok && current.pty == p {
 		delete(s.sessions, id)
 	}
 	s.mu.Unlock()
@@ -393,11 +391,11 @@ func (s *Service) Write(id, data string) error {
 // no-op. It is the shared sink for the RPC Write and the WebSocket
 // transport's input frames.
 func (s *Service) writeBytes(id string, data []byte) error {
-	ptmx := s.ptmxOf(id)
-	if ptmx == nil {
+	p := s.ptyOf(id)
+	if p == nil {
 		return nil
 	}
-	_, err := ptmx.Write(data)
+	_, err := p.Write(data)
 	return err
 }
 
@@ -419,11 +417,11 @@ func (s *Service) SetVisible(id string, visible bool) error {
 // the visible terminal; a hidden terminal is resized on the next time it is
 // shown.
 func (s *Service) Resize(id string, cols, rows int) error {
-	ptmx := s.ptmxOf(id)
-	if ptmx == nil {
+	p := s.ptyOf(id)
+	if p == nil {
 		return nil
 	}
-	return pty.Setsize(ptmx, &pty.Winsize{Rows: uint16(rows), Cols: uint16(cols)})
+	return p.Resize(cols, rows)
 }
 
 // Close terminates a session's shell, if any.
@@ -438,19 +436,19 @@ func (s *Service) Close(id string) error {
 	if !ok {
 		return nil
 	}
-	err := sess.ptmx.Close()
+	err := sess.pty.Close()
 	if sess.cmd.Process != nil {
 		_ = sess.cmd.Process.Kill()
 	}
 	return err
 }
 
-// ptmxOf returns the PTY for a session, or nil if it is not running.
-func (s *Service) ptmxOf(id string) *os.File {
+// ptyOf returns the PTY for a session, or nil if it is not running.
+func (s *Service) ptyOf(id string) ptyHandle {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if sess, ok := s.sessions[id]; ok {
-		return sess.ptmx
+		return sess.pty
 	}
 	return nil
 }

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/creack/pty"
-
 	"github.com/omartelo/lich/internal/events"
 )
 
@@ -187,17 +185,17 @@ func TestSetVisibleReachesCoalescer(t *testing.T) {
 func spawnSession(t *testing.T) *session {
 	t.Helper()
 	cmd := exec.Command("/bin/cat")
-	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: 24, Cols: 80})
+	p, err := startPTY(cmd, 80, 24)
 	if err != nil {
-		t.Fatalf("pty.StartWithSize: %v", err)
+		t.Fatalf("startPTY: %v", err)
 	}
 	t.Cleanup(func() {
-		_ = ptmx.Close()
+		_ = p.Close()
 		if cmd.Process != nil {
 			_ = cmd.Process.Kill()
 		}
 	})
-	return &session{ptmx: ptmx, cmd: cmd}
+	return &session{pty: p, cmd: cmd}
 }
 
 // TestWriteResizeCloseOnLiveSession drives a real session end to end: input is
@@ -215,7 +213,7 @@ func TestWriteResizeCloseOnLiveSession(t *testing.T) {
 	if err := svc.Close("s1"); err != nil {
 		t.Errorf("Close = %v, want nil", err)
 	}
-	if svc.ptmxOf("s1") != nil {
+	if svc.ptyOf("s1") != nil {
 		t.Error("session still present after Close")
 	}
 }
@@ -340,21 +338,22 @@ func TestResumeArgs(t *testing.T) {
 	}
 }
 
-// TestPTYEcho proves the core assumption of the service: a process spawns under
-// a PTY and its output is readable. If creack/pty breaks, this fails.
+// TestPTYEcho proves the core assumption of the service: a process spawns
+// under a PTY and its output is readable. If this platform's startPTY breaks,
+// this fails.
 func TestPTYEcho(t *testing.T) {
 	const marker = "lich-pty-test"
 
 	cmd := exec.Command("/bin/sh", "-c", "echo "+marker)
-	ptmx, err := pty.StartWithSize(cmd, &pty.Winsize{Rows: 24, Cols: 80})
+	p, err := startPTY(cmd, 80, 24)
 	if err != nil {
-		t.Fatalf("pty.StartWithSize: %v", err)
+		t.Fatalf("startPTY: %v", err)
 	}
-	t.Cleanup(func() { _ = ptmx.Close() })
+	t.Cleanup(func() { _ = p.Close() })
 
 	done := make(chan string, 1)
 	go func() {
-		out, _ := io.ReadAll(ptmx)
+		out, _ := io.ReadAll(p)
 		done <- string(out)
 	}()
 

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -1,9 +1,14 @@
+// The suite spawns /bin/cat and /bin/sh under real PTYs, so it is Unix-only;
+// the pure helpers it also covers (resumeArgs, childEnv, resolveCommand) are
+// platform-independent logic exercised here all the same. A Windows CI run
+// needs its own conpty-backed spawn tests before this tag can narrow.
+//go:build !windows
+
 package terminal
 
 import (
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -184,18 +189,12 @@ func TestSetVisibleReachesCoalescer(t *testing.T) {
 // going through Start, so no stream() goroutine emits events.
 func spawnSession(t *testing.T) *session {
 	t.Helper()
-	cmd := exec.Command("/bin/cat")
-	p, err := startPTY(cmd, 80, 24)
+	p, err := startPTY(ptySpec{bin: "/bin/cat", cols: 80, rows: 24})
 	if err != nil {
 		t.Fatalf("startPTY: %v", err)
 	}
-	t.Cleanup(func() {
-		_ = p.Close()
-		if cmd.Process != nil {
-			_ = cmd.Process.Kill()
-		}
-	})
-	return &session{pty: p, cmd: cmd}
+	t.Cleanup(func() { _ = p.Close() })
+	return &session{pty: p}
 }
 
 // TestWriteResizeCloseOnLiveSession drives a real session end to end: input is
@@ -245,6 +244,18 @@ func stayAliveBin(t *testing.T) string {
 	return path
 }
 
+// spawnedArgs returns the argv of a session's spawned process. It reaches
+// through the seam to the Unix implementation — these tests only run where a
+// real PTY exists, and argv is not part of the ptyHandle contract.
+func spawnedArgs(t *testing.T, svc *Service, id string) []string {
+	t.Helper()
+	p, ok := svc.sessions[id].pty.(*unixPTY)
+	if !ok {
+		t.Fatalf("session %q pty is %T, want *unixPTY", id, svc.sessions[id].pty)
+	}
+	return p.cmd.Args
+}
+
 // TestStartPassesResumeToTheProcess proves the resume id reaches the spawned
 // binary's argv — the wiring resumeArgs' unit test cannot see.
 func TestStartPassesResumeToTheProcess(t *testing.T) {
@@ -257,7 +268,7 @@ func TestStartPassesResumeToTheProcess(t *testing.T) {
 	}
 
 	svc.mu.Lock()
-	got := svc.sessions["s1"].cmd.Args
+	got := spawnedArgs(t, svc, "s1")
 	svc.mu.Unlock()
 
 	want := []string{bin, resumeFlag, "abc-123"}
@@ -278,7 +289,7 @@ func TestStartWithoutResumeSpawnsBare(t *testing.T) {
 	}
 
 	svc.mu.Lock()
-	got := svc.sessions["s1"].cmd.Args
+	got := spawnedArgs(t, svc, "s1")
 	svc.mu.Unlock()
 
 	if !slices.Equal(got, []string{bin}) {
@@ -344,8 +355,12 @@ func TestResumeArgs(t *testing.T) {
 func TestPTYEcho(t *testing.T) {
 	const marker = "lich-pty-test"
 
-	cmd := exec.Command("/bin/sh", "-c", "echo "+marker)
-	p, err := startPTY(cmd, 80, 24)
+	p, err := startPTY(ptySpec{
+		bin:  "/bin/sh",
+		args: []string{"-c", "echo " + marker},
+		cols: 80,
+		rows: 24,
+	})
 	if err != nil {
 		t.Fatalf("startPTY: %v", err)
 	}


### PR DESCRIPTION
## Summary

Ports lich to Windows (experimental): the terminal runs under ConPTY, the window opens in Chrome/Edge/Brave found via their conventional install paths, and every release now ships a `windows-amd64.exe` built — and backend-tested — on a Windows runner in parallel with the Linux packages.

The port follows the Go idiom for OS-specific code end to end: build-tag-selected files behind small seams, zero `runtime.GOOS` checks in common code.

### How it's built

- **PTY seam** (`internal/terminal/pty.go`): `terminal.go` drives sessions through `startPTY(ptySpec)` + a `ptyHandle` interface (Read/Write/Resize/Wait/Close) and never touches a platform PTY API. The seam speaks in primitives (bin/args/dir/env/size) because ConPTY has no `exec.Cmd` — CreateProcess needs one command-line string and an attribute list `os/exec` cannot set (go#62708).
- **Unix side** keeps creack/pty exactly as before; `unixPTY` pairs the master file with the child it drives.
- **Windows side** wraps `UserExistsError/conpty` (dimensions, workdir, env — the `LICH_*` hook coordinates pass through). The binary resolves via `exec.LookPath` (PATHEXT), and `.cmd`/`.bat` shims — npm ships Claude Code as `claude.cmd` — run through `cmd.exe /c`.
- **Browser discovery per OS** (`internal/chromium/candidates_*.go`): Unix keeps bare PATH names; Windows expands chrome > edge > brave under the ProgramFiles/LocalAppData roots (installs never land on PATH), bare names last. Edge being on every Windows guarantees a window. The list logic stays in the untagged file, testable from any OS.
- **Shell sessions**: `COMSPEC`/`cmd.exe` replaces `$SHELL`/`/bin/sh` behind the same per-OS file pattern.
- **Worktree paths** are folded into the platform's native form by the porcelain parser — git prints forward slashes even on Windows, which would never compare equal to the paths `CreateWorktree` builds with `filepath.Join`.

### CI

The release pipeline fans out into parallel `linux` (frontend tests, backend tests, nfpm packages) and `windows` (`task build:windows`, backend suite on windows-latest) jobs; a `release` job fans in, checksums every asset into one file and publishes. `workflow_dispatch` from any branch exercises the whole pipeline without publishing — and its first run caught four Unix assumptions in the suite, fixed in `36d3125` (autocrlf, USERPROFILE, hardcoded candidate names, 8.3 short paths).

### Known ceilings (documented in CLAUDE.md)

Bare unsigned `.exe` (SmartScreen warns; no installer), no Windows PTY tests yet (`terminal_test.go` stays `!windows` until conpty-backed spawn tests exist), cmd.exe only (no PowerShell preference), console subsystem on purpose while the port is young.

## Test plan

- [x] `go test -race ./...` — 204 passed (Linux)
- [x] `go test ./...` on windows-latest — green (first real Windows run of the suite)
- [x] `-count=20` on `internal/terminal` after the seam change — 1640 passed, no flake
- [x] `GOOS=windows go build ./...` + `go vet` clean
- [x] Manual smoke on a real Windows machine: window opens, listener up, sessions spawn
- [x] Full pipeline validated via `workflow_dispatch` (both jobs green, artifacts produced, release correctly skipped)
- [x] Post-merge: next `vX.Y.Z` tag publishes the first release with a Windows asset
