### PR TITLE
fix: name the host a GitHub account lives on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   section in Settings names the account for the project at hand, chosen from the
   ones `gh auth status` lists, and every GitHub call lich makes for that project
   — the badge, the pull request list, checks, diffs, merges and PR checkouts —
-  runs as it. Left at "gh's active account", nothing changes. The account governs
+  runs as it. Left at "gh's active account", nothing changes. An account is named
+  by its host as well as its login, so one that lives on a GitHub Enterprise
+  instance is offered — and found — like any other, and the same login on two
+  hosts stays two accounts; the host is spelled out in the picker only when there
+  is more than one in play. The account governs
   what lich reads from GitHub, not what git does: a push still rides the remote's
   ssh key and signs with the global `user.email`.
 

--- a/frontend/src/components/settings/VersionControlSettings.tsx
+++ b/frontend/src/components/settings/VersionControlSettings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react"
 import { ProjectService, Store } from "@/lib/rpc"
+import { accountLabel, upgradeAccount } from "@/lib/gh-account"
 import { invalidatePullRequests } from "@/lib/pulls/pull-request-lookup"
 import { useProjects } from "@/providers/projects"
 import {
@@ -48,12 +49,26 @@ export function VersionControlSettings({ projectId }: { projectId?: string }) {
   }, [projectId])
 
   const persist = (value: string) => {
-    const login = value === ACTIVE_ACCOUNT ? "" : value
-    setAccount(login)
+    const chosen = value === ACTIVE_ACCOUNT ? "" : value
+    setAccount(chosen)
     if (projectId) {
-      void Store.SetSetting(GH_ACCOUNT_KEY, projectId, login).then(invalidatePullRequests)
+      void Store.SetSetting(GH_ACCOUNT_KEY, projectId, chosen).then(invalidatePullRequests)
     }
   }
