### PR TITLE
fix: Ctrl+V pulls clipboard image on Windows

### DIFF
--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -37,6 +37,12 @@ const REFIT_DEBOUNCE_MS = 100
 const COPY_DEBOUNCE_MS = 150
 const SCROLLBACK_LINES = 5000
 
+// Claude Code's clipboard-image-paste chord is Ctrl+V on Linux/macOS but Alt+V
+// on Windows (see term-keys.ts); the host OS is the machine lich runs on.
+// navigator.platform is "Win32" on Windows Chromium — same signal HotkeysSettings
+// uses for isMac.
+const IS_WINDOWS = navigator.platform.toLowerCase().includes("win")
+
 // cellDimensions reads the renderer's measured cell size — the same private
 // API FitAddon relies on ("TODO: Remove reliance" upstream). Null before the
 // first render measure or if xterm ever moves the private; refit then skips,
@@ -191,7 +197,7 @@ export function TerminalView({
       if (event.type !== "keydown") {
         return true
       }
-      const seq = chordSequence(event)
+      const seq = chordSequence(event, IS_WINDOWS)
       if (seq === null) {
         return true
       }

--- a/frontend/src/lib/term-keys.test.ts
+++ b/frontend/src/lib/term-keys.test.ts
@@ -16,9 +16,14 @@ describe("chordSequence", () => {
     expect(chordSequence(key({altKey: true, key: "Backspace"}))).toBeNull()
   })
 
-  it("maps Ctrl+V to SYN so TUIs see the keypress", () => {
+  it("maps Ctrl+V to SYN so TUIs see the keypress (Linux/macOS)", () => {
     expect(chordSequence(key({ctrlKey: true, key: "v", code: "KeyV"}))).toBe("\x16")
     expect(chordSequence(key({ctrlKey: true, key: "V", code: "KeyV"}))).toBe("\x16")
+  })
+
+  it("maps Ctrl+V to Alt+V (ESC+v) on Windows — Claude Code's image-paste binding there", () => {
+    expect(chordSequence(key({ctrlKey: true, key: "v", code: "KeyV"}), true)).toBe("\x1bv")
+    expect(chordSequence(key({ctrlKey: true, key: "V", code: "KeyV"}), true)).toBe("\x1bv")
   })
 
   it("leaves Ctrl+Shift+V (native text paste) alone", () => {

--- a/frontend/src/lib/term-keys.ts
+++ b/frontend/src/lib/term-keys.ts
@@ -6,8 +6,10 @@
 //   (\x17, readline's unix-word-rubout) so line editors erase the word.
 // - Ctrl+V: in Chromium the default action pastes text into the terminal,
 //   hiding the keypress from TUIs that read the clipboard themselves on ^V
-//   (Claude Code image attach). Send SYN (\x16) like a real terminal; text
-//   paste stays on Ctrl+Shift+V (untouched — native paste).
+//   (Claude Code image attach). Send SYN (\x16) like a real terminal — but on
+//   Windows Claude Code binds image-paste to Alt+V (ESC+v), not ^V, so emit
+//   that there instead. Text paste stays on Ctrl+Shift+V (untouched — native
+//   paste).
 // - Shift+Enter: xterm sends plain \r, indistinguishable from Enter. ESC+CR
 //   is what TUIs (Claude Code) accept as "insert newline" without
 //   kitty-protocol negotiation.
@@ -22,13 +24,13 @@ export type TermKeyState = Pick<
   "ctrlKey" | "metaKey" | "shiftKey" | "altKey" | "key"
 > & { code?: string }
 
-export function chordSequence(event: TermKeyState): string | null {
+export function chordSequence(event: TermKeyState, isWindows = false): string | null {
   const ctrlOnly = event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey
   if (ctrlOnly && event.key === "Backspace") {
     return "\x17"
   }
   if (ctrlOnly && (event.code === "KeyV" || event.key.toLowerCase() === "v")) {
-    return "\x16"
+    return isWindows ? "\x1bv" : "\x16"
   }
   if (event.key === "Enter" && event.shiftKey && !event.altKey && !event.ctrlKey && !event.metaKey) {
     return "\x1b\r"


### PR DESCRIPTION
## Problema

No Windows, `Ctrl+V` não anexava a imagem da clipboard no Claude Code rodando dentro do lich. O `lich.log` não registra nada — é comportamental, não crash.

**Root cause:** o Claude Code liga o paste-de-imagem-da-clipboard a **`Alt+V`** (`ESC+v`) no Windows/WSL, não a `Ctrl+V` ([doc oficial `interactive-mode`](https://code.claude.com/docs/en/interactive-mode)). O lich interceptava `Ctrl+V` e emitia `SYN` (`\x16`) em **todo SO** (`term-keys.ts`). No Windows esse `\x16` chega no Claude mas não está mapeado lá → nada acontece. O byte trafega verbatim pelo ConPTY (`writeBytes` → `p.Write`), então o problema é puramente *qual sequência emitir*, não a mecânica de transporte.

## Fix

No Windows, o chord `Ctrl+V` passa a emitir `\x1bv` (a sequência do `Alt+V`) em vez de `\x16`. Linux/macOS seguem com `\x16`. Paste de texto continua no `Ctrl+Shift+V` (intocado). `Alt+V` já funcionava nativamente no Windows (xterm.js codifica como `\x1bv`) e continua.

Detecção de plataforma via `navigator.platform` — mesmo sinal que `HotkeysSettings` já usa pro `isMac`; lich roda o Chromium no mesmo host do backend/PTY, então o SO da página é o SO onde o Claude roda.

### Comportamento por SO

| Tecla | Linux/macOS | Windows |
|---|---|---|
| Ctrl+V | `\x16` → imagem | `\x1bv` (Alt+V) → imagem |
| Alt+V | nativo | nativo → imagem |
| Ctrl+Shift+V | paste texto | paste texto |

## Arquivos

- `frontend/src/lib/term-keys.ts` — `chordSequence(event, isWindows=false)`; Ctrl+V → `isWindows ? "\x1bv" : "\x16"`.
- `frontend/src/components/TerminalView.tsx` — `IS_WINDOWS` via `navigator.platform`, passado ao chord.
- `frontend/src/lib/term-keys.test.ts` — caso Windows → `\x1bv`.

## Test plan

- [x] `pnpm test` (vitest): 267/267 verde, incluindo o novo caso Windows e o `Ctrl+Shift+V` (paste texto) intocado.
- [x] `tsc --noEmit` limpo.
- [x] Smoke manual no Windows: com imagem na clipboard, `Ctrl+V` dentro do Claude anexa `[Image #N]`; `Ctrl+Shift+V` continua colando texto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
