### PR TITLE
feat: session card follows the terminal's working directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Session cards follow the terminal's working directory: a `cd` in the session
+  moves the card's path line — and with it the git branch, diff badge and PR
+  badge, which reflect whatever directory is shown. The backend polls the PTY
+  child's cwd every 2s (`/proc`, so live tracking is Linux-only; elsewhere the
+  card keeps the start path) and reports changes over the existing events
+  channel. Nothing is persisted: a respawned session reports its start
+  directory again and the card resets with it.
+
 - A read-only **Code** tab in the terminal's right dock: a tree of the active
   session's tracked files (`git ls-files`, so `.gitignore` is honoured and only
   versioned files appear — no `node_modules`, no build output) with an in-dock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Session cards follow the terminal's working directory: a `cd` in the session
   moves the card's path line — and with it the git branch, diff badge and PR
   badge, which reflect whatever directory is shown. The backend polls the PTY
-  child's cwd every 2s (`/proc`, so live tracking is Linux-only; elsewhere the
-  card keeps the start path) and reports changes over the existing events
-  channel. Nothing is persisted: a respawned session reports its start
-  directory again and the card resets with it.
+  child's cwd every 2s — `/proc` on Linux, `proc_pidinfo` on macOS, a PEB read
+  on Windows — and reports changes over the existing events channel; a failed
+  read keeps the start path. Nothing is persisted: a respawned session reports
+  its start directory again and the card resets with it.
 
 - A read-only **Code** tab in the terminal's right dock: a tree of the active
   session's tracked files (`git ls-files`, so `.gitignore` is honoured and only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,14 +114,18 @@ Before tagging:
 
 Deliberate limits and shortcuts, with the upgrade path when it matters:
 
-- **Session cwd is polled every ~2 s** from `/proc/<pid>/cwd` of the PTY child
+- **Session cwd is polled every ~2 s** from the PTY child
   (`internal/terminal/cwd.go`), emitted as `session-cwd` only on change and kept
   frontend-side in `session-cwd-store.ts` (never persisted; every PTY spawn
-  re-reports its start directory). Linux-only by build tag — macOS
-  (`proc_pidinfo`) and Windows (`NtQueryInformationProcess`) are the upgrade
-  path, until then those cards keep the start path. Reading the direct child
-  misses a nested shell's `cd`, which is fine: the card tracks the session's
-  shell, not arbitrary descendants.
+  re-reports its start directory). Per-platform reads behind the usual build-tag
+  seam: `/proc/<pid>/cwd` on Linux, `proc_pidinfo(PROC_PIDVNODEPATHINFO)` on
+  macOS (bound from libSystem x/sys-style — cgo_import_dynamic + asm trampoline,
+  still pure Go), and a PEB walk on Windows (`NtQueryInformationProcess` +
+  `ReadProcessMemory`; assumes the child matches our architecture — a 32-bit
+  child degrades to the start path). Any failed read degrades the card to the
+  directory the session started in. Reading the direct child misses a nested
+  shell's `cd`, which is fine: the card tracks the session's shell, not
+  arbitrary descendants.
 - **git status is polled every ~3 s** — one shared poller per repository path
   (`frontend/src/lib/git-status-store.ts`), no filesystem watch. Unchanged status short-circuits (same reference, zero
   re-renders). The lich plugin's `session-touched` hook nudges an immediate refresh after Claude edits files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,14 @@ Before tagging:
 
 Deliberate limits and shortcuts, with the upgrade path when it matters:
 
+- **Session cwd is polled every ~2 s** from `/proc/<pid>/cwd` of the PTY child
+  (`internal/terminal/cwd.go`), emitted as `session-cwd` only on change and kept
+  frontend-side in `session-cwd-store.ts` (never persisted; every PTY spawn
+  re-reports its start directory). Linux-only by build tag — macOS
+  (`proc_pidinfo`) and Windows (`NtQueryInformationProcess`) are the upgrade
+  path, until then those cards keep the start path. Reading the direct child
+  misses a nested shell's `cd`, which is fine: the card tracks the session's
+  shell, not arbitrary descendants.
 - **git status is polled every ~3 s** — one shared poller per repository path
   (`frontend/src/lib/git-status-store.ts`), no filesystem watch. Unchanged status short-circuits (same reference, zero
   re-renders). The lich plugin's `session-touched` hook nudges an immediate refresh after Claude edits files

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -7,6 +7,7 @@ import {cn} from "@/lib/utils"
 import {displayPath} from "@/lib/paths"
 import {type Session} from "@/lib/sessions"
 import {useSessionStatus} from "@/lib/useSessionStatus"
+import {useSessionCwd} from "@/lib/useSessionCwd"
 import {useGitStatus} from "@/lib/useGitStatus"
 import {usePullRequest} from "@/lib/usePullRequest"
 import {System} from "@/lib/rpc"
