### PR TITLE
fix: open a terminal link once, not once per handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Ctrl+Click on a link inside a session opens one tab, not two.** Claude Code
+  reads the mouse itself and opens the links it prints, so the same click was
+  being served twice: once by the session, once by lich. Whenever the running
+  app is reading the mouse, the click is now its own — lich opens the link only
+  where nothing else will.
+
 ## [0.24.0] - 2026-08-04
 
 ### Added

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -19,7 +19,7 @@ import { takeSetup } from "@/lib/terminal/setup-queue"
 import { recordChunk } from "@/lib/terminal/term-perf"
 import { copyToastMessage, COPY_TOAST_DURATION_MS } from "@/lib/terminal/copy-toast"
 import { computeGrid } from "@/lib/terminal/term-fit"
-import { mouseEncodingSequence } from "@/lib/terminal/term-modes"
+import { linkClickIsOurs, mouseEncodingSequence } from "@/lib/terminal/term-modes"
 import { useSettings } from "@/providers/settings"
 import type { SessionKind } from "@/lib/session/sessions"
 import "@xterm/xterm/css/xterm.css"
@@ -246,7 +246,7 @@ export function TerminalView({
     term.loadAddon(serialize)
     term.loadAddon(
       new WebLinksAddon((event, uri) => {
-        if (event.ctrlKey || event.metaKey) {
+        if (linkClickIsOurs(event, term.modes.mouseTrackingMode)) {
           void System.OpenExternal(uri)
         }
       }),

--- a/frontend/src/lib/terminal/term-modes.test.ts
+++ b/frontend/src/lib/terminal/term-modes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { mouseEncodingSequence } from "./term-modes"
+import { linkClickIsOurs, mouseEncodingSequence } from "./term-modes"
 
 describe("mouseEncodingSequence", () => {
   it("restores SGR, the encoding every modern TUI selects", () => {
@@ -20,5 +20,22 @@ describe("mouseEncodingSequence", () => {
     expect(mouseEncodingSequence(undefined)).toBe("")
     expect(mouseEncodingSequence("")).toBe("")
     expect(mouseEncodingSequence("SOMETHING_NEW")).toBe("")
+  })
+})
+
+describe("linkClickIsOurs", () => {
+  it("opens the link when no app is reading the mouse", () => {
+    expect(linkClickIsOurs({ ctrlKey: true, metaKey: false }, "none")).toBe(true)
+    expect(linkClickIsOurs({ ctrlKey: false, metaKey: true }, "none")).toBe(true)
+  })
+
+  it("stands down while an app reads the mouse — it got the same click", () => {
+    for (const mode of ["x10", "vt200", "drag", "any"]) {
+      expect(linkClickIsOurs({ ctrlKey: true, metaKey: false }, mode)).toBe(false)
+    }
+  })
+
+  it("ignores a plain click, which selects rather than opens", () => {
+    expect(linkClickIsOurs({ ctrlKey: false, metaKey: false }, "none")).toBe(false)
   })
 })

--- a/frontend/src/lib/terminal/term-modes.ts
+++ b/frontend/src/lib/terminal/term-modes.ts
@@ -25,3 +25,18 @@ const MOUSE_ENCODING_SEQUENCES: Record<string, string> = {
 export function mouseEncodingSequence(encoding: string | undefined): string {
   return encoding ? (MOUSE_ENCODING_SEQUENCES[encoding] ?? "") : ""
 }
+
+/**
+ * Whether a click on a link is ours to open. Only Shift bypasses xterm's mouse
+ * reporting, so an app that asked for mouse events gets the Ctrl+Click too —
+ * and an app that opens its own links (Claude Code does) then opens the same
+ * URL a second time, one browser tab each. The app owns the click; we stand
+ * down. The cost is that a mouse-reporting TUI which ignores link clicks makes
+ * Ctrl+Click open nothing.
+ */
+export function linkClickIsOurs(
+  event: Pick<MouseEvent, "ctrlKey" | "metaKey">,
+  mouseTrackingMode: string,
+): boolean {
+  return (event.ctrlKey || event.metaKey) && mouseTrackingMode === "none"
+}


### PR DESCRIPTION
## What

Ctrl+Click on a link printed by Claude Code opened **two** browser tabs.

## Why

The click is served twice:

1. Claude Code turns mouse reporting on (`?1000h` + `?1006h`) and opens the links it prints itself — its bundle carries `getHyperlinkAt`, `onOpenHyperlink`, `pendingHyperlinkTimer` and an SGR report parser.
2. xterm only lets **Shift** bypass mouse reporting (`SelectionService.shouldForceSelection` → `event.shiftKey` on Linux), so the Ctrl+Click reaches the PTY *and* fires the `WebLinksAddon` handler, which calls `System.OpenExternal` → `xdg-open`.

Tab one is Claude Code's, tab two is lich's. The backend was never involved twice — `OpenExternal` runs `xdg-open` once per call.

## How

The app that asked for mouse events owns the click. `linkClickIsOurs` (`frontend/src/lib/terminal/term-modes.ts`) opens a link only while `mouseTrackingMode === "none"`.

The trade is named in the comment: a mouse-reporting TUI that ignores link clicks (vim, htop, lazygit) makes Ctrl+Click open nothing. Swallowing the report before xterm sees it — what ghostty does — means intercepting mousedown in the capture phase and reimplementing URL detection, far more code for the rarer case.

## Test plan

- [x] `pnpm test` — 624 passed, 3 of them new on `linkClickIsOurs`
- [x] `tsc --noEmit` and `biome check` clean
- [x] `task dev`: Ctrl+Click a link printed by Claude Code → one tab
- [x] `task dev`: Ctrl+Click a link in plain shell output (no mouse reporting) → one tab