### PR TITLE
feat: pluggable providers (Claude Code, Codex, opencode, Crush)

### DIFF
--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -73,3 +73,11 @@ export interface AppUpdateStatus {
   canSelfApply: boolean
   releaseUrl: string
 }
+
+/** internal/providers.Detected — a known provider and whether it is on PATH. */
+export interface DetectedProvider {
+  id: string
+  name: string
+  installed: boolean
+  path: string
+}

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -10,6 +10,7 @@ import {
   activeSessionId,
   addSession,
   closeSession as removeSession,
+  isSessionKind,
   projectOfSession,
   removeProject,
   renameSession as relabelSession,
@@ -94,7 +95,7 @@ function buildSessionState(loaded: StoreProject[]): SessionState {
     const sessions = (p.sessions ?? []).map((s) => ({
       id: s.id,
       label: s.label,
-      kind: (s.kind === "shell" ? "shell" : "claude") as SessionKind,
+      kind: isSessionKind(s.kind) ? s.kind : "claude",
       ...(s.path ? { path: s.path } : {}),
       ...(s.claudeSessionId ? { claudeSessionId: s.claudeSessionId } : {}),
     }))

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -9,6 +9,7 @@
 import type {
   AppUpdateStatus,
   Branches,
+  DetectedProvider,
   DiffStats,
   PluginStatus,
   Project,
@@ -162,4 +163,9 @@ export const AppUpdate = {
 
 export const System = {
   OpenExternal: (url: string) => call<null>("system.OpenExternal", [url]),
+}
+
+export const Providers = {
+  /** Every known provider with its install state (binary found on PATH). */
+  Detect: () => call<DetectedProvider[]>("providers.Detect", []),
 }

--- a/frontend/src/lib/sessions.test.ts
+++ b/frontend/src/lib/sessions.test.ts
@@ -4,6 +4,7 @@ import {
   addSession,
   closeSession,
   createProjectSessions,
+  isSessionKind,
   projectOfSession,
   removeProject,
   renameSession,
@@ -25,6 +26,20 @@ function buildState(n: number): SessionState {
   }
   return state
 }
+
+describe("isSessionKind", () => {
+  it("accepts every provider kind and the shell", () => {
+    for (const kind of ["claude", "codex", "opencode", "crush", "shell"]) {
+      expect(isSessionKind(kind)).toBe(true)
+    }
+  })
+
+  it("rejects unknown strings", () => {
+    for (const kind of ["", "bash", "gpt", "Claude", "worktree"]) {
+      expect(isSessionKind(kind)).toBe(false)
+    }
+  })
+})
 
 // withClaudeSession stamps a restored session's Claude session id onto the
 // state, the way hydration from the store does.

--- a/frontend/src/lib/sessions.ts
+++ b/frontend/src/lib/sessions.ts
@@ -8,9 +8,21 @@
 
 import { applyOrder } from "./reorder"
 
-// What a session's PTY runs: the Claude Code binary or the user's shell.
-// Values match the backend (store column + terminal.Start).
-export type SessionKind = "claude" | "shell"
+// Provider ids that can back a session, mirrored from internal/providers.Registry
+// (Go) — keep in sync. A session's kind is one of these or the plain shell.
+export const PROVIDER_KINDS = ["claude", "codex", "opencode", "crush"] as const
+export type ProviderKind = (typeof PROVIDER_KINDS)[number]
+
+// What a session's PTY runs: a provider's CLI or the user's shell. Values match
+// the backend (store column + terminal.Start).
+export type SessionKind = ProviderKind | "shell"
+
+// isSessionKind narrows a persisted or otherwise untrusted string to a
+// SessionKind, so hydration can fall back on an unrecognized value instead of
+// carrying a bad kind into state.
+export function isSessionKind(value: string): value is SessionKind {
+  return value === "shell" || (PROVIDER_KINDS as readonly string[]).includes(value)
+}
 
 export interface Session {
   id: string

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -1,0 +1,83 @@
+// Package providers is the registry of AI coding CLI harnesses lich can run in
+// a session (Claude Code, Codex, opencode, Crush). A provider id doubles as the
+// session kind that spawns it; the terminal resolves the id to a binary, and the
+// settings store keys per-provider overrides on it. Detection is a PATH scan,
+// mirroring internal/chromium's browser detection.
+package providers
+
+import "os/exec"
+
+// Provider ids. Each id is also the session kind (store column + terminal.Start)
+// that runs the provider. Kept in sync with frontend/src/lib/sessions.ts.
+const (
+	Claude   = "claude"
+	Codex    = "codex"
+	OpenCode = "opencode"
+	Crush    = "crush"
+)
+
+// Provider is a known harness: a stable id, a display name, and the executable
+// names to look for on PATH (in preference order).
+type Provider struct {
+	ID       string
+	Name     string
+	Binaries []string
+}
+
+// Registry is every provider lich knows about, in display order. Claude Code is
+// first: it is the default and the only one wired for resume, the plugin and
+// ai-titles — the rest just spawn their TUI in a PTY.
+var Registry = []Provider{
+	{ID: Claude, Name: "Claude Code", Binaries: []string{"claude"}},
+	{ID: Codex, Name: "Codex", Binaries: []string{"codex"}},
+	{ID: OpenCode, Name: "opencode", Binaries: []string{"opencode"}},
+	{ID: Crush, Name: "Crush", Binaries: []string{"crush"}},
+}
+
+// DefaultBinary returns a provider's preferred executable name, or "" for an
+// unknown id.
+func DefaultBinary(id string) string {
+	for _, p := range Registry {
+		if p.ID == id && len(p.Binaries) > 0 {
+			return p.Binaries[0]
+		}
+	}
+	return ""
+}
+
+// Detected reports a provider and whether one of its binaries was found on PATH.
+type Detected struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Installed bool   `json:"installed"`
+	Path      string `json:"path"`
+}
+
+// Service detects installed providers. lookPath is injected so tests drive
+// detection without touching the machine.
+type Service struct {
+	lookPath func(string) (string, error)
+}
+
+// New returns a Service that scans the real PATH.
+func New() *Service {
+	return &Service{lookPath: exec.LookPath}
+}
+
+// Detect returns every known provider with its install state, resolving the
+// first candidate binary found on PATH. The list order matches Registry.
+func (s *Service) Detect() ([]Detected, error) {
+	out := make([]Detected, 0, len(Registry))
+	for _, p := range Registry {
+		d := Detected{ID: p.ID, Name: p.Name}
+		for _, name := range p.Binaries {
+			if path, err := s.lookPath(name); err == nil {
+				d.Installed = true
+				d.Path = path
+				break
+			}
+		}
+		out = append(out, d)
+	}
+	return out, nil
+}

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -1,0 +1,71 @@
+package providers
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+func TestDefaultBinary(t *testing.T) {
+	cases := map[string]string{
+		Claude:   "claude",
+		Codex:    "codex",
+		OpenCode: "opencode",
+		Crush:    "crush",
+		"nope":   "",
+		"":       "",
+	}
+	for id, want := range cases {
+		if got := DefaultBinary(id); got != want {
+			t.Errorf("DefaultBinary(%q) = %q, want %q", id, got, want)
+		}
+	}
+}
+
+func TestDetect(t *testing.T) {
+	// Only claude and crush are "installed"; the fake resolves their binaries to
+	// a path and reports the rest missing.
+	installed := map[string]string{
+		"claude": "/usr/bin/claude",
+		"crush":  "/opt/bin/crush",
+	}
+	svc := &Service{
+		lookPath: func(name string) (string, error) {
+			if path, ok := installed[name]; ok {
+				return path, nil
+			}
+			return "", exec.ErrNotFound
+		},
+	}
+
+	got, err := svc.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if len(got) != len(Registry) {
+		t.Fatalf("Detect returned %d providers, want %d", len(got), len(Registry))
+	}
+	// Order matches Registry, and install state/path track the fake.
+	if got[0].ID != Claude || !got[0].Installed || got[0].Path != "/usr/bin/claude" {
+		t.Errorf("claude = %+v, want installed at /usr/bin/claude", got[0])
+	}
+	if got[1].ID != Codex || got[1].Installed {
+		t.Errorf("codex = %+v, want not installed", got[1])
+	}
+	if got[3].ID != Crush || !got[3].Installed || got[3].Path != "/opt/bin/crush" {
+		t.Errorf("crush = %+v, want installed at /opt/bin/crush", got[3])
+	}
+}
+
+func TestDetectAllMissing(t *testing.T) {
+	svc := &Service{lookPath: func(string) (string, error) { return "", errors.New("nope") }}
+	got, err := svc.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	for _, d := range got {
+		if d.Installed || d.Path != "" {
+			t.Errorf("%s reported installed with no binary on PATH: %+v", d.ID, d)
+		}
+	}
+}

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 )
 
-// claudeBinKey is the settings key holding the Claude Code binary path.
+// claudeBinKey is the settings key holding the Claude Code binary path. Claude
+// keeps this legacy key (rather than the "provider.<id>.bin" scheme the others
+// use) so overrides configured before the providers feature keep resolving.
 const claudeBinKey = "claude.bin"
 
 // globalScope is the sentinel project_id for settings that apply to every
@@ -44,19 +46,35 @@ func (s *Service) SetSetting(key, projectID, value string) error {
 	return nil
 }
 
-// ClaudeBin resolves the Claude Code binary path for a project: the project
+// binKey is the settings key holding a provider's custom binary path. Claude
+// uses the legacy "claude.bin"; every other provider is namespaced by id.
+func binKey(providerID string) string {
+	if providerID == "claude" {
+		return claudeBinKey
+	}
+	return "provider." + providerID + ".bin"
+}
+
+// ProviderBin resolves a provider's binary path for a project: the project
 // override wins, then the global value, then "" (letting the terminal fall back
-// to its default). It is the single call the terminal service makes when
-// spawning a session's PTY.
-func (s *Service) ClaudeBin(projectID string) string {
+// to the provider's default). It is the single call the terminal service makes
+// when spawning a session's PTY.
+func (s *Service) ProviderBin(providerID, projectID string) string {
+	key := binKey(providerID)
 	if projectID != globalScope {
-		if bin, err := s.GetSetting(claudeBinKey, projectID); err == nil && bin != "" {
+		if bin, err := s.GetSetting(key, projectID); err == nil && bin != "" {
 			return bin
 		}
 	}
-	bin, err := s.GetSetting(claudeBinKey, globalScope)
+	bin, err := s.GetSetting(key, globalScope)
 	if err != nil {
 		return ""
 	}
 	return bin
+}
+
+// ClaudeBin is ProviderBin for Claude Code, kept for the plugin service that
+// resolves the same binary outside the terminal's spawn path.
+func (s *Service) ClaudeBin(projectID string) string {
+	return s.ProviderBin("claude", projectID)
 }

--- a/internal/store/settings_test.go
+++ b/internal/store/settings_test.go
@@ -56,3 +56,27 @@ func TestClaudeBinResolution(t *testing.T) {
 		t.Errorf("p2 = %q, want global-claude", got)
 	}
 }
+
+func TestProviderBinResolution(t *testing.T) {
+	svc := newTestStore(t)
+
+	// A non-claude provider is keyed by "provider.<id>.bin", independent of the
+	// legacy claude.bin key, with the same project-over-global fallback.
+	if got := svc.ProviderBin("codex", "p1"); got != "" {
+		t.Errorf("unconfigured codex = %q, want \"\"", got)
+	}
+	_ = svc.SetSetting("provider.codex.bin", globalScope, "global-codex")
+	if got := svc.ProviderBin("codex", "p1"); got != "global-codex" {
+		t.Errorf("global codex = %q, want global-codex", got)
+	}
+	_ = svc.SetSetting("provider.codex.bin", "p1", "p1-codex")
+	if got := svc.ProviderBin("codex", "p1"); got != "p1-codex" {
+		t.Errorf("p1 codex override = %q, want p1-codex", got)
+	}
+
+	// Claude routes through the legacy key, so ProviderBin and ClaudeBin agree.
+	_ = svc.SetSetting(claudeBinKey, globalScope, "global-claude")
+	if got := svc.ProviderBin("claude", "p2"); got != "global-claude" {
+		t.Errorf("ProviderBin claude = %q, want global-claude", got)
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 
 	"github.com/omartelo/lich/internal/events"
+	"github.com/omartelo/lich/internal/providers"
 )
 
 // Event names. A terminal I/O event carries the session ID as a suffix (e.g.
@@ -70,12 +71,12 @@ type session struct {
 	out *coalescer
 }
 
-// Store is the persistence the terminal service depends on: the Claude Code
-// binary to spawn for a project (empty return spawns the default), and where to
-// record the Claude session id a PTY reports through the SessionStart hook. The
-// store implements both.
+// Store is the persistence the terminal service depends on: the binary to spawn
+// for a provider in a project (empty return spawns the provider's default), and
+// where to record the Claude session id a PTY reports through the SessionStart
+// hook. The store implements both.
 type Store interface {
-	ClaudeBin(projectID string) string
+	ProviderBin(providerID, projectID string) string
 	SetClaudeSession(sessionID, claudeSessionID string) error
 	SetSessionTitle(sessionID, title string) (bool, error)
 }
@@ -185,41 +186,46 @@ func (s *Service) sessionEnv(id string) []string {
 	)
 }
 
-// defaultBin is the Claude Code binary spawned when the user has not configured
-// a custom path.
-const defaultBin = "claude"
+// defaultBin is the binary spawned when the session's kind is not a known
+// provider and no custom path is set — a safety net; real sessions always carry
+// a registered provider kind.
+const defaultBin = providers.Claude
 
-// KindShell marks a session that runs the user's shell instead of Claude Code.
+// KindShell marks a session that runs the user's shell instead of a provider.
 const KindShell = "shell"
 
 // readBufSize is the chunk size read from a session's PTY per iteration.
 const readBufSize = 32 * 1024
 
-// resolveBin returns the configured binary, or the default when it is empty.
-func resolveBin(bin string) string {
-	if bin == "" {
-		return defaultBin
+// resolveBin returns the configured binary, or the provider's default when it is
+// empty (falling back to defaultBin for an unknown kind).
+func resolveBin(kind, bin string) string {
+	if bin != "" {
+		return bin
 	}
-	return bin
+	if def := providers.DefaultBinary(kind); def != "" {
+		return def
+	}
+	return defaultBin
 }
 
 // resumeFlag is the Claude Code flag that reopens an existing session by id.
 const resumeFlag = "--resume"
 
-// resumeArgs returns the arguments that reopen the Claude session resume names,
-// or nil when the session must start fresh. A "shell" session never resumes:
-// its PTY runs the user's shell, which knows nothing about --resume, and a
-// stray claude_session_id can land on its row when the user ran Claude Code by
-// hand inside it.
+// resumeArgs returns the arguments that reopen a Claude session, or nil when the
+// session must start fresh. Resume is Claude-specific: "--resume" is Claude
+// Code's flag, so a shell or any other provider never grows it (the frontend
+// only ever passes a resume id for a claude session, but a stray one must not
+// reach codex/opencode/crush either).
 func resumeArgs(kind, resume string) []string {
-	if kind == KindShell || resume == "" {
+	if kind != providers.Claude || resume == "" {
 		return nil
 	}
 	return []string{resumeFlag, resume}
 }
 
 // resolveCommand picks the binary a session runs: the user's shell for "shell"
-// sessions, otherwise the configured Claude Code binary.
+// sessions, otherwise the provider binary for the session's kind.
 func resolveCommand(kind, bin, shellEnv string) string {
 	if kind == KindShell {
 		if shellEnv == "" {
@@ -227,7 +233,7 @@ func resolveCommand(kind, bin, shellEnv string) string {
 		}
 		return shellEnv
 	}
-	return resolveBin(bin)
+	return resolveBin(kind, bin)
 }
 
 // appImageVars are injected by the AppImage runtime or AppImageLauncher and
@@ -313,10 +319,10 @@ func scrubPathList(value, dir string) (string, bool) {
 }
 
 // Start spawns the binary for session id under project projectID — the user's
-// shell when kind is "shell", otherwise the Claude Code binary resolved from the
-// project's settings (falling back to "claude" via $PATH) — attached to a new
-// PTY sized to cols x rows and rooted at cwd, then streams its output to the
-// frontend. An empty cwd defaults to the user's home directory. Starting a
+// shell when kind is "shell", otherwise the provider binary for that kind
+// resolved from the project's settings (falling back to the provider's default
+// on $PATH) — attached to a new PTY sized to cols x rows and rooted at cwd, then
+// streams its output to the frontend. An empty cwd defaults to the user's home directory. Starting a
 // session that is already running is a no-op.
 //
 // A non-empty resume is a Claude session id to reopen (`--resume`), which the
@@ -340,7 +346,7 @@ func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int)
 	}
 
 	p, err := startPTY(ptySpec{
-		bin:  resolveCommand(kind, s.store.ClaudeBin(projectID), userShell()),
+		bin:  resolveCommand(kind, s.store.ProviderBin(kind, projectID), userShell()),
 		args: resumeArgs(kind, resume),
 		dir:  cwd,
 		env:  s.sessionEnv(id),

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -23,7 +23,7 @@ import (
 // SessionStart or ai-title paths.
 type stubBins struct{ bin string }
 
-func (s stubBins) ClaudeBin(string) string                   { return s.bin }
+func (s stubBins) ProviderBin(_, _ string) string            { return s.bin }
 func (s stubBins) SetClaudeSession(_, _ string) error        { return nil }
 func (s stubBins) SetSessionTitle(_, _ string) (bool, error) { return false, nil }
 
@@ -297,13 +297,20 @@ func TestStartWithoutResumeSpawnsBare(t *testing.T) {
 	}
 }
 
-// TestResolveBin proves an empty custom path falls back to the default binary
-// while a configured path is passed through unchanged.
+// TestResolveBin proves an empty custom path falls back to the provider's
+// default binary (and to defaultBin for an unknown kind), while a configured
+// path is passed through unchanged.
 func TestResolveBin(t *testing.T) {
-	if got := resolveBin(""); got != defaultBin {
-		t.Errorf("resolveBin(%q) = %q, want %q", "", got, defaultBin)
+	if got := resolveBin("claude", ""); got != defaultBin {
+		t.Errorf("resolveBin(claude, %q) = %q, want %q", "", got, defaultBin)
 	}
-	if got := resolveBin("/opt/claude.sh"); got != "/opt/claude.sh" {
+	if got := resolveBin("codex", ""); got != "codex" {
+		t.Errorf("resolveBin(codex, %q) = %q, want codex", "", got)
+	}
+	if got := resolveBin("mystery", ""); got != defaultBin {
+		t.Errorf("resolveBin(unknown, %q) = %q, want %q", "", got, defaultBin)
+	}
+	if got := resolveBin("claude", "/opt/claude.sh"); got != "/opt/claude.sh" {
 		t.Errorf("resolveBin custom = %q, want %q", got, "/opt/claude.sh")
 	}
 }
@@ -314,8 +321,11 @@ func TestResolveCommand(t *testing.T) {
 	cases := []struct {
 		name, kind, bin, shell, want string
 	}{
-		{"claude default", "", "", "/bin/zsh", defaultBin},
+		{"claude default", "claude", "", "/bin/zsh", defaultBin},
 		{"claude custom bin", "claude", "/opt/claude.sh", "/bin/zsh", "/opt/claude.sh"},
+		{"codex default", "codex", "", "/bin/zsh", "codex"},
+		{"crush custom bin", "crush", "/opt/crush", "/bin/zsh", "/opt/crush"},
+		{"unknown kind falls back", "mystery", "", "/bin/zsh", defaultBin},
 		{"shell from env", KindShell, "/opt/claude.sh", "/bin/zsh", "/bin/zsh"},
 		{"shell fallback", KindShell, "", "", defaultShell},
 	}
@@ -327,8 +337,9 @@ func TestResolveCommand(t *testing.T) {
 	}
 }
 
-// TestResumeArgs proves a Claude session resumes only when an id is given, and
-// that a shell session never grows a --resume flag its shell cannot parse.
+// TestResumeArgs proves --resume is Claude-only: a claude session resumes when
+// an id is given, and neither a shell nor any other provider ever grows the flag
+// (it is Claude Code's, and a stray id must not reach codex/opencode/crush).
 func TestResumeArgs(t *testing.T) {
 	cases := []struct {
 		name, kind, resume string
@@ -336,7 +347,7 @@ func TestResumeArgs(t *testing.T) {
 	}{
 		{"claude fresh", "claude", "", nil},
 		{"claude resume", "claude", "abc-123", []string{resumeFlag, "abc-123"}},
-		{"default kind resumes", "", "abc-123", []string{resumeFlag, "abc-123"}},
+		{"codex never resumes", "codex", "abc-123", nil},
 		{"shell never resumes", KindShell, "abc-123", nil},
 		{"shell fresh", KindShell, "", nil},
 	}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/omartelo/lich/internal/fonts"
 	"github.com/omartelo/lich/internal/logging"
 	"github.com/omartelo/lich/internal/project"
+	"github.com/omartelo/lich/internal/providers"
 	"github.com/omartelo/lich/internal/restart"
 	"github.com/omartelo/lich/internal/rpc"
 	"github.com/omartelo/lich/internal/store"
@@ -88,6 +89,7 @@ func main() {
 	dispatcher.Register("appupdate", appupdate.New(version))
 	dispatcher.Register("store", db)
 	dispatcher.Register("system", system.New())
+	dispatcher.Register("providers", providers.New())
 	dispatcher.Deny("store.Close")
 	term.Mount("/rpc/", dispatcher)
 	term.Mount("/events", hub)


### PR DESCRIPTION
## What

Adds pluggable AI CLI harnesses to lich. Detects Claude Code / Codex / opencode / Crush on the machine, lets the user enable the ones they want (global choice), drives the **New Session** menu off the enabled set, and shows each harness's **brand icon** instead of the generic Bot. Enabling a provider reveals its config (custom binary path, global + per-project). **Claude stays enabled by default, so nothing changes until the user opts in.**

Single feature, three clear commits: **backend/model** → **UI** → **drop the heavy icon dep**.

Design decisions (agreed): enable is **global**; per-provider binary path keeps a **per-project override** (like `claude.bin`); the settings UI lists **all known providers, marking installed vs not**; a not-installed provider can't be enabled.

## Commit 1 — provider registry + generalized spawn (backend/model)

- `internal/providers` — registry of known harnesses (each `id` doubles as the session `kind`) + a PATH-scan `Detect` service, mirroring `internal/chromium` (`lookPath` injected for tests). New RPC `providers.Detect`.
- `store.ProviderBin(providerID, projectID)` generalizes `ClaudeBin`'s project→global resolution. Claude keeps the legacy `claude.bin` key (**zero migration**); others use `provider.<id>.bin`.
- `terminal` resolves the binary from the session's kind via the registry default. `resumeArgs` narrowed to **Claude-only** — `--resume` is Claude Code's flag, never reaches other providers.
- Frontend: `SessionKind` widens to `shell | claude | codex | opencode | crush` + `isSessionKind` guard; `buildSessionState` now **preserves any known kind** on hydration (was collapsing everything non-`shell` to `claude`).

## Commit 2 — provider selection UI

- `providers-store` — shared, dependency-injected store over `providers.Detect` + the enabled flags. Claude defaults enabled; the rest opt-in. One source of truth for the menu and settings.
- Settings **"Providers"** group: hub listing every harness with install state + an enable **Switch** (not-installed → can't enable). Enabling one reveals its **config section** (custom bin path, global + per-project) under a "Provider settings" header. `SECTIONS` is now computed from the enabled set; the two Claude-specific settings files collapse into one generic `ProviderBinSettings`.
- **New Session** menu driven by enabled providers. Sessions show their provider's mark on the card when idle.

## Commit 3 — vendor the brand icons

`@lobehub/icons` would have dragged **~514 transitive packages** (antd, shiki, @ant-design/icons, …) into the lockfile for three SVGs. Instead the Claude/Codex/opencode marks are **inlined as vendored paths (MIT, lobe-icons)** in a tiny `BrandIcon` — **no new runtime dependency**, lockfile stays at its pre-feature state. Crush uses a lucide fallback (lobehub has no Crush mark).

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` — 250 pass (17 pkgs), incl. `internal/providers` + `store.ProviderBin`
- [x] `tsc --noEmit` clean, `vitest run` — 241 pass (incl. `providers-store` factory + `isSessionKind`), `vite build` OK
- [ ] **Manual (please verify):**
  - New Session → **Claude Code** and **Terminal** still start; custom `claude.bin` (global + per-project) still honored; resume still works
  - Settings → **Providers**: install `codex`/`opencode`/`crush` on PATH → shows Installed → toggle on → appears in New Session with its icon → starts its TUI
  - Not-installed provider: toggle disabled

## Known limits / follow-ups

- Non-Claude providers get a plain PTY: **no resume, ai-title, or status badges** (those are Claude-plugin-fed). Their cards show the brand icon but no live status.
- **Worktree** sessions still spawn Claude (the resumable one).
- **Crush** has no vendored mark yet — lucide fallback; drop in a real SVG later.
- Enable is global only (no per-project provider set) — by design.