### PR TITLE
feat: seed new worktrees with env files and a per-project setup script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the provider's work. The prompt is now gated on the closing session being the
   last occupant of its worktree path; while a sibling still lives there, closing
   just closes.
->>>>>>> origin/main
 
 ## [0.15.0] - 2026-07-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A fresh worktree now sets itself up.** Creating a worktree copies the
+  gitignored `.env*` files over from the main checkout — a worktree starts
+  with tracked files only, so env files and local credentials were always
+  missing from a new checkout. A `.worktreeinclude` file at the repository
+  root overrides the patterns (globs, one per line; a slashless pattern
+  matches by basename at any depth). Wholly ignored directories
+  (`node_modules`, build output) are never copied — installing those is the
+  job of the new per-project **setup script** (Settings › Worktree), which
+  runs in the new worktree session's terminal ahead of the agent, so a
+  `pnpm install` happens where you can watch it. The session opens even if
+  the script fails, resuming a kept worktree never re-runs it, and Windows
+  skips the script wrap while the port stays experimental.
+
 ## [0.15.0] - 2026-07-23
 
 ### Added

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -14,6 +14,7 @@ import { ensureTransport, onSessionData, sendInput } from "@/lib/term-transport"
 import { chordSequence, isSearchOpenChord } from "@/lib/term-keys"
 import { makeReplayBuffer } from "@/lib/replay-buffer"
 import { takePaste } from "@/lib/paste-queue"
+import { takeSetup } from "@/lib/setup-queue"
 import { recordChunk } from "@/lib/term-perf"
 import { copyToastMessage, COPY_TOAST_DURATION_MS } from "@/lib/copy-toast"
 import { computeGrid } from "@/lib/term-fit"
@@ -466,7 +467,16 @@ export function TerminalView({
         resizeObserver.disconnect()
       })
 
