### PR TITLE
fix: reopening a worktree resumes it instead of forking a new one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the next launch. The poll never stacks a second toast for a release it already
   surfaced, and dismissing one still holds until a genuinely newer version
   ships. Hourly keeps well within the unauthenticated GitHub API's rate limit.
+- **Keeping a worktree now keeps its session, ready to resume.** Closing a
+  worktree session and choosing to keep the checkout used to throw the session
+  away — reopening the worktree later started a blank Claude with none of the
+  earlier conversation. lich now parks the session instead of deleting it, so
+  reopening the worktree brings it back and offers to continue the same Claude
+  conversation right where it left off. Removing the worktree (rather than
+  keeping it) still clears the session for good.
+
+### Fixed
+
+- **Reopening an existing worktree no longer spawns a new one from its branch.**
+  The new-worktree picker listed a worktree's branch twice — under "Worktrees",
+  where picking it reopens the worktree, and under "Local branches", where
+  picking it creates a new worktree off that branch — with the local list open
+  by default, so the obvious choice quietly made a second worktree from the
+  first. A branch already checked out in a worktree is now shown only under
+  "Worktrees", and that group is expanded by default, so selecting it resumes
+  the existing worktree.
 
 ## [0.10.0] - 2026-07-20
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,8 +134,13 @@ Deliberate limits and shortcuts, with the upgrade path when it matters:
 - **Persistence is hybrid**: UI preferences live in the page's `localStorage` (`lich.*` keys) — which physically lives
   in the Chromium profile and is keyed to the page origin, which is why the listener port is pinned (47821,
   `LICH_LISTEN_PORT` overrides; distinct from `LICH_PORT`, the per-session hook variable). The workspace lives in
-  SQLite (`<config-dir>/lich/lich.db`). Closing a session does not delete its row (close ≠ delete). Card and tab order
-  is a `position` column written whole on every drag and read back as `ORDER BY position, rowid`.
+  SQLite (`<config-dir>/lich/lich.db`). A plain session close deletes its row, but **keeping** a worktree parks its
+  session instead (`is_open = 0`, hidden from `LoadState`) so its `claude_session_id` survives to be resumed later;
+  resume re-adds the row under a *fresh* id (`ReopenWorktreeSession`) so the terminal treats it as unspawned and the
+  resume prompt fires, and removing the worktree purges any parked row for its path (`PurgeWorktreeSessions`) so a
+  stale one can never resurrect a resume against a gone checkout. A closed *project* is only hidden, never deleted, and
+  keeps all its sessions. Card and tab order is a `position` column written whole on every drag and read back as
+  `ORDER BY position, rowid`.
 - **Hidden sessions are serialized and destroyed** (waveterm model, frontend edition): PTY output queues in a 2MB
   replay buffer (`frontend/src/lib/replay-buffer.ts`); show rebuilds from snapshot + tail; queue overflow drops the
   snapshot and starts clean from the tail (circular-buffer artifact contract). That page-side buffer only bridges

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -2,7 +2,7 @@ import {useState, useSyncExternalStore} from "react"
 import {useMatch, useNavigate} from "react-router-dom"
 import {GitBranch, Plus, Terminal} from "lucide-react"
 import {toast} from "sonner"
-import {ProjectService} from "@/lib/rpc"
+import {ProjectService, Store} from "@/lib/rpc"
 import {closeSettings, isSettingsOpen, subscribeSettingsCard} from "@/lib/settings-card-store"
 import {enabledProviders, useProviders} from "@/lib/providers-store"
 import {ProviderIcon} from "@/lib/provider-icons"
