### PR TITLE
fix(chromium): stop the app window opening on browser prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Windows: the app list and the file picker wear the current icon.** The icon
+- **The app window no longer opens on a Google account chooser.** On Windows,
+  the first thing a new install showed was not lich: a Chrome that knows more
+  than one Google account greeted the launch with a profile picker asking which
+  account to use, and once past it a second bar offered to translate lich's own
+  interface. Two browser prompts in a window that is not a browser, both in the
+  first ten seconds of the first run. lich now names its profile on the command
+  line, which is what keeps the picker shut, and writes the two preferences that
+  hold it — browser sign-in and translate, both off — into its own Chromium
+  profile before the window opens. The preferences are re-applied on every
+  launch, so installs that already met the prompts are quiet from the next start
+  onwards, and nothing else in the profile is touched. The icon
   linked into the executable was still the purple meteor retired two releases
   ago, and it is the one Windows draws in two places the window itself never
   covers: the Start Menu's app list, and the taskbar button of the native file

--- a/internal/chromium/chromium.go
+++ b/internal/chromium/chromium.go
@@ -7,6 +7,7 @@ package chromium
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 )
@@ -86,12 +87,18 @@ func Args(url, dataDir, class string, extra []string) []string {
 	args := []string{
 		"--app=" + url,
 		"--user-data-dir=" + dataDir,
+		// Naming the profile is also what keeps the profile picker shut:
+		// Chromium documents the picker as suppressed whenever the command line
+		// names a profile directory. Without it, a Chrome that knows several
+		// Google accounts can open the app on an account chooser.
+		"--profile-directory=" + profileName,
 		"--class=" + class,
 		"--no-first-run",
 		"--no-default-browser-check",
 		// The translate bubble compares the page's language against the browser
 		// locale and offers to translate lich's own UI — a browser prompt in a
-		// window that is not a browser.
+		// window that is not a browser. The profile pref of the same name
+		// (profile.go) is what actually holds it down; this only asks.
 		"--disable-features=Translate",
 	}
 	return append(args, extra...)
@@ -107,8 +114,16 @@ func Run(url, dataDir, class string, extra []string, onStart func(*os.Process)) 
 	if err != nil {
 		return err
 	}
+	// The data dir is required to launch at all; the prefs inside it only
+	// decide how quiet the window is.
 	if err := os.MkdirAll(dataDir, 0o700); err != nil {
 		return fmt.Errorf("chromium profile dir: %w", err)
+	}
+	if err := writePrefs(dataDir); err != nil {
+		// A profile lich could not pre-configure is a browser that may ask
+		// about translation or Google accounts. Annoying; not a reason to
+		// refuse to open the window.
+		slog.Warn("chromium profile prefs", "err", err)
 	}
 	cmd := exec.Command(browser, Args(url, dataDir, class, extra)...)
 	cmd.Stdout = os.Stdout

--- a/internal/chromium/chromium_test.go
+++ b/internal/chromium/chromium_test.go
@@ -121,6 +121,9 @@ func TestArgs(t *testing.T) {
 	for _, want := range []string{
 		"--app=http://127.0.0.1:47821/?token=x",
 		"--user-data-dir=/home/u/.config/lich/chromium-profile",
+		// Naming the profile is what keeps Chromium's profile picker — the
+		// Google account chooser — off a launch.
+		"--profile-directory=Default",
 		"--class=lichdev",
 		"--disable-features=Translate",
 		"--ozone-platform=wayland",

--- a/internal/chromium/profile.go
+++ b/internal/chromium/profile.go
@@ -1,0 +1,129 @@
+package chromium
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// profileName is the profile directory lich uses inside its user-data-dir. It
+// is Chromium's own default name; naming it explicitly is what matters (see
+// Args), so the name and the --profile-directory switch share this constant.
+const profileName = "Default"
+
+// appPrefs are the preferences lich owns in its Chromium profile. Each one
+// silences a prompt Chromium raises over the window as if it were a browser —
+// the two a stranger's first launch met on Windows.
+//
+// They are preferences rather than command-line switches because a switch only
+// asks at launch, in whatever vocabulary that Chromium build happens to speak:
+// --disable-features=Translate is one feature rename away from being ignored,
+// while translate.enabled is the toggle the Settings page writes and every
+// build honours. The switches stay too — belt and braces on a surface neither
+// of us can test on every browser a user might have installed.
+var appPrefs = []struct {
+	path  []string
+	value any
+}{
+	// The bubble offering to translate lich's own UI into the browser locale.
+	{[]string{"translate", "enabled"}, false},
+	// The Google account chooser Chrome opens on a profile it considers new —
+	// on a machine whose Chrome knows several accounts, that chooser is the
+	// first thing the app shows. A window that is not a browser has no account
+	// to sign in to, and --app mode offers no way to sign in anyway.
+	// allowed_on_next_startup is the desktop toggle that feeds signin.allowed
+	// on the following launch; both are set so the prompt cannot return on the
+	// second run.
+	{[]string{"signin", "allowed"}, false},
+	{[]string{"signin", "allowed_on_next_startup"}, false},
+}
+
+// writePrefs merges appPrefs into the profile's Preferences file, creating the
+// profile when it is new and leaving every other key of an existing one
+// untouched. Chromium reads that file at startup and rewrites it at exit, so
+// the merge has to happen before the browser launches — and it happens on every
+// launch, not only the first: a profile created by an older lich already
+// carries the prompts, and nobody is going to delete their profile to lose an
+// account chooser.
+func writePrefs(dataDir string) error {
+	profileDir := filepath.Join(dataDir, profileName)
+	if err := os.MkdirAll(profileDir, 0o700); err != nil {
+		return fmt.Errorf("chromium profile dir: %w", err)
+	}
+	path := filepath.Join(profileDir, "Preferences")
+	prefs, err := readPrefs(path)
+	if err != nil {
+		return err
+	}
+	for _, pref := range appPrefs {
+		setPref(prefs, pref.path, pref.value)
+	}
+	return writePrefsFile(path, prefs)
+}
+
+// readPrefs decodes an existing Preferences file, or returns an empty object
+// when the profile has none yet. Numbers stay json.Number so the round-trip
+// hands back every value lich does not understand exactly as Chromium wrote it.
+// A file that will not parse is returned as an error and never overwritten:
+// silencing a bubble is not worth resetting somebody's profile.
+func readPrefs(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return map[string]any{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read chromium prefs: %w", err)
+	}
+	prefs := map[string]any{}
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+	if err := dec.Decode(&prefs); err != nil {
+		return nil, fmt.Errorf("parse chromium prefs %s: %w", path, err)
+	}
+	return prefs, nil
+}
+
+// setPref writes value at a pref path, creating the intermediate objects
+// Chromium's nested Preferences JSON uses. Anything that is not an object in
+// the way is replaced: lich's prefs win over a shape they cannot merge into.
+func setPref(root map[string]any, path []string, value any) {
+	node := root
+	for _, key := range path[:len(path)-1] {
+		child, ok := node[key].(map[string]any)
+		if !ok {
+			child = map[string]any{}
+			node[key] = child
+		}
+		node = child
+	}
+	node[path[len(path)-1]] = value
+}
+
+// writePrefsFile replaces the Preferences file in one step. Chromium writes it
+// the same way, and a half-written profile is a browser that refuses to open.
+func writePrefsFile(path string, prefs map[string]any) error {
+	data, err := json.Marshal(prefs)
+	if err != nil {
+		return fmt.Errorf("encode chromium prefs: %w", err)
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), "prefs-*")
+	if err != nil {
+		return fmt.Errorf("write chromium prefs: %w", err)
+	}
+	defer os.Remove(tmp.Name()) // no-op once the rename succeeds
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return fmt.Errorf("write chromium prefs: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("write chromium prefs: %w", err)
+	}
+	if err := os.Rename(tmp.Name(), path); err != nil {
+		return fmt.Errorf("write chromium prefs: %w", err)
+	}
+	return nil
+}

--- a/internal/chromium/profile_test.go
+++ b/internal/chromium/profile_test.go
@@ -1,0 +1,173 @@
+package chromium
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// prefsPath is where writePrefs is expected to land, spelled out here so the
+// tests fail if the profile layout moves rather than following it.
+func prefsPath(dataDir string) string {
+	return filepath.Join(dataDir, "Default", "Preferences")
+}
+
+func readPrefsFile(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read prefs: %v", err)
+	}
+	var prefs map[string]any
+	if err := json.Unmarshal(data, &prefs); err != nil {
+		t.Fatalf("prefs are not valid JSON: %v", err)
+	}
+	return prefs
+}
+
+// prefAt walks a nested pref path, failing the test if any hop is missing.
+func prefAt(t *testing.T, prefs map[string]any, path ...string) any {
+	t.Helper()
+	var node any = prefs
+	for i, key := range path {
+		obj, ok := node.(map[string]any)
+		if !ok {
+			t.Fatalf("%v is not an object at %q", path[:i], key)
+		}
+		if node, ok = obj[key]; !ok {
+			t.Fatalf("pref %v missing", path[:i+1])
+		}
+	}
+	return node
+}
+
+// TestWritePrefsSilencesBrowserPrompts is the contract: a fresh profile starts
+// with the translate bubble and browser sign-in — the Google account chooser —
+// turned off, because neither belongs in a window that is not a browser.
+func TestWritePrefsSilencesBrowserPrompts(t *testing.T) {
+	dir := t.TempDir()
+	if err := writePrefs(dir); err != nil {
+		t.Fatalf("writePrefs: %v", err)
+	}
+	prefs := readPrefsFile(t, prefsPath(dir))
+
+	for _, path := range [][]string{
+		{"translate", "enabled"},
+		{"signin", "allowed"},
+		{"signin", "allowed_on_next_startup"},
+	} {
+		if got := prefAt(t, prefs, path...); got != false {
+			t.Fatalf("pref %v = %v, want false", path, got)
+		}
+	}
+}
+
+// TestWritePrefsKeepsExistingProfile proves the merge is surgical: everything
+// Chromium wrote about the profile survives, values lich does not own included,
+// and untouched numbers come back exactly as they went in.
+func TestWritePrefsKeepsExistingProfile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(prefsPath(dir)), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	existing := `{"browser":{"window_placement":{"bottom":1080}},` +
+		`"profile":{"exit_type":"Normal"},` +
+		`"signin":{"allowed":true},` +
+		`"session":{"startup_id":9007199254740993}}`
+	if err := os.WriteFile(prefsPath(dir), []byte(existing), 0o600); err != nil {
+		t.Fatalf("seed prefs: %v", err)
+	}
+
+	if err := writePrefs(dir); err != nil {
+		t.Fatalf("writePrefs: %v", err)
+	}
+	prefs := readPrefsFile(t, prefsPath(dir))
+
+	if got := prefAt(t, prefs, "browser", "window_placement", "bottom"); got != float64(1080) {
+		t.Fatalf("window placement = %v, want it preserved", got)
+	}
+	if got := prefAt(t, prefs, "profile", "exit_type"); got != "Normal" {
+		t.Fatalf("exit_type = %v, want it preserved", got)
+	}
+	// An existing profile is exactly the case that needs fixing: a lich that
+	// already ran once carries the prompts until something turns them off.
+	if got := prefAt(t, prefs, "signin", "allowed"); got != false {
+		t.Fatalf("signin.allowed = %v, want lich's value to win", got)
+	}
+	// json.Number, not float64: a 2^53+1 id must survive the round-trip.
+	data, err := os.ReadFile(prefsPath(dir))
+	if err != nil {
+		t.Fatalf("read prefs: %v", err)
+	}
+	if want := `9007199254740993`; !strings.Contains(string(data), want) {
+		t.Fatalf("prefs %s lost the exact number %s", data, want)
+	}
+}
+
+// TestWritePrefsReplacesNonObject proves a pref path blocked by a scalar is
+// rebuilt rather than crashing the launch.
+func TestWritePrefsReplacesNonObject(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(prefsPath(dir)), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(prefsPath(dir), []byte(`{"translate":"nonsense"}`), 0o600); err != nil {
+		t.Fatalf("seed prefs: %v", err)
+	}
+	if err := writePrefs(dir); err != nil {
+		t.Fatalf("writePrefs: %v", err)
+	}
+	if got := prefAt(t, readPrefsFile(t, prefsPath(dir)), "translate", "enabled"); got != false {
+		t.Fatalf("translate.enabled = %v, want false", got)
+	}
+}
+
+// TestWritePrefsRefusesUnparseableProfile proves a corrupt Preferences file is
+// reported and left alone — resetting somebody's profile is worse than the
+// bubble the merge was there to silence.
+func TestWritePrefsRefusesUnparseableProfile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Dir(prefsPath(dir)), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	garbage := []byte("{not json")
+	if err := os.WriteFile(prefsPath(dir), garbage, 0o600); err != nil {
+		t.Fatalf("seed prefs: %v", err)
+	}
+	if err := writePrefs(dir); err == nil {
+		t.Fatal("want an error for a Preferences file that will not parse")
+	}
+	data, err := os.ReadFile(prefsPath(dir))
+	if err != nil {
+		t.Fatalf("read prefs: %v", err)
+	}
+	if string(data) != string(garbage) {
+		t.Fatalf("prefs = %s, want the file left untouched", data)
+	}
+}
+
+// TestWritePrefsErrorsWhenPrefsUnreadable proves a Preferences path that cannot
+// be read at all is reported rather than replaced with a fresh profile.
+func TestWritePrefsErrorsWhenPrefsUnreadable(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(prefsPath(dir), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := writePrefs(dir); err == nil {
+		t.Fatal("want an error when Preferences cannot be read")
+	}
+}
+
+// TestWritePrefsErrorsWhenProfileDirBlocked proves an unusable data dir surfaces
+// as an error instead of a silent no-op.
+func TestWritePrefsErrorsWhenProfileDirBlocked(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(dir, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+	if err := writePrefs(dir); err == nil {
+		t.Fatal("want an error when the profile dir cannot be created")
+	}
+}


### PR DESCRIPTION
A first launch on Windows showed a Google account chooser before it showed
lich: Chromium's profile picker, raised because the command line never named
a profile and the machine's Chrome knew several accounts. Past it came the
translate bar, offering to translate lich's own interface — the switch that
was supposed to stop it, --disable-features=Translate, only asks at launch
and in a vocabulary that moves between builds.

Name the profile directory (Chromium suppresses the picker whenever the
command line names one) and merge the two preferences that actually hold
these down — signin.allowed and translate.enabled — into the profile before
the browser opens. The merge runs on every launch so profiles created by an
older lich are fixed too, keeps every other key Chromium wrote, preserves
numbers exactly, and refuses to touch a Preferences file it cannot parse.
A profile it cannot pre-configure is a warning, never a refused window.

Windows and macOS remain unverified here — no hardware.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XqT84Egx81TK3TNzKL1G97