### PR TITLE
fix: transport tests ignore inherited LICH_LISTEN_PORT

### DIFF
--- a/internal/terminal/transport_test.go
+++ b/internal/terminal/transport_test.go
@@ -6,12 +6,21 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/coder/websocket"
 )
+
+// TestMain drops LICH_LISTEN_PORT so every transport in this package binds a
+// random port: a test run spawned from inside a lich terminal inherits the
+// pinned port of the running instance and would collide with it.
+func TestMain(m *testing.M) {
+	os.Unsetenv("LICH_LISTEN_PORT")
+	os.Exit(m.Run())
+}
 
 func TestFrameRoundTrip(t *testing.T) {
 	frame, err := encodeFrame("sess-1", []byte("hello"))


### PR DESCRIPTION
## Summary

Running `go test` from a terminal session inside lich inherits `LICH_LISTEN_PORT=47821` from the running instance. `newTransport` honours the variable, so every transport-binding test tried to bind the pinned port the production app holds and failed with `failed to listen for transport on 127.0.0.1:47821`. Go's test cache could mask it by replaying an earlier green run.

A package-level `TestMain` in `internal/terminal` now unsets the variable, so every test — current and future — binds a random loopback port regardless of the spawning environment.

## Test plan

- [x] Deterministic repro: with `LICH_LISTEN_PORT=47821` in the environment and lich running, the package failed every `-count=1` run; with this change it passes 92/92 under the same environment
- [x] Full gate: `gofmt`/`go vet` clean, `go test ./...` 260 pass, `vitest` 266 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)