### PR TITLE
chore: cut v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-07-30
+
 ### Added
 
 - **Review a pull request without leaving lich.** Pulls only ever showed the
@@ -1253,7 +1255,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.22.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.23.0...HEAD
+[0.23.0]: https://github.com/omartelo/lich/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/omartelo/lich/compare/v0.21.1...v0.22.0
 [0.21.1]: https://github.com/omartelo/lich/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/omartelo/lich/compare/v0.20.0...v0.21.0


### PR DESCRIPTION
Moves the `[Unreleased]` entries under a `v0.23.0` heading and refreshes the
compare links. No code changes.

## What lands

Nine pull requests since v0.22.0 (#123, #124, #125, #126, #127, #128, #129,
#130, #132). Every commit in the range maps to at least one changelog entry and
every entry maps to a commit — 4 Added, 1 Changed, 12 Fixed.

Minor rather than patch: four of the nine add something a user did not have —
reviewing a pull request inside the diff, review comments handed to the session
as one prompt, a dev-server port per worktree, and the session cost readout.

## Deliberately not in this release

`#131 feat: add custom themes` is left out: it is unreviewed, and it conflicts
with main, so it does not merge as it stands.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test -race ./...` green, no data races
- [x] `pnpm check`, `tsc --noEmit`, `vitest run` (587 tests, 57 files), `vite build`
- [ ] Tag `v0.23.0` and watch the release pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVfeykRkJkTPTzSRWLYSKP