### PR TITLE
fix: swallow the browser chords Shift was still letting through

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   picker, a signed-out `gh` names `gh auth login`, a rate limit says to wait, a
   refused merge says why. Anything unrecognised says so plainly; `gh`'s own text
   goes to lich's log, where it was always the more useful place for it.
+- **Three more browser reflexes stop firing.** Holding Shift used to let a chord
+  through: Ctrl+Shift+P still raised the system print dialog, Ctrl+Shift+O the
+  bookmark manager, and Ctrl+Shift+Q quit Chromium, which quits lich — the same
+  fatal move Ctrl+W was already stopped from making. They fired everywhere,
+  terminals included, since a terminal encodes neither of them. The devtools
+  chords, reload and F11 stay where they are.
 - **The pull request badge follows the project's GitHub account too.** It looked
   the branch's PR up on its own path, so it kept answering as `gh`'s active
   account while the screen beside it used the project's — a badge that vanished

--- a/frontend/src/lib/browser-defaults.test.ts
+++ b/frontend/src/lib/browser-defaults.test.ts
@@ -20,7 +20,7 @@ describe("isBrowserChord", () => {
   })
 
   it("swallows the shifted commands, including the browsing-data wipe", () => {
-    for (const key of ["T", "W", "N", "M", "Delete"]) {
+    for (const key of ["T", "W", "N", "M", "P", "O", "Q", "Delete"]) {
       expect(isBrowserChord(chord({ ctrlKey: true, shiftKey: true, key }))).toBe(true)
     }
   })

--- a/frontend/src/lib/browser-defaults.ts
+++ b/frontend/src/lib/browser-defaults.ts
@@ -11,11 +11,14 @@
 // The subset of KeyboardEvent the matcher needs — lets tests pass plain objects.
 type ChordState = Pick<KeyboardEvent, "ctrlKey" | "metaKey" | "shiftKey" | "altKey" | "key">
 
-// Tab and window commands (new/close/restore), the file and page commands whose
-// dialogs or navigation have nowhere to land, and the browsing-data wipe, which
-// would take lich's own localStorage settings with it.
+// Tab and window commands (new/close/restore/quit), the file and page commands
+// whose dialogs or navigation have nowhere to land, and the browsing-data wipe,
+// which would take lich's own localStorage settings with it. Shift does not make
+// a chord harmless: it only changes which surface opens — Ctrl+Shift+P prints
+// through the system dialog, Ctrl+Shift+O opens the bookmark manager, and
+// Ctrl+Shift+Q exits Chromium, which quits lich exactly as Ctrl+W does.
 const MOD_KEYS = new Set(["t", "w", "n", "p", "s", "o", "u", "d", "h", "j"])
-const MOD_SHIFT_KEYS = new Set(["t", "w", "n", "m", "delete"])
+const MOD_SHIFT_KEYS = new Set(["t", "w", "n", "m", "p", "o", "q", "delete"])
 
 // Deliberately still live: Ctrl+R and F5 (a reload recovers a wedged UI and
 // costs nothing — the session lives in the backend), the devtools chords


### PR DESCRIPTION
#99 taught the `--app` window to stop behaving like a browser, but the shifted
list was enumerated from the tab and window commands plus the browsing-data
wipe (`t w n m delete`) and stopped there. Shift became a way past the refusal
rather than part of it:

- **Ctrl+Shift+P** — `p` was refused unshifted, and still raised the system
  print dialog with Shift held. This is the one that turned up in testing.
- **Ctrl+Shift+O** — same shape: `o` refused, bookmark manager still opened.
- **Ctrl+Shift+Q** — exits Chromium, which quits lich, exactly the fatal move
  Ctrl+W was already stopped from making.

They fired on every screen, a focused terminal included: xterm only
`preventDefault`s the chords it encodes as a PTY sequence, and none of these
are one, so the window listener was the only thing that could have claimed
them.

Kept live on purpose: the devtools chords (Ctrl+Shift+I/J/C), reload, F11, and
now-confirmed **Ctrl+Shift+B** and **Ctrl+Shift+A** — an `--app` window has no
bookmarks bar and no tabstrip, so both are no-ops here.

## Test plan

- [x] `browser-defaults.test.ts` covers the three new keys in the shifted case;
      the devtools-chords assertion still pins Ctrl+Shift+I/J/C as untouched.
- [x] `vitest run` — 468 passed (45 files).
- [x] `biome check` clean, `tsc --noEmit` clean.
- [x] Ctrl+Shift+A and Ctrl+Shift+B exercised by hand in the real window —
      nothing appeared.
- [ ] Ctrl+Shift+P / O / Q by hand in the packaged window, terminal focused and
      not.