### PR TITLE
fix: keep a dragged card at its own size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A dragged card keeps its own shape.** Dragging a session card past a taller
+  neighbour — a worktree card with a long title, say — stretched it to that
+  neighbour's size, smearing its text until the drop. Cards, session groups and
+  project tabs now only move while dragging, never resize.
+
 ## [0.28.0] - 2026-08-09
 
 ### Added

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -12,8 +12,8 @@ import {
   X,
 } from "lucide-react"
 import { useSortable } from "@dnd-kit/sortable"
-import { CSS } from "@dnd-kit/utilities"
 import { cn } from "@/lib/utils"
+import { dragStyle } from "@/lib/use-sortable-list"
 import { displayPath } from "@/lib/paths"
 import type { Session } from "@/lib/session/sessions"
 import { useSessionStatus, useSessionStatusAge } from "@/lib/session/use-session-status"
@@ -135,7 +135,7 @@ export function SessionCard({
     // triggers that render it.
     <div
       ref={setNodeRef}
-      style={{ transform: CSS.Transform.toString(transform), transition }}
+      style={dragStyle(transform, transition)}
       className={cn("relative", isDragging && "pointer-events-none z-10 rounded-lg shadow-md")}
       {...attributes}
       {...listeners}

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -2,8 +2,7 @@ import { useSyncExternalStore } from "react"
 import { useNavigate } from "react-router-dom"
 import { DndContext, closestCenter } from "@dnd-kit/core"
 import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable"
-import { CSS } from "@dnd-kit/utilities"
-import { useSortableList, verticalAxis } from "@/lib/use-sortable-list"
+import { dragStyle, useSortableList, verticalAxis } from "@/lib/use-sortable-list"
 import { cn } from "@/lib/utils"
 import { checkoutLabel } from "@/lib/git/checkout-label"
 import { groupKey, type Session } from "@/lib/session/sessions"
@@ -85,7 +84,7 @@ export function SessionGroup({
   return (
     <div
       ref={group.setNodeRef}
-      style={{ transform: CSS.Transform.toString(group.transform), transition: group.transition }}
+      style={dragStyle(group.transform, group.transition)}
       className={cn(
         "flex flex-col gap-1.5",
         group.isDragging && "pointer-events-none relative z-10 rounded-lg bg-sidebar shadow-md",

--- a/frontend/src/components/tabs/ProjectTab.tsx
+++ b/frontend/src/components/tabs/ProjectTab.tsx
@@ -1,8 +1,8 @@
 import { NavLink } from "react-router-dom"
 import { Bell, Check, LoaderCircle } from "lucide-react"
 import { useSortable } from "@dnd-kit/sortable"
-import { CSS } from "@dnd-kit/utilities"
 import { CloseButton } from "@/components/common/CloseButton"
+import { dragStyle } from "@/lib/use-sortable-list"
 import { cn } from "@/lib/utils"
 import { useProjectStatus } from "@/lib/session/use-session-status"
 import type { Project } from "@/lib/api-types"
@@ -26,7 +26,7 @@ export function ProjectTab({ project, sessionIds, onClose }: ProjectTabProps) {
   return (
     <div
       ref={setNodeRef}
-      style={{ transform: CSS.Transform.toString(transform), transition }}
+      style={dragStyle(transform, transition)}
       className={cn("shrink-0", isDragging && "z-10 rounded-md bg-accent shadow-md")}
       {...attributes}
       {...listeners}

--- a/frontend/src/lib/use-sortable-list.ts
+++ b/frontend/src/lib/use-sortable-list.ts
@@ -7,6 +7,7 @@ import {
   type Modifier,
 } from "@dnd-kit/core"
 import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable"
+import { CSS, type Transform } from "@dnd-kit/utilities"
 
 // How far the pointer must travel before a press turns into a drag. Without it
 // the sensor claims the press outright and a plain click stops selecting the
@@ -15,6 +16,14 @@ const DRAG_THRESHOLD_PX = 5
 
 export const horizontalAxis: Modifier = ({ transform }) => ({ ...transform, y: 0 })
 export const verticalAxis: Modifier = ({ transform }) => ({ ...transform, x: 0 })
+
+// The style every sortable node wears while it moves. Translate, never
+// Transform: dnd-kit's transform also carries the scale needed to match the
+// item being displaced, so a card dragged past a taller neighbour would stretch
+// to that neighbour's size instead of keeping its own.
+export function dragStyle(transform: Transform | null, transition?: string) {
+  return { transform: CSS.Translate.toString(transform), transition }
+}
 
 // useSortableList wires the sensors and the drop handler shared by the two
 // reorderable surfaces (session cards, project tabs). It reports the new id


### PR DESCRIPTION
Dragging a session card past a taller neighbour — a worktree card with a long title — stretched the card to that neighbour's box, smearing its text until the drop.

`useSortable`'s `transform` carries `scaleX`/`scaleY` alongside the translation, so it can morph a node into the size of the item it displaces. All three sortables rendered it through `CSS.Transform.toString`, which applies that scale. Project tabs had the same bug on the horizontal axis, where tab widths differ.

They now share a `dragStyle` helper in `lib/use-sortable-list.ts` built on `CSS.Translate`: a drag moves a node, never resizes it.

## Test plan

- [x] `biome check .`, `tsc --noEmit`, `vitest run` (727 passed) green.
- [x] Drag a session card across a group whose cards have long titles — the card keeps its size the whole way.
- [x] Reorder a group header and a project tab — same, no stretch, drop still lands where it did.