### PR TITLE
feat: open a terminal in an agent session's directory

### DIFF
--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -1,6 +1,6 @@
 import {useEffect, useRef, useState} from "react"
 import type {KeyboardEvent} from "react"
-import {GitBranch, GitPullRequestArrow, Pencil, X} from "lucide-react"
+import {GitBranch, GitPullRequestArrow, Pencil, Terminal, X} from "lucide-react"
 import {useSortable} from "@dnd-kit/sortable"
 import {CSS} from "@dnd-kit/utilities"
 import {cn} from "@/lib/utils"
@@ -30,6 +30,10 @@ interface SessionCardProps {
   onSelect: () => void
   onClose: () => void
   onRename: (label: string) => void
+  // Open a shell session rooted at this card's shown directory. Wired only for
+  // agent sessions, so the user can drop into a terminal in the worktree the
+  // agent is working in without cd-ing there by hand.
+  onOpenTerminal: (cwd: string) => void
 }
 
 // SessionCard is one session entry: a card showing the session label, the
@@ -43,6 +47,7 @@ export function SessionCard({
                               onSelect,
                               onClose,
                               onRename,
+                              onOpenTerminal,
                             }: SessionCardProps) {
   const pathRef = useRef<HTMLSpanElement>(null)
   const [pathOverflow, setPathOverflow] = useState(false)
@@ -244,6 +249,12 @@ export function SessionCard({
             <Pencil/>
             Rename
           </ContextMenuItem>
+          {session.kind !== "shell" && (
+            <ContextMenuItem onClick={() => onOpenTerminal(shownPath)}>
+              <Terminal/>
+              Open Terminal
+            </ContextMenuItem>
+          )}
           <ContextMenuSeparator/>
           <ContextMenuItem variant="destructive" onClick={onClose}>
             <X/>

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -238,6 +238,7 @@ export function SessionSidebar() {
                 }}
                 onClose={() => requestClose(session)}
                 onRename={(label) => renameSession(projectId, session.id, label)}
+                onOpenTerminal={(cwd) => newSession(projectId, "shell", cwd)}
               />
             ))}
           </SortableContext>

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -50,8 +50,8 @@ interface ProjectsValue {
   /** Close a project's tab (kept in the store so it can be reopened later). */
   closeProject: (id: string) => void
   /** Open a new session in a project and focus it, returning its id. Kind
-   * defaults to Claude Code. */
-  newSession: (projectId: string, kind?: SessionKind) => string
+   * defaults to Claude Code; path defaults to the project's own directory. */
+  newSession: (projectId: string, kind?: SessionKind, path?: string) => string
   /** Open a Claude Code session rooted at a git worktree, labeled after it. */
   newWorktreeSession: (projectId: string, wt: { name: string; path: string }) => void
   /** Permanently delete a session; deleting the last one recreates an empty one. */
@@ -242,13 +242,13 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     [projects, activeProjectId, navigate],
   )
 
-  const newSession = useCallback((projectId: string, kind: SessionKind = "claude") => {
+  const newSession = useCallback((projectId: string, kind: SessionKind = "claude", path = "") => {
     const sessionId = newSessionId()
-    const next = addSession(sessionsRef.current, projectId, sessionId, kind)
+    const next = addSession(sessionsRef.current, projectId, sessionId, kind, path)
     const project = next[projectId]
     const created = project.sessions[project.sessions.length - 1]
     setSessions(next)
-    void Store.AddSession(projectId, sessionId, created.label, kind, "", project.nextSeq)
+    void Store.AddSession(projectId, sessionId, created.label, kind, path, project.nextSeq)
     return sessionId
   }, [])
 


### PR DESCRIPTION
## What

Adds an **Open Terminal** item to the session card context menu, shown only for **agent sessions** (claude, codex, opencode, crush). It spawns a plain shell session rooted at the card's directory — no new backend, it reuses the same path the folder launcher already threads to the PTY.

## Why

Opening a worktree spins up an agent in the worktree checkout, but there was no one-click way to get a terminal in that same directory — you had to `pwd` in the agent, open a Terminal, then `cd <pwd>` to run e.g. `task dev`. This closes that gap.

## How

- `newSession` now takes an optional `path` (already carried end-to-end by `addSession` and `Store.AddSession`); it defaults to `""` so every existing caller is unchanged.
- `SessionCard` gains an `onOpenTerminal(cwd)` prop and a context-menu item gated on `session.kind !== "shell"`. It passes the card's resolved `shownPath` — the live cwd when the watcher has reported one, else the session's start path — so if the agent `cd`'d somewhere, the terminal opens where it is now.
- `SessionSidebar` wires it to `newSession(projectId, "shell", cwd)`.

The new shell is a full, persisted session (own card), matching the existing `+ → Terminal` launcher. It gets the default `Session N` label.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 266 passing
- [x] `vite build` succeeds
- [x] Manually verified: agent session → Open Terminal drops a shell in the worktree directory