### PR TITLE
refactor: make the duplicate-launch decision testable

### DIFF
--- a/internal/singleton/singleton.go
+++ b/internal/singleton/singleton.go
@@ -96,6 +96,34 @@ func Detect(configDir string, wantPort int, ping func(port int, token string) bo
 	return info, nil
 }
 
+// BindVerdict is what a failed bind of the pinned listener port means.
+type BindVerdict int
+
+const (
+	// BindFailureIsReal: log and exit 1 — the port is held by something that is
+	// not a lich we can hand over to, or this process is a restart successor,
+	// which legitimately expects a busy port and retries the bind itself (so a
+	// failure here is genuine).
+	BindFailureIsReal BindVerdict = iota
+	// BindFailureIsDuplicate: another live lich holds the port — focus its
+	// window and exit 0. Re-launching an app you already have open should give
+	// you the window, not an error.
+	BindFailureIsDuplicate
+)
+
+// BindFailureVerdict decides what a failed bind means. restartWait is the
+// restart.WaitEnv value; running is what Detect found, which the caller probes
+// for only when restartWait is empty (a successor never pays for the probe).
+func BindFailureVerdict(restartWait string, running *Info) BindVerdict {
+	if restartWait != "" {
+		return BindFailureIsReal
+	}
+	if running == nil {
+		return BindFailureIsReal
+	}
+	return BindFailureIsDuplicate
+}
+
 // Ping reports whether a token-gated lich listener answers on port. It is the
 // production probe passed to Detect: only lich serves /ping behind the token, so
 // a 204 proves the recorded instance is alive and is lich.

--- a/internal/singleton/singleton_test.go
+++ b/internal/singleton/singleton_test.go
@@ -176,6 +176,31 @@ func TestPing(t *testing.T) {
 	}
 }
 
