### PR TITLE
fix: name a checkout the same way on both sides of the comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "Go to session" once one is live — and a pull request from a fork is refused
   up front, since its commits could never be pushed back.
 
+### Fixed
+
+- **A worktree behind a symlinked path is recognised as the checkout it is.**
+  git reports a checkout by its fully resolved path while lich built one by
+  joining names onto the data dir, so the same directory travelled under two
+  spellings wherever a symlink sat in the way — every path on macOS, and a short
+  name on Windows. The session living in a worktree was then not seen to live
+  there: resuming a kept worktree opened a second one beside it, and **Open in
+  Session** offered to create what was already checked out. Both sides of the
+  comparison now resolve the same way.
+
 ## [0.19.0] - 2026-07-25
 
 ### Added

--- a/internal/project/worktree.go
+++ b/internal/project/worktree.go
@@ -119,7 +119,19 @@ func (s *Service) ListCheckouts(path string) ([]Worktree, error) {
 	if err != nil {
 		return nil, err
 	}
-	return parseCheckouts(out), nil
+	checkouts := parseCheckouts(out)
+	// The caller's own directory is handed back spelled the way the caller
+	// named it. A project's path is its identity in the workspace — it is what
+	// projectID hashes and what every stored session carries — so a checkout
+	// the caller cannot recognise as "the project itself" sends it down the
+	// worktree flows, which is precisely what this call exists to prevent.
+	own := canonicalPath(path)
+	for i, c := range checkouts {
+		if c.Path == own {
+			checkouts[i].Path = filepath.Clean(path)
+		}
+	}
+	return checkouts, nil
 }
 
 // parseCheckouts reads every block of `git worktree list --porcelain`, main
@@ -135,6 +147,22 @@ func parseCheckouts(out string) []Worktree {
 	return checkouts
 }
 
