### PR TITLE
feat: point one Claude session at another

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Point one Claude session at another.** Claude Code can message your other
+  sessions, but only if it knows what they are called — and left to itself it
+  names a session after its directory, so every session in one checkout looks
+  alike. lich now names each Claude session it starts, shows that name in the
+  card's tooltip, and adds **Mention session** to the context menu of the card
+  you are working in: pick any Claude session from any open project and its name
+  lands at your prompt, ready for you to finish the sentence. lich carries no
+  message itself — the Claude reading your prompt is the one that addresses the
+  other session.
+
 ### Fixed
 
 - **A dragged card keeps its own shape.** Dragging a session card past a taller

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -16,6 +16,8 @@ import { chordSequence, isSearchOpenChord } from "@/lib/terminal/term-keys"
 import { makeReplayBuffer } from "@/lib/terminal/replay-buffer"
 import { takePaste } from "@/lib/terminal/paste-queue"
 import { takeSetup } from "@/lib/terminal/setup-queue"
+import { peerName } from "@/lib/session/peer-name"
+import { onTerminalFocusRequest } from "@/lib/terminal/focus-request"
 import { recordChunk } from "@/lib/terminal/term-perf"
 import { copyToastMessage, COPY_TOAST_DURATION_MS } from "@/lib/terminal/copy-toast"
 import { computeGrid } from "@/lib/terminal/term-fit"
