### PR TITLE
feat: discreet app-wide scrollbar

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -199,6 +199,25 @@
 .dark .tok-typeName, .dark .tok-className, .dark .tok-namespace { color: oklch(0.8 0.09 200); }
 .dark .tok-propertyName { color: oklch(0.75 0.1 255); }
 .dark .tok-variableName.tok-definition { color: oklch(0.75 0.1 255); }
+/* App-wide scrollbar, discreet: post-Chromium the native dark scrollbar reads
+   as a heavy stripe. Chromium-only shell, so ::-webkit-scrollbar is guaranteed.
+   Thin thumb from currentColor, transparent track — every overflow container
+   (diff, settings, sidebar, tabs) inherits it. */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: color-mix(in oklch, currentColor 25%, transparent);
+  border-radius: 4px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in oklch, currentColor 40%, transparent);
+}
+
 /* xterm viewport scrollbar, discreet: today's dark native scrollbar reads as
    a stripe between the terminal and the window edge. Thin overlay thumb,
    transparent track; the overview ruler (TerminalView) marks scroll position. */


### PR DESCRIPTION
## Summary

Native Chromium scrollbars read as a heavy dark stripe on every overflow
container after the Chromium migration. This adds a single global
`::-webkit-scrollbar` rule in `frontend/src/index.css`, reusing the
existing `.xterm-viewport` thumb idiom (`currentColor` at 25%, transparent
track, rounded thumb, hover bump to 40%).

Chosen over shadcn `ScrollArea`: the shell is Chromium-only, so
`::-webkit-scrollbar` is guaranteed — no `@radix-ui/react-scroll-area`
dependency, no per-container JSX wrapping, and native scroll behavior stays
intact (keyboard, scroll-into-view, dnd-kit autoscroll in the sidebar).

## Scope

One global rule covers all real scroll containers plus radix menus:

- `DiffPanel` (diff viewport)
- `Settings`
- `SessionSidebar` (dnd-kit cards)
- `WorktreeDialog`
- `ProjectTabs` (horizontal)

The `.xterm-viewport` rule is untouched — higher specificity keeps its 6px
width and the overview-ruler contract.

## Test plan

- [x] `task dev` — thumb is thin/translucent in diff, settings, sidebar, tabs
- [x] Terminal scrollbar unchanged (still 6px, overview ruler intact)
- [x] Light and dark themes both legible