### PR TITLE
refactor(backend): keep routine git answers out of the log, and dedupe the safety primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The log file stops burying real failures under routine git output.** The
+  footer polls every open checkout several times a second, and two of the git
+  calls behind it answer "no" as a matter of course: a repository with no
+  commits has no `HEAD` to resolve, and a path that is not a repository has no
+  branch to name. Both ran through the path that treats any failure as one worth
+  reporting, so each poll filed a warning — thousands a day into a log that
+  rotates at 5MB, pushing out the failures a bug report is actually about.
+  Discarding a newly created file did the same, once per discard, for the check
+  that asks whether the file exists in `HEAD`. Those calls now ask quietly;
+  everything a person is waiting on still reports as before.
+
 ## [0.21.1] - 2026-07-27
 
 ### Fixed

--- a/internal/claudeplugin/claudeplugin_test.go
+++ b/internal/claudeplugin/claudeplugin_test.go
@@ -1,11 +1,14 @@
 package claudeplugin
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 	"testing"
 )
 
@@ -211,5 +214,143 @@ func TestStatusNotInstalled(t *testing.T) {
 	}
 	if got.LatestVersion != "0.2.0" {
 		t.Fatalf("LatestVersion = %q, want %q", got.LatestVersion, "0.2.0")
+	}
+}
+
+// The `claude plugin` calls are the supported interface for every mutation this
+// package makes, so nothing below can be asserted without spawning something.
+// The test binary doubles as that something: TestMain hands control to a fake
+// CLI when the guard variable is set, which is how the child tells its two roles
+// apart. Portable by construction — no shell script, no per-OS fixture.
+const (
+	fakeClaudeGuard = "LICH_TEST_FAKE_CLAUDE"
+	fakeClaudeLog   = "LICH_TEST_FAKE_CLAUDE_LOG"
+	fakeClaudeFail  = "LICH_TEST_FAKE_CLAUDE_FAIL"
+)
+
+func TestMain(m *testing.M) {
+	if os.Getenv(fakeClaudeGuard) == "" {
+		os.Exit(m.Run())
+	}
+	// Recording before the exit code: a call that fails still has to show which
+	// call it was.
+	if log := os.Getenv(fakeClaudeLog); log != "" {
+		line := strings.Join(os.Args[1:], " ") + "\n"
+		f, err := os.OpenFile(log, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			os.Exit(2)
+		}
+		_, _ = f.WriteString(line)
+		_ = f.Close()
+	}
+	if failOn := os.Getenv(fakeClaudeFail); failOn != "" && strings.Contains(strings.Join(os.Args[1:], " "), failOn) {
+		fmt.Fprintln(os.Stderr, "fake claude: refusing "+failOn)
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+// stubBin is a BinResolver naming a fixed binary, standing in for the store.
+type stubBin string
+
+func (b stubBin) ClaudeBin(string) string { return string(b) }
+
+// fakeClaude points a Service's shell-out at the test binary's fake CLI and
+// returns a reader of the calls it received. failOn, when non-empty, makes the
+// fake fail any call whose arguments contain it.
+func fakeClaude(t *testing.T, failOn string) (*Service, func() []string) {
+	t.Helper()
+	log := filepath.Join(t.TempDir(), "calls.log")
+	t.Setenv(fakeClaudeGuard, "1")
+	t.Setenv(fakeClaudeLog, log)
+	t.Setenv(fakeClaudeFail, failOn)
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test binary: %v", err)
+	}
+	calls := func() []string {
+		data, err := os.ReadFile(log)
+		if err != nil {
+			return nil
+		}
+		return strings.Split(strings.TrimSpace(string(data)), "\n")
+	}
+	return &Service{bins: stubBin(self)}, calls
+}
+
+// TestInstallAddsMarketplaceThenPlugin pins the order and the exact targets: the
+// marketplace has to be added before the plugin can resolve, and both name the
+// keys Claude Code stores the plugin under.
+func TestInstallAddsMarketplaceThenPlugin(t *testing.T) {
+	s, calls := fakeClaude(t, "")
+
+	if err := s.Install(); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	want := []string{
+		"plugin marketplace add " + marketplaceRepo,
+		"plugin install " + pluginKey,
+	}
+	if got := calls(); !slices.Equal(got, want) {
+		t.Errorf("calls = %v, want %v", got, want)
+	}
+}
+
+// TestInstallSurvivesARepeatMarketplaceAdd proves the documented tolerance: a
+// marketplace already present makes `marketplace add` fail, and that failure
+// must not cost the install that follows it.
+func TestInstallSurvivesARepeatMarketplaceAdd(t *testing.T) {
+	s, calls := fakeClaude(t, "marketplace add")
+
+	if err := s.Install(); err != nil {
+		t.Fatalf("Install after a repeat marketplace add: %v", err)
+	}
+	if got := calls(); len(got) != 2 || got[1] != "plugin install "+pluginKey {
+		t.Errorf("calls = %v, want the install to have run anyway", got)
+	}
+}
+
+// TestInstallReportsTheInstallFailure proves the other half: when the install
+// itself fails, the error carries both the call and what the CLI said, which is
+// all the settings screen has to show.
+func TestInstallReportsTheInstallFailure(t *testing.T) {
+	s, _ := fakeClaude(t, "plugin install")
+
+	err := s.Install()
+	if err == nil {
+		t.Fatal("Install: want an error, got nil")
+	}
+	for _, want := range []string{"plugin install " + pluginKey, "refusing"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q missing %q", err, want)
+		}
+	}
+}
+
+// TestUpdateTargetsThePluginKey proves Update names the same key Status reads
+// the installed version under — a mismatch would silently update nothing.
+func TestUpdateTargetsThePluginKey(t *testing.T) {
+	s, calls := fakeClaude(t, "")
+
+	if err := s.Update(); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got := calls(); !slices.Equal(got, []string{"plugin update " + pluginKey}) {
+		t.Errorf("calls = %v, want a single plugin update", got)
+	}
+}
+
+// TestRunClaudeFallsBackToPath proves an unset binary override spawns plain
+// "claude" rather than an empty command — the store answers "" for every
+// project that configured no path.
+func TestRunClaudeFallsBackToPath(t *testing.T) {
+	s := &Service{bins: stubBin("")}
+	err := s.runClaude("plugin", "update", pluginKey)
+	if err == nil {
+		return // a machine with Claude Code installed: the call really ran
+	}
+	if !strings.Contains(err.Error(), "claude plugin update") {
+		t.Errorf("error %q does not name the claude call", err)
 	}
 }

