### PR TITLE
feat: show open PR badge on session cards

### DIFF
--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -1,6 +1,6 @@
 import {useEffect, useRef, useState} from "react"
 import type {KeyboardEvent} from "react"
-import {Bell, Check, GitBranch, LoaderCircle, Pencil, X} from "lucide-react"
+import {Bell, Check, GitBranch, GitPullRequestArrow, LoaderCircle, Pencil, X} from "lucide-react"
 import {useSortable} from "@dnd-kit/sortable"
 import {CSS} from "@dnd-kit/utilities"
 import {cn} from "@/lib/utils"
@@ -8,6 +8,8 @@ import {displayPath} from "@/lib/paths"
 import {type Session} from "@/lib/sessions"
 import {useSessionStatus} from "@/lib/useSessionStatus"
 import {useGitStatus} from "@/lib/useGitStatus"
+import {usePullRequest} from "@/lib/usePullRequest"
+import {System} from "@/lib/rpc"
 import {DiffStat} from "@/components/DiffStat"
 import {Tooltip, TooltipContent, TooltipTrigger} from "@/components/ui/tooltip"
 import {
@@ -50,6 +52,7 @@ export function SessionCard({
   // git status, so the badge reflects the worktree's branch, not the project's.
   const shownPath = session.path || path
   const git = useGitStatus(shownPath)
+  const pr = usePullRequest(shownPath, git?.branch ?? "")
   // Renaming disables the drag: the sensor would otherwise claim the pointer
   // before the input could be clicked into or its text selected.
   const {
@@ -167,11 +170,27 @@ export function SessionCard({
                   <GitBranch className="size-3 shrink-0"/>
                   <span className="truncate">{git.branch}</span>
                 </span>
-                  {git.files > 0 && (
-                    <span className="flex shrink-0 items-center gap-1 px-1 py-0.5 bg-muted-foreground/10 rounded">
-                      <DiffStat added={git.added} deleted={git.deleted}/>
-                    </span>
-                  )}
+                  <span className="flex shrink-0 items-center gap-1.5">
+                    {pr && (
+                      <span
+                        role="button"
+                        aria-label={`Open pull request #${pr.number} on GitHub`}
+                        onClick={(event) => {
+                          event.stopPropagation()
+                          void System.OpenExternal(pr.url)
+                        }}
+                        className="flex items-center gap-1 px-1 py-0.5 bg-muted-foreground/10 rounded transition-colors hover:bg-accent hover:text-accent-foreground"
+                      >
+                        <GitPullRequestArrow className="size-3 shrink-0"/>
+                        #{pr.number}
+                      </span>
+                    )}
+                    {git.files > 0 && (
+                      <span className="flex items-center gap-1 px-1 py-0.5 bg-muted-foreground/10 rounded">
+                        <DiffStat added={git.added} deleted={git.deleted}/>
+                      </span>
+                    )}
+                  </span>
               </span>
               )}
             </div>


### PR DESCRIPTION
## What

Adds an open-PR badge to each session card in the sidebar, mirroring the one already in the footer: an icon + `#<number>` that opens the pull request in the browser on click.

## Why

The footer only shows the PR for the *active* session. This surfaces a session's open GitHub PR right on its card, so you can see which sessions have a PR open — and jump to it — without selecting the card first. Same idea as the diff badge already on the card.

## How

- Reuses `usePullRequest(path, branch)` and `System.OpenExternal` — no new logic, same hook/RPC the footer uses.
- The badge sits in the branch row's right cluster, next to the diff badge.
- It is a `span role="button"` (the card is itself a `<button>`, so a nested `<button>` would be invalid) with `stopPropagation` on click — matching the existing close control — so clicking the badge opens the PR instead of selecting the session.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec vitest run` — 207 pass
- [x] Manual: on a session whose branch has an open PR, the card shows the `#N` badge; clicking opens the PR in the browser; no badge when the branch has no open PR; clicking does not select/change the active session.

Note: UI-boundary change (no pure logic added); the project tests logic in `src/lib`, not components — consistent with the untested footer badge it mirrors.