### PR TITLE
refactor: one copy of git's binary heuristic and of the size ceiling

### DIFF
--- a/internal/project/difftext.go
+++ b/internal/project/difftext.go
@@ -12,10 +12,6 @@ import (
 // repository whose HEAD does not exist yet (no commits).
 const emptyTreeHash = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
-// maxUntrackedDiffSize caps how large an untracked file may be before it is
-// skipped in the textual diff, matching countFileLines' ceiling.
-const maxUntrackedDiffSize = 10 << 20
-
 // DiffText returns the full unified diff of uncommitted changes (staged +
 // unstaged + untracked) against HEAD. A repository without commits diffs
 // against git's empty tree. Untracked files are rendered as new-file hunks so
@@ -47,7 +43,7 @@ func untrackedFiles(path string) []string {
 // git diff --no-index, which exits 1 when the files differ — success here.
 // Any other failure (file vanished between ls-files and now) yields "".
 func untrackedDiff(dir, rel string) string {
-	if info, err := os.Stat(filepath.Join(dir, rel)); err != nil || !info.Mode().IsRegular() || info.Size() > maxUntrackedDiffSize {
+	if info, err := os.Stat(filepath.Join(dir, rel)); err != nil || !info.Mode().IsRegular() || info.Size() > maxTextFileBytes {
 		return ""
 	}
 	cmd := command("git", "-C", dir, "diff", "--no-index", "--", os.DevNull, rel)

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -218,20 +218,17 @@ func numstatTotals(out string) (added, deleted int) {
 	return added, deleted
 }
 
-// countFileLines returns the line count of a text file, or 0 for binaries
-// (NUL byte in the first 8000 bytes, git's own heuristic) and unreadable files.
-// It reads the whole file with a 10MB cap — untracked source files are small;
-// stream in chunks if that assumption ever breaks.
+// countFileLines returns the line count of a text file, or 0 for binaries and
+// unreadable files.
 func countFileLines(name string) int {
-	const maxSize = 10 << 20
-	if info, err := os.Stat(name); err != nil || !info.Mode().IsRegular() || info.Size() > maxSize {
+	if info, err := os.Stat(name); err != nil || !info.Mode().IsRegular() || info.Size() > maxTextFileBytes {
 		return 0
 	}
 	data, err := os.ReadFile(name)
 	if err != nil || len(data) == 0 {
 		return 0
 	}
-	if bytes.IndexByte(data[:min(len(data), 8000)], 0) >= 0 {
+	if isBinary(data) {
 		return 0
 	}
 	n := bytes.Count(data, []byte{'\n'})

--- a/internal/project/tree.go
+++ b/internal/project/tree.go
@@ -12,8 +12,24 @@ import (
 
 // maxReadFileSize caps a previewed file. CodeMirror is a source viewer, not a
 // blob viewer, and the RPC body limit rejects a response this large anyway
-// (internal/rpc.bodyLimit). Kept in step with the diff viewer's own ceilings.
+// (internal/rpc.bodyLimit). Deliberately tighter than maxTextFileBytes: this one
+// crosses the wire, the others only ever reach a line count or a diff.
 const maxReadFileSize = 1 << 20
+
+// maxTextFileBytes caps the files lich will read whole: the untracked-file line
+// count and the untracked new-file diff. Untracked source files are small;
+// stream in chunks if that assumption ever breaks.
+const maxTextFileBytes = 10 << 20
+
+// binarySniffBytes is how far into a file git looks for a NUL before calling it
+// binary. Matching git means a file lich refuses to preview is the same file git
+// refuses to diff — the two answers have to agree or the review panel
+// contradicts the diff beside it.
+const binarySniffBytes = 8000
+
+func isBinary(data []byte) bool {
+	return bytes.IndexByte(data[:min(len(data), binarySniffBytes)], 0) >= 0
+}
 
 // Tree lists the work tree's files as repo-relative, slash-separated paths,
 // sorted. It merges tracked files with untracked-but-not-ignored ones
@@ -80,8 +96,7 @@ func (s *Service) ReadFile(path, rel string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("read %s: %w", rel, err)
 	}
-	// git's own binary heuristic: a NUL byte in the first 8000 bytes.
-	if bytes.IndexByte(data[:min(len(data), 8000)], 0) >= 0 {
+	if isBinary(data) {
 		return "", fmt.Errorf("%s is a binary file", rel)
 	}
 	return string(data), nil

--- a/internal/project/tree_test.go
+++ b/internal/project/tree_test.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"slices"
@@ -99,6 +100,37 @@ func TestReadFileRejectsLarge(t *testing.T) {
 	write(t, repo, "big", strings.Repeat("x", maxReadFileSize+1))
 	if _, err := New(nil).ReadFile(repo, "big"); err == nil {
 		t.Error("ReadFile(oversize): want error, got nil")
+	}
+}
+
+// TestIsBinaryWindow pins the edge of git's sniff window, the one thing the
+// callers' own tests cannot see: they only ever feed a NUL near byte 0, so a
+// wider or narrower window still passes them. The offsets are git's literal
+// 8000 on purpose — deriving them from binarySniffBytes would make the test
+// follow the constant instead of pinning it.
+func TestIsBinaryWindow(t *testing.T) {
+	nulAt := func(offset int) []byte {
+		data := bytes.Repeat([]byte("x"), offset+1)
+		data[offset] = 0
+		return data
+	}
+	tests := []struct {
+		name string
+		data []byte
+		want bool
+	}{
+		{"empty", nil, false},
+		{"short text", []byte("package main\n"), false},
+		{"short with NUL", []byte("ab\x00c"), true},
+		{"last byte in window", nulAt(7999), true},
+		{"first byte past window", nulAt(8000), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isBinary(tt.data); got != tt.want {
+				t.Errorf("isBinary(%s) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What

Git's binary heuristic and the 10 MiB whole-file read ceiling each existed twice in `internal/project`. This collapses both to one copy and routes all three call sites through them.

**The binary heuristic, twice verbatim**, each with its own comment re-explaining the same naked `8000`:

- `project.go`, inside `countFileLines`
- `tree.go`, inside `ReadFile`

**The 10 MiB ceiling, twice under two names**, each documented as tracking the other:

- `difftext.go` — `maxUntrackedDiffSize`, package level
- `project.go` — `maxSize`, declared *inside* `countFileLines`, commented as "matching countFileLines' ceiling" while `difftext.go` made the same claim in the other direction

Two constants that nothing stopped from drifting, each pointing at the other as its source of truth.

## The fix

One `isBinary` helper plus `binarySniffBytes` and `maxTextFileBytes`, used by `countFileLines`, `untrackedDiff` and `ReadFile`.

They land in `tree.go` rather than a new `filetext.go`: `tree.go` already owns `maxReadFileSize`, the package's other file-reading ceiling, and it is the smallest file of the three (88 lines). Putting the shared ceiling directly beside the one that is deliberately different is what makes the difference legible — the trap this refactor removes is drift between ceilings, so adjacency is the point. `project.go` is the package grab-bag and would have buried it; a new file would have separated the two constants a reader most needs to see together.

`maxReadFileSize` (1 MiB) keeps its own value and its own comment now says *why* it is tighter: that response crosses the wire, the other two only ever reach a line count or a diff. `internal/rpc.bodyLimit` is untouched — same magnitude, different rule.

## Behavior

None changed. The existing `internal/project` suite passes **unchanged** — no test was edited, only added to.

## Tests

One table test, `TestIsBinaryWindow`. The existing tests exercise `isBinary` through its callers, but they only ever feed a NUL near byte 0, so they pin *that a window exists*, not *where its edge is*. Verified by mutation in a scratch copy:

| `binarySniffBytes` | before this PR | with `TestIsBinaryWindow` |
|---|---|---|
| `1` | caught | caught |
| `7999` | **passed silently** | caught |
| `16000` | **passed silently** | caught |

The test uses git's literal `7999`/`8000` offsets rather than deriving them from `binarySniffBytes` — the first version derived them, which made the data follow the constant and let the `16000` mutant through.

`internal/project` coverage: 89.2%.

## Gate

```
gofmt -l ./internal ./main.go   → 0
go vet ./...                    → 0
LICH_LISTEN_PORT= go test ./...        → 0
LICH_LISTEN_PORT= go test -race ./...  → 0
```

Run with the real Go binary and `$?` read directly, not through the `rtk` wrapper.

No cross-compile loop and no `ci:os`: no OS seam and no `_test.go` build tag was touched.

## Out of scope

The frontend is untouched. No `CHANGELOG.md` entry — nothing a user can observe changed.