### PR TITLE
fix: sweep the review's LOW findings and dead paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Zoom now works on layouts with a dedicated "+" key** (German, for one).
+  The chords matched only the physical Equal/Minus keys, so on those layouts
+  nothing claimed the press and Chromium's own zoom ran instead — the exact
+  double-zoom the physical-key matching was built to prevent. The typed
+  character is now checked as a fallback.
+- **Stale results can no longer outrace fresh ones in the footer badges.** A
+  slow git-status poll resolving late could overwrite the newer status the
+  session hooks had just fetched, and the pull-request badge kept showing the
+  previous directory's PR while the new lookup was in flight.
+- **The command palette reopens clean.** Toggling it closed with the hotkey
+  kept the previous filter and cursor for the next open; and Ctrl+F no longer
+  opens the terminal search box hidden beneath an open palette.
+- **A failing file picker now says so** with an error toast instead of
+  failing silently.
+
 - **The self-update download no longer dies on a normal connection.** The
   binary download shared the 5-second timeout meant for small metadata reads,
   and that timeout covers the whole transfer — so on anything but a very fast

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -37,6 +37,8 @@ export function CommandPalette() {
         event.preventDefault()
         event.stopPropagation()
         setOpen((v) => !v)
+        setQuery("")
+        setSelected(0)
       }
     }
     window.addEventListener("keydown", onKey, true)

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -1,4 +1,5 @@
 import {useEffect, useState} from "react"
+import {toast} from "sonner"
 import {Code, FileText, GitBranch, Folder, Plus, Diff, GitPullRequestArrow} from "lucide-react"
 import {ProjectService, System, Terminal as TerminalService} from "@/lib/rpc"
 import type {DockTab} from "@/components/dock/RightDock"
