### PR TITLE
fix: hand back the terminal's WebGL context when it is destroyed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Terminals stop degrading after a dozen tab switches.** Hiding a session
+  destroys its terminal and showing it builds a new one, but the renderer's
+  graphics context was only handed back when the browser got around to
+  collecting it. Chromium keeps sixteen alive and force-loses the oldest beyond
+  that, so switching between sessions eventually killed the renderer of a
+  terminal in use: it froze for the three seconds spent waiting for a restore
+  that never came, then fell back to the slower text renderer for good, with
+  cell metrics that no longer matched the ones its grid had been fitted to. The
+  context is now released the moment the terminal is destroyed.
+
 ## [0.21.0] - 2026-07-27
 
 ### Added

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -332,7 +332,18 @@ export function TerminalView({
         resizeInput.dispose()
         selection.dispose()
         searchResults.dispose()
+        // Disposing the WebGL addon only detaches its canvas — the GL context
+        // lives on until the canvas is collected, and Chromium force-loses the
+        // oldest of them once 16 are alive. Since every hide destroys a
+        // terminal and every show builds a new one, a dozen tab switches are
+        // enough to start killing live renderers (a frozen terminal for the 3s
+        // xterm waits for a restore, then a permanent fall back to the slower
+        // DOM renderer). Hand the context back here instead.
+        const canvases = [...container.querySelectorAll("canvas")]
         term.dispose()
+        for (const canvas of canvases) {
+          canvas.getContext("webgl2")?.getExtension("WEBGL_lose_context")?.loseContext()
+        }
       },
     }
   }


### PR DESCRIPTION
## The bug

Hidden sessions serialize and destroy their xterm instance (the waveterm model), and showing one builds a fresh terminal — so **a WebGL context is created on every session switch**. `WebglAddon.dispose()` only detaches its canvas; the GL context lives until the canvas is collected.

Chromium keeps sixteen contexts alive and force-loses the oldest past that, so tab switching walks the page straight into the cap.

## Evidence

Headless Chromium driving the same hide/show cycle this component performs, with real (trusted) input for the probes:

```
before:  switch 1..16 -> gl = 1, 2, 3 ... 16, then one forced context loss per switch
after:   gl = 1, constant across 21 switches
```

A forced loss on a terminal *in use* costs:

1. the **3 seconds** xterm spends waiting for a `webglcontextrestored` that never comes — the terminal is frozen for all of it;
2. then a permanent fall back to the DOM renderer, whose cell metrics differ from the WebGL renderer's (`7x18` → `7.796875x18` in the same probe), so the grid no longer matches the fit it was given.

## The change

Collect the canvases before `term.dispose()`, release their contexts after it. The order is load-bearing: disposing first removes the renderer's own `webglcontextlost` listener, so releasing the context cannot start the 3s restoration timer on a renderer that is already gone. `getContext("webgl2")` returns `null` on the 2D layer canvases, so the loop is a no-op for them.

## Test plan

- [x] Measured before/after in the harness above (real `Input.dispatchMouseEvent` wheel + drag): wheel scroll, drag select and `scrollLines` all still work after 21 switches.
- [x] `pnpm check` clean, `tsc --noEmit` clean, `vitest run` 480 pass, `vite build` ok
- [x] `go test ./...` 498 pass (untouched, verified anyway)

The gate cannot render components (node env, no jsdom), so the check that matters here is the harness measurement, not the suite.

## Not in this PR

This does **not** explain every report of losing scroll and selection in a terminal — under a live flood of output, drag-select returns 0 characters and recovers only when the output stops (xterm clears the selection as the buffer trims). That one is still being pinned down.