### PR TITLE
chore: cut v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-08-05
+
 ### Added
 
 - **Comment on a file you opened whole.** The dock's **Code** tab reads a file
@@ -1441,7 +1443,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.25.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.26.0...HEAD
+[0.26.0]: https://github.com/omartelo/lich/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/omartelo/lich/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/omartelo/lich/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/omartelo/lich/compare/v0.22.0...v0.23.0


### PR DESCRIPTION
Moves the `[Unreleased]` entries under a `v0.26.0` heading and refreshes the compare links, so the release notes read from the right section when the tag is pushed.

Everything since `v0.25.0`: the dock following the active session anywhere in the project, one batch of session comments per checkout, comments on a file opened whole, dropping files on a terminal, the expiry of the copies a drop leaves behind, and the plugin marketplace refresh that no longer reports a silent no-op as success.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test -race ./...` — 787 tests across 25 packages, no races
- [x] `GOOS=linux|darwin|windows go build ./... && go vet ./...` all clean
- [x] `biome check .` clean, `vitest run` — 636 tests in 61 files
- [x] `tsc --noEmit` + `vite build --mode production`