### PR TITLE
feat: notify the desktop when a session finishes working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a dialog puts the question, and either answer settles it. **Settings ›
   Notifications** holds the switch afterwards, whichever way you answered.
 
+- **And so does a session that finished working.** The other half of walking
+  away: a run you left going ends, says nothing, and you find out whenever you
+  next look. A second switch under **Settings › Notifications** raises a desktop
+  notification when a session ends its turn with nothing left to ask you — same
+  rule as the one above, so it only fires while the lich window is not the one
+  you are in. It is off until you turn it on, including if you already said yes
+  to the question above: the two are separate, because a long run finishing and a
+  session blocked on you are not equally worth an interruption. Nothing changes
+  inside lich — no new toast; the card and its project tab still do the telling.
+
 - **A worktree's setup script can now find the project it came from.** Sessions get
   `$LICH_PROJECT_DIR`, the project's own checkout — which, for a session running in a
   worktree, is somewhere else entirely and previously had no name the script could

--- a/frontend/src/components/settings/NotificationsSettings.tsx
+++ b/frontend/src/components/settings/NotificationsSettings.tsx
@@ -2,22 +2,41 @@ import { SettingBlock } from "./SettingBlock"
 import { Switch } from "@/components/ui/switch"
 import { useSettings } from "@/providers/settings"
 
-// The one setting that reaches outside the app window. An unanswered opt-in
-// (null) reads as off here: until the user says yes, nothing notifies — and
-// turning it on from this switch is itself an answer, so the dialog never
-// appears afterwards.
+// The two settings that reach outside the app window, one per reason to
+// interrupt. An unanswered opt-in (null) reads as off for the first: until the
+// user says yes, nothing notifies — and turning it on from this switch is itself
+// an answer, so the dialog never appears afterwards. The second is never asked
+// about at all; it is off until it is turned on here.
 export function NotificationsSettings() {
-  const { desktopNotifications, setDesktopNotifications } = useSettings()
+  const {
+    desktopNotifications,
+    setDesktopNotifications,
+    finishedTurnNotifications,
+    setFinishedTurnNotifications,
+  } = useSettings()
   return (
-    <SettingBlock
-      title="Notify me when a session needs input"
-      description="Raise a desktop notification when a session is blocked on you — a permission prompt, a question — and the lich window is not the one you are in. While you are in lich nothing changes: the card's bell and the toast do the telling."
-    >
-      <Switch
-        checked={desktopNotifications === true}
-        onCheckedChange={setDesktopNotifications}
-        aria-label="Raise a desktop notification when a session needs input"
-      />
-    </SettingBlock>
+    <>
+      <SettingBlock
+        title="Notify me when a session needs input"
+        description="Raise a desktop notification when a session is blocked on you — a permission prompt, a question — and the lich window is not the one you are in. While you are in lich nothing changes: the card's bell and the toast do the telling."
+      >
+        <Switch
+          checked={desktopNotifications === true}
+          onCheckedChange={setDesktopNotifications}
+          aria-label="Raise a desktop notification when a session needs input"
+        />
+      </SettingBlock>
+
+      <SettingBlock
+        title="Notify me when a session finishes working"
+        description="Raise a desktop notification when a session ends its turn with nothing left to ask you, and the lich window is not the one you are in. Independent of the setting above — a long run you walked away from is worth knowing about even if you would rather not hear about every prompt. No toast comes with it: inside lich, the card and its project tab already say so."
+      >
+        <Switch
+          checked={finishedTurnNotifications}
+          onCheckedChange={setFinishedTurnNotifications}
+          aria-label="Raise a desktop notification when a session finishes working"
+        />
+      </SettingBlock>
+    </>
   )
 }

--- a/frontend/src/lib/session/session-events.test.ts
+++ b/frontend/src/lib/session/session-events.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   decideDesktopNotice,
+  decideStatusNotice,
   isAgentEvent,
   isCwdEvent,
   isIdEvent,
