### PR TITLE
feat: per-project settings as a sidebar card

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -53,7 +53,10 @@ function App() {
               {/* Terminals are rendered by TerminalHost; the route only selects
                   which one is visible, so this element is empty. */}
               <Route path="/projects/:projectId" element={null} />
-              <Route path="/settings" element={<Settings />} />
+              {/* Settings is a per-project screen: it carries the project id so
+                  it can show that project's overrides, and renders in the main
+                  area with the session sidebar kept beside it. */}
+              <Route path="/projects/:projectId/settings" element={<Settings />} />
             </Route>
           </Routes>
           {/* Inside ProjectsProvider + the router: the update flow opens a shell

--- a/frontend/src/components/settings/ProjectClaudeCodeSettings.tsx
+++ b/frontend/src/components/settings/ProjectClaudeCodeSettings.tsx
@@ -10,29 +10,36 @@ import { SettingBlock } from "./SettingBlock"
 const GLOBAL_SCOPE = ""
 const CLAUDE_BIN_KEY = "claude.bin"
 
-export function ProjectClaudeCodeSettings() {
+// Per-project override for the current project (the one whose Settings screen is
+// open). Empty inherits the global custom path.
+export function ProjectClaudeCodeSettings({ projectId }: { projectId?: string }) {
   const { projects } = useProjects()
+  const project = projects.find((p) => p.id === projectId)
   const [globalBin, setGlobalBin] = useState("")
-  const [bins, setBins] = useState<Record<string, string>>({})
+  const [bin, setBin] = useState("")
 
   useEffect(() => {
     void Store.GetSetting(CLAUDE_BIN_KEY, GLOBAL_SCOPE).then(setGlobalBin)
-    for (const project of projects) {
-      void Store.GetSetting(CLAUDE_BIN_KEY, project.id).then((value) =>
-        setBins((prev) => ({ ...prev, [project.id]: value })),
-      )
-    }
-  }, [projects])
+  }, [])
 
-  const persist = (projectId: string, value: string) => {
-    setBins((prev) => ({ ...prev, [projectId]: value }))
-    void Store.SetSetting(CLAUDE_BIN_KEY, projectId, value.trim())
+  useEffect(() => {
+    if (!projectId) {
+      return
+    }
+    void Store.GetSetting(CLAUDE_BIN_KEY, projectId).then(setBin)
+  }, [projectId])
+
+  const persist = (value: string) => {
+    setBin(value)
+    if (projectId) {
+      void Store.SetSetting(CLAUDE_BIN_KEY, projectId, value.trim())
+    }
   }
 
-  if (projects.length === 0) {
+  if (!project) {
     return (
       <p className="py-5 text-sm text-muted-foreground">
-        No open projects. Open a project to configure its overrides.
+        No project selected.
       </p>
     )
   }
@@ -40,24 +47,18 @@ export function ProjectClaudeCodeSettings() {
   return (
     <SettingBlock
       title="Custom path"
-      description="Per-project path to the Claude Code binary or a launcher script spawned in the project's terminals. Leave a project empty to inherit the global custom path."
+      description="Path to the Claude Code binary or a launcher script spawned in this project's terminals. Leave empty to inherit the global custom path."
     >
-      <div className="space-y-5">
-        {projects.map((project) => (
-          <div key={project.id}>
-            <div className="text-sm font-medium text-foreground">{project.name}</div>
-            <p className="mb-2 mt-0.5 text-xs text-muted-foreground">{project.path}</p>
-            <Input
-              value={bins[project.id] ?? ""}
-              onChange={(event) => persist(project.id, event.target.value)}
-              placeholder={globalBin || "claude"}
-              spellCheck={false}
-              aria-label={`Claude Code path for ${project.name}`}
-              className="w-96 max-w-full font-mono"
-            />
-          </div>
-        ))}
-      </div>
+      <div className="text-sm font-medium text-foreground">{project.name}</div>
+      <p className="mb-2 mt-0.5 text-xs text-muted-foreground">{project.path}</p>
+      <Input
+        value={bin}
+        onChange={(event) => persist(event.target.value)}
+        placeholder={globalBin || "claude"}
+        spellCheck={false}
+        aria-label={`Claude Code path for ${project.name}`}
+        className="w-96 max-w-full font-mono"
+      />
     </SettingBlock>
   )
 }

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react"
 import type { ComponentType } from "react"
+import { useParams } from "react-router-dom"
 import { Search } from "lucide-react"
 import { TerminalSettings } from "./TerminalSettings"
 import { AppearanceSettings } from "./AppearanceSettings"
@@ -28,15 +29,18 @@ const SECTIONS = [
   id: string
   label: string
   group: "app" | "project"
-  Component: ComponentType
+  Component: ComponentType<{ projectId?: string }>
 }>
 
 type SectionId = (typeof SECTIONS)[number]["id"]
 
-// Settings is a full screen (not a modal): it fills the main area and sits on
-// top of the persistent terminals, which stay mounted and running behind it. A
-// category nav sits on the left; content is on the right.
+// Settings is the per-project settings screen (not a modal): it fills the main
+// area and sits on top of the persistent terminals, which stay mounted and
+// running behind it, with the session sidebar kept beside it. The route carries
+// the project id, which the "project" sections use for that project's
+// overrides. A category nav sits on the left; content is on the right.
 export function Settings() {
+  const { projectId } = useParams()
   const [active, setActive] = useState<SectionId>("terminal")
   const [query, setQuery] = useState("")
 
@@ -96,7 +100,7 @@ export function Settings() {
                 {activeSection.label}
               </h1>
               <div className="divide-y divide-border">
-                <ActiveComponent />
+                <ActiveComponent projectId={projectId} />
               </div>
             </>
           )}

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -1,8 +1,10 @@
-import {useState} from "react"
-import {useMatch} from "react-router-dom"
+import {useState, useSyncExternalStore} from "react"
+import {useMatch, useNavigate} from "react-router-dom"
 import {Bot, GitBranch, Plus, Terminal} from "lucide-react"
 import {toast} from "sonner"
 import {ProjectService} from "@/lib/rpc"
+import {closeSettings, isSettingsOpen, subscribeSettingsCard} from "@/lib/settings-card-store"
+import {SettingsCard} from "./SettingsCard"
 import {Button} from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -41,8 +43,15 @@ export function SessionSidebar() {
     renameSession,
     reorderSessions,
   } = useProjects()
-  const match = useMatch("/projects/:projectId")
+  // Match the project subtree ("/*") so the sidebar stays mounted — and keeps
+  // resolving its project — while the per-project Settings screen is open.
+  const match = useMatch("/projects/:projectId/*")
   const projectId = match?.params.projectId
+  const onSettings = !!useMatch("/projects/:projectId/settings")
+  const navigate = useNavigate()
+  const settingsOpen = useSyncExternalStore(subscribeSettingsCard, () =>
+    isSettingsOpen(projectId ?? ""),
+  )
   const path = projects.find((p) => p.id === projectId)?.path ?? ""
   const git = useGitStatus(path)
   const {width, handleProps} = usePanelWidth({
@@ -176,6 +185,19 @@ export function SessionSidebar() {
         </DropdownMenu>
       </div>
       <div className="flex flex-1 flex-col gap-1.5 overflow-y-auto">
+        {settingsOpen && (
+          <SettingsCard
+            active={onSettings}
+            onSelect={() => navigate(`/projects/${projectId}/settings`)}
+            onClose={() => {
+              closeSettings(projectId)
+              // Leaving settings drops back to the project's active terminal.
+              if (onSettings) {
+                navigate(`/projects/${projectId}`)
+              }
+            }}
+          />
+        )}
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
@@ -190,8 +212,15 @@ export function SessionSidebar() {
                 key={session.id}
                 session={session}
                 path={path}
-                active={session.id === activeId}
-                onSelect={() => activateSession(projectId, session.id)}
+                // A session is never highlighted while the Settings screen owns
+                // the view, so the Settings card reads as the active one.
+                active={session.id === activeId && !onSettings}
+                onSelect={() => {
+                  activateSession(projectId, session.id)
+                  // From the settings screen this returns to the terminal; on
+                  // the project route it is a no-op.
+                  navigate(`/projects/${projectId}`)
+                }}
                 onClose={() => requestClose(session)}
                 onRename={(label) => renameSession(projectId, session.id, label)}
               />

--- a/frontend/src/components/sidebar/SettingsCard.tsx
+++ b/frontend/src/components/sidebar/SettingsCard.tsx
@@ -1,0 +1,39 @@
+import { Settings, X } from "lucide-react"
+import { cn } from "@/lib/utils"
+
+interface SettingsCardProps {
+  active: boolean
+  onSelect: () => void
+  onClose: () => void
+}
+
+// SettingsCard is the project's Settings entry in the session list: it appears
+// when settings is opened for the project and stays parked (inactive) while the
+// user works in a terminal, mirroring SessionCard's shape so it reads as a peer
+// of the sessions rather than a separate control.
+export function SettingsCard({ active, onSelect, onClose }: SettingsCardProps) {
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        "group relative flex w-full items-center gap-2 rounded-lg border border-border/60 bg-card px-3 py-3 text-left text-sm font-medium text-foreground transition-colors hover:bg-accent/60",
+        active && "border-accent-foreground/20 bg-accent text-accent-foreground",
+      )}
+    >
+      <Settings className="size-4 shrink-0 text-muted-foreground" />
+      <span>Settings</span>
+      <span
+        role="button"
+        aria-label="Close settings"
+        onClick={(event) => {
+          event.stopPropagation()
+          onClose()
+        }}
+        className="absolute right-2 top-1/2 flex size-4 -translate-y-1/2 items-center justify-center rounded opacity-0 transition-opacity hover:bg-foreground/15 group-hover:opacity-100"
+      >
+        <X className="size-3" />
+      </span>
+    </button>
+  )
+}

--- a/frontend/src/components/tabs/ProjectTabs.tsx
+++ b/frontend/src/components/tabs/ProjectTabs.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from "react-router-dom"
+import { useMatch, useNavigate } from "react-router-dom"
 import { Plus, Settings } from "lucide-react"
 import { DndContext, closestCenter } from "@dnd-kit/core"
 import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortable"
@@ -6,15 +6,30 @@ import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { useProjects } from "@/lib/projects"
 import { sessionsOf } from "@/lib/sessions"
+import { openSettings } from "@/lib/settings-card-store"
 import { useSortableList } from "@/lib/use-sortable-list"
 import { ProjectTab } from "./ProjectTab"
 import { HomeTab } from "./HomeTab"
 
 // ProjectTabs is the top strip: the pinned Home tab, open projects as tabs
-// (drag to reorder), a button to open another, and settings pinned to the right.
+// (drag to reorder), a button to open another, and a settings button pinned to
+// the right that opens the current project's Settings card.
 export function ProjectTabs() {
   const { projects, sessions, homeId, openProject, closeProject, reorderProjects } =
     useProjects()
+  const navigate = useNavigate()
+  // The project the settings gear targets: whichever one is in view, falling
+  // back to Home when the app is on the bare landing screen.
+  const activeProjectId = useMatch("/projects/:projectId/*")?.params.projectId ?? homeId
+  const onSettings = !!useMatch("/projects/:projectId/settings")
+
+  const openProjectSettings = () => {
+    if (!activeProjectId) {
+      return
+    }
+    openSettings(activeProjectId)
+    navigate(`/projects/${activeProjectId}/settings`)
+  }
   // Home is pinned first and stays out of the drag list so it never reorders.
   const rest = projects.filter((project) => project.id !== homeId)
   const ids = rest.map((project) => project.id)
@@ -53,19 +68,20 @@ export function ProjectTabs() {
         </Button>
       </div>
 
-      <NavLink
-        to="/settings"
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={openProjectSettings}
+        disabled={!activeProjectId}
         title="Settings"
         aria-label="Settings"
-        className={({ isActive }) =>
-          cn(
-            "flex size-8 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground",
-            isActive && "bg-accent text-accent-foreground",
-          )
-        }
+        className={cn(
+          "shrink-0 text-muted-foreground",
+          onSettings && "bg-accent text-accent-foreground",
+        )}
       >
         <Settings className="size-4" />
-      </NavLink>
+      </Button>
     </div>
   )
 }

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -125,7 +125,9 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
   const homeIdRef = useRef<string | null>(null)
   homeIdRef.current = homeId
   const navigate = useNavigate()
-  const activeProjectId = useMatch("/projects/:projectId")?.params.projectId
+  // "/*" so a project stays the active one while its Settings screen is open
+  // (keeps the new-session hotkey, attention toasts and seen-tracking working).
+  const activeProjectId = useMatch("/projects/:projectId/*")?.params.projectId
   // Latest focused project id for the attention toast, read inside a once-only
   // event subscription without re-subscribing on every navigation.
   const activeProjectIdRef = useRef(activeProjectId)

--- a/frontend/src/lib/settings-card-store.test.ts
+++ b/frontend/src/lib/settings-card-store.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+  closeSettings,
+  isSettingsOpen,
+  openSettings,
+  subscribeSettingsCard,
+} from "./settings-card-store"
+
+// The store is module-level (shared across tests): every test closes what it
+// opened so the next one starts from a clean slate.
+afterEach(() => {
+  closeSettings("a")
+  closeSettings("b")
+})
+
+describe("settings-card-store", () => {
+  it("starts closed", () => {
+    expect(isSettingsOpen("a")).toBe(false)
+  })
+
+  it("open then close flips the flag", () => {
+    openSettings("a")
+    expect(isSettingsOpen("a")).toBe(true)
+    closeSettings("a")
+    expect(isSettingsOpen("a")).toBe(false)
+  })
+
+  it("tracks projects independently", () => {
+    openSettings("a")
+    expect(isSettingsOpen("a")).toBe(true)
+    expect(isSettingsOpen("b")).toBe(false)
+  })
+
+  it("notifies subscribers on open and close", () => {
+    const listener = vi.fn()
+    const off = subscribeSettingsCard(listener)
+    openSettings("a")
+    closeSettings("a")
+    expect(listener).toHaveBeenCalledTimes(2)
+    off()
+  })
+
+  it("does not notify when the state is unchanged", () => {
+    const listener = vi.fn()
+    const off = subscribeSettingsCard(listener)
+    openSettings("a")
+    openSettings("a") // already open
+    closeSettings("b") // never opened
+    expect(listener).toHaveBeenCalledTimes(1)
+    off()
+  })
+
+  it("stops notifying after unsubscribe", () => {
+    const listener = vi.fn()
+    const off = subscribeSettingsCard(listener)
+    off()
+    openSettings("a")
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/settings-card-store.ts
+++ b/frontend/src/lib/settings-card-store.ts
@@ -1,0 +1,45 @@
+// Tracks which projects have their Settings card open in the sidebar. This is a
+// pure UI concern that is never persisted: the settings screen itself is
+// route-driven, this only remembers that a project's Settings card should stay
+// parked in its session list (inactive) while the user works in a terminal, so
+// it can be clicked back to. A restart starts with no cards open — settings are
+// reopened on demand, the stored workspace is untouched.
+//
+// Module-level store + a subscribe/getSnapshot pair for useSyncExternalStore,
+// matching the app's no-state-library pattern.
+const openIds = new Set<string>()
+const listeners = new Set<() => void>()
+
+function emit(): void {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+/** Open a project's Settings card. No-op (and no notification) if already open. */
+export function openSettings(projectId: string): void {
+  if (openIds.has(projectId)) {
+    return
+  }
+  openIds.add(projectId)
+  emit()
+}
+
+/** Close a project's Settings card. No-op (and no notification) if not open. */
+export function closeSettings(projectId: string): void {
+  if (!openIds.delete(projectId)) {
+    return
+  }
+  emit()
+}
+
+export function isSettingsOpen(projectId: string): boolean {
+  return openIds.has(projectId)
+}
+
+export function subscribeSettingsCard(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}


### PR DESCRIPTION
## What

Settings is now a **per-project screen** instead of a global one. It opens as a **Settings card** in the project's session sidebar (Warp-style): click the gear → a Settings card appears in the sidebar and the settings screen fills the main area, **with the session sidebar kept visible** (before, the sidebar disappeared on `/settings`).

The route carries the project id (`/projects/:projectId/settings`), so the project section shows **that project's** overrides.

Motivation: segment configuration per project.

## Behaviour

- Gear (top-right) → opens settings for the project in view (falls back to Home on the bare landing screen).
- The Settings card stays **parked** (inactive) in the sidebar while you work in a terminal — click it to return, **X** to close.
- Opening a terminal from settings drops back to that terminal; a session is never highlighted while settings owns the view.

## Changes

- `lib/settings-card-store.ts` — module-level store (`Set<projectId>`) tracking which projects have their Settings card parked, surfaced via `useSyncExternalStore`. **Never persisted** — the stored workspace is untouched (only `claude.bin` remains per-project; appearance/font/hotkeys stay global).
- `sidebar/SettingsCard.tsx` — sidebar entry mirroring `SessionCard`.
- `App.tsx` — `/settings` → `/projects/:projectId/settings`.
- `sidebar/SessionSidebar.tsx`, `tabs/ProjectTabs.tsx`, `lib/projects.tsx` — match `"/projects/:projectId/*"` so the project stays active (sidebar mounted, new-session hotkey / attention toasts / seen-tracking intact) while settings is open.
- `settings/Settings.tsx` — reads `projectId` from the route, injects it into the "project" section.
- `settings/ProjectClaudeCodeSettings.tsx` — scopes to the current project instead of iterating every open project.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 230 pass (23 files, incl. new `settings-card-store.test.ts`, 6 cases)
- [x] `vite build` succeeds
- [x] Verified `matchPath("/projects/:projectId/*")` resolves both `/projects/x` and `/projects/x/settings` (sidebar-stays-visible depends on it)
- [x] Manual: opening/parking/closing the Settings card, per-project `claude.bin` override — confirmed by author

## Deliberately skipped (upgrade paths)

- Parked card does **not** survive a restart, and closing a project leaves a dead `Set` entry (harmless) → add `closeSettings` in `closeProject` if it matters.
- Only `claude.bin` is per-project; appearance/font/hotkeys stay global → migrate section-by-section (`Store.SetSetting(key, scope)` infra already exists).
- Settings opens on the "Terminal" section (current default) → switch to the project section if preferred (one line).