### PR TITLE
chore: cut v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-07-25
+
 ### Added
 
 - **The Pulls screen now lists the commits a pull request would land.** A new
@@ -959,7 +961,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.19.0...HEAD
+[0.19.0]: https://github.com/omartelo/lich/compare/v0.18.0...v0.19.0
 [0.18.0]: https://github.com/omartelo/lich/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/omartelo/lich/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/omartelo/lich/compare/v0.15.0...v0.16.0


### PR DESCRIPTION
Moves the `[Unreleased]` entries under a `v0.19.0` heading and refreshes the compare links, so `release.yml` can read the notes from the matching section when the tag lands.

Minor bump: the release carries one feature (#98, the Pulls screen's Commits tab) alongside six fixes.

## What lands

**Added** — #98 commits tab on the Pulls screen.

**Fixed** — #99 browser reflexes in the shell, #96 untracked-directory file count, #97 stale PR badge after a merge, #94 unknown model's context window, #93 lazy diff editors and the pull request screen's skeletons.

#91 (biome adoption, `lib/` regrouping) and #95 (CLAUDE.md prune) are internal and carry no entry, which is why they are absent.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test -race ./...` — 404 passed, no data races
- [x] `biome check .` clean (exit 0), `tsc --noEmit` clean, `vite build` succeeds
- [x] `vitest run` — 416 passed in 44 files
- [x] Cross-compile loop `GOOS=linux/darwin/windows go build ./... && go vet ./...` clean
- [x] `awk` extraction from `release.yml` yields the full 0.19.0 section (7 entries)