### PR TITLE
fix: count untracked additions in a repo with no commits

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -142,20 +142,24 @@ func (s *Service) Diff(path string) DiffStats {
 	if out, err := exec.Command("git", "-C", path, "status", "--porcelain").Output(); err == nil {
 		stats.Files = countLines(out)
 	}
-	out, err := exec.Command("git", "-C", path, "diff", "--numstat", "HEAD").Output()
-	if err != nil {
-		return stats
+	// A repository without commits has no HEAD; diff against git's empty tree,
+	// same as DiffText. Errors here must not skip the untracked block below.
+	base := "HEAD"
+	if _, err := runGit(path, "rev-parse", "--verify", "HEAD"); err != nil {
+		base = emptyTreeHash
 	}
-	for line := range strings.Lines(string(out)) {
-		cols := strings.Fields(line)
-		if len(cols) < 3 {
-			continue
+	if out, err := exec.Command("git", "-C", path, "diff", "--numstat", base).Output(); err == nil {
+		for line := range strings.Lines(string(out)) {
+			cols := strings.Fields(line)
+			if len(cols) < 3 {
+				continue
+			}
+			// Binary files report "-" for both counts; Atoi fails and adds zero.
+			added, _ := strconv.Atoi(cols[0])
+			deleted, _ := strconv.Atoi(cols[1])
+			stats.Added += added
+			stats.Deleted += deleted
 		}
-		// Binary files report "-" for both counts; Atoi fails and adds zero.
-		added, _ := strconv.Atoi(cols[0])
-		deleted, _ := strconv.Atoi(cols[1])
-		stats.Added += added
-		stats.Deleted += deleted
 	}
 	// Untracked files are invisible to `git diff`; count their lines as
 	// additions, the way Warp and forge diff views present a fresh file.

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -150,3 +150,21 @@ func TestDiff(t *testing.T) {
 		t.Errorf("Diff(non-repo) = %+v, want zero", got)
 	}
 }
+
+// TestDiffNoCommits covers a freshly `git init`'d repo with no HEAD: numstat
+// against HEAD fails, and the untracked additions must still be counted rather
+// than the whole stat collapsing to +0 -0.
+func TestDiffNoCommits(t *testing.T) {
+	repo := t.TempDir()
+	if out, err := exec.Command("git", "init", repo).CombinedOutput(); err != nil {
+		t.Skipf("git init unavailable: %v (%s)", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "new.txt"), []byte("x\ny\nz\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := New(nil).Diff(repo)
+	if got.Files != 1 || got.Added != 3 || got.Deleted != 0 {
+		t.Errorf("Diff(no-commit repo) = %+v, want {Files:1 Added:3 Deleted:0}", got)
+	}
+}


### PR DESCRIPTION
## Problem

In a project set up with a fresh `git init` (no commits yet), the +/- diff
badge on the session card and footer showed **+0 -0**, even though the review
panel rendered the full diff correctly.

Files count was still right (`12`) — that comes from `git status --porcelain`,
which runs first and works fine.

## Root cause

`Service.Diff` (`internal/project/project.go`) ran `git diff --numstat HEAD`.
A repository with no commits has no `HEAD`, so the command errors and the
function `return`ed early — **before** the block that counts untracked files
as additions. Result: every stat collapsed to `+0 -0`.

`DiffText` already handled this by falling back to git's empty tree hash when
`HEAD` is missing; `Diff` did not mirror that.

## Fix

- Resolve the diff base via `rev-parse --verify HEAD`, falling back to the
  empty tree (`emptyTreeHash`) when there are no commits — same approach as
  `DiffText`.
- Wrap the `--numstat` parse in an `err == nil` guard so a numstat failure can
  never short-circuit the untracked-file counting block that follows.

The untracked counting logic itself was already correct — it just never got
reached in the no-HEAD case.

## Test

New `TestDiffNoCommits`: freshly `git init`'d repo + one untracked 3-line file
asserts `{Files:1 Added:3 Deleted:0}` (was `Added:0` before the fix).

## Local gate

- `gofmt -l internal/project/` clean
- `go vet ./internal/project/` clean
- `go test ./internal/project/` — 39 passed