### PR TITLE
fix: stop the replaced websocket client from stalling the new one

### DIFF
--- a/internal/events/hub_test.go
+++ b/internal/events/hub_test.go
@@ -85,11 +85,11 @@ func TestReplacedClientDoesNotSilenceHub(t *testing.T) {
 	server := httptest.NewServer(hub)
 	defer server.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	swapped, cancelSwap := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelSwap()
 	url := "ws" + strings.TrimPrefix(server.URL, "http")
 
-	first, _, err := websocket.Dial(ctx, url, nil)
+	first, _, err := websocket.Dial(swapped, url, nil)
 	if err != nil {
 		t.Fatalf("dial first: %v", err)
 	}
@@ -99,7 +99,7 @@ func TestReplacedClientDoesNotSilenceHub(t *testing.T) {
 	replaced := hub.conn
 	hub.mu.Unlock()
 
-	second, _, err := websocket.Dial(ctx, url, nil)
+	second, _, err := websocket.Dial(swapped, url, nil)
 	if err != nil {
 		t.Fatalf("dial second: %v", err)
 	}
@@ -110,7 +110,7 @@ func TestReplacedClientDoesNotSilenceHub(t *testing.T) {
 	// hub's client. Polling hub.conn would be the worse signal: without the
 	// identity guard the read loop nils it out, and the wait would fail on its
 	// own before the assertion below ever ran.
-	if _, _, err := first.Read(ctx); err == nil {
+	if _, _, err := first.Read(swapped); err == nil {
 		t.Fatal("the hub never closed the replaced client")
 	}
 
@@ -121,7 +121,12 @@ func TestReplacedClientDoesNotSilenceHub(t *testing.T) {
 	hub.drop(replaced)
 
 	hub.Emit("session-title", map[string]string{"id": "s1", "label": "x"})
-	_, payload, err := second.Read(ctx)
+
+	// Its own deadline: sharing the one above would let a slow swap eat this
+	// wait's budget and report a silent hub that is merely late.
+	delivered, cancelDelivery := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelDelivery()
+	_, payload, err := second.Read(delivered)
 	if err != nil {
 		t.Fatalf("live client received nothing after the replaced one was dropped: %v", err)
 	}

--- a/internal/events/hub_test.go
+++ b/internal/events/hub_test.go
@@ -74,6 +74,63 @@ func TestEmitDropsDeadClient(t *testing.T) {
 	t.Fatal("dead client never detached")
 }
 
+// TestReplacedClientDoesNotSilenceHub models a page reload: a second /events
+// socket opens, the hub replaces the first, and the first's read loop then
+// drops the connection it was reading. The live client must keep receiving —
+// forgetting the replaced connection must not forget the current one. A hub
+// that goes silent here never closes the live socket either, so the window,
+// which only reconnects on close, stays dark until the page is reloaded again.
+func TestReplacedClientDoesNotSilenceHub(t *testing.T) {
+	hub := New()
+	server := httptest.NewServer(hub)
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	url := "ws" + strings.TrimPrefix(server.URL, "http")
+
+	first, _, err := websocket.Dial(ctx, url, nil)
+	if err != nil {
+		t.Fatalf("dial first: %v", err)
+	}
+	defer first.CloseNow()
+	waitForAttach(t, hub)
+	hub.mu.Lock()
+	replaced := hub.conn
+	hub.mu.Unlock()
+
+	second, _, err := websocket.Dial(ctx, url, nil)
+	if err != nil {
+		t.Fatalf("dial second: %v", err)
+	}
+	defer second.CloseNow()
+
+	// attach swaps the hub's connection before it closes the one it replaced,
+	// so the first client's read failing proves the second one is already the
+	// hub's client. Polling hub.conn would be the worse signal: without the
+	// identity guard the read loop nils it out, and the wait would fail on its
+	// own before the assertion below ever ran.
+	if _, _, err := first.Read(ctx); err == nil {
+		t.Fatal("the hub never closed the replaced client")
+	}
+
+	// The replaced connection's read loop calls drop on its own the moment it
+	// notices attach closed it; calling drop here asserts on that outcome
+	// instead of racing the goroutine for it. Under the identity guard the
+	// second call is the no-op the first one already was.
+	hub.drop(replaced)
+
+	hub.Emit("session-title", map[string]string{"id": "s1", "label": "x"})
+	_, payload, err := second.Read(ctx)
+	if err != nil {
+		t.Fatalf("live client received nothing after the replaced one was dropped: %v", err)
+	}
+	var env Envelope
+	if err := json.Unmarshal(payload, &env); err != nil || env.Name != "session-title" {
+		t.Fatalf("envelope: %s (%v)", payload, err)
+	}
+}
+
 func waitForAttach(t *testing.T, hub *Hub) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -481,7 +481,10 @@ func (t *transport) handle(w http.ResponseWriter, r *http.Request) {
 	t.conn = conn
 	t.mu.Unlock()
 	if previous != nil {
-		_ = previous.Close(websocket.StatusPolicyViolation, "replaced by new client")
+		// Not a graceful close: that waits for the replaced client's close
+		// reply, on this goroutine, before the new client's read loop starts.
+		// Nothing reads the status anyway — the page reconnects on any close.
+		_ = previous.CloseNow()
 	}
 	go t.readLoop(conn)
 }

--- a/internal/terminal/transport_drop_test.go
+++ b/internal/terminal/transport_drop_test.go
@@ -1,0 +1,91 @@
+package terminal
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+)
+
+// TestReplacedClientDoesNotSilenceTransport models a page reload: a second /ws
+// socket opens, the transport replaces the first, and the first's read loop
+// then drops the connection it was reading. The live client must keep receiving
+// — forgetting the replaced connection must not forget the current one. A
+// transport that forgets it has a client sends every session's output down the
+// /events fallback instead, for a socket that is still open.
+func TestReplacedClientDoesNotSilenceTransport(t *testing.T) {
+	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+
+	first, err := dial(t, tr, tr.token)
+	if err != nil {
+		t.Fatalf("dial first: %v", err)
+	}
+	defer func() { _ = first.CloseNow() }()
+	replaced := waitForClient(t, tr)
+
+	second, err := dial(t, tr, tr.token)
+	if err != nil {
+		t.Fatalf("dial second: %v", err)
+	}
+	defer func() { _ = second.CloseNow() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// handle swaps the transport's connection before it closes the one it
+	// replaced, so the first client's read failing proves the second one is
+	// already the transport's client. Polling t.conn would be the worse signal:
+	// without the identity guard the read loop nils it out, and the wait would
+	// fail on its own before the assertion below ever ran. This read is also
+	// what answers the close handshake — handle's close waits for the reply.
+	if _, _, err := first.Read(ctx); err == nil {
+		t.Fatal("the transport never closed the replaced client")
+	}
+
+	// The replaced connection's read loop calls drop on its own the moment it
+	// notices handle closed it; calling drop here asserts on that outcome
+	// instead of racing the goroutine for it. Under the identity guard the
+	// second call is the no-op the first one already was.
+	tr.drop(replaced)
+
+	if !tr.send("sess", []byte("output")) {
+		t.Fatal("send reported no client after the replaced one was dropped")
+	}
+	kind, data, err := second.Read(ctx)
+	if err != nil {
+		t.Fatalf("live client received nothing after the replaced one was dropped: %v", err)
+	}
+	if kind != websocket.MessageBinary {
+		t.Fatalf("got message type %v", kind)
+	}
+	id, payload, err := decodeFrame(data)
+	if err != nil {
+		t.Fatalf("decodeFrame: %v", err)
+	}
+	if id != "sess" || string(payload) != "output" {
+		t.Fatalf("got id=%q payload=%q", id, payload)
+	}
+}
+
+// waitForClient blocks until the transport has registered a client, and returns
+// it. Dial returning only means the client read the handshake response; handle
+// registers the connection in its own goroutine.
+func waitForClient(t *testing.T, tr *transport) *websocket.Conn {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		tr.mu.Lock()
+		current := tr.conn
+		tr.mu.Unlock()
+		if current != nil {
+			return current
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("transport never registered a client")
+	return nil
+}

--- a/internal/terminal/transport_drop_test.go
+++ b/internal/terminal/transport_drop_test.go
@@ -33,8 +33,8 @@ func TestReplacedClientDoesNotSilenceTransport(t *testing.T) {
 	}
 	defer func() { _ = second.CloseNow() }()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+	swapped, cancelSwap := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelSwap()
 
 	// handle swaps the transport's connection before it closes the one it
 	// replaced, so the first client's read failing proves the second one is
@@ -42,7 +42,7 @@ func TestReplacedClientDoesNotSilenceTransport(t *testing.T) {
 	// without the identity guard the read loop nils it out, and the wait would
 	// fail on its own before the assertion below ever ran. This read is also
 	// what answers the close handshake — handle's close waits for the reply.
-	if _, _, err := first.Read(ctx); err == nil {
+	if _, _, err := first.Read(swapped); err == nil {
 		t.Fatal("the transport never closed the replaced client")
 	}
 
@@ -55,7 +55,11 @@ func TestReplacedClientDoesNotSilenceTransport(t *testing.T) {
 	if !tr.send("sess", []byte("output")) {
 		t.Fatal("send reported no client after the replaced one was dropped")
 	}
-	kind, data, err := second.Read(ctx)
+	// Its own deadline: sharing the one above would let a slow swap eat this
+	// wait's budget and report a silent transport that is merely late.
+	delivered, cancelDelivery := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelDelivery()
+	kind, data, err := second.Read(delivered)
 	if err != nil {
 		t.Fatalf("live client received nothing after the replaced one was dropped: %v", err)
 	}

--- a/internal/terminal/transport_replace_test.go
+++ b/internal/terminal/transport_replace_test.go
@@ -40,8 +40,7 @@ func TestReplacedClientDoesNotSilenceTransport(t *testing.T) {
 	// replaced, so the first client's read failing proves the second one is
 	// already the transport's client. Polling t.conn would be the worse signal:
 	// without the identity guard the read loop nils it out, and the wait would
-	// fail on its own before the assertion below ever ran. This read is also
-	// what answers the close handshake — handle's close waits for the reply.
+	// fail on its own before the assertion below ever ran.
 	if _, _, err := first.Read(swapped); err == nil {
 		t.Fatal("the transport never closed the replaced client")
 	}
@@ -72,6 +71,56 @@ func TestReplacedClientDoesNotSilenceTransport(t *testing.T) {
 	}
 	if id != "sess" || string(payload) != "output" {
 		t.Fatalf("got id=%q payload=%q", id, payload)
+	}
+}
+
+// stallCeiling bounds how long input from a freshly connected client may take
+// to reach the service. The work in between is an accept and a loopback write,
+// so the real number is microseconds; the ceiling only has to sit far below the
+// close handshake's own timeout, which is what a graceful close of the replaced
+// client would spend here.
+const stallCeiling = 2 * time.Second
+
+// TestReplacingAClientDoesNotStallTheNewOne pins that handle starts reading
+// from the new client without waiting on the one it replaced. A graceful close
+// waits for the peer's close reply, and it runs on the handler goroutine before
+// the read loop starts — so a replaced client that is alive but not reading
+// would hold the new client's input hostage for the length of that handshake.
+func TestReplacingAClientDoesNotStallTheNewOne(t *testing.T) {
+	arrived := make(chan struct{}, 1)
+	tr, err := newTransport(func(string, []byte) { arrived <- struct{}{} }, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+
+	// Never read from: a client that reads would answer the close handshake and
+	// hide the stall.
+	first, err := dial(t, tr, tr.token)
+	if err != nil {
+		t.Fatalf("dial first: %v", err)
+	}
+	defer func() { _ = first.CloseNow() }()
+	waitForClient(t, tr)
+
+	second, err := dial(t, tr, tr.token)
+	if err != nil {
+		t.Fatalf("dial second: %v", err)
+	}
+	defer func() { _ = second.CloseNow() }()
+
+	frame, err := encodeFrame("sess", []byte("x"))
+	if err != nil {
+		t.Fatalf("encodeFrame: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := second.Write(ctx, websocket.MessageBinary, frame); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	select {
+	case <-arrived:
+	case <-time.After(stallCeiling):
+		t.Fatalf("the new client's input did not reach the service within %v: handle is waiting on the client it replaced", stallCeiling)
 	}
 }
 


### PR DESCRIPTION
## What

Started as coverage for two untested guards and grew one production fix that writing them exposed. Both changes are about the same moment: a second websocket client connecting and replacing the first.

## 1. The `drop` identity guard (tests only)

`internal/events/hub.go` and `internal/terminal/transport.go` each keep a single client (the window) and replace it when a new one connects: `attach`/`handle` swap the pointer, then close the connection they replaced. That connection's read loop wakes up and calls `drop`. Without the `if conn == active` check, dropping the *replaced* connection nils out the pointer to the *live* one — and nothing ever closes the live socket, so `frontend/src/lib/app-events.ts`, which reconnects on `onclose`, never notices. The window goes silent until the page is reloaded again. Mutating either guard to `if true` survived the whole suite.

### How the tests avoid a sleep

Each test dials twice, then waits for the *first client's read to fail*. Both owners set the new connection before closing the old one, so that failure proves the swap already landed. Polling `conn` instead would be the worse signal: without the guard the read loop nils it out, and the wait would fail on its own before the real assertion ran.

They then call `drop(replaced)` directly rather than race the read loop for it — under the guard that call is the same no-op the read loop's is — and assert the live client still receives. Each wait carries its own deadline, so a slow swap cannot spend the delivery assertion's budget and report a silent hub that is merely late.

No sleeps, so no `-count=200` rate to report; every test here runs in ~0.00s and all three were run 20× green.

### Mutation evidence

In a scratch copy, `if h.conn == conn` → `if true` and `if t.conn == conn` → `if true`:

```
--- FAIL: TestReplacedClientDoesNotSilenceHub (5.00s)
    hub_test.go:131: live client received nothing after the replaced one was dropped: failed to get reader: context deadline exceeded
--- FAIL: TestReplacedClientDoesNotSilenceTransport (0.00s)
    transport_replace_test.go:55: send reported no client after the replaced one was dropped
```

Guards restored, both pass.

## 2. `handle` waited on the client it replaced (production fix)

Found while writing the above. `transport.handle` closed the replaced connection **gracefully** — `previous.Close(StatusPolicyViolation, "replaced by new client")` — and a graceful close waits for the peer's close reply. It ran on the handler goroutine *before* `go t.readLoop(conn)`, so a replaced client that is alive but not reading held the new client's input hostage for the length of the handshake.

`TestReplacingAClientDoesNotStallTheNewOne` fails against the old code with the real number:

```
--- FAIL: TestReplacingAClientDoesNotStallTheNewOne (2.00s)
    the new client's input did not reach the service within 2s: handle is waiting on the client it replaced
```

(The uncapped measurement was 5.000295341s — the close handshake's own timeout.)

The fix is `previous.CloseNow()`, which is what `events.Hub.attach` has always done; the two owners now agree. Nothing is lost with the status code and reason: `frontend/src/lib/terminal/term-transport.ts` reconnects on any close and reads neither. The test's 2s ceiling is not a timing guess — the correct path is an accept plus a loopback write, so it lands in microseconds, three orders of magnitude under the bar.

`drop`'s own graceful close is left alone: its only caller is `readLoop`, after the read already failed, so the peer is gone and it returns immediately.

**Reachability, honestly:** I could not produce this through lich's own UI. Single instance means one window, and `term-transport.ts` only dials again from `onclose`, so the connection it replaces is already dead and the close write fails fast. It needs a second live client — a stray dev tab, a wedged page. Latent, not lived.

## CHANGELOG

No entry. The tests are invisible by definition, and the stall is not reachable from a published build for the reason above — an entry would describe something no user experienced.

## Gate

Run with the real binaries, exit codes read directly:

- `gofmt -l ./internal ./main.go` — clean
- `go vet ./...` — clean
- `LICH_LISTEN_PORT= go test ./...` — green
- `LICH_LISTEN_PORT= go test -race ./...` — green
- `for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done` — all three OK (the new file carries no build tag and `internal/terminal` has per-OS variants, so the cross-vet is what proves it)

The frontend is untouched, so its gate was not run.
