### PR TITLE
fix: expire the copies a dropped file leaves behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Files and folders found under the session's own directory — or under your
   home — paste their real path, so an edit lands on your file; a screenshot or
   a log from anywhere else is copied into `<config-dir>/lich/dropped/` and
-  pastes the copy's path — a copy that is deleted a week later, so the folder
-  cannot grow for as long as you use lich. A folder that neither search finds
+  pastes the copy's path — a copy that is deleted three days later, so the
+  folder cannot grow for as long as you use lich. A folder that neither search finds
   has no copy to fall back on, and says so rather than pretending.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Files and folders found under the session's own directory — or under your
   home — paste their real path, so an edit lands on your file; a screenshot or
   a log from anywhere else is copied into `<config-dir>/lich/dropped/` and
-  pastes the copy's path. A folder that neither search finds has no copy to
-  fall back on, and says so rather than pretending.
+  pastes the copy's path — a copy that is deleted a week later, so the folder
+  cannot grow for as long as you use lich. A folder that neither search finds
+  has no copy to fall back on, and says so rather than pretending.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ nobody knows it and that the call site never shows. The mechanism and the histor
   down from the search root. Three consequences: twins at the same depth are ambiguous and resolve to nothing,
   anything neither tree holds is *copied* to `<config-dir>/lich/dropped/` — so an agent told to edit it edits the
   copy — and a directory, which has no copy to fall back on, simply fails when the budget or the skip list hides
-  it. A copy is deleted 7 days after it is written (on the next drop, or at startup), so a path pasted into a
+  it. A copy is deleted 3 days after it is written (on the next drop, or at startup), so a path pasted into a
   prompt older than that no longer resolves.
 - **git status is polled** — one shared poller per repository path (`frontend/src/lib/git/git-status-store.ts`); the
   lich plugin's `session-touched` hook nudges an immediate refresh. An fs watcher is the upgrade path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,8 @@ nobody knows it and that the call site never shows. The mechanism and the histor
   down from the search root. Three consequences: twins at the same depth are ambiguous and resolve to nothing,
   anything neither tree holds is *copied* to `<config-dir>/lich/dropped/` — so an agent told to edit it edits the
   copy — and a directory, which has no copy to fall back on, simply fails when the budget or the skip list hides
-  it. The copies are never pruned.
+  it. A copy is deleted 7 days after it is written (on the next drop, or at startup), so a path pasted into a
+  prompt older than that no longer resolves.
 - **git status is polled** — one shared poller per repository path (`frontend/src/lib/git/git-status-store.ts`); the
   lich plugin's `session-touched` hook nudges an immediate refresh. An fs watcher is the upgrade path.
 - **Persistence is hybrid**: UI prefs in the page's localStorage (`lich.*` keys — the reason the listener port is

--- a/internal/drop/drop.go
+++ b/internal/drop/drop.go
@@ -50,10 +50,10 @@ var homeDir = os.UserHomeDir
 const mtimeSlackMs = 2_000
 
 // keepDropped is how long a copy outlives its drop. Long enough that a path
-// pasted into a prompt still resolves days later — a session can sit unsent
-// over a weekend — and short enough that the directory cannot grow without
-// bound, which is the only reason it is deleted at all.
-const keepDropped = 7 * 24 * time.Hour
+// pasted into a prompt still resolves after a weekend of it sitting unsent,
+// and short enough that the directory cannot grow without bound, which is the
+// only reason it is deleted at all.
+const keepDropped = 3 * 24 * time.Hour
 
 // skipDirs are trees a dropped file is never meaningfully found in, and the
 // ones that make the search expensive.

