### PR TITLE
feat: show the tool a session's agent is running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A card says which tool its agent is running.** A busy session showed a
+  spinning ring and nothing else: whether it was three seconds into a file read
+  or three minutes into a test run, the card looked the same. It now names the
+  tool under the session's label while the turn is inside one — `Bash · pnpm
+  test`, `apply_patch · usage.go` — and goes back to its usual shape the moment
+  the tool ends. Both providers report it, each in its own vocabulary — mostly
+  the same one, with a Codex edit arriving as `apply_patch`. Needs the companion
+  plugin updated (Settings › Updates); an older one leaves the card exactly as it
+  was.
+
 ### Fixed
 
 - **A dragged card keeps its own shape.** Dragging a session card past a taller

--- a/docs/hooks/fixtures/session-state.jsonl
+++ b/docs/hooks/fixtures/session-state.jsonl
@@ -1,7 +1,13 @@
-{"name":"busy","body":{"session_id":"s1","state":"busy"},"accept":{"session_id":"s1","state":"busy"}}
+{"name":"busy","body":{"session_id":"s1","state":"busy"},"accept":{"session_id":"s1","state":"busy","tool":"","detail":""}}
 {"name":"done","body":{"session_id":"s1","state":"done"},"accept":{"session_id":"s1","state":"done"}}
 {"name":"waiting","body":{"session_id":"s1","state":"waiting"},"accept":{"session_id":"s1","state":"waiting"}}
 {"name":"idle","body":{"session_id":"s1","state":"idle"},"accept":{"session_id":"s1","state":"idle"}}
+{"name":"busy names the tool it is about to run","body":{"session_id":"s1","state":"busy","tool":"Bash","detail":"pnpm test"},"accept":{"session_id":"s1","state":"busy","tool":"Bash","detail":"pnpm test"}}
+{"name":"a tool with nothing to say about it","body":{"session_id":"s1","state":"busy","tool":"Read"},"accept":{"session_id":"s1","state":"busy","tool":"Read","detail":""}}
+{"name":"each harness names its own tools","body":{"session_id":"s1","state":"busy","tool":"apply_patch","detail":"internal/terminal/usage.go"},"accept":{"session_id":"s1","state":"busy","tool":"apply_patch","detail":"internal/terminal/usage.go"}}
+{"name":"tool and detail are trimmed","body":{"session_id":"s1","state":"busy","tool":"  shell  ","detail":"  go test ./...  "},"accept":{"session_id":"s1","state":"busy","tool":"shell","detail":"go test ./..."}}
+{"name":"a detail with no tool names nothing","body":{"session_id":"s1","state":"busy","detail":"pnpm test"},"accept":{"session_id":"s1","state":"busy","tool":"","detail":""}}
+{"name":"whitespace is not a tool","body":{"session_id":"s1","state":"busy","tool":"   ","detail":"pnpm test"},"accept":{"session_id":"s1","state":"busy","tool":"","detail":""}}
 {"name":"missing session_id","body":{"state":"busy"},"reject":"session_id is required"}
 {"name":"empty session_id","body":{"session_id":"","state":"busy"},"reject":"session_id is required"}
 {"name":"unknown state","body":{"session_id":"s1","state":"cooking"},"reject":"state must be one of busy, done, waiting, idle"}

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -1,8 +1,10 @@
 # Contract: session state
 
-Reports a session's Claude Code processing state to lich so its card shows a
-spinner while Claude is working, a check when the turn ends, and a bell when
-Claude is blocked on the user — plus a toast that routes to the waiting card.
+Reports a session's processing state to lich so its card shows a spinner while
+the agent is working, a check when the turn ends, and a bell when it is blocked
+on the user — plus a toast that routes to the waiting card. A `busy` report may
+also name the tool the agent is about to run, which the card shows under the
+session's label.
 
 See [README.md](README.md) for the shared transport (`LICH_PORT` / `LICH_TOKEN`
 / `LICH_SESSION_ID`) and the client rules every hook follows.
@@ -13,10 +15,17 @@ See [README.md](README.md) for the shared transport (`LICH_PORT` / `LICH_TOKEN`
 POST http://127.0.0.1:${LICH_PORT}/hook?token=${LICH_TOKEN}
 Content-Type: application/json
 
-{"session_id": "<LICH_SESSION_ID>", "state": "<busy|done|waiting|idle>"}
+{"session_id": "<LICH_SESSION_ID>", "state": "<busy|done|waiting|idle>",
+ "tool": "<tool name>", "detail": "<what it acts on>"}
 ```
 
 States: `busy`, `done`, `waiting`, `idle`. lich rejects anything else.
+
+`tool` and `detail` are optional and belong to the pre-tool report alone (see
+below). Both are trimmed and capped at 120 characters — they decorate a state
+that has to land either way, so an over-long value is truncated, never a reason
+to reject the report. A `detail` with no `tool` to qualify names nothing and is
+dropped.
 
 Responses: `204` ok · `401` invalid token · `400` invalid body.
 