--- a/internal/project/difftext.go
+++ b/internal/project/difftext.go
@@ -21,10 +21,7 @@ const maxUntrackedDiffSize = 10 << 20
 // against git's empty tree. Untracked files are rendered as new-file hunks so
 // the review panel shows them alongside tracked changes.
 func (s *Service) DiffText(path string) (string, error) {
-	base := "HEAD"
-	if _, err := runGit(path, "rev-parse", "--verify", "HEAD"); err != nil {
-		base = emptyTreeHash
-	}
+	_, base := diffBase(path)
 	tracked, err := runGit(path, "diff", base)
 	if err != nil {
 		return "", err
@@ -39,19 +36,11 @@ func (s *Service) DiffText(path string) (string, error) {
 }
 
 // untrackedFiles lists paths unknown to git, relative to the work tree root.
-// Errors yield an empty list — the tracked diff is still worth returning.
+// A failure yields an empty list — both callers (the polled Diff counts and the
+// review panel's full text) are worth returning without it.
 func untrackedFiles(path string) []string {
-	out, err := command("git", "-C", path, "ls-files", "--others", "--exclude-standard", "-z").Output()
-	if err != nil {
-		return nil
-	}
-	var files []string
-	for rel := range strings.SplitSeq(string(out), "\x00") {
-		if rel != "" {
-			files = append(files, rel)
-		}
-	}
-	return files
+	out, _ := gitQuiet(path, "ls-files", "--others", "--exclude-standard", "-z")
+	return splitNUL(out)
 }
 
 // untrackedDiff renders an untracked file as a new-file unified diff via

--- a/internal/project/discard.go
+++ b/internal/project/discard.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
+
+	"github.com/omartelo/lich/internal/relpath"
 )
 
 // DiscardFile reverts one file's uncommitted changes. A file known to HEAD is
@@ -13,10 +14,12 @@ import (
 // repo-relative path — the review panel passes paths parsed from git's own
 // diff output.
 func (s *Service) DiscardFile(path, rel string) error {
-	if err := validateRelPath(rel); err != nil {
+	if err := relpath.Validate(rel); err != nil {
 		return err
 	}
-	if _, err := runGit(path, "cat-file", "-e", "HEAD:"+rel); err == nil {
+	// Quiet: "HEAD does not know this file" is the answer that routes to the
+	// new-file branch below, not a failure worth a log line per discard.
+	if _, known := gitQuiet(path, "cat-file", "-e", "HEAD:"+rel); known {
 		_, err := runGit(path, "checkout", "HEAD", "--", rel)
 		return err
 	}
@@ -27,23 +30,4 @@ func (s *Service) DiscardFile(path, rel string) error {
 		return fmt.Errorf("remove %s: %w", rel, err)
 	}
 	return nil
-}
-
-// validateRelPath rejects rooted paths and traversal outside the work tree
-// before rel is ever joined onto it.
-func validateRelPath(rel string) error {
-	clean := filepath.Clean(rel)
-	if isRooted(clean) || clean == ".." ||
-		strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
-		return fmt.Errorf("invalid repository path %q", rel)
-	}
-	return nil
-}
-
-// isRooted reports whether a cleaned path starts at a root. IsAbs alone is not
-// enough on Windows, where it demands a volume name and so reads "/etc/passwd"
-// as relative; a work-tree path is always relative, so a leading separator is
-// refused too (os.IsPathSeparator counts "\" only where it is one).
-func isRooted(clean string) bool {
-	return filepath.IsAbs(clean) || os.IsPathSeparator(clean[0])
 }

--- a/internal/project/discard_test.go
+++ b/internal/project/discard_test.go
@@ -55,27 +55,6 @@ func TestDiscardFileNew(t *testing.T) {
 	}
 }
 
-// TestValidateRelPathRejectsRootedPaths pins the guard itself. The callers'
-// escape tests pass on Windows for the wrong reason — the joined path simply
-// misses on disk — so the rule is asserted here directly: a path starting at a
-// root is never a work-tree path, whether or not it carries a volume name.
-func TestValidateRelPathRejectsRootedPaths(t *testing.T) {
-	rooted := []string{"/etc/passwd", "/"}
-	if os.IsPathSeparator('\\') {
-		rooted = append(rooted, `\Windows\System32\config`, `C:\Windows`)
-	}
-	for _, rel := range rooted {
-		if err := validateRelPath(rel); err == nil {
-			t.Errorf("validateRelPath(%q): want error, got nil", rel)
-		}
-	}
-	for _, rel := range []string{"a.txt", "internal/rpc/rpc.go", "a/b/../c.txt"} {
-		if err := validateRelPath(rel); err != nil {
-			t.Errorf("validateRelPath(%q): want nil, got %v", rel, err)
-		}
-	}
-}
-
 // TestDiscardFileRejectsEscape proves traversal and absolute paths never reach
 // the filesystem.
 func TestDiscardFileRejectsEscape(t *testing.T) {

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -1,0 +1,76 @@
+package project
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+
+	"github.com/omartelo/lich/internal/winexec"
+)
+
+// command builds an exec.Cmd for a child console tool (git, gh) with its
+// console window suppressed on Windows — lich's GUI-subsystem binary would
+// otherwise pop one per spawn (winexec.Hide). Used across this package instead
+// of exec.Command so no call site can forget it.
+func command(name string, args ...string) *exec.Cmd {
+	cmd := exec.Command(name, args...)
+	winexec.Hide(cmd)
+	return cmd
+}
+
+// runGit runs git -C dir args... for a call whose failure is shown to someone:
+// it comes back as the screen's message and git's stderr reaches the log
+// (giterror.go). Every failure it sees is reported as one.
+//
+// That makes it the wrong runner for two other kinds of call, which take
+// gitQuiet instead: a polled read, where a failure means "no answer, try again
+// in a second", and a probe whose negative answer *is* the result ("does HEAD
+// know this file?"). Routed here, both would file a warning per call — several
+// per second on a repository with no commits — and bury the failures that
+// actually mean something.
+func runGit(dir string, args ...string) (string, error) {
+	cmd := command("git", append([]string{"-C", dir}, args...)...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", gitFailure(args, stderr.String(), err)
+	}
+	return string(out), nil
+}
+
+// gitQuiet runs git -C dir args... and reports only whether it succeeded. ok is
+// false for every failure alike — the caller asked a question git may legitimately
+// answer "no" to, so there is nothing to log and nothing to show. See runGit for
+// which calls belong here and which do not.
+func gitQuiet(dir string, args ...string) (string, bool) {
+	out, err := command("git", append([]string{"-C", dir}, args...)...).Output()
+	if err != nil {
+		return "", false
+	}
+	return string(out), true
+}
+
+// splitNUL splits the -z output of a git list command into its entries. git
+// terminates each with a NUL, so the trailing empty element is dropped along
+// with any other.
+func splitNUL(out string) []string {
+	var entries []string
+	for entry := range strings.SplitSeq(out, "\x00") {
+		if entry != "" {
+			entries = append(entries, entry)
+		}
+	}
+	return entries
+}
+
+// splitLines splits command output into its non-empty lines.
+func splitLines(out string) []string {
+	lines := []string{}
+	for line := range strings.Lines(out) {
+		if trimmed := strings.TrimSpace(line); trimmed != "" {
+			lines = append(lines, trimmed)
+		}
+	}
+	return lines
+}

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -1,0 +1,123 @@
+package project
+
+import (
+	"bytes"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// captureLog points slog's default logger at a buffer for the duration of a
+// test and returns what was written. runGit files a warning per failure, so the
+// buffer is how a call is shown to be off that path.
+func captureLog(t *testing.T) func() string {
+	t.Helper()
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	return buf.String
+}
+
+// initBareRepo makes a repository with no commits at all — the state where
+// HEAD does not resolve, which every diff read has to treat as ordinary.
+func initBareRepo(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	if out, err := exec.Command("git", "init", "-b", "main", repo).CombinedOutput(); err != nil {
+		t.Skipf("git init unavailable: %v (%s)", err, out)
+	}
+	return repo
+}
+
+// TestDiffOnARepositoryWithoutCommitsStaysSilent pins the contract that makes
+// the footer poll affordable: Diff runs several git calls a second, per open
+// checkout, and a repository with no commits fails the HEAD probe on every one
+// of them. Routed through runGit that would file a warning per poll — thousands
+// a day into a log that rotates at 5MB, burying the failures that mean
+// something. The counts still have to be right, so both are asserted together.
+func TestDiffOnARepositoryWithoutCommitsStaysSilent(t *testing.T) {
+	repo := initBareRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "new.txt"), []byte("a\nb\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	logged := captureLog(t)
+
+	stats := New(nil).Diff(repo)
+	if stats.Files != 1 || stats.Added != 2 || stats.Deleted != 0 {
+		t.Errorf("Diff = %+v, want 1 file and 2 added lines", stats)
+	}
+	if stats.Head != "" {
+		t.Errorf("Head = %q, want empty on a repository with no commits", stats.Head)
+	}
+	if out := logged(); out != "" {
+		t.Errorf("a polled Diff logged:\n%s", out)
+	}
+}
+
+// TestBranchOnANonRepositoryStaysSilent covers the other polled read: the footer
+// asks every open path for its branch, including ones that turned out not to be
+// repositories at all.
+func TestBranchOnANonRepositoryStaysSilent(t *testing.T) {
+	logged := captureLog(t)
+
+	if got := New(nil).Branch(t.TempDir()); got != "" {
+		t.Errorf("Branch = %q, want empty outside a repository", got)
+	}
+	if out := logged(); out != "" {
+		t.Errorf("a polled Branch logged:\n%s", out)
+	}
+}
+
+// TestDiscardNewFileStaysSilent pins the probe whose negative answer is the
+// result: "HEAD does not know this file" is what routes a discard to the
+// delete-from-disk branch, so it is not a failure and must not read as one.
+func TestDiscardNewFileStaysSilent(t *testing.T) {
+	repo, _ := initRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "loose.txt"), []byte("l\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	logged := captureLog(t)
+
+	if err := New(nil).DiscardFile(repo, "loose.txt"); err != nil {
+		t.Fatalf("DiscardFile: %v", err)
+	}
+	if out := logged(); out != "" {
+		t.Errorf("discarding a new file logged:\n%s", out)
+	}
+}
+
+// TestRunGitStillReportsRealFailures is the counterweight: the quiet runner
+// exists for polls and probes, and must not have swallowed the failures a
+// person is waiting on. A read of a directory that is not a repository still
+// yields the screen's sentence and still reaches the log.
+func TestRunGitStillReportsRealFailures(t *testing.T) {
+	logged := captureLog(t)
+
+	_, err := New(nil).Tree(t.TempDir())
+	if err == nil {
+		t.Fatal("Tree outside a repository: want an error, got nil")
+	}
+	if want := "not a git repository"; !strings.Contains(err.Error(), "not a git repository") {
+		t.Errorf("error %q does not name %q", err, want)
+	}
+	if !strings.Contains(logged(), "git failed") {
+		t.Errorf("a reported failure never reached the log:\n%s", logged())
+	}
+}
+
+// TestSplitNULDropsTheTrailingTerminator proves the shared splitter reads git's
+// -z output the way git writes it: a NUL after every entry, so the last one is
+// a terminator and never an empty path.
+func TestSplitNULDropsTheTrailingTerminator(t *testing.T) {
+	got := splitNUL("a.txt\x00dir/b.txt\x00")
+	if len(got) != 2 || got[0] != "a.txt" || got[1] != "dir/b.txt" {
+		t.Errorf("splitNUL = %q, want [a.txt dir/b.txt]", got)
+	}
+	if got := splitNUL(""); got != nil {
+		t.Errorf("splitNUL(\"\") = %q, want nil", got)
+	}
+}

--- a/internal/project/pr.go
+++ b/internal/project/pr.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -128,28 +127,6 @@ type PRCommit struct {
 	Date     string `json:"date"` // gh's ISO committedDate
 }
 
-// ChecksRollup collapses gh's statusCheckRollup array into the counts the panel
-// shows. Total is every check, so "all green" is Passed == Total && Total > 0.
-type ChecksRollup struct {
-	Passed  int `json:"passed"`
-	Failed  int `json:"failed"`
-	Pending int `json:"pending"`
-	Total   int `json:"total"`
-}
-
-// CheckItem is one check, flattened from gh's two rollup shapes into what the
-// Checks tab lists. State is this package's own passed|failed|pending, the same
-// verdict ChecksRollup counts. The timestamps are gh's ISO strings, left for the
-// frontend to turn into a duration.
-type CheckItem struct {
-	Name        string `json:"name"`
-	State       string `json:"state"`
-	Description string `json:"description"` // workflow name, or the status context's own line
-	URL         string `json:"url"`         // where to read the run; "" when gh reports none
-	StartedAt   string `json:"startedAt"`
-	CompletedAt string `json:"completedAt"`
-}
-
 // ghPRView mirrors the requested gh payload; statusCheckRollup is reduced to
 // ChecksRollup inside parsePRDetail and never leaves this package raw.
 type ghPRView struct {
@@ -182,25 +159,6 @@ type ghCommit struct {
 type ghCommitAuthor struct {
 	Login string `json:"login"`
 	Name  string `json:"name"`
-}
-
-// checkItem is one statusCheckRollup entry. gh emits two shapes: a CheckRun
-// (Actions/apps) carries name/status/conclusion/detailsUrl; a StatusContext
-// (legacy commit statuses) carries context/state/targetUrl. checkState reads
-// whichever is populated, and toCheckItems flattens the pair.
-type checkItem struct {
-	Status     string `json:"status"`     // CheckRun: QUEUED|IN_PROGRESS|COMPLETED|…
-	Conclusion string `json:"conclusion"` // CheckRun: SUCCESS|FAILURE|NEUTRAL|SKIPPED|…
-	State      string `json:"state"`      // StatusContext: SUCCESS|FAILURE|PENDING|ERROR
-
-	Name         string `json:"name"`    // CheckRun
-	Context      string `json:"context"` // StatusContext
-	WorkflowName string `json:"workflowName"`
-	Description  string `json:"description"` // StatusContext
-	DetailsURL   string `json:"detailsUrl"`  // CheckRun
-	TargetURL    string `json:"targetUrl"`   // StatusContext
-	StartedAt    string `json:"startedAt"`
-	CompletedAt  string `json:"completedAt"`
 }
 
 // PullRequestDetail returns one open pull request in full: the given number, or
@@ -278,79 +236,6 @@ func toCommits(commits []ghCommit) []PRCommit {
 	return out
 }
 
-// The verdict of one check, shared by the rollup counts and the Checks tab.
-const (
-	checkPassed  = "passed"
-	checkFailed  = "failed"
-	checkPending = "pending"
-)
-
-// checkState reads gh's mixed CheckRun/StatusContext shapes into one verdict. A
-// CheckRun is pending until its status is COMPLETED, then passes unless the
-// conclusion is a failure; a StatusContext maps its state directly. Anything
-// unrecognised is pending, so an in-flight check never reads as passed.
-func checkState(it checkItem) string {
-	switch {
-	case it.Status != "" && it.Status != "COMPLETED":
-		return checkPending
-	case it.Conclusion != "":
-		if isFailureConclusion(it.Conclusion) {
-			return checkFailed
-		}
-		return checkPassed
-	case it.State == "SUCCESS":
-		return checkPassed
-	case it.State == "FAILURE" || it.State == "ERROR":
-		return checkFailed
-	default:
-		return checkPending
-	}
-}
-
-// reduceChecks collapses the rollup into the counts the header shows.
-func reduceChecks(items []checkItem) ChecksRollup {
-	r := ChecksRollup{Total: len(items)}
-	for _, it := range items {
-		switch checkState(it) {
-		case checkPassed:
-			r.Passed++
-		case checkFailed:
-			r.Failed++
-		default:
-			r.Pending++
-		}
-	}
-	return r
-}
-
-// checkOrder ranks the states for the Checks tab: what broke first, what is
-// still running next, what already passed last.
-var checkOrder = map[string]int{checkFailed: 0, checkPending: 1, checkPassed: 2}
-
-// toCheckItems flattens the rollup into the list the Checks tab renders, worst
-// state first and otherwise in gh's own order. Returns nil for no checks, so the
-// tab can tell "none reported" from a list.
-func toCheckItems(items []checkItem) []CheckItem {
-	if len(items) == 0 {
-		return nil
-	}
-	out := make([]CheckItem, 0, len(items))
-	for _, it := range items {
-		out = append(out, CheckItem{
-			Name:        firstNonEmpty(it.Name, it.Context),
-			State:       checkState(it),
-			Description: firstNonEmpty(it.WorkflowName, it.Description),
-			URL:         firstNonEmpty(it.DetailsURL, it.TargetURL),
-			StartedAt:   it.StartedAt,
-			CompletedAt: it.CompletedAt,
-		})
-	}
-	sort.SliceStable(out, func(i, j int) bool {
-		return checkOrder[out[i].State] < checkOrder[out[j].State]
-	})
-	return out
-}
-
 func firstNonEmpty(values ...string) string {
 	for _, v := range values {
 		if v != "" {
@@ -358,14 +243,6 @@ func firstNonEmpty(values ...string) string {
 		}
 	}
 	return ""
-}
-
-func isFailureConclusion(c string) bool {
-	switch c {
-	case "FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE":
-		return true
-	}
-	return false
 }
 
 // mergeMethods maps each accepted method to its gh flag, and doubles as the

--- a/internal/project/prchecks.go
+++ b/internal/project/prchecks.go
@@ -1,0 +1,130 @@
+package project
+
+import "sort"
+
+// gh reports a pull request's CI as a mixed array of two unrelated shapes. This
+// file is the whole translation from that array into the two things the screen
+// wants — a header count and a ranked list — and nothing else in the package
+// needs to know either shape exists.
+
+// ChecksRollup collapses gh's statusCheckRollup array into the counts the panel
+// shows. Total is every check, so "all green" is Passed == Total && Total > 0.
+type ChecksRollup struct {
+	Passed  int `json:"passed"`
+	Failed  int `json:"failed"`
+	Pending int `json:"pending"`
+	Total   int `json:"total"`
+}
+
+// CheckItem is one check, flattened from gh's two rollup shapes into what the
+// Checks tab lists. State is this package's own passed|failed|pending, the same
+// verdict ChecksRollup counts. The timestamps are gh's ISO strings, left for the
+// frontend to turn into a duration.
+type CheckItem struct {
+	Name        string `json:"name"`
+	State       string `json:"state"`
+	Description string `json:"description"` // workflow name, or the status context's own line
+	URL         string `json:"url"`         // where to read the run; "" when gh reports none
+	StartedAt   string `json:"startedAt"`
+	CompletedAt string `json:"completedAt"`
+}
+
+// checkItem is one statusCheckRollup entry. gh emits two shapes: a CheckRun
+// (Actions/apps) carries name/status/conclusion/detailsUrl; a StatusContext
+// (legacy commit statuses) carries context/state/targetUrl. checkState reads
+// whichever is populated, and toCheckItems flattens the pair.
+type checkItem struct {
+	Status     string `json:"status"`     // CheckRun: QUEUED|IN_PROGRESS|COMPLETED|…
+	Conclusion string `json:"conclusion"` // CheckRun: SUCCESS|FAILURE|NEUTRAL|SKIPPED|…
+	State      string `json:"state"`      // StatusContext: SUCCESS|FAILURE|PENDING|ERROR
+
+	Name         string `json:"name"`    // CheckRun
+	Context      string `json:"context"` // StatusContext
+	WorkflowName string `json:"workflowName"`
+	Description  string `json:"description"` // StatusContext
+	DetailsURL   string `json:"detailsUrl"`  // CheckRun
+	TargetURL    string `json:"targetUrl"`   // StatusContext
+	StartedAt    string `json:"startedAt"`
+	CompletedAt  string `json:"completedAt"`
+}
+
+// The verdict of one check, shared by the rollup counts and the Checks tab.
+const (
+	checkPassed  = "passed"
+	checkFailed  = "failed"
+	checkPending = "pending"
+)
+
+// checkState reads gh's mixed CheckRun/StatusContext shapes into one verdict. A
+// CheckRun is pending until its status is COMPLETED, then passes unless the
+// conclusion is a failure; a StatusContext maps its state directly. Anything
+// unrecognised is pending, so an in-flight check never reads as passed.
+func checkState(it checkItem) string {
+	switch {
+	case it.Status != "" && it.Status != "COMPLETED":
+		return checkPending
+	case it.Conclusion != "":
+		if isFailureConclusion(it.Conclusion) {
+			return checkFailed
+		}
+		return checkPassed
+	case it.State == "SUCCESS":
+		return checkPassed
+	case it.State == "FAILURE" || it.State == "ERROR":
+		return checkFailed
+	default:
+		return checkPending
+	}
+}
+
+func isFailureConclusion(c string) bool {
+	switch c {
+	case "FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE":
+		return true
+	}
+	return false
+}
+
+// reduceChecks collapses the rollup into the counts the header shows.
+func reduceChecks(items []checkItem) ChecksRollup {
+	r := ChecksRollup{Total: len(items)}
+	for _, it := range items {
+		switch checkState(it) {
+		case checkPassed:
+			r.Passed++
+		case checkFailed:
+			r.Failed++
+		default:
+			r.Pending++
+		}
+	}
+	return r
+}
+
+// checkOrder ranks the states for the Checks tab: what broke first, what is
+// still running next, what already passed last.
+var checkOrder = map[string]int{checkFailed: 0, checkPending: 1, checkPassed: 2}
+
+// toCheckItems flattens the rollup into the list the Checks tab renders, worst
+// state first and otherwise in gh's own order. Returns nil for no checks, so the
+// tab can tell "none reported" from a list.
+func toCheckItems(items []checkItem) []CheckItem {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make([]CheckItem, 0, len(items))
+	for _, it := range items {
+		out = append(out, CheckItem{
+			Name:        firstNonEmpty(it.Name, it.Context),
+			State:       checkState(it),
+			Description: firstNonEmpty(it.WorkflowName, it.Description),
+			URL:         firstNonEmpty(it.DetailsURL, it.TargetURL),
+			StartedAt:   it.StartedAt,
+			CompletedAt: it.CompletedAt,
+		})
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return checkOrder[out[i].State] < checkOrder[out[j].State]
+	})
+	return out
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -11,24 +11,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/omartelo/lich/internal/winexec"
 )
-
-// command builds an exec.Cmd for a child console tool (git, gh) with its
-// console window suppressed on Windows — lich's GUI-subsystem binary would
-// otherwise pop one per spawn (winexec.Hide). Used across this package instead
-// of exec.Command so no polling call site can forget it.
-func command(name string, args ...string) *exec.Cmd {
-	cmd := exec.Command(name, args...)
-	winexec.Hide(cmd)
-	return cmd
-}
 
 // Project identifies an opened project directory.
 type Project struct {
@@ -96,11 +83,8 @@ func newProject(path string) *Project {
 // the current state on call, so a checkout made after opening is not reflected
 // until the branch is resolved again.
 func (s *Service) Branch(path string) string {
-	out, err := command("git", "-C", path, "symbolic-ref", "--short", "HEAD").Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
+	out, _ := gitQuiet(path, "symbolic-ref", "--short", "HEAD")
+	return strings.TrimSpace(out)
 }
 
 // PullRequest identifies the open GitHub pull request for a work tree's current
@@ -171,40 +155,48 @@ func (s *Service) Diff(path string) DiffStats {
 	// --untracked-files=all, because the default collapses a new directory into
 	// one "?? dir/" line: an agent writing 25 files into fresh packages would
 	// count as one changed file.
-	if out, err := command("git", "-C", path, "status", "--porcelain", "--untracked-files=all").Output(); err == nil {
+	if out, ok := gitQuiet(path, "status", "--porcelain", "--untracked-files=all"); ok {
 		stats.Files = countLines(out)
 	}
-	// A repository without commits has no HEAD; diff against git's empty tree,
-	// same as DiffText. Errors here must not skip the untracked block below.
-	base := "HEAD"
-	if out, err := runGit(path, "rev-parse", "--verify", "HEAD"); err == nil {
-		stats.Head = strings.TrimSpace(out)
-	} else {
-		base = emptyTreeHash
-	}
-	if out, err := command("git", "-C", path, "diff", "--numstat", base).Output(); err == nil {
-		for line := range strings.Lines(string(out)) {
-			cols := strings.Fields(line)
-			if len(cols) < 3 {
-				continue
-			}
-			// Binary files report "-" for both counts; Atoi fails and adds zero.
-			added, _ := strconv.Atoi(cols[0])
-			deleted, _ := strconv.Atoi(cols[1])
-			stats.Added += added
-			stats.Deleted += deleted
-		}
+	head, base := diffBase(path)
+	stats.Head = head
+	if out, ok := gitQuiet(path, "diff", "--numstat", base); ok {
+		stats.Added, stats.Deleted = numstatTotals(out)
 	}
 	// Untracked files are invisible to `git diff`; count their lines as
 	// additions, the way Warp and forge diff views present a fresh file.
-	if out, err := command("git", "-C", path, "ls-files", "--others", "--exclude-standard", "-z").Output(); err == nil {
-		for _, rel := range strings.Split(string(out), "\x00") {
-			if rel != "" {
-				stats.Added += countFileLines(filepath.Join(path, rel))
-			}
-		}
+	for _, rel := range untrackedFiles(path) {
+		stats.Added += countFileLines(filepath.Join(path, rel))
 	}
 	return stats
+}
+
+// diffBase resolves what uncommitted changes are diffed against: HEAD and its
+// commit, or git's empty tree with no commit at all when the repository has no
+// HEAD yet. A repository without commits is an ordinary state here, not a
+// failure — hence the quiet probe.
+func diffBase(path string) (head, base string) {
+	out, ok := gitQuiet(path, "rev-parse", "--verify", "HEAD")
+	if !ok {
+		return "", emptyTreeHash
+	}
+	return strings.TrimSpace(out), "HEAD"
+}
+
+// numstatTotals sums the added and deleted line counts of `git diff --numstat`.
+func numstatTotals(out string) (added, deleted int) {
+	for line := range strings.Lines(out) {
+		cols := strings.Fields(line)
+		if len(cols) < 3 {
+			continue
+		}
+		// Binary files report "-" for both counts; Atoi fails and adds zero.
+		a, _ := strconv.Atoi(cols[0])
+		d, _ := strconv.Atoi(cols[1])
+		added += a
+		deleted += d
+	}
+	return added, deleted
 }
 
 // countFileLines returns the line count of a text file, or 0 for binaries
@@ -230,9 +222,9 @@ func countFileLines(name string) int {
 	return n
 }
 
-func countLines(out []byte) int {
+func countLines(out string) int {
 	n := 0
-	for line := range strings.Lines(string(out)) {
+	for line := range strings.Lines(out) {
 		if strings.TrimSpace(line) != "" {
 			n++
 		}

--- a/internal/project/tree.go
+++ b/internal/project/tree.go
@@ -6,7 +6,8 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
+
+	"github.com/omartelo/lich/internal/relpath"
 )
 
 // maxReadFileSize caps a previewed file. CodeMirror is a source viewer, not a
@@ -52,22 +53,16 @@ func lsFiles(path string, args ...string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	var files []string
-	for rel := range strings.SplitSeq(out, "\x00") {
-		if rel != "" {
-			files = append(files, rel)
-		}
-	}
-	return files, nil
+	return splitNUL(out), nil
 }
 
 // ReadFile returns the text content of one repo-relative file for the read-only
-// preview. rel is validated against traversal (validateRelPath, shared with
-// DiscardFile) before it is joined onto the work-tree root. Binaries, irregular
-// files, and files above maxReadFileSize are refused — the preview is for
-// source, not blobs.
+// preview. rel is validated against traversal (internal/relpath, shared with
+// DiscardFile and the editor launch) before it is joined onto the work-tree
+// root. Binaries, irregular files, and files above maxReadFileSize are refused —
+// the preview is for source, not blobs.
 func (s *Service) ReadFile(path, rel string) (string, error) {
-	if err := validateRelPath(rel); err != nil {
+	if err := relpath.Validate(rel); err != nil {
 		return "", err
 	}
 	full := filepath.Join(path, rel)

--- a/internal/project/worktree.go
+++ b/internal/project/worktree.go
@@ -1,7 +1,6 @@
 package project
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -25,21 +24,6 @@ type Branches struct {
 	Local     []string   `json:"local"`
 	Remote    []string   `json:"remote"` // "origin/main" form
 	Worktrees []Worktree `json:"worktrees"`
-}
-
-// runGit runs git -C dir args... and returns stdout. Unlike Branch/Diff, which
-// deliberately swallow errors for polling, a failure here is shown to someone —
-// so it comes back as the screen's message and git's stderr reaches the log
-// (giterror.go).
-func runGit(dir string, args ...string) (string, error) {
-	cmd := command("git", append([]string{"-C", dir}, args...)...)
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	out, err := cmd.Output()
-	if err != nil {
-		return "", gitFailure(args, stderr.String(), err)
-	}
-	return string(out), nil
 }
 
 // ListBranches returns the repository's local and remote branches and its
@@ -342,10 +326,12 @@ func (s *Service) WorktreeDirty(wtPath string) (bool, error) {
 	return strings.TrimSpace(out) != "", nil
 }
 
-// branchExists reports whether refs/heads/<name> exists in the repository.
+// branchExists reports whether refs/heads/<name> exists in the repository. A
+// name that does not exist is the answer the caller is looking for, not a
+// failure, so the probe stays off runGit's reporting path.
 func branchExists(projectPath, name string) bool {
-	err := command("git", "-C", projectPath, "show-ref", "--verify", "--quiet", "refs/heads/"+name).Run()
-	return err == nil
+	_, ok := gitQuiet(projectPath, "show-ref", "--verify", "--quiet", "refs/heads/"+name)
+	return ok
 }
 
 // worktreesRoot resolves <XDG_DATA_HOME|~/.local/share>/lich/worktrees, the
@@ -360,15 +346,4 @@ func worktreesRoot() (string, error) {
 		dir = filepath.Join(home, ".local", "share")
 	}
 	return filepath.Join(dir, "lich", "worktrees"), nil
-}
-
-// splitLines splits command output into its non-empty lines.
-func splitLines(out string) []string {
-	lines := []string{}
-	for line := range strings.Lines(out) {
-		if trimmed := strings.TrimSpace(line); trimmed != "" {
-			lines = append(lines, trimmed)
-		}
-	}
-	return lines
 }

--- a/internal/relpath/relpath.go
+++ b/internal/relpath/relpath.go
@@ -1,0 +1,32 @@
+// Package relpath validates the repo-relative paths lich receives from the
+// page — a file picked in the review panel, a path parsed out of git's diff
+// output — before they are joined onto a work-tree root. It is the one copy of
+// that rule: every surface that opens, reads or deletes a file by relative path
+// answers to it, so an escape closed here is closed everywhere.
+package relpath
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Validate rejects rooted paths and parent-directory escapes, so joining rel
+// onto a work-tree root can never leave it.
+func Validate(rel string) error {
+	clean := filepath.Clean(rel)
+	if isRooted(clean) || clean == ".." ||
+		strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return fmt.Errorf("invalid repository path %q", rel)
+	}
+	return nil
+}
+
+// isRooted reports whether a cleaned path starts at a root. IsAbs alone is not
+// enough on Windows, where it demands a volume name and so reads "/etc/passwd"
+// as relative; a work-tree path is always relative, so a leading separator is
+// refused too (os.IsPathSeparator counts "\" only where it is one).
+func isRooted(clean string) bool {
+	return filepath.IsAbs(clean) || os.IsPathSeparator(clean[0])
+}

--- a/internal/relpath/relpath_test.go
+++ b/internal/relpath/relpath_test.go
@@ -1,0 +1,44 @@
+package relpath
+
+import (
+	"os"
+	"testing"
+)
+
+// TestValidateRejectsRootedPaths pins the guard itself. The callers' escape
+// tests pass on Windows for the wrong reason — the joined path simply misses on
+// disk — so the rule is asserted here directly: a path starting at a root is
+// never a work-tree path, whether or not it carries a volume name.
+// "/etc/passwd" is the case Windows used to wave through: filepath.IsAbs wants
+// a volume name there, so a leading separator alone read as relative.
+func TestValidateRejectsRootedPaths(t *testing.T) {
+	rooted := []string{"/etc/passwd", "/"}
+	if os.IsPathSeparator('\\') {
+		rooted = append(rooted, `\Windows\System32\config`, `C:\Windows`)
+	}
+	for _, rel := range rooted {
+		if err := Validate(rel); err == nil {
+			t.Errorf("Validate(%q): want error, got nil", rel)
+		}
+	}
+}
+
+// TestValidateRejectsTraversal proves a path cannot climb out of the root it
+// will be joined onto, including the forms Clean leaves behind.
+func TestValidateRejectsTraversal(t *testing.T) {
+	for _, rel := range []string{"..", "../etc/passwd", "a/../../b", "./.."} {
+		if err := Validate(rel); err == nil {
+			t.Errorf("Validate(%q): want error, got nil", rel)
+		}
+	}
+}
+
+// TestValidateAcceptsWorkTreePaths proves the ordinary shapes still pass —
+// including a traversal that stays inside the root.
+func TestValidateAcceptsWorkTreePaths(t *testing.T) {
+	for _, rel := range []string{"a.txt", "internal/rpc/rpc.go", "src/main.go", "a/b/../c.txt"} {
+		if err := Validate(rel); err != nil {
+			t.Errorf("Validate(%q): want nil, got %v", rel, err)
+		}
+	}
+}

--- a/internal/shquote/shquote.go
+++ b/internal/shquote/shquote.go
@@ -1,0 +1,16 @@
+// Package shquote quotes a string for a POSIX shell command line. lich composes
+// two of those — the worktree setup wrapper that execs a provider
+// (internal/terminal) and the terminal-editor invocation handed to a session
+// (internal/system) — and both interpolate a path or a binary name the user or
+// an agent chose. One copy of the rule, so a metacharacter that survives one
+// call site cannot survive the other.
+package shquote
+
+import "strings"
+
+// Quote returns s single-quoted, safe against embedded single quotes. It
+// assumes an sh/bash/zsh-style shell; cmd.exe (experimental Windows) quotes
+// differently, which is why the setup wrapper skips Windows entirely.
+func Quote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}

--- a/internal/shquote/shquote_test.go
+++ b/internal/shquote/shquote_test.go
@@ -1,0 +1,22 @@
+package shquote
+
+import "testing"
+
+// TestQuote proves quoting survives the shell round trip's edge cases — above
+// all a single quote, which must not break out of the quoting, and the
+// metacharacters a path or a binary name could otherwise smuggle in.
+func TestQuote(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"plain", "'plain'"},
+		{"with space", "'with space'"},
+		{"it's", `'it'\''s'`},
+		{"a'b.txt", `'a'\''b.txt'`},
+		{"", "''"},
+		{"$HOME `id` ;rm", "'$HOME `id` ;rm'"},
+	}
+	for _, tt := range tests {
+		if got := Quote(tt.in); got != tt.want {
+			t.Errorf("Quote(%q) = %s, want %s", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -8,6 +8,26 @@ import (
 	"github.com/omartelo/lich/internal/providers"
 )
 
+// nextSessionPosition is the position a newly inserted session takes: after the
+// project's last one, so a new card appends to the list even once the user has
+// dragged the others around. A subquery rather than a read-then-write, so the
+// order can never be decided against a stale count.
+const nextSessionPosition = `(SELECT COALESCE(MAX(position), -1) + 1 FROM sessions WHERE project_id = ?)`
+
+// setActiveSession points a project at the session that should hold focus. Every
+// mutation that adds, parks or removes a session ends by calling it inside the
+// same transaction: the active id and the session set have to move together, or
+// a reload restores a project focused on a session that is no longer there.
+func setActiveSession(tx *sql.Tx, projectID, sessionID string) error {
+	if _, err := tx.Exec(
+		`UPDATE projects SET active_session_id = ? WHERE id = ?`,
+		sessionID, projectID,
+	); err != nil {
+		return fmt.Errorf("set active session of %q: %w", projectID, err)
+	}
+	return nil
+}
+
 // AddProject persists a newly opened project and marks it open. Reopening a
 // previously closed project keeps its stored sessions, name, path and tab
 // position intact — only is_open flips back to 1. A brand-new project takes the
@@ -48,12 +68,13 @@ func (s *Service) AddSession(projectID, sessionID, label, kind, path string, nex
 	return s.tx(func(tx *sql.Tx) error {
 		if _, err := tx.Exec(
 			`INSERT INTO sessions (id, project_id, label, kind, path, position)
-			 VALUES (?, ?, ?, ?, ?,
-			         (SELECT COALESCE(MAX(position), -1) + 1 FROM sessions WHERE project_id = ?))`,
+			 VALUES (?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
 			sessionID, projectID, label, kind, path, projectID,
 		); err != nil {
 			return fmt.Errorf("insert session %q: %w", sessionID, err)
 		}
+		// Not setActiveSession: the label counter moves with the insert too, and
+		// one statement is what keeps the pair atomic.
 		if _, err := tx.Exec(
 			`UPDATE projects SET active_session_id = ?, next_seq = ? WHERE id = ?`,
 			sessionID, nextSeq, projectID,
@@ -71,13 +92,7 @@ func (s *Service) DeleteSession(projectID, sessionID, activeID string) error {
 		if _, err := tx.Exec(`DELETE FROM sessions WHERE id = ?`, sessionID); err != nil {
 			return fmt.Errorf("delete session %q: %w", sessionID, err)
 		}
-		if _, err := tx.Exec(
-			`UPDATE projects SET active_session_id = ? WHERE id = ?`,
-			activeID, projectID,
-		); err != nil {
-			return fmt.Errorf("update active session of %q: %w", projectID, err)
-		}
-		return nil
+		return setActiveSession(tx, projectID, activeID)
 	})
 }
 
@@ -91,13 +106,7 @@ func (s *Service) CloseSession(projectID, sessionID, activeID string) error {
 		if _, err := tx.Exec(`UPDATE sessions SET is_open = 0 WHERE id = ?`, sessionID); err != nil {
 			return fmt.Errorf("close session %q: %w", sessionID, err)
 		}
-		if _, err := tx.Exec(
-			`UPDATE projects SET active_session_id = ? WHERE id = ?`,
-			activeID, projectID,
-		); err != nil {
-			return fmt.Errorf("update active session of %q: %w", projectID, err)
-		}
-		return nil
+		return setActiveSession(tx, projectID, activeID)
 	})
 }
 
@@ -134,17 +143,13 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 		}
 		if _, err := tx.Exec(
 			`INSERT INTO sessions (id, project_id, label, kind, path, provider_session_id, label_auto, position)
-			 VALUES (?, ?, ?, ?, ?, ?, ?,
-			         (SELECT COALESCE(MAX(position), -1) + 1 FROM sessions WHERE project_id = ?))`,
+			 VALUES (?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
 			newSessionID, projectID, old.Label, old.Kind, path, old.ProviderSessionID, labelAuto, projectID,
 		); err != nil {
 			return fmt.Errorf("reinsert session %q: %w", newSessionID, err)
 		}
-		if _, err := tx.Exec(
-			`UPDATE projects SET active_session_id = ? WHERE id = ?`,
-			newSessionID, projectID,
-		); err != nil {
-			return fmt.Errorf("activate reopened session on %q: %w", projectID, err)
+		if err := setActiveSession(tx, projectID, newSessionID); err != nil {
+			return err
 		}
 		restored = &Session{ID: newSessionID, Label: old.Label, Kind: old.Kind, Path: path, ProviderSessionID: old.ProviderSessionID}
 		return nil

--- a/internal/store/settings_test.go
+++ b/internal/store/settings_test.go
@@ -122,3 +122,26 @@ func TestProviderBinResolution(t *testing.T) {
 		t.Errorf("ProviderBin claude = %q, want global-claude", got)
 	}
 }
+
+// TestWorktreeSetupIsProjectScoped pins the setup script the terminal service
+// reads when it spawns the first session of a fresh worktree. Project-scoped
+// only: a global value must never leak into a project that configured none,
+// because the script it would run is another repository's.
+func TestWorktreeSetupIsProjectScoped(t *testing.T) {
+	svc := newTestStore(t)
+
+	if got := svc.WorktreeSetup("p1"); got != "" {
+		t.Errorf("unconfigured project = %q, want \"\"", got)
+	}
+	if err := svc.SetSetting(worktreeSetupKey, "p1", "pnpm install"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	if got := svc.WorktreeSetup("p1"); got != "pnpm install" {
+		t.Errorf("p1 setup = %q, want \"pnpm install\"", got)
+	}
+
+	_ = svc.SetSetting(worktreeSetupKey, globalScope, "make bootstrap")
+	if got := svc.WorktreeSetup("p2"); got != "" {
+		t.Errorf("p2 setup = %q, want \"\" — a global value must not apply", got)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -135,6 +135,35 @@ func TestSetProviderSessionUnknownSessionNoop(t *testing.T) {
 	}
 }
 
+// TestProviderSessionReadsBackWhatWasReported pins the read half of the pair the
+// context-usage readout depends on: the terminal service resolves a transcript
+// by this id after every non-idle hook, so it has to answer the newest reported
+// id and it has to answer "" — never an error — for the three shapes of "not
+// yet": no row, no report, and a session that never had one.
+func TestProviderSessionReadsBackWhatWasReported(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
+	_ = svc.AddSession("p1", "shell", "Shell", "shell", "", 3)
+
+	_ = svc.SetProviderSession("s1", "uuid-abc")
+	_ = svc.SetProviderSession("s1", "uuid-def")
+	got, err := svc.ProviderSession("s1")
+	if err != nil || got != "uuid-def" {
+		t.Errorf("ProviderSession(s1) = (%q, %v), want (uuid-def, nil)", got, err)
+	}
+
+	// A shell session never reports one, and a session that does not exist at
+	// all is the hook racing persistence — both are "keep the last value", not
+	// a failure the caller has to handle.
+	for _, id := range []string{"shell", "ghost"} {
+		got, err := svc.ProviderSession(id)
+		if err != nil || got != "" {
+			t.Errorf("ProviderSession(%s) = (%q, %v), want (\"\", nil)", id, got, err)
+		}
+	}
+}
+
 // mustLoadSessions loads the single test project's sessions or fails.
 func mustLoadSessions(t *testing.T, svc *Service) []Session {
 	t.Helper()

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -6,10 +6,12 @@ package system
 import (
 	"fmt"
 	"net/url"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/omartelo/lich/internal/relpath"
+	"github.com/omartelo/lich/internal/shquote"
 )
 
 type Service struct {
@@ -40,9 +42,9 @@ func (s *Service) OpenExternal(rawURL string) error {
 }
 
 // OpenInEditor decides how to open a work-tree file. rel is validated against
-// traversal, then joined onto dir (mirroring project.ReadFile's guard). It
-// prefers $VISUAL, then $EDITOR — resolved from the login shell, so a GUI launch
-// still sees rc exports.
+// traversal (internal/relpath, the same guard project.ReadFile answers to), then
+// joined onto dir. It prefers $VISUAL, then $EDITOR — resolved from the login
+// shell, so a GUI launch still sees rc exports.
 //
 // When the editor is a terminal editor (vim, nvim, nano, …) it launches nothing
 // and returns the shell command line to run in a lich terminal session: a
@@ -51,7 +53,7 @@ func (s *Service) OpenExternal(rawURL string) error {
 // detached, and returns "". The caller runs the returned command in a terminal
 // only when it is non-empty.
 func (s *Service) OpenInEditor(dir, rel string) (string, error) {
-	if err := validateRel(rel); err != nil {
+	if err := relpath.Validate(rel); err != nil {
 		return "", err
 	}
 	full := filepath.Join(dir, rel)
@@ -60,7 +62,9 @@ func (s *Service) OpenInEditor(dir, rel string) (string, error) {
 		editor = s.getenv("EDITOR")
 	}
 	if editor != "" && isTerminalEditor(editor) {
-		return editor + " " + shellQuote(full), nil
+		// The command runs in the session's shell, so the file path — the
+		// caller-influenced part — must survive spaces and metacharacters.
+		return editor + " " + shquote.Quote(full), nil
 	}
 	if editor != "" {
 		return "", s.runEditor(editor, full)
@@ -100,14 +104,6 @@ func isTerminalEditor(editor string) bool {
 	return terminalEditors[filepath.Base(fields[0])]
 }
 
-// shellQuote wraps s in single quotes for a POSIX shell, escaping embedded
-// single quotes — the command runs in the session's shell, so the file path (the
-// caller-influenced part) must survive spaces and metacharacters. Assumes an
-// sh/bash/zsh-style shell; cmd.exe (experimental Windows) quotes differently.
-func shellQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
-}
-
 // getenv reads a key from the resolved shell env, "" when absent.
 func (s *Service) getenv(key string) string {
 	prefix := key + "="
@@ -117,25 +113,6 @@ func (s *Service) getenv(key string) string {
 		}
 	}
 	return ""
-}
-
-// validateRel rejects rooted paths and parent-directory escapes, so a joined
-// path can never leave the work-tree root. Mirrors project.validateRelPath.
-func validateRel(rel string) error {
-	clean := filepath.Clean(rel)
-	if isRooted(clean) || clean == ".." ||
-		strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
-		return fmt.Errorf("invalid repository path %q", rel)
-	}
-	return nil
-}
-
-// isRooted reports whether a cleaned path starts at a root. IsAbs alone is not
-// enough on Windows, where it demands a volume name and so reads "/etc/passwd"
-// as relative; a work-tree path is always relative, so a leading separator is
-// refused too (os.IsPathSeparator counts "\" only where it is one).
-func isRooted(clean string) bool {
-	return filepath.IsAbs(clean) || os.IsPathSeparator(clean[0])
 }
 
 // ValidateExternalURL accepts absolute http/https URLs only.

--- a/internal/system/system_test.go
+++ b/internal/system/system_test.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -136,33 +135,5 @@ func TestOpenInEditorFallsBackToDefault(t *testing.T) {
 	}
 	if want := filepath.Join("/repo", "a.txt"); len(args) == 0 || args[len(args)-1] != want {
 		t.Errorf("args = %v, want file %s as last arg", args, want)
-	}
-}
-
-// TestValidateRelRejectsRootedPaths pins the guard itself: a path that starts
-// at a root is never a work-tree path. "/etc/passwd" is the case Windows used to
-// wave through — filepath.IsAbs wants a volume name there, so a leading
-// separator alone read as relative.
-func TestValidateRelRejectsRootedPaths(t *testing.T) {
-	rooted := []string{"/etc/passwd", "/"}
-	if os.IsPathSeparator('\\') {
-		rooted = append(rooted, `\Windows\System32\config`, `C:\Windows`)
-	}
-	for _, rel := range rooted {
-		if err := validateRel(rel); err == nil {
-			t.Errorf("validateRel(%q): want error, got nil", rel)
-		}
-	}
-	for _, rel := range []string{"a.txt", "src/main.go", "a/b/../c.txt"} {
-		if err := validateRel(rel); err != nil {
-			t.Errorf("validateRel(%q): want nil, got %v", rel, err)
-		}
-	}
-}
-
-func TestShellQuoteEscapesSingleQuote(t *testing.T) {
-	// A path with a single quote must not break out of the quoting.
-	if got, want := shellQuote("a'b.txt"), `'a'\''b.txt'`; got != want {
-		t.Errorf("shellQuote = %q, want %q", got, want)
 	}
 }

--- a/internal/terminal/childenv.go
+++ b/internal/terminal/childenv.go
@@ -1,0 +1,85 @@
+package terminal
+
+import "strings"
+
+// appImageVars are injected by the AppImage runtime or AppImageLauncher and
+// must not leak into the shell: ARGV0 (the .AppImage's invocation name) makes
+// mise/asdf-style shims misread the shell as an invalid shim, and the rest
+// are runtime internals a child never needs.
+var appImageVars = map[string]bool{
+	"ARGV0":              true,
+	"APPIMAGE":           true,
+	"APPDIR":             true,
+	"OWD":                true,
+	"TARGET_APPIMAGE":    true,
+	"REDIRECT_APPIMAGE":  true,
+	"DESKTOPINTEGRATION": true,
+}
+
+// childEnv returns env cleaned of everything the AppImage runtime injected, so
+// spawned shells inherit the environment lich itself was launched with. Outside
+// an AppImage (no APPDIR — the deb/rpm/dev case) env is returned unchanged.
+// Inside one, appImageVars are dropped and every value is scrubbed of
+// colon-separated path entries under the AppImage mount — our AppRun adds
+// none, but wrappers like AppImageLauncher may prepend the mount to path
+// lists, and a mount path in a child's PATH dies with the parent. Entries the
+// user set survive verbatim, so a pre-existing LD_LIBRARY_PATH keeps working.
+func childEnv(env []string) []string {
+	appdir := ""
+	for _, kv := range env {
+		if v, ok := strings.CutPrefix(kv, "APPDIR="); ok {
+			appdir = v
+			break
+		}
+	}
+	if appdir == "" {
+		return env
+	}
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		key, value, _ := strings.Cut(kv, "=")
+		if appImageVars[key] {
+			continue
+		}
+		scrubbed, changed := scrubPathList(value, appdir)
+		switch {
+		case changed && scrubbed == "":
+			// The variable only pointed into the mount (AppRun's "${VAR:-}"
+			// expansion can also leave a dangling empty entry): drop it.
+		case changed:
+			out = append(out, key+"="+scrubbed)
+		default:
+			out = append(out, kv)
+		}
+	}
+	return out
+}
+
+// scrubPathList drops colon-separated entries of value that live under dir.
+// changed reports whether anything was dropped; values without such entries are
+// returned untouched, so non-path variables are never rewritten. When only
+// empty entries remain the returned value is "".
+func scrubPathList(value, dir string) (string, bool) {
+	if !strings.Contains(value, dir) {
+		return value, false
+	}
+	var kept []string
+	changed, nonEmpty := false, false
+	for entry := range strings.SplitSeq(value, ":") {
+		if entry == dir || strings.HasPrefix(entry, dir+"/") {
+			changed = true
+			continue
+		}
+		if entry != "" {
+			nonEmpty = true
+		}
+		kept = append(kept, entry)
+	}
+	if !changed {
+		return value, false
+	}
+	if !nonEmpty {
+		return "", true
+	}
+	return strings.Join(kept, ":"), true
+}

--- a/internal/terminal/command.go
+++ b/internal/terminal/command.go
@@ -1,0 +1,54 @@
+package terminal
+
+import "github.com/omartelo/lich/internal/providers"
+
+// What a session's PTY runs: which binary, and with which arguments. Every
+// decision here is pure and takes its inputs as parameters, so the spawn path
+// (spawnSession) stays a sequence of calls rather than a nest of conditionals.
+
+// defaultBin is the binary spawned when the session's kind is not a known
+// provider and no custom path is set — a safety net; real sessions always carry
+// a registered provider kind.
+const defaultBin = providers.Claude
+
+// KindShell marks a session that runs the user's shell instead of a provider.
+const KindShell = "shell"
+
+// resumeFlag is the Claude Code flag that reopens an existing session by id.
+const resumeFlag = "--resume"
+
+// resolveCommand picks the binary a session runs: the user's shell for "shell"
+// sessions, otherwise the provider binary for the session's kind.
+func resolveCommand(kind, bin, shellEnv string) string {
+	if kind == KindShell {
+		if shellEnv == "" {
+			return defaultShell
+		}
+		return shellEnv
+	}
+	return resolveBin(kind, bin)
+}
+
+// resolveBin returns the configured binary, or the provider's default when it is
+// empty (falling back to defaultBin for an unknown kind).
+func resolveBin(kind, bin string) string {
+	if bin != "" {
+		return bin
+	}
+	if def := providers.DefaultBinary(kind); def != "" {
+		return def
+	}
+	return defaultBin
+}
+
+// resumeArgs returns the arguments that reopen a Claude session, or nil when the
+// session must start fresh. Resume is Claude-specific: "--resume" is Claude
+// Code's flag, so a shell or any other provider never grows it (the frontend
+// only ever passes a resume id for a claude session, but a stray one must not
+// reach codex/opencode/crush either).
+func resumeArgs(kind, resume string) []string {
+	if kind != providers.Claude || resume == "" {
+		return nil
+	}
+	return []string{resumeFlag, resume}
+}

--- a/internal/terminal/setup.go
+++ b/internal/terminal/setup.go
@@ -1,6 +1,10 @@
 package terminal
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/omartelo/lich/internal/shquote"
+)
 
 // wrapSetup rewrites a session's spawn so the project's worktree setup script
 // runs first, in the same PTY — its output lands in the terminal the user is
@@ -17,7 +21,7 @@ func wrapSetup(spec ptySpec, script, goos string) ptySpec {
 	}
 	argv := make([]string, 0, len(spec.args)+1)
 	for _, arg := range append([]string{spec.bin}, spec.args...) {
-		argv = append(argv, shQuote(arg))
+		argv = append(argv, shquote.Quote(arg))
 	}
 	spec.bin = "sh"
 	spec.args = []string{
@@ -25,9 +29,4 @@ func wrapSetup(spec ptySpec, script, goos string) ptySpec {
 		"(\n" + script + "\n) || echo \"[lich] worktree setup failed (exit $?)\"; exec " + strings.Join(argv, " "),
 	}
 	return spec
-}
-
-// shQuote returns s single-quoted for POSIX sh, safe against embedded quotes.
-func shQuote(s string) string {
-	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
 }

--- a/internal/terminal/setup_test.go
+++ b/internal/terminal/setup_test.go
@@ -44,19 +44,3 @@ func TestWrapSetup(t *testing.T) {
 		t.Errorf("wrap changed dir/size: %+v", got)
 	}
 }
-
-// TestShQuote proves quoting survives the shell round trip's edge cases.
-func TestShQuote(t *testing.T) {
-	tests := []struct{ in, want string }{
-		{"plain", "'plain'"},
-		{"with space", "'with space'"},
-		{"it's", `'it'\''s'`},
-		{"", "''"},
-		{"$HOME `id` ;rm", "'$HOME `id` ;rm'"},
-	}
-	for _, tt := range tests {
-		if got := shQuote(tt.in); got != tt.want {
-			t.Errorf("shQuote(%q) = %s, want %s", tt.in, got, tt.want)
-		}
-	}
-}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"runtime"
 	"strconv"
-	"strings"
 	"sync"
 
 	"github.com/omartelo/lich/internal/events"
@@ -225,137 +224,8 @@ func (s *Service) sessionEnv(id string) []string {
 	)
 }
 
-// defaultBin is the binary spawned when the session's kind is not a known
-// provider and no custom path is set — a safety net; real sessions always carry
-// a registered provider kind.
-const defaultBin = providers.Claude
-
-// KindShell marks a session that runs the user's shell instead of a provider.
-const KindShell = "shell"
-
 // readBufSize is the chunk size read from a session's PTY per iteration.
 const readBufSize = 32 * 1024
-
-// resolveBin returns the configured binary, or the provider's default when it is
-// empty (falling back to defaultBin for an unknown kind).
-func resolveBin(kind, bin string) string {
-	if bin != "" {
-		return bin
-	}
-	if def := providers.DefaultBinary(kind); def != "" {
-		return def
-	}
-	return defaultBin
-}
-
-// resumeFlag is the Claude Code flag that reopens an existing session by id.
-const resumeFlag = "--resume"
-
-// resumeArgs returns the arguments that reopen a Claude session, or nil when the
-// session must start fresh. Resume is Claude-specific: "--resume" is Claude
-// Code's flag, so a shell or any other provider never grows it (the frontend
-// only ever passes a resume id for a claude session, but a stray one must not
-// reach codex/opencode/crush either).
-func resumeArgs(kind, resume string) []string {
-	if kind != providers.Claude || resume == "" {
-		return nil
-	}
-	return []string{resumeFlag, resume}
-}
-
-// resolveCommand picks the binary a session runs: the user's shell for "shell"
-// sessions, otherwise the provider binary for the session's kind.
-func resolveCommand(kind, bin, shellEnv string) string {
-	if kind == KindShell {
-		if shellEnv == "" {
-			return defaultShell
-		}
-		return shellEnv
-	}
-	return resolveBin(kind, bin)
-}
-
-// appImageVars are injected by the AppImage runtime or AppImageLauncher and
-// must not leak into the shell: ARGV0 (the .AppImage's invocation name) makes
-// mise/asdf-style shims misread the shell as an invalid shim, and the rest
-// are runtime internals a child never needs.
-var appImageVars = map[string]bool{
-	"ARGV0":              true,
-	"APPIMAGE":           true,
-	"APPDIR":             true,
-	"OWD":                true,
-	"TARGET_APPIMAGE":    true,
-	"REDIRECT_APPIMAGE":  true,
-	"DESKTOPINTEGRATION": true,
-}
-
-// childEnv returns env cleaned of everything the AppImage runtime injected, so
-// spawned shells inherit the environment lich itself was launched with. Outside
-// an AppImage (no APPDIR — the deb/rpm/dev case) env is returned unchanged.
-// Inside one, appImageVars are dropped and every value is scrubbed of
-// colon-separated path entries under the AppImage mount — our AppRun adds
-// none, but wrappers like AppImageLauncher may prepend the mount to path
-// lists, and a mount path in a child's PATH dies with the parent. Entries the
-// user set survive verbatim, so a pre-existing LD_LIBRARY_PATH keeps working.
-func childEnv(env []string) []string {
-	appdir := ""
-	for _, kv := range env {
-		if v, ok := strings.CutPrefix(kv, "APPDIR="); ok {
-			appdir = v
-			break
-		}
-	}
-	if appdir == "" {
-		return env
-	}
-	out := make([]string, 0, len(env))
-	for _, kv := range env {
-		key, value, _ := strings.Cut(kv, "=")
-		if appImageVars[key] {
-			continue
-		}
-		scrubbed, changed := scrubPathList(value, appdir)
-		switch {
-		case changed && scrubbed == "":
-			// The variable only pointed into the mount (AppRun's "${VAR:-}"
-			// expansion can also leave a dangling empty entry): drop it.
-		case changed:
-			out = append(out, key+"="+scrubbed)
-		default:
-			out = append(out, kv)
-		}
-	}
-	return out
-}
-
-// scrubPathList drops colon-separated entries of value that live under dir.
-// changed reports whether anything was dropped; values without such entries are
-// returned untouched, so non-path variables are never rewritten. When only
-// empty entries remain the returned value is "".
-func scrubPathList(value, dir string) (string, bool) {
-	if !strings.Contains(value, dir) {
-		return value, false
-	}
-	var kept []string
-	changed, nonEmpty := false, false
-	for entry := range strings.SplitSeq(value, ":") {
-		if entry == dir || strings.HasPrefix(entry, dir+"/") {
-			changed = true
-			continue
-		}
-		if entry != "" {
-			nonEmpty = true
-		}
-		kept = append(kept, entry)
-	}
-	if !changed {
-		return value, false
-	}
-	if !nonEmpty {
-		return "", true
-	}
-	return strings.Join(kept, ":"), true
-}
 
 // Start spawns the binary for session id under project projectID — the user's
 // shell when kind is "shell", otherwise the provider binary for that kind

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -16,17 +16,25 @@ import (
 	"time"
 
 	"github.com/omartelo/lich/internal/events"
+	"github.com/omartelo/lich/internal/shquote"
 )
 
 // stubBins is a Store returning a fixed binary path and worktree setup script,
-// for tests that never spawn. Its persistence methods are no-ops — none of
-// these tests exercise the SessionStart or ai-title paths.
-type stubBins struct{ bin, setup string }
+// for tests that never spawn. Its write methods are no-ops — none of these tests
+// exercise the SessionStart or ai-title paths — while providerSession and its
+// error drive the context-usage read (usage_test.go).
+type stubBins struct {
+	bin, setup      string
+	providerSession string
+	providerErr     error
+}
 
-func (s stubBins) ProviderBin(_, _ string) string            { return s.bin }
-func (s stubBins) WorktreeSetup(_ string) string             { return s.setup }
-func (s stubBins) SetProviderSession(_, _ string) error      { return nil }
-func (s stubBins) ProviderSession(_ string) (string, error)  { return "", nil }
+func (s stubBins) ProviderBin(_, _ string) string       { return s.bin }
+func (s stubBins) WorktreeSetup(_ string) string        { return s.setup }
+func (s stubBins) SetProviderSession(_, _ string) error { return nil }
+func (s stubBins) ProviderSession(_ string) (string, error) {
+	return s.providerSession, s.providerErr
+}
 func (s stubBins) SetSessionTitle(_, _ string) (bool, error) { return false, nil }
 
 // TestChildEnvStripsAppImageVars proves the AppImage runtime variables that break
@@ -318,7 +326,7 @@ func TestStartWithSetupWrapsTheSpawn(t *testing.T) {
 	if len(got) != 3 || got[0] != "sh" || got[1] != "-c" {
 		t.Fatalf("spawned argv = %v, want sh -c <cmd>", got)
 	}
-	for _, want := range []string{"echo setup-ran", "exec " + shQuote(bin)} {
+	for _, want := range []string{"echo setup-ran", "exec " + shquote.Quote(bin)} {
 		if !strings.Contains(got[2], want) {
 			t.Errorf("spawned command missing %q:\n%s", want, got[2])
 		}

--- a/internal/terminal/usage.go
+++ b/internal/terminal/usage.go
@@ -33,24 +33,33 @@ type usageEvent struct {
 // one selects its own reader here by the session's kind — not an interface until
 // there are two to hide behind it.
 func (s *Service) emitUsage(id string) {
+	if event, ok := s.sessionUsage(id); ok {
+		s.hub.Emit(usageEventName, event)
+	}
+}
+
+// sessionUsage resolves the event emitUsage would push for session id, or
+// ok=false for every miss the doc above lists. Split from the emit so the
+// resolution is testable without a connected window — pollCwd's pattern.
+func (s *Service) sessionUsage(id string) (usageEvent, bool) {
 	providerSessionID, err := s.store.ProviderSession(id)
 	if err != nil {
 		slog.Warn("terminal: read provider session", "session", id, "err", err)
-		return
+		return usageEvent{}, false
 	}
 	if providerSessionID == "" {
-		return
+		return usageEvent{}, false
 	}
 	u, ok := claudeContextUsage(providerSessionID)
 	if !ok {
-		return
+		return usageEvent{}, false
 	}
-	s.hub.Emit(usageEventName, usageEvent{
+	return usageEvent{
 		ID:      id,
 		Percent: u.percent,
 		Tokens:  u.tokens,
 		Window:  u.window,
 		Model:   u.model,
 		Effort:  u.effort,
-	})
+	}, true
 }

--- a/internal/terminal/usage_test.go
+++ b/internal/terminal/usage_test.go
@@ -1,0 +1,94 @@
+// The suite reuses stubBins from terminal_test.go, which is Unix-tagged for its
+// PTY spawns; this file carries the same tag so the package still builds on
+// Windows. Nothing here is platform-specific.
+//go:build !windows
+
+package terminal
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/omartelo/lich/internal/events"
+)
+
+// writeTranscript plants a Claude transcript for providerSessionID under a
+// throwaway CLAUDE_CONFIG_DIR, the way claudeTranscriptPath expects to find one.
+func writeTranscript(t *testing.T, providerSessionID, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	projects := filepath.Join(dir, "projects", "-home-user-repo")
+	if err := os.MkdirAll(projects, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(projects, providerSessionID+".jsonl")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", dir)
+}
+
+// TestSessionUsageReportsTheTranscriptTail proves the whole read the card's
+// context gauge rides on: session id → recorded provider session → transcript →
+// the event's numbers.
+func TestSessionUsageReportsTheTranscriptTail(t *testing.T) {
+	writeTranscript(t, "uuid-abc", assistantLine(modelOpus, 2, 64798, 0)+"\n")
+	svc := New(stubBins{providerSession: "uuid-abc"}, nil, events.New())
+
+	got, ok := svc.sessionUsage("s1")
+	if !ok {
+		t.Fatal("sessionUsage: want ok, got false")
+	}
+	want := usageEvent{ID: "s1", Percent: 6, Tokens: 64800, Window: 1_000_000, Model: modelOpus}
+	if got != want {
+		t.Errorf("sessionUsage = %+v, want %+v", got, want)
+	}
+}
+
+// TestSessionUsageMissesKeepTheLastValue pins the contract every miss shares:
+// no report, an unreadable store, and a transcript with nothing to read all
+// yield ok=false, so the gauge holds its previous number instead of flickering
+// to zero. emitUsage runs after every non-idle hook, so a miss is routine.
+func TestSessionUsageMissesKeepTheLastValue(t *testing.T) {
+	writeTranscript(t, "uuid-abc", assistantLine(modelOpus, 2, 64798, 0)+"\n")
+
+	tests := []struct {
+		name  string
+		store stubBins
+	}{
+		{"no provider session reported yet", stubBins{}},
+		{"the store could not be read", stubBins{providerErr: errors.New("db is gone")}},
+		{"the transcript does not exist", stubBins{providerSession: "uuid-nothing"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := New(tc.store, nil, events.New())
+			if got, ok := svc.sessionUsage("s1"); ok {
+				t.Errorf("sessionUsage = %+v, want a miss", got)
+			}
+			// The emit wrapper must swallow the miss rather than push a zeroed
+			// event — and must not panic without a connected window.
+			svc.emitUsage("s1")
+		})
+	}
+}
+
+// TestSessionUsageCarriesTheReasoningEffort proves the effort level rides along
+// with the counts: it lives on the transcript line, not inside message.usage,
+// so a refactor of the parse can drop it without any count changing.
+func TestSessionUsageCarriesTheReasoningEffort(t *testing.T) {
+	line := `{"type":"assistant","effort":"high","message":{"model":"` + modelHaiku +
+		`","usage":{"input_tokens":1000,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}`
+	writeTranscript(t, "uuid-effort", line+"\n")
+	svc := New(stubBins{providerSession: "uuid-effort"}, nil, events.New())
+
+	got, ok := svc.sessionUsage("s1")
+	if !ok {
+		t.Fatal("sessionUsage: want ok, got false")
+	}
+	if got.Effort != "high" || got.Window != 200_000 {
+		t.Errorf("sessionUsage = %+v, want effort high and a 200k window", got)
+	}
+}


### PR DESCRIPTION
A maintainability pass over the backend: dead code, duplication, complexity, and the regression tests that were missing. No behaviour a user drives changes, except the one fix below.

## The fix: routine git answers were being reported as failures

`runGit` maps every failure to a screen message **and** files a `slog.Warn` with git's stderr. Three call sites use a git failure as a legitimate answer:

| call | when it "fails" | how often |
| --- | --- | --- |
| `Diff` → `rev-parse --verify HEAD` | repository has no commits | the footer polls every open checkout several times a second |
| `Branch` → `symbolic-ref` | path is not a repository | same poll |
| `DiscardFile` → `cat-file -e HEAD:<file>` | file is new — the branch that routes to "delete from disk" | once per discard of a new file |

So a checkout with no commits wrote thousands of warnings a day into a log that rotates at 5MB, pushing out the failures a bug report is actually about.

`runGit`'s own doc already said *"unlike Branch/Diff, which deliberately swallow errors for polling"* — the intent was written down, the implementation had drifted from it. `internal/project/git.go` now holds both runners side by side, with the doc naming which calls belong to which. Everything a person is waiting on still reports exactly as before, which is what `TestRunGitStillReportsRealFailures` pins.

## Duplication

- **Path-traversal guard existed twice** — `project.validateRelPath` and `system.validateRel`, verbatim, in packages that cannot see each other. Both comments said "mirrors the other", which is the problem: a fix to one copy silently leaves the other exposed. Now `internal/relpath`.
- **POSIX shell quoter existed twice** — `terminal.shQuote` and `system.shellQuote`, also verbatim, also a safety primitive. Now `internal/shquote`.
- Both sit next to `internal/winexec` — the package already establishes tiny, purpose-named packages as the house style for OS-boundary primitives.
- **Three implementations of "run `ls-files -z`, split on NUL"** collapsed to one `splitNUL`.
- **`UPDATE projects SET active_session_id`** was written four times in `internal/store/mutations.go`; now one `setActiveSession`, with a comment on the one call site that deliberately does not use it (the label counter has to move in the same statement).

## Complexity

Pure moves, no logic touched:

- `terminal.go` 566 → 436 — the AppImage env scrub (`childenv.go`) and the command resolution (`command.go`) had nothing to do with session lifecycle.
- `pr.go` 572 → 449 — gh's two-shaped check rollup and its translation are now `prchecks.go`, and nothing else in the package needs to know either shape exists.
- `Diff` was four responsibilities in one block; now `diffBase` + `numstatTotals` + the loop.

Both files were under the 800-line ceiling but over the 200–400 typical band.

## Dead code

None found. `deadcode` over the module reports only the build-tagged Windows/macOS functions, and every registered RPC method is called by the frontend.

## Tests

Four things had **0% coverage**: `store.ProviderSession`, `store.WorktreeSetup`, the context-usage read, and the `claude plugin` calls. All covered now, plus the silence contract above and its counterweight.

To test `emitUsage` I split the decision from the effect — `sessionUsage` is pure, `emitUsage` is five lines — following the `pollCwd`/`watchCwd` pattern the package already uses. That reads better than standing up a websocket in a test, and the value is in the three early returns anyway.

`claudeplugin` shells out to the `claude` CLI, so the test binary doubles as a fake one behind an env guard — portable, no shell-script fixture, so it works on the Windows and macOS runners too.

| package | before | after |
| --- | --- | --- |
| `store` | 79.7% — **below the invariant** | 84.7% |
| `claudeplugin` | 65.1% | 100% |
| `terminal` | 85.9% | 87.5% |
| `system` | 91.1% | 89.7% (guard moved to `relpath`, at 100%) |

Every package now clears 80% except `chromium` (63.9%) and `restart` (73.9%) — the OS boundaries CLAUDE.md documents as the exception.

## Gate

- `gofmt -l .` and `go vet ./...` clean
- `go test ./internal/...` green, and green under `-race`
- Cross-compile loop run for linux/darwin/windows — this adds a `//go:build !windows` tag to a new `_test.go`, so **this PR wants the `ci:os` label** before merge
- `CHANGELOG.md` `[Unreleased]` entry included: the log file is what a bug report quotes, so the fix is user-visible
- Frontend untouched — no Go JSON tag changed, so `api-types.ts` does not move

## A note on the branch

Opened off `main`: gitflow puts feature branches on `develop`, and this repository has none.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DjSWtPwdZZCvgVqtM6QE6Y)_