### PR TITLE
fix: refresh the plugin marketplace before installing or updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A plugin install or update that cannot see the newest release now says so,
+  instead of reporting success and leaving the old one in place.** Claude Code
+  keeps a local clone of the plugin's marketplace, and both the install and the
+  update refresh it themselves — but when that refresh fails, they only warn:
+  they read the clone as it stands, decide the version already installed is the
+  newest one, and exit reporting success. lich had no way to tell that apart
+  from a real update, so it announced one, and the next session started on the
+  same old plugin. The refresh is now lich's own first step, where it either
+  succeeds or fails loudly with what Claude Code said about it.
+
 ## [0.25.0] - 2026-08-05
 
 ### Added

--- a/internal/claudeplugin/claudeplugin.go
+++ b/internal/claudeplugin/claudeplugin.go
@@ -92,10 +92,8 @@ func computeStatus(installed bool, installedVer, latestVer string) Status {
 
 // Install adds the marketplace and installs the plugin at user scope.
 func (s *Service) Install() error {
-	// A repeat marketplace add errors ("already exists"); that is harmless —
-	// the install below is what matters, so only its error is surfaced.
-	if err := s.runClaude("plugin", "marketplace", "add", marketplaceRepo); err != nil {
-		slog.Debug("claudeplugin: marketplace add", "err", err)
+	if err := s.syncMarketplace(); err != nil {
+		return err
 	}
 	return s.runClaude("plugin", "install", pluginKey)
 }
@@ -103,7 +101,29 @@ func (s *Service) Install() error {
 // Update pulls the latest released version. Claude Code applies it on the next
 // session (a restart is required, which the UI signals).
 func (s *Service) Update() error {
+	if err := s.syncMarketplace(); err != nil {
+		return err
+	}
 	return s.runClaude("plugin", "update", pluginKey)
+}
+
+// syncMarketplace brings the local marketplace clone level with the remote: an
+// add for the first install, an update for one already there.
+//
+// Both `plugin install` and `plugin update` refresh the marketplace themselves,
+// but a failed refresh only downgrades them to a warning — they read the stale
+// clone, report "already at the latest version" and exit 0. That is a success
+// lich has no way to tell from a real one, so the refresh runs here first, where
+// its failure is an error the user sees.
+func (s *Service) syncMarketplace() error {
+	// A repeat add errors ("already exists"), which is how an existing clone
+	// announces itself; the update is the branch that then matters.
+	err := s.runClaude("plugin", "marketplace", "add", marketplaceRepo)
+	if err == nil {
+		return nil
+	}
+	slog.Debug("claudeplugin: marketplace add", "err", err)
+	return s.runClaude("plugin", "marketplace", "update", marketplaceName)
 }
 
 func (s *Service) runClaude(args ...string) error {

--- a/internal/claudeplugin/claudeplugin_test.go
+++ b/internal/claudeplugin/claudeplugin_test.go
@@ -299,15 +299,21 @@ func TestInstallAddsMarketplaceThenPlugin(t *testing.T) {
 
 // TestInstallSurvivesARepeatMarketplaceAdd proves the documented tolerance: a
 // marketplace already present makes `marketplace add` fail, and that failure
-// must not cost the install that follows it.
+// must not cost the install that follows it — it only redirects the refresh to
+// the existing clone.
 func TestInstallSurvivesARepeatMarketplaceAdd(t *testing.T) {
 	s, calls := fakeClaude(t, "marketplace add")
 
 	if err := s.Install(); err != nil {
 		t.Fatalf("Install after a repeat marketplace add: %v", err)
 	}
-	if got := calls(); len(got) != 2 || got[1] != "plugin install "+pluginKey {
-		t.Errorf("calls = %v, want the install to have run anyway", got)
+	want := []string{
+		"plugin marketplace add " + marketplaceRepo,
+		"plugin marketplace update " + marketplaceName,
+		"plugin install " + pluginKey,
+	}
+	if got := calls(); !slices.Equal(got, want) {
+		t.Errorf("calls = %v, want %v", got, want)
 	}
 }
 
@@ -336,8 +342,61 @@ func TestUpdateTargetsThePluginKey(t *testing.T) {
 	if err := s.Update(); err != nil {
 		t.Fatalf("Update: %v", err)
 	}
-	if got := calls(); !slices.Equal(got, []string{"plugin update " + pluginKey}) {
-		t.Errorf("calls = %v, want a single plugin update", got)
+	if got := calls(); got[len(got)-1] != "plugin update "+pluginKey {
+		t.Errorf("calls = %v, want the last one to be the plugin update", got)
+	}
+}
+
+// TestUpdateRefreshesTheMarketplaceFirst pins the order on the real-world path,
+// where the marketplace is already present: the clone is refreshed before the
+// plugin update reads a version off it. Reversed, the update reads the stale
+// clone and reports the version it already has as the newest one.
+func TestUpdateRefreshesTheMarketplaceFirst(t *testing.T) {
+	s, calls := fakeClaude(t, "marketplace add")
+
+	if err := s.Update(); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	want := []string{
+		"plugin marketplace add " + marketplaceRepo,
+		"plugin marketplace update " + marketplaceName,
+		"plugin update " + pluginKey,
+	}
+	if got := calls(); !slices.Equal(got, want) {
+		t.Errorf("calls = %v, want %v", got, want)
+	}
+}
+
+// TestMarketplaceRefreshFailureStopsTheRun is the regression this package exists
+// to prevent: an unrefreshable marketplace must surface as an error, never as a
+// plugin call that exits 0 on the stale clone and reads as a successful update.
+func TestMarketplaceRefreshFailureStopsTheRun(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		run  func(*Service) error
+	}{
+		{"install", (*Service).Install},
+		{"update", (*Service).Update},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// "marketplace" fails both the add and the update, leaving the clone
+			// as it was; "plugin install"/"plugin update" still match nothing.
+			s, calls := fakeClaude(t, "marketplace")
+
+			err := tc.run(s)
+			if err == nil {
+				t.Fatal("want an error when the marketplace cannot be refreshed, got nil")
+			}
+			if !strings.Contains(err.Error(), "plugin marketplace update "+marketplaceName) {
+				t.Errorf("error %q does not name the refresh that failed", err)
+			}
+			for _, call := range calls() {
+				if strings.HasPrefix(call, "plugin install") || strings.HasPrefix(call, "plugin update") {
+					t.Errorf("calls = %v, want no plugin call after a failed refresh", calls())
+					break
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What happened

The plugin was released as 0.5.0, lich's update reported success, and the next session still loaded 0.4.1. Running the same update through Claude Code's own `/plugin` showed why:

```
lich is already at the latest version (0.4.1). Warning: marketplace not refreshed
(Failed to refresh marketplace 'lich-plugin': ...) — version shown may be stale.
```

`claude plugin update` refreshes the marketplace clone itself, but a failed refresh is only a warning: it reads the clone as it stands, concludes the installed version *is* the newest, and **exits 0**. `runClaude` checks the exit code alone, so lich could not tell that apart from a real update — and announced one.

`claude plugin marketplace update <name>`, run on its own, exits 1 in the same state (verified against the local install). So the refresh only needs to happen where lich can see it fail.

## The change

`Install` and `Update` both call a new `syncMarketplace` first: `marketplace add` for a first install, falling back to `marketplace update` when the clone is already there (a repeat add errors with "already exists"). A refresh that fails aborts the run and surfaces the CLI's own message, which the settings screen already renders.

Nothing else moves — same plugin key, same scope, same `Status` read.

## Test plan

- [x] `TestUpdateRefreshesTheMarketplaceFirst` pins the order on the real-world path (clone already present): add → marketplace update → plugin update.
- [x] `TestMarketplaceRefreshFailureStopsTheRun` is the regression itself, for both entry points: an unrefreshable marketplace errors and no `plugin install`/`plugin update` runs behind it.
- [x] `TestInstallSurvivesARepeatMarketplaceAdd` keeps the existing tolerance — a failed add still ends in an install, now by way of the refresh.
- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` clean.
- [ ] Manual: with the marketplace clone deliberately stale, the update toast now fails visibly instead of claiming success.