### PR TITLE
feat: keep terminal scrollback across a full page reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Terminal scrollback now survives a full page reload.** Reloading the window
+  used to leave every terminal blank until new output arrived — the shells kept
+  running, but their recent history lived only in the page. The backend now
+  keeps a capped tail of each session's output and replays it into the terminal
+  on reconnect, so a reload restores what you were looking at. The tail is
+  bounded (2 MB per session), so very old scrollback still ages out.
+
 ### Changed
 
 - **The update check now repeats hourly, not just at startup.** A session left

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,8 +138,14 @@ Deliberate limits and shortcuts, with the upgrade path when it matters:
   is a `position` column written whole on every drag and read back as `ORDER BY position, rowid`.
 - **Hidden sessions are serialized and destroyed** (waveterm model, frontend edition): PTY output queues in a 2MB
   replay buffer (`frontend/src/lib/replay-buffer.ts`); show rebuilds from snapshot + tail; queue overflow drops the
-  snapshot and starts clean from the tail (circular-buffer artifact contract). The replay state lives in the page —
-  a full page reload loses hidden-session scrollback; a backend-kept tail (waveterm's filestore) is the upgrade path.
+  snapshot and starts clean from the tail (circular-buffer artifact contract). That page-side buffer only bridges
+  hide→show within one page load; a **backend replay tail** (`internal/terminal/replay.go`, a 2MB in-memory ring per
+  running session, matching the frontend cap) survives a full page reload, when the PTY lives on but the page-side
+  scrollback is gone. On mount `TerminalView` fetches it via `terminal.Replay` and writes it before wiring the live
+  listeners — so the tail lands ahead of any live frame, and output produced during that round-trip is dropped
+  (a small seam gap, not a dup or a reorder — `term-transport` drops frames for an unlistened session). The ring is
+  in memory per session; waveterm's disk filestore is the upgrade path if session count or size ever makes that cost
+  matter.
 - **Terminal I/O rides the loopback WebSocket** — token auth, binary frames multiplexing all sessions
   (`internal/terminal/transport.go` ↔ `frontend/src/lib/term-transport.ts`). When the socket is down, output falls
   back to the `/events` channel and input to the RPC — slower, never broken.

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -315,6 +315,26 @@ export function TerminalView({
       startedRef.current = true
       ensureTransport()
 
+      // Reseed scrollback from the backend tail. A full page reload discards the
+      // page-side buffer, but the PTY — and its backend replay tail — lived on,
+      // so its recent output is written here before the live listeners are
+      // wired: the tail lands ahead of any live frame (correct order), and
+      // output produced during this round-trip is dropped rather than
+      // duplicated (term-transport drops frames for an unlistened session), a
+      // small seam gap like the replay buffer's overflow artifact. Empty for a
+      // brand-new session.
+      try {
+        const tail = await Service.Replay(sessionId)
+        if (disposed) {
+          return
+        }
+        if (tail && liveRef.current === live) {
+          live.term.write(decodeBase64(tail))
+        }
+      } catch {
+        // No tail is fine — the terminal just starts from live output.
+      }
+
       const offData = onAppEvent(DATA_EVENT_PREFIX + sessionId, (data) => {
         const t0 = performance.now()
         const bytes = decodeBase64(data as string)

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -83,6 +83,8 @@ export const Terminal = {
     call<null>("terminal.Resize", [id, cols, rows]),
   SetVisible: (id: string, visible: boolean) =>
     call<null>("terminal.SetVisible", [id, visible]),
+  // Base64 tail of a session's output, to reseed scrollback after a reload.
+  Replay: (id: string) => call<string>("terminal.Replay", [id]),
   Close: (id: string) => call<null>("terminal.Close", [id]),
 }
 

--- a/internal/terminal/replay.go
+++ b/internal/terminal/replay.go
@@ -1,0 +1,59 @@
+package terminal
+
+import "sync"
+
+// replayCapBytes caps a session's server-side replay tail, matching the
+// frontend replay buffer (replay-buffer.ts). Per running session, in memory —
+// a personal harness runs a handful; a disk-backed store (waveterm's filestore)
+// is the upgrade path if session count or size ever makes that cost matter.
+const replayCapBytes = 2 << 20
+
+// replayBuffer keeps a capped tail of a session's raw PTY output so a
+// reconnecting frontend can reseed its scrollback — most importantly after a
+// full page reload, which discards the page-side buffer while the PTY (and this
+// tail) live on in the backend. It mirrors the frontend replay buffer: a chunk
+// list dropped from the front on overflow, so after a drop the head may be a
+// partial ANSI sequence — the same accepted artifact (TUIs repaint, shells
+// scroll it away). Safe for concurrent append (the stream goroutine) and
+// snapshot (an RPC call).
+type replayBuffer struct {
+	mu       sync.Mutex
+	chunks   [][]byte
+	total    int
+	capBytes int
+}
+
+func newReplayBuffer(capBytes int) *replayBuffer {
+	return &replayBuffer{capBytes: capBytes}
+}
+
+// append copies data (the caller reuses its read buffer) and enqueues it,
+// dropping the oldest chunks while the total exceeds the cap. One chunk is
+// always kept, so a single write larger than the cap still replays.
+func (b *replayBuffer) append(data []byte) {
+	if len(data) == 0 {
+		return
+	}
+	chunk := make([]byte, len(data))
+	copy(chunk, data)
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.chunks = append(b.chunks, chunk)
+	b.total += len(chunk)
+	for b.total > b.capBytes && len(b.chunks) > 1 {
+		b.total -= len(b.chunks[0])
+		b.chunks = b.chunks[1:]
+	}
+}
+
+// snapshot returns the queued tail as one contiguous slice in arrival order.
+func (b *replayBuffer) snapshot() []byte {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]byte, 0, b.total)
+	for _, c := range b.chunks {
+		out = append(out, c...)
+	}
+	return out
+}

--- a/internal/terminal/replay_test.go
+++ b/internal/terminal/replay_test.go
@@ -5,8 +5,6 @@ import (
 	"encoding/base64"
 	"strings"
 	"testing"
-
-	"github.com/omartelo/lich/internal/events"
 )
 
 func TestReplayBufferKeepsOutputInOrder(t *testing.T) {
@@ -60,12 +58,12 @@ func TestReplayBufferKeepsOneChunkLargerThanCap(t *testing.T) {
 	}
 }
 
+// A bare Service with a hand-built session exercises Replay without a PTY, so
+// this stays OS-agnostic (no !windows build tag): Replay only reads the tail.
 func TestServiceReplayEncodesTheTail(t *testing.T) {
-	svc := New(stubBins{}, nil, events.New())
-	sess := spawnSession(t)
-	sess.replay = newReplayBuffer(replayCapBytes)
-	sess.replay.append([]byte("scrollback"))
-	svc.sessions["s1"] = sess
+	b := newReplayBuffer(replayCapBytes)
+	b.append([]byte("scrollback"))
+	svc := &Service{sessions: map[string]*session{"s1": {replay: b}}}
 
 	encoded, err := svc.Replay("s1")
 	if err != nil {
@@ -81,7 +79,7 @@ func TestServiceReplayEncodesTheTail(t *testing.T) {
 }
 
 func TestServiceReplayUnknownSessionIsEmpty(t *testing.T) {
-	svc := New(stubBins{}, nil, events.New())
+	svc := &Service{sessions: map[string]*session{}}
 	got, err := svc.Replay("nope")
 	if err != nil {
 		t.Fatalf("Replay = %v, want nil", err)

--- a/internal/terminal/replay_test.go
+++ b/internal/terminal/replay_test.go
@@ -1,0 +1,92 @@
+package terminal
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/events"
+)
+
+func TestReplayBufferKeepsOutputInOrder(t *testing.T) {
+	b := newReplayBuffer(1024)
+	b.append([]byte("hello "))
+	b.append([]byte("world"))
+	if got := string(b.snapshot()); got != "hello world" {
+		t.Fatalf("snapshot = %q, want %q", got, "hello world")
+	}
+}
+
+func TestReplayBufferIgnoresEmptyAppend(t *testing.T) {
+	b := newReplayBuffer(1024)
+	b.append(nil)
+	b.append([]byte{})
+	if got := b.snapshot(); len(got) != 0 {
+		t.Fatalf("snapshot = %q, want empty", got)
+	}
+}
+
+func TestReplayBufferCopiesInput(t *testing.T) {
+	b := newReplayBuffer(1024)
+	buf := []byte("abc")
+	b.append(buf)
+	copy(buf, "XYZ") // the caller reuses its read buffer for the next PTY read
+	if got := string(b.snapshot()); got != "abc" {
+		t.Fatalf("snapshot = %q, want %q — append must copy, not alias", got, "abc")
+	}
+}
+
+func TestReplayBufferDropsOldestOnOverflow(t *testing.T) {
+	b := newReplayBuffer(10)
+	b.append([]byte("aaaaa")) // 5
+	b.append([]byte("bbbbb")) // 10, still within cap
+	b.append([]byte("ccccc")) // 15 → drops the first chunk
+	got := string(b.snapshot())
+	if strings.Contains(got, "a") {
+		t.Fatalf("snapshot = %q, still holds the dropped chunk", got)
+	}
+	if got != "bbbbbccccc" {
+		t.Fatalf("snapshot = %q, want %q", got, "bbbbbccccc")
+	}
+}
+
+func TestReplayBufferKeepsOneChunkLargerThanCap(t *testing.T) {
+	b := newReplayBuffer(4)
+	big := bytes.Repeat([]byte("x"), 100)
+	b.append(big)
+	if got := b.snapshot(); len(got) != 100 {
+		t.Fatalf("snapshot len = %d, want 100 — a lone oversized chunk must survive", len(got))
+	}
+}
+
+func TestServiceReplayEncodesTheTail(t *testing.T) {
+	svc := New(stubBins{}, nil, events.New())
+	sess := spawnSession(t)
+	sess.replay = newReplayBuffer(replayCapBytes)
+	sess.replay.append([]byte("scrollback"))
+	svc.sessions["s1"] = sess
+
+	encoded, err := svc.Replay("s1")
+	if err != nil {
+		t.Fatalf("Replay = %v, want nil", err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if string(decoded) != "scrollback" {
+		t.Fatalf("Replay tail = %q, want %q", decoded, "scrollback")
+	}
+}
+
+func TestServiceReplayUnknownSessionIsEmpty(t *testing.T) {
+	svc := New(stubBins{}, nil, events.New())
+	got, err := svc.Replay("nope")
+	if err != nil {
+		t.Fatalf("Replay = %v, want nil", err)
+	}
+	if got != "" {
+		t.Fatalf("Replay unknown = %q, want empty", got)
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -80,11 +80,13 @@ type agentEvent struct {
 
 // session is a single running PTY-backed shell. done closes when the session
 // is reaped (by stream or Close — whichever removes it from the map), stopping
-// its cwd watcher.
+// its cwd watcher. replay holds a capped tail of the PTY's output so a
+// reconnecting frontend can reseed its scrollback after a page reload.
 type session struct {
-	pty  ptyHandle
-	out  *coalescer
-	done chan struct{}
+	pty    ptyHandle
+	out    *coalescer
+	done   chan struct{}
+	replay *replayBuffer
 }
 
 // Store is the persistence the terminal service depends on: the binary to spawn
@@ -389,8 +391,9 @@ func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int)
 		s.hub.Emit(dataEventPrefix+id, encoded)
 	}, visibleFlushInterval, hiddenFlushInterval)
 	done := make(chan struct{})
-	s.sessions[id] = &session{pty: p, out: out, done: done}
-	go s.stream(id, p, out)
+	replay := newReplayBuffer(replayCapBytes)
+	s.sessions[id] = &session{pty: p, out: out, done: done, replay: replay}
+	go s.stream(id, p, out, replay)
 	// The start directory and a cleared agent are reported unconditionally so
 	// a respawn overwrites whatever the previous PTY left in the frontend's
 	// stores (a provider session's own agent re-reports via its hook).
@@ -404,11 +407,12 @@ func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int)
 // the process, drops the session and emits its exit event. Output goes through
 // the session's coalescer, which batches it on a short cadence while the
 // terminal is visible and a long one while it is hidden.
-func (s *Service) stream(id string, p ptyHandle, out *coalescer) {
+func (s *Service) stream(id string, p ptyHandle, out *coalescer, replay *replayBuffer) {
 	buf := make([]byte, readBufSize)
 	for {
 		n, err := p.Read(buf)
 		if n > 0 {
+			replay.append(buf[:n])
 			out.Write(buf[:n])
 		}
 		if err != nil {
@@ -459,6 +463,21 @@ func (s *Service) SetVisible(id string, visible bool) error {
 	}
 	sess.out.SetVisible(visible)
 	return nil
+}
+
+// Replay returns the capped tail of a session's PTY output, base64-encoded, so a
+// reconnecting frontend can reseed its scrollback after a page reload discarded
+// the page-side buffer. Empty for an unknown session — a brand-new one has no
+// history yet. Base64 for the same reason the data event is: raw PTY bytes may
+// split a multi-byte UTF-8 sequence across the JSON envelope.
+func (s *Service) Replay(id string) (string, error) {
+	s.mu.Lock()
+	sess, ok := s.sessions[id]
+	s.mu.Unlock()
+	if !ok {
+		return "", nil
+	}
+	return base64.StdEncoding.EncodeToString(sess.replay.snapshot()), nil
 }
 
 // Resize updates a session's PTY window size. The frontend only calls this for


### PR DESCRIPTION
## What

A full page reload used to leave every terminal **blank until new output arrived** — the PTYs kept running (they are independent of the page), but their scrollback lived only in the page and was discarded on reload. The backend now keeps a capped tail of each session's output and replays it into the terminal on reconnect, so a reload restores what you were looking at.

## Why

Closes the "a full page reload loses hidden-session scrollback" known ceiling. (It applies to visible sessions too — any reload lost history.)

## Design

- **Backend** (`internal/terminal/replay.go`): a 2 MB in-memory ring per running session (mirrors the frontend replay buffer cap), appended in `stream()` alongside the coalescer. Exposed as `terminal.Replay(id) → base64 tail`.
- **Frontend** (`TerminalView`): on mount, fetch the tail and write it into the fresh xterm **before** wiring the live listeners. Two consequences, both deliberate:
  - The tail lands **ahead of** any live frame → correct scrollback order.
  - Output produced during the fetch round-trip is **dropped, not duplicated** (`term-transport` drops frames for a session with no listener yet) → a small seam gap, consistent with the existing overflow artifact contract (partial ANSI at a boundary; TUIs repaint, shells scroll it away).
- The page-side replay buffer **stays** as the cheap path for hide/show within one page load; the backend tail only covers reconnect after a reload. No behavior change to the in-page path.
- The ring is **in memory, per session**. waveterm's disk filestore is the upgrade path if session count or size ever makes that cost matter.

## Tests

- `replay_test.go`: ring order, empty-append no-op, input is copied (caller reuses the read buffer), oldest-dropped-on-overflow, a lone oversized chunk survives; plus `Service.Replay` encodes the tail and returns empty for an unknown session.
- Gate green locally: `go test -race ./...` (278), `go vet`, `gofmt`; frontend `tsc`, vitest (279), `vite build`.

## Manual smoke test (reviewer)

Run some output in a session, hard-reload the window (Ctrl+R) → the scrollback should come back (minus at most a sliver produced during the reconnect), not a blank screen.