### PR TITLE
chore: cut v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-08-09
+
 ### Added
 
 - **A Codex session resumes, and wears its own icon.** The companion plugin now
@@ -115,6 +117,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stacked on another feature branch is measured against the wrong one. The
   readout is absent entirely on a repository with no `origin`.
 
+- **lich asks which agents you use, instead of assuming Claude Code.** The first
+  launch opened on a Claude session because Claude was the only harness lich's
+  author ran: a machine with Codex and nothing else met a first session that died
+  on `claude: command not found`, and the three other harnesses lich supports were
+  off in a Settings screen nobody had been told about. lich now scans for agents
+  before showing anything and opens on the providers it found — a list of what is
+  actually installed, a switch each, and the pick of which one new sessions spawn.
+  The first one found is on already, so the common case is one click, and the
+  panel is the Settings › Providers screen verbatim, so the place to change it
+  later is a screen already met. Nothing installed is its own answer: lich names
+  what it looks for rather than failing inside a terminal. Existing installs that
+  never chose a default see it once.
+
+- **oh-my-pi joins the harnesses lich can run.** A Pi fork with an IDE wired in,
+  spawned like the rest from its `omp` binary and off until turned on.
+
+- **Switch sessions from the keyboard.** Reaching another session without the
+  mouse meant opening the command palette and typing its name. **Ctrl+Shift+↓**
+  and **Ctrl+Shift+↑** now step to the next and previous session of the project
+  you are in, wrapping around at both ends and walking the sidebar exactly as it
+  is drawn — pinned cards first, worktree groups in the order the dividers show.
+  Both fire while you are typing in a terminal, and both are rebindable in
+  Settings › Hotkeys like the shortcuts already there.
+
 ### Changed
 
 - **A worktree's dev-server port is now reserved, not guessed.** `LICH_WORKTREE_PORT`
@@ -146,30 +172,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   header, and the divider stopped telling you which sessions were whose. The
   header now reads the name the worktree was created with, slashes and all. A
   worktree without a slash in it looks exactly as it did.
-
-- **lich asks which agents you use, instead of assuming Claude Code.** The first
-  launch opened on a Claude session because Claude was the only harness lich's
-  author ran: a machine with Codex and nothing else met a first session that died
-  on `claude: command not found`, and the three other harnesses lich supports were
-  off in a Settings screen nobody had been told about. lich now scans for agents
-  before showing anything and opens on the providers it found — a list of what is
-  actually installed, a switch each, and the pick of which one new sessions spawn.
-  The first one found is on already, so the common case is one click, and the
-  panel is the Settings › Providers screen verbatim, so the place to change it
-  later is a screen already met. Nothing installed is its own answer: lich names
-  what it looks for rather than failing inside a terminal. Existing installs that
-  never chose a default see it once.
-
-- **oh-my-pi joins the harnesses lich can run.** A Pi fork with an IDE wired in,
-  spawned like the rest from its `omp` binary and off until turned on.
-
-- **Switch sessions from the keyboard.** Reaching another session without the
-  mouse meant opening the command palette and typing its name. **Ctrl+Shift+↓**
-  and **Ctrl+Shift+↑** now step to the next and previous session of the project
-  you are in, wrapping around at both ends and walking the sidebar exactly as it
-  is drawn — pinned cards first, worktree groups in the order the dividers show.
-  Both fire while you are typing in a terminal, and both are rebindable in
-  Settings › Hotkeys like the shortcuts already there.
 
 ## [0.27.0] - 2026-08-07
 
@@ -1684,7 +1686,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.27.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.28.0...HEAD
+[0.28.0]: https://github.com/omartelo/lich/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/omartelo/lich/compare/v0.26.1...v0.27.0
 [0.26.1]: https://github.com/omartelo/lich/compare/v0.26.0...v0.26.1
 [0.26.0]: https://github.com/omartelo/lich/compare/v0.25.0...v0.26.0

