### PR TITLE
feat: ask before closing a project with a session running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Closing a project asks when an agent is still working.** The tab's × took a
+  project's terminals down with it, killing whatever was mid-turn — with a
+  spinner on that very tab as the only warning, and no undo. Closing a project
+  whose sessions are busy or waiting on you now names how many and asks first;
+  a project where nothing is running still closes on the click.
+
 ### Fixed
 
 - **A dragged card keeps its own shape.** Dragging a session card past a taller

--- a/frontend/src/components/tabs/ProjectTabs.tsx
+++ b/frontend/src/components/tabs/ProjectTabs.tsx
@@ -1,11 +1,15 @@
+import { useState } from "react"
 import { useMatch, useNavigate } from "react-router-dom"
 import { GitPullRequestArrow, Settings } from "lucide-react"
 import { DndContext, closestCenter } from "@dnd-kit/core"
 import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortable"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
+import { ConfirmDialog } from "@/components/ConfirmDialog"
 import { useProjects } from "@/providers/projects"
 import { sessionsOf } from "@/lib/session/sessions"
+import { runningSessions } from "@/lib/session/use-session-status"
+import type { Project } from "@/lib/api-types"
 import { openSettings } from "@/lib/settings-card-store"
 import { openPullsList } from "@/lib/pulls-list-card-store"
 import { NotificationsButton } from "./NotificationsButton"
