### PR TITLE
feat: notify the desktop when a session needs you

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A session waiting on you now reaches the desktop.** The bell on the card and
+  the toast beside it only ever worked while you were looking at lich — walk away
+  to a browser or another workspace and a session blocked on a permission prompt
+  sat there until you happened to come back. When a session needs your input and
+  the lich window is not the one you are in, lich now raises a desktop
+  notification through the system's own notifier, naming the session and its
+  project so you know where to go. Nothing changes while the window has focus:
+  the in-app toast is still the one that fires, and it still routes to the card.
+  lich asks before it starts — the first time a session would have notified you,
+  a dialog puts the question, and either answer settles it. **Settings ›
+  Notifications** holds the switch afterwards, whichever way you answered.
+
 ## [0.27.0] - 2026-08-07
 
 ### Added

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -71,6 +71,15 @@ what re-arms the spinner after them. Every tool re-reports `busy` (idempotent);
   the session already focused. It reads the raw event rather than the store: the
   store collapses a repeat state into no notification, which would swallow a
   toast.
+- **Desktop notification** — same handler, `system.Notify`
+  (`internal/system/system.go`, zenity's per-OS notifier). It answers to
+  `document.hasFocus()`, not to the toast's rule: with the window unfocused every
+  `waiting` session is unseen, the focused one included, so that exclusion does
+  not apply here. The page decides, the backend only delivers — focus is a fact
+  only the page holds. Gated on an opt-in (`lich.notifications.desktop`, tri-state
+  so "refused" and "not asked" stay apart): the first report that would have
+  notified puts the dialog instead (`NotificationsOptIn`), and **Settings ›
+  Notifications** owns the switch from then on.
 
 ## Known ceilings
 
@@ -90,5 +99,12 @@ what re-arms the spinner after them. Every tool re-reports `busy` (idempotent);
   a permission and let Claude end the turn without another tool and the card
   stays `waiting` until `Stop → done`. Rare, and it self-corrects on the next
   turn.
+- The desktop notification is not clickable: clicking it focuses nothing and
+  routes nowhere, which is why its text names the session and the project — the
+  user navigates by hand. Making it actionable is per-OS and none of it is
+  cheap: Linux needs `notify-send --wait --action`, holding a process per
+  notification; macOS needs lich shipped as a signed `.app` bundle with
+  `UNUserNotificationCenter`; Windows needs a registered AppUserModelID with a
+  COM activation handler.
 - Adding another state beyond `busy`/`done`/`waiting`/`idle` is a contract
   change — see the versioning note in the README.

--- a/frontend/src/components/NotificationsOptIn.tsx
+++ b/frontend/src/components/NotificationsOptIn.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+interface NotificationsOptInProps {
+  open: boolean
+  /** Escape or the backdrop: closed without an answer, so it is put again. */
+  onDismiss: () => void
+  /** An answer, stored either way — this dialog is asked once. */
+  onDecide: (enabled: boolean) => void
+}
+
+// The one-time opt-in for desktop notifications, put the first time a session
+// would have notified: the user is being asked about something that just
+// happened to them, not about a hypothetical at launch.
+export function NotificationsOptIn({ open, onDismiss, onDecide }: NotificationsOptInProps) {
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onDismiss()}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Notify you when a session needs you?</DialogTitle>
+          <DialogDescription>
+            A session just asked for your input while you were somewhere else. lich can raise a
+            desktop notification when that happens, naming the session and its project, so you can
+            start something and walk away from the window. Sessions you are looking at never notify.
+            You can change this any time in Settings › Notifications.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onDecide(false)}>
+            No thanks
+          </Button>
+          <Button onClick={() => onDecide(true)}>Notify me</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/settings/NotificationsSettings.tsx
+++ b/frontend/src/components/settings/NotificationsSettings.tsx
@@ -1,0 +1,23 @@
+import { SettingBlock } from "./SettingBlock"
+import { Switch } from "@/components/ui/switch"
+import { useSettings } from "@/providers/settings"
+
+// The one setting that reaches outside the app window. An unanswered opt-in
+// (null) reads as off here: until the user says yes, nothing notifies — and
+// turning it on from this switch is itself an answer, so the dialog never
+// appears afterwards.
+export function NotificationsSettings() {
+  const { desktopNotifications, setDesktopNotifications } = useSettings()
+  return (
+    <SettingBlock
+      title="Notify me when a session needs input"
+      description="Raise a desktop notification when a session is blocked on you — a permission prompt, a question — and the lich window is not the one you are in. While you are in lich nothing changes: the card's bell and the toast do the telling."
+    >
+      <Switch
+        checked={desktopNotifications === true}
+        onCheckedChange={setDesktopNotifications}
+        aria-label="Raise a desktop notification when a session needs input"
+      />
+    </SettingBlock>
+  )
+}

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import type { ReactNode } from "react"
 import { useParams } from "react-router-dom"
 import { AppearanceSettings } from "./AppearanceSettings"
