### PR TITLE
feat: give each worktree its own dev-server port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Every worktree gets a dev-server port of its own.** Two worktrees of one
+  project both ran `pnpm dev` and both wanted the same port, so the second one
+  lost — and the setup script that had just installed the dependencies had no
+  way to know it should have picked another number. Every session now starts
+  with `LICH_WORKTREE_PORT` set to a port derived from its checkout's path:
+  `PORT=$LICH_WORKTREE_PORT pnpm dev` in the setup script (Settings › Project),
+  or in the terminal, and both worktrees come up. The number is the same every
+  time for a given checkout, so a bookmark to it keeps working across restarts.
+
 ### Fixed
 
 - **Settings › Font lists your installed fonts on Windows.** The picker read the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,11 @@ nobody knows it and that the call site never shows. The mechanism and the histor
   account's token in `GH_TOKEN` for every gh call lich makes for that project. A push still rides the remote's
   ssh key and signs with the global `user.email`, so a PR can be *read* by one account and its commits *land*
   under another, with no error anywhere. Per-worktree `core.sshCommand` + `user.email` is the upgrade path.
+- **`LICH_WORKTREE_PORT` is a hash, not a reservation** (`internal/terminal/worktreeport.go`): the session's
+  start directory folded into a fixed 1000-port window. Nothing probes and nothing binds, so two checkouts can
+  land on the same number and only the dev server started second finds out. Stability is the trade — a probe
+  would move the port every time the previous server still held it. The main checkout is assigned one like any
+  worktree; the range is fixed, not per-project.
 - **git status is polled** — one shared poller per repository path (`frontend/src/lib/git/git-status-store.ts`); the
   lich plugin's `session-touched` hook nudges an immediate refresh. An fs watcher is the upgrade path.
 - **Persistence is hybrid**: UI prefs in the page's localStorage (`lich.*` keys — the reason the listener port is

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -31,6 +31,11 @@ environment of **every PTY it spawns**, inherited by `claude` and its hooks:
 Outside lich these are absent, so every hook must no-op and exit 0 — the plugin
 stays safe to install globally.
 
+These three are the hook contract, not the whole session environment: lich also
+exports `LICH_WORKTREE_PORT`, a dev-server port belonging to the session's
+checkout. It addresses nothing in lich and no hook reads it — it exists for the
+project's own setup script and commands (`PORT=$LICH_WORKTREE_PORT pnpm dev`).
+
 ## Client rules (all hooks)
 
 - Missing env vars → no-op, exit 0.

