### PR TITLE
fix: footer working directory follows cd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-07-21
+
+### Fixed
+
+- **The footer bar's working directory now follows `cd`.** It read the
+  session's static start path, so a `cd` in the terminal moved the session
+  card but left the footer stale. It now overlays the same live-cwd source the
+  card follows.
+
+### Changed
+
+- **The session cwd is polled every ~300 ms** (was every 2 s), so a `cd` shows
+  up in the card and footer promptly. Each read is one cheap syscall and emits
+  only on change, so a static directory still costs nothing.
+
 ## [0.11.0] - 2026-07-21
 
 ### Added
@@ -586,7 +601,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/omartelo/lich/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/omartelo/lich/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/omartelo/lich/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/omartelo/lich/compare/v0.8.1...v0.9.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,10 +114,11 @@ Before tagging:
 
 Deliberate limits and shortcuts, with the upgrade path when it matters:
 
-- **Session cwd is polled every ~2 s** from the PTY child
+- **Session cwd is polled every ~300 ms** from the PTY child
   (`internal/terminal/cwd.go`), emitted as `session-cwd` only on change and kept
   frontend-side in `session-cwd-store.ts` (never persisted; every PTY spawn
-  re-reports its start directory). Per-platform reads behind the usual build-tag
+  re-reports its start directory). Both the session card and the footer bar
+  consume it, so a `cd` moves both. Per-platform reads behind the usual build-tag
   seam: `/proc/<pid>/cwd` on Linux, `proc_pidinfo(PROC_PIDVNODEPATHINFO)` on
   macOS (bound from libSystem x/sys-style — cgo_import_dynamic + asm trampoline,
   still pure Go), and a PEB walk on Windows (`NtQueryInformationProcess` +

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -3,6 +3,7 @@ import {Code, FileText, GitBranch, Folder, Plus, Diff, GitPullRequestArrow} from
 import {ProjectService, System, Terminal as TerminalService} from "@/lib/rpc"
 import type {DockTab} from "@/components/dock/RightDock"
 import {useActiveSession} from "@/lib/useActiveSession"
+import {useSessionCwd} from "@/lib/useSessionCwd"
 import {displayPath} from "@/lib/paths"
 import {useGitStatus} from "@/lib/useGitStatus"
 import {usePullRequest} from "@/lib/usePullRequest"
@@ -39,7 +40,11 @@ interface FooterBarProps {
 // branch and diff. The Files button and the diff counters toggle the dock's two
 // tabs.
 export function FooterBar({dock, onDock}: FooterBarProps) {
-  const {sessionId, path} = useActiveSession()
+  const {sessionId, path: basePath} = useActiveSession()
+  // Overlay the backend's live cwd so a `cd` in the terminal moves the footer
+  // with it — same source the session card follows. Falls back to the session's
+  // static start path until the watcher reports.
+  const path = useSessionCwd(sessionId) || basePath
   const status = useGitStatus(path)
   const pr = usePullRequest(path, status?.branch ?? "")
   const now = useNow()

--- a/internal/terminal/cwd.go
+++ b/internal/terminal/cwd.go
@@ -19,9 +19,10 @@ type cwdEvent struct {
 }
 
 // cwdPollInterval is how often a session's child working directory is read.
-// Matches the spirit of the frontend's ~3s git-status poll: cheap enough to
-// never matter, fresh enough to feel live.
-const cwdPollInterval = 2 * time.Second
+// Sub-second so a `cd` shows up promptly; each read is one cheap syscall
+// (readlink on Linux, proc_pidinfo on macOS, a PEB walk on Windows) and emits
+// only on change, so a static directory costs nothing to re-render.
+const cwdPollInterval = 300 * time.Millisecond
 
 // watchCwd reports the session child's working directory to the frontend
 // whenever it changes, until done closes. Each platform brings its own read


### PR DESCRIPTION
## What

The footer bar's working directory now follows `cd` in the terminal, and the cwd poll is tightened to feel live.

## Why

The footer read the session's **static** start path (`useActiveSession().path`), while the session card overlays the backend's live cwd via `useSessionCwd`. So a `cd` moved the card but left the footer stale — same class of bug we just fixed for the card, one caller over.

## Changes

- **`FooterBar.tsx`** — overlay `useSessionCwd(sessionId)` on the base path, exactly as the card does. `useGitStatus`/`usePullRequest` derive from it, so the footer's git + PR segments follow the shown directory for free.
- **`internal/terminal/cwd.go`** — poll interval 2 s → 300 ms. Each read is one cheap syscall (readlink / proc_pidinfo / PEB walk) and emits only on change, so a static directory costs nothing. Comment refreshed.
- **`CLAUDE.md`** — cwd ceiling updated (~2 s → ~300 ms; note both card and footer consume it).
- **`CHANGELOG.md`** — cut `0.11.1`.

## Test plan

- [x] `go vet ./...`, `gofmt -l .` clean
- [x] `go test ./...` — 287 passed
- [x] frontend `tsc --noEmit` + `vitest run` — 304 passed
- [x] Manual: `cd` around in a session, confirm the footer path tracks the terminal (both card and footer move together)