### PR TITLE
feat: Updates section in Settings with manual checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **An Updates section in Settings.** It shows the running lich version with a
+  "Check for updates" button that forces the release check right now (the
+  automatic one still runs at startup and hourly), reopens the current
+  version's patch notes on demand, and shows the Claude Code plugin's installed
+  version with its own check, install and update actions.
+
 ## [0.14.0] - 2026-07-23
 
 ### Changed

--- a/frontend/src/components/AppUpdateGate.tsx
+++ b/frontend/src/components/AppUpdateGate.tsx
@@ -6,6 +6,7 @@ import {decideUpdateAction, UPDATE_DISMISSED_KEY, type UpdateAction} from "@/lib
 import {AppUpdate, System} from "@/lib/rpc"
 import {useProjects} from "@/lib/projects"
 import {queuePaste} from "@/lib/paste-queue"
+import {registerUpdateChecker} from "@/lib/update-check"
 import {errorText} from "@/lib/utils"
 
 // How often to re-check for a release after startup, so a long-running session
@@ -37,6 +38,20 @@ export function AppUpdateGate() {
     return () => clearInterval(id)
   }, [])
 
+  useEffect(() => {
+    registerUpdateChecker(checkNow)
+    return () => registerUpdateChecker(null)
+  })
+
+  const prompt = (action: UpdateAction & {kind: "update"}) => {
+    promptedVersion.current = action.version
+    if (action.canSelfApply) {
+      promptSelfApply(action.version)
+    } else {
+      promptInstall(action.version, action.releaseUrl, action.installCommand)
+    }
+  }
+
   const check = async () => {
     let action: UpdateAction
     try {
@@ -47,12 +62,17 @@ export function AppUpdateGate() {
     }
     if (action.kind !== "update") return
     if (promptedVersion.current === action.version) return
-    promptedVersion.current = action.version
-    if (action.canSelfApply) {
-      promptSelfApply(action.version)
-    } else {
-      promptInstall(action.version, action.releaseUrl, action.installCommand)
+    prompt(action)
+  }
+
+  // Manual check: prompts even for a dismissed or already-toasted version.
+  const checkNow = async () => {
+    const status = await AppUpdate.Status()
+    const action = decideUpdateAction(status, null)
+    if (action.kind === "update") {
+      prompt(action)
     }
+    return status
   }
 
   const dismiss = (version: string) => localStorage.setItem(UPDATE_DISMISSED_KEY, version)

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -7,6 +7,7 @@ import { AppearanceSettings } from "./AppearanceSettings"
 import { HotkeysSettings } from "./HotkeysSettings"
 import { ProvidersSettings } from "./ProvidersSettings"
 import { ProviderBinSettings } from "./ProviderBinSettings"
+import { UpdatesSettings } from "./UpdatesSettings"
 import { enabledProviders, useProviders } from "@/lib/providers-store"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
@@ -28,6 +29,7 @@ const BASE_SECTIONS: Section[] = [
   { id: "terminal", label: "Terminal", group: "app", render: () => <TerminalSettings /> },
   { id: "hotkeys", label: "Hotkeys", group: "app", render: () => <HotkeysSettings /> },
   { id: "providers", label: "Providers", group: "app", render: () => <ProvidersSettings /> },
+  { id: "updates", label: "Updates", group: "app", render: () => <UpdatesSettings /> },
 ]
 
 // Settings is the per-project settings screen (not a modal): it fills the main

--- a/frontend/src/components/settings/UpdatesSettings.tsx
+++ b/frontend/src/components/settings/UpdatesSettings.tsx
@@ -1,0 +1,167 @@
+import {useEffect, useState} from "react"
+import {LoaderCircle, Puzzle, RefreshCw, Sparkles} from "lucide-react"
+import {Button} from "@/components/ui/button"
+import {SettingBlock} from "./SettingBlock"
+import {PatchNotesDialog} from "@/components/PatchNotesDialog"
+import {ClaudePlugin, PatchNotes} from "@/lib/rpc"
+import {runUpdateCheck} from "@/lib/update-check"
+import {runWithToast} from "@/lib/toast-async"
+import type {PatchNotes as PatchNotesData, PluginStatus} from "@/lib/api-types"
+
+export function UpdatesSettings() {
+  const [notes, setNotes] = useState<PatchNotesData | null>(null)
+  const [notesOpen, setNotesOpen] = useState(false)
+  const [checking, setChecking] = useState(false)
+  const [checkResult, setCheckResult] = useState("")
+  const [plugin, setPlugin] = useState<PluginStatus | null>(null)
+  const [pluginBusy, setPluginBusy] = useState(false)
+  const [pluginResult, setPluginResult] = useState("")
+
+  useEffect(() => {
+    void PatchNotes.Current().then(setNotes).catch(() => {})
+    void ClaudePlugin.Status().then(setPlugin).catch(() => {})
+  }, [])
+
+  const checkApp = async () => {
+    setChecking(true)
+    setCheckResult("")
+    try {
+      const status = await runUpdateCheck()
+      setCheckResult(
+        status.updateAvailable
+          ? `lich ${status.latestVersion} is available — follow the prompt.`
+          : "You're on the latest version.",
+      )
+    } catch {
+      setCheckResult("Check failed — are you online?")
+    } finally {
+      setChecking(false)
+    }
+  }
+
+  const checkPlugin = async () => {
+    setPluginBusy(true)
+    setPluginResult("")
+    try {
+      const status = await ClaudePlugin.Status()
+      setPlugin(status)
+      if (status.installed && !status.updateAvailable) {
+        setPluginResult("You're on the latest version.")
+      }
+    } catch {
+      setPluginResult("Check failed — are you online?")
+    } finally {
+      setPluginBusy(false)
+    }
+  }
+
+  const runPlugin = async (
+    run: () => Promise<null>,
+    progress: string,
+    done: string,
+    failed: string,
+  ) => {
+    setPluginBusy(true)
+    if (await runWithToast(progress, run, done, failed)) {
+      await ClaudePlugin.Status().then(setPlugin).catch(() => {})
+    }
+    setPluginBusy(false)
+  }
+
+  const spinner = <LoaderCircle className="size-4 animate-spin" />
+  const restartHint = "restart your Claude sessions to apply."
+
+  return (
+    <>
+      <SettingBlock
+        icon={<RefreshCw className="size-4" />}
+        title="Application"
+        description={`lich ${notes ? `v${notes.version}` : ""} — checks for updates on startup and hourly.`}
+      >
+        <div className="flex items-center gap-3">
+          <Button size="sm" onClick={() => void checkApp()} disabled={checking}>
+            {checking ? spinner : null}
+            Check for updates
+          </Button>
+          {checkResult && <span className="text-xs text-muted-foreground">{checkResult}</span>}
+        </div>
+      </SettingBlock>
+
+      <SettingBlock
+        icon={<Sparkles className="size-4" />}
+        title="What's new"
+        description={notes?.groups ? `Patch notes for v${notes.version}.` : "No patch notes for this build."}
+      >
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => setNotesOpen(true)}
+          disabled={!notes?.groups}
+        >
+          View patch notes
+        </Button>
+        {notesOpen && notes && (
+          <PatchNotesDialog notes={notes} onClose={() => setNotesOpen(false)} />
+        )}
+      </SettingBlock>
+
+      <SettingBlock
+        icon={<Puzzle className="size-4" />}
+        title="Claude Code plugin"
+        description={
+          plugin === null
+            ? "The lich plugin for Claude Code."
+            : plugin.installed
+              ? `Installed: v${plugin.installedVersion}.`
+              : "Not installed."
+        }
+      >
+        <div className="flex items-center gap-3">
+          {plugin !== null && !plugin.installed && (
+            <Button
+              size="sm"
+              onClick={() =>
+                void runPlugin(
+                  ClaudePlugin.Install,
+                  "Installing lich plugin…",
+                  `Plugin installed — ${restartHint}`,
+                  "Install failed",
+                )
+              }
+              disabled={pluginBusy}
+            >
+              {pluginBusy ? spinner : null}
+              Install
+            </Button>
+          )}
+          {plugin?.installed && plugin.updateAvailable && (
+            <Button
+              size="sm"
+              onClick={() =>
+                void runPlugin(
+                  ClaudePlugin.Update,
+                  "Updating lich plugin…",
+                  `Plugin updated — ${restartHint}`,
+                  "Update failed",
+                )
+              }
+              disabled={pluginBusy}
+            >
+              {pluginBusy ? spinner : null}
+              Update to v{plugin.latestVersion}
+            </Button>
+          )}
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => void checkPlugin()}
+            disabled={pluginBusy}
+          >
+            Check for updates
+          </Button>
+          {pluginResult && <span className="text-xs text-muted-foreground">{pluginResult}</span>}
+        </div>
+      </SettingBlock>
+    </>
+  )
+}

