### PR TITLE
File tree: live working-tree view, per-file diffs, right-click menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Opus/Sonnet/Fable, 200k for Haiku). The readout can be turned off under
   Settings › Providers › Claude Code. Needs no change to the user's statusline;
   other providers stay blank until they report a session id of their own.
+- **The file tree tracks the working tree live.** The Files tab now lists
+  untracked-but-not-ignored files alongside tracked ones and drops any file
+  deleted from disk, so a file created or removed during a session shows up
+  without a commit — it is no longer frozen at the session's starting set.
+- **The file tree shows each changed file's line delta.** A modified or new
+  file carries the same `+added −deleted` pair the review panel and footer use,
+  reusing the diff already parsed for the review — a clean file stays bare.
+- **Right-click in the file tree.** A directory's context menu offers Expand all
+  and Collapse all over that folder's subtree; a file's offers Open in editor. A
+  GUI `$VISUAL`/`$EDITOR` — or the platform opener (`xdg-open`, `open -t`,
+  `start`) when neither is set — launches detached; a terminal editor (vim,
+  nvim, nano, …) opens in a fresh lich terminal session rooted at the checkout,
+  since a detached launch would leave it with no controlling terminal. The
+  editor is resolved from the login shell, so a GUI launch still sees rc exports.
 
 ## [0.17.0] - 2026-07-24
 

--- a/frontend/src/components/dock/FilesPanel.tsx
+++ b/frontend/src/components/dock/FilesPanel.tsx
@@ -1,11 +1,14 @@
 import {useCallback, useEffect, useState} from "react"
 import {ChevronDown, ChevronLeft, ChevronRight, Folder, FolderOpen} from "lucide-react"
-import {ProjectService, Terminal as TerminalService} from "@/lib/rpc"
+import {ProjectService, System, Terminal as TerminalService} from "@/lib/rpc"
 import {useActiveSession} from "@/lib/useActiveSession"
+import {useProjects} from "@/lib/projects"
+import {queuePaste} from "@/lib/paste-queue"
 import {useGitStatus} from "@/lib/useGitStatus"
 import {buildTree, type TreeNode} from "@/lib/file-tree"
 import {FileIcon} from "@/lib/file-icon"
-import {formatLineRef} from "@/lib/diff"
+import {DiffStat} from "@/components/DiffStat"
+import {formatLineRef, parseDiff, type DiffFile} from "@/lib/diff"
 import {errorText} from "@/lib/utils"
 import type {DocLineSelection} from "@/lib/codemirror"
 import {
@@ -24,8 +27,10 @@ import {useFileEditor} from "./useFileEditor"
 // path/line references into the session's PTY.
 export function FilesPanel() {
   const {projectId, sessionId, path} = useActiveSession()
+  const {newSession, activateSession} = useProjects()
   const status = useGitStatus(path)
   const [tree, setTree] = useState<TreeNode[] | null>(null)
+  const [stats, setStats] = useState<Map<string, DiffFile>>(new Map())
   const [failed, setFailed] = useState(false)
   const [open, setOpen] = useState<string | null>(null)
 
@@ -34,11 +39,18 @@ export function FilesPanel() {
       return
     }
     try {
-      const files = await ProjectService.Tree(path)
+      // The diff feeds each row its +/- badge; a diff failure (nothing to diff)
+      // just means no badges, never a broken tree — hence the swallowed catch.
+      const [files, diffText] = await Promise.all([
+        ProjectService.Tree(path),
+        ProjectService.DiffText(path).catch(() => ""),
+      ])
       setTree(buildTree(files ?? []))
+      setStats(diffStatsByPath(parseDiff(diffText)))
       setFailed(false)
     } catch {
       setTree([])
+      setStats(new Map())
       setFailed(true)
     }
   }, [path])
@@ -64,6 +76,26 @@ export function FilesPanel() {
     }
   }
 
