### PR TITLE
test: pin the seed's skip of a collapsed ignored tree

### DIFF
--- a/internal/project/seed.go
+++ b/internal/project/seed.go
@@ -41,7 +41,10 @@ func seedWorktree(projectPath, wtPath string) []string {
 	for entry := range strings.SplitSeq(out, "\x00") {
 		// Directory entries carry a trailing slash: whole ignored trees are
 		// deliberately not copied (that is dependency/build output territory —
-		// the setup script's job, not the seed's).
+		// the setup script's job, not the seed's). copyFile refuses one too,
+		// but as an error the loop logs: skipping here keeps a policy decision
+		// out of the warning log, where a line is supposed to mean the seed
+		// failed at something it meant to do.
 		if entry == "" || strings.HasSuffix(entry, "/") {
 			continue
 		}

--- a/internal/project/seed_test.go
+++ b/internal/project/seed_test.go
@@ -134,6 +134,47 @@ func TestCreateWorktreeSeedsIgnored(t *testing.T) {
 	}
 }
 
+// TestCreateWorktreeSkipsACollapsedIgnoredTreeSilently pins the trailing-slash
+// guard, which only shows itself in the log. `git ls-files --directory`
+// collapses a wholly ignored tree into a single entry ("secrets/"), and a
+// slashless include pattern matches that entry by basename — so the seed does
+// reach a directory here. Whether it is skipped by the guard or refused by
+// copyFile, nothing lands in the worktree and nothing joins the copied slice;
+// the difference is that copyFile refuses it as an error and the loop files a
+// warning for a tree the seed was never going to copy. The absence of that
+// warning is the contract.
+func TestCreateWorktreeSkipsACollapsedIgnoredTreeSilently(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	repo, git := initRepo(t)
+	for rel, content := range map[string]string{
+		".gitignore":        "secrets/\n",
+		".worktreeinclude":  "secrets*\n",
+		"secrets/token.txt": "s3cret\n",
+	} {
+		p := filepath.Join(repo, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	git("add", ".gitignore", ".worktreeinclude")
+	git("commit", "-m", "ignore secrets")
+
+	logged := captureLog(t)
+	wt, err := New(nil).CreateWorktree(repo, "pid", "collapsed", "main", false)
+	if err != nil {
+		t.Fatalf("CreateWorktree: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(wt.Path, "secrets")); !os.IsNotExist(err) {
+		t.Errorf("ignored tree seeded, want absent (err=%v)", err)
+	}
+	if out := logged(); out != "" {
+		t.Errorf("seeding a collapsed ignored tree logged:\n%s", out)
+	}
+}
+
 // TestCreateWorktreeSeedsFromIncludeFile proves .worktreeinclude replaces the
 // default patterns instead of extending them.
 func TestCreateWorktreeSeedsFromIncludeFile(t *testing.T) {


### PR DESCRIPTION
## The finding

`seedWorktree` skipped entries with a trailing slash, and `copyFile` refused the same entries again with `not a regular file`. Removing `|| strings.HasSuffix(entry, "/")` survived the whole suite: two guards, one outcome, no test telling them apart.

## The decision: keep the skip

The two guards are not the same rule.

- The trailing-slash skip is **policy**: `git ls-files --directory` collapses a wholly ignored tree into one entry, and a tree is dependency/build-output territory — the setup script's job, not the seed's. Expected, so silent.
- `copyFile`'s `IsRegular` check is **safety**: the source is a symlink, a device, something the seed must not copy blindly. Unexpected, so the loop logs `slog.Warn("worktree seed: copy", …)`.

Deleting the skip routes a deliberate non-copy through the error path.

## The log-noise question

That is the whole observable difference, and it decides the PR. With the skip gone, a wholly ignored tree that matches an include pattern produces, on every worktree creation:

```
level=WARN msg="worktree seed: copy" file=secrets/ err="not a regular file"
```

A warning for something the seed was never going to copy. Rare with the default `.env*` pattern, routine with a `.worktreeinclude` like `config/*` or `secrets*` over an ignored directory. The repo already treats warn-level noise as a real cost — see `TestDiffOnARepositoryWithoutCommitsStaysSilent`, which pins silence for the same reason. Avoiding it is worth one `strings.HasSuffix`.

## The test

`TestCreateWorktreeSkipsACollapsedIgnoredTreeSilently` builds a repo with `secrets/` wholly ignored and `.worktreeinclude` = `secrets*`, so the collapsed entry `secrets/` matches by basename and the seed really does reach a directory.

The obvious assertions do **not** distinguish the two guards: nothing lands in the worktree either way (`copyFile` fails before `MkdirAll`), and the `copied` slice is empty either way. So the test asserts the one thing that differs — the log stays empty — via the package's existing `captureLog` helper.

Verified in a scratch copy: with `|| strings.HasSuffix(entry, "/")` removed, the new test fails with exactly the warn line quoted above.

The comment now says why the earlier guard exists given the later one, which the previous one did not.

## Gate

Backend only; the frontend is untouched.

```
gofmt -l ./internal ./main.go   clean   (no ./cmd in this repo)
go vet ./...                    clean
LICH_LISTEN_PORT= go test ./...        pass (22 packages)
LICH_LISTEN_PORT= go test -race ./...  pass
```

No `CHANGELOG.md` entry: no observable change to the running program.