### PR TITLE
fix: refuse a rooted work-tree path on Windows, and show a red suite in the log

### DIFF
--- a/.github/scripts/go-test-summary.sh
+++ b/.github/scripts/go-test-summary.sh
@@ -19,6 +19,23 @@ read -r pass fail skip < <(jq -rs '
       (map(select(.Action == "skip")) | length) ] | @tsv
 ' "$json")
 
+# -json sends every line of test output to the file, not the log, so a red run
+# would otherwise leave the job with an exit code and nothing to read — the
+# summary lands in the job summary, which the log does not carry. Replay the
+# failing tests' own output (plus their package's, where a build failure lands)
+# to the log before writing the summary.
+if [ "$code" != "0" ]; then
+  echo "::group::Failed test output"
+  # -j: the captured Output lines already carry their newline.
+  jq -js '
+    [ .[] | select(.Action == "fail") | .Package ] as $failed
+    | .[]
+    | select(.Action == "output" and (.Package | IN($failed[])))
+    | .Output
+  ' "$json"
+  echo "::endgroup::"
+fi
+
 total="$(go tool cover -func="$cover" | awk '/^total:/ {print $3}')"
 
 summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: ci
 
 # Fast per-PR gate: format/vet + both suites, with pass/fail counts and
-# coverage rendered into the job summary. Windows backend is validated at
-# release time (release.yml); a PR runs the linux path only for quick feedback.
+# coverage rendered into the job summary. A PR runs the linux path only, for
+# quick feedback; the windows and macOS suites ride the os-tests job below.
 on:
   pull_request:
+    # labeled: adding `ci:os` to an open PR is what arms the os-tests job, so the
+    # label has to be an event, not just a state read on the next push.
+    types: [opened, synchronize, reopened, labeled]
   push:
     branches: [main]
 
@@ -72,3 +75,57 @@ jobs:
 
       - name: Backend tests
         run: bash .github/scripts/go-test-summary.sh linux
+
+  # The backend suite on the OSes the linux job cannot speak for. The
+  # cross-compile step above proves every target still builds; only a real runner
+  # proves it still passes — v0.18.0 shipped a path guard that read a rooted path
+  # as relative on Windows, and the tag's release build was the first thing to
+  # say so.
+  #
+  # Always after a merge to main, so a regression is caught before a tag is ever
+  # pushed; on a PR only when it carries the `ci:os` label, so touching an OS seam
+  # can be checked before the merge without slowing every other PR down.
+  os-tests:
+    if: >-
+      github.event_name == 'push' ||
+      contains(github.event.pull_request.labels.*.name, 'ci:os')
+    strategy:
+      # One red OS still reports the other, rather than cancelling it.
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        # git-bash on Windows keeps these steps byte-identical to the linux job's.
+        shell: bash
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          package_json_file: frontend/package.json
+
+      - name: Set up Node
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      # dist must exist before the Go suite (go:embed), same as the linux job.
+      # The frontend suite is OS-independent and already ran there.
+      - name: Frontend install + build
+        working-directory: frontend
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm build
+
+      - name: Backend tests
+        run: bash .github/scripts/go-test-summary.sh ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The work-tree path guard now rejects a rooted path on Windows too.** The
+  guard behind "open in editor", the file preview and discard leaned on
+  `filepath.IsAbs`, which on Windows demands a volume name — so `/etc/passwd`
+  read as a relative path and walked straight through. Nothing escaped the work
+  tree (the join pinned it back inside), but the rule the guard promises now
+  holds on every OS: a path starting at a root is refused, volume name or not.
+  This is what turned the v0.18.0 release build red on the Windows job.
+
+- **A red backend suite now says which test failed in the CI log.** The test
+  summary script sends `go test -json` to a file and its table to the job
+  summary, so a failing job showed an exit code and not one line of the failure.
+  The failing packages' output is replayed into the log before the summary is
+  written; the job still fails on a red test, exactly as before.
+
 ## [0.18.0] - 2026-07-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   holds on every OS: a path starting at a root is refused, volume name or not.
   This is what turned the v0.18.0 release build red on the Windows job.
 
