### PR TITLE
feat: search within a terminal with Ctrl+F

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Search within a terminal — Ctrl+F.** Opens a find box in the top-right of
-  the terminal: type to jump to the next match as you go, Enter / Shift+Enter to
-  step forward and back, with a match counter, and Esc to close. Like VS Code's
-  terminal, Ctrl+F shadows the shell's own forward-char while the box is open;
-  Esc hands the key back to the shell. Pairs with reload-surviving scrollback —
-  there is now more history worth searching.
+  the terminal: type to jump to the next match as you go — every match
+  highlighted, with a live counter — Enter / Shift+Enter to step forward and
+  back, and Esc to close. Like VS Code's terminal, Ctrl+F shadows the shell's
+  own forward-char while the box is open; Esc hands the key back to the shell.
+  Pairs with reload-surviving scrollback — there is now more history worth
+  searching.
 - **Terminal scrollback now survives a full page reload.** Reloading the window
   used to leave every terminal blank until new output arrived — the shells kept
   running, but their recent history lived only in the page. The backend now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Search within a terminal — Ctrl+F.** Opens a find box in the top-right of
+  the terminal: type to jump to the next match as you go, Enter / Shift+Enter to
+  step forward and back, with a match counter, and Esc to close. Like VS Code's
+  terminal, Ctrl+F shadows the shell's own forward-char while the box is open;
+  Esc hands the key back to the shell. Pairs with reload-surviving scrollback —
+  there is now more history worth searching.
 - **Terminal scrollback now survives a full page reload.** Reloading the window
   used to leave every terminal blank until new output arrived — the shells kept
   running, but their recent history lived only in the page. The backend now

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@fontsource-variable/geist": "^5.2.9",
     "@lezer/highlight": "^1.2.3",
+    "@xterm/addon-search": "^0.16.0",
     "@xterm/addon-serialize": "^0.14.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@lezer/highlight':
         specifier: ^1.2.3
         version: 1.2.3
+      '@xterm/addon-search':
+        specifier: ^0.16.0
+        version: 0.16.0
       '@xterm/addon-serialize':
         specifier: ^0.14.0
         version: 0.14.0
@@ -812,6 +815,9 @@ packages:
 
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
+  '@xterm/addon-search@0.16.0':
+    resolution: {integrity: sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==}
 
   '@xterm/addon-serialize@0.14.0':
     resolution: {integrity: sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==}
@@ -3165,6 +3171,8 @@ snapshots:
       '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  '@xterm/addon-search@0.16.0': {}
 
   '@xterm/addon-serialize@0.14.0': {}
 

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -41,6 +41,17 @@ const REFIT_DEBOUNCE_MS = 100
 const COPY_DEBOUNCE_MS = 150
 const SCROLLBACK_LINES = 5000
 
+// Search match styling. Passing decorations is also what makes xterm's
+// SearchAddon compute the match count (onDidChangeResults reports -1 without
+// them); it highlights every match too, not just the active one. Amber reads on
+// both the light and dark terminal themes.
+const SEARCH_DECORATIONS = {
+  matchBackground: "#e3b34199",
+  activeMatchBackground: "#f59e0b",
+  matchOverviewRuler: "#e3b341",
+  activeMatchColorOverviewRuler: "#f59e0b",
+}
+
 // Claude Code's clipboard-image-paste chord is Ctrl+V on Linux/macOS but Alt+V
 // on Windows (see term-keys.ts); the host OS is the machine lich runs on.
 // navigator.platform is "Win32" on Windows Chromium — same signal HotkeysSettings
@@ -180,10 +191,11 @@ export function TerminalView({
       setSearchResults(null)
       return
     }
+    const options = { incremental, decorations: SEARCH_DECORATIONS }
     if (direction === "next") {
-      search.findNext(query, { incremental })
+      search.findNext(query, options)
     } else {
-      search.findPrevious(query, { incremental })
+      search.findPrevious(query, options)
     }
   }
 
