### PR TITLE
fix: keep one session's flood from freezing every PTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **One session loading no longer freezes every other terminal.** A resumed
+  Claude session with a large transcript floods its terminal, and while the
+  window was busy swallowing it the socket that carries terminal output stopped
+  being read. That backpressure used to land on the loop reading the PTYs: the
+  read stalled, the PTY buffers filled, and every shell in every session — not
+  just the one that was loading — stopped dead until the socket recovered.
+  Output now leaves each session through a queue of its own, so a window that
+  falls behind slows down the session producing the flood and nothing else.
+
 ## [0.21.0] - 2026-07-27
 
 ### Added

--- a/internal/terminal/outbox.go
+++ b/internal/terminal/outbox.go
@@ -1,0 +1,50 @@
+package terminal
+
+// outboxDepth is how many flushed frames may wait on a stalled frontend before
+// the session's own PTY read blocks. A frame is one coalescer flush — 8ms of
+// output while visible, capped at maxPendingBytes — so this bounds both the
+// memory one session may hold and how far ahead of the window it may run.
+const outboxDepth = 32
+
+// outbox carries one session's coalesced output to the frontend on a goroutine
+// of its own.
+//
+// Delivery blocks: one WebSocket carries every session (transport.send) and
+// the /events fallback is one socket too, so a window that stops reading — the
+// page busy parsing a resumed session's transcript is enough — backs pressure
+// up into whoever is writing. Doing that on the PTY read path stalls the read,
+// the PTY buffer fills, and the child stops producing; because the socket is
+// shared, that reaches every session, not just the slow one. The queue is what
+// decouples them: a stalled window backs up one session's frames and, only
+// once the queue is full, that session's PTY. The backpressure that remains is
+// honest — it reaches the session that is producing, never its neighbours.
+type outbox struct {
+	frames chan []byte
+	done   chan struct{}
+}
+
+// newOutbox starts the delivery goroutine. deliver is called with one frame at
+// a time, in order, and owns the slice it is handed.
+func newOutbox(deliver func(data []byte), depth int) *outbox {
+	o := &outbox{frames: make(chan []byte, depth), done: make(chan struct{})}
+	go func() {
+		defer close(o.done)
+		for frame := range o.frames {
+			deliver(frame)
+		}
+	}()
+	return o
+}
+
+// push queues one frame for delivery, blocking only while this session's queue
+// is full. The frame is copied: the coalescer reuses the buffer it passes.
+func (o *outbox) push(data []byte) {
+	o.frames <- append([]byte(nil), data...)
+}
+
+// close stops the queue and waits for the frames still in it to be delivered,
+// so the caller can order a later event (the exit banner) after the last byte.
+func (o *outbox) close() {
+	close(o.frames)
+	<-o.done
+}

