### PR TITLE
ci: bump actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,20 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           package_json_file: frontend/package.json
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,16 +9,6 @@ on:
 permissions:
   contents: write
 
-# setup-go v7 exports GOTOOLCHAIN=local, which pins every go command to the
-# toolchain go.mod asks for and refuses to fetch another. The build steps below
-# `go install ...@latest` for task and nfpm, and those pull whatever is newest —
-# task 3.52 already requires a newer Go than our go.mod line — so `local` fails
-# the install outright. `auto` is what the older setup-go left in place: fetch a
-# newer toolchain when a tool demands one. Pinning the tool versions instead
-# would fix this at the root, but that is a policy change, not a runtime bump.
-env:
-  GOTOOLCHAIN: auto
-
 jobs:
   # linux and windows build in parallel; release fans in and publishes.
   linux:
@@ -48,7 +38,15 @@ jobs:
 
       # The binary is pure Go (CGO_ENABLED=0) — no C toolchain, no system
       # libraries. Packaging needs nfpm only.
+      #
+      # GOTOOLCHAIN=auto only here: setup-go exports `local`, which is right for
+      # building lich (it holds every go command to the go.mod line) but breaks
+      # installing these tools, since `@latest` resolves to releases that ask for
+      # a newer Go than we declare. Scoped to the step because setup-go writes
+      # `local` through GITHUB_ENV, which outranks a workflow-level env.
       - name: Install task and nfpm
+        env:
+          GOTOOLCHAIN: auto
         run: |
           go install github.com/go-task/task/v3/cmd/task@latest
           go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
@@ -119,7 +117,10 @@ jobs:
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
 
+      # GOTOOLCHAIN=auto for the tool install only — see the linux job.
       - name: Install task and Inno Setup
+        env:
+          GOTOOLCHAIN: auto
         run: |
           go install github.com/go-task/task/v3/cmd/task@latest
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
@@ -174,7 +175,10 @@ jobs:
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
 
+      # GOTOOLCHAIN=auto for the tool install only — see the linux job.
       - name: Install task
+        env:
+          GOTOOLCHAIN: auto
         run: |
           go install github.com/go-task/task/v3/cmd/task@latest
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,16 @@ on:
 permissions:
   contents: write
 
+# setup-go v7 exports GOTOOLCHAIN=local, which pins every go command to the
+# toolchain go.mod asks for and refuses to fetch another. The build steps below
+# `go install ...@latest` for task and nfpm, and those pull whatever is newest —
+# task 3.52 already requires a newer Go than our go.mod line — so `local` fails
+# the install outright. `auto` is what the older setup-go left in place: fetch a
+# newer toolchain when a tool demands one. Pinning the tool versions instead
+# would fix this at the root, but that is a policy change, not a runtime bump.
+env:
+  GOTOOLCHAIN: auto
+
 jobs:
   # linux and windows build in parallel; release fans in and publishes.
   linux:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,23 +14,23 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # git describe needs the tag history for the package version.
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           package_json_file: frontend/package.json
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -76,7 +76,7 @@ jobs:
           ls -la lich-${tag}-*
 
       - name: Upload Linux assets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lich-linux
           path: bin/lich-*
@@ -88,22 +88,22 @@ jobs:
         # bash (git-bash) keeps the steps byte-identical to the linux job's.
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           package_json_file: frontend/package.json
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -135,7 +135,7 @@ jobs:
           ls -la lich-${tag}-*
 
       - name: Upload Windows assets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lich-windows
           path: bin/lich-*
@@ -143,22 +143,22 @@ jobs:
   mac:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: go.mod
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           package_json_file: frontend/package.json
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 22
           cache: pnpm
@@ -193,7 +193,7 @@ jobs:
           ls -la lich-${tag}-*
 
       - name: Upload macOS assets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: lich-macos
           path: bin/lich-*
@@ -204,10 +204,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checkout only for CHANGELOG.md — the notes come from it.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Download build assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: bin
           merge-multiple: true
@@ -248,7 +248,7 @@ jobs:
     needs: [release]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Render PKGBUILD
         run: |


### PR DESCRIPTION
## Summary

Every CI and release run was annotating that six actions target Node 20 and were being forced onto Node 24. That fallback is temporary — when GitHub removes it, a release stops building. This moves all of them to majors that run on `node24` natively.

| action | before | after |
|---|---|---|
| `actions/checkout` | v4 | v7 |
| `actions/setup-go` | v5 | v7 |
| `actions/setup-node` | v4 | v7 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `pnpm/action-setup` | v4 | v6 |

`KSXGitHub/github-actions-deploy-aur` stays at v4.2.0 — current release, and it does not run on Node.

## Compatibility

Checked every input this repo actually passes against the new majors' `action.yml`, since a major bump is where inputs get dropped:

- `checkout`: `fetch-depth` ✅
- `setup-go`: `go-version-file` ✅
- `setup-node`: `node-version`, `cache`, `cache-dependency-path` ✅
- `pnpm/action-setup`: `package_json_file` ✅
- `upload-artifact`: `name`, `path` ✅
- `download-artifact`: `path`, `merge-multiple` ✅ — this is the one that matters, it is what fans the three build jobs into `release`

The artifact pair gained knobs that could have changed behaviour silently, and both default to what v4 did: `upload`'s `archive` defaults to `true`, `download`'s `skip-decompress` to `false`.

## Test plan

`ci.yml` runs on this PR, but it only covers the backend and frontend gates — it never exercises the release pipeline, which is where the artifact fan-in lives and where a bad bump would actually bite. So the release workflow was also dispatched from this branch, which builds and uploads everything without publishing (per the release checklist in CLAUDE.md).