### PR TITLE
fix: keep the dev shell out of the daily driver's runtime file

### DIFF
--- a/internal/singleton/singleton.go
+++ b/internal/singleton/singleton.go
@@ -31,8 +31,19 @@ type Info struct {
 // so a slow one means the recorded instance is gone and the file is stale.
 const pingTimeout = time.Second
 
+// path resolves runtime.json. LICH_DEV (set by `task dev`) selects a separate
+// file, mirroring the store's database split: the dev shell records itself on
+// its own port, and must not overwrite — or, on exit, delete — the daily
+// driver's runtime file.
 func path(configDir string) string {
-	return filepath.Join(configDir, "lich", "runtime.json")
+	return filepath.Join(configDir, "lich", fileName(os.Getenv("LICH_DEV") != ""))
+}
+
+func fileName(dev bool) string {
+	if dev {
+		return "runtime-dev.json"
+	}
+	return "runtime.json"
 }
 
 // Write records this process as the running instance. Mode 0600: the token is a

--- a/internal/singleton/singleton_test.go
+++ b/internal/singleton/singleton_test.go
@@ -108,6 +108,48 @@ func TestDetect(t *testing.T) {
 	})
 }
 
+// TestDevSplit proves a `task dev` shell records itself in its own file: it
+// neither overwrites the daily driver's runtime.json nor, when main.go removes
+// the path it was handed on exit, takes that file down with it.
+func TestDevSplit(t *testing.T) {
+	if got := fileName(false); got != "runtime.json" {
+		t.Errorf("fileName(false) = %q, want runtime.json", got)
+	}
+	if got := fileName(true); got != "runtime-dev.json" {
+		t.Errorf("fileName(true) = %q, want runtime-dev.json", got)
+	}
+
+	configDir := writeConfig(t)
+	t.Setenv("LICH_DEV", "")
+	if _, err := Write(configDir, 47821, "daily"); err != nil {
+		t.Fatalf("Write daily: %v", err)
+	}
+
+	t.Setenv("LICH_DEV", "1")
+	devPath, err := Write(configDir, 47822, "dev")
+	if err != nil {
+		t.Fatalf("Write dev: %v", err)
+	}
+	if filepath.Base(devPath) != "runtime-dev.json" {
+		t.Errorf("dev path = %q, want .../runtime-dev.json", devPath)
+	}
+	if got, err := Read(configDir); err != nil || got == nil || got.Token != "dev" {
+		t.Fatalf("dev Read = %+v (err %v), want the dev record", got, err)
+	}
+	if err := os.Remove(devPath); err != nil {
+		t.Fatalf("remove dev path: %v", err)
+	}
+
+	t.Setenv("LICH_DEV", "")
+	got, err := Read(configDir)
+	if err != nil {
+		t.Fatalf("Read daily: %v", err)
+	}
+	if got == nil || got.Port != 47821 || got.Token != "daily" {
+		t.Fatalf("daily record = %+v, want port=47821 tok=daily", got)
+	}
+}
+
 // TestPing exercises the production probe against a listener that mimics the
 // transport's token-gated /ping: 204 with the token, 401 without.
 func TestPing(t *testing.T) {


### PR DESCRIPTION
## The bug

`runChromium` records `runtime.json` before the `LICH_DEV_URL` branch, so every `task dev` run wrote its own port and
token into the daily driver's runtime file — and deleted that file on its clean exit (`defer os.Remove(path)`). Two
casualties: `install.sh` could no longer reach the running daily driver for `/restart`, and a second daily-driver
launch stopped recognising itself as a duplicate, dying with a bare bind error instead of focusing the open window.

## The fix

`singleton.path` now gates the filename on `LICH_DEV`, mirroring `store.databasePath` and `logging.fileName`:
`runtime-dev.json` for a `task dev` shell, `runtime.json` for the daily driver.

The gate lives at the shared path rather than at the call site because `Write`, `Read` and `Detect` all route through
`path` — one guard covers the write, the read and the exit-time removal, and the dev shell's duplicate detection now
finds its own instance (on 47822) instead of reading the daily driver's record and mistaking a live app for a dead
port. `install.sh` keeps reading `runtime.json` and keeps finding the real instance.

No `CHANGELOG.md` entry: the bug is reachable only through `task dev`, so no user of a published version lived it.

## Test plan

- [x] `TestDevSplit` covers both halves of the bug: a dev `Write` leaves the daily record intact, and removing the path
      dev was handed (what `main.go` defers) leaves `runtime.json` standing.
- [x] `go test ./...` — 405 passed in 19 packages.
- [x] `go vet ./...` and `gofmt -l .` clean.
- [x] Cross-compile loop for linux, darwin and windows builds and vets clean.
