### PR TITLE
docs: correct two Known Ceilings and the session-state example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,8 @@ nobody knows it and that the call site never shows. The mechanism and the histor
 - **Persistence is hybrid**: UI prefs in the page's localStorage (`lich.*` keys — the reason the listener port is
   pinned at 47821; `LICH_LISTEN_PORT` overrides it, `LICH_PORT` is the distinct per-session hook variable), the
   workspace in SQLite (`<config-dir>/lich/lich.db`, `internal/store`). Closing a session deletes its row; keeping a
-  worktree parks its session for a later resume; a closed project is hidden, never deleted.
+  worktree parks its session for a later resume; closing a project hides it, but reopening one whose directory is
+  gone silently deletes it and its sessions.
 - **Hidden sessions are serialized and destroyed**: 2MB replay rings on both sides (`frontend/src/lib/terminal/replay-buffer.ts`
   page-side, `internal/terminal/replay.go` backend-side — the latter survives a full page reload). waveterm's disk
   filestore is the upgrade path if size ever matters.
@@ -132,5 +133,6 @@ nobody knows it and that the call site never shows. The mechanism and the histor
   is load-bearing — without it plain clicks stop selecting a session.
 - **Windows is experimental**: cmd.exe is the shell, and the GUI subsystem build has no console — diagnostics only
   reach `%AppData%\lich\lich.log`. The PTY has no Windows tests.
-- **macOS is experimental**: the window path has never run on real hardware, and the binaries are unsigned, so
-  Gatekeeper quarantines them. Only darwin-specific code: the browser candidates (`internal/chromium`).
+- **macOS is experimental**: unsigned (Gatekeeper quarantines them) and never run on real hardware. Three darwin
+  seams: `internal/chromium`, `internal/system`, and `internal/terminal`'s cwd reader, which hardcodes libSystem
+  struct offsets.

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -62,7 +62,7 @@ project's own setup script and commands (`PORT=$LICH_WORKTREE_PORT pnpm dev`).
 ## Contracts
 
 - [session-state.md](session-state.md) — a session's processing state
-  (`busy`/`done`) shown on its card.
+  (`busy`/`done`/`waiting`/`idle`) shown on its card.
 - [session-start.md](session-start.md) — the Claude session id, persisted
   against the lich session for later features.
 - [session-title.md](session-title.md) — Claude's auto-generated `ai-title`,

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -13,7 +13,7 @@ See [README.md](README.md) for the shared transport (`LICH_PORT` / `LICH_TOKEN`
 POST http://127.0.0.1:${LICH_PORT}/hook?token=${LICH_TOKEN}
 Content-Type: application/json
 
-{"session_id": "<LICH_SESSION_ID>", "state": "<busy|done>"}
+{"session_id": "<LICH_SESSION_ID>", "state": "<busy|done|waiting|idle>"}
 ```
 
 States: `busy`, `done`, `waiting`, `idle`. lich rejects anything else.


### PR DESCRIPTION
Prose only — not a line of Go or TypeScript changes. Three corrections, each verified against the code at `v0.24.0`.

## The macOS ceiling was false

It ended with *"Only darwin-specific code: the browser candidates (`internal/chromium`)"*. There are four darwin files across three packages:

```
$ find internal -name '*darwin*'
internal/chromium/candidates_darwin.go
internal/system/open_darwin.go
internal/terminal/cwd_darwin.go
internal/terminal/cwd_darwin.s
```

The cwd reader is the riskiest macOS code in the repo — a `go:linkname` into `syscall.syscall6`, a `cgo_import_dynamic` of `proc_pidinfo`, an assembly trampoline, and a hand-mirrored `struct vnode_info_path` whose opaque prefix is a hardcoded offset into a system header — and per the same bullet nothing darwin has ever run on real hardware. The old wording steered a reader straight past it.

The bullet now names the three seams and makes the trap the hardcoded struct offsets in an unexercised path. The mechanism stays documented at the call site in `cwd_darwin.go`; none of it was copied into `CLAUDE.md`.

## The persistence ceiling was false

It ended with *"a closed project is hidden, never deleted"*:

```
$ grep -rn "DeleteProject" frontend/src internal/store
frontend/src/providers/projects.tsx:225:      await Store.DeleteProject(recent.id)
internal/store/mutations.go:60:func (s *Service) DeleteProject(id string) error {
...
```

`openRecent` deletes the row when `ProjectService.Exists` reports the directory is gone, and its sessions go with it via `ON DELETE CASCADE` (`internal/store/store.go:37`). This shipped in v0.24.0 — the CHANGELOG entry for it says *"leaves the list for good"* (`CHANGELOG.md:61`). The bullet now says closing hides, reopening a vanished directory silently deletes; the trap is that a project whose folder was merely unmounted loses its stored sessions with a toast and no undo.

The rest of that bullet (localStorage vs SQLite, the pinned-port reason, `LICH_LISTEN_PORT` vs `LICH_PORT`) still checks out and is untouched.

Both rewrites still name exactly one trap and stay level in length.

## The hook contract's example was behind the server

`docs/hooks/session-state.md:16` showed `<busy|done>` while the line directly under it, the event→state table further down, and the server all list four states — `parseHookRequest` (`internal/terminal/transport.go:346`) rejects anything outside `statusBusy`/`statusDone`/`statusWaiting`/`statusIdle` (:51-54). `docs/hooks/README.md`'s one-line summary said the same thing. Both now list all four.

**Spec-only correction — no plugin release is implied.** The server already honors all four states, so the versioning note in `docs/hooks/README.md` does not apply and there is no matching change in `omartelo/lich-plugin` to go looking for.

While in `docs/hooks/README.md`: the three injected env vars still match `Service.sessionEnv` (`internal/terminal/terminal.go:229`), and the `LICH_WORKTREE_PORT` note still matches `internal/terminal/worktreeport.go` (derived from cwd alone, nothing bound or probed). No new findings.

## CHANGELOG

No entry. `CLAUDE.md` and `docs/` are not user-facing release notes, and nothing about the running program changes.

## Gate

Prose-only diff, so no test run. Formatting and vet still verified clean:

- `gofmt -l ./internal ./main.go` — clean. (There is no `./cmd` in this repo; `main.go` is at the root.)
- `go vet ./...` — clean. It needs `frontend/dist` to exist for the `all:frontend/dist` embed; a throwaway placeholder was created for the run and removed after.