### PR TITLE
feat: install themes from a git repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Install a theme from a git repository, and update it later.** A theme file
+  you pick has no version and no way back to whoever wrote it: a fix means being
+  sent another file and importing it again. Settings › Appearance › **Import**
+  now opens a dialog that takes a repository URL as well — a repository with a
+  `lich-theme.json` manifest and its themes beside it. lich clones it, checks
+  the manifest and every theme, and installs the pack only if all of it is
+  valid; ids you already have are named and confirmed before anything is
+  replaced. Each installed theme then shows where it came from and at which
+  version, with an action that re-clones the repository and takes the newer
+  release when there is one. Picking a single file still works exactly as it
+  did, and is still the right way to try a theme you are writing — it simply
+  reads as unversioned, because it is.
+
 ## [0.24.0] - 2026-08-04
 
 ### Added

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -62,7 +62,81 @@ does not match `<id>.json` is ignored.
 ```
 
 `origin` is optional in imported JSON. The backend overwrites it with `custom`
-before saving.
+before saving. `source` is written by lich for a theme installed from a
+repository (below) and stripped from a picked file — a standalone theme carries
+no version and is never updated in place.
+
+## Theme Repositories
+
+A repository is the versioned way in. It is a plain git repository with a
+manifest at its root and one or more theme files beside it:
+
+```
+lich-theme.json      { "name": "Sample pack", "version": "1.2.0" }
+tokyo-night.json
+gruvbox.json
+```
+
+- `name` is required and cannot exceed 128 characters.
+- `version` must be `MAJOR.MINOR.PATCH` (a leading `v` is accepted and dropped).
+  A pre-release is rejected: the update check orders no two of them.
+- The manifest deliberately does not list the themes. Every other root-level
+  `*.json` is read as one, up to 32; anything else in the repository — `README`,
+  subdirectories — is ignored.
+- Version is per repository, not per theme. Installing takes the whole pack, and
+  so does updating it.
+
+Install clones the repository shallowly into a temporary directory, validates
+the manifest and every theme, and only then writes. One invalid file fails the
+whole install — a half-installed pack is worse than a rejected one. Theme ids
+already present are reported back for confirmation before anything is replaced.
+The clone is discarded: an update is another clone.
+
+The stored theme records where it came from:
+
+```json
+"source": { "url": "https://github.com/you/lich-themes.git", "version": "1.2.0" }
+```
+
+Updating re-clones that URL and installs the pack again when the manifest
+carries a newer version; an equal or older one is reported as up to date.
+
+Accepted remotes are `https://`, `ssh://`, `file://`, an absolute path, and
+git's `user@host:path` shorthand. Everything else is rejected before git runs:
+`ext::` resolves through a remote helper that executes a shell command, and an
+argument starting with `-` would be read as a flag. Credential prompts are
+disabled, so a private repository fails instead of hanging — authentication
+rides the ssh key or credential helper git already has.
+
+### Start a repository
+
+```bash
+mkdir my-lich-themes && cd my-lich-themes
+git init
+cat > lich-theme.json <<'EOF'
+{
+  "name": "My themes",
+  "version": "1.0.0"
+}
+EOF
+```
+
+Put a theme beside it. Settings › Appearance › **Save template** writes a valid
+starter naming every supported color — save it into the repository, then set its
+`id`, `name` and `scheme`. File names inside the repository are yours; lich
+stores each theme as `<id>.json` under its own directory on install.
+
+```bash
+git add . && git commit -m "themes"
+```
+
+An absolute path is an accepted remote, so the repository installs before it is
+pushed anywhere: **Import**, paste the directory, **Install**. Once it is on a
+host, the clone URL is what other people paste.
+
+Shipping a change: edit the themes, bump `version` in the manifest, commit and
+push. An install still on the old version takes it with **Update**; forget the
+bump and lich reports the pack as already up to date.
 
 ## Validation Rules
 
@@ -92,9 +166,10 @@ Each color block takes what its consumer actually parses:
   goes through a round-trip that fails on translucency and is swallowed into a
   silent fallback, which would apply a theme only halfway with no error shown.
 
-Import uses lich's native file picker. Re-importing a theme whose `id` already
-exists asks for confirmation before replacing the stored file; cancelling the
-confirmation leaves the existing theme unchanged.
+Import opens a dialog holding both ways in: a repository URL, or the native file
+picker for a single theme. Re-importing a theme whose `id` already exists asks
+for confirmation before replacing the stored file; cancelling the confirmation
+leaves the existing theme unchanged.
 
 The template download uses the native save dialog, so the file lands where you
 choose it; the dialog confirms replacing an existing file.