--- a/internal/drop/drop.go
+++ b/internal/drop/drop.go
@@ -235,6 +235,12 @@ func (s *Service) Save(name string, body io.Reader) (string, error) {
 	}
 	defer file.Close()
 	if _, err := io.Copy(file, body); err != nil {
+		// A body that stops mid-write — an aborted request, a full disk —
+		// otherwise leaves a truncated copy nobody asked for and nobody pasted,
+		// under a name the next drop of the same file will then avoid.
+		if err := os.Remove(path); err != nil {
+			slog.Warn("drop: could not remove a half-written copy", "path", path, "err", err)
+		}
 		return "", fmt.Errorf("write %s: %w", path, err)
 	}
 	s.Prune()

--- a/internal/drop/drop.go
+++ b/internal/drop/drop.go
@@ -12,7 +12,7 @@
 //     on the user's file.
 //   - Upload: for anything neither tree holds, keep a copy under the config dir
 //     and paste the copy's path. Reading it works; editing it edits the copy —
-//     which is why Resolve is tried first.
+//     which is why Resolve is tried first. The copies expire (see Prune).
 //
 // A dropped directory only ever takes the first path: the page can walk one,
 // but copying a tree to paste a path to the copy is not what the drop meant.
@@ -29,6 +29,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // maxUpload bounds one dropped file. Screenshots and logs are the payload; a
@@ -47,6 +48,12 @@ var homeDir = os.UserHomeDir
 // mtimeSlackMs absorbs the rounding between the browser's millisecond
 // File.lastModified and the filesystem's timestamp.
 const mtimeSlackMs = 2_000
+
+// keepDropped is how long a copy outlives its drop. Long enough that a path
+// pasted into a prompt still resolves days later — a session can sit unsent
+// over a weekend — and short enough that the directory cannot grow without
+// bound, which is the only reason it is deleted at all.
+const keepDropped = 7 * 24 * time.Hour
 
 // skipDirs are trees a dropped file is never meaningfully found in, and the
 // ones that make the search expensive.
@@ -230,7 +237,41 @@ func (s *Service) Save(name string, body io.Reader) (string, error) {
 	if _, err := io.Copy(file, body); err != nil {
 		return "", fmt.Errorf("write %s: %w", path, err)
 	}
+	s.Prune()
 	return path, nil
+}
+
+// Prune deletes copies older than keepDropped. Called after each new copy —
+// which is the only thing that grows the directory — and once at startup, so
+// the last of them is cleared even by a lich that is never dropped on again.
+//
+// Age is the rule because a copy's whole purpose is the prompt it was pasted
+// into: once that conversation is days behind, the path in it is scrollback.
+// A failure here is never the caller's problem — the copy it just wrote is
+// good, and the stale ones get another chance on the next drop.
+func (s *Service) Prune() {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		// Nothing dropped yet is the common case, not a fault.
+		if !errors.Is(err, fs.ErrNotExist) {
+			slog.Warn("drop: prune could not read the copies dir", "dir", s.dir, "err", err)
+		}
+		return
+	}
+	deadline := time.Now().Add(-keepDropped)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil || info.ModTime().After(deadline) {
+			continue
+		}
+		path := filepath.Join(s.dir, entry.Name())
+		if err := os.Remove(path); err != nil {
+			slog.Warn("drop: prune failed", "path", path, "err", err)
+		}
+	}
 }
 
 // uniquePath is name, or name-2, name-3… up to a bound past which a caller is

--- a/internal/drop/drop_test.go
+++ b/internal/drop/drop_test.go
@@ -371,6 +371,37 @@ func TestSavePrunes(t *testing.T) {
 	}
 }
 