+// canonicalPath renders a checkout path the one way lich compares them. git
+// reports a worktree by its fully resolved path, while lich builds one by
+// joining names onto the data dir — the same directory under two spellings the
+// moment a symlink is in the way (macOS puts every temp and /var path behind
+// one) or the platform has more than one form for a name (Windows 8.3). Every
+// path that will be compared goes through here, on both sides.
+//
+// A path that no longer exists (a stale registration) cannot be resolved; Clean
+// is the best available answer and keeps the entry readable.
+func canonicalPath(p string) string {
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return resolved
+	}
+	return filepath.Clean(p)
+}
+
 // parseWorktreeBlock extracts one worktree entry; ok is false for bare or
 // detached entries and malformed blocks.
 func parseWorktreeBlock(block string) (Worktree, bool) {
@@ -142,11 +170,8 @@ func parseWorktreeBlock(block string) (Worktree, bool) {
 	for line := range strings.SplitSeq(block, "\n") {
 		switch {
 		case strings.HasPrefix(line, "worktree "):
-			// git prints forward slashes even on Windows; Clean folds the
-			// path into the platform's native form so it compares equal to
-			// the paths CreateWorktree builds with filepath.Join.
 			if p := strings.TrimPrefix(line, "worktree "); p != "" {
-				wt.Path = filepath.Clean(p)
+				wt.Path = canonicalPath(p)
 			}
 		case strings.HasPrefix(line, "branch refs/heads/"):
 			wt.Name = strings.TrimPrefix(line, "branch refs/heads/")
@@ -223,7 +248,7 @@ func (s *Service) CreateWorktree(projectPath, projectID, name, base string, base
 		return nil, fmt.Errorf("worktree created but unusable: %w", err)
 	}
 	seedWorktree(projectPath, wtPath)
-	return &Worktree{Name: name, Path: wtPath}, nil
+	return &Worktree{Name: name, Path: canonicalPath(wtPath)}, nil
 }
 
 // prHead is the little of a pull request CreateWorktreeFromPR needs: which
@@ -284,7 +309,7 @@ func (s *Service) CreateWorktreeFromPR(projectPath, projectID string, number int
 		return nil, fmt.Errorf("gh pr checkout: %w", err)
 	}
 	seedWorktree(projectPath, wtPath)
-	return &Worktree{Name: head.RefName, Path: wtPath}, nil
+	return &Worktree{Name: head.RefName, Path: canonicalPath(wtPath)}, nil
 }
 
 // RemoveWorktree removes a worktree checkout. Without force git refuses to

--- a/internal/project/worktree_test.go
+++ b/internal/project/worktree_test.go
@@ -93,7 +93,7 @@ func TestListBranches(t *testing.T) {
 		t.Fatalf("Worktrees = %v, want one entry", got.Worktrees)
 	}
 	if got.Worktrees[0].Name != "resume-me" ||
-		canonPath(t, got.Worktrees[0].Path) != canonPath(t, wt.Path) {
+		got.Worktrees[0].Path != wt.Path {
 		t.Errorf("Worktrees = %v, want [{resume-me %s}]", got.Worktrees, wt.Path)
 	}
 	// resume-me is now checked out in a worktree, so it belongs only to the
@@ -106,18 +106,6 @@ func TestListBranches(t *testing.T) {
 	if _, err := svc.ListBranches(t.TempDir()); err == nil {
 		t.Error("ListBranches(non-repo) = nil error, want error")
 	}
-}
-
-// canonPath resolves platform aliasing — Windows 8.3 short names (the CI
-// runner's TEMP), symlinked temp dirs — so a path reported by git and one
-// built by Go compare equal when they name the same directory.
-func canonPath(t *testing.T, p string) string {
-	t.Helper()
-	resolved, err := filepath.EvalSymlinks(p)
-	if err != nil {
-		return filepath.Clean(p)
-	}
-	return resolved
 }
 
 // TestParseWorktrees proves the porcelain parser skips the main worktree and
@@ -166,7 +154,7 @@ func TestCreateWorktree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateWorktree: %v", err)
 	}
-	if want := filepath.Join(data, "lich", "worktrees", "pid", "feat/x"); wt.Path != want {
+	if want := canonicalPath(filepath.Join(data, "lich", "worktrees", "pid", "feat/x")); wt.Path != want {
 		t.Errorf("Path = %q, want %q", wt.Path, want)
 	}
 	if got := svc.Branch(wt.Path); got != "feat/x" {
@@ -373,13 +361,13 @@ func TestCreateWorktreeFromPR(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		want := filepath.Join(data, "lich", "worktrees", "proj", "fix/poll")
+		want := canonicalPath(filepath.Join(data, "lich", "worktrees", "proj", "fix/poll"))
 		if wt.Path != want || wt.Name != "fix/poll" {
 			t.Errorf("worktree = %+v, want name fix/poll at %s", wt, want)
 		}
 		// The checkout has to run inside the new worktree: run in the project it
 		// would move the project's own HEAD instead.
-		if gh.checkoutDir != wt.Path {
+		if canonicalPath(gh.checkoutDir) != wt.Path {
 			t.Errorf("gh pr checkout ran in %q, want %q", gh.checkoutDir, wt.Path)
 		}
 		if gh.viewDir != repo {
@@ -389,7 +377,14 @@ func TestCreateWorktreeFromPR(t *testing.T) {
 		if err != nil || strings.TrimSpace(string(out)) != "fix/poll" {
 			t.Errorf("worktree is not on the head branch: %q (%v)", out, err)
 		}
-		if !strings.Contains(git("worktree", "list"), wt.Path) {
+		// Compared through the same canonical form the product uses: git lists
+		// a worktree by its resolved path and with forward slashes on Windows,
+		// which is never the literal string filepath.Join built.
+		registered := false
+		for _, listed := range parseCheckouts(git("worktree", "list", "--porcelain")) {
+			registered = registered || listed.Path == wt.Path
+		}
+		if !registered {
 			t.Errorf("the worktree is not registered with git: %s", git("worktree", "list"))
 		}
 	})
@@ -522,6 +517,34 @@ func TestCreateWorktreeFromPRRejectsRefName(t *testing.T) {
 	}
 }
 
+// TestCheckoutPathsSurviveASymlink reproduces on any platform what macOS does
+// to every path under /var and Windows to a short name: git reports a checkout
+// by its resolved path while lich builds one by joining names, and the two
+// spellings have to still name one worktree. Without it the session opened on a
+// worktree is never recognised as living in that worktree.
+func TestCheckoutPathsSurviveASymlink(t *testing.T) {
+	target := t.TempDir()
+	link := filepath.Join(t.TempDir(), "data-link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	t.Setenv("XDG_DATA_HOME", link)
+	repo, _ := initRepo(t)
+	svc := &Service{}
+
+	wt, err := svc.CreateWorktree(repo, "proj", "feature", "main", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	checkouts, err := svc.ListCheckouts(repo)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !slices.ContainsFunc(checkouts, func(c Worktree) bool { return c.Path == wt.Path }) {
+		t.Errorf("CreateWorktree returned %q, which is in none of %+v", wt.Path, checkouts)
+	}
+}
+
 // TestListCheckouts proves the main checkout is included — the omission that
 // let "Open in Session" try to check out a branch the project itself held.
 func TestListCheckouts(t *testing.T) {
@@ -566,6 +589,20 @@ func TestListCheckouts(t *testing.T) {
 		}
 		if !slices.ContainsFunc(checkouts, func(c Worktree) bool { return c.Path == wt.Path }) {
 			t.Errorf("the linked worktree's path is missing from %+v", checkouts)
+		}
+	})
+
+	// The caller's own directory comes back spelled the way it was passed in.
+	// git answers with the resolved path, which on macOS and Windows is a
+	// different string for the same directory — and the caller compares what it
+	// gets against the project path it already holds.
+	t.Run("the caller's own path is handed back unchanged", func(t *testing.T) {
+		checkouts, err := svc.ListCheckouts(repo)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !slices.ContainsFunc(checkouts, func(c Worktree) bool { return c.Path == repo }) {
+			t.Errorf("the project's own path is missing from %+v (asked as %q)", checkouts, repo)
 		}
 	})
 


### PR DESCRIPTION
The v0.20.0 tag's release run failed the backend suite on macOS and Windows. The failing assertions were right and the product was wrong.

git reports a worktree by its fully resolved path; lich built one by joining names onto the data dir. Same string on Linux most of the time — not the same string wherever a symlink sits in the way (macOS puts every `/var` and temp path behind one) or where the platform has two spellings for a name (Windows 8.3).

Everything downstream compares those paths for identity: the session living in a worktree, the checkout a PR's branch is already in, whether a checkout is the project's own directory. Under two spellings each of those silently answered no — resuming a kept worktree opened a second one beside it, and **Open in Session** offered to create what was already checked out. Pre-existing, and invisible because the old tests only ever compared *names*.

`ListCheckouts` is the deliberate exception: it hands the caller's own directory back spelled the way the caller named it. A project's path is its identity in the workspace — `projectID` hashes it, every stored session carries it — so resolving it there would break the very comparison the call exists to answer.

A test helper had been quietly papering over this on macOS; it is gone, and the tests now assert through the product's own function.

## Test plan

- [x] `TestCheckoutPathsSurviveASymlink` reproduces the failure on any platform by putting the data dir behind a symlink — **fails without the fix, passes with it** (verified both ways)
- [x] `go test -race ./...` — 443 passed
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] Cross-compile loop for linux/darwin/windows (build + vet)
- [ ] `ci:os` — the backend suite on real Windows and macOS runners, which is what this PR is answering to

🤖 Generated with [Claude Code](https://claude.com/claude-code)