### PR TITLE
feat: let a project sit with no session open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **A project may now sit with no session at all.** Closing the last one no
+  longer spawns a replacement, and opening a project no longer seeds a first
+  session — both land on an empty screen, the same shape as the no-project-open
+  landing screen, with a button that opens a session when you want one. The
+  sidebar's "+" still picks the kind. An empty project stays empty across a
+  restart, Home included.
+
 ### Fixed
 
 - **Zoom now works on layouts with a dedicated "+" key** (German, for one).

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { TerminalHost } from "@/components/TerminalHost"
 import { RightDock, type DockTab } from "@/components/dock/RightDock"
 import { FooterBar } from "@/components/FooterBar"
 import { Home } from "@/components/Home"
+import { EmptySessions } from "@/components/EmptySessions"
 import { Settings } from "@/components/settings/Settings"
 import { Toaster } from "@/components/ui/sonner"
 import { ClaudePluginGate } from "@/components/ClaudePluginGate"
@@ -60,8 +61,8 @@ function App() {
             <Route element={<Layout />}>
               <Route index element={<Home />} />
               {/* Terminals are rendered by TerminalHost; the route only selects
-                  which one is visible, so this element is empty. */}
-              <Route path="/projects/:projectId" element={null} />
+                  which one is visible. */}
+              <Route path="/projects/:projectId" element={<EmptySessions />} />
               {/* Settings is a per-project screen: it carries the project id so
                   it can show that project's overrides, and renders in the main
                   area with the session sidebar kept beside it. */}

