### PR TITLE
fix: retire the pull request badge when the merge lands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Merging a pull request now clears its badge everywhere, at once.** The
+  footer, the session cards and the sidebar's "Pull request" entry only looked
+  the pull request up again when the checkout's HEAD moved, or when the window
+  lost focus and got it back — and a merge does neither, since the commit lands
+  on the base branch, on the remote. Merging from the Pulls screen emptied that
+  screen while every badge around it went on reading `#N Open` until you clicked
+  away to another window and back. Merging, opening a pull request and the
+  header's reload button now retire the shared answer and re-read it.
 - **A model newer than your lich no longer reads its context window as 200k.**
   Opus 5 sessions showed five times their real usage in the footer, because the
   window came from a table of the 1M models and anything missing from it fell

--- a/frontend/src/components/pulls/Pulls.tsx
+++ b/frontend/src/components/pulls/Pulls.tsx
@@ -22,6 +22,7 @@ import { Notice } from "@/components/common/Notice"
 import { closePulls } from "@/lib/pulls-card-store"
 import { activeTarget, sessionsOf } from "@/lib/session/sessions"
 import { useGitStatus } from "@/lib/git/use-git-status"
+import { invalidatePullRequests } from "@/lib/pulls/pull-request-lookup"
 import { usePullRequestDetail } from "@/lib/pulls/use-pull-request-detail"
 import { useInject } from "@/lib/use-inject"
 import { cn, errorText } from "@/lib/utils"