--- a/frontend/src/lib/update-check.test.ts
+++ b/frontend/src/lib/update-check.test.ts
@@ -1,0 +1,38 @@
+import {afterEach, describe, expect, it, vi} from "vitest"
+import {registerUpdateChecker, runUpdateCheck} from "./update-check"
+import type {AppUpdateStatus} from "./api-types"
+
+const status: AppUpdateStatus = {
+  currentVersion: "0.14.0",
+  latestVersion: "0.14.0",
+  updateAvailable: false,
+  canSelfApply: false,
+  releaseUrl: "https://github.com/omartelo/lich/releases/tag/v0.14.0",
+  installCommand: "",
+}
+
+afterEach(() => registerUpdateChecker(null))
+
+describe("runUpdateCheck", () => {
+  it("rejects when no checker is registered", async () => {
+    await expect(runUpdateCheck()).rejects.toThrow("update checker not ready")
+  })
+
+  it("runs the registered checker and returns its status", async () => {
+    const checker = vi.fn().mockResolvedValue(status)
+    registerUpdateChecker(checker)
+    await expect(runUpdateCheck()).resolves.toEqual(status)
+    expect(checker).toHaveBeenCalledOnce()
+  })
+
+  it("rejects again after the checker unregisters", async () => {
+    registerUpdateChecker(vi.fn().mockResolvedValue(status))
+    registerUpdateChecker(null)
+    await expect(runUpdateCheck()).rejects.toThrow("update checker not ready")
+  })
+
+  it("propagates the checker's failure", async () => {
+    registerUpdateChecker(vi.fn().mockRejectedValue(new Error("offline")))
+    await expect(runUpdateCheck()).rejects.toThrow("offline")
+  })
+})

