### PR TITLE
feat: command palette (Ctrl/Cmd+K) to jump to any session or project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Command palette — Ctrl/Cmd+K.** One shortcut, from anywhere, to jump to any
+  session across every project — or to a project — without hunting through the
+  tabs (which only show the active project's sessions). Type to filter by
+  session label, project or path; ↑↓ to move, ↵ to open, Esc to close. Each
+  session row shows its project, path and live status (busy / waiting / done).
+  The shortcut is rebindable in Settings › Hotkeys, since Ctrl+K otherwise
+  shadows the shell's kill-line. Jump-only for now — running actions from it can
+  come later.
 - **Search within a terminal — Ctrl+F.** Opens a find box in the top-right of
   the terminal: type to jump to the next match as you go — every match
   highlighted, with a live counter — Enter / Shift+Enter to step forward and

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { Settings } from "@/components/settings/Settings"
 import { Toaster } from "@/components/ui/sonner"
 import { ClaudePluginGate } from "@/components/ClaudePluginGate"
 import { AppUpdateGate } from "@/components/AppUpdateGate"
+import { CommandPalette } from "@/components/CommandPalette"
 
 // Layout is persistent across navigation: the project tabs, session sidebar and
 // TerminalHost stay mounted while the Outlet swaps screens (Home, Settings) on
@@ -69,6 +70,9 @@ function App() {
           {/* Inside ProjectsProvider + the router: the update flow opens a shell
               session and navigates to it. */}
           <AppUpdateGate />
+          {/* Global quick switcher; also needs the provider (sessions/projects)
+              and the router (navigation). */}
+          <CommandPalette />
         </ProjectsProvider>
       </HashRouter>
       <ClaudePluginGate />

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,14 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
 import { useNavigate } from "react-router-dom"
-import { CornerDownLeft, Folder, Search, Sparkles, SquareTerminal } from "lucide-react"
+import { CornerDownLeft, Folder, Search } from "lucide-react"
 import { useProjects } from "@/lib/projects"
 import { useSettings } from "@/lib/settings"
 import { isRecordingTarget, matchesCombo } from "@/lib/hotkeys"
 import { useSessionStatus } from "@/lib/useSessionStatus"
+import { SessionStatusIcon } from "@/components/sidebar/SessionStatusIcon"
 import { filterPalette, paletteSessions, type PaletteSession } from "@/lib/command-palette"
 import type { Project } from "@/lib/api-types"
-import type { SessionStatus } from "@/lib/session-events"
 import { cn } from "@/lib/utils"
 
 // CommandPalette is the app-wide quick switcher: one shortcut (Ctrl/Cmd+K by
@@ -214,22 +214,14 @@ function SessionRow({
   onRun: () => void
 }) {
   const status = useSessionStatus(session.sessionId)
-  const meta = statusMeta(status)
-  const Icon = session.kind === "shell" ? SquareTerminal : Sparkles
   return (
     <Row selected={selected} onSelect={onSelect} onRun={onRun}>
-      <Icon className="size-4 shrink-0 text-muted-foreground" />
+      <SessionStatusIcon kind={session.kind} status={status} />
       <span className="flex min-w-0 flex-1 flex-col">
         <span className="truncate text-sm">{session.label}</span>
         <span className="truncate font-mono text-xs text-muted-foreground">
           <span className="text-foreground/70">{session.projectName}</span> · {session.path}
         </span>
-      </span>
-      <span className="flex shrink-0 items-center gap-2 font-mono text-[10px] uppercase text-muted-foreground">
-        <span>{session.kind}</span>
-        {meta && (
-          <span className={cn("rounded-full border px-1.5 py-0.5 lowercase", meta.className)}>{meta.label}</span>
-        )}
       </span>
     </Row>
   )
@@ -260,19 +252,6 @@ function ProjectRow({
       </span>
     </Row>
   )
-}
-
-function statusMeta(status: SessionStatus | null): { label: string; className: string } | null {
-  switch (status) {
-    case "busy":
-      return { label: "busy", className: "border-sky-400/30 text-sky-400" }
-    case "waiting":
-      return { label: "waiting", className: "border-amber-500/30 text-amber-500" }
-    case "done":
-      return { label: "done", className: "border-emerald-500/30 text-emerald-500" }
-    default:
-      return null
-  }
 }
 
 function Hint({ keys, children }: { keys: string[]; children: React.ReactNode }) {

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,0 +1,294 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+import { useNavigate } from "react-router-dom"
+import { CornerDownLeft, Folder, Search, Sparkles, SquareTerminal } from "lucide-react"
+import { useProjects } from "@/lib/projects"
+import { useSettings } from "@/lib/settings"
+import { isRecordingTarget, matchesCombo } from "@/lib/hotkeys"
+import { useSessionStatus } from "@/lib/useSessionStatus"
+import { filterPalette, paletteSessions, type PaletteSession } from "@/lib/command-palette"
+import type { Project } from "@/lib/api-types"
+import type { SessionStatus } from "@/lib/session-events"
+import { cn } from "@/lib/utils"
+
+// CommandPalette is the app-wide quick switcher: one shortcut (Ctrl/Cmd+K by
+// default, rebindable in Settings) to jump to any session across every project,
+// or to a project — reachable from anywhere, unlike the tab strip which only
+// shows the active project's sessions. Mounted once at the app root; it renders
+// nothing until opened.
+//
+// The trigger is caught in the window capture phase (like the other global
+// hotkeys) so it beats the shell binding it shadows; while open, focus is
+// trapped in the dialog and keys never reach the terminal.
+export function CommandPalette() {
+  const { projects, sessions, activateSession } = useProjects()
+  const { hotkeys } = useSettings()
+  const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState("")
+  const [selected, setSelected] = useState(0)
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (isRecordingTarget(event)) {
+        return
+      }
+      if (matchesCombo(event, hotkeys.commandPalette)) {
+        event.preventDefault()
+        event.stopPropagation()
+        setOpen((v) => !v)
+      }
+    }
+    window.addEventListener("keydown", onKey, true)
+    return () => window.removeEventListener("keydown", onKey, true)
+  }, [hotkeys])
+
+  const all = useMemo(() => paletteSessions(projects, sessions), [projects, sessions])
+  const results = useMemo(() => filterPalette(query, all, projects), [query, all, projects])
+  const total = results.sessions.length + results.projects.length
+
+  // Reset the cursor to the top whenever the visible set changes.
+  useEffect(() => setSelected(0), [query])
+  const active = Math.min(selected, Math.max(0, total - 1))
+
+  const openProject = (projectId: string, sessionId?: string) => {
+    navigate(`/projects/${projectId}`)
+    if (sessionId) {
+      activateSession(projectId, sessionId)
+    }
+    close()
+  }
+
+  const runIndex = (index: number) => {
+    if (index < results.sessions.length) {
+      const s = results.sessions[index]
+      if (s) {
+        openProject(s.projectId, s.sessionId)
+      }
+      return
+    }
+    const p = results.projects[index - results.sessions.length]
+    if (p) {
+      openProject(p.id)
+    }
+  }
+
+  const close = () => {
+    setOpen(false)
+    setQuery("")
+    setSelected(0)
+  }
+
+  const onInputKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === "ArrowDown") {
+      event.preventDefault()
+      setSelected((i) => Math.min(i + 1, total - 1))
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault()
+      setSelected((i) => Math.max(i - 1, 0))
+    } else if (event.key === "Enter") {
+      event.preventDefault()
+      runIndex(active)
+    }
+  }
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={(next) => (next ? setOpen(true) : close())}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-black/50 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
+        <DialogPrimitive.Popup className="fixed left-1/2 top-[14vh] z-50 flex max-h-[70vh] w-full max-w-[640px] -translate-x-1/2 flex-col overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-2xl ring-1 ring-foreground/10 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0">
+          <DialogPrimitive.Title className="sr-only">Command palette</DialogPrimitive.Title>
+
+          <div className="flex items-center gap-3 border-b px-4 py-3">
+            <Search className="size-4 shrink-0 text-muted-foreground" />
+            <input
+              autoFocus
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={onInputKeyDown}
+              placeholder="Jump to a session or project…"
+              aria-label="Search sessions and projects"
+              autoComplete="off"
+              spellCheck={false}
+              className="flex-1 bg-transparent text-[15px] outline-none placeholder:text-muted-foreground"
+            />
+          </div>
+
+          <div className="flex-1 overflow-y-auto p-1.5">
+            {total === 0 ? (
+              <div className="px-3 py-8 text-center text-sm text-muted-foreground">
+                No matches for <span className="font-mono text-foreground/80">{query.trim()}</span>
+              </div>
+            ) : (
+              <>
+                {results.sessions.length > 0 && <GroupLabel>Sessions</GroupLabel>}
+                {results.sessions.map((session, i) => (
+                  <SessionRow
+                    key={session.sessionId}
+                    session={session}
+                    selected={i === active}
+                    onSelect={() => setSelected(i)}
+                    onRun={() => runIndex(i)}
+                  />
+                ))}
+                {results.projects.length > 0 && <GroupLabel>Projects</GroupLabel>}
+                {results.projects.map((project, j) => {
+                  const index = results.sessions.length + j
+                  return (
+                    <ProjectRow
+                      key={project.id}
+                      project={project}
+                      sessionCount={sessions[project.id]?.sessions.length ?? 0}
+                      selected={index === active}
+                      onSelect={() => setSelected(index)}
+                      onRun={() => runIndex(index)}
+                    />
+                  )
+                })}
+              </>
+            )}
+          </div>
+
+          <div className="flex items-center gap-4 border-t bg-black/10 px-4 py-2 text-xs text-muted-foreground">
+            <Hint keys={["↑", "↓"]}>navigate</Hint>
+            <Hint keys={["↵"]}>open</Hint>
+            <Hint keys={["esc"]}>close</Hint>
+          </div>
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  )
+}
+
+function GroupLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="px-3 pb-1 pt-3 text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">
+      {children}
+    </div>
+  )
+}
+
+interface RowProps {
+  selected: boolean
+  onSelect: () => void
+  onRun: () => void
+  children: React.ReactNode
+}
+
+function Row({ selected, onSelect, onRun, children }: RowProps) {
+  const ref = useRef<HTMLButtonElement>(null)
+  useEffect(() => {
+    if (selected) {
+      ref.current?.scrollIntoView({ block: "nearest" })
+    }
+  }, [selected])
+  return (
+    <button
+      ref={ref}
+      type="button"
+      aria-selected={selected}
+      onMouseMove={onSelect}
+      onClick={onRun}
+      className={cn(
+        "group flex w-full items-center gap-3 rounded-md px-3 py-2 text-left outline-none",
+        selected ? "bg-accent text-accent-foreground" : "text-foreground",
+      )}
+    >
+      {children}
+      <CornerDownLeft
+        className={cn("size-3.5 shrink-0 text-muted-foreground", selected ? "opacity-100" : "opacity-0")}
+      />
+    </button>
+  )
+}
+
+function SessionRow({
+  session,
+  selected,
+  onSelect,
+  onRun,
+}: {
+  session: PaletteSession
+  selected: boolean
+  onSelect: () => void
+  onRun: () => void
+}) {
+  const status = useSessionStatus(session.sessionId)
+  const meta = statusMeta(status)
+  const Icon = session.kind === "shell" ? SquareTerminal : Sparkles
+  return (
+    <Row selected={selected} onSelect={onSelect} onRun={onRun}>
+      <Icon className="size-4 shrink-0 text-muted-foreground" />
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-sm">{session.label}</span>
+        <span className="truncate font-mono text-xs text-muted-foreground">
+          <span className="text-foreground/70">{session.projectName}</span> · {session.path}
+        </span>
+      </span>
+      <span className="flex shrink-0 items-center gap-2 font-mono text-[10px] uppercase text-muted-foreground">
+        <span>{session.kind}</span>
+        {meta && (
+          <span className={cn("rounded-full border px-1.5 py-0.5 lowercase", meta.className)}>{meta.label}</span>
+        )}
+      </span>
+    </Row>
+  )
+}
+
+function ProjectRow({
+  project,
+  sessionCount,
+  selected,
+  onSelect,
+  onRun,
+}: {
+  project: Project
+  sessionCount: number
+  selected: boolean
+  onSelect: () => void
+  onRun: () => void
+}) {
+  return (
+    <Row selected={selected} onSelect={onSelect} onRun={onRun}>
+      <Folder className="size-4 shrink-0 text-muted-foreground" />
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-sm">{project.name}</span>
+        <span className="truncate font-mono text-xs text-muted-foreground">{project.path}</span>
+      </span>
+      <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+        {sessionCount} {sessionCount === 1 ? "session" : "sessions"}
+      </span>
+    </Row>
+  )
+}
+
+function statusMeta(status: SessionStatus | null): { label: string; className: string } | null {
+  switch (status) {
+    case "busy":
+      return { label: "busy", className: "border-sky-400/30 text-sky-400" }
+    case "waiting":
+      return { label: "waiting", className: "border-amber-500/30 text-amber-500" }
+    case "done":
+      return { label: "done", className: "border-emerald-500/30 text-emerald-500" }
+    default:
+      return null
+  }
+}
+
+function Hint({ keys, children }: { keys: string[]; children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span className="inline-flex gap-1">
+        {keys.map((k) => (
+          <kbd
+            key={k}
+            className="rounded border border-b-2 bg-muted px-1.5 py-0.5 font-mono text-[10px] leading-none text-muted-foreground"
+          >
+            {k}
+          </kbd>
+        ))}
+      </span>
+      {children}
+    </span>
+  )
+}

