### PR TITLE
fix: stop the shell behaving like a browser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The shell no longer behaves like a browser.** The window is one only by
+  construction, and its reflexes leaked through everywhere except a focused
+  terminal, which already swallows them: a locale that did not match the UI
+  raised the translate bubble on startup; Ctrl+W closed the window, which quits
+  lich; Ctrl+T and Ctrl+N opened tabs and windows; Ctrl+P, Ctrl+S and Ctrl+O
+  opened dialogs with nowhere to land; Ctrl+Shift+Delete would have wiped lich's
+  own saved settings along with the browsing data; right-clicking the UI offered
+  Back, Reload and Save as; dropping a file on the window replaced the app with
+  that file, with no address bar to come back from; and middle-clicking a link
+  spawned a browser window. All of it is now refused. Reload, the devtools chords
+  and the terminal's own right-click menu are deliberately kept, and every chord
+  still reaches a terminal as its PTY sequence — Ctrl+W stays delete-word,
+  Ctrl+U kill-line, Ctrl+D end-of-file.
 - **A new directory of files now counts as the files it holds, not as one.** The
   changed-file count came from `git status --porcelain`, which reports an
   untracked directory as a single `?? pkg/` entry — so an agent writing 25 files

--- a/frontend/src/components/Markdown.tsx
+++ b/frontend/src/components/Markdown.tsx
@@ -45,6 +45,9 @@ const components: Components = {
             void System.OpenExternal(href)
           }
         }}
+        // Middle-click never reaches onClick, and its default is a new Chromium
+        // window. Kill it — the plain click already opens the link.
+        onAuxClick={(e) => e.preventDefault()}
       >
         {children}
       </a>

--- a/frontend/src/lib/browser-defaults.test.ts
+++ b/frontend/src/lib/browser-defaults.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import { isAppContextMenu, isBrowserChord } from "./browser-defaults"
+
+const chord = (over: Partial<KeyboardEvent>) =>
+  ({
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    altKey: false,
+    key: "a",
+    ...over,
+  }) as KeyboardEvent
+
+describe("isBrowserChord", () => {
+  it("swallows the tab, window, file and page commands under either modifier", () => {
+    for (const key of ["t", "w", "n", "p", "s", "o", "u", "d", "h", "j"]) {
+      expect(isBrowserChord(chord({ ctrlKey: true, key }))).toBe(true)
+      expect(isBrowserChord(chord({ metaKey: true, key }))).toBe(true)
+    }
+  })
+
+  it("swallows the shifted commands, including the browsing-data wipe", () => {
+    for (const key of ["T", "W", "N", "M", "Delete"]) {
+      expect(isBrowserChord(chord({ ctrlKey: true, shiftKey: true, key }))).toBe(true)
+    }
+  })
+
+  it("leaves the devtools chords alone — Shift changes what the key means", () => {
+    for (const key of ["i", "j", "c"]) {
+      expect(isBrowserChord(chord({ ctrlKey: true, shiftKey: true, key }))).toBe(false)
+    }
+  })
+
+  it("leaves reload, editing chords and bare keys alone", () => {
+    for (const key of ["r", "a", "c", "v", "x", "z", "f", "k"]) {
+      expect(isBrowserChord(chord({ ctrlKey: true, key }))).toBe(false)
+    }
+    expect(isBrowserChord(chord({ key: "t" }))).toBe(false)
+  })
+
+  it("ignores AltGr, which arrives as Ctrl+Alt and types real characters", () => {
+    expect(isBrowserChord(chord({ ctrlKey: true, altKey: true, key: "w" }))).toBe(false)
+  })
+})
+
+describe("isAppContextMenu", () => {
+  const target = (closestHit: boolean) =>
+    ({ closest: () => (closestHit ? {} : null) }) as unknown as EventTarget
+
+  it("claims the app's own chrome", () => {
+    expect(isAppContextMenu(target(false))).toBe(true)
+  })
+
+  it("leaves a terminal's menu alone — that is where Copy and Paste live", () => {
+    expect(isAppContextMenu(target(true))).toBe(false)
+  })
+
+  it("claims a null target rather than letting the browser menu through", () => {
+    expect(isAppContextMenu(null)).toBe(true)
+  })
+})

