### PR TITLE
feat: Windows GUI-subsystem build — no more console window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The Windows binary is now a GUI-subsystem build: launching `lich.exe` no
+  longer drags a console window along, and closing that console can no longer
+  kill the app by accident. Logs live in `%AppData%\lich\lich.log` — the
+  console mirror became best-effort so a missing stderr never poisons the
+  file half of the log.
+
 ### Added
 
 - lich keeps a persistent log: `<config-dir>/lich/lich.log` (`lich-dev.log`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Deliberate limits and shortcuts, with the upgrade path when it matters:
   If bundling ever matters, that's option 2 (CEF) of `docs/chromium-shell.md`, not an AppImage.
 - **Windows is experimental.** What holds it up: the backend suite runs on a Windows CI runner every release, and the
   window/terminal path was smoke-tested by hand. What's missing: no installer or package (a bare unsigned `.exe`, so
-  SmartScreen warns — run it from a terminal, its console carries the logs), no Windows PTY tests
-  (`terminal_test.go` is `!windows`; conpty-backed spawn tests are the gap to close before the tag can narrow), and
-  the shell session is `COMSPEC`/cmd.exe — no PowerShell preference yet. The console subsystem build is deliberate
-  while the port is young: errors stay visible; `-H=windowsgui` is the flip when it stabilizes.
+  SmartScreen warns), no Windows PTY tests (`terminal_test.go` is `!windows`; conpty-backed spawn tests are the gap
+  to close before the tag can narrow), and the shell session is `COMSPEC`/cmd.exe — no PowerShell preference yet.
+  The build is GUI subsystem (`-H=windowsgui`): no console rides along, stdout/stderr go nowhere, and
+  `%AppData%\lich\lich.log` is the diagnostic surface — "double-clicked and nothing happened" means read the log.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -26,10 +26,12 @@ tasks:
       - cmd: CGO_ENABLED=0 go build {{.GO_BUILD_FLAGS}} -o {{.BIN_DIR}}/{{.APP_NAME}} .
 
   build:windows:
-    summary: Cross-compiles the Windows binary (experimental — untested runtime)
+    summary: Cross-compiles the Windows binary (experimental)
     deps: [build:frontend]
     cmds:
-      - cmd: CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build {{.GO_BUILD_FLAGS}} -o {{.BIN_DIR}}/{{.APP_NAME}}.exe .
+      # GUI subsystem: no console window rides along. stdout/stderr go
+      # nowhere — the persistent lich.log is the diagnostic surface.
+      - cmd: CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -trimpath -ldflags "-s -w -H=windowsgui" -o {{.BIN_DIR}}/{{.APP_NAME}}.exe .
 
   run:
     summary: Builds and runs the application

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -31,7 +31,11 @@ func Init(dir string) (io.Closer, error) {
 	out := io.Writer(os.Stderr)
 	var closer io.Closer
 	if err == nil {
-		out = io.MultiWriter(os.Stderr, file)
+		// File first: it is the record of truth, and io.MultiWriter stops at
+		// the first failing writer. The console mirror is best-effort — the
+		// windowsgui build has no stderr at all, and its write failures must
+		// never poison the file half.
+		out = io.MultiWriter(file, bestEffort{os.Stderr})
 		closer = file
 	}
 	slog.SetDefault(slog.New(slog.NewTextHandler(out, &slog.HandlerOptions{
@@ -39,6 +43,17 @@ func Init(dir string) (io.Closer, error) {
 		Level:     parseLevel(os.Getenv("LICH_LOG_LEVEL")),
 	})))
 	return closer, err
+}
+
+// bestEffort forwards writes and swallows failures — for mirror destinations
+// whose loss must not fail the write (a console that does not exist).
+type bestEffort struct {
+	w io.Writer
+}
+
+func (b bestEffort) Write(p []byte) (int, error) {
+	_, _ = b.w.Write(p)
+	return len(p), nil
 }
 
 // openLogFile opens the append-mode log file, first rotating the previous

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -108,6 +108,24 @@ func TestInitRotatesOversizedLog(t *testing.T) {
 	}
 }
 
+// failingWriter always errors, standing in for the dead stderr of a
+// windowsgui process.
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) {
+	return 0, os.ErrInvalid
+}
+
+// TestBestEffortSwallowsMirrorFailure proves a dead mirror destination never
+// fails the write — the exact contract the file half of the log depends on
+// when the Windows GUI build has no console.
+func TestBestEffortSwallowsMirrorFailure(t *testing.T) {
+	n, err := bestEffort{failingWriter{}}.Write([]byte("record"))
+	if err != nil || n != len("record") {
+		t.Fatalf("Write = (%d, %v), want (%d, nil)", n, err, len("record"))
+	}
+}
+
 // TestInitSurvivesUnwritableDir proves logging still works on stderr when the
 // file half cannot exist: an error comes back, the closer is nil, and the
 // default logger is usable.


### PR DESCRIPTION
## Summary

Flips \`task build:windows\` to \`-H=windowsgui\`, unblocked by the persistent log (#17). The console window that launched alongside \`lich.exe\` is gone — and with it the accidental kill switch: closing that console killed the app (reported by the first Windows user).

The flip activated a latent ordering bug, fixed here: \`logging.Init\` used \`MultiWriter(stderr, file)\` — stderr first. A windowsgui process has no stderr, \`io.MultiWriter\` stops at the first failing writer, so **the file half would never be written** — exactly on the platform that depends on it. Now the file writes first and the console mirror is a \`bestEffort\` wrapper that swallows failures.

Docs updated: CLAUDE.md's Windows ceiling now states the contract — "double-clicked and nothing happened" means read \`%AppData%\lich\lich.log\`.

## Test plan

- [x] \`TestBestEffortSwallowsMirrorFailure\` — dead mirror never fails the write (the windowsgui contract)
- [x] \`go test -race ./...\` — 210 passed
- [x] \`task build:windows\` → \`file bin/lich.exe\`: \`PE32+ ... (GUI)\` (was \`(console)\`)
- [x] Smoke on the Windows machine: double-click, no console, window opens, lich.log carries the startup records