### PR TITLE
feat: show the active session's context window in the footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **The footer shows the active session's context window.** A small ring in the
-  status strip fills with the percent of its context window the active Claude
-  session is using, with the percent beside it; hovering shows the model, a
-  fuller bar, and the exact tokens against the window size. Read off the
-  conversation's transcript at each turn's
-  end, it turns amber past 80% and red past 95%, so a session drifting toward
-  auto-compaction is visible without opening `/context`. The percent is taken
-  against the model's native window (1M for current Opus/Sonnet/Fable, 200k for
-  Haiku). It can be turned off under Settings › Providers › Claude Code. Needs no
-  change to the user's statusline; other providers stay blank until they report a
-  session id of their own.
+- **The footer shows the active session's model and context window.** The status
+  strip now names the model the active Claude session runs, marked with the
+  provider's icon, and a small ring beside it fills with the percent of its
+  context window in use; hovering the ring shows a fuller bar and the exact
+  tokens against the window size. Read off the conversation's transcript at each
+  turn's end, the ring turns amber past 80% and red past 95%, so a session
+  drifting toward auto-compaction is visible without opening `/context`. The
+  percent is taken against the model's native window (1M for current
+  Opus/Sonnet/Fable, 200k for Haiku). The ring can be turned off under Settings ›
+  Providers › Claude Code. Needs no change to the user's statusline; other
+  providers stay blank until they report a session id of their own.
 
 ## [0.17.0] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **The footer shows the active session's model and context window.** The status
-  strip now names the model the active Claude session runs, marked with the
-  provider's icon, and a small ring beside it fills with the percent of its
-  context window in use; hovering the ring shows a fuller bar and the exact
-  tokens against the window size. Read off the conversation's transcript at each
-  turn's end, the ring turns amber past 80% and red past 95%, so a session
+  strip now names the model the active Claude session runs and its reasoning
+  effort (e.g. `opus 4.8 · xhigh`), marked with the provider's icon, and a small
+  ring beside it fills with the percent of its context window in use; hovering
+  the ring shows a fuller bar and the exact tokens against the window size. It
+  refreshes as the context grows through a turn, read off the conversation's
+  transcript. The ring turns amber past 80% and red past 95%, so a session
   drifting toward auto-compaction is visible without opening `/context`. The
   percent is taken against the model's native window (1M for current
-  Opus/Sonnet/Fable, 200k for Haiku). The ring can be turned off under Settings ›
-  Providers › Claude Code. Needs no change to the user's statusline; other
-  providers stay blank until they report a session id of their own.
+  Opus/Sonnet/Fable, 200k for Haiku). The readout can be turned off under
+  Settings › Providers › Claude Code. Needs no change to the user's statusline;
+  other providers stay blank until they report a session id of their own.
 
 ## [0.17.0] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The footer shows the active session's context window.** A small ring in the
+  status strip fills with the percent of its context window the active Claude
+  session is using, with the percent beside it; hovering shows the model, a
+  fuller bar, and the exact tokens against the window size. Read off the
+  conversation's transcript at each turn's
+  end, it turns amber past 80% and red past 95%, so a session drifting toward
+  auto-compaction is visible without opening `/context`. The percent is taken
+  against the model's native window (1M for current Opus/Sonnet/Fable, 200k for
+  Haiku). It can be turned off under Settings › Providers › Claude Code. Needs no
+  change to the user's statusline; other providers stay blank until they report a
+  session id of their own.
+
 ## [0.17.0] - 2026-07-24
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,17 @@ Deliberate limits and shortcuts — one line of *what and where*; the mechanism 
   failed read degrades to the session's start directory. Tracks the direct child only, not nested shells.
 - **git status is polled** — one shared poller per repository path (`frontend/src/lib/git-status-store.ts`); the
   lich plugin's `session-touched` hook nudges an immediate refresh. An fs watcher is the upgrade path.
+- **Context-window usage is read off the transcript** (`internal/terminal/usage_claude.go`): on a turn-boundary
+  status hook, the tail of `~/.claude/projects/<slug>/<id>.jsonl` is parsed for the last main-thread assistant
+  `usage` (sidechain sub-agent lines skipped), shown in the footer for the active session. The JSONL layout is
+  Claude-internal and unstable across releases — the read fails soft (the readout keeps its last number). The
+  percent is taken against the model's native window from a small `model → window` table (`modelWindows`: current
+  Opus/Sonnet/Fable are 1M, Haiku and pre-4.6 are 200k) — the transcript records the model but not the window; an
+  unlisted model falls back to inferring the window from the token count. Two deliberate ceilings: the table goes
+  stale as models ship (Models API `max_input_tokens` is the upgrade path), and it assumes the model's *native*
+  window — a session that runs a 1M-capable model at 200k reads double its true percent, because the exact window
+  lives only in the statusLine JSON (`context_window.context_window_size`), never in the transcript. The reader is
+  Claude-only (the sole provider reporting a session id today), isolated for a per-provider selection later.
 - **Persistence is hybrid**: UI prefs in the page's localStorage (`lich.*` keys — the reason the listener port is
   pinned at 47821; `LICH_LISTEN_PORT` overrides it, `LICH_PORT` is the distinct per-session hook variable), the
   workspace in SQLite (`<config-dir>/lich/lich.db`, `internal/store`). Closing a session deletes its row; keeping a

--- a/frontend/src/components/ContextRing.test.ts
+++ b/frontend/src/components/ContextRing.test.ts
@@ -1,0 +1,19 @@
+import {describe, expect, it} from "vitest"
+import {contextColor} from "./ContextRing"
+
+describe("contextColor", () => {
+  it("is muted below 80%", () => {
+    expect(contextColor(0)).toBe("text-muted-foreground")
+    expect(contextColor(79)).toBe("text-muted-foreground")
+  })
+
+  it("turns amber from 80% up to 95%", () => {
+    expect(contextColor(80)).toBe("text-amber-500")
+    expect(contextColor(94)).toBe("text-amber-500")
+  })
+
+  it("turns red from 95%", () => {
+    expect(contextColor(95)).toBe("text-red-500")
+    expect(contextColor(100)).toBe("text-red-500")
+  })
+})

--- a/frontend/src/components/ContextRing.tsx
+++ b/frontend/src/components/ContextRing.tsx
@@ -1,0 +1,57 @@
+import {cn} from "@/lib/utils"
+
+// contextColor is the semantic text colour for a context-window fill, shared by
+// the ring, the footer percent, and the tooltip bar so they always agree: muted
+// at rest, amber as the window fills, red near the limit.
+export function contextColor(percent: number): string {
+  if (percent >= 95) {
+    return "text-red-500"
+  }
+  if (percent >= 80) {
+    return "text-amber-500"
+  }
+  return "text-muted-foreground"
+}
+
+interface ContextRingProps {
+  // Share of the context window in use, 0–100.
+  percent: number
+  className?: string
+}
+
+// ContextRing draws a compact donut filled to `percent` — a pure fill glyph, no
+// label (the number lives beside it, at footer size where it is legible). The
+// radius 15.9155 makes the circumference exactly 100, so the arc's dash length
+// is the percent directly. Strokes use currentColor, so the caller sets the
+// colour (see contextColor) once for the ring and its adjacent text.
+export function ContextRing({percent, className}: ContextRingProps) {
+  return (
+    <svg
+      viewBox="0 0 36 36"
+      className={cn("size-4 shrink-0", className)}
+      role="img"
+      aria-label={`Context window ${percent}% used`}
+    >
+      <circle
+        cx="18"
+        cy="18"
+        r="15.9155"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="4"
+        className="opacity-20"
+      />
+      <circle
+        cx="18"
+        cy="18"
+        r="15.9155"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="4"
+        strokeDasharray={`${percent} 100`}
+        strokeLinecap="round"
+        transform="rotate(-90 18 18)"
+      />
+    </svg>
+  )
+}

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -5,10 +5,15 @@ import {ProjectService, System, Terminal as TerminalService} from "@/lib/rpc"
 import type {DockTab} from "@/components/dock/RightDock"
 import {useActiveSession} from "@/lib/useActiveSession"
 import {useSessionCwd} from "@/lib/useSessionCwd"
+import {useSessionUsage} from "@/lib/useSessionUsage"
 import {displayPath} from "@/lib/paths"