@@ -50,9 +51,13 @@ export function FooterBar({dock, onDock}: FooterBarProps) {
   const now = useNow()
 
   const attachFile = async () => {
-    const file = await ProjectService.PickFile()
-    if (file && sessionId) {
-      void TerminalService.Write(sessionId, `${file} `)
+    try {
+      const file = await ProjectService.PickFile()
+      if (file && sessionId) {
+        void TerminalService.Write(sessionId, `${file} `)
+      }
+    } catch {
+      toast.error("Could not open the file picker")
     }
   }
 

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -386,6 +386,10 @@ export function TerminalView({
       if (!visibleRef.current || !isSearchOpenChord(event)) {
         return
       }
+      const target = event.target as HTMLElement | null
+      if (target?.closest?.('[role="dialog"]')) {
+        return
+      }
       event.preventDefault()
       event.stopPropagation()
       setSearchOpen(true)
@@ -532,44 +536,10 @@ export function TerminalView({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible, sessionId])
 
-  // Font changes apply to the live terminal; a hidden one picks the ref up
-  // on recreation.
-  useEffect(() => {
-    const live = liveRef.current
-    if (!live) {
-      return
-    }
-    void (async () => {
-      await ensureFontLoaded(font)
-      live.term.options.fontFamily = `"${font}", monospace`
-      if (containerRef.current) {
-        fitTerminal(live.term, containerRef.current)
-      }
-      if (visibleRef.current) {
-        void Service.Resize(sessionId, live.term.cols, live.term.rows)
-      }
-    })()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [font, sessionId])
-
-  // Text size likewise. Unlike the app zoom this does change the cell size, so
-  // the grid is refit and the PTY told about the new cols×rows.
-  useEffect(() => {
-    const live = liveRef.current
-    if (!live) {
-      return
-    }
-    live.term.options.fontSize = terminalFontSize
-    if (containerRef.current) {
-      fitTerminal(live.term, containerRef.current)
-    }
-    if (visibleRef.current) {
-      void Service.Resize(sessionId, live.term.cols, live.term.rows)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [terminalFontSize, sessionId])
-
-  // Theme changes likewise.
+  // Font family and size need no live-update path: changing them means being
+  // on the Settings route, where TerminalHost destroys every live terminal —
+  // recreation reads the refs. The theme can flip with a terminal on screen
+  // (OS scheme under "system").
   useEffect(() => {
     const live = liveRef.current
     if (live) {

--- a/frontend/src/lib/git-status-store.test.ts
+++ b/frontend/src/lib/git-status-store.test.ts
@@ -121,6 +121,25 @@ describe("createGitStatusStore", () => {
     expect(fetch).not.toHaveBeenCalled()
   })
 
+  it("a stale fetch resolving late cannot overwrite a fresher one", async () => {
+    const resolvers: Array<(value: GitStatus | null) => void> = []
+    const fetch = vi.fn(
+      () => new Promise<GitStatus | null>((r) => resolvers.push(r)),
+    )
+    const store = createGitStatusStore(fetch, POLL_MS)
+    const listener = vi.fn()
+    store.subscribe("/repo", listener) // fetch #1 — the slow poll
+    store.refresh("/repo") // fetch #2 — the session-touched nudge
+    resolvers[1]?.(status(5)) // fresh result lands first
+    await vi.advanceTimersByTimeAsync(0)
+    expect(store.get("/repo")?.files).toBe(5)
+
+    resolvers[0]?.(status(1)) // the stale poll resolves late
+    await vi.advanceTimersByTimeAsync(0)
+    expect(store.get("/repo")?.files).toBe(5)
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
   it("drops an in-flight result after teardown", async () => {
     let resolve: (value: GitStatus | null) => void = () => {}
     const fetch = vi.fn(

--- a/frontend/src/lib/git-status-store.ts
+++ b/frontend/src/lib/git-status-store.ts
@@ -14,6 +14,8 @@ interface Entry {
   // Fetches this path once, off the interval cadence. Reused for the
   // visibilitychange re-fetch and the store's manual refresh(path).
   refresh: () => void
+  // Monotonic fetch id — only the latest-started fetch may publish.
+  seq: number
 }
 
 const unchanged = (a: GitStatus | null, b: GitStatus | null): boolean =>
@@ -41,11 +43,12 @@ export function createGitStatusStore(fetch: GitStatusFetcher, pollMs: number) {
         if (typeof document !== "undefined" && document.hidden) {
           return
         }
+        const seq = ++created.seq
         void fetch(path).then((next) => {
-          // Drop the result if every subscriber left mid-flight or the status
-          // is identical: same object identity means subscribers skip their
-          // re-render entirely.
-          if (entries.get(path) !== created || unchanged(created.status, next)) {
+          // Drop the result if every subscriber left mid-flight, a newer fetch
+          // started since, or the status is identical: same object identity
+          // means subscribers skip their re-render entirely.
+          if (entries.get(path) !== created || seq !== created.seq || unchanged(created.status, next)) {
             return
           }
           created.status = next
@@ -59,6 +62,7 @@ export function createGitStatusStore(fetch: GitStatusFetcher, pollMs: number) {
         listeners: new Set(),
         timer: setInterval(refresh, pollMs),
         refresh,
+        seq: 0,
       }
       entries.set(path, created)
       if (typeof document !== "undefined") {

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useRef, useState } from "react"
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
 import type { ReactNode } from "react"
 import { toast } from "sonner"
 import { useMatch, useNavigate } from "react-router-dom"
@@ -488,29 +488,44 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     [],
   )
 
-  return (
-    <ProjectsContext.Provider
-      value={{
-        projects,
-        sessions,
-        homeId,
-        openProject,
-        ensureHomeProject,
-        closeProject,
-        newSession,
-        newWorktreeSession,
-        reopenWorktreeSession,
-        closeSession,
-        keepSession,
-        activateSession,
-        renameSession,
-        reorderProjects,
-        reorderSessions,
-      }}
-    >
-      {children}
-    </ProjectsContext.Provider>
+  const value = useMemo(
+    () => ({
+      projects,
+      sessions,
+      homeId,
+      openProject,
+      ensureHomeProject,
+      closeProject,
+      newSession,
+      newWorktreeSession,
+      reopenWorktreeSession,
+      closeSession,
+      keepSession,
+      activateSession,
+      renameSession,
+      reorderProjects,
+      reorderSessions,
+    }),
+    [
+      projects,
+      sessions,
+      homeId,
+      openProject,
+      ensureHomeProject,
+      closeProject,
+      newSession,
+      newWorktreeSession,
+      reopenWorktreeSession,
+      closeSession,
+      keepSession,
+      activateSession,
+      renameSession,
+      reorderProjects,
+      reorderSessions,
+    ],
   )
+
+  return <ProjectsContext.Provider value={value}>{children}</ProjectsContext.Provider>
 }
 
 export function useProjects(): ProjectsValue {

--- a/frontend/src/lib/usePullRequest.ts
+++ b/frontend/src/lib/usePullRequest.ts
@@ -20,6 +20,7 @@ export function usePullRequest(path: string, branch: string): PullRequest | null
       return
     }
     let alive = true
+    setPr(null)
     const load = () => {
       ProjectService.PullRequest(path)
         .then((result) => {

--- a/frontend/src/lib/zoom-keys.test.ts
+++ b/frontend/src/lib/zoom-keys.test.ts
@@ -7,6 +7,7 @@ const press = (over: Partial<ZoomKeyState>): ZoomKeyState => ({
   shiftKey: false,
   altKey: false,
   code: "",
+  key: "",
   ...over,
 })
 
@@ -31,6 +32,13 @@ describe("zoomIntent", () => {
     expect(zoomIntent(press({ ctrlKey: true, code: "NumpadAdd" }))).toBe("in")
     expect(zoomIntent(press({ ctrlKey: true, code: "NumpadSubtract" }))).toBe("out")
     expect(zoomIntent(press({ ctrlKey: true, code: "Numpad0" }))).toBe("reset")
+  })
+
+  it("falls back to the character on layouts whose +/− are dedicated keys", () => {
+    // German: "+" is its own key (code BracketRight) and "-" sits on Slash —
+    // neither code is in the table, but the character says what the press means.
+    expect(zoomIntent(press({ ctrlKey: true, key: "+", code: "BracketRight" }))).toBe("in")
+    expect(zoomIntent(press({ ctrlKey: true, key: "-", code: "Slash" }))).toBe("out")
   })
 
   it("accepts Cmd as the primary modifier", () => {

--- a/frontend/src/lib/zoom-keys.ts
+++ b/frontend/src/lib/zoom-keys.ts
@@ -7,10 +7,14 @@
 // Chromium's own zoom accelerator runs instead. That is how the app ended up
 // with two zooms at once — the app's for Ctrl+"−", Chromium's for Ctrl+"+".
 //
-// event.code is the same on every layout, so one table covers all of them.
-// These deliberately are not user-configurable hotkeys: the whole point is to
-// shadow the browser accelerators, and an accelerator is bound to a physical
-// key, not to a character.
+// event.code is the same on every layout, so one table covers the layouts
+// where +/− live on the Equal/Minus keys (US, ABNT2, …). Layouts with a
+// dedicated "+" key (German: code BracketRight; its "-" sits on Slash) miss
+// the table, so the character is checked as a fallback — there event.key
+// already says what the press means. These deliberately are not
+// user-configurable hotkeys: the whole point is to shadow the browser
+// accelerators, and an accelerator is bound to a physical key, not to a
+// character.
 
 export type ZoomIntent = "in" | "out" | "reset"
 
@@ -18,7 +22,7 @@ export type ZoomIntent = "in" | "out" | "reset"
 // objects, same shape trick as hotkeys.ts and term-keys.ts.
 export type ZoomKeyState = Pick<
   KeyboardEvent,
-  "ctrlKey" | "metaKey" | "shiftKey" | "altKey" | "code"
+  "ctrlKey" | "metaKey" | "shiftKey" | "altKey" | "code" | "key"
 >
 
 const ZOOM_CODES: Record<string, ZoomIntent> = {
@@ -28,6 +32,11 @@ const ZOOM_CODES: Record<string, ZoomIntent> = {
   NumpadSubtract: "out",
   Digit0: "reset",
   Numpad0: "reset",
+}
+
+const ZOOM_CHARS: Record<string, ZoomIntent> = {
+  "+": "in",
+  "-": "out",
 }
 
 // Shift is only accepted on Equal, because there it is what types the "+".
@@ -41,6 +50,8 @@ const SHIFTABLE_CODE = "Equal"
 export function zoomIntent(event: ZoomKeyState): ZoomIntent | null {
   if (!(event.ctrlKey || event.metaKey)) return null
   if (event.altKey) return null
+  const byChar = ZOOM_CHARS[event.key]
+  if (byChar) return byChar
   if (event.shiftKey && event.code !== SHIFTABLE_CODE) return null
   return ZOOM_CODES[event.code] ?? null
 }

--- a/internal/project/worktree.go
+++ b/internal/project/worktree.go
@@ -167,12 +167,13 @@ func (s *Service) CreateWorktree(projectPath, projectID, name, base string, base
 		if !ok {
 			return nil, fmt.Errorf("remote branch %q has no remote prefix", base)
 		}
-		if _, err := runGit(projectPath, "fetch", remote, branch); err != nil {
+		if _, err := runGit(projectPath, "fetch", "--", remote, branch); err != nil {
 			return nil, err
 		}
 		args = append(args, "--track")
 	}
-	args = append(args, "-b", name, wtPath, base)
+	// "--": base is unvalidated, and "-"-prefixed it would parse as a flag.
+	args = append(args, "-b", name, "--", wtPath, base)
 	if _, err := runGit(projectPath, args...); err != nil {
 		return nil, err
 	}

--- a/internal/terminal/replay.go
+++ b/internal/terminal/replay.go
@@ -43,6 +43,8 @@ func (b *replayBuffer) append(data []byte) {
 	b.total += len(chunk)
 	for b.total > b.capBytes && len(b.chunks) > 1 {
 		b.total -= len(b.chunks[0])
+		// Reslicing alone keeps the chunk reachable through the backing array.
+		b.chunks[0] = nil
 		b.chunks = b.chunks[1:]
 	}
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -356,17 +356,35 @@ func scrubPathList(value, dir string) (string, bool) {
 // this card ran before the last restart. An id Claude no longer knows fails in
 // the PTY like any other bad invocation — the user sees Claude's own error.
 func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int) error {
+	sess, cwd, err := s.spawnSession(id, projectID, cwd, kind, resume, cols, rows)
+	if err != nil || sess == nil {
+		return err
+	}
+	// Emitted outside s.mu: Emit blocks on a stalled /events client, which
+	// would freeze every session's I/O. Both are unconditional so a respawn
+	// overwrites whatever the previous PTY left in the frontend's stores.
+	s.hub.Emit(cwdEventName, cwdEvent{ID: id, Cwd: cwd})
+	s.hub.Emit(agentEventName, agentEvent{ID: id, Agent: ""})
+	go watchCwd(id, sess.pty.Pid(), cwd, sess.done, s.hub)
+	return nil
+}
+
+// spawnSession is the locked half of Start: dedupe, PTY spawn and session-map
+// registration. A nil session with a nil error means id was already running.
+// The returned cwd is the effective start directory (the input, or the
+// resolved home when it was empty).
+func (s *Service) spawnSession(id, projectID, cwd, kind, resume string, cols, rows int) (*session, string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if _, running := s.sessions[id]; running {
-		return nil
+		return nil, "", nil
 	}
 
 	if cwd == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
-			return fmt.Errorf("failed to resolve home directory: %w", err)
+			return nil, "", fmt.Errorf("failed to resolve home directory: %w", err)
 		}
 		cwd = home
 	}
@@ -380,7 +398,7 @@ func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int)
 		rows: rows,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to start pty for %q: %w", id, err)
+		return nil, "", fmt.Errorf("failed to start pty for %q: %w", id, err)
 	}
 
 	out := newCoalescer(func(data []byte) {
@@ -390,17 +408,10 @@ func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int)
 		encoded := base64.StdEncoding.EncodeToString(data)
 		s.hub.Emit(dataEventPrefix+id, encoded)
 	}, visibleFlushInterval, hiddenFlushInterval)
-	done := make(chan struct{})
-	replay := newReplayBuffer(replayCapBytes)
-	s.sessions[id] = &session{pty: p, out: out, done: done, replay: replay}
-	go s.stream(id, p, out, replay)
-	// The start directory and a cleared agent are reported unconditionally so
-	// a respawn overwrites whatever the previous PTY left in the frontend's
-	// stores (a provider session's own agent re-reports via its hook).
-	s.hub.Emit(cwdEventName, cwdEvent{ID: id, Cwd: cwd})
-	s.hub.Emit(agentEventName, agentEvent{ID: id, Agent: ""})
-	go watchCwd(id, p.Pid(), cwd, done, s.hub)
-	return nil
+	sess := &session{pty: p, out: out, done: make(chan struct{}), replay: newReplayBuffer(replayCapBytes)}
+	s.sessions[id] = sess
+	go s.stream(id, p, out, sess.replay)
+	return sess, cwd, nil
 }
 
 // stream copies PTY output to the frontend until the PTY is closed, then reaps


### PR DESCRIPTION
## Summary

Closes out the LOW findings and simplification items from the code-review sweep (the HIGH/MEDIUM batch landed in #71).

**Backend**
- `internal/terminal`: `Start` split into a locked `spawnSession` + lock-free hub emits — `Emit` blocks on a stalled `/events` client, and under `s.mu` that stall froze write/resize/close for every session.
- `internal/terminal/replay.go`: dropped chunks are nil'd out; reslicing alone kept them reachable through the backing array (~2x cap over-retention per busy session).
- `internal/project/worktree.go`: `--` end-of-options guard before positional refs in `worktree add` and `fetch` — `base` is unvalidated and a `-`-prefixed value would parse as a flag.

**Frontend**
- `git-status-store`: per-entry monotonic fetch id — a slow poll resolving late can no longer overwrite the fresher `session-touched` refresh (new test with controlled promises).
- `zoom-keys`: character fallback for layouts with dedicated +/− keys (German: `BracketRight`/`Slash`) where the code table missed and Chromium's own zoom ran — the header's "one table covers all layouts" claim was wrong (new tests).
- Command palette: hotkey toggle resets query/cursor; Ctrl+F is ignored when a dialog owns focus, so the find box no longer opens beneath the palette.
- `usePullRequest`: badge clears on path/branch change instead of showing the previous repo's PR mid-lookup.
- `FooterBar.attachFile`: failure surfaces a toast instead of an unhandled rejection.
- `TerminalView`: dead font/size live-update effects deleted (~35 lines) — Settings is a full route, TerminalHost destroys every live terminal there, recreation reads the refs. Verified against `useMatch("/projects/:projectId")` before cutting. The theme effect stays (OS scheme can flip live).
- `projects.tsx`: context value memoized — consumers stopped re-rendering on every provider render (navigation, settings ticks).

**Deliberately skipped**
- WS reconnect-scaffolding dedup (`app-events` vs `term-transport`): they differ in sync/async endpoint, ready/binary state and payload shape — a shared helper would be config soup taller than the duplication.
- The `/ws` write-under-mutex (review B6): documented tradeoff, bounded at 5s; restructuring the transport locking isn't worth the risk here.

## Test plan

- [x] `gofmt`/`go vet` clean; backend `go test -race ./...` — 298 passed.
- [x] Frontend vitest — 324 passed (2 new: stale-fetch ordering, layout fallback); `tsc` + `vite build` clean.
- [x] Cross-compile gate: `GOOS=linux|darwin|windows go build && go vet` green.
- [x] CHANGELOG updated under `[Unreleased]`.