### PR TITLE
fix: close a half-written copy before removing it

### DIFF
--- a/internal/drop/drop.go
+++ b/internal/drop/drop.go
@@ -237,7 +237,10 @@ func (s *Service) Save(name string, body io.Reader) (string, error) {
 	if _, err := io.Copy(file, body); err != nil {
 		// A body that stops mid-write — an aborted request, a full disk —
 		// otherwise leaves a truncated copy nobody asked for and nobody pasted,
-		// under a name the next drop of the same file will then avoid.
+		// under a name the next drop of the same file will then avoid. Windows
+		// refuses to remove a file that still has an open handle, so the close
+		// happens here rather than in the deferred one below it.
+		file.Close()
 		if err := os.Remove(path); err != nil {
 			slog.Warn("drop: could not remove a half-written copy", "path", path, "err", err)
 		}


### PR DESCRIPTION
The `v0.26.0` release run failed its Windows backend suite on `TestSaveLeavesNothingBehindOnFailure`, and the failure is a real bug rather than a flake.

`Save` cleans up after a body that stops mid-write by removing the truncated copy, but the file's handle is only released by the deferred `Close` at the end of the function — after the `os.Remove` has already run. Unix unlinks an open file happily, so the cleanup worked everywhere the suite normally runs; Windows refuses, the remove failed with `The process cannot access the file because it is being used by another process`, and the truncated copy stayed in the dropped-files directory under a name the next drop of the same file then routes around.

The close now happens on the failure path, before the remove. The deferred close still covers the success path.

No CHANGELOG entry: the drop feature this sits in has not shipped in a published version yet, so no user has lived this.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test -race ./internal/drop/` green on Linux
- [x] `GOOS=linux|darwin|windows go build ./... && go vet ./...` all clean
- [ ] `ci:os` — the Windows runner is the one that has to go green here