### PR TITLE
feat: configurable default provider for new sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Pick which provider new sessions spawn by default.** lich was wired to open
+  Claude Code for the routines that don't ask — a new worktree, the new-session
+  hotkey, a project's first session. Settings › Providers now has a "Default
+  provider" picker over the enabled harnesses, so those routines spawn Codex,
+  opencode or Crush instead if you prefer. Disabling the chosen default falls
+  back to the first enabled provider; the per-session New Session menu still
+  picks a one-off provider as before.
 - **Command palette — Ctrl/Cmd+K.** One shortcut, from anywhere, to jump to any
   session across every project — or to a project — without hunting through the
   tabs (which only show the active project's sessions). Type to filter by

--- a/frontend/src/components/settings/ProvidersSettings.tsx
+++ b/frontend/src/components/settings/ProvidersSettings.tsx
@@ -1,14 +1,32 @@
-import { setProviderEnabled, useProviders } from "@/lib/providers-store"
+import {
+  enabledProviders,
+  setProviderDefault,
+  setProviderEnabled,
+  useDefaultProvider,
+  useProviders,
+} from "@/lib/providers-store"
 import { ProviderIcon } from "@/lib/provider-icons"
+import type { ProviderKind } from "@/lib/sessions"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { SettingBlock } from "./SettingBlock"
 import { Switch } from "@/components/ui/switch"
 
 // ProvidersSettings lists every known harness with its install state and an
-// enable toggle. Enabling a provider surfaces its config section (a
-// ProviderBinSettings entry) and offers it in New Session. A provider that is
-// not installed cannot be turned on — but one already enabled (Claude, on by
-// default) stays togglable so it is never trapped off-screen.
+// enable toggle, and picks the one new sessions spawn by default. Enabling a
+// provider surfaces its config section (a ProviderBinSettings entry) and offers
+// it in New Session. A provider that is not installed cannot be turned on — but
+// one already enabled (Claude, on by default) stays togglable so it is never
+// trapped off-screen.
 export function ProvidersSettings() {
   const providers = useProviders()
+  const defaultProvider = useDefaultProvider()
 
   if (providers.length === 0) {
     return (
@@ -16,27 +34,58 @@ export function ProvidersSettings() {
     )
   }
 
+  const enabled = enabledProviders(providers)
+
   return (
-    <div className="flex flex-col divide-y divide-border">
-      {providers.map((provider) => (
-        <div key={provider.id} className="flex items-center justify-between gap-4 py-4">
-          <div className="flex min-w-0 items-center gap-3">
-            <ProviderIcon kind={provider.id} />
-            <div className="min-w-0">
-              <div className="text-sm font-medium text-foreground">{provider.name}</div>
-              <div className="text-xs text-muted-foreground">
-                {provider.installed ? "Installed" : "Not found on PATH"}
+    <div className="flex flex-col">
+      {enabled.length > 0 && (
+        <SettingBlock
+          title="Default provider"
+          description="Which harness a new worktree, the new-session hotkey, and a project's first session spawn."
+        >
+          <Select
+            value={defaultProvider}
+            onValueChange={(value) => value && setProviderDefault(value as ProviderKind)}
+          >
+            <SelectTrigger className="w-64">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                {enabled.map((provider) => (
+                  <SelectItem key={provider.id} value={provider.id}>
+                    <span className="flex items-center gap-2">
+                      <ProviderIcon kind={provider.id} size={14} />
+                      {provider.name}
+                    </span>
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </SettingBlock>
+      )}
+      <div className="flex flex-col divide-y divide-border">
+        {providers.map((provider) => (
+          <div key={provider.id} className="flex items-center justify-between gap-4 py-4">
+            <div className="flex min-w-0 items-center gap-3">
+              <ProviderIcon kind={provider.id} />
+              <div className="min-w-0">
+                <div className="text-sm font-medium text-foreground">{provider.name}</div>
+                <div className="text-xs text-muted-foreground">
+                  {provider.installed ? "Installed" : "Not found on PATH"}
+                </div>
               </div>
             </div>
+            <Switch
+              checked={provider.enabled}
+              disabled={!provider.installed && !provider.enabled}
+              onCheckedChange={(checked) => setProviderEnabled(provider.id, checked)}
+              aria-label={`Enable ${provider.name}`}
+            />
           </div>
-          <Switch
-            checked={provider.enabled}
-            disabled={!provider.installed && !provider.enabled}
-            onCheckedChange={(checked) => setProviderEnabled(provider.id, checked)}
-            aria-label={`Enable ${provider.name}`}
-          />
-        </div>
-      ))}
+        ))}
+      </div>
     </div>
   )
 }

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -23,6 +23,7 @@ import {
   type SessionState,
 } from "./sessions"
 import { applyOrder, pinFirst } from "./reorder"
+import { defaultProviderKind } from "./providers-store"
 import {
   isIdEvent,
   isStatusEvent,
@@ -205,7 +206,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     let loaded = (await Store.LoadState()) ?? []
     const mine = loaded.find((p) => p.id === picked.id)
     if (!mine || (mine.sessions ?? []).length === 0) {
-      await Store.AddSession(picked.id, newSessionId(), FIRST_LABEL, "claude", "", FIRST_NEXT_SEQ)
+      await Store.AddSession(picked.id, newSessionId(), FIRST_LABEL, defaultProviderKind(), "", FIRST_NEXT_SEQ)
       loaded = (await Store.LoadState()) ?? []
     }
     applyLoaded(loaded)
@@ -249,7 +250,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     [projects, activeProjectId, navigate],
   )
 
-  const newSession = useCallback((projectId: string, kind: SessionKind = "claude", path = "") => {
+  const newSession = useCallback((projectId: string, kind: SessionKind = defaultProviderKind(), path = "") => {
     const sessionId = newSessionId()
     const next = addSession(sessionsRef.current, projectId, sessionId, kind, path)
     const project = next[projectId]
@@ -262,11 +263,12 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
   const newWorktreeSession = useCallback(
     (projectId: string, wt: { name: string; path: string }) => {
       const sessionId = newSessionId()
-      const next = addSession(sessionsRef.current, projectId, sessionId, "claude", wt.path, wt.name)
+      const kind = defaultProviderKind()
+      const next = addSession(sessionsRef.current, projectId, sessionId, kind, wt.path, wt.name)
       const project = next[projectId]
       const created = project.sessions[project.sessions.length - 1]
       setSessions(next)
-      void Store.AddSession(projectId, sessionId, created.label, "claude", wt.path, project.nextSeq)
+      void Store.AddSession(projectId, sessionId, created.label, kind, wt.path, project.nextSeq)
     },
     [],
   )
@@ -330,7 +332,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       }
       if (sessionsOf(removed, projectId).length === 0) {
         const recreatedId = newSessionId()
-        const kind: SessionKind = projectId === homeIdRef.current ? "shell" : "claude"
+        const kind: SessionKind = projectId === homeIdRef.current ? "shell" : defaultProviderKind()
         const next = addSession(removed, projectId, recreatedId, kind)
         const project = next[projectId]
         const created = project.sessions[project.sessions.length - 1]

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -6,6 +6,7 @@ import {
   enabledKey,
   enabledProviders,
   readEnabled,
+  resolveDefaultProvider,
   type ProviderState,
 } from "./providers-store"
 
@@ -49,6 +50,30 @@ describe("enabledProviders", () => {
   })
 })
 
+describe("resolveDefaultProvider", () => {
+  const p = (id: string, enabled: boolean): ProviderState => ({
+    id: id as ProviderState["id"],
+    name: id,
+    installed: true,
+    enabled,
+  })
+
+  it("uses the stored default when it names an enabled provider", () => {
+    const list = [p("claude", true), p("codex", true)]
+    expect(resolveDefaultProvider(list, "codex")).toBe("codex")
+  })
+
+  it("falls back to the first enabled provider when the default is disabled", () => {
+    const list = [p("claude", true), p("codex", false)]
+    expect(resolveDefaultProvider(list, "codex")).toBe("claude")
+  })
+
+  it("falls back to claude when nothing is enabled or loaded", () => {
+    expect(resolveDefaultProvider([], "")).toBe("claude")
+    expect(resolveDefaultProvider([p("codex", false)], "")).toBe("claude")
+  })
+})
+
 describe("createProvidersStore", () => {
   const detected: DetectedProvider[] = [
     { id: "claude", name: "Claude Code", installed: true, path: "/usr/bin/claude" },
@@ -56,14 +81,17 @@ describe("createProvidersStore", () => {
     { id: "mystery", name: "Mystery", installed: true, path: "/x" }, // unknown id
   ]
 
-  function build(enabledValues: Record<string, string> = {}) {
+  function build(enabledValues: Record<string, string> = {}, defaultValue = "") {
     const persistEnabled = vi.fn()
+    const persistDefault = vi.fn()
     const store = createProvidersStore({
       detect: async () => detected,
       getEnabled: async (id) => enabledValues[id] ?? "",
       persistEnabled,
+      getDefault: async () => defaultValue,
+      persistDefault,
     })
-    return { store, persistEnabled }
+    return { store, persistEnabled, persistDefault }
   }
 
   it("loads only known providers with their install + default enabled state", async () => {
@@ -106,10 +134,33 @@ describe("createProvidersStore", () => {
       detect,
       getEnabled: async () => "",
       persistEnabled: vi.fn(),
+      getDefault: async () => "",
+      persistDefault: vi.fn(),
     })
     store.ensureLoaded()
     store.ensureLoaded()
     await vi.waitFor(() => expect(store.getSnapshot().length).toBe(2))
     expect(detect).toHaveBeenCalledTimes(1)
+  })
+
+  it("loads the stored default provider", async () => {
+    const { store } = build({ codex: "1" }, "codex")
+    await store.load()
+    expect(store.getDefaultSnapshot()).toBe("codex")
+  })
+
+  it("setDefault updates the snapshot, notifies, and persists", async () => {
+    const { store, persistDefault } = build()
+    await store.load()
+    const seen = vi.fn()
+    const off = store.subscribe(seen)
+    store.setDefault("codex")
+    expect(store.getDefaultSnapshot()).toBe("codex")
+    expect(seen).toHaveBeenCalledTimes(1)
+    expect(persistDefault).toHaveBeenCalledWith("codex")
+    off()
+    store.setDefault("claude")
+    expect(seen).toHaveBeenCalledTimes(1) // unsubscribed
+    expect(persistDefault).toHaveBeenLastCalledWith("claude")
   })
 })

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -13,6 +13,11 @@ import { PROVIDER_KINDS, type ProviderKind } from "./sessions"
 
 const GLOBAL_SCOPE = ""
 
+// defaultKey holds the global id of the provider new sessions spawn by default
+// (worktrees, the new-session hotkey, a project's first session). Empty resolves
+// to the first enabled provider — Claude, until the user turns others on.
+const defaultKey = "provider.default"
+
 // enabledKey holds a provider's global enabled flag; binKey its custom binary
 // path. Claude keeps the legacy "claude.bin" key (mirrors store.binKey in Go),
 // so overrides set before the providers feature keep resolving.
@@ -47,6 +52,20 @@ export function enabledProviders(list: ProviderState[]): ProviderState[] {
   return list.filter((p) => p.enabled)
 }
 
+// resolveDefaultProvider picks the kind a new session spawns: the stored default
+// if it still names an enabled provider, else the first enabled one, else Claude
+// (nothing loaded yet, or every provider off). Mirrors enabledProviders in
+// ignoring install state — a disabled default falls back, a missing binary does
+// not, that shows up as a PTY error.
+export function resolveDefaultProvider(
+  list: ProviderState[],
+  defaultId: string,
+): ProviderKind {
+  const enabled = enabledProviders(list)
+  const chosen = enabled.find((p) => p.id === defaultId)
+  return chosen?.id ?? enabled[0]?.id ?? "claude"
+}
+
 function isProviderKind(id: string): id is ProviderKind {
   return (PROVIDER_KINDS as readonly string[]).includes(id)
 }
@@ -55,17 +74,23 @@ export interface ProvidersDeps {
   detect: () => Promise<DetectedProvider[] | null>
   getEnabled: (id: string) => Promise<string>
   persistEnabled: (id: string, value: string) => void
+  getDefault: () => Promise<string>
+  persistDefault: (id: string) => void
 }
 
 // createProvidersStore builds a subscribable provider store over injected RPC.
 export function createProvidersStore(deps: ProvidersDeps) {
   let providers: ProviderState[] = []
+  let defaultId = ""
   let state: "idle" | "loading" | "ready" = "idle"
   const listeners = new Set<() => void>()
   const emit = () => listeners.forEach((listener) => listener())
 
   const load = async (): Promise<void> => {
-    const detected = (await deps.detect()) ?? []
+    const [detected, storedDefault] = await Promise.all([
+      deps.detect().then((d) => d ?? []),
+      deps.getDefault(),
+    ])
     providers = await Promise.all(
       detected.filter((d) => isProviderKind(d.id)).map(async (d) => ({
         id: d.id as ProviderKind,
@@ -74,6 +99,7 @@ export function createProvidersStore(deps: ProvidersDeps) {
         enabled: readEnabled(d.id, await deps.getEnabled(d.id)),
       })),
     )
+    defaultId = storedDefault
     state = "ready"
     emit()
   }
@@ -95,6 +121,12 @@ export function createProvidersStore(deps: ProvidersDeps) {
     deps.persistEnabled(id, enabled ? "1" : "0")
   }
 
+  const setDefault = (id: ProviderKind): void => {
+    defaultId = id
+    emit()
+    deps.persistDefault(id)
+  }
+
   const subscribe = (listener: () => void): (() => void) => {
     listeners.add(listener)
     return () => {
@@ -102,7 +134,15 @@ export function createProvidersStore(deps: ProvidersDeps) {
     }
   }
 
-  return { load, ensureLoaded, setEnabled, subscribe, getSnapshot: () => providers }
+  return {
+    load,
+    ensureLoaded,
+    setEnabled,
+    setDefault,
+    subscribe,
+    getSnapshot: () => providers,
+    getDefaultSnapshot: () => defaultId,
+  }
 }
 
 // The app-wide singleton, wired to the real RPC.
@@ -112,11 +152,27 @@ const store = createProvidersStore({
   persistEnabled: (id, value) => {
     void Store.SetSetting(enabledKey(id), GLOBAL_SCOPE, value)
   },
+  getDefault: () => Store.GetSetting(defaultKey, GLOBAL_SCOPE),
+  persistDefault: (id) => {
+    void Store.SetSetting(defaultKey, GLOBAL_SCOPE, id)
+  },
 })
 
 // setProviderEnabled flips a provider's global flag and persists it.
 export function setProviderEnabled(id: ProviderKind, enabled: boolean): void {
   store.setEnabled(id, enabled)
+}
+
+// setProviderDefault records the provider new sessions spawn by default.
+export function setProviderDefault(id: ProviderKind): void {
+  store.setDefault(id)
+}
+
+// defaultProviderKind resolves the current default synchronously, for the
+// imperative session-spawn call sites that cannot use a hook. Before the store
+// loads it resolves to Claude (empty list, empty default).
+export function defaultProviderKind(): ProviderKind {
+  return resolveDefaultProvider(store.getSnapshot(), store.getDefaultSnapshot())
 }
 
 // useProviders returns the known providers with their install + enabled state,
@@ -125,4 +181,13 @@ export function useProviders(): ProviderState[] {
   const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot)
   useEffect(store.ensureLoaded, [])
   return snapshot
+}
+
+// useDefaultProvider returns the resolved default provider kind, tracking both
+// the stored default and enable changes (a disabled default falls back live).
+export function useDefaultProvider(): ProviderKind {
+  const providers = useSyncExternalStore(store.subscribe, store.getSnapshot)
+  const defaultId = useSyncExternalStore(store.subscribe, store.getDefaultSnapshot)
+  useEffect(store.ensureLoaded, [])
+  return resolveDefaultProvider(providers, defaultId)
 }


### PR DESCRIPTION
## What

lich was wired to spawn **Claude Code** for every session-spawn routine that doesn't ask for a provider:

- a new **worktree**
- the **new-session hotkey** (Ctrl+T)
- a **project's first session** (on open)
- **recreating** a project's last-closed session

This makes that default **configurable**. Settings › Providers gains a **"Default provider"** picker over the *enabled* harnesses (Claude / Codex / opencode / Crush), so those routines spawn whichever provider you prefer.

## How

- **`providers-store.ts`** — the store now loads/persists `provider.default`, a **global setting** mirroring the existing `provider.<id>.enabled` flags (backend settings store, not localStorage). New surface: `resolveDefaultProvider` (pure), `setProviderDefault`, `defaultProviderKind()` (synchronous, for the imperative spawn call sites) and `useDefaultProvider()` (hook; re-resolves live when the chosen default is disabled).
- **`projects.tsx`** — the 4 hardcoded `"claude"` spawn sites now read `defaultProviderKind()`. Home stays `shell`.
- **`ProvidersSettings.tsx`** — a "Default provider" `SettingBlock` with a Select over the enabled providers.
- **CHANGELOG** — Added entry.

### Fallbacks
`resolveDefaultProvider` returns the stored default when it still names an enabled provider, else the first enabled one, else `claude` (nothing loaded yet, or everything disabled) — so a routine never spawns a provider the user turned off.

## Not in scope
- The per-session **New Session menu** is unchanged — it still picks a one-off provider explicitly.
- Default is **global**, not per-project.
- Boot race: a session spawned before the store finishes loading resolves to `claude` (identical to today's behavior).

## Test plan
- [x] `tsc --noEmit` clean
- [x] `vitest run` — 300 passed (new: `resolveDefaultProvider` cases, stored-default load, `setDefault` persist/notify)
- [x] `vite build` succeeds
- [ ] Manual: pick a non-Claude default in Settings, confirm a new worktree / Ctrl+T spawns it; disable it and confirm fallback — *frontend gate is node-only (no jsdom), so the Select render path wants a real check in `task dev`*