@@ -28,6 +37,7 @@ Both sides test against the payloads in
 | Claude Code hook   | Codex hook          | state     |
 |--------------------|---------------------|-----------|
 | `UserPromptSubmit` | `UserPromptSubmit`  | `busy`    |
+| `PreToolUse`       | `PreToolUse`        | `busy` + `tool` |
 | `PostToolUse`      | `PostToolUse`       | `busy`    |
 | `Notification`     | `PermissionRequest` | `waiting` |
 | `Stop`             | `Stop`              | `done`    |
@@ -50,23 +60,69 @@ question does not** — those resume by running a tool, so `PostToolUse → busy
 what re-arms the spinner after them. Every tool re-reports `busy` (idempotent);
 `Stop → done` ends the turn.
 
+## The tool a turn is running
+
+`PreToolUse` reports `busy` like every other event, and adds two fields: `tool`,
+the harness's own name for what is about to run, and `detail`, its own words for
+what that tool acts on. Both are passed through as sent — lich does not
+translate between vocabularies, because the word on the card should be the word
+in the terminal beside it.
+
+The two vocabularies overlap more than the harnesses' own tool sets do. Codex's
+hook payload reports a shell call as `Bash`, the same name and the same
+`tool_input.command` string Claude Code sends, and routes reading and searching
+through it; the one word of its own that reaches a card is `apply_patch`:
+
+| Action        | Claude Code                | Codex                    |
+|---------------|----------------------------|--------------------------|
+| run a command | `Bash`                     | `Bash`                   |
+| edit a file   | `Edit` / `Write`           | `apply_patch`            |
+| read a file   | `Read`                     | — (goes through `Bash`)  |
+| search        | `Grep` / `Glob`            | — (goes through `Bash`)  |
+| an MCP tool   | `mcp__srv__tool`           | `mcp__srv__tool`         |
+
+Each row was taken off a real run of both CLIs against a stub listener, not from
+their documentation. A harness is free to report a name outside this table; the
+card shows whatever arrives.
+
+`detail` is whatever identifies the call at a glance — the command line, the
+file path, the pattern. It is free text: a harness that offers nothing usable
+sends only `tool`, and the card shows only the name. The client is what makes
+it readable (both harnesses report absolute paths, which no 240px card can
+show); lich takes what it is given.
+
+**A report holds the tool until the state leaves `busy`.** `PostToolUse` fires
+between tools with no `tool` field, so treating "no tool" as "clear" would blink
+the line off and on at every step. lich therefore keeps the last name for as
+long as the session is `busy`, and drops it on `done`, `waiting` and `idle` —
+never on `idle` alone, which Codex has no event for.
+
+`PreToolUse` is the first contract event on the agent's critical path: in both
+harnesses a hook exiting `2` there **blocks the tool call**. Until now the worst
+a broken script could do was lose a status report.
+
 ## lich server side
 
 - **Env injection** — `internal/terminal/terminal.go`, `Service.sessionEnv`:
   adds the three `LICH_*` vars to each PTY's environment.
 - **Endpoint** — `internal/terminal/transport.go`, `transport.hook`: validates
   the token and body (`parseHookRequest`) on the same loopback listener as
-  terminal I/O, then forwards `(session_id, state)`.
+  terminal I/O, then forwards the whole report.
 - **UI push** — `internal/terminal/terminal.go`: emits the global app event
-  `session-status` (`{id, state}`). Global rather than per-session because its
-  consumers outlive any one card.
+  `session-status` (`{id, state, tool, detail}`). Global rather than per-session
+  because its consumers outlive any one card.
 - **Store** — `frontend/src/lib/session/session-status-store.ts`: one subscription taken
   at page load keeps the last state of every session, keyed by id. The card
   cannot hold it: the sidebar only renders cards for the active project, so
   switching projects unmounts them, and a status reported meanwhile would be lost.
-- **Render** — `frontend/src/components/sidebar/SessionCard.tsx`: reads the store
-  (`useSessionStatus`) and shows a spinner (`busy`), check (`done`) or bell
-  (`waiting`); any other value, including `idle`, clears the indicator.
+  `session-tool-store.ts` reads the same event for the tool pair, keeping its own
+  keyed entry so a repeat `busy` — which the status store collapses into no
+  change at all — still moves the tool line.
+- **Render** — `frontend/src/components/sidebar/SessionCard.tsx`: reads the stores
+  (`useSessionStatus`, `useSessionTool`) and shows a spinner (`busy`), check
+  (`done`) or bell (`waiting`); any other value, including `idle`, clears the
+  indicator. The tool line sits under the session's label and exists only while
+  one is reported, so a card outside a turn is exactly the card it was before.
 - **Tab badge** — `frontend/src/components/tabs/ProjectTab.tsx`: reduces a
   project's sessions to one indicator (`useProjectStatus`, ranking `waiting` over
   `busy` over `done`), shown only while the project is not the active one. A
@@ -119,5 +175,10 @@ what re-arms the spinner after them. Every tool re-reports `busy` (idempotent);
   notification; macOS needs lich shipped as a signed `.app` bundle with
   `UNUserNotificationCenter`; Windows needs a registered AppUserModelID with a
   COM activation handler.
+- **The tool line names the call, not its progress.** It appears when the tool
+  starts and holds that name for however long the tool runs — a 3-minute build
+  and a 30ms read look identical. Nothing reports a tool finishing on its own:
+  `PostToolUse` says `busy` with no tool, which by the rule above changes
+  nothing.
 - Adding another state beyond `busy`/`done`/`waiting`/`idle` is a contract
   change — see the versioning note in the README.

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -19,6 +19,8 @@ import type { Session } from "@/lib/session/sessions"
 import { useSessionStatus, useSessionStatusAge } from "@/lib/session/use-session-status"
 import { useSessionCwd } from "@/lib/session/use-session-cwd"
 import { useSessionAgent } from "@/lib/session/use-session-agent"
+import { useSessionTool } from "@/lib/session/use-session-tool"
+import { toolGlyph } from "@/lib/session/tool-glyph"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { baseReadout } from "@/lib/git/base-status"
 import { usePullRequest } from "@/lib/pulls/use-pull-request"
@@ -82,6 +84,11 @@ export function SessionCard({
   // `codex` in a shell session puts that provider's mark on the card while it
   // runs; null falls back to the session's own kind.
   const agent = useSessionAgent(session.id)
+  // The tool the turn is running right now, reported by the provider's pre-tool
+  // hook: null outside a tool call, which is what keeps the card its usual size
+  // whenever nothing is happening in it.
+  const tool = useSessionTool(session.id)
+  const ToolGlyph = tool && toolGlyph(tool.name)
   // The live working directory the backend's cwd watcher reports ("" until it
   // does): a `cd` in the terminal moves the card with it. Falls back to the
   // session's static start path — a worktree session lives in its own checkout,
@@ -189,6 +196,21 @@ export function SessionCard({
                   <span className="truncate text-sm font-medium text-foreground">
                     {session.label}
                   </span>
+                </span>
+              )}
+              {/* Under the label, so the card reads name → what it is doing →
+                  where. It is the only row that comes and goes with the turn,
+                  which is the cost of putting it where the eye already is. */}
+              {tool && (
+                <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">
+                  {ToolGlyph && <ToolGlyph className="size-3 shrink-0" />}
+                  <span className="shrink-0 font-medium text-foreground">{tool.name}</span>
+                  {tool.detail && (
+                    <>
+                      <span className="shrink-0 opacity-50">·</span>
+                      <span className="truncate font-mono">{tool.detail}</span>
+                    </>
+                  )}
                 </span>
               )}
               {/* rtl anchors the tail (project folder) to the right so overflow is

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -82,6 +82,27 @@ export function isStatusEvent(data: unknown): data is { id: string; state: strin
   return isIdEvent(data) && typeof (data as { state?: unknown }).state === "string"
 }
 
+// The tool a session's turn is running: the harness's own name for it, and its
+// own words for what it acts on ("" when it offered none). Never translated
+// between providers: the word on the card is the word in the terminal beside
+// it (the vocabularies are tabled in docs/hooks/session-state.md).
+export interface SessionTool {
+  name: string
+  detail: string
+}
+
+// statusTool reads the tool pair off a status payload, or null when the report
+// names no tool. Whether a report *clears* the line is the store's call, not
+// this one's: a "busy" naming nothing is the gap between two tools, not the end
+// of the turn (see session-tool-store).
+export function statusTool(data: unknown): SessionTool | null {
+  const { tool, detail } = (data ?? {}) as { tool?: unknown; detail?: unknown }
+  if (typeof tool !== "string" || tool === "") {
+    return null
+  }
+  return { name: tool, detail: typeof detail === "string" ? detail : "" }
+}
+
 export function isTitleEvent(data: unknown): data is { id: string; label: string } {
   return isIdEvent(data) && typeof (data as { label?: unknown }).label === "string"
 }

--- a/frontend/src/lib/session/session-tool-store.test.ts
+++ b/frontend/src/lib/session/session-tool-store.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest"
+import { createSessionToolStore } from "./session-tool-store"
+
+// harness wires a store to a hand-driven status source.
+function harness() {
+  let onStatus: (data: unknown) => void = () => {}
+  const store = createSessionToolStore((h) => {
+    onStatus = h
+    return () => {}
+  })
+  return { store, status: (data: unknown) => onStatus(data) }
+}
+
+describe("createSessionToolStore", () => {
+  it("has no tool for a session nothing has reported", () => {
+    const { store } = harness()
+    expect(store.get("s1")).toBeNull()
+  })
+
+  it("takes the tool a busy report names", () => {
+    const { store, status } = harness()
+    status({ id: "s1", state: "busy", tool: "Bash", detail: "pnpm test" })
+    expect(store.get("s1")).toEqual({ name: "Bash", detail: "pnpm test" })
+  })
+
+  it("keeps each harness's own word for the tool", () => {
+    const { store, status } = harness()
+    status({ id: "s1", state: "busy", tool: "apply_patch", detail: "usage.go" })
+    expect(store.get("s1")).toEqual({ name: "apply_patch", detail: "usage.go" })
+  })
+
+  it("takes a tool with no detail", () => {
+    const { store, status } = harness()
+    status({ id: "s1", state: "busy", tool: "Read" })
+    expect(store.get("s1")).toEqual({ name: "Read", detail: "" })
+  })
+
+  // PostToolUse reports busy between every two tools. Clearing there would
+  // blink the line off and back on at every step of a turn.
+  it("holds the last tool through a busy that names none", () => {
+    const { store, status } = harness()
+    status({ id: "s1", state: "busy", tool: "Bash", detail: "pnpm test" })
+    status({ id: "s1", state: "busy" })
+    expect(store.get("s1")).toEqual({ name: "Bash", detail: "pnpm test" })
+  })
+
+  it("replaces the tool when the next one is reported", () => {
+    const { store, status } = harness()
+    status({ id: "s1", state: "busy", tool: "Bash", detail: "pnpm test" })
+    status({ id: "s1", state: "busy", tool: "Edit", detail: "SessionCard.tsx" })
+    expect(store.get("s1")).toEqual({ name: "Edit", detail: "SessionCard.tsx" })
+  })
+
+  it.each(["done", "waiting", "idle"])("drops the tool on %s", (state) => {
+    const { store, status } = harness()
+    status({ id: "s1", state: "busy", tool: "Bash", detail: "pnpm test" })
+    status({ id: "s1", state })
+    expect(store.get("s1")).toBeNull()
+  })
+
+  // Codex has no SessionEnd, so "idle" never arrives there: leaving busy is
+  // what has to clear the line, not idle alone.
+  it("drops the tool on a state it does not know", () => {
+    const { store, status } = harness()
+    status({ id: "s1", state: "busy", tool: "Bash", detail: "pnpm test" })
+    status({ id: "s1", state: "compacting" })
+    expect(store.get("s1")).toBeNull()
+  })
+
+  it("keeps sessions apart", () => {
+    const { store, status } = harness()
+    status({ id: "s1", state: "busy", tool: "Bash", detail: "pnpm test" })
+    status({ id: "s2", state: "busy", tool: "apply_patch", detail: "usage.go" })
+    status({ id: "s2", state: "done" })
+    expect(store.get("s1")).toEqual({ name: "Bash", detail: "pnpm test" })
+    expect(store.get("s2")).toBeNull()
+  })
+
+  it("ignores a payload that is not a status event", () => {
+    const { store, status } = harness()
+    status({ id: "s1", state: "busy", tool: "Bash", detail: "pnpm test" })
+    status({ id: "s1" })
+    status({ state: "done" })
+    status(null)
+    status("busy")
+    expect(store.get("s1")).toEqual({ name: "Bash", detail: "pnpm test" })
+  })
+
+  it("ignores a tool that is not a string", () => {
+    const { store, status } = harness()
+    status({ id: "s1", state: "busy", tool: 42, detail: "pnpm test" })
+    expect(store.get("s1")).toBeNull()
+  })
+
+  it("treats a detail that is not a string as none", () => {
+    const { store, status } = harness()
+    status({ id: "s1", state: "busy", tool: "Bash", detail: { cmd: "pnpm test" } })
+    expect(store.get("s1")).toEqual({ name: "Bash", detail: "" })
+  })
+
+  // The store rebuilds the object on every report, so without an equality guard
+  // a repeat would hand useSyncExternalStore a new reference every time.
+  it("does not notify when the same tool is reported again", () => {
+    const { store, status } = harness()
+    const listener = vi.fn()
+    store.subscribe("s1", listener)
+    status({ id: "s1", state: "busy", tool: "Bash", detail: "pnpm test" })
+    expect(listener).toHaveBeenCalledTimes(1)
+    status({ id: "s1", state: "busy", tool: "Bash", detail: "pnpm test" })
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it("notifies when only the detail moves", () => {
+    const { store, status } = harness()
+    const listener = vi.fn()
+    store.subscribe("s1", listener)
+    status({ id: "s1", state: "busy", tool: "Bash", detail: "pnpm test" })
+    status({ id: "s1", state: "busy", tool: "Bash", detail: "pnpm build" })
+    expect(listener).toHaveBeenCalledTimes(2)
+    expect(store.get("s1")).toEqual({ name: "Bash", detail: "pnpm build" })
+  })
+})

--- a/frontend/src/lib/session/session-tool-store.ts
+++ b/frontend/src/lib/session/session-tool-store.ts
@@ -1,0 +1,54 @@
+import { createKeyedStore, type ReadableKeyedStore } from "@/lib/keyed-store"
+import { isStatusEvent, statusTool, type SessionTool } from "./session-events"
+
+// A subscription to the global status event, injected so the store is testable
+// without standing up the /events socket. Returns its unsubscribe.
+export type ToolEventSource = (handler: (data: unknown) => void) => () => void
+
+// Two reports name the same tool when both fields match. The store rebuilds the
+// object on every event, so without this a repeat report would hand
+// useSyncExternalStore a new reference and re-render the card for nothing.
+function sameTool(a: SessionTool | null, b: SessionTool | null): boolean {
+  if (a === null || b === null) {
+    return a === b
+  }
+  return a.name === b.name && a.detail === b.detail
+}
+
+// createSessionToolStore keeps the tool each session's turn is running, keyed by
+// session id, fed by the status event the same hook already reports on (see
+// docs/hooks/session-state.md). It reads that event rather than the status store
+// for two reasons: a repeat "busy" is exactly what carries a *new* tool, and the
+// status store collapses repeats into no change at all.
+//
+// The clearing rule is the whole of this store:
+//
+// - a state other than "busy" ends the tool, whatever the payload says;
+// - a "busy" naming a tool sets it;
+// - a "busy" naming none changes nothing. PostToolUse reports one between every
+//   two tools, so treating it as a clear would blink the line off and on at
+//   every step of a turn.
+//
+// Leaving "busy" is what clears, never "idle" alone: Codex has no SessionEnd
+// event and would otherwise hold a dead tool name until its next PTY spawn.
+export function createSessionToolStore(
+  statusSource: ToolEventSource,
+): ReadableKeyedStore<SessionTool | null> {
+  const store = createKeyedStore<SessionTool | null>(null, sameTool)
+
+  statusSource((data) => {
+    if (!isStatusEvent(data)) {
+      return
+    }
+    if (data.state !== "busy") {
+      store.set(data.id, null)
+      return
+    }
+    const tool = statusTool(data)
+    if (tool) {
+      store.set(data.id, tool)
+    }
+  })
+
+  return store
+}

--- a/frontend/src/lib/session/tool-glyph.test.ts
+++ b/frontend/src/lib/session/tool-glyph.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+import { toolGlyph } from "./tool-glyph"
+
+describe("toolGlyph", () => {
+  it("gives the same glyph to both harnesses' word for one action", () => {
+    // Codex reports an edit as apply_patch and everything else under the names
+    // Claude Code uses (docs/hooks/session-state.md).
+    expect(toolGlyph("Edit")).toBe(toolGlyph("apply_patch"))
+    expect(toolGlyph("Write")).toBe(toolGlyph("apply_patch"))
+    expect(toolGlyph("Grep")).toBe(toolGlyph("Glob"))
+  })
+
+  it("has no glyph for a tool it does not know", () => {
+    expect(toolGlyph("mcp__ai-memory__memory_query")).toBeNull()
+    expect(toolGlyph("")).toBeNull()
+  })
+
+  // The name arrives over the wire. An object literal would answer this one
+  // with Object.prototype.constructor, which React would then try to render.
+  it("has no glyph for an inherited object property", () => {
+    expect(toolGlyph("constructor")).toBeNull()
+    expect(toolGlyph("toString")).toBeNull()
+    expect(toolGlyph("__proto__")).toBeNull()
+  })
+})

--- a/frontend/src/lib/session/tool-glyph.ts
+++ b/frontend/src/lib/session/tool-glyph.ts
@@ -1,0 +1,29 @@
+import { FileText, Globe, ListTodo, Pencil, Search, Terminal, type LucideIcon } from "lucide-react"
+
+// The glyph a tool family wears on the session card. Keyed by the names both
+// harnesses actually report (tabled in docs/hooks/session-state.md) — Codex
+// says "Bash" like Claude Code does, and `apply_patch` is its one own word.
+// A Map rather than an object literal because the key arrives over the wire:
+// an object would answer "constructor" with a function, which React would then
+// try to render.
+const GLYPHS = new Map<string, LucideIcon>([
+  ["Bash", Terminal],
+  ["Read", FileText],
+  ["Edit", Pencil],
+  ["Write", Pencil],
+  ["NotebookEdit", Pencil],
+  ["apply_patch", Pencil],
+  ["Grep", Search],
+  ["Glob", Search],
+  ["WebFetch", Globe],
+  ["WebSearch", Globe],
+  ["TodoWrite", ListTodo],
+])
+
+// toolGlyph resolves a reported tool name to its glyph, or null for a name the
+// map does not know — an MCP tool, one shipped after this build. The line reads
+// fine without one, which is why an unknown name draws nothing rather than a
+// placeholder.
+export function toolGlyph(name: string): LucideIcon | null {
+  return GLYPHS.get(name) ?? null
+}

--- a/frontend/src/lib/session/use-session-tool.ts
+++ b/frontend/src/lib/session/use-session-tool.ts
@@ -1,0 +1,16 @@
+import { onAppEvent } from "@/lib/app-events"
+import { STATUS_EVENT, type SessionTool } from "./session-events"
+import { createSessionToolStore } from "./session-tool-store"
+import { useKeyedStore } from "@/lib/use-keyed-store"
+
+// Subscribed at import rather than on first use: that opens the /events socket
+// at page load, so a tool reported before any card mounts still lands.
+const store = createSessionToolStore((handler) => onAppEvent(STATUS_EVENT, handler))
+
+// useSessionTool reads the tool a session's turn is running from the shared
+// store (see session-tool-store), which retains it across the card's unmount.
+// Returns null whenever the session is not inside a tool call — which is most of
+// the time, and is what leaves the card the size it was.
+export function useSessionTool(sessionId: string): SessionTool | null {
+  return useKeyedStore(store, sessionId)
+}

--- a/internal/terminal/fixtures_test.go
+++ b/internal/terminal/fixtures_test.go
@@ -220,7 +220,7 @@ func assertFixtureFields(t *testing.T, parsed any, want map[string]any) {
 func TestHookFixturesMatchEndpoints(t *testing.T) {
 	tr, err := newTransport(
 		func(string, []byte) {},
-		func(string, string) {},
+		func(hookRequest) {},
 		func(string, string, string) error { return nil },
 		func(string, string) error { return nil },
 		func(string) {},

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -32,11 +32,12 @@ const (
 	dataEventPrefix = "terminal:data:"
 	// exitEventPrefix is emitted once when a session's shell process exits.
 	exitEventPrefix = "terminal:exit:"
-	// statusEventName carries a session's Claude Code processing state
-	// ({id, state} — "busy"/"done"/"waiting"/"idle"), reported by the lich hook
-	// running inside the PTY (see transport.hook and docs/hooks/session-state.md).
-	// The frontend keeps it in a store keyed by id (session-status-store.ts)
-	// rather than in the card, which is only mounted while its project is active.
+	// statusEventName carries a session's processing state ({id, state, tool,
+	// detail} — "busy"/"done"/"waiting"/"idle", plus the tool a pre-tool report
+	// names), reported by the lich hooks running inside the PTY (see
+	// transport.hook and docs/hooks/session-state.md). The frontend keeps it in
+	// stores keyed by id (session-status-store.ts, session-tool-store.ts) rather
+	// than in the card, which is only mounted while its project is active.
 	statusEventName = "session-status"
 	// titleEventName carries an auto-applied session label ({id, label}).
 	titleEventName = "session-title"
@@ -51,11 +52,15 @@ const (
 	agentEventName = "session-agent"
 )
 
-// statusEvent is the payload of statusEventName: the session whose Claude Code
-// processing state changed, and the new state.
+// statusEvent is the payload of statusEventName: the session whose processing
+// state changed, the new state, and — on a pre-tool report alone — the tool it
+// is about to run and what that tool acts on. Both are the provider's own
+// words, never translated here (docs/hooks/session-state.md tables them).
 type statusEvent struct {
-	ID    string `json:"id"`
-	State string `json:"state"`
+	ID     string `json:"id"`
+	State  string `json:"state"`
+	Tool   string `json:"tool,omitempty"`
+	Detail string `json:"detail,omitempty"`
 }
 
 // titleEvent is the payload of titleEventName: the session whose label changed
@@ -150,15 +155,20 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 				slog.Warn("terminal: input write failed", "session", id, "err", err)
 			}
 		},
-		func(id, state string) {
-			hub.Emit(statusEventName, statusEvent{ID: id, State: state})
+		func(req hookRequest) {
+			hub.Emit(statusEventName, statusEvent{
+				ID:     req.SessionID,
+				State:  req.State,
+				Tool:   req.Tool,
+				Detail: req.Detail,
+			})
 			// Every non-idle state is a point where a fresh assistant usage line
 			// may have landed — a tool call mid-turn (busy), a prompt (waiting),
 			// or the turn's end (done) — so refresh the context window then, and
 			// off-thread so a stalled emit never blocks the hook's response. Skip
 			// idle (SessionEnd): the session is ending, nothing new to read.
-			if state != "idle" {
-				go s.emitUsage(id)
+			if req.State != statusIdle {
+				go s.emitUsage(req.SessionID)
 			}
 		},
 		func(sessionID, providerSessionID, provider string) error {

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -90,7 +90,7 @@ type transport struct {
 	token       string
 	mux         *http.ServeMux
 	input       func(id string, data []byte)
-	status      func(id, state string)
+	status      func(req hookRequest)
 	linkSession func(sessionID, providerSessionID, provider string) error
 	setTitle    func(sessionID, title string) error
 	touched     func(sessionID string)
@@ -103,14 +103,14 @@ type transport struct {
 
 // newTransport starts the listener on a random loopback port. input receives
 // decoded input frames (keyboard data for a session's PTY); status receives a
-// session's processing state reported by the Claude Code hook (see /hook);
-// linkSession records the provider session id a PTY reports at start (see
-// /session-start); setTitle applies an auto-generated session label (see
-// /session-title); touched signals a session likely changed files on disk (see
-// /session-touched).
+// session's processing state, and the tool it is about to run, as reported by
+// the provider's hooks (see /hook); linkSession records the provider session id
+// a PTY reports at start (see /session-start); setTitle applies an
+// auto-generated session label (see /session-title); touched signals a session
+// likely changed files on disk (see /session-touched).
 func newTransport(
 	input func(id string, data []byte),
-	status func(id, state string),
+	status func(req hookRequest),
 	linkSession func(sessionID, providerSessionID, provider string) error,
 	setTitle func(sessionID, title string) error,
 	touched func(sessionID string),
@@ -316,26 +316,38 @@ func servePost[T any](
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// hookRequest is a status POST body.
+// hookRequest is a status POST body. Tool and Detail are the optional pair a
+// pre-tool report carries — the provider's own name for the tool it is about to
+// run, and its own words for what that tool acts on. Both are absent from every
+// other report.
 type hookRequest struct {
 	SessionID string `json:"session_id"`
 	State     string `json:"state"`
+	Tool      string `json:"tool"`
+	Detail    string `json:"detail"`
 }
 
-// hook receives a session status POST from the Claude Code hook running inside a
+// hookTextLimit bounds the tool name and detail a report may carry, in runes.
+// Over-long values are truncated rather than rejected: they are decoration on a
+// state that has to land either way, and losing the spinner because a command
+// line grew is the worse failure.
+const hookTextLimit = 120
+
+// hook receives a session status POST from a provider's hook running inside a
 // spawned PTY and forwards it to the frontend via the status callback.
 func (t *transport) hook(w http.ResponseWriter, r *http.Request) {
 	servePost(t, w, r, parseHookRequest, func(req hookRequest) error {
 		if t.status != nil {
-			t.status(req.SessionID, req.State)
+			t.status(req)
 		}
 		return nil
 	})
 }
 
-// parseHookRequest validates a status POST body: a session id and one of the
-// known states. It never trusts the payload — an unknown state is rejected so a
-// stray or hostile POST can't drive the UI into an undefined status.
+// parseHookRequest validates a status POST body: a session id, one of the known
+// states, and the optional tool pair. It never trusts the payload — an unknown
+// state is rejected so a stray or hostile POST can't drive the UI into an
+// undefined status, and the free text is trimmed and capped (see hookTextLimit).
 func parseHookRequest(body []byte) (hookRequest, error) {
 	var req hookRequest
 	if err := json.Unmarshal(body, &req); err != nil {
@@ -348,7 +360,24 @@ func parseHookRequest(body []byte) (hookRequest, error) {
 		req.State != statusWaiting && req.State != statusIdle {
 		return hookRequest{}, fmt.Errorf("hook has unknown state %q", req.State)
 	}
+	req.Tool = clampRunes(strings.TrimSpace(req.Tool), hookTextLimit)
+	req.Detail = clampRunes(strings.TrimSpace(req.Detail), hookTextLimit)
+	// A detail with no tool to qualify names nothing, so it is dropped rather
+	// than shown on its own.
+	if req.Tool == "" {
+		req.Detail = ""
+	}
 	return req, nil
+}
+
+// clampRunes truncates s to at most max runes, counting runes rather than bytes
+// so a cut never lands mid-character.
+func clampRunes(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max])
 }
 
 // startRequest is a session-start POST body. LegacyClaudeSessionID accepts the

--- a/internal/terminal/transport_test.go
+++ b/internal/terminal/transport_test.go
@@ -3,6 +3,7 @@ package terminal
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -219,6 +220,47 @@ func TestParseHookRequest(t *testing.T) {
 	}
 }
 
+// The cap is pinned as a literal rather than read off hookTextLimit: a test
+// that derives its input from the constant passes whatever the constant becomes,
+// which is exactly the mutation it exists to catch.
+func TestParseHookRequestCapsToolText(t *testing.T) {
+	tests := []struct {
+		name       string
+		tool       string
+		wantLength int
+	}{
+		{"at the cap", strings.Repeat("x", 120), 120},
+		{"one past the cap", strings.Repeat("x", 121), 120},
+		{"far past the cap", strings.Repeat("x", 5000), 120},
+		// Runes, not bytes: a cut between the two bytes of "é" would produce a
+		// name the page renders as a replacement character.
+		{"multi-byte runes", strings.Repeat("é", 200), 120},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			body, err := json.Marshal(hookRequest{
+				SessionID: "s1",
+				State:     "busy",
+				Tool:      tc.tool,
+				Detail:    tc.tool,
+			})
+			if err != nil {
+				t.Fatalf("marshal body: %v", err)
+			}
+			req, err := parseHookRequest(body)
+			if err != nil {
+				t.Fatalf("parseHookRequest: %v", err)
+			}
+			if got := len([]rune(req.Tool)); got != tc.wantLength {
+				t.Errorf("tool is %d runes, want %d", got, tc.wantLength)
+			}
+			if got := len([]rune(req.Detail)); got != tc.wantLength {
+				t.Errorf("detail is %d runes, want %d", got, tc.wantLength)
+			}
+		})
+	}
+}
+
 func TestPingAnswersWithToken(t *testing.T) {
 	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil, nil)
 	if err != nil {
@@ -250,15 +292,16 @@ func TestPingRejectsBadToken(t *testing.T) {
 }
 
 func TestHookForwardsStatus(t *testing.T) {
-	got := make(chan string, 1)
-	tr, err := newTransport(func(string, []byte) {}, func(id, state string) {
-		got <- id + ":" + state
+	got := make(chan hookRequest, 1)
+	tr, err := newTransport(func(string, []byte) {}, func(req hookRequest) {
+		got <- req
 	}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
 	url := fmt.Sprintf("http://127.0.0.1:%d/hook?token=%s", tr.port, tr.token)
-	resp, err := http.Post(url, "application/json", strings.NewReader(`{"session_id":"sess","state":"busy"}`))
+	body := `{"session_id":"sess","state":"busy","tool":"Bash","detail":"pnpm test"}`
+	resp, err := http.Post(url, "application/json", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("post: %v", err)
 	}
@@ -267,9 +310,10 @@ func TestHookForwardsStatus(t *testing.T) {
 		t.Fatalf("status = %d, want 204", resp.StatusCode)
 	}
 	select {
-	case v := <-got:
-		if v != "sess:busy" {
-			t.Fatalf("got %q", v)
+	case req := <-got:
+		want := hookRequest{SessionID: "sess", State: "busy", Tool: "Bash", Detail: "pnpm test"}
+		if req != want {
+			t.Fatalf("got %#v, want %#v", req, want)
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("status never forwarded to the callback")
@@ -278,7 +322,7 @@ func TestHookForwardsStatus(t *testing.T) {
 
 func TestHookRejectsBadToken(t *testing.T) {
 	fired := make(chan struct{}, 1)
-	tr, err := newTransport(func(string, []byte) {}, func(string, string) { fired <- struct{}{} }, nil, nil, nil)
+	tr, err := newTransport(func(string, []byte) {}, func(hookRequest) { fired <- struct{}{} }, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}
@@ -683,7 +727,7 @@ func TestStoreFailuresReport500(t *testing.T) {
 // mid-document and the parse fails. Without the limit this would be a 204.
 func TestHookBodyLimit(t *testing.T) {
 	fired := make(chan struct{}, 1)
-	tr, err := newTransport(func(string, []byte) {}, func(string, string) { fired <- struct{}{} }, nil, nil, nil)
+	tr, err := newTransport(func(string, []byte) {}, func(hookRequest) { fired <- struct{}{} }, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("newTransport: %v", err)
 	}


### PR DESCRIPTION
A busy card showed a spinning ring and nothing else, so three seconds into a file read and three minutes into a test run looked identical. The card now names the tool under the session's label while the turn is inside one, and goes back to its usual shape the moment the tool ends.

## The contract

`session-state` gains an optional pair on the pre-tool report: `tool`, the harness's own name for what is about to run, and `detail`, its own words for what it acts on. Neither is translated — the word on the card should be the word in the terminal beside it. Both are trimmed and capped at 120 runes rather than rejected: they decorate a state that has to land either way, and losing the spinner because a command line grew is the worse failure.

`PreToolUse` is the first contract event on the agent's critical path — in both harnesses a hook exiting `2` there blocks the tool call. The client rules (silent, always exit 0) stop being merely polite.

## The vocabularies came off real runs

Not off the harnesses' docs. Both CLIs were driven against a stub listener in an isolated home, and two guesses died there:

- Codex reports a shell call as **`Bash`**, not `shell`, carrying the same `command` string Claude Code sends, and routes reading and searching through it. Its one own word that reaches a card is `apply_patch`.
- Codex passes the **whole patch** as `apply_patch`'s command, so the naive rule put `*** Begin Patch` on the card.
- Both harnesses report **absolute paths**, which no 240px card can show.

The last two are the client's to solve and are fixed in the plugin PR; the table in `docs/hooks/session-state.md` now records what was observed.

## Why a second store

`session-tool-store.ts` reads the status event directly rather than the status store: a repeat `busy` is exactly what carries a *new* tool, and the status store collapses repeats into no change at all. The clearing rule is the whole of it — leaving `busy` clears, never `idle` alone (Codex has no `SessionEnd`), and a `busy` naming no tool holds the last one, since `PostToolUse` reports one between every two tools and clearing there would blink the line at every step.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...`
- [x] `pnpm check`, `pnpm test`, `pnpm build`
- [x] Cross-compile loop for linux/darwin/windows (build + vet)
- [x] Contract fixtures extended and asserted at both the parser and the live endpoint; the rune cap pinned as a literal, not derived from the constant
- [x] Render smoked in an isolated `task dev` over CDP: the line appears under the label, truncates at 240px, holds through a `busy` naming no tool, and disappears on `done`

Needs the companion plugin's side of the contract (omartelo/lich-plugin). An older plugin sends no tool and leaves the card exactly as it was.
