### PR TITLE
chore: add a feature request form and a plugin contact link

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,7 @@
+# Blank issues stay on: the two forms cover the common cases, and the rest of
+# what people report does not fit a form.
+blank_issues_enabled: true
+contact_links:
+  - name: lich plugin (session titles, git refresh, resume)
+    url: https://github.com/omartelo/lich-plugin/issues
+    about: The Claude Code hooks ship from their own repository — report those there.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Something lich should do, or should do differently
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Broken behaviour belongs in the bug form instead — this one is for what
+        lich does not do yet.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What you are trying to do
+      description: |
+        The work you are doing when lich gets in the way, and what it makes you
+        do instead — leave the app, keep a second terminal open, do it by hand
+        every time. The problem is the half that decides whether this gets
+        built, so it is the only required field.
+    validations:
+      required: true
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: What you have in mind
+      description: |
+        Optional. If you already know the shape you want, describe it. If not,
+        skip it — a well-described problem often has a better answer than the
+        one either of us reaches for first.
+    validations:
+      required: false


### PR DESCRIPTION
Six of the seven issues filed so far carry `enhancement`; one carries `bug`. The only form was the bug report — the most-used door was the one without a template.

**Added**

- `feature.yml` — asks for the problem (required) and the proposed shape (optional). That order is the point: a described problem often has a better answer than the first shape either side reaches for, and a wish list without a problem cannot be judged.
- `config.yml` — one contact link routing hook / session-title / resume reports to [lich-plugin](https://github.com/omartelo/lich-plugin/issues), which ships from its own repository. `blank_issues_enabled: true` — two forms do not cover everything, and the blank issue is the escape hatch.

**Not added**

`question`, `documentation`, `performance` and a theme-submission form. With this issue volume they are friction, not funnel — and a question form without Discussions enabled just collects support requests in the tracker.

**Left alone**

`bug.yml` is untouched: `frontend/src/lib/support-url.ts` builds `?template=bug.yml&version=…&platform=…` from Settings › Help, and `support-url.test.ts` pins it. Renaming the file or the `version` / `platform` field ids would break that hand-off silently.

**Test plan**

- [x] All three YAML files parse; field ids, required flags and labels inspected.
- [x] Labels referenced (`bug`, `enhancement`) both exist in the repository.
- [ ] After merge: open the "New issue" chooser and confirm both forms plus the contact link render.