### PR TITLE
feat: report a bug from settings without hunting for the log

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,49 @@
+name: Bug report
+description: Something in lich is broken
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Settings → Help → **Report a bug** opens this form with the version and
+        platform already filled in, and **Open log folder** puts you next to the
+        file to attach.
+
+        The log holds absolute paths, project and branch names, and your gh
+        login — never a session token. Read it before you attach it.
+
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, what you expected, what you got instead.
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: lich version
+      description: Settings → Help, or `lich --version`.
+      placeholder: "0.23.0"
+    validations:
+      required: true
+
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      placeholder: linux/amd64
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Log
+      description: |
+        Attach `lich.log` (drag it in), or paste the lines around the failure.
+        `lich.log.old` is the previous generation — if the bug is older than
+        today's session, it is probably in there.
+    validations:
+      required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Report a bug without being told where the log file is.** Reporting anything
+  meant being walked to a directory you had no reason to know, to a file whose
+  name nobody had said out loud. Settings now ends in **Help**: one button opens
+  the log's folder in your file manager — the rotated generation in view beside
+  the live one, since a bug older than today's session is usually in there — and
+  another opens the bug form in your browser with the version and platform
+  already filled in. lich never files the issue for you, and never needs `gh`
+  installed or logged in to do any of this: it hands you the form and the file,
+  you write the report and attach it. The section also says what the log carries
+  — paths, project and branch names, your gh login, and never a session token —
+  so you know what you are sending before you send it. It sits at the foot of
+  the settings nav next to **Updates**, the two of them apart from the sections
+  that configure a project: neither is something you set, and neither is
+  something you open twice in a session.
+
 - **Reopen a recent project without the file picker.** A closed project keeps
   everything it was closed with — its sessions, its name, its tab position —
   but finding it again meant walking the directory picker back to it. The "+"

--- a/frontend/src/components/settings/HelpSettings.tsx
+++ b/frontend/src/components/settings/HelpSettings.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react"
+import { Bug, Info, ScrollText } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { SettingBlock } from "./SettingBlock"
+import { System } from "@/lib/rpc"
+import { REPO_URL, bugReportUrl } from "@/lib/support-url"
+import { runWithToast } from "@/lib/toast-async"
+import type { Diagnostics } from "@/lib/api-types"
+
+// The section a bug report starts from: the two things a reporter otherwise has
+// to be walked through — where the log file lives, and what to put in the issue.
+export function HelpSettings() {
+  const [diagnostics, setDiagnostics] = useState<Diagnostics | null>(null)
+
+  useEffect(() => {
+    void System.Diagnostics()
+      .then(setDiagnostics)
+      .catch(() => {})
+  }, [])
+
+  return (
+    <>
+      <SettingBlock
+        icon={<Bug className="size-4" />}
+        title="Report a bug"
+        description="Opens the bug form in your browser with the version and platform filled in. lich does not file the issue — you write it and attach the log yourself."
+      >
+        <Button
+          size="sm"
+          onClick={() => diagnostics && void System.OpenExternal(bugReportUrl(diagnostics))}
+          disabled={!diagnostics}
+        >
+          Open bug report
+        </Button>
+      </SettingBlock>
+
+      <SettingBlock
+        icon={<ScrollText className="size-4" />}
+        title="Log file"
+        description="The log holds absolute paths, project and branch names, and your gh login — never a session token. Read it before you attach it to anything."
+      >
+        <div className="flex items-center gap-3">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() =>
+              void runWithToast(
+                "Opening log folder…",
+                System.RevealLog,
+                "Log folder opened.",
+                "Could not open the log folder",
+              )
+            }
+            disabled={!diagnostics?.logPath}
+          >
+            Open log folder
+          </Button>
+          <code className="min-w-0 truncate font-mono text-xs text-muted-foreground">
+            {diagnostics?.logPath || "Logging to stderr only — there is no log file."}
+          </code>
+        </div>
+      </SettingBlock>
+
+      <SettingBlock
+        icon={<Info className="size-4" />}
+        title="About"
+        description={
+          diagnostics ? `lich ${diagnostics.version} — ${diagnostics.platform}.` : "lich."
+        }
+      >
+        <Button size="sm" variant="ghost" onClick={() => void System.OpenExternal(REPO_URL)}>
+          Repository
+        </Button>
+      </SettingBlock>
+    </>
+  )
+}

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -8,17 +8,19 @@ import { ProviderBinSettings } from "./ProviderBinSettings"
 import { WorktreeSetupSettings } from "./WorktreeSetupSettings"
 import { VersionControlSettings } from "./VersionControlSettings"
 import { UpdatesSettings } from "./UpdatesSettings"
