### PR TITLE
feat: rich session card tooltip

### DIFF
--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -206,7 +206,33 @@ export function SessionCard({
             <X className="size-3"/>
           </span>
           </ContextMenuTrigger>
-          <TooltipContent>{shownPath}</TooltipContent>
+          <TooltipContent
+            side="right"
+            className="max-w-xs border border-border bg-card text-foreground"
+          >
+            <div className="flex flex-col gap-1.5">
+              <span className="font-medium">{session.label}</span>
+              <span className="font-mono text-muted-foreground">{shownPath}</span>
+              {git?.branch && (
+                <span className="flex flex-wrap items-center gap-2 text-muted-foreground">
+                  <span className="flex items-center gap-1">
+                    <GitBranch className="size-3 shrink-0" />
+                    {git.branch}
+                  </span>
+                  {pr && (
+                    <span className="flex items-center gap-1">
+                      <GitPullRequestArrow className="size-3 shrink-0" />#{pr.number}
+                    </span>
+                  )}
+                  {git.files > 0 && (
+                    <span className="flex items-center gap-1.5">
+                      <DiffStat added={git.added} deleted={git.deleted} />
+                    </span>
+                  )}
+                </span>
+              )}
+            </div>
+          </TooltipContent>
         </Tooltip>
         <ContextMenuContent>
           <ContextMenuItem onClick={() => setEditing(true)}>

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -54,7 +54,7 @@ function TooltipContent({
           {...props}
         >
           {children}
-          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-inherit fill-inherit data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>


### PR DESCRIPTION
## What

The session card tooltip showed only the working directory. A long label that clipped in the card was unreadable without widening the sidebar.

This turns the tooltip into a **mini card** that opens to the right of the session card, mirroring the detail you'd want at a glance:

- Full session **label** (no longer clipped)
- Working **path**
- Git **branch**, **PR** number, and **diff badge** — reusing the `git`/`pr` data the card already computes (no new fetches)

## Theming

The default shadcn tooltip is an inverted pill (`bg-foreground`/`text-background`) — a white box in dark mode, jarring next to the card. This instance is themed to match the card: `bg-card`, `border-border`, `foreground`/`muted` text, so `DiffStat` renders in its intended emerald/red.

The `TooltipContent` arrow color was hardcoded to `bg-foreground`; it now uses `bg-inherit`/`fill-inherit` so it follows the popup background. Default tooltips are unaffected (their popup is still `bg-foreground`, so the arrow inherits the same color as before).

## Test plan

- [ ] `pnpm build` (tsc + vite) — passing
- [ ] `pnpm test` — 209 passing
- [ ] Hover a session card in **dark** mode → tooltip matches the card, opens to the right, arrow blends in
- [ ] Hover a card with a long label → full label visible in the tooltip
- [ ] Other tooltips (unchanged) still render as inverted pills

🤖 Generated with [Claude Code](https://claude.com/claude-code)