### PR TITLE
feat: focus the open window when lich is launched twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Launching lich twice now focuses the open window** instead of failing. The
+  second process detects the running instance holding the pinned port (via
+  `runtime.json` and a token-gated liveness ping) and hands its URL to Chromium,
+  which forwards to the running browser and brings its window to the front, then
+  exits cleanly. A genuine port conflict — a non-lich process on the port —
+  still fails with the same clear error as before. Window focus is best-effort:
+  Wayland forbids an external process from raising a window, so lich relies on
+  Chromium's own profile-lock IPC.
 - A **notification queue** in the top strip — a bell beside the settings gear —
   gathers every session needing attention across all projects into one
   count-badged list: a session blocked waiting on you, or a turn that finished

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,9 +143,15 @@ Deliberate limits and shortcuts, with the upgrade path when it matters:
 - **Terminal I/O rides the loopback WebSocket** — token auth, binary frames multiplexing all sessions
   (`internal/terminal/transport.go` ↔ `frontend/src/lib/term-transport.ts`). When the socket is down, output falls
   back to the `/events` channel and input to the RPC — slower, never broken.
-- **No single-instance lock**: two lich processes race the pinned listener port; the second fails with a clear error.
-  Add a lock + focus-existing-window protocol if it ever matters. (`runtime.json` in the config dir now carries
-  `{pid,port,token}` for the self-update restart channel — it is not a lock, but it is the natural base for one.)
+- **Single instance via the pinned port; focus is best-effort.** The pinned listener bind *is* the lock — only one
+  process holds it. A second launch that cannot bind reads `runtime.json` (`{pid,port,token}`) and pings the recorded
+  instance's token-gated `/ping` (`internal/singleton`): a live lich on the same port means a duplicate launch, so it
+  focuses that window and exits 0 instead of erroring; anything else (a stray process on the port, a restart successor
+  that never got the port back) still logs and exits 1. Focus hands the running instance's URL to Chromium against the
+  shared profile, letting Chromium's profile-lock IPC forward to the running browser — the only *portable* raise, since
+  an external process cannot raise a window under Wayland. It is untested against a real window and may open a second
+  app window on some Chromium builds (`focusRunning` in `main.go`); a per-platform window raise is the upgrade path if
+  it matters.
 - **Self-update checks once, at startup** (`internal/appupdate` + `frontend/.../AppUpdateGate.tsx`), mirroring the
   Claude-plugin gate — a long-running session does not notice a release mid-run. A periodic frontend poll (the
   git-status-store pattern) is the upgrade path. Self-*apply* (download + checksum + in-place swap via

--- a/internal/singleton/singleton.go
+++ b/internal/singleton/singleton.go
@@ -1,0 +1,100 @@
+// Package singleton keeps a second lich launch from racing the pinned listener
+// port and dying with a bare error. It owns runtime.json — the file recording
+// the running instance's loopback coordinates ({pid,port,token}) — and, when a
+// fresh launch cannot bind, uses it to tell "another live lich already holds my
+// port" (a duplicate launch, exit cleanly and focus it) apart from "the port is
+// taken by something else" (a real error). The pinned port bind is itself the
+// lock; this package is only the detection and the read/write of the file.
+package singleton
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// Info is the running lich recorded in runtime.json. It lets install.sh reach a
+// running lich for /restart when it runs outside a lich terminal, and lets a
+// second launch find the instance already holding the pinned port.
+type Info struct {
+	PID   int    `json:"pid"`
+	Port  int    `json:"port"`
+	Token string `json:"token"`
+}
+
+// pingTimeout bounds the liveness probe: a loopback GET answers in microseconds,
+// so a slow one means the recorded instance is gone and the file is stale.
+const pingTimeout = time.Second
+
+func path(configDir string) string {
+	return filepath.Join(configDir, "lich", "runtime.json")
+}
+
+// Write records this process as the running instance. Mode 0600: the token is a
+// loopback credential and the file persists across sessions. Returns the path so
+// the caller can remove it on the clean window-close exit.
+func Write(configDir string, port int, token string) (string, error) {
+	p := path(configDir)
+	data, err := json.Marshal(Info{PID: os.Getpid(), Port: port, Token: token})
+	if err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(p, data, 0o600); err != nil {
+		return "", err
+	}
+	return p, nil
+}
+
+// Read loads runtime.json. A missing file returns (nil, nil): no instance
+// recorded, not an error.
+func Read(configDir string) (*Info, error) {
+	data, err := os.ReadFile(path(configDir))
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read runtime file: %w", err)
+	}
+	var info Info
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, fmt.Errorf("parse runtime file: %w", err)
+	}
+	return &info, nil
+}
+
+// Detect reports the live lich holding wantPort, or nil if there is none. It
+// returns the recorded instance only when runtime.json names wantPort (so a dev
+// instance on another port is never mistaken for this one) and its token pings
+// back (proving the recorded process is both alive and actually lich, not a
+// stray process that grabbed the port). ping is injectable for tests; production
+// passes Ping. A nil result with a nil error means "not a duplicate launch" —
+// the caller should treat the bind failure as the real error it is.
+func Detect(configDir string, wantPort int, ping func(port int, token string) bool) (*Info, error) {
+	info, err := Read(configDir)
+	if err != nil || info == nil {
+		return nil, err
+	}
+	if info.Port != wantPort || info.Token == "" || !ping(info.Port, info.Token) {
+		return nil, nil
+	}
+	return info, nil
+}
+
+// Ping reports whether a token-gated lich listener answers on port. It is the
+// production probe passed to Detect: only lich serves /ping behind the token, so
+// a 204 proves the recorded instance is alive and is lich.
+func Ping(port int, token string) bool {
+	client := http.Client{Timeout: pingTimeout}
+	url := fmt.Sprintf("http://127.0.0.1:%d/ping?token=%s", port, token)
+	resp, err := client.Get(url)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusNoContent
+}

