### PR TITLE
feat: pick which GitHub account a project talks to, and approve pull requests from lich

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A project can pick which GitHub account it talks to.** `gh` keeps one active
+  account per host, so a repository only a second account can see answered every
+  pull request lookup with "Could not resolve to a Repository" — the same message
+  GitHub gives for a repository that does not exist. A new **Version Control**
+  section in Settings names the account for the project at hand, chosen from the
+  ones `gh auth status` lists, and every GitHub call lich makes for that project
+  — the badge, the pull request list, checks, diffs, merges and PR checkouts —
+  runs as it. Left at "gh's active account", nothing changes. The account governs
+  what lich reads from GitHub, not what git does: a push still rides the remote's
+  ssh key and signs with the global `user.email`.
+
+### Fixed
+
+- **git failures read as sentences too.** The worktree dialog, the discard flow
+  and the sidebar used to show git's own stderr, prefixed by the subcommand lich
+  had run — `git worktree: fatal: '…' contains modified or untracked files, use
+  --force to delete it`, or, when git refuses by exit status alone, the words
+  `exit status 1`. A rejected branch name now names the branch, a taken name says
+  it is taken, a folder that is not a repository says so, and a dirty worktree
+  says where to remove it. git's own text goes to lich's log.
+- **GitHub failures now read as sentences instead of `gh` output.** The pull
+  request screens used to paste whatever `gh` printed — `GraphQL: Could not
+  resolve to a Repository with the name 'acme/private'. (repository)`, prefixed
+  by the command lich had run. Each failure lich can actually hit now says what
+  happened and what to do about it: an invisible repository points at the account
+  picker, a signed-out `gh` names `gh auth login`, a rate limit says to wait, a
+  refused merge says why. Anything unrecognised says so plainly; `gh`'s own text
+  goes to lich's log, where it was always the more useful place for it.
+- **The pull request badge follows the project's GitHub account too.** It looked
+  the branch's PR up on its own path, so it kept answering as `gh`'s active
+  account while the screen beside it used the project's — a badge that vanished
+  on the repositories the account picker exists for.
+
 ## [0.20.0] - 2026-07-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Approving a pull request no longer means leaving lich.** An Approve button
+  sits beside Merge on the pull request screen and files the approving review
+  through the project's GitHub account. Once the review lands, the button reads
+  Approved and stops offering itself — GitHub would happily take a second one,
+  but nobody means to send it. A pull request that is already merged or closed
+  cannot be reviewed and says so; a draft or a conflicting one still can. GitHub
+  refuses an account approving its own pull request, and that refusal now reads
+  as the sentence it is. Reviews with a body, and requesting changes, are not
+  here: a review comment belongs to the line it is about, and lich has nowhere to
+  attach one yet.
+
 - **A project can pick which GitHub account it talks to.** `gh` keeps one active
   account per host, so a repository only a second account can see answered every
   pull request lookup with "Could not resolve to a Repository" — the same message

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,10 @@ nobody knows it and that the call site never shows. The mechanism and the histor
 
 - **Session cwd is polled** from the PTY child (`internal/terminal/cwd.go`, per-OS readers behind build tags); a
   failed read degrades to the session's start directory. Tracks the direct child only, not nested shells.
+- **A project's gh account governs gh, not git**: `vcs.account` (`internal/project/ghaccount.go`) puts one
+  account's token in `GH_TOKEN` for every gh call lich makes for that project. A push still rides the remote's
+  ssh key and signs with the global `user.email`, so a PR can be *read* by one account and its commits *land*
+  under another, with no error anywhere. Per-worktree `core.sshCommand` + `user.email` is the upgrade path.
 - **git status is polled** — one shared poller per repository path (`frontend/src/lib/git/git-status-store.ts`); the
   lich plugin's `session-touched` hook nudges an immediate refresh. An fs watcher is the upgrade path.
 - **Persistence is hybrid**: UI prefs in the page's localStorage (`lich.*` keys — the reason the listener port is

