### PR TITLE
feat: "what's new" popup after an update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A "what's new" popup after an update.** The first time you open lich on a
+  new version, a dialog summarizes what changed — the release's changelog
+  section, grouped into Added / Changed / Fixed, with a link to the full notes.
+  It fires once per release and never on a fresh install. The notes are read
+  from the changelog baked into the binary, so the popup works offline.
 - **Pick which provider new sessions spawn by default.** lich was wired to open
   Claude Code for the routines that don't ask — a new worktree, the new-session
   hotkey, a project's first session. Settings › Providers now has a "Default

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,6 +12,7 @@ import { Settings } from "@/components/settings/Settings"
 import { Toaster } from "@/components/ui/sonner"
 import { ClaudePluginGate } from "@/components/ClaudePluginGate"
 import { AppUpdateGate } from "@/components/AppUpdateGate"
+import { PatchNotesGate } from "@/components/PatchNotesGate"
 import { CommandPalette } from "@/components/CommandPalette"
 
 // Layout is persistent across navigation: the project tabs, session sidebar and
@@ -76,6 +77,7 @@ function App() {
         </ProjectsProvider>
       </HashRouter>
       <ClaudePluginGate />
+      <PatchNotesGate />
       <Toaster />
     </SettingsProvider>
   )

--- a/frontend/src/components/PatchNotesDialog.tsx
+++ b/frontend/src/components/PatchNotesDialog.tsx
@@ -64,19 +64,21 @@ export function PatchNotesDialog({notes, onClose}: PatchNotesDialogProps) {
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
       <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-lg">
-        <DialogHeader className="flex-row items-start gap-3 p-6 pb-4">
+        <DialogHeader className="flex-row items-start gap-3 p-6 pr-12 pb-4">
           <span className="grid size-10 flex-none place-items-center rounded-lg bg-emerald-500/15 text-emerald-500 ring-1 ring-emerald-500/30">
             <Sparkles className="size-5" />
           </span>
-          <div className="flex-1 pt-0.5">
-            <DialogTitle className="text-[1.0625rem]">What's new in lich</DialogTitle>
+          <div className="min-w-0 flex-1 pt-0.5">
+            <div className="flex flex-wrap items-center gap-2">
+              <DialogTitle className="text-[1.0625rem]">What's new in lich</DialogTitle>
+              <span className="flex-none rounded-full border bg-accent px-2 py-0.5 text-xs font-medium tabular-nums">
+                v{notes.version}
+              </span>
+            </div>
             <DialogDescription className="mt-1">
               You updated to a new version — here's what changed.
             </DialogDescription>
           </div>
-          <span className="mt-0.5 rounded-full border bg-accent px-2 py-0.5 text-xs font-medium tabular-nums">
-            v{notes.version}
-          </span>
         </DialogHeader>
 
         <div className="max-h-[55vh] overflow-y-auto px-6">

--- a/frontend/src/components/PatchNotesDialog.tsx
+++ b/frontend/src/components/PatchNotesDialog.tsx
@@ -1,0 +1,119 @@
+import type {ReactNode} from "react"
+import {ArrowUpRight, Sparkles} from "lucide-react"
+import {Button} from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {System} from "@/lib/rpc"
+import type {PatchNotes} from "@/lib/api-types"
+
+const RELEASE_TAG_BASE = "https://github.com/omartelo/lich/releases/tag/v"
+
+// dotColor maps a changelog group to a semantic accent, kept separate from the
+// app accent: Added emerald, Changed amber, Fixed sky, anything else muted.
+function dotColor(label: string): string {
+  switch (label.toLowerCase()) {
+    case "added":
+      return "bg-emerald-500"
+    case "changed":
+      return "bg-amber-500"
+    case "fixed":
+      return "bg-sky-500"
+    default:
+      return "bg-muted-foreground"
+  }
+}
+
+// renderInline renders a changelog item's markdown: **bold** lead-ins and
+// `code` spans. No full markdown parser — those two are all the CHANGELOG uses.
+function renderInline(text: string): ReactNode[] {
+  return text.split(/(\*\*[^*]+\*\*|`[^`]+`)/g).map((part, i) => {
+    if (part.startsWith("**") && part.endsWith("**")) {
+      return (
+        <strong key={i} className="font-medium text-foreground">
+          {part.slice(2, -2)}
+        </strong>
+      )
+    }
+    if (part.startsWith("`") && part.endsWith("`")) {
+      return (
+        <code key={i} className="rounded bg-accent px-1 py-0.5 font-mono text-[0.85em]">
+          {part.slice(1, -1)}
+        </code>
+      )
+    }
+    return part
+  })
+}
+
+interface PatchNotesDialogProps {
+  notes: PatchNotes
+  /** Dismiss — also fired on Escape/backdrop; the gate records the version. */
+  onClose: () => void
+}
+
+// PatchNotesDialog shows the running build's changelog section after an update:
+// a grouped, scrollable "what's new" list with a link to the full release notes.
+export function PatchNotesDialog({notes, onClose}: PatchNotesDialogProps) {
+  const groups = notes.groups ?? []
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-lg">
+        <DialogHeader className="flex-row items-start gap-3 p-6 pb-4">
+          <span className="grid size-10 flex-none place-items-center rounded-lg bg-emerald-500/15 text-emerald-500 ring-1 ring-emerald-500/30">
+            <Sparkles className="size-5" />
+          </span>
+          <div className="flex-1 pt-0.5">
+            <DialogTitle className="text-[1.0625rem]">What's new in lich</DialogTitle>
+            <DialogDescription className="mt-1">
+              You updated to a new version — here's what changed.
+            </DialogDescription>
+          </div>
+          <span className="mt-0.5 rounded-full border bg-accent px-2 py-0.5 text-xs font-medium tabular-nums">
+            v{notes.version}
+          </span>
+        </DialogHeader>
+
+        <div className="max-h-[55vh] overflow-y-auto px-6">
+          {groups.map((group) => (
+            <div key={group.label} className="border-t py-3.5 first:border-t-0 first:pt-1">
+              <div className="mb-2.5 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                <span className={`size-2 rounded-full ${dotColor(group.label)}`} />
+                {group.label}
+              </div>
+              <ul className="flex flex-col gap-2.5">
+                {group.items.map((item, i) => (
+                  <li
+                    key={i}
+                    className="relative pl-3.5 text-[0.8125rem] leading-relaxed text-muted-foreground before:absolute before:top-2 before:left-0 before:size-1 before:rounded-full before:bg-border"
+                  >
+                    {renderInline(item)}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        <DialogFooter className="flex-row items-center justify-between border-t p-6 pt-4 sm:justify-between">
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 text-[0.8125rem] text-muted-foreground hover:text-foreground"
+            onClick={() => void System.OpenExternal(RELEASE_TAG_BASE + notes.version)}
+          >
+            View full changelog
+            <ArrowUpRight className="size-3.5" />
+          </button>
+          <Button size="sm" onClick={onClose}>
+            Got it
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/PatchNotesGate.tsx
+++ b/frontend/src/components/PatchNotesGate.tsx
@@ -1,0 +1,40 @@
+import {useEffect, useState} from "react"
+import {PatchNotesDialog} from "@/components/PatchNotesDialog"
+import {decidePatchNotes, PATCH_NOTES_SEEN_KEY} from "@/lib/patch-notes-gate"
+import {PatchNotes} from "@/lib/rpc"
+import type {PatchNotes as PatchNotesData} from "@/lib/api-types"
+
+// PatchNotesGate shows lich's "what's new" popup once per release, right after
+// an update. On startup it fetches this build's changelog section and decides:
+// show the popup, silently record the version (first run — no popup on a fresh
+// install), or nothing. Any failure is silent — it must never block startup.
+export function PatchNotesGate() {
+  const [notes, setNotes] = useState<PatchNotesData | null>(null)
+
+  useEffect(() => {
+    let alive = true
+    void PatchNotes.Current()
+      .then((current) => {
+        if (!alive) return
+        const action = decidePatchNotes(current, localStorage.getItem(PATCH_NOTES_SEEN_KEY))
+        if (action.kind === "record") {
+          localStorage.setItem(PATCH_NOTES_SEEN_KEY, action.version)
+        } else if (action.kind === "show") {
+          setNotes(action.notes)
+        }
+      })
+      .catch(() => {})
+    return () => {
+      alive = false
+    }
+  }, [])
+
+  if (!notes) return null
+
+  const close = () => {
+    localStorage.setItem(PATCH_NOTES_SEEN_KEY, notes.version)
+    setNotes(null)
+  }
+
+  return <PatchNotesDialog notes={notes} onClose={close} />
+}

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -74,6 +74,20 @@ export interface AppUpdateStatus {
   releaseUrl: string
 }
 
+/** internal/patchnotes.Group — one "### Added/Changed/Fixed" block of a release. */
+export interface PatchNotesGroup {
+  label: string
+  /** Item text with markdown bold/code markers intact, rendered by the gate. */
+  items: string[]
+}
+
+/** internal/patchnotes.Notes — the running build's changelog section. */
+export interface PatchNotes {
+  version: string
+  /** null when no section matches (a dev build, or a version not in the changelog). */
+  groups: PatchNotesGroup[] | null
+}
+
 /** internal/providers.Detected — a known provider and whether it is on PATH. */
 export interface DetectedProvider {
   id: string

--- a/frontend/src/lib/patch-notes-gate.test.ts
+++ b/frontend/src/lib/patch-notes-gate.test.ts
@@ -1,0 +1,32 @@
+import {describe, expect, it} from "vitest"
+import {decidePatchNotes} from "./patch-notes-gate"
+import type {PatchNotes} from "./api-types"
+
+const notes: PatchNotes = {
+  version: "0.11.0",
+  groups: [{label: "Added", items: ["**A thing.** It does stuff."]}],
+}
+
+describe("decidePatchNotes", () => {
+  it("shows when the seen version differs from the current one", () => {
+    expect(decidePatchNotes(notes, "0.10.0")).toEqual({
+      kind: "show",
+      version: "0.11.0",
+      notes,
+    })
+  })
+
+  it("records silently on the first run (nothing seen yet), so launch is quiet", () => {
+    expect(decidePatchNotes(notes, null)).toEqual({kind: "record", version: "0.11.0"})
+  })
+
+  it("does nothing when the current version was already seen", () => {
+    expect(decidePatchNotes(notes, "0.11.0")).toEqual({kind: "none"})
+  })
+
+  it("does nothing without a section — a dev build or unreleased version", () => {
+    expect(decidePatchNotes({version: "dev", groups: null}, "0.10.0")).toEqual({kind: "none"})
+    expect(decidePatchNotes({version: "0.11.0", groups: []}, "0.10.0")).toEqual({kind: "none"})
+    expect(decidePatchNotes({version: "", groups: null}, null)).toEqual({kind: "none"})
+  })
+})

--- a/frontend/src/lib/patch-notes-gate.ts
+++ b/frontend/src/lib/patch-notes-gate.ts
@@ -1,0 +1,40 @@
+// Startup decision for the "what's new" popup: show this build's changelog
+// section, silently remember it, or do nothing. Kept pure (no bindings, no
+// storage) so it is trivially testable; the component wires it to Current(),
+// localStorage and the dialog. Mirrors app-update-gate.ts.
+
+import type {PatchNotes} from "./api-types"
+
+// Stores the version whose notes were last shown (or silently recorded on first
+// run), so a given release's popup fires exactly once.
+export const PATCH_NOTES_SEEN_KEY = "lich.patchNotesSeen"
+
+// PatchNotesAction is what the gate should do:
+// - show: open the popup for this version's notes.
+// - record: remember this version without a popup — the first run that ever
+//   sees the feature (or a fresh install), so users are not greeted on launch.
+// - none: nothing new to show.
+export type PatchNotesAction =
+  | {kind: "none"}
+  | {kind: "record"; version: string}
+  | {kind: "show"; version: string; notes: PatchNotes}
+
+// decidePatchNotes resolves the startup popup. No section (dev build, or a
+// version absent from the changelog) → none. Never recorded before → record
+// silently. Same version already seen → none. A different version with notes →
+// show.
+export function decidePatchNotes(
+  notes: PatchNotes,
+  lastSeenVersion: string | null,
+): PatchNotesAction {
+  if (!notes.version || !notes.groups || notes.groups.length === 0) {
+    return {kind: "none"}
+  }
+  if (lastSeenVersion === null) {
+    return {kind: "record", version: notes.version}
+  }
+  if (lastSeenVersion === notes.version) {
+    return {kind: "none"}
+  }
+  return {kind: "show", version: notes.version, notes}
+}

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -11,6 +11,7 @@ import type {
   Branches,
   DetectedProvider,
   DiffStats,
+  PatchNotes as PatchNotesData,
   PluginStatus,
   Project,
   PullRequest,
@@ -174,6 +175,11 @@ export const AppUpdate = {
   Status: () => call<AppUpdateStatus>("appupdate.Status", []),
   /** Download, verify and swap the binary. Only valid where canSelfApply. */
   Apply: () => call<null>("appupdate.Apply", []),
+}
+
+export const PatchNotes = {
+  /** The running build's changelog section, for the "what's new" popup. */
+  Current: () => call<PatchNotesData>("patchnotes.Current", []),
 }
 
 export const System = {

--- a/internal/patchnotes/patchnotes.go
+++ b/internal/patchnotes/patchnotes.go
@@ -1,0 +1,120 @@
+// Package patchnotes serves the changelog section for the running build so the
+// app can show a "what's new" popup after an update. CHANGELOG.md is embedded
+// at the module root (see main.go) and parsed into groups here — the frontend
+// stays a dumb renderer.
+package patchnotes
+
+import "strings"
+
+// Group is one "### Added / Changed / Fixed" block of a release's notes.
+type Group struct {
+	Label string `json:"label"`
+	// Items keep their markdown bold/code markers; the frontend renders them.
+	Items []string `json:"items"`
+}
+
+// Notes is a release's changelog section, ready for the frontend to render.
+type Notes struct {
+	Version string  `json:"version"`
+	Groups  []Group `json:"groups"`
+}
+
+// Service serves the notes for one fixed version — the running build.
+type Service struct {
+	version   string
+	changelog string
+}
+
+// New returns a service that parses changelog for version's section on demand.
+func New(version, changelog string) *Service {
+	return &Service{version: version, changelog: changelog}
+}
+
+// Current returns the running build's changelog section. Groups is empty when
+// no section matches (a dev build, or a version not yet in the changelog), and
+// the frontend then shows nothing.
+func (s *Service) Current() Notes {
+	return Notes{Version: normalize(s.version), Groups: Section(s.changelog, s.version)}
+}
+
+// normalize drops a leading "v" so "v0.11.0" and "0.11.0" compare equal.
+func normalize(version string) string {
+	return strings.TrimPrefix(version, "v")
+}
+
+// Section returns the groups under the "## [<version>]" heading, or nil when
+// that heading is absent. The heading may carry a trailing date
+// ("## [0.11.0] - 2026-07-21"); only the bracketed version is matched.
+func Section(changelog, version string) []Group {
+	body, ok := sliceSection(changelog, normalize(version))
+	if !ok {
+		return nil
+	}
+	return parseGroups(body)
+}
+
+// sliceSection returns the lines between the version's "## [..]" heading and the
+// next "## " heading (end of file if none). ok is false when no heading matches.
+func sliceSection(changelog, version string) ([]string, bool) {
+	header := "## [" + version + "]"
+	lines := strings.Split(changelog, "\n")
+	start := -1
+	for i, line := range lines {
+		if strings.HasPrefix(line, header) {
+			start = i + 1
+			break
+		}
+	}
+	if start == -1 {
+		return nil, false
+	}
+	for i := start; i < len(lines); i++ {
+		if strings.HasPrefix(lines[i], "## ") {
+			return lines[start:i], true
+		}
+	}
+	return lines[start:], true
+}
+
+// parseGroups turns the section lines into groups. A "### Label" opens a group,
+// a "- " opens an item, wrapped continuation lines fold into it with a space,
+// and a blank line ends an item. Groups that gather no items are dropped.
+func parseGroups(lines []string) []Group {
+	var groups []Group
+	var item strings.Builder
+	flush := func() {
+		if item.Len() == 0 || len(groups) == 0 {
+			item.Reset()
+			return
+		}
+		last := len(groups) - 1
+		groups[last].Items = append(groups[last].Items, item.String())
+		item.Reset()
+	}
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "### "):
+			flush()
+			groups = append(groups, Group{Label: strings.TrimSpace(line[4:])})
+		case strings.HasPrefix(line, "- "):
+			flush()
+			item.WriteString(strings.TrimSpace(line[2:]))
+		case strings.TrimSpace(line) == "":
+			flush()
+		default:
+			if item.Len() > 0 {
+				item.WriteByte(' ')
+				item.WriteString(strings.TrimSpace(line))
+			}
+		}
+	}
+	flush()
+
+	out := groups[:0]
+	for _, g := range groups {
+		if len(g.Items) > 0 {
+			out = append(out, g)
+		}
+	}
+	return out
+}

--- a/internal/patchnotes/patchnotes_test.go
+++ b/internal/patchnotes/patchnotes_test.go
@@ -1,0 +1,107 @@
+package patchnotes
+
+import (
+	"reflect"
+	"testing"
+)
+
+const sample = `# Changelog
+
+Some preamble.
+
+## [Unreleased]
+
+### Added
+
+- Nothing yet.
+
+## [0.11.0] - 2026-07-21
+
+### Added
+
+- **Default provider for new sessions.** Pick which harness a new worktree,
+  the new-session hotkey, and a project's first session spawn.
+- **Command palette.** Jump to any session from anywhere.
+
+### Fixed
+
+- **Reopening a worktree no longer forks a new one** from its branch.
+
+## [0.10.0] - 2026-07-01
+
+### Added
+
+- An older feature.
+`
+
+func TestSectionParsesGroupsAndFoldsWrappedItems(t *testing.T) {
+	got := Section(sample, "v0.11.0")
+	want := []Group{
+		{Label: "Added", Items: []string{
+			"**Default provider for new sessions.** Pick which harness a new worktree, the new-session hotkey, and a project's first session spawn.",
+			"**Command palette.** Jump to any session from anywhere.",
+		}},
+		{Label: "Fixed", Items: []string{
+			"**Reopening a worktree no longer forks a new one** from its branch.",
+		}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Section mismatch:\n got %#v\nwant %#v", got, want)
+	}
+}
+
+func TestSectionMatchesRegardlessOfLeadingV(t *testing.T) {
+	withV := Section(sample, "v0.11.0")
+	withoutV := Section(sample, "0.11.0")
+	if !reflect.DeepEqual(withV, withoutV) {
+		t.Fatalf("leading v changed the result: %#v vs %#v", withV, withoutV)
+	}
+}
+
+func TestSectionStopsAtNextVersion(t *testing.T) {
+	// 0.11.0 must not bleed into 0.10.0's "An older feature." item.
+	got := Section(sample, "0.11.0")
+	for _, g := range got {
+		for _, item := range g.Items {
+			if item == "An older feature." {
+				t.Fatalf("section leaked into the next release")
+			}
+		}
+	}
+}
+
+func TestSectionMissingVersionIsNil(t *testing.T) {
+	if got := Section(sample, "9.9.9"); got != nil {
+		t.Fatalf("want nil for absent version, got %#v", got)
+	}
+	if got := Section(sample, "dev"); got != nil {
+		t.Fatalf("want nil for dev build, got %#v", got)
+	}
+}
+
+func TestCurrentReportsNormalizedVersion(t *testing.T) {
+	svc := New("v0.11.0", sample)
+	got := svc.Current()
+	if got.Version != "0.11.0" {
+		t.Fatalf("Version = %q, want 0.11.0", got.Version)
+	}
+	if len(got.Groups) != 2 {
+		t.Fatalf("Groups = %d, want 2", len(got.Groups))
+	}
+}
+
+func TestSectionDropsEmptyGroups(t *testing.T) {
+	const cl = `## [1.0.0]
+
+### Added
+
+### Changed
+
+- A real change.
+`
+	got := Section(cl, "1.0.0")
+	want := []Group{{Label: "Changed", Items: []string{"A real change."}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("empty group not dropped:\n got %#v\nwant %#v", got, want)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/omartelo/lich/internal/events"
 	"github.com/omartelo/lich/internal/fonts"
 	"github.com/omartelo/lich/internal/logging"
+	"github.com/omartelo/lich/internal/patchnotes"
 	"github.com/omartelo/lich/internal/project"
 	"github.com/omartelo/lich/internal/providers"
 	"github.com/omartelo/lich/internal/restart"
@@ -31,6 +32,12 @@ import (
 
 //go:embed all:frontend/dist
 var assets embed.FS
+
+// changelog is embedded so the app can show a "what's new" popup after an
+// update, parsed for the running version's section (internal/patchnotes).
+//
+//go:embed CHANGELOG.md
+var changelog string
 
 // defaultListenPort pins the loopback listener so the page origin — and with
 // it the frontend's localStorage (lich.* settings) — survives restarts.
@@ -88,6 +95,7 @@ func main() {
 	dispatcher.Register("project", proj)
 	dispatcher.Register("claudeplugin", claudeplugin.New(db))
 	dispatcher.Register("appupdate", appupdate.New(version))
+	dispatcher.Register("patchnotes", patchnotes.New(version, changelog))
 	dispatcher.Register("store", db)
 	dispatcher.Register("system", system.New())
 	dispatcher.Register("providers", providers.New())


### PR DESCRIPTION
## What

The first time lich opens on a **new version**, a dialog summarizes what changed — the release's changelog section, grouped **Added / Changed / Fixed**, with a link to the full notes on GitHub.

- Fires **once per release**, keyed on `lich.patchNotesSeen` in localStorage.
- **Never on a fresh install** — the first run that ever sees the feature records the version silently, so users aren't greeted on launch. (Practically: this ships in the release that introduces it, so the first popup a user sees is the release *after* this one.)
- Notes are read from the **CHANGELOG baked into the binary**, so it works offline and stays a single source of truth with the release notes.

Design was validated against a mockup before implementation.

## How

**Backend**
- `main.go` `//go:embed CHANGELOG.md` and passes it to a new `internal/patchnotes` package.
- `patchnotes.Section(changelog, version)` parses the `## [x.y.z]` block into groups — folding wrapped continuation lines, matching the version regardless of a leading `v` or a trailing ` - date`, and dropping empty groups.
- `patchnotes.Current` RPC serves the running build's section. A dev build or a version absent from the changelog yields no groups → nothing shows.

**Frontend**
- `PatchNotesGate` fetches the section on startup and decides via the pure `decidePatchNotes`: **show** / **record** (silent first run) / **none**.
- `PatchNotesDialog` renders the grouped notes (semantic dots: Added emerald, Changed amber, Fixed sky) with a "View full changelog" link. Reuses the app's `Dialog` primitives and tokens.
- Mounted globally in `App.tsx` alongside the other gates.

## Test plan
- [x] `go test -race ./...` — 287 passed (new `internal/patchnotes`: parse, wrapped-line folding, leading-v, section boundary, missing version, empty-group drop)
- [x] `gofmt` / `go vet` clean; cross-builds for `darwin/arm64` and `windows/amd64`
- [x] `vitest run` — 304 passed (new `decidePatchNotes`: show / record / already-seen / no-section)
- [x] `tsc --noEmit` + `vite build` succeed
- [ ] Manual: pending a `task dev` check of the dialog render (the frontend gate is node-only, so it does not exercise the base-ui render path)

## Notes / out of scope
- The full-changelog link opens `releases/tag/v<version>` in the browser via `System.OpenExternal`.
- Inline markdown is deliberately minimal (**bold** + `code` only — all the CHANGELOG uses); no markdown dependency added.