+- **The backend suite now runs on Windows and macOS before a tag, not after
+  one.** Per-PR CI only ever ran Linux, so an OS-specific regression stayed
+  invisible until the release build — which happens once the tag is already
+  pushed. A new `os-tests` job runs the suite on both OSes on every push to
+  `main`, and on a pull request labelled `ci:os`, so a PR touching an OS seam can
+  ask for the real runners before it merges.
+
 - **A red backend suite now says which test failed in the CI log.** The test
   summary script sends `go test -json` to a file and its table to the job
   summary, so a failing job showed an exit code and not one line of the failure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,9 +45,13 @@ Frontend in isolation: `cd frontend && pnpm run build` (runs `tsc` + `vite build
 - `cd frontend && pnpm build` succeeds (tsc typecheck + vite).
 - Touched an OS seam or a `_test.go` build tag? Run the same cross-compile loop CI runs:
   `for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done`
+  Cross-compiling only proves it builds — label the PR `ci:os` to run the backend suite on real Windows and macOS
+  runners before the merge.
 
 CI (`.github/workflows/ci.yml`) runs this gate on every PR and push to `main` and renders pass/fail counts plus
-coverage into the job summary. The summary is transparency, never the gate — a red test fails the job.
+coverage into the job summary. The summary is transparency, never the gate — a red test fails the job. The
+`os-tests` job runs the backend suite on Windows and macOS: always on a push to `main` (so a regression is caught
+before a tag), on a PR only when it carries the `ci:os` label.
 
 ## Hard Invariants
 

--- a/internal/project/discard.go
+++ b/internal/project/discard.go
@@ -29,13 +29,21 @@ func (s *Service) DiscardFile(path, rel string) error {
 	return nil
 }
 
-// validateRelPath rejects absolute paths and traversal outside the work tree
+// validateRelPath rejects rooted paths and traversal outside the work tree
 // before rel is ever joined onto it.
 func validateRelPath(rel string) error {
 	clean := filepath.Clean(rel)
-	if filepath.IsAbs(clean) || clean == ".." ||
+	if isRooted(clean) || clean == ".." ||
 		strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
 		return fmt.Errorf("invalid repository path %q", rel)
 	}
 	return nil
+}
+
+// isRooted reports whether a cleaned path starts at a root. IsAbs alone is not
+// enough on Windows, where it demands a volume name and so reads "/etc/passwd"
+// as relative; a work-tree path is always relative, so a leading separator is
+// refused too (os.IsPathSeparator counts "\" only where it is one).
+func isRooted(clean string) bool {
+	return filepath.IsAbs(clean) || os.IsPathSeparator(clean[0])
 }

--- a/internal/project/discard_test.go
+++ b/internal/project/discard_test.go
@@ -55,6 +55,27 @@ func TestDiscardFileNew(t *testing.T) {
 	}
 }
 
+// TestValidateRelPathRejectsRootedPaths pins the guard itself. The callers'
+// escape tests pass on Windows for the wrong reason — the joined path simply
+// misses on disk — so the rule is asserted here directly: a path starting at a
+// root is never a work-tree path, whether or not it carries a volume name.
+func TestValidateRelPathRejectsRootedPaths(t *testing.T) {
+	rooted := []string{"/etc/passwd", "/"}
+	if os.IsPathSeparator('\\') {
+		rooted = append(rooted, `\Windows\System32\config`, `C:\Windows`)
+	}
+	for _, rel := range rooted {
+		if err := validateRelPath(rel); err == nil {
+			t.Errorf("validateRelPath(%q): want error, got nil", rel)
+		}
+	}
+	for _, rel := range []string{"a.txt", "internal/rpc/rpc.go", "a/b/../c.txt"} {
+		if err := validateRelPath(rel); err != nil {
+			t.Errorf("validateRelPath(%q): want nil, got %v", rel, err)
+		}
+	}
+}
+
 // TestDiscardFileRejectsEscape proves traversal and absolute paths never reach
 // the filesystem.
 func TestDiscardFileRejectsEscape(t *testing.T) {

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -6,6 +6,7 @@ package system
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -118,15 +119,23 @@ func (s *Service) getenv(key string) string {
 	return ""
 }
 
-// validateRel rejects absolute paths and parent-directory escapes, so a joined
+// validateRel rejects rooted paths and parent-directory escapes, so a joined
 // path can never leave the work-tree root. Mirrors project.validateRelPath.
 func validateRel(rel string) error {
 	clean := filepath.Clean(rel)
-	if filepath.IsAbs(clean) || clean == ".." ||
+	if isRooted(clean) || clean == ".." ||
 		strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
 		return fmt.Errorf("invalid repository path %q", rel)
 	}
 	return nil
+}
+
+// isRooted reports whether a cleaned path starts at a root. IsAbs alone is not
+// enough on Windows, where it demands a volume name and so reads "/etc/passwd"
+// as relative; a work-tree path is always relative, so a leading separator is
+// refused too (os.IsPathSeparator counts "\" only where it is one).
+func isRooted(clean string) bool {
+	return filepath.IsAbs(clean) || os.IsPathSeparator(clean[0])
 }
 
 // ValidateExternalURL accepts absolute http/https URLs only.

--- a/internal/system/system_test.go
+++ b/internal/system/system_test.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -135,6 +136,27 @@ func TestOpenInEditorFallsBackToDefault(t *testing.T) {
 	}
 	if want := filepath.Join("/repo", "a.txt"); len(args) == 0 || args[len(args)-1] != want {
 		t.Errorf("args = %v, want file %s as last arg", args, want)
+	}
+}
+
+// TestValidateRelRejectsRootedPaths pins the guard itself: a path that starts
+// at a root is never a work-tree path. "/etc/passwd" is the case Windows used to
+// wave through — filepath.IsAbs wants a volume name there, so a leading
+// separator alone read as relative.
+func TestValidateRelRejectsRootedPaths(t *testing.T) {
+	rooted := []string{"/etc/passwd", "/"}
+	if os.IsPathSeparator('\\') {
+		rooted = append(rooted, `\Windows\System32\config`, `C:\Windows`)
+	}
+	for _, rel := range rooted {
+		if err := validateRel(rel); err == nil {
+			t.Errorf("validateRel(%q): want error, got nil", rel)
+		}
+	}
+	for _, rel := range []string{"a.txt", "src/main.go", "a/b/../c.txt"} {
+		if err := validateRel(rel); err != nil {
+			t.Errorf("validateRel(%q): want nil, got %v", rel, err)
+		}
 	}
 }
 


### PR DESCRIPTION
The v0.18.0 release build failed on the windows job's backend suite.
validateRel/validateRelPath both gated on filepath.IsAbs, which on Windows
requires a volume name — "/etc/passwd" cleans to "\etc\passwd", carries no
volume, and read as relative. TestOpenInEditorRejectsTraversal is the only
caller that asserts the guard without touching the filesystem, so it was the
only one to notice; the project-side escape tests passed for the wrong reason
(the joined path simply missed on disk).

Both guards now refuse a leading path separator as well, via os.IsPathSeparator
— a no-op on Unix, where such a path is already absolute. Each package gets a
test pinning the guard directly instead of through a caller.

The failure was also invisible: go-test-summary.sh sends -json to a temp file
and its table to the job summary, leaving the log with an exit code and nothing
else. The failing packages' output is now replayed into the log first.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013bvEsEjHfaEvv8X678m2oR