--- a/frontend/src/components/pulls/Pulls.tsx
+++ b/frontend/src/components/pulls/Pulls.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, type ReactNode } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { toast } from "sonner"
 import {
+  Check,
   ChevronDown,
   ExternalLink,
   GitBranch,
@@ -353,6 +354,7 @@ function PullRequestView({
   onInject,
 }: PullRequestViewProps) {
   const [merging, setMerging] = useState(false)
+  const [approving, setApproving] = useState(false)
   const [edit, setEdit] = useState<EditState | null>(null)
   const [tab, setTab] = useState<"overview" | "commits" | "files" | "checks">("overview")
   const commitCount = detail.commits?.length ?? 0
@@ -377,6 +379,24 @@ function PullRequestView({
       toast.error(`Merge failed: ${errorText(err)}`)
     } finally {
       setMerging(false)
+    }
+  }
+
+  // A draft or a conflicting pull request can still be reviewed — only one that
+  // is already over cannot, which is why this does not reuse the merge gate.
+  const reviewBlocked =
+    detail.state !== "OPEN" ? `Pull request is ${detail.state.toLowerCase()}` : null
+
+  const approve = async () => {
+    setApproving(true)
+    try {
+      await ProjectService.ApprovePullRequest(path, detail.number)
+      toast.success(`Approved #${detail.number}`)
+      onRefresh()
+    } catch (err: unknown) {
+      toast.error(`Approve failed: ${errorText(err)}`)
+    } finally {
+      setApproving(false)
     }
   }
 
@@ -418,6 +438,26 @@ function PullRequestView({
               >
                 <SquareTerminal />
                 {session.busy ? "Opening…" : session.label}
+              </Button>
+            </span>
+            {/* Approving twice is something GitHub allows and nobody means to
+                do, so an approved pull request says so instead of offering it
+                again — the verdict is in ReviewStat below either way. */}
+            <span title={reviewBlocked ?? undefined}>
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={
+                  approving || reviewBlocked !== null || detail.reviewDecision === "APPROVED"
+                }
+                onClick={() => void approve()}
+              >
+                <Check />
+                {approving
+                  ? "Approving…"
+                  : detail.reviewDecision === "APPROVED"
+                    ? "Approved"
+                    : "Approve"}
               </Button>
             </span>
             {/* The reason rides on a wrapper: a disabled button takes no pointer

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -6,6 +6,7 @@ import { HotkeysSettings } from "./HotkeysSettings"
 import { ProvidersSettings } from "./ProvidersSettings"
 import { ProviderBinSettings } from "./ProviderBinSettings"
 import { WorktreeSetupSettings } from "./WorktreeSetupSettings"
+import { VersionControlSettings } from "./VersionControlSettings"
 import { UpdatesSettings } from "./UpdatesSettings"
 import { SearchInput } from "@/components/common/SearchInput"
 import { enabledProviders, useProviders } from "@/lib/providers-store"
@@ -32,6 +33,12 @@ const BASE_SECTIONS: Section[] = [
     label: "Worktree",
     group: "app",
     render: (id) => <WorktreeSetupSettings projectId={id} />,
+  },
+  {
+    id: "version-control",
+    label: "Version Control",
+    group: "app",
+    render: (id) => <VersionControlSettings projectId={id} />,
   },
   { id: "updates", label: "Updates", group: "app", render: () => <UpdatesSettings /> },
 ]

--- a/frontend/src/components/settings/VersionControlSettings.tsx
+++ b/frontend/src/components/settings/VersionControlSettings.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from "react"
+import { ProjectService, Store } from "@/lib/rpc"
+import { invalidatePullRequests } from "@/lib/pulls/pull-request-lookup"
+import { useProjects } from "@/providers/projects"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { SettingBlock } from "./SettingBlock"
+
+// Same key the Go store resolves (internal/store ghAccountKey).
+export const GH_ACCOUNT_KEY = "vcs.account"
+
+// The stored value for "no override" is "", which a Select item cannot carry —
+// this stands in for it in the picker only.
+const ACTIVE_ACCOUNT = "__active__"
+
+// VersionControlSettings picks which authenticated GitHub account lich's gh
+// calls run as for this project. gh keeps one active account per host, so a
+// repository only one of your accounts can see reads as "not found" until the
+// project names that account. Project-scoped: naming one globally would be the
+// same trap in the other direction.
+export function VersionControlSettings({ projectId }: { projectId?: string }) {
+  const { projects } = useProjects()
+  const project = projects.find((p) => p.id === projectId)
+  const [accounts, setAccounts] = useState<string[]>([])
+  const [account, setAccount] = useState("")
+  const [error, setError] = useState("")
+
+  useEffect(() => {
+    void ProjectService.GitHubAccounts()
+      .then((list) => {
+        setAccounts(list ?? [])
+        setError("")
+      })
+      .catch((err: unknown) => setError(err instanceof Error ? err.message : String(err)))
+  }, [])
+
+  useEffect(() => {
+    if (!projectId) {
+      return
+    }
+    void Store.GetSetting(GH_ACCOUNT_KEY, projectId).then(setAccount)
+  }, [projectId])
+
+  const persist = (value: string) => {
+    const login = value === ACTIVE_ACCOUNT ? "" : value
+    setAccount(login)
+    if (projectId) {
+      void Store.SetSetting(GH_ACCOUNT_KEY, projectId, login).then(invalidatePullRequests)
+    }
+  }
+
+  if (!project) {
+    return (
+      <p className="py-4 text-sm text-muted-foreground">
+        Open a project to configure its version control.
+      </p>
+    )
+  }
+
+  // The configured account survives a gh that no longer lists it, so a stale
+  // value is visible (and changeable) instead of silently reading as default.
+  const options = Array.from(new Set([...accounts, ...(account ? [account] : [])]))
+
+  return (
+    <SettingBlock
+      title={`GitHub account for ${project.name}`}
+      description={
+        "Which account lich runs gh as for this project — pull requests, checks and PR checkouts. " +
+        "gh keeps one active account per host, so a repository only another account can see reads " +
+        "as not found. Pushes are unaffected: they still ride the remote's ssh key and the git " +
+        "user.email."
+      }
+    >
+      <p className="mb-2 text-xs text-muted-foreground">{project.path}</p>
+      <Select value={account || ACTIVE_ACCOUNT} onValueChange={(value) => value && persist(value)}>
+        <SelectTrigger className="w-72">
+          <SelectValue placeholder="Select an account" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectItem value={ACTIVE_ACCOUNT}>gh's active account</SelectItem>
+            {options.map((login) => (
+              <SelectItem key={login} value={login}>
+                {login}
+              </SelectItem>
+            ))}
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+      {error && (
+        <p className="mt-2 text-xs text-destructive">
+          Could not list GitHub accounts: {error}. Run `gh auth login` to authenticate.
+        </p>
+      )}
+    </SettingBlock>
+  )
+}

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -143,6 +143,10 @@ export const ProjectService = {
     subject: string,
     body: string,
   ) => call<null>("project.MergePullRequest", [path, number, method, subject, body]),
+  /** Submit an approving review (0 = the checkout's branch). GitHub refuses a
+   * PR opened by the same account. */
+  ApprovePullRequest: (path: string, number: number) =>
+    call<null>("project.ApprovePullRequest", [path, number]),
   /** Open GitHub's "new pull request" page in the browser (gh pr create --web). */
   CreatePullRequest: (path: string) => call<null>("project.CreatePullRequest", [path]),
   /** A PR's unified diff (gh pr diff) for the Files changed tab; 0 = the checkout's branch. */

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -121,6 +121,9 @@ export const ProjectService = {
   ReadFile: (path: string, rel: string) => call<string>("project.ReadFile", [path, rel]),
   DiscardFile: (path: string, rel: string) => call<null>("project.DiscardFile", [path, rel]),
   ListBranches: (path: string) => call<Branches>("project.ListBranches", [path]),
+  /** The logins gh is authenticated as, for the project's account picker;
+   * errors when gh is missing or logged out. */
+  GitHubAccounts: () => call<string[] | null>("project.GitHubAccounts", []),
   /** Every checkout holding a branch, the project's own directory included —
    * which ListBranches omits, since it cannot be resumed as a worktree. */
   ListCheckouts: (path: string) => call<Worktree[] | null>("project.ListCheckouts", [path]),

--- a/internal/project/ghaccount.go
+++ b/internal/project/ghaccount.go
@@ -28,7 +28,16 @@ func (s *Service) SetAccounts(lookup accountLookup) {
 // gh runs one gh subcommand for the checkout at dir, as the account that
 // checkout's project selected.
 func (s *Service) gh(timeout time.Duration, dir string, args ...string) ([]byte, error) {
-	return s.runner(timeout, dir, s.tokenFor(dir), args...)
+	return s.ghFor(dir, timeout, dir, args...)
+}
+
+// ghFor runs a gh subcommand inside dir as the account resolved for accountDir.
+// The two differ whenever gh has to run inside a checkout the store has never
+// seen — a worktree created moments ago has no session row yet, so asking it
+// which account to use would answer "none" and silently fall back to gh's
+// active one, which is the whole failure this feature exists to prevent.
+func (s *Service) ghFor(accountDir string, timeout time.Duration, dir string, args ...string) ([]byte, error) {
+	return s.runner(timeout, dir, s.tokenFor(accountDir), args...)
 }
 
 // tokenFor resolves the token of the account the checkout's project selected.

--- a/internal/project/ghaccount.go
+++ b/internal/project/ghaccount.go
@@ -1,0 +1,87 @@
+package project
+
+import (
+	"regexp"
+	"strings"
+	"time"
+)
+
+// gh authenticates one active account per host, globally. lich works across
+// repositories that answer to different accounts, so a project picks the
+// account its gh calls run as: the login is stored per project (the store's
+// "vcs.account"), turned into a token here, and passed to every gh call.
+//
+// The account only governs what lich asks gh. It does not govern git: a push
+// still rides the remote's ssh key and signs with the global user.email.
+const ghAccountTimeout = 5 * time.Second
+
+// accountLookup resolves the gh account login for the checkout at path, or ""
+// for "whatever account gh has active".
+type accountLookup func(path string) string
+
+// SetAccounts wires the per-project account resolution. Left unset, every gh
+// call runs as gh's active account — lich's behaviour before this existed.
+func (s *Service) SetAccounts(lookup accountLookup) {
+	s.accounts = lookup
+}
+
+// gh runs one gh subcommand for the checkout at dir, as the account that
+// checkout's project selected.
+func (s *Service) gh(timeout time.Duration, dir string, args ...string) ([]byte, error) {
+	return s.runner(timeout, dir, s.tokenFor(dir), args...)
+}
+
+// tokenFor resolves the token of the account the checkout's project selected.
+// Anything that fails — no project, no account, gh not authenticated as it —
+// yields "", which runs the call as gh's active account rather than failing it.
+//
+// Ceiling: one extra `gh auth token` per gh call. The tokens are short-lived
+// and gh owns their refresh, so caching them here would mean owning the
+// invalidation too; cache only if the Pulls screen ever feels it.
+func (s *Service) tokenFor(dir string) string {
+	if s.accounts == nil {
+		return ""
+	}
+	login := s.accounts(dir)
+	if login == "" {
+		return ""
+	}
+	out, err := s.runner(ghAccountTimeout, dir, "", "auth", "token", "--user", login)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// ghAccountLine matches one authenticated account in `gh auth status` output:
+// "✓ Logged in to github.com account omartelo (keyring)". Anchored on the
+// whole phrase because the same output repeats the word "account" in the
+// "Active account: true" line below it.
+var ghAccountLine = regexp.MustCompile(`Logged in to \S+ account (\S+)`)
+
+// GitHubAccounts lists the logins gh is authenticated as, in gh's own order
+// (the host's active account first). It backs the account picker in the
+// project's Version Control settings; an unauthenticated gh yields an error,
+// which the picker shows instead of an empty list.
+func (s *Service) GitHubAccounts() ([]string, error) {
+	out, err := s.runner(ghAccountTimeout, "", "", "auth", "status")
+	if err != nil {
+		return nil, err
+	}
+	return parseGHAccounts(string(out)), nil
+}
+
+// parseGHAccounts pulls the logins out of `gh auth status`. Deliberately
+// tolerant: an unparseable line is skipped, so a future gh reword degrades to a
+// shorter list (the account stays configurable by hand) rather than an error.
+func parseGHAccounts(out string) []string {
+	matches := ghAccountLine.FindAllStringSubmatch(out, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	logins := make([]string, 0, len(matches))
+	for _, m := range matches {
+		logins = append(logins, m[1])
+	}
+	return logins
+}

--- a/internal/project/ghaccount_test.go
+++ b/internal/project/ghaccount_test.go
@@ -1,0 +1,147 @@
+package project
+
+import (
+	"slices"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseGHAccounts(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want []string
+	}{
+		{
+			"two accounts on one host, active first",
+			"github.com\n" +
+				"  ✓ Logged in to github.com account omartelo (keyring)\n" +
+				"  - Active account: true\n" +
+				"  - Token scopes: 'gist', 'read:org', 'repo'\n\n" +
+				"  ✓ Logged in to github.com account marcelo-filho_snk (keyring)\n" +
+				"  - Active account: false\n",
+			[]string{"omartelo", "marcelo-filho_snk"},
+		},
+		{
+			"a second host contributes its own accounts",
+			"github.com\n  ✓ Logged in to github.com account omartelo (keyring)\n" +
+				"ghe.example.com\n  ✓ Logged in to ghe.example.com account work-login (keyring)\n",
+			[]string{"omartelo", "work-login"},
+		},
+		{"not logged in", "You are not logged into any GitHub hosts.\n", nil},
+		{"empty", "", nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseGHAccounts(tt.out); !slices.Equal(got, tt.want) {
+				t.Errorf("parseGHAccounts() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGitHubAccounts(t *testing.T) {
+	gh := &fakeGH{out: []byte("  ✓ Logged in to github.com account omartelo (keyring)\n")}
+	got, err := withGH(gh).GitHubAccounts()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !slices.Equal(got, []string{"omartelo"}) {
+		t.Errorf("GitHubAccounts() = %v, want [omartelo]", got)
+	}
+	if want := "auth status"; strings.Join(gh.args, " ") != want {
+		t.Errorf("ran %q, want %q", strings.Join(gh.args, " "), want)
+	}
+
+	gh = &fakeGH{err: errTest}
+	if _, err := withGH(gh).GitHubAccounts(); err == nil {
+		t.Error("unauthenticated gh = nil error, want the failure surfaced")
+	}
+}
+
+// TestAccountTokenReachesGH proves the configured account governs the gh call:
+// its token is resolved once and carried by the pull request lookup.
+func TestAccountTokenReachesGH(t *testing.T) {
+	var seen []string
+	gh := &accountGH{token: "gho_secret", pr: `{"number":7,"state":"OPEN"}`, calls: &seen}
+	svc := &Service{runner: gh.run}
+	svc.SetAccounts(func(string) string { return "marcelo-filho_snk" })
+
+	pr, err := svc.PullRequestDetail("/repo", 0)
+	if err != nil || pr == nil {
+		t.Fatalf("PullRequestDetail = (%v, %v), want the PR", pr, err)
+	}
+	if gh.viewToken != "gho_secret" {
+		t.Errorf("pr view ran with token %q, want the configured account's", gh.viewToken)
+	}
+	if want := "auth token --user marcelo-filho_snk"; !slices.Contains(seen, want) {
+		t.Errorf("calls = %v, want one resolving the account (%q)", seen, want)
+	}
+}
+
+// TestNoAccountRunsAsActive proves both no-override paths run gh with no token,
+// which is gh answering as its own active account.
+func TestNoAccountRunsAsActive(t *testing.T) {
+	tests := []struct {
+		name    string
+		lookup  accountLookup
+		wantGet int
+	}{
+		{"no lookup wired", nil, 1},
+		{"lookup returns no account", func(string) string { return "" }, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gh := &fakeGH{out: []byte(`{"number":7,"state":"OPEN"}`)}
+			svc := &Service{runner: gh.run, accounts: tt.lookup}
+			if _, err := svc.PullRequestDetail("/repo", 0); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if gh.token != "" {
+				t.Errorf("token = %q, want empty (gh's active account)", gh.token)
+			}
+			if gh.calls != tt.wantGet {
+				t.Errorf("gh calls = %d, want %d (no token lookup)", gh.calls, tt.wantGet)
+			}
+		})
+	}
+}
+
+// TestAccountTokenFailureFallsBack proves a token that cannot be resolved (gh
+// is not authenticated as that account anymore) degrades to the active account
+// instead of failing the lookup.
+func TestAccountTokenFailureFallsBack(t *testing.T) {
+	gh := &accountGH{tokenErr: errTest, pr: `{"number":7,"state":"OPEN"}`}
+	svc := &Service{runner: gh.run}
+	svc.SetAccounts(func(string) string { return "gone" })
+
+	pr, err := svc.PullRequestDetail("/repo", 0)
+	if err != nil || pr == nil {
+		t.Fatalf("PullRequestDetail = (%v, %v), want the PR", pr, err)
+	}
+	if gh.viewToken != "" {
+		t.Errorf("token = %q, want empty after the lookup failed", gh.viewToken)
+	}
+}
+
+// accountGH answers `auth token` with a token (or an error) and every other
+// subcommand with the canned pull request, recording the token each one ran as.
+type accountGH struct {
+	token     string
+	tokenErr  error
+	pr        string
+	viewToken string
+	calls     *[]string
+}
+
+func (g *accountGH) run(_ time.Duration, _, token string, args ...string) ([]byte, error) {
+	if g.calls != nil {
+		*g.calls = append(*g.calls, strings.Join(args, " "))
+	}
+	if len(args) > 1 && args[0] == "auth" && args[1] == "token" {
+		return []byte(g.token + "\n"), g.tokenErr
+	}
+	g.viewToken = token
+	return []byte(g.pr), nil
+}

--- a/internal/project/gherror.go
+++ b/internal/project/gherror.go
@@ -1,0 +1,62 @@
+package project
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+)
+
+// ghFailure turns one failed gh call into the message the screen shows. See
+// toolerror.go for why the raw stderr never travels with it.
+func ghFailure(args []string, stderr string, runErr, ctxErr error) error {
+	logToolFailure("gh", args, stderr, runErr)
+	return errors.New(ghMessage(stderr, runErr, ctxErr))
+}
+
+// errUnreadableAnswer covers gh answering with something this build cannot
+// decode — a field it renamed, a broken pipe mid-JSON. The decoder's own text
+// names Go types, so it goes to the log like the rest.
+//
+// The messages here are sentences on purpose (capitalised, punctuated): they
+// are read by a person on screen, not appended to another Go error.
+func errUnreadableAnswer(err error) error {
+	slog.Warn("gh answer could not be decoded", "err", err)
+	return errors.New("GitHub's answer could not be read.")
+}
+
+// ghFailures maps what gh reports onto what the person reading the screen can
+// do about it.
+var ghFailures = []toolFailure{
+	{
+		"could not resolve to a repository",
+		"GitHub does not show this repository to the account lich is using here. " +
+			"Choose the account that can see it in Settings → Version Control.",
+	},
+	{"could not resolve to a pullrequest", "GitHub has no pull request with that number."},
+	{"gh auth login", "gh is not signed in to GitHub. Run `gh auth login` in a terminal."},
+	{"not logged into", "gh is not signed in to GitHub. Run `gh auth login` in a terminal."},
+	{"api rate limit exceeded", "GitHub is rate-limiting this account. Try again in a few minutes."},
+	{"none of the git remotes", "This checkout's git remotes do not point at GitHub."},
+	{"no git remotes found", "This checkout has no git remote to look up on GitHub."},
+	{"not a git repository", "This folder is not a git repository."},
+	{"not mergeable", "GitHub will not merge this pull request yet — it has conflicts or an unmet requirement."},
+	{"protected branch", "A branch protection rule on GitHub blocks this merge."},
+	{"required status check", "GitHub requires a status check that has not passed yet."},
+	{"review required", "GitHub requires a review before this pull request can merge."},
+}
+
+// ghMessage picks the message for one gh failure. Anything unrecognised — a new
+// gh wording, a forge error lich has never hit — falls back to a plain sentence
+// that points at the log rather than pasting gh's own words on screen.
+func ghMessage(stderr string, runErr, ctxErr error) string {
+	if errors.Is(ctxErr, context.DeadlineExceeded) {
+		return "GitHub did not answer in time. Check the connection and try again."
+	}
+	if missingTool(stderr, runErr) {
+		return "The GitHub CLI (gh) is not installed."
+	}
+	if message, ok := matchFailure(ghFailures, stderr); ok {
+		return message
+	}
+	return "gh could not complete the request. lich's log has what it reported."
+}

--- a/internal/project/gherror.go
+++ b/internal/project/gherror.go
@@ -33,6 +33,11 @@ var ghFailures = []toolFailure{
 			"Choose the account that can see it in Settings → Version Control.",
 	},
 	{"could not resolve to a pullrequest", "GitHub has no pull request with that number."},
+	{
+		"can not approve your own pull request",
+		"GitHub does not let an account approve its own pull request — this one was opened by the " +
+			"account lich is using here.",
+	},
 	{"gh auth login", "gh is not signed in to GitHub. Run `gh auth login` in a terminal."},
 	{"not logged into", "gh is not signed in to GitHub. Run `gh auth login` in a terminal."},
 	{"api rate limit exceeded", "GitHub is rate-limiting this account. Try again in a few minutes."},

--- a/internal/project/gherror_test.go
+++ b/internal/project/gherror_test.go
@@ -33,6 +33,13 @@ func TestGHMessage(t *testing.T) {
 			"GitHub has no pull request with that number.",
 		},
 		{
+			"approving your own pull request",
+			"failed to create review: GraphQL: Review Can not approve your own pull request (addPullRequestReview)",
+			errTest, nil,
+			"GitHub does not let an account approve its own pull request — this one was opened by the " +
+				"account lich is using here.",
+		},
+		{
 			"logged out",
 			"To get started with GitHub CLI, please run: gh auth login",
 			errTest, nil,

--- a/internal/project/gherror_test.go
+++ b/internal/project/gherror_test.go
@@ -1,0 +1,117 @@
+package project
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestGHMessage pins the contract the pull request screen depends on: every
+// failure comes back as a sentence about what happened, and gh's own words are
+// never part of it.
+func TestGHMessage(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+		runErr error
+		ctxErr error
+		want   string
+	}{
+		{
+			"a repository the account cannot see points at the account picker",
+			"GraphQL: Could not resolve to a Repository with the name 'acme/private'. (repository)",
+			errTest, nil,
+			"GitHub does not show this repository to the account lich is using here. " +
+				"Choose the account that can see it in Settings → Version Control.",
+		},
+		{
+			"a missing pull request is not the same failure",
+			"GraphQL: Could not resolve to a PullRequest with the number 9999.",
+			errTest, nil,
+			"GitHub has no pull request with that number.",
+		},
+		{
+			"logged out",
+			"To get started with GitHub CLI, please run: gh auth login",
+			errTest, nil,
+			"gh is not signed in to GitHub. Run `gh auth login` in a terminal.",
+		},
+		{
+			"rate limited",
+			"HTTP 403: API rate limit exceeded for user ID 42.",
+			errTest, nil,
+			"GitHub is rate-limiting this account. Try again in a few minutes.",
+		},
+		{
+			"no GitHub remote",
+			"none of the git remotes configured for this repository point to a known GitHub host",
+			errTest, nil,
+			"This checkout's git remotes do not point at GitHub.",
+		},
+		{
+			"an unmergeable pull request",
+			"Pull request is not mergeable: the merge commit cannot be cleanly created.",
+			errTest, nil,
+			"GitHub will not merge this pull request yet — it has conflicts or an unmet requirement.",
+		},
+		{
+			"gh missing, reported by exec",
+			"", &exec.Error{Name: "gh", Err: exec.ErrNotFound}, nil,
+			"The GitHub CLI (gh) is not installed.",
+		},
+		{
+			"a timeout beats whatever the killed process wrote",
+			"signal: killed", errTest, context.DeadlineExceeded,
+			"GitHub did not answer in time. Check the connection and try again.",
+		},
+		{
+			"an unknown failure never quotes gh",
+			"GraphQL: something lich has never seen (field)",
+			errTest, nil,
+			"gh could not complete the request. lich's log has what it reported.",
+		},
+		{
+			"an empty stderr still says something",
+			"", errTest, nil,
+			"gh could not complete the request. lich's log has what it reported.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ghMessage(tt.stderr, tt.runErr, tt.ctxErr)
+			if got != tt.want {
+				t.Errorf("ghMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGHMessageLeaksNothing is the rule itself rather than one case of it: no
+// message may carry gh's vocabulary onto the screen.
+func TestGHMessageLeaksNothing(t *testing.T) {
+	leaks := []string{"graphql", "stderr", "exit status", "http 4", "http 5", "gh: "}
+	stderrs := []string{
+		"GraphQL: Could not resolve to a Repository with the name 'acme/private'. (repository)",
+		"HTTP 403: API rate limit exceeded for user ID 42.",
+		"gh: command not found",
+		"exit status 1",
+		"",
+	}
+	for _, stderr := range stderrs {
+		got := strings.ToLower(ghMessage(stderr, errTest, nil))
+		for _, leak := range leaks {
+			if strings.Contains(got, leak) {
+				t.Errorf("ghMessage(%q) = %q, which leaks %q", stderr, got, leak)
+			}
+		}
+	}
+}
+
+func TestErrUnreadableAnswer(t *testing.T) {
+	err := errUnreadableAnswer(errors.New("invalid character 'n' looking for beginning of value"))
+	if want := "GitHub's answer could not be read."; err.Error() != want {
+		t.Errorf("errUnreadableAnswer() = %q, want %q", err, want)
+	}
+}

--- a/internal/project/giterror.go
+++ b/internal/project/giterror.go
@@ -1,0 +1,47 @@
+package project
+
+import "errors"
+
+// gitFailure turns one failed git call into the message the screen shows. See
+// toolerror.go for why git's own stderr never travels with it.
+func gitFailure(args []string, stderr string, runErr error) error {
+	logToolFailure("git", args, stderr, runErr)
+	return errors.New(gitMessage(stderr, runErr))
+}
+
+// gitFailures maps what git reports onto what the person reading the screen can
+// do about it. Only the failures lich's own flows can produce are here — the
+// worktree lifecycle, a discard, a read of a folder that turned out not to be a
+// repository.
+var gitFailures = []toolFailure{
+	{"not a git repository", "This folder is not a git repository."},
+	{"already exists", "A branch or worktree with that name already exists."},
+	{"is already checked out", "That branch is already checked out in another worktree."},
+	{
+		"contains modified or untracked files",
+		"That worktree has uncommitted changes. Remove it from the sidebar to discard them.",
+	},
+	{"is locked", "git has that worktree locked."},
+	{"is not a working tree", "git no longer knows that worktree — it may already be gone."},
+	{"couldn't find remote ref", "That branch is no longer on the remote."},
+	{"could not read from remote repository", "The remote refused the connection — check its ssh key or credentials."},
+	{"authentication failed", "The remote refused the connection — check its ssh key or credentials."},
+	{"permission denied (publickey)", "The remote refused the connection — check its ssh key or credentials."},
+	{"does not appear to be a git repository", "That remote could not be reached."},
+	{"did not match any file", "git does not track that file."},
+	{"unknown revision", "git does not know that branch or commit."},
+	{"permission denied", "The filesystem refused the change."},
+}
+
+// gitMessage picks the message for one git failure. git also fails with nothing
+// on stderr at all — `check-ref-format` rejects a branch name by exit status
+// alone — which is why the fallback never quotes the process error either.
+func gitMessage(stderr string, runErr error) string {
+	if missingTool(stderr, runErr) {
+		return "git is not installed."
+	}
+	if message, ok := matchFailure(gitFailures, stderr); ok {
+		return message
+	}
+	return "git could not complete the operation. lich's log has what it reported."
+}

--- a/internal/project/giterror_test.go
+++ b/internal/project/giterror_test.go
@@ -1,0 +1,119 @@
+package project
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestGitMessage(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+		runErr error
+		want   string
+	}{
+		{
+			"a folder that is not a repository",
+			"fatal: not a git repository (or any of the parent directories): .git",
+			errTest,
+			"This folder is not a git repository.",
+		},
+		{
+			"a branch that is taken",
+			"fatal: a branch named 'fix/poll' already exists",
+			errTest,
+			"A branch or worktree with that name already exists.",
+		},
+		{
+			"a branch checked out elsewhere",
+			"fatal: 'fix/poll' is already checked out at '/data/worktrees/p/fix'",
+			errTest,
+			"That branch is already checked out in another worktree.",
+		},
+		{
+			"a dirty worktree git refuses to remove",
+			"fatal: '/data/worktrees/p/fix' contains modified or untracked files, use --force to delete it",
+			errTest,
+			"That worktree has uncommitted changes. Remove it from the sidebar to discard them.",
+		},
+		{
+			"a remote that rejected the key",
+			"git@github.com: Permission denied (publickey).\nfatal: Could not read from remote repository.",
+			errTest,
+			"The remote refused the connection — check its ssh key or credentials.",
+		},
+		{
+			"a remote branch that is gone",
+			"fatal: couldn't find remote ref feature/old",
+			errTest,
+			"That branch is no longer on the remote.",
+		},
+		{
+			"a worktree git has no registration for",
+			"fatal: '/data/worktrees/p/gone' is not a working tree",
+			errTest,
+			"git no longer knows that worktree — it may already be gone.",
+		},
+		{
+			"a path git does not track",
+			"error: pathspec 'nope.txt' did not match any file(s) known to git",
+			errTest,
+			"git does not track that file.",
+		},
+		{
+			"git missing",
+			"", &exec.Error{Name: "git", Err: exec.ErrNotFound},
+			"git is not installed.",
+		},
+		{
+			// check-ref-format's own refusal: exit status, nothing on stderr.
+			"a refusal with nothing on stderr",
+			"", errTest,
+			"git could not complete the operation. lich's log has what it reported.",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gitMessage(tt.stderr, tt.runErr); got != tt.want {
+				t.Errorf("gitMessage() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGitMessageLeaksNothing is the rule rather than one case of it: git's own
+// vocabulary never reaches the screen.
+func TestGitMessageLeaksNothing(t *testing.T) {
+	leaks := []string{"fatal:", "error:", "exit status", "usage:", "hint:", "--force"}
+	stderrs := []string{
+		"fatal: not a git repository (or any of the parent directories): .git",
+		"fatal: '/data/wt' contains modified or untracked files, use --force to delete it",
+		"error: pathspec 'nope.txt' did not match any file(s) known to git",
+		"hint: Updates were rejected because the tip of your current branch is behind",
+		"",
+	}
+	for _, stderr := range stderrs {
+		got := strings.ToLower(gitMessage(stderr, errTest))
+		for _, leak := range leaks {
+			if strings.Contains(got, leak) {
+				t.Errorf("gitMessage(%q) = %q, which leaks %q", stderr, got, leak)
+			}
+		}
+	}
+}
+
+// TestRunGitMessage runs the real git against a directory that is not a
+// repository: the whole path, from stderr to the sentence the screen shows.
+func TestRunGitMessage(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable")
+	}
+	_, err := runGit(t.TempDir(), "status", "--porcelain")
+	if err == nil {
+		t.Fatal("runGit(non-repo) = nil error, want a failure")
+	}
+	if want := "This folder is not a git repository."; err.Error() != want {
+		t.Errorf("runGit error = %q, want %q", err, want)
+	}
+}

--- a/internal/project/pr.go
+++ b/internal/project/pr.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"sort"
 	"strconv"
@@ -27,10 +28,11 @@ const (
 	prCheckoutTimeout = 90 * time.Second
 )
 
-// ghRunner runs one gh subcommand inside dir and returns its stdout. It is a
-// field on Service so the pull request flows can be exercised without a GitHub
-// remote; production wiring is runGH.
-type ghRunner func(timeout time.Duration, dir string, args ...string) ([]byte, error)
+// ghRunner runs one gh subcommand inside dir as the account token (empty: gh's
+// own active account) and returns its stdout. It is a field on Service so the
+// pull request flows can be exercised without a GitHub remote; production
+// wiring is runGH.
+type ghRunner func(timeout time.Duration, dir, token string, args ...string) ([]byte, error)
 
 // errNoPullRequest marks gh's "no pull requests found" — the one failure that
 // means the branch simply has no PR, which the read flows turn into an empty
@@ -38,13 +40,17 @@ type ghRunner func(timeout time.Duration, dir string, args ...string) ([]byte, e
 var errNoPullRequest = errors.New("no pull request for this branch")
 
 // runGH shells out to gh with the call capped by timeout, and turns a failure
-// into an error carrying gh's own stderr (it names the cause — not mergeable,
-// branch protection, auth, missing repo).
-func runGH(timeout time.Duration, dir string, args ...string) ([]byte, error) {
+// into the message the screen shows (gherror.go); gh's own stderr reaches the
+// log, never the page. A non-empty token rides in GH_TOKEN, which is how gh is
+// told to answer as one specific account.
+func runGH(timeout time.Duration, dir, token string, args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "gh", args...)
 	cmd.Dir = dir
+	if token != "" {
+		cmd.Env = append(os.Environ(), "GH_TOKEN="+token)
+	}
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	winexec.Hide(cmd)
@@ -53,7 +59,7 @@ func runGH(timeout time.Duration, dir string, args ...string) ([]byte, error) {
 		if isNoPullRequest(stderr.String()) {
 			return nil, errNoPullRequest
 		}
-		return nil, errors.New(ghError(stderr.String(), err))
+		return nil, ghFailure(args, stderr.String(), err, ctx.Err())
 	}
 	return out, nil
 }
@@ -208,7 +214,7 @@ func (s *Service) PullRequestDetail(path string, number int) (*PRDetail, error) 
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("gh pr view: %w", err)
+		return nil, err
 	}
 	// The OPEN-only gate belongs to the branch lookup alone. Naming a number is
 	// asking for that pull request, whatever became of it — the list can show
@@ -223,7 +229,7 @@ func (s *Service) PullRequestDetail(path string, number int) (*PRDetail, error) 
 func parsePRDetail(out []byte, openOnly bool) (*PRDetail, error) {
 	var v ghPRView
 	if err := json.Unmarshal(out, &v); err != nil {
-		return nil, fmt.Errorf("decode gh pr view: %w", err)
+		return nil, errUnreadableAnswer(err)
 	}
 	if v.Number == 0 || (openOnly && v.State != "OPEN") {
 		return nil, nil
@@ -382,7 +388,7 @@ func (s *Service) MergePullRequest(path string, number int, method, subject, bod
 		return err
 	}
 	if _, err := s.gh(prMergeTimeout, path, args...); err != nil {
-		return fmt.Errorf("gh pr merge: %w", err)
+		return err
 	}
 	return nil
 }
@@ -410,7 +416,7 @@ func mergeArgs(number int, method, subject, body string) ([]string, error) {
 // title, body, reviewers and template. Returns once the browser is launched.
 func (s *Service) CreatePullRequest(path string) error {
 	if _, err := s.gh(prCreateTimeout, path, "pr", "create", "--web"); err != nil {
-		return fmt.Errorf("gh pr create: %w", err)
+		return err
 	}
 	return nil
 }
@@ -431,7 +437,7 @@ func (s *Service) PullRequestDiff(path string, number int) (string, error) {
 		return "", nil
 	}
 	if err != nil {
-		return "", fmt.Errorf("gh pr diff: %w", err)
+		return "", err
 	}
 	return string(out), nil
 }
@@ -511,7 +517,7 @@ func (s *Service) ListPullRequests(path, state string) ([]PRSummary, error) {
 	out, err := s.gh(prReadTimeout, path,
 		"pr", "list", "--state", state, "--limit", strconv.Itoa(prListLimit), "--json", prListFields)
 	if err != nil {
-		return nil, fmt.Errorf("gh pr list: %w", err)
+		return nil, err
 	}
 	return parsePRList(out)
 }
@@ -520,7 +526,7 @@ func (s *Service) ListPullRequests(path, state string) ([]PRSummary, error) {
 func parsePRList(out []byte) ([]PRSummary, error) {
 	var items []ghPRListItem
 	if err := json.Unmarshal(out, &items); err != nil {
-		return nil, fmt.Errorf("decode gh pr list: %w", err)
+		return nil, errUnreadableAnswer(err)
 	}
 	if len(items) == 0 {
 		return nil, nil
@@ -547,13 +553,4 @@ func parsePRList(out []byte) ([]PRSummary, error) {
 // failure that means an empty panel rather than a real error.
 func isNoPullRequest(stderr string) bool {
 	return strings.Contains(strings.ToLower(stderr), "no pull requests found")
-}
-
-// ghError prefers gh's own stderr (it names the cause — not mergeable, auth,
-// missing repo) and falls back to the bare exec error when stderr is empty.
-func ghError(stderr string, err error) string {
-	if msg := strings.TrimSpace(stderr); msg != "" {
-		return msg
-	}
-	return err.Error()
 }

--- a/internal/project/pr.go
+++ b/internal/project/pr.go
@@ -23,6 +23,7 @@ const (
 	prReadTimeout   = 8 * time.Second
 	prMergeTimeout  = 30 * time.Second
 	prCreateTimeout = 20 * time.Second
+	prReviewTimeout = 20 * time.Second
 	// A checkout fetches the head ref, so it is bounded by the size of the
 	// branch rather than by a round-trip.
 	prCheckoutTimeout = 90 * time.Second
@@ -408,6 +409,21 @@ func mergeArgs(number int, method, subject, body string) ([]string, error) {
 		args = append(args, "--subject", subject, "--body", body)
 	}
 	return args, nil
+}
+
+// ApprovePullRequest submits an approving review on GitHub — the given number,
+// or the PR of the branch checked out at path when number is zero. The review is
+// filed by whichever account the project talks to (ghaccount.go), which is also
+// why GitHub can refuse it: nobody may approve their own pull request.
+//
+// Deliberately no review body: a comment belongs to the line it is about, and
+// the screen has no diff-commenting surface to attach one to. Approve is the
+// verdict, nothing more.
+func (s *Service) ApprovePullRequest(path string, number int) error {
+	if _, err := s.gh(prReviewTimeout, path, prArgs("review", number, "--approve")...); err != nil {
+		return err
+	}
+	return nil
 }
 
 // CreatePullRequest opens GitHub's "new pull request" page in the browser for

--- a/internal/project/pr_test.go
+++ b/internal/project/pr_test.go
@@ -352,14 +352,8 @@ func TestIsNoPullRequest(t *testing.T) {
 	}
 }
 
-func TestGhError(t *testing.T) {
-	if got := ghError("  boom  ", errTest); got != "boom" {
-		t.Errorf("stderr should win and be trimmed, got %q", got)
-	}
-	if got := ghError("   ", errTest); got != "sentinel" {
-		t.Errorf("empty stderr should fall back to the error, got %q", got)
-	}
-}
+// ghError's contract moved to gherror.go: gh's stderr no longer reaches the
+// caller at all. TestGHMessage covers what replaced it.
 
 // errTest is a fixed error for ghError's fallback branch.
 var errTest = testError("sentinel")
@@ -377,17 +371,18 @@ type fakeGH struct {
 	calls   int
 	timeout time.Duration
 	dir     string
+	token   string
 	args    []string
 }
 
-func (f *fakeGH) run(timeout time.Duration, dir string, args ...string) ([]byte, error) {
+func (f *fakeGH) run(timeout time.Duration, dir, token string, args ...string) ([]byte, error) {
 	f.calls++
-	f.timeout, f.dir, f.args = timeout, dir, args
+	f.timeout, f.dir, f.token, f.args = timeout, dir, token, args
 	return f.out, f.err
 }
 
 // withGH builds a Service whose gh calls land on the fake instead of the CLI.
-func withGH(f *fakeGH) *Service { return &Service{gh: f.run} }
+func withGH(f *fakeGH) *Service { return &Service{runner: f.run} }
 
 func TestPullRequestDetailFlow(t *testing.T) {
 	t.Run("open PR decodes, scoped to the path", func(t *testing.T) {
@@ -420,14 +415,17 @@ func TestPullRequestDetailFlow(t *testing.T) {
 		}
 	})
 
-	t.Run("a real gh failure surfaces its cause", func(t *testing.T) {
-		gh := &fakeGH{err: errors.New("gh auth login required")}
+	t.Run("a real gh failure reaches the caller as written", func(t *testing.T) {
+		// The runner already turned gh's stderr into the screen's message
+		// (gherror.go); the flow must pass it through rather than prefix it
+		// with the command it ran.
+		gh := &fakeGH{err: errors.New("gh is not signed in to GitHub.")}
 		_, err := withGH(gh).PullRequestDetail("/repo", 0)
 		if err == nil {
 			t.Fatal("expected an error")
 		}
-		if !strings.Contains(err.Error(), "gh pr view") || !strings.Contains(err.Error(), "auth login") {
-			t.Errorf("error should name the command and the cause, got %q", err)
+		if err.Error() != "gh is not signed in to GitHub." {
+			t.Errorf("error = %q, want the runner's message unchanged", err)
 		}
 	})
 
@@ -436,6 +434,39 @@ func TestPullRequestDetailFlow(t *testing.T) {
 			t.Error("expected a decode error")
 		}
 	})
+}
+
+// TestPullRequestBadgeRunsThroughTheRunner pins the badge to the same runner as
+// the rest: it used to shell out to gh on its own, which left it running as
+// whatever account gh had active while the screen beside it used the project's.
+func TestPullRequestBadgeRunsThroughTheRunner(t *testing.T) {
+	gh := &fakeGH{out: []byte(`{"number":7,"url":"https://github.com/o/r/pull/7","state":"OPEN"}`)}
+	pr := withGH(gh).PullRequest("/repo")
+	if pr == nil || pr.Number != 7 {
+		t.Fatalf("PullRequest() = %+v, want the open PR", pr)
+	}
+	if want := []string{"pr", "view", "--json", "number,url,state"}; !slices.Equal(gh.args, want) {
+		t.Errorf("args = %v, want %v", gh.args, want)
+	}
+	if gh.dir != "/repo" || gh.timeout != prLookupTimeout {
+		t.Errorf("wrong scope: dir %q timeout %v", gh.dir, gh.timeout)
+	}
+
+	// A failure still hides the badge rather than surfacing anything.
+	if pr := withGH(&fakeGH{err: errTest}).PullRequest("/repo"); pr != nil {
+		t.Errorf("failed lookup = %+v, want nil", pr)
+	}
+
+	// And it runs as the project's account, like every other GitHub call.
+	account := &accountGH{token: "gho_secret", pr: `{"number":7,"url":"u","state":"OPEN"}`}
+	svc := &Service{runner: account.run}
+	svc.SetAccounts(func(string) string { return "octocat" })
+	if pr := svc.PullRequest("/repo"); pr == nil {
+		t.Fatal("PullRequest() = nil, want the open PR")
+	}
+	if account.viewToken != "gho_secret" {
+		t.Errorf("badge ran with token %q, want the configured account's", account.viewToken)
+	}
 }
 
 func TestMergePullRequestFlow(t *testing.T) {
@@ -468,8 +499,8 @@ func TestMergePullRequestFlow(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected an error")
 		}
-		if !strings.Contains(err.Error(), "gh pr merge") || !strings.Contains(err.Error(), "not mergeable") {
-			t.Errorf("error should name the command and the cause, got %q", err)
+		if err.Error() != "Pull request is not mergeable" {
+			t.Errorf("error = %q, want the runner's message unchanged", err)
 		}
 	})
 }
@@ -494,8 +525,8 @@ func TestCreatePullRequestFlow(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected an error")
 		}
-		if !strings.Contains(err.Error(), "gh pr create") || !strings.Contains(err.Error(), "no git remote") {
-			t.Errorf("error should name the command and the cause, got %q", err)
+		if err.Error() != "no git remote found" {
+			t.Errorf("error = %q, want the runner's message unchanged", err)
 		}
 	})
 }
@@ -532,8 +563,8 @@ func TestPullRequestDiffFlow(t *testing.T) {
 		gh := &fakeGH{err: errors.New("could not resolve to a Repository")}
 		if _, err := withGH(gh).PullRequestDiff("/repo", 0); err == nil {
 			t.Fatal("expected an error")
-		} else if !strings.Contains(err.Error(), "gh pr diff") {
-			t.Errorf("error should name the command, got %q", err)
+		} else if err.Error() != "could not resolve to a Repository" {
+			t.Errorf("error = %q, want the runner's message unchanged", err)
 		}
 	})
 }
@@ -668,8 +699,8 @@ func TestListPullRequestsFlow(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected an error")
 		}
-		if !strings.Contains(err.Error(), "gh pr list") || !strings.Contains(err.Error(), "auth login") {
-			t.Errorf("error should name the command and the cause, got %q", err)
+		if err.Error() != "gh auth login required" {
+			t.Errorf("error = %q, want the runner's message unchanged", err)
 		}
 	})
 

--- a/internal/project/pr_test.go
+++ b/internal/project/pr_test.go
@@ -505,6 +505,44 @@ func TestMergePullRequestFlow(t *testing.T) {
 	})
 }
 
+func TestApprovePullRequestFlow(t *testing.T) {
+	t.Run("the branch's own pull request needs no selector", func(t *testing.T) {
+		gh := &fakeGH{}
+		if err := withGH(gh).ApprovePullRequest("/repo", 0); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := []string{"pr", "review", "--approve"}; !slices.Equal(gh.args, want) {
+			t.Errorf("args = %v, want %v", gh.args, want)
+		}
+		if gh.dir != "/repo" || gh.timeout != prReviewTimeout {
+			t.Errorf("wrong scope: dir %q timeout %v", gh.dir, gh.timeout)
+		}
+	})
+
+	t.Run("a numbered pull request is addressed by number", func(t *testing.T) {
+		gh := &fakeGH{}
+		if err := withGH(gh).ApprovePullRequest("/repo", 42); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := []string{"pr", "review", "42", "--approve"}; !slices.Equal(gh.args, want) {
+			t.Errorf("args = %v, want %v", gh.args, want)
+		}
+	})
+
+	t.Run("gh's refusal reaches the caller as written", func(t *testing.T) {
+		// The one refusal this flow meets in practice: GitHub lets nobody
+		// approve their own pull request.
+		gh := &fakeGH{err: errors.New("GitHub does not let an account approve its own pull request")}
+		err := withGH(gh).ApprovePullRequest("/repo", 7)
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		if err.Error() != "GitHub does not let an account approve its own pull request" {
+			t.Errorf("error = %q, want the runner's message unchanged", err)
+		}
+	})
+}
+
 func TestCreatePullRequestFlow(t *testing.T) {
 	t.Run("opens the web flow in the path", func(t *testing.T) {
 		gh := &fakeGH{}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -6,7 +6,6 @@ package project
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -48,14 +47,19 @@ type Picker interface {
 // Service opens project directories via the native file picker.
 type Service struct {
 	picker Picker
-	// gh runs the GitHub CLI for the pull request flows (pr.go); a seam so they
-	// are testable without a GitHub remote.
-	gh ghRunner
+	// runner runs the GitHub CLI for the pull request flows (pr.go); a seam so
+	// they are testable without a GitHub remote. Call it through s.gh, which
+	// resolves the account the checkout runs as.
+	runner ghRunner
+	// accounts resolves the gh account a checkout's calls run as; nil (the
+	// default, and every test that does not wire it) means gh's own active
+	// account. Wired to the store in main (ghaccount.go).
+	accounts accountLookup
 }
 
 // New returns a project service using the given picker.
 func New(picker Picker) *Service {
-	return &Service{picker: picker, gh: runGH}
+	return &Service{picker: picker, runner: runGH}
 }
 
 // Open shows the native directory picker and returns the chosen project, or nil
@@ -117,12 +121,7 @@ const prLookupTimeout = 5 * time.Second
 // repo. It shells out to `gh pr view`, which resolves the PR from the checked-out
 // branch. Any failure yields nil, matching Branch's "hide the segment" contract.
 func (s *Service) PullRequest(path string) *PullRequest {
-	ctx, cancel := context.WithTimeout(context.Background(), prLookupTimeout)
-	defer cancel()
-	cmd := exec.CommandContext(ctx, "gh", "pr", "view", "--json", "number,url,state")
-	cmd.Dir = path
-	winexec.Hide(cmd)
-	out, err := cmd.Output()
+	out, err := s.gh(prLookupTimeout, path, "pr", "view", "--json", "number,url,state")
 	if err != nil {
 		return nil
 	}

--- a/internal/project/toolerror.go
+++ b/internal/project/toolerror.go
@@ -1,0 +1,49 @@
+package project
+
+import (
+	"errors"
+	"log/slog"
+	"os/exec"
+	"strings"
+)
+
+// lich drives two command-line tools, gh and git, and both write their failures
+// for a terminal: "fatal:" prefixes, GraphQL envelopes, flag hints, exit
+// statuses. None of that belongs on screen — so each tool keeps a table of the
+// failures lich can actually hit (gherror.go, giterror.go), the raw text goes to
+// the log, and the screen gets a sentence it can act on.
+//
+// The messages are causes, not sentences about an operation: every call site in
+// the frontend already says which one failed ("Failed to remove worktree: …").
+
+// toolFailure is one recognised failure: what the tool's stderr contains,
+// lowercased, and what the screen says in its place.
+type toolFailure struct{ match, message string }
+
+// matchFailure returns the message for the first entry the stderr matches, so
+// the specific entries in a table have to come before the general ones.
+func matchFailure(failures []toolFailure, stderr string) (string, bool) {
+	low := strings.ToLower(stderr)
+	for _, failure := range failures {
+		if strings.Contains(low, failure.match) {
+			return failure.message, true
+		}
+	}
+	return "", false
+}
+
+// missingTool reports the failure of a tool that is not installed at all — the
+// one failure exec reports instead of the tool.
+func missingTool(stderr string, runErr error) bool {
+	return errors.Is(runErr, exec.ErrNotFound) ||
+		strings.Contains(strings.ToLower(stderr), "executable file not found")
+}
+
+// logToolFailure keeps what the tool actually said, which is the part worth
+// reading when a message here turns out to be the wrong guess.
+func logToolFailure(tool string, args []string, stderr string, runErr error) {
+	slog.Warn(tool+" failed",
+		"command", strings.Join(args, " "),
+		"err", runErr,
+		"stderr", strings.TrimSpace(stderr))
+}

--- a/internal/project/worktree.go
+++ b/internal/project/worktree.go
@@ -304,7 +304,10 @@ func (s *Service) CreateWorktreeFromPR(projectPath, projectID string, number int
 	if _, err := runGit(projectPath, "worktree", "add", "--detach", wtPath); err != nil {
 		return nil, err
 	}
-	if _, err := s.gh(prCheckoutTimeout, wtPath, "pr", "checkout", strconv.Itoa(number)); err != nil {
+	// The checkout runs inside the new worktree but answers to the project's
+	// account: the worktree has no session row yet, so it can name no account
+	// of its own.
+	if _, err := s.ghFor(projectPath, prCheckoutTimeout, wtPath, "pr", "checkout", strconv.Itoa(number)); err != nil {
 		if _, rmErr := runGit(projectPath, "worktree", "remove", "--force", wtPath); rmErr != nil {
 			slog.Warn("worktree left behind by a failed PR checkout", "path", wtPath, "err", rmErr)
 			return nil, fmt.Errorf("%w Its half-made worktree could not be removed either.", err)

--- a/internal/project/worktree.go
+++ b/internal/project/worktree.go
@@ -3,7 +3,9 @@ package project
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -26,19 +28,16 @@ type Branches struct {
 }
 
 // runGit runs git -C dir args... and returns stdout. Unlike Branch/Diff, which
-// deliberately swallow errors for polling, failures here carry git's stderr in
-// the message so the frontend can show it verbatim.
+// deliberately swallow errors for polling, a failure here is shown to someone —
+// so it comes back as the screen's message and git's stderr reaches the log
+// (giterror.go).
 func runGit(dir string, args ...string) (string, error) {
 	cmd := command("git", append([]string{"-C", dir}, args...)...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()
 	if err != nil {
-		msg := strings.TrimSpace(stderr.String())
-		if msg == "" {
-			msg = err.Error()
-		}
-		return "", fmt.Errorf("git %s: %s", args[0], msg)
+		return "", gitFailure(args, stderr.String(), err)
 	}
 	return string(out), nil
 }
@@ -192,8 +191,10 @@ func parseWorktreeBlock(block string) (Worktree, bool) {
 // manual rm) so they cannot block re-creating a worktree under the same name,
 // and an occupied path is refused here rather than by a half-finished git call.
 func reserveWorktreePath(projectPath, projectID, name string) (string, error) {
+	// check-ref-format says no by exit status alone, with nothing on stderr, so
+	// the name it rejected has to come from here.
 	if _, err := runGit(projectPath, "check-ref-format", "--branch", name); err != nil {
-		return "", err
+		return "", fmt.Errorf("%q is not a name git accepts for a branch.", name)
 	}
 	root, err := worktreesRoot()
 	if err != nil {
@@ -204,10 +205,11 @@ func reserveWorktreePath(projectPath, projectID, name string) (string, error) {
 		return "", err
 	}
 	if _, err := os.Stat(wtPath); err == nil {
-		return "", fmt.Errorf("worktree path already exists: %s", wtPath)
+		return "", fmt.Errorf("A worktree named %q already exists.", name)
 	}
 	if err := os.MkdirAll(filepath.Dir(wtPath), 0o755); err != nil {
-		return "", fmt.Errorf("create worktrees dir: %w", err)
+		slog.Warn("create worktrees dir", "path", filepath.Dir(wtPath), "err", err)
+		return "", errors.New("The worktree directory could not be created.")
 	}
 	return wtPath, nil
 }
@@ -229,7 +231,7 @@ func (s *Service) CreateWorktree(projectPath, projectID, name, base string, base
 	if baseIsRemote {
 		remote, branch, ok := strings.Cut(base, "/")
 		if !ok {
-			return nil, fmt.Errorf("remote branch %q has no remote prefix", base)
+			return nil, fmt.Errorf("%q is not a remote branch lich can track.", base)
 		}
 		if _, err := runGit(projectPath, "fetch", "--", remote, branch); err != nil {
 			return nil, err
@@ -245,7 +247,7 @@ func (s *Service) CreateWorktree(projectPath, projectID, name, base string, base
 	// The session spawns claude at wtPath immediately after; make sure the
 	// checkout actually works before handing it over.
 	if _, err := runGit(wtPath, "rev-parse", "--is-inside-work-tree"); err != nil {
-		return nil, fmt.Errorf("worktree created but unusable: %w", err)
+		return nil, errors.New("The worktree was created but git does not read it as a checkout.")
 	}
 	seedWorktree(projectPath, wtPath)
 	return &Worktree{Name: name, Path: canonicalPath(wtPath)}, nil
@@ -262,14 +264,14 @@ type prHead struct {
 func (s *Service) pullRequestHead(path string, number int) (prHead, error) {
 	out, err := s.gh(prReadTimeout, path, prArgs("view", number, "--json", "headRefName,isCrossRepository")...)
 	if err != nil {
-		return prHead{}, fmt.Errorf("gh pr view: %w", err)
+		return prHead{}, err
 	}
 	var head prHead
 	if err := json.Unmarshal(out, &head); err != nil {
-		return prHead{}, fmt.Errorf("decode gh pr view: %w", err)
+		return prHead{}, errUnreadableAnswer(err)
 	}
 	if head.RefName == "" {
-		return prHead{}, fmt.Errorf("pull request #%d has no head branch", number)
+		return prHead{}, fmt.Errorf("GitHub reports no head branch for pull request #%d.", number)
 	}
 	return head, nil
 }
@@ -286,14 +288,14 @@ func (s *Service) pullRequestHead(path string, number int) (prHead, error) {
 // of nothing, and would hold the path against a second attempt.
 func (s *Service) CreateWorktreeFromPR(projectPath, projectID string, number int) (*Worktree, error) {
 	if number <= 0 {
-		return nil, fmt.Errorf("invalid pull request number %d", number)
+		return nil, fmt.Errorf("%d is not a pull request number.", number)
 	}
 	head, err := s.pullRequestHead(projectPath, number)
 	if err != nil {
 		return nil, err
 	}
 	if head.CrossRepo {
-		return nil, fmt.Errorf("pull request #%d comes from a fork: its branch cannot be pushed back", number)
+		return nil, fmt.Errorf("Pull request #%d comes from a fork: its branch could not be pushed back.", number)
 	}
 	wtPath, err := reserveWorktreePath(projectPath, projectID, head.RefName)
 	if err != nil {
@@ -304,9 +306,10 @@ func (s *Service) CreateWorktreeFromPR(projectPath, projectID string, number int
 	}
 	if _, err := s.gh(prCheckoutTimeout, wtPath, "pr", "checkout", strconv.Itoa(number)); err != nil {
 		if _, rmErr := runGit(projectPath, "worktree", "remove", "--force", wtPath); rmErr != nil {
-			return nil, fmt.Errorf("gh pr checkout: %w (and the worktree could not be removed: %v)", err, rmErr)
+			slog.Warn("worktree left behind by a failed PR checkout", "path", wtPath, "err", rmErr)
+			return nil, fmt.Errorf("%w Its half-made worktree could not be removed either.", err)
 		}
-		return nil, fmt.Errorf("gh pr checkout: %w", err)
+		return nil, err
 	}
 	seedWorktree(projectPath, wtPath)
 	return &Worktree{Name: head.RefName, Path: canonicalPath(wtPath)}, nil

--- a/internal/project/worktree_test.go
+++ b/internal/project/worktree_test.go
@@ -181,14 +181,16 @@ func TestCreateWorktreeErrors(t *testing.T) {
 	git("branch", "taken")
 
 	svc := New(nil)
+	// The messages are what the dialog shows, so they name the branch rather
+	// than the git plumbing that rejected it (giterror.go).
 	tests := []struct {
 		name    string
 		wtName  string
 		wantSub string
 	}{
-		{"invalid name", "has space", "check-ref-format"},
-		{"dotdot name", "a..b", "check-ref-format"},
-		{"duplicate branch", "taken", "taken"},
+		{"invalid name", "has space", `"has space" is not a name git accepts`},
+		{"dotdot name", "a..b", `"a..b" is not a name git accepts`},
+		{"duplicate branch", "taken", "already exists"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -324,7 +326,7 @@ type scriptedGH struct {
 	calls       []string
 }
 
-func (g *scriptedGH) run(_ time.Duration, dir string, args ...string) ([]byte, error) {
+func (g *scriptedGH) run(_ time.Duration, dir, _ string, args ...string) ([]byte, error) {
 	g.calls = append(g.calls, strings.Join(args, " "))
 	if len(args) > 1 && args[1] == "checkout" {
 		g.checkoutDir = dir
@@ -355,7 +357,7 @@ func TestCreateWorktreeFromPR(t *testing.T) {
 		t.Setenv("XDG_DATA_HOME", data)
 		repo, git := initRepo(t)
 		gh := &scriptedGH{headJSON: `{"headRefName":"fix/poll","isCrossRepository":false}`}
-		svc := &Service{gh: gh.run}
+		svc := &Service{runner: gh.run}
 
 		wt, err := svc.CreateWorktreeFromPR(repo, "proj", 105)
 		if err != nil {
@@ -394,7 +396,7 @@ func TestCreateWorktreeFromPR(t *testing.T) {
 		repo, _ := initRepo(t)
 		gh := &scriptedGH{headJSON: `{"headRefName":"patch-1","isCrossRepository":true}`}
 
-		_, err := (&Service{gh: gh.run}).CreateWorktreeFromPR(repo, "proj", 103)
+		_, err := (&Service{runner: gh.run}).CreateWorktreeFromPR(repo, "proj", 103)
 		if err == nil || !strings.Contains(err.Error(), "fork") {
 			t.Fatalf("want a fork refusal, got %v", err)
 		}
@@ -412,7 +414,7 @@ func TestCreateWorktreeFromPR(t *testing.T) {
 			checkoutErr: errors.New("fatal: 'fix/poll' is already checked out"),
 		}
 
-		_, err := (&Service{gh: gh.run}).CreateWorktreeFromPR(repo, "proj", 105)
+		_, err := (&Service{runner: gh.run}).CreateWorktreeFromPR(repo, "proj", 105)
 		if err == nil || !strings.Contains(err.Error(), "already checked out") {
 			t.Fatalf("want gh's own refusal, got %v", err)
 		}
@@ -437,7 +439,7 @@ func TestCreateWorktreeFromPR(t *testing.T) {
 			lockOnFail:  true,
 		}
 
-		_, err := (&Service{gh: gh.run}).CreateWorktreeFromPR(repo, "proj", 105)
+		_, err := (&Service{runner: gh.run}).CreateWorktreeFromPR(repo, "proj", 105)
 		if err == nil {
 			t.Fatal("expected an error")
 		}
@@ -451,7 +453,7 @@ func TestCreateWorktreeFromPR(t *testing.T) {
 
 	t.Run("a number that cannot name a pull request never reaches gh", func(t *testing.T) {
 		gh := &scriptedGH{}
-		if _, err := (&Service{gh: gh.run}).CreateWorktreeFromPR(t.TempDir(), "proj", 0); err == nil {
+		if _, err := (&Service{runner: gh.run}).CreateWorktreeFromPR(t.TempDir(), "proj", 0); err == nil {
 			t.Error("expected an error for pull request 0")
 		}
 		if len(gh.calls) != 0 {
@@ -469,7 +471,7 @@ func TestCreateWorktreeFromPR(t *testing.T) {
 		}
 		gh := &scriptedGH{headJSON: `{"headRefName":"fix/poll","isCrossRepository":false}`}
 
-		_, err := (&Service{gh: gh.run}).CreateWorktreeFromPR(repo, "proj", 105)
+		_, err := (&Service{runner: gh.run}).CreateWorktreeFromPR(repo, "proj", 105)
 		if err == nil || !strings.Contains(err.Error(), "already exists") {
 			t.Fatalf("want an already-exists refusal, got %v", err)
 		}
@@ -484,12 +486,14 @@ func TestPullRequestHead(t *testing.T) {
 		gh   *scriptedGH
 		want string
 	}{
-		{"payload gh could not have meant", &scriptedGH{headJSON: `{not json`}, "decode"},
+		// The decoder's own text names Go types, so the flow answers with the
+		// screen's sentence instead (gherror.go).
+		{"payload gh could not have meant", &scriptedGH{headJSON: `{not json`}, "could not be read"},
 		{"a pull request with no head branch", &scriptedGH{headJSON: `{}`}, "no head branch"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := (&Service{gh: tt.gh.run}).pullRequestHead("/repo", 7)
+			_, err := (&Service{runner: tt.gh.run}).pullRequestHead("/repo", 7)
 			if err == nil || !strings.Contains(err.Error(), tt.want) {
 				t.Fatalf("want an error naming %q, got %v", tt.want, err)
 			}
@@ -506,7 +510,7 @@ func TestCreateWorktreeFromPRRejectsRefName(t *testing.T) {
 	repo, _ := initRepo(t)
 	gh := &scriptedGH{headJSON: `{"headRefName":"../../escaped","isCrossRepository":false}`}
 
-	if _, err := (&Service{gh: gh.run}).CreateWorktreeFromPR(repo, "proj", 105); err == nil {
+	if _, err := (&Service{runner: gh.run}).CreateWorktreeFromPR(repo, "proj", 105); err == nil {
 		t.Fatal("expected check-ref-format to refuse the head branch")
 	}
 	if gh.checkoutDir != "" {

--- a/internal/project/worktree_test.go
+++ b/internal/project/worktree_test.go
@@ -320,16 +320,24 @@ type scriptedGH struct {
 	checkoutErr error
 	// lockOnFail locks the worktree before failing. git refuses to remove a
 	// locked worktree, which is how the cleanup itself is made to fail.
-	lockOnFail  bool
-	viewDir     string
-	checkoutDir string
-	calls       []string
+	lockOnFail bool
+	// token is what `gh auth token` answers with, so a test can follow which
+	// account each call in the flow ran as.
+	token         string
+	viewDir       string
+	viewToken     string
+	checkoutDir   string
+	checkoutToken string
+	calls         []string
 }
 
-func (g *scriptedGH) run(_ time.Duration, dir, _ string, args ...string) ([]byte, error) {
+func (g *scriptedGH) run(_ time.Duration, dir, token string, args ...string) ([]byte, error) {
 	g.calls = append(g.calls, strings.Join(args, " "))
+	if len(args) > 1 && args[0] == "auth" && args[1] == "token" {
+		return []byte(g.token + "\n"), nil
+	}
 	if len(args) > 1 && args[1] == "checkout" {
-		g.checkoutDir = dir
+		g.checkoutDir, g.checkoutToken = dir, token
 		if g.checkoutErr != nil {
 			if g.lockOnFail {
 				if out, err := exec.Command("git", "-C", dir, "worktree", "lock", dir).CombinedOutput(); err != nil {
@@ -347,7 +355,7 @@ func (g *scriptedGH) run(_ time.Duration, dir, _ string, args ...string) ([]byte
 		}
 		return nil, nil
 	}
-	g.viewDir = dir
+	g.viewDir, g.viewToken = dir, token
 	return []byte(g.headJSON), nil
 }
 
@@ -388,6 +396,37 @@ func TestCreateWorktreeFromPR(t *testing.T) {
 		}
 		if !registered {
 			t.Errorf("the worktree is not registered with git: %s", git("worktree", "list"))
+		}
+	})
+
+	// The checkout runs inside a worktree the store has never seen — it has no
+	// session row until the frontend opens one — so resolving the account from
+	// the directory gh runs in would answer "none" and fall back to gh's active
+	// account, failing on exactly the repositories the picker exists for.
+	t.Run("the checkout runs as the project's account", func(t *testing.T) {
+		t.Setenv("XDG_DATA_HOME", t.TempDir())
+		repo, _ := initRepo(t)
+		gh := &scriptedGH{
+			headJSON: `{"headRefName":"fix/account","isCrossRepository":false}`,
+			token:    "gho_project",
+		}
+		svc := &Service{runner: gh.run}
+		// Only the project directory names an account, as the store would.
+		svc.SetAccounts(func(dir string) string {
+			if dir == repo {
+				return "marcelo-filho_snk"
+			}
+			return ""
+		})
+
+		if _, err := svc.CreateWorktreeFromPR(repo, "proj", 105); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gh.checkoutToken != "gho_project" {
+			t.Errorf("gh pr checkout ran with token %q, want the project's", gh.checkoutToken)
+		}
+		if gh.viewToken != "gho_project" {
+			t.Errorf("gh pr view ran with token %q, want the project's", gh.viewToken)
 		}
 	})
 

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -81,6 +81,49 @@ func (s *Service) ClaudeBin(projectID string) string {
 	return s.ProviderBin(providers.Claude, projectID)
 }
 
+// ghAccountKey is the settings key holding the gh account a project's GitHub
+// calls run as. Project-scoped only, no global fallback: gh already has a
+// global answer (its active account), and this exists precisely to override it
+// for one repository.
+const ghAccountKey = "vcs.account"
+
+// GHAccountForPath returns the gh account login configured for the project the
+// checkout at path belongs to, or "" for none. The path is a project directory
+// or one of its worktrees — the project services address a checkout by path,
+// never by project id, so the mapping is resolved here.
+func (s *Service) GHAccountForPath(path string) string {
+	projectID := s.projectIDForPath(path)
+	if projectID == "" {
+		return ""
+	}
+	login, err := s.GetSetting(ghAccountKey, projectID)
+	if err != nil {
+		return ""
+	}
+	return login
+}
+
+// projectIDForPath resolves which project a checkout belongs to: its own
+// directory, or a session's (a worktree lives outside the project directory, so
+// only its session row ties it back). Returns "" when neither matches.
+func (s *Service) projectIDForPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	var id string
+	err := s.db.QueryRow(
+		`SELECT id FROM projects WHERE path = ?
+		 UNION ALL
+		 SELECT project_id FROM sessions WHERE path = ?
+		 LIMIT 1`,
+		path, path,
+	).Scan(&id)
+	if err != nil {
+		return ""
+	}
+	return id
+}
+
 // worktreeSetupKey is the settings key holding a project's worktree setup
 // script. Project-scoped only, no global fallback: a setup command is
 // repo-specific, so a global value would be wrong more often than useful.

--- a/internal/store/settings_test.go
+++ b/internal/store/settings_test.go
@@ -57,6 +57,48 @@ func TestClaudeBinResolution(t *testing.T) {
 	}
 }
 
+func TestGHAccountForPath(t *testing.T) {
+	svc := newTestStore(t)
+	if err := svc.AddProject("p1", "lich", "/repo/lich"); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+	// A worktree lives outside the project directory; only its session row ties
+	// the path back to the project.
+	if err := svc.AddSession("p1", "s1", "fix", "claude", "/data/worktrees/p1/fix", 2); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+	if err := svc.SetSetting(ghAccountKey, "p1", "octocat"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"project directory", "/repo/lich", "octocat"},
+		{"worktree of the project", "/data/worktrees/p1/fix", "octocat"},
+		{"unknown path", "/elsewhere", ""},
+		{"empty path", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := svc.GHAccountForPath(tt.path); got != tt.want {
+				t.Errorf("GHAccountForPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+
+	// A project with no account configured resolves to "", which runs gh as its
+	// own active account.
+	if err := svc.AddProject("p2", "other", "/repo/other"); err != nil {
+		t.Fatalf("AddProject p2: %v", err)
+	}
+	if got := svc.GHAccountForPath("/repo/other"); got != "" {
+		t.Errorf("unconfigured project = %q, want \"\"", got)
+	}
+}
+
 func TestProviderBinResolution(t *testing.T) {
 	svc := newTestStore(t)
 

--- a/main.go
+++ b/main.go
@@ -87,6 +87,8 @@ func main() {
 	hub := events.New()
 	term := terminal.New(db, env, hub)
 	proj := project.New(project.ZenityPicker{})
+	// gh has one active account per host; a project can name a different one.
+	proj.SetAccounts(db.GHAccountForPath)
 
 	// Every service the frontend uses goes through the loopback RPC
 	// (internal/rpc). store.Close manages the DB lifecycle and stays Go-only.


### PR DESCRIPTION
## Why

`gh` keeps **one active account per host**, globally. On a machine signed in as two GitHub accounts, a private repository only the second one can see answers every lookup with:

```
gh pr view: GraphQL: Could not resolve to a Repository with the name 'acme/private'. (repository)
```

GitHub does not distinguish 404 from 403, so the message reads as "this repository does not exist" — and lich pasted it on screen verbatim, command prefix and all. The screen looked broken on a repository that was fine.

## What this does

**A project names the GitHub account its calls run as.** `vcs.account` in the store (project-scoped — gh already has a global answer, and this exists to override it for one repository), resolved to a token via `gh auth token --user <login>` and passed to gh in `GH_TOKEN`. Every gh call routes through one seam (`Service.gh`), so the badge, the list, the detail, the checks, the diff, the merge and the PR checkout all answer as the same account. Unset, nothing changes.

A checkout is addressed by path everywhere in the project services, so the path → project mapping is resolved in the store: the project's own directory, or a session's (a worktree lives outside the project directory, so only its session row ties it back). No RPC signature changed.

**A new Version Control section in Settings** picks the account, filled from `gh auth status`.

**The badge was shelling out to gh on its own**, outside the seam — it would have kept answering as gh's active account while the screen beside it used the project's, vanishing on exactly the repositories the picker exists for. It takes the same path now.

**Neither tool's stderr reaches the screen anymore.** `gherror.go` and `giterror.go` each hold a table of the failures lich can actually hit; `toolerror.go` holds what they share. gh's GraphQL envelopes, git's `fatal:` lines, and — when git refuses by exit status alone (`check-ref-format`) — the literal words `exit status 1` are replaced by a sentence that says what to do. The raw text goes to lich's log, which is where it was always the more useful half.

| the tool said | the screen says |
| --- | --- |
| `GraphQL: Could not resolve to a Repository with the name '…'` | GitHub does not show this repository to the account lich is using here. Choose the account that can see it in Settings → Version Control. |
| `To get started with GitHub CLI, please run: gh auth login` | gh is not signed in to GitHub. Run `gh auth login` in a terminal. |
| `git check-ref-format: exit status 1` | `"has space"` is not a name git accepts for a branch. |
| `fatal: '…' contains modified or untracked files, use --force to delete it` | That worktree has uncommitted changes. Remove it from the sidebar to discard them. |

**Approving a pull request no longer means opening the browser.** An Approve button sits beside Merge and files the approving review through the project's account. Once it lands the button reads Approved and stops offering itself — GitHub would take a second review, but nobody means to send one. The gate is not the merge gate: a draft and a conflicting pull request can both still be reviewed, only one already merged or closed cannot. Reviews with a body and requesting changes are deliberately absent — a review comment belongs to the line it is about, and lich has nowhere to attach one yet.

## Ceiling

The account governs what lich reads from GitHub, **not what git does**: a push still rides the remote's ssh key and signs with the global `user.email`, so a PR can be read by one account and its commits land under another with no error anywhere. Documented as a Known Ceiling; per-worktree `core.sshCommand` + `user.email` is the upgrade path.

## Test plan

- [x] End-to-end against the real repository that produced the bug, driven over the RPC on an isolated instance: **before** — `Could not resolve to a Repository`; **after setting the account** — the list of open PRs.
- [x] `project.GitHubAccounts` against the real `gh auth status` returns `["omartelo", "marcelo-filho_snk"]`.
- [x] Every git failure path exercised over the RPC against real git (invalid name, taken name, non-repository, unknown worktree) — each answers with its sentence, and the raw stderr is in the log.
- [x] Settings pane smoked in headless Chromium (the frontend gate is node-only and cannot render): the section renders, the picker opens with `gh's active account` + both logins, the stored value is selected, no page errors.
- [x] `TestGHMessageLeaksNothing` / `TestGitMessageLeaksNothing` assert the rule, not just the cases: no message may contain `graphql`, `http 4xx`, `exit status`, `fatal:`, `hint:`, `--force`.
- [x] `TestRunGitMessage` runs real git against a non-repository and asserts the sentence — the whole path, not just the table.
- [x] `go test ./...`, `gofmt -l .`, `go vet ./...` clean; frontend `biome check` (0 errors), `vitest` 468 passed, `tsc --noEmit` clean, `vite build` ok.
- [x] Cross-compile loop for linux/darwin/windows (build + vet).
- [x] Open in Session was the bug homologation found: `gh pr checkout` runs inside the worktree it just created, which has no session row yet, so the account resolved to none and the checkout fell back to gh's active one. Fixed by separating "where the command runs" from "whose account it runs as" (`ghFor`); the regression test fails without the fix with `token ""`.
- [x] Approve verified by hand in the dev instance, and its one real refusal was triggered against this very PR to read GitHub's exact wording: `Review Can not approve your own pull request`.
- [ ] Merge failures were exercised through their message table, not against a live refusal from GitHub.

Five backend tests changed: they asserted the command prefix and the tool's own words, which is precisely what leaked. Each now asserts the message passes through unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
