### PR TITLE
fix: show the chosen row in a settings dropdown, not its stored value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   requires — the message, author or committer email patterns, and what each one
   expects.
 
+### Fixed
+
+- **Settings dropdowns read back what you picked.** A closed dropdown showed the
+  stored value instead of the row you had chosen, so the default provider read
+  `claude` rather than "Claude Code", and the GitHub account read `__active__`
+  — an internal placeholder that means "no override" — or the host-qualified
+  `github.com/you` where the row itself had said `you`. Picking again was the
+  only way to be sure what was set, and the account one could easily read as
+  something having gone wrong. Every dropdown now shows the same words when
+  closed that it shows when open.
+
 ## [0.23.0] - 2026-07-30
 
 ### Added

--- a/frontend/src/components/settings/ProvidersSettings.tsx
+++ b/frontend/src/components/settings/ProvidersSettings.tsx
@@ -43,6 +43,7 @@ export function ProvidersSettings() {
         >
           <Select
             value={defaultProvider}
+            items={Object.fromEntries(enabled.map((provider) => [provider.id, provider.name]))}
             onValueChange={(value) => value && setProviderDefault(value as ProviderKind)}
           >
             <SelectTrigger className="w-64">

--- a/frontend/src/components/settings/VersionControlSettings.tsx
+++ b/frontend/src/components/settings/VersionControlSettings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react"
 import { ProjectService, Store } from "@/lib/rpc"
-import { accountLabel, upgradeAccount } from "@/lib/gh-account"
+import { accountLabel, accountSelectItems, upgradeAccount } from "@/lib/gh-account"
 import { GH_ACCOUNT_KEY } from "@/lib/project-settings"
 import { errorText } from "@/lib/utils"
 import { invalidatePullRequests } from "@/lib/pulls/pull-request-lookup"
@@ -18,6 +18,7 @@ import { SettingBlock } from "./SettingBlock"
 // The stored value for "no override" is "", which a Select item cannot carry —
 // this stands in for it in the picker only.
 const ACTIVE_ACCOUNT = "__active__"
+const ACTIVE_ACCOUNT_LABEL = "gh's active account"
 
 // VersionControlSettings picks which authenticated GitHub account lich's gh
 // calls run as for this project. gh keeps one active account per host, so a
@@ -92,13 +93,17 @@ export function VersionControlSettings({ projectId }: { projectId?: string }) {
       }
     >
       <p className="mb-2 text-xs text-muted-foreground">{project.path}</p>
-      <Select value={account || ACTIVE_ACCOUNT} onValueChange={(value) => value && persist(value)}>
+      <Select
+        value={account || ACTIVE_ACCOUNT}
+        items={accountSelectItems(ACTIVE_ACCOUNT, ACTIVE_ACCOUNT_LABEL, options)}
+        onValueChange={(value) => value && persist(value)}
+      >
         <SelectTrigger className="w-72">
           <SelectValue placeholder="Select an account" />
         </SelectTrigger>
         <SelectContent>
           <SelectGroup>
-            <SelectItem value={ACTIVE_ACCOUNT}>gh's active account</SelectItem>
+            <SelectItem value={ACTIVE_ACCOUNT}>{ACTIVE_ACCOUNT_LABEL}</SelectItem>
             {options.map((option) => (
               <SelectItem key={option} value={option}>
                 {accountLabel(option, options)}

--- a/frontend/src/lib/gh-account.test.ts
+++ b/frontend/src/lib/gh-account.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { accountLabel, splitAccount, upgradeAccount } from "./gh-account"
+import { accountLabel, accountSelectItems, splitAccount, upgradeAccount } from "./gh-account"
 
 describe("upgradeAccount", () => {
   const accounts = ["github.com/omartelo", "ghe.example.com/work-login"]
@@ -61,5 +61,23 @@ describe("accountLabel", () => {
 
   it("shows a host-less account as its bare login", () => {
     expect(accountLabel("omartelo", ["omartelo"])).toBe("omartelo")
+  })
+})
+
+describe("accountSelectItems", () => {
+  it("labels the no-override row and every account the picker offers", () => {
+    const accounts = ["github.com/omartelo", "ghe.example.com/omartelo"]
+    const items = accountSelectItems("__active__", "gh's active account", accounts)
+
+    expect(items.__active__).toBe("gh's active account")
+    expect(items["github.com/omartelo"]).toBe("omartelo — github.com")
+    expect(items["ghe.example.com/omartelo"]).toBe("omartelo — ghe.example.com")
+    expect(Object.keys(items)).toHaveLength(accounts.length + 1)
+  })
+
+  it("offers the no-override row on its own when gh lists nothing", () => {
+    expect(accountSelectItems("__active__", "gh's active account", [])).toEqual({
+      __active__: "gh's active account",
+    })
   })
 })

--- a/frontend/src/lib/gh-account.ts
+++ b/frontend/src/lib/gh-account.ts
@@ -33,3 +33,19 @@ export function accountLabel(account: string, accounts: readonly string[]): stri
   const hosts = new Set(accounts.map((a) => splitAccount(a)[0]))
   return hosts.size > 1 || host !== "github.com" ? `${login} — ${host}` : login
 }
+
+/** Every row the account picker offers, as the value→label map a Select needs
+ * to label its own trigger. Without it the closed trigger stringifies the
+ * value, showing the stand-in for "no override" and the host-qualified form
+ * of an account rather than the words the rows read. */
+export function accountSelectItems(
+  activeValue: string,
+  activeLabel: string,
+  accounts: readonly string[],
+): Record<string, string> {
+  const items: Record<string, string> = { [activeValue]: activeLabel }
+  for (const account of accounts) {
+    items[account] = accountLabel(account, accounts)
+  }
+  return items
+}


### PR DESCRIPTION
## Summary

A closed `Select` trigger showed the stored value instead of the row that was picked. Fixing the theme pickers in #131 turned up the same thing in two more places, and this closes them.

base-ui resolves a trigger's label from the `items` map on `Select.Root`. Without it, `resolveSelectedLabel` falls through to stringifying the value — and since items only register themselves once the popup has been opened, a trigger the user never opened has nothing else to go on.

Three rows read wrong:

| where | showed | should show |
|---|---|---|
| Providers › Default provider | `claude` | Claude Code |
| Version control › GitHub account | `__active__` | gh's active account |
| Version control › GitHub account | `github.com/you` | `you` |

The `__active__` one is the worst of the three: it is an internal placeholder standing in for "no override", because a Select item cannot carry the empty string that setting is actually stored as. On screen it reads like something broke.

## What changed

- `accountSelectItems` in `lib/gh-account.ts`, next to `accountLabel`, builds the account picker's map so a row's two forms cannot drift apart. Covered by tests.
- Providers passes its map inline — `id` to `name` is the whole mapping.
- `ACTIVE_ACCOUNT_LABEL` is a constant now, so the row and the map cannot disagree about its wording.

`FontSetting` is deliberately untouched: its value *is* the family name it displays, so it was already showing the right words.

## Not in this PR

There is no guard against the next `Select` shipping without `items`. The obvious one — making the prop required in `components/ui/select.tsx` — would force a redundant identity map on every picker whose value already equals its label, and `ui/` is shadcn-CLI territory, so a regenerate would drop the guard silently. The frontend gate is node-only, so no test can catch it either. Left as a known edge rather than papered over.

## Testing

- `gofmt -l .`, `go vet ./...`, `go test ./...` (22 packages)
- `cd frontend && ./node_modules/.bin/tsc --noEmit`
- `cd frontend && ./node_modules/.bin/vitest run` — 621 passing
- `cd frontend && ./node_modules/.bin/biome check src` — 11 warnings, all pre-existing, none in these files
- `cd frontend && ./node_modules/.bin/vite build`

Worth a look in the running app rather than on the diff: open Settings › Providers and Settings › Version control without touching either dropdown, and read what the closed trigger says.