@@ -198,5 +199,62 @@ describe("decideDesktopNotice", () => {
 
   it("keeps quiet for a refusal instead of asking again", () => {
     expect(decideDesktopNotice(false, false)).toBe("none")
+  })
+})
+
+describe("decideStatusNotice", () => {
+  const BOTH_ON = { attention: true, finishedTurn: true }
+  const BOTH_OFF = { attention: false, finishedTurn: false }
+  const FRESH = null // no previous status: nothing to collapse against
+
+  it("stays out of the way while the user is at the window", () => {
+    expect(decideStatusNotice("waiting", FRESH, true, BOTH_ON)).toBe("none")
+    expect(decideStatusNotice("done", FRESH, true, BOTH_ON)).toBe("none")
+  })
+
+  it("notifies for each channel the user turned on", () => {
+    expect(decideStatusNotice("waiting", FRESH, false, BOTH_ON)).toBe("notify")
+    expect(decideStatusNotice("done", "busy", false, BOTH_ON)).toBe("notify")
+  })
+
+  it("stays silent for each channel the user left off", () => {
+    expect(decideStatusNotice("waiting", FRESH, false, BOTH_OFF)).toBe("none")
+    expect(decideStatusNotice("done", "busy", false, BOTH_OFF)).toBe("none")
+  })
+
+  // The switches are independent: neither channel rides the other's answer.
+  it("keeps the two channels apart", () => {
+    const onlyAttention = { attention: true, finishedTurn: false }
+    expect(decideStatusNotice("waiting", FRESH, false, onlyAttention)).toBe("notify")
+    expect(decideStatusNotice("done", "busy", false, onlyAttention)).toBe("none")
+
+    const onlyFinished = { attention: false, finishedTurn: true }
+    expect(decideStatusNotice("waiting", FRESH, false, onlyFinished)).toBe("none")
+    expect(decideStatusNotice("done", "busy", false, onlyFinished)).toBe("notify")
+  })
+
+  it("says nothing about a session that is merely running", () => {
+    expect(decideStatusNotice("busy", "waiting", false, BOTH_ON)).toBe("none")
+    expect(decideStatusNotice(null, "busy", false, BOTH_ON)).toBe("none")
+  })
+
+  // The dialog belongs to the blocked-on-you channel alone: a finished turn with
+  // the opt-in unanswered must not put a question the user never asked for.
+  it("only ever puts the question for a blocked session", () => {
+    const unanswered = { attention: null, finishedTurn: true }
+    expect(decideStatusNotice("waiting", FRESH, false, unanswered)).toBe("ask")
+    expect(decideStatusNotice("done", "busy", false, unanswered)).toBe("notify")
+  })
+
+  it("does not notify twice for the same finished turn", () => {
+    expect(decideStatusNotice("done", "done", false, BOTH_ON)).toBe("none")
+    // A turn that ran again is a new one, so it announces itself again.
+    expect(decideStatusNotice("done", "busy", false, BOTH_ON)).toBe("notify")
+  })
+
+  // The toast's contract, which the desktop channel shares: a second prompt is
+  // a second thing to answer, so a repeat "waiting" is not collapsed.
+  it("notifies again for a repeated waiting report", () => {
+    expect(decideStatusNotice("waiting", "waiting", false, BOTH_ON)).toBe("notify")
   })
 })

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -163,3 +163,39 @@ export function decideDesktopNotice(
   }
   return enabled ? "notify" : "none"
 }
