### PR TITLE
docs: add a Simplified Chinese version of the site

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -5,6 +5,7 @@
   </picture>
   <h1>lich</h1>
   <p><a href="README.md">English</a> · <strong>简体中文</strong></p>
+  <p><a href="https://omartelo.github.io/lich/index.zh-CN.html"><strong>omartelo.github.io/lich</strong></a></p>
   <p><strong>为 AI 编码智能体打造的终端优先工作台。</strong></p>
   <p>
     打开你的项目，在真实终端里运行 Claude Code、Codex、Opencode 这样的智能体，

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,156 +11,8 @@
 <meta property="og:image" content="https://omartelo.github.io/lich/media/session.png" />
 <meta property="og:url" content="https://omartelo.github.io/lich/" />
 <meta name="twitter:card" content="summary_large_image" />
-<style>
-:root {
-  color-scheme: light dark;
-  --background: oklch(0.94 0.003 286.32);
-  --foreground: oklch(0.21 0.006 285.885);
-  --card: oklch(0.98 0.002 286.32);
-  --muted-foreground: oklch(0.505 0.016 285.938);
-  --accent: oklch(0.9 0.004 286.32);
-  --border: oklch(0.888 0.004 286.32);
-  --primary: oklch(0.21 0.006 285.885);
-  --primary-foreground: oklch(0.985 0 0);
-  --radius: 0.45rem;
-  --sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
-  --mono: ui-monospace, "Fira Code", "JetBrains Mono", "SFMono-Regular", Menlo, monospace;
-}
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: oklch(0.141 0.005 285.823);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.21 0.006 285.885);
-    --muted-foreground: oklch(0.705 0.015 286.067);
-    --accent: oklch(0.274 0.006 286.033);
-    --border: oklch(1 0 0 / 10%);
-    --primary: oklch(0.92 0.004 286.32);
-    --primary-foreground: oklch(0.21 0.006 285.885);
-  }
-}
-
-* { box-sizing: border-box; margin: 0; padding: 0; }
-html { scroll-behavior: smooth; }
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: var(--sans);
-  font-size: 15px;
-  line-height: 1.6;
-  -webkit-font-smoothing: antialiased;
-}
-a { color: inherit; }
-img { max-width: 100%; display: block; }
-code, kbd { font-family: var(--mono); }
-
-.wrap { max-width: 980px; margin: 0 auto; padding: 0 24px; }
-
-/* ---- top bar: a hairline seam, nothing enclosed ---- */
-header {
-  position: sticky; top: 0; z-index: 10;
-  background: color-mix(in oklab, var(--background) 88%, transparent);
-  backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--border);
-}
-header .wrap { display: flex; align-items: center; gap: 10px; height: 52px; }
-header img { width: 20px; height: 20px; }
-header .name { font-weight: 600; letter-spacing: -0.01em; }
-header nav { margin-left: auto; display: flex; gap: 2px; }
-header nav a {
-  color: var(--muted-foreground); text-decoration: none;
-  font-size: 13.5px; padding: 5px 10px; border-radius: var(--radius);
-}
-header nav a:hover { background: color-mix(in oklab, var(--accent) 55%, transparent); color: var(--foreground); }
-
-/* ---- hero ---- */
-.hero { padding: 76px 0 44px; text-align: center; }
-.hero img.mark { width: 72px; height: 72px; margin: 0 auto 22px; }
-.hero h1 {
-  font-size: clamp(30px, 5vw, 42px); line-height: 1.2;
-  letter-spacing: -0.03em; font-weight: 600; max-width: 26ch; margin: 0 auto;
-}
-.hero p.lede {
-  margin: 18px auto 0; max-width: 60ch;
-  color: var(--muted-foreground); font-size: 16px;
-}
-.cta { margin-top: 30px; display: flex; gap: 10px; justify-content: center; flex-wrap: wrap; }
-.btn {
-  display: inline-flex; align-items: center; gap: 7px;
-  padding: 9px 16px; border-radius: var(--radius);
-  font-size: 14px; font-weight: 500; text-decoration: none;
-  background: var(--primary); color: var(--primary-foreground);
-}
-.btn.ghost { background: transparent; color: var(--muted-foreground); }
-.btn.ghost:hover { background: color-mix(in oklab, var(--accent) 55%, transparent); color: var(--foreground); }
-
-.install {
-  margin: 26px auto 0; max-width: 720px;
-  display: flex; align-items: flex-start; gap: 10px;
-  border: 1px solid var(--border); border-radius: var(--radius);
-  padding: 11px 12px 11px 14px; background: var(--card);
-  font-family: var(--mono); font-size: 13px; text-align: left;
-}
-.install span { flex: 1; overflow-wrap: anywhere; }
-.install span::before { content: "$ "; color: var(--muted-foreground); }
-.install button {
-  flex: none; font: inherit; font-size: 12px; cursor: pointer;
-  border: 0; border-radius: 6px; padding: 4px 9px;
-  background: transparent; color: var(--muted-foreground);
-}
-.install button:hover { background: var(--accent); color: var(--foreground); }
-.hero .note { margin-top: 12px; font-size: 12.5px; color: var(--muted-foreground); }
-
-/* ---- shots ---- */
-figure { margin: 0; }
-figure img { border: 1px solid var(--border); border-radius: var(--radius); }
-figure figcaption {
-  margin-top: 10px; font-size: 12.5px; color: var(--muted-foreground); text-align: center;
-}
-.shot-hero { margin: 40px 0 0; }
-
-/* ---- sections ---- */
-section { padding: 68px 0; border-top: 1px solid var(--border); }
-section.flush { border-top: 0; padding-top: 0; }
-h2 {
-  font-size: 22px; font-weight: 600; letter-spacing: -0.02em; margin-bottom: 8px;
-}
-.section-lede { color: var(--muted-foreground); max-width: 62ch; }
-
-.features { display: grid; gap: 34px; grid-template-columns: repeat(2, 1fr); margin-top: 34px; }
-.feature h3 { font-size: 15px; font-weight: 600; margin-bottom: 5px; }
-.feature p { color: var(--muted-foreground); font-size: 14px; }
-.feature code { font-size: 12.5px; color: var(--foreground); }
-
-.gallery { display: grid; gap: 40px; margin-top: 36px; }
-
-/* ---- table ---- */
-table { width: 100%; border-collapse: collapse; margin-top: 26px; font-size: 14px; }
-th, td { text-align: left; padding: 11px 12px 11px 0; vertical-align: top; }
-th {
-  font-size: 11.5px; font-weight: 500; text-transform: uppercase;
-  letter-spacing: 0.06em; color: var(--muted-foreground);
-}
-tbody tr { border-top: 1px solid var(--border); }
-td:first-child { white-space: nowrap; font-weight: 500; }
-td .exp { font-weight: 400; color: var(--muted-foreground); font-style: italic; }
-td:last-child { color: var(--muted-foreground); }
-a.link { color: inherit; text-decoration-color: var(--border); text-underline-offset: 3px; }
-a.link:hover { text-decoration-color: currentColor; }
-
-/* ---- footer ---- */
-footer { border-top: 1px solid var(--border); padding: 30px 0 60px; }
-footer .wrap { display: flex; gap: 16px; flex-wrap: wrap; align-items: center; }
-footer p { font-size: 13px; color: var(--muted-foreground); }
-footer nav { margin-left: auto; display: flex; gap: 16px; font-size: 13px; }
-footer nav a { color: var(--muted-foreground); text-decoration: none; }
-footer nav a:hover { color: var(--foreground); }
-
-@media (max-width: 720px) {
-  .features { grid-template-columns: 1fr; }
-  .hero { padding-top: 52px; }
-  header nav a:not(.gh) { display: none; }
-}
-</style>
+<link rel="alternate" hreflang="zh-CN" href="https://omartelo.github.io/lich/index.zh-CN.html" />
+<link rel="stylesheet" href="style.css" />
 </head>
 <body>
 
