### PR TITLE
fix: order recent projects by when they were closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The project you just closed is the first one the "+" offers back.** The
+  recent list was ordered by when a project was *first* opened, so closing a
+  long-standing one put it behind five newer projects — the list you reach for
+  right after closing something was the one place that thing could not be. It is
+  now ordered by the close itself, and reopening a project and closing it again
+  returns it to the top. Projects already closed keep the order they had.
+
 ## [0.26.0] - 2026-08-05
 
 ### Added

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -46,9 +46,18 @@ func (s *Service) AddProject(id, name, path string) error {
 }
 
 // CloseProject marks a project closed without deleting it or its sessions, so it
-// can be reopened later with its session state restored.
+// can be reopened later with its session state restored. closed_seq is what
+// orders the reopen menu; a counter rather than a timestamp, so two closes in
+// the same second still order.
 func (s *Service) CloseProject(id string) error {
-	if _, err := s.db.Exec(`UPDATE projects SET is_open = 0 WHERE id = ?`, id); err != nil {
+	_, err := s.db.Exec(
+		`UPDATE projects
+		    SET is_open = 0,
+		        closed_seq = (SELECT COALESCE(MAX(closed_seq), 0) + 1 FROM projects)
+		  WHERE id = ?`,
+		id,
+	)
+	if err != nil {
 		return fmt.Errorf("close project %q: %w", id, err)
 	}
 	return nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -29,7 +29,8 @@ CREATE TABLE IF NOT EXISTS projects (
     is_open           INTEGER NOT NULL DEFAULT 1,
     next_seq          INTEGER NOT NULL DEFAULT 1,
     active_session_id TEXT    NOT NULL DEFAULT '',
-    position          INTEGER NOT NULL DEFAULT 0
+    position          INTEGER NOT NULL DEFAULT 0,
+    closed_seq        INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE TABLE IF NOT EXISTS sessions (
@@ -145,6 +146,7 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN is_open INTEGER NOT NULL DEFAULT 1`,
 		`ALTER TABLE sessions ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE projects ADD COLUMN closed_seq INTEGER NOT NULL DEFAULT 0`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.Exec(stmt); err != nil && !migrationApplied(err) {
@@ -234,14 +236,16 @@ type Recent struct {
 const recentLimit = 5
 
 // RecentProjects returns the closed projects (is_open = 0) offered for
-// reopening, newest first.
+// reopening, the last one closed first.
 //
-// rowid DESC orders by when a project was first added, not when it was last
-// open — reopening keeps the row, so a project that has been through the list
-// does not move back to the top. A last_opened_at column is the upgrade path.
+// rowid is the tiebreaker, not the order: it dates a project's first open, so
+// on its own it hid a long-standing project behind five newer ones the moment
+// it was closed. Rows closed before closed_seq existed carry 0 and keep falling
+// back to it.
 func (s *Service) RecentProjects() ([]Recent, error) {
 	rows, err := s.db.Query(
-		`SELECT id, name, path FROM projects WHERE is_open = 0 ORDER BY rowid DESC LIMIT ?`,
+		`SELECT id, name, path FROM projects WHERE is_open = 0
+		  ORDER BY closed_seq DESC, rowid DESC LIMIT ?`,
 		recentLimit,
 	)
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -867,6 +868,99 @@ func TestRecentProjectsListsClosedOnesNewestFirst(t *testing.T) {
 	}
 	if recents[0].Name != "p6" || recents[0].Path != "/tmp/p6" {
 		t.Errorf("recent metadata = %+v", recents[0])
+	}
+}
+
+// recentIDs is the reopen menu's list reduced to what its order is asserted on.
+func recentIDs(t *testing.T, svc *Service) []string {
+	t.Helper()
+	recents, err := svc.RecentProjects()
+	if err != nil {
+		t.Fatalf("RecentProjects: %v", err)
+	}
+	ids := make([]string, len(recents))
+	for i, r := range recents {
+		ids[i] = r.ID
+	}
+	return ids
+}
+
+// TestRecentProjectsOrderByWhenTheyWereClosed pins the list to the last close
+// rather than to the first open: the oldest project, closed last, leads it, and
+// reopening one and closing it again puts it back on top.
+func TestRecentProjectsOrderByWhenTheyWereClosed(t *testing.T) {
+	svc := newTestStore(t)
+	for _, id := range []string{"p1", "p2", "p3"} {
+		if err := svc.AddProject(id, id, "/tmp/"+id); err != nil {
+			t.Fatalf("AddProject(%s): %v", id, err)
+		}
+	}
+	for _, id := range []string{"p3", "p2", "p1"} {
+		if err := svc.CloseProject(id); err != nil {
+			t.Fatalf("CloseProject(%s): %v", id, err)
+		}
+	}
+	if got := recentIDs(t, svc); !slices.Equal(got, []string{"p1", "p2", "p3"}) {
+		t.Fatalf("recent ids = %v, want [p1 p2 p3]", got)
+	}
+
+	if err := svc.AddProject("p3", "p3", "/tmp/p3"); err != nil {
+		t.Fatalf("AddProject (reopen): %v", err)
+	}
+	if err := svc.CloseProject("p3"); err != nil {
+		t.Fatalf("CloseProject (reclose): %v", err)
+	}
+	if got := recentIDs(t, svc); !slices.Equal(got, []string{"p3", "p1", "p2"}) {
+		t.Fatalf("recent ids after reopen and close = %v, want [p3 p1 p2]", got)
+	}
+}
+
+// TestRecentProjectsFallBackToRowidForRowsClosedBeforeTheColumn covers the
+// upgrade: projects already closed when closed_seq arrived carry 0, so they hold
+// the order they had, and the first project closed afterwards outranks all of
+// them.
+func TestRecentProjectsFallBackToRowidForRowsClosedBeforeTheColumn(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "pre-closed-seq.db")
+
+	// The projects table as it stood before closed_seq, with two rows already
+	// closed and one still open.
+	const oldSchema = `
+CREATE TABLE projects (
+    id                TEXT    PRIMARY KEY,
+    name              TEXT    NOT NULL,
+    path              TEXT    NOT NULL,
+    is_open           INTEGER NOT NULL DEFAULT 1,
+    next_seq          INTEGER NOT NULL DEFAULT 1,
+    active_session_id TEXT    NOT NULL DEFAULT '',
+    position          INTEGER NOT NULL DEFAULT 0
+);
+INSERT INTO projects (id, name, path, is_open) VALUES ('old', 'old', '/tmp/old', 0);
+INSERT INTO projects (id, name, path, is_open) VALUES ('newer', 'newer', '/tmp/newer', 0);
+INSERT INTO projects (id, name, path, is_open) VALUES ('open', 'open', '/tmp/open', 1);`
+
+	seed, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open seed db: %v", err)
+	}
+	if _, err := seed.Exec(oldSchema); err != nil {
+		t.Fatalf("seed pre-closed_seq schema: %v", err)
+	}
+	_ = seed.Close()
+
+	svc, err := open(path)
+	if err != nil {
+		t.Fatalf("open pre-closed_seq db: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Close() })
+
+	if got := recentIDs(t, svc); !slices.Equal(got, []string{"newer", "old"}) {
+		t.Fatalf("migrated recent ids = %v, want [newer old]", got)
+	}
+	if err := svc.CloseProject("open"); err != nil {
+		t.Fatalf("CloseProject: %v", err)
+	}
+	if got := recentIDs(t, svc); !slices.Equal(got, []string{"open", "newer", "old"}) {
+		t.Fatalf("recent ids after first close = %v, want [open newer old]", got)
 	}
 }
 


### PR DESCRIPTION
## What

The `+` menu's **Recent projects** list ranked closed projects by `rowid` — the order they were *first* added — with a `LIMIT 5`. Reopening keeps the row, so a project never moved back up. Closing a long-standing project therefore dropped it behind five newer ones and it simply did not appear, which is the one moment the list is reached for.

Reported from a real workspace: with 25 projects on record, closing anything added before the five most recent made it invisible.

## How

- `projects.closed_seq`, bumped to `MAX(closed_seq) + 1` on every `CloseProject`.
- `RecentProjects` orders by `closed_seq DESC, rowid DESC`.
- A counter, not a timestamp: two closes in the same second still order, and the tests do not need a clock.
- Rows closed before the column existed carry `0` and fall back to `rowid DESC` — the order they already had. The first close after the upgrade outranks all of them.

The known ceiling the old comment named (`a last_opened_at column is the upgrade path`) is now taken; no ceiling left to record.

## Test plan

- [x] `TestRecentProjectsOrderByWhenTheyWereClosed` — oldest project closed last leads the list; reopening one and closing it again returns it to the top.
- [x] `TestRecentProjectsFallBackToRowidForRowsClosedBeforeTheColumn` — seeds the pre-`closed_seq` schema with two already-closed rows: they keep their order, and the first project closed after the migration outranks them.
- [x] Existing `TestRecentProjectsListsClosedOnesNewestFirst` unchanged and green — the contract it pinned (open projects excluded, cap at five) did not move.
- [x] `go test ./...`, `go vet ./...`, `gofmt -l .` clean.

Frontend untouched — the payload shape is the same.