--- a/README.md
+++ b/README.md
@@ -42,9 +42,10 @@ version is in [CHANGELOG.md](CHANGELOG.md).
 
 - **Bring your own agent.** [Claude Code](https://www.anthropic.com/claude-code)
   (Anthropic), [Codex](https://github.com/openai/codex) (OpenAI),
-  [opencode](https://github.com/sst/opencode) (SST) and
+  [opencode](https://github.com/sst/opencode) (SST), oh-my-pi and
   [Crush](https://github.com/charmbracelet/crush) (Charm) are all first-class:
-  point lich at each binary in Settings, pick the default, or choose per session.
+  the first launch asks which of them you have, then point lich at each binary in
+  Settings, pick the default, or choose per session.
 - **Terminal-first sessions.** Real PTY-backed shells, several per project,
   rendered by xterm.js on the GPU (WebGL). Search the scrollback (`Ctrl+F`); the
   buffer survives a full page reload. A Warp-style footer follows `cd` and
@@ -87,8 +88,11 @@ version is in [CHANGELOG.md](CHANGELOG.md).
   **Save template** writes a starter naming every supported color. Format and
   repository layout: [`docs/themes.md`](docs/themes.md).
 - **The rest of the window.** `Ctrl`/`Cmd`+`K` jumps between sessions and
-  projects. A session waiting on your input raises a toast and a dot on the bell,
-  collected in a titled dropdown; with the
+  projects — by name, or by what was said in the conversation; `Ctrl+Shift+↓`/`↑`
+  steps between them without the palette. A session waiting on your input raises
+  a toast and a dot on the bell, collected in a titled dropdown, and — if you let
+  it — a desktop notification when the lich window is not the one you are in;
+  with the
   [lich plugin](https://github.com/omartelo/lich-plugin) installed — in Claude
   Code, in Codex, or in both — a session also titles its own card and refreshes
   git the moment it writes a file.
@@ -131,8 +135,9 @@ hand.
 1. **Install** and launch `lich`.
 2. **Open a project** — the `+` in the tab strip lists what you closed recently
    and opens your OS folder picker; point it at a git repository.
-3. **Point lich at your agent** — in Settings › Providers, set the binary path
-   for Claude Code, Codex, opencode or Crush, and choose a default.
+3. **Point lich at your agent** — the first launch lists the agents it found on
+   your machine; in Settings › Providers you can set each binary path and change
+   which one new sessions default to.
 4. **Start a session** — *New Session* spawns a terminal running your agent in
    the project.
 5. **Branch off a worktree** *(optional)* — create one from any base branch;

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -40,9 +40,10 @@
 
 - **自带智能体。** [Claude Code](https://www.anthropic.com/claude-code)（Anthropic）、
   [Codex](https://github.com/openai/codex)（OpenAI）、
-  [opencode](https://github.com/sst/opencode)（SST）和
-  [Crush](https://github.com/charmbracelet/crush)（Charm）都是一等公民：在设置里把
-  lich 指向各自的二进制文件，选一个默认的，或者逐个会话单独指定。
+  [opencode](https://github.com/sst/opencode)（SST）、oh-my-pi 和
+  [Crush](https://github.com/charmbracelet/crush)（Charm）都是一等公民：首次启动会
+  问你装了其中哪几个，之后可以在设置里把 lich 指向各自的二进制文件，选一个默认的，
+  或者逐个会话单独指定。
 - **终端优先的会话。** 真正由 PTY 支撑的 shell，每个项目可以开好几个，由 xterm.js 在
   GPU 上（WebGL）渲染。可以搜索滚动缓冲区（`Ctrl+F`）；缓冲区能挺过整页刷新。Warp 风格
   的底栏跟随 `cd` 并显示 git 状态；对于 Claude 会话，它还会标明模型、用一个圆环填充已
@@ -75,11 +76,13 @@
   重新上色。从一个 git 仓库安装一套主题包，等它发布新版本时就地更新；**Save template**
   会写出一份列明所有受支持颜色的模板。格式与仓库布局见
   [`docs/themes.md`](docs/themes.md)。
-- **窗口里的其余部分。** `Ctrl`/`Cmd`+`K` 在会话与项目之间跳转。某个会话在等你输入时会
-  弹出一个 toast，并在铃铛上点亮一个小圆点，统一收进带标题的下拉列表；装上
-  [lich 插件](https://github.com/omartelo/lich-plugin)之后，Claude 会话还会给自己的卡片
-  起标题，并在它写入文件的那一刻刷新 git。设置 › 帮助可以打开日志文件夹和一份预填好的
-  bug 报告。
+- **窗口里的其余部分。** `Ctrl`/`Cmd`+`K` 在会话与项目之间跳转 —— 既可以按名字，也可以
+  按对话里说过的内容；`Ctrl+Shift+↓`/`↑` 则不经过命令面板直接切换。某个会话在等你输入时会
+  弹出一个 toast，并在铃铛上点亮一个小圆点，统一收进带标题的下拉列表；如果你允许，在 lich
+  窗口不是当前窗口时还会发一条桌面通知。装上
+  [lich 插件](https://github.com/omartelo/lich-plugin)之后（Claude Code、Codex 或两者都装），
+  会话还会给自己的卡片起标题，并在它写入文件的那一刻刷新 git。设置 › 帮助可以打开日志文件夹
+  和一份预填好的 bug 报告。
 
 <div align="center">
   <img src="docs/media/pulls-list.png" alt="Pull Request 列表：每个开启的 Pull Request 及其作者、时长和检查状态，由筛选框收窄" width="900" />
@@ -116,8 +119,8 @@ Homebrew 安装可以绕开 Gatekeeper 的提示；从 Releases 页面下载的�
 1. **安装**并启动 `lich`。
 2. **打开一个项目** —— 标签栏里的 `+` 会列出你最近关掉的项目，也能调起系统的文件夹
    选择器；指向一个 git 仓库即可。
-3. **把 lich 指向你的智能体** —— 在设置 › Providers 里，为 Claude Code、Codex、
-   opencode 或 Crush 设置二进制文件路径，并选一个默认的。
+3. **把 lich 指向你的智能体** —— 首次启动会列出在你机器上找到的智能体；之后可以在
+   设置 › Providers 里设置各自的二进制文件路径，并改掉新会话默认用哪一个。
 4. **开一个会话** —— *New Session* 会在项目里启动一个跑着你的智能体的终端。
 5. **分出一个 worktree**（可选）—— 从任意基础分支创建一个；lich 会为它播种文件，并把你
    带进一个新的会话。


### PR DESCRIPTION
Release chore for v0.28.0, plus the doc drift the validation turned up.

## CHANGELOG

Thirteen pull requests landed since v0.27.0 and every one has an entry, but three of them are features filed under `### Fixed`: the first-launch provider prompt (#190), oh-my-pi, and keyboard session switching (#191). They move to `### Added`. The `[Unreleased]` block then moves under a `## [0.28.0] - 2026-08-09` heading and the compare links follow.

## README

Both translations had drifted from the app:

- The first-class agent list named four; the registry holds five (`internal/providers/providers.go`). oh-my-pi is named without a link — there is no upstream URL anywhere in the tree and a guessed one is worse than none.
- Getting started still sent you to Settings to type a binary path; the first launch now detects what is installed and asks.
- The window bullet knew nothing of desktop notifications, transcript search in the palette, or `Ctrl+Shift+↓`/`↑`.
- The Chinese README still said only a Claude session titles its own card with the plugin installed. Codex does too.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test -race ./...` — 884 tests, 25 packages
- [x] `biome check`, `vitest run` — 727 tests, `tsc --noEmit`, `vite build`
- [ ] Tag `v0.28.0` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SM3oLftZ8KMjqbTGuyNAJH