### PR TITLE
chore: cut v0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.1] - 2026-08-05
+
 ### Fixed
 
 - **The project you just closed is the first one the "+" offers back.** The
@@ -1452,7 +1454,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.26.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.26.1...HEAD
+[0.26.1]: https://github.com/omartelo/lich/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/omartelo/lich/compare/v0.25.0...v0.26.0
 [0.25.0]: https://github.com/omartelo/lich/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/omartelo/lich/compare/v0.23.0...v0.24.0


### PR DESCRIPTION
Release prep for v0.26.1 — a patch carrying the recent-projects ordering fix (#162).

- `[Unreleased]` moved under a `v0.26.1` heading dated 2026-08-05.
- Compare links refreshed.

The tag goes up once this lands.