### PR TITLE
feat: shell card wears Claude's icon while claude runs inside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A shell session's card now wears Claude's icon while a hand-run `claude` is
+  live inside it, reported by the plugin's SessionStart hook (so it needs the
+  lich plugin, like the status ring). The mark clears when Claude exits
+  (SessionEnd) and on every session respawn; the card's real kind — what a
+  respawn runs, what the resume prompt keys on — is untouched.
+
 - Session cards follow the terminal's working directory: a `cd` in the session
   moves the card's path line — and with it the git branch, diff badge and PR
   badge, which reflect whatever directory is shown. The backend polls the PTY

--- a/docs/hooks/session-start.md
+++ b/docs/hooks/session-start.md
@@ -27,9 +27,10 @@ failed to persist.
 
 ## Event → action mapping
 
-| Claude Code hook | action                                              |
-|------------------|-----------------------------------------------------|
-| `SessionStart`   | store `claude_session_id` on the lich session row   |
+| Claude Code hook | action                                                       |
+|------------------|--------------------------------------------------------------|
+| `SessionStart`   | store `claude_session_id` on the lich session row, and mark  |
+|                  | the card as running Claude (the `session-agent` app event)   |
 
 `SessionStart` fires on startup, resume, `/clear` and compaction. A resume
 reports the resumed session's id and overwrites the stored value — lich always
@@ -43,6 +44,15 @@ holds the id of the Claude session currently in the card.
 - **Persistence** — `internal/store/mutations.go`, `Service.SetClaudeSession`:
   `UPDATE sessions SET claude_session_id`. Surfaced on `store.Session`
   (`claudeSessionId`) and returned by `LoadState`.
+- **UI push** — after persisting, the same closure (`internal/terminal/terminal.go`,
+  `New`) emits the global app event `session-agent` (`{id, agent: "claude"}`):
+  a report is proof Claude runs in this PTY, so a shell card wears Claude's
+  icon while it does. The mark lives in
+  `frontend/src/lib/session-agent-store.ts`, never the store: it clears on the
+  session-state contract's `idle` (SessionEnd — Claude left) and on every PTY
+  spawn (the backend emits an empty agent), so it dies with the process that
+  earned it. The card's persisted kind — what a respawn runs, what the resume
+  prompt keys on — never changes.
 - **Consumer** — the resume prompt. `LoadState` hydrates the id onto the
   frontend session (`resumableSession` in `frontend/src/lib/sessions.ts`), and
   the first time a restored card is opened `TerminalHost` asks before spawning:

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -8,6 +8,7 @@ import {displayPath} from "@/lib/paths"
 import {type Session} from "@/lib/sessions"
 import {useSessionStatus} from "@/lib/useSessionStatus"
 import {useSessionCwd} from "@/lib/useSessionCwd"
+import {useSessionAgent} from "@/lib/useSessionAgent"
 import {useGitStatus} from "@/lib/useGitStatus"
 import {usePullRequest} from "@/lib/usePullRequest"
 import {System} from "@/lib/rpc"