@@ -17,6 +21,11 @@ import { OpenProjectMenu } from "./OpenProjectMenu"
 export function ProjectTabs() {
   const { projects, sessions, homeId, closeProject, reorderProjects } = useProjects()
   const navigate = useNavigate()
+  // The project waiting on the "sessions are still running" confirmation, with
+  // how many were running when it was asked for. Closing a project unmounts its
+  // terminals, which kills their PTYs — an agent mid-turn dies with them, and no
+  // undo brings that turn back, so this one asks first.
+  const [pending, setPending] = useState<{ project: Project; running: number } | null>(null)
   // The project the settings gear targets: whichever one is in view, falling
   // back to Home when the app is on the bare landing screen.
   const activeProjectId = useMatch("/projects/:projectId/*")?.params.projectId ?? homeId
@@ -43,6 +52,15 @@ export function ProjectTabs() {
     openPullsList(activeProjectId)
     navigate(`/projects/${activeProjectId}/pulls/all`)
   }
+  const requestClose = (project: Project) => {
+    const running = runningSessions(sessionsOf(sessions, project.id).map((s) => s.id))
+    if (running.length === 0) {
+      closeProject(project.id)
+      return
+    }
+    setPending({ project, running: running.length })
+  }
+
   // Home is pinned first and stays out of the drag list so it never reorders.
   const rest = projects.filter((project) => project.id !== homeId)
   const ids = rest.map((project) => project.id)
@@ -50,58 +68,84 @@ export function ProjectTabs() {
   const showHome = homeId !== null && projects.some((p) => p.id === homeId)
 
   return (
-    <div className="flex h-10 shrink-0 items-center gap-1 border-b border-border bg-sidebar px-2">
-      <div className="flex flex-1 items-center gap-1 overflow-x-auto overflow-y-hidden">
-        {showHome && homeId && <HomeTab projectId={homeId} />}
-        <DndContext
-          sensors={sensors}
-          collisionDetection={closestCenter}
-          modifiers={[horizontalAxis]}
-          onDragEnd={onDragEnd}
+    <>
+      <div className="flex h-10 shrink-0 items-center gap-1 border-b border-border bg-sidebar px-2">
+        <div className="flex flex-1 items-center gap-1 overflow-x-auto overflow-y-hidden">
+          {showHome && homeId && <HomeTab projectId={homeId} />}
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            modifiers={[horizontalAxis]}
+            onDragEnd={onDragEnd}
+          >
+            <SortableContext items={ids} strategy={horizontalListSortingStrategy}>
+              {rest.map((project) => (
+                <ProjectTab
+                  key={project.id}
+                  project={project}
+                  sessionIds={sessionsOf(sessions, project.id).map((s) => s.id)}
+                  onClose={() => requestClose(project)}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
+          <OpenProjectMenu />
+        </div>
+        <div aria-hidden className="mx-1 h-5 w-px shrink-0 bg-border" />
+        <NotificationsButton />
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={openProjectPulls}
+          disabled={!activeProjectId}
+          title="Pull requests"
+          aria-label="Pull requests"
+          className={cn(
+            "shrink-0 text-muted-foreground",
+            onPulls && "bg-accent text-accent-foreground",
+          )}
         >
-          <SortableContext items={ids} strategy={horizontalListSortingStrategy}>
-            {rest.map((project) => (
-              <ProjectTab
-                key={project.id}
-                project={project}
-                sessionIds={sessionsOf(sessions, project.id).map((s) => s.id)}
-                onClose={() => closeProject(project.id)}
-              />
-            ))}
-          </SortableContext>
-        </DndContext>
-        <OpenProjectMenu />
+          <GitPullRequestArrow className="size-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={openProjectSettings}
+          disabled={!activeProjectId}
+          title="Settings"
+          aria-label="Settings"
+          className={cn(
+            "shrink-0 text-muted-foreground",
+            onSettings && "bg-accent text-accent-foreground",
+          )}
+        >
+          <Settings className="size-4" />
+        </Button>
       </div>
-      <div aria-hidden className="mx-1 h-5 w-px shrink-0 bg-border" />
-      <NotificationsButton />
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        onClick={openProjectPulls}
-        disabled={!activeProjectId}
-        title="Pull requests"
-        aria-label="Pull requests"
-        className={cn(
-          "shrink-0 text-muted-foreground",
-          onPulls && "bg-accent text-accent-foreground",
-        )}
+      <ConfirmDialog
+        open={pending !== null}
+        onCancel={() => setPending(null)}
+        title="Sessions are still running"
+        description={
+          <>
+            Closing <span className="font-medium">{pending?.project.name}</span> stops{" "}
+            {pending?.running === 1 ? "a session" : `${pending?.running} sessions`} mid-turn.
+            Reopening the project offers to resume where each left off; the turn in flight is lost.
+          </>
+        }
       >
-        <GitPullRequestArrow className="size-4" />
-      </Button>
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        onClick={openProjectSettings}
-        disabled={!activeProjectId}
-        title="Settings"
-        aria-label="Settings"
-        className={cn(
-          "shrink-0 text-muted-foreground",
-          onSettings && "bg-accent text-accent-foreground",
-        )}
-      >
-        <Settings className="size-4" />
-      </Button>
-    </div>
+        <Button
+          variant="destructive"
+          onClick={() => {
+            if (pending) {
+              closeProject(pending.project.id)
+            }
+            setPending(null)
+          }}
+        >
+          Close anyway
+        </Button>
+      </ConfirmDialog>
+    </>
   )
 }

--- a/frontend/src/lib/session/session-status-store.test.ts
+++ b/frontend/src/lib/session/session-status-store.test.ts
@@ -197,6 +197,51 @@ describe("pendingOf", () => {
   })
 })
 
+describe("runningOf", () => {
+  it("returns nothing when no session of the project is mid-turn", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "done"))
+    expect(store.runningOf([])).toEqual([])
+    expect(store.runningOf(["s1", "ghost"])).toEqual([])
+  })
+
+  it("counts both a working agent and one blocked on the user", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "busy"))
+    emit(report("s2", "waiting"))
+    emit(report("s3", "done"))
+    expect(store.runningOf(["s1", "s2", "s3"])).toEqual(["s1", "s2"])
+  })
+
+  it("only counts the sessions of the project asked about", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("mine", "busy"))
+    emit(report("theirs", "busy"))
+    expect(store.runningOf(["mine"])).toEqual(["mine"])
+  })
+
+  // Unlike a tab badge, a running turn is not something the user can dismiss by
+  // looking at it: the guard must still fire for a session already seen.
+  it("keeps counting a running session that was marked seen", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "busy"))
+    store.markSeen("s1")
+    expect(store.runningOf(["s1"])).toEqual(["s1"])
+  })
+
+  it("stops counting a session once its turn ends", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "busy"))
+    emit(report("s1", "done"))
+    expect(store.runningOf(["s1"])).toEqual([])
+  })
+})
+
 describe("since", () => {
   beforeEach(() => {
     vi.useFakeTimers()

--- a/frontend/src/lib/session/session-status-store.ts
+++ b/frontend/src/lib/session/session-status-store.ts
@@ -153,6 +153,17 @@ export function createSessionStatusStore(source: StatusEventSource) {
     return BADGE_PRIORITY.find((status) => live.has(status)) ?? null
   }
 
+  // runningOf returns the sessions of these ids that still hold a turn: an agent
+  // working, or one blocked on a prompt nobody has answered. Unlike pendingOf
+  // this ignores "seen" — a turn does not stop running because it was looked at
+  // — and it answers with the sessions themselves, since a caller asking this
+  // is about to say how many are at stake.
+  const runningOf = (ids: readonly string[]): string[] =>
+    ids.filter((id) => {
+      const status = entries.get(id)?.status
+      return status === "busy" || status === "waiting"
+    })
+
   const subscribe = (id: string, listener: () => void): (() => void) => {
     const entry = entryOf(id)
     entry.listeners.add(listener)
@@ -184,5 +195,5 @@ export function createSessionStatusStore(source: StatusEventSource) {
   // changes, so it is safe to hand straight to useSyncExternalStore.
   const pendingAll = (): PendingStatus[] => pending
 
-  return { subscribe, get, since, markSeen, pendingOf, subscribeAll, pendingAll }
+  return { subscribe, get, since, markSeen, pendingOf, runningOf, subscribeAll, pendingAll }
 }

--- a/frontend/src/lib/session/use-session-status.ts
+++ b/frontend/src/lib/session/use-session-status.ts
@@ -76,6 +76,15 @@ export function useProjectStatus(sessionIds: readonly string[]): SessionStatus |
   return useSyncExternalStore(subscribe, snapshot)
 }
 
+// runningSessions returns which of these sessions are mid-turn right now (see
+// session-status-store.runningOf). Read imperatively rather than subscribed to:
+// its caller is a click that has to decide about this instant, and a component
+// re-rendering on every status change to hold a number it only reads on close
+// would be the subscription doing nothing the rest of the time.
+export function runningSessions(sessionIds: readonly string[]): string[] {
+  return store.runningOf(sessionIds)
+}
+
 // usePendingStatuses returns every session needing attention across all
 // projects — the notification queue (see session-status-store.pendingAll).
 // subscribeAll and pendingAll are module-stable, so no memoization is needed.


### PR DESCRIPTION
## What

The project tab's × took every terminal in that project down with it: unmounting a `TerminalView` closes its PTY, so an agent mid-turn died on the click. The only warning was the busy spinner on the tab being closed, and unlike a closed session — which raises an **Undo** toast — a closed project offered no way back for the turn in flight.

Closing a project whose sessions are `busy` or `waiting` now asks first and says how many are at stake. A project with nothing running closes on the click, exactly as before.

## How

- `session-status-store.runningOf(ids)` — the sessions of a project that still hold a turn. Unlike `pendingOf` it ignores the `seen` flag: a turn does not stop running because someone looked at the tab.
- `runningSessions` in `use-session-status` exposes it imperatively. Read at the moment of the click rather than subscribed to — the tab strip would otherwise re-render on every status change to hold a number it only reads when a close is requested.
- `ProjectTabs` holds the pending project and renders the existing `ConfirmDialog` (same shape as the worktree close dialogs). `closeProject` itself is untouched, so the "Home is permanent" rule and the focus fallback stay where they were.

Session rows survive a close either way — reopening the project brings the cards back and offers to resume each conversation. What is lost is the turn that was running, which is what the dialog says.

## Test plan

- [x] `runningOf` unit tests: nothing running, busy + waiting counted, other projects ignored, a marked-seen session still counted, a finished turn dropped.
- [x] `pnpm check`, `vitest run` (732 passing), `tsc` + `vite build`, `gofmt -l .`, `go vet ./...`, `go test ./...` — all clean.
- [x] Driven in a real (headless) window against a throwaway config dir, statuses reported through the plugin's `/hook` endpoint:
  - project with no reported status → closes on the click, no dialog
  - project with one `busy` + one `waiting` session → dialog reads "Closing busyproj stops 2 sessions mid-turn"
  - **Cancel** → dialog closes, project stays
  - **Close anyway** → project closes