### PR TITLE
feat: drop files on a terminal to put their paths at the prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Drag files onto a terminal to put their paths at the prompt — any kind of
+  file, a whole folder, or several at once.** Claude Code suggests dropping
+  images into your terminal; in lich the terminal is a browser window, so a
+  drop did nothing useful (and a drop that missed one navigated the window away
+  from the app). Now anything dropped on a session lands at its prompt as a
+  path, quoted where it needs to be and left unsent, exactly as a paste would —
+  the agent then treats an image path as an image and any other path as a path.
+  Files and folders found under the session's own directory — or under your
+  home — paste their real path, so an edit lands on your file; a screenshot or
+  a log from anywhere else is copied into `<config-dir>/lich/dropped/` and
+  pastes the copy's path. A folder that neither search finds has no copy to
+  fall back on, and says so rather than pretending.
+
 ### Fixed
 
 - **A plugin install or update that cannot see the newest release now says so,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,14 @@ nobody knows it and that the call site never shows. The mechanism and the histor
   no total), and the accounting is per `(session, transcript)` in `session_costs`, so a conversation forked
   inside the PTY — which copies its history into a new transcript — bills that history twice. lich's own
   resume continues the same transcript and is unaffected.
+- **A dropped file has no path, so lich guesses it**: Chromium hands the page a drop's bytes and metadata but never
+  its path (no `text/uri-list`, no `File.path`), so `internal/drop` searches for it by name + size + mtime — the
+  session's directory first, then home. The search is breadth-first under a 50k-entry budget per tree, and skips
+  home's dot directories: depth-first spent the whole budget inside `~/.cache` and missed a directory one level
+  down from the search root. Three consequences: twins at the same depth are ambiguous and resolve to nothing,
+  anything neither tree holds is *copied* to `<config-dir>/lich/dropped/` — so an agent told to edit it edits the
+  copy — and a directory, which has no copy to fall back on, simply fails when the budget or the skip list hides
+  it. The copies are never pruned.
 - **git status is polled** — one shared poller per repository path (`frontend/src/lib/git/git-status-store.ts`); the
   lich plugin's `session-touched` hook nudges an immediate refresh. An fs watcher is the upgrade path.
 - **Persistence is hybrid**: UI prefs in the page's localStorage (`lich.*` keys — the reason the listener port is

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useEffect, useState } from "react"
 import { HashRouter, Outlet, Route, Routes } from "react-router-dom"
 import { SettingsProvider } from "@/providers/settings"
 import { ProjectsProvider } from "@/providers/projects"
@@ -45,6 +45,20 @@ function Layout() {
 }
 
 function App() {
+  // A drop that misses a terminal must do nothing. The browser's default action
+  // for a file is to navigate to it, which in the --app window replaces lich
+  // with a file viewer — sessions keep running, but the only way back is a
+  // reload. Terminals stop the event before it reaches here (TerminalView).
+  useEffect(() => {
+    const swallow = (event: DragEvent) => event.preventDefault()
+    window.addEventListener("dragover", swallow)
+    window.addEventListener("drop", swallow)
+    return () => {
+      window.removeEventListener("dragover", swallow)
+      window.removeEventListener("drop", swallow)
+    }
+  }, [])
+
   return (
     <SettingsProvider>
       <HashRouter>

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -20,6 +20,11 @@ import { recordChunk } from "@/lib/terminal/term-perf"
 import { copyToastMessage, COPY_TOAST_DURATION_MS } from "@/lib/terminal/copy-toast"
 import { computeGrid } from "@/lib/terminal/term-fit"
 import { linkClickIsOurs, mouseEncodingSequence } from "@/lib/terminal/term-modes"
+import {
+  composeDroppedPaths,
+  readDroppedFiles,
+  resolveDroppedFiles,
+} from "@/lib/terminal/drop-files"
 import { useSettings } from "@/providers/settings"
 import type { SessionKind } from "@/lib/session/sessions"
 import "@xterm/xterm/css/xterm.css"
@@ -119,6 +124,12 @@ async function ensureFontLoaded(font: string): Promise<void> {
   }
 }
 
+// carriesFiles tells a file drag from text dragged out of the app's own UI —
+// a selection, a link — which the terminal leaves alone.
+function carriesFiles(transfer: DataTransfer): boolean {
+  return [...transfer.types].includes("Files")
+}
+
 // decodeBase64 turns the base64 PTY payload back into bytes. The backend
 // encodes output so multi-byte UTF-8 sequences survive the JSON envelope.
 function decodeBase64(data: string): Uint8Array {
@@ -196,6 +207,10 @@ export function TerminalView({
 
   // In-terminal search (Ctrl+F). The open flag mirrors into a ref so the
   // terminal's key handler — wired once at creation — reads the live value.
+  // A file drag is over the terminal; see onDragEnter for the depth counter.
+  const [dropping, setDropping] = useState(false)
+  const dragDepth = useRef(0)
+
   const [searchOpen, setSearchOpen] = useState(false)
   const [searchQuery, setSearchQuery] = useState("")
   const [searchResults, setSearchResults] = useState<SearchResults | null>(null)
@@ -228,6 +243,14 @@ export function TerminalView({
       live.search.clearDecorations()
       live.term.clearSelection()
       live.term.focus()
+    }
+  }
+
+  // writeInput sends to the PTY over the WebSocket, falling back to the RPC
+  // while it is down (term-transport.ts).
+  const writeInput = (data: string) => {
+    if (!sendInput(sessionId, data)) {
+      void Service.Write(sessionId, data)
     }
   }
 
@@ -267,12 +290,6 @@ export function TerminalView({
     })
     term.loadAddon(webgl)
     fitTerminal(term, container)
-
-    const writeInput = (data: string) => {
-      if (!sendInput(sessionId, data)) {
-        void Service.Write(sessionId, data)
-      }
-    }
 
     // Chords xterm encodes differently from what our TUIs expect go straight
     // to the PTY (see term-keys.ts). Returning false makes xterm skip the
@@ -397,6 +414,56 @@ export function TerminalView({
     serializedRef.current = null
     mouseEncodingRef.current = ""
     liveRef.current = live
+  }
+
+  // Files dropped on the terminal land at the prompt as paths, the way a
+  // native emulator pastes a drop (lib/terminal/drop-files.ts). dragDepth
+  // counts enter/leave: they also fire crossing xterm's own child elements, so
+  // the hint would flicker off mid-drag on the plain boolean.
+  const onDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    dragDepth.current = 0
+    setDropping(false)
+    const dropped = readDroppedFiles(event.dataTransfer)
+    if (dropped.length === 0) {
+      return
+    }
+    void (async () => {
+      const { paths, skipped } = await resolveDroppedFiles(cwd, dropped)
+      const paste = composeDroppedPaths(paths, IS_WINDOWS)
+      if (paste !== "") {
+        writeInput(paste)
+        liveRef.current?.term.focus()
+      }
+      if (skipped.length > 0) {
+        toast.error(`Not attached: ${skipped.join(", ")}`)
+      }
+    })()
+  }
+
+  const onDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!carriesFiles(event.dataTransfer)) {
+      return
+    }
+    dragDepth.current += 1
+    setDropping(true)
+  }
+
+  const onDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!carriesFiles(event.dataTransfer)) {
+      return
+    }
+    // Without this the drop event never fires — and App's window handler
+    // swallows what lands outside a terminal.
+    event.preventDefault()
+    event.dataTransfer.dropEffect = "copy"
+  }
+
+  const onDragLeave = () => {
+    dragDepth.current = Math.max(0, dragDepth.current - 1)
+    if (dragDepth.current === 0) {
+      setDropping(false)
+    }
   }
 
   // Create the terminal and its PTY session once per session id. The session