--- a/internal/singleton/singleton_test.go
+++ b/internal/singleton/singleton_test.go
@@ -1,0 +1,148 @@
+package singleton
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// writeConfig lays out the <configDir>/lich directory Write and Read expect and
+// returns the config dir.
+func writeConfig(t *testing.T) string {
+	t.Helper()
+	configDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(configDir, "lich"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	return configDir
+}
+
+func TestWriteThenRead(t *testing.T) {
+	configDir := writeConfig(t)
+	if _, err := Write(configDir, 47821, "tok"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	got, err := Read(configDir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got == nil || got.Port != 47821 || got.Token != "tok" || got.PID != os.Getpid() {
+		t.Fatalf("round trip = %+v, want pid=%d port=47821 tok", got, os.Getpid())
+	}
+}
+
+func TestReadMissingIsNotAnError(t *testing.T) {
+	got, err := Read(t.TempDir())
+	if err != nil {
+		t.Fatalf("Read missing: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("Read missing = %+v, want nil", got)
+	}
+}
+
+func TestReadRejectsGarbage(t *testing.T) {
+	configDir := writeConfig(t)
+	if err := os.WriteFile(filepath.Join(configDir, "lich", "runtime.json"), []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := Read(configDir); err == nil {
+		t.Fatal("Read garbage: want error, got nil")
+	}
+}
+
+func TestDetect(t *testing.T) {
+	const want = 47821
+	seed := func(t *testing.T, port int, token string) string {
+		configDir := writeConfig(t)
+		if _, err := Write(configDir, port, token); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		return configDir
+	}
+	alive := func(int, string) bool { return true }
+	dead := func(int, string) bool { return false }
+
+	t.Run("live instance on the wanted port is a duplicate", func(t *testing.T) {
+		got, err := Detect(seed(t, want, "tok"), want, alive)
+		if err != nil {
+			t.Fatalf("Detect: %v", err)
+		}
+		if got == nil || got.Port != want {
+			t.Fatalf("Detect = %+v, want the recorded instance", got)
+		}
+	})
+
+	t.Run("recorded instance on another port is not this one", func(t *testing.T) {
+		got, err := Detect(seed(t, 40000, "tok"), want, alive)
+		if err != nil {
+			t.Fatalf("Detect: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("Detect other-port = %+v, want nil", got)
+		}
+	})
+
+	t.Run("dead instance is not a duplicate", func(t *testing.T) {
+		got, err := Detect(seed(t, want, "tok"), want, dead)
+		if err != nil {
+			t.Fatalf("Detect: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("Detect dead = %+v, want nil", got)
+		}
+	})
+
+	t.Run("no runtime file means no instance", func(t *testing.T) {
+		got, err := Detect(t.TempDir(), want, alive)
+		if err != nil {
+			t.Fatalf("Detect: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("Detect missing = %+v, want nil", got)
+		}
+	})
+}
+
+// TestPing exercises the production probe against a listener that mimics the
+// transport's token-gated /ping: 204 with the token, 401 without.
+func TestPing(t *testing.T) {
+	const token = "sekret"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/ping" || r.URL.Query().Get("token") != token {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+	port := serverPort(t, srv)
+
+	if !Ping(port, token) {
+		t.Fatal("Ping with the right token = false, want true")
+	}
+	if Ping(port, "wrong") {
+		t.Fatal("Ping with a bad token = true, want false")
+	}
+	// A port nothing listens on must read as dead, not hang.
+	if Ping(1, token) {
+		t.Fatal("Ping unreachable port = true, want false")
+	}
+}
+
+func serverPort(t *testing.T, srv *httptest.Server) int {
+	t.Helper()
+	_, portStr, ok := strings.Cut(strings.TrimPrefix(srv.URL, "http://"), ":")
+	if !ok {
+		t.Fatalf("unexpected server URL %q", srv.URL)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+	return port
+}

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -144,6 +144,7 @@ func newTransport(
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/ws", t.handle)
+	mux.HandleFunc("/ping", t.ping)
 	mux.HandleFunc("/hook", t.hook)
 	mux.HandleFunc("/session-start", t.sessionStart)
 	mux.HandleFunc("/session-title", t.sessionTitle)
@@ -228,6 +229,19 @@ func (t *transport) setRestart(fn func() error) {
 	t.mu.Lock()
 	t.restart = fn
 	t.mu.Unlock()
+}
+
+// ping is the liveness probe a second lich launch uses to tell "a live lich
+// already holds my pinned port" from "the port is taken by something else": only
+// lich serves this behind the token, so a 204 proves the recorded instance is
+// alive and is lich (see internal/singleton). Token-gated like every endpoint
+// but /'s static assets.
+func (t *transport) ping(w http.ResponseWriter, r *http.Request) {
+	if !t.authorized(r) {
+		http.Error(w, "invalid token", http.StatusUnauthorized)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // mount adds a handler to the transport listener behind the same token check

--- a/internal/terminal/transport_test.go
+++ b/internal/terminal/transport_test.go
@@ -219,6 +219,36 @@ func TestParseHookRequest(t *testing.T) {
 	}
 }
 
+func TestPingAnswersWithToken(t *testing.T) {
+	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/ping?token=%s", tr.port, tr.token))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", resp.StatusCode)
+	}
+}
+
+func TestPingRejectsBadToken(t *testing.T) {
+	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/ping?token=wrong", tr.port))
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
 func TestHookForwardsStatus(t *testing.T) {
 	got := make(chan string, 1)
 	tr, err := newTransport(func(string, []byte) {}, func(id, state string) {

--- a/main.go
+++ b/main.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"embed"
-	"encoding/json"
 	"fmt"
 	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/omartelo/lich/internal/appupdate"
 	"github.com/omartelo/lich/internal/chromium"
@@ -20,6 +20,7 @@ import (
 	"github.com/omartelo/lich/internal/providers"
 	"github.com/omartelo/lich/internal/restart"
 	"github.com/omartelo/lich/internal/rpc"
+	"github.com/omartelo/lich/internal/singleton"
 	"github.com/omartelo/lich/internal/store"
 	"github.com/omartelo/lich/internal/system"
 	"github.com/omartelo/lich/internal/terminal"
@@ -120,16 +121,16 @@ func main() {
 func runChromium(term *terminal.Service, configDir string, coord *restart.Coordinator) {
 	info := term.Transport()
 	if info.Port == 0 {
-		slog.Error("loopback listener failed to start — is the port free?",
-			"port", os.Getenv("LICH_LISTEN_PORT"))
-		os.Exit(1)
+		handleBindFailure(configDir) // never returns
 	}
 
 	// The runtime file lets install.sh reach a running lich for /restart when it
-	// runs outside a lich terminal (no LICH_PORT/LICH_TOKEN in the env). Removed
-	// on the clean window-close exit; a stale file from a crash is harmless (the
-	// token check rejects a mismatched or dead listener).
-	if path, err := writeRuntimeFile(configDir, info.Port, info.Token); err != nil {
+	// runs outside a lich terminal (no LICH_PORT/LICH_TOKEN in the env), and lets
+	// a second launch find this instance to focus it instead of dying (see
+	// handleBindFailure). Removed on the clean window-close exit; a stale file
+	// from a crash is harmless (the token check rejects a mismatched or dead
+	// listener).
+	if path, err := singleton.Write(configDir, info.Port, info.Token); err != nil {
 		slog.Warn("runtime file", "err", err)
 	} else {
 		defer func() { _ = os.Remove(path) }()
@@ -170,21 +171,46 @@ func runChromium(term *terminal.Service, configDir string, coord *restart.Coordi
 	slog.Info("window closed, exiting")
 }
 
-// writeRuntimeFile records this process's pid and loopback coordinates so a
-// script (install.sh) can reach lich for /restart without inheriting the
-// per-session hook env. Mode 0600: the token is a loopback credential.
-func writeRuntimeFile(configDir string, port int, token string) (string, error) {
-	path := filepath.Join(configDir, "lich", "runtime.json")
-	data, err := json.Marshal(struct {
-		PID   int    `json:"pid"`
-		Port  int    `json:"port"`
-		Token string `json:"token"`
-	}{os.Getpid(), port, token})
-	if err != nil {
-		return "", err
+// handleBindFailure runs when the pinned listener would not bind, and never
+// returns. A fresh launch whose port is held by another live lich is a duplicate
+// launch: focus that window and exit 0 — the user re-launching an app they
+// already have open should get the window, not an error. Anything else (a
+// restart successor that never got the port back, or a non-lich process sitting
+// on the port) is a real failure: log it and exit 1.
+func handleBindFailure(configDir string) {
+	port := os.Getenv("LICH_LISTEN_PORT")
+	// A restart successor legitimately expects the port to be busy for a moment
+	// (it retries the bind); a failure there is real, not a duplicate launch.
+	if os.Getenv(restart.WaitEnv) == "" {
+		want, _ := strconv.Atoi(port)
+		if running, _ := singleton.Detect(configDir, want, singleton.Ping); running != nil {
+			slog.Info("lich already running, focusing existing window",
+				"pid", running.PID, "port", running.Port)
+			focusRunning(configDir, running)
+			os.Exit(0)
+		}
 	}
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		return "", err
+	slog.Error("loopback listener failed to start — is the port free?", "port", port)
+	os.Exit(1)
+}
+
+// focusRunning brings the already-running lich's window to the front by handing
+// its URL to Chromium against the shared profile: Chromium's profile-lock IPC
+// forwards the command to the running browser (the same lock that stops a second
+// window spawning its own process — see chromium.Args) instead of opening a new
+// one. Best effort — a failure only means the user raises the window by hand.
+//
+// Skipped for the dev shell (its own profile/port). On some Chromium builds a
+// forwarded --app may open a second app window rather than focus; the dup-free
+// fix is a per-platform window raise, which Wayland forbids for an external
+// process, so Chromium's IPC is the portable lever we have.
+func focusRunning(configDir string, running *singleton.Info) {
+	if os.Getenv("LICH_DEV_URL") != "" {
+		return
 	}
-	return path, nil
+	profileDir := filepath.Join(configDir, "lich", "chromium-profile")
+	url := fmt.Sprintf("http://127.0.0.1:%d/?token=%s", running.Port, running.Token)
+	if err := chromium.Run(url, profileDir, "lich", nil, nil); err != nil {
+		slog.Warn("focus existing window", "err", err)
+	}
 }


### PR DESCRIPTION
## What

Launching lich a second time now **focuses the already-open window** instead of dying with a port-bind error.

The second process detects the running instance holding the pinned listener port — reading `runtime.json` (`{pid,port,token}`) and confirming liveness+identity via a token-gated `GET /ping` — and hands its URL to Chromium. Chromium's profile-lock IPC forwards the command to the running browser (the same lock that already stops a second window spawning its own process), raising its window; the second process then exits 0.

A genuine conflict is unchanged: a non-lich process on the port, or a restart successor that never got the port back, still logs the clear error and exits 1.

## Why

Closes the "No single-instance lock" known ceiling. The pinned-port bind *is* the lock (only one process holds it) — no separate lock file — and `runtime.json` was already the natural base for the focus half.

## Design notes

- **`internal/singleton`** (new) owns `runtime.json`: `Write`/`Read`/`Detect`/`Ping`. `Detect` requires the recorded port to match the pinned port (a dev instance on another port is never mistaken for this one) and the token to ping back (proving the process is alive *and* is lich).
- Restart successors (`LICH_RESTART_WAIT`) skip single-instance handling — they legitimately expect the port busy and retry.
- **Focus is best-effort.** Wayland forbids an external process from raising a window, so lich relies on Chromium's own IPC. On some Chromium builds a forwarded `--app` may open a second app window rather than focus — a per-platform window raise is the upgrade path. **Not verifiable headless; needs a real-window smoke test.**

## Tests

- `internal/singleton`: write/read round-trip, missing-file, garbage, and `Detect` (same-port live = duplicate, other-port, dead, missing) + `Ping` against a mock listener. 90% pkg coverage.
- `transport`: `GET /ping` answers 204 with the token, 401 without.

## Manual smoke test (reviewer)

With lich open, run `lich` again from a terminal → the existing window should come to the front, with **no** second window.