### PR TITLE
fix: grow a review comment's box with the comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **A review comment's box grows with the comment.** Every field review prose is
+  typed into — the line comment, the batch note for the session, the reply, the
+  summary above a review — was a fixed three lines tall, so anything longer than a
+  sentence had to be dragged open before the first line was finished. The box now
+  grows as it is filled, up to a much taller ceiling, then scrolls; the drag
+  handle still overrides it in either direction.
+
 ### Fixed
 
 - **Windows: the app list and the file picker wear the current icon.** The icon

--- a/frontend/src/components/diff/ReviewSlots.tsx
+++ b/frontend/src/components/diff/ReviewSlots.tsx
@@ -91,7 +91,6 @@ export function ReviewSlot({
           }
           autoFocus
           submitOnEnter={session}
-          rows={session ? 2 : 3}
         />
       </div>
     )

--- a/frontend/src/components/pulls/CommentBox.tsx
+++ b/frontend/src/components/pulls/CommentBox.tsx
@@ -5,8 +5,12 @@ import { cn } from "@/lib/utils"
  * submit dialog writes the review's summary into a bare textarea — it carries
  * the dialog's own footer instead of this box's buttons — and the two fields
  * drifting apart would read as two different controls for the same thing. */
+// The box grows with what is typed instead of holding one fixed height: a review
+// comment is prose of unknown length, and a field that needs dragging open on the
+// first line taxes every comment. `field-sizing: content` makes `rows` inert, so
+// the floor and the ceiling are the min/max height — past the ceiling it scrolls.
 export const commentFieldClass =
-  "w-full resize-y rounded-md border border-input bg-transparent px-2.5 py-1.5 font-sans text-sm shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
+  "max-h-64 min-h-16 w-full resize-y rounded-md border border-input bg-transparent px-2.5 py-1.5 font-sans text-sm shadow-xs outline-none transition-[color,box-shadow] field-sizing-content placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30"
 
 interface CommentBoxProps {
   value: string
@@ -19,7 +23,6 @@ interface CommentBoxProps {
   busy?: boolean
   placeholder?: string
   autoFocus?: boolean
-  rows?: number
   className?: string
   /** Send on a bare ⏎, with ⇧⏎ for a new line. For a one-line note taken while
    * reading — a comment for the session — where reaching for a modifier is the
@@ -44,7 +47,6 @@ export function CommentBox({
   busy = false,
   placeholder,
   autoFocus = false,
-  rows = 3,
   className,
   submitOnEnter = false,
 }: CommentBoxProps) {
@@ -68,7 +70,6 @@ export function CommentBox({
             onCancel()
           }
         }}
-        rows={rows}
         placeholder={placeholder}
         // biome-ignore lint/a11y/noAutofocus: the box only exists because the reviewer just asked for it — typing is the next thing they do.
         autoFocus={autoFocus}

--- a/frontend/src/components/pulls/SubmitReviewDialog.tsx
+++ b/frontend/src/components/pulls/SubmitReviewDialog.tsx
@@ -69,7 +69,6 @@ export function SubmitReviewDialog({
           <textarea
             value={review.body}
             onChange={(e) => onBodyChange(e.target.value)}
-            rows={6}
             placeholder="Summary — optional"
             autoFocus
             className={cn(commentFieldClass, "min-h-24")}


### PR DESCRIPTION
## What

Every field review prose is typed into — the line comment, the batch note for the session, the reply, the summary above a review — was pinned at three lines. Anything longer than a sentence had to be dragged open before the first line was finished.

The field now sizes to its content: `field-sizing: content` on the shared `commentFieldClass`, with `min-h-16` as the floor and `max-h-64` as the ceiling; past the ceiling it scrolls. `resize-y` stays, so a drag still overrides it in either direction.

`rows` is inert under `field-sizing`, so the `CommentBox` prop and its call sites go with it. `SubmitReviewDialog` keeps its taller `min-h-24` floor.

No JS: the growth is the browser's, and the shell is Chromium.

## Test plan

- [x] `biome check` clean (the standing a11y warning backlog only), `tsc` clean, `vitest` 636 passed, `vite build` succeeds.
- [x] `field-sizing:content` lands in the built CSS bundle.
- [ ] In `task dev`, on a pull request: open a line comment, a batch note for the session and a reply — each starts short, grows while typing, stops at the ceiling and scrolls. The resize handle still drags in both directions.