### PR TITLE
feat: reopen a recent project from the tab strip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Reopen a recent project without the file picker.** A closed project keeps
+  everything it was closed with — its sessions, its name, its tab position —
+  but finding it again meant walking the directory picker back to it. The "+"
+  in the tab strip now lists the last five projects you closed, each reopening
+  where you left it, with the picker one entry below for every other folder.
+  A project whose directory has been moved or deleted says so and leaves the
+  list for good. With nothing closed yet the button is the picker it always was.
+
 - **Merge past a rule that is holding a pull request back.** Once GitHub answers
   that a rule on the base branch stands in the way, gh refuses the merge without
   ever calling GitHub — so there was nothing lich could do with that pull request

--- a/frontend/src/components/tabs/OpenProjectMenu.tsx
+++ b/frontend/src/components/tabs/OpenProjectMenu.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState } from "react"
+import { Folder, FolderOpen, Plus } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import type { RecentProject } from "@/lib/api-types"
+import { displayPath } from "@/lib/paths"
+import { Store } from "@/lib/rpc"
+import { useProjects } from "@/providers/projects"
+
+// OpenProjectMenu is the top strip's "+": the projects closed earlier, newest
+// first, above the directory picker that opens any other one. With no closed
+// project to offer there is no menu at all — the button is the picker, which is
+// what it was before this list existed.
+export function OpenProjectMenu() {
+  const { projects, openProject, openRecent } = useProjects()
+  const [recents, setRecents] = useState<RecentProject[]>([])
+
+  // The open projects are exactly what the recent ones are not, so the list is
+  // refetched whenever they change: closing a tab adds one, opening removes it.
+  useEffect(() => {
+    let live = true
+    void Store.RecentProjects().then((rows) => {
+      if (live) {
+        setRecents(rows ?? [])
+      }
+    })
+    return () => {
+      live = false
+    }
+  }, [projects])
+
+  // Picking an entry whose directory is gone drops its row without opening
+  // anything, so the open projects — and the effect above — never move. The
+  // list has to be asked again, or the dead entry stays on offer.
+  const pick = async (recent: RecentProject) => {
+    await openRecent(recent)
+    setRecents((await Store.RecentProjects()) ?? [])
+  }
+
+  if (recents.length === 0) {
+    return (
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={() => void openProject()}
+        title="Open project"
+        aria-label="Open project"
+        className="text-muted-foreground"
+      >
+        <Plus className="size-4" />
+      </Button>
+    )
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        title="Open project"
+        aria-label="Open project"
+        render={
+          <Button variant="ghost" size="icon-sm" className="shrink-0 text-muted-foreground" />
+        }
+      >
+        <Plus className="size-4" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-72">
+        {/* A plain div, not DropdownMenuLabel: that is base-ui's Menu.GroupLabel
+            and throws outside a Menu.Group. */}
+        <div className="px-2 py-1.5 text-xs font-semibold tracking-wide text-foreground">
+          Recent projects
+        </div>
+        <DropdownMenuSeparator />
+        {recents.map((recent) => (
+          <DropdownMenuItem
+            key={recent.id}
+            className="gap-2"
+            onClick={() => void pick(recent)}
+          >
+            <Folder className="size-4 shrink-0 text-muted-foreground" />
+            <span className="flex min-w-0 flex-col">
+              <span className="truncate">{recent.name}</span>
+              <span className="truncate text-xs text-muted-foreground">
+                {displayPath(recent.path)}
+              </span>
+            </span>
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="gap-2" onClick={() => void openProject()}>
+          <FolderOpen className="size-4 shrink-0 text-muted-foreground" />
+          Open folder…
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/frontend/src/components/tabs/OpenProjectMenu.tsx
+++ b/frontend/src/components/tabs/OpenProjectMenu.tsx
@@ -78,11 +78,7 @@ export function OpenProjectMenu() {
         </div>
         <DropdownMenuSeparator />
         {recents.map((recent) => (
-          <DropdownMenuItem
-            key={recent.id}
-            className="gap-2"
-            onClick={() => void pick(recent)}
-          >
+          <DropdownMenuItem key={recent.id} className="gap-2" onClick={() => void pick(recent)}>
             <Folder className="size-4 shrink-0 text-muted-foreground" />
             <span className="flex min-w-0 flex-col">
               <span className="truncate">{recent.name}</span>

--- a/frontend/src/components/tabs/ProjectTabs.tsx
+++ b/frontend/src/components/tabs/ProjectTabs.tsx
@@ -1,5 +1,5 @@
 import { useMatch, useNavigate } from "react-router-dom"
-import { GitPullRequestArrow, Plus, Settings } from "lucide-react"
+import { GitPullRequestArrow, Settings } from "lucide-react"
 import { DndContext, closestCenter } from "@dnd-kit/core"
 import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortable"
 import { cn } from "@/lib/utils"
@@ -12,9 +12,10 @@ import { NotificationsButton } from "./NotificationsButton"
 import { horizontalAxis, useSortableList } from "@/lib/use-sortable-list"
 import { ProjectTab } from "./ProjectTab"
 import { HomeTab } from "./HomeTab"
+import { OpenProjectMenu } from "./OpenProjectMenu"
 
 export function ProjectTabs() {
-  const { projects, sessions, homeId, openProject, closeProject, reorderProjects } = useProjects()
+  const { projects, sessions, homeId, closeProject, reorderProjects } = useProjects()
   const navigate = useNavigate()
   // The project the settings gear targets: whichever one is in view, falling
   // back to Home when the app is on the bare landing screen.
@@ -69,16 +70,7 @@ export function ProjectTabs() {
             ))}
           </SortableContext>
         </DndContext>
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          onClick={() => void openProject()}
-          title="Open project"
-          aria-label="Open project"
-          className="text-muted-foreground"
-        >
-          <Plus className="size-4" />
-        </Button>
+        <OpenProjectMenu />
       </div>
       <div aria-hidden className="mx-1 h-5 w-px shrink-0 bg-border" />
       <NotificationsButton />

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -9,6 +9,10 @@ export interface Project {
   path: string
 }
 
+/** internal/store.Recent — a closed project offered for reopening. Identity
+ * only, hence the same shape as an opened one. */
+export type RecentProject = Project
+
 /** internal/project.DiffStats — uncommitted-changes summary of a work tree. */
 export interface DiffStats {
   files: number

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -21,6 +21,7 @@ import type {
   PullRequestConversation,
   PullRequestDetail,
   PullRequestSummary,
+  RecentProject,
   ReviewEvent,
   StoredProject,
   StoredSession,
@@ -125,6 +126,8 @@ export const ProjectService = {
   /** A project rooted at the user's home dir, no picker (the update flow's
    * install terminal when no project is in view). */
   Home: () => call<Project>("project.Home", []),
+  /** Whether a stored project's directory is still there, before reopening it. */
+  Exists: (path: string) => call<boolean>("project.Exists", [path]),
   PickFile: () => call<string>("project.PickFile", []),
   Branch: (path: string) => call<string>("project.Branch", [path]),
   Diff: (path: string) => call<DiffStats>("project.Diff", [path]),
@@ -222,6 +225,10 @@ export const Store = {
   AddProject: (id: string, name: string, path: string) =>
     call<null>("store.AddProject", [id, name, path]),
   CloseProject: (id: string) => call<null>("store.CloseProject", [id]),
+  /** The closed projects offered for reopening, newest first (capped backend-side). */
+  RecentProjects: () => call<RecentProject[] | null>("store.RecentProjects", []),
+  /** Drop a project and its sessions for good — the row whose directory is gone. */
+  DeleteProject: (id: string) => call<null>("store.DeleteProject", [id]),
   AddSession: (
     projectID: string,
     sessionID: string,

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react"
 import { toast } from "sonner"
 import { Bell, Folder } from "lucide-react"
 import { useMatch, useNavigate } from "react-router-dom"
-import type { Project } from "@/lib/api-types"
+import type { Project, RecentProject } from "@/lib/api-types"
 import type { StoredProject as StoreProject } from "@/lib/api-types"
 import { ProjectService, Store } from "@/lib/rpc"
 import { onAppEvent } from "@/lib/app-events"
@@ -24,6 +24,7 @@ import {
   type SessionState,
 } from "@/lib/session/sessions"
 import { applyOrder, pinFirst } from "@/lib/reorder"
+import { displayPath } from "@/lib/paths"
 import { defaultProviderKind } from "@/lib/providers-store"
 import {
   isIdEvent,
@@ -48,6 +49,9 @@ interface ProjectsValue {
   homeId: string | null
   /** Show the OS directory picker, add the chosen project and navigate to it. */
   openProject: () => Promise<void>
+  /** Reopen a closed project without the picker. A project whose directory is
+   * gone is dropped from the store instead, with a toast saying so. */
+  openRecent: (recent: RecentProject) => Promise<void>
   /** Ensure a project rooted at $HOME exists (no picker) and return its id — the
    * update flow's install terminal when no project is in view. */
   ensureHomeProject: () => Promise<string>
@@ -190,18 +194,39 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     return () => off()
   }, [])
 
+  // A reopened project keeps the sessions it was closed with, hence the reload.
+  // Nothing is seeded: a brand-new project lands on the empty screen.
+  const adopt = useCallback(
+    async (project: Project) => {
+      await Store.AddProject(project.id, project.name, project.path)
+      applyLoaded((await Store.LoadState()) ?? [])
+      navigate(`/projects/${project.id}`)
+    },
+    [applyLoaded, navigate],
+  )
+
   const openProject = useCallback(async () => {
     const picked = await ProjectService.Open()
     if (!picked) {
       return
     }
-    await Store.AddProject(picked.id, picked.name, picked.path)
+    await adopt(picked)
+  }, [adopt])
 
-    // A reopened project keeps the sessions it was closed with, hence the reload.
-    // Nothing is seeded: a brand-new project lands on the empty screen.
-    applyLoaded((await Store.LoadState()) ?? [])
-    navigate(`/projects/${picked.id}`)
-  }, [applyLoaded, navigate])
+  // Reopening skips the picker, so nothing guarantees the directory is still
+  // there — a project whose folder was moved or deleted can never be opened
+  // again, so its row goes with it rather than sitting in the list forever.
+  const openRecent = useCallback(
+    async (recent: RecentProject) => {
+      if (await ProjectService.Exists(recent.path)) {
+        await adopt(recent)
+        return
+      }
+      await Store.DeleteProject(recent.id)
+      toast.error(`Project not found: ${displayPath(recent.path)}`)
+    },
+    [adopt],
+  )
 
   // Add a $HOME-rooted project without the picker, idempotent by its stable id
   // (the same directory always maps to the same project), and return its id. The
@@ -480,6 +505,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       sessions,
       homeId,
       openProject,
+      openRecent,
       ensureHomeProject,
       closeProject,
       newSession,
@@ -497,6 +523,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       sessions,
       homeId,
       openProject,
+      openRecent,
       ensureHomeProject,
       closeProject,
       newSession,

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -127,6 +127,14 @@ func parsePullRequest(out []byte) *PullRequest {
 	return &pr
 }
 
+// Exists reports whether path is still a directory on disk. A stored project
+// outlives the folder it points at — the picker guarantees the directory exists
+// when a project is first opened, nothing does when one is reopened from a row.
+func (s *Service) Exists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
 // PickFile shows the native file picker and returns the chosen file path, or ""
 // if the user cancels the dialog.
 func (s *Service) PickFile() (string, error) {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -212,3 +212,24 @@ func TestDiffNoCommits(t *testing.T) {
 		t.Errorf("Diff(no-commit repo).Head = %q, want empty", got.Head)
 	}
 }
+
+// TestExistsAcceptsOnlyDirectories: a project path that now names a file is as
+// unopenable as one that names nothing, so both have to read as gone.
+func TestExistsAcceptsOnlyDirectories(t *testing.T) {
+	svc := New(nil)
+	dir := t.TempDir()
+	file := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	if !svc.Exists(dir) {
+		t.Errorf("Exists(%q) = false, want true", dir)
+	}
+	if svc.Exists(file) {
+		t.Errorf("Exists(file) = true, want false")
+	}
+	if svc.Exists(filepath.Join(dir, "gone")) {
+		t.Errorf("Exists(missing) = true, want false")
+	}
+}

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -54,6 +54,16 @@ func (s *Service) CloseProject(id string) error {
 	return nil
 }
 
+// DeleteProject removes a project and, through ON DELETE CASCADE, its sessions.
+// Closing keeps a project for a later reopen; this is for the row that outlived
+// the directory it points at, which nothing can reopen anymore.
+func (s *Service) DeleteProject(id string) error {
+	if _, err := s.db.Exec(`DELETE FROM projects WHERE id = ?`, id); err != nil {
+		return fmt.Errorf("delete project %q: %w", id, err)
+	}
+	return nil
+}
+
 // AddSession inserts a session, makes it the project's active one and records the
 // project's next label counter — all atomically, mirroring the frontend reducer.
 // Kind selects what the session's PTY runs (a provider id or "shell"); empty

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -221,6 +221,48 @@ func (s *Service) LoadState() ([]Project, error) {
 	return projects, nil
 }
 
+// Recent is a closed project offered for reopening — identity only, since the
+// menu that lists them shows a name and a path and nothing else.
+type Recent struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Path string `json:"path"`
+}
+
+// recentLimit caps the reopen list. Five is what fits above the picker entry
+// without turning the menu into a second project list.
+const recentLimit = 5
+
+// RecentProjects returns the closed projects (is_open = 0) offered for
+// reopening, newest first.
+//
+// rowid DESC orders by when a project was first added, not when it was last
+// open — reopening keeps the row, so a project that has been through the list
+// does not move back to the top. A last_opened_at column is the upgrade path.
+func (s *Service) RecentProjects() ([]Recent, error) {
+	rows, err := s.db.Query(
+		`SELECT id, name, path FROM projects WHERE is_open = 0 ORDER BY rowid DESC LIMIT ?`,
+		recentLimit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query recent projects: %w", err)
+	}
+	defer rows.Close()
+
+	recents := []Recent{}
+	for rows.Next() {
+		var r Recent
+		if err := rows.Scan(&r.ID, &r.Name, &r.Path); err != nil {
+			return nil, fmt.Errorf("scan recent project: %w", err)
+		}
+		recents = append(recents, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate recent projects: %w", err)
+	}
+	return recents, nil
+}
+
 // sessionsOf returns a project's sessions in the order the user dragged them
 // into, falling back to insertion order for rows never reordered.
 func (s *Service) sessionsOf(projectID string) ([]Session, error) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -831,3 +831,97 @@ func TestPurgeWorktreeSessions(t *testing.T) {
 		t.Errorf("pathless rows after empty-path purge = %d, want 1 (guard held)", n)
 	}
 }
+
+// TestRecentProjectsListsClosedOnesNewestFirst covers the whole contract of the
+// reopen menu's list: open projects stay out of it, closed ones come back
+// newest first, and the list is capped.
+func TestRecentProjectsListsClosedOnesNewestFirst(t *testing.T) {
+	svc := newTestStore(t)
+	for _, id := range []string{"p1", "p2", "p3", "p4", "p5", "p6", "p7"} {
+		if err := svc.AddProject(id, id, "/tmp/"+id); err != nil {
+			t.Fatalf("AddProject(%s): %v", id, err)
+		}
+	}
+	for _, id := range []string{"p1", "p2", "p3", "p4", "p5", "p6"} {
+		if err := svc.CloseProject(id); err != nil {
+			t.Fatalf("CloseProject(%s): %v", id, err)
+		}
+	}
+
+	recents, err := svc.RecentProjects()
+	if err != nil {
+		t.Fatalf("RecentProjects: %v", err)
+	}
+	got := make([]string, len(recents))
+	for i, r := range recents {
+		got[i] = r.ID
+	}
+	want := []string{"p6", "p5", "p4", "p3", "p2"} // p7 is open, p1 falls off the limit
+	if len(got) != len(want) {
+		t.Fatalf("recent ids = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("recent ids = %v, want %v", got, want)
+		}
+	}
+	if recents[0].Name != "p6" || recents[0].Path != "/tmp/p6" {
+		t.Errorf("recent metadata = %+v", recents[0])
+	}
+}
+
+// TestReopeningARecentProjectRestoresItsSessions proves the menu's entry is the
+// same reopen path a tab close/reopen takes: the row is kept, so are its
+// sessions, and the project leaves the recent list once it is open again.
+func TestReopeningARecentProjectRestoresItsSessions(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
+	_ = svc.CloseProject("p1")
+
+	if err := svc.AddProject("p1", "alpha", "/tmp/alpha"); err != nil {
+		t.Fatalf("AddProject (reopen): %v", err)
+	}
+	recents, err := svc.RecentProjects()
+	if err != nil {
+		t.Fatalf("RecentProjects: %v", err)
+	}
+	if len(recents) != 0 {
+		t.Errorf("recents after reopen = %+v, want none", recents)
+	}
+	projects, err := svc.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if len(projects) != 1 || len(projects[0].Sessions) != 1 {
+		t.Fatalf("reopened state = %+v, want one project with one session", projects)
+	}
+}
+
+// TestDeleteProjectRemovesItsSessions covers the missing-directory path: the
+// row is dropped for good, and the cascade takes its sessions with it.
+func TestDeleteProjectRemovesItsSessions(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
+	_ = svc.CloseProject("p1")
+
+	if err := svc.DeleteProject("p1"); err != nil {
+		t.Fatalf("DeleteProject: %v", err)
+	}
+	recents, err := svc.RecentProjects()
+	if err != nil {
+		t.Fatalf("RecentProjects: %v", err)
+	}
+	if len(recents) != 0 {
+		t.Errorf("recents after delete = %+v, want none", recents)
+	}
+	var sessions int
+	if err := svc.db.QueryRow(`SELECT COUNT(*) FROM sessions WHERE project_id = ?`, "p1").
+		Scan(&sessions); err != nil {
+		t.Fatalf("count sessions: %v", err)
+	}
+	if sessions != 0 {
+		t.Errorf("sessions after delete = %d, want 0 (cascade)", sessions)
+	}
+}


### PR DESCRIPTION
## What

The `+` in the tab strip now opens a menu: the last five projects you closed, newest first, with the directory picker one entry below. Picking one reopens it with the sessions it was closed with.

With nothing closed yet there is no menu — the button is the picker it always was, so the common path keeps its single click.

## How

- `store.RecentProjects` reads the closed rows themselves (`is_open = 0`, `rowid DESC`, capped at 5). Nothing new is persisted to track the list: closing a project already keeps its row, and `AddProject` already flips it back open with its sessions intact, so reopening from the menu is the picker path minus the picker.
- `rowid DESC` orders by when a project was first added, not when it was last open — reopening keeps the row, so a project that has been through the list does not move back to the top. A `last_opened_at` column is the upgrade path, noted in the code.
- Nothing guarantees a stored directory still exists once the picker is out of the loop, so `project.Exists` is checked first. A missing one toasts `Project not found: <path>` and `store.DeleteProject` drops the row (its sessions go with it through the existing cascade) — no picker will ever hand that path back.

## Test plan

- [x] `go test ./...` — 637 pass, including the recent-list contract (open projects excluded, newest first, capped), reopen-restores-sessions, and the delete cascade.
- [x] `pnpm test` (603), `tsc --noEmit`, `vite build`, `biome check` (only the pre-existing a11y backlog and the `biome.jsonc` deprecation, both on `main` too).
- [x] `GOOS={linux,darwin,windows} go build ./... && go vet ./...`.
- [x] Driven in a real window (isolated `XDG_CONFIG_HOME`, headless Chromium over CDP): menu lists the closed projects with their paths; the entry whose directory was deleted toasts and leaves the list; a live one opens as a tab.

Not labeled `ci:os` — no OS seam touched (`os.Stat` and a SQLite query).