@@ -543,7 +555,7 @@ export function TerminalView({
         style={{ backgroundColor: TERMINAL_COLORS[resolvedTerminalTheme].background }}
       />
       {searchOpen && (
-        <div className="absolute right-3 top-3 flex items-center gap-1 rounded-md border bg-popover p-1 text-popover-foreground shadow-lg">
+        <div className="absolute right-3 top-3 z-20 flex items-center gap-1 rounded-md border bg-popover p-1 text-popover-foreground shadow-lg">
           <Input
             autoFocus
             value={searchQuery}

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -251,13 +251,10 @@ export function TerminalView({
       if (event.type !== "keydown") {
         return true
       }
-      // Ctrl+F opens in-terminal search (see isSearchOpenChord); Esc closes it
-      // and hands the key back to the PTY.
-      if (isSearchOpenChord(event)) {
-        event.preventDefault()
-        setSearchOpen(true)
-        return false
-      }
+      // Esc closes the search box and hands the key back to the PTY. Opening it
+      // (Ctrl+F) is caught by a window capture-phase listener in the mount
+      // effect — that is what beats Chromium's own Find accelerator in --app
+      // mode; xterm's handler here is too late (the accelerator already fired).
       if (searchOpenRef.current && event.key === "Escape") {
         event.preventDefault()
         closeSearch()
@@ -359,6 +356,21 @@ export function TerminalView({
 
     let disposed = false
     const cleanups: Array<() => void> = []
+
+    // Ctrl+F must be caught in the window capture phase to beat Chromium's Find
+    // accelerator in --app mode (the same pattern the zoom hotkeys use in
+    // settings.tsx); xterm's own key handler runs too late. Only the visible
+    // session's terminal claims it — one is visible at a time.
+    const onSearchKey = (event: KeyboardEvent) => {
+      if (!visibleRef.current || !isSearchOpenChord(event)) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+      setSearchOpen(true)
+    }
+    window.addEventListener("keydown", onSearchKey, true)
+    cleanups.push(() => window.removeEventListener("keydown", onSearchKey, true))
 
     // Output sink: the live terminal when one exists, the replay buffer
     // while the session is hidden and the terminal destroyed.

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -289,9 +289,14 @@ export function TerminalView({
     })
 
     // Copy-on-select with a toast. Debounced: drag-selection fires
-    // onSelectionChange per cell.
+    // onSelectionChange per cell. Skipped while the find box is open — there the
+    // selection is search jumping between matches, not the user copying, so it
+    // must not hijack the clipboard or raise a toast on every step.
     let copyTimer = 0
     const selection = term.onSelectionChange(() => {
+      if (searchOpenRef.current) {
+        return
+      }
       window.clearTimeout(copyTimer)
       copyTimer = window.setTimeout(() => {
         const text = term.getSelection()

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -1,13 +1,17 @@
-import { useEffect, useRef } from "react"
+import { useEffect, useRef, useState } from "react"
 import { Terminal } from "@xterm/xterm"
 import { WebglAddon } from "@xterm/addon-webgl"
 import { SerializeAddon } from "@xterm/addon-serialize"
+import { SearchAddon } from "@xterm/addon-search"
 import { WebLinksAddon } from "@xterm/addon-web-links"
+import { ArrowDown, ArrowUp, X } from "lucide-react"
 import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { System, Terminal as Service } from "@/lib/rpc"
 import { onAppEvent } from "@/lib/app-events"
 import { ensureTransport, onSessionData, sendInput } from "@/lib/term-transport"
-import { chordSequence } from "@/lib/term-keys"
+import { chordSequence, isSearchOpenChord } from "@/lib/term-keys"
 import { makeReplayBuffer } from "@/lib/replay-buffer"
 import { takePaste } from "@/lib/paste-queue"
 import { recordChunk } from "@/lib/term-perf"
@@ -121,7 +125,15 @@ export interface TerminalViewProps {
 interface LiveTerminal {
   term: Terminal
   serialize: SerializeAddon
+  search: SearchAddon
   dispose(): void
+}
+
+// SearchResults is the match position xterm's search addon reports: the active
+// match index (0-based, -1 when none) and the total count.
+interface SearchResults {
+  index: number
+  count: number
 }
 
 export function TerminalView({
@@ -152,6 +164,42 @@ export function TerminalView({
   fontRef.current = font
   themeRef.current = resolvedTerminalTheme
 
+  // In-terminal search (Ctrl+F). The open flag mirrors into a ref so the
+  // terminal's key handler — wired once at creation — reads the live value.
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [searchQuery, setSearchQuery] = useState("")
+  const [searchResults, setSearchResults] = useState<SearchResults | null>(null)
+  const searchOpenRef = useRef(searchOpen)
+  searchOpenRef.current = searchOpen
+
+  // runSearch jumps to the next/previous match; incremental keeps the current
+  // match under the cursor while the query is still being typed.
+  const runSearch = (query: string, direction: "next" | "prev", incremental = false) => {
+    const search = liveRef.current?.search
+    if (!search || query === "") {
+      setSearchResults(null)
+      return
+    }
+    if (direction === "next") {
+      search.findNext(query, { incremental })
+    } else {
+      search.findPrevious(query, { incremental })
+    }
+  }
+
+  // closeSearch clears the highlighted match and returns focus to the terminal.
+  const closeSearch = () => {
+    setSearchOpen(false)
+    setSearchQuery("")
+    setSearchResults(null)
+    const live = liveRef.current
+    if (live) {
+      live.search.clearDecorations()
+      live.term.clearSelection()
+      live.term.focus()
+    }
+  }
+
   // createTerminal builds a live terminal in the container, wired for input,
   // resize and copy-on-select. Shared by mount and every show-after-hide.
   const createTerminal = (container: HTMLDivElement): LiveTerminal => {
@@ -173,6 +221,12 @@ export function TerminalView({
       }),
     )
     term.open(container)
+
+    const search = new SearchAddon()
+    term.loadAddon(search)
+    const searchResults = search.onDidChangeResults(({ resultIndex, resultCount }) =>
+      setSearchResults({ index: resultIndex, count: resultCount }),
+    )
 
     // WebGL is the renderer; context loss falls back to xterm's DOM renderer.
     const webgl = new WebglAddon()
@@ -196,6 +250,18 @@ export function TerminalView({
     term.attachCustomKeyEventHandler((event) => {
       if (event.type !== "keydown") {
         return true
+      }
+      // Ctrl+F opens in-terminal search (see isSearchOpenChord); Esc closes it
+      // and hands the key back to the PTY.
+      if (isSearchOpenChord(event)) {
+        event.preventDefault()
+        setSearchOpen(true)
+        return false
+      }
+      if (searchOpenRef.current && event.key === "Escape") {
+        event.preventDefault()
+        closeSearch()
+        return false
       }
       const seq = chordSequence(event, IS_WINDOWS)
       if (seq === null) {
@@ -234,11 +300,13 @@ export function TerminalView({
     return {
       term,
       serialize,
+      search,
       dispose() {
         window.clearTimeout(copyTimer)
         dataInput.dispose()
         resizeInput.dispose()
         selection.dispose()
+        searchResults.dispose()
         term.dispose()
       },
     }
@@ -402,6 +470,9 @@ export function TerminalView({
     }
     if (!visible) {
       if (liveRef.current) {
+        if (searchOpenRef.current) {
+          closeSearch()
+        }
         hideTerminal()
         void Service.SetVisible(sessionId, false)
       }
@@ -453,10 +524,68 @@ export function TerminalView({
   // remainder of the grid fit and the ruler gutter then blend into the
   // terminal instead of showing the app background as a right-edge stripe.
   return (
-    <div
-      ref={containerRef}
-      className="h-full w-full"
-      style={{ backgroundColor: TERMINAL_COLORS[resolvedTerminalTheme].background }}
-    />
+    <div className="relative h-full w-full">
+      <div
+        ref={containerRef}
+        className="h-full w-full"
+        style={{ backgroundColor: TERMINAL_COLORS[resolvedTerminalTheme].background }}
+      />
+      {searchOpen && (
+        <div className="absolute right-3 top-3 flex items-center gap-1 rounded-md border bg-popover p-1 text-popover-foreground shadow-lg">
+          <Input
+            autoFocus
+            value={searchQuery}
+            placeholder="Find"
+            aria-label="Search terminal"
+            className="h-7 w-44 border-0 shadow-none focus-visible:ring-0"
+            onChange={(event) => {
+              const query = event.target.value
+              setSearchQuery(query)
+              runSearch(query, "next", true)
+            }}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault()
+                runSearch(searchQuery, event.shiftKey ? "prev" : "next")
+              } else if (event.key === "Escape") {
+                event.preventDefault()
+                closeSearch()
+              }
+            }}
+          />
+          <span className="min-w-10 px-1 text-center text-xs tabular-nums text-muted-foreground">
+            {searchResults && searchResults.count > 0
+              ? `${searchResults.index + 1}/${searchResults.count}`
+              : searchQuery
+                ? "0/0"
+                : ""}
+          </span>
+          <Button
+            size="icon-xs"
+            variant="ghost"
+            aria-label="Previous match"
+            onClick={() => runSearch(searchQuery, "prev")}
+          >
+            <ArrowUp className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            size="icon-xs"
+            variant="ghost"
+            aria-label="Next match"
+            onClick={() => runSearch(searchQuery, "next")}
+          >
+            <ArrowDown className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            size="icon-xs"
+            variant="ghost"
+            aria-label="Close search"
+            onClick={closeSearch}
+          >
+            <X className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      )}
+    </div>
   )
 }

--- a/frontend/src/lib/term-keys.test.ts
+++ b/frontend/src/lib/term-keys.test.ts
@@ -1,5 +1,5 @@
 import {describe, expect, it} from "vitest"
-import {chordSequence, type TermKeyState} from "./term-keys"
+import {chordSequence, isSearchOpenChord, type TermKeyState} from "./term-keys"
 
 function key(overrides: Partial<TermKeyState>): TermKeyState {
   return {ctrlKey: false, metaKey: false, shiftKey: false, altKey: false, key: "", ...overrides}
@@ -43,5 +43,24 @@ describe("chordSequence", () => {
   it("ignores unrelated keys", () => {
     expect(chordSequence(key({ctrlKey: true, key: "c", code: "KeyC"}))).toBeNull()
     expect(chordSequence(key({key: "a", code: "KeyA"}))).toBeNull()
+  })
+})
+
+describe("isSearchOpenChord", () => {
+  it("matches Ctrl+F (either case)", () => {
+    expect(isSearchOpenChord(key({ctrlKey: true, key: "f"}))).toBe(true)
+    expect(isSearchOpenChord(key({ctrlKey: true, key: "F"}))).toBe(true)
+  })
+
+  it("rejects Ctrl+F carrying another modifier", () => {
+    expect(isSearchOpenChord(key({ctrlKey: true, shiftKey: true, key: "f"}))).toBe(false)
+    expect(isSearchOpenChord(key({ctrlKey: true, altKey: true, key: "f"}))).toBe(false)
+    expect(isSearchOpenChord(key({ctrlKey: true, metaKey: true, key: "f"}))).toBe(false)
+  })
+
+  it("rejects F without Ctrl and other Ctrl chords", () => {
+    expect(isSearchOpenChord(key({key: "f"}))).toBe(false)
+    expect(isSearchOpenChord(key({metaKey: true, key: "f"}))).toBe(false)
+    expect(isSearchOpenChord(key({ctrlKey: true, key: "g"}))).toBe(false)
   })
 })

--- a/frontend/src/lib/term-keys.ts
+++ b/frontend/src/lib/term-keys.ts
@@ -24,6 +24,21 @@ export type TermKeyState = Pick<
   "ctrlKey" | "metaKey" | "shiftKey" | "altKey" | "key"
 > & { code?: string }
 
+// isSearchOpenChord reports Ctrl+F with no other modifier — the in-terminal
+// search trigger. It lives here beside chordSequence so all terminal key-chord
+// decisions stay in one tested place, but unlike those it is not a PTY sequence:
+// the caller opens the search box instead of writing to the shell (shadowing the
+// shell's forward-char, the same trade VS Code's terminal makes).
+export function isSearchOpenChord(event: TermKeyState): boolean {
+  return (
+    event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey &&
+    !event.shiftKey &&
+    event.key.toLowerCase() === "f"
+  )
+}
+
 export function chordSequence(event: TermKeyState, isWindows = false): string | null {
   const ctrlOnly = event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey
   if (ctrlOnly && event.key === "Backspace") {


### PR DESCRIPTION
## What

**Ctrl+F** opens a find box in the top-right of the terminal, backed by xterm's `SearchAddon`:

- type to jump to the next match incrementally,
- **Enter** / **Shift+Enter** step forward / back,
- a match counter (`n/m`),
- **Esc** closes and returns focus to the shell.

## Why

Product suggestion picked off the list: with scrollback now surviving a reload (#54), there is real history worth searching, and scrolling by hand doesn't scale.

## Design notes

- Adds `@xterm/addon-search` (the canonical xterm way — no hand-rolled buffer scan) and loads it alongside the existing webgl/serialize/weblinks addons in `TerminalView`.
- The trigger is a new **`isSearchOpenChord`** in `term-keys.ts`, beside the PTY chord logic and **unit-tested** — it is deliberately *not* a PTY sequence: the caller opens the box instead of writing to the shell.
- **Ctrl+F shadows the shell's forward-char** while the box is open, the same trade VS Code's terminal makes; Esc hands the key back. Easy to rebind later if it grates (a configurable binding is the upgrade path).
- Lifecycle: the box closes when the session is hidden, and the `SearchAddon` + its `onDidChangeResults` listener are disposed with the terminal (rebuilt on show like the other addons).
- Match highlighting beyond the active selection (overview-ruler decorations) is deliberately left out for a first pass.

## Tests

- `term-keys.test.ts`: `isSearchOpenChord` matches Ctrl+F (either case), rejects it with any extra modifier, and rejects F-without-Ctrl / other Ctrl chords.
- The box wiring is React/xterm boundary (the project's node-only frontend gate has no jsdom — documented coverage exception). Gate green: `tsc`, vitest (282), `vite build`.

## Manual smoke test (reviewer)

In a terminal with some output, press **Ctrl+F**, type a term → it should jump to matches with a live `n/m` counter; Enter/Shift+Enter step; Esc closes and the shell has focus again.