--- a/frontend/src/lib/command-palette.test.ts
+++ b/frontend/src/lib/command-palette.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+import { filterPalette, matchesQuery, paletteSessions } from "./command-palette"
+import type { Project } from "./api-types"
+import type { SessionState } from "./sessions"
+
+const projects: Project[] = [
+  { id: "p1", name: "lich", path: "/home/u/try/skipo" },
+  { id: "p2", name: "revu", path: "/home/u/try/revu" },
+]
+
+const sessions: SessionState = {
+  p1: {
+    sessions: [
+      { id: "s1", label: "Fix flaky test", kind: "claude" },
+      { id: "s2", label: "build watch", kind: "shell", path: "/home/u/try/skipo/frontend" },
+    ],
+    activeId: "s1",
+    nextSeq: 3,
+  },
+  p2: {
+    sessions: [{ id: "s3", label: "Wire revu auth middleware", kind: "claude" }],
+    activeId: "s3",
+    nextSeq: 2,
+  },
+  // A project with sessions but no open tab — must be dropped.
+  ghost: {
+    sessions: [{ id: "s9", label: "orphan", kind: "claude" }],
+    activeId: "s9",
+    nextSeq: 2,
+  },
+}
+
+describe("paletteSessions", () => {
+  it("flattens sessions of open projects with their project", () => {
+    const rows = paletteSessions(projects, sessions)
+    expect(rows.map((r) => r.sessionId)).toEqual(["s1", "s2", "s3"])
+    expect(rows[0]).toMatchObject({ projectId: "p1", projectName: "lich", label: "Fix flaky test" })
+  })
+
+  it("uses the worktree path when set, else the project path", () => {
+    const rows = paletteSessions(projects, sessions)
+    expect(rows.find((r) => r.sessionId === "s1")?.path).toBe("/home/u/try/skipo")
+    expect(rows.find((r) => r.sessionId === "s2")?.path).toBe("/home/u/try/skipo/frontend")
+  })
+
+  it("drops sessions whose project has no open tab", () => {
+    const rows = paletteSessions(projects, sessions)
+    expect(rows.some((r) => r.projectId === "ghost")).toBe(false)
+  })
+})
+
+describe("matchesQuery", () => {
+  it("matches when every token is present, in any order", () => {
+    expect(matchesQuery("Wire revu auth middleware", "revu auth")).toBe(true)
+    expect(matchesQuery("Wire revu auth middleware", "auth revu")).toBe(true)
+  })
+
+  it("is case-insensitive and matches an empty query", () => {
+    expect(matchesQuery("lich", "LICH")).toBe(true)
+    expect(matchesQuery("anything", "  ")).toBe(true)
+  })
+
+  it("fails when a token is absent", () => {
+    expect(matchesQuery("Wire revu auth", "revu payments")).toBe(false)
+  })
+})
+
+describe("filterPalette", () => {
+  const all = paletteSessions(projects, sessions)
+
+  it("filters sessions by label, project name and path", () => {
+    expect(filterPalette("flaky", all, projects).sessions.map((s) => s.sessionId)).toEqual(["s1"])
+    expect(filterPalette("revu", all, projects).sessions.map((s) => s.sessionId)).toEqual(["s3"])
+    expect(filterPalette("frontend", all, projects).sessions.map((s) => s.sessionId)).toEqual(["s2"])
+  })
+
+  it("filters projects by name and path", () => {
+    expect(filterPalette("revu", all, projects).projects.map((p) => p.id)).toEqual(["p2"])
+    expect(filterPalette("skipo", all, projects).projects.map((p) => p.id)).toEqual(["p1"])
+  })
+
+  it("returns everything for an empty query", () => {
+    const r = filterPalette("", all, projects)
+    expect(r.sessions).toHaveLength(3)
+    expect(r.projects).toHaveLength(2)
+  })
+})

