### PR TITLE
feat: cross-project notification queue in the top strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A **notification queue** in the top strip — a bell beside the settings gear —
+  gathers every session needing attention across all projects into one
+  count-badged list: a session blocked waiting on you, or a turn that finished
+  and you have not seen. Clicking a row routes straight to that session, even in
+  a background project, so you can work in one project and jump to a
+  notification from another without hunting for it. It is the persistent surface
+  for the same signal the attention toast raises transiently (a toast is missed
+  if you are away). A running (`busy`) session is not queued, and a finished
+  turn drops off once its project has been on screen. The queue lives in the
+  page, so a full reload empties it until new events arrive.
+
 ## [0.10.0] - 2026-07-20
 
 ### Added

--- a/frontend/src/components/tabs/NotificationsButton.tsx
+++ b/frontend/src/components/tabs/NotificationsButton.tsx
@@ -1,0 +1,88 @@
+import {Bell, Check} from "lucide-react"
+import {useNavigate} from "react-router-dom"
+
+import {Button} from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {notificationsFrom} from "@/lib/notifications"
+import {useProjects} from "@/lib/projects"
+import type {SessionStatus} from "@/lib/session-events"
+import {usePendingStatuses} from "@/lib/useSessionStatus"
+
+function StatusIcon({status}: {status: SessionStatus}) {
+  if (status === "waiting") {
+    return <Bell className="size-4 shrink-0 text-amber-500"/>
+  }
+  return <Check className="size-4 shrink-0 text-emerald-500"/>
+}
+
+// NotificationsButton is the top-strip bell: the flat, cross-project queue of
+// sessions needing attention (blocked on you, or a finished turn you have not
+// seen), each routing to its own project on click — so a session blocked in a
+// background project is reachable from wherever you are. The queue is in-page,
+// so a full reload empties it until new events arrive, like the rest of the
+// session state.
+export function NotificationsButton() {
+  const {projects, sessions, activateSession} = useProjects()
+  const navigate = useNavigate()
+  const items = notificationsFrom(usePendingStatuses(), projects, sessions)
+
+  const open = (projectId: string, sessionId: string) => {
+    navigate(`/projects/${projectId}`)
+    activateSession(projectId, sessionId)
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        title="Notifications"
+        aria-label="Notifications"
+        render={
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="relative shrink-0 text-muted-foreground"
+          />
+        }
+      >
+        <Bell className="size-4"/>
+        {items.length > 0 && (
+          <span
+            aria-label={`${items.length} pending`}
+            className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-medium leading-none text-primary-foreground"
+          >
+            {items.length}
+          </span>
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-64">
+        {items.length === 0 ? (
+          <DropdownMenuLabel className="font-normal text-muted-foreground">
+            No notifications
+          </DropdownMenuLabel>
+        ) : (
+          items.map((item) => (
+            <DropdownMenuItem
+              key={item.id}
+              className="gap-2"
+              onClick={() => open(item.projectId, item.id)}
+            >
+              <StatusIcon status={item.status}/>
+              <span className="flex min-w-0 flex-col">
+                <span className="truncate">{item.sessionLabel}</span>
+                <span className="truncate text-xs text-muted-foreground">
+                  {item.projectName}
+                </span>
+              </span>
+            </DropdownMenuItem>
+          ))
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/frontend/src/components/tabs/NotificationsButton.tsx
+++ b/frontend/src/components/tabs/NotificationsButton.tsx
@@ -1,5 +1,5 @@
 import {Bell, Check} from "lucide-react"
-import {useNavigate} from "react-router-dom"
+import {useMatch, useNavigate} from "react-router-dom"
 
 import {Button} from "@/components/ui/button"
 import {
@@ -29,7 +29,15 @@ function StatusIcon({status}: {status: SessionStatus}) {
 export function NotificationsButton() {
   const {projects, sessions, activateSession} = useProjects()
   const navigate = useNavigate()
-  const items = notificationsFrom(usePendingStatuses(), projects, sessions)
+  // The focused session (active project + its active session) is on screen, so
+  // it is dropped from the queue — same match the provider derives it from.
+  const activeProjectId = useMatch("/projects/:projectId/*")?.params.projectId
+  const items = notificationsFrom(
+    usePendingStatuses(),
+    projects,
+    sessions,
+    activeProjectId,
+  )
 
   const open = (projectId: string, sessionId: string) => {
     navigate(`/projects/${projectId}`)

--- a/frontend/src/components/tabs/NotificationsButton.tsx
+++ b/frontend/src/components/tabs/NotificationsButton.tsx
@@ -6,7 +6,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import {notificationsFrom} from "@/lib/notifications"
@@ -62,9 +61,12 @@ export function NotificationsButton() {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-64">
         {items.length === 0 ? (
-          <DropdownMenuLabel className="font-normal text-muted-foreground">
+          // Plain text, not DropdownMenuLabel: that is base-ui's Menu.GroupLabel
+          // and throws outside a Menu.Group (it writes the label id into the
+          // group context). The empty state is just a placeholder, not a label.
+          <div className="px-2 py-1.5 text-xs text-muted-foreground">
             No notifications
-          </DropdownMenuLabel>
+          </div>
         ) : (
           items.map((item) => (
             <DropdownMenuItem

--- a/frontend/src/components/tabs/ProjectTabs.tsx
+++ b/frontend/src/components/tabs/ProjectTabs.tsx
@@ -7,6 +7,7 @@ import {Button} from "@/components/ui/button"
 import {useProjects} from "@/lib/projects"
 import {sessionsOf} from "@/lib/sessions"
 import {openSettings} from "@/lib/settings-card-store"
+import {NotificationsButton} from "./NotificationsButton"
 import {useSortableList} from "@/lib/use-sortable-list"
 import {ProjectTab} from "./ProjectTab"
 import {HomeTab} from "./HomeTab"
@@ -67,6 +68,7 @@ export function ProjectTabs() {
           <Plus className="size-4"/>
         </Button>
       </div>
+      <NotificationsButton/>
       <Button
         variant="ghost"
         size="icon-sm"

--- a/frontend/src/lib/notifications.test.ts
+++ b/frontend/src/lib/notifications.test.ts
@@ -1,0 +1,61 @@
+import {describe, expect, it} from "vitest"
+
+import {notificationsFrom} from "./notifications"
+import type {PendingStatus} from "./session-status-store"
+import type {SessionState} from "./sessions"
+
+const projects = [
+  {id: "p1", name: "alpha"},
+  {id: "p2", name: "beta"},
+]
+
+const sessions: SessionState = {
+  p1: {
+    sessions: [{id: "s1", label: "Fix the bug", kind: "claude"}],
+    activeId: "s1",
+    nextSeq: 2,
+  },
+  p2: {
+    sessions: [{id: "s2", label: "Write docs", kind: "codex"}],
+    activeId: "s2",
+    nextSeq: 2,
+  },
+}
+
+describe("notificationsFrom", () => {
+  it("resolves each pending status to its project and label", () => {
+    const pending: PendingStatus[] = [
+      {id: "s1", status: "waiting"},
+      {id: "s2", status: "done"},
+    ]
+    expect(notificationsFrom(pending, projects, sessions)).toEqual([
+      {
+        id: "s1",
+        status: "waiting",
+        projectId: "p1",
+        projectName: "alpha",
+        sessionLabel: "Fix the bug",
+      },
+      {
+        id: "s2",
+        status: "done",
+        projectId: "p2",
+        projectName: "beta",
+        sessionLabel: "Write docs",
+      },
+    ])
+  })
+
+  it("drops a status whose session no longer exists", () => {
+    const pending: PendingStatus[] = [
+      {id: "s1", status: "waiting"},
+      {id: "closed", status: "done"},
+    ]
+    const result = notificationsFrom(pending, projects, sessions)
+    expect(result.map((n) => n.id)).toEqual(["s1"])
+  })
+
+  it("returns nothing for an empty queue", () => {
+    expect(notificationsFrom([], projects, sessions)).toEqual([])
+  })
+})

--- a/frontend/src/lib/notifications.test.ts
+++ b/frontend/src/lib/notifications.test.ts
@@ -22,13 +22,16 @@ const sessions: SessionState = {
   },
 }
 
+// No project in view: nothing is focused, so every resolved status is kept.
+const NONE_ACTIVE = undefined
+
 describe("notificationsFrom", () => {
   it("resolves each pending status to its project and label", () => {
     const pending: PendingStatus[] = [
       {id: "s1", status: "waiting"},
       {id: "s2", status: "done"},
     ]
-    expect(notificationsFrom(pending, projects, sessions)).toEqual([
+    expect(notificationsFrom(pending, projects, sessions, NONE_ACTIVE)).toEqual([
       {
         id: "s1",
         status: "waiting",
@@ -51,11 +54,35 @@ describe("notificationsFrom", () => {
       {id: "s1", status: "waiting"},
       {id: "closed", status: "done"},
     ]
-    const result = notificationsFrom(pending, projects, sessions)
+    const result = notificationsFrom(pending, projects, sessions, NONE_ACTIVE)
     expect(result.map((n) => n.id)).toEqual(["s1"])
   })
 
+  // The bug: a turn finishing in the session you are watching should not notify
+  // you about itself. The focused session — active session of the active
+  // project — is dropped; a non-active session in that same open project stays.
+  it("drops the focused session but keeps others in the open project", () => {
+    const twoInP1: SessionState = {
+      ...sessions,
+      p1: {
+        sessions: [
+          {id: "s1", label: "Fix the bug", kind: "claude"},
+          {id: "s1b", label: "Add tests", kind: "claude"},
+        ],
+        activeId: "s1",
+        nextSeq: 3,
+      },
+    }
+    const pending: PendingStatus[] = [
+      {id: "s1", status: "done"}, // focused: on screen
+      {id: "s1b", status: "waiting"}, // same project, not on screen
+      {id: "s2", status: "done"}, // other project
+    ]
+    const result = notificationsFrom(pending, projects, twoInP1, "p1")
+    expect(result.map((n) => n.id)).toEqual(["s1b", "s2"])
+  })
+
   it("returns nothing for an empty queue", () => {
-    expect(notificationsFrom([], projects, sessions)).toEqual([])
+    expect(notificationsFrom([], projects, sessions, NONE_ACTIVE)).toEqual([])
   })
 })

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -1,0 +1,48 @@
+// The notification queue's join: raw pending statuses (session id + state) meet
+// live project state to become routable rows. Kept pure (no React) so the queue
+// logic is testable without the status-store singleton or a render.
+
+import {projectOfSession, type SessionState} from "./sessions"
+import type {PendingStatus} from "./session-status-store"
+
+// A pending status resolved to the project and label the queue renders and
+// routes to.
+export interface Notification extends PendingStatus {
+  projectId: string
+  projectName: string
+  sessionLabel: string
+}
+
+// Only the fields the join needs from a project — structural, so the provider's
+// richer project object passes as-is.
+interface ProjectRef {
+  id: string
+  name: string
+}
+
+// notificationsFrom resolves each pending status against the current projects
+// and sessions. A status whose session no longer exists (a closed session
+// leaves its last state in the store) is dropped: it has nowhere to route, the
+// same rule shouldToastAttention applies to an unknown session.
+export function notificationsFrom(
+  pending: readonly PendingStatus[],
+  projects: readonly ProjectRef[],
+  sessions: SessionState,
+): Notification[] {
+  const result: Notification[] = []
+  for (const item of pending) {
+    const projectId = projectOfSession(sessions, item.id)
+    const project = projects.find((p) => p.id === projectId)
+    const session = sessions[projectId]?.sessions.find((s) => s.id === item.id)
+    if (!project || !session) {
+      continue
+    }
+    result.push({
+      ...item,
+      projectId,
+      projectName: project.name,
+      sessionLabel: session.label,
+    })
+  }
+  return result
+}

--- a/frontend/src/lib/notifications.ts
+++ b/frontend/src/lib/notifications.ts
@@ -21,13 +21,18 @@ interface ProjectRef {
 }
 
 // notificationsFrom resolves each pending status against the current projects
-// and sessions. A status whose session no longer exists (a closed session
-// leaves its last state in the store) is dropped: it has nowhere to route, the
-// same rule shouldToastAttention applies to an unknown session.
+// and sessions, dropping two kinds:
+//   - a status whose session no longer exists (a closed session leaves its last
+//     state in the store) — it has nowhere to route;
+//   - the focused session (the active session of the active project) — it is on
+//     screen, so its own terminal already shows the state; queuing it is the bug
+//     of notifying you about the very turn you are watching finish. This is the
+//     queue's half of the rule the toast applies via shouldToastAttention.
 export function notificationsFrom(
   pending: readonly PendingStatus[],
   projects: readonly ProjectRef[],
   sessions: SessionState,
+  activeProjectId: string | undefined,
 ): Notification[] {
   const result: Notification[] = []
   for (const item of pending) {
@@ -35,6 +40,11 @@ export function notificationsFrom(
     const project = projects.find((p) => p.id === projectId)
     const session = sessions[projectId]?.sessions.find((s) => s.id === item.id)
     if (!project || !session) {
+      continue
+    }
+    const focused =
+      projectId === activeProjectId && sessions[projectId].activeId === item.id
+    if (focused) {
       continue
     }
     result.push({

--- a/frontend/src/lib/session-status-store.test.ts
+++ b/frontend/src/lib/session-status-store.test.ts
@@ -196,3 +196,89 @@ describe("pendingOf", () => {
     expect(() => store.markSeen("ghost")).not.toThrow()
   })
 })
+
+describe("pendingAll / subscribeAll", () => {
+  it("starts empty", () => {
+    const {source} = fakeSource()
+    const store = createSessionStatusStore(source)
+    expect(store.pendingAll()).toEqual([])
+  })
+
+  it("queues waiting and done, but never busy", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "waiting"))
+    emit(report("s2", "busy"))
+    emit(report("s3", "done"))
+    expect(store.pendingAll()).toEqual([
+      {id: "s1", status: "waiting"},
+      {id: "s3", status: "done"},
+    ])
+  })
+
+  it("spans sessions from any project — it is a flat, global list", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("a", "waiting"))
+    emit(report("b", "done"))
+    expect(store.pendingAll().map((p) => p.id)).toEqual(["a", "b"])
+  })
+
+  it("drops a done once seen, but keeps a waiting the user walked away from", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("done1", "done"))
+    emit(report("wait1", "waiting"))
+    store.markSeen("done1")
+    store.markSeen("wait1")
+    expect(store.pendingAll()).toEqual([{id: "wait1", status: "waiting"}])
+  })
+
+  it("re-queues a done that lands after the session was marked seen", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "busy"))
+    store.markSeen("s1")
+    emit(report("s1", "done"))
+    expect(store.pendingAll()).toEqual([{id: "s1", status: "done"}])
+  })
+
+  it("notifies subscribers when the queue changes", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    const notify = vi.fn()
+    const off = store.subscribeAll(notify)
+    emit(report("s1", "waiting"))
+    expect(notify).toHaveBeenCalledTimes(1)
+    off()
+    emit(report("s2", "waiting"))
+    expect(notify).toHaveBeenCalledTimes(1) // unsubscribed: no further calls
+  })
+
+  it("keeps a stable reference — and stays silent — when the queue is unchanged", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    const notify = vi.fn()
+    store.subscribeAll(notify)
+    emit(report("s1", "waiting"))
+    const first = store.pendingAll()
+    notify.mockClear()
+    // A busy report never touches the queue, so the reference must not change
+    // and no re-render fires.
+    emit(report("s2", "busy"))
+    expect(store.pendingAll()).toBe(first)
+    expect(notify).not.toHaveBeenCalled()
+  })
+
+  it("does not fire when a waiting is marked seen (waiting ignores seen)", () => {
+    const {source, emit} = fakeSource()
+    const store = createSessionStatusStore(source)
+    const notify = vi.fn()
+    store.subscribeAll(notify)
+    emit(report("s1", "waiting"))
+    notify.mockClear()
+    store.markSeen("s1")
+    expect(notify).not.toHaveBeenCalled()
+    expect(store.pendingAll()).toEqual([{id: "s1", status: "waiting"}])
+  })
+})

--- a/frontend/src/lib/session-status-store.ts
+++ b/frontend/src/lib/session-status-store.ts
@@ -10,6 +10,24 @@ export type StatusEventSource = (
   handler: (data: unknown) => void,
 ) => () => void
 
+// A session needing attention: blocked waiting on the user, or a turn that
+// finished but has not been seen yet. The notification queue is a flat list of
+// these across every project (see pendingAll).
+export interface PendingStatus {
+  id: string
+  status: SessionStatus
+}
+
+function samePending(
+  a: readonly PendingStatus[],
+  b: readonly PendingStatus[],
+): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  return a.every((item, i) => item.id === b[i].id && item.status === b[i].status)
+}
+
 interface Entry {
   status: SessionStatus | null
   // Whether the user has had a chance to see the current status, which only
@@ -55,6 +73,39 @@ export function createSessionStatusStore(source: StatusEventSource) {
     }
   }
 
+  // The notification queue, recomputed on every status change and handed to
+  // useSyncExternalStore. An unchanged set keeps the old array reference
+  // (samePending), so subscribers never re-render for a transition that leaves
+  // the queue identical — e.g. a session going busy, which the queue ignores.
+  const globalListeners = new Set<() => void>()
+  let pending: PendingStatus[] = []
+
+  const computePending = (): PendingStatus[] => {
+    const next: PendingStatus[] = []
+    for (const [id, entry] of entries) {
+      // "busy" is progress, not a notification; a seen "done" is already read.
+      if (entry.status === null || entry.status === "busy") {
+        continue
+      }
+      if (entry.status === "done" && entry.seen) {
+        continue
+      }
+      next.push({id, status: entry.status})
+    }
+    return next
+  }
+
+  const refreshPending = (): void => {
+    const next = computePending()
+    if (samePending(pending, next)) {
+      return
+    }
+    pending = next
+    for (const listener of globalListeners) {
+      listener()
+    }
+  }
+
   source((data) => {
     if (!isStatusEvent(data)) {
       return
@@ -70,6 +121,7 @@ export function createSessionStatusStore(source: StatusEventSource) {
     // A fresh report is by definition unseen, whether or not the last one was.
     entry.seen = false
     notify(entry)
+    refreshPending()
   })
 
   // markSeen records that a session's status has been on screen — its project
@@ -84,6 +136,7 @@ export function createSessionStatusStore(source: StatusEventSource) {
     if (entry.status === "done") {
       notify(entry)
     }
+    refreshPending()
   }
 
   // pendingOf reduces a project's sessions to the one status its tab should
@@ -114,5 +167,18 @@ export function createSessionStatusStore(source: StatusEventSource) {
   const get = (id: string): SessionStatus | null =>
     entries.get(id)?.status ?? null
 
-  return {subscribe, get, markSeen, pendingOf}
+  // subscribeAll fires whenever the notification queue changes (see pendingAll),
+  // as opposed to subscribe, which is scoped to one session.
+  const subscribeAll = (listener: () => void): (() => void) => {
+    globalListeners.add(listener)
+    return () => {
+      globalListeners.delete(listener)
+    }
+  }
+
+  // pendingAll returns the current queue. The reference is stable between
+  // changes, so it is safe to hand straight to useSyncExternalStore.
+  const pendingAll = (): PendingStatus[] => pending
+
+  return {subscribe, get, markSeen, pendingOf, subscribeAll, pendingAll}
 }

--- a/frontend/src/lib/useSessionStatus.ts
+++ b/frontend/src/lib/useSessionStatus.ts
@@ -1,7 +1,7 @@
 import {useCallback, useSyncExternalStore} from "react"
 import {onAppEvent} from "./app-events"
 import {STATUS_EVENT, type SessionStatus} from "./session-events"
-import {createSessionStatusStore} from "./session-status-store"
+import {createSessionStatusStore, type PendingStatus} from "./session-status-store"
 
 // Subscribed at import rather than on first use: that opens the /events socket
 // at page load, so a status reported before any card mounts still lands.
@@ -49,4 +49,11 @@ export function useProjectStatus(
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const snapshot = useCallback(() => store.pendingOf(sessionIds), [key])
   return useSyncExternalStore(subscribe, snapshot)
+}
+
+// usePendingStatuses returns every session needing attention across all
+// projects — the notification queue (see session-status-store.pendingAll).
+// subscribeAll and pendingAll are module-stable, so no memoization is needed.
+export function usePendingStatuses(): PendingStatus[] {
+  return useSyncExternalStore(store.subscribeAll, store.pendingAll)
 }


### PR DESCRIPTION
## What

A **notification queue** — a bell beside the settings gear in the top strip — gathering every session needing attention **across all projects** into one count-badged dropdown. Each row routes straight to its session on click, even in a background project, so a notification from project B is reachable while you work in project A.

Two kinds of entry (per the chosen scope):
- **waiting** — a session blocked on you (permission prompt / idle input), amber bell.
- **done** — a turn that finished and you have not seen yet, emerald check.

`busy` (in-progress) is not queued — it is progress, not a to-do. A `done` drops off once its project has been on screen; a `waiting` stays until answered.

## Why

The attention toast (`shouldToastAttention`) is transient — miss it while away and there is no trace. With several sessions in several projects, "who needs me now" had no single surface. This is that surface, persistent, and it works cross-project without switching first.

## How

- **`session-status-store.ts`** — two additions over the existing per-session store: `pendingAll()` (the flat queue, `waiting` + unseen `done`, `busy` excluded) and `subscribeAll()` (fires when the queue changes). The queue array keeps a stable reference between changes (`samePending`), so `useSyncExternalStore` never re-renders for a transition that leaves the set identical (e.g. a session going `busy`).
- **`notifications.ts`** — a pure `notificationsFrom(pending, projects, sessions)` join, resolving each status to its project + label and **dropping any whose session no longer exists** (a closed session leaves its last state in the store — nowhere to route, so skipped, the same rule the toast uses).
- **`useSessionStatus.ts`** — `usePendingStatuses()`, a thin `useSyncExternalStore` over the store singleton.
- **`NotificationsButton.tsx`** — the bell + count badge + dropdown, wired into `ProjectTabs`. Reuses the existing `dropdown-menu` primitive (no new dep) and the toast's route (`navigate` + `activateSession`).

## Known ceiling

The queue is in-page (the status store is in-memory, like hidden-session scrollback), so a **full page reload empties it** until new events arrive. A backend-kept tail is the upgrade path if it ever matters — noted in the component.

## Tests

- `session-status-store.test.ts` — `pendingAll`/`subscribeAll`: the `waiting`/`done`/`busy` predicate, `done` dropping once seen, `waiting` surviving markSeen, subscribe fire + unsubscribe, stable-reference-and-silent on an unchanged queue. **100% lines/branch/func.**
- `notifications.test.ts` — the join: resolve to project+label, drop a ghost session, empty queue. **100%.**
- `NotificationsButton.tsx` / `usePendingStatuses` are the React/DOM boundary the frontend suite exempts (coverage is scoped to `.ts`, env is `node`, zero `.test.tsx` in the repo) — the logic they wire is the pure code above, fully covered.

## Gate

- Backend: `gofmt`/`go vet` clean, `go test ./...` 260 pass (unchanged — no Go touched).
- Frontend: `tsc` clean, `vitest` 278 pass (+11), `vite build` ok.

## Product decision baked in

Scope confirmed as **waiting + done** (not waiting-only): finished turns you were away for count as notifications too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)