--- a/frontend/src/lib/update-check.ts
+++ b/frontend/src/lib/update-check.ts
@@ -1,0 +1,19 @@
+// AppUpdateGate registers its forced check here; the Settings "Check for
+// updates" button runs it, so the gate stays the single owner of the update UX.
+
+import type {AppUpdateStatus} from "./api-types"
+
+export type UpdateChecker = () => Promise<AppUpdateStatus>
+
+let checker: UpdateChecker | null = null
+
+export function registerUpdateChecker(fn: UpdateChecker | null): void {
+  checker = fn
+}
+
+export function runUpdateCheck(): Promise<AppUpdateStatus> {
+  if (!checker) {
+    return Promise.reject(new Error("update checker not ready"))
+  }
+  return checker()
+}


### PR DESCRIPTION
## Summary

- New **Updates** section in Settings (nav group "app", after Providers):
  - **Application** row — shows the running version (from `patchnotes.Current`, embedded changelog, no network) and a **Check for updates** button. The manual check runs through `AppUpdateGate` via a tiny checker registry (`lib/update-check.ts`), so the gate remains the single owner of the update UX (self-apply toast, restart, AUR/install paste). The forced variant bypasses the per-version dismissal and the same-session dedup; the row shows an inline result ("latest version" / "vX available" / "check failed").
  - **What's new** row — reopens the existing `PatchNotesDialog` on demand, so patch notes can be consulted after the one-shot startup popup.
  - **Claude Code plugin** row — installed version, plus Check / Install / Update actions over the existing `ClaudePlugin` RPCs with `runWithToast`.
- No backend changes.

## Test plan

- [x] `update-check.test.ts`: checker registration lifecycle, propagation, no-checker rejection
- [x] `tsc --noEmit` clean, vitest 328/328, `vite build` green
- [x] Smoke in `task dev`: Updates section renders, manual check toasts on an available release, patch notes reopen, plugin row reflects install state