### PR TITLE
fix: resolve login-shell env so directly-spawned providers inherit it

### DIFF
--- a/internal/terminal/shellenv.go
+++ b/internal/terminal/shellenv.go
@@ -1,0 +1,116 @@
+package terminal
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// shellEnvTimeout caps the rc dump so a hung interactive shell can't block
+// startup; overshooting just loses that launch's resolved vars, never the app.
+const shellEnvTimeout = 5 * time.Second
+
+// shellEnvSentinel fences the env dump off from rc chatter (greetings, MOTD,
+// job-control warnings). Matched by last occurrence so rc that echoes it loses.
+const shellEnvSentinel = "__LICH_SHELL_ENV__"
+
+// ResolveShellEnv augments base with the variables a login+interactive shell
+// exports. lich is launched from a GUI, so its environment is the graphical
+// session's — it never sourced .zshrc/.bashrc/config.fish/.profile, where users
+// commonly export things like an MCP server's auth token. A "shell" session
+// hides this because the shell we spawn sources those rc files itself; a provider
+// spawned directly (claude/codex/...) does not, so its ${VAR} expansions in
+// .mcp.json come up empty. We run the user's shell the way a terminal emulator
+// does and merge its environment over base.
+//
+// SHELL unset (normal Windows: cmd.exe has no rc) or any failure returns base
+// unchanged — the resolution is best-effort, never load-bearing.
+func ResolveShellEnv(base []string) []string {
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		return base
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), shellEnvTimeout)
+	defer cancel()
+
+	// -l -i so both login profiles (bash/zsh) and interactive rc (fish's
+	// config.fish is interactive-only) run; `env` is external, so the command is
+	// identical across shells. Nil Stdin feeds EOF instead of a tty, so the
+	// interactive shell never blocks on a read.
+	cmd := exec.CommandContext(ctx, shell, "-l", "-i", "-c", "echo "+shellEnvSentinel+"; env")
+	cmd.Env = base
+	out, err := cmd.Output() // stderr, carrying rc warnings, is discarded
+
+	extra := parseShellEnvDump(shellEnvSentinel, string(out))
+	if extra == nil {
+		slog.Warn("terminal: shell env resolution yielded nothing, using launch env", "shell", shell, "err", err)
+		return base
+	}
+	return mergeEnv(base, extra)
+}
+
+// parseShellEnvDump returns the KEY=VALUE lines env printed after the last
+// sentinel, or nil when the sentinel is absent (shell died before env ran).
+//
+// ponytail: line-based, so a value spanning a newline loses its tail. Switch the
+// dump to `env -0` and split on NUL if that ever bites.
+func parseShellEnvDump(sentinel, out string) []string {
+	idx := strings.LastIndex(out, sentinel)
+	if idx < 0 {
+		return nil
+	}
+	var kv []string
+	for line := range strings.SplitSeq(out[idx+len(sentinel):], "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		if key, _, ok := strings.Cut(line, "="); ok && validEnvKey(key) {
+			kv = append(kv, line)
+		}
+	}
+	return kv
+}
+
+// validEnvKey rejects a multi-line value's continuation line (which may still
+// contain '=') by holding lines to a POSIX variable name.
+func validEnvKey(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r == '_':
+		case r >= 'A' && r <= 'Z', r >= 'a' && r <= 'z':
+		case i > 0 && r >= '0' && r <= '9':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// mergeEnv layers extra over base, extra winning on collision: the shell's rc is
+// what defines the fuller PATH and the auth vars this whole dance exists to
+// recover, so its values must beat the launch env's.
+func mergeEnv(base, extra []string) []string {
+	slot := make(map[string]int, len(base))
+	merged := make([]string, len(base))
+	copy(merged, base)
+	for i, kv := range base {
+		if key, _, ok := strings.Cut(kv, "="); ok {
+			slot[key] = i
+		}
+	}
+	for _, kv := range extra {
+		key, _, _ := strings.Cut(kv, "=")
+		if i, ok := slot[key]; ok {
+			merged[i] = kv
+			continue
+		}
+		slot[key] = len(merged)
+		merged = append(merged, kv)
+	}
+	return merged
+}

--- a/internal/terminal/shellenv.go
+++ b/internal/terminal/shellenv.go
@@ -54,10 +54,9 @@ func ResolveShellEnv(base []string) []string {
 }
 
 // parseShellEnvDump returns the KEY=VALUE lines env printed after the last
-// sentinel, or nil when the sentinel is absent (shell died before env ran).
-//
-// ponytail: line-based, so a value spanning a newline loses its tail. Switch the
-// dump to `env -0` and split on NUL if that ever bites.
+// sentinel, or nil when the sentinel is absent (shell died before env ran). It
+// is line-based, so a value spanning a newline loses its tail; switch the dump
+// to `env -0` and split on NUL if that ever bites.
 func parseShellEnvDump(sentinel, out string) []string {
 	idx := strings.LastIndex(out, sentinel)
 	if idx < 0 {

--- a/internal/terminal/shellenv_test.go
+++ b/internal/terminal/shellenv_test.go
@@ -1,0 +1,140 @@
+package terminal
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"testing"
+)
+
+func TestParseShellEnvDump(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want []string
+	}{
+		{
+			name: "no sentinel keeps launch env",
+			out:  "FOO=bar\nBAZ=qux\n",
+			want: nil,
+		},
+		{
+			name: "chatter before sentinel is dropped",
+			out:  "Welcome to zsh!\nbash: no job control in this shell\n" + shellEnvSentinel + "\nTOKEN=secret\nPATH=/x\n",
+			want: []string{"TOKEN=secret", "PATH=/x"},
+		},
+		{
+			name: "last sentinel wins when rc echoes it",
+			out:  shellEnvSentinel + "\nSTALE=1\n" + shellEnvSentinel + "\nREAL=2\n",
+			want: []string{"REAL=2"},
+		},
+		{
+			name: "non-key lines are skipped",
+			out:  shellEnvSentinel + "\nGOOD=1\n  continuation of a value\nALSO_GOOD=2\n",
+			want: []string{"GOOD=1", "ALSO_GOOD=2"},
+		},
+		{
+			name: "carriage returns are trimmed",
+			out:  shellEnvSentinel + "\r\nWIN=1\r\n",
+			want: []string{"WIN=1"},
+		},
+		{
+			name: "empty value is preserved",
+			out:  shellEnvSentinel + "\nEMPTY=\n",
+			want: []string{"EMPTY="},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseShellEnvDump(shellEnvSentinel, tt.out)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("parseShellEnvDump() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidEnvKey(t *testing.T) {
+	valid := []string{"PATH", "_", "_X", "A1", "MY_VAR_2"}
+	invalid := []string{"", "1ABC", "MY-VAR", "MY VAR", "="}
+	for _, k := range valid {
+		if !validEnvKey(k) {
+			t.Errorf("validEnvKey(%q) = false, want true", k)
+		}
+	}
+	for _, k := range invalid {
+		if validEnvKey(k) {
+			t.Errorf("validEnvKey(%q) = true, want false", k)
+		}
+	}
+}
+
+func TestMergeEnv(t *testing.T) {
+	base := []string{"PATH=/orig", "BASE_ONLY=1"}
+	extra := []string{"PATH=/shell/bin", "TOKEN=secret"}
+	got := mergeEnv(base, extra)
+	want := []string{"PATH=/shell/bin", "BASE_ONLY=1", "TOKEN=secret"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("mergeEnv() = %v, want %v", got, want)
+	}
+}
+
+func TestMergeEnvBaseUntouchedWithoutExtra(t *testing.T) {
+	base := []string{"A=1", "B=2"}
+	if got := mergeEnv(base, nil); !slices.Equal(got, base) {
+		t.Fatalf("mergeEnv(base, nil) = %v, want %v", got, base)
+	}
+}
+
+// TestResolveShellEnv drives the real spawn through a fake $SHELL. It prints the
+// dump lines directly instead of shelling out to `env`, whose resolution would
+// depend on the very PATH the test rewrites; INHERITED echoes a base var back to
+// prove cmd.Env reached the child.
+func TestResolveShellEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake POSIX $SHELL script is not runnable on Windows")
+	}
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "fakeshell")
+	script := "#!/bin/sh\n" +
+		"echo " + shellEnvSentinel + "\n" +
+		"echo FROM_SHELL=yes\n" +
+		"echo PATH=/shell/bin\n" +
+		"echo INHERITED=$LAUNCH_ONLY\n"
+	if err := os.WriteFile(fake, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SHELL", fake)
+
+	got := ResolveShellEnv([]string{"LAUNCH_ONLY=1", "PATH=/orig"})
+
+	if !slices.Contains(got, "FROM_SHELL=yes") {
+		t.Errorf("shell-exported var missing: %v", got)
+	}
+	if !slices.Contains(got, "INHERITED=1") {
+		t.Errorf("launch env not passed to child shell: %v", got)
+	}
+	if !slices.Contains(got, "LAUNCH_ONLY=1") {
+		t.Errorf("launch-only var dropped: %v", got)
+	}
+	if !slices.Contains(got, "PATH=/shell/bin") || slices.Contains(got, "PATH=/orig") {
+		t.Errorf("shell PATH did not override launch PATH: %v", got)
+	}
+}
+
+func TestResolveShellEnvNoShell(t *testing.T) {
+	t.Setenv("SHELL", "")
+	base := []string{"A=1"}
+	if got := ResolveShellEnv(base); !slices.Equal(got, base) {
+		t.Fatalf("ResolveShellEnv without SHELL = %v, want %v", got, base)
+	}
+}
+
+func TestResolveShellEnvBrokenShell(t *testing.T) {
+	t.Setenv("SHELL", filepath.Join(t.TempDir(), "does-not-exist"))
+	base := []string{"A=1"}
+	if got := ResolveShellEnv(base); !slices.Equal(got, base) {
+		t.Fatalf("ResolveShellEnv with broken shell = %v, want %v", got, base)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -51,8 +51,9 @@ var version = "dev"
 
 func main() {
 	// Snapshot before any env tweaks: spawned terminal sessions must inherit
-	// what the user launched lich with (see terminal.childEnv).
-	env := os.Environ()
+	// what the user launched lich with (see terminal.childEnv). ResolveShellEnv
+	// recovers the rc-exported vars a GUI launch misses (see its doc).
+	env := terminal.ResolveShellEnv(os.Environ())
 
 	configDir, err := os.UserConfigDir()
 	if err != nil {


### PR DESCRIPTION
## Problem

An `.mcp.json` MCP server authenticated via an environment variable failed to authenticate when its session was **spawned directly on the provider** (Claude Code, Codex, …), but worked when the provider was launched **manually inside a terminal session**. Reported on Windows and some Linux setups.

## Root cause

lich is a GUI app (desktop launcher / Chromium `--app`), never started from a terminal. Its `os.Environ()` snapshot is the graphical session's environment — it never sourced the user's shell rc (`.zshrc`/`.bashrc`/`config.fish`/`.profile`), where such vars are commonly exported.

- A `shell` session hid the bug: the spawned `$SHELL` sources rc itself.
- A provider spawned directly (`resolveBin` → `startPTY`) inherited only the launch env, so `${VAR}` expansions in `.mcp.json` came up empty.

The OS split matches the symptom: Windows (GUI-subsystem, `cmd.exe`, no rc) and the Linux users who export in `.bashrc`/`.zshrc` (interactive-only rc the graphical session never reads), versus those who use `.profile`/systemd env (which it does).

## Fix

Resolve the shell environment once at startup: `terminal.ResolveShellEnv(os.Environ())` runs the user's shell login+interactive (`$SHELL -l -i -c 'echo <sentinel>; env'` — covers bash/zsh/fish), parses the dump after the sentinel, and merges it over the launch snapshot (shell wins on collision, e.g. `PATH`). Both provider and shell sessions now get the full env.

Best-effort: `$SHELL` unset or any failure returns the launch env unchanged — never load-bearing.

## Known ceilings

- **Windows without `$SHELL` is not fixed** — Windows env comes from the registry, a separate mechanism. Git Bash (which sets `$SHELL`) is covered for free.
- Line-based parse: a value spanning a newline loses its tail (`env -0` is the upgrade path).
- 5s timeout on the rc dump; a heavier rc loses that launch's resolved vars.
- Adds one shell startup to boot (once, synchronous).

## Test plan

- [x] `go test ./internal/terminal/` — 116 pass (13 new: parse/merge/validKey + a fake-`$SHELL` happy path)
- [x] `gofmt -l` clean, `go vet ./internal/terminal/` clean
- [x] cross-compile build + vet green on linux/darwin/windows
- [x] Verify on a real Windows box whether the affected setup has `$SHELL` (Git Bash) or needs the registry follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)