### PR TITLE
fix: rework the light theme into a light-gray canvas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ bin
 frontend/dist
 frontend/node_modules
 frontend/coverage
+# tsc --build incremental cache
+*.tsbuildinfo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The light theme no longer glares.** Every surface was pure white, so panels
+  had no separation and the large terminal pane was blinding. Light is now a
+  soft light-gray canvas with near-white raised chrome, mirroring the dark
+  theme's depth: the ground (and terminal) sit darker than the sidebar, cards
+  and menus that lift above them, and the hover/selection fill is dark enough to
+  read again.
 - **A deletion line no longer bleeds through a diff file's sticky header.** The
   header's rounded corners let the red of a scrolled-under deletion peek out; it
   now sits flush and covers the content beneath it.

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -89,11 +89,11 @@ function fitTerminal(term: Terminal, container: HTMLElement): void {
   }
 }
 
-// Light keeps a high-contrast foreground so CLI output stays legible against
-// the pale background.
+// Light matches the app's light-gray canvas (--background) rather than pure
+// white, which glared; the dark foreground keeps CLI output high-contrast.
 const TERMINAL_COLORS: Record<ResolvedTheme, { background: string; foreground: string }> = {
   dark: { background: "#06070f", foreground: "#e5e7eb" },
-  light: { background: "#ffffff", foreground: "#1f2328" },
+  light: { background: "#e8e8ea", foreground: "#1f2328" },
 }
 
 // ensureFontLoaded blocks until a font is available. The renderer measures

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -59,39 +59,46 @@
     --color-background: var(--background);
 }
 
+/* Light is a light-gray canvas with near-white raised chrome (the mirror of
+   dark, where the ground is darkest and chrome lifts lighter). Pure white
+   everywhere glared, so the ground/terminal sit at ~0.94 and card/sidebar/
+   popover at ~0.98 — raised surfaces read without a border and nothing is
+   blinding white. Accent drops to ~0.9 so the hover/selection fill is visible
+   on the chrome. Keep TERMINAL_COLORS.light in TerminalView.tsx aligned with
+   --background. */
 :root {
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.141 0.005 285.823);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.141 0.005 285.823);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.141 0.005 285.823);
+    --background: oklch(0.94 0.003 286.32);
+    --foreground: oklch(0.21 0.006 285.885);
+    --card: oklch(0.98 0.002 286.32);
+    --card-foreground: oklch(0.21 0.006 285.885);
+    --popover: oklch(0.98 0.002 286.32);
+    --popover-foreground: oklch(0.21 0.006 285.885);
     --primary: oklch(0.21 0.006 285.885);
     --primary-foreground: oklch(0.985 0 0);
-    --secondary: oklch(0.967 0.001 286.375);
+    --secondary: oklch(0.92 0.003 286.32);
     --secondary-foreground: oklch(0.21 0.006 285.885);
-    --muted: oklch(0.967 0.001 286.375);
-    --muted-foreground: oklch(0.552 0.016 285.938);
-    --accent: oklch(0.967 0.001 286.375);
+    --muted: oklch(0.935 0.003 286.32);
+    --muted-foreground: oklch(0.505 0.016 285.938);
+    --accent: oklch(0.9 0.004 286.32);
     --accent-foreground: oklch(0.21 0.006 285.885);
     --destructive: oklch(0.577 0.245 27.325);
-    --border: oklch(0.92 0.004 286.32);
-    --input: oklch(0.92 0.004 286.32);
-    --ring: oklch(0.705 0.015 286.067);
+    --border: oklch(0.888 0.004 286.32);
+    --input: oklch(0.888 0.004 286.32);
+    --ring: oklch(0.6 0.015 286.067);
     --chart-1: oklch(0.871 0.006 286.286);
     --chart-2: oklch(0.552 0.016 285.938);
     --chart-3: oklch(0.442 0.017 285.786);
     --chart-4: oklch(0.37 0.013 285.805);
     --chart-5: oklch(0.274 0.006 286.033);
     --radius: 0.45rem;
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.141 0.005 285.823);
+    --sidebar: oklch(0.98 0.002 286.32);
+    --sidebar-foreground: oklch(0.21 0.006 285.885);
     --sidebar-primary: oklch(0.21 0.006 285.885);
     --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.967 0.001 286.375);
+    --sidebar-accent: oklch(0.9 0.004 286.32);
     --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
-    --sidebar-border: oklch(0.92 0.004 286.32);
-    --sidebar-ring: oklch(0.705 0.015 286.067);
+    --sidebar-border: oklch(0.888 0.004 286.32);
+    --sidebar-ring: oklch(0.6 0.015 286.067);
 }
 
 .dark {


### PR DESCRIPTION
## What

The light theme was reworked so it stops glaring. Every light surface was pure
white — `--background`, `--card`, `--popover` and `--sidebar` all sat at
`oklch(1 0 0)` — so panels had no separation from each other and the terminal,
the largest pane, was a blinding white rectangle. Since the reskin defines
surfaces by fill rather than borders, white-on-white left nothing to read.

Light now mirrors the dark theme's depth model instead of collapsing it:

- **Canvas** (the ground, and the terminal — whose own `TERMINAL_COLORS.light`
  tracks `--background`) drops to a soft light-gray `~0.94`.
- **Raised chrome** (`--card` / `--popover` / `--sidebar`) stays near-white
  `~0.98`, so the sidebar, cards, menus and dialogs lift off the canvas without
  a border — the same "raised is lighter than the ground" relationship the dark
  theme already has.
- **Accent** drops to `~0.9` and **muted-foreground** darkens, so the
  hover/selection fill and secondary text read against the lighter chrome again.
- **Foreground** softens from near-black `0.141` to `0.21` to cut the harsh
  black-on-white contrast.

The dark theme, the zinc hue and the layout are untouched.

## Kept fixed by decision

Zinc, achromatic — no brand accent. This only moves lightness values; the hue
(`286`) and the "open surfaces, not boxes" idiom are unchanged.

## Notes

- Also ignores `*.tsbuildinfo` (the `tsc --build` incremental cache), which was
  otherwise untracked in `frontend/`.

## Test plan

- [x] `pnpm build` (tsc + vite) green
- [x] `pnpm test` — 342 passing
- [x] Smoke-tested live in `task dev` — light theme, glare gone, panels separate,
  hover/selection reads
- [x] Dark theme unaffected (untouched, but worth a glance)