@@ -52,6 +53,10 @@ export function SessionCard({
   // null before the first report, and whenever the hook reports a state with
   // no indicator (see toSessionStatus) — then the icon shows ringless.
   const status = useSessionStatus(session.id)
+  // The provider CLI live inside the PTY right now — a hand-run `claude` in a
+  // shell session puts Claude's mark on the card while it runs; null falls
+  // back to the session's own kind.
+  const agent = useSessionAgent(session.id)
   // The live working directory the backend's cwd watcher reports ("" until it
   // does): a `cd` in the terminal moves the card with it. Falls back to the
   // session's static start path — a worktree session lives in its own checkout,
@@ -144,7 +149,7 @@ export function SessionCard({
                 />
               ) : (
                 <span className="flex w-full min-w-0 items-center gap-1.5 pr-5">
-                  <SessionStatusIcon kind={session.kind} status={status}/>
+                  <SessionStatusIcon kind={agent ?? session.kind} status={status}/>
                   <span className="truncate text-sm font-medium text-foreground">
                     {session.label}
                   </span>

--- a/frontend/src/lib/session-agent-store.test.ts
+++ b/frontend/src/lib/session-agent-store.test.ts
@@ -1,0 +1,92 @@
+import {describe, expect, it} from "vitest"
+import {createSessionAgentStore} from "./session-agent-store"
+
+// harness wires a store to hand-driven agent and status sources.
+function harness() {
+  let onAgent: (data: unknown) => void = () => {}
+  let onStatus: (data: unknown) => void = () => {}
+  const store = createSessionAgentStore(
+    (h) => {
+      onAgent = h
+      return () => {}
+    },
+    (h) => {
+      onStatus = h
+      return () => {}
+    },
+  )
+  return {
+    store,
+    agent: (data: unknown) => onAgent(data),
+    status: (data: unknown) => onStatus(data),
+  }
+}
+
+describe("createSessionAgentStore", () => {
+  it("returns null while nothing has been reported", () => {
+    const {store} = harness()
+    expect(store.get("s1")).toBeNull()
+  })
+
+  it("keeps the reported agent per session", () => {
+    const {store, agent} = harness()
+    agent({id: "s1", agent: "claude"})
+    expect(store.get("s1")).toBe("claude")
+    expect(store.get("s2")).toBeNull()
+  })
+
+  it("clears the mark on an empty agent, like a PTY respawn", () => {
+    const {store, agent} = harness()
+    agent({id: "s1", agent: "claude"})
+    agent({id: "s1", agent: ""})
+    expect(store.get("s1")).toBeNull()
+  })
+
+  it("clears the mark when the session reports idle (SessionEnd)", () => {
+    const {store, agent, status} = harness()
+    agent({id: "s1", agent: "claude"})
+    status({id: "s1", state: "idle"})
+    expect(store.get("s1")).toBeNull()
+  })
+
+  it("keeps the mark through live states", () => {
+    const {store, agent, status} = harness()
+    agent({id: "s1", agent: "claude"})
+    for (const state of ["busy", "waiting", "done"]) {
+      status({id: "s1", state})
+    }
+    expect(store.get("s1")).toBe("claude")
+  })
+
+  it("drops an agent no known kind names", () => {
+    const {store, agent} = harness()
+    agent({id: "s1", agent: "claude"})
+    agent({id: "s1", agent: "future-provider"})
+    expect(store.get("s1")).toBeNull()
+  })
+
+  it("notifies subscribers only on change", () => {
+    const {store, agent} = harness()
+    let calls = 0
+    store.subscribe("s1", () => calls++)
+    agent({id: "s1", agent: "claude"})
+    agent({id: "s1", agent: "claude"})
+    expect(calls).toBe(1)
+  })
+
+  it("retains the mark across an unsubscribe, like a card unmount", () => {
+    const {store, agent} = harness()
+    const off = store.subscribe("s1", () => {})
+    agent({id: "s1", agent: "claude"})
+    off()
+    expect(store.get("s1")).toBe("claude")
+  })
+
+  it("ignores malformed payloads on both sources", () => {
+    const {store, agent, status} = harness()
+    agent({id: "s1"})
+    agent(null)
+    status({id: "s1"})
+    expect(store.get("s1")).toBeNull()
+  })
+})

--- a/frontend/src/lib/session-agent-store.ts
+++ b/frontend/src/lib/session-agent-store.ts
@@ -1,0 +1,78 @@
+import {isAgentEvent, isStatusEvent} from "./session-events"
+import {isSessionKind, type SessionKind} from "./sessions"
+
+// A subscription to one of the global session events, injected so the store is
+// testable without standing up the /events socket. Returns its unsubscribe.
+export type AgentEventSource = (handler: (data: unknown) => void) => () => void
+
+interface Entry {
+  agent: SessionKind | null
+  listeners: Set<() => void>
+}
+
+// createSessionAgentStore keeps the provider CLI currently live inside each
+// session's PTY, keyed by session id — the hand-run `claude` in a shell
+// session that its card should wear the mark of. Fed by two subscriptions
+// taken at creation, before any card mounts (same shape as
+// session-status-store, for the same unmount reason):
+//
+// - the agent event sets the mark (an empty or unknown agent clears it — the
+//   backend emits "" on every PTY spawn so a respawn drops a stale mark);
+// - a status report of "idle" clears it: that is SessionEnd, Claude leaving
+//   the PTY, and the card falls back to its own kind.
+//
+// Never persisted: the mark is live PTY state, like the cwd.
+export function createSessionAgentStore(
+  agentSource: AgentEventSource,
+  statusSource: AgentEventSource,
+) {
+  const entries = new Map<string, Entry>()
+
+  const entryOf = (id: string): Entry => {
+    let entry = entries.get(id)
+    if (!entry) {
+      entry = {agent: null, listeners: new Set()}
+      entries.set(id, entry)
+    }
+    return entry
+  }
+
+  const set = (id: string, agent: SessionKind | null): void => {
+    const entry = entryOf(id)
+    if (entry.agent === agent) {
+      return
+    }
+    entry.agent = agent
+    for (const listener of entry.listeners) {
+      listener()
+    }
+  }
+
+  agentSource((data) => {
+    if (!isAgentEvent(data)) {
+      return
+    }
+    // The payload crosses a process boundary: anything but a known kind — the
+    // clearing "", a provider from a newer backend — falls back to no mark.
+    set(data.id, isSessionKind(data.agent) ? data.agent : null)
+  })
+
+  statusSource((data) => {
+    if (!isStatusEvent(data) || data.state !== "idle") {
+      return
+    }
+    set(data.id, null)
+  })
+
+  const subscribe = (id: string, listener: () => void): (() => void) => {
+    const entry = entryOf(id)
+    entry.listeners.add(listener)
+    return () => {
+      entry.listeners.delete(listener)
+    }
+  }
+
+  const get = (id: string): SessionKind | null => entries.get(id)?.agent ?? null
+
+  return {subscribe, get}
+}

--- a/frontend/src/lib/session-events.test.ts
+++ b/frontend/src/lib/session-events.test.ts
@@ -1,5 +1,6 @@
 import {describe, expect, it} from "vitest"
 import {
+  isAgentEvent,
   isCwdEvent,
   isIdEvent,
   isStatusEvent,
@@ -99,6 +100,20 @@ describe("isCwdEvent", () => {
     expect(isCwdEvent({cwd: "/home/user"})).toBe(false)
     expect(isCwdEvent({id: "s1", cwd: 2})).toBe(false)
     expect(isCwdEvent(null)).toBe(false)
+  })
+})
+
+describe("isAgentEvent", () => {
+  it("accepts a payload carrying a string id and agent, empty included", () => {
+    expect(isAgentEvent({id: "s1", agent: "claude"})).toBe(true)
+    expect(isAgentEvent({id: "s1", agent: ""})).toBe(true)
+  })
+
+  it("rejects a payload missing either half", () => {
+    expect(isAgentEvent({id: "s1"})).toBe(false)
+    expect(isAgentEvent({agent: "claude"})).toBe(false)
+    expect(isAgentEvent({id: "s1", agent: 2})).toBe(false)
+    expect(isAgentEvent(null)).toBe(false)
   })
 })
 

--- a/frontend/src/lib/session-events.ts
+++ b/frontend/src/lib/session-events.ts
@@ -27,6 +27,11 @@ export const TOUCHED_EVENT = "session-touched"
 // every change the cwd watcher observes. Payload: { id, cwd }.
 export const CWD_EVENT = "session-cwd"
 
+// Global event the backend emits when a provider CLI starts inside a session's
+// PTY (see terminal.agentEventName) — a hand-run `claude` in a shell session.
+// Payload: { id, agent }; an empty agent (every PTY spawn) clears the mark.
+export const AGENT_EVENT = "session-agent"
+
 // The states a card renders an indicator for. The contract also defines "idle"
 // (SessionEnd), which maps to no indicator like any unknown value does.
 const RENDERED_STATUSES = ["busy", "done", "waiting"] as const
@@ -65,6 +70,10 @@ export function isTitleEvent(data: unknown): data is {id: string; label: string}
 
 export function isCwdEvent(data: unknown): data is {id: string; cwd: string} {
   return isIdEvent(data) && typeof (data as {cwd?: unknown}).cwd === "string"
+}
+
+export function isAgentEvent(data: unknown): data is {id: string; agent: string} {
+  return isIdEvent(data) && typeof (data as {agent?: unknown}).agent === "string"
 }
 
 // shouldToastAttention decides whether a session needing the user deserves the

--- a/frontend/src/lib/useSessionAgent.ts
+++ b/frontend/src/lib/useSessionAgent.ts
@@ -1,0 +1,24 @@
+import {useCallback, useSyncExternalStore} from "react"
+import {onAppEvent} from "./app-events"
+import {AGENT_EVENT, STATUS_EVENT} from "./session-events"
+import {createSessionAgentStore} from "./session-agent-store"
+import type {SessionKind} from "./sessions"
+
+// Subscribed at import rather than on first use: that opens the /events socket
+// at page load, so an agent reported before any card mounts still lands.
+const store = createSessionAgentStore(
+  (handler) => onAppEvent(AGENT_EVENT, handler),
+  (handler) => onAppEvent(STATUS_EVENT, handler),
+)
+
+// useSessionAgent reads the provider CLI currently live inside a session's PTY
+// from the shared store (see session-agent-store), which retains it across the
+// card's unmount. Returns null while nothing runs there — the card then shows
+// its own kind.
+export function useSessionAgent(sessionId: string): SessionKind | null {
+  const subscribe = useCallback(
+    (onChange: () => void) => store.subscribe(sessionId, onChange),
+    [sessionId],
+  )
+  return useSyncExternalStore(subscribe, () => store.get(sessionId))
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -43,6 +43,12 @@ const (
 	// touchedEventName carries the id of a session that likely changed files on
 	// disk, nudging an immediate git-status refresh ahead of the steady poll.
 	touchedEventName = "session-touched"
+	// agentEventName carries which provider CLI is live inside a session's PTY
+	// ({id, agent}) — today only Claude reports it, through the session-start
+	// hook, so a shell card shows Claude's mark while Claude runs in it. An
+	// empty agent clears the mark; every PTY spawn emits that clear so a
+	// respawned session never wears a dead agent's icon.
+	agentEventName = "session-agent"
 )
 
 // statusEvent is the payload of statusEventName: the session whose Claude Code
@@ -63,6 +69,13 @@ type titleEvent struct {
 // likely changed.
 type touchedEvent struct {
 	ID string `json:"id"`
+}
+
+// agentEvent is the payload of agentEventName: the session and the provider
+// CLI now live in its PTY ("" when none is).
+type agentEvent struct {
+	ID    string `json:"id"`
+	Agent string `json:"agent"`
 }
 
 // session is a single running PTY-backed shell. done closes when the session
@@ -120,7 +133,15 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 		func(id, state string) {
 			hub.Emit(statusEventName, statusEvent{ID: id, State: state})
 		},
-		store.SetClaudeSession,
+		func(sessionID, claudeSessionID string) error {
+			if err := store.SetClaudeSession(sessionID, claudeSessionID); err != nil {
+				return err
+			}
+			// A SessionStart report is proof Claude is running in this PTY —
+			// whatever the card's kind, its icon can wear Claude's mark now.
+			hub.Emit(agentEventName, agentEvent{ID: sessionID, Agent: providers.Claude})
+			return nil
+		},
 		func(id, title string) error {
 			applied, err := store.SetSessionTitle(id, title)
 			if err != nil {
@@ -370,9 +391,11 @@ func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int)
 	done := make(chan struct{})
 	s.sessions[id] = &session{pty: p, out: out, done: done}
 	go s.stream(id, p, out)
-	// The start directory is reported unconditionally so a respawn overwrites
-	// whatever cwd the previous PTY left in the frontend's store.
+	// The start directory and a cleared agent are reported unconditionally so
+	// a respawn overwrites whatever the previous PTY left in the frontend's
+	// stores (a provider session's own agent re-reports via its hook).
 	s.hub.Emit(cwdEventName, cwdEvent{ID: id, Cwd: cwd})
+	s.hub.Emit(agentEventName, agentEvent{ID: id, Agent: ""})
 	go watchCwd(id, p.Pid(), cwd, done, s.hub)
 	return nil
 }


### PR DESCRIPTION
## Summary

A hand-run `claude` inside a shell session now updates the session card: while Claude is live in the PTY, the card's icon shows Claude's mark (with the status ring working as usual); when Claude exits, the card falls back to its own kind.

- **Backend**: the `linkSession` closure (the `/session-start` hook endpoint, which already proves Claude is running in that PTY) now also emits a global `session-agent` app event (`{id, agent: "claude"}`) after persisting the Claude session id. Every PTY spawn emits an empty-agent clear so a respawned session never wears a dead agent's icon.
- **Frontend**: `session-agent-store.ts` (module store + `useSyncExternalStore`, the session-status-store pattern) keeps the mark per session id, clearing it on the state contract's `idle` (SessionEnd) and on the empty-agent event. `SessionCard` renders `agent ?? session.kind`.
- **Nothing persisted, kind untouched**: the card's real kind still decides what a respawn runs and what the resume prompt keys on (`resumableSession` already excludes shell sessions deliberately). The mark is live PTY state, like the cwd from #45.
- Plugin-gated like the status ring: without the lich plugin the hook never reports and the card simply keeps its kind.
- Contract doc updated (`docs/hooks/session-start.md`).

## Test plan

- [x] Go: `gofmt`/`go vet` clean, `go test -race ./...` green (260)
- [x] Frontend: vitest green (266 — new store suite: set/clear on idle/clear on respawn/unknown agent/malformed payloads; `isAgentEvent` guard cases), `pnpm build` (tsc + vite) passes