### PR TITLE
fix: clamp reorder drags to their strip's axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dragging a tab or session card no longer scrolls its strip.** Reorder drags
   are clamped to the strip's own axis, so pulling a project tab downward (or a
   session card sideways) can't overflow the container and trigger dnd-kit's
-  auto-scroll on the cross axis. The dragged tab also reads as lifted — solid
-  background and shadow — instead of a see-through ghost over its neighbours.
+  auto-scroll on the cross axis. The dragged tab and session card also stay
+  solid instead of turning into a see-through ghost — the old opacity fade is
+  gone, and the card no longer sits in its translucent hover state (the pointer
+  rides it for the whole drag) while sliding across its neighbours.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dragging a tab or session card no longer scrolls its strip.** Reorder drags
+  are clamped to the strip's own axis, so pulling a project tab downward (or a
+  session card sideways) can't overflow the container and trigger dnd-kit's
+  auto-scroll on the cross axis. The dragged tab also reads as lifted — solid
+  background and shadow — instead of a see-through ghost over its neighbours.
+
 ### Changed
 
 - **A project may now sit with no session at all.** Closing the last one no

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -114,7 +114,13 @@ export function SessionCard({
     <div
       ref={setNodeRef}
       style={{transform: CSS.Transform.toString(transform), transition}}
-      className={cn("relative", isDragging && "z-10 opacity-60")}
+      // pointer-events-none while dragging kills the :hover state — otherwise
+      // the pointer sits on the card the whole drag and hover:bg-accent/60
+      // turns its background translucent over the cards it slides across.
+      className={cn(
+        "relative",
+        isDragging && "pointer-events-none z-10 rounded-lg shadow-md",
+      )}
       {...attributes}
       {...listeners}
     >

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -114,9 +114,6 @@ export function SessionCard({
     <div
       ref={setNodeRef}
       style={{transform: CSS.Transform.toString(transform), transition}}
-      // pointer-events-none while dragging kills the :hover state — otherwise
-      // the pointer sits on the card the whole drag and hover:bg-accent/60
-      // turns its background translucent over the cards it slides across.
       className={cn(
         "relative",
         isDragging && "pointer-events-none z-10 rounded-lg shadow-md",

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -25,7 +25,7 @@ import {DndContext, closestCenter} from "@dnd-kit/core"
 import {SortableContext, verticalListSortingStrategy} from "@dnd-kit/sortable"
 import {useGitStatus} from "@/lib/useGitStatus"
 import {usePanelWidth} from "@/lib/use-panel-width"
-import {useSortableList} from "@/lib/use-sortable-list"
+import {useSortableList, verticalAxis} from "@/lib/use-sortable-list"
 import {errorText} from "@/lib/utils"
 
 // SessionSidebar lists the active project's sessions and can be drag-resized
@@ -204,7 +204,7 @@ export function SessionSidebar() {
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      <div className="flex flex-1 flex-col gap-1.5 overflow-y-auto">
+      <div className="flex flex-1 flex-col gap-1.5 overflow-y-auto overflow-x-hidden">
         {settingsOpen && (
           <SettingsCard
             active={onSettings}
@@ -221,6 +221,7 @@ export function SessionSidebar() {
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
+          modifiers={[verticalAxis]}
           onDragEnd={onDragEnd}
         >
           <SortableContext

--- a/frontend/src/components/tabs/ProjectTab.tsx
+++ b/frontend/src/components/tabs/ProjectTab.tsx
@@ -25,7 +25,10 @@ export function ProjectTab({ project, sessionIds, onClose }: ProjectTabProps) {
     <div
       ref={setNodeRef}
       style={{ transform: CSS.Transform.toString(transform), transition }}
-      className={cn("shrink-0", isDragging && "z-10 opacity-60")}
+      className={cn(
+        "shrink-0",
+        isDragging && "z-10 rounded-lg bg-accent shadow-md",
+      )}
       {...attributes}
       {...listeners}
     >

--- a/frontend/src/components/tabs/ProjectTabs.tsx
+++ b/frontend/src/components/tabs/ProjectTabs.tsx
@@ -8,7 +8,7 @@ import {useProjects} from "@/lib/projects"
 import {sessionsOf} from "@/lib/sessions"
 import {openSettings} from "@/lib/settings-card-store"
 import {NotificationsButton} from "./NotificationsButton"
-import {useSortableList} from "@/lib/use-sortable-list"
+import {horizontalAxis, useSortableList} from "@/lib/use-sortable-list"
 import {ProjectTab} from "./ProjectTab"
 import {HomeTab} from "./HomeTab"
 
@@ -36,11 +36,12 @@ export function ProjectTabs() {
 
   return (
     <div className="flex h-11 shrink-0 items-center gap-1 border-b border-border bg-sidebar px-2">
-      <div className="flex flex-1 items-center gap-1 overflow-x-auto">
+      <div className="flex flex-1 items-center gap-1 overflow-x-auto overflow-y-hidden">
         {showHome && homeId && <HomeTab projectId={homeId}/>}
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
+          modifiers={[horizontalAxis]}
           onDragEnd={onDragEnd}
         >
           <SortableContext items={ids} strategy={horizontalListSortingStrategy}>

--- a/frontend/src/lib/use-sortable-list.ts
+++ b/frontend/src/lib/use-sortable-list.ts
@@ -4,6 +4,7 @@ import {
   useSensor,
   useSensors,
   type DragEndEvent,
+  type Modifier,
 } from "@dnd-kit/core"
 import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable"
 
@@ -11,6 +12,13 @@ import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable"
 // the sensor claims the press outright and a plain click stops selecting the
 // session or navigating to the tab.
 const DRAG_THRESHOLD_PX = 5
+
+// Both sortable surfaces reorder along a single axis. Clamping the drag
+// transform to that axis keeps the dragged item inside its strip — a free
+// transform lets it overflow the container, which turns the overflow-auto
+// ancestor scrollable on the cross axis and dnd-kit's auto-scroll kicks in.
+export const horizontalAxis: Modifier = ({transform}) => ({...transform, y: 0})
+export const verticalAxis: Modifier = ({transform}) => ({...transform, x: 0})
 
 // useSortableList wires the sensors and the drop handler shared by the two
 // reorderable surfaces (session cards, project tabs). It reports the new id

--- a/frontend/src/lib/use-sortable-list.ts
+++ b/frontend/src/lib/use-sortable-list.ts
@@ -13,10 +13,6 @@ import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable"
 // session or navigating to the tab.
 const DRAG_THRESHOLD_PX = 5
 
-// Both sortable surfaces reorder along a single axis. Clamping the drag
-// transform to that axis keeps the dragged item inside its strip — a free
-// transform lets it overflow the container, which turns the overflow-auto
-// ancestor scrollable on the cross axis and dnd-kit's auto-scroll kicks in.
 export const horizontalAxis: Modifier = ({transform}) => ({...transform, y: 0})
 export const verticalAxis: Modifier = ({transform}) => ({...transform, x: 0})
 


### PR DESCRIPTION
## Summary

Dragging a project tab downward made the tab bar scroll vertically: `overflow-x-auto` computes `overflow-y` to `auto` as well, so the dragged tab's free y transform overflowed the bar and dnd-kit's pointer-driven auto-scroll started scrolling inside it. The dragged tab also rendered as a see-through `opacity-60` ghost with no background, letting the tabs behind bleed through.

- Clamp the drag transform to the strip's own axis via shared one-line modifiers (`horizontalAxis`/`verticalAxis`) in `use-sortable-list.ts` — no `@dnd-kit/modifiers` dependency needed.
- Pin the cross-axis overflow to `hidden` on both strips (tab bar and session sidebar), so auto-scroll has nothing to scroll on that axis.
- Mirror the clamp on the session sidebar's vertical list, which had the same latent bug sideways.
- Dragged tab now reads as lifted: solid `bg-accent` + shadow instead of the opacity ghost.

## Test plan

- [x] `tsc --noEmit` clean, vitest 324/324 green
- [x] Manual: dragging a tab down no longer scrolls the bar; dragged tab looks lifted (verified in `task dev`)