@@ -601,12 +668,28 @@ export function TerminalView({
   // remainder of the grid fit and the ruler gutter then blend into the
   // terminal instead of showing the app background as a right-edge stripe.
   return (
-    <div className="relative h-full w-full">
+    // A drop target has no keyboard equivalent to offer, and a role here would
+    // speak over xterm's own accessibility tree inside it.
+    // biome-ignore lint/a11y/noStaticElementInteractions: drop target, see above
+    <div
+      className="relative h-full w-full"
+      onDrop={onDrop}
+      onDragEnter={onDragEnter}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+    >
       <div
         ref={containerRef}
         className="h-full w-full"
         style={{ backgroundColor: terminalColors.background }}
       />
+      {dropping && (
+        <div className="pointer-events-none absolute inset-0 z-10 flex items-end justify-center bg-accent/10 pb-6 ring-2 ring-inset ring-ring">
+          <span className="rounded-md bg-popover px-2 py-1 text-xs text-muted-foreground shadow-lg">
+            Drop to paste at the prompt
+          </span>
+        </div>
+      )}
       {searchOpen && (
         <div className="absolute right-3 top-3 z-20 flex items-center gap-1 rounded-md border bg-popover p-1 text-popover-foreground shadow-lg">
           <Input

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -270,6 +270,19 @@ export interface AppUpdateStatus {
   installCommand: string
 }
 
+/**
+ * internal/drop.Item — one entry of a terminal file drop, described by the
+ * only thing Chromium tells the page about a local file. mtime is
+ * File.lastModified (milliseconds); size is 0 for a directory, whose reported
+ * one is a placeholder.
+ */
+export interface DropItem {
+  name: string
+  size: number
+  mtime: number
+  dir: boolean
+}
+
 /** internal/themes.Theme — a color theme for the UI tokens and xterm. */
 export interface ThemeDefinition {
   id: string

--- a/frontend/src/lib/review-comments.ts
+++ b/frontend/src/lib/review-comments.ts
@@ -16,6 +16,8 @@
 // replaced, never mutated, so subscribers keep a stable reference until
 // something actually changes.
 
+import { bracketedPaste } from "./terminal/bracketed-paste"
+
 export interface ReviewComment {
   /** Identity for the list and for removal; carries no meaning of its own. */
   id: string
@@ -78,21 +80,16 @@ export function subscribeReviewComments(listener: () => void): () => void {
   }
 }
 
-// Bracketed paste. The block is multi-line, and a newline written straight into
-// a TUI's prompt is a send — one per line, so the agent would answer the first
-// comment while the rest were still being typed. Wrapping the batch the way
-// xterm wraps text pasted by hand lands it in the prompt as a single paste, and
-// unsent: the user presses Enter, exactly as they do after an inject.
-const PASTE_START = "\x1b[200~"
-const PASTE_END = "\x1b[201~"
-
 /**
  * The batch as one terminal write: the comments as a markdown list, each
- * anchored the way an inject writes a line reference, wrapped as a paste.
+ * anchored the way an inject writes a line reference, wrapped as a paste. The
+ * block is multi-line, and a newline written straight into a TUI's prompt is a
+ * send — one per line, so the agent would answer the first comment while the
+ * rest were still being typed.
  */
 export function composeReviewComments(list: readonly ReviewComment[]): string {
   const items = list.map((c) => `- ${c.path}:${c.lines} — ${continuation(c.text)}`)
-  return `${PASTE_START}Review comments:\n\n${items.join("\n")}${PASTE_END}`
+  return bracketedPaste(`Review comments:\n\n${items.join("\n")}`)
 }
 
 // A comment written across several lines stays one list item: its own newlines

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -14,6 +14,7 @@ import type {
   Diagnostics as DiagnosticsData,
   DiffStats,
   DraftReviewComment,
+  DropItem,
   MergeMethod,
   PatchNotes as PatchNotesData,
   PluginStatus,
@@ -123,6 +124,14 @@ export const Terminal = {
   // Base64 tail of a session's output, to reseed scrollback after a reload.
   Replay: (id: string) => call<string>("terminal.Replay", [id]),
   Close: (id: string) => call<null>("terminal.Close", [id]),
+}
+
+export const DropService = {
+  /** Absolute paths for the dropped items found under root, in order; "" where
+   * the tree holds no single match and the caller must upload a copy instead.
+   * The upload is not here — its body is the file, so it has its own endpoint
+   * (see lib/terminal/drop-files.ts). */
+  Resolve: (root: string, items: DropItem[]) => call<string[]>("drop.Resolve", [root, items]),
 }
 
 export const ProjectService = {

--- a/frontend/src/lib/terminal/bracketed-paste.ts
+++ b/frontend/src/lib/terminal/bracketed-paste.ts
@@ -1,0 +1,11 @@
+// Bracketed paste: the escape pair a terminal wraps hand-pasted text in, so a
+// TUI reads the block as one paste instead of typing. It is what keeps a
+// newline inside the block from being a send, and it leaves the text unsent at
+// the prompt — the user presses Enter.
+
+const PASTE_START = "\x1b[200~"
+const PASTE_END = "\x1b[201~"
+
+export function bracketedPaste(text: string): string {
+  return `${PASTE_START}${text}${PASTE_END}`
+}

--- a/frontend/src/lib/terminal/drop-files.test.ts
+++ b/frontend/src/lib/terminal/drop-files.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import { composeDroppedPaths } from "./drop-files"
+
+const PASTE_START = "\x1b[200~"
+const PASTE_END = "\x1b[201~"
+
+describe("composeDroppedPaths", () => {
+  it("writes nothing for an empty drop", () => {
+    expect(composeDroppedPaths([])).toBe("")
+  })
+
+  // Bracketed, so the prompt takes the block as one paste and leaves it unsent
+  // — the user presses Enter, as after any drop into a terminal.
+  it("wraps the paths as a single unsent paste", () => {
+    expect(composeDroppedPaths(["/home/u/a.ts"])).toBe(`${PASTE_START}/home/u/a.ts ${PASTE_END}`)
+  })
+
+  it("separates a batch and leaves room for what is typed next", () => {
+    const paste = composeDroppedPaths(["/home/u/a.ts", "/home/u/b.ts"])
+
+    expect(paste).toBe(`${PASTE_START}/home/u/a.ts /home/u/b.ts ${PASTE_END}`)
+  })
+
+  // A path with a space is one argument or it is two files that do not exist.
+  it("quotes a path a shell would split", () => {
+    expect(composeDroppedPaths(["/home/u/my notes.md"])).toBe(
+      `${PASTE_START}'/home/u/my notes.md' ${PASTE_END}`,
+    )
+  })
+
+  it("quotes a path holding a quote", () => {
+    expect(composeDroppedPaths(["/home/u/it's.md"])).toBe(
+      `${PASTE_START}'/home/u/it'\\''s.md' ${PASTE_END}`,
+    )
+  })
+
+  // Backslash and the drive colon are in the safe set, so an ordinary path of
+  // either OS is written bare.
+  it("leaves a plain Windows path alone", () => {
+    expect(composeDroppedPaths(["C:\\Users\\u\\a.ts", "/home/u/a.ts"], true)).toBe(
+      `${PASTE_START}C:\\Users\\u\\a.ts /home/u/a.ts ${PASTE_END}`,
+    )
+  })
+
+  // cmd.exe has no single quotes: quoting a Windows path with them hands the
+  // prompt a path that does not exist, quotes and all.
+  it("quotes a Windows path with a space the way cmd.exe reads it", () => {
+    expect(composeDroppedPaths(["C:\\Program Files\\a.ts"], true)).toBe(
+      `${PASTE_START}"C:\\Program Files\\a.ts" ${PASTE_END}`,
+    )
+  })
+})

--- a/frontend/src/lib/terminal/drop-files.ts
+++ b/frontend/src/lib/terminal/drop-files.ts
@@ -1,0 +1,145 @@
+// Files dropped on a terminal, turned into paths at its prompt.
+//
+// A native terminal emulator pastes the path of what was dropped on it; the
+// shell here is a Chromium window, and Chromium hands the page the bytes but
+// never the path (no `text/uri-list`, no `File.path` — measured, not assumed).
+// So the backend takes it from here: it looks the item up by name, size and
+// mtime — under the session's directory, then under home (internal/drop) — and
+// only what it cannot find is uploaded and pasted as a copy.
+//
+// The provider on the other end does the rest — a pasted image path is
+// attached as an image, any other path is read as a path.
+
+import { DropService, endpoint } from "@/lib/rpc"
+import type { DropItem } from "@/lib/api-types"
+import { bracketedPaste } from "./bracketed-paste"
+
+// Matches internal/drop's maxUpload: bigger than a screenshot or a log is a
+// mis-drag, and the backend refuses it anyway.
+const MAX_UPLOAD_BYTES = 32 << 20
+
+/** One dropped entry: what the page can say about it, plus its bytes. */
+export interface DroppedFile extends DropItem {
+  /** Null for a directory — the page has no bytes to upload for one. */
+  blob: Blob | null
+}
+
+/**
+ * The drop's entries, read while the event is still live. DataTransfer is
+ * neutered the moment the handler awaits anything, so every field — including
+ * the directory flag, which only `webkitGetAsEntry` carries — has to be taken
+ * out synchronously. The Blob references survive.
+ */
+export function readDroppedFiles(transfer: DataTransfer): DroppedFile[] {
+  const dropped: DroppedFile[] = []
+  for (const item of transfer.items) {
+    if (item.kind !== "file") {
+      continue
+    }
+    const file = item.getAsFile()
+    if (!file) {
+      continue
+    }
+    const dir = item.webkitGetAsEntry?.()?.isDirectory ?? false
+    dropped.push({
+      name: file.name,
+      size: dir ? 0 : file.size,
+      mtime: file.lastModified,
+      dir,
+      blob: dir ? null : file,
+    })
+  }
+  return dropped
+}
+
+export interface DropResult {
+  /** Absolute paths, in the order they were dropped. */
+  paths: string[]
+  /** Names of entries that yielded no path, with why. */
+  skipped: string[]
+}
+
+/**
+ * Paths for a drop: the real one where the session's tree holds the file, a
+ * copy's otherwise. `cwd` is the session's directory — the tree searched.
+ */
+export async function resolveDroppedFiles(
+  cwd: string,
+  dropped: readonly DroppedFile[],
+): Promise<DropResult> {
+  const paths: string[] = []
+  const skipped: string[] = []
+  if (dropped.length === 0) {
+    return { paths, skipped }
+  }
+  const items = dropped.map(({ name, size, mtime, dir }) => ({ name, size, mtime, dir }))
+  const found = await DropService.Resolve(cwd, items)
+  for (const [index, entry] of dropped.entries()) {
+    const path = found[index] ?? ""
+    if (path !== "") {
+      paths.push(path)
+      continue
+    }
+    // Nothing to fall back to: a directory cannot be uploaded, and copying one
+    // to paste the copy's path is not the drop the user made.
+    if (entry.dir || !entry.blob) {
+      skipped.push(`${entry.name} (folder not found under this session or your home)`)
+      continue
+    }
+    if (entry.blob.size > MAX_UPLOAD_BYTES) {
+      skipped.push(`${entry.name} (over ${MAX_UPLOAD_BYTES >> 20}MB)`)
+      continue
+    }
+    try {
+      paths.push(await uploadDroppedFile(entry.name, entry.blob))
+    } catch {
+      skipped.push(entry.name)
+    }
+  }
+  return { paths, skipped }
+}
+
+// uploadDroppedFile stores one file's bytes on the backend and answers with the
+// path of the copy. Its own endpoint, not the RPC: the body is the file.
+async function uploadDroppedFile(name: string, blob: Blob): Promise<string> {
+  const { base, token } = endpoint()
+  const url = `${base}/drop?token=${token}&name=${encodeURIComponent(name)}`
+  const response = await fetch(url, { method: "POST", body: blob })
+  if (!response.ok) {
+    throw new Error(`drop upload: HTTP ${response.status}`)
+  }
+  const body = (await response.json()) as { path?: string }
+  if (!body.path) {
+    throw new Error("drop upload: no path in response")
+  }
+  return body.path
+}
+
+/**
+ * The paths as one terminal write, quoted and space-separated the way a
+ * terminal emulator pastes a drop — with a trailing space, so what the user
+ * types next does not run into the last path. Empty for an empty drop, which
+ * the caller must not write.
+ */
+export function composeDroppedPaths(paths: readonly string[], isWindows = false): string {
+  if (paths.length === 0) {
+    return ""
+  }
+  return bracketedPaste(`${paths.map((path) => quotePath(path, isWindows)).join(" ")} `)
+}
+
+// quotePath keeps a path with spaces — or anything else a shell would act on —
+// a single argument, because the prompt underneath may well be a shell. The
+// safe set covers both separators, so an ordinary path of either OS is written
+// bare. Beyond it the quote is the host's: cmd.exe knows only double quotes
+// (and a Windows path cannot contain one), POSIX gets single quotes, where a
+// path holding one closes, escapes it and reopens.
+function quotePath(path: string, isWindows: boolean): string {
+  if (/^[\w@%+=:,./\\-]+$/.test(path)) {
+    return path
+  }
+  if (isWindows) {
+    return `"${path}"`
+  }
+  return `'${path.split("'").join(`'\\''`)}'`
+}

--- a/internal/drop/drop.go
+++ b/internal/drop/drop.go
@@ -1,0 +1,249 @@
+// Package drop turns a file dropped on the terminal into a path the session
+// can paste.
+//
+// The shell is a Chromium window, not a native terminal emulator, so a drop
+// arrives through the page's DataTransfer — which carries the bytes and the
+// metadata (name, size, mtime) but never the file's path: Chromium exposes
+// neither `text/uri-list` nor `File.path` for a local drop. Two ways back to a
+// path, in order:
+//
+//   - Resolve: find the item by that metadata — under the session's directory
+//     first, then under home. The path is then the real one, so an edit lands
+//     on the user's file.
+//   - Upload: for anything neither tree holds, keep a copy under the config dir
+//     and paste the copy's path. Reading it works; editing it edits the copy —
+//     which is why Resolve is tried first.
+//
+// A dropped directory only ever takes the first path: the page can walk one,
+// but copying a tree to paste a path to the copy is not what the drop meant.
+package drop
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// maxUpload bounds one dropped file. Screenshots and logs are the payload; a
+// bigger drop is a mistake the terminal should refuse rather than copy.
+const maxUpload = 32 << 20
+
+// maxEntries bounds one searched tree, so a drop over a home directory or a
+// vendored monorepo cannot stall the window. Past it the search gives up and
+// the item falls through to the upload copy.
+const maxEntries = 50_000
+
+// homeDir is os.UserHomeDir, replaced in tests: the search must never reach
+// the machine's real home, on any OS.
+var homeDir = os.UserHomeDir
+
+// mtimeSlackMs absorbs the rounding between the browser's millisecond
+// File.lastModified and the filesystem's timestamp.
+const mtimeSlackMs = 2_000
+
+// skipDirs are trees a dropped file is never meaningfully found in, and the
+// ones that make the search expensive.
+var skipDirs = map[string]bool{
+	".git":         true,
+	"node_modules": true,
+	"vendor":       true,
+	"target":       true,
+	"dist":         true,
+	".venv":        true,
+}
+
+// Item is one dropped entry as the page sees it — the whole of what Chromium
+// hands over about a local file. Mtime is File.lastModified: milliseconds.
+type Item struct {
+	Name  string `json:"name"`
+	Size  int64  `json:"size"`
+	Mtime int64  `json:"mtime"`
+	Dir   bool   `json:"dir"`
+}
+
+type Service struct {
+	dir string
+}
+
+// New keeps uploaded copies under <configDir>/lich/dropped.
+func New(configDir string) *Service {
+	return &Service{dir: filepath.Join(configDir, "lich", "dropped")}
+}
+
+// Resolve maps each item to its absolute path, or "" when neither the
+// session's tree nor the home directory holds a match for it.
+//
+// The session's directory is searched first, then home — a drop is most often
+// the session's own file, but it is just as often a screenshot or a directory
+// from somewhere else entirely, and a directory has no copy to fall back to.
+func (s *Service) Resolve(root string, items []Item) []string {
+	paths := make([]string, len(items))
+	pending := make(map[int]bool, len(items))
+	for i := range items {
+		pending[i] = true
+	}
+	home, err := homeDir()
+	if err != nil {
+		slog.Warn("drop: no home directory to search", "err", err)
+	}
+	for _, search := range []struct {
+		root string
+		// Hidden directories are the session tree's own (.github, .config of a
+		// dotfiles checkout) but home's are its caches — tens of thousands of
+		// files that would spend the whole budget before the search reaches
+		// anything a person drags.
+		skipHidden bool
+	}{{root: root}, {root: home, skipHidden: true}} {
+		if len(pending) == 0 || search.root == "" || (search.root == root && search.skipHidden) {
+			continue
+		}
+		find(search.root, search.skipHidden, items, pending, paths)
+	}
+	return paths
+}
+
+// find walks root a level at a time, resolving each pending item to the
+// shallowest match it has. Breadth first, because depth first spends its
+// budget on whichever subtree sorts first — the caches under a home directory,
+// which is how a directory sitting right beside the search root goes missing.
+//
+// Deciding at the end of a level is what keeps the ambiguity rule meaningful:
+// every twin at the same depth is seen together, and two of them resolve to
+// nothing rather than to the wrong one.
+func find(root string, skipHidden bool, items []Item, pending map[int]bool, paths []string) {
+	wanted := make(map[string][]int, len(items))
+	for i, item := range items {
+		wanted[item.Name] = append(wanted[item.Name], i)
+	}
+	budget := maxEntries
+	for level := []string{root}; len(level) > 0 && len(pending) > 0 && budget > 0; {
+		hits := make(map[int][]string)
+		var next []string
+		for _, dir := range level {
+			entries, err := os.ReadDir(dir)
+			if err != nil {
+				// An unreadable directory costs its items their real path,
+				// nothing more.
+				continue
+			}
+			for _, entry := range entries {
+				budget--
+				if budget <= 0 {
+					break
+				}
+				path := filepath.Join(dir, entry.Name())
+				if entry.IsDir() && !skipDirs[entry.Name()] &&
+					!(skipHidden && strings.HasPrefix(entry.Name(), ".")) {
+					next = append(next, path)
+				}
+				for _, i := range wanted[entry.Name()] {
+					if pending[i] && matches(items[i], entry) {
+						hits[i] = append(hits[i], path)
+					}
+				}
+			}
+		}
+		for i, candidates := range hits {
+			if len(candidates) == 1 {
+				paths[i] = candidates[0]
+			}
+			// Ambiguous at this depth is answered here and not deeper: a match
+			// further down is not the one the shallow twins were competing for.
+			delete(pending, i)
+		}
+		level = next
+	}
+}
+
+// matches reports whether entry is the dropped item. A directory can only be
+// matched by name — the page reports a placeholder size for one — so the
+// uniqueness rule in Resolve is what keeps that honest.
+func matches(item Item, entry fs.DirEntry) bool {
+	if entry.IsDir() != item.Dir {
+		return false
+	}
+	if item.Dir {
+		return true
+	}
+	info, err := entry.Info()
+	if err != nil || info.Size() != item.Size {
+		return false
+	}
+	delta := info.ModTime().UnixMilli() - item.Mtime
+	return delta > -mtimeSlackMs && delta < mtimeSlackMs
+}
+
+// Upload stores one dropped file's bytes and answers with the path it landed
+// at. The name rides the query because the body is the file itself.
+func (s *Service) Upload(w http.ResponseWriter, r *http.Request) {
+	// CORS like the RPC's (internal/rpc): in dev the page's origin is the Vite
+	// server, not this listener, and the token is the actual auth. The preflight
+	// is not optional here — the body carries the file's own content type, which
+	// is not one a simple request may have.
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, OPTIONS")
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "POST only", http.StatusMethodNotAllowed)
+		return
+	}
+	name := filepath.Base(filepath.FromSlash(r.URL.Query().Get("name")))
+	if name == "" || name == "." || name == string(filepath.Separator) || name == ".." {
+		http.Error(w, "missing name", http.StatusBadRequest)
+		return
+	}
+	path, err := s.Save(name, http.MaxBytesReader(w, r.Body, maxUpload))
+	if err != nil {
+		slog.Warn("drop: upload failed", "name", name, "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]string{"path": path}); err != nil {
+		slog.Warn("drop: encode response", "path", path, "err", err)
+	}
+}
+
+// Save writes one dropped file under the copies directory, without ever
+// overwriting an earlier drop — its path may still be sitting in a prompt.
+func (s *Service) Save(name string, body io.Reader) (string, error) {
+	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+		return "", fmt.Errorf("dropped-files dir: %w", err)
+	}
+	path := uniquePath(s.dir, name)
+	file, err := os.Create(path)
+	if err != nil {
+		return "", fmt.Errorf("create %s: %w", path, err)
+	}
+	defer file.Close()
+	if _, err := io.Copy(file, body); err != nil {
+		return "", fmt.Errorf("write %s: %w", path, err)
+	}
+	return path, nil
+}
+
+// uniquePath is name, or name-2, name-3… up to a bound past which a caller is
+// looping on something other than collisions.
+func uniquePath(dir, name string) string {
+	path := filepath.Join(dir, name)
+	ext := filepath.Ext(name)
+	stem := strings.TrimSuffix(name, ext)
+	for i := 2; i < 1_000; i++ {
+		if _, err := os.Stat(path); errors.Is(err, fs.ErrNotExist) {
+			break
+		}
+		path = filepath.Join(dir, fmt.Sprintf("%s-%d%s", stem, i, ext))
+	}
+	return path
+}

--- a/internal/drop/drop_test.go
+++ b/internal/drop/drop_test.go
@@ -1,0 +1,341 @@
+package drop
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newService builds a Service whose home fallback is an empty directory, so a
+// test that expects no match cannot be answered by the machine's real home.
+// homeAt does the same with a home the test controls.
+func newService(t *testing.T) *Service {
+	t.Helper()
+	return homeAt(t, t.TempDir())
+}
+
+func homeAt(t *testing.T, home string) *Service {
+	t.Helper()
+	previous := homeDir
+	homeDir = func() (string, error) { return home, nil }
+	t.Cleanup(func() { homeDir = previous })
+	return New(t.TempDir())
+}
+
+// writeFile creates path with size bytes and a known modification time,
+// standing in for the file the user drags out of a file manager.
+func writeFile(t *testing.T, path string, size int, mtime time.Time) Item {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, make([]byte, size), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	if err := os.Chtimes(path, mtime, mtime); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+	return Item{Name: filepath.Base(path), Size: int64(size), Mtime: mtime.UnixMilli()}
+}
+
+// TestResolveFindsFileByMetadata proves the one thing the whole feature rests
+// on: name, size and mtime are enough to turn a pathless drop back into the
+// user's own file, nested dirs included.
+func TestResolveFindsFileByMetadata(t *testing.T) {
+	root := t.TempDir()
+	mtime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	want := filepath.Join(root, "src", "app.ts")
+	item := writeFile(t, want, 41, mtime)
+
+	got := newService(t).Resolve(root, []Item{item})
+
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("Resolve = %v, want [%s]", got, want)
+	}
+}
+
+// TestResolveRejectsNearMiss pins the fields that must disagree for a match to
+// be refused. Sizes are literals a mutation cannot make agree by widening the
+// slack, and the stale mtime is a whole minute past it.
+func TestResolveRejectsNearMiss(t *testing.T) {
+	root := t.TempDir()
+	mtime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	item := writeFile(t, filepath.Join(root, "app.ts"), 41, mtime)
+
+	cases := map[string]Item{
+		"wrong size":  {Name: "app.ts", Size: 42, Mtime: item.Mtime},
+		"stale mtime": {Name: "app.ts", Size: 41, Mtime: mtime.Add(-time.Minute).UnixMilli()},
+		"wrong name":  {Name: "other.ts", Size: 41, Mtime: item.Mtime},
+		"file as dir": {Name: "app.ts", Size: 41, Mtime: item.Mtime, Dir: true},
+	}
+	for name, dropped := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := newService(t).Resolve(root, []Item{dropped}); got[0] != "" {
+				t.Fatalf("Resolve = %q, want no match", got[0])
+			}
+		})
+	}
+}
+
+// TestResolveAcceptsMtimeWithinSlack keeps the browser's millisecond clock and
+// the filesystem's from having to agree exactly.
+func TestResolveAcceptsMtimeWithinSlack(t *testing.T) {
+	root := t.TempDir()
+	mtime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	item := writeFile(t, filepath.Join(root, "app.ts"), 41, mtime)
+	item.Mtime += mtimeSlackMs - 1
+
+	if got := newService(t).Resolve(root, []Item{item}); got[0] == "" {
+		t.Fatal("Resolve found nothing, want the file within the mtime slack")
+	}
+}
+
+// TestResolveRefusesTwins is the safety rule: two identical files under the
+// tree make the drop ambiguous, and pasting the wrong one silently edits the
+// wrong file. No path is the correct answer — the caller falls back to a copy.
+func TestResolveRefusesTwins(t *testing.T) {
+	root := t.TempDir()
+	mtime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	item := writeFile(t, filepath.Join(root, "a", "app.ts"), 41, mtime)
+	writeFile(t, filepath.Join(root, "b", "app.ts"), 41, mtime)
+
+	if got := newService(t).Resolve(root, []Item{item}); got[0] != "" {
+		t.Fatalf("Resolve = %q, want no match for twins", got[0])
+	}
+}
+
+// TestResolveSkipsNoiseDirs proves the skip list is a search boundary, not a
+// speed-up: a match found inside .git would be the wrong file to hand a
+// session, and it must not even count towards ambiguity.
+func TestResolveSkipsNoiseDirs(t *testing.T) {
+	root := t.TempDir()
+	mtime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	want := filepath.Join(root, "app.ts")
+	item := writeFile(t, want, 41, mtime)
+	writeFile(t, filepath.Join(root, ".git", "app.ts"), 41, mtime)
+	writeFile(t, filepath.Join(root, "node_modules", "pkg", "app.ts"), 41, mtime)
+
+	if got := newService(t).Resolve(root, []Item{item}); got[0] != want {
+		t.Fatalf("Resolve = %q, want %q", got[0], want)
+	}
+}
+
+// TestResolveMatchesDirectoryByName covers the item the page cannot describe:
+// a dropped directory reports a placeholder size, so the name is all there is.
+func TestResolveMatchesDirectoryByName(t *testing.T) {
+	root := t.TempDir()
+	want := filepath.Join(root, "src", "components")
+	if err := os.MkdirAll(want, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	item := Item{Name: "components", Size: 4096, Mtime: 0, Dir: true}
+
+	if got := newService(t).Resolve(root, []Item{item}); got[0] != want {
+		t.Fatalf("Resolve = %q, want %q", got[0], want)
+	}
+}
+
+// TestResolveMapsEveryItem proves a batch drop keeps its order and reports the
+// unfound ones in place, so the caller can pair path to item by index.
+func TestResolveMapsEveryItem(t *testing.T) {
+	root := t.TempDir()
+	mtime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	first := writeFile(t, filepath.Join(root, "a.ts"), 10, mtime)
+	third := writeFile(t, filepath.Join(root, "c.ts"), 30, mtime)
+	elsewhere := Item{Name: "b.ts", Size: 20, Mtime: mtime.UnixMilli()}
+
+	got := newService(t).Resolve(root, []Item{first, elsewhere, third})
+
+	if len(got) != 3 || got[0] == "" || got[1] != "" || got[2] == "" {
+		t.Fatalf("Resolve = %v, want the outer two found and the middle empty", got)
+	}
+}
+
+// TestResolveFindsShallowSiblingBeforeNoise is the measured regression: a home
+// directory's caches sort before an ordinary name and hold tens of thousands
+// of files, so a depth-first search spent its whole budget inside them and
+// reported the directory sitting right beside it as missing. The noise here is
+// one entry over the budget for exactly that reason.
+func TestResolveFindsShallowSiblingBeforeNoise(t *testing.T) {
+	root := t.TempDir()
+	noise := filepath.Join(root, ".cache", "pkg")
+	if err := os.MkdirAll(noise, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for i := 0; i <= maxEntries; i++ {
+		if err := os.WriteFile(filepath.Join(noise, fmt.Sprint(i)), nil, 0o644); err != nil {
+			t.Fatalf("write noise: %v", err)
+		}
+	}
+	want := filepath.Join(root, "project")
+	if err := os.Mkdir(want, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	item := Item{Name: "project", Dir: true}
+
+	if got := newService(t).Resolve(root, []Item{item}); got[0] != want {
+		t.Fatalf("Resolve = %q, want %q", got[0], want)
+	}
+}
+
+// TestResolveFallsBackToHome covers the drop a session's own tree can never
+// answer: a directory from elsewhere, which has no copy to fall back on.
+func TestResolveFallsBackToHome(t *testing.T) {
+	home := t.TempDir()
+	want := filepath.Join(home, "notes")
+	if err := os.Mkdir(want, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	service := homeAt(t, home)
+
+	got := service.Resolve(t.TempDir(), []Item{{Name: "notes", Dir: true}})
+
+	if got[0] != want {
+		t.Fatalf("Resolve = %q, want %q", got[0], want)
+	}
+}
+
+// TestResolveSearchesHiddenDirsOfTheSessionOnly draws the line between the two
+// trees: .github is part of a checkout and worth searching, while home's dot
+// directories are caches whose size is the reason the search is bounded.
+func TestResolveSearchesHiddenDirsOfTheSessionOnly(t *testing.T) {
+	mtime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	root := t.TempDir()
+	inSession := writeFile(t, filepath.Join(root, ".github", "ci.yml"), 12, mtime)
+	home := t.TempDir()
+	inHome := writeFile(t, filepath.Join(home, ".cache", "blob.bin"), 13, mtime)
+
+	got := homeAt(t, home).Resolve(root, []Item{inSession, inHome})
+
+	if want := filepath.Join(root, ".github", "ci.yml"); got[0] != want {
+		t.Fatalf("session hidden dir = %q, want %q", got[0], want)
+	}
+	if got[1] != "" {
+		t.Fatalf("home hidden dir = %q, want no match", got[1])
+	}
+}
+
+func TestResolveEmptyRoot(t *testing.T) {
+	if got := newService(t).Resolve("", []Item{{Name: "app.ts"}}); len(got) != 1 || got[0] != "" {
+		t.Fatalf("Resolve = %v, want one empty path", got)
+	}
+}
+
+// TestUploadAnswersPreflight is the one the browser asks first: the body
+// carries the dropped file's own content type, which is not a type a simple
+// request may have, so a POST that skips this never leaves the page.
+func TestUploadAnswersPreflight(t *testing.T) {
+	recorder := httptest.NewRecorder()
+
+	New(t.TempDir()).Upload(recorder, httptest.NewRequest(http.MethodOptions, "/drop", nil))
+
+	if recorder.Code != http.StatusNoContent {
+		t.Fatalf("preflight = %d, want %d", recorder.Code, http.StatusNoContent)
+	}
+	if got := recorder.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("preflight Allow-Origin = %q, want %q", got, "*")
+	}
+}
+
+// TestUploadStoresBytes covers the whole endpoint: the page posts the file and
+// gets back a path that holds exactly what it sent. The CORS header is asserted
+// with it because in dev the page's origin is the Vite server, so a response
+// without it is one the page is not allowed to read.
+func TestUploadStoresBytes(t *testing.T) {
+	dir := t.TempDir()
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodPost, "/drop?name=shot.png", strings.NewReader("bytes"))
+
+	New(dir).Upload(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("upload = %d (%s), want %d", recorder.Code, recorder.Body, http.StatusOK)
+	}
+	if got := recorder.Header().Get("Access-Control-Allow-Origin"); got != "*" {
+		t.Fatalf("Allow-Origin = %q, want %q", got, "*")
+	}
+	var answer struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &answer); err != nil {
+		t.Fatalf("decode %s: %v", recorder.Body, err)
+	}
+	if want := filepath.Join(dir, "lich", "dropped", "shot.png"); answer.Path != want {
+		t.Fatalf("path = %q, want %q", answer.Path, want)
+	}
+	if got, err := os.ReadFile(answer.Path); err != nil || string(got) != "bytes" {
+		t.Fatalf("stored = %q (%v), want %q", got, err, "bytes")
+	}
+}
+
+// TestUploadRejectsBadName keeps a dropped name from steering the write out of
+// the copies directory — the name is attacker-shaped input in the sense that
+// nothing about a drop guarantees its shape.
+func TestUploadRejectsBadName(t *testing.T) {
+	for _, name := range []string{"", "..", ".", "../../etc/passwd", "/etc/passwd"} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			recorder := httptest.NewRecorder()
+			target := "/drop?name=" + url.QueryEscape(name)
+			request := httptest.NewRequest(http.MethodPost, target, strings.NewReader("x"))
+
+			New(dir).Upload(recorder, request)
+
+			if name == "../../etc/passwd" || name == "/etc/passwd" {
+				// Base() reduces a traversal to its last element, which is a
+				// legitimate file name — it must land inside the directory.
+				if recorder.Code != http.StatusOK {
+					t.Fatalf("upload = %d, want %d", recorder.Code, http.StatusOK)
+				}
+				var answer struct {
+					Path string `json:"path"`
+				}
+				if err := json.Unmarshal(recorder.Body.Bytes(), &answer); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if want := filepath.Join(dir, "lich", "dropped", "passwd"); answer.Path != want {
+					t.Fatalf("path = %q, want %q", answer.Path, want)
+				}
+				return
+			}
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("upload = %d, want %d", recorder.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
+// TestSaveKeepsEarlierDrops pins the no-overwrite rule: the first copy's path
+// may still be sitting unsent in a prompt when the second file lands.
+func TestSaveKeepsEarlierDrops(t *testing.T) {
+	service := New(t.TempDir())
+
+	first, err := service.Save("shot.png", strings.NewReader("one"))
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	second, err := service.Save("shot.png", strings.NewReader("two"))
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if first == second {
+		t.Fatalf("Save reused %s for a second drop", first)
+	}
+	if got, err := os.ReadFile(first); err != nil || string(got) != "one" {
+		t.Fatalf("first copy = %q (%v), want %q", got, err, "one")
+	}
+	if got, err := os.ReadFile(second); err != nil || string(got) != "two" {
+		t.Fatalf("second copy = %q (%v), want %q", got, err, "two")
+	}
+	if want := "shot-2.png"; filepath.Base(second) != want {
+		t.Fatalf("second copy named %q, want %q", filepath.Base(second), want)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/omartelo/lich/internal/appupdate"
 	"github.com/omartelo/lich/internal/chromium"
 	"github.com/omartelo/lich/internal/claudeplugin"
+	"github.com/omartelo/lich/internal/drop"
 	"github.com/omartelo/lich/internal/events"
 	"github.com/omartelo/lich/internal/fonts"
 	"github.com/omartelo/lich/internal/logging"
@@ -99,7 +100,9 @@ func main() {
 	// Every service the frontend uses goes through the loopback RPC
 	// (internal/rpc). store.Close manages the DB lifecycle and stays Go-only.
 	dispatcher := rpc.New()
+	drops := drop.New(configDir)
 	dispatcher.Register("terminal", term)
+	dispatcher.Register("drop", drops)
 	dispatcher.Register("fonts", fonts.New())
 	dispatcher.Register("project", proj)
 	dispatcher.Register("claudeplugin", claudeplugin.New(db))
@@ -110,7 +113,12 @@ func main() {
 	dispatcher.Register("providers", providers.New())
 	dispatcher.Register("themes", themes.New())
 	dispatcher.Deny("store.Close")
+	// The dropped file's bytes are the request body, so the upload is its own
+	// endpoint: the RPC envelope is a JSON argument array with a 1MB bound.
+	dispatcher.Deny("drop.Upload")
+	dispatcher.Deny("drop.Save")
 	term.Mount("/rpc/", dispatcher)
+	term.Mount("/drop", http.HandlerFunc(drops.Upload))
 	term.Mount("/events", hub)
 
 	// In-place restart: the update flow (install.sh) POSTs /restart after


### PR DESCRIPTION
Claude Code suggests dragging image files into your terminal. In lich the terminal is a Chromium window, so the drop did nothing useful — and one that missed a terminal navigated the window away from the app.

This goes past the tip: any file, a whole directory, or several at once.

## The fact this rests on

Chromium hands the page a local drop's bytes and metadata but never its path. Measured against a real drag out of a file manager, in an `--app` window on this listener:

```
types: ["Files"]        text/uri-list: ""        File.path: null
webkitGetAsEntry().fullPath: "/demo-example.png"   ← relative to the drop root
```

So the path has to be found, not read.

## How

| drop | becomes |
|---|---|
| file or folder under the session's directory | its **real** path |
| anything under home (a screenshot, a log) | its **real** path |
| anything else | copied to `<config-dir>/lich/dropped/`, the copy's path |
| twins at the same depth | nothing — pasting the wrong one is worse |
| a folder neither search finds | an error, since a folder has no copy to fall back on |

`internal/drop` matches on name + size + mtime. The search is **breadth first**: depth first is lexical, so a dot directory sorts ahead of an ordinary name and `~/.cache` alone spent the whole 50k budget — a directory one level down from the search root was reported missing (measured: `visited=50001`, `found=""`, budget gone inside `~/.cache/.bun/...`, target at depth 1). Level order finds the shallowest match, which is also the likelier one, and deciding at the end of each level is what keeps the ambiguity rule meaningful.

Home's dot directories are not descended into — they are the caches that made the budget the problem. The session's own are, since `.github` belongs to the checkout.

Paths go in quoted (single quotes on POSIX, double on cmd.exe) and bracketed, so a batch lands as one **unsent** paste and the user presses Enter, exactly as after a drop into a native terminal. The provider does the rest: an image path is attached as an image, any other path is read as a path.

The upload is its own endpoint rather than an RPC call — the body is the file, and the RPC envelope is a JSON argument array bounded at 1MB. It carries the RPC's CORS headers and answers the preflight, which the dev split between the Vite origin and this listener makes mandatory.

Also here:
- A drop that misses a terminal is swallowed at the window. The browser's default action for a file is to navigate to it, which in the `--app` window replaces lich with a file viewer.
- `bracketedPaste()` is lifted out of `review-comments.ts`, which already had the escape pair inline.

## Test plan

Backend (`internal/drop`, 19 tests) covers the metadata match and its near misses, the twins rule, the skip list, directories by name, the batch's index pairing, both search roots, the hidden-directory line between them, the no-overwrite rule, the upload endpoint and its preflight, and the measured regression — a `.cache` one entry over the budget with the target beside it.

Frontend covers the paste composition: bracketing, batching, and quoting on both hosts.

Hand-tested in `task dev` on Linux, dragging out of a file manager:

- [x] one file, from the project and from home
- [x] three files at once, mixed extensions
- [x] four at once including an image, attached as an image
- [x] a directory from home
- [x] the drop hint while dragging over a terminal
- [x] a drop that misses a terminal does nothing

## Known ceilings (recorded in `CLAUDE.md`)

The search cost is bounded but not free, and the copies under `dropped/` are never pruned. Follow-up: #157

