### PR TITLE
docs(hooks): pin every hook contract with wire fixtures

### DIFF
--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -21,6 +21,12 @@ This directory is the **canonical, contract-first source** for those hooks:
 
 Define the contract here first, then implement both sides against it.
 
+Prose alone could not hold that line across two repositories — a renamed field
+went red in neither. [`fixtures/`](fixtures/) is every contract as bytes, one
+case per line, and both sides assert against the same lines: lich in
+`internal/terminal/fixtures_test.go`, the plugin in its own suite. A payload
+that moves now fails on whichever side moved first.
+
 ## Shared transport
 
 Every hook rides the same loopback channel lich already runs for terminal I/O
@@ -57,15 +63,20 @@ project's own setup script and commands (`PORT=$LICH_WORKTREE_PORT pnpm dev`,
   release — no lich release needed.
 - A change **to** a contract (new endpoint, field, or accepted value) is a
   breaking change: ship the lich server side first, then the plugin. Keep the
-  two in lockstep.
+  two in lockstep. The order runs through the fixtures: the prose here moves,
+  then [`fixtures/`](fixtures/), then lich's endpoint, then the plugin.
 
 ## Adding a new hook
 
 1. Write its contract in this directory (transport is already shared; document
    the endpoint, payload, accepted values, and event→action mapping).
