### PR TITLE
docs: changelog for session card tooltip and no-commit diff count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- The session card tooltip is now a rich mini-card: full label, working path,
+  branch, open-PR badge and diff stat, opening to the right and themed to match
+  the card. A long label clipped in the card is readable on hover without
+  widening the sidebar. It reuses the git and PR data the card already computes.
+
+### Fixed
+
+- The session card and footer diff badge showed `+0 −0` in a repository with no
+  commits, even though the review panel rendered the full diff: `git diff
+  --numstat HEAD` errors without a HEAD and skipped the untracked-file count. It
+  now diffs against git's empty tree when HEAD is missing, and a numstat failure
+  no longer skips counting untracked additions.
+
 ## [0.6.0] - 2026-07-16
 
 ### Added


### PR DESCRIPTION
Backfill the two `[Unreleased]` CHANGELOG entries for PRs merged after the v0.6.0 cut (#28) that did not touch `CHANGELOG.md`:

- **#30** — rich session card tooltip (Added)
- **#29** — fix for the `+/−` diff badge showing `+0 −0` in a repo with no commits (Fixed)

Docs-only, no code change.

## Test plan
- [x] N/A — CHANGELOG.md only