--- a/frontend/src/components/settings/WorktreeSetupSettings.tsx
+++ b/frontend/src/components/settings/WorktreeSetupSettings.tsx
@@ -43,7 +43,9 @@ export function WorktreeSetupSettings({ projectId }: { projectId?: string }) {
       description={
         "Runs in every new worktree's terminal before the agent starts — chain steps with &&. " +
         "The session opens even if it fails. Gitignored .env* files are copied into the new " +
-        "worktree automatically; a .worktreeinclude file at the repo root overrides the patterns."
+        "worktree automatically; a .worktreeinclude file at the repo root overrides the patterns. " +
+        "$LICH_WORKTREE_PORT holds a port of this worktree's own, so two of them can run a dev " +
+        "server at once: PORT=$LICH_WORKTREE_PORT pnpm dev."
       }
     >
       <p className="mb-2 text-xs text-muted-foreground">{project.path}</p>

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -205,18 +205,25 @@ func (s *Service) SetRestart(fn func() error) {
 	s.ws.setRestart(fn)
 }
 
-// sessionEnv is the environment for one PTY: the shared base plus the loopback
-// coordinates a Claude Code hook needs to report this session's status back to
-// lich. LICH_SESSION_ID is per-session, so this returns a fresh slice rather
-// than aliasing (and appending to) the shared s.env. When the transport failed
-// to start there is nowhere to report, so the base env is used unchanged — a
-// hook spawned in this PTY sees no LICH_PORT and no-ops.
-func (s *Service) sessionEnv(id string) []string {
-	if s.ws == nil {
-		return s.env
-	}
-	env := make([]string, len(s.env), len(s.env)+3)
+// sessionEnv is the environment for one PTY: the shared base, the dev-server
+// port this session's checkout owns, and the loopback coordinates a Claude Code
+// hook needs to report this session's status back to lich. All of it is
+// per-session, so this returns a fresh slice rather than aliasing (and
+// appending to) the shared s.env.
+//
+// LICH_WORKTREE_PORT is derived from cwd alone — it belongs to the checkout,
+// not to the transport, so it is exported even when the transport failed to
+// start. The loopback coordinates are: with no transport there is nowhere to
+// report, so a hook spawned in this PTY sees no LICH_PORT and no-ops.
+func (s *Service) sessionEnv(id, cwd string) []string {
+	env := make([]string, len(s.env), len(s.env)+4)
 	copy(env, s.env)
+	if port := worktreePort(cwd); port > 0 {
+		env = append(env, "LICH_WORKTREE_PORT="+strconv.Itoa(port))
+	}
+	if s.ws == nil {
+		return env
+	}
 	return append(env,
 		"LICH_PORT="+strconv.Itoa(s.ws.port),
 		"LICH_TOKEN="+s.ws.token,
@@ -245,7 +252,8 @@ const readBufSize = 32 * 1024
 // setup is passed once, by the flow that just created this session's worktree:
 // it runs the project's worktree setup script (Settings › Project) in the PTY
 // before the provider, so a fresh checkout installs its dependencies in view.
-// A respawn or resume never sets it.
+// A respawn or resume never sets it. The script runs in the session's own
+// environment, so it reads the same LICH_WORKTREE_PORT the provider will.
 func (s *Service) Start(id, projectID, cwd, kind, resume string, setup bool, cols, rows int) error {
 	sess, cwd, err := s.spawnSession(id, projectID, cwd, kind, resume, setup, cols, rows)
 	if err != nil || sess == nil {
@@ -284,7 +292,7 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume string, setup bo
 		bin:  resolveCommand(kind, s.store.ProviderBin(kind, projectID), userShell()),
 		args: resumeArgs(kind, resume),
 		dir:  cwd,
-		env:  s.sessionEnv(id),
+		env:  s.sessionEnv(id, cwd),
 		cols: cols,
 		rows: rows,
 	}

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -450,16 +451,18 @@ func TestPTYEcho(t *testing.T) {
 }
 
 // TestSessionEnvInjectsCoordinates proves a spawned PTY gets the loopback
-// coordinates a Claude Code hook needs, without aliasing the shared base env.
+// coordinates a Claude Code hook needs plus its checkout's dev-server port,
+// without aliasing the shared base env.
 func TestSessionEnvInjectsCoordinates(t *testing.T) {
 	s := &Service{env: []string{"A=1"}, ws: &transport{port: 4321, token: "tok"}}
-	env := s.sessionEnv("sess")
+	env := s.sessionEnv("sess", "/src/repo")
 
 	want := map[string]bool{
 		"A=1":                  true,
 		"LICH_PORT=4321":       true,
 		"LICH_TOKEN=tok":       true,
 		"LICH_SESSION_ID=sess": true,
+		"LICH_WORKTREE_PORT=" + strconv.Itoa(worktreePort("/src/repo")): true,
 	}
 	for _, e := range env {
 		delete(want, e)
@@ -473,10 +476,28 @@ func TestSessionEnvInjectsCoordinates(t *testing.T) {
 }
 
 // TestSessionEnvNoTransport proves that without a transport there is nothing to
-// report to, so the base env is returned unchanged (the hook will no-op).
+// report to, so the hook coordinates are left out (the hook will no-op) — but
+// the checkout's dev-server port, which owes the transport nothing, still lands.
 func TestSessionEnvNoTransport(t *testing.T) {
 	s := &Service{env: []string{"A=1"}}
-	env := s.sessionEnv("sess")
+	env := s.sessionEnv("sess", "/src/repo")
+
+	want := []string{"A=1", "LICH_WORKTREE_PORT=" + strconv.Itoa(worktreePort("/src/repo"))}
+	if !slices.Equal(env, want) {
+		t.Fatalf("env = %v, want %v", env, want)
+	}
+	for _, e := range env {
+		if strings.HasPrefix(e, "LICH_PORT=") || strings.HasPrefix(e, "LICH_TOKEN=") {
+			t.Fatalf("transport coordinates leaked without a transport: %v", env)
+		}
+	}
+}
+
+// TestSessionEnvWithoutCwd proves a session with no start directory names no
+// checkout, so no port is invented for it.
+func TestSessionEnvWithoutCwd(t *testing.T) {
+	s := &Service{env: []string{"A=1"}}
+	env := s.sessionEnv("sess", "")
 	if len(env) != 1 || env[0] != "A=1" {
 		t.Fatalf("expected base env unchanged, got %v", env)
 	}

--- a/internal/terminal/worktreeport.go
+++ b/internal/terminal/worktreeport.go
@@ -1,0 +1,35 @@
+package terminal
+
+import (
+	"hash/fnv"
+	"path/filepath"
+)
+
+// The window a checkout's dev-server port is drawn from. It sits below the
+// ephemeral range Linux allocates outbound connections from (32768 by default),
+// so an assigned port is never transiently held by an unrelated socket, and
+// clear of both the ports frameworks default to (3000, 5173, 8080) and lich's
+// own pinned listener (47821).
+const (
+	worktreePortBase  = 24000
+	worktreePortCount = 1000
+)
+
+// worktreePort derives the dev-server port for the checkout at path: the same
+// path always yields the same port, so a worktree keeps its number across a
+// restart of lich and of the session, and two worktrees of one project stop
+// fighting over the framework's default. Nothing is bound or probed here — the
+// port is a name the checkout owns, and the dev server started in it is what
+// actually claims it.
+//
+// An empty path has no checkout to name and yields 0, which the caller reads as
+// "no port to export".
+func worktreePort(path string) int {
+	if path == "" {
+		return 0
+	}
+	h := fnv.New32a()
+	// Hash.Write never returns an error.
+	_, _ = h.Write([]byte(filepath.Clean(path)))
+	return worktreePortBase + int(h.Sum32()%worktreePortCount)
+}

--- a/internal/terminal/worktreeport_test.go
+++ b/internal/terminal/worktreeport_test.go
@@ -1,0 +1,69 @@
+package terminal
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestWorktreePortIsStable pins the property the whole feature rests on: the
+// port is a function of the path and nothing else, so a worktree keeps its
+// number across restarts of the session and of lich.
+func TestWorktreePortIsStable(t *testing.T) {
+	path := filepath.Join("src", "repo", "feature-a")
+	first := worktreePort(path)
+	for range 100 {
+		if got := worktreePort(path); got != first {
+			t.Fatalf("worktreePort(%q) = %d then %d, want a stable value", path, first, got)
+		}
+	}
+}
+
+// TestWorktreePortIgnoresPathNoise proves two spellings of one directory name
+// the same port — otherwise a trailing slash would hand the same checkout two
+// numbers depending on which caller asked.
+func TestWorktreePortIgnoresPathNoise(t *testing.T) {
+	clean := filepath.Join("src", "repo")
+	noisy := filepath.Join("src", "nested", "..", "repo") + string(filepath.Separator)
+	if worktreePort(clean) != worktreePort(noisy) {
+		t.Fatalf("worktreePort(%q) = %d, worktreePort(%q) = %d, want equal",
+			clean, worktreePort(clean), noisy, worktreePort(noisy))
+	}
+}
+
+// TestWorktreePortSeparatesCheckouts proves the point of the feature: sibling
+// worktrees of one project get different numbers, so both can run the dev
+// server at once. Not a guarantee for arbitrary paths (the hash may collide),
+// which is why these are named rather than generated.
+func TestWorktreePortSeparatesCheckouts(t *testing.T) {
+	seen := map[int]string{}
+	for _, name := range []string{"repo", "repo-feature-a", "repo-feature-b", "repo-fix"} {
+		path := filepath.Join("src", name)
+		port := worktreePort(path)
+		if other, dup := seen[port]; dup {
+			t.Fatalf("%q and %q both got port %d", other, path, port)
+		}
+		seen[port] = path
+	}
+}
+
+// TestWorktreePortStaysInRange proves every assigned port lands inside the
+// documented window — below the ephemeral range and clear of lich's listener.
+func TestWorktreePortStaysInRange(t *testing.T) {
+	for i := range 5000 {
+		path := filepath.Join("src", "repo", string(rune('a'+i%26)), string(rune(i)))
+		port := worktreePort(path)
+		if port < worktreePortBase || port >= worktreePortBase+worktreePortCount {
+			t.Fatalf("worktreePort(%q) = %d, outside [%d, %d)",
+				path, port, worktreePortBase, worktreePortBase+worktreePortCount)
+		}
+	}
+}
+
+// TestWorktreePortWithoutPath proves an empty path names no checkout, so the
+// caller is told there is no port to export rather than handed a number every
+// pathless session would share.
+func TestWorktreePortWithoutPath(t *testing.T) {
+	if got := worktreePort(""); got != 0 {
+		t.Fatalf("worktreePort(\"\") = %d, want 0", got)
+	}
+}


### PR DESCRIPTION
Two worktrees of one project both ran `pnpm dev` and both wanted the
framework's default port, so the second one lost — and the setup script
that had just installed the dependencies had no way to know it should
have picked another number.

Every session now starts with LICH_WORKTREE_PORT set to a port derived
from its checkout's path, so a setup script (or a command typed in the
terminal) reads `PORT=$LICH_WORKTREE_PORT pnpm dev` and both worktrees
come up. The port is a pure function of the path: the same checkout gets
the same number across restarts of the session and of lich.

The variable is derived from the session's start directory alone, so it
is exported even when the transport failed to start — unlike LICH_PORT,
which addresses that transport. It is deliberately not LICH_PORT: that
name is the hook listener (docs/hooks/README.md).

Nothing probes and nothing binds — two checkouts can hash to the same
number, and only the dev server started second finds out. Probing was
the alternative and it costs the stability that is the point: the
previous server still holding the port would move it on every restart.
Recorded as a Known Ceiling.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018Rne8dofV1xs996xDBhRWH