--- a/frontend/src/components/settings/AppearanceSettings.tsx
+++ b/frontend/src/components/settings/AppearanceSettings.tsx
@@ -2,8 +2,10 @@ import {
   CaseSensitive,
   ChevronDown,
   Download,
+  GitBranch,
   Minus,
   Plus,
+  RefreshCw,
   SquareTerminal,
   Trash2,
   Upload,
@@ -30,6 +32,7 @@ import { ConfirmDialog } from "@/components/ConfirmDialog"
 import { Stepper } from "@/components/common/Stepper"
 import { SettingBlock, SettingGroup } from "./SettingBlock"
 import { FontSetting } from "./FontSetting"
+import { ImportThemeDialog } from "./ImportThemeDialog"
 import { Button } from "@/components/ui/button"
 import {
   Select,
@@ -45,6 +48,7 @@ import {
   bundledThemes,
   customThemes,
   MATCH_TERMINAL_THEME,
+  repoLabel,
   SYSTEM_THEME,
   THEME_TEMPLATE_FILENAME,
   themeSelectItems,
@@ -61,12 +65,21 @@ export function AppearanceSettings() {
     path: string
     theme: ThemeDefinition
   } | null>(null)
+  const [packPendingOverwrite, setPackPendingOverwrite] = useState<{
+    url: string
+    conflicts: string[]
+  } | null>(null)
+  const [importOpen, setImportOpen] = useState(false)
+  const [importing, setImporting] = useState(false)
+  const [updatingID, setUpdatingID] = useState<string | null>(null)
   const [importedThemesOpen, setImportedThemesOpen] = useState(false)
   const {
     themes,
     theme,
     setTheme,
     importTheme,
+    installThemesFromGit,
+    updateThemeFromGit,
     removeTheme,
     zoom,
     setZoom,
@@ -78,11 +91,13 @@ export function AppearanceSettings() {
   const importedThemes = customThemes(themes)
   const hasCustomThemes = importedThemes.length > 0
 
-  const onImportTheme = async () => {
+  const onChooseThemeFile = async () => {
+    setImporting(true)
     try {
       const path = await ProjectService.PickFile("Import Theme")
       if (!path) return
       const result = await importTheme(path, false)
+      setImportOpen(false)
       if (result.needsOverwrite) {
         setThemePendingOverwrite({ path, theme: result.theme })
         return
@@ -90,6 +105,45 @@ export function AppearanceSettings() {
       toast.success(`Imported theme: ${result.theme.name}`)
     } catch (error) {
       toast.error(`Theme import failed: ${errorText(error)}`)
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  const installRepository = async (url: string, overwrite: boolean) => {
+    setImporting(true)
+    try {
+      const result = await installThemesFromGit(url, overwrite)
+      setImportOpen(false)
+      const conflicts = result.conflicts ?? []
+      if (conflicts.length > 0) {
+        setPackPendingOverwrite({ url, conflicts })
+        return
+      }
+      setPackPendingOverwrite(null)
+      toast.success(
+        `Installed ${themeCount(result.themes?.length ?? 0)} from ${result.pack} v${result.version}`,
+      )
+    } catch (error) {
+      toast.error(`Theme install failed: ${errorText(error)}`)
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  const onUpdateTheme = async (item: ThemeDefinition) => {
+    setUpdatingID(item.id)
+    try {
+      const result = await updateThemeFromGit(item.id)
+      toast.success(
+        result.upToDate
+          ? `${result.pack} is already at v${result.version}`
+          : `Updated ${result.pack} to v${result.version}`,
+      )
+    } catch (error) {
+      toast.error(`Theme update failed: ${errorText(error)}`)
+    } finally {
+      setUpdatingID(null)
     }
   }
 
@@ -152,7 +206,7 @@ export function AppearanceSettings() {
                 <ThemeOptions themes={themes} />
               </SelectContent>
             </Select>
-            <Button type="button" variant="outline" onClick={() => void onImportTheme()}>
+            <Button type="button" variant="outline" onClick={() => setImportOpen(true)}>
               <Upload />
               Import
             </Button>
@@ -203,10 +257,41 @@ export function AppearanceSettings() {
                       />
                       <span className="min-w-0 flex-1">
                         <span className="block truncate text-sm">{item.name}</span>
-                        <span className="block truncate font-mono text-xs text-muted-foreground">
-                          {item.id}
-                        </span>
+                        {/* The row is narrow: the repository replaces the id
+                            rather than sharing the line, or both truncate away. */}
+                        {item.source ? (
+                          <span className="flex min-w-0 items-center gap-1.5 font-mono text-xs text-muted-foreground">
+                            <GitBranch className="size-3 shrink-0" />
+                            <span className="truncate" title={item.source.url}>
+                              {repoLabel(item.source.url)}
+                            </span>
+                            <span className="shrink-0 tabular-nums">v{item.source.version}</span>
+                          </span>
+                        ) : (
+                          <span className="block truncate font-mono text-xs text-muted-foreground">
+                            {item.id}
+                          </span>
+                        )}
                       </span>
+                      {item.source && (
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon-sm"
+                                aria-label={`Update ${item.name}`}
+                                disabled={updatingID !== null}
+                                onClick={() => void onUpdateTheme(item)}
+                              />
+                            }
+                          >
+                            <RefreshCw className={updatingID === item.id ? "animate-spin" : ""} />
+                          </TooltipTrigger>
+                          <TooltipContent>Check the repository for a newer version</TooltipContent>
+                        </Tooltip>
+                      )}
                       <Tooltip>
                         <TooltipTrigger
                           render={
@@ -229,6 +314,35 @@ export function AppearanceSettings() {
               )}
             </div>
           )}
+          <ImportThemeDialog
+            open={importOpen}
+            onOpenChange={setImportOpen}
+            onInstallRepository={(url) => installRepository(url, false)}
+            onChooseFile={onChooseThemeFile}
+            busy={importing}
+          />
+          <ConfirmDialog
+            open={packPendingOverwrite !== null}
+            onCancel={() => setPackPendingOverwrite(null)}
+            title="Replace imported themes?"
+            description={
+              <>
+                The repository carries themes that are already installed:{" "}
+                <span className="font-medium">{packPendingOverwrite?.conflicts.join(", ")}</span>.
+                Install anyway? This permanently deletes the previous versions.
+              </>
+            }
+          >
+            <Button
+              variant="destructive"
+              disabled={importing}
+              onClick={() => {
+                if (packPendingOverwrite) void installRepository(packPendingOverwrite.url, true)
+              }}
+            >
+              Replace themes
+            </Button>
+          </ConfirmDialog>
           <ConfirmDialog
             open={themePendingRemoval !== null}
             onCancel={() => setThemePendingRemoval(null)}
@@ -331,6 +445,10 @@ export function AppearanceSettings() {
       </SettingGroup>
     </>
   )
+}
+
+function themeCount(count: number): string {
+  return count === 1 ? "1 theme" : `${count} themes`
 }
 
 interface ThemeOptionsProps {

--- a/frontend/src/components/settings/ImportThemeDialog.tsx
+++ b/frontend/src/components/settings/ImportThemeDialog.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from "react"
+import { FileJson } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface ImportThemeDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Clone and install a repository. Resolves once the attempt is finished. */
+  onInstallRepository: (url: string) => Promise<void>
+  /** Open the native picker for a single theme file. */
+  onChooseFile: () => Promise<void>
+  /** True while a clone or a file import is in flight. */
+  busy: boolean
+}
+
+// The two ways a theme arrives, in one place: a repository lich can clone
+// again later, and the single file that has always worked and stays unversioned.
+export function ImportThemeDialog({
+  open,
+  onOpenChange,
+  onInstallRepository,
+  onChooseFile,
+  busy,
+}: ImportThemeDialogProps) {
+  const [url, setUrl] = useState("")
+
+  useEffect(() => {
+    if (!open) setUrl("")
+  }, [open])
+
+  const trimmed = url.trim()
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Import theme</DialogTitle>
+          <DialogDescription>
+            Install from a git repository to keep the theme versioned, or pick a single theme file.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          className="flex flex-col gap-2"
+          onSubmit={(event) => {
+            event.preventDefault()
+            if (trimmed && !busy) void onInstallRepository(trimmed)
+          }}
+        >
+          <Label htmlFor="theme-repository-url">Repository URL</Label>
+          <div className="flex items-center gap-2">
+            <Input
+              id="theme-repository-url"
+              className="font-mono text-xs"
+              value={url}
+              onChange={(event) => setUrl(event.target.value)}
+              placeholder="https://github.com/you/lich-themes.git"
+              autoComplete="off"
+              spellCheck={false}
+              disabled={busy}
+            />
+            <Button type="submit" disabled={!trimmed || busy}>
+              {busy ? "Installing…" : "Install"}
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            A repository holding <code className="font-mono">lich-theme.json</code> and one or more
+            theme files. Its manifest version is what lich compares on update.
+          </p>
+        </form>
+        <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          <span className="h-px flex-1 bg-border" />
+          or
+          <span className="h-px flex-1 bg-border" />
+        </div>
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={busy}
+            onClick={() => void onChooseFile()}
+          >
+            <FileJson />
+            Choose file…
+          </Button>
+          <span className="text-xs text-muted-foreground">
+            A single theme file. No version, no updates.
+          </span>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" disabled={busy} onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -276,14 +276,34 @@ export interface ThemeDefinition {
   name: string
   scheme: "light" | "dark"
   origin: "bundled" | "custom"
+  /** Set only for a theme installed from a repository; a picked file has none. */
+  source?: ThemeSource
   app: Record<string, string>
   terminal: Record<string, string>
+}
+
+/** internal/themes.Source — the repository a theme was installed from. */
+export interface ThemeSource {
+  url: string
+  version: string
 }
 
 /** internal/themes.ImportResult — import outcome before an optional overwrite. */
 export interface ThemeImportResult {
   theme: ThemeDefinition
   needsOverwrite: boolean
+}
+
+/**
+ * internal/themes.GitInstallResult — a repository install. A non-empty
+ * conflicts means nothing was written and those ids need confirmation.
+ */
+export interface ThemeGitInstallResult {
+  pack: string
+  version: string
+  themes: ThemeDefinition[] | null
+  conflicts: string[] | null
+  upToDate: boolean
 }
 
 /** internal/patchnotes.Group — one "### Added/Changed/Fixed" block of a release. */

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -27,6 +27,7 @@ import type {
   StoredProject,
   StoredSession,
   ThemeDefinition,
+  ThemeGitInstallResult,
   ThemeImportResult,
   Worktree,
 } from "./api-types"
@@ -314,6 +315,11 @@ export const Themes = {
   /** Import a picked theme file, reporting an existing id before replacement. */
   Import: (path: string, overwrite: boolean) =>
     call<ThemeImportResult>("themes.Import", [path, overwrite]),
+  /** Clone a theme repository and install every theme its manifest versions. */
+  InstallFromGit: (url: string, overwrite: boolean) =>
+    call<ThemeGitInstallResult>("themes.InstallFromGit", [url, overwrite]),
+  /** Re-clone the repository a theme came from, installing a newer manifest. */
+  UpdateFromGit: (id: string) => call<ThemeGitInstallResult>("themes.UpdateFromGit", [id]),
   /** Remove a user-imported theme. Bundled themes are rejected by the backend. */
   Remove: (id: string) => call<null>("themes.Remove", [id]),
   /** Write the bundled starter theme to a destination the user picked. */

--- a/frontend/src/lib/themes.test.ts
+++ b/frontend/src/lib/themes.test.ts
@@ -8,9 +8,10 @@ import {
   customThemes,
   DEFAULT_TERMINAL_THEME,
   DEFAULT_THEME,
-  mergeImportedTheme,
+  mergeImportedThemes,
   mergeThemes,
   reconcileThemeSelections,
+  repoLabel,
   resolveTerminalTheme,
   resolveTheme,
   selectionsAfterThemeRemoval,
@@ -50,9 +51,36 @@ describe("themes", () => {
   it("merges an imported theme by id", () => {
     const original = customTheme("custom")
     const replacement = { ...original, name: "Replacement" }
-    const themes = mergeImportedTheme(mergeThemes([original]), replacement)
+    const themes = mergeImportedThemes(mergeThemes([original]), [replacement])
     expect(themes).toHaveLength(3)
     expect(themes[2].name).toBe("Replacement")
+  })
+
+  it("merges a whole installed pack at once", () => {
+    const themes = mergeImportedThemes(BUNDLED_THEMES, [
+      customTheme("pack-a"),
+      customTheme("pack-b"),
+    ])
+    expect(themes.map((theme) => theme.id)).toEqual(["light", "dark", "pack-a", "pack-b"])
+  })
+
+  it("keeps the repository source of an installed theme", () => {
+    const installed = {
+      ...customTheme("installed"),
+      source: { url: "https://github.com/you/lich-themes.git", version: "1.2.0" },
+    }
+    const merged = mergeThemes([installed])
+    expect(merged[2].source).toEqual(installed.source)
+    // The merge must copy the source, not alias the caller's object.
+    expect(merged[2].source).not.toBe(installed.source)
+    expect(mergeThemes([customTheme("plain")])[2].source).toBeUndefined()
+  })
+
+  it("shortens a clone URL to owner/repo", () => {
+    expect(repoLabel("https://github.com/you/lich-themes.git")).toBe("you/lich-themes")
+    expect(repoLabel("git@github.com:you/lich-themes.git")).toBe("you/lich-themes")
+    expect(repoLabel("https://gitlab.com/team/group/themes/")).toBe("group/themes")
+    expect(repoLabel("/home/you/themes")).toBe("you/themes")
   })
 
   it("resolves system to the bundled light or dark theme", () => {

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -102,11 +102,22 @@ export function themeSelectItems(
   return items
 }
 
-export function mergeImportedTheme(
+export function mergeImportedThemes(
   themes: readonly ThemeDefinition[],
-  imported: ThemeDefinition,
+  imported: readonly ThemeDefinition[],
 ): ThemeDefinition[] {
-  return mergeThemes([...themes, imported])
+  return mergeThemes([...themes, ...imported])
+}
+
+// repoLabel shortens a clone URL to the "owner/repo" a user recognizes; the
+// full URL is kept for the tooltip, since only the tail fits a theme row.
+export function repoLabel(url: string): string {
+  const trimmed = url
+    .trim()
+    .replace(/\.git$/, "")
+    .replace(/[/\\]+$/, "")
+  const segments = trimmed.split(/[/\\:]+/).filter(Boolean)
+  return segments.slice(-2).join("/") || trimmed
 }
 
 export interface ThemeSelections {
@@ -148,6 +159,7 @@ function normalizeTheme(theme: ThemeDefinition): ThemeDefinition {
     name: theme.name,
     scheme: theme.scheme,
     origin: theme.origin,
+    ...(theme.source ? { source: { ...theme.source } } : {}),
     app: { ...theme.app },
     terminal: { ...theme.terminal },
   }

--- a/frontend/src/providers/settings.tsx
+++ b/frontend/src/providers/settings.tsx
@@ -18,7 +18,7 @@ import {
   DARK_THEME_SCHEME,
   DEFAULT_TERMINAL_THEME,
   DEFAULT_THEME,
-  mergeImportedTheme,
+  mergeImportedThemes,
   mergeThemes,
   reconcileThemeSelections,
   resolveTerminalTheme,
@@ -27,7 +27,7 @@ import {
   SYSTEM_THEME,
 } from "@/lib/themes"
 import type { TerminalTheme, Theme, ResolvedTheme } from "@/lib/themes"
-import type { ThemeDefinition, ThemeImportResult } from "@/lib/api-types"
+import type { ThemeDefinition, ThemeGitInstallResult, ThemeImportResult } from "@/lib/api-types"
 
 export type { TerminalTheme, Theme, ResolvedTheme } from "@/lib/themes"
 export { DEFAULT_TERMINAL_THEME, DEFAULT_THEME } from "@/lib/themes"
@@ -104,6 +104,10 @@ interface SettingsValue {
   /** Bundled and imported themes available to the app. */
   themes: ThemeDefinition[]
   importTheme: (path: string, overwrite: boolean) => Promise<ThemeImportResult>
+  /** Install every theme of a repository, versioned by its manifest. */
+  installThemesFromGit: (url: string, overwrite: boolean) => Promise<ThemeGitInstallResult>
+  /** Re-clone the repository a theme came from and install a newer manifest. */
+  updateThemeFromGit: (id: string) => Promise<ThemeGitInstallResult>
   removeTheme: (id: string) => Promise<void>
   /** Theme resolved to concrete colors (system already mapped to the OS). */
   resolvedTheme: ResolvedTheme
@@ -209,12 +213,45 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     async (path: string, overwrite: boolean) => {
       const result = await ThemeRPC.Import(path, overwrite)
       if (!result.needsOverwrite) {
-        setThemes((prev) => mergeImportedTheme(prev, result.theme))
+        setThemes((prev) => mergeImportedThemes(prev, [result.theme]))
         setTheme(result.theme.id)
       }
       return result
     },
     [setTheme],
+  )
+
+  // A pack installs as a whole, so its first theme is what gets selected —
+  // selecting nothing would leave the user with no sign the install landed.
+  const adoptInstalledThemes = useCallback(
+    (installed: readonly ThemeDefinition[], select: boolean) => {
+      if (installed.length === 0) return
+      setThemes((prev) => mergeImportedThemes(prev, installed))
+      if (select) {
+        setTheme(installed[0].id)
+      }
+    },
+    [setTheme],
+  )
+
+  const installThemesFromGit = useCallback(
+    async (url: string, overwrite: boolean) => {
+      const result = await ThemeRPC.InstallFromGit(url, overwrite)
+      adoptInstalledThemes(result.themes ?? [], true)
+      return result
+    },
+    [adoptInstalledThemes],
+  )
+
+  const updateThemeFromGit = useCallback(
+    async (id: string) => {
+      const result = await ThemeRPC.UpdateFromGit(id)
+      // An update repaints themes the user may already be looking at, but it
+      // must not move the selection off the one they picked.
+      adoptInstalledThemes(result.themes ?? [], false)
+      return result
+    },
+    [adoptInstalledThemes],
   )
 
   const removeTheme = useCallback(
@@ -343,6 +380,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         theme,
         setTheme,
         importTheme,
+        installThemesFromGit,
+        updateThemeFromGit,
         removeTheme,
         resolvedTheme,
         zoom,

--- a/internal/themes/git.go
+++ b/internal/themes/git.go
@@ -1,0 +1,281 @@
+package themes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/omartelo/lich/internal/semver"
+)
+
+const (
+	cloneTimeout     = 90 * time.Second
+	remoteMaxLength  = 512
+	maxThemesPerPack = 32
+)
+
+// scpLike matches git's shorthand remote (user@host:path), the form an ssh
+// remote is usually copied in.
+var scpLike = regexp.MustCompile(`^[a-zA-Z0-9._-]+@[a-zA-Z0-9._-]+:[^\s]+$`)
+
+// GitInstallResult reports what installing a repository produced. Conflicts is
+// non-empty only when the install was refused because those theme ids already
+// exist locally; nothing was written in that case.
+type GitInstallResult struct {
+	Pack      string   `json:"pack"`
+	Version   string   `json:"version"`
+	Themes    []Theme  `json:"themes"`
+	Conflicts []string `json:"conflicts"`
+	UpToDate  bool     `json:"upToDate"`
+}
+
+// pack is a validated theme repository: its manifest plus every theme the
+// clone carried, already stamped with their source.
+type pack struct {
+	manifest Manifest
+	themes   []Theme
+}
+
+// InstallFromGit clones a theme repository and installs every theme in it. The
+// install is all-or-nothing: one unreadable or invalid theme fails the whole
+// repository instead of leaving half a pack behind.
+func (s *Service) InstallFromGit(url string, overwrite bool) (GitInstallResult, error) {
+	if s.initErr != nil {
+		return GitInstallResult{}, s.initErr
+	}
+	installed, err := fetchPack(url)
+	if err != nil {
+		return GitInstallResult{}, err
+	}
+	return s.installPack(installed, overwrite)
+}
+
+// UpdateFromGit re-clones the repository a theme came from and installs it
+// again when the manifest carries a newer version. The whole pack moves
+// together — the repository, not the single theme, is what is versioned.
+func (s *Service) UpdateFromGit(id string) (GitInstallResult, error) {
+	if s.initErr != nil {
+		return GitInstallResult{}, s.initErr
+	}
+	theme, err := s.read(id)
+	if err != nil {
+		return GitInstallResult{}, err
+	}
+	if theme.Source == nil {
+		return GitInstallResult{}, fmt.Errorf("theme %q was imported as a single file and has no repository to update from", id)
+	}
+	latest, err := fetchPack(theme.Source.URL)
+	if err != nil {
+		return GitInstallResult{}, err
+	}
+	result := GitInstallResult{Pack: latest.manifest.Name, Version: latest.manifest.version()}
+	if !semver.Less(theme.Source.Version, result.Version) {
+		result.UpToDate = true
+		return result, nil
+	}
+	return s.installPack(latest, true)
+}
+
+func (s *Service) installPack(installed pack, overwrite bool) (GitInstallResult, error) {
+	result := GitInstallResult{
+		Pack:    installed.manifest.Name,
+		Version: installed.manifest.version(),
+	}
+	if !overwrite {
+		for _, theme := range installed.themes {
+			if _, err := os.Stat(s.path(theme.ID)); err == nil {
+				result.Conflicts = append(result.Conflicts, theme.ID)
+			}
+		}
+		if len(result.Conflicts) > 0 {
+			return result, nil
+		}
+	}
+	if err := os.MkdirAll(s.dir, 0o700); err != nil {
+		return GitInstallResult{}, fmt.Errorf("create themes dir: %w", err)
+	}
+	for _, theme := range installed.themes {
+		if _, err := s.install(theme, true); err != nil {
+			return GitInstallResult{}, err
+		}
+	}
+	result.Themes = installed.themes
+	return result, nil
+}
+
+// fetchPack clones url into a temporary directory and reads the pack out of
+// it. The clone is thrown away: an update is another clone, which costs one
+// shallow fetch and saves reconciling a cache nobody watches.
+func fetchPack(url string) (pack, error) {
+	remote, err := validateRemote(url)
+	if err != nil {
+		return pack{}, err
+	}
+	tmp, err := os.MkdirTemp("", "lich-theme-repo-")
+	if err != nil {
+		return pack{}, fmt.Errorf("create temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tmp) }()
+	dir := filepath.Join(tmp, "repo")
+	ctx, cancel := context.WithTimeout(context.Background(), cloneTimeout)
+	defer cancel()
+	if err := clone(ctx, remote, dir); err != nil {
+		return pack{}, err
+	}
+	return readPack(dir, remote)
+}
+
+func clone(ctx context.Context, url, dir string) error {
+	cmd := exec.CommandContext(ctx, "git",
+		// ext:: resolves through a remote helper that runs a shell command.
+		// validateRemote already rejects it; this makes the ban git's too.
+		"-c", "protocol.ext.allow=never",
+		"-c", "credential.helper=",
+		"clone", "--depth", "1", "--single-branch", "--no-tags", "--", url, dir)
+	// Without these a private repository stops on a credential prompt that has
+	// no terminal to answer it, and the install hangs until the timeout.
+	cmd.Env = append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_ASKPASS=",
+		"SSH_ASKPASS=",
+		"GCM_INTERACTIVE=never",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("clone %s: timed out after %s", url, cloneTimeout)
+		}
+		return fmt.Errorf("clone %s: %s", url, gitError(out, err))
+	}
+	return nil
+}
+
+// gitError reduces git's output to its last meaningful line, which is the one
+// naming the failure ("repository not found", "could not read Username").
+func gitError(out []byte, err error) string {
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line != "" {
+			return line
+		}
+	}
+	return err.Error()
+}
+
+// readPack validates a cloned working tree: the manifest first, then every
+// other JSON beside it as a theme.
+func readPack(dir, url string) (pack, error) {
+	raw, err := readThemeFile(filepath.Join(dir, manifestName))
+	if err != nil {
+		return pack{}, fmt.Errorf("repository has no readable %s: %w", manifestName, err)
+	}
+	var manifest Manifest
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		return pack{}, fmt.Errorf("parse %s: %w", manifestName, err)
+	}
+	if err := manifest.validate(); err != nil {
+		return pack{}, err
+	}
+	files, err := themeFiles(dir)
+	if err != nil {
+		return pack{}, err
+	}
+	out := pack{manifest: manifest}
+	seen := make(map[string]struct{}, len(files))
+	for _, name := range files {
+		theme, err := readPackTheme(filepath.Join(dir, name), url, manifest.version())
+		if err != nil {
+			return pack{}, fmt.Errorf("%s: %w", name, err)
+		}
+		if _, dup := seen[theme.ID]; dup {
+			return pack{}, fmt.Errorf("%s: theme id %q is used by more than one file", name, theme.ID)
+		}
+		seen[theme.ID] = struct{}{}
+		out.themes = append(out.themes, theme)
+	}
+	return out, nil
+}
+
+func readPackTheme(path, url, version string) (Theme, error) {
+	data, err := readThemeFile(path)
+	if err != nil {
+		return Theme{}, err
+	}
+	var theme Theme
+	if err := json.Unmarshal(data, &theme); err != nil {
+		return Theme{}, fmt.Errorf("parse theme JSON: %w", err)
+	}
+	theme.Origin = OriginCustom
+	theme.Source = &Source{URL: url, Version: version}
+	if err := validateCustom(theme); err != nil {
+		return Theme{}, err
+	}
+	return theme, nil
+}
+
+func themeFiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read repository: %w", err)
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || name == manifestName || filepath.Ext(name) != ".json" {
+			continue
+		}
+		names = append(names, name)
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("repository has no theme JSON next to %s", manifestName)
+	}
+	if len(names) > maxThemesPerPack {
+		return nil, fmt.Errorf("repository holds more than %d themes", maxThemesPerPack)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// validateRemote is this package's trust boundary. git resolves an ext:: URL
+// through a remote helper that runs a shell command, and an argument starting
+// with "-" is read as a flag, so a URL typed into the UI is checked against a
+// transport allowlist before it ever reaches git.
+func validateRemote(url string) (string, error) {
+	remote := strings.TrimSpace(url)
+	switch {
+	case remote == "":
+		return "", fmt.Errorf("repository URL is required")
+	case len(remote) > remoteMaxLength:
+		return "", fmt.Errorf("repository URL cannot exceed %d characters", remoteMaxLength)
+	case strings.HasPrefix(remote, "-"):
+		return "", fmt.Errorf("repository URL cannot start with %q", "-")
+	case strings.HasPrefix(remote, "https://"),
+		strings.HasPrefix(remote, "ssh://"),
+		strings.HasPrefix(remote, "file://"),
+		filepath.IsAbs(remote),
+		scpLike.MatchString(remote):
+		return remote, nil
+	}
+	return "", fmt.Errorf("repository URL must be https://, ssh://, file://, an absolute path or user@host:path")
+}
+
+func validateSource(source *Source) error {
+	if source == nil {
+		return nil
+	}
+	if _, err := validateRemote(source.URL); err != nil {
+		return fmt.Errorf("theme source: %w", err)
+	}
+	if !semver.IsRelease(source.Version) {
+		return fmt.Errorf("theme source version %q must be MAJOR.MINOR.PATCH", source.Version)
+	}
+	return nil
+}

--- a/internal/themes/git_test.go
+++ b/internal/themes/git_test.go
@@ -1,0 +1,428 @@
+package themes
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is not installed")
+	}
+}
+
+func git(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	// The repository is a fixture, so it must not inherit the developer's
+	// identity or commit signing: a machine with gpgsign on would fail here.
+	base := []string{
+		"-c", "user.email=tests@lich.invalid",
+		"-c", "user.name=lich tests",
+		"-c", "commit.gpgsign=false",
+		"-c", "init.defaultBranch=main",
+	}
+	cmd := exec.Command("git", append(base, args...)...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+	}
+}
+
+func writeFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func manifestJSON(t *testing.T, name, version string) string {
+	t.Helper()
+	data, err := json.Marshal(Manifest{Name: name, Version: version})
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	return string(data)
+}
+
+// packDir writes a theme repository without a git history — enough for the
+// readPack rules, which never touch git.
+func packDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		writeFile(t, dir, name, body)
+	}
+	return dir
+}
+
+// themeRepo turns a set of files into a committed git repository and returns
+// its path, which doubles as the clone URL.
+func themeRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	requireGit(t)
+	dir := packDir(t, files)
+	git(t, dir, "init")
+	git(t, dir, "add", ".")
+	git(t, dir, "commit", "-m", "themes")
+	return dir
+}
+
+func commitAll(t *testing.T, dir, message string) {
+	t.Helper()
+	git(t, dir, "add", ".")
+	git(t, dir, "commit", "-m", message)
+}
+
+func TestInstallFromGitInstallsEveryThemeInThePack(t *testing.T) {
+	dir := t.TempDir()
+	s := NewInDir(dir)
+	repo := themeRepo(t, map[string]string{
+		manifestName:       manifestJSON(t, "Sample pack", "1.2.0"),
+		"tokyo-night.json": rawTheme(t, customTheme("tokyo-night")),
+		"gruvbox.json":     rawTheme(t, customTheme("gruvbox")),
+	})
+
+	result, err := s.InstallFromGit(repo, false)
+	if err != nil {
+		t.Fatalf("InstallFromGit: %v", err)
+	}
+	if result.Pack != "Sample pack" || result.Version != "1.2.0" {
+		t.Fatalf("result = %#v", result)
+	}
+	if len(result.Themes) != 2 || len(result.Conflicts) != 0 {
+		t.Fatalf("installed %d themes, %d conflicts", len(result.Themes), len(result.Conflicts))
+	}
+	for _, theme := range result.Themes {
+		if theme.Source == nil || theme.Source.URL != repo || theme.Source.Version != "1.2.0" {
+			t.Fatalf("theme %q source = %#v", theme.ID, theme.Source)
+		}
+	}
+	listed, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	// Two bundled themes plus the pack.
+	if len(listed) != 4 {
+		t.Fatalf("got %d themes, want 4", len(listed))
+	}
+	stored, err := s.read("gruvbox")
+	if err != nil {
+		t.Fatalf("read stored theme: %v", err)
+	}
+	if stored.Source == nil || stored.Source.Version != "1.2.0" {
+		t.Fatalf("stored source = %#v", stored.Source)
+	}
+}
+
+func TestInstallFromGitRejectsPackWithAnInvalidTheme(t *testing.T) {
+	dir := t.TempDir()
+	s := NewInDir(dir)
+	broken := customTheme("broken")
+	delete(broken.App, "background")
+	repo := themeRepo(t, map[string]string{
+		manifestName:  manifestJSON(t, "Sample pack", "1.0.0"),
+		"good.json":   rawTheme(t, customTheme("good")),
+		"broken.json": rawTheme(t, broken),
+	})
+
+	_, err := s.InstallFromGit(repo, false)
+	if err == nil {
+		t.Fatal("InstallFromGit accepted a pack holding an invalid theme")
+	}
+	if !strings.Contains(err.Error(), "broken.json") {
+		t.Fatalf("error does not name the file: %v", err)
+	}
+	// All-or-nothing: the valid sibling must not have been written either.
+	if _, err := os.Stat(filepath.Join(dir, "good.json")); !os.IsNotExist(err) {
+		t.Fatalf("valid theme was installed from a rejected pack: %v", err)
+	}
+}
+
+func TestInstallFromGitReportsConflictsBeforeWriting(t *testing.T) {
+	dir := t.TempDir()
+	s := NewInDir(dir)
+	existing := customTheme("tokyo-night")
+	existing.Name = "Mine"
+	if _, err := importTheme(t, s, existing); err != nil {
+		t.Fatalf("seed import: %v", err)
+	}
+	repo := themeRepo(t, map[string]string{
+		manifestName:       manifestJSON(t, "Sample pack", "1.0.0"),
+		"tokyo-night.json": rawTheme(t, customTheme("tokyo-night")),
+	})
+
+	result, err := s.InstallFromGit(repo, false)
+	if err != nil {
+		t.Fatalf("InstallFromGit: %v", err)
+	}
+	if len(result.Conflicts) != 1 || result.Conflicts[0] != "tokyo-night" {
+		t.Fatalf("conflicts = %#v", result.Conflicts)
+	}
+	if len(result.Themes) != 0 {
+		t.Fatalf("themes were installed despite the conflict: %#v", result.Themes)
+	}
+	kept, err := s.read("tokyo-night")
+	if err != nil {
+		t.Fatalf("read kept theme: %v", err)
+	}
+	if kept.Name != "Mine" || kept.Source != nil {
+		t.Fatalf("existing theme was replaced: %#v", kept)
+	}
+
+	replaced, err := s.InstallFromGit(repo, true)
+	if err != nil {
+		t.Fatalf("InstallFromGit overwrite: %v", err)
+	}
+	if len(replaced.Themes) != 1 {
+		t.Fatalf("overwrite installed %d themes", len(replaced.Themes))
+	}
+	updated, err := s.read("tokyo-night")
+	if err != nil {
+		t.Fatalf("read replaced theme: %v", err)
+	}
+	if updated.Source == nil || updated.Source.URL != repo {
+		t.Fatalf("replaced theme source = %#v", updated.Source)
+	}
+}
+
+func TestUpdateFromGitInstallsANewerManifest(t *testing.T) {
+	s := NewInDir(t.TempDir())
+	repo := themeRepo(t, map[string]string{
+		manifestName:       manifestJSON(t, "Sample pack", "1.0.0"),
+		"tokyo-night.json": rawTheme(t, customTheme("tokyo-night")),
+	})
+	if _, err := s.InstallFromGit(repo, false); err != nil {
+		t.Fatalf("InstallFromGit: %v", err)
+	}
+
+	renamed := customTheme("tokyo-night")
+	renamed.Name = "Tokyo Night II"
+	writeFile(t, repo, manifestName, manifestJSON(t, "Sample pack", "1.1.0"))
+	writeFile(t, repo, "tokyo-night.json", rawTheme(t, renamed))
+	commitAll(t, repo, "bump")
+
+	result, err := s.UpdateFromGit("tokyo-night")
+	if err != nil {
+		t.Fatalf("UpdateFromGit: %v", err)
+	}
+	if result.UpToDate || result.Version != "1.1.0" || len(result.Themes) != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	stored, err := s.read("tokyo-night")
+	if err != nil {
+		t.Fatalf("read updated theme: %v", err)
+	}
+	if stored.Name != "Tokyo Night II" || stored.Source.Version != "1.1.0" {
+		t.Fatalf("stored theme = %#v", stored)
+	}
+}
+
+func TestUpdateFromGitKeepsAnUpToDatePack(t *testing.T) {
+	s := NewInDir(t.TempDir())
+	repo := themeRepo(t, map[string]string{
+		manifestName:       manifestJSON(t, "Sample pack", "1.0.0"),
+		"tokyo-night.json": rawTheme(t, customTheme("tokyo-night")),
+	})
+	if _, err := s.InstallFromGit(repo, false); err != nil {
+		t.Fatalf("InstallFromGit: %v", err)
+	}
+
+	result, err := s.UpdateFromGit("tokyo-night")
+	if err != nil {
+		t.Fatalf("UpdateFromGit: %v", err)
+	}
+	if !result.UpToDate || len(result.Themes) != 0 {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestUpdateFromGitRejectsAFileImportedTheme(t *testing.T) {
+	s := NewInDir(t.TempDir())
+	if _, err := importTheme(t, s, customTheme("standalone")); err != nil {
+		t.Fatalf("seed import: %v", err)
+	}
+	_, err := s.UpdateFromGit("standalone")
+	if err == nil {
+		t.Fatal("UpdateFromGit accepted a theme with no repository")
+	}
+	if !strings.Contains(err.Error(), "single file") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestImportDropsAClaimedSource(t *testing.T) {
+	s := NewInDir(t.TempDir())
+	claimed := customTheme("claimed")
+	claimed.Source = &Source{URL: "https://example.invalid/themes.git", Version: "9.9.9"}
+
+	result, err := importTheme(t, s, claimed)
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if result.Theme.Source != nil {
+		t.Fatalf("import kept a claimed source: %#v", result.Theme.Source)
+	}
+	stored, err := s.read("claimed")
+	if err != nil {
+		t.Fatalf("read stored theme: %v", err)
+	}
+	if stored.Source != nil {
+		t.Fatalf("stored theme kept a claimed source: %#v", stored.Source)
+	}
+}
+
+func TestValidateRemoteAllowsOnlyKnownTransports(t *testing.T) {
+	absolute := filepath.Join(t.TempDir(), "themes")
+	cases := []struct {
+		name  string
+		url   string
+		valid bool
+	}{
+		{"https", "https://github.com/omartelo/lich-themes.git", true},
+		{"ssh", "ssh://git@github.com/omartelo/lich-themes.git", true},
+		{"scp shorthand", "git@github.com:omartelo/lich-themes.git", true},
+		{"file", "file://" + absolute, true},
+		{"absolute path", absolute, true},
+		{"remote helper", "ext::sh -c 'touch /tmp/pwned'", false},
+		{"flag", "--upload-pack=touch /tmp/pwned", false},
+		{"unencrypted git", "git://github.com/omartelo/lich-themes.git", false},
+		{"relative path", "../themes", false},
+		{"empty", "   ", false},
+		{"overlong", "https://example.invalid/" + strings.Repeat("a", remoteMaxLength), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := validateRemote(tc.url)
+			if tc.valid && err != nil {
+				t.Fatalf("validateRemote(%q) = %v, want accepted", tc.url, err)
+			}
+			if !tc.valid && err == nil {
+				t.Fatalf("validateRemote(%q) accepted a rejected transport", tc.url)
+			}
+		})
+	}
+}
+
+func TestInstallFromGitRejectsAnUnsupportedRemote(t *testing.T) {
+	s := NewInDir(t.TempDir())
+	if _, err := s.InstallFromGit("ext::sh -c 'touch /tmp/pwned'", false); err == nil {
+		t.Fatal("InstallFromGit accepted a remote-helper URL")
+	}
+}
+
+func TestReadPackRejectsMalformedRepositories(t *testing.T) {
+	valid := rawTheme(t, customTheme("one"))
+	duplicate := rawTheme(t, customTheme("dup"))
+	crowded := map[string]string{manifestName: manifestJSON(t, "Crowded", "1.0.0")}
+	for i := 0; i <= maxThemesPerPack; i++ {
+		crowded[string(rune('a'+i%26))+string(rune('a'+i/26))+".json"] = "{}"
+	}
+	cases := []struct {
+		name  string
+		files map[string]string
+		want  string
+	}{
+		{
+			name:  "no manifest",
+			files: map[string]string{"one.json": valid},
+			want:  manifestName,
+		},
+		{
+			name:  "malformed manifest",
+			files: map[string]string{manifestName: "{", "one.json": valid},
+			want:  "parse",
+		},
+		{
+			name:  "manifest without a release version",
+			files: map[string]string{manifestName: manifestJSON(t, "Pack", "1.2"), "one.json": valid},
+			want:  "MAJOR.MINOR.PATCH",
+		},
+		{
+			name:  "manifest without a name",
+			files: map[string]string{manifestName: manifestJSON(t, "  ", "1.0.0"), "one.json": valid},
+			want:  "name is required",
+		},
+		{
+			name:  "no themes",
+			files: map[string]string{manifestName: manifestJSON(t, "Pack", "1.0.0")},
+			want:  "no theme JSON",
+		},
+		{
+			name: "duplicate id",
+			files: map[string]string{
+				manifestName: manifestJSON(t, "Pack", "1.0.0"),
+				"a.json":     duplicate,
+				"b.json":     duplicate,
+			},
+			want: "more than one file",
+		},
+		{
+			name:  "too many themes",
+			files: crowded,
+			want:  "more than",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := readPack(packDir(t, tc.files), "https://example.invalid/themes.git")
+			if err == nil {
+				t.Fatalf("readPack accepted %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not mention %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestReadPackIgnoresNonThemeEntries(t *testing.T) {
+	files := map[string]string{
+		manifestName: manifestJSON(t, "Pack", "2.0.0"),
+		"one.json":   rawTheme(t, customTheme("one")),
+		"README.md":  "# themes",
+	}
+	dir := packDir(t, files)
+	if err := os.Mkdir(filepath.Join(dir, "docs"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	pack, err := readPack(dir, "https://example.invalid/themes.git")
+	if err != nil {
+		t.Fatalf("readPack: %v", err)
+	}
+	if len(pack.themes) != 1 || pack.themes[0].ID != "one" {
+		t.Fatalf("pack = %#v", pack.themes)
+	}
+}
+
+func TestListKeepsTheSourceOfAnInstalledTheme(t *testing.T) {
+	dir := t.TempDir()
+	s := NewInDir(dir)
+	repo := themeRepo(t, map[string]string{
+		manifestName: manifestJSON(t, "Sample pack", "3.1.4"),
+		"one.json":   rawTheme(t, customTheme("one")),
+	})
+	if _, err := s.InstallFromGit(repo, false); err != nil {
+		t.Fatalf("InstallFromGit: %v", err)
+	}
+
+	listed, err := s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, theme := range listed {
+		if theme.ID != "one" {
+			continue
+		}
+		if theme.Source == nil || theme.Source.Version != "3.1.4" || theme.Source.URL != repo {
+			t.Fatalf("listed source = %#v", theme.Source)
+		}
+		return
+	}
+	t.Fatal("installed theme is missing from List")
+}

--- a/internal/themes/manifest.go
+++ b/internal/themes/manifest.go
@@ -1,0 +1,42 @@
+package themes
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/omartelo/lich/internal/semver"
+)
+
+// manifestName is what marks a repository as a lich theme pack. Every other
+// *.json next to it is read as a theme.
+const manifestName = "lich-theme.json"
+
+// Manifest is the versioning stamp of a theme repository. It deliberately does
+// not list the themes: id and name already live inside each theme file, and a
+// second copy here would be a list to keep in sync for no gain.
+type Manifest struct {
+	Name    string `json:"name"`
+	Version string `json:"version"`
+}
+
+func (m Manifest) validate() error {
+	if strings.TrimSpace(m.Name) == "" {
+		return fmt.Errorf("manifest name is required")
+	}
+	if utf8.RuneCountInString(m.Name) > themeNameMaxLength {
+		return fmt.Errorf("manifest name cannot exceed %d characters", themeNameMaxLength)
+	}
+	// Update compares versions with semver.Less, which orders no two distinct
+	// pre-releases — a pack that versioned itself "1.2.0-rc1" would never be
+	// seen as newer than "1.2.0-rc2".
+	if !semver.IsRelease(m.Version) {
+		return fmt.Errorf("manifest version %q must be MAJOR.MINOR.PATCH", m.Version)
+	}
+	return nil
+}
+
+// version is the manifest version normalized for storage and display.
+func (m Manifest) version() string {
+	return strings.TrimPrefix(strings.TrimSpace(m.Version), "v")
+}

--- a/internal/themes/themes.go
+++ b/internal/themes/themes.go
@@ -62,8 +62,18 @@ type Theme struct {
 	Name     string            `json:"name"`
 	Scheme   string            `json:"scheme"`
 	Origin   string            `json:"origin"`
+	Source   *Source           `json:"source,omitempty"`
 	App      map[string]string `json:"app"`
 	Terminal map[string]string `json:"terminal"`
+}
+
+// Source records the repository a theme was installed from and the manifest
+// version it came in at, so lich can clone it again to look for a newer one. It
+// is written by lich, never by a picked file: a standalone import has no
+// source and stays unversioned.
+type Source struct {
+	URL     string `json:"url"`
+	Version string `json:"version"`
 }
 
 // ImportResult either reports the installed theme or asks the UI to confirm
@@ -134,36 +144,66 @@ func (s *Service) Import(path string, overwrite bool) (ImportResult, error) {
 		return ImportResult{}, fmt.Errorf("parse theme JSON: %w", err)
 	}
 	theme.Origin = OriginCustom
+	// A picked file names no repository: whatever it claims as its source would
+	// point a later update check at a URL lich never cloned.
+	theme.Source = nil
 	if err := validateCustom(theme); err != nil {
 		return ImportResult{}, err
 	}
 	if err := os.MkdirAll(s.dir, 0o700); err != nil {
 		return ImportResult{}, fmt.Errorf("create themes dir: %w", err)
 	}
-	data, err := encodeTheme(theme)
+	installed, err := s.install(theme, overwrite)
 	if err != nil {
 		return ImportResult{}, err
 	}
+	if !installed {
+		return ImportResult{Theme: theme, NeedsOverwrite: true}, nil
+	}
+	return ImportResult{Theme: theme}, nil
+}
+
+// install writes theme to its file. Without overwrite an existing file is left
+// untouched and install reports false, which the callers turn into a question
+// for the user.
+func (s *Service) install(theme Theme, overwrite bool) (bool, error) {
+	data, err := encodeTheme(theme)
+	if err != nil {
+		return false, err
+	}
 	destination := s.path(theme.ID)
 	if !overwrite {
-		created, err := writeNewTheme(destination, data)
-		if err != nil {
-			return ImportResult{}, err
-		}
-		if !created {
-			return ImportResult{Theme: theme, NeedsOverwrite: true}, nil
-		}
-		return ImportResult{Theme: theme}, nil
+		return writeNewTheme(destination, data)
 	}
 	tmp := destination + ".tmp"
 	if err := os.WriteFile(tmp, data, 0o600); err != nil {
-		return ImportResult{}, fmt.Errorf("write theme: %w", err)
+		return false, fmt.Errorf("write theme: %w", err)
 	}
 	if err := os.Rename(tmp, destination); err != nil {
 		_ = os.Remove(tmp)
-		return ImportResult{}, fmt.Errorf("install theme: %w", err)
+		return false, fmt.Errorf("install theme: %w", err)
 	}
-	return ImportResult{Theme: theme}, nil
+	return true, nil
+}
+
+// read loads one installed theme by id.
+func (s *Service) read(id string) (Theme, error) {
+	if err := validateID(id); err != nil {
+		return Theme{}, err
+	}
+	data, err := os.ReadFile(s.path(id))
+	if err != nil {
+		return Theme{}, fmt.Errorf("read theme %q: %w", id, err)
+	}
+	var theme Theme
+	if err := json.Unmarshal(data, &theme); err != nil {
+		return Theme{}, fmt.Errorf("parse theme %q: %w", id, err)
+	}
+	theme.Origin = OriginCustom
+	if err := validateCustom(theme); err != nil {
+		return Theme{}, err
+	}
+	return theme, nil
 }
 
 // SaveTemplate writes the bundled starter theme to a destination the user
@@ -313,6 +353,9 @@ func validateTheme(theme Theme) error {
 	if theme.Scheme != SchemeLight && theme.Scheme != SchemeDark {
 		return fmt.Errorf("theme scheme must be %q or %q", SchemeLight, SchemeDark)
 	}
+	if err := validateSource(theme.Source); err != nil {
+		return err
+	}
 	if err := validateColors("app", theme.App, appTokens, appColorValue, true); err != nil {
 		return err
 	}
@@ -377,7 +420,7 @@ func validateColorValue(group, key, value string, pattern *regexp.Regexp) error 
 }
 
 func cloneTheme(theme Theme) Theme {
-	return Theme{
+	out := Theme{
 		ID:       theme.ID,
 		Name:     theme.Name,
 		Scheme:   theme.Scheme,
@@ -385,6 +428,11 @@ func cloneTheme(theme Theme) Theme {
 		App:      cloneMap(theme.App),
 		Terminal: cloneMap(theme.Terminal),
 	}
+	if theme.Source != nil {
+		source := *theme.Source
+		out.Source = &source
+	}
+	return out
 }
 
 func cloneMap(in map[string]string) map[string]string {


### PR DESCRIPTION
Import takes a git repository now, and keeps what it installs versioned. The single-file path is untouched — it just reads as what it is: unversioned.

A repository is a manifest plus its themes:

```
lich-theme.json      {"name": "My themes", "version": "1.2.0"}
tokyo-night.json
gruvbox.json
```

Install clones it shallowly into a temp directory, validates the manifest and every theme, and only then writes. **Update** on a theme's row re-clones and takes the pack again when the manifest is newer.

## Decisions

- **The manifest lists nothing.** Every root-level `*.json` beside it is a theme — no second list to drift from the `id`/`name` already inside each file.
- **The version is the pack's, not the theme's.** One number to bump; installing and updating both take the whole repository.
- **No clone cache.** The clone is deleted; an update is another clone. A kept checkout is a working tree to reconcile, and one the user can edit behind lich's back.
- **All-or-nothing install.** One invalid theme fails the repository; the valid siblings are not written either. Existing ids come back as conflicts and are confirmed before replacement.
- **`validateRemote` is the trust boundary.** `ext::` resolves through a remote helper that runs a shell command and a leading `-` is read as a flag, so the URL is checked against an allowlist (https, ssh, file, absolute path, `user@host:path`) before git sees it — and the ban is repeated to git with `protocol.ext.allow=never`. Credential prompts are off, so a private repo fails instead of hanging.
- **Procedence rides the theme.** `source: {url, version}` inside the stored `<id>.json`; `origin` stays `custom`, so nothing that filters on it changed. A picked file gets its claimed `source` stripped.

Cut from v1 on purpose: pinning a tag/ref, installing one theme out of a pack, and a `lich` minimum-version field in the manifest.

## Test plan

- [x] `go test -race ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] Cross-compile loop for linux/darwin/windows (build + vet)
- [x] `pnpm check`, `tsc --noEmit`, `vitest run` (624), `vite build`
- [x] Backend suite covers: pack install, an invalid theme aborting the pack, conflicts left unwritten, update to a newer manifest, up-to-date update, a file-imported theme refusing to update, the transport allowlist, and the malformed-repository rules
- [x] Driven in the running app (headless Chromium over CDP): install applies and selects, update moves the whole pack to v1.1.0, a second update reports it as already at v1.1.0, no console errors — this is what caught the theme row truncating its own meta line
- [x] `ci:os` label set: the backend suite now shells out to `git`, so it needs a real Windows and macOS runner

`docs/themes.md` carries the repository contract and a **Start a repository** quickstart; the `lich:theme` skill learns the same layout in omartelo/lich-plugin.