+  // Right-click → Open in editor. The backend either launched a GUI editor
+  // detached (empty reply) or, for a terminal editor like vim, handed back the
+  // command to run: spawn a shell session at this checkout and let the paste
+  // queue deliver it once the PTY exists, the way the self-update flow does.
+  const openInEditor = (rel: string) => {
+    if (!path) {
+      return
+    }
+    void System.OpenInEditor(path, rel)
+      .then((command) => {
+        if (!command) {
+          return
+        }
+        const id = newSession(projectId, "shell", path)
+        queuePaste(id, command + "\n")
+        activateSession(projectId, id)
+      })
+      .catch(() => undefined)
+  }
+
   if (open !== null) {
     return (
       <FilePreview
@@ -74,16 +106,40 @@ export function FilesPanel() {
       />
     )
   }
-  return <TreeBody tree={tree} failed={failed} onOpen={setOpen}/>
+  return (
+    <TreeBody
+      tree={tree}
+      stats={stats}
+      failed={failed}
+      onOpen={setOpen}
+      onEditor={openInEditor}
+    />
+  )
+}
+
+// diffStatsByPath keys each changed file's +/- counts by its current path so a
+// tree row can look up its own line delta. parseDiff already computed the counts
+// for the review panel; this only reshapes them for lookup.
+function diffStatsByPath(files: DiffFile[]): Map<string, DiffFile> {
+  const map = new Map<string, DiffFile>()
+  for (const file of files) {
+    const key = file.newPath || file.oldPath
+    if (key) {
+      map.set(key, file)
+    }
+  }
+  return map
 }
 
 interface TreeBodyProps {
   tree: TreeNode[] | null
+  stats: Map<string, DiffFile>
   failed: boolean
   onOpen: (rel: string) => void
+  onEditor: (rel: string) => void
 }
 
-function TreeBody({tree, failed, onOpen}: TreeBodyProps) {
+function TreeBody({tree, stats, failed, onOpen, onEditor}: TreeBodyProps) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   const toggle = (rel: string) =>
     setExpanded((prev) => {
@@ -93,6 +149,26 @@ function TreeBody({tree, failed, onOpen}: TreeBodyProps) {
       } else {
         next.add(rel)
       }
+      return next
+    })
+
+  // Expand/collapse a directory and every directory beneath it, the scope a
+  // right-click on that folder implies.
+  const setSubtree = (node: TreeNode, expand: boolean) =>
+    setExpanded((prev) => {
+      const next = new Set(prev)
+      const walk = (n: TreeNode) => {
+        if (n.type !== "dir") {
+          return
+        }
+        if (expand) {
+          next.add(n.path)
+        } else {
+          next.delete(n.path)
+        }
+        n.children.forEach(walk)
+      }
+      walk(node)
       return next
     })
 
@@ -112,9 +188,13 @@ function TreeBody({tree, failed, onOpen}: TreeBodyProps) {
           key={node.path}
           node={node}
           depth={0}
+          stats={stats}
           expanded={expanded}
           onToggle={toggle}
+          onExpandAll={(n) => setSubtree(n, true)}
+          onCollapseAll={(n) => setSubtree(n, false)}
           onOpen={onOpen}
+          onEditor={onEditor}
         />
       ))}
     </div>