--- a/internal/terminal/outbox_test.go
+++ b/internal/terminal/outbox_test.go
@@ -1,0 +1,105 @@
+package terminal
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestOutboxQueuesWhileDeliveryIsStuck is the regression for the freeze a large
+// resumed session caused: with delivery blocked (a window that stopped reading
+// the socket), pushes must keep returning until the queue is full, so the PTY
+// read loop behind them keeps draining and only this session — never its
+// neighbours — feels the backpressure.
+func TestOutboxQueuesWhileDeliveryIsStuck(t *testing.T) {
+	release := make(chan struct{})
+	entered := make(chan struct{}, 1)
+	box := newOutbox(func([]byte) {
+		select {
+		case entered <- struct{}{}:
+		default:
+		}
+		<-release
+	}, 2)
+
+	// The first frame is taken by the (stuck) delivery goroutine; two more fit
+	// the queue.
+	pushed := make(chan struct{})
+	go func() {
+		box.push([]byte("one"))
+		box.push([]byte("two"))
+		box.push([]byte("three"))
+		close(pushed)
+	}()
+	<-entered
+	select {
+	case <-pushed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("push blocked while the queue still had room")
+	}
+
+	// A fourth has nowhere to go: this session's producer waits, which is the
+	// backpressure we keep.
+	blocked := make(chan struct{})
+	go func() {
+		box.push([]byte("four"))
+		close(blocked)
+	}()
+	select {
+	case <-blocked:
+		t.Fatal("push past the queue depth did not block")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	<-blocked
+	box.close()
+}
+
+// TestOutboxDeliversInOrderAndDrainsOnClose proves close waits for the frames
+// already queued: the exit event a caller emits after it can never overtake the
+// session's last bytes.
+func TestOutboxDeliversInOrderAndDrainsOnClose(t *testing.T) {
+	var mu sync.Mutex
+	var got []string
+	box := newOutbox(func(data []byte) {
+		mu.Lock()
+		got = append(got, string(data))
+		mu.Unlock()
+	}, 4)
+
+	for _, frame := range []string{"a", "b", "c", "d", "e"} {
+		box.push([]byte(frame))
+	}
+	box.close()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if want := "abcde"; join(got) != want {
+		t.Errorf("delivered %q, want %q", join(got), want)
+	}
+}
+
+// TestOutboxCopiesTheFrame proves a caller may reuse its buffer after push —
+// the coalescer hands over the slice it keeps appending to.
+func TestOutboxCopiesTheFrame(t *testing.T) {
+	delivered := make(chan []byte, 1)
+	box := newOutbox(func(data []byte) { delivered <- data }, 1)
+
+	buf := []byte("live")
+	box.push(buf)
+	copy(buf, "dead")
+	box.close()
+
+	if got := string(<-delivered); got != "live" {
+		t.Errorf("delivered %q, want %q — the frame was not copied", got, "live")
+	}
+}
+
+func join(frames []string) string {
+	out := ""
+	for _, frame := range frames {
+		out += frame
+	}
+	return out
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -82,12 +82,14 @@ type agentEvent struct {
 // session is a single running PTY-backed shell. done closes when the session
 // is reaped (by stream or Close — whichever removes it from the map), stopping
 // its cwd watcher. replay holds a capped tail of the PTY's output so a
-// reconnecting frontend can reseed its scrollback after a page reload.
+// reconnecting frontend can reseed its scrollback after a page reload. outbox
+// carries the coalesced output to the frontend off the PTY read path.
 type session struct {
 	pty    ptyHandle
 	out    *coalescer
 	done   chan struct{}
 	replay *replayBuffer
+	outbox *outbox
 }
 
 // Store is the persistence the terminal service depends on: the binary to spawn
@@ -421,30 +423,39 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume string, setup bo
 		return nil, "", fmt.Errorf("failed to start pty for %q: %w", id, err)
 	}
 
-	out := newCoalescer(func(data []byte) {
+	box := newOutbox(func(data []byte) {
 		if s.ws != nil && s.ws.send(id, data) {
 			return
 		}
 		encoded := base64.StdEncoding.EncodeToString(data)
 		s.hub.Emit(dataEventPrefix+id, encoded)
-	}, visibleFlushInterval, hiddenFlushInterval)
-	sess := &session{pty: p, out: out, done: make(chan struct{}), replay: newReplayBuffer(replayCapBytes)}
+	}, outboxDepth)
+	out := newCoalescer(box.push, visibleFlushInterval, hiddenFlushInterval)
+	sess := &session{
+		pty:    p,
+		out:    out,
+		done:   make(chan struct{}),
+		replay: newReplayBuffer(replayCapBytes),
+		outbox: box,
+	}
 	s.sessions[id] = sess
-	go s.stream(id, p, out, sess.replay)
+	go s.stream(id, sess)
 	return sess, cwd, nil
 }
 
 // stream copies PTY output to the frontend until the PTY is closed, then reaps
 // the process, drops the session and emits its exit event. Output goes through
 // the session's coalescer, which batches it on a short cadence while the
-// terminal is visible and a long one while it is hidden.
-func (s *Service) stream(id string, p ptyHandle, out *coalescer, replay *replayBuffer) {
+// terminal is visible and a long one while it is hidden, and then through its
+// outbox, which delivers it off this goroutine.
+func (s *Service) stream(id string, sess *session) {
+	p := sess.pty
 	buf := make([]byte, readBufSize)
 	for {
 		n, err := p.Read(buf)
 		if n > 0 {
-			replay.append(buf[:n])
-			out.Write(buf[:n])
+			sess.replay.append(buf[:n])
+			sess.out.Write(buf[:n])
 		}
 		if err != nil {
 			break
@@ -455,9 +466,11 @@ func (s *Service) stream(id string, p ptyHandle, out *coalescer, replay *replayB
 	// (Close only reaps sessions still in the map), and the user-driven Close
 	// path tolerates this as a no-op double close.
 	_ = p.Close()
-	// Flush any batched output before the exit event so the frontend always
-	// sees the final bytes ahead of the exit banner.
-	out.Close()
+	// Flush any batched output and wait for it to be delivered before the exit
+	// event, so the frontend always sees the final bytes ahead of the exit
+	// banner.
+	sess.out.Close()
+	sess.outbox.close()
 
 	s.mu.Lock()
 	if current, ok := s.sessions[id]; ok && current.pty == p {


### PR DESCRIPTION
## The bug

A resumed Claude session with a large transcript (the one that surfaced this had a 69MB `.jsonl`) floods its terminal, and while the window is busy parsing it **every** shell in **every** session stops dead — not only the one that is loading.

## Root cause

One WebSocket carries terminal output for all sessions, and the `/events` fallback is one socket too. A window that stops reading applies backpressure to whoever is writing, and that write happened on the PTY read path:

```
stream()  -> coalescer.Write (holds c.mu)
          -> emit, still under the mutex
          -> transport.send (holds t.mu)
          -> conn.Write, blocking up to wsWriteTimeout (5s)
```

So a stalled window stalled the read loop, the PTY buffer filled, and the child process blocked on write. Because the socket is shared, that reached every session at once.

Moving the lock is not a fix: `coder/websocket` serializes writes for the connection itself (`writeFrameMu`), so one socket has exactly one head to block. Decoupling is the only way out — which is the upgrade path `transport.send`'s own comment already named ("per-session queues only if a local loopback write ever measurably stalls"). It measurably stalls.

## The change

Output leaves each session through an `outbox`: a bounded queue drained by a goroutine of its own.

- A stalled window backs up that session's frames and, only once the queue is full (`outboxDepth`, 32 frames), its PTY.
- The backpressure that remains is honest — it reaches the session producing the flood, never its neighbours.
- Ordering per session is unchanged: one queue, one writer.
- `close()` drains before the caller emits the exit event, so `[process exited]` still lands after the last byte.

## Test plan

- [x] `outbox_test.go` covers the invariant that regressed: pushes keep returning while delivery is stuck, block once the queue is full, deliver in order, drain on close, and copy the frame the coalescer reuses.
- [x] `go test ./...` — 498 pass
- [x] `go test -race -count=3 ./internal/terminal/` clean
- [x] `gofmt -l .` clean, `go vet ./...` clean for linux, darwin and windows
- [x] `pnpm check` / `vitest` / `vite build` clean (untouched, verified anyway)

No OS seam touched, so no `ci:os` label.