+// failingReader gives some bytes and then stops, like a request the page
+// aborts halfway through.
+type failingReader struct{ read bool }
+
+func (r *failingReader) Read(p []byte) (int, error) {
+	if r.read {
+		return 0, errors.New("connection went away")
+	}
+	r.read = true
+	return copy(p, "half"), nil
+}
+
+// TestSaveLeavesNothingBehindOnFailure: the caller is told the copy failed, so
+// no path was ever pasted — a truncated file under that name would be waste
+// the next drop of the same file has to route around.
+func TestSaveLeavesNothingBehindOnFailure(t *testing.T) {
+	service := New(t.TempDir())
+
+	if _, err := service.Save("shot.png", &failingReader{}); err == nil {
+		t.Fatal("Save reported success on a body that failed")
+	}
+
+	entries, err := os.ReadDir(service.dir)
+	if err != nil {
+		t.Fatalf("read copies dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("copies dir holds %d entries, want none", len(entries))
+	}
+}
+
 // TestPruneWithoutCopiesDir covers the first launch: nothing has been dropped,
 // so the directory does not exist, and that is not a fault.
 func TestPruneWithoutCopiesDir(t *testing.T) {

--- a/internal/drop/drop_test.go
+++ b/internal/drop/drop_test.go
@@ -335,11 +335,11 @@ func agedCopy(t *testing.T, service *Service, name string, age time.Duration) st
 // TestPruneDeletesOnlyExpiredCopies pins both sides of the deadline. The ages
 // are literal days, not keepDropped ± something: a test that derives them from
 // the constant moves with it, and would stay green for a window widened to a
-// month.
+// week or a month.
 func TestPruneDeletesOnlyExpiredCopies(t *testing.T) {
 	service := New(t.TempDir())
-	expired := agedCopy(t, service, "old.png", 8*24*time.Hour)
-	kept := agedCopy(t, service, "recent.png", 6*24*time.Hour)
+	expired := agedCopy(t, service, "old.png", 4*24*time.Hour)
+	kept := agedCopy(t, service, "recent.png", 2*24*time.Hour)
 
 	service.Prune()
 
@@ -356,7 +356,7 @@ func TestPruneDeletesOnlyExpiredCopies(t *testing.T) {
 // clear the ones before it.
 func TestSavePrunes(t *testing.T) {
 	service := New(t.TempDir())
-	expired := agedCopy(t, service, "old.png", 8*24*time.Hour)
+	expired := agedCopy(t, service, "old.png", 4*24*time.Hour)
 
 	fresh, err := service.Save("new.png", strings.NewReader("bytes"))
 	if err != nil {

--- a/internal/drop/drop_test.go
+++ b/internal/drop/drop_test.go
@@ -2,7 +2,9 @@ package drop
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -310,6 +312,69 @@ func TestUploadRejectsBadName(t *testing.T) {
 			}
 		})
 	}
+}
+
+// agedCopy puts a file in the copies directory with a chosen age, standing in
+// for a copy an earlier drop left behind.
+func agedCopy(t *testing.T, service *Service, name string, age time.Duration) string {
+	t.Helper()
+	if err := os.MkdirAll(service.dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	path := filepath.Join(service.dir, name)
+	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	stamp := time.Now().Add(-age)
+	if err := os.Chtimes(path, stamp, stamp); err != nil {
+		t.Fatalf("chtimes %s: %v", path, err)
+	}
+	return path
+}
+
+// TestPruneDeletesOnlyExpiredCopies pins both sides of the deadline. The ages
+// are literal days, not keepDropped ± something: a test that derives them from
+// the constant moves with it, and would stay green for a window widened to a
+// month.
+func TestPruneDeletesOnlyExpiredCopies(t *testing.T) {
+	service := New(t.TempDir())
+	expired := agedCopy(t, service, "old.png", 8*24*time.Hour)
+	kept := agedCopy(t, service, "recent.png", 6*24*time.Hour)
+
+	service.Prune()
+
+	if _, err := os.Stat(expired); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("expired copy still there (%v)", err)
+	}
+	if _, err := os.Stat(kept); err != nil {
+		t.Fatalf("copy inside the window was deleted: %v", err)
+	}
+}
+
+// TestSavePrunes is the trigger that matters most: a lich left running for
+// weeks never restarts, so the copy that grows the directory is what has to
+// clear the ones before it.
+func TestSavePrunes(t *testing.T) {
+	service := New(t.TempDir())
+	expired := agedCopy(t, service, "old.png", 8*24*time.Hour)
+
+	fresh, err := service.Save("new.png", strings.NewReader("bytes"))
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	if _, err := os.Stat(expired); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("Save left the expired copy behind (%v)", err)
+	}
+	if _, err := os.Stat(fresh); err != nil {
+		t.Fatalf("Save pruned the copy it had just written: %v", err)
+	}
+}
+
+// TestPruneWithoutCopiesDir covers the first launch: nothing has been dropped,
+// so the directory does not exist, and that is not a fault.
+func TestPruneWithoutCopiesDir(t *testing.T) {
+	New(t.TempDir()).Prune()
 }
 
 // TestSaveKeepsEarlierDrops pins the no-overwrite rule: the first copy's path

--- a/main.go
+++ b/main.go
@@ -101,6 +101,9 @@ func main() {
 	// (internal/rpc). store.Close manages the DB lifecycle and stays Go-only.
 	dispatcher := rpc.New()
 	drops := drop.New(configDir)
+	// The other prune runs after each new copy; this one is what clears the
+	// last of them for a lich that is never dropped on again.
+	drops.Prune()
 	dispatcher.Register("terminal", term)
 	dispatcher.Register("drop", drops)
 	dispatcher.Register("fonts", fonts.New())


### PR DESCRIPTION
The third item of #157, which is the one worth fixing now.

A drop that neither search tree could resolve is copied under `<config-dir>/lich/dropped/` so there is a path to paste — and nothing ever removed those copies. Every screenshot and log dropped over the life of an install stayed on disk at full size, forever.

## When a copy is made

Worth being exact, since it bounds how much this can grow: the copy is a **fallback, never unconditional**.

1. `drop.Resolve` runs first, on metadata alone — no bytes leave the page.
2. Resolved to a real path → nothing is copied.
3. Only what came back `""` from both trees uploads its bytes and is written to `dropped/`.

So a file from the project or from home never produces one.

## The rule

Copies expire three days after they are written. Age is the rule because a copy exists for the prompt it was pasted into: once that conversation is days behind, the path in it is scrollback. Three days is long enough that a prompt left unsent over a weekend still resolves.

Two triggers, because either alone leaves a real case unbounded:

- **after each new copy** — the only thing that grows the directory, and the only trigger a lich left running for weeks ever reaches;
- **once at startup** — what clears the last of them for a lich that is never dropped on again.

A prune failure is never the caller's problem: the copy it just wrote is good, and the stale ones get another chance next time.

## Test plan

- Both sides of the deadline, aged in **literal days** (four expired, two kept) rather than `keepDropped ± a minute` — derived bounds move with the constant and would stay green for a window widened to a week or a month.
- `Save` prunes what came before it and not what it just wrote.
- A first launch, where nothing has been dropped and the directory does not exist, is not a fault.

Mutants run and killed: `keepDropped` 3d → 7d and 3d → 30d, and `After` → `Before` in the deadline comparison. Backend suite green with `-race`; cross-vet clean on linux, darwin and windows.

The `CHANGELOG.md` entry is folded into the drop feature's own, which is still unreleased — nobody ran a published lich that grew this directory.



## While in here

A directory is never copied — worth stating plainly, since the copies directory is what this PR is about. Two guards, and no backend path that could do it anyway (`Save` writes one file from one body):

```ts
blob: dir ? null : file,                    // a directory never even holds bytes
if (entry.dir || !entry.blob) { skipped… }  // returns before the upload branch
```

What a failed upload *did* leave behind is now removed: a body that stops mid-write (an aborted request, a full disk) wrote a truncated file that nobody pasted a path to and that took a name the next drop of the same file had to route around. The failure path deletes it, which is what keeps every entry in that directory a copy somebody actually holds a path to. Mutation-checked by deleting the cleanup.
