### PR TITLE
test: make the port-window and log-rotation assertions capable of failing

### DIFF
--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -144,6 +144,37 @@ func TestInitRotatesOversizedLog(t *testing.T) {
 	}
 }
 
+// TestInitKeepsUndersizedLog proves a log below the threshold is appended to
+// rather than rotated. Rotating on every boot would overwrite .old with the
+// session that just started — destroying the generation a bug report is told
+// to attach, and the one RevealLog puts in view.
+func TestInitKeepsUndersizedLog(t *testing.T) {
+	restoreDefault(t)
+	t.Setenv("LICH_DEV", "")
+	dir := logDir(t)
+	path := filepath.Join(dir, "lich.log")
+	if err := os.WriteFile(path, []byte("previous generation\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	closer, err := Init(dir)
+	if err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	defer closer.Close()
+
+	if _, err := os.Stat(path + ".old"); !os.IsNotExist(err) {
+		t.Errorf("undersized log was rotated: stat(.old) = %v", err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.HasPrefix(string(content), "previous generation") {
+		t.Errorf("existing log not appended to:\n%s", content)
+	}
+}
+
 // failingWriter always errors, standing in for the dead stderr of a
 // windowsgui process.
 type failingWriter struct{}

--- a/internal/terminal/worktreeport_test.go
+++ b/internal/terminal/worktreeport_test.go
@@ -46,16 +46,33 @@ func TestWorktreePortSeparatesCheckouts(t *testing.T) {
 	}
 }
 
+// lichListenPort duplicates defaultListenPort from package main, where it is a
+// string and out of reach from here. Moving it there without moving it here is
+// what the window test below is for.
+const lichListenPort = 47821
+
 // TestWorktreePortStaysInRange proves every assigned port lands inside the
-// documented window — below the ephemeral range and clear of lich's listener.
+// documented window. The bounds are literals on purpose: the window is a
+// promise about the machine — below Linux's ephemeral range (32768), never
+// lich's own listener — and comparing against the constants under test would
+// only restate the arithmetic.
 func TestWorktreePortStaysInRange(t *testing.T) {
 	for i := range 5000 {
 		path := filepath.Join("src", "repo", string(rune('a'+i%26)), string(rune(i)))
 		port := worktreePort(path)
-		if port < worktreePortBase || port >= worktreePortBase+worktreePortCount {
-			t.Fatalf("worktreePort(%q) = %d, outside [%d, %d)",
-				path, port, worktreePortBase, worktreePortBase+worktreePortCount)
+		if port < 24000 || port >= 32768 || port == lichListenPort {
+			t.Fatalf("worktreePort(%q) = %d, outside the documented window", path, port)
 		}
+	}
+}
+
+// TestWorktreePortWindowClearsListener proves the whole window clears lich's
+// pinned listener, not merely the paths the range test happens to sample: a
+// checkout handed the app's own port would collide with lich itself.
+func TestWorktreePortWindowClearsListener(t *testing.T) {
+	if lichListenPort >= worktreePortBase && lichListenPort < worktreePortBase+worktreePortCount {
+		t.Fatalf("window [%d, %d) contains lich's listener %d",
+			worktreePortBase, worktreePortBase+worktreePortCount, lichListenPort)
 	}
 }
 


### PR DESCRIPTION
Two existing tests passed no matter what the production code did. Neither behaviour was wrong — the assertions were. Test-only; no production file changed, no CHANGELOG entry.

## `internal/terminal/worktreeport_test.go`

`TestWorktreePortStaysInRange` compared the port against `worktreePortBase` and `worktreePortBase+worktreePortCount` — the constants under test. Any base value passed; the test could only fail if the modulo arithmetic itself broke, while its comment claimed it proved the window sits below the ephemeral range and clear of lich's listener.

The bounds are literals now, and a second test ties the window as a whole to the pinned listener port. `defaultListenPort` lives in `package main` as a string and is not importable from `internal/terminal`, so the literal is duplicated with a comment naming its source rather than lifted into a package for one constant.

The other four tests in the file are untouched — they pin real properties.

## `internal/logging/logging_test.go`

`TestInitRotatesOversizedLog` only covered the oversized half, so mutating the guard to `info.Size() >= 0` survived: every boot would rotate and overwrite `<path>.old` — precisely the generation `system.RevealLog` puts in view for a bug report. `TestInitKeepsUndersizedLog` pins the other half: an undersized log gets appended to, not rotated. It follows the file's existing `restoreDefault`/`logDir` helpers for the process-global state `Init` touches.

## Mutations, in a scratch copy

`worktreePortBase = 47000`:

```
--- FAIL: TestWorktreePortStaysInRange (0.00s)
    worktreeport_test.go:64: worktreePort("src/repo/a/\x00") = 47345, outside the documented window
--- FAIL: TestWorktreePortWindowClearsListener (0.00s)
    worktreeport_test.go:74: window [47000, 48000) contains lich's listener 47821
FAIL	github.com/omartelo/lich/internal/terminal	0.004s
```

`info.Size() >= 0`:

```
--- FAIL: TestInitKeepsUndersizedLog (0.00s)
    logging_test.go:167: undersized log was rotated: stat(.old) = <nil>
    logging_test.go:174: existing log not appended to:
FAIL	github.com/omartelo/lich/internal/logging	0.013s
```

Both green again once restored.

## Test plan

- [x] `gofmt -l ./internal ./main.go` clean, `go vet ./...` clean
- [x] `LICH_LISTEN_PORT= go test ./...` green
- [x] `LICH_LISTEN_PORT= go test -race ./...` green
- [x] Both new/rewritten assertions shown failing against the mutations above