--- a/frontend/src/lib/command-palette.ts
+++ b/frontend/src/lib/command-palette.ts
@@ -1,0 +1,77 @@
+// The command palette's data join: open projects and their sessions become a
+// flat, filterable list the palette lists and routes to. Kept pure (no React,
+// no stores) so the flatten and filter are testable without a render.
+
+import type { Project } from "./api-types"
+import type { SessionKind, SessionState } from "./sessions"
+
+// PaletteSession is one session flattened with the project it belongs to — what
+// a "jump to session" row shows and routes to.
+export interface PaletteSession {
+  sessionId: string
+  projectId: string
+  projectName: string
+  label: string
+  kind: SessionKind
+  // Where the session runs: its own worktree path, else the project's path.
+  path: string
+}
+
+// paletteSessions flattens every session of the open projects. Sessions whose
+// project has no open tab are dropped — they are not reachable by navigation,
+// the same rule the notification queue applies.
+export function paletteSessions(
+  projects: readonly Project[],
+  sessions: SessionState,
+): PaletteSession[] {
+  const rows: PaletteSession[] = []
+  for (const project of projects) {
+    const entry = sessions[project.id]
+    if (!entry) {
+      continue
+    }
+    for (const session of entry.sessions) {
+      rows.push({
+        sessionId: session.id,
+        projectId: project.id,
+        projectName: project.name,
+        label: session.label,
+        kind: session.kind,
+        path: session.path ?? project.path,
+      })
+    }
+  }
+  return rows
+}
+
+// matchesQuery reports whether every whitespace-separated token of the query
+// appears in haystack, case-insensitively — a light fuzzy filter, so "revu auth"
+// matches "Wire revu auth middleware". An empty query matches everything.
+export function matchesQuery(haystack: string, query: string): boolean {
+  const q = query.trim().toLowerCase()
+  if (q === "") {
+    return true
+  }
+  const hay = haystack.toLowerCase()
+  return q.split(/\s+/).every((token) => hay.includes(token))
+}
+
+export interface PaletteResults {
+  sessions: PaletteSession[]
+  projects: Project[]
+}
+
+// filterPalette narrows sessions and projects to those matching query. A session
+// matches on its label, project name or path; a project on its name or path.
+export function filterPalette(
+  query: string,
+  allSessions: readonly PaletteSession[],
+  projects: readonly Project[],
+): PaletteResults {
+  return {
+    sessions: allSessions.filter((s) =>
+      matchesQuery(`${s.label} ${s.projectName} ${s.path}`, query),
+    ),
+    projects: projects.filter((p) => matchesQuery(`${p.name} ${p.path}`, query)),
+  }
+}

