### PR TITLE
fix: keep the theme suite honest on a Windows runner

### DIFF
--- a/internal/themes/themes.go
+++ b/internal/themes/themes.go
@@ -239,10 +239,21 @@ func (s *Service) Remove(id string) error {
 }
 
 func (s *Service) customThemes() ([]Theme, error) {
-	entries, err := os.ReadDir(s.dir)
+	// Stat before reading: a file sitting where the themes directory belongs
+	// makes ReadDir report not-exist on Windows, which the "nothing imported
+	// yet" branch below would swallow into an empty list on that OS and an
+	// error everywhere else.
+	info, err := os.Stat(s.dir)
 	if os.IsNotExist(err) {
 		return nil, nil
 	}
+	if err != nil {
+		return nil, fmt.Errorf("read themes dir: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("themes path is not a directory: %s", s.dir)
+	}
+	entries, err := os.ReadDir(s.dir)
 	if err != nil {
 		return nil, fmt.Errorf("read themes dir: %w", err)
 	}

--- a/internal/themes/themes_test.go
+++ b/internal/themes/themes_test.go
@@ -577,6 +577,28 @@ func TestImportRejectsWindowsDeviceNames(t *testing.T) {
 	}
 }
 
+// \r? because the repo pins no .gitattributes, so a Windows checkout hands this
+// test CRLF and a bare \n matches nothing there.
+var docJSONBlock = regexp.MustCompile("(?s)```json\r?\n(.*?)```")
+
+func TestDocJSONBlockReadsBothLineEndings(t *testing.T) {
+	for _, tt := range []struct{ name, newline string }{
+		{name: "lf", newline: "\n"},
+		{name: "crlf", newline: "\r\n"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := "text" + tt.newline + "```json" + tt.newline + "{}" + tt.newline + "```"
+			block := docJSONBlock.FindStringSubmatch(doc)
+			if block == nil {
+				t.Fatalf("no JSON block found in a %s document", tt.name)
+			}
+			if strings.TrimSpace(block[1]) != "{}" {
+				t.Fatalf("block = %q, want the JSON body", block[1])
+			}
+		})
+	}
+}
+
 // The documented example is the shape users copy from, so it answers to the
 // validator like any other imported theme.
 func TestDocumentedExampleIsImportable(t *testing.T) {
@@ -584,7 +606,7 @@ func TestDocumentedExampleIsImportable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read docs/themes.md: %v", err)
 	}
-	block := regexp.MustCompile("(?s)```json\n(.*?)```").FindSubmatch(data)
+	block := docJSONBlock.FindSubmatch(data)
 	if block == nil {
 		t.Fatal("docs/themes.md has no JSON example")
 	}


### PR DESCRIPTION
## Summary

`main` has been red on the Windows runner since #131 merged — three consecutive failing runs (0980607, aae21c2, 789f8f1). It surfaced when the `v0.24.0` tag ran `release.yml`: the `windows` job failed, so `release`, `aur` and `homebrew` were skipped and **nothing was published**.

Two tests fail, both from #131, and neither is a Windows bug in the feature. Both are the suite assuming Linux.

## `TestListReturnsDirectoryError`

The test puts a regular file where the themes directory belongs and expects `List` to fail. On Windows, `ReadDir` on that file reports not-exist, and `customThemes` had a `os.IsNotExist` branch meaning "nothing imported yet" — so identical state read as an error on Linux and as silence on Windows.

Fixed in the product rather than the test, since the divergence was real: `customThemes` now stats the path first and says outright that it is not a directory. Same answer on every OS, and the "nothing imported yet" branch still means only that.

## `TestDocumentedExampleIsImportable`

Mine, from the review follow-up. It finds the documented JSON with ` ```json ` followed by a bare `\n`. The repo pins no `.gitattributes`, so a Windows checkout carries CRLF and the pattern matched nothing — the test reported "docs/themes.md has no JSON example" on a file that has one.

The pattern takes either ending now, and `TestDocJSONBlockReadsBothLineEndings` feeds it both, so the assumption fails on Linux if anyone hardcodes `\n` again.

## Why neither PR caught it

`os-tests` runs on a push to `main`, or on a pull request carrying `ci:os`. Neither #131 nor #140 had the label. The local cross-compile loop passed on both — but as CLAUDE.md says, that only proves the code builds; it never runs the suite. #131 touched `_test.go` and added Windows-specific validation, so it was exactly the case the label exists for.

This PR carries `ci:os`, so the real Windows and macOS runners have to go green before it merges.

## Testing

- `gofmt -l .`, `go vet ./...`, `go test -race ./...` — 22 packages
- cross-compile build + vet for `linux`, `darwin`, `windows`
- `cd frontend && ./node_modules/.bin/vite build`

No `CHANGELOG.md` entry: `v0.24.0` never published, so no released version ever carried this, and the behaviour change it does contain — an error instead of an empty list when a file occupies the themes directory path — is not a state a user reaches.
