### PR TITLE
fix: disable the Merge button when GitHub will not merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Merge button says no before the click, not after.** Merging a pull
+  request GitHub would not take — a required review missing, a required check
+  still running, the base branch moved on, or GitHub simply still working out
+  whether the branch merges — offered the button anyway and answered with a
+  toast that named none of those reasons. The button is now disabled whenever
+  GitHub reports it cannot merge, and hovering it says which of them it is. A
+  failing check that no rule requires still merges: the checks readout shows it
+  red, and the call stays yours.
 - **Settings › Font lists your installed fonts on Windows.** The picker read the
   font list from fontconfig, which Windows does not have, so it offered nothing
   beyond the bundled default and whatever was already selected. It now reads the

--- a/frontend/src/components/pulls/PullRequestView.tsx
+++ b/frontend/src/components/pulls/PullRequestView.tsx
@@ -11,6 +11,7 @@ import {
 } from "lucide-react"
 import { ProjectService, System } from "@/lib/rpc"
 import type { MergeMethod, PullRequestDetail } from "@/lib/api-types"
+import { mergeBlockedReason } from "@/lib/pulls/merge-gate"
 import { cn, errorText } from "@/lib/utils"
 import { Markdown } from "@/components/Markdown"
 import { Button } from "@/components/ui/button"