@@ -51,9 +52,13 @@ export function SessionCard({
   // null before the first report, and whenever the hook reports a state with
   // no indicator (see toSessionStatus) — then the icon shows ringless.
   const status = useSessionStatus(session.id)
-  // A worktree session lives in its own checkout: show that path and poll its
-  // git status, so the badge reflects the worktree's branch, not the project's.
-  const shownPath = session.path || path
+  // The live working directory the backend's cwd watcher reports ("" until it
+  // does): a `cd` in the terminal moves the card with it. Falls back to the
+  // session's static start path — a worktree session lives in its own checkout,
+  // so that path (not the project's) is the fallback. Git status and the PR
+  // badge follow whatever is shown, so they reflect the directory's repo.
+  const liveCwd = useSessionCwd(session.id)
+  const shownPath = liveCwd || session.path || path
   const git = useGitStatus(shownPath)
   const pr = usePullRequest(shownPath, git?.branch ?? "")
   // Renaming disables the drag: the sensor would otherwise claim the pointer

--- a/frontend/src/lib/session-cwd-store.test.ts
+++ b/frontend/src/lib/session-cwd-store.test.ts
@@ -1,0 +1,70 @@
+import {describe, expect, it} from "vitest"
+import {createSessionCwdStore} from "./session-cwd-store"
+
+// harness wires a store to a hand-driven event source, returning the emitter.
+function harness() {
+  let handler: (data: unknown) => void = () => {}
+  const store = createSessionCwdStore((h) => {
+    handler = h
+    return () => {}
+  })
+  return {store, emit: (data: unknown) => handler(data)}
+}
+
+describe("createSessionCwdStore", () => {
+  it("returns empty while nothing has been reported", () => {
+    const {store} = harness()
+    expect(store.get("s1")).toBe("")
+  })
+
+  it("keeps the last reported cwd per session", () => {
+    const {store, emit} = harness()
+    emit({id: "s1", cwd: "/home/user/project"})
+    emit({id: "s2", cwd: "/tmp"})
+    expect(store.get("s1")).toBe("/home/user/project")
+    expect(store.get("s2")).toBe("/tmp")
+  })
+
+  it("notifies only the session's subscribers on change", () => {
+    const {store, emit} = harness()
+    let s1 = 0
+    let s2 = 0
+    store.subscribe("s1", () => s1++)
+    store.subscribe("s2", () => s2++)
+    emit({id: "s1", cwd: "/a"})
+    expect(s1).toBe(1)
+    expect(s2).toBe(0)
+  })
+
+  it("stays silent on a repeated cwd", () => {
+    const {store, emit} = harness()
+    let calls = 0
+    store.subscribe("s1", () => calls++)
+    emit({id: "s1", cwd: "/a"})
+    emit({id: "s1", cwd: "/a"})
+    expect(calls).toBe(1)
+  })
+
+  it("retains the cwd across an unsubscribe, like a card unmount", () => {
+    const {store, emit} = harness()
+    const off = store.subscribe("s1", () => {})
+    emit({id: "s1", cwd: "/a"})
+    off()
+    expect(store.get("s1")).toBe("/a")
+  })
+
+  it("ignores malformed payloads", () => {
+    const {store, emit} = harness()
+    emit({id: "s1"})
+    emit({cwd: "/a"})
+    emit(null)
+    expect(store.get("s1")).toBe("")
+  })
+
+  it("overwrites a stale cwd when the backend re-reports on respawn", () => {
+    const {store, emit} = harness()
+    emit({id: "s1", cwd: "/somewhere/deep"})
+    emit({id: "s1", cwd: "/home/user/project"})
+    expect(store.get("s1")).toBe("/home/user/project")
+  })
+})

--- a/frontend/src/lib/session-cwd-store.ts
+++ b/frontend/src/lib/session-cwd-store.ts
@@ -1,0 +1,59 @@
+import {isCwdEvent} from "./session-events"
+
+// A subscription to the global cwd event, injected so the store is testable
+// without standing up the /events socket. Returns its unsubscribe.
+export type CwdEventSource = (handler: (data: unknown) => void) => () => void
+
+interface Entry {
+  cwd: string
+  listeners: Set<() => void>
+}
+
+// createSessionCwdStore keeps the last reported working directory of every
+// session, keyed by session id, fed by one subscription taken at creation —
+// before any card mounts. Same shape as session-status-store, for the same
+// reason: cards unmount with their project, so the value cannot live in them.
+// The backend re-reports the start directory on every PTY spawn, so a respawn
+// overwrites whatever the previous shell left here.
+export function createSessionCwdStore(source: CwdEventSource) {
+  const entries = new Map<string, Entry>()
+
+  const entryOf = (id: string): Entry => {
+    let entry = entries.get(id)
+    if (!entry) {
+      entry = {cwd: "", listeners: new Set()}
+      entries.set(id, entry)
+    }
+    return entry
+  }
+
+  source((data) => {
+    if (!isCwdEvent(data)) {
+      return
+    }
+    const entry = entryOf(data.id)
+    // Snapshots are plain strings, so identity is free: bail on a repeat and
+    // subscribers skip the re-render entirely.
+    if (entry.cwd === data.cwd) {
+      return
+    }
+    entry.cwd = data.cwd
+    for (const listener of entry.listeners) {
+      listener()
+    }
+  })
+
+  const subscribe = (id: string, listener: () => void): (() => void) => {
+    const entry = entryOf(id)
+    entry.listeners.add(listener)
+    return () => {
+      entry.listeners.delete(listener)
+    }
+  }
+
+  // get returns "" while nothing has been reported — the card then falls back
+  // to the session's static path.
+  const get = (id: string): string => entries.get(id)?.cwd ?? ""
+
+  return {subscribe, get}
+}

--- a/frontend/src/lib/session-events.test.ts
+++ b/frontend/src/lib/session-events.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from "vitest"
 import {
+  isCwdEvent,
   isIdEvent,
   isStatusEvent,
   isTitleEvent,
@@ -85,6 +86,19 @@ describe("isTitleEvent", () => {
     expect(isTitleEvent({label: "build"})).toBe(false)
     expect(isTitleEvent({id: "s1", label: 2})).toBe(false)
     expect(isTitleEvent(null)).toBe(false)
+  })
+})
+
+describe("isCwdEvent", () => {
+  it("accepts a payload carrying a string id and cwd", () => {
+    expect(isCwdEvent({id: "s1", cwd: "/home/user"})).toBe(true)
+  })
+
+  it("rejects a payload missing either half", () => {
+    expect(isCwdEvent({id: "s1"})).toBe(false)
+    expect(isCwdEvent({cwd: "/home/user"})).toBe(false)
+    expect(isCwdEvent({id: "s1", cwd: 2})).toBe(false)
+    expect(isCwdEvent(null)).toBe(false)
   })
 })
 

--- a/frontend/src/lib/session-events.ts
+++ b/frontend/src/lib/session-events.ts
@@ -22,6 +22,11 @@ export const TITLE_EVENT = "session-title"
 // (see terminal.touchedEventName). Payload: { id }.
 export const TOUCHED_EVENT = "session-touched"
 
+// Global event the backend emits with a session's live working directory (see
+// terminal.cwdEventName): once with the directory the PTY starts in, then on
+// every change the cwd watcher observes. Payload: { id, cwd }.
+export const CWD_EVENT = "session-cwd"
+
 // The states a card renders an indicator for. The contract also defines "idle"
 // (SessionEnd), which maps to no indicator like any unknown value does.
 const RENDERED_STATUSES = ["busy", "done", "waiting"] as const
@@ -56,6 +61,10 @@ export function isStatusEvent(data: unknown): data is {id: string; state: string
 
 export function isTitleEvent(data: unknown): data is {id: string; label: string} {
   return isIdEvent(data) && typeof (data as {label?: unknown}).label === "string"
+}
+
+export function isCwdEvent(data: unknown): data is {id: string; cwd: string} {
+  return isIdEvent(data) && typeof (data as {cwd?: unknown}).cwd === "string"
 }
 
 // shouldToastAttention decides whether a session needing the user deserves the

--- a/frontend/src/lib/useSessionCwd.ts
+++ b/frontend/src/lib/useSessionCwd.ts
@@ -1,0 +1,19 @@
+import {useCallback, useSyncExternalStore} from "react"
+import {onAppEvent} from "./app-events"
+import {CWD_EVENT} from "./session-events"
+import {createSessionCwdStore} from "./session-cwd-store"
+
+// Subscribed at import rather than on first use: that opens the /events socket
+// at page load, so a cwd reported before any card mounts still lands.
+const store = createSessionCwdStore((handler) => onAppEvent(CWD_EVENT, handler))
+
+// useSessionCwd reads a session's live working directory from the shared store
+// (see session-cwd-store), which retains it across the card's unmount. Returns
+// "" while the backend has reported nothing for the session.
+export function useSessionCwd(sessionId: string): string {
+  const subscribe = useCallback(
+    (onChange: () => void) => store.subscribe(sessionId, onChange),
+    [sessionId],
+  )
+  return useSyncExternalStore(subscribe, () => store.get(sessionId))
+}

--- a/internal/terminal/cwd.go
+++ b/internal/terminal/cwd.go
@@ -24,8 +24,9 @@ type cwdEvent struct {
 const cwdPollInterval = 2 * time.Second
 
 // watchCwd reports the session child's working directory to the frontend
-// whenever it changes, until done closes. No-op on platforms without cwd
-// tracking (only Linux has /proc) and when the PTY reports no child PID.
+// whenever it changes, until done closes. Each platform brings its own read
+// (see the cwd_* files); on one without any, and when the PTY reports no
+// child PID, this is a no-op.
 func watchCwd(id string, pid int, initial string, done <-chan struct{}, hub *events.Hub) {
 	if !cwdTracked || pid <= 0 {
 		return

--- a/internal/terminal/cwd.go
+++ b/internal/terminal/cwd.go
@@ -1,0 +1,58 @@
+package terminal
+
+import (
+	"time"
+
+	"github.com/omartelo/lich/internal/events"
+)
+
+// cwdEventName carries a session's live working directory ({id, cwd}), emitted
+// once with the directory the PTY starts in and again whenever the child
+// process moves (the user runs `cd`). Global like the other session events:
+// its consumer (the session card's path line) may be unmounted when it fires.
+const cwdEventName = "session-cwd"
+
+// cwdEvent is the payload of cwdEventName.
+type cwdEvent struct {
+	ID  string `json:"id"`
+	Cwd string `json:"cwd"`
+}
+
+// cwdPollInterval is how often a session's child working directory is read.
+// Matches the spirit of the frontend's ~3s git-status poll: cheap enough to
+// never matter, fresh enough to feel live.
+const cwdPollInterval = 2 * time.Second
+
+// watchCwd reports the session child's working directory to the frontend
+// whenever it changes, until done closes. No-op on platforms without cwd
+// tracking (only Linux has /proc) and when the PTY reports no child PID.
+func watchCwd(id string, pid int, initial string, done <-chan struct{}, hub *events.Hub) {
+	if !cwdTracked || pid <= 0 {
+		return
+	}
+	ticker := time.NewTicker(cwdPollInterval)
+	defer ticker.Stop()
+	pollCwd(pid, initial, ticker.C, done, func(cwd string) {
+		hub.Emit(cwdEventName, cwdEvent{ID: id, Cwd: cwd})
+	})
+}
+
+// pollCwd reads pid's working directory on every tick and calls emit when it
+// differs from the last seen value, returning when done closes. An unreadable
+// directory (the process just died, done is about to close) is skipped rather
+// than reported. Split from watchCwd so tests drive the ticks.
+func pollCwd(pid int, last string, tick <-chan time.Time, done <-chan struct{}, emit func(string)) {
+	for {
+		select {
+		case <-done:
+			return
+		case <-tick:
+			cwd := processCwd(pid)
+			if cwd == "" || cwd == last {
+				continue
+			}
+			last = cwd
+			emit(cwd)
+		}
+	}
+}

--- a/internal/terminal/cwd_darwin.go
+++ b/internal/terminal/cwd_darwin.go
@@ -1,0 +1,66 @@
+package terminal
+
+import (
+	"bytes"
+	"syscall"
+	"unsafe"
+	_ "unsafe" // for go:linkname
+)
+
+const cwdTracked = true
+
+// proc_pidinfo is not exposed by x/sys/unix, so this file binds it from
+// libSystem the way x/sys itself binds libc calls: a cgo_import_dynamic symbol
+// reached through an assembly trampoline (cwd_darwin.s) and the runtime's
+// libSystem-aware syscall6 — no CGO involved, the binary stays pure Go.
+
+//go:linkname syscall_syscall6 syscall.syscall6
+func syscall_syscall6(fn, a1, a2, a3, a4, a5, a6 uintptr) (r1, r2 uintptr, err syscall.Errno)
+
+var libc_proc_pidinfo_trampoline_addr uintptr
+
+//go:cgo_import_dynamic libc_proc_pidinfo proc_pidinfo "/usr/lib/libSystem.B.dylib"
+
+// procPidVnodePathInfo is the proc_pidinfo flavor returning a process's
+// current and root directories (PROC_PIDVNODEPATHINFO, sys/proc_info.h).
+const procPidVnodePathInfo = 9
+
+// vnodeInfoPath mirrors struct vnode_info_path: an opaque struct vnode_info
+// (vinfo_stat 136 bytes + vi_type 4 + vi_pad 4 + vi_fsid 8) followed by the
+// path (MAXPATHLEN). Only the path is read, so the stat half stays opaque.
+type vnodeInfoPath struct {
+	_    [152]byte
+	Path [1024]byte
+}
+
+// procVnodePathInfo mirrors struct proc_vnodepathinfo: the current directory,
+// then the root directory.
+type procVnodePathInfo struct {
+	Cdir vnodeInfoPath
+	Rdir vnodeInfoPath
+}
+
+// processCwd returns pid's current working directory, or "" when it cannot be
+// read (the process exited, or was never ours to inspect). proc_pidinfo
+// returns the number of bytes filled; anything short of the full struct is a
+// failure.
+func processCwd(pid int) string {
+	var info procVnodePathInfo
+	n, _, _ := syscall_syscall6(
+		libc_proc_pidinfo_trampoline_addr,
+		uintptr(pid),
+		procPidVnodePathInfo,
+		0,
+		uintptr(unsafe.Pointer(&info)),
+		unsafe.Sizeof(info),
+		0,
+	)
+	if n != unsafe.Sizeof(info) {
+		return ""
+	}
+	path := info.Cdir.Path[:]
+	if i := bytes.IndexByte(path, 0); i >= 0 {
+		path = path[:i]
+	}
+	return string(path)
+}

--- a/internal/terminal/cwd_darwin.s
+++ b/internal/terminal/cwd_darwin.s
@@ -1,0 +1,10 @@
+// Trampoline for the libSystem proc_pidinfo binding in cwd_darwin.go,
+// following x/sys/unix's zsyscall_darwin_*.s pattern. Identical on amd64 and
+// arm64 — a bare jump to the dynamically imported symbol.
+
+#include "textflag.h"
+
+TEXT libc_proc_pidinfo_trampoline<>(SB),NOSPLIT,$0-0
+	JMP	libc_proc_pidinfo(SB)
+GLOBL	·libc_proc_pidinfo_trampoline_addr(SB), RODATA, $8
+DATA	·libc_proc_pidinfo_trampoline_addr(SB)/8, $libc_proc_pidinfo_trampoline<>(SB)

--- a/internal/terminal/cwd_linux.go
+++ b/internal/terminal/cwd_linux.go
@@ -1,0 +1,23 @@
+//go:build linux
+
+package terminal
+
+import (
+	"os"
+	"strconv"
+)
+
+// cwdTracked reports whether this platform can read a live process working
+// directory. Linux reads /proc; the seam degrades the card to its start path
+// elsewhere (macOS would need proc_pidinfo, Windows NtQueryInformationProcess).
+const cwdTracked = true
+
+// processCwd returns pid's current working directory, or "" when it cannot be
+// read (the process exited, or was never ours to inspect).
+func processCwd(pid int) string {
+	cwd, err := os.Readlink("/proc/" + strconv.Itoa(pid) + "/cwd")
+	if err != nil {
+		return ""
+	}
+	return cwd
+}

--- a/internal/terminal/cwd_linux.go
+++ b/internal/terminal/cwd_linux.go
@@ -8,8 +8,8 @@ import (
 )
 
 // cwdTracked reports whether this platform can read a live process working
-// directory. Linux reads /proc; the seam degrades the card to its start path
-// elsewhere (macOS would need proc_pidinfo, Windows NtQueryInformationProcess).
+// directory; declared per platform so an unimplemented one (cwd_other.go)
+// skips the watcher entirely.
 const cwdTracked = true
 
 // processCwd returns pid's current working directory, or "" when it cannot be

--- a/internal/terminal/cwd_linux_test.go
+++ b/internal/terminal/cwd_linux_test.go
@@ -1,0 +1,93 @@
+package terminal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// waitEmit receives one emitted cwd or fails the test after a grace period.
+func waitEmit(t *testing.T, emits <-chan string) string {
+	t.Helper()
+	select {
+	case cwd := <-emits:
+		return cwd
+	case <-time.After(5 * time.Second):
+		t.Fatal("pollCwd emitted nothing")
+		return ""
+	}
+}
+
+// TestProcessCwdReadsSelf proves the /proc read resolves a live process's
+// working directory — exercised against the test process itself.
+func TestProcessCwdReadsSelf(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if got := processCwd(os.Getpid()); got != wd {
+		t.Errorf("processCwd(self) = %q, want %q", got, wd)
+	}
+}
+
+// TestProcessCwdOfDeadPidIsEmpty proves an unreadable /proc entry degrades to
+// "", which pollCwd skips instead of reporting.
+func TestProcessCwdOfDeadPidIsEmpty(t *testing.T) {
+	// PIDs are capped by /proc/sys/kernel/pid_max (< 2^22 by default); one far
+	// beyond it can never name a live process.
+	if got := processCwd(1 << 30); got != "" {
+		t.Errorf("processCwd(dead) = %q, want empty", got)
+	}
+}
+
+// TestPollCwdEmitsOnlyOnChange drives pollCwd tick by tick against the test
+// process: an unchanged directory stays silent, a chdir is reported exactly
+// once, and closing done ends the loop.
+func TestPollCwdEmitsOnlyOnChange(t *testing.T) {
+	start, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	// /proc reports the resolved directory, so compare against the symlink-free
+	// form of the temp dir.
+	tmp, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+
+	tick := make(chan time.Time)
+	done := make(chan struct{})
+	emits := make(chan string, 8)
+	finished := make(chan struct{})
+	go func() {
+		defer close(finished)
+		pollCwd(os.Getpid(), start, tick, done, func(cwd string) { emits <- cwd })
+	}()
+
+	// Unchanged directory: the tick is consumed without an emit. tick is
+	// unbuffered, so each send returns only after the previous one was handled.
+	tick <- time.Time{}
+
+	t.Chdir(tmp)
+	tick <- time.Time{}
+	if got := waitEmit(t, emits); got != tmp {
+		t.Errorf("emitted %q, want %q", got, tmp)
+	}
+
+	// Same directory again: accepting this tick proves the change above
+	// emitted exactly once.
+	tick <- time.Time{}
+	select {
+	case cwd := <-emits:
+		t.Errorf("unexpected emit %q for unchanged cwd", cwd)
+	default:
+	}
+
+	close(done)
+	select {
+	case <-finished:
+	case <-time.After(5 * time.Second):
+		t.Fatal("pollCwd did not stop after done closed")
+	}
+}

--- a/internal/terminal/cwd_other.go
+++ b/internal/terminal/cwd_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package terminal
+
+// cwdTracked: see cwd_linux.go — no /proc here, so the card keeps showing the
+// directory the session started in.
+const cwdTracked = false
+
+func processCwd(int) string { return "" }

--- a/internal/terminal/cwd_other.go
+++ b/internal/terminal/cwd_other.go
@@ -1,8 +1,8 @@
-//go:build !linux
+//go:build !linux && !darwin && !windows
 
 package terminal
 
-// cwdTracked: see cwd_linux.go — no /proc here, so the card keeps showing the
+// cwdTracked: no live cwd read on this platform, so the card keeps showing the
 // directory the session started in.
 const cwdTracked = false
 

--- a/internal/terminal/cwd_track_test.go
+++ b/internal/terminal/cwd_track_test.go
@@ -1,8 +1,13 @@
+// Exercises the live-cwd read on every platform that implements it: /proc on
+// Linux, proc_pidinfo on macOS, the PEB walk on Windows. Always against the
+// test process itself, whose cwd t.Chdir controls; expectations compare with
+// os.Getwd(), which reads the same kernel state processCwd does.
+//go:build linux || darwin || windows
+
 package terminal
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 )
@@ -19,7 +24,7 @@ func waitEmit(t *testing.T, emits <-chan string) string {
 	}
 }
 
-// TestProcessCwdReadsSelf proves the /proc read resolves a live process's
+// TestProcessCwdReadsSelf proves the platform read resolves a live process's
 // working directory — exercised against the test process itself.
 func TestProcessCwdReadsSelf(t *testing.T) {
 	wd, err := os.Getwd()
@@ -31,11 +36,11 @@ func TestProcessCwdReadsSelf(t *testing.T) {
 	}
 }
 
-// TestProcessCwdOfDeadPidIsEmpty proves an unreadable /proc entry degrades to
+// TestProcessCwdOfDeadPidIsEmpty proves an unresolvable process degrades to
 // "", which pollCwd skips instead of reporting.
 func TestProcessCwdOfDeadPidIsEmpty(t *testing.T) {
-	// PIDs are capped by /proc/sys/kernel/pid_max (< 2^22 by default); one far
-	// beyond it can never name a live process.
+	// Far beyond any real PID space (Linux pid_max < 2^22, macOS ~1e5); Windows
+	// simply finds no such process to open.
 	if got := processCwd(1 << 30); got != "" {
 		t.Errorf("processCwd(dead) = %q, want empty", got)
 	}
@@ -48,12 +53,6 @@ func TestPollCwdEmitsOnlyOnChange(t *testing.T) {
 	start, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Getwd: %v", err)
-	}
-	// /proc reports the resolved directory, so compare against the symlink-free
-	// form of the temp dir.
-	tmp, err := filepath.EvalSymlinks(t.TempDir())
-	if err != nil {
-		t.Fatalf("EvalSymlinks: %v", err)
 	}
 
 	tick := make(chan time.Time)
@@ -69,10 +68,17 @@ func TestPollCwdEmitsOnlyOnChange(t *testing.T) {
 	// unbuffered, so each send returns only after the previous one was handled.
 	tick <- time.Time{}
 
-	t.Chdir(tmp)
+	t.Chdir(t.TempDir())
+	// Expect Getwd rather than the TempDir value: the kernel reports the
+	// physical path, and Getwd reads the same state (a symlinked /tmp or /var,
+	// Windows 8.3 short names would diverge from the literal TempDir string).
+	moved, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
 	tick <- time.Time{}
-	if got := waitEmit(t, emits); got != tmp {
-		t.Errorf("emitted %q, want %q", got, tmp)
+	if got := waitEmit(t, emits); got != moved {
+		t.Errorf("emitted %q, want %q", got, moved)
 	}
 
 	// Same directory again: accepting this tick proves the change above

--- a/internal/terminal/cwd_track_test.go
+++ b/internal/terminal/cwd_track_test.go
@@ -8,9 +8,23 @@ package terminal
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
+
+// physical resolves path's symlinks, the form the kernel reports a process
+// cwd in. os.Getwd may return the logical path instead — t.Chdir sets $PWD,
+// and macOS reaches its temp dir through /var → /private/var — so both sides
+// of every comparison go through this.
+func physical(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", path, err)
+	}
+	return resolved
+}
 
 // waitEmit receives one emitted cwd or fails the test after a grace period.
 func waitEmit(t *testing.T, emits <-chan string) string {
@@ -31,7 +45,7 @@ func TestProcessCwdReadsSelf(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Getwd: %v", err)
 	}
-	if got := processCwd(os.Getpid()); got != wd {
+	if got := processCwd(os.Getpid()); physical(t, got) != physical(t, wd) {
 		t.Errorf("processCwd(self) = %q, want %q", got, wd)
 	}
 }
@@ -69,15 +83,14 @@ func TestPollCwdEmitsOnlyOnChange(t *testing.T) {
 	tick <- time.Time{}
 
 	t.Chdir(t.TempDir())
-	// Expect Getwd rather than the TempDir value: the kernel reports the
-	// physical path, and Getwd reads the same state (a symlinked /tmp or /var,
-	// Windows 8.3 short names would diverge from the literal TempDir string).
+	// Expect Getwd rather than the TempDir value (Windows may hand out 8.3
+	// short names), resolved to its physical form (see physical).
 	moved, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Getwd: %v", err)
 	}
 	tick <- time.Time{}
-	if got := waitEmit(t, emits); got != moved {
+	if got := waitEmit(t, emits); physical(t, got) != physical(t, moved) {
 		t.Errorf("emitted %q, want %q", got, moved)
 	}
 

--- a/internal/terminal/cwd_windows.go
+++ b/internal/terminal/cwd_windows.go
@@ -1,0 +1,71 @@
+package terminal
+
+import (
+	"path/filepath"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const cwdTracked = true
+
+// processCwd returns pid's current working directory, or "" when it cannot be
+// read (the process exited, or was never ours to inspect). Windows keeps a
+// process's cwd in its PEB (ProcessParameters.CurrentDirectory), so the read
+// is a pointer walk through the child's memory: NtQueryInformationProcess for
+// the PEB address, then ReadProcessMemory for the PEB, the process parameters
+// and finally the path buffer. Assumes the child matches our architecture (a
+// 32-bit child's PEB has a different layout) — there the walk dereferences
+// garbage and fails, degrading to "" like any dead process.
+func processCwd(pid int) string {
+	h, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_INFORMATION|windows.PROCESS_VM_READ,
+		false,
+		uint32(pid),
+	)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = windows.CloseHandle(h) }()
+
+	var pbi windows.PROCESS_BASIC_INFORMATION
+	var retLen uint32
+	err = windows.NtQueryInformationProcess(h, windows.ProcessBasicInformation,
+		unsafe.Pointer(&pbi), uint32(unsafe.Sizeof(pbi)), &retLen)
+	if err != nil || pbi.PebBaseAddress == nil {
+		return ""
+	}
+
+	var peb windows.PEB
+	if err := readMemory(h, uintptr(unsafe.Pointer(pbi.PebBaseAddress)),
+		unsafe.Pointer(&peb), unsafe.Sizeof(peb)); err != nil {
+		return ""
+	}
+	if peb.ProcessParameters == nil {
+		return ""
+	}
+
+	var params windows.RTL_USER_PROCESS_PARAMETERS
+	if err := readMemory(h, uintptr(unsafe.Pointer(peb.ProcessParameters)),
+		unsafe.Pointer(&params), unsafe.Sizeof(params)); err != nil {
+		return ""
+	}
+
+	dos := params.CurrentDirectory.DosPath
+	if dos.Length == 0 || dos.Buffer == nil {
+		return ""
+	}
+	buf := make([]uint16, dos.Length/2)
+	if err := readMemory(h, uintptr(unsafe.Pointer(dos.Buffer)),
+		unsafe.Pointer(&buf[0]), uintptr(dos.Length)); err != nil {
+		return ""
+	}
+	// DosPath carries a trailing backslash ("C:\Users\x\"); Clean drops it
+	// while keeping a bare drive root intact.
+	return filepath.Clean(windows.UTF16ToString(buf))
+}
+
+// readMemory reads size bytes of the process behind h at base into out.
+func readMemory(h windows.Handle, base uintptr, out unsafe.Pointer, size uintptr) error {
+	return windows.ReadProcessMemory(h, base, (*byte)(out), size, nil)
+}

--- a/internal/terminal/pty.go
+++ b/internal/terminal/pty.go
@@ -19,15 +19,16 @@ type ptySpec struct {
 
 // ptyHandle is a running session's PTY end, the seam between the service and
 // the platform PTY API: Read streams the child's output, Write delivers
-// input, Resize changes the window size, Wait reaps the exited child and
-// Close hangs up and terminates it. Each OS provides startPTY(spec) plus an
-// implementation of this interface (build tags select the file, the Go idiom
-// for OS-specific code) — terminal.go never touches a platform PTY API
-// directly.
+// input, Resize changes the window size, Pid identifies the child (0 when
+// unknown), Wait reaps the exited child and Close hangs up and terminates it.
+// Each OS provides startPTY(spec) plus an implementation of this interface
+// (build tags select the file, the Go idiom for OS-specific code) —
+// terminal.go never touches a platform PTY API directly.
 type ptyHandle interface {
 	Read(p []byte) (int, error)
 	Write(p []byte) (int, error)
 	Resize(cols, rows int) error
+	Pid() int
 	Wait() error
 	Close() error
 }

--- a/internal/terminal/pty_unix.go
+++ b/internal/terminal/pty_unix.go
@@ -33,6 +33,8 @@ func (p *unixPTY) Resize(cols, rows int) error {
 	return pty.Setsize(p.File, winsize(cols, rows))
 }
 
+func (p *unixPTY) Pid() int { return p.cmd.Process.Pid }
+
 func (p *unixPTY) Wait() error { return p.cmd.Wait() }
 
 func (p *unixPTY) Close() error {

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -65,10 +65,13 @@ type touchedEvent struct {
 	ID string `json:"id"`
 }
 
-// session is a single running PTY-backed shell.
+// session is a single running PTY-backed shell. done closes when the session
+// is reaped (by stream or Close — whichever removes it from the map), stopping
+// its cwd watcher.
 type session struct {
-	pty ptyHandle
-	out *coalescer
+	pty  ptyHandle
+	out  *coalescer
+	done chan struct{}
 }
 
 // Store is the persistence the terminal service depends on: the binary to spawn
@@ -364,8 +367,13 @@ func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int)
 		encoded := base64.StdEncoding.EncodeToString(data)
 		s.hub.Emit(dataEventPrefix+id, encoded)
 	}, visibleFlushInterval, hiddenFlushInterval)
-	s.sessions[id] = &session{pty: p, out: out}
+	done := make(chan struct{})
+	s.sessions[id] = &session{pty: p, out: out, done: done}
 	go s.stream(id, p, out)
+	// The start directory is reported unconditionally so a respawn overwrites
+	// whatever cwd the previous PTY left in the frontend's store.
+	s.hub.Emit(cwdEventName, cwdEvent{ID: id, Cwd: cwd})
+	go watchCwd(id, p.Pid(), cwd, done, s.hub)
 	return nil
 }
 
@@ -392,6 +400,7 @@ func (s *Service) stream(id string, p ptyHandle, out *coalescer) {
 	s.mu.Lock()
 	if current, ok := s.sessions[id]; ok && current.pty == p {
 		delete(s.sessions, id)
+		close(current.done)
 	}
 	s.mu.Unlock()
 
@@ -446,6 +455,7 @@ func (s *Service) Close(id string) error {
 	sess, ok := s.sessions[id]
 	if ok {
 		delete(s.sessions, id)
+		close(sess.done)
 	}
 	s.mu.Unlock()
 

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -194,7 +194,7 @@ func spawnSession(t *testing.T) *session {
 		t.Fatalf("startPTY: %v", err)
 	}
 	t.Cleanup(func() { _ = p.Close() })
-	return &session{pty: p}
+	return &session{pty: p, done: make(chan struct{})}
 }
 
 // TestWriteResizeCloseOnLiveSession drives a real session end to end: input is


### PR DESCRIPTION
## Summary

Fixes the stale path on session cards: a `cd` inside the terminal now moves the card's path line — and with it the git branch, diff badge and PR badge, which already follow whatever path the card shows.

- **Backend** (`internal/terminal`): the `ptyHandle` seam gains `Pid()` (creack/pty's `cmd.Process.Pid` on Unix; ConPTY already embeds a `Pid()` on Windows). A per-session watcher reads the child's cwd from `/proc/<pid>/cwd` every 2s and emits a global `session-cwd` event only on change; it stops via a `done` channel closed by whichever of `stream`/`Close` reaps the session. `Start` re-reports the spawn directory unconditionally, so a respawned PTY overwrites whatever the previous shell left behind.
- **Platform seam**: live tracking is Linux-only by build tag (`cwd_linux.go` / `cwd_other.go`); macOS/Windows keep today's behavior (start path), with the upgrade path noted in Known Ceilings.
- **Frontend**: `session-cwd-store.ts` mirrors the session-status-store pattern (module store + `useSyncExternalStore`, subscribed at page load so events landing while a card is unmounted still stick). `SessionCard` shows `liveCwd || session.path || path`.
- Nothing is persisted — the cwd is live PTY state and dies with it.

## Test plan

- [x] `gofmt` clean, `go vet ./...` clean, `go test -race ./...` green (260 tests) — new coverage: `processCwd` against the test process and a dead PID, `pollCwd` driven tick-by-tick (change → exactly one emit, repeat → silent, `done` → stop)
- [x] `GOOS=windows` / `GOOS=darwin` builds of the package pass
- [x] Frontend: `vitest` green (255 tests) — new store suite + `isCwdEvent` guard cases; `pnpm build` (tsc + vite) passes