+import { NotificationsSettings } from "./NotificationsSettings"
 import { HotkeysSettings } from "./HotkeysSettings"
 import { ProvidersSettings } from "./ProvidersSettings"
 import { ProviderBinSettings } from "./ProviderBinSettings"
@@ -28,6 +29,12 @@ interface Section {
 // toggles; enabling a provider adds its own section below (see providerSections).
 const BASE_SECTIONS: Section[] = [
   { id: "appearance", label: "Appearance", group: "app", render: () => <AppearanceSettings /> },
+  {
+    id: "notifications",
+    label: "Notifications",
+    group: "app",
+    render: () => <NotificationsSettings />,
+  },
   { id: "hotkeys", label: "Hotkeys", group: "app", render: () => <HotkeysSettings /> },
   { id: "providers", label: "Providers", group: "app", render: () => <ProvidersSettings /> },
   {

--- a/frontend/src/lib/prefs.test.ts
+++ b/frontend/src/lib/prefs.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { parseBoolPref, parseEnumPref, parseNumberPref } from "./prefs"
+import { parseBoolPref, parseEnumPref, parseNumberPref, parseOptionalBoolPref } from "./prefs"
 
 const THEMES = ["system", "light", "dark"] as const
 
@@ -64,5 +64,22 @@ describe("parseBoolPref", () => {
     expect(parseBoolPref("1", true)).toBe(true)
     expect(parseBoolPref("1", false)).toBe(false)
     expect(parseBoolPref("yes", false)).toBe(false)
+  })
+})
+
+describe("parseOptionalBoolPref", () => {
+  it("reads what writePref emits", () => {
+    expect(parseOptionalBoolPref("true")).toBe(true)
+    expect(parseOptionalBoolPref("false")).toBe(false)
+  })
+
+  it("keeps an absent key apart from a refusal", () => {
+    expect(parseOptionalBoolPref(null)).toBeNull()
+  })
+
+  it("treats a value it did not write as undecided, not as off", () => {
+    expect(parseOptionalBoolPref("1")).toBeNull()
+    expect(parseOptionalBoolPref("no")).toBeNull()
+    expect(parseOptionalBoolPref("")).toBeNull()
   })
 })

--- a/frontend/src/lib/prefs.ts
+++ b/frontend/src/lib/prefs.ts
@@ -43,6 +43,21 @@ export function parseNumberPref(
   return raw !== null && Number.isFinite(value) && value > 0 ? clamp(value) : fallback
 }
 
+/** A flag with a third answer: never decided. For a setting the user is asked
+ * about once, where "off" and "not asked yet" have to stay apart — the same
+ * stored value cannot mean both a refusal and a pending question. Anything
+ * other than what writePref emits reads as undecided, so a foreign value asks
+ * rather than silently answering for the user. */
+export function parseOptionalBoolPref(raw: string | null): boolean | null {
+  if (raw === "true") {
+    return true
+  }
+  if (raw === "false") {
+    return false
+  }
+  return null
+}
+
 /** A flag. Only what writePref emits for a boolean counts; anything else is
  * the fallback, so a half-written or foreign value cannot pin a toggle. */
 export function parseBoolPref(raw: string | null, fallback: boolean): boolean {

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -326,6 +326,9 @@ export const System = {
   Diagnostics: () => call<DiagnosticsData>("system.Diagnostics", []),
   /** Open the log's folder in the platform's file manager, for attaching it. */
   RevealLog: () => call<null>("system.RevealLog", []),
+  /** Raise a desktop notification: a headline and an optional second line.
+   * The caller decides it is warranted — the backend only delivers. */
+  Notify: (summary: string, detail: string) => call<null>("system.Notify", [summary, detail]),
 }
 
 export const Providers = {

--- a/frontend/src/lib/session/session-events.test.ts
+++ b/frontend/src/lib/session/session-events.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  decideDesktopNotice,
   isAgentEvent,
   isCwdEvent,
   isIdEvent,
@@ -177,5 +178,25 @@ describe("shouldToastAttention", () => {
 
   it("stays silent for an empty state", () => {
     expect(shouldToastAttention({}, "s1", ACTIVE)).toBe(false)
+  })
+})
+
+describe("decideDesktopNotice", () => {
+  it("stays out of the way while the user is at the window", () => {
+    expect(decideDesktopNotice(true, true)).toBe("none")
+    expect(decideDesktopNotice(true, null)).toBe("none")
+    expect(decideDesktopNotice(true, false)).toBe("none")
+  })
+
+  it("notifies once the user has opted in and left the window", () => {
+    expect(decideDesktopNotice(false, true)).toBe("notify")
+  })
+
+  it("puts the question on the first report that would have notified", () => {
+    expect(decideDesktopNotice(false, null)).toBe("ask")
+  })
+
+  it("keeps quiet for a refusal instead of asking again", () => {
+    expect(decideDesktopNotice(false, false)).toBe("none")
   })
 })

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -139,3 +139,27 @@ export function shouldToastAttention(
   const focused = projectId === activeProjectId && project.activeId === sessionId
   return !focused
 }
+
+/** What the desktop channel does with a session that needs the user. */
+export type DesktopNotice = "none" | "ask" | "notify"
+
+// decideDesktopNotice is the desktop half of the same report shouldToastAttention
+// answers, and it asks a different question: not which session the user is on,
+// but whether they are at the window at all. With lich in front there is nothing
+// to do — the card's bell and the toast are already in view. With the window
+// behind something else every waiting session is unseen, the active one
+// included, and the notification is the only channel left. Until the opt-in has
+// been answered (null) the first such report puts the question instead of the
+// notification.
+export function decideDesktopNotice(
+  windowFocused: boolean,
+  enabled: boolean | null,
+): DesktopNotice {
+  if (windowFocused) {
+    return "none"
+  }
+  if (enabled === null) {
+    return "ask"
+  }
+  return enabled ? "notify" : "none"
+}

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -5,7 +5,7 @@ import { Bell, Folder } from "lucide-react"
 import { useMatch, useNavigate } from "react-router-dom"
 import type { Project, RecentProject } from "@/lib/api-types"
 import type { StoredProject as StoreProject } from "@/lib/api-types"
-import { ProjectService, Store } from "@/lib/rpc"
+import { ProjectService, Store, System } from "@/lib/rpc"
 import { onAppEvent } from "@/lib/app-events"
 import {
   activeSessionId,
@@ -28,6 +28,7 @@ import { applyOrder, pinFirst } from "@/lib/reorder"
 import { displayPath } from "@/lib/paths"
 import { defaultProviderKind } from "@/lib/providers-store"
 import {
+  decideDesktopNotice,
   isIdEvent,
   isStatusEvent,
   isTitleEvent,
@@ -37,6 +38,7 @@ import {
   toSessionStatus,
   TOUCHED_EVENT,
 } from "@/lib/session/session-events"
+import { NotificationsOptIn } from "@/components/NotificationsOptIn"
 import { refreshGitStatus } from "@/lib/git/use-git-status"
 import { markSessionSeen } from "@/lib/session/use-session-status"
 import { isRecordingTarget, matchesCombo } from "@/lib/hotkeys"
@@ -148,7 +150,16 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
   // event subscription without re-subscribing on every navigation.
   const activeProjectIdRef = useRef(activeProjectId)
   activeProjectIdRef.current = activeProjectId
-  const { hotkeys } = useSettings()
+  const { hotkeys, desktopNotifications, setDesktopNotifications } = useSettings()
+  // Read inside the same once-only subscription, for the same reason as the
+  // active project: a preference change must not tear down the status listener.
+  const desktopNotificationsRef = useRef(desktopNotifications)
+  desktopNotificationsRef.current = desktopNotifications
+  // Whether the opt-in dialog is up. Raised by the first report that would have
+  // notified, never at launch — the question lands with the event that motivates
+  // it. Dismissing without an answer leaves the preference unset, so the next
+  // one asks again.
+  const [askNotifications, setAskNotifications] = useState(false)
 
   const applyLoaded = useCallback((loaded: StoreProject[]) => {
     setProjects(loaded.map(toProject))
@@ -395,14 +406,28 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
         return
       }
       const { id } = data
+      const projectId = projectOfSession(sessionsRef.current, id)
+      const project = sessionsRef.current[projectId]
+      if (!project) {
+        return
+      }
+      const label = project.sessions.find((s) => s.id === id)?.label ?? UNLABELED_SESSION
+      const projectName = projectsRef.current.find((p) => p.id === projectId)?.name
+
+      // The desktop channel answers to window focus, decided by
+      // decideDesktopNotice; the toast below keeps its own, unchanged rule. The
+      // two are independent: a report can raise both, either, or neither.
+      const notice = decideDesktopNotice(document.hasFocus(), desktopNotificationsRef.current)
+      if (notice === "ask") {
+        setAskNotifications(true)
+      } else if (notice === "notify") {
+        // A failure is the backend's to log; the page has nothing to do with it.
+        System.Notify(`${label} needs your input`, projectName ?? "").catch(() => {})
+      }
+
       if (!shouldToastAttention(sessionsRef.current, id, activeProjectIdRef.current)) {
         return
       }
-      const projectId = projectOfSession(sessionsRef.current, id)
-      const label =
-        sessionsRef.current[projectId]?.sessions.find((s) => s.id === id)?.label ??
-        UNLABELED_SESSION
-      const projectName = projectsRef.current.find((p) => p.id === projectId)?.name
       toast(
         <div className="flex min-w-0 flex-col">
           <span>{label} needs your input</span>
@@ -554,7 +579,19 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     ],
   )
 
-  return <ProjectsContext.Provider value={value}>{children}</ProjectsContext.Provider>
+  return (
+    <ProjectsContext.Provider value={value}>
+      {children}
+      <NotificationsOptIn
+        open={askNotifications}
+        onDismiss={() => setAskNotifications(false)}
+        onDecide={(enabled) => {
+          setDesktopNotifications(enabled)
+          setAskNotifications(false)
+        }}
+      />
+    </ProjectsContext.Provider>
+  )
 }
 
 export function useProjects(): ProjectsValue {

--- a/frontend/src/providers/settings.tsx
+++ b/frontend/src/providers/settings.tsx
@@ -10,7 +10,13 @@ import {
   type Hotkeys,
 } from "@/lib/hotkeys"
 import { zoomIntent } from "@/lib/terminal/zoom-keys"
-import { parseBoolPref, parseNumberPref, readPref, writePref } from "@/lib/prefs"
+import {
+  parseBoolPref,
+  parseNumberPref,
+  parseOptionalBoolPref,
+  readPref,
+  writePref,
+} from "@/lib/prefs"
 import { Themes as ThemeRPC } from "@/lib/rpc"
 import {
   applyAppTheme,
@@ -38,6 +44,7 @@ const THEME_STORAGE_KEY = "lich.appearance.theme"
 const ZOOM_STORAGE_KEY = "lich.appearance.zoom"
 const TERMINAL_THEME_STORAGE_KEY = "lich.appearance.terminalTheme"
 const CONTEXT_USAGE_STORAGE_KEY = "lich.footer.contextUsage"
+const DESKTOP_NOTIFICATIONS_STORAGE_KEY = "lich.notifications.desktop"
 
 // DEFAULT_FONT is the bundled FiraCode Nerd Font Mono. It is not installed via
 // fontconfig, so it must be offered explicitly alongside the system fonts.
@@ -91,6 +98,12 @@ const readZoom = (): number => parseNumberPref(readPref(ZOOM_STORAGE_KEY), DEFAU
 // Default on: the footer context readout shows unless the user turned it off.
 const readContextUsage = (): boolean => parseBoolPref(readPref(CONTEXT_USAGE_STORAGE_KEY), true)
 
+// No default: a desktop notification interrupts the user outside the app, so it
+// is the one preference lich asks about instead of assuming. null means the
+// question has not been put yet — see the opt-in dialog.
+const readDesktopNotifications = (): boolean | null =>
+  parseOptionalBoolPref(readPref(DESKTOP_NOTIFICATIONS_STORAGE_KEY))
+
 interface SettingsValue {
   /** Terminal font family, applied globally across all project terminals. */
   font: string
@@ -126,6 +139,10 @@ interface SettingsValue {
   /** Whether the footer shows the active session's context-window usage. */
   showContextUsage: boolean
   setShowContextUsage: (show: boolean) => void
+  /** Whether a session needing input notifies the desktop while the lich window
+   * is unfocused. null until the user has answered the opt-in dialog. */
+  desktopNotifications: boolean | null
+  setDesktopNotifications: (enabled: boolean) => void
 }
 
 const SettingsContext = createContext<SettingsValue | null>(null)
@@ -141,6 +158,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [terminalTheme, setTerminalThemeState] = useState<TerminalTheme>(readTerminalTheme)
   const [hotkeys, setHotkeys] = useState<Hotkeys>(loadHotkeys)
   const [showContextUsage, setShowContextUsageState] = useState<boolean>(readContextUsage)
+  const [desktopNotifications, setDesktopNotificationsState] = useState<boolean | null>(
+    readDesktopNotifications,
+  )
 
   useEffect(() => {
     let cancelled = false
@@ -289,6 +309,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     writePref(CONTEXT_USAGE_STORAGE_KEY, next)
   }, [])
 
+  // Writing either answer settles the question for good: a refusal is stored,
+  // not left absent, so the dialog is put once and the toggle owns it after.
+  const setDesktopNotifications = useCallback((next: boolean) => {
+    setDesktopNotificationsState(next)
+    writePref(DESKTOP_NOTIFICATIONS_STORAGE_KEY, next)
+  }, [])
+
   // Apply the resolved theme's CSS variables and toggle `.dark` for existing
   // dark variants. For "system", follow the OS scheme and keep following it
   // live.
@@ -398,6 +425,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       resetHotkey,
       showContextUsage,
       setShowContextUsage,
+      desktopNotifications,
+      setDesktopNotifications,
     }),
     [
       font,
@@ -422,6 +451,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       resetHotkey,
       showContextUsage,
       setShowContextUsage,
+      desktopNotifications,
+      setDesktopNotifications,
     ],
   )
 

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -1,10 +1,12 @@
 // Package system holds the few OS integrations the frontend needs that are
 // not tied to any domain service — opening a URL in the user's default browser,
-// opening a work-tree file in their editor, and the handful of facts a bug
-// report needs (version, platform, where the log lives).
+// opening a work-tree file in their editor, raising a desktop notification, and
+// the handful of facts a bug report needs (version, platform, where the log
+// lives).
 package system
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os/exec"
@@ -12,6 +14,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/ncruces/zenity"
 	"github.com/omartelo/lich/internal/relpath"
 )
 
@@ -26,6 +29,9 @@ type Service struct {
 	version string
 	// run launches a detached process; injected in tests, exec in production.
 	run func(name string, args ...string) error
+	// notify posts one desktop notification; injected in tests, zenity in
+	// production (see Notify).
+	notify func(text, title string) error
 }
 
 func New(env []string, logPath, version string) *Service {
@@ -35,6 +41,9 @@ func New(env []string, logPath, version string) *Service {
 		version: version,
 		run: func(name string, args ...string) error {
 			return exec.Command(name, args...).Start()
+		},
+		notify: func(text, title string) error {
+			return zenity.Notify(text, zenity.Title(title))
 		},
 	}
 }
@@ -64,6 +73,46 @@ func (s *Service) RevealLog() error {
 		return fmt.Errorf("no log file: lich is logging to stderr only")
 	}
 	return s.openDefault(filepath.Dir(s.logPath))
+}
+
+// notifyTitle is the app name carried by every notification lich raises. macOS
+// shows it as the notification's title and Windows as the toast's source; Linux
+// ignores it, taking the text's first line as the summary — which is why the
+// text, not the title, has to carry what happened.
+const notifyTitle = "lich"
+
+// notifyLimit bounds each line of a notification, in runes. Both lines are
+// labels a user or an agent wrote (a session's name, a project's), and a
+// desktop notification is not the place to render an essay.
+const notifyLimit = 120
+
+// Notify raises a desktop notification through the OS's own notification
+// service — the one channel that still reaches the user after they leave the
+// lich window. summary is the headline, detail the second line (empty omits
+// it).
+//
+// Delivery only: the page decides when a notification is warranted, because it
+// is the side that knows whether the window has focus and which session the
+// user is looking at.
+func (s *Service) Notify(summary, detail string) error {
+	text := truncate(summary, notifyLimit)
+	if detail != "" {
+		text += "\n" + truncate(detail, notifyLimit)
+	}
+	if strings.TrimSpace(text) == "" {
+		return errors.New("refusing to raise an empty notification")
+	}
+	return s.notify(text, notifyTitle)
+}
+
+// truncate caps s at limit runes — never bytes, which would cut a multi-byte
+// character in half and hand the notifier invalid UTF-8.
+func truncate(s string, limit int) string {
+	runes := []rune(s)
+	if len(runes) <= limit {
+		return s
+	}
+	return string(runes[:limit]) + "…"
 }
 
 // OpenExternal opens an http(s) URL in the default browser. Scheme-gated so a

--- a/internal/system/system_test.go
+++ b/internal/system/system_test.go
@@ -3,6 +3,7 @@ package system
 import (
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -288,5 +289,81 @@ func TestOpenInEditorFallsBackToDefault(t *testing.T) {
 	}
 	if want := filepath.Join("/repo", "a.txt"); len(args) == 0 || args[len(args)-1] != want {
 		t.Errorf("args = %v, want file %s as last arg", args, want)
+	}
+}
+
+// captureNotify records the one notification a test raises.
+func captureNotify(text, title *string) func(string, string) error {
+	return func(gotText, gotTitle string) error {
+		*text, *title = gotText, gotTitle
+		return nil
+	}
+}
+
+// TestNotifyBuildsTwoLineText proves the detail becomes the text's second line
+// rather than a separate field: Linux takes the first line as the summary, so
+// the split has to live in the text itself.
+func TestNotifyBuildsTwoLineText(t *testing.T) {
+	var text, title string
+	s := &Service{notify: captureNotify(&text, &title)}
+
+	if err := s.Notify("api needs your input", "lich"); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if want := "api needs your input\nlich"; text != want {
+		t.Errorf("text = %q, want %q", text, want)
+	}
+	if title != "lich" {
+		t.Errorf("title = %q, want lich", title)
+	}
+
+	if err := s.Notify("api needs your input", ""); err != nil {
+		t.Fatalf("Notify without detail: %v", err)
+	}
+	if strings.Contains(text, "\n") {
+		t.Errorf("text = %q, want no second line when detail is empty", text)
+	}
+}
+
+// TestNotifyTruncatesEachLine pins the 120-rune cap on both lines, counted in
+// runes: a byte cap would split a multi-byte character and hand the notifier
+// invalid UTF-8.
+func TestNotifyTruncatesEachLine(t *testing.T) {
+	var text, title string
+	s := &Service{notify: captureNotify(&text, &title)}
+
+	exact := strings.Repeat("é", 120)
+	if err := s.Notify(exact, exact); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if text != exact+"\n"+exact {
+		t.Errorf("120 runes were altered: %q", text)
+	}
+
+	over := strings.Repeat("é", 121)
+	if err := s.Notify(over, over); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	want := exact + "…\n" + exact + "…"
+	if text != want {
+		t.Errorf("text = %q, want each line cut to 120 runes plus an ellipsis", text)
+	}
+}
+
+// TestNotifyRejectsEmpty proves a blank notification never reaches the desktop:
+// a card with no label must not raise an empty popup.
+func TestNotifyRejectsEmpty(t *testing.T) {
+	raised := false
+	s := &Service{notify: func(string, string) error {
+		raised = true
+		return nil
+	}}
+	for _, summary := range []string{"", "   ", "\n"} {
+		if err := s.Notify(summary, ""); err == nil {
+			t.Errorf("summary %q: want error", summary)
+		}
+	}
+	if raised {
+		t.Error("an empty notification reached the desktop")
 	}
 }


### PR DESCRIPTION
## Why

The card's bell and the toast only ever reached someone who was looking at lich. Leave the window for a browser and a session blocked on a permission prompt sits there until you happen to come back — the one case where you had walked away and most needed telling.

## What

A `waiting` report now also raises a desktop notification through the OS's own notifier — `zenity.Notify`, a dependency the project already carries, so Linux, macOS and Windows are covered without per-OS code of our own.

- **It answers to window focus, not to the toast's rule.** With lich behind something else every waiting session is unseen, the active one included, so `shouldToastAttention`'s exclusion of the focused session does not apply. The two channels are independent: a report can raise both, either, or neither.
- **The page decides, the backend delivers.** Focus is a fact only the page holds; `system.Notify` takes a headline and a second line, caps each at 120 runes and refuses an empty one.
- **One-time opt-in, put in context.** The first report that would have notified opens the dialog instead — the question lands with the event that motivates it, not as a modal at launch. The preference is tri-state (`parseOptionalBoolPref`) so a refusal and an unanswered question stay apart, and **Settings › Notifications** owns the switch either way.

## Ceiling

The notification is not clickable, which is why its text names the session and the project. Making it actionable is per-OS and none of it is cheap: Linux needs `notify-send --wait --action` holding a process per notification, macOS a signed `.app` bundle with `UNUserNotificationCenter`, Windows a registered AppUserModelID with a COM activation handler. Recorded in `docs/hooks/session-state.md`.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test ./...` green — 3 new cases on `Notify` (two-line text, the rune cap pinned at 120, empty refused)
- [x] `pnpm check`, `pnpm test` (656) and `pnpm build` green — 4 new cases on `decideDesktopNotice`, 3 on `parseOptionalBoolPref`
- [x] Cross-compile loop for linux/darwin/windows: build and vet clean
- [x] A real notification fired through the production path on Linux (GNOME), text and formatting confirmed by hand
- [x] macOS and Windows: `ci:os` runs the backend suite; the notifier itself is unverified there — no hardware