### PR TITLE
chore: strip comments that narrate readable code

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,8 +20,6 @@ import { CommandPalette } from "@/components/CommandPalette"
 // top of the terminals.
 function Layout() {
   const [dock, setDock] = useState<DockTab | null>(null)
-  // Clicking a footer toggle opens that tab, or closes the dock if that tab is
-  // already showing.
   const toggleDock = (tab: DockTab) =>
     setDock((cur) => (cur === tab ? null : tab))
   return (

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -49,7 +49,6 @@ export function CommandPalette() {
   const results = useMemo(() => filterPalette(query, all, projects), [query, all, projects])
   const total = results.sessions.length + results.projects.length
 
-  // Reset the cursor to the top whenever the visible set changes.
   useEffect(() => setSelected(0), [query])
   const active = Math.min(selected, Math.max(0, total - 1))
 

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -34,12 +34,9 @@ interface FooterBarProps {
   onDock: (tab: DockTab) => void
 }
 
-// FooterBar is the Warp-style status strip: attach-file button, a file-browser
-// toggle and diff counters on the left, git branch, working directory and clock
-// on the right. Git segments only render while a project is active. Everything
-// follows the active session: a worktree session shows its checkout's path,
-// branch and diff. The Files button and the diff counters toggle the dock's two
-// tabs.
+// FooterBar is the Warp-style status strip. Git segments only render while a
+// project is active; everything follows the active session — a worktree session
+// shows its checkout's path, branch and diff.
 export function FooterBar({dock, onDock}: FooterBarProps) {
   const {sessionId, path: basePath} = useActiveSession()
   // Overlay the backend's live cwd so a `cd` in the terminal moves the footer

--- a/frontend/src/components/PatchNotesDialog.tsx
+++ b/frontend/src/components/PatchNotesDialog.tsx
@@ -14,8 +14,7 @@ import type {PatchNotes} from "@/lib/api-types"
 
 const RELEASE_TAG_BASE = "https://github.com/omartelo/lich/releases/tag/v"
 
-// dotColor maps a changelog group to a semantic accent, kept separate from the
-// app accent: Added emerald, Changed amber, Fixed sky, anything else muted.
+// Semantic per-group accents, deliberately separate from the app accent.
 function dotColor(label: string): string {
   switch (label.toLowerCase()) {
     case "added":
@@ -57,8 +56,6 @@ interface PatchNotesDialogProps {
   onClose: () => void
 }
 
-// PatchNotesDialog shows the running build's changelog section after an update:
-// a grouped, scrollable "what's new" list with a link to the full release notes.
 export function PatchNotesDialog({notes, onClose}: PatchNotesDialogProps) {
   const groups = notes.groups ?? []
   return (

--- a/frontend/src/components/TerminalHost.tsx
+++ b/frontend/src/components/TerminalHost.tsx
@@ -84,7 +84,7 @@ export function TerminalHost() {
         const projectActiveId = activeSessionId(sessions, project.id)
         return sessionsOf(sessions, project.id).map((session) => {
           if (!spawned.has(session.id)) {
-            return null // lazy: not viewed yet, no PTY spawned
+            return null
           }
           const visible =
             project.id === activeProjectId && session.id === projectActiveId

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -88,8 +88,8 @@ function fitTerminal(term: Terminal, container: HTMLElement): void {
   }
 }
 
-// Terminal color schemes. Light keeps a high-contrast foreground so CLI output
-// stays legible against the pale background.
+// Light keeps a high-contrast foreground so CLI output stays legible against
+// the pale background.
 const TERMINAL_COLORS: Record<ResolvedTheme, { background: string; foreground: string }> = {
   dark: { background: "#06070f", foreground: "#e5e7eb" },
   light: { background: "#ffffff", foreground: "#1f2328" },

--- a/frontend/src/components/diff/FileDiff.tsx
+++ b/frontend/src/components/diff/FileDiff.tsx
@@ -35,10 +35,8 @@ interface FileDiffProps {
   onDiscard: () => void
 }
 
-// FileDiff is one card of the review panel: a sticky header with a language
-// badge, the file name, +/- counts and per-file actions, and a read-only
-// CodeMirror diff below. The card must not clip overflow — a clipping
-// ancestor would break the sticky header.
+// The card must not clip overflow — a clipping ancestor would break the
+// sticky header.
 export function FileDiff({file, onInject, onDiscard}: FileDiffProps) {
   const doc = useMemo(() => buildFileDoc(file), [file])
   const [expanded, setExpanded] = useState(
@@ -99,8 +97,6 @@ interface HeaderActionProps {
   children: ReactNode
 }
 
-// HeaderAction is one tooltip-labeled icon button in a review-panel header,
-// styled after the footer's attach-file button.
 export function HeaderAction({label, onClick, children}: HeaderActionProps) {
   return (
     <Tooltip>

--- a/frontend/src/components/dock/FilesPanel.tsx
+++ b/frontend/src/components/dock/FilesPanel.tsx
@@ -131,7 +131,7 @@ interface TreeRowProps {
 
 function TreeRow({node, depth, expanded, onToggle, onOpen}: TreeRowProps) {
   const isOpen = expanded.has(node.path)
-  // Indent by depth; the base padding keeps even top-level rows off the edge.
+  // The 0.5rem base keeps even top-level rows off the edge.
   const indent = {paddingLeft: `${depth * 0.75 + 0.5}rem`}
   if (node.type === "file") {
     // A chevron-width spacer keeps file names aligned under their folder's name;

--- a/frontend/src/components/settings/SegmentedControl.tsx
+++ b/frontend/src/components/settings/SegmentedControl.tsx
@@ -7,8 +7,6 @@ interface SegmentedOption<T extends string> {
   icon?: ReactNode
 }
 
-// SegmentedControl is a single-select row of equal-width option buttons; the
-// active option is outlined with the app accent. Used for theme pickers.
 export function SegmentedControl<T extends string>({
   value,
   onChange,

--- a/frontend/src/components/settings/SettingBlock.tsx
+++ b/frontend/src/components/settings/SettingBlock.tsx
@@ -1,8 +1,6 @@
 import type { ReactNode } from "react"
 
-// SettingBlock is a stacked setting: an icon+title heading, an optional
-// description, then the control below. It is the single layout for every
-// settings row, so all sections read the same.
+// The single layout for every settings row, so all sections read the same.
 export function SettingBlock({
   icon,
   title,

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -33,15 +33,13 @@ const BASE_SECTIONS: Section[] = [
 // Settings is the per-project settings screen (not a modal): it fills the main
 // area and sits on top of the persistent terminals, with the session sidebar
 // kept beside it. The route carries the project id, which the provider sections
-// use for that project's overrides. A category nav sits on the left; content is
-// on the right.
+// use for that project's overrides.
 export function Settings() {
   const { projectId } = useParams()
   const providers = useProviders()
   const [active, setActive] = useState("providers")
   const [query, setQuery] = useState("")
 
-  // One config section per enabled provider, appended after the base sections.
   const providerSections: Section[] = enabledProviders(providers).map((provider) => ({
     id: `provider-${provider.id}`,
     label: provider.name,

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -36,10 +36,7 @@ interface SessionCardProps {
   onOpenTerminal: (cwd: string) => void
 }
 
-// SessionCard is one session entry: a card showing the session label, the
-// session's working directory, and that directory's git branch with a diff
-// badge (when it is a repo), with a close button on hover. The card itself is
-// the drag grip for reordering the list.
+// The card itself is the drag grip for reordering the list — no separate handle.
 export function SessionCard({
                               session,
                               path,
@@ -82,7 +79,6 @@ export function SessionCard({
     isDragging,
   } = useSortable({id: session.id, disabled: editing})
 
-  // Commit the edited label: keep the old one if it is blank or unchanged.
   const commit = (value: string) => {
     setEditing(false)
     const label = value.trim()

--- a/frontend/src/components/sidebar/SessionStatusIcon.tsx
+++ b/frontend/src/components/sidebar/SessionStatusIcon.tsx
@@ -18,8 +18,7 @@ interface SessionStatusIconProps {
   status: SessionStatus | null
 }
 
-// SessionStatusIcon is a session's provider mark wrapped in a status ring. The
-// slot is a fixed size so the icon never shifts as the state changes.
+// The slot is a fixed size so the icon never shifts as the state changes.
 export function SessionStatusIcon({kind, status}: SessionStatusIconProps) {
   return (
     <span className="relative flex size-[1.375rem] shrink-0 items-center justify-center text-muted-foreground">

--- a/frontend/src/components/sidebar/WorktreeDialog.tsx
+++ b/frontend/src/components/sidebar/WorktreeDialog.tsx
@@ -57,8 +57,6 @@ interface BranchGroupProps {
   children: ReactNode
 }
 
-// BranchGroup is one collapsible section of the list: a sticky header with a
-// chevron and item count, and the rows when expanded.
 function BranchGroup({title, count, open, onToggle, children}: BranchGroupProps) {
   return (
     <>

--- a/frontend/src/components/tabs/ProjectTab.tsx
+++ b/frontend/src/components/tabs/ProjectTab.tsx
@@ -12,9 +12,7 @@ interface ProjectTabProps {
   onClose: () => void
 }
 
-// ProjectTab is a browser-style tab: the project name, active underline, and a
-// close affordance that appears on hover. The tab is its own drag grip for
-// reordering the strip.
+// The tab is its own drag grip for reordering the strip — no separate handle.
 export function ProjectTab({ project, sessionIds, onClose }: ProjectTabProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: project.id })

--- a/frontend/src/components/tabs/ProjectTabs.tsx
+++ b/frontend/src/components/tabs/ProjectTabs.tsx
@@ -12,9 +12,6 @@ import {useSortableList} from "@/lib/use-sortable-list"
 import {ProjectTab} from "./ProjectTab"
 import {HomeTab} from "./HomeTab"
 
-// ProjectTabs is the top strip: the pinned Home tab, open projects as tabs
-// (drag to reorder), a button to open another, and a settings button pinned to
-// the right that opens the current project's Settings card.
 export function ProjectTabs() {
   const {projects, sessions, homeId, openProject, closeProject, reorderProjects} =
     useProjects()

--- a/frontend/src/lib/command-palette.ts
+++ b/frontend/src/lib/command-palette.ts
@@ -61,8 +61,6 @@ export interface PaletteResults {
   projects: Project[]
 }
 
-// filterPalette narrows sessions and projects to those matching query. A session
-// matches on its label, project name or path; a project on its name or path.
 export function filterPalette(
   query: string,
   allSessions: readonly PaletteSession[],

--- a/frontend/src/lib/copy-toast.ts
+++ b/frontend/src/lib/copy-toast.ts
@@ -4,7 +4,6 @@
  * rendering the terminal or the toast host.
  */
 
-/** How long the copy toast stays visible, in milliseconds. */
 export const COPY_TOAST_DURATION_MS = 1500
 
 /** Count user-perceived characters (code points, not UTF-16 code units). */
@@ -12,7 +11,6 @@ export function countChars(text: string): number {
   return [...text].length
 }
 
-/** Build the toast text for a copied selection, e.g. "copied 83 chars to clipboard". */
 export function copyToastMessage(text: string): string {
   const count = countChars(text)
   return `copied ${count} ${count === 1 ? "char" : "chars"} to clipboard`

--- a/frontend/src/lib/file-icon.tsx
+++ b/frontend/src/lib/file-icon.tsx
@@ -59,8 +59,6 @@ interface FileIconProps {
   path: string
 }
 
-// FileIcon renders a file's language icon for the tree, or a neutral glyph for
-// extensions devicon doesn't cover (sql, toml, extensionless).
 export function FileIcon({path}: FileIconProps) {
   const def = ICONS[extname(path)]
   if (!def) {

--- a/frontend/src/lib/file-tree.ts
+++ b/frontend/src/lib/file-tree.ts
@@ -18,8 +18,8 @@ export interface TreeNode {
 // and each group sorted case-insensitively — the order an explorer expects,
 // independent of git's byte order.
 //
-// ponytail: linear find per level, O(files · siblings); swap in a Map keyed by
-// name if a huge monorepo ever makes this lag.
+// Linear find per level, O(files · siblings); swap in a Map keyed by name if
+// a huge monorepo ever makes this lag.
 export function buildTree(paths: string[]): TreeNode[] {
   const root: TreeNode[] = []
   for (const path of paths) {

--- a/frontend/src/lib/paste-queue.ts
+++ b/frontend/src/lib/paste-queue.ts
@@ -10,7 +10,6 @@ export function queuePaste(sessionId: string, text: string): void {
   pending.set(sessionId, text)
 }
 
-// takePaste returns and clears the queued text for a session, or undefined.
 export function takePaste(sessionId: string): string | undefined {
   const text = pending.get(sessionId)
   if (text !== undefined) {

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -89,14 +89,10 @@ const toProject = (p: StoreProject): Project => ({
   path: p.path,
 })
 
-// How long the "needs you" toast stays before auto-dismissing.
 const ATTENTION_TOAST_MS = 10_000
 
-// Shown when a toasted session has no label to name it by.
 const UNLABELED_SESSION = "A session"
 
-// buildSessionState rebuilds the in-memory session map from the persisted
-// projects returned by the store.
 function buildSessionState(loaded: StoreProject[]): SessionState {
   const state: SessionState = {}
   for (const p of loaded) {

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -78,7 +78,6 @@ export interface ProvidersDeps {
   persistDefault: (id: string) => void
 }
 
-// createProvidersStore builds a subscribable provider store over injected RPC.
 export function createProvidersStore(deps: ProvidersDeps) {
   let providers: ProviderState[] = []
   let defaultId = ""
@@ -145,7 +144,6 @@ export function createProvidersStore(deps: ProvidersDeps) {
   }
 }
 
-// The app-wide singleton, wired to the real RPC.
 const store = createProvidersStore({
   detect: () => Providers.Detect(),
   getEnabled: (id) => Store.GetSetting(enabledKey(id), GLOBAL_SCOPE),
@@ -158,12 +156,10 @@ const store = createProvidersStore({
   },
 })
 
-// setProviderEnabled flips a provider's global flag and persists it.
 export function setProviderEnabled(id: ProviderKind, enabled: boolean): void {
   store.setEnabled(id, enabled)
 }
 
-// setProviderDefault records the provider new sessions spawn by default.
 export function setProviderDefault(id: ProviderKind): void {
   store.setDefault(id)
 }

--- a/frontend/src/lib/sessions.ts
+++ b/frontend/src/lib/sessions.ts
@@ -48,7 +48,6 @@ export interface ProjectSessions {
 
 export type SessionState = Record<string, ProjectSessions>
 
-// createProjectSessions seeds a project with its first session.
 export function createProjectSessions(
   firstSessionId: string,
   kind: SessionKind = "claude",
@@ -207,7 +206,6 @@ export function reorderSessions(
   return { ...state, [projectId]: { ...current, sessions } }
 }
 
-// removeProject drops a project and all its sessions.
 export function removeProject(
   state: SessionState,
   projectId: string,


### PR DESCRIPTION
## Summary

Full comment sweep of both sides against the bar: **a comment documents a non-explicit rule or non-obvious behavior — nothing else.**

- **Backend (75 files): zero changes.** Every comment already carries a contract, concurrency rule, security guard, OS/framework quirk or test-seam rationale.
- **Frontend (122 files): 24 deleted, 11 trimmed** (−65/+17). What fell: component headers narrating their own JSX (`SegmentedControl`, `HeaderAction`, `PatchNotesDialog`), constants re-described by their names (`ATTENTION_TOAST_MS`, `copy-toast`), standard React patterns explained (cursor reset, dock toggle), module-header content duplicated at use sites (`providers-store` ×4), and one stray `ponytail:` marker (`file-tree.ts`).
- Trims keep the load-bearing why, drop the inventory — e.g. `FileDiff` keeps "must not clip overflow — breaks the sticky header" and loses the card tour.
- Kept deliberately: module headers recording design (term-transport fallback, replay-buffer model, zoom-keys chord rationale), framework quirks (xterm `_core` private API, base-ui contracts, Chromium accelerators), lifecycle/race notes, and every test comment (they document regressions and fixture shapes).

Comments only — zero behavior change.

## Test plan

- [x] `gofmt`/`go build` clean (backend diff is empty).
- [x] `tsc` clean; vitest — 324 passed; `vite build` clean.