+import {formatModel} from "@/lib/model-name"
 import {useGitStatus} from "@/lib/useGitStatus"
 import {usePullRequest} from "@/lib/usePullRequest"
+import {useSettings} from "@/lib/settings"
+import {cn} from "@/lib/utils"
 import {DiffStat} from "@/components/DiffStat"
+import {ContextRing, contextColor} from "@/components/ContextRing"
 import {Separator} from "@/components/ui/separator"
 import {
   Tooltip,
@@ -43,6 +48,11 @@ export function FooterBar({dock, onDock}: FooterBarProps) {
   // with it — same source the session card follows. Falls back to the session's
   // static start path until the watcher reports.
   const path = useSessionCwd(sessionId) || basePath
+  // Context-window occupancy of the active session, read off its transcript at
+  // each turn's end (null until the first turn of a Claude session lands).
+  const usage = useSessionUsage(sessionId)
+  // The footer context readout is opt-out (Settings › Providers).
+  const {showContextUsage} = useSettings()
   const status = useGitStatus(path)
   const pr = usePullRequest(path, status?.branch ?? "")
   const now = useNow()
@@ -57,6 +67,51 @@ export function FooterBar({dock, onDock}: FooterBarProps) {
       toast.error("Could not open the file picker")
     }
   }
+
+  // The context-window readout — the ring plus percent, with a detailed
+  // tooltip. Null when the user turned it off (Settings › Providers).
+  const contextReadout = usage && showContextUsage ? (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            className={cn(
+              "flex items-center gap-1.5 tabular-nums",
+              contextColor(usage.percent),
+            )}
+          />
+        }
+      >
+        <ContextRing percent={usage.percent}/>
+        {usage.percent}%
+      </TooltipTrigger>
+      <TooltipContent
+        side="top"
+        className="border border-border bg-card text-foreground"
+      >
+        <div className="flex flex-col gap-1.5">
+          <span className="flex items-center justify-between gap-4">
+            <span className="font-medium">Context window</span>
+            <span className="font-mono text-xs text-muted-foreground">
+              {formatModel(usage.model)}
+            </span>
+          </span>
+          <div className={cn("flex items-center gap-2", contextColor(usage.percent))}>
+            <span className="h-1.5 w-24 overflow-hidden rounded-full bg-muted">
+              <span
+                className="block h-full rounded-full bg-current"
+                style={{width: `${usage.percent}%`}}
+              />
+            </span>
+            <span className="tabular-nums">{usage.percent}%</span>
+          </div>
+          <span className="font-mono text-xs text-muted-foreground">
+            {usage.tokens.toLocaleString()} / {usage.window.toLocaleString()} tokens
+          </span>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  ) : null
 
   return (
     <footer
@@ -144,6 +199,10 @@ export function FooterBar({dock, onDock}: FooterBarProps) {
       )}
 
       <span className="ml-auto flex items-center gap-4">
