### PR TITLE
feat: persistent structured logging (slog) + auditable error funnels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- lich keeps a persistent log: `<config-dir>/lich/lich.log` (`lich-dev.log`
+  under `task dev`), structured records with source file:line, rotated at 5MB
+  with one previous generation kept. `LICH_LOG_LEVEL` (`debug`/`warn`/`error`)
+  tunes verbosity. Every RPC failure is recorded with its method name, and the
+  session token never reaches the log. This is the audit trail the future
+  console-less Windows build will rely on.
 - Experimental Windows build (`lich.exe`, `task build:windows`). Terminal
   sessions run under ConPTY, the window opens in Chrome or Edge (found via
   their conventional install paths), shell cards fall back to `COMSPEC`, and

--- a/internal/claudeplugin/claudeplugin.go
+++ b/internal/claudeplugin/claudeplugin.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/exec"
@@ -96,7 +97,9 @@ func computeStatus(installed bool, installedVer, latestVer string) Status {
 func (s *Service) Install() error {
 	// A repeat marketplace add errors ("already exists"); that is harmless —
 	// the install below is what matters, so only its error is surfaced.
-	_ = s.runClaude("plugin", "marketplace", "add", marketplaceRepo)
+	if err := s.runClaude("plugin", "marketplace", "add", marketplaceRepo); err != nil {
+		slog.Debug("claudeplugin: marketplace add", "err", err)
+	}
 	return s.runClaude("plugin", "install", pluginKey)
 }
 

--- a/internal/events/hub.go
+++ b/internal/events/hub.go
@@ -9,7 +9,7 @@ package events
 import (
 	"context"
 	"encoding/json"
-	"log"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -46,7 +46,7 @@ func (h *Hub) Emit(name string, data any) {
 	}
 	payload, err := json.Marshal(Envelope{Name: name, Data: data})
 	if err != nil {
-		log.Printf("events: marshal %s: %v", name, err)
+		slog.Warn("events: marshal", "event", name, "err", err)
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), writeTimeout)
@@ -83,7 +83,7 @@ func (h *Hub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		OriginPatterns: []string{"*"},
 	})
 	if err != nil {
-		log.Printf("events: accept: %v", err)
+		slog.Warn("events: accept", "err", err)
 		return
 	}
 	h.attach(conn)

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,86 @@
+// Package logging configures the process-wide slog logger: structured text
+// with source file:line on every record, mirrored to stderr and a persistent
+// file under the lich config dir. The file is the audit trail — it is what
+// remains on Windows once the GUI-subsystem build drops the console, and what
+// a bug report quotes. The session token is never logged: the file outlives
+// the session that would have made it useful.
+package logging
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// maxLogSize is the size at which the log is rotated on startup. One previous
+// generation is kept (*.old); lich emits little, so two generations outlive
+// any debugging session.
+const maxLogSize = 5 << 20
+
+// Init points slog's default logger at stderr plus <dir>/lich.log
+// (lich-dev.log under LICH_DEV, mirroring the store's database split), with
+// the level taken from LICH_LOG_LEVEL (debug|warn|error; default info). The
+// returned closer owns the file. When the file cannot be opened, logging
+// still works on stderr alone: the closer is nil and the error says why the
+// persistent half is missing — the caller reports it and carries on.
+func Init(dir string) (io.Closer, error) {
+	file, err := openLogFile(dir)
+	out := io.Writer(os.Stderr)
+	var closer io.Closer
+	if err == nil {
+		out = io.MultiWriter(os.Stderr, file)
+		closer = file
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(out, &slog.HandlerOptions{
+		AddSource: true,
+		Level:     parseLevel(os.Getenv("LICH_LOG_LEVEL")),
+	})))
+	return closer, err
+}
+
+// openLogFile opens the append-mode log file, first rotating the previous
+// generation out of the way once it outgrew maxLogSize.
+func openLogFile(dir string) (*os.File, error) {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return nil, fmt.Errorf("create log dir: %w", err)
+	}
+	path := filepath.Join(dir, fileName(os.Getenv("LICH_DEV") != ""))
+	if info, err := os.Stat(path); err == nil && info.Size() >= maxLogSize {
+		if err := os.Rename(path, path+".old"); err != nil {
+			return nil, fmt.Errorf("rotate log: %w", err)
+		}
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open log file: %w", err)
+	}
+	return file, nil
+}
+
+// fileName mirrors the store's database split: a `task dev` session logs
+// beside the dev DB and never pollutes the daily driver's audit trail.
+func fileName(dev bool) string {
+	if dev {
+		return "lich-dev.log"
+	}
+	return "lich.log"
+}
+
+// parseLevel maps LICH_LOG_LEVEL onto slog levels. Unknown or empty values
+// fall back to Info: an audit log that silently went quiet would be worse
+// than a slightly noisy one.
+func parseLevel(s string) slog.Level {
+	switch strings.ToLower(s) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,130 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// restoreDefault snapshots slog's process-global default logger, which Init
+// replaces, so tests leave the world as they found it.
+func restoreDefault(t *testing.T) {
+	t.Helper()
+	prev := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(prev) })
+}
+
+// TestParseLevel proves the LICH_LOG_LEVEL values map onto slog levels and
+// that anything unrecognized falls back to Info.
+func TestParseLevel(t *testing.T) {
+	cases := []struct {
+		in   string
+		want slog.Level
+	}{
+		{"debug", slog.LevelDebug},
+		{"WARN", slog.LevelWarn},
+		{"Error", slog.LevelError},
+		{"info", slog.LevelInfo},
+		{"", slog.LevelInfo},
+		{"verbose", slog.LevelInfo},
+	}
+	for _, tc := range cases {
+		if got := parseLevel(tc.in); got != tc.want {
+			t.Errorf("parseLevel(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestFileName proves the dev split mirrors the store's database naming.
+func TestFileName(t *testing.T) {
+	if got := fileName(false); got != "lich.log" {
+		t.Errorf("fileName(false) = %q", got)
+	}
+	if got := fileName(true); got != "lich-dev.log" {
+		t.Errorf("fileName(true) = %q", got)
+	}
+}
+
+// TestInitWritesRecordWithSource proves a record lands in the file carrying
+// the message, the attributes and the source file:line the audit trail
+// promises.
+func TestInitWritesRecordWithSource(t *testing.T) {
+	restoreDefault(t)
+	t.Setenv("LICH_DEV", "")
+	t.Setenv("LICH_LOG_LEVEL", "")
+	dir := t.TempDir()
+
+	closer, err := Init(dir)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	defer closer.Close()
+
+	slog.Info("probe message", "key", "value")
+
+	content, err := os.ReadFile(filepath.Join(dir, "lich.log"))
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	for _, want := range []string{"probe message", "key=value", "logging_test.go"} {
+		if !strings.Contains(string(content), want) {
+			t.Errorf("log file missing %q:\n%s", want, content)
+		}
+	}
+}
+
+// TestInitRotatesOversizedLog proves an outgrown log is renamed to .old and a
+// fresh file starts, keeping exactly one previous generation.
+func TestInitRotatesOversizedLog(t *testing.T) {
+	restoreDefault(t)
+	t.Setenv("LICH_DEV", "")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lich.log")
+	if err := os.WriteFile(path, []byte("old generation\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Truncate grows the file sparsely — no need to write 5MB.
+	if err := os.Truncate(path, maxLogSize); err != nil {
+		t.Fatal(err)
+	}
+
+	closer, err := Init(dir)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	defer closer.Close()
+
+	old, err := os.ReadFile(path + ".old")
+	if err != nil {
+		t.Fatalf("previous generation not kept: %v", err)
+	}
+	if !strings.HasPrefix(string(old), "old generation") {
+		t.Errorf(".old does not carry the previous content")
+	}
+	if info, err := os.Stat(path); err != nil || info.Size() >= maxLogSize {
+		t.Errorf("fresh log not started: size=%v err=%v", info, err)
+	}
+}
+
+// TestInitSurvivesUnwritableDir proves logging still works on stderr when the
+// file half cannot exist: an error comes back, the closer is nil, and the
+// default logger is usable.
+func TestInitSurvivesUnwritableDir(t *testing.T) {
+	restoreDefault(t)
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocked")
+	if err := os.WriteFile(blocker, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	closer, err := Init(filepath.Join(blocker, "sub"))
+	if err == nil {
+		t.Fatal("Init under a file path: want error")
+	}
+	if closer != nil {
+		t.Fatal("closer should be nil when the file half failed")
+	}
+	slog.Info("must not panic")
+}

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"reflect"
 	"strings"
@@ -68,22 +69,25 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	name := strings.TrimPrefix(r.URL.Path, "/rpc/")
 	method, err := h.lookup(name)
 	if err != nil {
+		slog.Warn("rpc: unknown method", "method", name, "err", err)
 		writeError(w, http.StatusNotFound, err.Error())
 		return
 	}
 
 	body, err := io.ReadAll(io.LimitReader(r.Body, bodyLimit))
 	if err != nil {
+		slog.Warn("rpc: unreadable body", "method", name, "err", err)
 		writeError(w, http.StatusBadRequest, "unreadable body")
 		return
 	}
 	args, err := decodeArgs(method.Type(), body)
 	if err != nil {
+		slog.Warn("rpc: bad arguments", "method", name, "err", err)
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 
-	writeResult(w, method.Call(args))
+	writeResult(w, name, method.Call(args))
 }
 
 func (h *Handler) lookup(name string) (reflect.Value, error) {
@@ -130,11 +134,15 @@ func decodeArgs(t reflect.Type, body []byte) ([]reflect.Value, error) {
 
 // writeResult maps Go returns onto the response: a trailing non-nil error is
 // a 500, otherwise the first non-error value (or null) is the 200 body.
-func writeResult(w http.ResponseWriter, results []reflect.Value) {
+// Every service error is also logged with the method name — the RPC is the
+// single funnel all frontend-triggered failures pass through, which makes
+// this the one line that turns them into an audit trail.
+func writeResult(w http.ResponseWriter, method string, results []reflect.Value) {
 	var payload any
 	for _, result := range results {
 		if result.Type().Implements(errType) {
 			if err, _ := result.Interface().(error); err != nil {
+				slog.Warn("rpc: call failed", "method", method, "err", err)
 				writeError(w, http.StatusInternalServerError, err.Error())
 				return
 			}
@@ -146,8 +154,9 @@ func writeResult(w http.ResponseWriter, results []reflect.Value) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(payload); err != nil {
-		// Headers are gone; nothing to do but log-free best effort.
-		_ = err
+		// Headers are gone — the response cannot change anymore, but the
+		// audit trail can still say the reply never reached the page.
+		slog.Warn("rpc: encode response", "method", method, "err", err)
 	}
 }
 

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -17,7 +17,7 @@ func (s *Service) AddProject(id, name, path string) error {
 		id, name, path,
 	)
 	if err != nil {
-		return fmt.Errorf("add project: %w", err)
+		return fmt.Errorf("add project %q: %w", id, err)
 	}
 	return nil
 }
@@ -26,7 +26,7 @@ func (s *Service) AddProject(id, name, path string) error {
 // can be reopened later with its session state restored.
 func (s *Service) CloseProject(id string) error {
 	if _, err := s.db.Exec(`UPDATE projects SET is_open = 0 WHERE id = ?`, id); err != nil {
-		return fmt.Errorf("close project: %w", err)
+		return fmt.Errorf("close project %q: %w", id, err)
 	}
 	return nil
 }
@@ -49,13 +49,13 @@ func (s *Service) AddSession(projectID, sessionID, label, kind, path string, nex
 			         (SELECT COALESCE(MAX(position), -1) + 1 FROM sessions WHERE project_id = ?))`,
 			sessionID, projectID, label, kind, path, projectID,
 		); err != nil {
-			return fmt.Errorf("insert session: %w", err)
+			return fmt.Errorf("insert session %q: %w", sessionID, err)
 		}
 		if _, err := tx.Exec(
 			`UPDATE projects SET active_session_id = ?, next_seq = ? WHERE id = ?`,
 			sessionID, nextSeq, projectID,
 		); err != nil {
-			return fmt.Errorf("update project counters: %w", err)
+			return fmt.Errorf("update project %q counters: %w", projectID, err)
 		}
 		return nil
 	})
@@ -66,13 +66,13 @@ func (s *Service) AddSession(projectID, sessionID, label, kind, path string, nex
 func (s *Service) DeleteSession(projectID, sessionID, activeID string) error {
 	return s.tx(func(tx *sql.Tx) error {
 		if _, err := tx.Exec(`DELETE FROM sessions WHERE id = ?`, sessionID); err != nil {
-			return fmt.Errorf("delete session: %w", err)
+			return fmt.Errorf("delete session %q: %w", sessionID, err)
 		}
 		if _, err := tx.Exec(
 			`UPDATE projects SET active_session_id = ? WHERE id = ?`,
 			activeID, projectID,
 		); err != nil {
-			return fmt.Errorf("update active session: %w", err)
+			return fmt.Errorf("update active session of %q: %w", projectID, err)
 		}
 		return nil
 	})
@@ -86,7 +86,7 @@ func (s *Service) RenameSession(sessionID, label string) error {
 		`UPDATE sessions SET label = ?, label_auto = 0 WHERE id = ?`,
 		label, sessionID,
 	); err != nil {
-		return fmt.Errorf("rename session: %w", err)
+		return fmt.Errorf("rename session %q: %w", sessionID, err)
 	}
 	return nil
 }
@@ -102,11 +102,11 @@ func (s *Service) SetSessionTitle(sessionID, title string) (bool, error) {
 		title, sessionID,
 	)
 	if err != nil {
-		return false, fmt.Errorf("set session title: %w", err)
+		return false, fmt.Errorf("set session %q title: %w", sessionID, err)
 	}
 	n, err := res.RowsAffected()
 	if err != nil {
-		return false, fmt.Errorf("set session title rows: %w", err)
+		return false, fmt.Errorf("set session %q title rows: %w", sessionID, err)
 	}
 	return n > 0, nil
 }
@@ -121,7 +121,7 @@ func (s *Service) SetClaudeSession(sessionID, claudeSessionID string) error {
 		`UPDATE sessions SET claude_session_id = ? WHERE id = ?`,
 		claudeSessionID, sessionID,
 	); err != nil {
-		return fmt.Errorf("set claude session: %w", err)
+		return fmt.Errorf("set claude session on %q: %w", sessionID, err)
 	}
 	return nil
 }
@@ -165,7 +165,7 @@ func (s *Service) SetActiveSession(projectID, sessionID string) error {
 		`UPDATE projects SET active_session_id = ? WHERE id = ?`,
 		sessionID, projectID,
 	); err != nil {
-		return fmt.Errorf("set active session: %w", err)
+		return fmt.Errorf("set active session %q on %q: %w", sessionID, projectID, err)
 	}
 	return nil
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -8,6 +8,7 @@ package terminal
 import (
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
@@ -107,7 +108,11 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 		env:      append(childEnv(env), "TERM=xterm-256color"),
 	}
 	ws, err := newTransport(
-		func(id string, data []byte) { _ = s.writeBytes(id, data) },
+		func(id string, data []byte) {
+			if err := s.writeBytes(id, data); err != nil {
+				slog.Warn("terminal: input write failed", "session", id, "err", err)
+			}
+		},
 		func(id, state string) {
 			hub.Emit(statusEventName, statusEvent{ID: id, State: state})
 		},

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -143,8 +144,13 @@ func newTransport(
 	mux.HandleFunc("/session-touched", t.sessionTouched)
 	t.mux = mux
 	// Server and listener live for the process lifetime, like the PTY sessions
-	// they serve; add Shutdown if the app ever needs teardown.
-	go func() { _ = http.Serve(listener, mux) }()
+	// they serve; add Shutdown if the app ever needs teardown. Serve returning
+	// is therefore always abnormal — the frontend just lost RPC and terminals.
+	go func() {
+		if err := http.Serve(listener, mux); err != nil {
+			slog.Error("transport listener stopped", "err", err)
+		}
+	}()
 	return t, nil
 }
 
@@ -205,10 +211,14 @@ func servePost[T any](
 	}
 	parsed, err := parse(body)
 	if err != nil {
+		// The hook client ignores responses, so the log is the only place a
+		// bad payload ever surfaces.
+		slog.Warn("hook: bad payload", "path", r.URL.Path, "err", err)
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	if err := apply(parsed); err != nil {
+		slog.Warn("hook: apply failed", "path", r.URL.Path, "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -13,6 +13,7 @@ import (
 	"github.com/omartelo/lich/internal/claudeplugin"
 	"github.com/omartelo/lich/internal/events"
 	"github.com/omartelo/lich/internal/fonts"
+	"github.com/omartelo/lich/internal/logging"
 	"github.com/omartelo/lich/internal/project"
 	"github.com/omartelo/lich/internal/rpc"
 	"github.com/omartelo/lich/internal/store"
@@ -36,15 +37,30 @@ func main() {
 	// what the user launched lich with (see terminal.childEnv).
 	env := os.Environ()
 
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		slog.Error("resolve config dir", "err", err)
+		os.Exit(1)
+	}
+	// File logging as early as possible: every startup failure below must be
+	// readable after the fact — on Windows the console may not exist at all.
+	if closer, err := logging.Init(filepath.Join(configDir, "lich")); err != nil {
+		slog.Warn("file log unavailable, stderr only", "err", err)
+	} else {
+		defer closer.Close()
+	}
+
 	if os.Getenv("LICH_LISTEN_PORT") == "" {
 		if err := os.Setenv("LICH_LISTEN_PORT", defaultListenPort); err != nil {
-			log.Fatalf("failed to set LICH_LISTEN_PORT: %v", err)
+			slog.Error("set LICH_LISTEN_PORT", "err", err)
+			os.Exit(1)
 		}
 	}
 
 	db, err := store.New()
 	if err != nil {
-		log.Fatal(err)
+		slog.Error("open store", "err", err)
+		os.Exit(1)
 	}
 	defer db.Close()
 
@@ -67,7 +83,7 @@ func main() {
 	term.Mount("/rpc/", dispatcher)
 	term.Mount("/events", hub)
 
-	runChromium(term)
+	runChromium(term, configDir)
 }
 
 // runChromium serves the embedded frontend on the loopback listener and opens
@@ -78,40 +94,45 @@ func main() {
 // LICH_DEV_URL points the window at the Vite dev server instead of the
 // embedded frontend (see `task dev`); the token and the backend port ride the
 // query string so the page can find the RPC listener across the origin split.
-func runChromium(term *terminal.Service) {
+func runChromium(term *terminal.Service, configDir string) {
 	info := term.Transport()
 	if info.Port == 0 {
-		log.Fatalf("loopback listener failed to start — is port %s (LICH_LISTEN_PORT) free?", os.Getenv("LICH_LISTEN_PORT"))
+		slog.Error("loopback listener failed to start — is the port free?",
+			"port", os.Getenv("LICH_LISTEN_PORT"))
+		os.Exit(1)
 	}
 
 	dist, err := fs.Sub(assets, "frontend/dist")
 	if err != nil {
-		log.Fatalf("embedded frontend: %v", err)
+		slog.Error("embedded frontend", "err", err)
+		os.Exit(1)
 	}
 	term.MountPublic("/", http.FileServerFS(dist))
 
-	configDir, err := os.UserConfigDir()
-	if err != nil {
-		log.Fatalf("resolve config dir: %v", err)
-	}
 	profileDir := filepath.Join(configDir, "lich", "chromium-profile")
 
-	url := fmt.Sprintf("http://127.0.0.1:%d/?token=%s", info.Port, info.Token)
+	// The token stays out of the logs on purpose: the log file persists
+	// across sessions, the token must not.
+	addr := fmt.Sprintf("http://127.0.0.1:%d/", info.Port)
+	url := addr + "?token=" + info.Token
 	class := "lich"
 	if dev := os.Getenv("LICH_DEV_URL"); dev != "" {
+		addr = dev + "/"
 		url = fmt.Sprintf("%s/?token=%s&backend=%d", dev, info.Token, info.Port)
 		profileDir = filepath.Join(configDir, "lich", "chromium-profile-dev")
 		// Own WM_CLASS: compositor rules for the daily driver must not
 		// capture the dev window.
 		class = "lichdev"
 	}
-	log.Printf("[lich] chromium shell on %s", url)
+	slog.Info("chromium shell opening", "addr", addr)
 
 	var extra []string
 	if args := os.Args[1:]; len(args) > 1 && args[0] == "--" {
 		extra = args[1:]
 	}
 	if err := chromium.Run(url, profileDir, class, extra); err != nil {
-		log.Fatal(err)
+		slog.Error("chromium shell", "err", err)
+		os.Exit(1)
 	}
+	slog.Info("window closed, exiting")
 }


### PR DESCRIPTION
## Summary

Gives lich a persistent, auditable log — the piece the Windows port needs before the console window can go away (`-H=windowsgui`), and the audit trail any bug report can quote.

### `internal/logging`

- `logging.Init(dir)` points slog's default at stderr **and** `<config-dir>/lich/lich.log` — text records with `source=file.go:line` on every entry (`AddSource`).
- `lich-dev.log` under `LICH_DEV`, mirroring the store's database split: `task dev` never pollutes the daily driver's trail.
- Dumb rotation on startup: ≥5MB renames to `.old`, one previous generation kept, no rotation lib.
- `LICH_LOG_LEVEL` = `debug|warn|error` (default info; unknown values fall back to info — an audit log that silently goes quiet is worse than a noisy one).
- File half unavailable → stderr-only, nil closer, error reported; logging never takes the app down.
- **The session token never reaches the log.** The startup line logs `addr` without the query string — the file persists across sessions, the token must not. Deliberate trade-off: no more copy-pasteable URL from the console.

### Audit funnels

- **RPC dispatcher** is the single path every frontend-triggered failure crosses: `writeResult` logs each service error with its method name; unknown methods, unreadable bodies and bad arguments too. One line covers every registered service, present and future.
- **Hook endpoints** (`servePost`): bad payloads and failed applies now log — the hook client ignores HTTP responses, so the log is the only place these ever surface (the old comment claimed "visible to logs"; now it's true).
- Previously swallowed, now recorded: post-header encode failures in the RPC, `http.Serve` returning on the transport listener (always abnormal — the frontend just lost RPC and terminals), terminal input-write failures (with session id), plugin marketplace-add errors (Debug — "already exists" is the normal path).
- Kept swallowed on purpose: Close/rollback/CloseNow paths — noise without audit value.

### Error messages

Store operations now name the record they failed on (`rename session "abc-123": …`, `set active session "s1" on "p1": …`) — a log line that doesn't say *which* row is not conclusive.

## Test plan

- [x] 5 new tests in `internal/logging` (rotation via sparse `os.Truncate`, source attr lands in the file, stderr fallback, level parsing, dev naming)
- [x] `go test -race ./...` — 209 passed, 11 packages
- [x] `-count=10` stress on `internal/logging` + `internal/rpc` — clean
- [x] `GOOS=windows go build ./...` + `go vet` clean
- [ ] Post-merge follow-up: flip `task build:windows` to `-H=windowsgui` once the log has proven itself on a real Windows machine
