### PR TITLE
fix: count every file in a new directory, not the directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A new directory of files now counts as the files it holds, not as one.** The
+  changed-file count came from `git status --porcelain`, which reports an
+  untracked directory as a single `?? pkg/` entry — so an agent writing 25 files
+  into fresh packages showed 4 changed files in the footer and on the session
+  card, while the Review tab listed all of them. The count now asks git for
+  every untracked file; the line totals were already right.
 - **A model newer than your lich no longer reads its context window as 200k.**
   Opus 5 sessions showed five times their real usage in the footer, because the
   window came from a table of the 1M models and anything missing from it fell

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -169,7 +169,10 @@ type DiffStats struct {
 // yields the zero value, matching Branch's contract.
 func (s *Service) Diff(path string) DiffStats {
 	var stats DiffStats
-	if out, err := command("git", "-C", path, "status", "--porcelain").Output(); err == nil {
+	// --untracked-files=all, because the default collapses a new directory into
+	// one "?? dir/" line: an agent writing 25 files into fresh packages would
+	// count as one changed file.
+	if out, err := command("git", "-C", path, "status", "--porcelain", "--untracked-files=all").Output(); err == nil {
 		stats.Files = countLines(out)
 	}
 	// A repository without commits has no HEAD; diff against git's empty tree,

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -170,6 +170,21 @@ func TestDiff(t *testing.T) {
 		t.Errorf("Diff(untracked binary).Added = %d, want 5", got.Added)
 	}
 
+	// Untracked files inside a new directory count one by one: git's default
+	// porcelain collapses them into a single "?? pkg/" entry, which would report
+	// a whole new package as one changed file.
+	if err := os.MkdirAll(filepath.Join(repo, "pkg", "deep"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"one.txt", "two.txt"} {
+		if err := os.WriteFile(filepath.Join(repo, "pkg", "deep", name), []byte("l\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := svc.Diff(repo); got.Files != 5 || got.Added != 7 {
+		t.Errorf("Diff(new directory) = %+v, want {Files:5 Added:7 Deleted:1}", got)
+	}
+
 	if got := svc.Diff(t.TempDir()); got != (DiffStats{}) {
 		t.Errorf("Diff(non-repo) = %+v, want zero", got)
 	}


### PR DESCRIPTION
## Problem

A session writing a whole new package showed **4 changed files** in the footer and on its session card, while the Review tab listed 25.

`Diff` counted the lines of `git status --porcelain`. Git's default `--untracked-files=normal` collapses an untracked directory into one entry:

```
 M a.txt
?? src/          <- 2 new files in here, reported as 1
```

The `+1175 -0` line totals were right the whole time — they come from `ls-files --others --exclude-standard`, which lists files, never directories.

## Fix

Pass `--untracked-files=all` to the status call (`internal/project/project.go`). One flag; the untracked-line counting below it is unchanged.

`worktree.go` also runs `status --porcelain`, but only to decide dirty vs clean — the collapse cannot change that answer, so it stays as is.

## Test plan

- [x] New case in `TestDiff`: two untracked files inside a fresh nested directory. Reports `Files:4` without the flag (the exact symptom), `Files:5` with it.
- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` — 400 passed.
- [x] Frontend gate green even though it is untouched: `biome check` clean (12 pre-existing a11y warnings), `vitest run` 406 passed in 43 files, `tsc --noEmit` clean, `vite build` succeeds.