+
+  // An account stored before hosts travelled with them is rewritten the moment
+  // gh says which host it lives on. It resolves either way, but leaving it
+  // half-formed would show the same account twice in the picker.
+  useEffect(() => {
+    if (!projectId) {
+      return
+    }
+    const upgraded = upgradeAccount(account, accounts)
+    if (upgraded) {
+      setAccount(upgraded)
+      void Store.SetSetting(GH_ACCOUNT_KEY, projectId, upgraded)
+    }
+  }, [account, accounts, projectId])
 
   if (!project) {
     return (
@@ -73,8 +88,8 @@ export function VersionControlSettings({ projectId }: { projectId?: string }) {
       description={
         "Which account lich runs gh as for this project — pull requests, checks and PR checkouts. " +
         "gh keeps one active account per host, so a repository only another account can see reads " +
-        "as not found. Pushes are unaffected: they still ride the remote's ssh key and the git " +
-        "user.email."
+        "as not found. Accounts on an enterprise host are listed with it. Pushes are unaffected: " +
+        "they still ride the remote's ssh key and the git user.email."
       }
     >
       <p className="mb-2 text-xs text-muted-foreground">{project.path}</p>
@@ -85,9 +100,9 @@ export function VersionControlSettings({ projectId }: { projectId?: string }) {
         <SelectContent>
           <SelectGroup>
             <SelectItem value={ACTIVE_ACCOUNT}>gh's active account</SelectItem>
-            {options.map((login) => (
-              <SelectItem key={login} value={login}>
-                {login}
+            {options.map((option) => (
+              <SelectItem key={option} value={option}>
+                {accountLabel(option, options)}
               </SelectItem>
             ))}
           </SelectGroup>

--- a/frontend/src/lib/gh-account.test.ts
+++ b/frontend/src/lib/gh-account.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+import { accountLabel, splitAccount, upgradeAccount } from "./gh-account"
+
+describe("upgradeAccount", () => {
+  const accounts = ["github.com/omartelo", "ghe.example.com/work-login"]
+
+  it("upgrades a host-less account gh knows on exactly one host", () => {
+    expect(upgradeAccount("omartelo", accounts)).toBe("github.com/omartelo")
+  })
+
+  it("leaves an account that already names its host alone", () => {
+    expect(upgradeAccount("github.com/omartelo", accounts)).toBeNull()
+  })
+
+  it("refuses to guess when the login exists on two hosts", () => {
+    expect(
+      upgradeAccount("omartelo", ["github.com/omartelo", "ghe.example.com/omartelo"]),
+    ).toBeNull()
+  })
+
+  it("leaves a login gh no longer knows alone, so it stays visible and changeable", () => {
+    expect(upgradeAccount("gone", accounts)).toBeNull()
+  })
+
+  it("has nothing to do for no account at all", () => {
+    expect(upgradeAccount("", accounts)).toBeNull()
+  })
+})
+
+describe("splitAccount", () => {
+  it("splits host from login", () => {
+    expect(splitAccount("github.com/omartelo")).toEqual(["github.com", "omartelo"])
+  })
+
+  it("reads an account stored before hosts travelled with them", () => {
+    expect(splitAccount("omartelo")).toEqual(["", "omartelo"])
+  })
+
+  it("keeps a login containing a slash on the login side", () => {
+    expect(splitAccount("ghe.example.com/team/bot")).toEqual(["ghe.example.com", "team/bot"])
+  })
+})
+
+describe("accountLabel", () => {
+  const single = ["github.com/omartelo", "github.com/marcelo-filho_snk"]
+  const mixed = ["github.com/omartelo", "ghe.example.com/omartelo"]
+
+  it("leaves the host out when every account shares github.com", () => {
+    expect(accountLabel("github.com/omartelo", single)).toBe("omartelo")
+  })
+
+  it("names the host once two of them are in play", () => {
+    expect(accountLabel("github.com/omartelo", mixed)).toBe("omartelo — github.com")
+    expect(accountLabel("ghe.example.com/omartelo", mixed)).toBe("omartelo — ghe.example.com")
+  })
+
+  it("names an enterprise host even when it is the only one", () => {
+    const only = ["ghe.example.com/work-login"]
+    expect(accountLabel("ghe.example.com/work-login", only)).toBe("work-login — ghe.example.com")
+  })
+
+  it("shows a host-less account as its bare login", () => {
+    expect(accountLabel("omartelo", ["omartelo"])).toBe("omartelo")
+  })
+})

--- a/frontend/src/lib/gh-account.ts
+++ b/frontend/src/lib/gh-account.ts
@@ -1,0 +1,35 @@
+// A gh account is "<host>/<login>" (internal/project/ghaccount.go): a login only
+// identifies an account within one host, and the same name can exist on
+// github.com and on an enterprise instance at once.
+
+/** Splits "<host>/<login>", tolerating the host-less form stored before
+ * accounts carried one. The host is "" for those. */
+export function splitAccount(account: string): [host: string, login: string] {
+  const cut = account.indexOf("/")
+  return cut === -1 ? ["", account] : [account.slice(0, cut), account.slice(cut + 1)]
+}
+
+/** The host-carrying form of an account stored before hosts travelled with
+ * them, or null when it cannot be upgraded without guessing: gh knows no such
+ * login, or knows it on more than one host and only the user can say which.
+ * Left alone, such a value would sit in the picker beside the same account in
+ * its full form — two rows, one account. */
+export function upgradeAccount(stored: string, accounts: readonly string[]): string | null {
+  if (!stored || stored.includes("/")) {
+    return null
+  }
+  const matches = accounts.filter((account) => splitAccount(account)[1] === stored)
+  return matches.length === 1 ? matches[0] : null
+}
+
+/** How one account reads in the picker. The host only earns its place when
+ * there is more than one to tell apart, or when it is not github.com — on a
+ * single-host machine it would be the same word on every row. */
+export function accountLabel(account: string, accounts: readonly string[]): string {
+  const [host, login] = splitAccount(account)
+  if (!host) {
+    return login
+  }
+  const hosts = new Set(accounts.map((a) => splitAccount(a)[0]))
+  return hosts.size > 1 || host !== "github.com" ? `${login} — ${host}` : login
+}

--- a/internal/project/ghaccount.go
+++ b/internal/project/ghaccount.go
@@ -8,15 +8,21 @@ import (
 
 // gh authenticates one active account per host, globally. lich works across
 // repositories that answer to different accounts, so a project picks the
-// account its gh calls run as: the login is stored per project (the store's
+// account its gh calls run as: the account is stored per project (the store's
 // "vcs.account"), turned into a token here, and passed to every gh call.
+//
+// An account is "<host>/<login>", because a login only identifies an account
+// within one host — the same name can exist on github.com and on an enterprise
+// instance, and `gh auth token` looks the login up on the default host unless
+// told otherwise. A value with no host is an account stored before this was
+// true; it resolves on gh's default host, which is where it was found.
 //
 // The account only governs what lich asks gh. It does not govern git: a push
 // still rides the remote's ssh key and signs with the global user.email.
 const ghAccountTimeout = 5 * time.Second
 
-// accountLookup resolves the gh account login for the checkout at path, or ""
-// for "whatever account gh has active".
+// accountLookup resolves the gh account ("<host>/<login>") for the checkout at
+// path, or "" for "whatever account gh has active".
 type accountLookup func(path string) string
 
 // SetAccounts wires the per-project account resolution. Left unset, every gh
@@ -51,27 +57,51 @@ func (s *Service) tokenFor(dir string) string {
 	if s.accounts == nil {
 		return ""
 	}
-	login := s.accounts(dir)
-	if login == "" {
+	account := s.accounts(dir)
+	if account == "" {
 		return ""
 	}
-	out, err := s.runner(ghAccountTimeout, dir, "", "auth", "token", "--user", login)
+	out, err := s.runner(ghAccountTimeout, dir, "", tokenArgs(account)...)
 	if err != nil {
 		return ""
 	}
 	return strings.TrimSpace(string(out))
 }
 
+// tokenArgs builds the `gh auth token` call for one account. The host is named
+// whenever the account carries one: without --hostname gh looks the login up on
+// its default host only, so an account that lives on an enterprise instance
+// would answer "no oauth token found" and fall back to the active account —
+// silently, which is the failure this whole feature exists to prevent.
+func tokenArgs(account string) []string {
+	host, login := splitAccount(account)
+	args := []string{"auth", "token"}
+	if host != "" {
+		args = append(args, "--hostname", host)
+	}
+	return append(args, "--user", login)
+}
+
+// splitAccount reads "<host>/<login>", tolerating the host-less form written
+// before accounts carried one.
+func splitAccount(account string) (host, login string) {
+	if host, login, ok := strings.Cut(account, "/"); ok {
+		return host, login
+	}
+	return "", account
+}
+
 // ghAccountLine matches one authenticated account in `gh auth status` output:
 // "✓ Logged in to github.com account omartelo (keyring)". Anchored on the
 // whole phrase because the same output repeats the word "account" in the
-// "Active account: true" line below it.
-var ghAccountLine = regexp.MustCompile(`Logged in to \S+ account (\S+)`)
+// "Active account: true" line below it. The host is captured too: it is half
+// of an account's identity, and gh needs it back to find the token.
+var ghAccountLine = regexp.MustCompile(`Logged in to (\S+) account (\S+)`)
 
-// GitHubAccounts lists the logins gh is authenticated as, in gh's own order
-// (the host's active account first). It backs the account picker in the
-// project's Version Control settings; an unauthenticated gh yields an error,
-// which the picker shows instead of an empty list.
+// GitHubAccounts lists the accounts gh is authenticated as, "<host>/<login>",
+// in gh's own order (each host's active account first). It backs the account
+// picker in the project's Version Control settings; an unauthenticated gh
+// yields an error, which the picker shows instead of an empty list.
 func (s *Service) GitHubAccounts() ([]string, error) {
 	out, err := s.runner(ghAccountTimeout, "", "", "auth", "status")
 	if err != nil {
@@ -80,7 +110,7 @@ func (s *Service) GitHubAccounts() ([]string, error) {
 	return parseGHAccounts(string(out)), nil
 }
 
-// parseGHAccounts pulls the logins out of `gh auth status`. Deliberately
+// parseGHAccounts pulls the accounts out of `gh auth status`. Deliberately
 // tolerant: an unparseable line is skipped, so a future gh reword degrades to a
 // shorter list (the account stays configurable by hand) rather than an error.
 func parseGHAccounts(out string) []string {
@@ -88,9 +118,9 @@ func parseGHAccounts(out string) []string {
 	if len(matches) == 0 {
 		return nil
 	}
-	logins := make([]string, 0, len(matches))
+	accounts := make([]string, 0, len(matches))
 	for _, m := range matches {
-		logins = append(logins, m[1])
+		accounts = append(accounts, m[1]+"/"+m[2])
 	}
-	return logins
+	return accounts
 }

--- a/internal/project/ghaccount_test.go
+++ b/internal/project/ghaccount_test.go
@@ -21,13 +21,15 @@ func TestParseGHAccounts(t *testing.T) {
 				"  - Token scopes: 'gist', 'read:org', 'repo'\n\n" +
 				"  ✓ Logged in to github.com account marcelo-filho_snk (keyring)\n" +
 				"  - Active account: false\n",
-			[]string{"omartelo", "marcelo-filho_snk"},
+			[]string{"github.com/omartelo", "github.com/marcelo-filho_snk"},
 		},
 		{
+			// The same login can exist on both hosts, so the host travels with
+			// it — and gh needs it back to find the token.
 			"a second host contributes its own accounts",
 			"github.com\n  ✓ Logged in to github.com account omartelo (keyring)\n" +
-				"ghe.example.com\n  ✓ Logged in to ghe.example.com account work-login (keyring)\n",
-			[]string{"omartelo", "work-login"},
+				"ghe.example.com\n  ✓ Logged in to ghe.example.com account omartelo (keyring)\n",
+			[]string{"github.com/omartelo", "ghe.example.com/omartelo"},
 		},
 		{"not logged in", "You are not logged into any GitHub hosts.\n", nil},
 		{"empty", "", nil},
@@ -47,8 +49,8 @@ func TestGitHubAccounts(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !slices.Equal(got, []string{"omartelo"}) {
-		t.Errorf("GitHubAccounts() = %v, want [omartelo]", got)
+	if !slices.Equal(got, []string{"github.com/omartelo"}) {
+		t.Errorf("GitHubAccounts() = %v, want [github.com/omartelo]", got)
 	}
 	if want := "auth status"; strings.Join(gh.args, " ") != want {
 		t.Errorf("ran %q, want %q", strings.Join(gh.args, " "), want)
@@ -66,7 +68,7 @@ func TestAccountTokenReachesGH(t *testing.T) {
 	var seen []string
 	gh := &accountGH{token: "gho_secret", pr: `{"number":7,"state":"OPEN"}`, calls: &seen}
 	svc := &Service{runner: gh.run}
-	svc.SetAccounts(func(string) string { return "marcelo-filho_snk" })
+	svc.SetAccounts(func(string) string { return "github.com/marcelo-filho_snk" })
 
 	pr, err := svc.PullRequestDetail("/repo", 0)
 	if err != nil || pr == nil {
@@ -75,7 +77,7 @@ func TestAccountTokenReachesGH(t *testing.T) {
 	if gh.viewToken != "gho_secret" {
 		t.Errorf("pr view ran with token %q, want the configured account's", gh.viewToken)
 	}
-	if want := "auth token --user marcelo-filho_snk"; !slices.Contains(seen, want) {
+	if want := "auth token --hostname github.com --user marcelo-filho_snk"; !slices.Contains(seen, want) {
 		t.Errorf("calls = %v, want one resolving the account (%q)", seen, want)
 	}
 }
@@ -114,7 +116,7 @@ func TestNoAccountRunsAsActive(t *testing.T) {
 func TestAccountTokenFailureFallsBack(t *testing.T) {
 	gh := &accountGH{tokenErr: errTest, pr: `{"number":7,"state":"OPEN"}`}
 	svc := &Service{runner: gh.run}
-	svc.SetAccounts(func(string) string { return "gone" })
+	svc.SetAccounts(func(string) string { return "github.com/gone" })
 
 	pr, err := svc.PullRequestDetail("/repo", 0)
 	if err != nil || pr == nil {
@@ -144,4 +146,41 @@ func (g *accountGH) run(_ time.Duration, _, token string, args ...string) ([]byt
 	}
 	g.viewToken = token
 	return []byte(g.pr), nil
+}
+
+// TestTokenArgs pins how an account is turned back into a gh call. Naming the
+// host is what makes an enterprise account resolvable at all: without it gh
+// looks the login up on its default host, answers "no oauth token found", and
+// tokenFor falls back to the active account without a word.
+func TestTokenArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		account string
+		want    []string
+	}{
+		{
+			"an account names its host",
+			"github.com/omartelo",
+			[]string{"auth", "token", "--hostname", "github.com", "--user", "omartelo"},
+		},
+		{
+			"an enterprise account is looked up on its own host",
+			"ghe.example.com/work-login",
+			[]string{"auth", "token", "--hostname", "ghe.example.com", "--user", "work-login"},
+		},
+		{
+			// Written before accounts carried a host: gh's default host is
+			// where it was found, so that is where it still resolves.
+			"a host-less account still resolves",
+			"omartelo",
+			[]string{"auth", "token", "--user", "omartelo"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tokenArgs(tt.account); !slices.Equal(got, tt.want) {
+				t.Errorf("tokenArgs(%q) = %v, want %v", tt.account, got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Why

#107 stored a GitHub account as its login alone. A login only identifies an account **within one host**, and `gh auth token --user <login>` looks it up on gh's default host only:

```
$ gh auth token --user naoexiste
no oauth token found for github.com account naoexiste
```

So an account authenticated on a GitHub Enterprise instance was listed in the picker, chosen by the user, not found by gh — and `tokenFor` fell back to the active account **without a word**. That silent fallback is the exact failure the account picker exists to prevent, and it hit precisely the people most likely to need the picker: anyone whose repositories live on an enterprise host.

The same login on two hosts was also a single ambiguous entry.

Worth saying plainly: nothing about the hostname can be inferred. git resolves a host through the ssh config — which is free to point `github.com` at an enterprise server — while gh reads the hostname from the remote and talks to *that name's* API. The two can reach different servers with no sign in the URL, so the host has to be carried, never guessed.

## What changed

- An account is `"<host>/<login>"`. The parser keeps the host `gh auth status` already prints, and `tokenArgs` names it back with `--hostname`.
- A value stored **without** a host still resolves on gh's default host, which is where it was found — no migration required to keep working.
- It is rewritten to the full form the moment gh says which host it lives on (`upgradeAccount`), and only when exactly one host claims that login. Otherwise the picker would list one account twice, once in each form. A login gh no longer knows is left alone, so it stays visible and changeable.
- The picker spells the host out only when there is more than one in play, or when it is not github.com — on a single-host machine it would be the same word on every row.
- The label logic moved to `src/lib/gh-account.ts`: it is pure, and in a `.tsx` the node-only test gate could not reach it.

## Test plan

- [x] Against the real `gh`: `project.GitHubAccounts` now answers `["github.com/omartelo", "github.com/marcelo-filho_snk"]`.
- [x] Against the real private repository, over the RPC: the **legacy** value (`marcelo-filho_snk`, the form already in my DB) resolves and lists the PRs; the **host-qualified** value (`github.com/marcelo-filho_snk`) resolves identically.
- [x] `TestTokenArgs` pins all three shapes — github.com, an enterprise host, and the host-less legacy form.
- [x] `upgradeAccount` covered for: one host claims the login, two hosts claim it (refuses to guess), gh no longer knows it, already upgraded, empty.
- [x] `go test ./...`, `gofmt -l .`, `go vet ./...` clean; `vitest` 480 passed, `biome check` 0 errors, `tsc --noEmit` clean, `vite build` ok.
- [x] Cross-compile loop for linux/darwin/windows (build + vet).
- [ ] No enterprise instance to test against here — the enterprise path is covered by the arguments lich builds, not by a live GHE round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
