### PR TITLE
chore: pre-release audit fixes (wrapArgv test + changelog gaps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- An open pull request now badges the session card too, not just the footer. The
+  same `PR #N` chip the footer shows for the active session appears on every card
+  whose branch has an open PR, so one is visible per session without selecting
+  the card first; clicking it opens the PR in the browser. Reuses the footer's PR
+  lookup, is hidden when `gh` is absent or unauthenticated, and clears when the
+  PR merges or closes.
 - Windows releases now ship an installer (`lich-*-windows-amd64-setup.exe`,
   Inno Setup): per-user install under `%LocalAppData%\Programs\lich` with no
   admin prompt, Start Menu entry, a proper "Installed apps" registration with
@@ -38,6 +44,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   scrollbar is replaced by a thin translucent thumb (diff, settings, sidebar,
   tabs) via a single global `::-webkit-scrollbar` rule; the terminal keeps its
   existing 6px overlay.
+
+### Fixed
+
+- A single-line selection in the diff review panel built a file reference with a
+  redundant end (`path:19-19`). It now collapses to `path:19`, keeping the
+  `start-end` range form only when the selection spans more than one line — for
+  both the injected PTY reference and the context-menu label.
 
 ## [0.5.0] - 2026-07-15
 

--- a/internal/terminal/pty.go
+++ b/internal/terminal/pty.go
@@ -1,5 +1,10 @@
 package terminal
 
+import (
+	"path/filepath"
+	"strings"
+)
+
 // ptySpec describes the child process a session's PTY runs. It carries
 // everything the platform needs to spawn: ConPTY has no exec.Cmd (CreateProcess
 // wants one command-line string plus explicit dir/env — see go#62708), so the
@@ -25,4 +30,20 @@ type ptyHandle interface {
 	Resize(cols, rows int) error
 	Wait() error
 	Close() error
+}
+
+// wrapArgv builds the argv for an already-resolved binary path. npm ships
+// Claude Code as claude.cmd, and Windows' CreateProcess runs neither .cmd nor
+// .bat directly — only cmd.exe can — so a script binary is prefixed with
+// `cmd.exe /c`; native executables pass through unchanged. It lives here, not
+// in the Windows PTY file, so the decision stays pure and testable off-Windows
+// (filepath.Ext is lexical); the OS boundaries — LookPath and
+// ComposeCommandLine — stay in pty_windows.go.
+func wrapArgv(path string, args []string) []string {
+	argv := append([]string{path}, args...)
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".cmd", ".bat":
+		argv = append([]string{"cmd.exe", "/c"}, argv...)
+	}
+	return argv
 }

--- a/internal/terminal/pty_test.go
+++ b/internal/terminal/pty_test.go
@@ -1,0 +1,35 @@
+package terminal
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestWrapArgv proves the Windows launch decision: npm's claude.cmd (and any
+// .bat) gets the `cmd.exe /c` prefix CreateProcess needs — case-insensitively —
+// while native executables and extensionless binaries pass through untouched.
+// This is the pure slice of commandLine; the LookPath/ComposeCommandLine
+// boundaries around it stay in pty_windows.go and run only under Windows CI.
+func TestWrapArgv(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		args []string
+		want []string
+	}{
+		{"cmd script wraps", `C:\n\claude.cmd`, []string{"--resume", "x"},
+			[]string{"cmd.exe", "/c", `C:\n\claude.cmd`, "--resume", "x"}},
+		{"bat script wraps case-insensitively", `C:\n\run.BAT`, nil,
+			[]string{"cmd.exe", "/c", `C:\n\run.BAT`}},
+		{"exe passes through", `C:\n\claude.exe`, []string{"--resume", "x"},
+			[]string{`C:\n\claude.exe`, "--resume", "x"}},
+		{"extensionless passes through", "/usr/bin/claude", nil,
+			[]string{"/usr/bin/claude"}},
+	}
+	for _, tc := range cases {
+		if got := wrapArgv(tc.path, tc.args); !slices.Equal(got, tc.want) {
+			t.Errorf("%s: wrapArgv(%q, %v) = %v, want %v",
+				tc.name, tc.path, tc.args, got, tc.want)
+		}
+	}
+}

--- a/internal/terminal/pty_windows.go
+++ b/internal/terminal/pty_windows.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
-	"path/filepath"
-	"strings"
 
 	"github.com/UserExistsError/conpty"
 	"golang.org/x/sys/windows"
@@ -40,12 +38,7 @@ func commandLine(bin string, args []string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("resolve %q: %w", bin, err)
 	}
-	argv := append([]string{path}, args...)
-	switch strings.ToLower(filepath.Ext(path)) {
-	case ".cmd", ".bat":
-		argv = append([]string{"cmd.exe", "/c"}, argv...)
-	}
-	return windows.ComposeCommandLine(argv), nil
+	return windows.ComposeCommandLine(wrapArgv(path, args)), nil
 }
 
 // windowsPTY adapts a ConPTY to the seam. The embedded type already carries


### PR DESCRIPTION
Pre-release audit of `v0.5.0..HEAD` before cutting the next tag. Backend suite (`-race`), `go vet` (Linux + `GOOS=windows`), gofmt, and frontend vitest all green.

## Code
- **Cover the Windows `.cmd`/`.bat` launch wrapping.** `commandLine` fused the pure claude.cmd wrap decision (npm ships Claude Code as `.cmd`; `CreateProcess` runs neither `.cmd` nor `.bat`, only `cmd.exe`) with the `LookPath`/`ComposeCommandLine` OS boundaries, and it was untested on any platform. Extracted the pure decision as `wrapArgv` into the shared `pty.go`; `commandLine` is now a thin boundary wrapper. `TestWrapArgv` (no build tag) runs on Linux **and** Windows CI.

## Docs
Two merged changes were missing from `CHANGELOG.md`'s `[Unreleased]`:
- **#20** — open-PR badge mirrored onto session cards (Added)
- **#18** — single-line diff file reference collapses `path:N-N` → `path:N` (Fixed)

## Audit summary (no code changes needed)
Reviewed logging, chromium (Windows candidates), the terminal seam, frontend, and the backend glue in parallel: **no logic bugs, no dead code, no blockers**. Two items deliberately left as documented boundaries: the `os.Rename` rotation-error branch (filesystem boundary) and `terminal_test.go`'s `!windows` tag (the author's documented deferral — `wrapArgv` closes the pure slice of it).

## Test plan
- [x] `go test -race ./...`
- [x] `go vet ./...` + `GOOS=windows go vet ./internal/terminal/`
- [x] `GOOS=windows go build ./internal/terminal/`
- [x] `TestWrapArgv` passes on Linux
- [x] frontend `vitest run` (209 passed)