@@ -573,6 +575,7 @@ export function TerminalView({
           cwd,
           kind,
           resume,
+          peerName(cwd, sessionId),
           takeSetup(sessionId),
           live.term.cols,
           live.term.rows,
@@ -652,6 +655,13 @@ export function TerminalView({
     void Service.Resize(sessionId, live.term.cols, live.term.rows)
     live.term.focus()
   }, [visible, sessionId])
+
+  // The sidebar writes a mention at this session's prompt and then asks for the
+  // cursor back, so the user carries on typing where they already were.
+  useEffect(
+    () => onTerminalFocusRequest(sessionId, () => liveRef.current?.term.focus()),
+    [sessionId],
+  )
 
   // Font family and size need no live-update path: changing them means being
   // on the Settings route, where TerminalHost destroys every live terminal —

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react"
 import type { KeyboardEvent } from "react"
 import {
   ArrowDown,
+  AtSign,
   GitBranch,
   GitPullRequestArrow,
   Pencil,
@@ -16,6 +17,7 @@ import { cn } from "@/lib/utils"
 import { dragStyle } from "@/lib/use-sortable-list"
 import { displayPath } from "@/lib/paths"
 import type { Session } from "@/lib/session/sessions"
+import { peerMention, peerName } from "@/lib/session/peer-name"
 import { useSessionStatus, useSessionStatusAge } from "@/lib/session/use-session-status"
 import { useSessionCwd } from "@/lib/session/use-session-cwd"
 import { useSessionAgent } from "@/lib/session/use-session-agent"
@@ -29,10 +31,19 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import {
   ContextMenu,
   ContextMenuContent,
+  ContextMenuGroup,
   ContextMenuItem,
+  ContextMenuLabel,
   ContextMenuSeparator,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
+import { Terminal as TerminalService } from "@/lib/rpc"
+import type { MentionGroup } from "@/lib/session/mention-targets"
+import { bracketedPaste } from "@/lib/terminal/bracketed-paste"
+import { requestTerminalFocus } from "@/lib/terminal/focus-request"
 
 interface SessionCardProps {
   session: Session
@@ -50,6 +61,11 @@ interface SessionCardProps {
   onOpenTerminal: (cwd: string) => void
   // Open the Pulls screen for this session's worktree, parking its PR card.
   onPulls: () => void
+  // Claude sessions this one can be pointed at, grouped by project. Only the
+  // card whose terminal is on screen offers them — the mention is written at
+  // that terminal's prompt, so any other card would be writing somewhere the
+  // user cannot see.
+  mentionGroups: MentionGroup[]
 }
 
 // The card itself is the drag grip for reordering the list — no separate handle.
@@ -63,6 +79,7 @@ export function SessionCard({
   onPin,
   onOpenTerminal,
   onPulls,
+  mentionGroups,
 }: SessionCardProps) {
   const pinned = !!session.pinned
   const pathRef = useRef<HTMLSpanElement>(null)
@@ -100,6 +117,16 @@ export function SessionCard({
     id: session.id,
     disabled: editing,
   })
+
+  // Write the target's roster name at this session's own prompt and hand the
+  // cursor back. lich stops here: the Claude reading that prompt is the one that
+  // addresses the other session, with the tool it already has.
+  const mention = (name: string) => {
+    void TerminalService.Write(session.id, bracketedPaste(peerMention(name)))
+    requestTerminalFocus(session.id)
+  }
+
+  const canMention = active && session.kind === "claude" && mentionGroups.length > 0
 
   const commit = (value: string) => {
     setEditing(false)
@@ -283,6 +310,15 @@ export function SessionCard({
             <div className="flex flex-col gap-1.5">
               <span className="font-medium">{session.label}</span>
               <span className="break-all font-mono text-muted-foreground">{shownPath}</span>
+              {/* The name this session answers to when another Claude Code
+                  session messages it. Built from the start path, not the shown
+                  one: a `cd` in the terminal never renames a running session. */}
+              {session.kind === "claude" && (
+                <span className="flex items-center gap-1 font-mono text-muted-foreground">
+                  <AtSign className="size-3 shrink-0" />
+                  {peerName(session.path || path, session.id)}
+                </span>
+              )}
               {git?.branch && (
                 <span className="flex flex-wrap items-center gap-2 text-muted-foreground">
                   <span className="flex items-center gap-1">
@@ -325,6 +361,33 @@ export function SessionCard({
           </TooltipContent>
         </Tooltip>
         <ContextMenuContent>
+          {canMention && (
+            <ContextMenuSub>
+              <ContextMenuSubTrigger>
+                <AtSign />
+                Mention session
+              </ContextMenuSubTrigger>
+              <ContextMenuSubContent>
+                {mentionGroups.map((group) => (
+                  <ContextMenuGroup key={group.projectId}>
+                    {/* The project only earns a heading when there is more than
+                        one to tell apart. */}
+                    {mentionGroups.length > 1 && (
+                      <ContextMenuLabel>{group.projectName}</ContextMenuLabel>
+                    )}
+                    {group.targets.map((target) => (
+                      <ContextMenuItem key={target.id} onClick={() => mention(target.name)}>
+                        <span className="truncate">{target.label}</span>
+                        <span className="ml-auto pl-3 font-mono text-xs text-muted-foreground">
+                          {target.name}
+                        </span>
+                      </ContextMenuItem>
+                    ))}
+                  </ContextMenuGroup>
+                ))}
+              </ContextMenuSubContent>
+            </ContextMenuSub>
+          )}
           <ContextMenuItem onClick={() => setEditing(true)}>
             <Pencil />
             Rename

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -5,6 +5,7 @@ import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-
 import { dragStyle, useSortableList, verticalAxis } from "@/lib/use-sortable-list"
 import { cn } from "@/lib/utils"
 import { checkoutLabel } from "@/lib/git/checkout-label"
+import type { MentionGroup } from "@/lib/session/mention-targets"
 import { groupKey, type Session } from "@/lib/session/sessions"
 import { useProjects } from "@/providers/projects"
 import { SessionCard } from "./SessionCard"
@@ -36,6 +37,10 @@ interface SessionGroupProps {
   pullsActive: boolean
   onPulls: () => void
   onClosePulls: () => void
+  // Workspace-wide, so it is resolved once by the sidebar rather than per group:
+  // the Claude sessions the active one can be pointed at, across every open
+  // project.
+  mentionGroups: MentionGroup[]
 }
 
 // SessionGroup renders one worktree's sessions under a static divider titled
@@ -61,6 +66,7 @@ export function SessionGroup({
   pullsActive,
   onPulls,
   onClosePulls,
+  mentionGroups,
 }: SessionGroupProps) {
   const { activateSession, renameSession, pinSession, newSession } = useProjects()
   const navigate = useNavigate()
@@ -122,6 +128,7 @@ export function SessionGroup({
                 onPin={(pinned) => pinSession(projectId, session.id, pinned)}
                 onOpenTerminal={(cwd) => newSession(projectId, "shell", cwd)}
                 onPulls={onPulls}
+                mentionGroups={mentionGroups}
               />
             ))}
           </div>

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -6,6 +6,7 @@ import { GitBranch, GitPullRequestArrow, Plus, Terminal } from "lucide-react"
 import { ProjectService } from "@/lib/rpc"
 import { closeSettings, isSettingsOpen, subscribeSettingsCard } from "@/lib/settings-card-store"
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
+import { mentionTargets } from "@/lib/session/mention-targets"
 import {
   closePullsList,
   isPullsListOpen,
@@ -113,6 +114,9 @@ export function SessionSidebar() {
   }
 
   const realActiveId = activeSessionId(sessions, projectId)
+  // Resolved once here, not per group: the list spans every open project, so
+  // it is the same for every card in the sidebar.
+  const mentionGroups = mentionTargets(projects, sessions, realActiveId)
   // No session card highlights while a full-screen route (Settings, Pulls) owns
   // the view; its own sidebar entry reads as active instead.
   const activeId = onSettings || onPullsRoute ? "" : realActiveId
@@ -258,6 +262,7 @@ export function SessionSidebar() {
                       navigate(`/projects/${projectId}`)
                     }
                   }}
+                  mentionGroups={mentionGroups}
                 />
               )
             })}

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -108,6 +108,8 @@ export const Terminal = {
   ResumeAvailable: (kind: string, providerSessionID: string) =>
     call<boolean>("terminal.ResumeAvailable", [kind, providerSessionID]),
   /** resume: a provider session id to reopen (--resume); "" starts fresh.
+   * name: what the session answers to in its provider's peer roster (lib/session/peer-name);
+   * only Claude Code has one, every other kind ignores it.
    * setup: run the project's worktree setup script ahead of the provider —
    * passed once, by the first Start after the worktree is created. */
   Start: (
@@ -116,10 +118,11 @@ export const Terminal = {
     cwd: string,
     kind: string,
     resume: string,
+    name: string,
     setup: boolean,
     cols: number,
     rows: number,
-  ) => call<null>("terminal.Start", [id, projectID, cwd, kind, resume, setup, cols, rows]),
+  ) => call<null>("terminal.Start", [id, projectID, cwd, kind, resume, name, setup, cols, rows]),
   Write: (id: string, data: string) => call<null>("terminal.Write", [id, data]),
   Resize: (id: string, cols: number, rows: number) =>
     call<null>("terminal.Resize", [id, cols, rows]),

--- a/frontend/src/lib/session/mention-targets.test.ts
+++ b/frontend/src/lib/session/mention-targets.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+import { mentionTargets } from "./mention-targets"
+import type { SessionState } from "./sessions"
+
+const PROJECTS = [
+  { id: "p1", name: "lich", path: "/home/me/code/lich" },
+  { id: "p2", name: "lich-plugin", path: "/home/me/code/lich-plugin" },
+]
+
+const state: SessionState = {
+  p1: {
+    activeId: "aaaa1111",
+    nextSeq: 4,
+    sessions: [
+      { id: "aaaa1111", label: "Sender", kind: "claude" },
+      {
+        id: "bbbb2222",
+        label: "Fix migration drift",
+        kind: "claude",
+        path: "/home/me/wt/migration",
+      },
+      { id: "cccc3333", label: "A shell", kind: "shell" },
+    ],
+  },
+  p2: {
+    activeId: "",
+    nextSeq: 2,
+    sessions: [{ id: "dddd4444", label: "Hook fixtures", kind: "claude" }],
+  },
+}
+
+describe("mentionTargets", () => {
+  it("spans every open project, in project order", () => {
+    const groups = mentionTargets(PROJECTS, state, "aaaa1111")
+    expect(groups.map((g) => g.projectName)).toEqual(["lich", "lich-plugin"])
+  })
+
+  it("leaves out the session doing the sending", () => {
+    const ids = mentionTargets(PROJECTS, state, "aaaa1111").flatMap((g) =>
+      g.targets.map((t) => t.id),
+    )
+    expect(ids).not.toContain("aaaa1111")
+    expect(ids).toContain("bbbb2222")
+  })
+
+  it("offers only Claude sessions", () => {
+    const ids = mentionTargets(PROJECTS, state, "aaaa1111").flatMap((g) =>
+      g.targets.map((t) => t.id),
+    )
+    expect(ids).not.toContain("cccc3333")
+  })
+
+  it("names a worktree session after its checkout, others after the project", () => {
+    const [lich, plugin] = mentionTargets(PROJECTS, state, "aaaa1111")
+    expect(lich.targets[0]).toMatchObject({ label: "Fix migration drift", name: "migration-bbbb" })
+    expect(plugin.targets[0]).toMatchObject({ name: "lich-plugin-dddd" })
+  })
+
+  it("drops a project with nothing to point at", () => {
+    const groups = mentionTargets(PROJECTS, state, "dddd4444")
+    expect(groups.map((g) => g.projectId)).toEqual(["p1"])
+  })
+
+  it("is empty when the sender is the only Claude session", () => {
+    const alone: SessionState = {
+      p1: { activeId: "aaaa1111", nextSeq: 2, sessions: [state.p1.sessions[0]] },
+    }
+    expect(mentionTargets(PROJECTS, alone, "aaaa1111")).toEqual([])
+  })
+})

--- a/frontend/src/lib/session/mention-targets.ts
+++ b/frontend/src/lib/session/mention-targets.ts
@@ -1,0 +1,58 @@
+// The sessions one Claude session can be pointed at, grouped by the project
+// they belong to. lich never carries the message itself: it writes the target's
+// roster name at the sender's own prompt, and the Claude there addresses it with
+// the SendMessage tool it already has (docs: cross-session messaging).
+//
+// The list spans every open project, because the sidebar shows one project at a
+// time and walking to another would change which session is sending.
+//
+// A card whose terminal was never opened is listed like any other — it has no
+// process, so no inbox socket, and the sender's Claude reports the name as
+// unreachable. Filtering those out would mean tracking spawn state outside the
+// component that owns it, for a case the user is told about anyway.
+
+import type { Project } from "@/lib/api-types"
+import { peerName } from "./peer-name"
+import type { SessionState } from "./sessions"
+import { sessionsOf } from "./sessions"
+
+export interface MentionTarget {
+  id: string
+  label: string
+  /** The name it answers to in the roster — what lands at the prompt. */
+  name: string
+}
+
+export interface MentionGroup {
+  projectId: string
+  projectName: string
+  targets: MentionTarget[]
+}
+
+/**
+ * Claude sessions across every open project, minus the one doing the sending,
+ * grouped in project order. A project with nothing to offer is left out, so an
+ * empty result means there is nobody to point at.
+ */
+export function mentionTargets(
+  projects: readonly Project[],
+  sessions: SessionState,
+  sourceId: string,
+): MentionGroup[] {
+  const groups: MentionGroup[] = []
+  for (const project of projects) {
+    const targets = sessionsOf(sessions, project.id)
+      .filter((session) => session.kind === "claude" && session.id !== sourceId)
+      .map((session) => ({
+        id: session.id,
+        label: session.label,
+        // The path the session spawned in, never its live cwd: the name was
+        // fixed at spawn, and a `cd` in the terminal does not rename it.
+        name: peerName(session.path || project.path, session.id),
+      }))
+    if (targets.length > 0) {
+      groups.push({ projectId: project.id, projectName: project.name, targets })
+    }
+  }
+  return groups
+}

--- a/frontend/src/lib/session/peer-name.test.ts
+++ b/frontend/src/lib/session/peer-name.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { peerMention, peerName } from "./peer-name"
+
+describe("peerMention", () => {
+  it("addresses the name and leaves room for what the user types next", () => {
+    expect(peerMention("lich-4f2a")).toBe("@lich-4f2a ")
+  })
+})
+
+describe("peerName", () => {
+  it("names a session after its directory and its id tail", () => {
+    expect(peerName("/home/me/code/lich", "4f2a1b3c-0000-4000-8000-000000000000")).toBe("lich-4f2a")
+  })
+
+  it("separates two sessions sharing a checkout", () => {
+    const cwd = "/home/me/code/lich"
+    const first = peerName(cwd, "4f2a1b3c-0000-4000-8000-000000000000")
+    const second = peerName(cwd, "9d8e7f6a-0000-4000-8000-000000000000")
+    expect(first).not.toBe(second)
+  })
+
+  it("ignores a trailing separator", () => {
+    expect(peerName("/home/me/code/lich/", "4f2a1b3c")).toBe("lich-4f2a")
+  })
+
+  it("reads a Windows path", () => {
+    expect(peerName("C:\\Users\\me\\code\\lich", "4f2a1b3c")).toBe("lich-4f2a")
+  })
+
+  it("falls back when there is no directory to name", () => {
+    expect(peerName("", "4f2a1b3c")).toBe("lich-4f2a")
+    expect(peerName("/", "4f2a1b3c")).toBe("lich-4f2a")
+  })
+
+  it("keeps the directory alone when the id carries nothing usable", () => {
+    expect(peerName("/home/me/code/lich", "---")).toBe("lich")
+  })
+})

--- a/frontend/src/lib/session/peer-name.ts
+++ b/frontend/src/lib/session/peer-name.ts
@@ -1,0 +1,34 @@
+// The name a session answers to in Claude Code's peer roster — the list its
+// cross-session messaging addresses, and what `/list-agents` prints. lich passes
+// it at spawn (terminal.Start) and shows the same string on the card, so both
+// come from here: derive it twice and the tooltip would name a session by an
+// address that reaches a different one.
+//
+// Left to itself Claude names a session after its working directory, which is
+// the same directory for every session lich runs in one checkout — the id tail
+// is what tells those apart.
+
+// How much of the session id trails the directory name. Four is enough to
+// separate the handful of sessions one checkout holds, and short enough to stay
+// readable in a roster row.
+const ID_CHARS = 4
+
+export function peerName(cwd: string, id: string): string {
+  // Windows separators too: the name is built the same way wherever lich runs,
+  // even though only macOS and Linux have the messaging feature.
+  const dir =
+    cwd
+      .replace(/[\\/]+$/, "")
+      .split(/[\\/]/)
+      .pop() || "lich"
+  const tail = id.replace(/[^a-z0-9]/gi, "").slice(0, ID_CHARS)
+  return tail ? `${dir}-${tail}` : dir
+}
+
+/**
+ * How a target is named at the sender's prompt. The trailing space is what the
+ * drop of a file does too: whatever the user types next must not run into it.
+ */
+export function peerMention(name: string): string {
+  return `@${name} `
+}

--- a/frontend/src/lib/terminal/focus-request.ts
+++ b/frontend/src/lib/terminal/focus-request.ts
@@ -1,0 +1,20 @@
+// "Put the cursor back in this session's terminal", raised by chrome outside the
+// terminal — the sidebar writing a mention at the prompt — and honoured by the
+// TerminalView that owns the session. Page-internal: app-events carries what the
+// backend has to say, never what one part of the page asks of another.
+//
+// The value is a tick rather than a state because focus is an event: two
+// requests in a row have to notify twice, and a store that skips an equal value
+// would swallow the second.
+
+import { createKeyedStore } from "@/lib/keyed-store"
+
+const ticks = createKeyedStore<number>(0)
+
+export function requestTerminalFocus(sessionId: string): void {
+  ticks.set(sessionId, ticks.get(sessionId) + 1)
+}
+
+export function onTerminalFocusRequest(sessionId: string, listener: () => void): () => void {
+  return ticks.subscribe(sessionId, listener)
+}

--- a/internal/terminal/command.go
+++ b/internal/terminal/command.go
@@ -1,6 +1,10 @@
 package terminal
 
-import "github.com/omartelo/lich/internal/providers"
+import (
+	"strings"
+
+	"github.com/omartelo/lich/internal/providers"
+)
 
 // What a session's PTY runs: which binary, and with which arguments. Every
 // decision here is pure and takes its inputs as parameters, so the spawn path
@@ -20,6 +24,11 @@ const (
 	claudeResumeFlag  = "--resume"
 	codexResumeSubcmd = "resume"
 )
+
+// claudeNameFlag sets the name a session answers to in Claude Code's peer
+// roster — the list its cross-session messaging addresses, and what
+// `/list-agents` prints.
+const claudeNameFlag = "--name"
 
 // resolveCommand picks the binary a session runs: the user's shell for "shell"
 // sessions, otherwise the provider binary for the session's kind.
@@ -43,6 +52,23 @@ func resolveBin(kind, bin string) string {
 		return def
 	}
 	return defaultBin
+}
+
+// nameArgs returns the arguments that name a session in the provider's peer
+// roster, or nil when the provider keeps no roster or the name is unusable.
+// Claude Code is the only one with a roster, and left to itself it names a
+// session after its working directory — the same directory for every session
+// lich runs in one checkout, which is exactly the set the user has to tell
+// apart. A name that would be read as a flag is dropped rather than passed on.
+func nameArgs(kind, name string) []string {
+	if kind != providers.Claude {
+		return nil
+	}
+	name = strings.TrimSpace(name)
+	if name == "" || strings.HasPrefix(name, "-") {
+		return nil
+	}
+	return []string{claudeNameFlag, name}
 }
 
 // resumeArgs returns the arguments that reopen a provider conversation, or nil

--- a/internal/terminal/respawn_test.go
+++ b/internal/terminal/respawn_test.go
@@ -125,7 +125,7 @@ func waitFor(t *testing.T, cond func() bool, what string) {
 // is all that goroutine has left to do.
 func respawn(t *testing.T, svc *Service, id string) *session {
 	t.Helper()
-	if err := svc.Start(id, "p1", t.TempDir(), "claude", "", false, 80, 24); err != nil {
+	if err := svc.Start(id, "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
 		t.Fatalf("first start: %v", err)
 	}
 	svc.mu.Lock()
@@ -138,7 +138,7 @@ func respawn(t *testing.T, svc *Service, id string) *session {
 	if err := svc.Close(id); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	if err := svc.Start(id, "p1", t.TempDir(), "claude", "", false, 80, 24); err != nil {
+	if err := svc.Start(id, "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
 		t.Fatalf("second start: %v", err)
 	}
 

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -267,13 +267,17 @@ const readBufSize = 32 * 1024
 // that slips through (pruned between the check and the spawn) fails in the PTY
 // like any other bad invocation — the user sees the provider's own error.
 //
+// name is what the session answers to in its provider's peer roster (Claude
+// Code's `/list-agents`), passed by the frontend so the roster names the card
+// the user sees. Only Claude Code has a roster; every other kind ignores it.
+//
 // setup is passed once, by the flow that just created this session's worktree:
 // it runs the project's worktree setup script (Settings › Project) in the PTY
 // before the provider, so a fresh checkout installs its dependencies in view.
 // A respawn or resume never sets it. The script runs in the session's own
 // environment, so it reads the same LICH_WORKTREE_PORT the provider will.
-func (s *Service) Start(id, projectID, cwd, kind, resume string, setup bool, cols, rows int) error {
-	sess, cwd, err := s.spawnSession(id, projectID, cwd, kind, resume, setup, cols, rows)
+func (s *Service) Start(id, projectID, cwd, kind, resume, name string, setup bool, cols, rows int) error {
+	sess, cwd, err := s.spawnSession(id, projectID, cwd, kind, resume, name, setup, cols, rows)
 	if err != nil || sess == nil {
 		return err
 	}
@@ -290,7 +294,7 @@ func (s *Service) Start(id, projectID, cwd, kind, resume string, setup bool, col
 // registration. A nil session with a nil error means id was already running.
 // The returned cwd is the effective start directory (the input, or the
 // resolved home when it was empty).
-func (s *Service) spawnSession(id, projectID, cwd, kind, resume string, setup bool, cols, rows int) (*session, string, error) {
+func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, setup bool, cols, rows int) (*session, string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -308,7 +312,7 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume string, setup bo
 
 	spec := ptySpec{
 		bin:  resolveCommand(kind, s.store.ProviderBin(kind, projectID), userShell()),
-		args: resumeArgs(kind, resume),
+		args: append(nameArgs(kind, name), resumeArgs(kind, resume)...),
 		dir:  cwd,
 		env:  s.sessionEnv(id, projectID, cwd),
 		cols: cols,

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -300,7 +300,7 @@ func TestStartIsNoopWhenAlreadyRunning(t *testing.T) {
 	sess := spawnSession(t)
 	svc.sessions["s1"] = sess
 
-	if err := svc.Start("s1", "p1", "", "", "", false, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", "", "", "", "", false, 80, 24); err != nil {
 		t.Errorf("Start(running) = %v, want nil", err)
 	}
 	if svc.sessions["s1"] != sess {
@@ -339,7 +339,7 @@ func TestStartPassesResumeToTheProcess(t *testing.T) {
 	svc := New(stubBins{bin: bin}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "abc-123", false, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "abc-123", "", false, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
@@ -360,7 +360,7 @@ func TestStartWithoutResumeSpawnsBare(t *testing.T) {
 	svc := New(stubBins{bin: bin}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", false, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
@@ -381,7 +381,7 @@ func TestStartWithSetupWrapsTheSpawn(t *testing.T) {
 	svc := New(stubBins{bin: bin, setup: "echo setup-ran"}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", true, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", true, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
@@ -406,7 +406,7 @@ func TestStartWithSetupButNoScriptSpawnsBare(t *testing.T) {
 	svc := New(stubBins{bin: bin}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", true, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", true, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
@@ -481,6 +481,52 @@ func TestResumeArgs(t *testing.T) {
 			t.Errorf("%s: resumeArgs(%q, %q) = %v, want %v",
 				tc.name, tc.kind, tc.resume, got, tc.want)
 		}
+	}
+}
+
+// TestNameArgs proves only Claude Code is named — the one provider with a peer
+// roster — and that a name which would be parsed as a flag never reaches argv.
+func TestNameArgs(t *testing.T) {
+	cases := []struct {
+		name, kind, peer string
+		want             []string
+	}{
+		{"claude named", "claude", "lich-4f2a", []string{"--name", "lich-4f2a"}},
+		{"claude unnamed", "claude", "", nil},
+		{"claude blank name", "claude", "   ", nil},
+		{"claude name trimmed", "claude", " lich-4f2a ", []string{"--name", "lich-4f2a"}},
+		{"claude flag-like name", "claude", "--dangerously-skip-permissions", nil},
+		{"codex has no roster", "codex", "lich-4f2a", nil},
+		{"opencode has no roster", "opencode", "lich-4f2a", nil},
+		{"shell has no roster", KindShell, "lich-4f2a", nil},
+	}
+	for _, tc := range cases {
+		got := nameArgs(tc.kind, tc.peer)
+		if !slices.Equal(got, tc.want) {
+			t.Errorf("%s: nameArgs(%q, %q) = %v, want %v",
+				tc.name, tc.kind, tc.peer, got, tc.want)
+		}
+	}
+}
+
+// TestStartPassesNameToTheProcess proves the peer name reaches the spawned
+// binary's argv beside the resume id, in the order claude parses.
+func TestStartPassesNameToTheProcess(t *testing.T) {
+	bin := stayAliveBin(t)
+	svc := New(stubBins{bin: bin}, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1") })
+
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "lich-4f2a", false, 80, 24); err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+
+	svc.mu.Lock()
+	got := spawnedArgs(t, svc, "s1")
+	svc.mu.Unlock()
+
+	want := []string{bin, "--name", "lich-4f2a"}
+	if !slices.Equal(got, want) {
+		t.Errorf("spawned argv = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
## Why

Claude Code can message your other sessions ([cross-session messaging](https://code.claude.com/docs/en/cross-session-messaging), 2.1.224+), and every lich session already qualifies: same machine, same user, same filesystem. The feature works today with no lich change at all.

What stops it being used is naming. Left to itself Claude names a session after its working directory, so the sessions lich runs side by side in one checkout all look alike — and nothing ties any of those names to a card. Nobody can address anybody, so nobody does.

## What this does

- **Names each Claude session lich starts.** `--name` at spawn, Claude Code only — no other provider keeps a roster, and a name that would parse as a flag is dropped rather than passed.
- **Shows the name on the card.** A row in the tooltip that is already there, between the path and the branch, on Claude cards only.
- **Adds `Mention session` to the context menu** of the card whose terminal is on screen. It lists the Claude sessions of every open project, grouped by project, and writes the chosen one's name at your own prompt as a bracketed paste with no trailing return. You finish the sentence; the Claude reading that prompt addresses the other session with the `SendMessage` tool it already has.

## What it deliberately does not do

**lich never speaks the messaging protocol.** A session's inbox socket is reachable — the path is derivable from the PTY pid and the framing is newline-delimited JSON — but the frame schema is documented nowhere, so lich would be asserting a shape read out of a minified bundle that can move on any release. And a message lich posted attests no permission class: a session running in bypass mode holds it for approval instead of delivering it. Delegating to the sender's own Claude avoids both, and keeps a prompt the user typed counting as the user rather than arriving stripped of their authority.

**Claude to Claude only.** Reaching providers without a roster — by writing at the target's prompt instead — is a separate question and is not in this PR.

## Known limits

- **The list spans every open project** because the sidebar shows one project at a time, and walking to another would change which session is sending.
- **A card whose terminal was never opened is listed like any other.** It has no process, so no inbox socket, and the sender's Claude reports the name as unreachable. Filtering those would mean lifting spawn state out of the component that owns it, for a case the user is told about anyway.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green (964 passed, 25 packages)
- [x] `pnpm check` clean, `tsc` clean, `vitest` green (740 passed), `vite build` succeeds
- [x] Cross-compile loop green for linux, darwin and windows (build + vet)
- [x] `nameArgs` covered by table test; the name reaching the spawned binary's argv covered end to end
- [x] `mentionTargets` covered: project order, sender excluded, non-Claude sessions excluded, worktree naming, empty groups dropped
- [x] Verified by hand in `task dev`: submenu renders, the mention lands at the prompt and the cursor returns to the terminal