### PR TITLE
fix: drop redundant end in single-line diff file reference

### DIFF
--- a/frontend/src/components/diff/FileDiff.tsx
+++ b/frontend/src/components/diff/FileDiff.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/tooltip"
 import {
   buildFileDoc,
+  formatLineRef,
   newLineRange,
   type DiffFile,
   type FileDoc,
@@ -154,11 +155,11 @@ function DiffBody({doc, path, onInject}: DiffBodyProps) {
         </ContextMenuItem>
         <ContextMenuItem
           disabled={range === null}
-          onClick={() => range && onInject(`${path}:${range.start}-${range.end} `)}
+          onClick={() => range && onInject(`${path}:${formatLineRef(range)} `)}
         >
           {range === null
             ? "Inject lines"
-            : `Inject lines ${range.start}-${range.end}`}
+            : `Inject lines ${formatLineRef(range)}`}
         </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>

--- a/frontend/src/lib/diff.test.ts
+++ b/frontend/src/lib/diff.test.ts
@@ -2,6 +2,7 @@ import {describe, expect, it} from "vitest"
 import {
   buildFileDoc,
   discardTargets,
+  formatLineRef,
   gutterNumber,
   newLineRange,
   parseDiff,
@@ -192,6 +193,16 @@ describe("newLineRange", () => {
 
   it("ignores separators inside the selection", () => {
     expect(newLineRange(meta, 5, 6)).toEqual({start: 4, end: 4})
+  })
+})
+
+describe("formatLineRef", () => {
+  it("collapses a single-line selection", () => {
+    expect(formatLineRef({start: 19, end: 19})).toBe("19")
+  })
+
+  it("keeps a multi-line range", () => {
+    expect(formatLineRef({start: 19, end: 24})).toBe("19-24")
   })
 })
 

--- a/frontend/src/lib/diff.ts
+++ b/frontend/src/lib/diff.ts
@@ -248,3 +248,9 @@ export function newLineRange(
   }
   return start === Infinity ? null : {start, end}
 }
+
+// formatLineRef renders a range for a file reference: a single-line selection
+// reads as "19", not "19-19".
+export function formatLineRef(r: NewLineRange): string {
+  return r.start === r.end ? `${r.start}` : `${r.start}-${r.end}`
+}


### PR DESCRIPTION
## What

A single-line selection in the review panel built a file reference like `CHANGELOG.md:19-19`. This collapses it to `CHANGELOG.md:19`, keeping the `start-end` range form only when the selection spans more than one line.

## Why

`19-19` is noise in the reference we hand to Claude — a one-line selection has no range to express.

## How

`formatLineRef` lands in `lib/diff.ts` next to `newLineRange` (its only caller is `FileDiff`), so both the injected reference (`${path}:${formatLineRef(range)}`) and the context-menu label route through one guard. Single line → `"19"`, span → `"19-24"`.

## Test plan

- [x] `formatLineRef` unit tests in `diff.test.ts` (single-line collapse + multi-line range)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec vitest run src/lib/diff.test.ts` — 21 pass