### PR TITLE
fix: a stale review diff, a lost worktree path, and seven more audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   did, and is still the right way to try a theme you are writing — it simply
   reads as unversioned, because it is.
 
+### Fixed
+
+- **The Review panel no longer shows a diff that has stopped being true.** It
+  decided when to re-read the diff from the changed-file counts alone, and an
+  edit that replaces text on a line already marked as changed leaves every one
+  of those counts exactly where it was — same files, same `+`, same `-`, and no
+  new commit. The panel held that stale diff not for a tick but indefinitely,
+  which is the worst thing a review surface can do: it was most likely to happen
+  while an agent was iterating on the same lines, which is precisely when you
+  are watching it. The panel now reads the diff itself while it is open and
+  publishes only when the text actually changed, so an idle repository still
+  costs nothing and your selection and scroll position still survive a tick.
+- **A file unticked by a new commit opens again instead of staying folded.**
+  Ticking a file off as viewed folds it away, and a commit that rewrites that
+  file correctly unticks it — but the fold was decided once and never revisited,
+  so the file came back unread *and* closed, with nothing on screen to say why.
+  A file whose content changes now returns to the state it would have had if it
+  had just arrived, which for anything but a very large file is open.
+- **The command palette tells a screen reader which row is selected.** The rows
+  carried `aria-selected` on a plain button, where it means nothing, so arrowing
+  through the list moved a highlight that was only ever visual. The list is now
+  a proper listbox of options and announces the row under the cursor.
+
 ## [0.24.0] - 2026-08-04
 
 ### Added

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -116,37 +116,53 @@ export function CommandPalette() {
             />
           </div>
 
-          <div className="flex-1 overflow-y-auto p-1.5">
+          {/* listbox/option, not bare buttons: `aria-selected` is meaningless
+              on a button's implicit role, so the row the arrow keys are on was
+              painted for the eye and announced to nobody. */}
+          <div role="listbox" aria-label="Results" className="flex-1 overflow-y-auto p-1.5">
             {total === 0 ? (
               <div className="px-3 py-8 text-center text-sm text-muted-foreground">
                 No matches for <span className="font-mono text-foreground/80">{query.trim()}</span>
               </div>
             ) : (
               <>
-                {results.sessions.length > 0 && <GroupLabel>Sessions</GroupLabel>}
-                {results.sessions.map((session, i) => (
-                  <SessionRow
-                    key={session.sessionId}
-                    session={session}
-                    selected={i === active}
-                    onSelect={() => setSelected(i)}
-                    onRun={() => runIndex(i)}
-                  />
-                ))}
-                {results.projects.length > 0 && <GroupLabel>Projects</GroupLabel>}
-                {results.projects.map((project, j) => {
-                  const index = results.sessions.length + j
-                  return (
-                    <ProjectRow
-                      key={project.id}
-                      project={project}
-                      sessionCount={sessions[project.id]?.sessions.length ?? 0}
-                      selected={index === active}
-                      onSelect={() => setSelected(index)}
-                      onRun={() => runIndex(index)}
-                    />
-                  )
-                })}
+                {/* A listbox takes only options and groups as children, so the
+                    section heading rides inside a group rather than sitting
+                    loose between the rows. */}
+                {results.sessions.length > 0 && (
+                  // biome-ignore lint/a11y/useSemanticElements: the rule offers <fieldset>, which groups form controls and is not a valid child of a listbox.
+                  <div role="group" aria-label="Sessions">
+                    <GroupLabel>Sessions</GroupLabel>
+                    {results.sessions.map((session, i) => (
+                      <SessionRow
+                        key={session.sessionId}
+                        session={session}
+                        selected={i === active}
+                        onSelect={() => setSelected(i)}
+                        onRun={() => runIndex(i)}
+                      />
+                    ))}
+                  </div>
+                )}
+                {results.projects.length > 0 && (
+                  // biome-ignore lint/a11y/useSemanticElements: same as above — a listbox takes group, not fieldset.
+                  <div role="group" aria-label="Projects">
+                    <GroupLabel>Projects</GroupLabel>
+                    {results.projects.map((project, j) => {
+                      const index = results.sessions.length + j
+                      return (
+                        <ProjectRow
+                          key={project.id}
+                          project={project}
+                          sessionCount={sessions[project.id]?.sessions.length ?? 0}
+                          selected={index === active}
+                          onSelect={() => setSelected(index)}
+                          onRun={() => runIndex(index)}
+                        />
+                      )
+                    })}
+                  </div>
+                )}
               </>
             )}
           </div>
@@ -188,6 +204,7 @@ function Row({ selected, onSelect, onRun, children }: RowProps) {
     <button
       ref={ref}
       type="button"
+      role="option"
       aria-selected={selected}
       onMouseMove={onSelect}
       onClick={onRun}

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -21,13 +21,22 @@ import { SessionModel } from "./SessionModel"
 import { Separator } from "@/components/ui/separator"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 
-const CLOCK_TICK_MS = 10_000
+const MINUTE_MS = 60_000
 
+// The readout is HH:MM, so it is scheduled on the minute rather than on a fixed
+// interval: a 10s tick spent five of every six renders redrawing the same
+// string, and still showed a minute that could be ten seconds stale.
 function useNow(): Date {
   const [now, setNow] = useState(() => new Date())
   useEffect(() => {
-    const timer = setInterval(() => setNow(new Date()), CLOCK_TICK_MS)
-    return () => clearInterval(timer)
+    let timer = 0
+    const tick = () => {
+      const at = new Date()
+      setNow(at)
+      timer = window.setTimeout(tick, MINUTE_MS - (at.getTime() % MINUTE_MS))
+    }
+    timer = window.setTimeout(tick, MINUTE_MS - (Date.now() % MINUTE_MS))
+    return () => window.clearTimeout(timer)
   }, [])
   return now
 }

--- a/frontend/src/components/diff/FileDiff.tsx
+++ b/frontend/src/components/diff/FileDiff.tsx
@@ -69,7 +69,24 @@ export function FileDiff({
   review,
 }: FileDiffProps) {
   const doc = useMemo(() => buildFileDoc(file), [file])
-  const [expanded, setExpanded] = useState(!file.binary && doc.lineMeta.length <= LARGE_FILE_LINES)
+  const openByDefault = !file.binary && doc.lineMeta.length <= LARGE_FILE_LINES
+  const [expanded, setExpanded] = useState(openByDefault)
+  // The card outlives its content: the panel keys files by path, so a refetch
+  // that rewrites this file reuses this component. Without the re-sync, a file
+  // folded away by its Viewed tick stayed folded after a commit unticked it —
+  // an unread file, closed, with nothing on screen saying why — and one that
+  // grew past the large-file bar stayed open.
+  //
+  // Keyed on the text and not on the doc object: every refetch builds a fresh
+  // one, so a reference check would reopen every hand-folded file on each
+  // window focus. Only the content actually changing counts as a new file.
+  const lastText = useRef(doc.text)
+  useEffect(() => {
+    if (lastText.current !== doc.text) {
+      lastText.current = doc.text
+      setExpanded(openByDefault)
+    }
+  }, [doc.text, openByDefault])
   // The nonce guard skips the initial mount so each file keeps its own
   // large-file default until the user actually triggers a bulk action.
   const lastNonce = useRef(bulk?.nonce)
@@ -200,6 +217,10 @@ function LazyDiffBody({ doc, path, onInject, onSessionComment, review }: DiffBod
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
+          // Its work is done, and the placeholder it watches is about to leave
+          // the DOM — an observer holds its target, so without this the removed
+          // node stays alive for as long as the panel does.
+          observer.disconnect()
           setMounted(true)
         }
       },

--- a/frontend/src/components/diff/ReviewPanel.tsx
+++ b/frontend/src/components/diff/ReviewPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 import { Notice } from "@/components/common/Notice"
 import { discardTargets, parseDiff, type DiffFile } from "@/lib/git/diff"
@@ -12,6 +12,14 @@ import { CommentBatch } from "./CommentBatch"
 import type { DiffBulk } from "./diff-bulk"
 import { DiscardDialog } from "./DiscardDialog"
 import { FileDiff } from "./FileDiff"
+
+// How often the diff *text* is re-read while the panel is open. The status
+// counts invalidate it the moment they move, but they cannot see an edit that
+// leaves them alone: replacing text on a line that was already modified keeps
+// files/added/deleted exactly where they were, and HEAD does not move either.
+// With no read of its own the panel held that stale diff for as long as the
+// counts stood still — not one tick, but indefinitely.
+const DIFF_POLL_MS = 2_000
 
 // ReviewPanel is the Review tab's body: the active session's uncommitted diff,
 // one collapsible file at a time. Context-menu actions write file/line
@@ -28,25 +36,48 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
   const [failed, setFailed] = useState(false)
   const [pendingDiscard, setPendingDiscard] = useState<DiffFile | null>(null)
 
+  // The text behind what is on screen, and the id of the newest read — a reply
+  // carrying an older one is dropped, so switching checkouts mid-flight cannot
+  // land the previous one's diff.
+  const lastText = useRef<string | null>(null)
+  const seq = useRef(0)
+
+  // Publishing only on a changed text is what lets this be polled at all: an
+  // identical read leaves `files` — and with it every mounted CodeMirror view,
+  // its selection and its scroll position — untouched.
   const refresh = useCallback(async () => {
     if (!path) {
       return
     }
+    const mine = ++seq.current
     try {
       const text = await ProjectService.DiffText(path)
-      setFiles(parseDiff(text))
+      if (mine !== seq.current) {
+        return
+      }
       setFailed(false)
+      if (text === lastText.current) {
+        return
+      }
+      lastText.current = text
+      setFiles(parseDiff(text))
     } catch {
+      if (mine !== seq.current) {
+        return
+      }
+      lastText.current = null
       setFiles([])
       setFailed(true)
     }
   }, [path])
 
-  // The 3s git-status poll doubles as the invalidation signal: the diff text is
-  // only re-fetched when the stats actually move, so selections and scroll
-  // survive idle ticks.
+  // Two signals feeding one read: the status counts move the instant a file is
+  // touched, so they invalidate immediately, and the interval covers the edits
+  // they are blind to (see DIFF_POLL_MS).
   useEffect(() => {
     void refresh()
+    const timer = setInterval(() => void refresh(), DIFF_POLL_MS)
+    return () => clearInterval(timer)
   }, [refresh, status?.files, status?.added, status?.deleted])
 
   // Reverting a rename touches both paths (new removed, old restored); the

--- a/frontend/src/components/dock/RightDock.tsx
+++ b/frontend/src/components/dock/RightDock.tsx
@@ -14,6 +14,16 @@ import { FilesPanel } from "./FilesPanel"
 
 export type DockTab = "files" | "review"
 
+// One dock width serves both tabs, so there is one key for it. Named here like
+// every other `lich.*` pref rather than spelled at the call site.
+const WIDTH_KEY = "lich.dock.width"
+
+// Wide enough for a diff line at the 12px review font, capped short of eating
+// the terminal whole.
+const MIN_REM = 20
+const MAX_REM = 60
+const DEFAULT_REM = 28
+
 // Ghost tabs, sized down to the dock's 40px header — not the stock filled pill.
 const TAB_CLASS =
   "gap-1 rounded-md px-2 py-0.5 text-xs hover:bg-accent/50 data-active:bg-accent data-active:text-accent-foreground dark:data-active:border-transparent dark:data-active:bg-accent dark:data-active:text-accent-foreground"
@@ -35,10 +45,10 @@ export function RightDock({ tab, onTab, onClose }: RightDockProps) {
   const [fullscreen, setFullscreen] = useState(false)
   const [bulk, toggleAll] = useDiffBulk()
   const { width, handleProps } = usePanelWidth({
-    storageKey: "lich.dock.width",
-    minRem: 20,
-    maxRem: 60,
-    defaultRem: 28,
+    storageKey: WIDTH_KEY,
+    minRem: MIN_REM,
+    maxRem: MAX_REM,
+    defaultRem: DEFAULT_REM,
     edge: "left",
   })
 

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -33,6 +33,14 @@ import { useWorktreeClose } from "./useWorktreeClose"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { usePanelWidth } from "@/lib/use-panel-width"
 
+// Named here like every other `lich.*` pref rather than spelled at the call
+// site. The bounds go with it: wide enough for a session label and its branch,
+// capped short of crowding the terminal.
+const WIDTH_KEY = "lich.sidebar.width"
+const MIN_REM = 12
+const MAX_REM = 30
+const DEFAULT_REM = 15
+
 // SessionSidebar lists the active project's sessions and can be drag-resized
 // within a fixed pixel range. Width persists across restarts. It renders nothing
 // when no project is active (Home, Settings), so it never competes with those
@@ -70,10 +78,10 @@ export function SessionSidebar() {
   const path = projects.find((p) => p.id === projectId)?.path ?? ""
   const git = useGitStatus(path)
   const { width, handleProps } = usePanelWidth({
-    storageKey: "lich.sidebar.width",
-    minRem: 12,
-    maxRem: 30,
-    defaultRem: 15,
+    storageKey: WIDTH_KEY,
+    minRem: MIN_REM,
+    maxRem: MAX_REM,
+    defaultRem: DEFAULT_REM,
     edge: "right",
   })
   const [worktreeOpen, setWorktreeOpen] = useState(false)

--- a/frontend/src/lib/pulls/conversation-timeline.test.ts
+++ b/frontend/src/lib/pulls/conversation-timeline.test.ts
@@ -42,12 +42,26 @@ describe("conversationTimeline", () => {
     ])
   })
 
-  it("files resolved threads separately, newest first", () => {
+  it("keeps a settled thread out of the timeline", () => {
     const timeline = conversationTimeline(conversation)
     expect(timeline.resolved.map((held) => held.id)).toEqual(["t-done"])
     expect(
       timeline.items.some((item) => item.kind === "thread" && item.thread.id === "t-done"),
     ).toBe(false)
+  })
+
+  // Two of them, deliberately: with one settled thread the assertion passes
+  // whichever way the comparator runs, so the order it promises goes unchecked.
+  it("files settled threads newest first", () => {
+    const timeline = conversationTimeline({
+      ...conversation,
+      threads: [
+        thread("t-open", "2026-07-30T08:00:00Z"),
+        thread("t-settled-early", "2026-07-30T07:00:00Z", true),
+        thread("t-settled-late", "2026-07-30T11:00:00Z", true),
+      ],
+    })
+    expect(timeline.resolved.map((held) => held.id)).toEqual(["t-settled-late", "t-settled-early"])
   })
 
   it("counts everything the tab shows, settled threads included", () => {

--- a/frontend/src/lib/session/session-events.test.ts
+++ b/frontend/src/lib/session/session-events.test.ts
@@ -9,7 +9,7 @@ import {
   shouldToastAttention,
   toSessionStatus,
 } from "./session-events"
-import { addSession, createProjectSessions, setActiveSession, type SessionState } from "./sessions"
+import { addSession, setActiveSession, type SessionState } from "./sessions"
 
 const ACTIVE = "project-active"
 const BACKGROUND = "project-background"
@@ -17,10 +17,8 @@ const BACKGROUND = "project-background"
 // Two projects of two sessions each; "s2"/"b2" are the active session of their
 // project, mirroring the shape the provider reads on an attention event.
 function buildState(): SessionState {
-  let state: SessionState = {
-    [ACTIVE]: createProjectSessions("s1"),
-    [BACKGROUND]: createProjectSessions("b1"),
-  }
+  let state: SessionState = addSession({}, ACTIVE, "s1")
+  state = addSession(state, BACKGROUND, "b1")
   state = addSession(state, ACTIVE, "s2")
   state = addSession(state, BACKGROUND, "b2")
   return state

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -4,7 +4,6 @@ import {
   activeTarget,
   addSession,
   closeSession,
-  createProjectSessions,
   groupByWorktree,
   isLastWorktreeSession,
   isSessionKind,
@@ -25,7 +24,7 @@ const P = "project-1"
 // buildState creates a project with `n` sessions (ids "s1".."sn"), the last one
 // active.
 function buildState(n: number): SessionState {
-  let state: SessionState = { [P]: createProjectSessions("s1") }
+  let state: SessionState = addSession({}, P, "s1")
   for (let i = 2; i <= n; i++) {
     state = addSession(state, P, `s${i}`)
   }
@@ -65,20 +64,29 @@ function withClaudeSession(
   }
 }
 
-describe("createProjectSessions", () => {
-  it("seeds one active claude session labeled Session 1", () => {
-    const project = createProjectSessions("s1")
-    expect(project.sessions).toEqual([{ id: "s1", label: "Session 1", kind: "claude" }])
-    expect(project.activeId).toBe("s1")
-    expect(project.nextSeq).toBe(2)
-  })
-})
-
 describe("addSession", () => {
-  it("creates the project entry when absent", () => {
+  it("creates the project entry when absent, as one active Session 1", () => {
     const state = addSession({}, P, "s1")
-    expect(sessionsOf(state, P)).toHaveLength(1)
+    expect(sessionsOf(state, P)).toEqual([{ id: "s1", label: "Session 1", kind: "claude" }])
     expect(activeSessionId(state, P)).toBe("s1")
+    expect(state[P].nextSeq).toBe(2)
+  })
+
+  // The first session of a project used to take a different code path from
+  // every later one, and that path ignored both arguments: a worktree opened
+  // as a project's first session lost its checkout and its name, spawning in
+  // the project root while the store recorded the worktree.
+  it("keeps the worktree path and label when it creates the project entry", () => {
+    const created = sessionsOf(
+      addSession({}, P, "s1", "claude", "/wt/lucky-otter", "lucky-otter"),
+      P,
+    )[0]
+    expect(created).toEqual({
+      id: "s1",
+      label: "lucky-otter",
+      kind: "claude",
+      path: "/wt/lucky-otter",
+    })
   })
 
   it("appends, focuses the new session and advances the label sequence", () => {

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -48,16 +48,13 @@ export interface ProjectSessions {
 
 export type SessionState = Record<string, ProjectSessions>
 
-export function createProjectSessions(
-  firstSessionId: string,
-  kind: SessionKind = "claude",
-): ProjectSessions {
-  return {
-    sessions: [{ id: firstSessionId, label: "Session 1", kind }],
-    activeId: firstSessionId,
-    nextSeq: 2,
-  }
-}
+// What a project with no entry yet counts as. Seeding the missing entry rather
+// than branching on it is what keeps the first session of a project from being
+// built by a second, poorer code path: the one that used to run here dropped
+// the worktree path and the label it was handed, so a worktree session opened
+// as a project's first landed in the project root while the store recorded the
+// checkout.
+const NO_SESSIONS: ProjectSessions = { sessions: [], activeId: "", nextSeq: 1 }
 
 // addSession appends a session to a project and makes it active. If the project
 // has no entry yet, it is created with this session as the first. A worktree
@@ -71,10 +68,7 @@ export function addSession(
   path = "",
   label?: string,
 ): SessionState {
-  const current = state[projectId]
-  if (!current) {
-    return { ...state, [projectId]: createProjectSessions(sessionId, kind) }
-  }
+  const current = state[projectId] ?? NO_SESSIONS
   const session: Session = {
     id: sessionId,
     label: label || `Session ${current.nextSeq}`,

--- a/frontend/src/lib/themes.test.ts
+++ b/frontend/src/lib/themes.test.ts
@@ -20,12 +20,15 @@ import {
   themeSelectItems,
 } from "./themes"
 
-function customTheme(id: string): ThemeDefinition {
+// The name is a parameter because mergeThemes orders custom themes by it: a
+// fixture that gave every theme the same name made that comparator a no-op and
+// left the picker's order unasserted.
+function customTheme(id: string, name = "Custom"): ThemeDefinition {
   const base = BUNDLED_THEMES[0]
   return {
     ...base,
     id,
-    name: "Custom",
+    name,
     origin: "custom",
     app: { ...base.app, background: "#101010" },
     terminal: { ...base.terminal, background: "#111111" },
@@ -41,6 +44,13 @@ describe("themes", () => {
   it("returns only imported custom themes", () => {
     const themes = mergeThemes([customTheme("custom-a"), customTheme("custom-b")])
     expect(customThemes(themes).map((theme) => theme.id)).toEqual(["custom-a", "custom-b"])
+  })
+
+  // Ids deliberately in the opposite order to the names: only an order taken
+  // from the name can produce this one, which is what the picker shows.
+  it("orders custom themes by name, after the bundled pair", () => {
+    const themes = mergeThemes([customTheme("aaa", "Zinc Night"), customTheme("zzz", "Amber Dusk")])
+    expect(themes.map((theme) => theme.id)).toEqual(["light", "dark", "zzz", "aaa"])
   })
 
   it("returns only bundled themes", () => {

--- a/frontend/src/lib/use-panel-visible.ts
+++ b/frontend/src/lib/use-panel-visible.ts
@@ -16,11 +16,12 @@ const SHOWN = "0"
 // never hidden the panel.
 export function usePanelVisible(storageKey: string): [boolean, () => void] {
   const [visible, setVisible] = useState(() => readPref(storageKey) !== HIDDEN)
+  // The write sits outside the updater: React treats one as pure and calls it
+  // twice under StrictMode.
   const toggle = () => {
-    setVisible((wasVisible) => {
-      writePref(storageKey, wasVisible ? HIDDEN : SHOWN)
-      return !wasVisible
-    })
+    const next = !visible
+    writePref(storageKey, next ? SHOWN : HIDDEN)
+    setVisible(next)
   }
   return [visible, toggle]
 }

--- a/frontend/src/providers/settings.tsx
+++ b/frontend/src/providers/settings.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useState } from "react"
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react"
 import type { ReactNode } from "react"
 import {
   DEFAULT_HOTKEYS,
@@ -188,20 +188,17 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     writePref(THEME_STORAGE_KEY, next)
   }, [])
 
+  // Neither of these persists: the zoom is mirrored to localStorage by the
+  // effect that applies it, so the one updater that has to be functional (see
+  // zoomBy) stays free of the side effect React calls twice under StrictMode.
   const setZoom = useCallback((next: number) => {
-    const clamped = clampZoom(next)
-    setZoomState(clamped)
-    writePref(ZOOM_STORAGE_KEY, clamped)
+    setZoomState(clampZoom(next))
   }, [])
 
   // zoomBy applies a relative step off the latest value so rapid wheel ticks
   // accumulate instead of collapsing to a single step between renders.
   const zoomBy = useCallback((delta: number) => {
-    setZoomState((prev) => {
-      const clamped = clampZoom(prev + delta)
-      writePref(ZOOM_STORAGE_KEY, clamped)
-      return clamped
-    })
+    setZoomState((prev) => clampZoom(prev + delta))
   }, [])
 
   const setTerminalTheme = useCallback((next: TerminalTheme) => {
@@ -328,8 +325,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   // every zoom step, wrapping whatever TUI was running. The terminal sizes its
   // text in absolute px (TerminalView's fontSize), so rem scaling leaves it
   // untouched by construction; its size is its own setting.
+  //
+  // Also where the value is persisted, so both setters can stay pure.
   useEffect(() => {
     document.documentElement.style.fontSize = `${zoom * 100}%`
+    writePref(ZOOM_STORAGE_KEY, zoom)
   }, [zoom])
 
   // Zoom via keyboard chords or Ctrl/Cmd + mouse wheel. Both listen on the
@@ -369,36 +369,63 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   const resolvedTerminalTheme = resolveTerminalTheme(terminalTheme, resolvedTheme, themes)
 
-  return (
-    <SettingsContext.Provider
-      value={{
-        font,
-        setFont,
-        terminalFontSize,
-        setTerminalFontSize,
-        themes,
-        theme,
-        setTheme,
-        importTheme,
-        installThemesFromGit,
-        updateThemeFromGit,
-        removeTheme,
-        resolvedTheme,
-        zoom,
-        setZoom,
-        terminalTheme,
-        setTerminalTheme,
-        resolvedTerminalTheme,
-        hotkeys,
-        setHotkey,
-        resetHotkey,
-        showContextUsage,
-        setShowContextUsage,
-      }}
-    >
-      {children}
-    </SettingsContext.Provider>
+  // Memoised for the same reason ProjectsProvider is: a literal here hands every
+  // consumer a new object on every render of this provider, and one of those
+  // consumers is TerminalView — one per spawned session. A Ctrl+wheel zoom is a
+  // burst of state changes, so the un-memoised value re-rendered every open
+  // terminal on every wheel tick.
+  const value = useMemo(
+    () => ({
+      font,
+      setFont,
+      terminalFontSize,
+      setTerminalFontSize,
+      themes,
+      theme,
+      setTheme,
+      importTheme,
+      installThemesFromGit,
+      updateThemeFromGit,
+      removeTheme,
+      resolvedTheme,
+      zoom,
+      setZoom,
+      terminalTheme,
+      setTerminalTheme,
+      resolvedTerminalTheme,
+      hotkeys,
+      setHotkey,
+      resetHotkey,
+      showContextUsage,
+      setShowContextUsage,
+    }),
+    [
+      font,
+      setFont,
+      terminalFontSize,
+      setTerminalFontSize,
+      themes,
+      theme,
+      setTheme,
+      importTheme,
+      installThemesFromGit,
+      updateThemeFromGit,
+      removeTheme,
+      resolvedTheme,
+      zoom,
+      setZoom,
+      terminalTheme,
+      setTerminalTheme,
+      resolvedTerminalTheme,
+      hotkeys,
+      setHotkey,
+      resetHotkey,
+      showContextUsage,
+      setShowContextUsage,
+    ],
   )
+
+  return <SettingsContext.Provider value={value}>{children}</SettingsContext.Provider>
 }
 
 export function useSettings(): SettingsValue {


### PR DESCRIPTION
A read-only audit of `frontend/src/` turned up eleven findings; this is nine of
them. Each commit stands on its own and can be read separately.

## The two that users hit

**The Review panel showed a diff that had stopped being true.** It decided when
to re-read the diff from the changed-file counts alone, and `project.Diff`
returns counts and nothing else. An edit that replaces text on a line already
marked as changed leaves every one of them untouched — same files, same `+`,
same `-`, and no new commit to move HEAD — so nothing invalidated the panel and
the stale diff stayed up not for a tick but until something else happened to
move a count. That is most likely to happen while an agent iterates on the same
lines, which is exactly when the panel is being watched.

The panel now reads the diff itself on a short interval while it is open and
publishes only when the text differs. Deduplicating on the text is what makes
the poll affordable: an unchanged read touches no state, so an idle repository
costs one `git diff` and every mounted editor keeps its selection and scroll
position the way an idle tick already left them.

**A file unticked by a new commit stayed folded.** `FileDiff` decided `expanded`
once at mount, but both panels key their cards by path, so a card outlives the
content it was built for. Ticking a file off folds it; a commit that rewrites it
correctly unticks it — and the fold never came back, leaving an unread file
closed with nothing on screen to say why. It re-syncs on the file's *text* now,
not on the doc object, because every refetch builds a fresh one and a reference
check would reopen every hand-folded file on each window focus.

## The one that was latent

`addSession` branched on a project with no session entry yet and handed that
case to `createProjectSessions`, which took neither the worktree path nor the
label. A worktree session opened as a project's first would have spawned in the
project root while the store recorded the checkout, and read "Session 1" instead
of the worktree's name. Nothing reaches that combination today, so no released
version can have shown it — hence no changelog entry — but the second, poorer
construction path is gone rather than taught the arguments, and the case the
suite never covered is now the test beside it.

## Two tests that could not fail

Both promised an order their fixture could not check, and a mutation proved it:
reversing the comparator left the whole suite green.

- The settled-thread test asserted "newest first" against a single resolved
  thread. It files two now.
- `mergeThemes` orders custom themes by name, but the fixture gave every theme
  the name `"Custom"` — the comparator always answered `0`, and the assertion
  only ever saw insertion order. The new case gives ids in the opposite order to
  the names, so only a name-ordered result satisfies it.

## The rest

- The settings context value is memoised, like `ProjectsProvider` already is. A
  literal handed every consumer a new object on every render, and one of those
  consumers is `TerminalView` — one per spawned session — so each Ctrl+wheel
  tick re-rendered every open terminal. Persisting the zoom moves into the
  effect that applies it, which lets both setters stay pure.
- The command palette announces its selected row. It carried `aria-selected` on
  a plain button, where the role does not support it, so the arrow keys moved a
  highlight that existed only for the eye.
- The footer clock is scheduled on the minute rather than every 10s; it renders
  `HH:MM`, so five of every six ticks redrew the same string and the minute could
  still be ten seconds behind.
- `LazyDiffBody` disconnects its `IntersectionObserver` once the editor is built
  — an observer holds its target, so the placeholder stayed alive for the life of
  the panel.
- The dock and sidebar widths take named constants for their key and bounds, and
  `usePanelVisible` writes its pref outside the state updater, which React treats
  as pure and calls twice under StrictMode.

## Deliberately not here

`--chart-1..5` are dead in the CSS — nothing in `src/` reads them — but
`appTokens` is derived from the bundled theme's keys with `requireAll`, so
removing them makes every installed custom theme that declares one fail with
`unknown app color "chart-1"`. That is a change to a published contract
(`docs/themes.md`, the saved template, third-party theme repos) and wants its own
PR with a migration, most likely tolerating an unknown app key first.

## Test plan

Local gate green on the merge commit: `tsc --noEmit` 0 · `biome check` 0 (10
warnings, down from 11 — the invalid `aria-selected` is gone and nothing was
added) · `vitest run` 0 (60 files, 629 tests) · `vite build` 0 · `gofmt -l` clean
· `go vet ./...` 0 · `go test ./...` 0.

The suite runs in node with no jsdom, so none of the render-path changes here are
covered by it. Before merge:

- [ ] `task dev`: edit a line that is already modified and watch the Review dock
      follow it; confirm a selection inside another file survives the tick.
- [ ] `task dev`: tick a file as Viewed in a PR's Files changed, commit a change
      to it, refresh — the file should come back unticked *and* open.
- [ ] `task dev`: open the command palette, arrow through both groups, confirm
      the rows still highlight and Enter still opens.
- [ ] `task dev`: Ctrl+wheel zoom with several sessions open; confirm no terminal
      reflows and the zoom still persists across a restart.
- [ ] `task dev`: drag the dock and sidebar edges, hide/show the pulls tree, and
      confirm all four still persist.