--- a/frontend/src/lib/browser-defaults.ts
+++ b/frontend/src/lib/browser-defaults.ts
@@ -1,0 +1,66 @@
+// The shell is a browser only by construction, and its reflexes leak into an
+// --app window that has no tabs, no address bar and no way back: the accelerators
+// still fire, a dropped file still navigates. One of each is fatal — Ctrl+W
+// closes the window, which quits lich, and a file drop replaces the app with the
+// file, with no address bar to return from.
+//
+// They only reach the browser when nothing on the page claims them first, which
+// is why they misfire everywhere except a focused terminal — xterm already
+// preventDefaults the chords it encodes.
+
+// The subset of KeyboardEvent the matcher needs — lets tests pass plain objects.
+type ChordState = Pick<KeyboardEvent, "ctrlKey" | "metaKey" | "shiftKey" | "altKey" | "key">
+
+// Tab and window commands (new/close/restore), the file and page commands whose
+// dialogs or navigation have nowhere to land, and the browsing-data wipe, which
+// would take lich's own localStorage settings with it.
+const MOD_KEYS = new Set(["t", "w", "n", "p", "s", "o", "u", "d", "h", "j"])
+const MOD_SHIFT_KEYS = new Set(["t", "w", "n", "m", "delete"])
+
+// Deliberately still live: Ctrl+R and F5 (a reload recovers a wedged UI and
+// costs nothing — the session lives in the backend), the devtools chords
+// (Ctrl+Shift+I/J/C, F12) and F11. Alt is excluded throughout because AltGr
+// arrives as Ctrl+Alt on Windows and Linux layouts, where it types characters.
+export function isBrowserChord(event: ChordState): boolean {
+  const mod = event.ctrlKey || event.metaKey
+  if (!mod || event.altKey) {
+    return false
+  }
+  const key = event.key.toLowerCase()
+  return event.shiftKey ? MOD_SHIFT_KEYS.has(key) : MOD_KEYS.has(key)
+}
+
+// isAppContextMenu reports a right-click on the app's own chrome — everything
+// outside a terminal. The terminal keeps Chromium's menu because that is where
+// its Copy and Paste entries live; the rest of the UI has no such use for it and
+// would only be offered Back, Reload, Save as, Print and View source.
+export function isAppContextMenu(target: EventTarget | null): boolean {
+  const element = target as HTMLElement | null
+  return !element?.closest?.(".xterm")
+}
+
+// installBrowserDefaults swallows the lot. preventDefault only, never
+// stopPropagation: a terminal must still receive every chord as a PTY sequence,
+// and most of these are real terminal bindings (Ctrl+W kills a word, Ctrl+U a
+// line, Ctrl+D is EOF, Ctrl+P walks shell history).
+export function installBrowserDefaults(target: Window): void {
+  target.addEventListener(
+    "keydown",
+    (event) => {
+      if (isBrowserChord(event)) {
+        event.preventDefault()
+      }
+    },
+    true,
+  )
+  target.addEventListener("contextmenu", (event) => {
+    if (isAppContextMenu(event.target)) {
+      event.preventDefault()
+    }
+  })
+  // Bubble phase, so a future drop zone of our own runs first and this only
+  // catches what nothing claimed. dnd-kit is untouched — it rides pointer
+  // events, not the HTML drag protocol.
+  target.addEventListener("dragover", (event) => event.preventDefault())
+  target.addEventListener("drop", (event) => event.preventDefault())
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,12 @@
 import React from "react"
 import ReactDOM from "react-dom/client"
 import App from "./App"
+import { installBrowserDefaults } from "@/lib/browser-defaults"
 import "./index.css"
+
+// Registered once for the page's life, before React: the shell's own reflexes
+// must die before any screen can see them, and there is no state to tear down.
+installBrowserDefaults(window)
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>

--- a/internal/chromium/chromium.go
+++ b/internal/chromium/chromium.go
@@ -89,6 +89,10 @@ func Args(url, dataDir, class string, extra []string) []string {
 		"--class=" + class,
 		"--no-first-run",
 		"--no-default-browser-check",
+		// The translate bubble compares the page's language against the browser
+		// locale and offers to translate lich's own UI — a browser prompt in a
+		// window that is not a browser.
+		"--disable-features=Translate",
 	}
 	return append(args, extra...)
 }

