### PR TITLE
feat: group session sidebar cards by worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The session sidebar now groups by worktree.** With several worktrees open,
   a flat list of cards made it hard to tell which terminal or provider belonged
   to which checkout. Sessions sharing a worktree now sit under one static
-  divider labelled with the folder name and its branch, so the checkout each
-  card belongs to reads at a glance. Grouping keys off each session's checkout
+  divider titled with the worktree folder name, so the checkout each card
+  belongs to reads at a glance while the branch stays on the card. Grouping
+  keys off each session's checkout
   path fixed at spawn, never its live cwd — a `cd` deeper into the tree never
   moves a card to another group. A drag reorders within a group only, and a
   project with no worktrees keeps its old flat, header-less list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The session sidebar now groups by worktree.** With several worktrees open,
+  a flat list of cards made it hard to tell which terminal or provider belonged
+  to which checkout. Sessions sharing a worktree now sit under one static
+  divider labelled with the folder name and its branch, shown once instead of
+  repeated on every card. Grouping keys off each session's checkout path fixed
+  at spawn, never its live cwd — a `cd` deeper into the tree never moves a card
+  to another group. A drag reorders within a group only, and a project with no
+  worktrees keeps its old flat, header-less list.
+
 ## [0.16.0] - 2026-07-23
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The session sidebar now groups by worktree.** With several worktrees open,
   a flat list of cards made it hard to tell which terminal or provider belonged
   to which checkout. Sessions sharing a worktree now sit under one static