+        {contextReadout}
+        {contextReadout && (status?.branch || path) && (
+          <Separator orientation="vertical" className="h-4"/>
+        )}
         {status?.branch && (
           <span className="flex items-center gap-1">
             <GitBranch className="size-3.5"/>

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -194,7 +194,7 @@ export function FooterBar({dock, onDock}: FooterBarProps) {
       )}
 
       <span className="ml-auto flex items-center gap-4">
-        <SessionModel sessionId={sessionId}/>
+        {showContextUsage && <SessionModel sessionId={sessionId}/>}
         {contextReadout}
         {contextReadout && (status?.branch || path) && (
           <Separator orientation="vertical" className="h-4"/>

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -7,13 +7,13 @@ import {useActiveSession} from "@/lib/useActiveSession"
 import {useSessionCwd} from "@/lib/useSessionCwd"
 import {useSessionUsage} from "@/lib/useSessionUsage"
 import {displayPath} from "@/lib/paths"
-import {formatModel} from "@/lib/model-name"
 import {useGitStatus} from "@/lib/useGitStatus"
 import {usePullRequest} from "@/lib/usePullRequest"
 import {useSettings} from "@/lib/settings"
 import {cn} from "@/lib/utils"
 import {DiffStat} from "@/components/DiffStat"
 import {ContextRing, contextColor} from "@/components/ContextRing"
+import {SessionModel} from "@/components/SessionModel"
 import {Separator} from "@/components/ui/separator"
 import {
   Tooltip,
@@ -90,12 +90,7 @@ export function FooterBar({dock, onDock}: FooterBarProps) {
         className="border border-border bg-card text-foreground"
       >
         <div className="flex flex-col gap-1.5">
-          <span className="flex items-center justify-between gap-4">
-            <span className="font-medium">Context window</span>
-            <span className="font-mono text-xs text-muted-foreground">
-              {formatModel(usage.model)}
-            </span>
-          </span>
+          <span className="font-medium">Context window</span>
           <div className={cn("flex items-center gap-2", contextColor(usage.percent))}>
             <span className="h-1.5 w-24 overflow-hidden rounded-full bg-muted">
               <span
@@ -199,6 +194,7 @@ export function FooterBar({dock, onDock}: FooterBarProps) {
       )}
 
       <span className="ml-auto flex items-center gap-4">
+        <SessionModel sessionId={sessionId}/>
         {contextReadout}
         {contextReadout && (status?.branch || path) && (
           <Separator orientation="vertical" className="h-4"/>

--- a/frontend/src/components/SessionModel.tsx
+++ b/frontend/src/components/SessionModel.tsx
@@ -1,0 +1,26 @@
+import {ProviderIcon} from "@/lib/provider-icons"
+import {formatModel} from "@/lib/model-name"
+import {useSessionUsage} from "@/lib/useSessionUsage"
+
+interface SessionModelProps {
+  sessionId: string
+}
+
+// SessionModel is the footer's AI-session slot: which model the active session
+// runs, read from the same usage report as the context ring (so it appears once
+// a Claude session has taken a turn, null before). Self-contained on purpose —
+// it reads its own data by id, so the slot can grow with more per-session detail
+// without touching FooterBar. Usage is Claude-only today, so the mark is
+// Claude's; a second provider that reports usage makes the kind dynamic here.
+export function SessionModel({sessionId}: SessionModelProps) {
+  const usage = useSessionUsage(sessionId)
+  if (!usage) {
+    return null
+  }
+  return (
+    <span className="flex items-center gap-1.5">
+      <ProviderIcon kind="claude" size={14}/>
+      {formatModel(usage.model)}
+    </span>
+  )
+}

--- a/frontend/src/components/SessionModel.tsx
+++ b/frontend/src/components/SessionModel.tsx
@@ -21,6 +21,7 @@ export function SessionModel({sessionId}: SessionModelProps) {
     <span className="flex items-center gap-1.5">
       <ProviderIcon kind="claude" size={14}/>
       {formatModel(usage.model)}
+      {usage.effort ? ` · ${usage.effort}` : ""}
     </span>
   )
 }

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from "react"
 import { Store } from "@/lib/rpc"
 import { useProjects } from "@/lib/projects"
 import { binKey } from "@/lib/providers-store"
+import { useSettings } from "@/lib/settings"
 import { Input } from "@/components/ui/input"
+import { Switch } from "@/components/ui/switch"
 import { SettingBlock } from "./SettingBlock"
 
 const GLOBAL_SCOPE = ""
@@ -19,6 +21,7 @@ export function ProviderBinSettings({
   projectId?: string
 }) {
   const { projects } = useProjects()
+  const { showContextUsage, setShowContextUsage } = useSettings()
   const project = projects.find((p) => p.id === projectId)
   const key = binKey(providerId)
   const [globalBin, setGlobalBin] = useState("")
@@ -76,6 +79,21 @@ export function ProviderBinSettings({
             spellCheck={false}
             aria-label={`${providerId} path for ${project.name}`}
             className="w-96 max-w-full font-mono"
+          />
+        </SettingBlock>
+      )}
+
+      {/* Only Claude Code reports context-window usage (via the lich plugin), so
+          the footer readout toggle lives in its section, not the generic hub. */}
+      {providerId === "claude" && (
+        <SettingBlock
+          title="Context window in the footer"
+          description="Show this session's context-window usage in the footer — a ring with the percent, read from the transcript at each turn's end."
+        >
+          <Switch
+            checked={showContextUsage}
+            onCheckedChange={setShowContextUsage}
+            aria-label="Show context window usage in the footer"
           />
         </SettingBlock>
       )}

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -87,13 +87,13 @@ export function ProviderBinSettings({
           the footer readout toggle lives in its section, not the generic hub. */}
       {providerId === "claude" && (
         <SettingBlock
-          title="Context window in the footer"
-          description="Show this session's context-window usage in the footer — a ring with the percent, read from the transcript at each turn's end."
+          title="Model & context in the footer"
+          description="Show this session's model and context-window usage in the footer — the model name plus a ring with the percent, read from the transcript."
         >
           <Switch
             checked={showContextUsage}
             onCheckedChange={setShowContextUsage}
-            aria-label="Show context window usage in the footer"
+            aria-label="Show model and context usage in the footer"
           />
         </SettingBlock>
       )}

--- a/frontend/src/lib/model-name.test.ts
+++ b/frontend/src/lib/model-name.test.ts
@@ -1,0 +1,18 @@
+import {describe, expect, it} from "vitest"
+import {formatModel} from "./model-name"
+
+describe("formatModel", () => {
+  it("drops the claude- prefix and dots the version", () => {
+    expect(formatModel("claude-opus-4-8")).toBe("opus 4.8")
+    expect(formatModel("claude-sonnet-5")).toBe("sonnet 5")
+    expect(formatModel("claude-fable-5")).toBe("fable 5")
+  })
+
+  it("strips a trailing date snapshot", () => {
+    expect(formatModel("claude-haiku-4-5-20251001")).toBe("haiku 4.5")
+  })
+
+  it("leaves an id without a version split stripped but intact", () => {
+    expect(formatModel("claude-experimental")).toBe("experimental")
+  })
+})

--- a/frontend/src/lib/model-name.ts
+++ b/frontend/src/lib/model-name.ts
@@ -1,0 +1,11 @@
+// formatModel turns a raw Claude model id into the short label the tooltip
+// shows: drop the "claude-" prefix and any trailing date snapshot, then render
+// the version dash-segments as a dotted number after the family word —
+// "claude-opus-4-8" → "opus 4.8", "claude-haiku-4-5-20251001" → "haiku 4.5",
+// "claude-fable-5" → "fable 5". An id that doesn't fit the shape (no family +
+// version split) is shown stripped but otherwise untouched.
+export function formatModel(id: string): string {
+  const stripped = id.replace(/^claude-/, "").replace(/-\d{8}$/, "")
+  const [family, ...version] = stripped.split("-")
+  return version.length > 0 ? `${family} ${version.join(".")}` : stripped
+}

--- a/frontend/src/lib/session-events.test.ts
+++ b/frontend/src/lib/session-events.test.ts
@@ -119,17 +119,25 @@ describe("isAgentEvent", () => {
 })
 
 describe("isUsageEvent", () => {
-  const full = {id: "s1", percent: 42, tokens: 84000, window: 200000, model: "claude-opus-4-8"}
+  const full = {
+    id: "s1",
+    percent: 42,
+    tokens: 84000,
+    window: 200000,
+    model: "claude-opus-4-8",
+    effort: "xhigh",
+  }
 
-  it("accepts a payload carrying id, percent, tokens, window and model", () => {
+  it("accepts a payload carrying id, percent, tokens, window, model and effort", () => {
     expect(isUsageEvent(full)).toBe(true)
-    expect(isUsageEvent({...full, percent: 0, tokens: 0})).toBe(true)
+    expect(isUsageEvent({...full, percent: 0, tokens: 0, effort: ""})).toBe(true)
   })
 
   it("rejects a payload missing a field or typed wrong", () => {
-    expect(isUsageEvent({id: "s1", percent: 42, tokens: 84000, window: 200000})).toBe(false)
+    expect(isUsageEvent({id: "s1", percent: 42, tokens: 84000, window: 200000, model: "x"})).toBe(false)
     expect(isUsageEvent({...full, window: undefined})).toBe(false)
     expect(isUsageEvent({...full, model: 5})).toBe(false)
+    expect(isUsageEvent({...full, effort: 3})).toBe(false)
     expect(isUsageEvent({...full, id: undefined})).toBe(false)
     expect(isUsageEvent({...full, percent: "42"})).toBe(false)
     expect(isUsageEvent(null)).toBe(false)

--- a/frontend/src/lib/session-events.test.ts
+++ b/frontend/src/lib/session-events.test.ts
@@ -5,6 +5,7 @@ import {
   isIdEvent,
   isStatusEvent,
   isTitleEvent,
+  isUsageEvent,
   shouldToastAttention,
   toSessionStatus,
 } from "./session-events"
@@ -114,6 +115,24 @@ describe("isAgentEvent", () => {
     expect(isAgentEvent({agent: "claude"})).toBe(false)
     expect(isAgentEvent({id: "s1", agent: 2})).toBe(false)
     expect(isAgentEvent(null)).toBe(false)
+  })
+})
+
+describe("isUsageEvent", () => {
+  const full = {id: "s1", percent: 42, tokens: 84000, window: 200000, model: "claude-opus-4-8"}
+
+  it("accepts a payload carrying id, percent, tokens, window and model", () => {
+    expect(isUsageEvent(full)).toBe(true)
+    expect(isUsageEvent({...full, percent: 0, tokens: 0})).toBe(true)
+  })
+
+  it("rejects a payload missing a field or typed wrong", () => {
+    expect(isUsageEvent({id: "s1", percent: 42, tokens: 84000, window: 200000})).toBe(false)
+    expect(isUsageEvent({...full, window: undefined})).toBe(false)
+    expect(isUsageEvent({...full, model: 5})).toBe(false)
+    expect(isUsageEvent({...full, id: undefined})).toBe(false)
+    expect(isUsageEvent({...full, percent: "42"})).toBe(false)
+    expect(isUsageEvent(null)).toBe(false)
   })
 })
 

--- a/frontend/src/lib/session-events.ts
+++ b/frontend/src/lib/session-events.ts
@@ -34,9 +34,9 @@ export const AGENT_EVENT = "session-agent"
 
 // Global event the backend emits after a turn ends with the session's
 // context-window usage (see terminal.usageEventName). Payload: { id, percent,
-// tokens, window, model } — percent is 0–100 of the window, tokens the raw
-// input-side count, window the model's context size, model its id (all for the
-// tooltip).
+// tokens, window, model, effort } — percent is 0–100 of the window, tokens the
+// raw input-side count, window the model's context size, model its id, effort
+// the reasoning level ("" when the turn records none).
 export const USAGE_EVENT = "session-usage"
 
 // A session's context-window occupancy as the footer shows it.
@@ -45,6 +45,7 @@ export interface SessionUsage {
   tokens: number
   window: number
   model: string
+  effort: string
 }
 
 // The states a card renders an indicator for. The contract also defines "idle"
@@ -93,13 +94,21 @@ export function isAgentEvent(data: unknown): data is {id: string; agent: string}
 
 export function isUsageEvent(
   data: unknown,
-): data is {id: string; percent: number; tokens: number; window: number; model: string} {
+): data is {
+  id: string
+  percent: number
+  tokens: number
+  window: number
+  model: string
+  effort: string
+} {
   return (
     isIdEvent(data) &&
     typeof (data as {percent?: unknown}).percent === "number" &&
     typeof (data as {tokens?: unknown}).tokens === "number" &&
     typeof (data as {window?: unknown}).window === "number" &&
-    typeof (data as {model?: unknown}).model === "string"
+    typeof (data as {model?: unknown}).model === "string" &&
+    typeof (data as {effort?: unknown}).effort === "string"
   )
 }
 

--- a/frontend/src/lib/session-events.ts
+++ b/frontend/src/lib/session-events.ts
@@ -32,6 +32,21 @@ export const CWD_EVENT = "session-cwd"
 // Payload: { id, agent }; an empty agent (every PTY spawn) clears the mark.
 export const AGENT_EVENT = "session-agent"
 
+// Global event the backend emits after a turn ends with the session's
+// context-window usage (see terminal.usageEventName). Payload: { id, percent,
+// tokens, window, model } — percent is 0–100 of the window, tokens the raw
+// input-side count, window the model's context size, model its id (all for the
+// tooltip).
+export const USAGE_EVENT = "session-usage"
+
+// A session's context-window occupancy as the footer shows it.
+export interface SessionUsage {
+  percent: number
+  tokens: number
+  window: number
+  model: string
+}
+
 // The states a card renders an indicator for. The contract also defines "idle"
 // (SessionEnd), which maps to no indicator like any unknown value does.
 const RENDERED_STATUSES = ["busy", "done", "waiting"] as const
@@ -74,6 +89,18 @@ export function isCwdEvent(data: unknown): data is {id: string; cwd: string} {
 
 export function isAgentEvent(data: unknown): data is {id: string; agent: string} {
   return isIdEvent(data) && typeof (data as {agent?: unknown}).agent === "string"
+}
+
+export function isUsageEvent(
+  data: unknown,
+): data is {id: string; percent: number; tokens: number; window: number; model: string} {
+  return (
+    isIdEvent(data) &&
+    typeof (data as {percent?: unknown}).percent === "number" &&
+    typeof (data as {tokens?: unknown}).tokens === "number" &&
+    typeof (data as {window?: unknown}).window === "number" &&
+    typeof (data as {model?: unknown}).model === "string"
+  )
 }
 
 // shouldToastAttention decides whether a session needing the user deserves the

--- a/frontend/src/lib/session-usage-store.test.ts
+++ b/frontend/src/lib/session-usage-store.test.ts
@@ -1,0 +1,78 @@
+import {describe, expect, it} from "vitest"
+import {createSessionUsageStore} from "./session-usage-store"
+
+// harness wires a store to a hand-driven event source, returning the emitter.
+function harness() {
+  let handler: (data: unknown) => void = () => {}
+  const store = createSessionUsageStore((h) => {
+    handler = h
+    return () => {}
+  })
+  return {store, emit: (data: unknown) => handler(data)}
+}
+
+describe("createSessionUsageStore", () => {
+  it("returns null while nothing has been reported", () => {
+    const {store} = harness()
+    expect(store.get("s1")).toBeNull()
+  })
+
+  const opus = "claude-opus-4-8"
+
+  it("keeps the last reported usage per session", () => {
+    const {store, emit} = harness()
+    emit({id: "s1", percent: 42, tokens: 84000, window: 200000, model: opus})
+    emit({id: "s2", percent: 5, tokens: 50000, window: 1000000, model: opus})
+    expect(store.get("s1")).toEqual({percent: 42, tokens: 84000, window: 200000, model: opus})
+    expect(store.get("s2")).toEqual({percent: 5, tokens: 50000, window: 1000000, model: opus})
+  })
+
+  it("notifies only the session's subscribers on change", () => {
+    const {store, emit} = harness()
+    let s1 = 0
+    let s2 = 0
+    store.subscribe("s1", () => s1++)
+    store.subscribe("s2", () => s2++)
+    emit({id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus})
+    expect(s1).toBe(1)
+    expect(s2).toBe(0)
+  })
+
+  it("stays silent, and keeps the reference, on an unchanged report", () => {
+    const {store, emit} = harness()
+    let calls = 0
+    store.subscribe("s1", () => calls++)
+    emit({id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus})
+    const first = store.get("s1")
+    emit({id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus})
+    expect(calls).toBe(1)
+    expect(store.get("s1")).toBe(first)
+  })
+
+  it("re-renders when percent changes at equal tokens", () => {
+    const {store, emit} = harness()
+    let calls = 0
+    store.subscribe("s1", () => calls++)
+    emit({id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus})
+    emit({id: "s1", percent: 11, tokens: 20000, window: 200000, model: opus})
+    expect(calls).toBe(2)
+    expect(store.get("s1")).toEqual({percent: 11, tokens: 20000, window: 200000, model: opus})
+  })
+
+  it("retains the usage across an unsubscribe, like a card unmount", () => {
+    const {store, emit} = harness()
+    const off = store.subscribe("s1", () => {})
+    emit({id: "s1", percent: 30, tokens: 60000, window: 200000, model: opus})
+    off()
+    expect(store.get("s1")).toEqual({percent: 30, tokens: 60000, window: 200000, model: opus})
+  })
+
+  it("ignores malformed payloads", () => {
+    const {store, emit} = harness()
+    emit({id: "s1", percent: 10, tokens: 20000, window: 200000})
+    emit({id: "s1", tokens: 20000, window: 200000, model: opus})
+    emit({percent: 10, tokens: 20000, window: 200000, model: opus})
+    emit(null)
+    expect(store.get("s1")).toBeNull()
+  })
+})

--- a/frontend/src/lib/session-usage-store.test.ts
+++ b/frontend/src/lib/session-usage-store.test.ts
@@ -18,13 +18,14 @@ describe("createSessionUsageStore", () => {
   })
 
   const opus = "claude-opus-4-8"
+  const eff = "high"
 
   it("keeps the last reported usage per session", () => {
     const {store, emit} = harness()
-    emit({id: "s1", percent: 42, tokens: 84000, window: 200000, model: opus})
-    emit({id: "s2", percent: 5, tokens: 50000, window: 1000000, model: opus})
-    expect(store.get("s1")).toEqual({percent: 42, tokens: 84000, window: 200000, model: opus})
-    expect(store.get("s2")).toEqual({percent: 5, tokens: 50000, window: 1000000, model: opus})
+    emit({id: "s1", percent: 42, tokens: 84000, window: 200000, model: opus, effort: eff})
+    emit({id: "s2", percent: 5, tokens: 50000, window: 1000000, model: opus, effort: eff})
+    expect(store.get("s1")).toEqual({percent: 42, tokens: 84000, window: 200000, model: opus, effort: eff})
+    expect(store.get("s2")).toEqual({percent: 5, tokens: 50000, window: 1000000, model: opus, effort: eff})
   })
 
   it("notifies only the session's subscribers on change", () => {
@@ -33,7 +34,7 @@ describe("createSessionUsageStore", () => {
     let s2 = 0
     store.subscribe("s1", () => s1++)
     store.subscribe("s2", () => s2++)
-    emit({id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus})
+    emit({id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus, effort: eff})
     expect(s1).toBe(1)
     expect(s2).toBe(0)
   })
@@ -42,36 +43,36 @@ describe("createSessionUsageStore", () => {
     const {store, emit} = harness()
     let calls = 0
     store.subscribe("s1", () => calls++)
-    emit({id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus})
+    emit({id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus, effort: eff})
     const first = store.get("s1")
-    emit({id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus})
+    emit({id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus, effort: eff})
     expect(calls).toBe(1)
     expect(store.get("s1")).toBe(first)
   })
 
-  it("re-renders when percent changes at equal tokens", () => {
+  it("re-renders when the effort changes at equal tokens", () => {
     const {store, emit} = harness()
     let calls = 0
     store.subscribe("s1", () => calls++)
-    emit({id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus})
-    emit({id: "s1", percent: 11, tokens: 20000, window: 200000, model: opus})
+    emit({id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus, effort: "high"})
+    emit({id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus, effort: "xhigh"})
     expect(calls).toBe(2)
-    expect(store.get("s1")).toEqual({percent: 11, tokens: 20000, window: 200000, model: opus})
+    expect(store.get("s1")).toEqual({percent: 10, tokens: 20000, window: 200000, model: opus, effort: "xhigh"})
   })
 
   it("retains the usage across an unsubscribe, like a card unmount", () => {
     const {store, emit} = harness()
     const off = store.subscribe("s1", () => {})
-    emit({id: "s1", percent: 30, tokens: 60000, window: 200000, model: opus})
+    emit({id: "s1", percent: 30, tokens: 60000, window: 200000, model: opus, effort: eff})
     off()
-    expect(store.get("s1")).toEqual({percent: 30, tokens: 60000, window: 200000, model: opus})
+    expect(store.get("s1")).toEqual({percent: 30, tokens: 60000, window: 200000, model: opus, effort: eff})
   })
 
   it("ignores malformed payloads", () => {
     const {store, emit} = harness()
-    emit({id: "s1", percent: 10, tokens: 20000, window: 200000})
-    emit({id: "s1", tokens: 20000, window: 200000, model: opus})
-    emit({percent: 10, tokens: 20000, window: 200000, model: opus})
+    emit({id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus})
+    emit({id: "s1", tokens: 20000, window: 200000, model: opus, effort: eff})
+    emit({percent: 10, tokens: 20000, window: 200000, model: opus, effort: eff})
     emit(null)
     expect(store.get("s1")).toBeNull()
   })

--- a/frontend/src/lib/session-usage-store.ts
+++ b/frontend/src/lib/session-usage-store.ts
@@ -1,0 +1,70 @@
+import {isUsageEvent, type SessionUsage} from "./session-events"
+
+// A subscription to the global usage event, injected so the store is testable
+// without standing up the /events socket. Returns its unsubscribe.
+export type UsageEventSource = (handler: (data: unknown) => void) => () => void
+
+interface Entry {
+  usage: SessionUsage | null
+  listeners: Set<() => void>
+}
+
+// createSessionUsageStore keeps the last reported context-window usage of every
+// session, keyed by session id, fed by one subscription taken at creation —
+// before any card mounts. Same shape and reason as session-cwd-store: cards
+// unmount with their project, so the value cannot live in them. The value object
+// is only replaced on a real change, so its reference is stable for
+// useSyncExternalStore between reports.
+export function createSessionUsageStore(source: UsageEventSource) {
+  const entries = new Map<string, Entry>()
+
+  const entryOf = (id: string): Entry => {
+    let entry = entries.get(id)
+    if (!entry) {
+      entry = {usage: null, listeners: new Set()}
+      entries.set(id, entry)
+    }
+    return entry
+  }
+
+  source((data) => {
+    if (!isUsageEvent(data)) {
+      return
+    }
+    const entry = entryOf(data.id)
+    // Bail on an unchanged report so subscribers skip the re-render, and the
+    // snapshot reference stays put for useSyncExternalStore.
+    if (
+      entry.usage &&
+      entry.usage.percent === data.percent &&
+      entry.usage.tokens === data.tokens &&
+      entry.usage.window === data.window &&
+      entry.usage.model === data.model
+    ) {
+      return
+    }
+    entry.usage = {
+      percent: data.percent,
+      tokens: data.tokens,
+      window: data.window,
+      model: data.model,
+    }
+    for (const listener of entry.listeners) {
+      listener()
+    }
+  })
+
+  const subscribe = (id: string, listener: () => void): (() => void) => {
+    const entry = entryOf(id)
+    entry.listeners.add(listener)
+    return () => {
+      entry.listeners.delete(listener)
+    }
+  }
+
+  // get returns null while nothing has been reported — the card then shows no
+  // context badge at all.
+  const get = (id: string): SessionUsage | null => entries.get(id)?.usage ?? null
+
+  return {subscribe, get}
+}

--- a/frontend/src/lib/session-usage-store.ts
+++ b/frontend/src/lib/session-usage-store.ts
@@ -39,7 +39,8 @@ export function createSessionUsageStore(source: UsageEventSource) {
       entry.usage.percent === data.percent &&
       entry.usage.tokens === data.tokens &&
       entry.usage.window === data.window &&
-      entry.usage.model === data.model
+      entry.usage.model === data.model &&
+      entry.usage.effort === data.effort
     ) {
       return
     }
@@ -48,6 +49,7 @@ export function createSessionUsageStore(source: UsageEventSource) {
       tokens: data.tokens,
       window: data.window,
       model: data.model,
+      effort: data.effort,
     }
     for (const listener of entry.listeners) {
       listener()

--- a/frontend/src/lib/settings.tsx
+++ b/frontend/src/lib/settings.tsx
@@ -22,6 +22,7 @@ const TERMINAL_FONT_SIZE_STORAGE_KEY = "lich.terminal.fontSize"
 const THEME_STORAGE_KEY = "lich.appearance.theme"
 const ZOOM_STORAGE_KEY = "lich.appearance.zoom"
 const TERMINAL_THEME_STORAGE_KEY = "lich.appearance.terminalTheme"
+const CONTEXT_USAGE_STORAGE_KEY = "lich.footer.contextUsage"
 
 // DEFAULT_FONT is the bundled FiraCode Nerd Font Mono. It is not installed via
 // fontconfig, so it must be offered explicitly alongside the system fonts.
@@ -94,6 +95,11 @@ function readZoom(): number {
   return Number.isFinite(stored) && stored > 0 ? clampZoom(stored) : DEFAULT_ZOOM
 }
 
+// Default on: the footer context readout shows unless the user turned it off.
+function readContextUsage(): boolean {
+  return localStorage.getItem(CONTEXT_USAGE_STORAGE_KEY) !== "false"
+}
+
 interface SettingsValue {
   /** Terminal font family, applied globally across all project terminals. */
   font: string
@@ -118,6 +124,9 @@ interface SettingsValue {
   hotkeys: Hotkeys
   setHotkey: (id: HotkeyId, combo: Combo) => void
   resetHotkey: (id: HotkeyId) => void
+  /** Whether the footer shows the active session's context-window usage. */
+  showContextUsage: boolean
+  setShowContextUsage: (show: boolean) => void
 }
 
 const SettingsContext = createContext<SettingsValue | null>(null)
@@ -134,6 +143,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [terminalTheme, setTerminalThemeState] =
     useState<TerminalTheme>(readTerminalTheme)
   const [hotkeys, setHotkeys] = useState<Hotkeys>(loadHotkeys)
+  const [showContextUsage, setShowContextUsageState] =
+    useState<boolean>(readContextUsage)
 
   const setFont = useCallback((next: string) => {
     setFontState(next)
@@ -186,6 +197,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       saveHotkeys(next)
       return next
     })
+  }, [])
+
+  const setShowContextUsage = useCallback((next: boolean) => {
+    setShowContextUsageState(next)
+    localStorage.setItem(CONTEXT_USAGE_STORAGE_KEY, String(next))
   }, [])
 
   // Toggle the `.dark` class on <html> and track the resolved scheme. For
@@ -279,6 +295,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         hotkeys,
         setHotkey,
         resetHotkey,
+        showContextUsage,
+        setShowContextUsage,
       }}
     >
       {children}

--- a/frontend/src/lib/useSessionUsage.ts
+++ b/frontend/src/lib/useSessionUsage.ts
@@ -1,0 +1,22 @@
+import {useCallback, useSyncExternalStore} from "react"
+import {onAppEvent} from "./app-events"
+import {USAGE_EVENT, type SessionUsage} from "./session-events"
+import {createSessionUsageStore} from "./session-usage-store"
+
+// Subscribed at import rather than on first use: that opens the /events socket
+// at page load, so a usage report before any card mounts still lands.
+const store = createSessionUsageStore((handler) =>
+  onAppEvent(USAGE_EVENT, handler),
+)
+
+// useSessionUsage reads a session's last reported context-window usage from the
+// shared store (see session-usage-store), which retains it across the card's
+// unmount. Returns null until the backend reports one — after the first turn
+// ends, for a Claude session.
+export function useSessionUsage(sessionId: string): SessionUsage | null {
+  const subscribe = useCallback(
+    (onChange: () => void) => store.subscribe(sessionId, onChange),
+    [sessionId],
+  )
+  return useSyncExternalStore(subscribe, () => store.get(sessionId))
+}

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -222,6 +222,24 @@ func (s *Service) SetProviderSession(sessionID, providerSessionID string) error 
 	return nil
 }
 
+// ProviderSession returns the provider conversation id recorded for a lich
+// session, or "" when none has been reported yet (or the session is gone — a
+// missing row is not an error). Pairs with SetProviderSession: the context-usage
+// read locates a transcript by this id.
+func (s *Service) ProviderSession(sessionID string) (string, error) {
+	var id sql.NullString
+	err := s.db.QueryRow(
+		`SELECT provider_session_id FROM sessions WHERE id = ?`, sessionID,
+	).Scan(&id)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("read provider session on %q: %w", sessionID, err)
+	}
+	return id.String, nil
+}
+
 // ReorderProjects records the tab order after a drag. It writes every project's
 // position from the full list the frontend rendered, so the stored order is
 // rewritten as a whole rather than patched around the moved tab.

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -137,10 +137,12 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 		},
 		func(id, state string) {
 			hub.Emit(statusEventName, statusEvent{ID: id, State: state})
-			// A turn-boundary state means the transcript's final usage for this
-			// turn is written; read the context window off-thread so a stalled
-			// emit never blocks the hook's response.
-			if state == "done" || state == "waiting" {
+			// Every non-idle state is a point where a fresh assistant usage line
+			// may have landed — a tool call mid-turn (busy), a prompt (waiting),
+			// or the turn's end (done) — so refresh the context window then, and
+			// off-thread so a stalled emit never blocks the hook's response. Skip
+			// idle (SessionEnd): the session is ending, nothing new to read.
+			if state != "idle" {
 				go s.emitUsage(id)
 			}
 		},

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -98,6 +98,7 @@ type Store interface {
 	ProviderBin(providerID, projectID string) string
 	WorktreeSetup(projectID string) string
 	SetProviderSession(sessionID, providerSessionID string) error
+	ProviderSession(sessionID string) (string, error)
 	SetSessionTitle(sessionID, title string) (bool, error)
 }
 
@@ -136,6 +137,12 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 		},
 		func(id, state string) {
 			hub.Emit(statusEventName, statusEvent{ID: id, State: state})
+			// A turn-boundary state means the transcript's final usage for this
+			// turn is written; read the context window off-thread so a stalled
+			// emit never blocks the hook's response.
+			if state == "done" || state == "waiting" {
+				go s.emitUsage(id)
+			}
 		},
 		func(sessionID, providerSessionID string) error {
 			if err := store.SetProviderSession(sessionID, providerSessionID); err != nil {

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -26,6 +26,7 @@ type stubBins struct{ bin, setup string }
 func (s stubBins) ProviderBin(_, _ string) string            { return s.bin }
 func (s stubBins) WorktreeSetup(_ string) string             { return s.setup }
 func (s stubBins) SetProviderSession(_, _ string) error      { return nil }
+func (s stubBins) ProviderSession(_ string) (string, error)  { return "", nil }
 func (s stubBins) SetSessionTitle(_, _ string) (bool, error) { return false, nil }
 
 // TestChildEnvStripsAppImageVars proves the AppImage runtime variables that break

--- a/internal/terminal/usage.go
+++ b/internal/terminal/usage.go
@@ -10,21 +10,23 @@ const usageEventName = "session-usage"
 
 // usageEvent is the payload of usageEventName. Percent is the share of the
 // context window the turn left occupied (0–100); Tokens is the raw input-side
-// count behind it, Window the model's context window, and Model the model id —
-// all for the tooltip.
+// count behind it, Window the model's context window, Model the model id, and
+// Effort the reasoning effort level ("" when the line records none).
 type usageEvent struct {
 	ID      string `json:"id"`
 	Percent int    `json:"percent"`
 	Tokens  int    `json:"tokens"`
 	Window  int    `json:"window"`
 	Model   string `json:"model"`
+	Effort  string `json:"effort"`
 }
 
 // emitUsage reads the context-window usage of the provider conversation running
-// in session id and pushes it to the frontend. Called off the status hook's
-// turn-boundary states (see New), where the transcript's final usage is written.
-// Silent on any miss — no provider id yet, no transcript, an unreadable or
-// half-written file — so a card keeps its last number instead of flickering.
+// in session id and pushes it to the frontend. Called off the status hook on
+// every non-idle state (see New), so it tracks the context as it grows through a
+// turn, not only at the end. Silent on any miss — no provider id yet, no
+// transcript, an unreadable or half-written file — so the readout keeps its last
+// value instead of flickering.
 //
 // Only Claude reports a provider session id today (resume and the session-start
 // hook are Claude-only), so the reader is Claude's. A second provider that grows
@@ -43,5 +45,12 @@ func (s *Service) emitUsage(id string) {
 	if !ok {
 		return
 	}
-	s.hub.Emit(usageEventName, usageEvent{ID: id, Percent: u.percent, Tokens: u.tokens, Window: u.window, Model: u.model})
+	s.hub.Emit(usageEventName, usageEvent{
+		ID:      id,
+		Percent: u.percent,
+		Tokens:  u.tokens,
+		Window:  u.window,
+		Model:   u.model,
+		Effort:  u.effort,
+	})
 }

--- a/internal/terminal/usage.go
+++ b/internal/terminal/usage.go
@@ -1,0 +1,47 @@
+package terminal
+
+import "log/slog"
+
+// usageEventName carries a session's context-window usage ({id, percent, tokens}),
+// emitted after a turn ends. Global like the other session events: the card that
+// shows it is only mounted while its project is active, so a per-session name
+// could not reach it.
+const usageEventName = "session-usage"
+
+// usageEvent is the payload of usageEventName. Percent is the share of the
+// context window the turn left occupied (0–100); Tokens is the raw input-side
+// count behind it, Window the model's context window, and Model the model id —
+// all for the tooltip.
+type usageEvent struct {
+	ID      string `json:"id"`
+	Percent int    `json:"percent"`
+	Tokens  int    `json:"tokens"`
+	Window  int    `json:"window"`
+	Model   string `json:"model"`
+}
+
+// emitUsage reads the context-window usage of the provider conversation running
+// in session id and pushes it to the frontend. Called off the status hook's
+// turn-boundary states (see New), where the transcript's final usage is written.
+// Silent on any miss — no provider id yet, no transcript, an unreadable or
+// half-written file — so a card keeps its last number instead of flickering.
+//
+// Only Claude reports a provider session id today (resume and the session-start
+// hook are Claude-only), so the reader is Claude's. A second provider that grows
+// one selects its own reader here by the session's kind — not an interface until
+// there are two to hide behind it.
+func (s *Service) emitUsage(id string) {
+	providerSessionID, err := s.store.ProviderSession(id)
+	if err != nil {
+		slog.Warn("terminal: read provider session", "session", id, "err", err)
+		return
+	}
+	if providerSessionID == "" {
+		return
+	}
+	u, ok := claudeContextUsage(providerSessionID)
+	if !ok {
+		return
+	}
+	s.hub.Emit(usageEventName, usageEvent{ID: id, Percent: u.percent, Tokens: u.tokens, Window: u.window, Model: u.model})
+}

--- a/internal/terminal/usage_claude.go
+++ b/internal/terminal/usage_claude.go
@@ -1,0 +1,180 @@
+package terminal
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// modelWindows maps a Claude model to its native context window — the transcript
+// records the model but not the window, so this is what the percent is taken
+// against. Current Opus/Sonnet/Fable are natively 1M (no beta); Haiku and pre-4.6
+// models are 200k. Matched by substring so a dated id ("…-4-5-20251001") still
+// hits. ponytail: this table goes stale as models ship — the Models API's
+// `max_input_tokens` is the authoritative upgrade path; an unlisted model falls
+// back to inferring the window from the token count (contextWindowFor).
+var modelWindows = []struct {
+	match  string
+	tokens int
+}{
+	{"opus-4-6", 1_000_000},
+	{"opus-4-7", 1_000_000},
+	{"opus-4-8", 1_000_000},
+	{"sonnet-4-6", 1_000_000},
+	{"sonnet-5", 1_000_000},
+	{"fable-5", 1_000_000},
+	{"mythos-5", 1_000_000},
+	{"haiku-4-5", 200_000},
+	// Older models (opus-4-5, sonnet-4-5, haiku-3-5, …) are unlisted and take
+	// the 200k fallback below — their native window.
+}
+
+// contextWindows are the standard sizes the fallback picks between when a model
+// is unlisted, smallest first.
+var contextWindows = []int{200_000, 1_000_000}
+
+// contextWindowFor returns the window for a token count when the model is
+// unknown: the smallest standard window it still fits inside, the largest once
+// it exceeds them all — exact the moment a session passes 200k (a 200k window
+// cannot hold more than that).
+func contextWindowFor(tokens int) int {
+	for _, w := range contextWindows {
+		if tokens <= w {
+			return w
+		}
+	}
+	return contextWindows[len(contextWindows)-1]
+}
+
+// windowForModel returns a model's native context window from modelWindows, or
+// falls back to inferring it from the token count for an unlisted model.
+func windowForModel(model string, tokens int) int {
+	for _, w := range modelWindows {
+		if strings.Contains(model, w.match) {
+			return w.tokens
+		}
+	}
+	return contextWindowFor(tokens)
+}
+
+// usageTailBytes bounds how much of a transcript's end is scanned for the last
+// assistant message. One JSONL line (a single message, tool results and all) can
+// run to tens of KB, so this holds several — the read stays O(tail), not
+// O(file), yet still reaches the last assistant line past a couple of large user
+// turns. ponytail: a turn larger than this whole window makes the read miss and
+// the readout keep its prior number — widen it then, nothing breaks.
+const usageTailBytes = 512 * 1024
+
+// contextUsage is one provider conversation's context-window occupancy.
+type contextUsage struct {
+	tokens  int
+	percent int
+	window  int
+	model   string
+}
+
+// claudeContextUsage reads the context-window usage of a Claude conversation
+// from its transcript. The transcript is ~/.claude/projects/<slug>/<id>.jsonl;
+// the id is a globally-unique UUID, so a glob across every project slug finds it
+// without reconstructing Claude's path-encoding of the slug. ok is false on any
+// miss (not found, unreadable, no assistant usage in the tail) — each is a "keep
+// the last value" for the caller, none worth logging once per turn.
+func claudeContextUsage(providerSessionID string) (contextUsage, bool) {
+	path, ok := claudeTranscriptPath(providerSessionID)
+	if !ok {
+		return contextUsage{}, false
+	}
+	tail, ok := readTail(path, usageTailBytes)
+	if !ok {
+		return contextUsage{}, false
+	}
+	return parseContextUsage(tail)
+}
+
+// claudeTranscriptPath locates a conversation's transcript by its UUID under the
+// Claude config dir ($CLAUDE_CONFIG_DIR, else ~/.claude). The UUID is unique, so
+// at most one file matches; false when none does yet.
+func claudeTranscriptPath(providerSessionID string) (string, bool) {
+	base := os.Getenv("CLAUDE_CONFIG_DIR")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", false
+		}
+		base = filepath.Join(home, ".claude")
+	}
+	matches, err := filepath.Glob(filepath.Join(base, "projects", "*", providerSessionID+".jsonl"))
+	if err != nil || len(matches) == 0 {
+		return "", false
+	}
+	return matches[0], true
+}
+
+// readTail returns up to the last max bytes of a file. false when it can't be
+// opened or stat'd — the transcript may not exist yet, or be mid-write.
+func readTail(path string, max int64) ([]byte, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, false
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return nil, false
+	}
+	start := int64(0)
+	if info.Size() > max {
+		start = info.Size() - max
+	}
+	buf := make([]byte, info.Size()-start)
+	if _, err := f.ReadAt(buf, start); err != nil && err != io.EOF {
+		return nil, false
+	}
+	return buf, true
+}
+
+// parseContextUsage pulls context-window occupancy from a transcript tail: the
+// newest main-thread assistant line's token usage. The context side is input +
+// cache-read + cache-creation (output is the reply, not context loaded); percent
+// is that against the line's model window (see windowForModel), capped at 100. false when the tail holds
+// no such line — a fresh conversation, or a tail of only user turns. Sidechain
+// lines (a Task sub-agent's own conversation, written into the same transcript)
+// are skipped: their context is the sub-agent's, not the window the user sees. A
+// leading partial line (the tail was cut mid-line) fails to parse and is skipped
+// like any malformed line.
+func parseContextUsage(tail []byte) (contextUsage, bool) {
+	lines := bytes.Split(tail, []byte("\n"))
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := bytes.TrimSpace(lines[i])
+		if len(line) == 0 {
+			continue
+		}
+		var entry struct {
+			Type        string `json:"type"`
+			IsSidechain bool   `json:"isSidechain"`
+			Message     struct {
+				Model string `json:"model"`
+				Usage *struct {
+					Input       int `json:"input_tokens"`
+					CacheRead   int `json:"cache_read_input_tokens"`
+					CacheCreate int `json:"cache_creation_input_tokens"`
+				} `json:"usage"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(line, &entry); err != nil {
+			continue
+		}
+		if entry.Type != "assistant" || entry.IsSidechain || entry.Message.Usage == nil {
+			continue
+		}
+		u := entry.Message.Usage
+		tokens := u.Input + u.CacheRead + u.CacheCreate
+		window := windowForModel(entry.Message.Model, tokens)
+		percent := min(tokens*100/window, 100)
+		return contextUsage{tokens: tokens, percent: percent, window: window, model: entry.Message.Model}, true
+	}
+	return contextUsage{}, false
+}

--- a/internal/terminal/usage_claude.go
+++ b/internal/terminal/usage_claude.go
@@ -74,6 +74,7 @@ type contextUsage struct {
 	percent int
 	window  int
 	model   string
+	effort  string
 }
 
 // claudeContextUsage reads the context-window usage of a Claude conversation
@@ -155,6 +156,7 @@ func parseContextUsage(tail []byte) (contextUsage, bool) {
 		var entry struct {
 			Type        string `json:"type"`
 			IsSidechain bool   `json:"isSidechain"`
+			Effort      string `json:"effort"`
 			Message     struct {
 				Model string `json:"model"`
 				Usage *struct {
@@ -174,7 +176,13 @@ func parseContextUsage(tail []byte) (contextUsage, bool) {
 		tokens := u.Input + u.CacheRead + u.CacheCreate
 		window := windowForModel(entry.Message.Model, tokens)
 		percent := min(tokens*100/window, 100)
-		return contextUsage{tokens: tokens, percent: percent, window: window, model: entry.Message.Model}, true
+		return contextUsage{
+			tokens:  tokens,
+			percent: percent,
+			window:  window,
+			model:   entry.Message.Model,
+			effort:  entry.Effort,
+		}, true
 	}
 	return contextUsage{}, false
 }

--- a/internal/terminal/usage_claude_test.go
+++ b/internal/terminal/usage_claude_test.go
@@ -1,0 +1,209 @@
+package terminal
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+const (
+	modelOpus  = "claude-opus-4-8"           // native 1M window
+	modelHaiku = "claude-haiku-4-5-20251001" // native 200k window (dated id)
+	modelNew   = "claude-someday-9"          // unlisted → window inferred from tokens
+)
+
+// assistantLine builds one transcript JSONL entry for a model with the given
+// input-side token counts, mirroring Claude's message.usage shape.
+func assistantLine(model string, input, cacheRead, cacheCreate int) string {
+	return `{"type":"assistant","message":{"model":"` + model + `","usage":{` +
+		`"input_tokens":` + strconv.Itoa(input) +
+		`,"cache_read_input_tokens":` + strconv.Itoa(cacheRead) +
+		`,"cache_creation_input_tokens":` + strconv.Itoa(cacheCreate) +
+		`,"output_tokens":1975}}}`
+}
+
+func TestParseContextUsage(t *testing.T) {
+	tests := []struct {
+		name        string
+		tail        string
+		wantOK      bool
+		wantTokens  int
+		wantPercent int
+	}{
+		{
+			name:        "a 1M model reads its context against 1M",
+			tail:        assistantLine(modelOpus, 2, 64798, 0) + "\n",
+			wantOK:      true,
+			wantTokens:  64800,
+			wantPercent: 6, // 64800 * 100 / 1_000_000
+		},
+		{
+			name:        "a 200k model reads its context against 200k",
+			tail:        assistantLine(modelHaiku, 2, 67673, 5550) + "\n",
+			wantOK:      true,
+			wantTokens:  73225,
+			wantPercent: 36, // 73225 * 100 / 200000
+		},
+		{
+			name: "picks the newest assistant line, not an earlier one",
+			tail: assistantLine(modelHaiku, 1, 1000, 0) + "\n" +
+				assistantLine(modelHaiku, 2, 40000, 0) + "\n",
+			wantOK:      true,
+			wantTokens:  40002,
+			wantPercent: 20,
+		},
+		{
+			name:        "an unlisted model past 200k infers a 1M window",
+			tail:        assistantLine(modelNew, 0, 300000, 0) + "\n",
+			wantOK:      true,
+			wantTokens:  300000,
+			wantPercent: 30, // 300000 * 100 / 1_000_000
+		},
+		{
+			name:        "an unlisted model under 200k infers a 200k window",
+			tail:        assistantLine(modelNew, 2, 40000, 0) + "\n",
+			wantOK:      true,
+			wantTokens:  40002,
+			wantPercent: 20,
+		},
+		{
+			name:        "caps percent at 100 past a full window",
+			tail:        assistantLine(modelOpus, 0, 1_200_000, 0) + "\n",
+			wantOK:      true,
+			wantTokens:  1_200_000,
+			wantPercent: 100,
+		},
+		{
+			name: "skips a sidechain assistant line for the main thread",
+			tail: assistantLine(modelHaiku, 2, 40000, 0) + "\n" +
+				`{"type":"assistant","isSidechain":true,"message":{"model":"` + modelHaiku + `","usage":{` +
+				`"input_tokens":1,"cache_read_input_tokens":150000,"cache_creation_input_tokens":0}}}` + "\n",
+			wantOK:      true,
+			wantTokens:  40002,
+			wantPercent: 20,
+		},
+		{
+			name: "skips a leading partial line from a mid-line cut",
+			tail: `he":{"usage":{"input_tokens":9}}}` + "\n" +
+				assistantLine(modelHaiku, 2, 5000, 0) + "\n",
+			wantOK:      true,
+			wantTokens:  5002,
+			wantPercent: 2,
+		},
+		{
+			name:   "no assistant line yields not-ok",
+			tail:   `{"type":"user","message":{"content":"hi"}}` + "\n",
+			wantOK: false,
+		},
+		{
+			name:   "an assistant line without usage is not-ok",
+			tail:   `{"type":"assistant","message":{"model":"x"}}` + "\n",
+			wantOK: false,
+		},
+		{
+			name:   "empty tail is not-ok",
+			tail:   "",
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseContextUsage([]byte(tt.tail))
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if got.tokens != tt.wantTokens {
+				t.Errorf("tokens = %d, want %d", got.tokens, tt.wantTokens)
+			}
+			if got.percent != tt.wantPercent {
+				t.Errorf("percent = %d, want %d", got.percent, tt.wantPercent)
+			}
+		})
+	}
+}
+
+func TestWindowForModel(t *testing.T) {
+	tests := []struct {
+		model  string
+		tokens int
+		want   int
+	}{
+		{modelOpus, 50_000, 1_000_000},
+		{modelHaiku, 50_000, 200_000},
+		{"claude-sonnet-5", 50_000, 1_000_000},
+		{"claude-fable-5", 50_000, 1_000_000},
+		{modelNew, 50_000, 200_000},    // unlisted, fits 200k
+		{modelNew, 500_000, 1_000_000}, // unlisted, exceeds 200k
+	}
+	for _, tt := range tests {
+		if got := windowForModel(tt.model, tt.tokens); got != tt.want {
+			t.Errorf("windowForModel(%q, %d) = %d, want %d", tt.model, tt.tokens, got, tt.want)
+		}
+	}
+}
+
+func TestReadTailReturnsLastBytes(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "t.jsonl")
+	if err := os.WriteFile(path, []byte("0123456789"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tail, ok := readTail(path, 4)
+	if !ok {
+		t.Fatal("readTail ok = false")
+	}
+	if string(tail) != "6789" {
+		t.Errorf("tail = %q, want %q", tail, "6789")
+	}
+}
+
+func TestReadTailWholeFileWhenSmaller(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "t.jsonl")
+	if err := os.WriteFile(path, []byte("abc"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tail, ok := readTail(path, 4096)
+	if !ok || string(tail) != "abc" {
+		t.Errorf("tail = %q ok = %v, want %q true", tail, ok, "abc")
+	}
+}
+
+func TestReadTailMissingFile(t *testing.T) {
+	if _, ok := readTail(filepath.Join(t.TempDir(), "nope.jsonl"), 16); ok {
+		t.Error("readTail on a missing file should be not-ok")
+	}
+}
+
+// TestClaudeContextUsageEndToEnd drives the glob-by-UUID locate through a
+// CLAUDE_CONFIG_DIR override, so no real ~/.claude is touched.
+func TestClaudeContextUsageEndToEnd(t *testing.T) {
+	base := t.TempDir()
+	slug := filepath.Join(base, "projects", "-home-user-proj")
+	if err := os.MkdirAll(slug, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	id := "abc123-uuid"
+	if err := os.WriteFile(
+		filepath.Join(slug, id+".jsonl"),
+		[]byte(assistantLine(modelHaiku, 2, 20000, 0)+"\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", base)
+
+	u, ok := claudeContextUsage(id)
+	if !ok {
+		t.Fatal("claudeContextUsage ok = false")
+	}
+	if u.tokens != 20002 || u.percent != 10 || u.model != modelHaiku {
+		t.Errorf("usage = %+v, want tokens 20002 percent 10 model %q", u, modelHaiku)
+	}
+
+	if _, ok := claudeContextUsage("no-such-id"); ok {
+		t.Error("an unknown id should be not-ok")
+	}
+}

--- a/internal/terminal/usage_claude_test.go
+++ b/internal/terminal/usage_claude_test.go
@@ -126,6 +126,21 @@ func TestParseContextUsage(t *testing.T) {
 	}
 }
 
+func TestParseContextUsageEffort(t *testing.T) {
+	// effort is a top-level field on the entry, beside type/isSidechain.
+	withEffort := `{"type":"assistant","effort":"xhigh","message":{"model":"` + modelOpus +
+		`","usage":{"input_tokens":2,"cache_read_input_tokens":20000,"cache_creation_input_tokens":0}}}`
+	got, ok := parseContextUsage([]byte(withEffort + "\n"))
+	if !ok || got.effort != "xhigh" {
+		t.Fatalf("effort = %q ok = %v, want %q true", got.effort, ok, "xhigh")
+	}
+	// A line without the field parses with an empty effort.
+	bare, ok := parseContextUsage([]byte(assistantLine(modelOpus, 2, 20000, 0) + "\n"))
+	if !ok || bare.effort != "" {
+		t.Errorf("effort = %q, want empty for a line that records none", bare.effort)
+	}
+}
+
 func TestWindowForModel(t *testing.T) {
 	tests := []struct {
 		model  string


### PR DESCRIPTION
## What

A small ring in the footer fills with the percent of its context window the active Claude session is using, the percent beside it. Hovering opens a tooltip with the model, a fuller bar, and the exact tokens against the window size. It turns amber past 80% and red past 95%, so a session drifting toward auto-compaction is visible without opening `/context`.

Toggle it off under **Settings › Providers › Claude Code** (default on).

## How it works

- **Backend reads the transcript, no plugin change.** On the turn-boundary status hook (`done`/`waiting`, already sent by the lich plugin), the backend tails `~/.claude/projects/**/<uuid>.jsonl` — located by globbing the provider-session UUID it already stores from the session-start hook — and parses the last **main-thread** assistant `usage` (sidechain sub-agent lines skipped). Reuses the existing `session-start` id and `session-state` signal; adds no hook and no contract.
- **Percent against the model's native window.** The transcript records the model but not the window, so a small `model → window` table maps it (1M for current Opus/Sonnet/Fable, 200k for Haiku); an unlisted model falls back to inferring the window from the token count.
- **Fails soft.** No provider id yet, no transcript, an unreadable/half-written file — every miss keeps the readout's last value rather than flickering.
- **Frontend** mirrors the existing module-store + `useSyncExternalStore` pattern (`session-usage-store`), the global `{id, ...}` event, and renders the ring in the footer's right cluster with a `SessionCard`-style tooltip.

## Known ceilings (documented in `CLAUDE.md`)

- The JSONL layout is Claude-internal and unstable across releases — the soft-fail read is the guard.
- The window is the model's *native* size; a session that runs a 1M-capable model at 200k reads double its true percent. The exact window lives only in the statusLine JSON, never in the transcript.
- It's a turn-end snapshot — updates on the next completed turn, not the instant you `/model`.

## Test plan

- [x] `gofmt`/`go vet` clean; `go test -race ./internal/terminal ./internal/store` green
- [x] Cross-compile + `go vet` for linux/darwin/windows
- [x] Frontend `vitest` (357) green; `pnpm build` (tsc + vite) clean
- [x] Manual smoke: ring + percent render in the footer, tooltip shows model/bar/tokens/window
- [x] Manual smoke: the toggle under Settings › Providers › Claude Code hides/shows the readout
