### PR TITLE
ci: publish lich-bin to the AUR on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,3 +239,29 @@ jobs:
             bin/lich-* bin/checksums.txt \
             --title "$GITHUB_REF_NAME" \
             --notes-file notes.md
+
+  # The AUR PKGBUILD sources point at the GitHub Release assets, so this runs
+  # only after `release` publishes them. updpkgsums fills the checksums by
+  # downloading those assets; the action then regenerates .SRCINFO and pushes
+  # to the lich-bin AUR repo over SSH.
+  aur:
+    needs: [release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Render PKGBUILD
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          sed "s/@VERSION@/${version}/" build/linux/aur/PKGBUILD.tpl > PKGBUILD
+
+      - name: Publish lich-bin to the AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.2.0
+        with:
+          pkgname: lich-bin
+          pkgbuild: ./PKGBUILD
+          updpkgsums: true
+          commit_username: omartelo
+          commit_email: meopedevts@proton.me
+          ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
+          commit_message: "Update to ${{ github.ref_name }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **lich is on the AUR.** `paru -S lich-bin` (or `yay -S lich-bin`) installs
+  the released binary; every release now pushes the updated PKGBUILD to the
+  AUR automatically.
+
 ## [0.11.1] - 2026-07-21
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **lich is on the AUR.** `paru -S lich-bin` (or `yay -S lich-bin`) installs
+- **lich is on the AUR.** `yay -S lich-bin` (or `paru -S lich-bin`) installs
   the released binary; every release now pushes the updated PKGBUILD to the
   AUR automatically.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,7 +55,7 @@ sudo dnf install chromium zenity
 From the AUR ([lich-bin](https://aur.archlinux.org/packages/lich-bin)):
 
 ```bash
-paru -S lich-bin   # or: yay -S lich-bin
+yay -S lich-bin   # or: paru -S lich-bin
 ```
 
 Or download the `.pkg.tar.zst` from the releases page and install it:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,7 +52,13 @@ sudo dnf install chromium zenity
 
 ## Arch
 
-Download the `.pkg.tar.zst` from the releases page, then install it:
+From the AUR ([lich-bin](https://aur.archlinux.org/packages/lich-bin)):
+
+```bash
+paru -S lich-bin   # or: yay -S lich-bin
+```
+
+Or download the `.pkg.tar.zst` from the releases page and install it:
 
 ```bash
 sudo pacman -U lich-*-x86_64.pkg.tar.zst

--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ its dependencies through your package manager:
 curl -fsSL https://raw.githubusercontent.com/omartelo/lich/main/install.sh | sh
 ```
 
+**Arch** — from the AUR
+([lich-bin](https://aur.archlinux.org/packages/lich-bin)):
+
+```bash
+yay -S lich-bin
+```
+
 **Manual** — per-distro packages, runtime dependencies and the static binary:
 [INSTALL.md](INSTALL.md).
 

--- a/build/linux/aur/PKGBUILD.tpl
+++ b/build/linux/aur/PKGBUILD.tpl
@@ -1,0 +1,26 @@
+# Maintainer: omartelo <meopedevts@proton.me>
+# Rendered by .github/workflows/release.yml (@VERSION@ -> tag, checksums via
+# updpkgsums) and pushed to the AUR — edit this template, never the AUR copy.
+pkgname=lich-bin
+pkgver=@VERSION@
+pkgrel=1
+pkgdesc="A personal harness for AI-assisted development"
+arch=('x86_64')
+url="https://github.com/omartelo/lich"
+license=('AGPL-3.0-only')
+provides=('lich')
+conflicts=('lich')
+optdepends=('chromium: app window (any Chromium-family browser works: chromium, google-chrome, brave)'
+            'zenity: native folder picker')
+source=("lich-v${pkgver}-linux-amd64::${url}/releases/download/v${pkgver}/lich-v${pkgver}-linux-amd64"
+        "lich-${pkgver}.desktop::https://raw.githubusercontent.com/omartelo/lich/v${pkgver}/build/linux/lich.desktop"
+        "lich-${pkgver}.png::https://raw.githubusercontent.com/omartelo/lich/v${pkgver}/build/appicon.png")
+sha256sums=('SKIP'
+            'SKIP'
+            'SKIP')
+
+package() {
+  install -Dm755 "lich-v${pkgver}-linux-amd64" "${pkgdir}/usr/bin/lich"
+  install -Dm644 "lich-${pkgver}.desktop" "${pkgdir}/usr/share/applications/lich.desktop"
+  install -Dm644 "lich-${pkgver}.png" "${pkgdir}/usr/share/icons/hicolor/128x128/apps/lich.png"
+}


### PR DESCRIPTION
## Summary

- New `aur` job in `release.yml`, fanning in after `release`: renders `build/linux/aur/PKGBUILD.tpl` with the tag version, fills checksums from the just-published release assets (`updpkgsums`), regenerates `.SRCINFO` and pushes to the `lich-bin` AUR repo over SSH (`KSXGitHub/github-actions-deploy-aur@v4.2.0`, `AUR_SSH_PRIVATE_KEY` secret — already set on the repo).
- `lich-bin` PKGBUILD: installs the released static binary to `/usr/bin/lich` plus desktop entry and icon; `provides`/`conflicts` `lich`; Chromium/zenity as `optdepends` (pacman has no Recommends). No `.install` script — pacman's own hooks handle the desktop/icon databases.
- `INSTALL.md` Arch section now leads with the AUR; changelog entry under Unreleased.

## Test plan

- [x] `makepkg -f` on the rendered 0.11.1 PKGBUILD builds `lich-bin 0.11.1-1` cleanly
- [x] Binary sha256 from `updpkgsums` matches the release `checksums.txt`
- [x] `makepkg --printsrcinfo` output sane (provides/conflicts/optdepends correct)
- [ ] First tag after merge publishes to the AUR (needs the deploy public key on the AUR account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)