### PR TITLE
refactor: rename the stored Claude session id to a provider session id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The stored Claude session id is now a provider session id.** lich runs four
+  provider CLIs, but the column, the struct field, the store method and the
+  hook payload were all still named after Claude alone. The `sessions` table's
+  `claude_session_id` is renamed to `provider_session_id` on open (existing ids
+  carry over — the rename is the migration, nothing is stranded);
+  `store.Session.ClaudeSessionID` becomes `ProviderSessionID`
+  (`providerSessionId` over the wire), and `SetClaudeSession` becomes
+  `SetProviderSession`. The `/session-start` hook now takes
+  `provider_session_id` and still accepts the old `claude_session_id` so plugin
+  releases before v0.3.0 keep working — see `docs/hooks/session-start.md`.
+  Resume itself stays Claude-only: `--resume` is a Claude Code flag.
+
 ### Fixed
 
 - **Zoom now works on layouts with a dedicated "+" key** (German, for one).

--- a/docs/hooks/session-start.md
+++ b/docs/hooks/session-start.md
@@ -1,10 +1,11 @@
 # Contract: session start
 
-Reports the Claude Code session id running inside a lich session's PTY, so lich
-can persist the link between its own session (the card) and Claude's session.
-That id is what lets a restored card offer to resume the conversation it ran
-before the last restart, and the key for later features that need to reach a
-session's transcript.
+Reports the provider conversation id running inside a lich session's PTY, so
+lich can persist the link between its own session (the card) and the provider's
+session. That id is what lets a restored card offer to resume the conversation
+it ran before the last restart, and the key for later features that need to
+reach a session's transcript. Claude Code is the only provider that reports one
+today.
 
 See [README.md](README.md) for the shared transport (`LICH_PORT` / `LICH_TOKEN`
 / `LICH_SESSION_ID`) and the client rules every hook follows.