+import { HelpSettings } from "./HelpSettings"
 import { SearchInput } from "@/components/common/SearchInput"
 import { enabledProviders, useProviders } from "@/lib/providers-store"
 import { cn } from "@/lib/utils"
 
 // A settings category: a nav entry plus the pane it renders. "app" sections are
 // global; "provider" sections are the per-provider config that appears when a
-// provider is enabled, and render under a "Provider settings" nav header.
+// provider is enabled, and render under a "Provider settings" nav header;
+// "footer" sections sit at the bottom of the nav, apart from the rest.
 interface Section {
   id: string
   label: string
-  group: "app" | "provider"
+  group: "app" | "provider" | "footer"
   render: (projectId?: string) => ReactNode
 }
 
@@ -40,7 +42,13 @@ const BASE_SECTIONS: Section[] = [
     group: "app",
     render: (id) => <VersionControlSettings projectId={id} />,
   },
-  { id: "updates", label: "Updates", group: "app", render: () => <UpdatesSettings /> },
+]
+
+// The two sections that configure nothing: they are about the app itself, and
+// are reached once in a while rather than while setting a project up.
+const FOOTER_SECTIONS: Section[] = [
+  { id: "updates", label: "Updates", group: "footer", render: () => <UpdatesSettings /> },
+  { id: "help", label: "Help", group: "footer", render: () => <HelpSettings /> },
 ]
 
 // Settings is the per-project settings screen (not a modal): it fills the main
@@ -59,13 +67,14 @@ export function Settings() {
     group: "provider",
     render: (id) => <ProviderBinSettings providerId={provider.id} projectId={id} />,
   }))
-  const sections = [...BASE_SECTIONS, ...providerSections]
+  const sections = [...BASE_SECTIONS, ...providerSections, ...FOOTER_SECTIONS]
 
   const filtered = sections.filter((section) =>
     section.label.toLowerCase().includes(query.toLowerCase()),
   )
   const appSections = filtered.filter((section) => section.group === "app")
   const provSections = filtered.filter((section) => section.group === "provider")
+  const footerSections = filtered.filter((section) => section.group === "footer")
   // Fall back to the first section when the active one vanished (a provider was
   // disabled) or was filtered out of view.
   const current = sections.find((section) => section.id === active) ?? sections[0]
