### PR TITLE
chore: cut v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-07-28
+
 ### Added
 
 - **macOS installs through Homebrew.** `brew install omartelo/tap/lich` puts the
@@ -1118,7 +1120,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.21.1...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/omartelo/lich/compare/v0.21.1...v0.22.0
 [0.21.1]: https://github.com/omartelo/lich/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/omartelo/lich/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/omartelo/lich/compare/v0.19.0...v0.20.0


### PR DESCRIPTION
Moves the `[Unreleased]` entries under a `0.22.0` heading and refreshes the compare links, so the release workflow reads the notes from a section that matches the tag.

Minor, not a patch: the release adds an install channel (Homebrew) alongside the two fixes.

- Added — macOS installs through Homebrew (#117)
- Changed — a Homebrew install updates through Homebrew (#117)
- Fixed — the mouse works again after coming back to a session (#116); the log file stops burying real failures under routine git output

## Test plan

- [x] `go test -race ./...` — 518 pass across 21 packages
- [x] `vitest` — 495 pass; biome and `tsc --noEmit` clean; `vite build --mode production` succeeds
- [x] The workflow's notes extractor run against this file for `0.22.0`: 40 lines, opening at `### Added` and stopping before `## [0.21.1]`
- [x] `internal/patchnotes` green against the edited changelog (it parses this file for the running version)

Tagging `v0.22.0` after this merges will be the first real run of the `homebrew` job. It runs after `release`, so a failure there leaves the published artifacts and notes intact — the tap would simply stay on the formula seeded at 0.21.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)