### PR TITLE
docs: link the site from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     terminals, and keep git — worktrees, diffs and pull requests — in view
     without leaving the window.
   </p>
+  <p><a href="https://omartelo.github.io/lich/"><strong>omartelo.github.io/lich</strong></a></p>
   <p>
     <a href="https://github.com/omartelo/lich/releases"><img alt="Release" src="https://img.shields.io/github/v/release/omartelo/lich?color=4285F4&label=release" /></a>
     <img alt="Go" src="https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white" />


### PR DESCRIPTION
Points the README at the landing page now that Pages serves it from `main` + `/docs`, and sets the repository's homepage to the same URL.

- https://omartelo.github.io/lich/ — one line under the lead paragraph, above the badges.
- Repository homepage set with `gh repo edit --homepage` (not a file change).

No `CHANGELOG.md` entry: nothing a user of a published version experiences.

**Test plan**

- [x] Live site returns 200, images and icon included, in both themes and at 390px wide.