+func TestBindFailureVerdict(t *testing.T) {
+	live := &Info{PID: 1, Port: 47821, Token: "t"}
+	tests := []struct {
+		name        string
+		restartWait string
+		running     *Info
+		want        BindVerdict
+	}{
+		{"restart successor, nothing detected", "1", nil, BindFailureIsReal},
+		// A successor races for a busy port on purpose; whatever still holds it
+		// is not a window to hand over to.
+		{"restart successor, lich still holding the port", "1", live, BindFailureIsReal},
+		{"fresh launch, port held by something else", "", nil, BindFailureIsReal},
+		{"fresh launch, another live lich", "", live, BindFailureIsDuplicate},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := BindFailureVerdict(tt.restartWait, tt.running); got != tt.want {
+				t.Errorf("BindFailureVerdict(%q, %+v) = %d, want %d",
+					tt.restartWait, tt.running, got, tt.want)
+			}
+		})
+	}
+}
+
 func serverPort(t *testing.T, srv *httptest.Server) int {
 	t.Helper()
 	_, portStr, ok := strings.Cut(strings.TrimPrefix(srv.URL, "http://"), ":")

--- a/main.go
+++ b/main.go
@@ -190,23 +190,23 @@ func runChromium(term *terminal.Service, configDir string, coord *restart.Coordi
 }
 
 // handleBindFailure runs when the pinned listener would not bind, and never
-// returns. A fresh launch whose port is held by another live lich is a duplicate
-// launch: focus that window and exit 0 — the user re-launching an app they
-// already have open should get the window, not an error. Anything else (a
-// restart successor that never got the port back, or a non-lich process sitting
-// on the port) is a real failure: log it and exit 1.
+// returns. It gathers the two inputs the decision needs, asks
+// singleton.BindFailureVerdict what they mean, and performs the effects.
 func handleBindFailure(configDir string) {
 	port := os.Getenv("LICH_LISTEN_PORT")
-	// A restart successor legitimately expects the port to be busy for a moment
-	// (it retries the bind); a failure there is real, not a duplicate launch.
-	if os.Getenv(restart.WaitEnv) == "" {
+	restartWait := os.Getenv(restart.WaitEnv)
+	// A restart successor never probes: the verdict is already decided, and the
+	// probe would only cost it a timeout on a port it is racing for.
+	var running *singleton.Info
+	if restartWait == "" {
 		want, _ := strconv.Atoi(port)
-		if running, _ := singleton.Detect(configDir, want, singleton.Ping); running != nil {
-			slog.Info("lich already running, focusing existing window",
-				"pid", running.PID, "port", running.Port)
-			focusRunning(configDir, running)
-			os.Exit(0)
-		}
+		running, _ = singleton.Detect(configDir, want, singleton.Ping)
+	}
+	if singleton.BindFailureVerdict(restartWait, running) == singleton.BindFailureIsDuplicate {
+		slog.Info("lich already running, focusing existing window",
+			"pid", running.PID, "port", running.Port)
+		focusRunning(configDir, running)
+		os.Exit(0)
 	}
 	slog.Error("loopback listener failed to start — is the port free?", "port", port)
 	os.Exit(1)


### PR DESCRIPTION
## What

`handleBindFailure` decided, logged and exited in one function, so the contract it owns lived somewhere no test could reach:

- a second launch of an already-running lich → focus its window, exit **0**;
- a restart successor that never got the pinned port back, or a non-lich process squatting the port → log the failure, exit **1**.

`go tool cover -func` had it at `main.go:198 handleBindFailure 0.0%`, with `package main` at 0.0% and no test file. A regression there inverts the exit codes silently — at worst a restart successor focuses its predecessor and exits 0 instead of retrying the bind, stranding the user with no running app after an update.

The decision is now `singleton.BindFailureVerdict(restartWait string, running *Info) BindVerdict`, a pure function over the two inputs. `main` gathers them and performs the effects.

**Behavior-preserving.** The short-circuit order (a restart successor never pays for the probe), both log messages and their fields, and both exit codes are unchanged. `focusRunning`'s `LICH_DEV_URL` early return stays where it was — a launcher concern, not part of the verdict.

## Why it landed in `internal/singleton`, not `main_test.go`

`package main` embeds `//go:embed all:frontend/dist`, which a clean checkout does not have (it is gitignored). Adding any test file there is moot — the root package already fails to build without a frontend build:

```
$ LICH_LISTEN_PORT= go test ./...
main.go:34:12: pattern all:frontend/dist: no matching files found
FAIL	github.com/omartelo/lich [setup failed]
```

`internal/singleton` already owns the detection half of the same contract (`Detect`, `Info`) and its package doc already describes this exact duplicate-vs-real distinction, so the verdict belongs next to it.

## Test

`TestBindFailureVerdict` in `internal/singleton/singleton_test.go`, table-driven over the four rows — no seams to inject, no process spawned. `handleBindFailure` itself is untested: it calls `os.Exit`, which is the documented boundary.

Verified the table earns its place. In a **scratch copy** of the package (not the repo), inverting the `restartWait != ""` branch to a no-op:

```
--- FAIL: TestBindFailureVerdict (0.00s)
    --- FAIL: TestBindFailureVerdict/restart_successor,_lich_still_holding_the_port (0.00s)
        singleton_test.go:197: BindFailureVerdict("1", &{PID:1 Port:47821 Token:t}) = 1, want 0
FAIL	scratch/singleton	0.004s
```

Coverage moved:

```
internal/singleton/singleton.go:117:	BindFailureVerdict	100.0%
total:					(statements)		92.1%
```

## Gate

Run with the real toolchain binaries, exit codes read directly (no `rtk`, no `tail`). `frontend/dist` was stubbed locally so the root package compiles — it is gitignored and not in this diff.

| command | exit |
|---|---|
| `gofmt -l ./internal ./main.go` | 0, no output (the goal's `./cmd` does not exist in this repo) |
| `go vet ./...` | 0 |
| `LICH_LISTEN_PORT= go test ./...` | 0 — 22 packages ok |
| `LICH_LISTEN_PORT= go test -race ./...` | 0 |

The frontend is untouched.

## CHANGELOG

No entry — no behavior change.