-2. Implement the lich server side (endpoint handler + however the data reaches
+2. Add its [`fixtures/`](fixtures/) file — the payloads it accepts and the ones
+   it refuses — and register it in `hookContracts`
+   (`internal/terminal/fixtures_test.go`). A contract with no fixture file fails
+   that test, so this step is not optional.
+3. Implement the lich server side (endpoint handler + however the data reaches
    the UI) with tests.
-3. In the plugin, add the hook script and point its doc at the contract here —
+4. In the plugin, add the hook script and point its doc at the contract here —
    the contract is the single source of truth.
 
 ## Contracts
@@ -78,3 +89,6 @@ project's own setup script and commands (`PORT=$LICH_WORKTREE_PORT pnpm dev`,
   applied as the session card's label.
 - [session-touched.md](session-touched.md) — a session changed files, so its
   git status refreshes immediately instead of on the next poll.
+
+Each has a fixture file of the same name in [`fixtures/`](fixtures/); the format
+is documented there.

--- a/docs/hooks/fixtures/README.md
+++ b/docs/hooks/fixtures/README.md
@@ -1,0 +1,72 @@
+# Hook contract fixtures
+
+The contracts in the parent directory are prose; these are the same contracts as
+**bytes**. One file per contract, one case per line, each naming a payload and
+what lich does with it.
+
+They exist because the two sides of every hook live in different repositories:
+lich owns the server side, the plugin ([`omartelo/lich-plugin`](https://github.com/omartelo/lich-plugin))
+owns the scripts that build the payloads. A field renamed on one side used to
+break the other silently — nothing in either repo's tests would go red. Both
+sides asserting against the same lines turns that into a failing test on
+whichever side moved first.
+
+## Files
+
+| Fixture                | Contract                                     | Endpoint           |
+|------------------------|----------------------------------------------|--------------------|
+| `session-state.jsonl`  | [session-state.md](../session-state.md)      | `/hook`            |
+| `session-start.jsonl`  | [session-start.md](../session-start.md)      | `/session-start`   |
+| `session-title.jsonl`  | [session-title.md](../session-title.md)      | `/session-title`   |
+| `session-touched.jsonl`| [session-touched.md](../session-touched.md)  | `/session-touched` |
+
+The file is named after the contract, not the endpoint — `/hook` predates the
+naming and keeps its path for the plugin releases already pointing at it.
+
+## Case format
+
+One JSON object per line:
+
+| Field    | Meaning                                                              |
+|----------|----------------------------------------------------------------------|
+| `name`   | What the case is. Unique within its file; used as the subtest name.  |
+| `body`   | The request body, as JSON. Exactly what a client POSTs.              |
+| `raw`    | The request body as a **string**, for bodies that are not valid JSON. |
+| `accept` | lich accepts it (`204`). The field values it holds *after* parsing.   |
+| `reject` | lich rejects it (`400`). Why, in prose.                              |
+
+Every line carries exactly one of `body` / `raw`, and exactly one of `accept` /
+`reject`.
+
+`accept` is the payload **normalized**, not echoed: it is what the contract's
+defaulting and trimming produce, so it is where `provider` defaults to `claude`
+and a title loses its surrounding whitespace. It lists only the fields a case is
+about — a field absent from `accept` is not asserted, which is how the
+deprecated `claude_session_id` stays out of the expectations while still being
+exercised by the payloads that send it.
+
+`reject` prose is documentation, not a matcher. lich's error strings are its own
+and change freely; what the fixture fixes is *that* the payload is refused.
+
+## Using them
+
+- **lich (server side)** — `internal/terminal/fixtures_test.go` runs every case
+  twice: through the contract's parse function, and as a real POST to a live
+  transport, asserting the status code and the normalized fields. A contract
+  without a fixture file fails that test, so a new hook cannot ship without one.
+- **The plugin (client side)** — the payload a script builds must match an
+  `accept` case's `body` for the shape it sends. Vendor the files or read them
+  from this repo at
+  `https://raw.githubusercontent.com/omartelo/lich/main/docs/hooks/fixtures/<name>.jsonl`.
+
+## Changing them
+
+A fixture moves for the same two reasons a test does: the contract changed, or
+the fixture asserted something the contract never promised. Name which one in
+the diff.
+
+Adding a case is not a contract change — cover a payload the contract already
+describes and ship it alone. Editing or deleting a case is: it means the
+contract moved, so the prose above moves first, then this file, then lich's
+server side, then the plugin. Never loosen a `reject` into an `accept` to get a
+green run.

--- a/docs/hooks/fixtures/session-start.jsonl
+++ b/docs/hooks/fixtures/session-start.jsonl
@@ -1,0 +1,9 @@
+{"name":"reported provider","body":{"session_id":"s1","provider_session_id":"018f9c5a-0000-7000-9a3b-1c2d3e4f5c01","provider":"codex"},"accept":{"session_id":"s1","provider_session_id":"018f9c5a-0000-7000-9a3b-1c2d3e4f5c01","provider":"codex"}}
+{"name":"absent provider defaults to claude","body":{"session_id":"s1","provider_session_id":"018f9c5a-0000-7000-9a3b-1c2d3e4f5c01"},"accept":{"session_id":"s1","provider_session_id":"018f9c5a-0000-7000-9a3b-1c2d3e4f5c01","provider":"claude"}}
+{"name":"legacy claude_session_id is folded","body":{"session_id":"s1","claude_session_id":"018f9c5a-0000-7000-9a3b-1c2d3e4f5c02"},"accept":{"session_id":"s1","provider_session_id":"018f9c5a-0000-7000-9a3b-1c2d3e4f5c02","provider":"claude"}}
+{"name":"provider_session_id wins over legacy","body":{"session_id":"s1","provider_session_id":"018f9c5a-0000-7000-9a3b-1c2d3e4f5c01","claude_session_id":"018f9c5a-0000-7000-9a3b-1c2d3e4f5c02"},"accept":{"session_id":"s1","provider_session_id":"018f9c5a-0000-7000-9a3b-1c2d3e4f5c01","provider":"claude"}}
+{"name":"missing session_id","body":{"provider_session_id":"018f9c5a-0000-7000-9a3b-1c2d3e4f5c01"},"reject":"session_id is required"}
+{"name":"missing provider_session_id","body":{"session_id":"s1"},"reject":"provider_session_id is required"}
+{"name":"empty provider_session_id","body":{"session_id":"s1","provider_session_id":""},"reject":"provider_session_id is required"}
+{"name":"unregistered provider","body":{"session_id":"s1","provider_session_id":"018f9c5a-0000-7000-9a3b-1c2d3e4f5c01","provider":"aider"},"reject":"provider must be a registered provider id"}
+{"name":"malformed json","raw":"{","reject":"body must be a JSON object"}

--- a/docs/hooks/fixtures/session-state.jsonl
+++ b/docs/hooks/fixtures/session-state.jsonl
@@ -1,0 +1,10 @@
+{"name":"busy","body":{"session_id":"s1","state":"busy"},"accept":{"session_id":"s1","state":"busy"}}
+{"name":"done","body":{"session_id":"s1","state":"done"},"accept":{"session_id":"s1","state":"done"}}
+{"name":"waiting","body":{"session_id":"s1","state":"waiting"},"accept":{"session_id":"s1","state":"waiting"}}
+{"name":"idle","body":{"session_id":"s1","state":"idle"},"accept":{"session_id":"s1","state":"idle"}}
+{"name":"missing session_id","body":{"state":"busy"},"reject":"session_id is required"}
+{"name":"empty session_id","body":{"session_id":"","state":"busy"},"reject":"session_id is required"}
+{"name":"unknown state","body":{"session_id":"s1","state":"cooking"},"reject":"state must be one of busy, done, waiting, idle"}
+{"name":"missing state","body":{"session_id":"s1"},"reject":"state must be one of busy, done, waiting, idle"}
+{"name":"state is case sensitive","body":{"session_id":"s1","state":"Busy"},"reject":"state must be one of busy, done, waiting, idle"}
+{"name":"malformed json","raw":"{","reject":"body must be a JSON object"}

--- a/docs/hooks/fixtures/session-title.jsonl
+++ b/docs/hooks/fixtures/session-title.jsonl
@@ -1,0 +1,7 @@
+{"name":"ok","body":{"session_id":"s1","title":"Fix the replay ring overflow"},"accept":{"session_id":"s1","title":"Fix the replay ring overflow"}}
+{"name":"surrounding whitespace is trimmed","body":{"session_id":"s1","title":"  Fix the replay ring overflow\n"},"accept":{"session_id":"s1","title":"Fix the replay ring overflow"}}
+{"name":"missing session_id","body":{"title":"Fix the replay ring overflow"},"reject":"session_id is required"}
+{"name":"missing title","body":{"session_id":"s1"},"reject":"title is required and must not be blank"}
+{"name":"empty title","body":{"session_id":"s1","title":""},"reject":"title is required and must not be blank"}
+{"name":"blank title","body":{"session_id":"s1","title":"   \n"},"reject":"title is required and must not be blank"}
+{"name":"malformed json","raw":"{","reject":"body must be a JSON object"}

--- a/docs/hooks/fixtures/session-touched.jsonl
+++ b/docs/hooks/fixtures/session-touched.jsonl
@@ -1,0 +1,5 @@
+{"name":"ok","body":{"session_id":"s1"},"accept":{"session_id":"s1"}}
+{"name":"extra fields are ignored","body":{"session_id":"s1","tool":"Edit"},"accept":{"session_id":"s1"}}
+{"name":"missing session_id","body":{},"reject":"session_id is required"}
+{"name":"empty session_id","body":{"session_id":""},"reject":"session_id is required"}
+{"name":"malformed json","raw":"{","reject":"body must be a JSON object"}

--- a/docs/hooks/session-start.md
+++ b/docs/hooks/session-start.md
@@ -36,6 +36,10 @@ Content-Type: application/json
 Responses: `204` ok · `401` invalid token · `400` invalid body · `500` lich
 failed to persist.
 
+Both sides test against the payloads in
+[`fixtures/session-start.jsonl`](fixtures/session-start.jsonl), including the
+deprecated alias and the defaulted `provider`.
+
 ## Event → action mapping
 
 | Claude Code hook | Codex hook     | action                                       |

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -20,6 +20,9 @@ States: `busy`, `done`, `waiting`, `idle`. lich rejects anything else.
 
 Responses: `204` ok · `401` invalid token · `400` invalid body.
 
+Both sides test against the payloads in
+[`fixtures/session-state.jsonl`](fixtures/session-state.jsonl).
+
 ## Event → state mapping
 
 | Claude Code hook   | Codex hook          | state     |

--- a/docs/hooks/session-title.md
+++ b/docs/hooks/session-title.md
@@ -23,6 +23,9 @@ Content-Type: application/json
 Responses: `204` ok · `401` invalid token · `400` invalid body · `500` lich
 failed to persist.
 
+Both sides test against the payloads in
+[`fixtures/session-title.jsonl`](fixtures/session-title.jsonl).
+
 ## Event → action mapping
 
 | Claude Code hook | Codex hook | action                                        |

--- a/docs/hooks/session-touched.md
+++ b/docs/hooks/session-touched.md
@@ -20,6 +20,9 @@ Content-Type: application/json
 
 Responses: `204` ok · `401` invalid token · `400` invalid body.
 
+Both sides test against the payloads in
+[`fixtures/session-touched.jsonl`](fixtures/session-touched.jsonl).
+
 ## Event → action mapping
 
 | Claude Code hook                        | Codex hook                          | action                           |

--- a/internal/terminal/fixtures_test.go
+++ b/internal/terminal/fixtures_test.go
@@ -1,0 +1,258 @@
+package terminal
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// The hook contracts in docs/hooks/ are implemented in two repositories: lich
+// owns the endpoints, the companion plugin owns the scripts that POST to them.
+// docs/hooks/fixtures/ is those contracts as bytes, and these tests are lich's
+// half of the deal — the plugin asserts against the same lines, so a payload
+// that moves on one side goes red on the other instead of silently drifting.
+// The format is documented in docs/hooks/fixtures/README.md.
+
+// hookFixtureDir holds one .jsonl per contract, relative to this package.
+const hookFixtureDir = "../../docs/hooks/fixtures"
+
+// hookFixtureCase is one line of a fixture file. Body and Raw are alternatives:
+// Raw carries the bodies that are not valid JSON and so cannot be embedded as
+// one. Accept and Reject are alternatives too — Accept lists the field values
+// parsing must produce, Reject says the payload is refused (its prose is
+// documentation, since lich's error strings are its own).
+type hookFixtureCase struct {
+	Name   string          `json:"name"`
+	Body   json.RawMessage `json:"body"`
+	Raw    *string         `json:"raw"`
+	Accept map[string]any  `json:"accept"`
+	Reject string          `json:"reject"`
+}
+
+// payload is the exact request body a client sends for this case.
+func (c hookFixtureCase) payload() []byte {
+	if c.Raw != nil {
+		return []byte(*c.Raw)
+	}
+	return c.Body
+}
+
+// hookContract binds a fixture file to the endpoint and the parser it pins. Its
+// file is named after the contract document, not the endpoint: /hook predates
+// the naming and keeps its path for the plugin releases pointing at it.
+type hookContract struct {
+	file  string
+	path  string
+	parse func([]byte) (any, error)
+}
+
+// hookContracts is the full set. A contract missing from here, or a fixture
+// file missing from the directory, fails TestHookFixturesCoverEveryContract —
+// that is what stops a new hook from shipping without its fixtures.
+var hookContracts = []hookContract{
+	{"session-state.jsonl", "/hook", func(b []byte) (any, error) {
+		return parseHookRequest(b)
+	}},
+	{"session-start.jsonl", "/session-start", func(b []byte) (any, error) {
+		return parseSessionStart(b)
+	}},
+	{"session-title.jsonl", "/session-title", func(b []byte) (any, error) {
+		return parseSessionTitle(b)
+	}},
+	{"session-touched.jsonl", "/session-touched", func(b []byte) (any, error) {
+		return parseSessionTouched(b)
+	}},
+}
+
+// loadHookFixtures reads one fixture file, skipping blank lines.
+func loadHookFixtures(t *testing.T, file string) []hookFixtureCase {
+	t.Helper()
+	f, err := os.Open(filepath.Join(hookFixtureDir, file))
+	if err != nil {
+		t.Fatalf("open fixture: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var cases []hookFixtureCase
+	scanner := bufio.NewScanner(f)
+	for line := 1; scanner.Scan(); line++ {
+		text := strings.TrimSpace(scanner.Text())
+		if text == "" {
+			continue
+		}
+		var c hookFixtureCase
+		if err := json.Unmarshal([]byte(text), &c); err != nil {
+			t.Fatalf("%s:%d is not a JSON object: %v", file, line, err)
+		}
+		cases = append(cases, c)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("read fixture %s: %v", file, err)
+	}
+	return cases
+}
+
+// TestHookFixturesCoverEveryContract pairs the directory with the table above,
+// in both directions: a contract without fixtures and a fixture file without a
+// contract are both failures.
+func TestHookFixturesCoverEveryContract(t *testing.T) {
+	found, err := filepath.Glob(filepath.Join(hookFixtureDir, "*.jsonl"))
+	if err != nil {
+		t.Fatalf("glob fixtures: %v", err)
+	}
+	onDisk := make(map[string]bool, len(found))
+	for _, path := range found {
+		onDisk[filepath.Base(path)] = true
+	}
+	for _, contract := range hookContracts {
+		if !onDisk[contract.file] {
+			t.Errorf("contract %s has no fixture file", contract.path)
+		}
+		delete(onDisk, contract.file)
+	}
+	for file := range onDisk {
+		t.Errorf("fixture %s pins no contract in hookContracts", file)
+	}
+}
+
+// TestHookFixturesAreWellFormed holds the format documented in the fixtures
+// README, so a malformed case fails as itself rather than as a confusing
+// failure in one of the tests below.
+func TestHookFixturesAreWellFormed(t *testing.T) {
+	for _, contract := range hookContracts {
+		t.Run(contract.file, func(t *testing.T) {
+			cases := loadHookFixtures(t, contract.file)
+			seen := make(map[string]bool, len(cases))
+			accepts, rejects := 0, 0
+			for i, c := range cases {
+				checkFixtureShape(t, i, c)
+				if seen[c.Name] {
+					t.Errorf("case %d: duplicate name %q", i, c.Name)
+				}
+				seen[c.Name] = true
+				if c.Accept != nil {
+					accepts++
+				} else {
+					rejects++
+				}
+			}
+			if accepts == 0 || rejects == 0 {
+				t.Errorf("got %d accept and %d reject cases, want at least one of each",
+					accepts, rejects)
+			}
+		})
+	}
+}
+
+// checkFixtureShape holds one case to the exactly-one-of rules.
+func checkFixtureShape(t *testing.T, i int, c hookFixtureCase) {
+	t.Helper()
+	if c.Name == "" {
+		t.Errorf("case %d: missing name", i)
+	}
+	if (c.Body == nil) == (c.Raw == nil) {
+		t.Errorf("case %q: want exactly one of body / raw", c.Name)
+	}
+	if (c.Accept == nil) == (c.Reject == "") {
+		t.Errorf("case %q: want exactly one of accept / reject", c.Name)
+	}
+}
+
+// TestHookFixturesMatchParsers runs every case through its contract's parser:
+// a reject case must error, and an accept case must produce exactly the field
+// values the fixture names, after the contract's defaulting and trimming.
+func TestHookFixturesMatchParsers(t *testing.T) {
+	for _, contract := range hookContracts {
+		t.Run(contract.file, func(t *testing.T) {
+			for _, c := range loadHookFixtures(t, contract.file) {
+				t.Run(c.Name, func(t *testing.T) {
+					parsed, err := contract.parse(c.payload())
+					if c.Accept == nil {
+						if err == nil {
+							t.Fatalf("parsed a payload the contract rejects (%s)", c.Reject)
+						}
+						return
+					}
+					if err != nil {
+						t.Fatalf("rejected a payload the contract accepts: %v", err)
+					}
+					assertFixtureFields(t, parsed, c.Accept)
+				})
+			}
+		})
+	}
+}
+
+// assertFixtureFields compares a parsed request against a case's accept map,
+// through the JSON tags the contract is written in. Only the named fields are
+// asserted: a field the case is not about stays out of its expectations.
+func assertFixtureFields(t *testing.T, parsed any, want map[string]any) {
+	t.Helper()
+	encoded, err := json.Marshal(parsed)
+	if err != nil {
+		t.Fatalf("marshal parsed request: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(encoded, &got); err != nil {
+		t.Fatalf("decode parsed request: %v", err)
+	}
+	for field, wantValue := range want {
+		gotValue, ok := got[field]
+		if !ok {
+			t.Errorf("accept names %q, which the request has no field for", field)
+			continue
+		}
+		if !reflect.DeepEqual(gotValue, wantValue) {
+			t.Errorf("%s = %#v, want %#v", field, gotValue, wantValue)
+		}
+	}
+}
+
+// TestHookFixturesMatchEndpoints POSTs every case to a live transport, so the
+// fixtures pin the wire contract a hook script actually meets — auth, body
+// limit, parse and apply — and not just the parser underneath it.
+func TestHookFixturesMatchEndpoints(t *testing.T) {
+	tr, err := newTransport(
+		func(string, []byte) {},
+		func(string, string) {},
+		func(string, string, string) error { return nil },
+		func(string, string) error { return nil },
+		func(string) {},
+	)
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+	for _, contract := range hookContracts {
+		t.Run(contract.file, func(t *testing.T) {
+			url := fmt.Sprintf("http://127.0.0.1:%d%s?token=%s", tr.port, contract.path, tr.token)
+			for _, c := range loadHookFixtures(t, contract.file) {
+				t.Run(c.Name, func(t *testing.T) {
+					want := http.StatusBadRequest
+					if c.Accept != nil {
+						want = http.StatusNoContent
+					}
+					assertPostStatus(t, url, c.payload(), want)
+				})
+			}
+		})
+	}
+}
+
+// assertPostStatus posts one fixture body and checks the status code.
+func assertPostStatus(t *testing.T, url string, body []byte, want int) {
+	t.Helper()
+	resp, err := http.Post(url, "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != want {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, want)
+	}
+}


### PR DESCRIPTION
## Why

`docs/hooks/` is the canonical, contract-first spec, but every contract is implemented in two repositories: lich owns the endpoints, [`omartelo/lich-plugin`](https://github.com/omartelo/lich-plugin) owns the scripts that build the payloads. Prose alone could not hold that seam — a field renamed on either side went red in neither repo's tests, which is the failure mode the repo `CLAUDE.md` already warns about ("an endpoint or payload change breaks a repo this one cannot see").

The idea is borrowed from [`jacobaraujo7/remote_pi`](https://github.com/jacobaraujo7/remote_pi), which spans three languages and keeps its cross-project protocol honest with per-message JSONL fixtures every side tests against.

## What

**`docs/hooks/fixtures/` — the four contracts as bytes.** One `.jsonl` per contract, one case per line, each naming a payload and what lich does with it:

```json
{"name":"legacy claude_session_id is folded","body":{"session_id":"s1","claude_session_id":"018f…c02"},"accept":{"session_id":"s1","provider_session_id":"018f…c02","provider":"claude"}}
{"name":"unregistered provider","body":{"session_id":"s1","provider_session_id":"018f…c01","provider":"aider"},"reject":"provider must be a registered provider id"}
```

Two format decisions worth naming:

- **`accept` is the payload normalized, not echoed** — it is what the contract's defaulting and trimming produce, so it is where `provider` becomes `claude` and a title loses its whitespace. That is what makes one file serve both sides: the plugin reads `body` (what to send), lich asserts `accept` (what parsing must yield). Only the fields a case names are asserted, so the deprecated `claude_session_id` stays out of the expectations while the payloads still exercise it.
- **`raw` instead of `body`** for bodies that are not valid JSON — otherwise the `{` case could not live in a JSONL file.
- **`reject` prose is documentation, not a matcher.** lich's error strings stay its own; what the fixture fixes is *that* the payload is refused.

**`internal/terminal/fixtures_test.go` — lich's half.** Every case runs twice: through the contract's parse function, and as a real POST to a live transport. The second pass is what makes these wire fixtures rather than parser fixtures — it covers auth, the body limit, parse and apply. It also pairs the directory against the `hookContracts` table in both directions, so a contract without a fixture file and a fixture file without a contract each fail. That is the step that stops a new hook from shipping without fixtures, and it is now written into the README's "Adding a new hook" checklist.

Docs updated: `docs/hooks/README.md` (why the fixtures exist, where they sit in the versioning order, the new checklist step) and a pointer in each of the four contracts.

## Verification

The guards were checked against real drift, not just for passing:

- removed the `claude_session_id` fold in `transport.go` → `FAIL … legacy_claude_session_id_is_folded: rejected a payload the contract accepts` — precisely the silent cross-repo break this targets;
- added a fixture file with no contract → `FAIL … session-bogus.jsonl pins no contract in hookContracts`.

`transport.go` was restored byte-for-byte before committing (`git diff` clean).

Local gate: `gofmt -l .` clean · `go vet ./...` clean · `go test ./...` green · `pnpm check` clean · `pnpm test` 727/727 · `pnpm build` ok. `internal/terminal` coverage **86.1%**. The linux/darwin/windows cross-compile loop was run too — not required (no OS seam, no build tag touched), but the test reads files from disk, so it was worth confirming.

## Notes

- **No `CHANGELOG.md` entry.** This is a contributor- and plugin-facing artifact under `docs/`; nothing a user of the app can see changes. Say the word if you count the published contract as user-visible surface and I will write one.
- **Test-only on the Go side** — no production code changes, so no behavior moves.
- **The circuit closes on the other side.** These fixtures only fully pay off once `lich-plugin` asserts against the same lines; until then, the side that breaks first is still only lich. `docs/hooks/fixtures/README.md` documents both ways to consume them (vendor, or read the raw URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hreov7UGAoLELb4xVibE6r

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hreov7UGAoLELb4xVibE6r)_