### PR TITLE
Fix zoom: one owner, physical keys, and a terminal that stays put

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Zoom no longer applies twice.** `Ctrl +` is physically `Ctrl+Shift+=` on
+  every common layout, but the shortcut was declared as the character `"+"` with
+  Shift explicitly off — a combination no keyboard can produce. Zoom in therefore
+  never matched, nothing called `preventDefault()`, and Chromium ran its own zoom
+  accelerator, while zoom out (`Ctrl −`, no Shift needed) matched and scaled the
+  app instead. Two zooms, disagreeing with each other and with the Appearance
+  buttons, and clipped layouts once they compounded. Zoom chords are now matched
+  on the physical key (`event.code`), which is the same on every layout, so the
+  app is the only thing that zooms. The numpad keys work too.
+
+### Removed
+
+- **The `Zoom in`, `Zoom out` and `Reset zoom` entries from configurable
+  hotkeys.** These chords exist to shadow Chromium's built-in accelerators, and
+  an accelerator is bound to a physical key rather than to a character, so they
+  cannot be expressed as a rebindable character combo — that mismatch was the bug
+  above. Any custom binding saved for them is ignored on load; every other hotkey
+  is untouched and still configurable.
+
 ## [0.12.0] - 2026-07-21
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   buttons, and clipped layouts once they compounded. Zoom chords are now matched
   on the physical key (`event.code`), which is the same on every layout, so the
   app is the only thing that zooms. The numpad keys work too.
