### PR TITLE
docs: expose the instruction files as AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md


### PR DESCRIPTION
## Summary

`AGENTS.md` is the filename Codex, OpenCode, pi and friends look for. lich already keeps its instructions in `CLAUDE.md`, so this exposes the same content under both names instead of maintaining a second copy that drifts.

- `AGENTS.md -> CLAUDE.md` (repo root)
- `frontend/AGENTS.md -> CLAUDE.md` (frontend rules + design system)

Both are relative symlinks committed with git mode `120000`, so a clone resolves them without any post-checkout step.

## Notes

- No `CHANGELOG.md` entry: nothing here reaches a user of a published version — it is a contributor-facing file only.
- Windows clones without symlink support get a plain text file containing the target path; harmless, and no build step reads either file.

## Test plan

- [x] `git ls-files -s` reports mode `120000` for both entries
- [x] `cat AGENTS.md` / `cat frontend/AGENTS.md` resolve to the CLAUDE.md contents
- [ ] CI green