@@ -15,12 +16,15 @@ See [README.md](README.md) for the shared transport (`LICH_PORT` / `LICH_TOKEN`
 POST http://127.0.0.1:${LICH_PORT}/session-start?token=${LICH_TOKEN}
 Content-Type: application/json
 
-{"session_id": "<LICH_SESSION_ID>", "claude_session_id": "<claude session id>"}
+{"session_id": "<LICH_SESSION_ID>", "provider_session_id": "<provider session id>"}
 ```
 
 - `session_id` — the lich card, from `LICH_SESSION_ID`.
-- `claude_session_id` — Claude Code's own session id, from the hook payload's
-  `session_id` field on stdin. Must be non-empty.
+- `provider_session_id` — the provider CLI's own session id; for Claude Code,
+  the hook payload's `session_id` field on stdin. Must be non-empty.
+- `claude_session_id` — **deprecated** alias for `provider_session_id`, still
+  accepted so plugin releases before v0.3.0 keep working. When both are
+  present, `provider_session_id` wins. New clients must not send it.
 
 Responses: `204` ok · `401` invalid token · `400` invalid body · `500` lich
 failed to persist.
@@ -29,7 +33,7 @@ failed to persist.
 
 | Claude Code hook | action                                                       |
 |------------------|--------------------------------------------------------------|
-| `SessionStart`   | store `claude_session_id` on the lich session row, and mark  |
+| `SessionStart`   | store `provider_session_id` on the lich session row, and mark|
 |                  | the card as running Claude (the `session-agent` app event)   |
 
 `SessionStart` fires on startup, resume, `/clear` and compaction. A resume
@@ -40,10 +44,11 @@ holds the id of the Claude session currently in the card.
 
 - **Endpoint** — `internal/terminal/transport.go`, `transport.sessionStart`:
   validates the token and body (`parseSessionStart`) on the same loopback
-  listener as terminal I/O, then forwards `(session_id, claude_session_id)`.
-- **Persistence** — `internal/store/mutations.go`, `Service.SetClaudeSession`:
-  `UPDATE sessions SET claude_session_id`. Surfaced on `store.Session`
-  (`claudeSessionId`) and returned by `LoadState`.
+  listener as terminal I/O, folds the deprecated `claude_session_id` into
+  `provider_session_id`, then forwards `(session_id, provider_session_id)`.
+- **Persistence** — `internal/store/mutations.go`, `Service.SetProviderSession`:
+  `UPDATE sessions SET provider_session_id`. Surfaced on `store.Session`
+  (`providerSessionId`) and returned by `LoadState`.
 - **UI push** — after persisting, the same closure (`internal/terminal/terminal.go`,
   `New`) emits the global app event `session-agent` (`{id, agent: "claude"}`):
   a report is proof Claude runs in this PTY, so a shell card wears Claude's
@@ -72,3 +77,12 @@ holds the id of the Claude session currently in the card.
 - **Not the transcript path.** The path is reconstructable from the id and cwd;
   storing it too is a contract change — add a field only when a feature needs
   it, per the versioning note in the README.
+- **Only Claude Code resumes.** The field and the column are provider-agnostic,
+  but `--resume` is a Claude Code flag: `resumeArgs` in
+  `internal/terminal/terminal.go` and `resumableSession` in
+  `frontend/src/lib/sessions.ts` both gate on the claude kind. Another provider
+  reporting an id would have it stored and ignored until its own resume flag is
+  wired.
+- **The deprecated `claude_session_id` alias stays until the install gate can
+  no longer meet a plugin older than v0.3.0.** Dropping it earlier silently
+  breaks resume for anyone who has not updated the plugin.

--- a/frontend/src/components/ResumeSessionDialog.tsx
+++ b/frontend/src/components/ResumeSessionDialog.tsx
@@ -31,7 +31,7 @@ export function ResumeSessionDialog({
         <>
           <span className="font-medium">{session?.label}</span> left a Claude
           Code session behind (
-          <span className="break-all font-mono">{session?.claudeSessionId}</span>
+          <span className="break-all font-mono">{session?.providerSessionId}</span>
           ). Resume it to pick the conversation up where it stopped, or start new
           for an empty one.
         </>

--- a/frontend/src/components/TerminalHost.tsx
+++ b/frontend/src/components/TerminalHost.tsx
@@ -111,7 +111,7 @@ export function TerminalHost() {
         session={asking}
         onStartNew={() => asking && answerResume(asking, "")}
         onResume={() =>
-          asking && answerResume(asking, asking.claudeSessionId ?? "")
+          asking && answerResume(asking, asking.providerSessionId ?? "")
         }
       />
     </>

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -43,7 +43,7 @@ export interface StoredSession {
   label: string
   kind: string
   path: string
-  claudeSessionId: string
+  providerSessionId: string
 }
 
 /** internal/store.Project — a persisted project with its session state. */

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -101,7 +101,7 @@ function buildSessionState(loaded: StoreProject[]): SessionState {
       label: s.label,
       kind: isSessionKind(s.kind) ? s.kind : "claude",
       ...(s.path ? { path: s.path } : {}),
-      ...(s.claudeSessionId ? { claudeSessionId: s.claudeSessionId } : {}),
+      ...(s.providerSessionId ? { providerSessionId: s.providerSessionId } : {}),
     }))
     state[p.id] = {
       sessions,
@@ -284,7 +284,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
         label: restored.label,
         kind: isSessionKind(restored.kind) ? restored.kind : "claude",
         path: restored.path,
-        ...(restored.claudeSessionId ? { claudeSessionId: restored.claudeSessionId } : {}),
+        ...(restored.providerSessionId ? { providerSessionId: restored.providerSessionId } : {}),
       }
       setSessions(restoreSession(sessionsRef.current, projectId, session))
     },

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -80,7 +80,7 @@ async function post(path: string): Promise<void> {
 }
 
 export const Terminal = {
-  /** resume: a Claude session id to reopen (--resume); "" starts fresh. */
+  /** resume: a provider session id to reopen (--resume); "" starts fresh. */
   Start: (
     id: string,
     projectID: string,
@@ -168,7 +168,6 @@ export const Store = {
   GetSetting: (key: string, projectID: string) => call<string>("store.GetSetting", [key, projectID]),
   SetSetting: (key: string, projectID: string, value: string) =>
     call<null>("store.SetSetting", [key, projectID, value]),
-  ClaudeBin: (projectID: string) => call<string>("store.ClaudeBin", [projectID]),
 }
 
 export const Fonts = {

--- a/frontend/src/lib/sessions.test.ts
+++ b/frontend/src/lib/sessions.test.ts
@@ -47,7 +47,7 @@ describe("isSessionKind", () => {
 function withClaudeSession(
   state: SessionState,
   sessionId: string,
-  claudeSessionId: string,
+  providerSessionId: string,
   kind: "claude" | "shell" = "claude",
 ): SessionState {
   return {
@@ -55,7 +55,7 @@ function withClaudeSession(
     [P]: {
       ...state[P],
       sessions: state[P].sessions.map((s) =>
-        s.id === sessionId ? { ...s, kind, claudeSessionId } : s,
+        s.id === sessionId ? { ...s, kind, providerSessionId } : s,
       ),
     },
   }
@@ -256,7 +256,7 @@ describe("resumableSession", () => {
     const state = withClaudeSession(buildState(2), "s1", "claude-abc")
     expect(resumableSession(state, P, "s1")).toMatchObject({
       id: "s1",
-      claudeSessionId: "claude-abc",
+      providerSessionId: "claude-abc",
     })
   })
 
@@ -286,7 +286,7 @@ describe("restoreSession", () => {
     label: "swift-rabbit",
     kind: "claude" as const,
     path: "/wt/swift-rabbit",
-    claudeSessionId: "claude-abc",
+    providerSessionId: "claude-abc",
   }
 
   it("re-adds the session, focuses it, and keeps its claude session id", () => {
@@ -294,7 +294,7 @@ describe("restoreSession", () => {
     const sessions = sessionsOf(state, P)
     expect(sessions.map((s) => s.id)).toEqual(["s1", "s2", "wt2"])
     expect(activeSessionId(state, P)).toBe("wt2")
-    expect(sessions[2].claudeSessionId).toBe("claude-abc")
+    expect(sessions[2].providerSessionId).toBe("claude-abc")
   })
 
   it("does not advance the label counter (not a new numbered session)", () => {

--- a/frontend/src/lib/sessions.ts
+++ b/frontend/src/lib/sessions.ts
@@ -31,11 +31,11 @@ export interface Session {
   // Working directory when the session lives in a git worktree; absent means
   // the project's own path.
   path?: string
-  // The Claude Code session this card ran before the last restart, reported by
-  // the SessionStart hook and read back on hydration. Only ever set by the
-  // store: a session created in this run has none, and the hook's later report
-  // is not mirrored here — a running session has nothing to resume.
-  claudeSessionId?: string
+  // The provider conversation this card ran before the last restart, reported
+  // by the provider's session-start hook and read back on hydration. Only ever
+  // set by the store: a session created in this run has none, and the hook's
+  // later report is not mirrored here — a running session has nothing to resume.
+  providerSessionId?: string
 }
 
 export interface ProjectSessions {
@@ -124,7 +124,7 @@ function neighborId(sessions: Session[], removedIndex: number): string {
 }
 
 // restoreSession re-adds a parked session — its own id, label and
-// claudeSessionId intact — to a project and focuses it, without advancing the
+// providerSessionId intact — to a project and focuses it, without advancing the
 // label counter: a resume brings back an existing session, it does not mint a
 // new numbered one. An id already present is just focused; an unknown project is
 // ignored.
@@ -219,17 +219,18 @@ export function removeProject(
 }
 
 // resumableSession returns the session whose PTY should ask before it spawns,
-// because it carries the Claude session it ran before the last restart. Null for
-// everything with nothing to resume: unknown ids, sessions created in this run,
-// and shell sessions — whose shell cannot reopen a Claude session even when a
-// hand-run Claude Code left an id on their row.
+// because it carries the provider conversation it ran before the last restart.
+// Null for everything with nothing to resume: unknown ids, sessions created in
+// this run, providers with no resume flag wired (only Claude Code has one), and
+// shell sessions — whose shell cannot reopen a conversation even when a hand-run
+// provider CLI left an id on their row.
 export function resumableSession(
   state: SessionState,
   projectId: string,
   sessionId: string,
 ): Session | null {
   const session = state[projectId]?.sessions.find((s) => s.id === sessionId)
-  if (!session || session.kind !== "claude" || !session.claudeSessionId) {
+  if (!session || session.kind !== "claude" || !session.providerSessionId) {
     return null
   }
   return session

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+
+	"github.com/omartelo/lich/internal/providers"
 )
 
 // AddProject persists a newly opened project and marks it open. Reopening a
@@ -34,14 +36,14 @@ func (s *Service) CloseProject(id string) error {
 
 // AddSession inserts a session, makes it the project's active one and records the
 // project's next label counter — all atomically, mirroring the frontend reducer.
-// Kind selects what the session's PTY runs ("claude" or "shell"); empty defaults
-// to "claude" so older callers keep the original behavior. Path is the session's
+// Kind selects what the session's PTY runs (a provider id or "shell"); empty
+// defaults to "claude" so older callers keep the original behavior. Path is the session's
 // working directory when it lives in a git worktree; empty means the project's.
 // The session takes the position after the project's last one, so it appends to
 // the card list even once the user has dragged the others around.
 func (s *Service) AddSession(projectID, sessionID, label, kind, path string, nextSeq int) error {
 	if kind == "" {
-		kind = "claude"
+		kind = providers.Claude
 	}
 	return s.tx(func(tx *sql.Tx) error {
 		if _, err := tx.Exec(
@@ -80,7 +82,7 @@ func (s *Service) DeleteSession(projectID, sessionID, activeID string) error {
 }
 
 // CloseSession parks a session instead of deleting it: is_open flips to 0, which
-// hides it from LoadState while keeping its row — and its Claude session id —
+// hides it from LoadState while keeping its row — and its provider session id —
 // intact for a later resume. The project's active session moves to activeID (the
 // neighbor the frontend picked). The keep-the-worktree close uses this; a plain
 // close still DeleteSessions for good.
@@ -101,9 +103,9 @@ func (s *Service) CloseSession(projectID, sessionID, activeID string) error {
 
 // ReopenWorktreeSession resumes a parked worktree session. It finds the parked
 // (is_open = 0) session for the worktree at path and re-adds it to the workspace
-// under a fresh id (newSessionID), carrying over the old label, kind, Claude
+// under a fresh id (newSessionID), carrying over the old label, kind, provider
 // session id and label_auto flag. The fresh id is deliberate: it makes the frontend treat the card
-// as never-spawned, so its resume prompt fires and the Claude conversation
+// as never-spawned, so its resume prompt fires and the provider conversation
 // continues instead of starting cold. Returns nil when nothing is parked at path
 // — the caller then opens a brand-new session.
 func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*Session, error) {
@@ -115,13 +117,13 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 		// stomp the chosen name, breaking SetSessionTitle's contract.
 		var labelAuto int
 		row := tx.QueryRow(
-			`SELECT id, label, kind, claude_session_id, label_auto
+			`SELECT id, label, kind, provider_session_id, label_auto
 			   FROM sessions
 			  WHERE project_id = ? AND path = ? AND is_open = 0
 			  ORDER BY rowid DESC LIMIT 1`,
 			projectID, path,
 		)