+
+/** The two desktop channels' opt-ins, as decideStatusNotice reads them. */
+export interface DesktopNotifyPrefs {
+  /** A session blocked on the user — the channel the opt-in dialog asks about,
+   * hence null while it has not been answered. */
+  attention: boolean | null
+  /** A turn that finished. A plain switch in Settings, off until it is turned
+   * on: never inherited from the answer given to the dialog above. */
+  finishedTurn: boolean
+}
+
+// decideStatusNotice routes a status report to the desktop channel that owns it.
+// Each channel has its own opt-in and both answer to the same focus rule, so
+// both go through decideDesktopNotice. Only "waiting" can come back "ask": the
+// finished-turn preference is a boolean, so turning it on is itself the answer
+// and there is no second question to put.
+//
+// A "done" repeated with no run in between is dropped: it is the same finished
+// turn reported again, not a new one to announce. That collapse lives here, off
+// the caller's previous status, rather than in the status store the toast path
+// deliberately bypasses — "waiting" must keep notifying on every report, because
+// a second permission prompt is a second thing to answer.
+export function decideStatusNotice(
+  status: SessionStatus | null,
+  previous: SessionStatus | null,
+  windowFocused: boolean,
+  prefs: DesktopNotifyPrefs,
+): DesktopNotice {
+  if (status === "waiting") {
+    return decideDesktopNotice(windowFocused, prefs.attention)
+  }
+  if (status === "done" && previous !== "done") {
+    return decideDesktopNotice(windowFocused, prefs.finishedTurn)
+  }
+  return "none"
+}

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -28,7 +28,7 @@ import { applyOrder, pinFirst } from "@/lib/reorder"
 import { displayPath } from "@/lib/paths"
 import { defaultProviderKind } from "@/lib/providers-store"
 import {
-  decideDesktopNotice,
+  decideStatusNotice,
   isIdEvent,
   isStatusEvent,
   isTitleEvent,
@@ -37,6 +37,7 @@ import {
   TITLE_EVENT,
   toSessionStatus,
   TOUCHED_EVENT,
+  type SessionStatus,
 } from "@/lib/session/session-events"
 import { NotificationsOptIn } from "@/components/NotificationsOptIn"
 import { refreshGitStatus } from "@/lib/git/use-git-status"
@@ -150,11 +151,18 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
   // event subscription without re-subscribing on every navigation.
   const activeProjectIdRef = useRef(activeProjectId)
   activeProjectIdRef.current = activeProjectId
-  const { hotkeys, desktopNotifications, setDesktopNotifications } = useSettings()
+  const { hotkeys, desktopNotifications, setDesktopNotifications, finishedTurnNotifications } =
+    useSettings()
   // Read inside the same once-only subscription, for the same reason as the
   // active project: a preference change must not tear down the status listener.
   const desktopNotificationsRef = useRef(desktopNotifications)
   desktopNotificationsRef.current = desktopNotifications
+  const finishedTurnNotificationsRef = useRef(finishedTurnNotifications)
+  finishedTurnNotificationsRef.current = finishedTurnNotifications
+  // The status each session last reported, which decideStatusNotice reads to
+  // drop a finished turn repeated with nothing run in between. A closed session
+  // leaves its entry behind; one string per session id is not worth a sweep.
+  const lastStatusRef = useRef(new Map<string, SessionStatus | null>())
   // Whether the opt-in dialog is up. Raised by the first report that would have
   // notified, never at launch — the question lands with the event that motivates
   // it. Dismissing without an answer leaves the preference unset, so the next
@@ -402,30 +410,45 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
   // for a second waiting report. One toast per report is the contract here.
   useEffect(() => {
     const off = onAppEvent(STATUS_EVENT, (data) => {
-      if (!isStatusEvent(data) || toSessionStatus(data.state) !== "waiting") {
+      if (!isStatusEvent(data)) {
         return
       }
       const { id } = data
+      const status = toSessionStatus(data.state)
+      const previous = lastStatusRef.current.get(id) ?? null
+      lastStatusRef.current.set(id, status)
+
       const projectId = projectOfSession(sessionsRef.current, id)
       const project = sessionsRef.current[projectId]
+      // A session whose project is closed — or whose own row is gone, which
+      // leaves projectOfSession with nothing to answer — has nowhere to route.
       if (!project) {
         return
       }
       const label = project.sessions.find((s) => s.id === id)?.label ?? UNLABELED_SESSION
       const projectName = projectsRef.current.find((p) => p.id === projectId)?.name
 
-      // The desktop channel answers to window focus, decided by
-      // decideDesktopNotice; the toast below keeps its own, unchanged rule. The
-      // two are independent: a report can raise both, either, or neither.
-      const notice = decideDesktopNotice(document.hasFocus(), desktopNotificationsRef.current)
+      // The desktop channel answers to window focus and to its own per-status
+      // preference, both decided by decideStatusNotice; the toast below keeps
+      // its own, unchanged rule. The two are independent: a report can raise
+      // both, either, or neither.
+      const notice = decideStatusNotice(status, previous, document.hasFocus(), {
+        attention: desktopNotificationsRef.current,
+        finishedTurn: finishedTurnNotificationsRef.current,
+      })
       if (notice === "ask") {
         setAskNotifications(true)
       } else if (notice === "notify") {
+        const summary =
+          status === "waiting" ? `${label} needs your input` : `${label} has finished working`
         // A failure is the backend's to log; the page has nothing to do with it.
-        System.Notify(`${label} needs your input`, projectName ?? "").catch(() => {})
+        System.Notify(summary, projectName ?? "").catch(() => {})
       }
 
-      if (!shouldToastAttention(sessionsRef.current, id, activeProjectIdRef.current)) {
+      if (
+        status !== "waiting" ||
+        !shouldToastAttention(sessionsRef.current, id, activeProjectIdRef.current)
+      ) {
         return
       }
       toast(

--- a/frontend/src/providers/settings.tsx
+++ b/frontend/src/providers/settings.tsx
@@ -46,6 +46,7 @@ const TERMINAL_THEME_STORAGE_KEY = "lich.appearance.terminalTheme"
 const CONTEXT_USAGE_STORAGE_KEY = "lich.footer.contextUsage"
 const COST_BUDGET_STORAGE_KEY = "lich.footer.costBudget"
 const DESKTOP_NOTIFICATIONS_STORAGE_KEY = "lich.notifications.desktop"
+const FINISHED_TURN_NOTIFICATIONS_STORAGE_KEY = "lich.notifications.finishedTurn"
 
 // DEFAULT_FONT is the bundled FiraCode Nerd Font Mono. It is not installed via
 // fontconfig, so it must be offered explicitly alongside the system fonts.
@@ -122,6 +123,13 @@ const readCostBudget = (): number =>
 const readDesktopNotifications = (): boolean | null =>
   parseOptionalBoolPref(readPref(DESKTOP_NOTIFICATIONS_STORAGE_KEY))
 
+// Off, and its own key: a finished turn is a weaker reason to interrupt someone
+// than a session blocked on them, so an install that already answered the opt-in
+// above never inherits it. Turning this on is an explicit act, hence a plain
+// flag with no undecided state — the dialog is not put for this channel.
+const readFinishedTurnNotifications = (): boolean =>
+  parseBoolPref(readPref(FINISHED_TURN_NOTIFICATIONS_STORAGE_KEY), false)
+
 interface SettingsValue {
   /** Terminal font family, applied globally across all project terminals. */
   font: string
@@ -164,6 +172,11 @@ interface SettingsValue {
    * is unfocused. null until the user has answered the opt-in dialog. */
   desktopNotifications: boolean | null
   setDesktopNotifications: (enabled: boolean) => void
+  /** Whether a session that finished its turn notifies the desktop while the
+   * lich window is unfocused. Independent of the opt-in above, and off until
+   * the user turns it on. */
+  finishedTurnNotifications: boolean
+  setFinishedTurnNotifications: (enabled: boolean) => void
 }
 
 const SettingsContext = createContext<SettingsValue | null>(null)
@@ -182,6 +195,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [costBudget, setCostBudgetState] = useState<number>(readCostBudget)
   const [desktopNotifications, setDesktopNotificationsState] = useState<boolean | null>(
     readDesktopNotifications,
+  )
+  const [finishedTurnNotifications, setFinishedTurnNotificationsState] = useState<boolean>(
+    readFinishedTurnNotifications,
   )
 
   useEffect(() => {
@@ -344,6 +360,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     writePref(DESKTOP_NOTIFICATIONS_STORAGE_KEY, next)
   }, [])
 
+  const setFinishedTurnNotifications = useCallback((next: boolean) => {
+    setFinishedTurnNotificationsState(next)
+    writePref(FINISHED_TURN_NOTIFICATIONS_STORAGE_KEY, next)
+  }, [])
+
   // Apply the resolved theme's CSS variables and toggle `.dark` for existing
   // dark variants. For "system", follow the OS scheme and keep following it
   // live.
@@ -457,6 +478,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setCostBudget,
       desktopNotifications,
       setDesktopNotifications,
+      finishedTurnNotifications,
+      setFinishedTurnNotifications,
     }),
     [
       font,
@@ -485,6 +508,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setCostBudget,
       desktopNotifications,
       setDesktopNotifications,
+      finishedTurnNotifications,
+      setFinishedTurnNotifications,
     ],
   )
 


### PR DESCRIPTION
The desktop channel shipped in #182 only carries a session blocked on you. The other half of walking away is a run you left going: it ends, says nothing, and you find out whenever you next look.

## What this adds

- **A second, independent preference** — `lich.notifications.finishedTurn`, beside the existing `lich.notifications.desktop`, read with the same `readPref`/`writePref` pattern. Off by default, **including for installs that already answered the opt-in dialog**: a long run finishing and a session blocked on you are not equally worth an interruption, so turning this on is an explicit act and never inherited.
- **A switch in Settings › Notifications**, next to the existing one. No second dialog: a user who has never answered the opt-in still gets the question from a waiting session, exactly as today.
- **The same focus rule for both channels.** `decideStatusNotice(status, previous, windowFocused, prefs)` routes a report to the preference that owns it and delegates to `decideDesktopNotice`, which is untouched and keeps its tests. Passing a plain `boolean` for the finished-turn opt-in is what keeps `"ask"` reachable from `"waiting"` alone.
- **Its own headline**: `<label> has finished working`, project name on the second line — the wording shape the blocked-on-you notification already uses.
- **The in-app toast is unchanged.** A finished turn raises no toast; inside lich the card and its project tab already say so.

## Edge cases

- **A repeat `"done"` does not notify twice.** The collapse lives in the pure function, off a previous status the provider keeps per session — not in the status store. The notify path deliberately reads the raw event, because a repeat `"waiting"` is a second prompt to answer and has to keep notifying; only `"done"` repeated with nothing run in between is the same turn reported again. The reason is a comment at both ends.
- **A session with nowhere to route stays silent.** `projectOfSession` answers `""` for a session no project holds, so a closed project and a deleted row hit the same existing guard before either channel fires.

The Go side is untouched — `system.Notify` already does the work.

## Test plan

- [x] `vitest run` — 698 passing, including the new `decideStatusNotice` matrix: on/off × focused/unfocused × waiting/done/busy, the unanswered opt-in, the two channels staying independent, and the repeat-`done` / repeat-`waiting` split.
- [x] `biome check` clean, `tsc --noEmit` clean, `vite build` succeeds.
- [ ] Smoke in `task dev`: the gate is node-only, so the two-block Settings section wants one look by hand.