-  divider labelled with the folder name and its branch, shown once instead of
-  repeated on every card. Grouping keys off each session's checkout path fixed
-  at spawn, never its live cwd — a `cd` deeper into the tree never moves a card
-  to another group. A drag reorders within a group only, and a project with no
-  worktrees keeps its old flat, header-less list.
+  divider labelled with the folder name and its branch, so the checkout each
+  card belongs to reads at a glance. Grouping keys off each session's checkout
+  path fixed at spawn, never its live cwd — a `cd` deeper into the tree never
+  moves a card to another group. A drag reorders within a group only, and a
+  project with no worktrees keeps its old flat, header-less list.
 
 ## [0.16.0] - 2026-07-23
 

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -27,6 +27,10 @@ interface SessionCardProps {
   session: Session
   path: string
   active: boolean
+  // True when the card sits under a worktree group header that already shows the
+  // path and branch. The card then drops both to avoid repeating them on every
+  // sibling, keeping only its per-session PR and diff badges.
+  inGroup?: boolean
   onSelect: () => void
   onClose: () => void
   onRename: (label: string) => void
@@ -41,6 +45,7 @@ export function SessionCard({
                               session,
                               path,
                               active,
+                              inGroup = false,
                               onSelect,
                               onClose,
                               onRename,
@@ -68,6 +73,9 @@ export function SessionCard({
   const shownPath = liveCwd || session.path || path
   const git = useGitStatus(shownPath)
   const pr = usePullRequest(shownPath, git?.branch ?? "")
+  // Under a group header the branch line is dropped; the badges row then renders
+  // only when there is a badge to show, instead of leaving an empty strip.
+  const hasBadges = Boolean(pr) || (git?.files ?? 0) > 0
   // Renaming disables the drag: the sensor would otherwise claim the pointer
   // before the input could be clicked into or its text selected.
   const {
@@ -161,24 +169,34 @@ export function SessionCard({
               )}
               {/* rtl anchors the tail (project folder) to the right so overflow is
                 clipped on the left; the leading LRM keeps "~/" in logical order
-                instead of letting bidi push it to the end. */}
-              <span
-                ref={pathRef}
-                dir="rtl"
-                className={cn(
-                  "block max-w-full overflow-hidden whitespace-nowrap text-left font-mono text-xs text-muted-foreground",
-                  pathOverflow &&
-                  "[mask-image:linear-gradient(to_right,transparent,black_1.25rem)]",
-                )}
-              >
-              {"\u200e" + displayPath(shownPath)}
-            </span>
-              {git?.branch && (
-                <span className="flex w-full items-center justify-between gap-2 text-xs text-muted-foreground">
-                <span className="flex min-w-0 items-center gap-1">
-                  <GitBranch className="size-3 shrink-0"/>
-                  <span className="truncate">{git.branch}</span>
+                instead of letting bidi push it to the end. The group header
+                already shows the path, so a grouped card drops this line. */}
+              {!inGroup && (
+                <span
+                  ref={pathRef}
+                  dir="rtl"
+                  className={cn(
+                    "block max-w-full overflow-hidden whitespace-nowrap text-left font-mono text-xs text-muted-foreground",
+                    pathOverflow &&
+                    "[mask-image:linear-gradient(to_right,transparent,black_1.25rem)]",
+                  )}
+                >
+                  {"\u200e" + displayPath(shownPath)}
                 </span>
+              )}
+              {git?.branch && (!inGroup || hasBadges) && (
+                <span
+                  className={cn(
+                    "flex w-full items-center gap-2 text-xs text-muted-foreground",
+                    inGroup ? "justify-end" : "justify-between",
+                  )}
+                >
+                {!inGroup && (
+                  <span className="flex min-w-0 items-center gap-1">
+                    <GitBranch className="size-3 shrink-0"/>
+                    <span className="truncate">{git.branch}</span>
+                  </span>
+                )}
                   <span className="flex shrink-0 items-center gap-1.5">
                     {pr && (
                       <span

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -27,10 +27,6 @@ interface SessionCardProps {
   session: Session
   path: string
   active: boolean
-  // True when the card sits under a worktree group header that already shows the
-  // path and branch. The card then drops both to avoid repeating them on every
-  // sibling, keeping only its per-session PR and diff badges.
-  inGroup?: boolean
   onSelect: () => void
   onClose: () => void
   onRename: (label: string) => void
@@ -45,7 +41,6 @@ export function SessionCard({
                               session,
                               path,
                               active,
-                              inGroup = false,
                               onSelect,
                               onClose,
                               onRename,
@@ -73,9 +68,6 @@ export function SessionCard({
   const shownPath = liveCwd || session.path || path
   const git = useGitStatus(shownPath)
   const pr = usePullRequest(shownPath, git?.branch ?? "")
-  // Under a group header the branch line is dropped; the badges row then renders
-  // only when there is a badge to show, instead of leaving an empty strip.
-  const hasBadges = Boolean(pr) || (git?.files ?? 0) > 0
   // Renaming disables the drag: the sensor would otherwise claim the pointer
   // before the input could be clicked into or its text selected.
   const {
@@ -169,34 +161,24 @@ export function SessionCard({
               )}
               {/* rtl anchors the tail (project folder) to the right so overflow is
                 clipped on the left; the leading LRM keeps "~/" in logical order
-                instead of letting bidi push it to the end. The group header
-                already shows the path, so a grouped card drops this line. */}
-              {!inGroup && (
-                <span
-                  ref={pathRef}
-                  dir="rtl"
-                  className={cn(
-                    "block max-w-full overflow-hidden whitespace-nowrap text-left font-mono text-xs text-muted-foreground",
-                    pathOverflow &&
-                    "[mask-image:linear-gradient(to_right,transparent,black_1.25rem)]",
-                  )}
-                >
-                  {"\u200e" + displayPath(shownPath)}
-                </span>
-              )}
-              {git?.branch && (!inGroup || hasBadges) && (
-                <span
-                  className={cn(
-                    "flex w-full items-center gap-2 text-xs text-muted-foreground",
-                    inGroup ? "justify-end" : "justify-between",
-                  )}
-                >
-                {!inGroup && (
-                  <span className="flex min-w-0 items-center gap-1">
-                    <GitBranch className="size-3 shrink-0"/>
-                    <span className="truncate">{git.branch}</span>
-                  </span>
+                instead of letting bidi push it to the end. */}
+              <span
+                ref={pathRef}
+                dir="rtl"
+                className={cn(
+                  "block max-w-full overflow-hidden whitespace-nowrap text-left font-mono text-xs text-muted-foreground",
+                  pathOverflow &&
+                  "[mask-image:linear-gradient(to_right,transparent,black_1.25rem)]",
                 )}
+              >
+              {"\u200e" + displayPath(shownPath)}
+            </span>
+              {git?.branch && (
+                <span className="flex w-full items-center justify-between gap-2 text-xs text-muted-foreground">
+                <span className="flex min-w-0 items-center gap-1">
+                  <GitBranch className="size-3 shrink-0"/>
+                  <span className="truncate">{git.branch}</span>
+                </span>
                   <span className="flex shrink-0 items-center gap-1.5">
                     {pr && (
                       <span

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -1,0 +1,92 @@
+import {DndContext, closestCenter} from "@dnd-kit/core"
+import {SortableContext, verticalListSortingStrategy} from "@dnd-kit/sortable"
+import {useGitStatus} from "@/lib/useGitStatus"
+import {useSortableList, verticalAxis} from "@/lib/use-sortable-list"
+import {baseName} from "@/lib/paths"
+import type {Session} from "@/lib/sessions"
+import {SessionCard} from "./SessionCard"
+
+interface SessionGroupProps {
+  // "" for the project's own root, else the worktree checkout path.
+  path: string
+  sessions: Session[]
+  projectPath: string
+  projectName: string
+  activeId: string
+  // A divider label is drawn only when the sidebar holds more than one group; a
+  // lone project with no worktrees keeps its old flat, header-less list.
+  showHeader: boolean
+  // Commits a new order for this group's sessions; a drag can only ever produce
+  // one, since each group owns an isolated DndContext.
+  onReorder: (ids: string[]) => void
+  onSelect: (id: string) => void
+  onClose: (session: Session) => void
+  onRename: (id: string, label: string) => void
+  onOpenTerminal: (cwd: string) => void
+}
+
+// SessionGroup renders one worktree's sessions under a static divider label
+// (folder name + branch). The label reads the group's own checkout path, never a
+// session's live cwd, so a `cd` deeper into the tree never restyles or re-buckets
+// the group. The isolated DndContext is what confines a drag to reordering
+// within the group.
+export function SessionGroup({
+  path,
+  sessions,
+  projectPath,
+  projectName,
+  activeId,
+  showHeader,
+  onReorder,
+  onSelect,
+  onClose,
+  onRename,
+  onOpenTerminal,
+}: SessionGroupProps) {
+  const git = useGitStatus(path || projectPath)
+  const ids = sessions.map((session) => session.id)
+  const {sensors, onDragEnd} = useSortableList(ids, onReorder)
+  const name = path ? baseName(path) : projectName
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {showHeader && (
+        <div className="flex items-center gap-2 px-1 pb-0.5 pt-1.5">
+          <span className="flex min-w-0 items-center gap-1.5 text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground/70">
+            <span className="truncate">{name}</span>
+            {git?.branch && (
+              <span className="shrink-0 font-mono font-normal normal-case tracking-normal text-muted-foreground/90">
+                · {git.branch}
+              </span>
+            )}
+          </span>
+          <span className="h-px flex-1 bg-border"/>
+        </div>
+      )}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        modifiers={[verticalAxis]}
+        onDragEnd={onDragEnd}
+      >
+        <SortableContext items={ids} strategy={verticalListSortingStrategy}>
+          <div className="flex flex-col gap-1.5">
+            {sessions.map((session) => (
+              <SessionCard
+                key={session.id}
+                session={session}
+                path={projectPath}
+                inGroup={showHeader}
+                active={session.id === activeId}
+                onSelect={() => onSelect(session.id)}
+                onClose={() => onClose(session)}
+                onRename={(label) => onRename(session.id, label)}
+                onOpenTerminal={onOpenTerminal}
+              />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+    </div>
+  )
+}

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -1,6 +1,5 @@
 import {DndContext, closestCenter} from "@dnd-kit/core"
 import {SortableContext, verticalListSortingStrategy} from "@dnd-kit/sortable"
-import {useGitStatus} from "@/lib/useGitStatus"
 import {useSortableList, verticalAxis} from "@/lib/use-sortable-list"
 import {baseName} from "@/lib/paths"
 import type {Session} from "@/lib/sessions"
@@ -25,11 +24,11 @@ interface SessionGroupProps {
   onOpenTerminal: (cwd: string) => void
 }
 
-// SessionGroup renders one worktree's sessions under a static divider label
-// (folder name + branch). The label reads the group's own checkout path, never a
-// session's live cwd, so a `cd` deeper into the tree never restyles or re-buckets
-// the group. The isolated DndContext is what confines a drag to reordering
-// within the group.
+// SessionGroup renders one worktree's sessions under a static divider titled
+// with the worktree folder name; the branch stays on each card. The title reads
+// the group's own checkout path, never a session's live cwd, so a `cd` deeper
+// into the tree never re-buckets the group. The isolated DndContext is what
+// confines a drag to reordering within the group.
 export function SessionGroup({
   path,
   sessions,
@@ -43,7 +42,6 @@ export function SessionGroup({
   onRename,
   onOpenTerminal,
 }: SessionGroupProps) {
-  const git = useGitStatus(path || projectPath)
   const ids = sessions.map((session) => session.id)
   const {sensors, onDragEnd} = useSortableList(ids, onReorder)
   const name = path ? baseName(path) : projectName
@@ -52,13 +50,8 @@ export function SessionGroup({
     <div className="flex flex-col gap-1.5">
       {showHeader && (
         <div className="flex items-center gap-2 px-1 pb-0.5 pt-1.5">
-          <span className="flex min-w-0 items-center gap-1.5 text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground/70">
-            <span className="truncate">{name}</span>
-            {git?.branch && (
-              <span className="shrink-0 font-mono font-normal normal-case tracking-normal text-muted-foreground/90">
-                · {git.branch}
-              </span>
-            )}
+          <span className="min-w-0 truncate text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground/70">
+            {name}
           </span>
           <span className="h-px flex-1 bg-border"/>
         </div>

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -76,7 +76,6 @@ export function SessionGroup({
                 key={session.id}
                 session={session}
                 path={projectPath}
-                inGroup={showHeader}
                 active={session.id === activeId}
                 onSelect={() => onSelect(session.id)}
                 onClose={() => onClose(session)}

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -18,15 +18,19 @@ import {
 } from "@/components/ui/dropdown-menu"
 import {useProjects} from "@/lib/projects"
 import {queueSetup} from "@/lib/setup-queue"
-import {activeSessionId, isLastWorktreeSession, sessionsOf, type Session} from "@/lib/sessions"
+import {
+  activeSessionId,
+  groupByWorktree,
+  isLastWorktreeSession,
+  sessionsOf,
+  type Session,
+} from "@/lib/sessions"
+import {baseName} from "@/lib/paths"
 import {CloseWorktreeDialog, ForceRemoveWorktreeDialog} from "./CloseWorktreeDialog"
-import {SessionCard} from "./SessionCard"
+import {SessionGroup} from "./SessionGroup"
 import {WorktreeDialog} from "./WorktreeDialog"
-import {DndContext, closestCenter} from "@dnd-kit/core"
-import {SortableContext, verticalListSortingStrategy} from "@dnd-kit/sortable"
 import {useGitStatus} from "@/lib/useGitStatus"
 import {usePanelWidth} from "@/lib/use-panel-width"
-import {useSortableList, verticalAxis} from "@/lib/use-sortable-list"
 import {errorText} from "@/lib/utils"
 
 // SessionSidebar lists the active project's sessions and can be drag-resized
@@ -73,16 +77,26 @@ export function SessionSidebar() {
   const [pendingForce, setPendingForce] = useState<Session | null>(null)
   // Resolved ahead of the no-project bail below: hooks cannot sit behind it.
   const list = sessionsOf(sessions, projectId ?? "")
-  const {sensors, onDragEnd} = useSortableList(
-    list.map((session) => session.id),
-    (ids) => reorderSessions(projectId ?? "", ids),
-  )
 
   if (!projectId) {
     return null
   }
 
-  const activeId = activeSessionId(sessions, projectId)
+  // No card is highlighted while the Settings screen owns the view, so the
+  // Settings card reads as the active one instead.
+  const activeId = onSettings ? "" : activeSessionId(sessions, projectId)
+  const groups = groupByWorktree(list)
+  const projectName = baseName(path)
+
+  // A drag reorders one group only; splice its new order back into the flat list
+  // in group order and persist the whole thing. reorderSessions bails on any
+  // id-set mismatch, so a close that raced the drop drops the stale order.
+  const commitGroupOrder = (groupPath: string, ids: string[]) => {
+    const flat = groups.flatMap((group) =>
+      group.path === groupPath ? ids : group.sessions.map((session) => session.id),
+    )
+    reorderSessions(projectId, flat)
+  }
 
   const createWorktree = async (name: string, base: string, baseIsRemote: boolean) => {
     const wt = await ProjectService.CreateWorktree(path, projectId, name, base, baseIsRemote)
@@ -219,37 +233,29 @@ export function SessionSidebar() {
             }}
           />
         )}
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          modifiers={[verticalAxis]}
-          onDragEnd={onDragEnd}
-        >
-          <SortableContext
-            items={list.map((session) => session.id)}
-            strategy={verticalListSortingStrategy}
-          >
-            {list.map((session) => (
-              <SessionCard
-                key={session.id}
-                session={session}
-                path={path}
-                // A session is never highlighted while the Settings screen owns
-                // the view, so the Settings card reads as the active one.
-                active={session.id === activeId && !onSettings}
-                onSelect={() => {
-                  activateSession(projectId, session.id)
-                  // From the settings screen this returns to the terminal; on
-                  // the project route it is a no-op.
-                  navigate(`/projects/${projectId}`)
-                }}
-                onClose={() => requestClose(session)}
-                onRename={(label) => renameSession(projectId, session.id, label)}
-                onOpenTerminal={(cwd) => newSession(projectId, "shell", cwd)}
-              />
-            ))}
-          </SortableContext>
-        </DndContext>
+        {groups.map((group) => (
+          <SessionGroup
+            key={group.path || "__root__"}
+            path={group.path}
+            sessions={group.sessions}
+            projectPath={path}
+            projectName={projectName}
+            activeId={activeId}
+            // The divider only earns its place once a worktree splits the list;
+            // a lone group keeps the old flat, header-less look.
+            showHeader={groups.length > 1}
+            onReorder={(ids) => commitGroupOrder(group.path, ids)}
+            onSelect={(id) => {
+              activateSession(projectId, id)
+              // From the settings screen this returns to the terminal; on the
+              // project route it is a no-op.
+              navigate(`/projects/${projectId}`)
+            }}
+            onClose={(session) => requestClose(session)}
+            onRename={(id, label) => renameSession(projectId, id, label)}
+            onOpenTerminal={(cwd) => newSession(projectId, "shell", cwd)}
+          />
+        ))}
       </div>
 
       <WorktreeDialog

--- a/frontend/src/lib/paths.test.ts
+++ b/frontend/src/lib/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { displayPath } from "./paths"
+import { baseName, displayPath } from "./paths"
 
 describe("displayPath", () => {
   it("collapses a POSIX home prefix to ~", () => {
@@ -18,5 +18,24 @@ describe("displayPath", () => {
     expect(displayPath("/opt/app/data")).toBe("/opt/app/data")
     expect(displayPath("/home")).toBe("/home")
     expect(displayPath("")).toBe("")
+  })
+})
+
+describe("baseName", () => {
+  it("returns the final POSIX segment", () => {
+    expect(baseName("/home/me/try/skipo")).toBe("skipo")
+  })
+
+  it("ignores a trailing slash", () => {
+    expect(baseName("/home/me/try/skipo/")).toBe("skipo")
+  })
+
+  it("handles Windows separators", () => {
+    expect(baseName("C:\\Users\\me\\worktrees\\windows-port")).toBe("windows-port")
+  })
+
+  it("returns empty for a root or empty path", () => {
+    expect(baseName("/")).toBe("")
+    expect(baseName("")).toBe("")
   })
 })

--- a/frontend/src/lib/paths.ts
+++ b/frontend/src/lib/paths.ts
@@ -6,3 +6,10 @@ const HOME_ROOTS = /^(?:\/home\/[^/]+|\/Users\/[^/]+|[A-Za-z]:\\Users\\[^\\]+)/
 export function displayPath(path: string): string {
   return path.replace(HOME_ROOTS, "~")
 }
+
+// baseName returns the final segment of a path — the folder name — tolerating
+// either separator and a trailing slash. Empty input (and a bare "/") returns "".
+export function baseName(path: string): string {
+  const segments = path.split(/[/\\]+/).filter(Boolean)
+  return segments[segments.length - 1] ?? ""
+}

--- a/frontend/src/lib/sessions.test.ts
+++ b/frontend/src/lib/sessions.test.ts
@@ -4,6 +4,7 @@ import {
   addSession,
   closeSession,
   createProjectSessions,
+  groupByWorktree,
   isLastWorktreeSession,
   isSessionKind,
   projectOfSession,
@@ -339,5 +340,41 @@ describe("isLastWorktreeSession", () => {
   it("is false while another session shares the same worktree path", () => {
     const s = wt("s1", "/wt/a")
     expect(isLastWorktreeSession([s, wt("s2", "/wt/a")], s)).toBe(false)
+  })
+})
+
+describe("groupByWorktree", () => {
+  const s = (id: string, path?: string): Session => ({
+    id,
+    label: id,
+    kind: "shell",
+    ...(path ? { path } : {}),
+  })
+
+  it("returns no groups for an empty list", () => {
+    expect(groupByWorktree([])).toEqual([])
+  })
+
+  it("keeps pathless sessions in the root group keyed by ''", () => {
+    const groups = groupByWorktree([s("s1"), s("s2")])
+    expect(groups).toHaveLength(1)
+    expect(groups[0].path).toBe("")
+    expect(groups[0].sessions.map((x) => x.id)).toEqual(["s1", "s2"])
+  })
+
+  it("buckets by checkout path in first-appearance order", () => {
+    const groups = groupByWorktree([s("s1"), s("wt1", "/wt/a"), s("wt2", "/wt/b")])
+    expect(groups.map((g) => g.path)).toEqual(["", "/wt/a", "/wt/b"])
+  })
+
+  it("merges interleaved paths into one group, preserving flat order", () => {
+    const groups = groupByWorktree([
+      s("a1", "/wt/a"),
+      s("b1", "/wt/b"),
+      s("a2", "/wt/a"),
+    ])
+    expect(groups.map((g) => g.path)).toEqual(["/wt/a", "/wt/b"])
+    expect(groups[0].sessions.map((x) => x.id)).toEqual(["a1", "a2"])
+    expect(groups[1].sessions.map((x) => x.id)).toEqual(["b1"])
   })
 })

--- a/frontend/src/lib/sessions.ts
+++ b/frontend/src/lib/sessions.ts
@@ -240,6 +240,33 @@ export function sessionsOf(state: SessionState, projectId: string): Session[] {
   return state[projectId]?.sessions ?? []
 }
 
+// A worktree's sessions under one roof. `path` is the checkout root ("" for the
+// project's own directory); `sessions` keeps the group's flat relative order.
+export interface SessionGroup {
+  path: string
+  sessions: Session[]
+}
+
+// groupByWorktree buckets sessions by their static checkout path (session.path;
+// "" = the project root), keeping first-appearance order for the groups and flat
+// order within each. It keys off the spawn-time path, never a live cwd, so a `cd`
+// deeper into a checkout never moves a card to another group.
+export function groupByWorktree(sessions: Session[]): SessionGroup[] {
+  const groups: SessionGroup[] = []
+  const byPath = new Map<string, SessionGroup>()
+  for (const session of sessions) {
+    const path = session.path ?? ""
+    let group = byPath.get(path)
+    if (!group) {
+      group = { path, sessions: [] }
+      byPath.set(path, group)
+      groups.push(group)
+    }
+    group.sessions.push(session)
+  }
+  return groups
+}
+
 // True only for the last session in a worktree checkout. Removing a checkout a
 // sibling session still occupies would throw away its work, so only the last
 // occupant gets offered the keep/remove prompt.


### PR DESCRIPTION
## What

With several worktrees open, the session sidebar was a flat list of cards and it was hard to tell which terminal or provider belonged to which checkout. Sessions sharing a worktree now render under a **static divider** titled with the worktree folder name.

Static headers over collapsible ones was a deliberate call (mocked both, picked static): zero extra state, minimal diff, clear hierarchy.

## Behaviour

- **Divider is a group title only.** It shows the worktree folder name; the branch (and full path) stay on each card, which owns the per-session detail. A `cd` inside a terminal still moves that card's own path readout.
- **`cd` never breaks a group.** Grouping keys off each session's checkout path (`session.path`), fixed at spawn — never the live cwd. Drilling `cd ~/proj/internal/store` never moves the card to another group.
- **Reorder within a group only.** Each group owns an isolated `DndContext`, so a drag can't cross groups. The new group order is spliced back into the flat session array before persisting (`reorderSessions` still bails on any id-set mismatch).
- **No worktrees = no change.** The divider appears only once more than one group exists; a lone project keeps its old flat, header-less list.

## Files

| File | Change |
|---|---|
| `lib/sessions.ts` | `groupByWorktree` — bucket by path, first-appearance order |
| `lib/paths.ts` | `baseName` — folder name for the divider title |
| `sidebar/SessionGroup.tsx` | **new** — static divider + per-group DndContext |
| `sidebar/SessionSidebar.tsx` | render groups; rebuild flat order on reorder |

## Test plan

- [x] `groupByWorktree` unit tests: empty, root bucket keyed `""`, first-appearance order, interleaved paths merge preserving flat order
- [x] `baseName` unit tests: POSIX, trailing slash, Windows separators, root/empty
- [x] Local gate: `tsc` clean, 342 frontend tests pass, `vite build` succeeds
- [ ] Manual smoke in `task dev` — sidebar render with 2+ worktrees is not covered by the node-only suite (project ceiling: base-ui render paths untested)

## Skipped (add if it comes up)

- Persisting collapse state — headers are static, nothing to collapse