-		if err := row.Scan(&old.ID, &old.Label, &old.Kind, &old.ClaudeSessionID, &labelAuto); err != nil {
+		if err := row.Scan(&old.ID, &old.Label, &old.Kind, &old.ProviderSessionID, &labelAuto); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return nil // nothing parked here; caller creates a new session
 			}
@@ -131,10 +133,10 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 			return fmt.Errorf("drop parked session %q: %w", old.ID, err)
 		}
 		if _, err := tx.Exec(
-			`INSERT INTO sessions (id, project_id, label, kind, path, claude_session_id, label_auto, position)
+			`INSERT INTO sessions (id, project_id, label, kind, path, provider_session_id, label_auto, position)
 			 VALUES (?, ?, ?, ?, ?, ?, ?,
 			         (SELECT COALESCE(MAX(position), -1) + 1 FROM sessions WHERE project_id = ?))`,
-			newSessionID, projectID, old.Label, old.Kind, path, old.ClaudeSessionID, labelAuto, projectID,
+			newSessionID, projectID, old.Label, old.Kind, path, old.ProviderSessionID, labelAuto, projectID,
 		); err != nil {
 			return fmt.Errorf("reinsert session %q: %w", newSessionID, err)
 		}
@@ -144,7 +146,7 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 		); err != nil {
 			return fmt.Errorf("activate reopened session on %q: %w", projectID, err)
 		}
-		restored = &Session{ID: newSessionID, Label: old.Label, Kind: old.Kind, Path: path, ClaudeSessionID: old.ClaudeSessionID}
+		restored = &Session{ID: newSessionID, Label: old.Label, Kind: old.Kind, Path: path, ProviderSessionID: old.ProviderSessionID}
 		return nil
 	})
 	if err != nil {
@@ -184,7 +186,7 @@ func (s *Service) RenameSession(sessionID, label string) error {
 	return nil
 }
 
-// SetSessionTitle sets a session's label from the Claude Code ai-title reported
+// SetSessionTitle sets a session's label from the provider's ai-title reported
 // by the Stop hook, but only while the label is still automatic: a prior
 // RenameSession clears label_auto and makes this a no-op, so a user's own name
 // is never overwritten. Reports whether the label actually changed, so the
@@ -204,17 +206,18 @@ func (s *Service) SetSessionTitle(sessionID, title string) (bool, error) {
 	return n > 0, nil
 }
 
-// SetClaudeSession records the Claude Code session id running inside a lich
-// session's PTY, reported by the SessionStart hook. A session whose row does not
-// exist yet (the hook racing session persistence) matches nothing and is not an
-// error — the id is simply dropped, which is acceptable for the features it
-// backs. Re-reporting (e.g. after a resume) overwrites with the latest id.
-func (s *Service) SetClaudeSession(sessionID, claudeSessionID string) error {
+// SetProviderSession records the provider conversation id running inside a lich
+// session's PTY, reported by the provider's session-start hook. A session whose
+// row does not exist yet (the hook racing session persistence) matches nothing
+// and is not an error — the id is simply dropped, which is acceptable for the
+// features it backs. Re-reporting (e.g. after a resume) overwrites with the
+// latest id.
+func (s *Service) SetProviderSession(sessionID, providerSessionID string) error {
 	if _, err := s.db.Exec(
-		`UPDATE sessions SET claude_session_id = ? WHERE id = ?`,
-		claudeSessionID, sessionID,
+		`UPDATE sessions SET provider_session_id = ? WHERE id = ?`,
+		providerSessionID, sessionID,
 	); err != nil {
-		return fmt.Errorf("set claude session on %q: %w", sessionID, err)
+		return fmt.Errorf("set provider session on %q: %w", sessionID, err)
 	}
 	return nil
 }

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+
+	"github.com/omartelo/lich/internal/providers"
 )
 
 // claudeBinKey is the settings key holding the Claude Code binary path. Claude
@@ -49,7 +51,7 @@ func (s *Service) SetSetting(key, projectID, value string) error {
 // binKey is the settings key holding a provider's custom binary path. Claude
 // uses the legacy "claude.bin"; every other provider is namespaced by id.
 func binKey(providerID string) string {
-	if providerID == "claude" {
+	if providerID == providers.Claude {
 		return claudeBinKey
 	}
 	return "provider." + providerID + ".bin"
@@ -76,5 +78,5 @@ func (s *Service) ProviderBin(providerID, projectID string) string {
 // ClaudeBin is ProviderBin for Claude Code, kept for the plugin service that
 // resolves the same binary outside the terminal's spawn path.
 func (s *Service) ClaudeBin(projectID string) string {
-	return s.ProviderBin("claude", projectID)
+	return s.ProviderBin(providers.Claude, projectID)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,6 +1,6 @@
 // Package store is lich's persistence layer: a single SQLite database holding
 // open projects, their terminal sessions and backend-read settings (currently
-// the Claude Code binary path, global or per-project). It never stores chat or
+// the provider binary paths, global or per-project). It never stores chat or
 // terminal content — only the metadata needed to restore the workspace after a
 // restart.
 //
@@ -33,15 +33,15 @@ CREATE TABLE IF NOT EXISTS projects (
 );
 
 CREATE TABLE IF NOT EXISTS sessions (
-    id                TEXT NOT NULL PRIMARY KEY,
-    project_id        TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
-    label             TEXT NOT NULL,
-    kind              TEXT NOT NULL DEFAULT 'claude',
-    path              TEXT NOT NULL DEFAULT '',
-    claude_session_id TEXT NOT NULL DEFAULT '',
-    label_auto        INTEGER NOT NULL DEFAULT 1,
-    is_open           INTEGER NOT NULL DEFAULT 1,
-    position          INTEGER NOT NULL DEFAULT 0
+    id                  TEXT NOT NULL PRIMARY KEY,
+    project_id          TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    label               TEXT NOT NULL,
+    kind                TEXT NOT NULL DEFAULT 'claude',
+    path                TEXT NOT NULL DEFAULT '',
+    provider_session_id TEXT NOT NULL DEFAULT '',
+    label_auto          INTEGER NOT NULL DEFAULT 1,
+    is_open             INTEGER NOT NULL DEFAULT 1,
+    position            INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
 
@@ -62,18 +62,19 @@ type Service struct {
 }
 
 // Session is a persisted terminal session (metadata only). Kind selects what
-// the PTY runs: "claude" (Claude Code binary) or "shell" (the user's shell).
-// Path is the session's working directory when it lives in a git worktree;
-// empty means the project's own path. ClaudeSessionID is the id Claude Code
-// assigns its own session, reported by the SessionStart hook; empty until the
-// hook fires (or for shell sessions), it is the key for future features that
-// need to reach a session's transcript or resume it.
+// the PTY runs: a provider id (see internal/providers) or "shell" (the user's
+// shell). Path is the session's working directory when it lives in a git
+// worktree; empty means the project's own path. ProviderSessionID is the id the
+// provider CLI assigns the conversation running in the PTY, reported by that
+// provider's session-start hook; empty until a hook fires (or for shell
+// sessions), it is the key for features that need to reach a session's
+// transcript or resume it. Only Claude Code reports one today.
 type Session struct {
-	ID              string `json:"id"`
-	Label           string `json:"label"`
-	Kind            string `json:"kind"`
-	Path            string `json:"path"`
-	ClaudeSessionID string `json:"claudeSessionId"`
+	ID                string `json:"id"`
+	Label             string `json:"label"`
+	Kind              string `json:"kind"`
+	Path              string `json:"path"`
+	ProviderSessionID string `json:"providerSessionId"`
 }
 
 // Project is a persisted project together with its restorable session state.
@@ -117,25 +118,39 @@ func open(path string) (*Service, error) {
 		return nil, fmt.Errorf("apply schema: %w", err)
 	}
 	// Migrations for databases created before these columns existed. SQLite has
-	// no ADD COLUMN IF NOT EXISTS; a duplicate-column error means it is already
-	// applied.
+	// no ADD COLUMN IF NOT EXISTS and no RENAME COLUMN IF EXISTS; the two errors
+	// tolerated below are exactly "the column is already there" and "there is
+	// nothing to rename", which is what an already-applied migration looks like.
+	//
+	// The rename/add pair covers all three shapes a database can be in: created
+	// fresh with provider_session_id (rename finds nothing, add is a duplicate),
+	// created with the old claude_session_id (rename carries the ids over, add is
+	// a duplicate), or predating the column entirely (rename finds nothing, add
+	// creates it).
 	migrations := []string{
 		`ALTER TABLE sessions ADD COLUMN kind TEXT NOT NULL DEFAULT 'claude'`,
 		`ALTER TABLE sessions ADD COLUMN path TEXT NOT NULL DEFAULT ''`,
-		`ALTER TABLE sessions ADD COLUMN claude_session_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions RENAME COLUMN claude_session_id TO provider_session_id`,
+		`ALTER TABLE sessions ADD COLUMN provider_session_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN label_auto INTEGER NOT NULL DEFAULT 1`,
 		`ALTER TABLE sessions ADD COLUMN is_open INTEGER NOT NULL DEFAULT 1`,
 		`ALTER TABLE sessions ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 	}
 	for _, stmt := range migrations {
-		if _, err := db.Exec(stmt); err != nil &&
-			!strings.Contains(err.Error(), "duplicate column") {
+		if _, err := db.Exec(stmt); err != nil && !migrationApplied(err) {
 			_ = db.Close()
 			return nil, fmt.Errorf("migrate schema: %w", err)
 		}
 	}
 	return &Service{db: db}, nil
+}
+
+// migrationApplied reports whether an ALTER TABLE failed because the migration
+// had already been applied — the column exists, or the one to rename is gone.
+func migrationApplied(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "duplicate column") || strings.Contains(msg, "no such column")
 }
 
 // databasePath resolves the on-disk location of the database file. LICH_DEV
