### PR TITLE
feat: status ring around provider icon on session cards

### DIFF
--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -1,17 +1,17 @@
 import {useEffect, useRef, useState} from "react"
 import type {KeyboardEvent} from "react"
-import {Bell, Check, GitBranch, GitPullRequestArrow, LoaderCircle, Pencil, X} from "lucide-react"
+import {GitBranch, GitPullRequestArrow, Pencil, X} from "lucide-react"
 import {useSortable} from "@dnd-kit/sortable"
 import {CSS} from "@dnd-kit/utilities"
 import {cn} from "@/lib/utils"
 import {displayPath} from "@/lib/paths"
 import {type Session} from "@/lib/sessions"
-import {ProviderIcon} from "@/lib/provider-icons"
 import {useSessionStatus} from "@/lib/useSessionStatus"
 import {useGitStatus} from "@/lib/useGitStatus"
 import {usePullRequest} from "@/lib/usePullRequest"
 import {System} from "@/lib/rpc"
 import {DiffStat} from "@/components/DiffStat"
+import {SessionStatusIcon} from "./SessionStatusIcon"
 import {Tooltip, TooltipContent, TooltipTrigger} from "@/components/ui/tooltip"
 import {
   ContextMenu,
@@ -45,10 +45,11 @@ export function SessionCard({
   const pathRef = useRef<HTMLSpanElement>(null)
   const [pathOverflow, setPathOverflow] = useState(false)
   const [editing, setEditing] = useState(false)
-  // Processing state reported by the lich Claude Code hook: a spinner while
-  // Claude produces output, a check once its turn ends, a bell when it is
-  // blocked on the user. null before the first report, and whenever the hook
-  // reports a state with no indicator (see toSessionStatus).
+  // Processing state reported by the lich Claude Code hook, drawn as a ring
+  // around the provider icon: a spinning ring while Claude produces output,
+  // solid emerald once its turn ends, amber when it is blocked on the user.
+  // null before the first report, and whenever the hook reports a state with
+  // no indicator (see toSessionStatus) — then the icon shows ringless.
   const status = useSessionStatus(session.id)
   // A worktree session lives in its own checkout: show that path and poll its
   // git status, so the badge reflects the worktree's branch, not the project's.
@@ -138,20 +139,7 @@ export function SessionCard({
                 />
               ) : (
                 <span className="flex w-full min-w-0 items-center gap-1.5 pr-5">
-                  {status === "busy" && (
-                    <LoaderCircle className="size-3 shrink-0 animate-spin text-muted-foreground"/>
-                  )}
-                  {status === "done" && (
-                    <Check className="size-3 shrink-0 text-emerald-500"/>
-                  )}
-                  {status === "waiting" && (
-                    <Bell className="size-3 shrink-0 text-amber-500"/>
-                  )}
-                  {!status && (
-                    <span className="flex shrink-0 items-center text-muted-foreground">
-                      <ProviderIcon kind={session.kind} size={14}/>
-                    </span>
-                  )}
+                  <SessionStatusIcon kind={session.kind} status={status}/>
                   <span className="truncate text-sm font-medium text-foreground">
                     {session.label}
                   </span>

--- a/frontend/src/components/sidebar/SessionStatusIcon.tsx
+++ b/frontend/src/components/sidebar/SessionStatusIcon.tsx
@@ -1,0 +1,32 @@
+import {cn} from "@/lib/utils"
+import {ProviderIcon} from "@/lib/provider-icons"
+import type {SessionKind} from "@/lib/sessions"
+import type {SessionStatus} from "@/lib/session-events"
+
+// Ring drawn around the provider icon per processing state: a spinning ring
+// while Claude produces output, solid emerald once its turn ends, amber when
+// it is blocked on the user.
+const RING: Record<SessionStatus, string> = {
+  busy: "animate-spin border-muted-foreground/25 border-t-muted-foreground",
+  done: "border-emerald-500",
+  waiting: "border-amber-500",
+}
+
+interface SessionStatusIconProps {
+  kind: SessionKind
+  // Last reported state from the lich hook; null renders the bare icon.
+  status: SessionStatus | null
+}
+
+// SessionStatusIcon is a session's provider mark wrapped in a status ring. The
+// slot is a fixed size so the icon never shifts as the state changes.
+export function SessionStatusIcon({kind, status}: SessionStatusIconProps) {
+  return (
+    <span className="relative flex size-[22px] shrink-0 items-center justify-center text-muted-foreground">
+      {status && (
+        <span className={cn("absolute inset-0 rounded-full border-[1.5px]", RING[status])} />
+      )}
+      <ProviderIcon kind={kind} size={14} />
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary

The leading slot on a session card was mutually exclusive: a processing status (busy/done/waiting) replaced the provider icon (`{!status && <ProviderIcon>}`), so a **running** session lost its agent identity — the one moment you most want to know which agent is churning.

Now the status is drawn as a **ring around the provider icon**, so identity and state are both visible at once:

- **busy** — spinning ring (`muted/25` track, `muted-foreground` head)
- **done** — solid emerald ring
- **waiting** — solid amber ring
- **idle** — bare icon, no ring

Extracted into a small `SessionStatusIcon` component (`kind` + `status` in). The fixed-size 22px slot also removes the per-state layout shift the old swap caused.

## Notes

- Old glyph imports (`Bell`, `Check`, `LoaderCircle`) dropped from `SessionCard`.
- No render test: the frontend suite is node-only (`*.test.ts`, no jsdom/testing-library) and covers pure logic; presentational components are a deliberate boundary (no component here has a render test). The only logic is a static `RING` map.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `pnpm build` (tsc + vite) succeeds
- [x] `pnpm test` — 241 passing
- [x] `task dev`: eyeball the ring in each state (busy/done/waiting/idle) in light + dark