### PR TITLE
chore: cut v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-08-05
+
 ### Added
 
 - **Install a theme from a git repository, and update it later.** A theme file
@@ -1385,7 +1387,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.24.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.25.0...HEAD
+[0.25.0]: https://github.com/omartelo/lich/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/omartelo/lich/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/omartelo/lich/compare/v0.22.0...v0.23.0
 [0.22.0]: https://github.com/omartelo/lich/compare/v0.21.1...v0.22.0


### PR DESCRIPTION
Moves the `[Unreleased]` entries under a `0.25.0` heading and refreshes the compare links. No code changes.

## Why minor

`[Unreleased]` carries one feature — theme install from a git repository (#142) — alongside four user-facing fixes, so `0.24.0` → `0.25.0`.

## CHANGELOG audit

Every commit since `v0.24.0` was checked against the entry criterion (an entry is what a user of a published version lived through):

| PR | Entry | Verdict |
|----|-------|---------|
| #142 install themes from a git repository | Added | correct |
| #143 open a terminal link once | Fixed | correct |
| #152 stale review diff, refold, palette a11y | Fixed ×3 | correct |
| #144, #149 tests | none | correct — invisible to users |
| #145, #146, #147 refactors | none | correct — no behaviour change |
| #148 docs | none | correct |
| #150 exit event kept with the PTY that died | none | correct — the same-id respawn is a `task dev` StrictMode path, unreachable in a published build (argued in the PR) |
| #151 replaced websocket client stalling the new one | none | correct — needs a second live client, which single-instance plus reconnect-on-close never produces (argued in the PR) |
| #152 worktree path lost in `createProjectSessions` | none | correct — nothing reaches that combination today |

Nothing user-facing shipped without an entry, and nothing invisible bought one.

## Gate

Run on the merge base with the real binaries, exit codes read directly:

- `gofmt -l .` — clean
- `go vet ./...` — clean
- `LICH_LISTEN_PORT= go test -race ./...` — green, 22 packages
- `biome check .` — 0 errors (10 warnings, unchanged)
- `tsc --noEmit` — 0
- `vitest run` — 60 files, 629 tests, all green
- `vite build` — OK

No OS seam touched, so no cross-compile loop and no `ci:os` label.