@@ -201,7 +216,7 @@ func (s *Service) LoadState() ([]Project, error) {
 // into, falling back to insertion order for rows never reordered.
 func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	rows, err := s.db.Query(
-		`SELECT id, label, kind, path, claude_session_id
+		`SELECT id, label, kind, path, provider_session_id
 		   FROM sessions WHERE project_id = ? AND is_open = 1 ORDER BY position, rowid`,
 		projectID,
 	)
@@ -213,7 +228,7 @@ func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	sessions := []Session{}
 	for rows.Next() {
 		var sess Session
-		if err := rows.Scan(&sess.ID, &sess.Label, &sess.Kind, &sess.Path, &sess.ClaudeSessionID); err != nil {
+		if err := rows.Scan(&sess.ID, &sess.Label, &sess.Kind, &sess.Path, &sess.ProviderSessionID); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}
 		sessions = append(sessions, sess)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -100,38 +100,38 @@ func TestSessionKindPersistsAndDefaults(t *testing.T) {
 	}
 }
 
-// TestSetClaudeSessionPersistsAndDefaults proves the Claude session id survives
+// TestSetProviderSessionPersistsAndDefaults proves the provider session id survives
 // a reload, defaults to "" before the SessionStart hook reports it, and that a
 // re-report overwrites with the latest id.
-func TestSetClaudeSessionPersistsAndDefaults(t *testing.T) {
+func TestSetProviderSessionPersistsAndDefaults(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
 	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
 	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3)
 
-	if err := svc.SetClaudeSession("s1", "uuid-abc"); err != nil {
-		t.Fatalf("SetClaudeSession: %v", err)
+	if err := svc.SetProviderSession("s1", "uuid-abc"); err != nil {
+		t.Fatalf("SetProviderSession: %v", err)
 	}
 	// Re-report (e.g. after a resume) overwrites with the newest id.
-	if err := svc.SetClaudeSession("s1", "uuid-def"); err != nil {
-		t.Fatalf("SetClaudeSession re-report: %v", err)
+	if err := svc.SetProviderSession("s1", "uuid-def"); err != nil {
+		t.Fatalf("SetProviderSession re-report: %v", err)
 	}
 
 	sessions := mustLoadSessions(t, svc)
-	if sessions[0].ClaudeSessionID != "uuid-def" {
-		t.Errorf("s1 claude id = %q, want uuid-def", sessions[0].ClaudeSessionID)
+	if sessions[0].ProviderSessionID != "uuid-def" {
+		t.Errorf("s1 claude id = %q, want uuid-def", sessions[0].ProviderSessionID)
 	}
-	if sessions[1].ClaudeSessionID != "" {
-		t.Errorf("s2 claude id = %q, want empty", sessions[1].ClaudeSessionID)
+	if sessions[1].ProviderSessionID != "" {
+		t.Errorf("s2 claude id = %q, want empty", sessions[1].ProviderSessionID)
 	}
 }
 
-// TestSetClaudeSessionUnknownSessionNoop proves reporting for a session whose
+// TestSetProviderSessionUnknownSessionNoop proves reporting for a session whose
 // row does not exist (the hook racing persistence) is not an error.
-func TestSetClaudeSessionUnknownSessionNoop(t *testing.T) {
+func TestSetProviderSessionUnknownSessionNoop(t *testing.T) {
 	svc := newTestStore(t)
-	if err := svc.SetClaudeSession("ghost", "uuid-x"); err != nil {
-		t.Errorf("SetClaudeSession unknown = %v, want nil", err)
+	if err := svc.SetProviderSession("ghost", "uuid-x"); err != nil {
+		t.Errorf("SetProviderSession unknown = %v, want nil", err)
 	}
 }
 
@@ -349,7 +349,7 @@ func TestOperationsOnClosedStoreReturnErrors(t *testing.T) {
 	assertErr("AddSession", svc.AddSession("p1", "s1", "Session 1", "", "", 2))
 	assertErr("DeleteSession", svc.DeleteSession("p1", "s1", ""))
 	assertErr("RenameSession", svc.RenameSession("s1", "x"))
-	assertErr("SetClaudeSession", svc.SetClaudeSession("s1", "uuid"))
+	assertErr("SetProviderSession", svc.SetProviderSession("s1", "uuid"))
 	assertErr("SetActiveSession", svc.SetActiveSession("p1", "s1"))
 	if _, err := svc.SetSessionTitle("s1", "x"); err == nil {
 		t.Error("SetSessionTitle on closed store = nil error, want error")
@@ -533,7 +533,7 @@ func TestOpenMigratesPreMigrationDatabase(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "old.db")
 
 	// The schema as it stood before the migrations: sessions without
-	// kind/path/claude_session_id/label_auto/position, projects without
+	// kind/path/provider_session_id/label_auto/position, projects without
 	// position.
 	const oldSchema = `
 CREATE TABLE projects (
@@ -584,6 +584,66 @@ CREATE TABLE sessions (
 	}
 }
 
+// TestOpenRenamesClaudeSessionColumn proves the multi-provider rename carries
+// stored ids over instead of stranding them: a database still on the
+// claude_session_id column comes back with its values readable under
+// provider_session_id.
+func TestOpenRenamesClaudeSessionColumn(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "claude-column.db")
+
+	// The schema as it stood while the column was Claude-specific.
+	const claudeSchema = `
+CREATE TABLE projects (
+    id                TEXT    PRIMARY KEY,
+    name              TEXT    NOT NULL,
+    path              TEXT    NOT NULL,
+    is_open           INTEGER NOT NULL DEFAULT 1,
+    next_seq          INTEGER NOT NULL DEFAULT 1,
+    active_session_id TEXT    NOT NULL DEFAULT '',
+    position          INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE sessions (
+    id                TEXT NOT NULL PRIMARY KEY,
+    project_id        TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    label             TEXT NOT NULL,
+    kind              TEXT NOT NULL DEFAULT 'claude',
+    path              TEXT NOT NULL DEFAULT '',
+    claude_session_id TEXT NOT NULL DEFAULT '',
+    label_auto        INTEGER NOT NULL DEFAULT 1,
+    is_open           INTEGER NOT NULL DEFAULT 1,
+    position          INTEGER NOT NULL DEFAULT 0
+);
+INSERT INTO projects (id, name, path) VALUES ('p1', 'alpha', '/tmp/alpha');
+INSERT INTO sessions (id, project_id, label, claude_session_id)
+     VALUES ('s1', 'p1', 'Session 1', 'uuid-kept');`
+
+	seed, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open seed db: %v", err)
+	}
+	if _, err := seed.Exec(claudeSchema); err != nil {
+		t.Fatalf("seed claude schema: %v", err)
+	}
+	_ = seed.Close()
+
+	svc, err := open(path)
+	if err != nil {
+		t.Fatalf("open claude-column db: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Close() })
+
+	got, err := svc.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if len(got) != 1 || len(got[0].Sessions) != 1 {
+		t.Fatalf("state after rename = %+v", got)
+	}
+	if id := got[0].Sessions[0].ProviderSessionID; id != "uuid-kept" {
+		t.Errorf("provider session id = %q, want uuid-kept", id)
+	}
+}
+
 // TestCloseSessionParksAndReopenRestores proves a kept worktree session survives
 // close as a hidden (parked) row and comes back — under a fresh id, with its
 // Claude session id intact — when its worktree is resumed.
@@ -596,8 +656,8 @@ func TestCloseSessionParksAndReopenRestores(t *testing.T) {
 	if err := svc.AddSession("p1", "wt", "swift-rabbit", "claude", "/data/wt/swift-rabbit", 3); err != nil {
 		t.Fatalf("AddSession worktree: %v", err)
 	}
-	if err := svc.SetClaudeSession("wt", "claude-uuid-1"); err != nil {
-		t.Fatalf("SetClaudeSession: %v", err)
+	if err := svc.SetProviderSession("wt", "claude-uuid-1"); err != nil {
+		t.Fatalf("SetProviderSession: %v", err)
 	}
 
 	// Keep-close parks the worktree session: gone from the workspace, base active.
@@ -625,7 +685,7 @@ func TestCloseSessionParksAndReopenRestores(t *testing.T) {
 		t.Fatal("ReopenWorktreeSession = nil, want the parked session")
 	}
 	if restored.ID != "wt2" || restored.Label != "swift-rabbit" ||
-		restored.Path != "/data/wt/swift-rabbit" || restored.ClaudeSessionID != "claude-uuid-1" {
+		restored.Path != "/data/wt/swift-rabbit" || restored.ProviderSessionID != "claude-uuid-1" {
 		t.Errorf("restored = %+v, want {wt2 swift-rabbit /data/wt/swift-rabbit claude-uuid-1}", restored)
 	}
 
@@ -638,7 +698,7 @@ func TestCloseSessionParksAndReopenRestores(t *testing.T) {
 	}
 	// The parked row is consumed, not duplicated: exactly one row for the path.
 	got := projects[0].Sessions[1]
-	if got.ID != "wt2" || got.ClaudeSessionID != "claude-uuid-1" {
+	if got.ID != "wt2" || got.ProviderSessionID != "claude-uuid-1" {
 		t.Errorf("reopened session = %+v, want id=wt2 claude=claude-uuid-1", got)
 	}
 	if projects[0].ActiveSessionID != "wt2" {

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -91,11 +91,11 @@ type session struct {
 
 // Store is the persistence the terminal service depends on: the binary to spawn
 // for a provider in a project (empty return spawns the provider's default), and
-// where to record the Claude session id a PTY reports through the SessionStart
+// where to record the provider session id a PTY reports through its session-start
 // hook. The store implements both.
 type Store interface {
 	ProviderBin(providerID, projectID string) string
-	SetClaudeSession(sessionID, claudeSessionID string) error
+	SetProviderSession(sessionID, providerSessionID string) error
 	SetSessionTitle(sessionID, title string) (bool, error)
 }
 
@@ -135,8 +135,8 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 		func(id, state string) {
 			hub.Emit(statusEventName, statusEvent{ID: id, State: state})
 		},
-		func(sessionID, claudeSessionID string) error {
-			if err := store.SetClaudeSession(sessionID, claudeSessionID); err != nil {
+		func(sessionID, providerSessionID string) error {
+			if err := store.SetProviderSession(sessionID, providerSessionID); err != nil {
 				return err
 			}
 			// A SessionStart report is proof Claude is running in this PTY —

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -24,7 +24,7 @@ import (
 type stubBins struct{ bin string }
 
 func (s stubBins) ProviderBin(_, _ string) string            { return s.bin }
-func (s stubBins) SetClaudeSession(_, _ string) error        { return nil }
+func (s stubBins) SetProviderSession(_, _ string) error      { return nil }
 func (s stubBins) SetSessionTitle(_, _ string) (bool, error) { return false, nil }
 
 // TestChildEnvStripsAppImageVars proves the AppImage runtime variables that break

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -90,7 +90,7 @@ type transport struct {
 	mux         *http.ServeMux
 	input       func(id string, data []byte)
 	status      func(id, state string)
-	linkSession func(sessionID, claudeSessionID string) error
+	linkSession func(sessionID, providerSessionID string) error
 	setTitle    func(sessionID, title string) error
 	touched     func(sessionID string)
 	// restart, when set, relaunches lich and closes this window; POST /restart
@@ -103,14 +103,14 @@ type transport struct {
 // newTransport starts the listener on a random loopback port. input receives
 // decoded input frames (keyboard data for a session's PTY); status receives a
 // session's processing state reported by the Claude Code hook (see /hook);
-// linkSession records the Claude session id a PTY reports at start (see
+// linkSession records the provider session id a PTY reports at start (see
 // /session-start); setTitle applies an auto-generated session label (see
 // /session-title); touched signals a session likely changed files on disk (see
 // /session-touched).
 func newTransport(
 	input func(id string, data []byte),
 	status func(id, state string),
-	linkSession func(sessionID, claudeSessionID string) error,
+	linkSession func(sessionID, providerSessionID string) error,
 	setTitle func(sessionID, title string) error,
 	touched func(sessionID string),
 ) (*transport, error) {
@@ -350,39 +350,46 @@ func parseHookRequest(body []byte) (hookRequest, error) {
 	return req, nil
 }
 
-// startRequest is a SessionStart POST body.
+// startRequest is a session-start POST body. LegacyClaudeSessionID accepts the
+// pre-multi-provider field name plugin releases before v0.3.0 send; parsing
+// folds it into ProviderSessionID, so nothing downstream sees two names. Drop it
+// once the install gate can no longer meet an older plugin.
 type startRequest struct {
-	SessionID       string `json:"session_id"`
-	ClaudeSessionID string `json:"claude_session_id"`
+	SessionID             string `json:"session_id"`
+	ProviderSessionID     string `json:"provider_session_id"`
+	LegacyClaudeSessionID string `json:"claude_session_id"`
 }
 
-// sessionStart receives the SessionStart POST from the Claude Code hook running
-// inside a spawned PTY and records the Claude session id against the lich
+// sessionStart receives the session-start POST from a provider's hook running
+// inside a spawned PTY and records the provider session id against the lich
 // session via the linkSession callback.
 func (t *transport) sessionStart(w http.ResponseWriter, r *http.Request) {
 	servePost(t, w, r, parseSessionStart, func(req startRequest) error {
 		if t.linkSession == nil {
 			return nil
 		}
-		if err := t.linkSession(req.SessionID, req.ClaudeSessionID); err != nil {
+		if err := t.linkSession(req.SessionID, req.ProviderSessionID); err != nil {
 			return fmt.Errorf("failed to record session: %w", err)
 		}
 		return nil
 	})
 }
 
-// parseSessionStart validates a SessionStart POST body: the lich session id and
-// the non-empty Claude session id it is reporting. Both must be present.
+// parseSessionStart validates a session-start POST body: the lich session id and
+// the non-empty provider session id it is reporting. Both must be present.
 func parseSessionStart(body []byte) (startRequest, error) {
 	var req startRequest
 	if err := json.Unmarshal(body, &req); err != nil {
 		return startRequest{}, fmt.Errorf("invalid session-start body: %w", err)
 	}
+	if req.ProviderSessionID == "" {
+		req.ProviderSessionID = req.LegacyClaudeSessionID
+	}
 	if req.SessionID == "" {
 		return startRequest{}, errors.New("session-start missing session_id")
 	}
-	if req.ClaudeSessionID == "" {
-		return startRequest{}, errors.New("session-start missing claude_session_id")
+	if req.ProviderSessionID == "" {
+		return startRequest{}, errors.New("session-start missing provider_session_id")
 	}
 	return req, nil
 }

--- a/internal/terminal/transport_test.go
+++ b/internal/terminal/transport_test.go
@@ -300,16 +300,20 @@ func TestHookRejectsBadToken(t *testing.T) {
 
 func TestParseSessionStart(t *testing.T) {
 	tests := []struct {
-		name         string
-		body         string
-		wantID       string
-		wantClaudeID string
-		wantErr      bool
+		name           string
+		body           string
+		wantID         string
+		wantProviderID string
+		wantErr        bool
 	}{
-		{"ok", `{"session_id":"s1","claude_session_id":"uuid-1"}`, "s1", "uuid-1", false},
-		{"missing session id", `{"claude_session_id":"uuid-1"}`, "", "", true},
-		{"missing claude id", `{"session_id":"s1"}`, "", "", true},
-		{"empty claude id", `{"session_id":"s1","claude_session_id":""}`, "", "", true},
+		{"ok", `{"session_id":"s1","provider_session_id":"uuid-1"}`, "s1", "uuid-1", false},
+		{"legacy claude field", `{"session_id":"s1","claude_session_id":"uuid-2"}`, "s1", "uuid-2", false},
+		{"new field wins over legacy",
+			`{"session_id":"s1","provider_session_id":"uuid-1","claude_session_id":"uuid-2"}`,
+			"s1", "uuid-1", false},
+		{"missing session id", `{"provider_session_id":"uuid-1"}`, "", "", true},
+		{"missing provider id", `{"session_id":"s1"}`, "", "", true},
+		{"empty provider id", `{"session_id":"s1","provider_session_id":""}`, "", "", true},
 		{"bad json", `{`, "", "", true},
 	}
 	for _, tc := range tests {
@@ -324,9 +328,9 @@ func TestParseSessionStart(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if req.SessionID != tc.wantID || req.ClaudeSessionID != tc.wantClaudeID {
+			if req.SessionID != tc.wantID || req.ProviderSessionID != tc.wantProviderID {
 				t.Fatalf("got (%q,%q), want (%q,%q)",
-					req.SessionID, req.ClaudeSessionID, tc.wantID, tc.wantClaudeID)
+					req.SessionID, req.ProviderSessionID, tc.wantID, tc.wantProviderID)
 			}
 		})
 	}
@@ -343,7 +347,7 @@ func TestSessionStartLinksSession(t *testing.T) {
 	}
 	url := fmt.Sprintf("http://127.0.0.1:%d/session-start?token=%s", tr.port, tr.token)
 	resp, err := http.Post(url, "application/json",
-		strings.NewReader(`{"session_id":"sess","claude_session_id":"uuid-9"}`))
+		strings.NewReader(`{"session_id":"sess","provider_session_id":"uuid-9"}`))
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}
@@ -372,7 +376,7 @@ func TestSessionStartRejectsBadToken(t *testing.T) {
 	}
 	url := fmt.Sprintf("http://127.0.0.1:%d/session-start?token=wrong", tr.port)
 	resp, err := http.Post(url, "application/json",
-		strings.NewReader(`{"session_id":"s","claude_session_id":"u"}`))
+		strings.NewReader(`{"session_id":"s","provider_session_id":"u"}`))
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}
@@ -547,7 +551,7 @@ var hookEndpoints = []struct {
 	body string
 }{
 	{"/hook", `{"session_id":"s","state":"busy"}`},
-	{"/session-start", `{"session_id":"s","claude_session_id":"u"}`},
+	{"/session-start", `{"session_id":"s","provider_session_id":"u"}`},
 	{"/session-title", `{"session_id":"s","title":"t"}`},
 	{"/session-touched", `{"session_id":"s"}`},
 }
@@ -630,7 +634,7 @@ func TestStoreFailuresReport500(t *testing.T) {
 		{
 			name: "session-start link failure",
 			path: "/session-start",
-			body: `{"session_id":"s","claude_session_id":"u"}`,
+			body: `{"session_id":"s","provider_session_id":"u"}`,
 			tr: func() (*transport, error) {
 				return newTransport(func(string, []byte) {}, nil,
 					func(string, string) error { return boom }, nil, nil)


### PR DESCRIPTION
## Why

lich runs four provider CLIs, but the field that records which conversation a
card ran was named after Claude at every layer: the `sessions.claude_session_id`
column, `store.Session.ClaudeSessionID`, `Service.SetClaudeSession`, the
`terminal.Store` interface, the frontend's `claudeSessionId`, and the
`/session-start` hook payload.

## What changed

**The column.** `claude_session_id` → `provider_session_id`. The rename *is* the
migration — `ALTER TABLE ... RENAME COLUMN` carries existing ids over, so nobody
loses a resume. The `ADD COLUMN` that follows it covers a database predating the
column entirely. `migrationApplied` tolerates exactly the two errors an
already-applied migration raises (`duplicate column`, `no such column`), which
between them make the pair idempotent across all three database shapes:

| database | rename | add |
|---|---|---|
| fresh (new schema) | nothing to rename | duplicate |
| on `claude_session_id` | **carries ids over** | duplicate |
| predates the column | nothing to rename | **creates it** |

**Inward from the column.** `ProviderSessionID` on `store.Session`
(`providerSessionId` in JSON), `SetProviderSession` on the store and on
`terminal.Store`, `providerSessionId` on the frontend `Session`.

**The hook wire.** `/session-start` now takes `provider_session_id`. It still
accepts `claude_session_id` as a deprecated alias — the installed plugin sends
it, and a hard rename would silently break resume for anyone who has not
updated. `provider_session_id` wins when both are present, and `parseSessionStart`
folds them so nothing downstream sees two names. The alias and its removal
condition are documented in `docs/hooks/session-start.md`.

> The plugin repo is being updated in parallel to send the new name.

## What deliberately stayed Claude-specific

`--resume` is a Claude Code flag, so `resumeArgs` (Go) and `resumableSession`
(TS) still gate on the claude kind — another provider reporting an id would have
it stored and ignored until its own resume flag is wired. That is now a written
ceiling instead of an implicit one. Likewise `internal/claudeplugin`, the legacy
`claude.bin` settings key, and the `session-agent` event's hardcoded agent: all
are facts about Claude Code, not leaked coupling.

## Swept while here

- `"claude"` string literal in `AddSession` and `binKey` → `providers.Claude`.
- The store package doc no longer claims it holds only the Claude binary path.
- Dead `Store.ClaudeBin` binding removed from `rpc.ts` — the frontend never called it.

## Test plan

- [x] `TestOpenRenamesClaudeSessionColumn` — a database on the old column comes
      back with its ids readable under the new one (new test).
- [x] `TestParseSessionStart` — new cases for the legacy field alone and for the
      new field winning when both are sent.
- [x] `gofmt -l .` clean, `go vet ./...` clean.
- [x] `go test ./...` — 301 passed. `pnpm test` — 324 passed.
- [x] `tsc --noEmit` + `vite build` clean.
- [x] Cross-compile loop: `GOOS=linux|darwin|windows` build + vet clean.
- [ ] Manual: open a workspace carrying pre-rename sessions, confirm the resume
      prompt still fires and reopens the right conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
