### PR TITLE
feat: re-check for updates hourly, not just at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The update check now repeats hourly, not just at startup.** A session left
+  open for a long time now notices a new lich release mid-run instead of only on
+  the next launch. The poll never stacks a second toast for a release it already
+  surfaced, and dismissing one still holds until a genuinely newer version
+  ships. Hourly keeps well within the unauthenticated GitHub API's rate limit.
+
 ### Added
 
 - **Launching lich twice now focuses the open window** instead of failing. The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,9 +152,10 @@ Deliberate limits and shortcuts, with the upgrade path when it matters:
   an external process cannot raise a window under Wayland. It is untested against a real window and may open a second
   app window on some Chromium builds (`focusRunning` in `main.go`); a per-platform window raise is the upgrade path if
   it matters.
-- **Self-update checks once, at startup** (`internal/appupdate` + `frontend/.../AppUpdateGate.tsx`), mirroring the
-  Claude-plugin gate — a long-running session does not notice a release mid-run. A periodic frontend poll (the
-  git-status-store pattern) is the upgrade path. Self-*apply* (download + checksum + in-place swap via
+- **Self-update checks at startup, then hourly** (`internal/appupdate` + `frontend/.../AppUpdateGate.tsx`) — a
+  `setInterval` poll in the gate, so a long-running session eventually notices a release mid-run; a session-scoped ref
+  keeps the poll from stacking a second toast for a release already shown (a genuinely newer one still toasts). Hourly
+  respects the unauthenticated GitHub API's 60-req/hour limit. Self-*apply* (download + checksum + in-place swap via
   `minio/selfupdate`) is Windows/macOS only, where lich owns its binary; on Linux the binary is package-manager owned,
   so the flow pastes the `install.sh` one-liner into a terminal and relaunches via `/restart` instead. The restart
   (`internal/restart`) spawns a detached successor that retries the pinned port (`LICH_RESTART_WAIT`) while the old

--- a/frontend/src/components/AppUpdateGate.tsx
+++ b/frontend/src/components/AppUpdateGate.tsx
@@ -10,15 +10,20 @@ import {runWithToast} from "@/lib/toast-async"
 
 const RESTART_HINT = "restart lich to apply."
 
+// How often to re-check for a release after startup, so a long-running session
+// eventually notices one. Hourly is plenty — releases are rare and the
+// unauthenticated GitHub API allows only 60 requests/hour per IP.
+const POLL_INTERVAL_MS = 60 * 60 * 1000
+
 // The one-liner from install.sh / the README. Pasted into a shell for the user
 // to run — never executed automatically.
 const INSTALL_CMD = "curl -fsSL https://raw.githubusercontent.com/omartelo/lich/main/install.sh | sh"
 
-// AppUpdateGate checks on startup whether a newer lich release exists. Where the
-// binary is writable (Windows/macOS) it offers a one-click self-update; on Linux
-// the binary is package-manager owned, so it offers to paste the install command
-// into a terminal (the user runs it) or open the release page. Any failure is
-// silent — it must never block or break startup.
+// AppUpdateGate checks on startup, then hourly, whether a newer lich release
+// exists. Where the binary is writable (Windows/macOS) it offers a one-click
+// self-update; on Linux the binary is package-manager owned, so it offers to
+// paste the install command into a terminal (the user runs it) or open the
+// release page. Any failure is silent — it must never block or break startup.
 export function AppUpdateGate() {
   const {newSession, ensureHomeProject} = useProjects()
   const navigate = useNavigate()
@@ -27,13 +32,15 @@ export function AppUpdateGate() {
   // Ref so the toast handler reads the latest active project without re-running.
   const activeRef = useRef(activeProjectId)
   activeRef.current = activeProjectId
-  // Guard React strict-mode's double effect: the check runs once per start.
-  const checked = useRef(false)
+  // The version last toasted this session, so the hourly poll (and strict-mode's
+  // double effect) never stacks a second toast for the same release; a genuinely
+  // newer release still gets one.
+  const promptedVersion = useRef<string | null>(null)
 
   useEffect(() => {
-    if (checked.current) return
-    checked.current = true
     void check()
+    const id = setInterval(() => void check(), POLL_INTERVAL_MS)
+    return () => clearInterval(id)
   }, [])
 
   const check = async () => {
@@ -45,6 +52,8 @@ export function AppUpdateGate() {
       return
     }
     if (action.kind !== "update") return
+    if (promptedVersion.current === action.version) return
+    promptedVersion.current = action.version
     if (action.canSelfApply) {
       promptSelfApply(action.version)
     } else {


### PR DESCRIPTION
## What

`AppUpdateGate` checked for a new release **once per launch**. A session left open for a long time never noticed a release that shipped mid-run. It now polls on an **hourly `setInterval`** on top of the startup check.

## Why

Closes the "Self-update checks once, at startup" known ceiling. The backend `appupdate.Status` already does a fresh GitHub lookup on every call, so this is a **frontend-only** change — the same shape as the git-status-store poll the ceiling pointed at.

## Design notes

- A session-scoped ref (`promptedVersion`) records the release last toasted, so the poll — and React strict mode's double effect — never stacks a second toast for a release already shown. A genuinely newer release still toasts.
- An explicit dismissal still holds across the session via `UPDATE_DISMISSED_KEY` (`decideUpdateAction` is unchanged).
- **Hourly** keeps well within the unauthenticated GitHub API's 60-request/hour-per-IP limit; releases are rare, so a tighter interval buys nothing.

## Tests

`decideUpdateAction` (the pure decision) is unchanged and still covered. The interval wiring and the ref dedupe are React-effect boundary — the documented no-jsdom coverage exception. Gate green locally: `tsc --noEmit`, vitest (279), `vite build`.