### PR TITLE
fix: only prompt to remove a worktree when closing its last session

### DIFF
--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -17,7 +17,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import {useProjects} from "@/lib/projects"
-import {activeSessionId, sessionsOf, type Session} from "@/lib/sessions"
+import {activeSessionId, isLastWorktreeSession, sessionsOf, type Session} from "@/lib/sessions"
 import {CloseWorktreeDialog, ForceRemoveWorktreeDialog} from "./CloseWorktreeDialog"
 import {SessionCard} from "./SessionCard"
 import {WorktreeDialog} from "./WorktreeDialog"
@@ -96,10 +96,8 @@ export function SessionSidebar() {
     setWorktreeOpen(false)
   }
 
-  // Closing a worktree session asks what to do with the checkout; regular
-  // sessions close immediately.
   const requestClose = (session: Session) => {
-    if (session.path) {
+    if (isLastWorktreeSession(list, session)) {
       setPendingClose(session)
       return
     }

--- a/frontend/src/lib/sessions.test.ts
+++ b/frontend/src/lib/sessions.test.ts
@@ -4,6 +4,7 @@ import {
   addSession,
   closeSession,
   createProjectSessions,
+  isLastWorktreeSession,
   isSessionKind,
   projectOfSession,
   removeProject,
@@ -13,6 +14,7 @@ import {
   resumableSession,
   sessionsOf,
   setActiveSession,
+  type Session,
   type SessionState,
 } from "./sessions"
 
@@ -313,5 +315,29 @@ describe("restoreSession", () => {
   it("ignores an unknown project", () => {
     const state = buildState(1)
     expect(restoreSession(state, "nope", parked)).toBe(state)
+  })
+})
+
+describe("isLastWorktreeSession", () => {
+  const wt = (id: string, path?: string): Session => ({
+    id,
+    label: id,
+    kind: "shell",
+    ...(path ? { path } : {}),
+  })
+
+  it("is false for a project-rooted (pathless) session", () => {
+    const s = wt("s1")
+    expect(isLastWorktreeSession([s], s)).toBe(false)
+  })
+
+  it("is true when the session is the only occupant of its worktree", () => {
+    const s = wt("s1", "/wt/a")
+    expect(isLastWorktreeSession([s, wt("s2", "/wt/b")], s)).toBe(true)
+  })
+
+  it("is false while another session shares the same worktree path", () => {
+    const s = wt("s1", "/wt/a")
+    expect(isLastWorktreeSession([s, wt("s2", "/wt/a")], s)).toBe(false)
   })
 })

--- a/frontend/src/lib/sessions.ts
+++ b/frontend/src/lib/sessions.ts
@@ -240,6 +240,19 @@ export function sessionsOf(state: SessionState, projectId: string): Session[] {
   return state[projectId]?.sessions ?? []
 }
 
+// True only for the last session in a worktree checkout. Removing a checkout a
+// sibling session still occupies would throw away its work, so only the last
+// occupant gets offered the keep/remove prompt.
+export function isLastWorktreeSession(
+  sessions: Session[],
+  session: Session,
+): boolean {
+  if (!session.path) {
+    return false
+  }
+  return !sessions.some((s) => s.id !== session.id && s.path === session.path)
+}
+
 export function activeSessionId(state: SessionState, projectId: string): string {
   return state[projectId]?.activeId ?? ""
 }


### PR DESCRIPTION
## Problem

Closing any session that lives in a worktree showed the keep/remove-worktree prompt. A worktree checkout can host more than one session — a provider session plus a hand-opened shell (the `onOpenTerminal` affordance spawns `newSession(projectId, "shell", cwd)` rooted at the same path). Closing the throwaway shell offered to remove the entire checkout; one accidental confirm on "Remove worktree" discarded the provider's work.

## Fix

Gate the prompt on the closing session being the **last occupant** of its worktree path, via a new pure predicate `isLastWorktreeSession(sessions, session)`. While any sibling session still lives in the same checkout, the closing one just closes — removing the worktree out from under a sibling would throw away its work. This covers both the throwaway-shell case and two providers sharing a worktree; the "last session" framing is the root-cause fix, not the narrower "only provider sessions prompt" heuristic (which still misfires when the provider is closed while a sibling shell is open).

## Changes

- `sessions.ts` — `isLastWorktreeSession` predicate.
- `SessionSidebar.tsx` — `requestClose` calls the predicate instead of testing `session.path`.
- `sessions.test.ts` — 3 cases (pathless, sole occupant, shared path).

## Test plan

- [x] `pnpm test` (frontend) — sessions suite green.
- [x] `pnpm build` — tsc + vite clean.
- [x] Manual: open a worktree provider session, open a shell in it via the card's terminal button, close the shell → no prompt; close the provider (now last) → prompt appears.