-      await Service.Start(sessionId, projectId, cwd, kind, resume, live.term.cols, live.term.rows)
+      await Service.Start(
+        sessionId,
+        projectId,
+        cwd,
+        kind,
+        resume,
+        takeSetup(sessionId),
+        live.term.cols,
+        live.term.rows,
+      )
       if (disposed) {
         // Unmounted during the Start round-trip: the cleanup's Close raced
         // ahead of the spawn, so close again now that the PTY exists. The

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -7,6 +7,7 @@ import { AppearanceSettings } from "./AppearanceSettings"
 import { HotkeysSettings } from "./HotkeysSettings"
 import { ProvidersSettings } from "./ProvidersSettings"
 import { ProviderBinSettings } from "./ProviderBinSettings"
+import { WorktreeSetupSettings } from "./WorktreeSetupSettings"
 import { UpdatesSettings } from "./UpdatesSettings"
 import { enabledProviders, useProviders } from "@/lib/providers-store"
 import { Input } from "@/components/ui/input"
@@ -29,6 +30,7 @@ const BASE_SECTIONS: Section[] = [
   { id: "terminal", label: "Terminal", group: "app", render: () => <TerminalSettings /> },
   { id: "hotkeys", label: "Hotkeys", group: "app", render: () => <HotkeysSettings /> },
   { id: "providers", label: "Providers", group: "app", render: () => <ProvidersSettings /> },
+  { id: "worktree", label: "Worktree", group: "app", render: (id) => <WorktreeSetupSettings projectId={id} /> },
   { id: "updates", label: "Updates", group: "app", render: () => <UpdatesSettings /> },
 ]
 

--- a/frontend/src/components/settings/WorktreeSetupSettings.tsx
+++ b/frontend/src/components/settings/WorktreeSetupSettings.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react"
+import { Store } from "@/lib/rpc"
+import { useProjects } from "@/lib/projects"
+import { Input } from "@/components/ui/input"
+import { SettingBlock } from "./SettingBlock"
+
+// Same key the Go store resolves (internal/store worktreeSetupKey).
+export const WORKTREE_SETUP_KEY = "worktree.setup"
+
+// WorktreeSetupSettings edits the project's worktree setup script: a shell
+// command run in a new worktree session's terminal ahead of the provider,
+// right after the worktree is created — dependency installs and generated
+// files, the things a fresh checkout is missing. Project-scoped only, no
+// global value: a setup command is repo-specific.
+export function WorktreeSetupSettings({ projectId }: { projectId?: string }) {
+  const { projects } = useProjects()
+  const project = projects.find((p) => p.id === projectId)
+  const [script, setScript] = useState("")
+
+  useEffect(() => {
+    if (!projectId) {
+      return
+    }
+    void Store.GetSetting(WORKTREE_SETUP_KEY, projectId).then(setScript)
+  }, [projectId])
+
+  const persist = (value: string) => {
+    setScript(value)
+    if (projectId) {
+      void Store.SetSetting(WORKTREE_SETUP_KEY, projectId, value.trim())
+    }
+  }
+
+  if (!project) {
+    return (
+      <p className="py-4 text-sm text-muted-foreground">
+        Open a project to configure its worktree setup.
+      </p>
+    )
+  }
+
+  return (
+    <SettingBlock
+      title={`Setup script for ${project.name}`}
+      description={
+        "Runs in every new worktree's terminal before the agent starts — chain steps with &&. " +
+        "The session opens even if it fails. Gitignored .env* files are copied into the new " +
+        "worktree automatically; a .worktreeinclude file at the repo root overrides the patterns."
+      }
+    >
+      <p className="mb-2 text-xs text-muted-foreground">{project.path}</p>
+      <Input
+        value={script}
+        onChange={(event) => persist(event.target.value)}
+        placeholder="pnpm install"
+        spellCheck={false}
+        aria-label={`Worktree setup script for ${project.name}`}
+        className="w-96 max-w-full font-mono"
+      />
+    </SettingBlock>
+  )
+}

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -17,6 +17,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import {useProjects} from "@/lib/projects"
+import {queueSetup} from "@/lib/setup-queue"
 import {activeSessionId, sessionsOf, type Session} from "@/lib/sessions"
 import {CloseWorktreeDialog, ForceRemoveWorktreeDialog} from "./CloseWorktreeDialog"
 import {SessionCard} from "./SessionCard"
@@ -86,7 +87,9 @@ export function SessionSidebar() {
   const createWorktree = async (name: string, base: string, baseIsRemote: boolean) => {
     const wt = await ProjectService.CreateWorktree(path, projectId, name, base, baseIsRemote)
     if (wt) {
-      newWorktreeSession(projectId, wt)
+      // A fresh checkout is the one moment the project's setup script runs;
+      // reopening an existing worktree never queues it.
+      queueSetup(newWorktreeSession(projectId, wt))
     }
     setWorktreeOpen(false)
   }

--- a/frontend/src/lib/projects.tsx
+++ b/frontend/src/lib/projects.tsx
@@ -55,8 +55,9 @@ interface ProjectsValue {
   /** Open a new session in a project and focus it, returning its id. Kind
    * defaults to Claude Code; path defaults to the project's own directory. */
   newSession: (projectId: string, kind?: SessionKind, path?: string) => string
-  /** Open a Claude Code session rooted at a git worktree, labeled after it. */
-  newWorktreeSession: (projectId: string, wt: { name: string; path: string }) => void
+  /** Open a Claude Code session rooted at a git worktree, labeled after it,
+   * returning its id. */
+  newWorktreeSession: (projectId: string, wt: { name: string; path: string }) => string
   /** Resume a worktree: reopen its parked session (continuing its Claude
    * conversation) when one exists, else open a fresh session on it. */
   reopenWorktreeSession: (projectId: string, wt: { name: string; path: string }) => Promise<void>
@@ -257,6 +258,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       const created = project.sessions[project.sessions.length - 1]
       setSessions(next)
       void Store.AddSession(projectId, sessionId, created.label, kind, wt.path, project.nextSeq)
+      return sessionId
     },
     [],
   )

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -80,16 +80,19 @@ async function post(path: string): Promise<void> {
 }
 
 export const Terminal = {
-  /** resume: a provider session id to reopen (--resume); "" starts fresh. */
+  /** resume: a provider session id to reopen (--resume); "" starts fresh.
+   * setup: run the project's worktree setup script ahead of the provider —
+   * passed once, by the first Start after the worktree is created. */
   Start: (
     id: string,
     projectID: string,
     cwd: string,
     kind: string,
     resume: string,
+    setup: boolean,
     cols: number,
     rows: number,
-  ) => call<null>("terminal.Start", [id, projectID, cwd, kind, resume, cols, rows]),
+  ) => call<null>("terminal.Start", [id, projectID, cwd, kind, resume, setup, cols, rows]),
   Write: (id: string, data: string) => call<null>("terminal.Write", [id, data]),
   Resize: (id: string, cols: number, rows: number) =>
     call<null>("terminal.Resize", [id, cols, rows]),

--- a/frontend/src/lib/setup-queue.test.ts
+++ b/frontend/src/lib/setup-queue.test.ts
@@ -1,0 +1,21 @@
+import {describe, expect, it} from "vitest"
+import {queueSetup, takeSetup} from "./setup-queue"
+
+describe("setup-queue", () => {
+  it("returns the mark once, then clears it", () => {
+    queueSetup("s1")
+    expect(takeSetup("s1")).toBe(true)
+    // One-shot: a respawn must not run the setup script again.
+    expect(takeSetup("s1")).toBe(false)
+  })
+
+  it("returns false for a session never marked", () => {
+    expect(takeSetup("never-marked")).toBe(false)
+  })
+
+  it("keeps sessions independent", () => {
+    queueSetup("a")
+    expect(takeSetup("b")).toBe(false)
+    expect(takeSetup("a")).toBe(true)
+  })
+})

--- a/frontend/src/lib/setup-queue.ts
+++ b/frontend/src/lib/setup-queue.ts
@@ -1,0 +1,15 @@
+// One-shot "run the worktree setup script" marks, keyed by session id: set by
+// the create-worktree flow before the session's PTY exists and consumed once
+// by TerminalView on the first Start. Lives in the page, like the paste
+// queue — a reload between creating the worktree and mounting its terminal
+// drops the mark, degrading to running the setup by hand.
+
+const pending = new Set<string>()
+
+export function queueSetup(sessionId: string): void {
+  pending.add(sessionId)
+}
+
+export function takeSetup(sessionId: string): boolean {
+  return pending.delete(sessionId)
+}

--- a/internal/project/seed.go
+++ b/internal/project/seed.go
@@ -1,0 +1,117 @@
+package project
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// defaultIncludes seeds every new worktree when the repository ships no
+// .worktreeinclude: env files by basename, at any depth.
+var defaultIncludes = []string{".env*"}
+
+// includeFile is the repository-root file that overrides defaultIncludes: one
+// glob per line, # comments and blank lines skipped. A present file governs
+// alone — an empty one seeds nothing.
+const includeFile = ".worktreeinclude"
+
+// seedWorktree copies gitignored files matching the include patterns from the
+// main checkout into a fresh worktree. A worktree starts with tracked files
+// only, so without this every new checkout is missing its .env files and
+// local credentials. Failures never fail the creation — a worktree without
+// its env files is still usable — they are logged and the rest is copied.
+// Returns the repo-relative paths copied, for the log and the tests.
+func seedWorktree(projectPath, wtPath string) []string {
+	patterns := includePatterns(projectPath)
+	if len(patterns) == 0 {
+		return nil
+	}
+	// --directory collapses wholly-ignored directories (node_modules) into one
+	// entry instead of enumerating every file inside; -z spares us git's
+	// C-style quoting of non-ASCII names.
+	out, err := runGit(projectPath, "ls-files", "-z", "--others", "--ignored", "--exclude-standard", "--directory")
+	if err != nil {
+		slog.Warn("worktree seed: list ignored files", "err", err)
+		return nil
+	}
+	var copied []string
+	for entry := range strings.SplitSeq(out, "\x00") {
+		// Directory entries carry a trailing slash: whole ignored trees are
+		// deliberately not copied (that is dependency/build output territory —
+		// the setup script's job, not the seed's).
+		if entry == "" || strings.HasSuffix(entry, "/") {
+			continue
+		}
+		if !matchesInclude(entry, patterns) {
+			continue
+		}
+		src := filepath.Join(projectPath, filepath.FromSlash(entry))
+		dst := filepath.Join(wtPath, filepath.FromSlash(entry))
+		if err := copyFile(src, dst); err != nil {
+			slog.Warn("worktree seed: copy", "file", entry, "err", err)
+			continue
+		}
+		copied = append(copied, entry)
+	}
+	if len(copied) > 0 {
+		slog.Info("worktree seed", "worktree", wtPath, "files", copied)
+	}
+	return copied
+}
+
+// includePatterns returns the seed patterns: .worktreeinclude at the repo
+// root when present, defaultIncludes otherwise.
+func includePatterns(projectPath string) []string {
+	data, err := os.ReadFile(filepath.Join(projectPath, includeFile))
+	if err != nil {
+		return defaultIncludes
+	}
+	patterns := []string{}
+	for _, line := range splitLines(string(data)) {
+		if !strings.HasPrefix(line, "#") {
+			patterns = append(patterns, line)
+		}
+	}
+	return patterns
+}
+
+// matchesInclude reports whether a repo-relative path (slash form) matches any
+// pattern. The gitignore convention, reduced to path.Match globs: a pattern
+// without a slash matches the basename at any depth, one with a slash matches
+// the whole relative path. No "**" and no "!" negation.
+func matchesInclude(rel string, patterns []string) bool {
+	for _, p := range patterns {
+		target := rel
+		if !strings.Contains(p, "/") {
+			target = path.Base(rel)
+		}
+		if ok, err := path.Match(p, target); ok && err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// copyFile copies a regular file preserving its permission bits — a private
+// key seeded world-readable would be a downgrade. Symlinks and other
+// non-regular files are refused so the caller logs them.
+func copyFile(src, dst string) error {
+	info, err := os.Lstat(src)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("not a regular file")
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, info.Mode().Perm())
+}

--- a/internal/project/seed_test.go
+++ b/internal/project/seed_test.go
@@ -1,0 +1,169 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"testing"
+)
+
+// TestMatchesInclude proves the reduced gitignore semantics: slashless
+// patterns match the basename at any depth, slashed patterns match the whole
+// repo-relative path, and an invalid pattern matches nothing instead of
+// panicking.
+func TestMatchesInclude(t *testing.T) {
+	tests := []struct {
+		name     string
+		rel      string
+		patterns []string
+		want     bool
+	}{
+		{"basename at root", ".env", []string{".env*"}, true},
+		{"basename nested", "api/.env.local", []string{".env*"}, true},
+		{"no match", "src/main.go", []string{".env*"}, false},
+		{"path pattern hits", "config/local.json", []string{"config/*.json"}, true},
+		{"path pattern misses sibling", "other/local.json", []string{"config/*.json"}, false},
+		{"path pattern is not recursive", "config/sub/local.json", []string{"config/*.json"}, false},
+		{"invalid pattern ignored", ".env", []string{"["}, false},
+		{"second pattern wins", "id_rsa", []string{".env*", "id_*"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchesInclude(tt.rel, tt.patterns); got != tt.want {
+				t.Errorf("matchesInclude(%q, %v) = %v, want %v", tt.rel, tt.patterns, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIncludePatterns proves the override semantics: no file falls back to the
+// default, a present file governs alone (comments and blanks skipped), and an
+// empty file means seed nothing.
+func TestIncludePatterns(t *testing.T) {
+	dir := t.TempDir()
+	if got := includePatterns(dir); !slices.Equal(got, defaultIncludes) {
+		t.Errorf("no file: patterns = %v, want %v", got, defaultIncludes)
+	}
+
+	write := func(content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, includeFile), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("# secrets\n\nconfig/*.json\n.npmrc\n")
+	if got := includePatterns(dir); !slices.Equal(got, []string{"config/*.json", ".npmrc"}) {
+		t.Errorf("file: patterns = %v, want [config/*.json .npmrc]", got)
+	}
+
+	write("# only comments\n\n")
+	if got := includePatterns(dir); len(got) != 0 {
+		t.Errorf("empty file: patterns = %v, want none", got)
+	}
+}
+
+// seedRepo builds a repository with a .gitignore and the ignored files the
+// seed should (and should not) pick up.
+func seedRepo(t *testing.T) (string, func(args ...string) string) {
+	t.Helper()
+	repo, git := initRepo(t)
+	files := map[string]string{
+		".gitignore":                ".env*\nnode_modules/\n",
+		".env":                      "SECRET=1\n",
+		"api/.env.local":            "LOCAL=1\n",
+		"node_modules/pkg/index.js": "js\n",
+		"notes.txt":                 "untracked but not ignored\n",
+	}
+	for rel, content := range files {
+		p := filepath.Join(repo, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(filepath.Join(repo, ".env"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git("add", ".gitignore")
+	git("commit", "-m", "ignore")
+	return repo, git
+}
+
+// TestCreateWorktreeSeedsIgnored proves a new worktree receives the ignored
+// env files — nested ones included, permissions preserved — while ignored
+// directories and plain untracked files stay behind.
+func TestCreateWorktreeSeedsIgnored(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	repo, _ := seedRepo(t)
+
+	svc := New(nil)
+	wt, err := svc.CreateWorktree(repo, "pid", "seeded", "main", false)
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+
+	env, err := os.ReadFile(filepath.Join(wt.Path, ".env"))
+	if err != nil {
+		t.Fatalf(".env not seeded: %v", err)
+	}
+	if string(env) != "SECRET=1\n" {
+		t.Errorf(".env content = %q, want SECRET=1", env)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(wt.Path, ".env"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf(".env perm = %o, want 600", perm)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(wt.Path, "api", ".env.local")); err != nil {
+		t.Errorf("nested .env.local not seeded: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wt.Path, "node_modules")); !os.IsNotExist(err) {
+		t.Errorf("node_modules seeded, want absent (err=%v)", err)
+	}
+	if _, err := os.Stat(filepath.Join(wt.Path, "notes.txt")); !os.IsNotExist(err) {
+		t.Errorf("plain untracked notes.txt seeded, want absent (err=%v)", err)
+	}
+}
+
+// TestCreateWorktreeSeedsFromIncludeFile proves .worktreeinclude replaces the
+// default patterns instead of extending them.
+func TestCreateWorktreeSeedsFromIncludeFile(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	repo, git := seedRepo(t)
+
+	if err := os.MkdirAll(filepath.Join(repo, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "config", "local.json"), []byte("{}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".gitignore"), []byte(".env*\nnode_modules/\nconfig/local.json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".worktreeinclude"), []byte("config/*.json\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", ".gitignore", ".worktreeinclude")
+	git("commit", "-m", "include file")
+
+	svc := New(nil)
+	wt, err := svc.CreateWorktree(repo, "pid", "included", "main", false)
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wt.Path, "config", "local.json")); err != nil {
+		t.Errorf("config/local.json not seeded: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wt.Path, ".env")); !os.IsNotExist(err) {
+		t.Errorf(".env seeded despite .worktreeinclude override (err=%v)", err)
+	}
+}

--- a/internal/project/worktree.go
+++ b/internal/project/worktree.go
@@ -183,6 +183,7 @@ func (s *Service) CreateWorktree(projectPath, projectID, name, base string, base
 	if _, err := runGit(wtPath, "rev-parse", "--is-inside-work-tree"); err != nil {
 		return nil, fmt.Errorf("worktree created but unusable: %w", err)
 	}
+	seedWorktree(projectPath, wtPath)
 	return &Worktree{Name: name, Path: wtPath}, nil
 }
 

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -80,3 +80,19 @@ func (s *Service) ProviderBin(providerID, projectID string) string {
 func (s *Service) ClaudeBin(projectID string) string {
 	return s.ProviderBin(providers.Claude, projectID)
 }
+
+// worktreeSetupKey is the settings key holding a project's worktree setup
+// script. Project-scoped only, no global fallback: a setup command is
+// repo-specific, so a global value would be wrong more often than useful.
+const worktreeSetupKey = "worktree.setup"
+
+// WorktreeSetup returns the project's worktree setup script, or "" when none
+// is configured. The terminal service resolves it when spawning the first
+// session of a freshly created worktree.
+func (s *Service) WorktreeSetup(projectID string) string {
+	script, err := s.GetSetting(worktreeSetupKey, projectID)
+	if err != nil {
+		return ""
+	}
+	return script
+}

--- a/internal/terminal/setup.go
+++ b/internal/terminal/setup.go
@@ -1,0 +1,33 @@
+package terminal
+
+import "strings"
+
+// wrapSetup rewrites a session's spawn so the project's worktree setup script
+// runs first, in the same PTY — its output lands in the terminal the user is
+// already looking at. The script runs in a subshell (a cd inside it cannot
+// move the provider's start directory) and the provider starts even when the
+// script fails: a broken setup must not cost the session, so the failure is
+// echoed and the provider execs anyway. goos is runtime.GOOS, passed in so the
+// decision stays pure and testable off-Windows (wrapArgv's pattern): Windows
+// is skipped — composing a cmd.exe chain around wrapArgv's own cmd.exe
+// handling is not worth it while the port stays experimental.
+func wrapSetup(spec ptySpec, script, goos string) ptySpec {
+	if script == "" || goos == "windows" {
+		return spec
+	}
+	argv := make([]string, 0, len(spec.args)+1)
+	for _, arg := range append([]string{spec.bin}, spec.args...) {
+		argv = append(argv, shQuote(arg))
+	}
+	spec.bin = "sh"
+	spec.args = []string{
+		"-c",
+		"(\n" + script + "\n) || echo \"[lich] worktree setup failed (exit $?)\"; exec " + strings.Join(argv, " "),
+	}
+	return spec
+}
+
+// shQuote returns s single-quoted for POSIX sh, safe against embedded quotes.
+func shQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/terminal/setup_test.go
+++ b/internal/terminal/setup_test.go
@@ -1,0 +1,62 @@
+package terminal
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestWrapSetup proves the wrap decision table: no script or Windows leaves
+// the spec untouched, otherwise the spawn becomes sh -c with the script in a
+// subshell and the original argv exec'd after it, quoted against spaces and
+// embedded quotes.
+func TestWrapSetup(t *testing.T) {
+	base := ptySpec{
+		bin:  "/opt/claude bin/claude",
+		args: []string{"--resume", "it's-an-id"},
+		dir:  "/wt",
+		env:  []string{"HOME=/home/user"},
+		cols: 80,
+		rows: 24,
+	}
+
+	if got := wrapSetup(base, "", "linux"); got.bin != base.bin || len(got.args) != 2 {
+		t.Errorf("empty script rewrote the spec: %+v", got)
+	}
+	if got := wrapSetup(base, "pnpm i", "windows"); got.bin != base.bin {
+		t.Errorf("windows rewrote the spec: %+v", got)
+	}
+
+	got := wrapSetup(base, "pnpm i", "linux")
+	if got.bin != "sh" || len(got.args) != 2 || got.args[0] != "-c" {
+		t.Fatalf("wrapped spec = %+v, want sh -c", got)
+	}
+	cmd := got.args[1]
+	for _, want := range []string{
+		"pnpm i",
+		"exec '/opt/claude bin/claude' '--resume' 'it'\\''s-an-id'",
+		"[lich] worktree setup failed",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("wrapped command missing %q:\n%s", want, cmd)
+		}
+	}
+	if got.dir != base.dir || got.cols != base.cols || got.rows != base.rows {
+		t.Errorf("wrap changed dir/size: %+v", got)
+	}
+}
+
+// TestShQuote proves quoting survives the shell round trip's edge cases.
+func TestShQuote(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"plain", "'plain'"},
+		{"with space", "'with space'"},
+		{"it's", `'it'\''s'`},
+		{"", "''"},
+		{"$HOME `id` ;rm", "'$HOME `id` ;rm'"},
+	}
+	for _, tt := range tests {
+		if got := shQuote(tt.in); got != tt.want {
+			t.Errorf("shQuote(%q) = %s, want %s", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -95,6 +96,7 @@ type session struct {
 // hook. The store implements both.
 type Store interface {
 	ProviderBin(providerID, projectID string) string
+	WorktreeSetup(projectID string) string
 	SetProviderSession(sessionID, providerSessionID string) error
 	SetSessionTitle(sessionID, title string) (bool, error)
 }
@@ -355,8 +357,13 @@ func scrubPathList(value, dir string) (string, bool) {
 // frontend passes after the user accepted the prompt to continue the session
 // this card ran before the last restart. An id Claude no longer knows fails in
 // the PTY like any other bad invocation — the user sees Claude's own error.
-func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int) error {
-	sess, cwd, err := s.spawnSession(id, projectID, cwd, kind, resume, cols, rows)
+//
+// setup is passed once, by the flow that just created this session's worktree:
+// it runs the project's worktree setup script (Settings › Project) in the PTY
+// before the provider, so a fresh checkout installs its dependencies in view.
+// A respawn or resume never sets it.
+func (s *Service) Start(id, projectID, cwd, kind, resume string, setup bool, cols, rows int) error {
+	sess, cwd, err := s.spawnSession(id, projectID, cwd, kind, resume, setup, cols, rows)
 	if err != nil || sess == nil {
 		return err
 	}
@@ -373,7 +380,7 @@ func (s *Service) Start(id, projectID, cwd, kind, resume string, cols, rows int)
 // registration. A nil session with a nil error means id was already running.
 // The returned cwd is the effective start directory (the input, or the
 // resolved home when it was empty).
-func (s *Service) spawnSession(id, projectID, cwd, kind, resume string, cols, rows int) (*session, string, error) {
+func (s *Service) spawnSession(id, projectID, cwd, kind, resume string, setup bool, cols, rows int) (*session, string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -389,14 +396,18 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume string, cols, ro
 		cwd = home
 	}
 
-	p, err := startPTY(ptySpec{
+	spec := ptySpec{
 		bin:  resolveCommand(kind, s.store.ProviderBin(kind, projectID), userShell()),
 		args: resumeArgs(kind, resume),
 		dir:  cwd,
 		env:  s.sessionEnv(id),
 		cols: cols,
 		rows: rows,
-	})
+	}
+	if setup {
+		spec = wrapSetup(spec, s.store.WorktreeSetup(projectID), runtime.GOOS)
+	}
+	p, err := startPTY(spec)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to start pty for %q: %w", id, err)
 	}

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -18,12 +18,13 @@ import (
 	"github.com/omartelo/lich/internal/events"
 )
 
-// stubBins is a Store returning a fixed binary path, for tests that never
-// spawn. Its persistence methods are no-ops — none of these tests exercise the
-// SessionStart or ai-title paths.
-type stubBins struct{ bin string }
+// stubBins is a Store returning a fixed binary path and worktree setup script,
+// for tests that never spawn. Its persistence methods are no-ops — none of
+// these tests exercise the SessionStart or ai-title paths.
+type stubBins struct{ bin, setup string }
 
 func (s stubBins) ProviderBin(_, _ string) string            { return s.bin }
+func (s stubBins) WorktreeSetup(_ string) string             { return s.setup }
 func (s stubBins) SetProviderSession(_, _ string) error      { return nil }
 func (s stubBins) SetSessionTitle(_, _ string) (bool, error) { return false, nil }
 
@@ -224,7 +225,7 @@ func TestStartIsNoopWhenAlreadyRunning(t *testing.T) {
 	sess := spawnSession(t)
 	svc.sessions["s1"] = sess
 
-	if err := svc.Start("s1", "p1", "", "", "", 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", "", "", "", false, 80, 24); err != nil {
 		t.Errorf("Start(running) = %v, want nil", err)
 	}
 	if svc.sessions["s1"] != sess {
@@ -263,7 +264,7 @@ func TestStartPassesResumeToTheProcess(t *testing.T) {
 	svc := New(stubBins{bin: bin}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "abc-123", 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "abc-123", false, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
@@ -284,7 +285,53 @@ func TestStartWithoutResumeSpawnsBare(t *testing.T) {
 	svc := New(stubBins{bin: bin}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", false, 80, 24); err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+
+	svc.mu.Lock()
+	got := spawnedArgs(t, svc, "s1")
+	svc.mu.Unlock()
+
+	if !slices.Equal(got, []string{bin}) {
+		t.Errorf("spawned argv = %v, want %v", got, []string{bin})
+	}
+}
+
+// TestStartWithSetupWrapsTheSpawn proves the setup flag reroutes the spawn
+// through sh -c with the project's script ahead of the exec'd provider — the
+// wiring wrapSetup's unit test cannot see.
+func TestStartWithSetupWrapsTheSpawn(t *testing.T) {
+	bin := stayAliveBin(t)
+	svc := New(stubBins{bin: bin, setup: "echo setup-ran"}, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1") })
+
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", true, 80, 24); err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+
+	svc.mu.Lock()
+	got := spawnedArgs(t, svc, "s1")
+	svc.mu.Unlock()
+
+	if len(got) != 3 || got[0] != "sh" || got[1] != "-c" {
+		t.Fatalf("spawned argv = %v, want sh -c <cmd>", got)
+	}
+	for _, want := range []string{"echo setup-ran", "exec " + shQuote(bin)} {
+		if !strings.Contains(got[2], want) {
+			t.Errorf("spawned command missing %q:\n%s", want, got[2])
+		}
+	}
+}
+
+// TestStartWithSetupButNoScriptSpawnsBare proves the flag is inert for a
+// project with no setup script configured — no sh indirection sneaks in.
+func TestStartWithSetupButNoScriptSpawnsBare(t *testing.T) {
+	bin := stayAliveBin(t)
+	svc := New(stubBins{bin: bin}, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1") })
+
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", true, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 


### PR DESCRIPTION
## Summary

Closes the biggest gap a fresh worktree has against the main checkout: tracked files only — no `.env`, no dependencies. Two layers, mirroring Conductor's split between static files and generated content:

- **Seed (backend, automatic):** after `git worktree add` succeeds, gitignored files matching `.env*` (basename, any depth) are copied from the main checkout into the new worktree, permissions preserved. A `.worktreeinclude` file at the repo root overrides the patterns (simple globs, one per line; present file governs alone). Wholly ignored directories (`node_modules`) are never copied. Seed failures log and never fail creation.
- **Setup script (per project, opt-in):** new Settings › Worktree section stores `worktree.setup` (project-scoped, no global). The create-worktree flow marks the new session (setup-queue, mirror of paste-queue) and `terminal.Start` gains a `setup` flag: the backend wraps the spawn in `sh -c '(script) || echo failed; exec provider args'` — output lands in the session's own terminal, the provider starts even if the script fails, a `cd` inside the script cannot move the provider's start directory. Resume/respawn never re-runs it.

Deliberate ceilings: no gitignore negation/`**` in patterns, files only (no directory copies), Windows skips the setup wrap (experimental port), a page reload between create and first mount drops the setup mark.

## Test plan

- [x] `gofmt`, `go vet`, backend suite with `-race`: 317 passed
- [x] Frontend: vitest 331 passed, `tsc --noEmit`, `vite build`
- [x] Cross-compile gate: `GOOS=linux|darwin|windows go build && go vet`
- [x] New coverage: seed matcher + include-file override + end-to-end seeding via `CreateWorktree` (temp repos); `wrapSetup`/`shQuote` tables; spawn-level argv assertions for setup wrap, no-script inertness; setup-queue one-shot semantics
- [x] Manual smoke in `task dev`: create worktree in a repo with `.env` + setup script configured, watch install run in the session terminal