### PR TITLE
fix: wrap long session path in card tooltip

### DIFF
--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -212,7 +212,7 @@ export function SessionCard({
           >
             <div className="flex flex-col gap-1.5">
               <span className="font-medium">{session.label}</span>
-              <span className="font-mono text-muted-foreground">{shownPath}</span>
+              <span className="break-all font-mono text-muted-foreground">{shownPath}</span>
               {git?.branch && (
                 <span className="flex flex-wrap items-center gap-2 text-muted-foreground">
                   <span className="flex items-center gap-1">


### PR DESCRIPTION
## What

Long worktree paths overflowed the session card tooltip bounds instead of wrapping.

## Why

The path `<span>` had no break rule. A path is one unbroken token (slashes are not word-break points), so `max-w-xs` could not wrap it and the text spilled past the tooltip edge — see the reported screenshot.

## Fix

Add `break-all` to the path span (`SessionCard.tsx`), so the path wraps within the tooltip's max width.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Manual: open a session card with a long worktree path, hover, confirm the path wraps inside the tooltip