### PR TITLE
fix: close six review findings across updater, terminal, store and hotkeys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The self-update download no longer dies on a normal connection.** The
+  binary download shared the 5-second timeout meant for small metadata reads,
+  and that timeout covers the whole transfer — so on anything but a very fast
+  link the download was cut mid-stream and self-apply (Windows/macOS) failed
+  every time. The download now gets its own generous ceiling.
+- **A renamed worktree session keeps its name across keep/resume.** Resuming a
+  kept worktree re-created the session with the "automatic title" flag reset,
+  so the next AI-generated title overwrote the name you chose. The flag now
+  survives the park/resume cycle.
+- **Holding a hotkey no longer fires it repeatedly.** Key auto-repeat on
+  Ctrl+Shift+T could spawn a stack of sessions from one held chord (and
+  Ctrl+K would flap the palette); hotkeys now fire once per press.
+- **A failed in-place restart can be retried.** If launching the successor
+  process failed (say, the binary mid-swap by the package manager), the
+  restart coordinator latched anyway and every later `/restart` silently did
+  nothing until the app was relaunched by hand.
+- **Sessions that exit on their own no longer leak their PTY handle**, and
+  closing a session during its spawn round-trip no longer strands the PTY or
+  drops a queued update command.
+
 ## [0.13.0] - 2026-07-23
 
 ### Added

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -463,6 +463,13 @@ export function TerminalView({
       })
 
       await Service.Start(sessionId, projectId, cwd, kind, resume, live.term.cols, live.term.rows)
+      if (disposed) {
+        // Unmounted during the Start round-trip: the cleanup's Close raced
+        // ahead of the spawn, so close again now that the PTY exists. The
+        // queued paste stays put for the session's next mount.
+        void Service.Close(sessionId)
+        return
+      }
       // Deliver any one-shot input queued for this session (the update flow's
       // install command) now that the PTY exists. No trailing newline, so it
       // sits at the prompt for the user to run.

--- a/frontend/src/lib/hotkeys.test.ts
+++ b/frontend/src/lib/hotkeys.test.ts
@@ -16,6 +16,7 @@ const key = (over: Partial<KeyState>): KeyState => ({
   shiftKey: false,
   altKey: false,
   key: "",
+  repeat: false,
   ...over,
 })
 
