### PR TITLE
chore: mutation testing via gremlins (task mutation)

### DIFF
--- a/.gremlins.yaml
+++ b/.gremlins.yaml
@@ -1,0 +1,11 @@
+# Mutation-testing config for `task mutation` (go-gremlins/gremlins).
+#
+# workers: 1 is load-bearing. Gremlins defaults to one worker per CPU and runs
+# mutant test binaries in parallel; the SQLite-backed store tests then contend
+# and start timing out — every mutant reported TIMED OUT, efficacy 0%. That is
+# machine contention, not a weak suite (single-worker efficacy on internal/store
+# is ~97%). timeout-coefficient buys slow packages (terminal spawns real PTYs)
+# headroom before a genuine hang is declared timed out.
+unleash:
+  workers: 1
+  timeout-coefficient: 20

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -64,6 +64,16 @@ tasks:
       - cmd: go test ./...
       - cmd: cd frontend && pnpm test
 
+  mutation:
+    summary: 'Mutation tests via gremlins (config: .gremlins.yaml). Scope with -- ./pkg/'
+    preconditions:
+      - sh: command -v gremlins
+        msg: "gremlins is required: go install github.com/go-gremlins/gremlins/cmd/gremlins@latest"
+    cmds:
+      # No path → whole module (slow: single-worker, terminal spawns real PTYs).
+      # Scope a run with: task mutation -- ./internal/store/
+      - cmd: gremlins unleash {{.CLI_ARGS}}
+
   package:
     summary: Builds the Linux packages (deb, rpm, archlinux) into bin/
     deps: [build]


### PR DESCRIPTION
Adds on-demand mutation testing — the mechanized form of the repo's Hard Invariant #2 (*a test earns its keep by failing when the product breaks*).

## What
- **`task mutation`** — runs [go-gremlins/gremlins](https://github.com/go-gremlins/gremlins) over the module. Scope a package with `task mutation -- ./internal/store/`.
- **`.gremlins.yaml`** — `workers: 1` (see below) + a `timeout-coefficient` cushion.

## Why `workers: 1` is load-bearing
Gremlins defaults to one worker per CPU and runs mutant test binaries in parallel. The SQLite-backed store tests then contend and **every mutant reports `TIMED OUT`, efficacy 0%** — machine contention, not a weak suite. Single-worker: `internal/store` scores **97.44% efficacy, 0 timeouts** (38 killed, 1 lived) in ~20s. The coefficient gives PTY-spawning packages headroom before a real hang is declared.

## Scope (deliberate)
On-demand only — **no CI wiring**. Mutation testing is slow (whole-module, single-worker, real PTYs) and belongs in a manual quality pass, not every-push CI.

## Signal it already surfaced
One survivor in `internal/store` (`store.go:130`): the `ALTER TABLE ... ADD COLUMN` migration is only tested on the *already-has-column* path (`duplicate column` ignored); the path where a migration **actually applies** to an old DB (`err == nil`) is uncovered, so flipping `err != nil` → `err == nil` goes unnoticed. Low severity, tracked separately.

## Test plan
- [x] `task mutation -- ./internal/store/` → 97.44% efficacy, 0 timeouts
- [x] `.gremlins.yaml` honored without CLI flags
- [ ] Full-module sweep (`task mutation`) — slow; run before the release tag