@@ -124,56 +204,105 @@ function TreeBody({tree, failed, onOpen}: TreeBodyProps) {
 interface TreeRowProps {
   node: TreeNode
   depth: number
+  stats: Map<string, DiffFile>
   expanded: Set<string>
   onToggle: (rel: string) => void
+  onExpandAll: (node: TreeNode) => void
+  onCollapseAll: (node: TreeNode) => void
   onOpen: (rel: string) => void
+  onEditor: (rel: string) => void
 }
 
-function TreeRow({node, depth, expanded, onToggle, onOpen}: TreeRowProps) {
+function TreeRow({
+  node,
+  depth,
+  stats,
+  expanded,
+  onToggle,
+  onExpandAll,
+  onCollapseAll,
+  onOpen,
+  onEditor,
+}: TreeRowProps) {
   const isOpen = expanded.has(node.path)
   // The 0.5rem base keeps even top-level rows off the edge.
   const indent = {paddingLeft: `${depth * 0.75 + 0.5}rem`}
   if (node.type === "file") {
+    const stat = stats.get(node.path)
     // A chevron-width spacer keeps file names aligned under their folder's name;
     // FileIcon draws the language's real logo (devicon).
     return (
-      <button
-        type="button"
-        onClick={() => onOpen(node.path)}
-        style={indent}
-        title={node.path}
-        className="flex items-center gap-1.5 py-0.5 pr-2 text-left text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-      >
-        <span className="size-3.5 shrink-0" aria-hidden/>
-        <FileIcon path={node.path}/>
-        <span className="truncate">{node.name}</span>
-      </button>
+      <ContextMenu>
+        <ContextMenuTrigger
+          render={
+            <button
+              type="button"
+              onClick={() => onOpen(node.path)}
+              style={indent}
+              title={node.path}
+              className="flex items-center gap-1.5 py-0.5 pr-2 text-left text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            />
+          }
+        >
+          <span className="size-3.5 shrink-0" aria-hidden/>
+          <FileIcon path={node.path}/>
+          <span className="min-w-0 truncate">{node.name}</span>
+          {stat && (
+            <span className="ml-auto flex shrink-0 items-center gap-1.5 pl-2 tabular-nums">
+              <DiffStat added={stat.added} deleted={stat.deleted}/>
+            </span>
+          )}
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem onClick={() => onEditor(node.path)}>
+            Open in editor
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
     )
   }
   const Chevron = isOpen ? ChevronDown : ChevronRight
   const FolderIcon = isOpen ? FolderOpen : Folder
   return (
     <>
-      <button
-        type="button"
-        onClick={() => onToggle(node.path)}
-        style={indent}
-        aria-expanded={isOpen}
-        className="flex items-center gap-1.5 py-0.5 pr-2 text-left font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
-      >
-        <Chevron className="size-3.5 shrink-0 text-muted-foreground"/>
-        <FolderIcon className="size-3.5 shrink-0 text-muted-foreground"/>
-        <span className="truncate">{node.name}</span>
-      </button>
+      <ContextMenu>
+        <ContextMenuTrigger
+          render={
+            <button
+              type="button"
+              onClick={() => onToggle(node.path)}
+              style={indent}
+              aria-expanded={isOpen}
+              className="flex items-center gap-1.5 py-0.5 pr-2 text-left font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
+            />
+          }
+        >
+          <Chevron className="size-3.5 shrink-0 text-muted-foreground"/>
+          <FolderIcon className="size-3.5 shrink-0 text-muted-foreground"/>
+          <span className="truncate">{node.name}</span>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem onClick={() => onExpandAll(node)}>
+            Expand all
+          </ContextMenuItem>
+          <ContextMenuItem onClick={() => onCollapseAll(node)}>
+            Collapse all
+          </ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>
       {isOpen &&
         node.children.map((child) => (
           <TreeRow
             key={child.path}
             node={child}
             depth={depth + 1}
+            stats={stats}
             expanded={expanded}
             onToggle={onToggle}
+            onExpandAll={onExpandAll}
+            onCollapseAll={onCollapseAll}
             onOpen={onOpen}
+            onEditor={onEditor}
           />
         ))}
     </>

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -199,6 +199,11 @@ export const PatchNotes = {
 
 export const System = {
   OpenExternal: (url: string) => call<null>("system.OpenExternal", [url]),
+  /** Open a work-tree file (repo-relative rel under dir) in $VISUAL/$EDITOR.
+   * Returns "" when it launched a GUI editor detached, or a shell command line
+   * to run in a terminal session when the editor is a terminal editor. */
+  OpenInEditor: (dir: string, rel: string) =>
+    call<string>("system.OpenInEditor", [dir, rel]),
 }
 
 export const Providers = {

--- a/internal/project/tree.go
+++ b/internal/project/tree.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -13,16 +14,41 @@ import (
 // (internal/rpc.bodyLimit). Kept in step with the diff viewer's own ceilings.
 const maxReadFileSize = 1 << 20
 
-// Tree lists the repository's tracked files as repo-relative, slash-separated
-// paths, already sorted (git's own order). It uses `git ls-files`, so
-// .gitignore is honored for free and only versioned files appear — no
-// node_modules, no build output. A non-repository path yields an error,
-// matching DiffText's contract.
-//
-// Ceiling: untracked files are invisible to ls-files, matching the file tree's
-// documented limit; merge `git status --porcelain` if they ever need to show.
+// Tree lists the work tree's files as repo-relative, slash-separated paths,
+// sorted. It merges tracked files with untracked-but-not-ignored ones
+// (`ls-files --cached --others --exclude-standard`) and drops any tracked file
+// deleted from disk (`--deleted`), so a file created or removed since the
+// session began shows without a commit. .gitignore is honored for free, so no
+// node_modules and no build output leak in. A non-repository path yields an
+// error, matching DiffText's contract.
 func (s *Service) Tree(path string) ([]string, error) {
-	out, err := runGit(path, "ls-files", "-z")
+	present, err := lsFiles(path, "--cached", "--others", "--exclude-standard")
+	if err != nil {
+		return nil, err
+	}
+	deleted, err := lsFiles(path, "--deleted")
+	if err != nil {
+		return nil, err
+	}
+	gone := make(map[string]struct{}, len(deleted))
+	for _, rel := range deleted {
+		gone[rel] = struct{}{}
+	}
+	var files []string
+	for _, rel := range present {
+		if _, ok := gone[rel]; !ok {
+			files = append(files, rel)
+		}
+	}
+	// The --cached/--others merge is not globally sorted; the tree wants one order.
+	slices.Sort(files)
+	return files, nil
+}
+
+// lsFiles runs `git ls-files -z` with the given selectors and splits its
+// NUL-delimited output into repo-relative paths.
+func lsFiles(path string, args ...string) ([]string, error) {
+	out, err := runGit(path, append([]string{"ls-files", "-z"}, args...)...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/project/tree_test.go
+++ b/internal/project/tree_test.go
@@ -3,12 +3,14 @@ package project
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
 
-// TestTree proves tracked files are listed repo-relative and slash-separated,
-// and that .gitignore'd and untracked files never appear.
+// TestTree proves the tree reflects the work tree: tracked files listed
+// repo-relative and slash-separated, untracked-but-not-ignored files included,
+// .gitignore'd files excluded, all sorted.
 func TestTree(t *testing.T) {
 	repo, git := initRepo(t)
 	mkdir(t, repo, "internal/rpc")
@@ -17,7 +19,7 @@ func TestTree(t *testing.T) {
 	git("add", ".")
 	git("commit", "-m", "add files")
 
-	// Ignored and untracked files must be invisible to the tree.
+	// Ignored files stay invisible; an untracked file now shows without a commit.
 	write(t, repo, ".gitignore", "ignored.txt\n")
 	write(t, repo, "ignored.txt", "secret\n")
 	write(t, repo, "untracked.txt", "new\n")
@@ -29,9 +31,25 @@ func TestTree(t *testing.T) {
 		t.Fatalf("Tree: %v", err)
 	}
 	got := strings.Join(files, ",")
-	want := ".gitignore,a.txt,internal/rpc/rpc.go,z.txt"
+	want := ".gitignore,a.txt,internal/rpc/rpc.go,untracked.txt,z.txt"
 	if got != want {
 		t.Errorf("Tree = %q, want %q", got, want)
+	}
+}
+
+// TestTreeDropsDeleted proves a tracked file removed from disk (but not yet
+// staged) disappears from the tree, so the list is not frozen at HEAD.
+func TestTreeDropsDeleted(t *testing.T) {
+	repo, _ := initRepo(t)
+	if err := os.Remove(filepath.Join(repo, "a.txt")); err != nil {
+		t.Fatal(err)
+	}
+	files, err := New(nil).Tree(repo)
+	if err != nil {
+		t.Fatalf("Tree: %v", err)
+	}
+	if slices.Contains(files, "a.txt") {
+		t.Errorf("Tree = %v, want a.txt dropped", files)
 	}
 }
 

--- a/internal/system/opendefault_darwin.go
+++ b/internal/system/opendefault_darwin.go
@@ -1,0 +1,8 @@
+package system
+
+// openDefault opens the file in the default text editor when no $VISUAL/$EDITOR
+// is set. `open -t` targets the editor bound to the Default Editor, not the
+// file type's app, so a source file lands in an editor rather than a viewer.
+func (s *Service) openDefault(full string) error {
+	return s.run("open", "-t", full)
+}

--- a/internal/system/opendefault_linux.go
+++ b/internal/system/opendefault_linux.go
@@ -1,0 +1,7 @@
+package system
+
+// openDefault hands the file to the desktop's default handler when no
+// $VISUAL/$EDITOR is set. xdg-open resolves the user's chosen application.
+func (s *Service) openDefault(full string) error {
+	return s.run("xdg-open", full)
+}

--- a/internal/system/opendefault_windows.go
+++ b/internal/system/opendefault_windows.go
@@ -1,0 +1,9 @@
+package system
+
+// openDefault hands the file to the shell's file association when no
+// $VISUAL/$EDITOR is set. `start` is a cmd builtin, hence `cmd /c`; the empty
+// first argument is start's title slot, which a quoted path would otherwise
+// consume.
+func (s *Service) openDefault(full string) error {
+	return s.run("cmd", "/c", "start", "", full)
+}

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -1,23 +1,31 @@
 // Package system holds the few OS integrations the frontend needs that are
-// not tied to any domain service — today only opening a URL in the user's
-// default browser via xdg-open.
+// not tied to any domain service — opening a URL in the user's default browser
+// and opening a work-tree file in their editor.
 package system
 
 import (
 	"fmt"
 	"net/url"
 	"os/exec"
+	"path/filepath"
+	"strings"
 )
 
 type Service struct {
-	// open launches the URL; injectable for tests, xdg-open in production.
-	open func(target string) error
+	// env is the resolved login-shell environment (see terminal.ResolveShellEnv),
+	// the source of $VISUAL/$EDITOR — a GUI launch never sourced the user's rc.
+	env []string
+	// run launches a detached process; injected in tests, exec in production.
+	run func(name string, args ...string) error
 }
 
-func New() *Service {
-	return &Service{open: func(target string) error {
-		return exec.Command("xdg-open", target).Start()
-	}}
+func New(env []string) *Service {
+	return &Service{
+		env: env,
+		run: func(name string, args ...string) error {
+			return exec.Command(name, args...).Start()
+		},
+	}
 }
 
 // OpenExternal opens an http(s) URL in the default browser. Scheme-gated so a
@@ -27,7 +35,98 @@ func (s *Service) OpenExternal(rawURL string) error {
 	if err := ValidateExternalURL(rawURL); err != nil {
 		return err
 	}
-	return s.open(rawURL)
+	return s.run("xdg-open", rawURL)
+}
+
+// OpenInEditor decides how to open a work-tree file. rel is validated against
+// traversal, then joined onto dir (mirroring project.ReadFile's guard). It
+// prefers $VISUAL, then $EDITOR — resolved from the login shell, so a GUI launch
+// still sees rc exports.
+//
+// When the editor is a terminal editor (vim, nvim, nano, …) it launches nothing
+// and returns the shell command line to run in a lich terminal session: a
+// detached launch would give it no controlling terminal. Otherwise it launches
+// the GUI editor — or, with no editor set, the platform's default opener —
+// detached, and returns "". The caller runs the returned command in a terminal
+// only when it is non-empty.
+func (s *Service) OpenInEditor(dir, rel string) (string, error) {
+	if err := validateRel(rel); err != nil {
+		return "", err
+	}
+	full := filepath.Join(dir, rel)
+	editor := s.getenv("VISUAL")
+	if editor == "" {
+		editor = s.getenv("EDITOR")
+	}
+	if editor != "" && isTerminalEditor(editor) {
+		return editor + " " + shellQuote(full), nil
+	}
+	if editor != "" {
+		return "", s.runEditor(editor, full)
+	}
+	return "", s.openDefault(full)
+}
+
+// runEditor launches a GUI $EDITOR value that may carry flags ("code --wait"),
+// appending the file as the final argument. An all-whitespace value degrades to
+// the default opener rather than launching an empty command.
+func (s *Service) runEditor(editor, full string) error {
+	fields := strings.Fields(editor)
+	if len(fields) == 0 {
+		return s.openDefault(full)
+	}
+	args := append(fields[1:], full)
+	return s.run(fields[0], args...)
+}
+
+// terminalEditors run inside the terminal; keyed by binary basename. A GUI
+// launch gives them no controlling terminal, so lich runs them in a session.
+// Ceiling: a fixed list — an unlisted terminal editor is treated as GUI and
+// launched detached (and silently fails to open); add it here.
+var terminalEditors = map[string]bool{
+	"vi": true, "vim": true, "nvim": true, "neovim": true, "nano": true,
+	"emacs": true, "emacsclient": true, "helix": true, "hx": true, "kak": true,
+	"kakoune": true, "micro": true, "vis": true, "joe": true, "ne": true,
+}
+
+// isTerminalEditor reports whether the editor command (which may carry flags,
+// e.g. "nvim -p") names a terminal editor, matched on the binary's basename.
+func isTerminalEditor(editor string) bool {
+	fields := strings.Fields(editor)
+	if len(fields) == 0 {
+		return false
+	}
+	return terminalEditors[filepath.Base(fields[0])]
+}
+
+// shellQuote wraps s in single quotes for a POSIX shell, escaping embedded
+// single quotes — the command runs in the session's shell, so the file path (the
+// caller-influenced part) must survive spaces and metacharacters. Assumes an
+// sh/bash/zsh-style shell; cmd.exe (experimental Windows) quotes differently.
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// getenv reads a key from the resolved shell env, "" when absent.
+func (s *Service) getenv(key string) string {
+	prefix := key + "="
+	for _, kv := range s.env {
+		if strings.HasPrefix(kv, prefix) {
+			return kv[len(prefix):]
+		}
+	}
+	return ""
+}
+
+// validateRel rejects absolute paths and parent-directory escapes, so a joined
+// path can never leave the work-tree root. Mirrors project.validateRelPath.
+func validateRel(rel string) error {
+	clean := filepath.Clean(rel)
+	if filepath.IsAbs(clean) || clean == ".." ||
+		strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("invalid repository path %q", rel)
+	}
+	return nil
 }
 
 // ValidateExternalURL accepts absolute http/https URLs only.

--- a/internal/system/system_test.go
+++ b/internal/system/system_test.go
@@ -1,6 +1,9 @@
 package system
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestValidateExternalURL(t *testing.T) {
 	valid := []string{"http://example.com", "https://github.com/omartelo/lich/pull/1"}
@@ -26,8 +29,10 @@ func TestValidateExternalURL(t *testing.T) {
 
 func TestOpenExternalGatesBeforeLaunching(t *testing.T) {
 	launched := ""
-	s := &Service{open: func(target string) error {
-		launched = target
+	s := &Service{run: func(_ string, args ...string) error {
+		if len(args) > 0 {
+			launched = args[0]
+		}
 		return nil
 	}}
 	if err := s.OpenExternal("file:///etc/passwd"); err == nil || launched != "" {
@@ -35,5 +40,107 @@ func TestOpenExternalGatesBeforeLaunching(t *testing.T) {
 	}
 	if err := s.OpenExternal("https://example.com"); err != nil || launched != "https://example.com" {
 		t.Fatalf("valid url not launched: %q (%v)", launched, err)
+	}
+}
+
+// captureRun records the last command the service launched.
+func captureRun(name *string, args *[]string) func(string, ...string) error {
+	return func(n string, a ...string) error {
+		*name, *args = n, a
+		return nil
+	}
+}
+
+func TestOpenInEditorTerminalReturnsCommand(t *testing.T) {
+	launched := false
+	s := &Service{env: []string{"EDITOR=nvim"}, run: func(string, ...string) error {
+		launched = true
+		return nil
+	}}
+
+	cmd, err := s.OpenInEditor("/repo", "src/main.go")
+	if err != nil {
+		t.Fatalf("OpenInEditor: %v", err)
+	}
+	if want := "nvim '" + filepath.Join("/repo", "src/main.go") + "'"; cmd != want {
+		t.Errorf("cmd = %q, want %q", cmd, want)
+	}
+	if launched {
+		t.Error("a terminal editor was launched detached instead of returned")
+	}
+}
+
+func TestOpenInEditorPrefersVisual(t *testing.T) {
+	// VISUAL wins over EDITOR: a terminal EDITOR is ignored when VISUAL is GUI.
+	var name string
+	var args []string
+	s := &Service{env: []string{"EDITOR=nvim", "VISUAL=zed"}, run: captureRun(&name, &args)}
+
+	cmd, err := s.OpenInEditor("/repo", "a.txt")
+	if err != nil {
+		t.Fatalf("OpenInEditor: %v", err)
+	}
+	if cmd != "" {
+		t.Errorf("cmd = %q, want empty (GUI editor launched)", cmd)
+	}
+	if want := filepath.Join("/repo", "a.txt"); name != "zed" || len(args) != 1 || args[0] != want {
+		t.Errorf("launched %q %v, want zed [%s]", name, args, want)
+	}
+}
+
+func TestOpenInEditorGUISplitsFlags(t *testing.T) {
+	var name string
+	var args []string
+	s := &Service{env: []string{"EDITOR=code --wait"}, run: captureRun(&name, &args)}
+
+	if _, err := s.OpenInEditor("/repo", "a.txt"); err != nil {
+		t.Fatalf("OpenInEditor: %v", err)
+	}
+	want := filepath.Join("/repo", "a.txt")
+	if name != "code" || len(args) != 2 || args[0] != "--wait" || args[1] != want {
+		t.Errorf("got %q %v, want code [--wait %s]", name, args, want)
+	}
+}
+
+func TestOpenInEditorRejectsTraversal(t *testing.T) {
+	launched := false
+	s := &Service{env: []string{"EDITOR=nvim"}, run: func(string, ...string) error {
+		launched = true
+		return nil
+	}}
+	for _, rel := range []string{"../escape", "/etc/passwd", "a/../../b"} {
+		if cmd, err := s.OpenInEditor("/repo", rel); err == nil || cmd != "" {
+			t.Errorf("rel %q: want error, got cmd %q err %v", rel, cmd, err)
+		}
+	}
+	if launched {
+		t.Error("a traversal path reached the launcher")
+	}
+}
+
+// TestOpenInEditorFallsBackToDefault proves that with no editor set the file is
+// handed to the default opener (launched, empty command). The opener command is
+// per-OS, so only the file argument (always last) is portable to assert.
+func TestOpenInEditorFallsBackToDefault(t *testing.T) {
+	var name string
+	var args []string
+	s := &Service{run: captureRun(&name, &args)}
+
+	cmd, err := s.OpenInEditor("/repo", "a.txt")
+	if err != nil {
+		t.Fatalf("OpenInEditor: %v", err)
+	}
+	if cmd != "" {
+		t.Errorf("cmd = %q, want empty (default opener launched)", cmd)
+	}
+	if want := filepath.Join("/repo", "a.txt"); len(args) == 0 || args[len(args)-1] != want {
+		t.Errorf("args = %v, want file %s as last arg", args, want)
+	}
+}
+
+func TestShellQuoteEscapesSingleQuote(t *testing.T) {
+	// A path with a single quote must not break out of the quoting.
+	if got, want := shellQuote("a'b.txt"), `'a'\''b.txt'`; got != want {
+		t.Errorf("shellQuote = %q, want %q", got, want)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func main() {
 	dispatcher.Register("appupdate", appupdate.New(version))
 	dispatcher.Register("patchnotes", patchnotes.New(version, changelog))
 	dispatcher.Register("store", db)
-	dispatcher.Register("system", system.New())
+	dispatcher.Register("system", system.New(env))
 	dispatcher.Register("providers", providers.New())
 	dispatcher.Deny("store.Close")
 	term.Mount("/rpc/", dispatcher)


### PR DESCRIPTION
## What

Three related upgrades to the Files tab of the right dock.

### Live working-tree view (fix)

The tree listed `git ls-files` — the index — so a **newly created file never
appeared** and a **file deleted from disk lingered** until it was staged; it
read as frozen at the session's starting set. `Tree` now lists the work tree:
tracked plus untracked-not-ignored files (`--cached --others
--exclude-standard`), minus any tracked file removed from disk (`--deleted`),
sorted. The git-status poll already re-runs it, so new and removed files show
without a commit. `.gitignore` is still honored — no `node_modules`, no build
output.

### Per-file line deltas

Every changed file in the tree now carries the same `+added −deleted` pair the
review panel and footer show, reusing the diff already parsed for the review
(`parseDiff`); a clean file stays bare.

### Right-click context menus

- **Directory** → Expand all / Collapse all over that folder's subtree.
- **File** → Open in editor. The backend resolves `$VISUAL` then `$EDITOR` from
  the login-shell env (so a GUI launch still sees rc exports):
  - a **GUI editor** (or, with neither set, the platform opener — `xdg-open`,
    `open -t`, `start`) launches **detached**;
  - a **terminal editor** (vim, nvim, nano, …) opens in a **fresh lich terminal
    session** rooted at the checkout — a detached launch would leave it with no
    controlling terminal. The editor command rides the existing paste queue,
    the same path the self-update flow uses to run a command in a new shell.

## Notes / ceilings

- Terminal-editor detection is a fixed basename list; an unlisted one is treated
  as GUI and launched detached — add it to `terminalEditors`.
- `shellQuote` assumes a POSIX shell; cmd.exe (experimental Windows) quotes
  differently.
- Each Open-in-editor spawns a new shell session (no dedup); a dedicated
  auto-closing editor session is the upgrade path if the shell cards pile up.
- Per-OS default opener sits behind build tags, matching the project's OS-seam
  idiom.

## Test plan

- [x] `go test ./...` (355 pass), `gofmt`/`go vet` clean, 3-OS cross-compile.
- [x] `pnpm build` + `pnpm test` green.
- [x] Manual smoke (`task dev`) — the render/session paths the node-only gate
  can't cover:
  - right-click a directory → Expand all / Collapse all;
  - create/delete a file → it appears/disappears within a poll tick, badges
    track edits;
  - right-click a file with `$EDITOR=nvim` → a new shell session opens at the
    checkout running nvim on the file; quitting drops back to a live shell;
  - with a GUI `$VISUAL`, the same click launches it detached (no session).