### PR TITLE
fix: keep the dock — and its comments — with the review it belongs to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Comment on a file you opened whole.** The dock's **Code** tab reads a file
+  the way the review reads a diff, and the reason to open it mid-review is a
+  change too small to judge on its own — but there was nothing to do with what
+  you found there except type it out again in the terminal. Selecting lines and
+  right-clicking now offers **Comment for the session**, the same box the diff
+  opens, and the batch strip sits at the foot of the tab.
+
+### Changed
+
+- **One batch of session comments per checkout, not one per screen.** The
+  comments held for the session's next prompt were keyed by whatever produced
+  them — the pull request for its diff, the checkout for the dock — so a review
+  that crossed the two ended up with two batches, sent as two prompts, neither
+  of them the review. They are now keyed by the checkout they are going to: a
+  note taken on a pull request's diff, on a file opened whole beside it, or on
+  the checkout's own uncommitted changes joins one list, visible from all three.
+
 ### Fixed
+
+- **The dock no longer empties itself the moment you open a pull request.** The
+  file tree and the review both follow the active session, and the session they
+  resolved was the one the *terminal* route named: on a pull request or the
+  settings screen there was no such route, so the dock kept its width and its
+  tabs while its contents went blank — and the footer lost the buttons that open
+  it. The session now resolves anywhere inside the project, which is where the
+  dock earns its keep: a pull request's diff shows a change in a dozen lines,
+  and the file it came from is one tab away.
 
 - **A plugin install or update that cannot see the newest release now says so,
   instead of reporting success and leaving the old one in place.** Claude Code