@@ -68,6 +69,15 @@ export function Pulls() {
   const { detail, loading, error, refresh } = usePullRequestDetail(path, branch, head)
   const inject = useInject(sessionId)
 
+  // This screen and the badges around it read the same pull request through two
+  // separate lookups, so a change with HEAD standing still — a merge, a PR
+  // opened, whatever the reload button was pressed for — has to retire both.
+  // The check poll and the focus re-read stay this screen's own.
+  const reload = () => {
+    invalidatePullRequests()
+    refresh()
+  }
+
   // A merged branch leaves its checkout behind — the one cleanup the user would
   // otherwise walk back to the sidebar for. Refuse a dirty worktree: whatever
   // was never committed lives only there, and the sidebar's flow is the one that
@@ -97,7 +107,7 @@ export function Pulls() {
   }
 
   const onMerged = () => {
-    refresh()
+    reload()
     const merged = `Merged #${detail?.number} into ${detail?.baseRefName}`
     // Only a worktree checkout has something to clean up; the project's own
     // directory stays where it is.
@@ -122,7 +132,7 @@ export function Pulls() {
         path={path}
         head={head}
         detail={detail}
-        onRefresh={refresh}
+        onRefresh={reload}
         onMerged={onMerged}
         onInject={inject}
       />
@@ -130,7 +140,7 @@ export function Pulls() {
   } else if (loading) {
     body = <PullSkeleton />
   } else {
-    body = <EmptyState path={path} branch={branch} onOpened={refresh} />
+    body = <EmptyState path={path} branch={branch} onOpened={reload} />
   }
 
   return <div className="absolute inset-0 z-10 flex flex-col bg-background">{body}</div>

--- a/frontend/src/lib/pulls/pull-request-lookup.test.ts
+++ b/frontend/src/lib/pulls/pull-request-lookup.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { lookupPullRequest } from "./pull-request-lookup"
+import {
+  invalidatePullRequests,
+  lookupPullRequest,
+  onPullRequestInvalidated,
+} from "./pull-request-lookup"
 
 // The RPC is the boundary here; stub it so the test asserts how many gh calls
 // the lookup actually makes. Each test uses its own checkout path, so the
@@ -68,6 +72,24 @@ describe("pull-request-lookup", () => {
     await lookupPullRequest("/f", "main", "sha1")
     await lookupPullRequest("/f", "main", "sha2")
     expect(pullRequest).toHaveBeenCalledTimes(2)
+  })
+
+  // Merging moves no HEAD and changes no branch, so an invalidation is the only
+  // thing that can retire the answer the badge is still showing.
+  it("asks gh again after an invalidation, inside the share window", async () => {
+    await lookupPullRequest("/g", "main", "sha1")
+    invalidatePullRequests()
+    await lookupPullRequest("/g", "main", "sha1")
+    expect(pullRequest).toHaveBeenCalledTimes(2)
+  })
+
+  it("notifies subscribers until they unsubscribe", () => {
+    const reload = vi.fn()
+    const unsubscribe = onPullRequestInvalidated(reload)
+    invalidatePullRequests()
+    unsubscribe()
+    invalidatePullRequests()
+    expect(reload).toHaveBeenCalledTimes(1)
   })
 
   it("resolves a failed lookup to no pull request", async () => {

--- a/frontend/src/lib/pulls/pull-request-lookup.ts
+++ b/frontend/src/lib/pulls/pull-request-lookup.ts
@@ -16,6 +16,34 @@ interface Shared {
 
 const shared = new Map<string, Shared>()
 
+const listeners = new Set<() => void>()
+
+// onPullRequestInvalidated registers a badge's re-read, returning its
+// unsubscribe. Every badge of every checkout is called, not just the one that
+// changed: a merge is a rare, deliberate action, and the callers of one
+// checkout still collapse into a single gh call. Key the listeners by path if
+// that ever stops being cheap enough.
+export function onPullRequestInvalidated(reload: () => void): () => void {
+  listeners.add(reload)
+  return () => {
+    listeners.delete(reload)
+  }
+}
+
+// invalidatePullRequests drops every shared answer and asks the badges to look
+// up again — for a change only lich itself can announce. Merging does not move
+// the checkout's HEAD (the commit lands on the base branch, on the remote), so
+// without this the footer, the session cards and the sidebar's pull request
+// entry keep reading "Open" until the window loses focus and gets it back.
+// Clearing the map matters as much as the notify: a re-read inside the share
+// window would otherwise replay the pre-merge answer.
+export function invalidatePullRequests(): void {
+  shared.clear()
+  for (const reload of listeners) {
+    reload()
+  }
+}
+
 // lookupPullRequest resolves a checkout's open PR, sharing one gh call across
 // every caller asking about the same checkout+branch+commit at the same time.
 // It never rejects: a failed lookup (no gh, not a GitHub repo) reads as "no

--- a/frontend/src/lib/pulls/use-pull-request.ts
+++ b/frontend/src/lib/pulls/use-pull-request.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { lookupPullRequest } from "./pull-request-lookup"
+import { lookupPullRequest, onPullRequestInvalidated } from "./pull-request-lookup"
 import type { PullRequest } from "@/lib/api-types"
 
 export type { PullRequest }
@@ -9,10 +9,11 @@ export type { PullRequest }
 // round-trip — but it refetches whenever the checkout's HEAD moves, so a PR the
 // session just opened (or a merge that closed one) reaches the badge without
 // waiting for a window focus. It also refetches on focus, for a PR opened or
-// merged in the browser. Callers asking about the same checkout share one gh
-// call (pull-request-lookup). Returns null while loading, on any error, or when
-// the branch has no open PR (a merged or closed one is filtered server-side),
-// so the caller hides the badge.
+// merged in the browser, and on invalidatePullRequests, for a merge landed from
+// the Pulls screen — which moves no HEAD at all. Callers asking about the same
+// checkout share one gh call (pull-request-lookup). Returns null while loading,
+// on any error, or when the branch has no open PR (a merged or closed one is
+// filtered server-side), so the caller hides the badge.
 export function usePullRequest(path: string, branch: string, head: string): PullRequest | null {
   const [pr, setPr] = useState<PullRequest | null>(null)
 
@@ -35,9 +36,11 @@ export function usePullRequest(path: string, branch: string, head: string): Pull
     }
     load()
     window.addEventListener("focus", load)
+    const unsubscribe = onPullRequestInvalidated(load)
     return () => {
       alive = false
       window.removeEventListener("focus", load)
+      unsubscribe()
     }
   }, [path, branch, head])
 


### PR DESCRIPTION
## What

Merging a pull request left every badge around the Pulls screen still reading `#N Open`.

The footer badge, the session cards and the sidebar's "Pull request" entry only look the pull request up again when the checkout's HEAD moves, or when the window loses focus and gets it back. A merge does neither — the commit lands on the base branch, on the remote, and the worktree's HEAD never budges. So merging from the Pulls screen emptied that screen (`onMerged` refreshes it) while the badges went on showing the merged PR as open until you clicked away to another window and back.

## How

`lib/pulls/pull-request-lookup.ts` — the shared lookup takes subscribers:

- `invalidatePullRequests()` clears the `shared` map **and** notifies. Clearing matters as much as the notify: inside the 2s `SHARE_MS` window a re-read would otherwise replay the pre-merge answer.
- `onPullRequestInvalidated(reload)` returns its unsubscribe; `usePullRequest` subscribes in the same effect that listens for focus.
- `Pulls.tsx` wraps `refresh` in a `reload` that invalidates first, and wires it to the three moments the state changes with HEAD standing still: the merge, the header's reload button, and a pull request opened from the empty state. The check poll and the focus re-read stay the screen's own — neither changes what a badge shows.

Every badge of every checkout is invalidated, not just the one that changed. A merge is rare and deliberate, and the callers of one checkout still collapse into a single `gh` call; the comment names the ceiling and the way out (key the listeners by path).

Not covered: `gh pr merge` run from a terminal next door. Nothing announces that, so it still waits for a window focus — same as before.

## Test plan

- [x] `vitest` — 408 passing, two new cases on the lookup: a re-read after an invalidation inside the share window, and subscribe/unsubscribe notification.
- [x] `biome check` clean (12 pre-existing a11y warnings).
- [x] `tsc -b --noEmit` + `vite build`.
- [x] `gofmt -l .` + `go vet ./...` (no Go touched).
- [ ] By hand in `task dev`: merge a PR from the Pulls screen, confirm the footer badge, the session card `#N` and the sidebar's "Open" all clear without touching another window.