@@ -41,7 +41,9 @@ export function SessionSidebar() {
     sessions,
     newSession,
     newWorktreeSession,
+    reopenWorktreeSession,
     closeSession,
+    keepSession,
     activateSession,
     renameSession,
     reorderSessions,
@@ -90,7 +92,7 @@ export function SessionSidebar() {
   }
 
   const resumeWorktree = (wt: { name: string; path: string }) => {
-    newWorktreeSession(projectId, wt)
+    void reopenWorktreeSession(projectId, wt)
     setWorktreeOpen(false)
   }
 
@@ -106,7 +108,7 @@ export function SessionSidebar() {
 
   const keepAndClose = () => {
     if (pendingClose) {
-      closeSession(projectId, pendingClose.id)
+      keepSession(projectId, pendingClose.id)
     }
     setPendingClose(null)
   }
@@ -116,6 +118,9 @@ export function SessionSidebar() {
   // disk and reappears in the new-worktree picker.
   const closeAndRemove = (session: Session, force: boolean) => {
     closeSession(projectId, session.id)
+    // The checkout is going away, so no parked row for it may linger — one would
+    // otherwise resurface a resume against a worktree that no longer exists.
+    void Store.PurgeWorktreeSessions(projectId, session.path ?? "")
     ProjectService.RemoveWorktree(path, session.path ?? "", force).catch(
       (err: unknown) => {
         toast.error(`Failed to remove worktree: ${errorText(err)}`)

--- a/frontend/src/components/sidebar/WorktreeDialog.tsx
+++ b/frontend/src/components/sidebar/WorktreeDialog.tsx
@@ -155,6 +155,11 @@ export function WorktreeDialog({
         const local = loaded.local ?? []
         const preferred = local.includes(currentBranch) ? currentBranch : local[0]
         setBase(preferred ? valueOf("local", preferred) : "")
+        // Existing worktrees are the resume targets; surface the group so a
+        // closed-but-kept worktree is one click away instead of behind a fold.
+        if ((loaded.worktrees ?? []).length > 0) {
+          setOpenGroups((prev) => ({...prev, worktrees: true}))
+        }
       })
       .catch((err: unknown) => {
         if (!stale) {

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -15,8 +15,10 @@ import {
   removeProject,
   renameSession as relabelSession,
   reorderSessions as rearrangeSessions,
+  restoreSession,
   sessionsOf,
   setActiveSession,
+  type Session,
   type SessionKind,
   type SessionState,
 } from "./sessions"
@@ -54,8 +56,13 @@ interface ProjectsValue {
   newSession: (projectId: string, kind?: SessionKind, path?: string) => string
   /** Open a Claude Code session rooted at a git worktree, labeled after it. */
   newWorktreeSession: (projectId: string, wt: { name: string; path: string }) => void
+  /** Resume a worktree: reopen its parked session (continuing its Claude
+   * conversation) when one exists, else open a fresh session on it. */
+  reopenWorktreeSession: (projectId: string, wt: { name: string; path: string }) => Promise<void>
   /** Permanently delete a session; deleting the last one recreates an empty one. */
   closeSession: (projectId: string, sessionId: string) => void
+  /** Close a worktree session but park its row so it can be resumed later. */
+  keepSession: (projectId: string, sessionId: string) => void
   /** Focus an existing session within a project. */
   activateSession: (projectId: string, sessionId: string) => void
   /** Rename a session's display label. */
@@ -264,6 +271,28 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     [],
   )
 
+  const reopenWorktreeSession = useCallback(
+    async (projectId: string, wt: { name: string; path: string }) => {
+      // Bring back the parked session for this worktree if there is one, so its
+      // Claude conversation can be resumed; a fresh id means the terminal treats
+      // it as unspawned and asks before continuing. No parked row → start fresh.
+      const restored = await Store.ReopenWorktreeSession(projectId, wt.path, newSessionId())
+      if (!restored) {
+        newWorktreeSession(projectId, wt)
+        return
+      }
+      const session: Session = {
+        id: restored.id,
+        label: restored.label,
+        kind: isSessionKind(restored.kind) ? restored.kind : "claude",
+        path: restored.path,
+        ...(restored.claudeSessionId ? { claudeSessionId: restored.claudeSessionId } : {}),
+      }
+      setSessions(restoreSession(sessionsRef.current, projectId, session))
+    },
+    [newWorktreeSession],
+  )
+
   // The new-session shortcut opens a session in the active project (mirrors the
   // "+" button). It fires even with terminal focus, so it stays reachable while
   // working in a terminal — the capture-phase listener sees the chord before
@@ -285,28 +314,53 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     return () => window.removeEventListener("keydown", onKey, true)
   }, [activeProjectId, newSession, hotkeys])
 
-  const closeSession = useCallback((projectId: string, sessionId: string) => {
-    const removed = removeSession(sessionsRef.current, projectId, sessionId)
-    if (removed === sessionsRef.current) {
-      return
-    }
-    // A project always keeps at least one session; recreate when emptied. Home
-    // stays a shell so it never turns into a Claude session.
-    if (sessionsOf(removed, projectId).length === 0) {
-      const recreatedId = newSessionId()
-      const kind: SessionKind = projectId === homeIdRef.current ? "shell" : "claude"
-      const next = addSession(removed, projectId, recreatedId, kind)
-      const project = next[projectId]
-      const created = project.sessions[project.sessions.length - 1]
-      setSessions(next)
-      void Store.DeleteSession(projectId, sessionId, "").then(() =>
-        Store.AddSession(projectId, recreatedId, created.label, created.kind, "", project.nextSeq),
-      )
-      return
-    }
-    setSessions(removed)
-    void Store.DeleteSession(projectId, sessionId, activeSessionId(removed, projectId))
-  }, [])
+  // dropSession removes a session's card and persists that removal via `persist`
+  // — DeleteSession (gone for good) or CloseSession (parked for a later resume).
+  // A project always keeps at least one session; recreate when emptied. Home
+  // stays a shell so it never turns into a Claude session.
+  const dropSession = useCallback(
+    (
+      projectId: string,
+      sessionId: string,
+      persist: (activeID: string) => Promise<unknown>,
+    ) => {
+      const removed = removeSession(sessionsRef.current, projectId, sessionId)
+      if (removed === sessionsRef.current) {
+        return
+      }
+      if (sessionsOf(removed, projectId).length === 0) {
+        const recreatedId = newSessionId()
+        const kind: SessionKind = projectId === homeIdRef.current ? "shell" : "claude"
+        const next = addSession(removed, projectId, recreatedId, kind)
+        const project = next[projectId]
+        const created = project.sessions[project.sessions.length - 1]
+        setSessions(next)
+        void persist("").then(() =>
+          Store.AddSession(projectId, recreatedId, created.label, created.kind, "", project.nextSeq),
+        )
+        return
+      }
+      setSessions(removed)
+      void persist(activeSessionId(removed, projectId))
+    },
+    [],
+  )
+
+  const closeSession = useCallback(
+    (projectId: string, sessionId: string) =>
+      dropSession(projectId, sessionId, (activeID) =>
+        Store.DeleteSession(projectId, sessionId, activeID),
+      ),
+    [dropSession],
+  )
+
+  const keepSession = useCallback(
+    (projectId: string, sessionId: string) =>
+      dropSession(projectId, sessionId, (activeID) =>
+        Store.CloseSession(projectId, sessionId, activeID),
+      ),
+    [dropSession],
+  )
 
   const activateSession = useCallback((projectId: string, sessionId: string) => {
     const next = setActiveSession(sessionsRef.current, projectId, sessionId)
@@ -443,7 +497,9 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
         closeProject,
         newSession,
         newWorktreeSession,
+        reopenWorktreeSession,
         closeSession,
+        keepSession,
         activateSession,
         renameSession,
         reorderProjects,

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -15,6 +15,7 @@ import type {
   Project,
   PullRequest,
   StoredProject,
+  StoredSession,
   Worktree,
 } from "./api-types"
 
@@ -137,6 +138,15 @@ export const Store = {
   ) => call<null>("store.AddSession", [projectID, sessionID, label, kind, path, nextSeq]),
   DeleteSession: (projectID: string, sessionID: string, activeID: string) =>
     call<null>("store.DeleteSession", [projectID, sessionID, activeID]),
+  /** Park a session (keep its row for a later resume) instead of deleting it. */
+  CloseSession: (projectID: string, sessionID: string, activeID: string) =>
+    call<null>("store.CloseSession", [projectID, sessionID, activeID]),
+  /** Resume a parked worktree session under a fresh id, or null when none. */
+  ReopenWorktreeSession: (projectID: string, path: string, newSessionID: string) =>
+    call<StoredSession | null>("store.ReopenWorktreeSession", [projectID, path, newSessionID]),
+  /** Drop every session row for a worktree path when the worktree is removed. */
+  PurgeWorktreeSessions: (projectID: string, path: string) =>
+    call<null>("store.PurgeWorktreeSessions", [projectID, path]),
   RenameSession: (sessionID: string, label: string) =>
     call<null>("store.RenameSession", [sessionID, label]),
   SetActiveSession: (projectID: string, sessionID: string) =>

--- a/frontend/src/lib/sessions.test.ts
+++ b/frontend/src/lib/sessions.test.ts
@@ -9,6 +9,7 @@ import {
   removeProject,
   renameSession,
   reorderSessions,
+  restoreSession,
   resumableSession,
   sessionsOf,
   setActiveSession,
@@ -276,5 +277,41 @@ describe("resumableSession", () => {
     const state = withClaudeSession(buildState(2), "s1", "claude-abc")
     expect(resumableSession(state, "nope", "s1")).toBeNull()
     expect(resumableSession(state, P, "ghost")).toBeNull()
+  })
+})
+
+describe("restoreSession", () => {
+  const parked = {
+    id: "wt2",
+    label: "swift-rabbit",
+    kind: "claude" as const,
+    path: "/wt/swift-rabbit",
+    claudeSessionId: "claude-abc",
+  }
+
+  it("re-adds the session, focuses it, and keeps its claude session id", () => {
+    const state = restoreSession(buildState(2), P, parked)
+    const sessions = sessionsOf(state, P)
+    expect(sessions.map((s) => s.id)).toEqual(["s1", "s2", "wt2"])
+    expect(activeSessionId(state, P)).toBe("wt2")
+    expect(sessions[2].claudeSessionId).toBe("claude-abc")
+  })
+
+  it("does not advance the label counter (not a new numbered session)", () => {
+    const before = buildState(2)[P].nextSeq
+    const state = restoreSession(buildState(2), P, parked)
+    expect(state[P].nextSeq).toBe(before)
+  })
+
+  it("just focuses an id already present instead of duplicating it", () => {
+    const seeded = restoreSession(buildState(1), P, parked)
+    const again = restoreSession(setActiveSession(seeded, P, "s1"), P, parked)
+    expect(sessionsOf(again, P).map((s) => s.id)).toEqual(["s1", "wt2"])
+    expect(activeSessionId(again, P)).toBe("wt2")
+  })
+
+  it("ignores an unknown project", () => {
+    const state = buildState(1)
+    expect(restoreSession(state, "nope", parked)).toBe(state)
   })
 })

--- a/frontend/src/lib/sessions.ts
+++ b/frontend/src/lib/sessions.ts
@@ -124,6 +124,33 @@ function neighborId(sessions: Session[], removedIndex: number): string {
   return next.id
 }
 
+// restoreSession re-adds a parked session — its own id, label and
+// claudeSessionId intact — to a project and focuses it, without advancing the
+// label counter: a resume brings back an existing session, it does not mint a
+// new numbered one. An id already present is just focused; an unknown project is
+// ignored.
+export function restoreSession(
+  state: SessionState,
+  projectId: string,
+  session: Session,
+): SessionState {
+  const current = state[projectId]
+  if (!current) {
+    return state
+  }
+  if (current.sessions.some((s) => s.id === session.id)) {
+    return setActiveSession(state, projectId, session.id)
+  }
+  return {
+    ...state,
+    [projectId]: {
+      ...current,
+      sessions: [...current.sessions, session],
+      activeId: session.id,
+    },
+  }
+}
+
 // setActiveSession focuses an existing session; unknown ids are ignored.
 export function setActiveSession(
   state: SessionState,

--- a/internal/project/worktree.go
+++ b/internal/project/worktree.go
@@ -46,11 +46,30 @@ func runGit(dir string, args ...string) (string, error) {
 func (s *Service) ListBranches(path string) (Branches, error) {
 	branches := Branches{Local: []string{}, Remote: []string{}, Worktrees: []Worktree{}}
 
+	list, err := runGit(path, "worktree", "list", "--porcelain")
+	if err != nil {
+		return branches, err
+	}
+	branches.Worktrees = append(branches.Worktrees, parseWorktrees(list)...)
+
+	// A branch checked out in a linked worktree belongs only to the Worktrees
+	// group, where selecting it resumes that worktree. Drop it from Local so the
+	// same branch cannot also offer "create a new worktree off it" — the trap
+	// that spawned a fresh worktree from a checkout the user meant to reopen.
+	occupied := make(map[string]bool, len(branches.Worktrees))
+	for _, wt := range branches.Worktrees {
+		occupied[wt.Name] = true
+	}
+
 	local, err := runGit(path, "for-each-ref", "--format=%(refname:short)", "refs/heads")
 	if err != nil {
 		return branches, err
 	}
-	branches.Local = append(branches.Local, splitLines(local)...)
+	for _, name := range splitLines(local) {
+		if !occupied[name] {
+			branches.Local = append(branches.Local, name)
+		}
+	}
 
 	// Full refnames, not :short — the short form of refs/remotes/origin/HEAD is
 	// just "origin", which would dodge a suffix filter.
@@ -65,11 +84,6 @@ func (s *Service) ListBranches(path string) (Branches, error) {
 		}
 	}
 
-	list, err := runGit(path, "worktree", "list", "--porcelain")
-	if err != nil {
-		return branches, err
-	}
-	branches.Worktrees = append(branches.Worktrees, parseWorktrees(list)...)
 	return branches, nil
 }
 

--- a/internal/project/worktree_test.go
+++ b/internal/project/worktree_test.go
@@ -92,6 +92,12 @@ func TestListBranches(t *testing.T) {
 		canonPath(t, got.Worktrees[0].Path) != canonPath(t, wt.Path) {
 		t.Errorf("Worktrees = %v, want [{resume-me %s}]", got.Worktrees, wt.Path)
 	}
+	// resume-me is now checked out in a worktree, so it belongs only to the
+	// Worktrees group — it must not also appear in Local, where it would offer
+	// to spawn a new worktree off itself.
+	if !slices.Equal(got.Local, []string{"extra", "main"}) {
+		t.Errorf("Local after create = %v, want [extra main] (resume-me is a worktree, not a plain base)", got.Local)
+	}
 
 	if _, err := svc.ListBranches(t.TempDir()); err == nil {
 		t.Error("ListBranches(non-repo) = nil error, want error")

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 )
 
@@ -76,6 +77,94 @@ func (s *Service) DeleteSession(projectID, sessionID, activeID string) error {
 		}
 		return nil
 	})
+}
+
+// CloseSession parks a session instead of deleting it: is_open flips to 0, which
+// hides it from LoadState while keeping its row — and its Claude session id —
+// intact for a later resume. The project's active session moves to activeID (the
+// neighbor the frontend picked). The keep-the-worktree close uses this; a plain
+// close still DeleteSessions for good.
+func (s *Service) CloseSession(projectID, sessionID, activeID string) error {
+	return s.tx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`UPDATE sessions SET is_open = 0 WHERE id = ?`, sessionID); err != nil {
+			return fmt.Errorf("close session %q: %w", sessionID, err)
+		}
+		if _, err := tx.Exec(
+			`UPDATE projects SET active_session_id = ? WHERE id = ?`,
+			activeID, projectID,
+		); err != nil {
+			return fmt.Errorf("update active session of %q: %w", projectID, err)
+		}
+		return nil
+	})
+}
+
+// ReopenWorktreeSession resumes a parked worktree session. It finds the parked
+// (is_open = 0) session for the worktree at path and re-adds it to the workspace
+// under a fresh id (newSessionID), carrying over the old label, kind and Claude
+// session id. The fresh id is deliberate: it makes the frontend treat the card
+// as never-spawned, so its resume prompt fires and the Claude conversation
+// continues instead of starting cold. Returns nil when nothing is parked at path
+// — the caller then opens a brand-new session.
+func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*Session, error) {
+	var restored *Session
+	err := s.tx(func(tx *sql.Tx) error {
+		var old Session
+		row := tx.QueryRow(
+			`SELECT id, label, kind, claude_session_id
+			   FROM sessions
+			  WHERE project_id = ? AND path = ? AND is_open = 0
+			  ORDER BY rowid DESC LIMIT 1`,
+			projectID, path,
+		)
+		if err := row.Scan(&old.ID, &old.Label, &old.Kind, &old.ClaudeSessionID); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil // nothing parked here; caller creates a new session
+			}
+			return fmt.Errorf("find parked session for %q: %w", path, err)
+		}
+		if _, err := tx.Exec(`DELETE FROM sessions WHERE id = ?`, old.ID); err != nil {
+			return fmt.Errorf("drop parked session %q: %w", old.ID, err)
+		}
+		if _, err := tx.Exec(
+			`INSERT INTO sessions (id, project_id, label, kind, path, claude_session_id, position)
+			 VALUES (?, ?, ?, ?, ?, ?,
+			         (SELECT COALESCE(MAX(position), -1) + 1 FROM sessions WHERE project_id = ?))`,
+			newSessionID, projectID, old.Label, old.Kind, path, old.ClaudeSessionID, projectID,
+		); err != nil {
+			return fmt.Errorf("reinsert session %q: %w", newSessionID, err)
+		}
+		if _, err := tx.Exec(
+			`UPDATE projects SET active_session_id = ? WHERE id = ?`,
+			newSessionID, projectID,
+		); err != nil {
+			return fmt.Errorf("activate reopened session on %q: %w", projectID, err)
+		}
+		restored = &Session{ID: newSessionID, Label: old.Label, Kind: old.Kind, Path: path, ClaudeSessionID: old.ClaudeSessionID}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return restored, nil
+}
+
+// PurgeWorktreeSessions deletes every session row for the worktree at path in a
+// project — the live one and any parked leftovers alike — so removing a worktree
+// never strands a hidden row that a later resume could resurrect against a
+// checkout that no longer exists. The empty-path guard is load-bearing: a
+// project's own sessions carry no path, so an unguarded delete would wipe them
+// all. Idempotent — no matching rows is not an error.
+func (s *Service) PurgeWorktreeSessions(projectID, path string) error {
+	if path == "" {
+		return nil
+	}
+	if _, err := s.db.Exec(
+		`DELETE FROM sessions WHERE project_id = ? AND path = ?`, projectID, path,
+	); err != nil {
+		return fmt.Errorf("purge worktree sessions for %q: %w", path, err)
+	}
+	return nil
 }
 
 // RenameSession updates a session's display label from an explicit user rename.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -40,6 +40,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     path              TEXT NOT NULL DEFAULT '',
     claude_session_id TEXT NOT NULL DEFAULT '',
     label_auto        INTEGER NOT NULL DEFAULT 1,
+    is_open           INTEGER NOT NULL DEFAULT 1,
     position          INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
@@ -123,6 +124,7 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN path TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN claude_session_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN label_auto INTEGER NOT NULL DEFAULT 1`,
+		`ALTER TABLE sessions ADD COLUMN is_open INTEGER NOT NULL DEFAULT 1`,
 		`ALTER TABLE sessions ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 	}
@@ -200,7 +202,7 @@ func (s *Service) LoadState() ([]Project, error) {
 func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	rows, err := s.db.Query(
 		`SELECT id, label, kind, path, claude_session_id
-		   FROM sessions WHERE project_id = ? ORDER BY position, rowid`,
+		   FROM sessions WHERE project_id = ? AND is_open = 1 ORDER BY position, rowid`,
 		projectID,
 	)
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -583,3 +583,130 @@ CREATE TABLE sessions (
 		t.Errorf("migrated session = %+v, want kind=shell path=/data/wt", s)
 	}
 }
+
+// TestCloseSessionParksAndReopenRestores proves a kept worktree session survives
+// close as a hidden (parked) row and comes back — under a fresh id, with its
+// Claude session id intact — when its worktree is resumed.
+func TestCloseSessionParksAndReopenRestores(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	if err := svc.AddSession("p1", "base", "Session 1", "claude", "", 2); err != nil {
+		t.Fatalf("AddSession base: %v", err)
+	}
+	if err := svc.AddSession("p1", "wt", "swift-rabbit", "claude", "/data/wt/swift-rabbit", 3); err != nil {
+		t.Fatalf("AddSession worktree: %v", err)
+	}
+	if err := svc.SetClaudeSession("wt", "claude-uuid-1"); err != nil {
+		t.Fatalf("SetClaudeSession: %v", err)
+	}
+
+	// Keep-close parks the worktree session: gone from the workspace, base active.
+	if err := svc.CloseSession("p1", "wt", "base"); err != nil {
+		t.Fatalf("CloseSession: %v", err)
+	}
+	projects, err := svc.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState after close: %v", err)
+	}
+	if len(projects[0].Sessions) != 1 || projects[0].Sessions[0].ID != "base" {
+		t.Fatalf("sessions after park = %+v, want only base", projects[0].Sessions)
+	}
+	if projects[0].ActiveSessionID != "base" {
+		t.Errorf("active after park = %q, want base", projects[0].ActiveSessionID)
+	}
+
+	// Resuming the worktree brings the session back under a new id, preserving
+	// its label and Claude session id so the conversation can be continued.
+	restored, err := svc.ReopenWorktreeSession("p1", "/data/wt/swift-rabbit", "wt2")
+	if err != nil {
+		t.Fatalf("ReopenWorktreeSession: %v", err)
+	}
+	if restored == nil {
+		t.Fatal("ReopenWorktreeSession = nil, want the parked session")
+	}
+	if restored.ID != "wt2" || restored.Label != "swift-rabbit" ||
+		restored.Path != "/data/wt/swift-rabbit" || restored.ClaudeSessionID != "claude-uuid-1" {
+		t.Errorf("restored = %+v, want {wt2 swift-rabbit /data/wt/swift-rabbit claude-uuid-1}", restored)
+	}
+
+	projects, err = svc.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState after reopen: %v", err)
+	}
+	if len(projects[0].Sessions) != 2 {
+		t.Fatalf("sessions after reopen = %+v, want base + wt2", projects[0].Sessions)
+	}
+	// The parked row is consumed, not duplicated: exactly one row for the path.
+	got := projects[0].Sessions[1]
+	if got.ID != "wt2" || got.ClaudeSessionID != "claude-uuid-1" {
+		t.Errorf("reopened session = %+v, want id=wt2 claude=claude-uuid-1", got)
+	}
+	if projects[0].ActiveSessionID != "wt2" {
+		t.Errorf("active after reopen = %q, want wt2", projects[0].ActiveSessionID)
+	}
+}
+
+// TestReopenWorktreeSessionNoParked proves resume returns nil when the worktree
+// has no parked session, so the caller opens a fresh one instead.
+func TestReopenWorktreeSessionNoParked(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2)
+
+	restored, err := svc.ReopenWorktreeSession("p1", "/data/wt/never-parked", "wt2")
+	if err != nil {
+		t.Fatalf("ReopenWorktreeSession: %v", err)
+	}
+	if restored != nil {
+		t.Errorf("restored = %+v, want nil (nothing parked)", restored)
+	}
+}
+
+// countSessions returns how many session rows exist for a path, parked or open —
+// LoadState hides parked rows, so the purge assertions read the table directly.
+func countSessions(t *testing.T, svc *Service, projectID, path string) int {
+	t.Helper()
+	var n int
+	if err := svc.db.QueryRow(
+		`SELECT COUNT(*) FROM sessions WHERE project_id = ? AND path = ?`, projectID, path,
+	).Scan(&n); err != nil {
+		t.Fatalf("count sessions for %q: %v", path, err)
+	}
+	return n
+}
+
+// TestPurgeWorktreeSessions proves removing a worktree drops every row for its
+// path (parked leftovers included), leaves other worktrees and the project's own
+// sessions alone, and that the empty-path guard never wipes pathless sessions.
+func TestPurgeWorktreeSessions(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2) // project's own, no path
+	_ = svc.AddSession("p1", "wtA", "foo", "claude", "/wt/foo", 3) // worktree foo
+	_ = svc.AddSession("p1", "wtB", "bar", "claude", "/wt/bar", 4) // worktree bar
+	if err := svc.CloseSession("p1", "wtA", "base"); err != nil {  // park foo (stale leftover)
+		t.Fatalf("CloseSession: %v", err)
+	}
+	_ = svc.AddSession("p1", "wtA2", "foo", "claude", "/wt/foo", 5) // live foo again, same path
+
+	if err := svc.PurgeWorktreeSessions("p1", "/wt/foo"); err != nil {
+		t.Fatalf("PurgeWorktreeSessions: %v", err)
+	}
+	if n := countSessions(t, svc, "p1", "/wt/foo"); n != 0 {
+		t.Errorf("rows for /wt/foo after purge = %d, want 0 (parked + live both gone)", n)
+	}
+	if n := countSessions(t, svc, "p1", "/wt/bar"); n != 1 {
+		t.Errorf("rows for /wt/bar after purge = %d, want 1 (untouched)", n)
+	}
+	if n := countSessions(t, svc, "p1", ""); n != 1 {
+		t.Errorf("pathless rows after purge = %d, want 1 (base untouched)", n)
+	}
+
+	// The empty-path guard must never sweep a project's own (pathless) sessions.
+	if err := svc.PurgeWorktreeSessions("p1", ""); err != nil {
+		t.Fatalf("PurgeWorktreeSessions(empty): %v", err)
+	}
+	if n := countSessions(t, svc, "p1", ""); n != 1 {
+		t.Errorf("pathless rows after empty-path purge = %d, want 1 (guard held)", n)
+	}
+}


### PR DESCRIPTION
## Problem

Closing a worktree session with **"keep"** leaves the checkout on disk. But in the new-worktree picker, that worktree's branch showed up in **two** groups:

- **Worktrees** → reopens it (collapsed by default)
- **Local branches** → `git worktree add -b <new> <path> <occupiedBranch>` = a **new worktree off the previous one** (open by default)

The obvious pick landed on the second → the production bug: "it's creating a new worktree from the previous one".

Second problem: even when reopened via the right group, the session was **deleted** on close (`DeleteSession`), so resume opened a blank Claude — the earlier conversation was gone.

## Fix

**Picker (root cause)**
- `ListBranches` drops branches already checked out in a linked worktree from **Local** — the branch now has a single home: the Worktrees group (resume). The main worktree's branch stays in Local (`parseWorktrees` skips the first block).
- The **Worktrees** group is expanded by default when any exist, so resume is visible.

**Session survives keep**
- Keep-worktree now **parks** the session (`is_open = 0`) instead of deleting it; `claude_session_id` is preserved. `LoadState` filters parked rows out.
- Resume re-adds it under a **fresh id** (`ReopenWorktreeSession`), carrying label/kind/`claude_session_id`. The fresh id is deliberate: the terminal treats it as unspawned → `ResumeSessionDialog` fires → Claude respawns with `--resume`. Reusing the old id would skip the prompt (it lingers in the `spawned` set) and spawn a cold conversation.

**Ceiling closed**
- Removing a worktree runs `PurgeWorktreeSessions` by path (with an empty-path guard — otherwise it would wipe a project's own pathless sessions) → no orphaned parked row can ever resurrect a resume against a checkout that no longer exists.

## Test plan

- [x] Backend `go test ./...` — 281 passed; `go vet ./...` and `gofmt` clean; cross-vet windows+darwin ok
- [x] Frontend — 295 passed; `tsc` ok; `vite build` ok
- [x] New: `TestCloseSessionParksAndReopenRestores`, `TestReopenWorktreeSessionNoParked`, `TestPurgeWorktreeSessions` (Go); `restoreSession` describe + Local-list assertion in the picker (vitest)
- [ ] Manual smoke on `task dev`: keep a worktree → reopen via the picker → confirm the resume prompt and that the conversation continues; remove a worktree → confirm it does not reappear

## Docs

- CHANGELOG: Changed (keep-session) + new Fixed section (the picker trap)
- CLAUDE.md: persistence ceiling corrected — the "close ≠ delete" line was inaccurate (a plain close deletes; keep-worktree parks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)