--- a/frontend/src/components/diff/CommentBatch.tsx
+++ b/frontend/src/components/diff/CommentBatch.tsx
@@ -13,7 +13,8 @@ import {
 } from "@/lib/review-comments"
 
 interface CommentBatchProps {
-  /** What is under review: the checkout's path, or the pull request's URL. */
+  /** Where the batch is going: the checkout's path, shared by every surface
+   * reviewing it. */
   target: string
   /** Write into the session's terminal; false when no session took it. */
   onInject: (text: string) => boolean

--- a/frontend/src/components/dock/FilesPanel.tsx
+++ b/frontend/src/components/dock/FilesPanel.tsx
@@ -1,10 +1,16 @@
 import { ChevronLeft } from "lucide-react"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { createPortal } from "react-dom"
 import { Notice } from "@/components/common/Notice"
+import { CommentBatch } from "@/components/diff/CommentBatch"
 import { InjectMenu } from "@/components/diff/InjectMenu"
+import { type Composer, ReviewSlot } from "@/components/diff/ReviewSlots"
 import { FileTree } from "@/components/FileTree"
+import { threadSlots, type SlotElements } from "@/lib/codemirror-threads"
 import { formatLineRef, parseDiff, type DiffFile } from "@/lib/git/diff"
 import { buildTree, type TreeNode } from "@/lib/git/file-tree"
+import { COMPOSER_KEY } from "@/lib/pulls/review-slots"
+import { addReviewComment } from "@/lib/review-comments"
 import { queuePaste } from "@/lib/terminal/paste-queue"
 import { useProjects } from "@/providers/projects"
 import { ProjectService, System } from "@/lib/rpc"
@@ -18,8 +24,11 @@ import { useFileEditor } from "./useFileEditor"
 // session's tracked files, master-detail with an in-dock preview. It follows the
 // active session like the review panel — a worktree session browses its
 // checkout, not the project root — so clicking a file opens it beside the same
-// terminal it belongs to. It never edits; clicks only navigate and inject
-// path/line references into the session's PTY.
+// terminal it belongs to. It never edits; clicks only navigate, inject
+// path/line references into the session's PTY, or leave a comment on the lines
+// under the selection. That comment joins the checkout's one batch, the same
+// one the review panel and a pull request's diff write into: reading a file
+// whole is part of reviewing, and a note taken there belongs with the rest.
 export function FilesPanel() {
   const { projectId, sessionId, path } = useActiveSession()
   const { newSession, activateSession } = useProjects()
@@ -86,11 +95,31 @@ export function FilesPanel() {
       .catch(() => undefined)
   }
 
-  if (open !== null) {
-    return <FilePreview path={path} rel={open} onBack={() => setOpen(null)} onInject={inject} />
-  }
   return (
-    <TreeBody tree={tree} stats={stats} failed={failed} onOpen={setOpen} onEditor={openInEditor} />
+    <div className="flex h-full flex-col">
+      <div className="flex flex-1 flex-col overflow-hidden">
+        {open !== null ? (
+          <FilePreview
+            path={path}
+            rel={open}
+            onBack={() => setOpen(null)}
+            onInject={inject}
+            onComment={(lines, text) => addReviewComment(path, open, lines, text)}
+          />
+        ) : (
+          <TreeBody
+            tree={tree}
+            stats={stats}
+            failed={failed}
+            onOpen={setOpen}
+            onEditor={openInEditor}
+          />
+        )}
+      </div>
+      {/* Below the tree as well as the preview: a batch written file by file
+          must not vanish on the way back to pick the next one. */}
+      <CommentBatch target={path} onInject={inject} />
+    </div>
   )
 }
 
@@ -142,9 +171,11 @@ interface FilePreviewProps {
   rel: string
   onBack: () => void
   onInject: (text: string) => void
+  /** Hold a comment on these file lines for the checkout's batch. */
+  onComment: (lines: string, text: string) => void
 }
 
-function FilePreview({ path, rel, onBack, onInject }: FilePreviewProps) {
+function FilePreview({ path, rel, onBack, onInject, onComment }: FilePreviewProps) {
   const [text, setText] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
@@ -192,7 +223,7 @@ function FilePreview({ path, rel, onBack, onInject }: FilePreviewProps) {
         ) : text === null ? (
           <Notice>Loading…</Notice>
         ) : (
-          <PreviewBody text={text} rel={rel} onInject={onInject} />
+          <PreviewBody text={text} rel={rel} onInject={onInject} onComment={onComment} />
         )}
       </div>
     </div>
@@ -203,29 +234,84 @@ interface PreviewBodyProps {
   text: string
   rel: string
   onInject: (text: string) => void
+  onComment: (lines: string, text: string) => void
 }
+
+const NO_SLOTS: SlotElements = new Map()
 
 // PreviewBody renders the file in a read-only CodeMirror view whose selection
 // drives the same inject context menu as the diff review — file lines map
-// straight through (doc line === file line), so the range needs no remap.
-function PreviewBody({ text, rel, onInject }: PreviewBodyProps) {
-  const { containerRef, getSelectedLines } = useFileEditor(text, rel)
-  const [lineRef, setLineRef] = useState<string | null>(null)
+// straight through (doc line === file line), so the range needs no remap, and
+// the composer hangs under the last line the selection covered.
+//
+// Only the comment for the session is offered. The other one is a review
+// comment on a pull request, which GitHub anchors to a line of *its* diff: a
+// line of the whole file is not that, even when the file is one the PR touched.
+function PreviewBody({ text, rel, onInject, onComment }: PreviewBodyProps) {
+  const [elements, setElements] = useState<SlotElements>(NO_SLOTS)
+  // Memoised because it is part of the view's identity: a new one would rebuild
+  // the editor on every render.
+  const slots = useMemo(() => threadSlots(setElements), [])
+  const { containerRef, getSelectedLines, view } = useFileEditor(text, rel, slots.extension)
+  const [selection, setSelection] = useState<Composer | null>(null)
+  const [composer, setComposer] = useState<Composer | null>(null)
+
+  // Keyed off the composer's line rather than the composer, so typing into it
+  // does not re-dispatch the gap on every keystroke.
+  const composerLine = composer?.docLine ?? 0
+  useEffect(() => {
+    if (view) {
+      slots.update(view, composerLine > 0 ? [{ key: COMPOSER_KEY, docLine: composerLine }] : [])
+    }
+  }, [view, slots, composerLine])
+
+  const file = (): void => {
+    const body = composer?.body.trim() ?? ""
+    if (!composer || body === "") {
+      return
+    }
+    onComment(composer.lines, body)
+    setComposer(null)
+  }
 
   return (
-    <InjectMenu
-      path={rel}
-      containerRef={containerRef}
-      lineRef={lineRef}
-      // Resolve the selection when the menu opens, not on every change.
-      onOpenChange={(open) => {
-        if (!open) {
-          return
-        }
-        const range = getSelectedLines()
-        setLineRef(range && formatLineRef({ start: range.from, end: range.to }))
-      }}
-      onInject={onInject}
-    />
+    <>
+      <InjectMenu
+        path={rel}
+        containerRef={containerRef}
+        lineRef={selection?.lines ?? null}
+        // Resolve the selection when the menu opens, not on every change.
+        onOpenChange={(open) => {
+          if (!open) {
+            return
+          }
+          const range = getSelectedLines()
+          setSelection(
+            range && {
+              kind: "session",
+              lines: formatLineRef({ start: range.from, end: range.to }),
+              range: { start: range.from, end: range.to },
+              docLine: range.to,
+              body: "",
+            },
+          )
+        }}
+        onInject={onInject}
+        onSessionComment={() => selection && setComposer(selection)}
+      />
+      {[...elements].map(([key, element]) =>
+        createPortal(
+          <ReviewSlot
+            slotKey={key}
+            composer={composer}
+            onComposerChange={(body) => setComposer((held) => held && { ...held, body })}
+            onComposerSubmit={file}
+            onComposerCancel={() => setComposer(null)}
+          />,
+          element,
+          key,
+        ),
+      )}
+    </>
   )
 }

--- a/frontend/src/components/dock/useFileEditor.ts
+++ b/frontend/src/components/dock/useFileEditor.ts
@@ -1,13 +1,17 @@
 import { useMemo } from "react"
 import type { RefObject } from "react"
+import type { Extension } from "@codemirror/state"
+import type { EditorView } from "@codemirror/view"
 import { lineNumbers } from "@codemirror/view"
-import type { DocLineSelection } from "@/lib/codemirror"
+import { blockWidgetGutter, type DocLineSelection } from "@/lib/codemirror"
 import { useCodeMirrorView } from "@/lib/use-codemirror-view"
 
 export interface FileEditor {
   containerRef: RefObject<HTMLDivElement>
   /** 1-based file line span of the current selection, or null when empty. */
   getSelectedLines: () => DocLineSelection | null
+  /** The live view, for a caller that dispatches into it. */
+  view: EditorView | null
 }
 
 // useFileEditor is the file-browser preview's read-only CodeMirror view: the
@@ -15,7 +19,14 @@ export interface FileEditor {
 // interleaving of added and deleted lines, so that gutter is identity — doc
 // line N is file line N, and a selection maps straight to file line numbers
 // with no remap.
-export function useFileEditor(text: string, filename: string): FileEditor {
-  const source = useMemo(() => ({ text, extensions: [lineNumbers()] }), [text])
+//
+// `extra` is laid on top for the gap the comment box opens between two lines.
+// It has to be a stable reference: it rides the view's identity, so a new one
+// on every render would rebuild the editor on every render.
+export function useFileEditor(text: string, filename: string, extra?: Extension): FileEditor {
+  const source = useMemo(
+    () => ({ text, extensions: [lineNumbers(), blockWidgetGutter(), ...(extra ? [extra] : [])] }),
+    [text, extra],
+  )
   return useCodeMirrorView(source, filename)
 }

--- a/frontend/src/components/pulls/Pulls.tsx
+++ b/frontend/src/components/pulls/Pulls.tsx
@@ -6,7 +6,8 @@ import { useProjects } from "@/providers/projects"
 import { baseName } from "@/lib/paths"
 import { Notice } from "@/components/common/Notice"
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
-import { activeTarget, sessionsOf } from "@/lib/session/sessions"
+import { sessionsOf } from "@/lib/session/sessions"
+import { useActiveSession } from "@/lib/session/use-active-session"
 import { queueSetup } from "@/lib/terminal/setup-queue"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { useCheckouts } from "@/lib/git/use-checkouts"
@@ -38,9 +39,8 @@ interface PullsProps {
 // Pulls is the per-project pull-request screen: it fills the main area on top of
 // the persistent terminals (like Settings), holding one pull request in full —
 // status, body and the full diff — with merge, create, open, and a session on
-// the PR's own branch. It resolves its path from the route's project id plus the
-// active session (the exact-match useActiveSession returns empty on this
-// subroute).
+// the PR's own branch. It reviews from the active session's checkout, the same
+// one the dock beside it browses.
 //
 // The pull request itself is PullRequestView's; what this owns is everything
 // around it — which one is in view, and what an action there means for the
@@ -58,7 +58,7 @@ export function Pulls({ list = false }: PullsProps) {
     activateSession,
   } = useProjects()
   const projectPath = projects.find((p) => p.id === projectId)?.path ?? ""
-  const { sessionId, path } = activeTarget(sessions, projectId ?? null, projectPath)
+  const { sessionId, path } = useActiveSession()
   const status = useGitStatus(path)
   const branch = status?.branch ?? ""
   const head = status?.head ?? ""

--- a/frontend/src/components/pulls/PullsFiles.tsx
+++ b/frontend/src/components/pulls/PullsFiles.tsx
@@ -80,13 +80,17 @@ function FilesSkeleton({ tree }: { tree: boolean }) {
 }
 
 interface PullsFilesProps {
+  /** The checkout the review runs from: where the diff is fetched, and what the
+   * session comments are held under — the dock browsing the same checkout adds
+   * to that batch too. */
   path: string
   /** Which pull request's diff to fetch. */
   number: number
   /** The checkout's HEAD; a new commit refetches the diff. */
   head: string
   /** Identity of the pull request being reviewed (its URL) — what the Viewed
-   * ticks and the draft review are keyed by, so two PRs never share them. */
+   * ticks and the draft review are keyed by, so two PRs never share them. The
+   * session comments are not among them: they are keyed by the checkout. */
   pullRequest: string
   /** Write into the session's terminal; false when no session took it. */
   onInject: (text: string) => boolean
@@ -227,8 +231,8 @@ export function PullsFiles({
                 <FileDiff
                   file={file}
                   onInject={onInject}
-                  onSessionComment={(path, lines, text) =>
-                    addReviewComment(pullRequest, path, lines, text)
+                  onSessionComment={(file, lines, text) =>
+                    addReviewComment(path, file, lines, text)
                   }
                   bulk={bulk}
                   viewed={isViewed(viewed, file.newPath, fingerprints.get(file.newPath) ?? "")}
@@ -241,7 +245,10 @@ export function PullsFiles({
             ))}
           </div>
         </div>
-        <CommentBatch target={pullRequest} onInject={onInject} />
+        {/* Keyed by the checkout, not by the pull request: these notes are
+            going to that checkout's session, and the dock's own comments are
+            waiting in the same batch. */}
+        <CommentBatch target={path} onInject={onInject} />
       </div>
     </div>
   )

--- a/frontend/src/lib/codemirror.ts
+++ b/frontend/src/lib/codemirror.ts
@@ -172,6 +172,12 @@ class BlockSpacer extends GutterMarker {
 
 const blockSpacer = new BlockSpacer()
 
+/** The gutter's half of a block widget, for any view that opens gaps — the
+ * diff's threads and comment boxes, and the file preview's composer. */
+export function blockWidgetGutter(): Extension {
+  return lineNumberWidgetMarker.of(() => blockSpacer)
+}
+
 // diffGutter is the single-column line gutter: numbers come from lineMeta
 // (old-file for deletions, new-file otherwise), not from doc line numbers.
 // lineNumbers' internal spacer probes formatNumber with out-of-range numbers
@@ -185,6 +191,6 @@ export function diffGutter(lineMeta: DiffLine[]): Extension {
         return meta ? gutterNumber(meta) : widest
       },
     }),
-    lineNumberWidgetMarker.of(() => blockSpacer),
+    blockWidgetGutter(),
   ]
 }

--- a/frontend/src/lib/review-comments.ts
+++ b/frontend/src/lib/review-comments.ts
@@ -2,9 +2,12 @@
 // session as one prompt. A comment is a place plus what should change there:
 // the file, the lines the selection covered, and the note.
 //
-// Keyed by what is under review — the checkout's path for the working diff, the
-// pull request's URL for a PR — so the dock and the Pulls screen never mix their
-// notes, and leaving a tab does not drop them.
+// Keyed by where the notes are going and not by what they were written on: the
+// checkout's path, which is the session that will be handed the batch. One
+// review crosses surfaces — a pull request's diff, the file it changed opened
+// whole in the dock, the checkout's own uncommitted changes — and a note taken
+// on any of them belongs in the same prompt. Two checkouts still keep their
+// batches apart, and leaving a tab does not drop them.
 //
 // In memory only, like the Viewed ticks next door: a comment anchors to line
 // numbers of the diff as it was rendered, and nothing tracks the file moving

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -230,9 +230,9 @@ export function sessionsOf(state: SessionState, projectId: string): Session[] {
 
 // activeTarget resolves what a project screen acts on: the active session's id
 // and the path it lives in — a worktree session resolves to its checkout,
-// everything else to the project root. Pure so both useActiveSession (the
-// project route) and the pull request screen (a subroute, where the exact-match
-// useMatch yields no project) read the same triple.
+// everything else to the project root. Pure, and the whole of useActiveSession's
+// answer: every screen inside a project — the terminal, its settings, its pull
+// requests — reads this same triple, and so does the chrome beside them.
 export function activeTarget(
   state: SessionState,
   projectId: string | null,

--- a/frontend/src/lib/session/use-active-session.ts
+++ b/frontend/src/lib/session/use-active-session.ts
@@ -6,14 +6,20 @@ import { activeTarget } from "./sessions"
 // active session and the working path that session lives in — a worktree
 // session resolves to its checkout, everything else to the project root. The
 // footer and the review panel follow this triple; projectId is null on
-// project-less screens (Home, Settings), where sessionId and path are empty.
+// project-less screens (Home), where sessionId and path are empty.
+//
+// The match is the project's whole subtree, not the bare route: Settings and
+// the pull-request screen are that project's screens too, and the chrome around
+// them — the footer, the dock beside them — follows the same session it did on
+// the terminal. Matching exactly is what used to empty the dock the moment the
+// user opened a pull request, which is where its file tree is needed most.
 export function useActiveSession(): {
   projectId: string | null
   sessionId: string
   path: string
 } {
   const { projects, sessions } = useProjects()
-  const match = useMatch("/projects/:projectId")
+  const match = useMatch({ path: "/projects/:projectId", end: false })
   const projectId = match?.params.projectId ?? null
   const projectPath = projects.find((p) => p.id === projectId)?.path ?? ""
   return { projectId, ...activeTarget(sessions, projectId, projectPath) }


### PR DESCRIPTION
Reported from a real review: open a pull request, reach for the dock to read the whole class behind a twelve-line change, and the dock is there — width, tabs, and nothing in them. Go back to the PR and the note you took on the way is in a different batch than the ones you took on its diff.

Three things, one review flow.

## The dock goes blank one route in

`useActiveSession` matched `"/projects/:projectId"` exactly. A pull request and the settings screen live one segment further in, so on both of them there was no project, no session and no path: the file tree and the review panel rendered empty, and the footer lost the buttons that open them. It now matches the project's whole subtree, so every screen inside a project resolves the same session — and `Pulls.tsx` drops the local `activeTarget` call it carried precisely because the old match returned nothing there.

## One batch per checkout, not one per screen

The comments held for the session's next prompt were keyed by what produced them — the pull request's URL for its diff, the checkout's path for the dock. A review that crossed the two ended up with two batches and sent two prompts. They are keyed by the checkout now: where the batch is going, rather than what it was written on. Two checkouts still keep their notes apart. The GitHub draft review is untouched — that one is genuinely per pull request.

## The Code tab can hold a comment

It could open a file and inject a reference, and that was all: whatever you found there had to be typed out again in the terminal. Selecting lines now offers **Comment for the session**, the same box the diff opens, in a gap under the selection. Only that one — a review comment on GitHub anchors to a line of *its* diff, which a line of the whole file is not.

That gap needed the gutter's half of a block widget, which until now only `diffGutter` installed. It is shared as `blockWidgetGutter()` rather than copied; without it every line number below an open box sits one box-height off its code.

## Test plan

- [x] `pnpm check`, `tsc --noEmit`, `pnpm test` (629), `vite build`, `gofmt`, `go vet`, `go test ./...`
- [x] Headless smoke over CDP against a real pull request (#158), since the node-only frontend gate cannot render:
  - comment written on the PR's diff shows up in the dock beside it, and one written in the dock's Code tab shows up on the PR — both strips read "2 comments"
  - the dock keeps its tree, its open file and its batch across the move to the pull-request screen, and the footer keeps its buttons
  - line numbers measure 0px of drift from their code with the comment box open
  - no console errors through the whole flow