### PR TITLE
style: tighten footer bar spacing and icon sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reopening the worktree brings it back and offers to continue the same Claude
   conversation right where it left off. Removing the worktree (rather than
   keeping it) still clears the session for good.
+- **Footer bar spacing tightened.** The items sit closer together and the Browse
+  code icon now matches the size of its neighbors.
 
 ### Fixed
 

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -53,7 +53,7 @@ export function FooterBar({dock, onDock}: FooterBarProps) {
 
   return (
     <footer
-      className="flex h-9 shrink-0 items-center gap-4 border-t border-border bg-sidebar px-3 text-xs text-muted-foreground">
+      className="flex h-9 shrink-0 items-center gap-2 border-t border-border bg-sidebar px-3 text-xs text-muted-foreground">
       <Tooltip>
         <TooltipTrigger
           render={
@@ -85,7 +85,7 @@ export function FooterBar({dock, onDock}: FooterBarProps) {
               />
             }
           >
-            <Code className="size-3.5"/>
+            <Code className="size-4"/>
           </TooltipTrigger>
           <TooltipContent>Browse code</TooltipContent>
         </Tooltip>
@@ -155,7 +155,7 @@ export function FooterBar({dock, onDock}: FooterBarProps) {
           </Tooltip>
         )}
         {(status?.branch || path) && (
-          <Separator orientation="vertical" className="h-4" />
+          <Separator orientation="vertical" className="h-4"/>
         )}
         <span>{now.toDateString()}</span>
         <span>{`${two(now.getHours())}:${two(now.getMinutes())}`}</span>


### PR DESCRIPTION
## What

Small footer bar polish:

- Item gap `gap-4` → `gap-2` (tighter row)
- Browse code icon `size-3.5` → `size-4` (matches neighboring icons)
- Drop a stray space in the date separator's self-closing tag

Visual-only, no behavior change.

## Test plan

- [x] `tsc` ok, `vite build` ok, `pnpm test` — 295 passed
- [ ] Eyeball the footer on `task dev`