@@ -30,6 +31,10 @@ describe("matchesCombo", () => {
   it("folds = into + so a combo recorded as + matches the unshifted key", () => {
     const plus: Combo = { mod: true, shift: false, alt: false, key: "+" }
     expect(matchesCombo(key({ ctrlKey: true, key: "=" }), plus)).toBe(true)
+  })
+
+  it("ignores key auto-repeat so a held chord fires once", () => {
+    expect(matchesCombo(key({ ctrlKey: true, shiftKey: true, key: "T", repeat: true }), newSession)).toBe(false)
   })
 
   it("rejects when a modifier differs", () => {

--- a/frontend/src/lib/hotkeys.ts
+++ b/frontend/src/lib/hotkeys.ts
@@ -38,7 +38,7 @@ export const DEFAULT_HOTKEYS: Hotkeys = Object.fromEntries(
 // The subset of KeyboardEvent the matcher needs — lets tests pass plain objects.
 export type KeyState = Pick<
   KeyboardEvent,
-  "ctrlKey" | "metaKey" | "shiftKey" | "altKey" | "key"
+  "ctrlKey" | "metaKey" | "shiftKey" | "altKey" | "key" | "repeat"
 >
 
 const MODIFIER_KEYS = new Set(["Control", "Meta", "Shift", "Alt", "AltGraph"])
@@ -55,6 +55,9 @@ function normalizeKey(key: string): string {
 }
 
 export function matchesCombo(event: KeyState, combo: Combo): boolean {
+  // A held chord auto-repeats; every action here is a discrete command (spawn
+  // a session, toggle the palette), so only the initial press may fire.
+  if (event.repeat) return false
   const mod = event.ctrlKey || event.metaKey
   return (
     mod === combo.mod &&

--- a/internal/appupdate/appupdate.go
+++ b/internal/appupdate/appupdate.go
@@ -44,6 +44,10 @@ const (
 	defaultOSRelease = "/etc/os-release"
 
 	httpTimeout = 5 * time.Second
+	// downloadTimeout bounds the binary download. A client Timeout spans the
+	// whole body read, so the metadata timeout above would cut a multi-MiB
+	// asset mid-stream on any modest link; this one is a hang stop, not a pace.
+	downloadTimeout = 5 * time.Minute
 	// bodyLimit caps the JSON/checksums reads; assetLimit caps the binary
 	// download (lich is a ~10-20 MiB static binary — 256 MiB is slack, not a
 	// target).
@@ -54,9 +58,13 @@ const (
 // Service reports lich's own update state and applies self-updates where the
 // binary is writable.
 type Service struct {
-	http    *http.Client
-	version string
-	exePath string
+	http *http.Client
+	// download carries the release-asset GET; separate from http so the short
+	// metadata timeout never applies to the body. Nil falls back to http
+	// (tests build bare Services against local servers).
+	download *http.Client
+	version  string
+	exePath  string
 	// goos is the platform, a field so tests can drive the self-apply path
 	// without running on that OS; defaults to runtime.GOOS.
 	goos string
@@ -80,6 +88,7 @@ func New(version string) *Service {
 	exe, _ := os.Executable() // "" if unresolved — canSelfApply then stays false.
 	return &Service{
 		http:          &http.Client{Timeout: httpTimeout},
+		download:      &http.Client{Timeout: downloadTimeout},
 		version:       version,
 		exePath:       exe,
 		goos:          runtime.GOOS,
@@ -149,7 +158,7 @@ func (s *Service) Apply() error {
 	if err != nil {
 		return err
 	}
-	resp, err := s.get(base + asset)
+	resp, err := s.getAsset(base + asset)
 	if err != nil {
 		return fmt.Errorf("download %s: %w", asset, err)
 	}
@@ -205,8 +214,8 @@ func (s *Service) installCommand() string {
 	}
 	data, _ := os.ReadFile(s.osReleasePath) // missing/unreadable → not arch → install.sh
 	if isArch(string(data)) {
-		// ponytail: assumes yay, the common AUR helper; a paru user edits the one
-		// word, since the command is pasted for review and never auto-run.
+		// Assumes yay, the common AUR helper; a paru user edits the one word,
+		// since the command is pasted for review and never auto-run.
 		return "yay -S " + aurPackage + restartChain
 	}
 	return installScript
@@ -283,13 +292,26 @@ func (s *Service) latestVersion() string {
 	return ghrelease.LatestTag(s.http, s.latestURL)
 }
 
-// get issues a GET with lich's identifying headers.
+// get issues a metadata GET (JSON, checksums) on the short-timeout client.
 func (s *Service) get(url string) (*http.Response, error) {
+	return s.getWith(s.http, url)
+}
+
+// getAsset issues the binary download on the long-timeout client.
+func (s *Service) getAsset(url string) (*http.Response, error) {
+	if s.download != nil {
+		return s.getWith(s.download, url)
+	}
+	return s.getWith(s.http, url)
+}
+
+// getWith issues a GET with lich's identifying headers.
+func (s *Service) getWith(c *http.Client, url string) (*http.Response, error) {
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", "lich")
-	return s.http.Do(req)
+	return c.Do(req)
 }

--- a/internal/appupdate/appupdate_test.go
+++ b/internal/appupdate/appupdate_test.go
@@ -277,6 +277,14 @@ func TestNewResolvesExe(t *testing.T) {
 	if s.version != "0.7.0" {
 		t.Fatalf("version = %q", s.version)
 	}
+	// The asset download must not ride the short metadata timeout: a client
+	// Timeout covers the whole body, and 5s cuts a multi-MiB binary mid-stream.
+	if s.download == nil {
+		t.Fatal("download client not set")
+	}
+	if s.download.Timeout <= s.http.Timeout {
+		t.Fatalf("download timeout = %v, want longer than metadata %v", s.download.Timeout, s.http.Timeout)
+	}
 	if s.latestURL != latestReleaseURL {
 		t.Fatalf("latestURL = %q", s.latestURL)
 	}

--- a/internal/restart/restart.go
+++ b/internal/restart/restart.go
@@ -59,20 +59,21 @@ func (c *Coordinator) Do() error {
 	}
 	// Once only: a second /restart (two install.sh runs) must not spawn a second
 	// successor that would then lose the port race and burn the bind timeout.
+	// The latch is set only after a successful spawn — a failed launch (say,
+	// the exe mid-swap by the package manager) must leave /restart retryable,
+	// not silently dead. The lock spans the spawn so concurrent calls cannot
+	// both slip past the check.
 	c.mu.Lock()
+	defer c.mu.Unlock()
 	if c.started {
-		c.mu.Unlock()
 		return nil
 	}
-	c.started = true
-	win := c.window
-	c.mu.Unlock()
-
 	if err := c.spawn(c.exePath, successorEnv(c.env)); err != nil {
 		return fmt.Errorf("restart: launch successor: %w", err)
 	}
-	if win != nil {
-		if err := c.terminate(win); err != nil {
+	c.started = true
+	if c.window != nil {
+		if err := c.terminate(c.window); err != nil {
 			return fmt.Errorf("restart: close window: %w", err)
 		}
 	}

--- a/internal/restart/restart_test.go
+++ b/internal/restart/restart_test.go
@@ -124,4 +124,27 @@ func TestDoErrors(t *testing.T) {
 			t.Fatal("Do() = nil, want spawn error")
 		}
 	})
+
+	t.Run("spawn failure leaves restart retryable", func(t *testing.T) {
+		calls := 0
+		c := &Coordinator{
+			exePath: "/usr/local/bin/lich",
+			spawn: func(string, []string) error {
+				calls++
+				if calls == 1 {
+					return errors.New("boom")
+				}
+				return nil
+			},
+		}
+		if err := c.Do(); err == nil {
+			t.Fatal("first Do() = nil, want spawn error")
+		}
+		if err := c.Do(); err != nil {
+			t.Fatalf("second Do() = %v, want a retried spawn to succeed", err)
+		}
+		if calls != 2 {
+			t.Fatalf("spawn calls = %d, want 2 (failure must not latch)", calls)
+		}
+	})
 }

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -101,8 +101,8 @@ func (s *Service) CloseSession(projectID, sessionID, activeID string) error {
 
 // ReopenWorktreeSession resumes a parked worktree session. It finds the parked
 // (is_open = 0) session for the worktree at path and re-adds it to the workspace
-// under a fresh id (newSessionID), carrying over the old label, kind and Claude
-// session id. The fresh id is deliberate: it makes the frontend treat the card
+// under a fresh id (newSessionID), carrying over the old label, kind, Claude
+// session id and label_auto flag. The fresh id is deliberate: it makes the frontend treat the card
 // as never-spawned, so its resume prompt fires and the Claude conversation
 // continues instead of starting cold. Returns nil when nothing is parked at path
 // — the caller then opens a brand-new session.
@@ -110,14 +110,18 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 	var restored *Session
 	err := s.tx(func(tx *sql.Tx) error {
 		var old Session
+		// label_auto rides along so a user rename survives the park/resume
+		// cycle — reinserting without it would reset to 1 and let the ai-title
+		// stomp the chosen name, breaking SetSessionTitle's contract.
+		var labelAuto int
 		row := tx.QueryRow(
-			`SELECT id, label, kind, claude_session_id
+			`SELECT id, label, kind, claude_session_id, label_auto
 			   FROM sessions
 			  WHERE project_id = ? AND path = ? AND is_open = 0
 			  ORDER BY rowid DESC LIMIT 1`,
 			projectID, path,
 		)
-		if err := row.Scan(&old.ID, &old.Label, &old.Kind, &old.ClaudeSessionID); err != nil {
+		if err := row.Scan(&old.ID, &old.Label, &old.Kind, &old.ClaudeSessionID, &labelAuto); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return nil // nothing parked here; caller creates a new session
 			}
@@ -127,10 +131,10 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 			return fmt.Errorf("drop parked session %q: %w", old.ID, err)
 		}
 		if _, err := tx.Exec(
-			`INSERT INTO sessions (id, project_id, label, kind, path, claude_session_id, position)
-			 VALUES (?, ?, ?, ?, ?, ?,
+			`INSERT INTO sessions (id, project_id, label, kind, path, claude_session_id, label_auto, position)
+			 VALUES (?, ?, ?, ?, ?, ?, ?,
 			         (SELECT COALESCE(MAX(position), -1) + 1 FROM sessions WHERE project_id = ?))`,
-			newSessionID, projectID, old.Label, old.Kind, path, old.ClaudeSessionID, projectID,
+			newSessionID, projectID, old.Label, old.Kind, path, old.ClaudeSessionID, labelAuto, projectID,
 		); err != nil {
 			return fmt.Errorf("reinsert session %q: %w", newSessionID, err)
 		}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -646,6 +646,38 @@ func TestCloseSessionParksAndReopenRestores(t *testing.T) {
 	}
 }
 
+// TestReopenWorktreeSessionKeepsManualRename proves a user rename survives the
+// park/resume cycle: the reinserted row carries label_auto over, so the ai-title
+// still cannot stomp the chosen name (SetSessionTitle's contract).
+func TestReopenWorktreeSessionKeepsManualRename(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2)
+	_ = svc.AddSession("p1", "wt1", "auto name", "claude", "/wt/foo", 3)
+	if err := svc.RenameSession("wt1", "my name"); err != nil {
+		t.Fatalf("RenameSession: %v", err)
+	}
+	if err := svc.CloseSession("p1", "wt1", "base"); err != nil { // park it
+		t.Fatalf("CloseSession: %v", err)
+	}
+
+	restored, err := svc.ReopenWorktreeSession("p1", "/wt/foo", "wt2")
+	if err != nil {
+		t.Fatalf("ReopenWorktreeSession: %v", err)
+	}
+	if restored == nil || restored.Label != "my name" {
+		t.Fatalf("restored = %+v, want the renamed label", restored)
+	}
+
+	changed, err := svc.SetSessionTitle("wt2", "ai title")
+	if err != nil {
+		t.Fatalf("SetSessionTitle: %v", err)
+	}
+	if changed {
+		t.Fatal("SetSessionTitle overwrote a manual rename after park/resume")
+	}
+}
+
 // TestReopenWorktreeSessionNoParked proves resume returns nil when the worktree
 // has no parked session, so the caller opens a fresh one instead.
 func TestReopenWorktreeSessionNoParked(t *testing.T) {

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -420,6 +420,10 @@ func (s *Service) stream(id string, p ptyHandle, out *coalescer, replay *replayB
 		}
 	}
 	_ = p.Wait()
+	// Release the PTY handle: on a natural child exit nobody else closes it
+	// (Close only reaps sessions still in the map), and the user-driven Close
+	// path tolerates this as a no-op double close.
+	_ = p.Close()
 	// Flush any batched output before the exit event so the frontend always
 	// sees the final bytes ahead of the exit banner.
 	out.Close()


### PR DESCRIPTION
## Summary

Fixes the HIGH + five MEDIUM findings from the code-review sweep of `main` (three verified passes: Go backend, frontend, security).

1. **Self-update download deterministically broken** — `internal/appupdate` used one `http.Client{Timeout: 5s}` for everything, and a client Timeout covers the entire body read, so the ~15–20 MiB binary had to finish in 5s. The asset GET now rides a dedicated client with a 5-minute ceiling (hang stop, not a pace); metadata keeps the short timeout. Pinned by a test so the clients can't be folded back together.
2. **PTY handle leak on natural exit** — `stream` reaped the child but never called `p.Close()`; only user-driven Close released the handle. One fd (Unix) / ConPTY pair (Windows) leaked per session that exited on its own. Double close on the user path is a tolerated no-op in both seams.
3. **User rename lost across worktree park/resume** — `ReopenWorktreeSession` reinserted without `label_auto`, resetting it to 1, so the next Stop-hook ai-title overwrote a manual rename — breaking `SetSessionTitle`'s documented contract. The flag now rides along; covered by a new store test.
4. **`/restart` bricked by one failed spawn** — the once-only latch was set *before* `spawn`, so a transient failure (exe mid-swap) latched anyway and every later `/restart` returned success while doing nothing. Latch now sets only after a successful spawn, with the lock spanning the spawn so concurrent calls can't double-launch. Covered by a new coordinator test.
5. **TerminalView unmount races the in-flight Start** — no `disposed` re-check after `await Service.Start`: the queued update paste was consumed and lost, `focus()` hit a disposed xterm, and the just-spawned PTY was orphaned (cleanup's Close had already landed before the PTY existed). Now it re-closes and leaves the paste queued for the next mount.
6. **Hotkey auto-repeat** — holding Ctrl+Shift+T created a session (SQLite row + PTY) per repeat tick (~35ms); Ctrl+K flapped the palette. `matchesCombo` now ignores `event.repeat`; zoom chords are unaffected (separate physical-key path where repeat is desired). Covered by a new hotkeys test.

Also drops a stray `ponytail:` comment in `appupdate.go`.

## Test plan

- [x] `gofmt`/`go vet` clean; backend `go test -race ./...` — 298 passed.
- [x] Frontend vitest — 322 passed; `tsc` + `vite build` clean.
- [x] Cross-compile gate: `GOOS=linux|darwin|windows go build && go vet` all green.
- [x] New regression tests: download-client split, `label_auto` across park/resume, restart retry after spawn failure, hotkey repeat guard.