@@ -171,6 +23,7 @@ footer nav a:hover { color: var(--foreground); }
     <nav>
       <a href="#features">Features</a>
       <a href="#install">Install</a>
+      <a href="index.zh-CN.html" class="lang">简体中文</a>
       <a href="https://github.com/omartelo/lich" class="gh">GitHub</a>
     </nav>
   </div>

--- a/docs/index.zh-CN.html
+++ b/docs/index.zh-CN.html
@@ -1,0 +1,186 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>lich — 面向 AI 编码智能体的终端优先工作台</title>
+<meta name="description" content="打开你的项目，在真实终端里运行 Claude Code、Codex、opencode 这样的智能体，并把 git —— worktree、diff 和 Pull Request —— 一并留在视野里，无需离开窗口。" />
+<link rel="icon" href="media/appicon.svg" />
+<meta property="og:title" content="lich" />
+<meta property="og:description" content="面向 AI 编码智能体的终端优先工作台。" />
+<meta property="og:image" content="https://omartelo.github.io/lich/media/session.png" />
+<meta property="og:url" content="https://omartelo.github.io/lich/index.zh-CN.html" />
+<meta name="twitter:card" content="summary_large_image" />
+<link rel="alternate" hreflang="en" href="https://omartelo.github.io/lich/" />
+<link rel="stylesheet" href="style.css" />
+</head>
+<body>
+
+<header>
+  <div class="wrap">
+    <img src="media/appicon.svg" alt="" />
+    <span class="name">lich</span>
+    <nav>
+      <a href="#features">特性</a>
+      <a href="#install">安装</a>
+      <a href="./" class="lang">English</a>
+      <a href="https://github.com/omartelo/lich" class="gh">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<main class="wrap">
+
+  <div class="hero">
+    <img class="mark" src="media/appicon.svg" alt="lich" />
+    <h1>面向 AI 编码智能体的终端优先工作台</h1>
+    <p class="lede">
+      打开你的项目，在真实终端里运行 Claude Code、Codex、opencode 这样的智能体，
+      并把 git —— worktree、diff 和 Pull Request —— 一并留在视野里，无需离开窗口。
+    </p>
+
+    <div class="cta">
+      <a class="btn" href="#install">安装</a>
+      <a class="btn ghost" href="https://github.com/omartelo/lich">在 GitHub 上查看源码</a>
+    </div>
+
+    <div class="install">
+      <span id="cmd">curl -fsSL https://raw.githubusercontent.com/omartelo/lich/main/install.sh | sh</span>
+      <button type="button" id="copy">复制</button>
+    </div>
+    <p class="note">Linux 一行命令 —— 识别发行版、校验校验和，并安装原生软件包。</p>
+  </div>
+
+  <figure class="shot-hero">
+    <img src="media/session.png" alt="标签栏上的四个项目，侧栏里的五个会话 —— 各自带着 worktree、分支和 diff 徽标 —— 与此同时一个 Claude Code 会话正在终端里工作" width="1800" />
+  </figure>
+
+  <section id="features">
+    <h2>它能做什么</h2>
+    <p class="section-lede">
+      单个静态 Go 二进制文件，界面在你系统自带的 Chromium 系浏览器中以 <code>--app</code> 模式打开。
+      没有 Electron，也不捆绑 webview。
+    </p>
+
+    <div class="features">
+      <div class="feature">
+        <h3>自带智能体</h3>
+        <p>Claude Code、Codex、opencode 等都是一等公民 —— 在设置里把 lich 指向各自的
+        二进制文件，选一个默认的，或者逐个会话单独指定。</p>
+      </div>
+      <div class="feature">
+        <h3>终端优先的会话</h3>
+        <p>真正由 PTY 支撑的 shell，在 GPU 上渲染。滚动缓冲区能挺过整页刷新；底栏跟随
+        <code>cd</code>、标明模型，并用一个圆环显示已占用的上下文窗口。</p>
+      </div>
+      <div class="feature">
+        <h3>内建 git worktree</h3>
+        <p>从任意基础分支开一个，自动播种被 gitignore 掉的 <code>.env*</code> 文件，并分配
+        一个稳定的开发服务器端口。被保留的 worktree，其会话之后可以接着原来的对话恢复。</p>
+      </div>
+      <div class="feature">
+        <h3>项目与会话</h3>
+        <p>项目在顶部标签栏，会话在侧栏里按 worktree 分组 —— 每张卡片都带着自己的工作目录、
+        分支、diff 徽标和 Pull Request 编号。</p>
+      </div>
+      <div class="feature">
+        <h3>审查，并把审查交回去</h3>
+        <p>diff 面板紧挨着实时文件树。右键选中的几行就能针对它们写评论；整批评论作为一条
+        prompt 落进会话，但不自动发送。</p>
+      </div>
+      <div class="feature">
+        <h3>Pull Request，端到端</h3>
+        <p>用 GitHub 自己的限定符筛选列表，把某个 PR 检出到它自己的 worktree，内联审查、
+        批准并合并 —— 全程不用打开浏览器标签页。</p>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>四处看看</h2>
+
+    <div class="gallery">
+      <figure>
+        <img loading="lazy" src="media/review-comments.png" alt="审查面板里针对 diff 若干行写下的两条评论" width="1800" />
+        <figcaption>写在 diff 上的评论，作为一条 prompt 交给会话。</figcaption>
+      </figure>
+      <figure>
+        <img loading="lazy" src="media/pulls-list.png" alt="Pull Request 列表，含作者、时长和检查状态，由筛选框收窄" width="1800" />
+        <figcaption>仓库的 Pull Request，用 GitHub 自己的限定符筛选。</figcaption>
+      </figure>
+      <figure>
+        <img loading="lazy" src="media/pull-request-review.png" alt="一条处于 pending 的审查评论，内联在它所针对的那几行下面" width="1800" />
+        <figcaption>写在 diff 本身上的审查 —— 每条评论都处于 pending，直到你把它们一起提交。</figcaption>
+      </figure>
+      <figure>
+        <img loading="lazy" src="media/themes.png" alt="设置，外观：内置主题旁边是一套导入的主题包，显示它来自哪个仓库以及版本号" width="1800" />
+        <figcaption>从 git 仓库安装的主题包，就地更新。</figcaption>
+      </figure>
+    </div>
+  </section>
+
+  <section id="install">
+    <h2>安装</h2>
+    <p class="section-lede">
+      手动的分发版软件包和静态二进制文件见
+      <a class="link" href="https://github.com/omartelo/lich/blob/main/INSTALL.md">INSTALL.md</a>。
+    </p>
+
+    <table>
+      <thead>
+        <tr><th>平台</th><th>安装方式</th><th>运行时依赖</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Linux</td>
+          <td>上面的一行命令，或 AUR 的 <a class="link" href="https://aur.archlinux.org/packages/lich-bin"><code>lich-bin</code></a></td>
+          <td><code>PATH</code> 上有 chromium / google-chrome / brave，外加 <code>zenity</code></td>
+        </tr>
+        <tr>
+          <td>macOS <span class="exp">实验性</span></td>
+          <td><code>brew install omartelo/tap/lich</code></td>
+          <td><code>/Applications</code> 里有 Chrome / Chromium / Edge / Brave</td>
+        </tr>
+        <tr>
+          <td>Windows <span class="exp">实验性</span></td>
+          <td>从 <a class="link" href="https://github.com/omartelo/lich/releases">Releases</a> 下载安装程序</td>
+          <td>Chrome / Edge / Brave</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>一切都跑在你自己的机器上</h2>
+    <p class="section-lede">
+      没有账号，不用登录，没有遥测。后端是一个带 token 鉴权的本地回环监听器，除了更新检查
+      —— 向 GitHub Releases 发一次版本查询 —— 之外，没有任何东西离开 <code>localhost</code>。
+      你的工作区存在配置目录下的 SQLite 里。
+    </p>
+  </section>
+
+</main>
+
+<footer>
+  <div class="wrap">
+    <p>AGPL-3.0-only © 2026 omartelo —— 自由软件，在开放中构建。</p>
+    <nav>
+      <a href="./">English</a>
+      <a href="https://github.com/omartelo/lich">GitHub</a>
+      <a href="https://github.com/omartelo/lich/blob/main/CHANGELOG.md">更新日志</a>
+      <a href="https://github.com/omartelo/lich/blob/main/docs/themes.md">主题</a>
+      <a href="https://github.com/omartelo/lich-plugin">插件</a>
+    </nav>
+  </div>
+</footer>
+
+<script>
+document.getElementById("copy").addEventListener("click", async (e) => {
+  await navigator.clipboard.writeText(document.getElementById("cmd").textContent);
+  e.target.textContent = "已复制";
+  setTimeout(() => { e.target.textContent = "复制"; }, 1600);
+});
+</script>
+
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,151 @@
+:root {
+  color-scheme: light dark;
+  --background: oklch(0.94 0.003 286.32);
+  --foreground: oklch(0.21 0.006 285.885);
+  --card: oklch(0.98 0.002 286.32);
+  --muted-foreground: oklch(0.505 0.016 285.938);
+  --accent: oklch(0.9 0.004 286.32);
+  --border: oklch(0.888 0.004 286.32);
+  --primary: oklch(0.21 0.006 285.885);
+  --primary-foreground: oklch(0.985 0 0);
+  --radius: 0.45rem;
+  --sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+  --mono: ui-monospace, "Fira Code", "JetBrains Mono", "SFMono-Regular", Menlo, monospace;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: oklch(0.141 0.005 285.823);
+    --foreground: oklch(0.985 0 0);
+    --card: oklch(0.21 0.006 285.885);
+    --muted-foreground: oklch(0.705 0.015 286.067);
+    --accent: oklch(0.274 0.006 286.033);
+    --border: oklch(1 0 0 / 10%);
+    --primary: oklch(0.92 0.004 286.32);
+    --primary-foreground: oklch(0.21 0.006 285.885);
+  }
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body {
+  background: var(--background);
+  color: var(--foreground);
+  font-family: var(--sans);
+  font-size: 15px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: inherit; }
+img { max-width: 100%; display: block; }
+code, kbd { font-family: var(--mono); }
+
+.wrap { max-width: 980px; margin: 0 auto; padding: 0 24px; }
+
+/* ---- top bar: a hairline seam, nothing enclosed ---- */
+header {
+  position: sticky; top: 0; z-index: 10;
+  background: color-mix(in oklab, var(--background) 88%, transparent);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+header .wrap { display: flex; align-items: center; gap: 10px; height: 52px; }
+header img { width: 20px; height: 20px; }
+header .name { font-weight: 600; letter-spacing: -0.01em; }
+header nav { margin-left: auto; display: flex; gap: 2px; }
+header nav a {
+  color: var(--muted-foreground); text-decoration: none;
+  font-size: 13.5px; padding: 5px 10px; border-radius: var(--radius);
+}
+header nav a:hover { background: color-mix(in oklab, var(--accent) 55%, transparent); color: var(--foreground); }
+
+/* ---- hero ---- */
+.hero { padding: 76px 0 44px; text-align: center; }
+.hero img.mark { width: 72px; height: 72px; margin: 0 auto 22px; }
+.hero h1 {
+  font-size: clamp(30px, 5vw, 42px); line-height: 1.2;
+  letter-spacing: -0.03em; font-weight: 600; max-width: 26ch; margin: 0 auto;
+}
+/* CJK has no spaces, so a 26ch measure breaks the title mid-word. Every glyph
+   is one em wide, which makes an em measure exact here. */
+html[lang="zh-CN"] .hero h1 { max-width: 21em; }
+.hero p.lede {
+  margin: 18px auto 0; max-width: 60ch;
+  color: var(--muted-foreground); font-size: 16px;
+}
+.cta { margin-top: 30px; display: flex; gap: 10px; justify-content: center; flex-wrap: wrap; }
+.btn {
+  display: inline-flex; align-items: center; gap: 7px;
+  padding: 9px 16px; border-radius: var(--radius);
+  font-size: 14px; font-weight: 500; text-decoration: none;
+  background: var(--primary); color: var(--primary-foreground);
+}
+.btn.ghost { background: transparent; color: var(--muted-foreground); }
+.btn.ghost:hover { background: color-mix(in oklab, var(--accent) 55%, transparent); color: var(--foreground); }
+
+.install {
+  margin: 26px auto 0; max-width: 720px;
+  display: flex; align-items: flex-start; gap: 10px;
+  border: 1px solid var(--border); border-radius: var(--radius);
+  padding: 11px 12px 11px 14px; background: var(--card);
+  font-family: var(--mono); font-size: 13px; text-align: left;
+}
+.install span { flex: 1; overflow-wrap: anywhere; }
+.install span::before { content: "$ "; color: var(--muted-foreground); }
+.install button {
+  flex: none; font: inherit; font-size: 12px; cursor: pointer;
+  border: 0; border-radius: 6px; padding: 4px 9px;
+  background: transparent; color: var(--muted-foreground);
+}
+.install button:hover { background: var(--accent); color: var(--foreground); }
+.hero .note { margin-top: 12px; font-size: 12.5px; color: var(--muted-foreground); }
+
+/* ---- shots ---- */
+figure { margin: 0; }
+figure img { border: 1px solid var(--border); border-radius: var(--radius); }
+figure figcaption {
+  margin-top: 10px; font-size: 12.5px; color: var(--muted-foreground); text-align: center;
+}
+.shot-hero { margin: 40px 0 0; }
+
+/* ---- sections ---- */
+section { padding: 68px 0; border-top: 1px solid var(--border); }
+section.flush { border-top: 0; padding-top: 0; }
+h2 {
+  font-size: 22px; font-weight: 600; letter-spacing: -0.02em; margin-bottom: 8px;
+}
+.section-lede { color: var(--muted-foreground); max-width: 62ch; }
+
+.features { display: grid; gap: 34px; grid-template-columns: repeat(2, 1fr); margin-top: 34px; }
+.feature h3 { font-size: 15px; font-weight: 600; margin-bottom: 5px; }
+.feature p { color: var(--muted-foreground); font-size: 14px; }
+.feature code { font-size: 12.5px; color: var(--foreground); }
+
+.gallery { display: grid; gap: 40px; margin-top: 36px; }
+
+/* ---- table ---- */
+table { width: 100%; border-collapse: collapse; margin-top: 26px; font-size: 14px; }
+th, td { text-align: left; padding: 11px 12px 11px 0; vertical-align: top; }
+th {
+  font-size: 11.5px; font-weight: 500; text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--muted-foreground);
+}
+tbody tr { border-top: 1px solid var(--border); }
+td:first-child { white-space: nowrap; font-weight: 500; }
+td .exp { font-weight: 400; color: var(--muted-foreground); font-style: italic; }
+td:last-child { color: var(--muted-foreground); }
+a.link { color: inherit; text-decoration-color: var(--border); text-underline-offset: 3px; }
+a.link:hover { text-decoration-color: currentColor; }
+
+/* ---- footer ---- */
+footer { border-top: 1px solid var(--border); padding: 30px 0 60px; }
+footer .wrap { display: flex; gap: 16px; flex-wrap: wrap; align-items: center; }
+footer p { font-size: 13px; color: var(--muted-foreground); }
+footer nav { margin-left: auto; display: flex; gap: 16px; font-size: 13px; }
+footer nav a { color: var(--muted-foreground); text-decoration: none; }
+footer nav a:hover { color: var(--foreground); }
+
+@media (max-width: 720px) {
+  .features { grid-template-columns: 1fr; }
+  .hero { padding-top: 52px; }
+  header nav a:not(.gh):not(.lang) { display: none; }
+}


### PR DESCRIPTION
The Chinese README already exists, but the site it points at was English only — a reader arriving from a Chinese-language community hit a wall one click in.

**Added**

- `docs/index.zh-CN.html` — the full page, translated.
- A language switcher in both headers, plus `rel="alternate" hreflang` in both heads.
- `README.zh-CN.md` now links the site, which the English one already did.

**The stylesheet moved out instead of being copied**

`docs/style.css` now holds what was inline in `index.html`. Duplicating 6 KB of CSS into the translation would have meant every future visual change landing in two files and drifting in one. Now a style change is one file and only the content is duplicated — which is unavoidable.

One rule is genuinely per-language: CJK has no spaces and every glyph is one em wide, so the `26ch` measure meant for the English headline broke 工作台 across two lines. `html[lang="zh-CN"] .hero h1` gets an em measure instead.

**Test plan**

- [x] Both pages rendered headless at 1280px — the English page is pixel-identical after the CSS move.
- [x] Language switcher survives the narrow-viewport media query, which previously hid every nav link but GitHub.
- [ ] After merge: confirm both URLs live, and that the switcher round-trips.