### PR TITLE
docs: record that Windows and macOS run in the field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,10 +141,9 @@ nobody knows it and that the call site never shows. The mechanism and the histor
   the running window (best-effort, untested against a real window) and exits 0.
 - **Reordering rides dnd-kit's pointer sensors** (`frontend/src/lib/use-sortable-list.ts`); the activation distance
   is load-bearing — without it plain clicks stop selecting a session.
-- **Windows and macOS run in the field, but not here**: five colleagues use them daily (four Windows, one macOS)
-  and talk to the author every day — no bug has come back yet. Neither OS is available for development, so that
-  channel, not a suite, is what catches a regression: a report from one of them is the only path to a repro, and
-  "it cross-compiles and CI is green" is not evidence either platform works.
+- **Neither Windows nor macOS is available for development here**: both are in daily use elsewhere, and a user
+  report is the only path to a repro. A green cross-compile proves the code builds, never that the platform
+  works.
 - **Windows is experimental**: cmd.exe is the shell, and the GUI subsystem build has no console — diagnostics only
   reach `%AppData%\lich\lich.log`. The PTY has no Windows tests.
 - **macOS is experimental**: unsigned (Gatekeeper quarantines them). Three darwin seams: `internal/chromium`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,8 +141,11 @@ nobody knows it and that the call site never shows. The mechanism and the histor
   the running window (best-effort, untested against a real window) and exits 0.
 - **Reordering rides dnd-kit's pointer sensors** (`frontend/src/lib/use-sortable-list.ts`); the activation distance
   is load-bearing — without it plain clicks stop selecting a session.
+- **Windows and macOS run in the field, but not here**: five colleagues use them daily (four Windows, one macOS)
+  and talk to the author every day — no bug has come back yet. Neither OS is available for development, so that
+  channel, not a suite, is what catches a regression: a report from one of them is the only path to a repro, and
+  "it cross-compiles and CI is green" is not evidence either platform works.
 - **Windows is experimental**: cmd.exe is the shell, and the GUI subsystem build has no console — diagnostics only
   reach `%AppData%\lich\lich.log`. The PTY has no Windows tests.
-- **macOS is experimental**: unsigned (Gatekeeper quarantines them) and never run on real hardware. Three darwin
-  seams: `internal/chromium`, `internal/system`, and `internal/terminal`'s cwd reader, which hardcodes libSystem
-  struct offsets.
+- **macOS is experimental**: unsigned (Gatekeeper quarantines them). Three darwin seams: `internal/chromium`,
+  `internal/system`, and `internal/terminal`'s cwd reader, which hardcodes libSystem struct offsets.


### PR DESCRIPTION
The macOS ceiling claimed the build had *"never run on real hardware"*. That stopped being true: five colleagues run lich daily — four on Windows, one on macOS — and talk to the author every day, with nothing reported back so far.

This matters beyond accuracy. `CLAUDE.md` is what an agent reads before writing anything user-facing, so a stale line propagates: the first draft of the Show HN post said the OS builds had never run on real hardware, straight out of this bullet.

**Changed**

A new bullet ahead of the two OS ones, naming the trap that is actually left — neither OS is available for development here, so those five are the only path to reproducing a platform bug, and a green cross-compile proves the code builds, not that the platform works. The macOS bullet drops the false clause and keeps the rest.

**Unchanged**

The builds are still unsigned, the Windows PTY still has no tests, and both platforms stay labelled *experimental* in the README and `INSTALL.md`. Five satisfied users are a signal, not a test suite.

**Test plan**

- [x] No other file repeats the "never run on real hardware" claim (grep).