@@ -71,16 +72,7 @@ export function PullRequestView({
   const [edit, setEdit] = useState<MergeEdit | null>(null)
   const [tab, setTab] = useState<Tab>("overview")
   const commitCount = detail.commits?.length ?? 0
-  // A pull request the list reached by number may be over already, in which
-  // case there is nothing to merge and gh would refuse anyway.
-  const blocked =
-    detail.state !== "OPEN"
-      ? `Pull request is ${detail.state.toLowerCase()}`
-      : detail.isDraft
-        ? "Pull request is a draft"
-        : detail.mergeable === "CONFLICTING"
-          ? `Conflicts with ${detail.baseRefName}`
-          : null
+  const blocked = mergeBlockedReason(detail)
 
   const merge = async (method: MergeMethod, subject = "", body = "") => {
     setMerging(true)

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -93,6 +93,9 @@ export interface PullRequestDetail {
   isDraft: boolean
   /** gh: MERGEABLE | CONFLICTING | UNKNOWN */
   mergeable: string
+  /** GitHub's own "can this merge right now": CLEAN | UNSTABLE | BLOCKED |
+   * BEHIND | DIRTY | DRAFT | HAS_HOOKS | UNKNOWN. See mergeBlockedReason. */
+  mergeStateStatus: string
   /** gh's aggregate verdict: APPROVED | CHANGES_REQUESTED | REVIEW_REQUIRED;
    * "" where the repository requires no review. */
   reviewDecision: string

--- a/frontend/src/lib/pulls/merge-gate.test.ts
+++ b/frontend/src/lib/pulls/merge-gate.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest"
+import { mergeBlockedReason } from "./merge-gate"
+import type { PullRequestDetail } from "@/lib/api-types"
+
+const detail = (over: Partial<PullRequestDetail> = {}): PullRequestDetail => ({
+  number: 130,
+  url: "https://github.com/o/l/pull/130",
+  title: "feat: something",
+  body: "",
+  state: "OPEN",
+  isDraft: false,
+  mergeable: "MERGEABLE",
+  mergeStateStatus: "CLEAN",
+  reviewDecision: "",
+  baseRefName: "main",
+  headRefName: "quiet-willow",
+  changedFiles: 1,
+  isCrossRepository: false,
+  checks: { total: 0, passed: 0, failed: 0, pending: 0 },
+  checkRuns: null,
+  commits: null,
+  ...over,
+})
+
+describe("mergeBlockedReason", () => {
+  it("lets a clean pull request through", () => {
+    expect(mergeBlockedReason(detail())).toBeNull()
+  })
+
+  it("lets a merge over a non-required red check through", () => {
+    expect(mergeBlockedReason(detail({ mergeStateStatus: "UNSTABLE" }))).toBeNull()
+  })
+
+  it("lets a repository with merge hooks through", () => {
+    expect(mergeBlockedReason(detail({ mergeStateStatus: "HAS_HOOKS" }))).toBeNull()
+  })
+
+  it("blocks a pull request that is already over", () => {
+    expect(mergeBlockedReason(detail({ state: "MERGED" }))).toBe("Pull request is merged")
+    expect(mergeBlockedReason(detail({ state: "CLOSED" }))).toBe("Pull request is closed")
+  })
+
+  it("blocks a draft before reading the merge state", () => {
+    expect(mergeBlockedReason(detail({ isDraft: true, mergeStateStatus: "DRAFT" }))).toBe(
+      "Pull request is a draft",
+    )
+  })
+
+  it("names the base branch on a conflict", () => {
+    const reason = mergeBlockedReason(
+      detail({ mergeStateStatus: "DIRTY", mergeable: "CONFLICTING", baseRefName: "develop" }),
+    )
+    expect(reason).toBe("Conflicts with develop")
+  })
+
+  it("blocks an unmet review or required check", () => {
+    expect(mergeBlockedReason(detail({ mergeStateStatus: "BLOCKED" }))).toBe(
+      "GitHub requires a review or a status check that has not passed",
+    )
+  })
+
+  it("blocks a branch the base has moved past", () => {
+    expect(mergeBlockedReason(detail({ mergeStateStatus: "BEHIND" }))).toBe(
+      "Base branch has moved — update this branch first",
+    )
+  })
+
+  // The state that produced the flat "not mergeable" toast: GitHub had not
+  // finished recomputing after a push, and the old gate only looked at
+  // mergeable === CONFLICTING.
+  it("blocks while GitHub is still recomputing", () => {
+    expect(mergeBlockedReason(detail({ mergeStateStatus: "UNKNOWN", mergeable: "UNKNOWN" }))).toBe(
+      "GitHub is still working out whether this can merge",
+    )
+  })
+
+  it("blocks a state this build has never seen", () => {
+    expect(mergeBlockedReason(detail({ mergeStateStatus: "SOMETHING_NEW" }))).toBe(
+      "GitHub will not merge this pull request yet",
+    )
+  })
+
+  it("falls back to mergeable when no merge state came back", () => {
+    expect(mergeBlockedReason(detail({ mergeStateStatus: "" }))).toBeNull()
+    expect(mergeBlockedReason(detail({ mergeStateStatus: "", mergeable: "CONFLICTING" }))).toBe(
+      "Conflicts with main",
+    )
+  })
+})

--- a/frontend/src/lib/pulls/merge-gate.ts
+++ b/frontend/src/lib/pulls/merge-gate.ts
@@ -1,0 +1,45 @@
+import type { PullRequestDetail } from "@/lib/api-types"
+
+// The merge states GitHub reports that it will still merge from. Everything
+// else it refuses, and gh's refusal reaches the screen as one flat sentence
+// (internal/project/gherror.go) that names none of the reasons below — so the
+// button has to answer this itself, before the click.
+//
+// UNSTABLE is in: a failing or pending check that no rule requires does not
+// block a merge on GitHub, and the checks readout already shows it red. Whether
+// to merge over it is the reader's call, not the button's.
+const MERGEABLE_STATES = new Set(["CLEAN", "UNSTABLE", "HAS_HOOKS"])
+
+// Why GitHub refuses each of the states it will not merge from. Keyed by gh's
+// mergeStateStatus. DRAFT is absent because isDraft says it first and says it
+// better; DIRTY is absent because its reason names the base branch.
+const BLOCKED_REASONS: Record<string, string> = {
+  BLOCKED: "GitHub requires a review or a status check that has not passed",
+  BEHIND: "Base branch has moved — update this branch first",
+  UNKNOWN: "GitHub is still working out whether this can merge",
+}
+
+// mergeBlockedReason names why a pull request cannot be merged right now, or
+// returns null when it can. The order is the order a reader would ask in: is
+// there anything to merge, is it ready to be merged, will GitHub take it.
+export function mergeBlockedReason(detail: PullRequestDetail): string | null {
+  if (detail.state !== "OPEN") {
+    return `Pull request is ${detail.state.toLowerCase()}`
+  }
+  if (detail.isDraft) {
+    return "Pull request is a draft"
+  }
+  // Older answers, and any state gh adds after this build, carry no
+  // mergeStateStatus. Fall back to the coarse field rather than blocking a
+  // merge GitHub would have taken.
+  if (detail.mergeStateStatus === "") {
+    return detail.mergeable === "CONFLICTING" ? `Conflicts with ${detail.baseRefName}` : null
+  }
+  if (MERGEABLE_STATES.has(detail.mergeStateStatus)) {
+    return null
+  }
+  if (detail.mergeStateStatus === "DIRTY") {
+    return `Conflicts with ${detail.baseRefName}`
+  }
+  return BLOCKED_REASONS[detail.mergeStateStatus] ?? "GitHub will not merge this pull request yet"
+}

--- a/internal/project/pr.go
+++ b/internal/project/pr.go
@@ -65,7 +65,7 @@ func runGH(timeout time.Duration, dir, token string, args ...string) ([]byte, er
 }
 
 // prViewFields is the gh `pr view --json` selection backing the Pulls panel.
-const prViewFields = "number,url,state,title,body,isDraft,mergeable,reviewDecision,baseRefName,headRefName,isCrossRepository,statusCheckRollup,changedFiles,commits"
+const prViewFields = "number,url,state,title,body,isDraft,mergeable,mergeStateStatus,reviewDecision,baseRefName,headRefName,isCrossRepository,statusCheckRollup,changedFiles,commits"
 
 // prSelector renders the pull request argument gh's subcommands take ahead of
 // their flags. Zero means "the branch checked out at path" — gh's own default,
@@ -101,6 +101,12 @@ type PRDetail struct {
 	State     string `json:"state"`
 	IsDraft   bool   `json:"isDraft"`
 	Mergeable string `json:"mergeable"` // gh: MERGEABLE | CONFLICTING | UNKNOWN
+	// MergeStateStatus is GitHub's own answer to "can this merge right now" —
+	// CLEAN | UNSTABLE | BLOCKED | BEHIND | DIRTY | DRAFT | HAS_HOOKS | UNKNOWN.
+	// Mergeable alone cannot gate the button: it says nothing about a required
+	// review or a required check, and it reads UNKNOWN while GitHub recomputes
+	// after a push.
+	MergeStateStatus string `json:"mergeStateStatus"`
 	// ReviewDecision is gh's aggregate verdict — APPROVED | CHANGES_REQUESTED |
 	// REVIEW_REQUIRED — and "" where the repository requires no review. Who
 	// reviewed is a different field (latestReviews) this does not carry.
@@ -137,6 +143,7 @@ type ghPRView struct {
 	Body              string      `json:"body"`
 	IsDraft           bool        `json:"isDraft"`
 	Mergeable         string      `json:"mergeable"`
+	MergeStateStatus  string      `json:"mergeStateStatus"`
 	ReviewDecision    string      `json:"reviewDecision"`
 	BaseRefName       string      `json:"baseRefName"`
 	HeadRefName       string      `json:"headRefName"`
@@ -201,6 +208,7 @@ func parsePRDetail(out []byte, openOnly bool) (*PRDetail, error) {
 		State:             v.State,
 		IsDraft:           v.IsDraft,
 		Mergeable:         v.Mergeable,
+		MergeStateStatus:  v.MergeStateStatus,
 		ReviewDecision:    v.ReviewDecision,
 		BaseRefName:       v.BaseRefName,
 		HeadRefName:       v.HeadRefName,

--- a/internal/project/pr_test.go
+++ b/internal/project/pr_test.go
@@ -18,6 +18,7 @@ func TestParsePRDetail(t *testing.T) {
 			"body": "makes the badge actionable",
 			"isDraft": false,
 			"mergeable": "MERGEABLE",
+			"mergeStateStatus": "UNSTABLE",
 			"baseRefName": "main",
 			"headRefName": "quiet-willow",
 			"changedFiles": 6,
@@ -41,6 +42,9 @@ func TestParsePRDetail(t *testing.T) {
 		}
 		if pr.Mergeable != "MERGEABLE" || pr.BaseRefName != "main" || pr.HeadRefName != "quiet-willow" {
 			t.Errorf("wrong refs/mergeable: %+v", pr)
+		}
+		if pr.MergeStateStatus != "UNSTABLE" {
+			t.Errorf("wrong merge state status: %q", pr.MergeStateStatus)
 		}
 		if pr.Checks.Passed != 2 || pr.Checks.Total != 2 || pr.Checks.Failed != 0 {
 			t.Errorf("wrong checks: %+v", pr.Checks)


### PR DESCRIPTION
## What

The Merge button was offered on pull requests GitHub would refuse. Clicking it produced:

> Merge failed: GitHub will not merge this pull request yet — it has conflicts or an unmet requirement.

which is `internal/project/gherror.go`'s mapping of gh's flat `not mergeable` — a sentence that names none of the actual reasons, arriving after the click instead of before it.

The gate (`PullRequestView.tsx`) read `mergeable`, which answers only "does this branch conflict". Four states passed it and then failed at gh:

- a required review missing (`BLOCKED`)
- a required check still running (`BLOCKED`)
- the base branch moved on, where a rule requires it up to date (`BEHIND`)
- GitHub still recomputing mergeability after a push (`UNKNOWN` — the one that produced the report)

## How

Carry gh's `mergeStateStatus` — GitHub's own answer to "can this merge right now" — through `PRDetail` to the panel, and gate on it:

| `mergeStateStatus` | gate |
|---|---|
| `CLEAN` · `UNSTABLE` · `HAS_HOOKS` | merges |
| `DIRTY` | blocked — "Conflicts with `<base>`" |
| `BLOCKED` | blocked — "GitHub requires a review or a status check that has not passed" |
| `BEHIND` | blocked — "Base branch has moved — update this branch first" |
| `UNKNOWN` | blocked — "GitHub is still working out whether this can merge" |
| anything newer than this build | blocked — "GitHub will not merge this pull request yet" |

`DRAFT` never reaches the table: `isDraft` is read first and says it better.

**`UNSTABLE` deliberately stays mergeable.** A failing or pending check that no branch rule requires does not block a merge on GitHub. The checks readout already shows it red; whether to merge over it is the reader's call, not the button's.

The reason rides the existing wrapper-`span` `title` — a disabled button takes no pointer events, so the hover has to sit outside it.

`MergeableStat` is unchanged on purpose: it answers "does this conflict", the button answers "can I merge now". Different questions, both true at once on a `BLOCKED` pull request.

## Notes

- The gate moved to `frontend/src/lib/pulls/merge-gate.ts` so the node-only suite can cover it — the component itself cannot be rendered by the gate (no jsdom).
- No backend gate: gh already refuses and `gherror.go` already maps the refusal. Validating in two places is two places to drift.
- An answer carrying no `mergeStateStatus` falls back to the old `mergeable === "CONFLICTING"` check, so a field gh renames blocks nothing that GitHub would have merged.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test ./internal/project/` — 197 pass, new assertion on the parsed field
- [x] `vitest run` — 527 pass, 11 new in `merge-gate.test.ts` (one per state, plus the fallback)
- [x] `tsc --noEmit` + `vite build` clean; `biome check` clean (12 warnings, all the standing a11y backlog)
- [x] cross-compile loop for linux/darwin/windows
- [ ] Manual in `task dev`: hover the disabled button on a `BLOCKED` PR and read the reason