### PR TITLE
chore: cut v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.1] - 2026-07-27
+
 ### Fixed
 
 - **One session loading no longer freezes every other terminal.** A resumed
@@ -1077,7 +1079,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.21.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.21.1...HEAD
+[0.21.1]: https://github.com/omartelo/lich/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/omartelo/lich/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/omartelo/lich/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/omartelo/lich/compare/v0.18.0...v0.19.0


### PR DESCRIPTION
Patch release: two terminal fixes, no new surface.

- #111 — one session's flood no longer freezes every PTY (per-session outbox)
- #112 — the terminal hands its WebGL context back when it is destroyed

`[Unreleased]` moved under `## [0.21.1]`, compare links refreshed.

## Pre-tag gate

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test -race ./...` — 498 pass
- [x] `pnpm check` (13 standing a11y warnings, no errors), `tsc --noEmit`, `vitest run` 480 pass, `vite build` ok

Tag `v0.21.1` goes up once this lands.