### PR TITLE
feat: update Arch through the AUR in the in-app updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The in-app updater now updates Arch through the AUR.** On Arch (and its
+  derivatives) the update prompt pastes `yay -S lich-bin` instead of the
+  `install.sh` one-liner, keeping the install tracked by the user's AUR helper.
+  Since `yay` does not know how to relaunch lich, the pasted command chains an
+  explicit restart using the terminal session's own loopback credentials. Other
+  distros are unchanged.
+
 ### Fixed
 
 - **The app window now shows the lich icon.** The frontend served no favicon,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,10 @@ Deliberate limits and shortcuts, with the upgrade path when it matters:
   keeps the poll from stacking a second toast for a release already shown (a genuinely newer one still toasts). Hourly
   respects the unauthenticated GitHub API's 60-req/hour limit. Self-*apply* (download + checksum + in-place swap via
   `minio/selfupdate`) is Windows/macOS only, where lich owns its binary; on Linux the binary is package-manager owned,
-  so the flow pastes the `install.sh` one-liner into a terminal and relaunches via `/restart` instead. The restart
+  so the flow pastes a distro-specific update command into a terminal instead (`appupdate.installCommand`, reported in
+  `Status`): Arch gets `yay -S lich-bin` plus an explicit `/restart` POST (yay knows nothing about lich, so the paste
+  chains the restart itself using the session's `LICH_PORT`/`LICH_TOKEN`); every other distro gets the `install.sh`
+  one-liner, which detects the distro and POSTs `/restart` on its own. The restart
   (`internal/restart`) spawns a detached successor that retries the pinned port (`LICH_RESTART_WAIT`) while the old
   process closes its window and exits — so the window blinks briefly, and if the successor cannot bind within ~10s it
   gives up and the user reopens by hand. Auto-restart is Unix-only (setsid); a Windows/macOS self-apply asks for a

--- a/frontend/src/components/AppUpdateGate.tsx
+++ b/frontend/src/components/AppUpdateGate.tsx
@@ -15,10 +15,6 @@ const RESTART_HINT = "restart lich to apply."
 // unauthenticated GitHub API allows only 60 requests/hour per IP.
 const POLL_INTERVAL_MS = 60 * 60 * 1000
 
-// The one-liner from install.sh / the README. Pasted into a shell for the user
-// to run — never executed automatically.
-const INSTALL_CMD = "curl -fsSL https://raw.githubusercontent.com/omartelo/lich/main/install.sh | sh"
-
 // AppUpdateGate checks on startup, then hourly, whether a newer lich release
 // exists. Where the binary is writable (Windows/macOS) it offers a one-click
 // self-update; on Linux the binary is package-manager owned, so it offers to
@@ -57,7 +53,7 @@ export function AppUpdateGate() {
     if (action.canSelfApply) {
       promptSelfApply(action.version)
     } else {
-      promptInstall(action.version, action.releaseUrl)
+      promptInstall(action.version, action.releaseUrl, action.installCommand)
     }
   }
 
@@ -83,7 +79,7 @@ export function AppUpdateGate() {
   // Linux: three choices — paste the install command into a terminal, open the
   // release page, or dismiss for this version. sonner's default toast has only
   // two buttons, so this is a custom one styled with the popover tokens.
-  const promptInstall = (version: string, releaseUrl: string) => {
+  const promptInstall = (version: string, releaseUrl: string, installCommand: string) => {
     toast.custom(
       (id) => (
         <div className="flex flex-col gap-3 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-lg">
@@ -93,7 +89,7 @@ export function AppUpdateGate() {
               size="sm"
               onClick={() => {
                 toast.dismiss(id)
-                void openInstall(releaseUrl)
+                void openInstall(releaseUrl, installCommand)
               }}
             >
               Install
@@ -129,7 +125,7 @@ export function AppUpdateGate() {
   // project in view; with none in view (the Home screen, e.g. right after
   // launch) a $HOME-rooted project is opened so Install never dead-ends. Falls
   // back to the release page only if even that fails (home dir unresolvable).
-  const openInstall = async (releaseUrl: string) => {
+  const openInstall = async (releaseUrl: string, installCommand: string) => {
     let projectId = activeRef.current
     if (!projectId) {
       try {
@@ -140,7 +136,7 @@ export function AppUpdateGate() {
       }
     }
     const sessionId = newSession(projectId, "shell")
-    queuePaste(sessionId, INSTALL_CMD)
+    queuePaste(sessionId, installCommand)
     navigate(`/projects/${projectId}`)
   }
 

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -72,6 +72,8 @@ export interface AppUpdateStatus {
   /** true where lich can swap its own binary (Windows/macOS); false on Linux. */
   canSelfApply: boolean
   releaseUrl: string
+  /** shell command the UI pastes to update a package-manager install; "" where canSelfApply. */
+  installCommand: string
 }
 
 /** internal/patchnotes.Group — one "### Added/Changed/Fixed" block of a release. */

--- a/frontend/src/lib/app-update-gate.test.ts
+++ b/frontend/src/lib/app-update-gate.test.ts
@@ -8,6 +8,7 @@ const status = (over: Partial<AppUpdateStatus>): AppUpdateStatus => ({
   updateAvailable: true,
   canSelfApply: false,
   releaseUrl: "https://github.com/omartelo/lich/releases/tag/v0.8.0",
+  installCommand: "curl -fsSL https://raw.githubusercontent.com/omartelo/lich/main/install.sh | sh",
   ...over,
 })
 
@@ -19,7 +20,13 @@ describe("decideUpdateAction", () => {
       version: "0.8.0",
       canSelfApply: false,
       releaseUrl: "https://github.com/omartelo/lich/releases/tag/v0.8.0",
+      installCommand: "curl -fsSL https://raw.githubusercontent.com/omartelo/lich/main/install.sh | sh",
     })
+  })
+
+  it("carries the distro install command through", () => {
+    const action = decideUpdateAction(status({installCommand: "yay -S lich-bin"}), null)
+    expect(action).toMatchObject({kind: "update", installCommand: "yay -S lich-bin"})
   })
 
   it("carries canSelfApply through for the self-apply platforms", () => {

--- a/frontend/src/lib/app-update-gate.ts
+++ b/frontend/src/lib/app-update-gate.ts
@@ -12,7 +12,7 @@ export const UPDATE_DISMISSED_KEY = "lich.appUpdateDismissed"
 // target version and how to apply it) or nothing.
 export type UpdateAction =
   | {kind: "none"}
-  | {kind: "update"; version: string; canSelfApply: boolean; releaseUrl: string}
+  | {kind: "update"; version: string; canSelfApply: boolean; releaseUrl: string; installCommand: string}
 
 // decideUpdateAction resolves the startup prompt. A newer release not yet
 // dismissed for that exact version → update; otherwise nothing.
@@ -26,6 +26,7 @@ export function decideUpdateAction(
       version: status.latestVersion,
       canSelfApply: status.canSelfApply,
       releaseUrl: status.releaseUrl,
+      installCommand: status.installCommand,
     }
   }
   return {kind: "none"}

--- a/internal/appupdate/appupdate.go
+++ b/internal/appupdate/appupdate.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"time"
 
@@ -26,6 +27,21 @@ const (
 	latestReleaseURL = "https://api.github.com/repos/" + repo + "/releases/latest"
 	releaseBase      = "https://github.com/" + repo + "/releases/download/"
 	releaseTagBase   = "https://github.com/" + repo + "/releases/tag/"
+
+	// aurPackage is the AUR name Arch users update through their helper.
+	aurPackage = "lich-bin"
+	// installScript is the deb/rpm/other-distro update path: install.sh detects
+	// the distro, installs the matching package, and POSTs /restart itself.
+	installScript = "curl -fsSL https://raw.githubusercontent.com/" + repo + "/main/install.sh | sh"
+	// restartChain relaunches lich after an install that, unlike install.sh, does
+	// not know how. It POSTs the same /restart endpoint using the
+	// LICH_PORT/LICH_TOKEN every lich PTY session exports, so the token is never
+	// rendered into the pasted text — it stays a shell env reference expanded at
+	// run time, not a literal baked into scrollback.
+	restartChain = ` && curl -fsS --max-time 5 -X POST "http://127.0.0.1:$LICH_PORT/restart?token=$LICH_TOKEN"`
+	// defaultOSRelease is where the distro identity lives; a Service field points
+	// tests elsewhere.
+	defaultOSRelease = "/etc/os-release"
 
 	httpTimeout = 5 * time.Second
 	// bodyLimit caps the JSON/checksums reads; assetLimit caps the binary
@@ -49,6 +65,9 @@ type Service struct {
 	latestURL    string
 	downloadBase string
 	tagBase      string
+	// osReleasePath is read to pick the Linux install command; a field so tests
+	// drive the arch/non-arch branches off a fixture instead of the host's file.
+	osReleasePath string
 	// applyBinary swaps the running binary for the downloaded one. A field so a
 	// test drives Apply's download+verify orchestration without the real swap
 	// (which would replace the test binary); defaults to selfupdateApply.
@@ -60,14 +79,15 @@ type Service struct {
 func New(version string) *Service {
 	exe, _ := os.Executable() // "" if unresolved — canSelfApply then stays false.
 	return &Service{
-		http:         &http.Client{Timeout: httpTimeout},
-		version:      version,
-		exePath:      exe,
-		goos:         runtime.GOOS,
-		latestURL:    latestReleaseURL,
-		downloadBase: releaseBase,
-		tagBase:      releaseTagBase,
-		applyBinary:  selfupdateApply,
+		http:          &http.Client{Timeout: httpTimeout},
+		version:       version,
+		exePath:       exe,
+		goos:          runtime.GOOS,
+		latestURL:     latestReleaseURL,
+		downloadBase:  releaseBase,
+		tagBase:       releaseTagBase,
+		osReleasePath: defaultOSRelease,
+		applyBinary:   selfupdateApply,
 	}
 }
 
@@ -85,6 +105,9 @@ type Status struct {
 	UpdateAvailable bool   `json:"updateAvailable"`
 	CanSelfApply    bool   `json:"canSelfApply"`
 	ReleaseURL      string `json:"releaseUrl"`
+	// InstallCommand is the shell command the UI pastes (never auto-runs) to
+	// update a package-manager-owned install; empty on the self-apply platforms.
+	InstallCommand string `json:"installCommand"`
 }
 
 // Status reports whether a newer release exists and whether this install can
@@ -97,6 +120,7 @@ func (s *Service) Status() Status {
 		LatestVersion:   latest,
 		UpdateAvailable: semver.IsRelease(s.version) && latest != "" && semver.Less(s.version, latest),
 		CanSelfApply:    canSelfApply(s.goos, s.exePath),
+		InstallCommand:  s.installCommand(),
 	}
 	if latest != "" {
 		st.ReleaseURL = s.tagBase + "v" + latest
@@ -168,6 +192,43 @@ func canSelfApply(goos, exePath string) bool {
 		return false
 	}
 	return dirWritable(filepath.Dir(exePath))
+}
+
+// installCommand is the shell command the UI pastes to update this install, or
+// "" on the self-apply platforms (they swap the binary through the button).
+// Arch goes through its AUR helper plus an explicit restart — yay knows nothing
+// about lich's /restart — while every other distro uses install.sh, which
+// restarts itself.
+func (s *Service) installCommand() string {
+	if s.goos != "linux" {
+		return ""
+	}
+	data, _ := os.ReadFile(s.osReleasePath) // missing/unreadable → not arch → install.sh
+	if isArch(string(data)) {
+		// ponytail: assumes yay, the common AUR helper; a paru user edits the one
+		// word, since the command is pasted for review and never auto-run.
+		return "yay -S " + aurPackage + restartChain
+	}
+	return installScript
+}
+
+// isArch reports whether os-release content describes Arch or an Arch
+// derivative, mirroring install.sh's detect_family (ID first, then ID_LIKE so
+// derivatives map to their parent).
+func isArch(osRelease string) bool {
+	return osReleaseField(osRelease, "ID") == "arch" ||
+		slices.Contains(strings.Fields(osReleaseField(osRelease, "ID_LIKE")), "arch")
+}
+
+// osReleaseField returns the unquoted value of a KEY=value line in os-release
+// content, or "" when the key is absent.
+func osReleaseField(content, key string) string {
+	for line := range strings.SplitSeq(content, "\n") {
+		if rest, ok := strings.CutPrefix(strings.TrimSpace(line), key+"="); ok {
+			return strings.Trim(rest, `"'`)
+		}
+	}
+	return ""
 }
 
 // dirWritable reports whether a temp file can be created in dir — the real

--- a/internal/appupdate/appupdate_test.go
+++ b/internal/appupdate/appupdate_test.go
@@ -135,6 +135,41 @@ func TestStatus(t *testing.T) {
 	})
 }
 
+func TestInstallCommand(t *testing.T) {
+	arch := "yay -S lich-bin" + restartChain
+
+	tests := []struct {
+		name      string
+		goos      string
+		osRelease string // written to a temp file; "" leaves osReleasePath missing
+		want      string
+	}{
+		{"windows self-apply", "windows", "", ""},
+		{"darwin self-apply", "darwin", "", ""},
+		{"arch by ID", "linux", "ID=arch\n", arch},
+		{"arch quoted ID", "linux", "ID=\"arch\"\n", arch},
+		{"arch derivative via ID_LIKE", "linux", "ID=manjaro\nID_LIKE=arch\n", arch},
+		{"debian uses install.sh", "linux", "ID=debian\n", installScript},
+		{"fedora uses install.sh", "linux", "ID=fedora\nID_LIKE=\"rhel centos\"\n", installScript},
+		{"missing os-release uses install.sh", "linux", "", installScript},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Service{goos: tc.goos, osReleasePath: filepath.Join("/nonexistent-abc123", "os-release")}
+			if tc.osRelease != "" {
+				path := filepath.Join(t.TempDir(), "os-release")
+				if err := os.WriteFile(path, []byte(tc.osRelease), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				s.osReleasePath = path
+			}
+			if got := s.installCommand(); got != tc.want {
+				t.Errorf("installCommand() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestApplyRejectedWhenNotSelfApply(t *testing.T) {
 	s := New("0.7.0")
 	s.exePath = "" // forces canSelfApply false regardless of platform


### PR DESCRIPTION
## Why

The AUR publish pipeline (#63) means Arch users install via `yay -S lich-bin`. But the in-app update prompt pasted the `install.sh` one-liner for every Linux distro, which on Arch downloads the release `.pkg.tar.zst` and `pacman -U`s it directly — bypassing the user's AUR helper and detaching the install from AUR tracking.

## What

- **Arch (and derivatives):** the update prompt now pastes `yay -S lich-bin` + an explicit `/restart` POST.
- **Other distros:** unchanged — still the `install.sh` one-liner, which detects the distro and restarts itself.

### The restart question

`yay` knows nothing about lich's `/restart` endpoint (only `install.sh` does). But the pasted command lands in a lich PTY session, and **every session already exports `LICH_PORT`/`LICH_TOKEN`** (`terminal.go` `sessionEnv`). So the paste chains the same `/restart` POST `install.sh` makes, using those env refs:

```sh
yay -S lich-bin && curl -fsS --max-time 5 -X POST "http://127.0.0.1:$LICH_PORT/restart?token=$LICH_TOKEN"
```

`&&` only fires the restart on a successful install. The token stays a **shell env reference** — never rendered into the command text or scrollback.

### Where the choice lives

The distro-specific command is picked backend-side: `appupdate.installCommand` reads `/etc/os-release` and mirrors `install.sh`'s `detect_family` (ID, then ID_LIKE so derivatives map to their parent), reported to the frontend as `Status.installCommand`. The frontend stays dumb — it pastes whatever `Status` reports (it can't read `/etc/os-release` from the page anyway).

## Ceilings

- Assumes `yay` (the common AUR helper). A `paru` user edits the one word — the command is **pasted for review, never auto-executed**, marked with a `ponytail:` comment.

## Test plan

- [x] `gofmt -l` clean, `go vet ./...` clean, cross-vet linux/windows/darwin clean
- [x] `go test ./...` — 296 passed (new `TestInstallCommand`: win/mac empty, arch by ID / quoted ID / ID_LIKE derivative, debian+fedora → install.sh, missing os-release → install.sh)
- [x] `pnpm exec tsc -b` + `vite build` green, `vitest run` — 305 passed
- [x] Manual: on Arch, trigger the update toast → Install → confirm `yay -S lich-bin && …restart` is pasted (not run) into a fresh shell session

🤖 Generated with [Claude Code](https://claude.com/claude-code)