### PR TITLE
docs: add SECURITY.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing
+
+Bugs and ideas are welcome, and so are patches. This file is the short version;
+`CLAUDE.md` holds the invariants and the deliberate limits behind them.
+
+## Reporting
+
+- **Something is broken** → the [bug form](https://github.com/omartelo/lich/issues/new?template=bug.yml).
+  Settings → Help → *Report a bug* opens it with the version and platform
+  already filled in, and *Open log folder* puts you next to the file to attach.
+  Read the log before attaching it: it carries paths, project and branch names
+  and your gh login — never a session token.
+- **Something is missing** → the [feature form](https://github.com/omartelo/lich/issues/new?template=feature.yml).
+  Describe the problem first; the shape you have in mind is optional, and a
+  well-described problem often has a better answer than either of us reaches
+  for first.
+- **A security problem** → not an issue. See [SECURITY.md](SECURITY.md).
+- **The session hooks** (titles, git refresh, resume) ship from
+  [lich-plugin](https://github.com/omartelo/lich-plugin) — report those there.
+
+## Getting it running
+
+Prerequisites: **Go 1.25+**, **Node + pnpm**, and **[Task](https://taskfile.dev)**.
+No C toolchain and no system dev libraries — the backend is pure Go
+(`CGO_ENABLED=0`). At runtime you need a Chromium-family browser on `PATH`,
+plus `zenity` on Linux for the folder picker.
+
+```bash
+task dev      # Vite HMR + backend
+task --list   # everything else
+```
+
+`task dev` gets its own database, port and Chromium profile, so it never
+touches the workspace of a lich you have installed.
+
+The frontend is **pnpm**, not npm — `npm install` errors out.
+
+## Before you open a pull request
+
+Run the same gate CI runs:
+
+```bash
+gofmt -l .                      # must print nothing (fix: gofmt -w .)
+go vet ./...
+cd frontend && pnpm check       # biome — the frontend's gofmt + vet
+cd frontend && pnpm build       # tsc typecheck + vite
+task test                       # both suites
+```
+
+Then:
+
+- **Shipping something a user can see?** Add its `CHANGELOG.md` `[Unreleased]`
+  entry in the same pull request. Release notes are read from that file, so an
+  entry written later is an entry that missed its release.
+- **Touched OS-specific code or a `_test.go` build tag?** Run the cross-compile
+  loop, then label the pull request `ci:os` so the backend suite runs on real
+  Windows and macOS runners:
+  ```bash
+  for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done
+  ```
+- **Touched a Go struct's JSON tags?** `frontend/src/lib/api-types.ts` mirrors
+  them by hand — there is no codegen, so it moves in the same change.
+- **Touched the UI?** `frontend/DESIGN.md` is the visual system, and it is
+  opinionated: surfaces are defined by space, hover and hairline seams rather
+  than by borders and nested boxes.
+
+Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
+(`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `perf:`, `ci:`).
+`main` takes squash and rebase merges only.
+
+## Two rules worth stating outright
+
+**Tests answer to the contract, never the other way round.** Never weaken, skip
+or delete a test to buy a green run. A test changes for exactly two reasons:
+the contract changed, or it asserted something the contract never promised —
+say which one in the pull request.
+
+**A flake is a bug with a root cause.** Don't re-run CI until it goes green.
+Reproduce it (`go test -count=200 -run TestX ./pkg/`), fix the cause, and say
+what the failure rate was before and after.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,52 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report it privately through GitHub:
+**[Security → Report a vulnerability](https://github.com/omartelo/lich/security/advisories/new)**.
+That opens a private advisory only you and the maintainer can read.
+
+Please don't open a public issue for a security problem — the issue tracker is
+world-readable, and a working report there is a working exploit for everyone
+else too.
+
+Include what you did, what happened, and the version (Settings → Help, or
+`lich --version`). A proof of concept helps; a patch is welcome but never
+expected.
+
+## Supported versions
+
+The latest release only. lich updates in place on Windows and macOS and through
+the AUR on Arch, so a fix ships as a new version rather than as a backport.
+
+## What the attack surface actually is
+
+lich runs entirely on your machine. There is no server, no account and no
+telemetry, so the interesting boundaries are local ones:
+
+- **The loopback listener.** One port (47821 by default) carries the HTTP RPC
+  and the WebSockets for terminal I/O and app events. It binds to loopback and
+  every request is authenticated by a per-run token. Anything that reaches it
+  without that token, or from off-host, is a vulnerability.
+- **The session token.** It is never written to the log. Finding it in a log,
+  a crash report or a URL is a vulnerability.
+- **The workspace.** Projects and sessions live in SQLite under your config
+  directory; UI preferences live in the Chromium profile beside it.
+- **`GH_TOKEN`.** A project can name the GitHub account `gh` runs as, which
+  puts that account's token in the environment of the `gh` calls lich makes.
+  A path that leaks it, or hands it to the wrong project, is a vulnerability.
+- **Session hooks.** The scripts ship from
+  [lich-plugin](https://github.com/omartelo/lich-plugin) and post to the same
+  authenticated listener. A payload that escapes its contract belongs here too;
+  a bug in the scripts themselves belongs in that repository.
+
+## What is not a vulnerability
+
+- **An agent running commands.** lich spawns your agent in a real PTY, and that
+  agent runs whatever it decides to run. That is the product, not a flaw — the
+  trust boundary is the agent you chose and pointed lich at.
+- **A dropped file resolving to a copy.** When a drop matches nothing in the
+  searched trees, lich copies it to a temporary directory and hands over that
+  path. Documented, deliberate.
+- **Two checkouts sharing a `LICH_WORKTREE_PORT`.** It is a hash of the path,
+  not a reservation, and nothing binds it.


### PR DESCRIPTION
A public project without a security policy has exactly one channel for a vulnerability report: a world-readable issue, where a working report is a working exploit for everyone reading. Private vulnerability reporting is now enabled on the repository and `SECURITY.md` points at it.

**SECURITY.md**

The useful half is the boundary, which for a local-first app is genuinely not obvious. In scope: the loopback listener and its per-run token, the workspace under the config directory, the `GH_TOKEN` a project's `vcs.account` puts in the environment, and the hook payloads. Explicitly *not* a vulnerability: an agent running commands — that is the product, and the trust boundary is the agent you chose — plus the documented drop-to-a-copy fallback and two checkouts sharing a `LICH_WORKTREE_PORT`.

Supported versions: the latest only. Updates apply in place, so a fix ships as a release rather than a backport.

**CONTRIBUTING.md**

The gate existed only in `CLAUDE.md`, which is written for an agent — nobody arriving from a link reads it. This puts the same commands where a human looks, plus the things that bite: pnpm is not npm, `api-types.ts` mirrors the Go JSON tags by hand, `ci:os` for OS-specific changes, the CHANGELOG entry in the same PR, and `main` taking squash and rebase only.

It also states two rules outright rather than by reference — tests answer to the contract, and a flake has a root cause — because those are the two a drive-by patch is most likely to get wrong.

**Also done outside this PR** (repository settings): description and 12 topics filled in, merge commits disabled to match the linear-history ruleset, private vulnerability reporting on, secret scanning and push protection on, Dependabot alerts on.

**Test plan**

- [x] Every link resolves: both issue forms, the advisory URL, lich-plugin, `DESIGN.md`, `SECURITY.md`.
- [x] Every command quoted is one the repo actually has (`task --list`, `pnpm check`, the GOOS loop).