--- a/internal/chromium/chromium_test.go
+++ b/internal/chromium/chromium_test.go
@@ -122,6 +122,7 @@ func TestArgs(t *testing.T) {
 		"--app=http://127.0.0.1:47821/?token=x",
 		"--user-data-dir=/home/u/.config/lich/chromium-profile",
 		"--class=lichdev",
+		"--disable-features=Translate",
 		"--ozone-platform=wayland",
 	} {
 		if !slices.Contains(args, want) {


### PR DESCRIPTION
The `--app` window is a browser only by construction, and its reflexes leaked
into every screen that is not a focused terminal — a terminal already swallows
them through xterm's own `preventDefault`, which is why they only ever misfired
elsewhere.

Two of them were fatal:

- **Ctrl+W closed the window**, and a closed window quits lich.
- **Dropping a file on the window navigated to it**, replacing the app with the
  file's contents, with no address bar to come back from. Easy to trigger by
  dragging a file at a terminal expecting to paste its path.

The rest were noise with real teeth:

| Chord / gesture | What leaked |
|---|---|
| Ctrl+T, Ctrl+N (+Shift) | tabs and browser windows |
| Ctrl+P, Ctrl+S, Ctrl+O | print/save/open dialogs; Open navigates away and kills the app |
| Ctrl+U, Ctrl+H, Ctrl+J | view-source, history, downloads |
| Ctrl+Shift+Delete | wipes lich's own `lich.*` localStorage settings with the browsing data |
| Ctrl+Shift+M | profile switcher |
| Right-click on the UI | Back, Reload, Save as, Print, View source |
| Middle-click a link | browser window (`onClick` never sees an aux click) |
| Startup with a mismatched locale | the translate bubble, offering to translate lich's own UI |

## What changed

- `internal/chromium`: launch with `--disable-features=Translate`.
- `frontend/src/lib/browser-defaults.ts` (new): the chord table, the context-menu
  rule and the drop guard, installed from `main.tsx` before React mounts.
- `Markdown.tsx`: `onAuxClick` refuses the middle-click navigation the existing
  `onClick` handler could not see.

Swallowing is `preventDefault` and **never** `stopPropagation`: a terminal must
still receive every chord as its PTY sequence, since most of these are real
terminal bindings — Ctrl+W kills a word, Ctrl+U a line, Ctrl+D is end-of-file,
Ctrl+P walks shell history.

## Kept on purpose

Reload (Ctrl+R / F5) recovers a wedged UI and costs nothing, since the session
lives in the backend; the devtools chords and F11 are worth more than the
purism; and the terminal keeps Chromium's right-click menu, which is where its
Copy and Paste live. Ctrl+F outside a terminal still opens Chromium's find bar —
searching the page is useful, and it is easy to add to the table later.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` — 400 pass
- [x] `pnpm test` — 416 pass, incl. the new `browser-defaults` table
- [x] `pnpm build`, `pnpm check`
- [x] **Hand-checked in `task dev`.** Chromium marks some accelerators
      *reserved*, and a reserved key cannot be cancelled by the page — Ctrl+W was
      the open question. It is not reserved in an `--app` window: the chord is
      refused and the window stays open.
- [x] A terminal still gets Ctrl+W / Ctrl+U / Ctrl+D / Ctrl+P as PTY sequences
- [x] Dragging a file onto the window leaves the app in place