--- a/frontend/src/lib/hotkeys.ts
+++ b/frontend/src/lib/hotkeys.ts
@@ -3,7 +3,12 @@
 // platform primary modifier — Ctrl on Windows/Linux, Cmd on macOS — so a single
 // stored combo works on both.
 
-export type HotkeyId = "newSession" | "zoomIn" | "zoomOut" | "zoomReset"
+export type HotkeyId =
+  | "commandPalette"
+  | "newSession"
+  | "zoomIn"
+  | "zoomOut"
+  | "zoomReset"
 
 export interface Combo {
   mod: boolean
@@ -20,6 +25,7 @@ export interface HotkeyAction {
 
 // HOTKEY_ACTIONS drives the defaults and the settings UI list.
 export const HOTKEY_ACTIONS: readonly HotkeyAction[] = [
+  { id: "commandPalette", label: "Command palette", combo: { mod: true, shift: false, alt: false, key: "k" } },
   { id: "newSession", label: "New session", combo: { mod: true, shift: true, alt: false, key: "t" } },
   { id: "zoomIn", label: "Zoom in", combo: { mod: true, shift: false, alt: false, key: "+" } },
   { id: "zoomOut", label: "Zoom out", combo: { mod: true, shift: false, alt: false, key: "-" } },


### PR DESCRIPTION
## What

A global **command palette** (default **Ctrl/Cmd+K**, rebindable) — one shortcut, from anywhere, to jump to any session across every project, or to a project. The tab strip only shows the active project's sessions; this reaches all of them.

- Type to filter by session label, project name, or path (token match — "revu auth" finds "Wire revu auth middleware").
- **↑↓** move, **↵** open, **Esc** close; click or hover to select.
- Session rows show project · path and **live status** (busy / waiting / done).

Matches the mockup reviewed earlier, in the app's own design tokens.

## Why

The product suggestion from the backlog: as sessions grow across projects, the notification queue was the only cross-project jump. This makes it a first-class, always-available switcher.

## Design notes

- **Reuses** the notification queue's routing (`navigate(/projects/:id)` + `activateSession`) and the existing **hotkey system** — a new `commandPalette` action in `hotkeys.ts`, so it shows up in **Settings › Hotkeys** and is rebindable. Default Ctrl/Cmd+K shadows the shell's kill-line (same class of trade as terminal Ctrl+F); rebindable is the escape hatch.
- The trigger is caught in the **window capture phase** (like the other global hotkeys), so it fires from anywhere including a focused terminal; base-ui's Dialog traps focus while open and restores it to the terminal on close.
- The **flatten + filter** are a pure `command-palette.ts` (`paletteSessions`, `matchesQuery`, `filterPalette`) — unit-tested. The dialog/keyboard wiring is the React boundary (node-only frontend gate, documented no-jsdom exception).
- Lists sessions of **open** projects only (a closed tab isn't navigable), same rule as the notification queue.

## Scope

**Jump-only** (sessions + projects), per the lazy first pass agreed on the mockup. Running actions (new session, settings, …) from the palette can follow.

## Tests

- `command-palette.test.ts`: `paletteSessions` (flatten, worktree vs project path, drop closed-project sessions), `matchesQuery` (tokens, case, empty), `filterPalette` (by label/name/path, empty query). 9 cases.
- Gate green: `tsc`, vitest (291), `vite build`.

## Manual smoke test (reviewer)

Press **Ctrl+K** anywhere → palette opens; type part of a session/project name → filters; ↑↓ + ↵ jumps to it (even in a background project); Esc closes and the terminal has focus again. Rebind it under Settings › Hotkeys.