@@ -95,7 +104,9 @@ export function Settings() {
             aria-label="Search settings"
           />
         </div>
-        <nav className="flex flex-col gap-0.5 px-2 pb-3">
+        {/* Scrolls on its own so a short window with several providers enabled
+            shrinks this list instead of pushing the footer out of view. */}
+        <nav className="flex min-h-0 flex-col gap-0.5 overflow-y-auto px-2 pb-3">
           {appSections.map(navButton)}
           {provSections.length > 0 && (
             <div className="mt-4 mb-1 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
@@ -104,6 +115,12 @@ export function Settings() {
           )}
           {provSections.map(navButton)}
         </nav>
+
+        {footerSections.length > 0 && (
+          <nav className="mt-auto flex flex-col gap-0.5 border-t border-border px-2 py-2">
+            {footerSections.map(navButton)}
+          </nav>
+        )}
       </aside>
 
       <div className="flex-1 overflow-auto">

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -284,6 +284,16 @@ export interface PatchNotes {
   groups: PatchNotesGroup[] | null
 }
 
+/** internal/system.Diagnostics — what a bug report opens with. */
+export interface Diagnostics {
+  /** "dev" outside a release build. */
+  version: string
+  /** GOOS/GOARCH, e.g. "linux/amd64". */
+  platform: string
+  /** "" when the log file could not be opened and lich logs to stderr only. */
+  logPath: string
+}
+
 /** internal/providers.Detected — a known provider and whether it is on PATH. */
 export interface DetectedProvider {
   id: string

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -11,6 +11,7 @@ import type {
   BranchRules,
   Branches,
   DetectedProvider,
+  Diagnostics as DiagnosticsData,
   DiffStats,
   DraftReviewComment,
   MergeMethod,
@@ -291,6 +292,10 @@ export const System = {
    * Returns "" when it launched a GUI editor detached, or a shell command line
    * to run in a terminal session when the editor is a terminal editor. */
   OpenInEditor: (dir: string, rel: string) => call<string>("system.OpenInEditor", [dir, rel]),
+  /** Version, platform and log path — the page cannot derive any of the three. */
+  Diagnostics: () => call<DiagnosticsData>("system.Diagnostics", []),
+  /** Open the log's folder in the platform's file manager, for attaching it. */
+  RevealLog: () => call<null>("system.RevealLog", []),
 }
 
 export const Providers = {

--- a/frontend/src/lib/support-url.test.ts
+++ b/frontend/src/lib/support-url.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+import { bugReportUrl } from "./support-url"
+
+describe("bugReportUrl", () => {
+  const diagnostics = { version: "0.23.0", platform: "linux/amd64", logPath: "/c/lich/lich.log" }
+
+  it("names the template and prefills version and platform", () => {
+    const params = new URL(bugReportUrl(diagnostics)).searchParams
+    expect(params.get("template")).toBe("bug.yml")
+    expect(params.get("version")).toBe("0.23.0")
+    // The slash has to survive the round trip: a raw one would end the path.
+    expect(params.get("platform")).toBe("linux/amd64")
+  })
+
+  it("points at the repository's new-issue form", () => {
+    const url = new URL(bugReportUrl(diagnostics))
+    expect(url.origin).toBe("https://github.com")
+    expect(url.pathname).toBe("/omartelo/lich/issues/new")
+  })
+
+  it("carries a dev build through instead of dropping the field", () => {
+    // A dev build reports "dev", and that is worth seeing in the issue: it says
+    // the reporter is not on a release.
+    const params = new URL(bugReportUrl({ ...diagnostics, version: "dev" })).searchParams
+    expect(params.get("version")).toBe("dev")
+  })
+})

--- a/frontend/src/lib/support-url.ts
+++ b/frontend/src/lib/support-url.ts
@@ -1,0 +1,23 @@
+// The links behind Settings → Help.
+//
+// A bug report is a browser hand-off, never a `gh` call. Two reasons, and both
+// outlive the convenience: `gh issue create` cannot attach a file, and the log
+// file is the attachment; and a project can name a gh account other than the
+// logged-in one (the vcs.account ceiling), so "which account files this?" has
+// no answer a single button can pick. lich prefills the form; the user sends it.
+
+import type { Diagnostics } from "./api-types"
+
+export const REPO_URL = "https://github.com/omartelo/lich"
+
+// bugReportUrl opens the bug form with the two fields a reporter should never
+// have to look up. The query keys are the `id`s in .github/ISSUE_TEMPLATE/bug.yml
+// — GitHub silently ignores a key that matches no field, so they move together.
+export function bugReportUrl(diagnostics: Diagnostics): string {
+  const params = new URLSearchParams({
+    template: "bug.yml",
+    version: diagnostics.version,
+    platform: diagnostics.platform,
+  })
+  return `${REPO_URL}/issues/new?${params}`
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -72,7 +72,7 @@ func openLogFile(dir string) (*os.File, error) {
 	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, fmt.Errorf("create log dir: %w", err)
 	}
-	path := filepath.Join(dir, fileName(os.Getenv("LICH_DEV") != ""))
+	path := Path(dir)
 	if info, err := os.Stat(path); err == nil && info.Size() >= maxLogSize {
 		if err := os.Rename(path, path+".old"); err != nil {
 			return nil, fmt.Errorf("rotate log: %w", err)
@@ -83,6 +83,12 @@ func openLogFile(dir string) (*os.File, error) {
 		return nil, fmt.Errorf("open log file: %w", err)
 	}
 	return file, nil
+}
+
+// Path is the file Init writes to under dir — what a bug report attaches, and
+// the only place the naming rule below is readable from outside the package.
+func Path(dir string) string {
+	return filepath.Join(dir, fileName(os.Getenv("LICH_DEV") != ""))
 }
 
 // fileName mirrors the store's database split: a `task dev` session logs

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -62,6 +62,27 @@ func TestFileName(t *testing.T) {
 	}
 }
 
+// TestPathIsWhatInitWrites proves the path the frontend reveals is the file
+// Init actually opened, under both the dev and the release name — the two
+// would drift apart the moment they were spelled out twice.
+func TestPathIsWhatInitWrites(t *testing.T) {
+	for _, dev := range []string{"", "1"} {
+		restoreDefault(t)
+		t.Setenv("LICH_DEV", dev)
+		dir := logDir(t)
+
+		closer, err := Init(dir)
+		if err != nil {
+			t.Fatalf("LICH_DEV=%q Init: %v", dev, err)
+		}
+		defer closer.Close()
+
+		if _, err := os.Stat(Path(dir)); err != nil {
+			t.Errorf("LICH_DEV=%q: Path reports %q, which Init did not write: %v", dev, Path(dir), err)
+		}
+	}
+}
+
 // TestInitWritesRecordWithSource proves a record lands in the file carrying
 // the message, the attributes and the source file:line the audit trail
 // promises.

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -1,6 +1,7 @@
 // Package system holds the few OS integrations the frontend needs that are
-// not tied to any domain service — opening a URL in the user's default browser
-// and opening a work-tree file in their editor.
+// not tied to any domain service — opening a URL in the user's default browser,
+// opening a work-tree file in their editor, and the handful of facts a bug
+// report needs (version, platform, where the log lives).
 package system
 
 import (
@@ -8,6 +9,7 @@ import (
 	"net/url"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/omartelo/lich/internal/relpath"
@@ -17,17 +19,51 @@ type Service struct {
 	// env is the resolved login-shell environment (see terminal.ResolveShellEnv),
 	// the source of $VISUAL/$EDITOR — a GUI launch never sourced the user's rc.
 	env []string
+	// logPath is the running build's log file (see logging.Path). The page cannot
+	// derive it: the config dir is resolved by the process, not by the browser.
+	logPath string
+	// version is the running build's version, "dev" outside a release.
+	version string
 	// run launches a detached process; injected in tests, exec in production.
 	run func(name string, args ...string) error
 }
 
-func New(env []string) *Service {
+func New(env []string, logPath, version string) *Service {
 	return &Service{
-		env: env,
+		env:     env,
+		logPath: logPath,
+		version: version,
 		run: func(name string, args ...string) error {
 			return exec.Command(name, args...).Start()
 		},
 	}
+}
+
+// Diagnostics is what a bug report opens with: the three facts that decide
+// whether a report is actionable, and the log path the user attaches.
+type Diagnostics struct {
+	Version  string `json:"version"`
+	Platform string `json:"platform"`
+	LogPath  string `json:"logPath"`
+}
+
+func (s *Service) Diagnostics() Diagnostics {
+	return Diagnostics{
+		Version:  s.version,
+		Platform: runtime.GOOS + "/" + runtime.GOARCH,
+		LogPath:  s.logPath,
+	}
+}
+
+// RevealLog opens the log's directory with the platform's file manager, not the
+// file itself: the rotated generation (*.old) is often the one holding the bug,
+// and a log file handed to its default handler opens in an editor, not beside
+// the sibling the reporter also needs.
+func (s *Service) RevealLog() error {
+	if s.logPath == "" {
+		return fmt.Errorf("no log file: lich is logging to stderr only")
+	}
+	return s.openDefault(filepath.Dir(s.logPath))
 }
 
 // OpenExternal opens an http(s) URL in the default browser. Scheme-gated so a

--- a/internal/system/system_test.go
+++ b/internal/system/system_test.go
@@ -77,6 +77,53 @@ func captureRun(name *string, args *[]string) func(string, ...string) error {
 	}
 }
 
+// TestRevealLogOpensTheDirectory proves the reveal hands the log's *directory*
+// to the opener, so the rotated generation is in view beside the live file.
+func TestRevealLogOpensTheDirectory(t *testing.T) {
+	var name string
+	var args []string
+	dir := filepath.Join("/config", "lich")
+	s := &Service{logPath: filepath.Join(dir, "lich.log"), run: captureRun(&name, &args)}
+
+	if err := s.RevealLog(); err != nil {
+		t.Fatalf("RevealLog: %v", err)
+	}
+	if name == "cmd" || name == "sh" || name == "bash" {
+		t.Errorf("launcher is %q: the path must not route through a shell", name)
+	}
+	if len(args) == 0 || args[len(args)-1] != dir {
+		t.Errorf("args = %v, want the directory %q as the last argument", args, dir)
+	}
+}
+
+// TestRevealLogWithoutAFileLaunchesNothing proves that a run with no log file
+// (Init fell back to stderr) reports it instead of opening filepath.Dir("") —
+// the working directory, which has nothing to do with the report.
+func TestRevealLogWithoutAFileLaunchesNothing(t *testing.T) {
+	launched := false
+	s := &Service{run: func(string, ...string) error {
+		launched = true
+		return nil
+	}}
+	if err := s.RevealLog(); err == nil {
+		t.Error("want an error when there is no log file")
+	}
+	if launched {
+		t.Error("something was opened for a log file that does not exist")
+	}
+}
+
+func TestDiagnosticsReportsTheRunningBuild(t *testing.T) {
+	s := New(nil, "/config/lich/lich.log", "0.23.0")
+	got := s.Diagnostics()
+	if got.Version != "0.23.0" || got.LogPath != "/config/lich/lich.log" {
+		t.Errorf("Diagnostics() = %+v, want the version and log path it was built with", got)
+	}
+	if want := runtime.GOOS + "/" + runtime.GOARCH; got.Platform != want {
+		t.Errorf("Platform = %q, want %q", got.Platform, want)
+	}
+}
+
 func TestOpenInEditorTerminalReturnsCommand(t *testing.T) {
 	launched := false
 	s := &Service{env: []string{"EDITOR=nvim"}, run: func(string, ...string) error {

--- a/main.go
+++ b/main.go
@@ -62,8 +62,13 @@ func main() {
 	}
 	// File logging as early as possible: every startup failure below must be
 	// readable after the fact — on Windows the console may not exist at all.
-	if closer, err := logging.Init(filepath.Join(configDir, "lich")); err != nil {
+	logDir := filepath.Join(configDir, "lich")
+	logPath := logging.Path(logDir)
+	if closer, err := logging.Init(logDir); err != nil {
 		slog.Warn("file log unavailable, stderr only", "err", err)
+		// Nothing to reveal or attach to a bug report; the Help section says so
+		// rather than pointing at a file that was never written.
+		logPath = ""
 	} else {
 		defer closer.Close()
 	}
@@ -100,7 +105,7 @@ func main() {
 	dispatcher.Register("appupdate", appupdate.New(version))
 	dispatcher.Register("patchnotes", patchnotes.New(version, changelog))
 	dispatcher.Register("store", db)
-	dispatcher.Register("system", system.New(env))
+	dispatcher.Register("system", system.New(env, logPath, version))
 	dispatcher.Register("providers", providers.New())
 	dispatcher.Deny("store.Close")
 	term.Mount("/rpc/", dispatcher)


### PR DESCRIPTION
## What

Settings ends in a **Help** section. One button opens the log's folder in the file manager, another opens the bug form in the browser with version and platform prefilled. A third names the version and links the repository.

Companion: `.github/ISSUE_TEMPLATE/bug.yml`, whose field ids are the query keys `bugReportUrl` sends.

## Why these calls

**No `gh`, ever.** The report is a browser hand-off. `gh issue create` cannot attach a file and the log *is* the attachment; and a project can name a gh account other than the logged-in one (the `vcs.account` ceiling), so "which account files this?" has no answer a single button can pick. Two users of this app do not have `gh` configured at all — they get the identical path everyone else does.

**The reveal opens the directory, not the file.** `lich.log.old` is usually where a bug older than today's session lives, and a log handed to its default handler opens in an editor, away from the sibling the reporter also needs. No new OS seam: `openDefault` already exists per-OS and takes a path.

**`logging.Path` is exported** because the page cannot derive what the section shows — the config dir is resolved by the process, not the browser. `openLogFile` now goes through it, so the `lich.log` / `lich-dev.log` rule is written once.

**An empty path is a live branch, not a guard against nothing.** When `Init` falls back to stderr, `main` passes `""`: the button disables and the section says so, instead of revealing `filepath.Dir("")` — the working directory, which has nothing to do with the report.

**Privacy is stated where the log is offered.** Absolute paths, project and branch names, gh login — never a session token, which `logging`'s doc has always guaranteed. It is in the section and in the template.

## Nav

Help and Updates form a footer group at the bottom of the settings nav, apart from the sections that configure a project. The list above them scrolls on its own, so a short window with several providers enabled shrinks that list instead of pushing the footer out of view.

## Gate

```
gofmt -l .                              clean
go vet ./...                            clean
go test ./...                           641 passed / 22 packages
GOOS=linux|darwin|windows build + vet   clean
tsc --noEmit                            clean
vitest run                              606 passed / 59 files
biome check .                           0 errors
vite build                              ok
```

Ran against an isolated instance (own `XDG_CONFIG_HOME`, port 47823, a `chromium` shim on PATH so no window opened):

- `system.Diagnostics` → `{"version":"dev","platform":"linux/amd64","logPath":"…/lich.log"}`
- the reported `logPath` is a file that exists on disk
- a wrong token → 403
- `system.RevealLog` dispatches, proven by an arity error and deliberately not by calling it — that opens a file manager

## Not verified here

- **The rendered layout.** vitest is node-only, so `mt-auto`, the footer hairline and the overflow only prove themselves by eye. No base-ui composition is involved, which is the documented way a render crash ships green.
- **GitHub's prefill.** A template outside the default branch is not recognised, and a query key matching no field is ignored silently. Both only prove out once this is on `main` and an issue is opened for real.