+- **Zooming no longer leaves the window part-empty or cuts the layout off.** CSS
+  `zoom` scales rendered boxes but leaves `vh`/`vw` as physical viewport units,
+  so the `100vh`/`100vw` app root rendered at viewport × zoom: short of the window
+  when zoomed out, overflowing when zoomed in — and the page's `overflow: hidden`
+  cut the overflow instead of scrolling it. The root now divides the viewport by
+  the zoom factor first, and the dialogs and command palette that size themselves
+  in `vh` use the same corrected unit.
 
 ### Removed
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,7 +25,7 @@ function Layout() {
   const toggleDock = (tab: DockTab) =>
     setDock((cur) => (cur === tab ? null : tab))
   return (
-    <div className="flex h-full w-full flex-col bg-background">
+    <div className="flex h-screen w-screen flex-col bg-background">
       <ProjectTabs />
       <div className="flex flex-1 overflow-hidden">
         <SessionSidebar />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,7 +25,7 @@ function Layout() {
   const toggleDock = (tab: DockTab) =>
     setDock((cur) => (cur === tab ? null : tab))
   return (
-    <div className="flex h-screen w-screen flex-col bg-background">
+    <div className="flex h-full w-full flex-col bg-background">
       <ProjectTabs />
       <div className="flex flex-1 overflow-hidden">
         <SessionSidebar />

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -96,7 +96,7 @@ export function CommandPalette() {
     <DialogPrimitive.Root open={open} onOpenChange={(next) => (next ? setOpen(true) : close())}>
       <DialogPrimitive.Portal>
         <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-black/50 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
-        <DialogPrimitive.Popup className="fixed left-1/2 top-[14vh] z-50 flex max-h-[70vh] w-full max-w-[640px] -translate-x-1/2 flex-col overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-2xl ring-1 ring-foreground/10 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0">
+        <DialogPrimitive.Popup className="fixed left-1/2 top-[calc(14*var(--app-vh))] z-50 flex max-h-[calc(70*var(--app-vh))] w-full max-w-[640px] -translate-x-1/2 flex-col overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-2xl ring-1 ring-foreground/10 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0">
           <DialogPrimitive.Title className="sr-only">Command palette</DialogPrimitive.Title>
 
           <div className="flex items-center gap-3 border-b px-4 py-3">

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -96,7 +96,7 @@ export function CommandPalette() {
     <DialogPrimitive.Root open={open} onOpenChange={(next) => (next ? setOpen(true) : close())}>
       <DialogPrimitive.Portal>
         <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-black/50 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
-        <DialogPrimitive.Popup className="fixed left-1/2 top-[calc(14*var(--app-vh))] z-50 flex max-h-[calc(70*var(--app-vh))] w-full max-w-[640px] -translate-x-1/2 flex-col overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-2xl ring-1 ring-foreground/10 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0">
+        <DialogPrimitive.Popup className="fixed left-1/2 top-[14vh] z-50 flex max-h-[70vh] w-full max-w-[40rem] -translate-x-1/2 flex-col overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-2xl ring-1 ring-foreground/10 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0">
           <DialogPrimitive.Title className="sr-only">Command palette</DialogPrimitive.Title>
 
           <div className="flex items-center gap-3 border-b px-4 py-3">
@@ -110,7 +110,7 @@ export function CommandPalette() {
               aria-label="Search sessions and projects"
               autoComplete="off"
               spellCheck={false}
-              className="flex-1 bg-transparent text-[15px] outline-none placeholder:text-muted-foreground"
+              className="flex-1 bg-transparent text-[0.9375rem] outline-none placeholder:text-muted-foreground"
             />
           </div>
 
@@ -162,7 +162,7 @@ export function CommandPalette() {
 
 function GroupLabel({ children }: { children: React.ReactNode }) {
   return (
-    <div className="px-3 pb-1 pt-3 text-[10.5px] font-semibold uppercase tracking-wider text-muted-foreground">
+    <div className="px-3 pb-1 pt-3 text-[0.65625rem] font-semibold uppercase tracking-wider text-muted-foreground">
       {children}
     </div>
   )
@@ -247,7 +247,7 @@ function ProjectRow({
         <span className="truncate text-sm">{project.name}</span>
         <span className="truncate font-mono text-xs text-muted-foreground">{project.path}</span>
       </span>
-      <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
+      <span className="shrink-0 font-mono text-[0.625rem] text-muted-foreground">
         {sessionCount} {sessionCount === 1 ? "session" : "sessions"}
       </span>
     </Row>
@@ -261,7 +261,7 @@ function Hint({ keys, children }: { keys: string[]; children: React.ReactNode })
         {keys.map((k) => (
           <kbd
             key={k}
-            className="rounded border border-b-2 bg-muted px-1.5 py-0.5 font-mono text-[10px] leading-none text-muted-foreground"
+            className="rounded border border-b-2 bg-muted px-1.5 py-0.5 font-mono text-[0.625rem] leading-none text-muted-foreground"
           >
             {k}
           </kbd>

--- a/frontend/src/components/PatchNotesDialog.tsx
+++ b/frontend/src/components/PatchNotesDialog.tsx
@@ -81,7 +81,7 @@ export function PatchNotesDialog({notes, onClose}: PatchNotesDialogProps) {
           </div>
         </DialogHeader>
 
-        <div className="max-h-[55vh] overflow-y-auto px-6">
+        <div className="max-h-[calc(55*var(--app-vh))] overflow-y-auto px-6">
           {groups.map((group) => (
             <div key={group.label} className="border-t py-3.5 first:border-t-0 first:pt-1">
               <div className="mb-2.5 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">

--- a/frontend/src/components/PatchNotesDialog.tsx
+++ b/frontend/src/components/PatchNotesDialog.tsx
@@ -81,7 +81,7 @@ export function PatchNotesDialog({notes, onClose}: PatchNotesDialogProps) {
           </div>
         </DialogHeader>
 
-        <div className="max-h-[calc(55*var(--app-vh))] overflow-y-auto px-6">
+        <div className="max-h-[55vh] overflow-y-auto px-6">
           {groups.map((group) => (
             <div key={group.label} className="border-t py-3.5 first:border-t-0 first:pt-1">
               <div className="mb-2.5 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -36,7 +36,9 @@ import "@xterm/xterm/css/xterm.css"
 const DATA_EVENT_PREFIX = "terminal:data:"
 const EXIT_EVENT_PREFIX = "terminal:exit:"
 
-const FONT_SIZE = 14
+// Size used only to ask the font loader for the face; the face is the same at
+// any size, and the terminal's real size is the terminalFontSize setting.
+const FONT_PROBE_SIZE = 14
 const REFIT_DEBOUNCE_MS = 100
 const COPY_DEBOUNCE_MS = 150
 const SCROLLBACK_LINES = 5000
@@ -99,8 +101,8 @@ const TERMINAL_COLORS: Record<ResolvedTheme, { background: string; foreground: s
 async function ensureFontLoaded(font: string): Promise<void> {
   try {
     await Promise.all([
-      document.fonts.load(`${FONT_SIZE}px "${font}"`),
-      document.fonts.load(`bold ${FONT_SIZE}px "${font}"`),
+      document.fonts.load(`${FONT_PROBE_SIZE}px "${font}"`),
+      document.fonts.load(`bold ${FONT_PROBE_SIZE}px "${font}"`),
     ])
   } catch {
     // Fall back to the system monospace face.
@@ -155,7 +157,7 @@ export function TerminalView({
   resume,
   visible,
 }: TerminalViewProps) {
-  const { font, resolvedTerminalTheme } = useSettings()
+  const { font, terminalFontSize, resolvedTerminalTheme } = useSettings()
   const containerRef = useRef<HTMLDivElement | null>(null)
   const liveRef = useRef<LiveTerminal | null>(null)
   // False until the mount effect's async setup builds the first terminal.
@@ -170,9 +172,11 @@ export function TerminalView({
   const replayRef = useRef(makeReplayBuffer())
   const visibleRef = useRef(visible)
   const fontRef = useRef(font)
+  const fontSizeRef = useRef(terminalFontSize)
   const themeRef = useRef(resolvedTerminalTheme)
   visibleRef.current = visible
   fontRef.current = font
+  fontSizeRef.current = terminalFontSize
   themeRef.current = resolvedTerminalTheme
 
   // In-terminal search (Ctrl+F). The open flag mirrors into a ref so the
@@ -216,7 +220,7 @@ export function TerminalView({
   // resize and copy-on-select. Shared by mount and every show-after-hide.
   const createTerminal = (container: HTMLDivElement): LiveTerminal => {
     const term = new Terminal({
-      fontSize: FONT_SIZE,
+      fontSize: fontSizeRef.current,
       fontFamily: `"${fontRef.current}", monospace`,
       cursorBlink: true,
       scrollback: SCROLLBACK_LINES,
@@ -540,6 +544,23 @@ export function TerminalView({
     })()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [font, sessionId])
+
+  // Text size likewise. Unlike the app zoom this does change the cell size, so
+  // the grid is refit and the PTY told about the new cols×rows.
+  useEffect(() => {
+    const live = liveRef.current
+    if (!live) {
+      return
+    }
+    live.term.options.fontSize = terminalFontSize
+    if (containerRef.current) {
+      fitTerminal(live.term, containerRef.current)
+    }
+    if (visibleRef.current) {
+      void Service.Resize(sessionId, live.term.cols, live.term.rows)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [terminalFontSize, sessionId])
 
   // Theme changes likewise.
   useEffect(() => {

--- a/frontend/src/components/diff/FileDiff.tsx
+++ b/frontend/src/components/diff/FileDiff.tsx
@@ -62,7 +62,7 @@ export function FileDiff({file, onInject, onDiscard}: FileDiffProps) {
         >
           <Chevron className="size-3.5 shrink-0 text-muted-foreground"/>
           <span
-            className={`flex size-5 shrink-0 items-center justify-center rounded text-[9px] font-bold ${badge.className}`}
+            className={`flex size-5 shrink-0 items-center justify-center rounded text-[0.5625rem] font-bold ${badge.className}`}
           >
             {badge.abbr}
           </span>

--- a/frontend/src/components/dock/FilesPanel.tsx
+++ b/frontend/src/components/dock/FilesPanel.tsx
@@ -225,7 +225,7 @@ function FilePreview({path, rel, onBack, onInject}: FilePreviewProps) {
         <span className="truncate font-mono" title={rel}>
           {rel}
         </span>
-        <span className="ml-auto shrink-0 rounded border border-border px-1 text-[9px] uppercase tracking-wide text-muted-foreground">
+        <span className="ml-auto shrink-0 rounded border border-border px-1 text-[0.5625rem] uppercase tracking-wide text-muted-foreground">
           read-only
         </span>
       </div>

--- a/frontend/src/components/settings/AppearanceSettings.tsx
+++ b/frontend/src/components/settings/AppearanceSettings.tsx
@@ -51,7 +51,7 @@ export function AppearanceSettings() {
       <SettingBlock
         icon={<ZoomIn className="size-4" />}
         title="Interface zoom"
-        description="Increases or decreases the size of everything in the app (rail, tabs…). You can also use Ctrl + / − or Ctrl + mouse wheel, even inside a terminal."
+        description="Increases or decreases the size of everything in the app (rail, tabs…). You can also use Ctrl/Cmd + / − / 0 or Ctrl + mouse wheel, even inside a terminal."
       >
         <div className="flex items-center gap-2">
           <Button

--- a/frontend/src/components/settings/AppearanceSettings.tsx
+++ b/frontend/src/components/settings/AppearanceSettings.tsx
@@ -68,7 +68,7 @@ export function AppearanceSettings() {
       <SettingBlock
         icon={<ZoomIn className="size-4" />}
         title="Interface zoom"
-        description="Scales the app's interface — rail, tabs, sidebar, footer. The terminal is not affected: its text has its own size below, so zooming never rewraps a running session. You can also use Ctrl/Cmd + / − / 0 or Ctrl + mouse wheel, even inside a terminal."
+        description="Scales the interface."
       >
         <div className="flex items-center gap-2">
           <Button
@@ -119,7 +119,7 @@ export function AppearanceSettings() {
       <SettingBlock
         icon={<CaseSensitive className="size-4" />}
         title="Terminal text size"
-        description="Size of the terminal's text, in pixels. Unlike interface zoom this does resize the grid, so a running session is told about the new width and height."
+        description="Scales the terminal."
       >
         <div className="flex items-center gap-2">
           <Button

--- a/frontend/src/components/settings/AppearanceSettings.tsx
+++ b/frontend/src/components/settings/AppearanceSettings.tsx
@@ -1,6 +1,21 @@
-import { Moon, Monitor, RotateCcw, Sun, SquareTerminal, ZoomIn, ZoomOut } from "lucide-react"
 import {
+  CaseSensitive,
+  Minus,
+  Monitor,
+  Moon,
+  Plus,
+  RotateCcw,
+  SquareTerminal,
+  Sun,
+  ZoomIn,
+  ZoomOut,
+} from "lucide-react"
+import {
+  DEFAULT_TERMINAL_FONT_SIZE,
   DEFAULT_ZOOM,
+  TERMINAL_FONT_SIZE_MAX,
+  TERMINAL_FONT_SIZE_MIN,
+  TERMINAL_FONT_SIZE_STEP,
   ZOOM_MAX,
   ZOOM_MIN,
   ZOOM_STEP,
@@ -33,6 +48,8 @@ export function AppearanceSettings() {
     setTheme,
     zoom,
     setZoom,
+    terminalFontSize,
+    setTerminalFontSize,
     terminalTheme,
     setTerminalTheme,
   } = useSettings()
@@ -51,7 +68,7 @@ export function AppearanceSettings() {
       <SettingBlock
         icon={<ZoomIn className="size-4" />}
         title="Interface zoom"
-        description="Increases or decreases the size of everything in the app (rail, tabs…). You can also use Ctrl/Cmd + / − / 0 or Ctrl + mouse wheel, even inside a terminal."
+        description="Scales the app's interface — rail, tabs, sidebar, footer. The terminal is not affected: its text has its own size below, so zooming never rewraps a running session. You can also use Ctrl/Cmd + / − / 0 or Ctrl + mouse wheel, even inside a terminal."
       >
         <div className="flex items-center gap-2">
           <Button
@@ -97,6 +114,44 @@ export function AppearanceSettings() {
           onChange={setTerminalTheme}
           options={TERMINAL_THEME_OPTIONS}
         />
+      </SettingBlock>
+
+      <SettingBlock
+        icon={<CaseSensitive className="size-4" />}
+        title="Terminal text size"
+        description="Size of the terminal's text, in pixels. Unlike interface zoom this does resize the grid, so a running session is told about the new width and height."
+      >
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label="Smaller terminal text"
+            disabled={terminalFontSize <= TERMINAL_FONT_SIZE_MIN}
+            onClick={() => setTerminalFontSize(terminalFontSize - TERMINAL_FONT_SIZE_STEP)}
+          >
+            <Minus />
+          </Button>
+          <div className="min-w-16 rounded-lg border border-border px-3 py-1.5 text-center text-sm tabular-nums text-foreground">
+            {terminalFontSize}px
+          </div>
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label="Larger terminal text"
+            disabled={terminalFontSize >= TERMINAL_FONT_SIZE_MAX}
+            onClick={() => setTerminalFontSize(terminalFontSize + TERMINAL_FONT_SIZE_STEP)}
+          >
+            <Plus />
+          </Button>
+          <Button
+            variant="ghost"
+            disabled={terminalFontSize === DEFAULT_TERMINAL_FONT_SIZE}
+            onClick={() => setTerminalFontSize(DEFAULT_TERMINAL_FONT_SIZE)}
+          >
+            <RotateCcw />
+            Reset
+          </Button>
+        </div>
       </SettingBlock>
     </>
   )

--- a/frontend/src/components/sidebar/SessionStatusIcon.tsx
+++ b/frontend/src/components/sidebar/SessionStatusIcon.tsx
@@ -22,9 +22,9 @@ interface SessionStatusIconProps {
 // slot is a fixed size so the icon never shifts as the state changes.
 export function SessionStatusIcon({kind, status}: SessionStatusIconProps) {
   return (
-    <span className="relative flex size-[22px] shrink-0 items-center justify-center text-muted-foreground">
+    <span className="relative flex size-[1.375rem] shrink-0 items-center justify-center text-muted-foreground">
       {status && (
-        <span className={cn("absolute inset-0 rounded-full border-[1.5px]", RING[status])} />
+        <span className={cn("absolute inset-0 rounded-full border-[0.09375rem]", RING[status])} />
       )}
       <ProviderIcon kind={kind} size={14} />
     </span>

--- a/frontend/src/components/sidebar/WorktreeDialog.tsx
+++ b/frontend/src/components/sidebar/WorktreeDialog.tsx
@@ -202,7 +202,7 @@ export function WorktreeDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* Fixed-height dialog: the base-branch section takes the leftover row
         (minmax(0,1fr)) so its list scrolls instead of growing the modal. */}
-      <DialogContent className="h-[85vh] grid-rows-[auto_auto_minmax(0,1fr)_auto_auto] sm:max-w-2xl">
+      <DialogContent className="h-[calc(85*var(--app-vh))] grid-rows-[auto_auto_minmax(0,1fr)_auto_auto] sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>New worktree</DialogTitle>
           <DialogDescription>

--- a/frontend/src/components/sidebar/WorktreeDialog.tsx
+++ b/frontend/src/components/sidebar/WorktreeDialog.tsx
@@ -66,7 +66,7 @@ function BranchGroup({title, count, open, onToggle, children}: BranchGroupProps)
         type="button"
         aria-expanded={open}
         onClick={onToggle}
-        className="sticky top-0 z-10 flex w-full items-center gap-1.5 border-y border-border bg-muted px-2.5 py-1.5 text-[10px] font-semibold tracking-wider text-muted-foreground uppercase outline-none first:border-t-0 hover:text-foreground"
+        className="sticky top-0 z-10 flex w-full items-center gap-1.5 border-y border-border bg-muted px-2.5 py-1.5 text-[0.625rem] font-semibold tracking-wider text-muted-foreground uppercase outline-none first:border-t-0 hover:text-foreground"
       >
         <ChevronRight className={cn("size-3 transition-transform", open && "rotate-90")}/>
         {title}
@@ -202,7 +202,7 @@ export function WorktreeDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* Fixed-height dialog: the base-branch section takes the leftover row
         (minmax(0,1fr)) so its list scrolls instead of growing the modal. */}
-      <DialogContent className="h-[calc(85*var(--app-vh))] grid-rows-[auto_auto_minmax(0,1fr)_auto_auto] sm:max-w-2xl">
+      <DialogContent className="h-[85vh] grid-rows-[auto_auto_minmax(0,1fr)_auto_auto] sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>New worktree</DialogTitle>
           <DialogDescription>

--- a/frontend/src/components/tabs/NotificationsButton.tsx
+++ b/frontend/src/components/tabs/NotificationsButton.tsx
@@ -61,7 +61,7 @@ export function NotificationsButton() {
         {items.length > 0 && (
           <span
             aria-label={`${items.length} pending`}
-            className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-medium leading-none text-primary-foreground"
+            className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[0.625rem] font-medium leading-none text-primary-foreground"
           >
             {items.length}
           </span>

--- a/frontend/src/components/ui/dropdown-menu.tsx
+++ b/frontend/src/components/ui/dropdown-menu.tsx
@@ -135,7 +135,7 @@ function DropdownMenuSubContent({
   return (
     <DropdownMenuContent
       data-slot="dropdown-menu-sub-content"
-      className={cn("w-auto min-w-[96px] rounded-md bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      className={cn("w-auto min-w-[6rem] rounded-md bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
       align={align}
       alignOffset={alignOffset}
       side={side}

--- a/frontend/src/components/ui/switch.tsx
+++ b/frontend/src/components/ui/switch.tsx
@@ -14,7 +14,7 @@ function Switch({
       data-slot="switch"
       data-size={size}
       className={cn(
-        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[18.4px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 data-[size=default]:h-[1.15rem] data-[size=default]:w-[2rem] data-[size=sm]:h-[0.875rem] data-[size=sm]:w-[1.5rem] dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:bg-primary data-unchecked:bg-input dark:data-unchecked:bg-input/80 data-disabled:cursor-not-allowed data-disabled:opacity-50",
         className
       )}
       {...props}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -22,7 +22,7 @@ function Tabs({
 }
 
 const tabsListVariants = cva(
-  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-9 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[0.1875rem] text-muted-foreground group-data-horizontal/tabs:h-9 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
   {
     variants: {
       variant: {
@@ -56,7 +56,7 @@ function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
     <TabsPrimitive.Tab
       data-slot="tabs-trigger"
       className={cn(
-        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[0.1875rem] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
         "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
         "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -54,7 +54,7 @@ function TooltipContent({
           {...props}
         >
           {children}
-          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-inherit fill-inherit data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
+          <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[0.125rem] bg-inherit fill-inherit data-[side=bottom]:top-1 data-[side=inline-end]:top-1/2! data-[side=inline-end]:-left-1 data-[side=inline-end]:-translate-y-1/2 data-[side=inline-start]:top-1/2! data-[side=inline-start]:-right-1 data-[side=inline-start]:-translate-y-1/2 data-[side=left]:top-1/2! data-[side=left]:-right-1 data-[side=left]:-translate-y-1/2 data-[side=right]:top-1/2! data-[side=right]:-left-1 data-[side=right]:-translate-y-1/2 data-[side=top]:-bottom-2.5" />
         </TooltipPrimitive.Popup>
       </TooltipPrimitive.Positioner>
     </TooltipPrimitive.Portal>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -241,3 +241,24 @@ html,
 body {
   overflow: hidden;
 }
+
+/* The app root is sized against the viewport divided by the zoom factor
+   (--app-zoom, set alongside documentElement.style.zoom in settings.tsx).
+   CSS `zoom` scales rendered boxes but leaves vh/vw as physical viewport units,
+   so a plain 100vh/100vw root ends up at viewport × zoom: it falls short of the
+   window when zoomed out and overflows — cut, not scrolled, by the rule above —
+   when zoomed in. Dividing first cancels the zoom back to exactly one window.
+   Children take their size from #root (h-full), never from vh/vw. */
+#root {
+  width: calc(100vw / var(--app-zoom, 1));
+  height: calc(100vh / var(--app-zoom, 1));
+}
+
+/* One viewport-height unit corrected for the zoom, for the overlays that size
+   themselves against the window instead of against #root (dialogs, the command
+   palette). Reach for this instead of vh anywhere inside the app:
+   `max-h-[calc(70*var(--app-vh))]` reads as 70vh and stays 70% of the window at
+   any zoom, where a bare 70vh would be 70% × zoom. */
+:root {
+  --app-vh: calc(1vh / var(--app-zoom, 1));
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -242,23 +242,3 @@ body {
   overflow: hidden;
 }
 
-/* The app root is sized against the viewport divided by the zoom factor
-   (--app-zoom, set alongside documentElement.style.zoom in settings.tsx).
-   CSS `zoom` scales rendered boxes but leaves vh/vw as physical viewport units,
-   so a plain 100vh/100vw root ends up at viewport × zoom: it falls short of the
-   window when zoomed out and overflows — cut, not scrolled, by the rule above —
-   when zoomed in. Dividing first cancels the zoom back to exactly one window.
-   Children take their size from #root (h-full), never from vh/vw. */
-#root {
-  width: calc(100vw / var(--app-zoom, 1));
-  height: calc(100vh / var(--app-zoom, 1));
-}
-
-/* One viewport-height unit corrected for the zoom, for the overlays that size
-   themselves against the window instead of against #root (dialogs, the command
-   palette). Reach for this instead of vh anywhere inside the app:
-   `max-h-[calc(70*var(--app-vh))]` reads as 70vh and stays 70% of the window at
-   any zoom, where a bare 70vh would be 70% × zoom. */
-:root {
-  --app-vh: calc(1vh / var(--app-zoom, 1));
-}

--- a/frontend/src/lib/hotkeys.test.ts
+++ b/frontend/src/lib/hotkeys.test.ts
@@ -27,8 +27,9 @@ describe("matchesCombo", () => {
     expect(matchesCombo(key({ metaKey: true, shiftKey: true, key: "T" }), newSession)).toBe(true)
   })
 
-  it("folds = into + so unshifted zoom-in matches", () => {
-    expect(matchesCombo(key({ ctrlKey: true, key: "=" }), DEFAULT_HOTKEYS.zoomIn)).toBe(true)
+  it("folds = into + so a combo recorded as + matches the unshifted key", () => {
+    const plus: Combo = { mod: true, shift: false, alt: false, key: "+" }
+    expect(matchesCombo(key({ ctrlKey: true, key: "=" }), plus)).toBe(true)
   })
 
   it("rejects when a modifier differs", () => {
@@ -86,7 +87,12 @@ describe("mergeHotkeys", () => {
   it("layers a valid override over the defaults", () => {
     const override = { newSession: { mod: true, shift: false, alt: true, key: "n" } }
     expect(mergeHotkeys(override).newSession).toEqual(override.newSession)
-    expect(mergeHotkeys(override).zoomIn).toEqual(DEFAULT_HOTKEYS.zoomIn)
+    expect(mergeHotkeys(override).commandPalette).toEqual(DEFAULT_HOTKEYS.commandPalette)
+  })
+
+  it("ignores ids that are no longer actions (the old zoom hotkeys)", () => {
+    expect(mergeHotkeys({ zoomIn: { mod: true, shift: false, alt: false, key: "+" } }))
+      .toEqual(DEFAULT_HOTKEYS)
   })
 
   it("drops malformed entries and non-objects", () => {
@@ -98,7 +104,7 @@ describe("mergeHotkeys", () => {
 
 describe("sameCombo", () => {
   it("compares every field", () => {
-    expect(sameCombo(DEFAULT_HOTKEYS.zoomIn, DEFAULT_HOTKEYS.zoomIn)).toBe(true)
-    expect(sameCombo(DEFAULT_HOTKEYS.zoomIn, DEFAULT_HOTKEYS.zoomOut)).toBe(false)
+    expect(sameCombo(DEFAULT_HOTKEYS.newSession, DEFAULT_HOTKEYS.newSession)).toBe(true)
+    expect(sameCombo(DEFAULT_HOTKEYS.newSession, DEFAULT_HOTKEYS.commandPalette)).toBe(false)
   })
 })

--- a/frontend/src/lib/hotkeys.ts
+++ b/frontend/src/lib/hotkeys.ts
@@ -3,12 +3,12 @@
 // platform primary modifier — Ctrl on Windows/Linux, Cmd on macOS — so a single
 // stored combo works on both.
 
+// Zoom is deliberately absent: those chords shadow Chromium's own accelerators,
+// which are bound to physical keys, so they are matched on event.code in
+// zoom-keys.ts instead of being character combos a user can rebind.
 export type HotkeyId =
   | "commandPalette"
   | "newSession"
-  | "zoomIn"
-  | "zoomOut"
-  | "zoomReset"
 
 export interface Combo {
   mod: boolean
@@ -27,9 +27,6 @@ export interface HotkeyAction {
 export const HOTKEY_ACTIONS: readonly HotkeyAction[] = [
   { id: "commandPalette", label: "Command palette", combo: { mod: true, shift: false, alt: false, key: "k" } },
   { id: "newSession", label: "New session", combo: { mod: true, shift: true, alt: false, key: "t" } },
-  { id: "zoomIn", label: "Zoom in", combo: { mod: true, shift: false, alt: false, key: "+" } },
-  { id: "zoomOut", label: "Zoom out", combo: { mod: true, shift: false, alt: false, key: "-" } },
-  { id: "zoomReset", label: "Reset zoom", combo: { mod: true, shift: false, alt: false, key: "0" } },
 ]
 
 export type Hotkeys = Record<HotkeyId, Combo>
@@ -49,6 +46,9 @@ const STORAGE_KEY = "lich.hotkeys"
 
 // normalizeKey folds "=" into "+" (same physical key) and lowercases single
 // characters so casing from Shift does not change the identity of the combo.
+// Folding a character pair like this is a patch over event.key being layout- and
+// Shift-dependent; it is kept because combos recorded before are persisted with
+// "+", but the real answer for a physical key is event.code (see zoom-keys.ts).
 function normalizeKey(key: string): string {
   if (key === "=") return "+"
   return key.length === 1 ? key.toLowerCase() : key

--- a/frontend/src/lib/settings-clamp.test.ts
+++ b/frontend/src/lib/settings-clamp.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import {
+  clampTerminalFontSize,
+  clampZoom,
+  DEFAULT_TERMINAL_FONT_SIZE,
+  DEFAULT_ZOOM,
+  TERMINAL_FONT_SIZE_MAX,
+  TERMINAL_FONT_SIZE_MIN,
+  ZOOM_MAX,
+  ZOOM_MIN,
+} from "./settings"
+
+describe("clampZoom", () => {
+  it("keeps a value inside the range", () => {
+    expect(clampZoom(DEFAULT_ZOOM)).toBe(DEFAULT_ZOOM)
+    expect(clampZoom(1.3)).toBe(1.3)
+  })
+
+  it("bounds both ends", () => {
+    expect(clampZoom(ZOOM_MIN - 1)).toBe(ZOOM_MIN)
+    expect(clampZoom(ZOOM_MAX + 1)).toBe(ZOOM_MAX)
+  })
+
+  // Repeated ±0.1 steps otherwise drift into 0.7000000000000001 and show as a
+  // wrong percentage.
+  it("snaps to one decimal so stepping does not drift", () => {
+    expect(clampZoom(0.1 + 0.2 + 0.4)).toBe(0.7)
+    expect(clampZoom(1.2000000000000002)).toBe(1.2)
+  })
+})
+
+describe("clampTerminalFontSize", () => {
+  it("keeps a value inside the range", () => {
+    expect(clampTerminalFontSize(DEFAULT_TERMINAL_FONT_SIZE)).toBe(DEFAULT_TERMINAL_FONT_SIZE)
+    expect(clampTerminalFontSize(20)).toBe(20)
+  })
+
+  it("bounds both ends", () => {
+    expect(clampTerminalFontSize(TERMINAL_FONT_SIZE_MIN - 5)).toBe(TERMINAL_FONT_SIZE_MIN)
+    expect(clampTerminalFontSize(TERMINAL_FONT_SIZE_MAX + 5)).toBe(TERMINAL_FONT_SIZE_MAX)
+  })
+
+  // xterm takes a number, and a fractional cell size makes the grid maths
+  // land between pixels — keep it whole.
+  it("rounds to a whole pixel", () => {
+    expect(clampTerminalFontSize(14.4)).toBe(14)
+    expect(clampTerminalFontSize(14.6)).toBe(15)
+  })
+})

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -10,12 +10,12 @@ import {
   DEFAULT_HOTKEYS,
   isRecordingTarget,
   loadHotkeys,
-  matchesCombo,
   saveHotkeys,
   type Combo,
   type HotkeyId,
   type Hotkeys,
 } from "./hotkeys"
+import { zoomIntent } from "./zoom-keys"
 
 const FONT_STORAGE_KEY = "lich.terminal.font"
 const THEME_STORAGE_KEY = "lich.appearance.theme"
@@ -177,24 +177,23 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   // Zoom via keyboard chords or Ctrl/Cmd + mouse wheel. Both listen on the
   // capture phase so they win even inside a terminal, which otherwise swallows
   // modifier chords and wheel events; propagation is stopped so the PTY never
-  // sees them. The wheel listener is non-passive to allow preventDefault, and
-  // bails on non-Ctrl scrolls so normal scrolling still works.
+  // sees them. Both also preventDefault, which is what keeps Chromium's own
+  // zoom accelerator from running on top of this one — miss that on any single
+  // chord and the app and the browser each apply a zoom (see zoom-keys.ts).
+  // The wheel listener is non-passive to allow preventDefault, and bails on
+  // non-Ctrl scrolls so normal scrolling still works.
   useEffect(() => {
     const onKey = (event: KeyboardEvent) => {
       if (isRecordingTarget(event)) return
-      if (matchesCombo(event, hotkeys.zoomIn)) {
-        event.preventDefault()
-        event.stopPropagation()
-        zoomBy(ZOOM_STEP)
-      } else if (matchesCombo(event, hotkeys.zoomOut)) {
-        event.preventDefault()
-        event.stopPropagation()
-        zoomBy(-ZOOM_STEP)
-      } else if (matchesCombo(event, hotkeys.zoomReset)) {
-        event.preventDefault()
-        event.stopPropagation()
+      const intent = zoomIntent(event)
+      if (!intent) return
+      event.preventDefault()
+      event.stopPropagation()
+      if (intent === "reset") {
         setZoom(DEFAULT_ZOOM)
+        return
       }
+      zoomBy(intent === "in" ? ZOOM_STEP : -ZOOM_STEP)
     }
     const onWheel = (event: WheelEvent) => {
       if (!event.ctrlKey) return
@@ -208,7 +207,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       window.removeEventListener("keydown", onKey, true)
       window.removeEventListener("wheel", onWheel, true)
     }
-  }, [zoomBy, setZoom, hotkeys])
+  }, [zoomBy, setZoom])
 
   const resolvedTerminalTheme: ResolvedTheme =
     terminalTheme === "match" ? resolvedTheme : terminalTheme

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -18,6 +18,7 @@ import {
 import { zoomIntent } from "./zoom-keys"
 
 const FONT_STORAGE_KEY = "lich.terminal.font"
+const TERMINAL_FONT_SIZE_STORAGE_KEY = "lich.terminal.fontSize"
 const THEME_STORAGE_KEY = "lich.appearance.theme"
 const ZOOM_STORAGE_KEY = "lich.appearance.zoom"
 const TERMINAL_THEME_STORAGE_KEY = "lich.appearance.terminalTheme"
@@ -52,6 +53,30 @@ export function clampZoom(value: number): number {
   return Math.round(bounded * 10) / 10
 }
 
+// Terminal text size, in absolute px. It is deliberately not part of the app
+// zoom: zoom rescales the chrome in rem, and the terminal stays out of it so a
+// zoom step never changes the PTY's cols×rows and never rewraps a running TUI.
+// Changing this one does resize the grid — that is the point of it.
+export const TERMINAL_FONT_SIZE_MIN = 8
+export const TERMINAL_FONT_SIZE_MAX = 32
+export const TERMINAL_FONT_SIZE_STEP = 1
+export const DEFAULT_TERMINAL_FONT_SIZE = 14
+
+export function clampTerminalFontSize(value: number): number {
+  const bounded = Math.min(
+    TERMINAL_FONT_SIZE_MAX,
+    Math.max(TERMINAL_FONT_SIZE_MIN, value),
+  )
+  return Math.round(bounded)
+}
+
+function readTerminalFontSize(): number {
+  const stored = Number(localStorage.getItem(TERMINAL_FONT_SIZE_STORAGE_KEY))
+  return Number.isFinite(stored) && stored > 0
+    ? clampTerminalFontSize(stored)
+    : DEFAULT_TERMINAL_FONT_SIZE
+}
+
 function readTheme(): Theme {
   const stored = localStorage.getItem(THEME_STORAGE_KEY)
   return THEMES.includes(stored as Theme) ? (stored as Theme) : DEFAULT_THEME
@@ -73,6 +98,9 @@ interface SettingsValue {
   /** Terminal font family, applied globally across all project terminals. */
   font: string
   setFont: (font: string) => void
+  /** Terminal text size in px. Independent of `zoom` — see the constants. */
+  terminalFontSize: number
+  setTerminalFontSize: (size: number) => void
   /** Color theme applied to the whole app via the `.dark` class on <html>. */
   theme: Theme
   setTheme: (theme: Theme) => void
@@ -98,6 +126,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [font, setFontState] = useState<string>(
     () => localStorage.getItem(FONT_STORAGE_KEY) ?? DEFAULT_FONT,
   )
+  const [terminalFontSize, setTerminalFontSizeState] =
+    useState<number>(readTerminalFontSize)
   const [theme, setThemeState] = useState<Theme>(readTheme)
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>("light")
   const [zoom, setZoomState] = useState<number>(readZoom)
@@ -108,6 +138,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const setFont = useCallback((next: string) => {
     setFontState(next)
     localStorage.setItem(FONT_STORAGE_KEY, next)
+  }, [])
+
+  const setTerminalFontSize = useCallback((next: number) => {
+    const clamped = clampTerminalFontSize(next)
+    setTerminalFontSizeState(clamped)
+    localStorage.setItem(TERMINAL_FONT_SIZE_STORAGE_KEY, String(clamped))
   }, [])
 
   const setTheme = useCallback((next: Theme) => {
@@ -167,17 +203,24 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     return () => media.removeEventListener("change", apply)
   }, [theme])
 
-  // Scale the whole app. `zoom` reflows layout (unlike transform: scale). It
-  // also scales the terminal canvas (slightly soft off 100%); a chrome-only
-  // wrapper excluding TerminalHost would avoid that if it becomes an issue.
+  // Scale the app by moving the root font size: every Tailwind spacing and type
+  // utility resolves in rem (--spacing is 0.25rem, --text-* are rem), so one
+  // percentage rescales the whole chrome and reflows it honestly.
   //
-  // --app-zoom carries the same factor to CSS, where #root divides the viewport
-  // by it: `zoom` does not scale vh/vw, so an unadjusted 100vh/100vw root renders
-  // at viewport × zoom — short of the window when zoomed out, overflowing (and
-  // silently cut by the page's overflow:hidden) when zoomed in. See index.css.
+  // A percentage, not a px value, so a user who raised Chromium's default font
+  // size keeps that as their 100%.
+  //
+  // This deliberately replaces CSS `zoom` on the root, which had two flaws:
+  // `zoom` does not scale vh/vw, so the 100vh/100vw root rendered at viewport ×
+  // zoom (window left showing through when zoomed out, layout cut by the page's
+  // overflow:hidden when zoomed in); and it scaled the terminal along with
+  // everything else, which — once the root filled the window — handed the
+  // terminal more CSS pixels and reflowed the PTY to a different cols×rows on
+  // every zoom step, wrapping whatever TUI was running. The terminal sizes its
+  // text in absolute px (TerminalView's fontSize), so rem scaling leaves it
+  // untouched by construction; its size is its own setting.
   useEffect(() => {
-    document.documentElement.style.zoom = String(zoom)
-    document.documentElement.style.setProperty("--app-zoom", String(zoom))
+    document.documentElement.style.fontSize = `${zoom * 100}%`
   }, [zoom])
 
   // Zoom via keyboard chords or Ctrl/Cmd + mouse wheel. Both listen on the
@@ -223,6 +266,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       value={{
         font,
         setFont,
+        terminalFontSize,
+        setTerminalFontSize,
         theme,
         setTheme,
         resolvedTheme,

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -170,8 +170,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   // Scale the whole app. `zoom` reflows layout (unlike transform: scale). It
   // also scales the terminal canvas (slightly soft off 100%); a chrome-only
   // wrapper excluding TerminalHost would avoid that if it becomes an issue.
+  //
+  // --app-zoom carries the same factor to CSS, where #root divides the viewport
+  // by it: `zoom` does not scale vh/vw, so an unadjusted 100vh/100vw root renders
+  // at viewport × zoom — short of the window when zoomed out, overflowing (and
+  // silently cut by the page's overflow:hidden) when zoomed in. See index.css.
   useEffect(() => {
     document.documentElement.style.zoom = String(zoom)
+    document.documentElement.style.setProperty("--app-zoom", String(zoom))
   }, [zoom])
 
   // Zoom via keyboard chords or Ctrl/Cmd + mouse wheel. Both listen on the

--- a/frontend/src/lib/zoom-keys.test.ts
+++ b/frontend/src/lib/zoom-keys.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+import { zoomIntent, type ZoomKeyState } from "./zoom-keys"
+
+const press = (over: Partial<ZoomKeyState>): ZoomKeyState => ({
+  ctrlKey: false,
+  metaKey: false,
+  shiftKey: false,
+  altKey: false,
+  code: "",
+  ...over,
+})
+
+describe("zoomIntent", () => {
+  // The regression this whole module exists for: "Ctrl +" is physically
+  // Ctrl+Shift+Equal on US and ABNT2 alike. Matching on the character made this
+  // press miss, so Chromium's accelerator zoomed on top of the app's own zoom.
+  it("reads Ctrl+Shift+Equal — the '+' a real keyboard types — as zoom in", () => {
+    expect(zoomIntent(press({ ctrlKey: true, shiftKey: true, code: "Equal" }))).toBe("in")
+  })
+
+  it("reads unshifted Ctrl+Equal as zoom in too", () => {
+    expect(zoomIntent(press({ ctrlKey: true, code: "Equal" }))).toBe("in")
+  })
+
+  it("reads Ctrl+Minus and Ctrl+Digit0", () => {
+    expect(zoomIntent(press({ ctrlKey: true, code: "Minus" }))).toBe("out")
+    expect(zoomIntent(press({ ctrlKey: true, code: "Digit0" }))).toBe("reset")
+  })
+
+  it("covers the numpad, where no layout needs Shift", () => {
+    expect(zoomIntent(press({ ctrlKey: true, code: "NumpadAdd" }))).toBe("in")
+    expect(zoomIntent(press({ ctrlKey: true, code: "NumpadSubtract" }))).toBe("out")
+    expect(zoomIntent(press({ ctrlKey: true, code: "Numpad0" }))).toBe("reset")
+  })
+
+  it("accepts Cmd as the primary modifier", () => {
+    expect(zoomIntent(press({ metaKey: true, code: "Minus" }))).toBe("out")
+  })
+
+  it("ignores the chord without a primary modifier", () => {
+    expect(zoomIntent(press({ code: "Equal" }))).toBeNull()
+    expect(zoomIntent(press({ shiftKey: true, code: "Equal" }))).toBeNull()
+  })
+
+  it("ignores Alt so Alt chords still reach the PTY", () => {
+    expect(zoomIntent(press({ ctrlKey: true, altKey: true, code: "Minus" }))).toBeNull()
+  })
+
+  // Shift is what types "+", so it is only meaningful on Equal. Claiming
+  // Ctrl+Shift+Minus / Ctrl+Shift+0 too would steal chords from the PTY for
+  // nothing.
+  it("does not claim shifted chords other than Equal", () => {
+    expect(zoomIntent(press({ ctrlKey: true, shiftKey: true, code: "Minus" }))).toBeNull()
+    expect(zoomIntent(press({ ctrlKey: true, shiftKey: true, code: "Digit0" }))).toBeNull()
+    expect(zoomIntent(press({ ctrlKey: true, shiftKey: true, code: "NumpadAdd" }))).toBeNull()
+  })
+
+  it("ignores unrelated keys", () => {
+    expect(zoomIntent(press({ ctrlKey: true, code: "KeyK" }))).toBeNull()
+    expect(zoomIntent(press({ ctrlKey: true, code: "Digit1" }))).toBeNull()
+  })
+})

--- a/frontend/src/lib/zoom-keys.ts
+++ b/frontend/src/lib/zoom-keys.ts
@@ -1,0 +1,46 @@
+// Zoom chords are matched on event.code — the physical key — not event.key.
+//
+// event.key carries the *character* the layout produces, and on every common
+// layout (US, ABNT2, …) "+" is Shift+"=". A combo written as {shift: false,
+// key: "+"} is therefore unsatisfiable: pressing what a user calls "Ctrl +"
+// arrives as Ctrl+Shift+"=", the match fails, nothing calls preventDefault, and
+// Chromium's own zoom accelerator runs instead. That is how the app ended up
+// with two zooms at once — the app's for Ctrl+"−", Chromium's for Ctrl+"+".
+//
+// event.code is the same on every layout, so one table covers all of them.
+// These deliberately are not user-configurable hotkeys: the whole point is to
+// shadow the browser accelerators, and an accelerator is bound to a physical
+// key, not to a character.
+
+export type ZoomIntent = "in" | "out" | "reset"
+
+// The subset of KeyboardEvent the matcher needs — lets tests pass plain
+// objects, same shape trick as hotkeys.ts and term-keys.ts.
+export type ZoomKeyState = Pick<
+  KeyboardEvent,
+  "ctrlKey" | "metaKey" | "shiftKey" | "altKey" | "code"
+>
+
+const ZOOM_CODES: Record<string, ZoomIntent> = {
+  Equal: "in",
+  NumpadAdd: "in",
+  Minus: "out",
+  NumpadSubtract: "out",
+  Digit0: "reset",
+  Numpad0: "reset",
+}
+
+// Shift is only accepted on Equal, because there it is what types the "+".
+// Everywhere else it would just steal another chord (Ctrl+Shift+−, Ctrl+Shift+0)
+// from the PTY for no gain.
+const SHIFTABLE_CODE = "Equal"
+
+// zoomIntent reports which zoom a keypress asks for, or null when it is not a
+// zoom chord. The caller is expected to preventDefault so Chromium does not
+// zoom on top of the app.
+export function zoomIntent(event: ZoomKeyState): ZoomIntent | null {
+  if (!(event.ctrlKey || event.metaKey)) return null
+  if (event.altKey) return null
+  if (event.shiftKey && event.code !== SHIFTABLE_CODE) return null
+  return ZOOM_CODES[event.code] ?? null
+}


### PR DESCRIPTION
## Summary

Zoom was broken in three separate ways. This fixes all three and gives the terminal its own text size, so a zoom step never rewraps a running session.

Supersedes #67, which found the same symptom from a different angle — see the discussion there for why that approach could not ship.

## The three bugs

**1. Zoom in escaped to Chromium while zoom out scaled the app.**

The shortcut was declared as the character `"+"` with Shift explicitly off:

```ts
{ id: "zoomIn", combo: { mod: true, shift: false, alt: false, key: "+" } }
```

No keyboard can produce that. On US, ABNT2 and every other common layout, `+` *is* `Shift`+`=`, so pressing what a user calls <kbd>Ctrl</kbd>+<kbd>+</kbd> arrived as `Ctrl+Shift+"="`, `matchesCombo` rejected it, nothing called `preventDefault()`, and Chromium ran its own zoom accelerator. Zoom out (<kbd>Ctrl</kbd>+<kbd>-</kbd>, no Shift needed) matched and scaled the app instead. Two zooms, compounding, disagreeing with each other and with the Appearance buttons.

Zoom chords now match on `event.code` — the physical key, identical on every layout — in a new `zoom-keys.ts`. Numpad included. Shift is accepted only on `Equal`, where it is what types the `+`; claiming `Ctrl+Shift+-` and `Ctrl+Shift+0` too would steal chords from the PTY for nothing.

For the same reason zoom stops being a rebindable hotkey: an accelerator is bound to a physical key, and a character combo cannot express one. That mismatch *was* the bug. Every other hotkey stays configurable.

**2. Zooming left the window part-empty, or cut the layout off.**

CSS `zoom` scales rendered boxes but leaves `vh`/`vw` as physical viewport units, so the `h-screen w-screen` root rendered at viewport × zoom: short of the window when zoomed out, overflowing when zoomed in — and `html, body { overflow: hidden }` cut the overflow rather than scrolling it. Present since zoom was introduced in 7058ba8, visible only in one direction until bug 1 was fixed.

**3. Zooming reflowed the PTY and rewrapped whatever was running.**

Once the root filled the window, every zoom-out step handed the terminal more CSS pixels, the grid refit, and the PTY was resized. Measured in a real window: 100% was `205x54`, 80% was `264x68`. Any TUI rewrapped and its scrollback kept the old wrap.

Bugs 2 and 3 have the same fix: **zoom moves the root font size instead of applying CSS `zoom`.** Every Tailwind spacing and type utility resolves in rem (`--spacing` is `0.25rem`, `--text-*` are rem), so one percentage rescales the whole chrome — and the terminal, which sizes its text in absolute px, is left out *by construction* rather than by a special case. A percentage rather than a px value, so a user who raised Chromium's default font size keeps that as their 100%. Absolute px in arbitrary utilities became rem so they scale along with everything else.

With no CSS `zoom`, `100vh` means `100vh` again — no viewport compensation needed anywhere.

## Terminal text size

New setting, 8–32px, persisted, with `−` / `+` / `Reset` in Appearance. This one *does* refit the grid and resize the PTY — it is the control whose job is to change how much fits on screen. Interface zoom no longer touches it.

## Test plan

- `zoom-keys.test.ts`: 10 cases, happy and bad path — the shifted `Equal` regression, the numpad, Cmd as primary modifier, and the chords deliberately left to the PTY.
- `settings-clamp.test.ts`: bounds and rounding for both clamps (`clampZoom` had no test before).
- `hotkeys.test.ts`: updated for the removed ids, plus a case asserting a persisted `zoomIn` override is ignored rather than resurrected.
- Full gate green: `gofmt`, `go vet`, `go test ./...` (296), `pnpm test` (321), `tsc`, `pnpm build`.

Checked by hand in a real window: zoom scales the chrome with no black band and no clipping, `stty size` holds steady across zoom steps, and changing terminal text size moves it and redraws the running session.