--- a/frontend/src/components/EmptySessions.tsx
+++ b/frontend/src/components/EmptySessions.tsx
@@ -1,0 +1,34 @@
+import { Plus, SquareTerminal } from "lucide-react"
+import { useParams } from "react-router-dom"
+import { Button } from "@/components/ui/button"
+import { useProjects } from "@/lib/projects"
+import { sessionsOf } from "@/lib/sessions"
+
+// A sessionless project is a legal state: the user is asked for a session rather
+// than having a replacement PTY spawned behind their back. The route matches for
+// every project, so the emptiness gate lives here — the router cannot express it
+// without covering the running terminals underneath.
+export function EmptySessions() {
+  const { sessions, newSession } = useProjects()
+  const { projectId = "" } = useParams()
+
+  if (sessionsOf(sessions, projectId).length > 0) {
+    return null
+  }
+
+  return (
+    <div className="absolute inset-0 z-10 flex flex-col items-center justify-center gap-4 bg-background">
+      <SquareTerminal className="size-12 text-muted-foreground" />
+      <div className="text-center">
+        <h1 className="text-lg font-semibold text-foreground">No session open</h1>
+        <p className="text-sm text-muted-foreground">
+          Open a session to start working in this project.
+        </p>
+      </div>
+      <Button onClick={() => newSession(projectId)}>
+        <Plus data-icon="inline-start" />
+        New session
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -60,7 +60,7 @@ interface ProjectsValue {
   /** Resume a worktree: reopen its parked session (continuing its Claude
    * conversation) when one exists, else open a fresh session on it. */
   reopenWorktreeSession: (projectId: string, wt: { name: string; path: string }) => Promise<void>
-  /** Permanently delete a session; deleting the last one recreates an empty one. */
+  /** Permanently delete a session; deleting the last one leaves the project with none. */
   closeSession: (projectId: string, sessionId: string) => void
   /** Close a worktree session but park its row so it can be resumed later. */
   keepSession: (projectId: string, sessionId: string) => void
@@ -158,12 +158,10 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       const home = await ProjectService.Home().catch(() => null)
       if (home) {
         setHomeId(home.id)
-        const existing = loaded.find((p) => p.id === home.id)
-        if (!existing) {
+        // Seeded only on the very first launch: an existing Home left without
+        // sessions was emptied on purpose and keeps its empty screen.
+        if (!loaded.some((p) => p.id === home.id)) {
           await Store.AddProject(home.id, home.name, home.path)
-          await Store.AddSession(home.id, newSessionId(), FIRST_LABEL, "shell", "", FIRST_NEXT_SEQ)
-          loaded = (await Store.LoadState()) ?? []
-        } else if ((existing.sessions ?? []).length === 0) {
           await Store.AddSession(home.id, newSessionId(), FIRST_LABEL, "shell", "", FIRST_NEXT_SEQ)
           loaded = (await Store.LoadState()) ?? []
         }
@@ -201,15 +199,9 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     }
     await Store.AddProject(picked.id, picked.name, picked.path)
 
-    // Reload from the store to pick up any sessions a reopened project kept, and
-    // seed a first session when it is brand new (or was left empty).
-    let loaded = (await Store.LoadState()) ?? []
-    const mine = loaded.find((p) => p.id === picked.id)
-    if (!mine || (mine.sessions ?? []).length === 0) {
-      await Store.AddSession(picked.id, newSessionId(), FIRST_LABEL, defaultProviderKind(), "", FIRST_NEXT_SEQ)
-      loaded = (await Store.LoadState()) ?? []
-    }
-    applyLoaded(loaded)
+    // A reopened project keeps the sessions it was closed with, hence the reload.
+    // Nothing is seeded: a brand-new project lands on the empty screen.
+    applyLoaded((await Store.LoadState()) ?? [])
     navigate(`/projects/${picked.id}`)
   }, [applyLoaded, navigate])
 
@@ -318,8 +310,8 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
 
   // dropSession removes a session's card and persists that removal via `persist`
   // — DeleteSession (gone for good) or CloseSession (parked for a later resume).
-  // A project always keeps at least one session; recreate when emptied. Home
-  // stays a shell so it never turns into a Claude session.
+  // Closing the last one leaves the project sessionless: the EmptySessions screen
+  // then offers a new one, rather than a replacement PTY spawning unasked.
   const dropSession = useCallback(
     (
       projectId: string,
@@ -328,18 +320,6 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     ) => {
       const removed = removeSession(sessionsRef.current, projectId, sessionId)
       if (removed === sessionsRef.current) {
-        return
-      }
-      if (sessionsOf(removed, projectId).length === 0) {
-        const recreatedId = newSessionId()
-        const kind: SessionKind = projectId === homeIdRef.current ? "shell" : defaultProviderKind()
-        const next = addSession(removed, projectId, recreatedId, kind)
-        const project = next[projectId]
-        const created = project.sessions[project.sessions.length - 1]
-        setSessions(next)
-        void persist("").then(() =>
-          Store.AddSession(projectId, recreatedId, created.label, created.kind, "", project.nextSeq),
-        )
         return
       }
       setSessions(removed)

--- a/frontend/src/lib/sessions.test.ts
+++ b/frontend/src/lib/sessions.test.ts
@@ -143,13 +143,13 @@ describe("closeSession", () => {
     expect(activeSessionId(state, P)).toBe("s2")
   })
 
-  it("empties the project but preserves nextSeq for recreate", () => {
+  it("empties the project but preserves nextSeq", () => {
     const state = closeSession(buildState(1), P, "s1")
     expect(sessionsOf(state, P)).toHaveLength(0)
     expect(activeSessionId(state, P)).toBe("")
-    // A recreate keeps counting up instead of reusing "Session 1".
-    const recreated = addSession(state, P, "s2")
-    expect(sessionsOf(recreated, P)[0].label).toBe("Session 2")
+    // The next session keeps counting up instead of reusing "Session 1".
+    const reopened = addSession(state, P, "s2")
+    expect(sessionsOf(reopened, P)[0].label).toBe("Session 2")
   })
 
   it("ignores unknown project or session ids", () => {

--- a/frontend/src/lib/sessions.ts
+++ b/frontend/src/lib/sessions.ts
@@ -93,8 +93,8 @@ export function addSession(
 }
 
 // closeSession removes a session. When the active one is closed, focus moves to
-// a neighbor. The project entry is kept even when empty so nextSeq (and the
-// caller's recreate-on-empty policy) survive.
+// a neighbor. The project entry is kept even when empty so nextSeq survives: a
+// project emptied and then reopened keeps counting labels up.
 export function closeSession(
   state: SessionState,
   projectId: string,


### PR DESCRIPTION
## Why

Closing the last session of a project spawned a replacement PTY, so an empty project was unreachable — you could never park a project without a running provider or shell in it. Opening a project seeded a session the same way.

## What

A sessionless project is now a legal state on every path that could produce one: the close, the picker, and a restart.

- **`EmptySessions`** renders on the project route while the session list is empty — the shape of the no-project-open landing screen, one level down, with a button that opens a session on demand. The sidebar's `+` still picks the kind. The emptiness gate lives in the component rather than the router, which matches for every project and would otherwise cover the running terminals.
- **`dropSession`** loses its recreate-on-empty branch, and with it the Home-stays-a-shell special case that only existed to pick the recreated session's kind.
- **`openProject`** no longer seeds a first session; a reopened project still comes back with the sessions it was closed with.
- **Home** keeps its seed on the very first launch only — an existing Home left without sessions was emptied on purpose and keeps its empty screen across restarts.

The store already accepted an empty active session id (`DeleteSession`/`CloseSession` document `""` as "none remain"), so nothing on the backend changed.

| Path | Before | After |
| --- | --- | --- |
| Close the last session | recreated one | project goes empty |
| Open a project (picker) | seeded `Session 1` | opens empty |
| Restart with an empty project | Home recreated one | stays empty |
| First launch ever (no Home row) | seeds a shell | unchanged |

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` — 298 pass, backend untouched
- [x] `tsc --noEmit`, `vitest run` — 324 pass
- [x] `vite build`

## Note

`EmptySessions` is a render path, and the frontend suite is node-only — the two manual checks above are what actually cover it.
