### PR TITLE
refactor: let OriginBundled decide a bundled theme's origin

### DIFF
--- a/internal/themes/bundled.go
+++ b/internal/themes/bundled.go
@@ -27,6 +27,11 @@ func mustBundledTheme(data []byte) Theme {
 	if err := json.Unmarshal(data, &theme); err != nil {
 		panic("invalid bundled theme: " + err.Error())
 	}
+	// The constant is the invariant; the asset's own "origin" only exists
+	// because the frontend imports the same JSON at build time. A typo there
+	// would otherwise ship a theme the UI sorts and filters as neither
+	// bundled nor custom.
+	theme.Origin = OriginBundled
 	return theme
 }
 

--- a/internal/themes/themes_test.go
+++ b/internal/themes/themes_test.go
@@ -518,6 +518,25 @@ func TestBundledThemesPassValidation(t *testing.T) {
 	}
 }
 
+// The bundled assets carry an "origin" for the frontend, which imports the same
+// JSON. Go must not read it back: a typo there would ship a theme the UI sorts
+// and filters as neither bundled nor custom.
+func TestBundledThemeOriginIgnoresAsset(t *testing.T) {
+	for name, field := range map[string]string{
+		"typo":    `"origin": "bundlde",`,
+		"custom":  `"origin": "custom",`,
+		"missing": "",
+	} {
+		t.Run(name, func(t *testing.T) {
+			raw := `{"id": "light", "name": "Light", "scheme": "light", ` + field +
+				`"app": {}, "terminal": {}}`
+			if got := mustBundledTheme([]byte(raw)).Origin; got != OriginBundled {
+				t.Fatalf("origin = %q, want %q", got, OriginBundled)
+			}
+		})
+	}
+}
+
 // The template ships as the answer to "what shape does a theme have", so it has
 // to survive the same validator an imported file meets — not just parse.
 func TestBundledTemplateIsImportable(t *testing.T) {


### PR DESCRIPTION
## What

`OriginBundled` (`internal/themes/themes.go:19`) had exactly one reference in production code: its own
declaration. What actually stamped a bundled theme's origin was the literal `"origin": "bundled"` inside
`themes/light.json` and `themes/dark.json` — `mustBundledTheme` only unmarshalled, and `List` handed the
parsed value through `cloneTheme` untouched.

One line in `internal/themes/bundled.go` makes the constant the thing that decides the value:

```go
theme.Origin = OriginBundled
```

## Why the JSON keeps its `origin`

Removing it from the assets was the tempting follow-up, but `frontend/src/lib/themes.ts:2-3` imports the same
two files at build time and reads `theme.origin` (`normalizeTheme`, plus the `bundled`/`custom` filters at
`:83,:87`). Dropping the field would leave the frontend's `BUNDLED` pair with `origin: undefined` and break the
sort and both filters. The field stays as the frontend's copy of the truth; Go no longer reads it back.
`themes/template.json` is untouched — it ships no origin on purpose, and `themes_test.go` asserts that.

## Honest correction to the audit finding

The audit said a typo in the asset would be caught by "nothing in Go or in the suite". The Go half is right;
the suite half is not — `TestListIncludesBundledThemes` already asserts `themes[0].Origin == OriginBundled`
through `List`, so a typo fails the suite today (transcript below). So this is a `refactor:`, not a `fix:`:
it removes a way for data to override the constant at runtime, it does not close a hole CI was missing.

## Verify

Scratch copy of `internal/`, `themes/`, `frontend/src/index.css` and `docs/themes.md`, with
`themes/light.json` edited to `"origin": "custum"`:

**Before the fix** (the stamp line removed in the copy):

```
--- FAIL: TestListIncludesBundledThemes (0.00s)
    themes_test.go:56: first bundled theme = themes.Theme{ID:"light", ..., Origin:"custum", ...}
--- FAIL: TestBundledThemeOriginIgnoresAsset (0.00s)
    --- FAIL: TestBundledThemeOriginIgnoresAsset/typo (0.00s)
        themes_test.go:534: origin = "bundlde", want "bundled"
    --- FAIL: TestBundledThemeOriginIgnoresAsset/custom (0.00s)
        themes_test.go:534: origin = "custom", want "bundled"
    --- FAIL: TestBundledThemeOriginIgnoresAsset/missing (0.00s)
        themes_test.go:534: origin = "", want "bundled"
FAIL	github.com/omartelo/lich/internal/themes	0.014s
```

**After the fix**, same typo in `light.json`:

```
ok  	github.com/omartelo/lich/internal/themes	0.011s
```

## Test

`TestBundledThemeOriginIgnoresAsset` parses a bundled-shaped payload three ways — a typo'd origin, a `custom`
origin, and no origin at all — and asserts `mustBundledTheme` yields `OriginBundled` every time. That is the
assertion the previous code could not satisfy. The existing `themes_test.go:55,:58` assertions now pass for the
right reason instead of by coincidence.

## Not done on purpose

No runtime validation pass over the bundled themes. `appTokens` is still derived from `bundledThemes[0].App`,
but `TestBundledThemesPassValidation` runs `validateTheme` over both assets and `TestBootCSSMatchesBundledThemes`
cross-checks them against `frontend/src/index.css` on every PR. An extra panic path in a package-level
initializer costs more than it buys.

## CHANGELOG

No entry — nothing a user of a published version experienced changes. The JSON already says `"bundled"`.

## Test plan

- [x] `gofmt -l ./internal ./main.go` — clean (exit 0)
- [x] `go vet ./...` — exit 0
- [x] `LICH_LISTEN_PORT= go test ./...` — exit 0, 22 packages ok
- [x] `LICH_LISTEN_PORT= go test -race ./...` — exit 0
- [x] `pnpm check` — exit 0
- [x] `vitest run` — exit 0, 621 tests in 60 files
- [x] `pnpm build` — exit 0
