### PR TITLE
feat: let sessions hand work to each other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **One session can hand work to another, whatever it is running.** Claude Code
+  sessions can already message each other; Codex, OpenCode and Crush cannot, and
+  nothing in lich reached across a card. Every session now carries a `lich`
+  command that does: `lich sessions` lists the live cards beside it,
+  `lich send "<card>" "<task>"` puts the task at that card's prompt and waits,
+  and the agent there answers with `lich reply`. The answer comes back as the
+  command's output, so the session that asked reads it without anyone carrying
+  text between two terminals. It works the same on all four providers precisely
+  because it never reads a terminal — the agent writes its own answer — and
+  cards are addressed by the label you see on them. The full surface is
+  `docs/cli.md`.
+
+- **Sessions find each other on their own.** A command only helps someone who
+  has been told it exists, and the person who would need telling is the one who
+  does not read release notes. So lich now registers itself as an MCP server
+  with each Claude Code and Codex session it opens: those agents see
+  `list_sessions`, `send_to_session`, `wait_for_answer` and `reply_to_session`
+  in their own tool list from the first turn, with nothing to install, type or
+  configure. Your own MCP servers are untouched, and the registration carries no
+  credential — it names lich and a subcommand, nothing else. opencode, oh-my-pi
+  and Crush offer no way to be told this at startup, so their sessions keep
+  using the `lich` command, which works everywhere.
+
+- **lich is scriptable from outside a session.** The same commands run from any
+  shell on the machine — a script, a scheduled job, your own terminal — finding
+  the running lich on their own instead of needing to be spawned by it. `--json`
+  gives `sessions`, `send` and `wait` a machine-readable line, so an automation
+  can hand a session a task and read its answer without a provider in the loop.
+  A message relayed that way says it came from the command line rather than
+  posing as another session.
+
 - **A card says which tool its agent is running.** A busy session showed a
   spinning ring and nothing else: whether it was three seconds into a file read
   or three minutes into a test run, the card looked the same. It now names the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,286 @@
+# Contract: the `lich` CLI
+
+An agent running in a lich session has a shell and nothing else — no window, no
+RPC client, no knowledge of this app. The `lich` command is the surface it uses
+to reach the sessions beside it: list them, hand one a task, answer one that
+handed it a task.
+
+It is not only for agents. The same commands run from any shell on the machine —
+a script, a scheduled job, the user's own terminal — which is what makes lich
+automatable without a provider in the loop. `--json` is there for exactly that.
+
+Agents mostly do not run it as a command. lich registers the same operations as
+**MCP tools** for the providers that can be told at spawn, so they are in the
+agent's own tool list without anybody being told anything — see
+[Registration](#registration). The command line stays because a tool list only
+reaches an agent: a script, a scheduled job or a plain terminal has no tool
+list, and the reply path has to work even where no server was registered.
+
+This document is **contract-first**, exactly as [`hooks/`](hooks/README.md) is.
+A flag, a tool name or an output line that moves here can break the companion
+plugin ([`omartelo/lich-plugin`](https://github.com/omartelo/lich-plugin)) and
+whatever the user automated on top, neither of which this repo can see. Move the
+contract first.
+
+## Why an agent writes its own answer
+
+lich delivers a message by typing it at the target's prompt, exactly as the user
+would. It never reads the answer off the terminal: a TUI's output is boxes,
+spinners and ANSI, and parsing it would mean a parser per provider, each hostage
+to that provider's next release.
+
+So the message lich types **asks the agent to report back** — with the
+`reply_to_session` tool where lich registered one, and always by running
+`lich reply <ticket>`, which needs nothing registered at all. The answer is
+written by the agent that produced it. That is the whole reason this works on
+every provider lich runs, rather than only on the ones that ship a messaging
+channel of their own: anything that can run a shell command can answer.
+
+## Transport
+
+Every command reads the coordinates lich already injects into each PTY (see the
+hooks [README](hooks/README.md)) and posts to the same loopback listener the
+window uses:
+
+| Var               | Purpose                                          |
+|-------------------|--------------------------------------------------|
+| `LICH_PORT`       | endpoint port (loopback)                         |
+| `LICH_TOKEN`      | auth token (`?token=`)                           |
+| `LICH_SESSION_ID` | the card this command is running in — the sender |
+| `LICH_BIN`        | the path of the lich this session belongs to     |
+
+```
+POST http://127.0.0.1:${LICH_PORT}/rpc/relay.<Method>?token=${LICH_TOKEN}
+```
+
+**Outside a session** those are absent, and the command finds the running lich
+on its own: it reads the coordinates from `runtime.json` (`internal/singleton`,
+mode 0600), the same file `install.sh` reads to reach a running lich for
+`/restart`. `LICH_DEV` selects the dev instance's file, as everywhere else. With
+no lich running at all, every command exits 1 with `lich: no lich is running`.
+
+The environment wins over the runtime file, and that order is load-bearing: a
+session belongs to the lich that spawned it, and on a machine running a daily
+driver beside a `task dev` build the runtime file names only one of them.
+
+Such a caller has **no session of its own**, so `LICH_SESSION_ID` is empty. That
+is passed on rather than rejected: the relayed message is then attributed to the
+command line instead of to a session (see below).
+
+**Always call it as `"$LICH_BIN"`, not as `lich`.** An installed lich is on
+`$PATH` and a `task dev` build is not; on a machine running both, the bare name
+resolves to whichever comes first rather than to the lich the session belongs
+to. `LICH_BIN` is the one that is right by construction, which is why the
+relayed message spells the reply command that way.
+
+## Commands
+
+Every command prints its result on stdout and its failure as one `lich: …` line
+on stderr, exiting 0 or 1. Anything that is not a subcommand below — including
+`lich -- <chromium flags>` — opens the app instead.
+
+`--json` on `sessions`, `send` and `wait` replaces the prose with one JSON line:
+the peer array and the result object exactly as this document describes them.
+An empty roster is `[]`, never `null` — a script should not have to tell those
+apart.
+
+### `lich sessions [--json]`
+
+Lists the live sessions the caller can address, tab-separated with a header:
+
+```
+session	project	provider
+docs	lich	codex
+api	revu	crush
+```
+
+`No other live sessions.` when there are none. A session is listed only while a
+process is running in it: a card whose terminal was never opened has nothing to
+type at.
+
+### `lich send [--project <name>] [--timeout <seconds>] <session> <prompt>`
+
+Types `<prompt>` at `<session>`'s prompt, submits it, and waits.
+
+- `<session>` is the label on the card. Labels are unique within a project, not
+  across them: a label two live sessions answer to is an error naming both, and
+  `--project` is what narrows it. Guessing which session a prompt lands in is
+  the one mistake this must not make.
+- `--timeout` bounds the wait in seconds. Default 100 — under the 120s an
+  agent's shell tool typically allows a command, so the wait ends in an answer
+  this side controls rather than a killed process. Capped at 30 minutes.
+- Answered: prints the answer alone, exit 0.
+- Not answered in time: the message was still delivered, so it prints the ticket
+  and the command that picks the answer up later, exit 0.
+
+```
+docs has not answered yet. The message was delivered; wait for it with:
+  lich wait a1b2c3d4
+```
+
+A prompt is capped at 8192 characters and stripped of control characters — the
+text is typed into a terminal, and an escape sequence inside it would stop being
+text.
+
+### `lich wait [--timeout <seconds>] <ticket>`
+
+Waits again on a ticket a previous `send` handed back. Same output as `send`.
+A ticket that was answered, or that nobody answered within an hour, is gone and
+waiting on it is an error.
+
+### `lich reply <ticket> <answer>`
+
+Hands `<answer>` to the session waiting on `<ticket>`; prints `Answer sent.`
+This is what a relayed message asks the receiving agent to run. An answer is
+capped at 64 KiB. Replying twice to one ticket is an error — the first answer
+already went home.
+
+### `lich mcp`
+
+Serves the commands above as MCP tools over stdio: one JSON-RPC 2.0 message per
+line, `initialize` / `tools/list` / `tools/call` / `ping`. stdout carries
+protocol and nothing else.
+
+You rarely run this by hand — lich registers it for the providers that can be
+told at spawn (see below). Run it yourself only to point some other MCP client
+at lich.
+
+| Tool | What it does |
+|------|--------------|
+| `list_sessions` | The live sessions that can be given work, as JSON. |
+| `send_to_session` | `session`, `prompt`, optional `project` and `timeout_seconds`. |
+| `wait_for_answer` | `ticket`, optional `timeout_seconds`. |
+| `reply_to_session` | `ticket`, `answer` — what a relayed message asks for. |
+
+A tool that fails answers with `isError` and the reason as text, not a JSON-RPC
+error: the agent should read what went wrong and act on it, not lose the turn.
+
+## Registration
+
+An MCP tool is in the agent's own tool list from the first turn. That is the
+point of it — a command line only helps an agent that has been told the command
+exists, and the person who would have to be told is the one who does not read
+release notes.
+
+So lich registers the server itself, per session, at spawn
+(`internal/terminal`, `mcpArgs`), for the providers that can be told on their
+own command line (`providers.AcceptsMCPServer`):
+
+| Provider | How | Registered |
+|---|---|---|
+| Claude Code | `--mcp-config` with a JSON string, no file on disk | yes |
+| Codex | `-c mcp_servers.lich.command=…` and `…args=["mcp"]` | yes |
+| opencode · oh-my-pi · Crush | no flag for it — Crush's whole flag list is cwd, data-dir, session and debug | no |
+
+The three without a flag would need lich to write a config file it does not own,
+so it does not: their sessions use the command line above.
+
+Two rules the registration must keep:
+
+- **Never `--strict-mcp-config`.** It would make Claude Code ignore every other
+  MCP configuration — the user's own servers dropped for the sake of lich's.
+- **Order is not free.** `--mcp-config` is variadic and reads whatever follows
+  it as another config path, so for Claude Code it goes last. Codex spells
+  resume as a subcommand and its global options must precede it, so for Codex it
+  goes first. `providerArgs` owns both.
+
+**Why stdio and not HTTP.** lich already serves HTTP on the loopback listener,
+and registering a URL would have been less code. But the registration lands in
+the provider's **argv**, and `/proc/<pid>/cmdline` is readable by any user on
+the machine while `/proc/<pid>/environ` is not. A URL registration means
+`?token=` in argv. The stdio one names a binary and a subcommand and carries no
+secret at all — the server inherits the coordinates from the PTY's environment,
+where they already were.
+
+## The message a target receives
+
+```
+[lich] Message from session "<sender label>", not from your own prompt.
+
+<prompt>
+
+When you have an answer, send it back by running:
+  "$LICH_BIN" reply <ticket> "<your answer>"
+Whoever asked is blocked waiting on that command.
+```
+
+A caller with no session of its own — the CLI run from a script or a plain
+shell — opens with `Message relayed by the lich command line` instead. The
+distinction is the point: the receiving agent must not read either as its user
+speaking, and the two are not the same kind of "not your user".
+
+A target whose provider has the registered server is offered the tool first:
+
+```
+When you have an answer, send it back with the lich tool `reply_to_session`
+(ticket <ticket>), or by running:
+  "$LICH_BIN" reply <ticket> "<your answer>"
+```
+
+The command is named either way. A session whose shell is locked down would
+otherwise have no way to answer at all, and the reply path exists for the
+receiving agent only because this text describes it.
+
+## lich server side
+
+- **Relay** — `internal/relay`: resolves a label to a live session, composes the
+  message above, types it through the terminal service, and holds the ticket the
+  answer comes back on. Tickets live in memory: one exists for as long as its
+  errand does, and a lich that restarted has no PTY left to answer into.
+- **Delivery** — `internal/terminal`, `Service.Write`: the same PTY write the
+  window's keyboard input takes. The message is wrapped in bracketed paste
+  (`\x1b[200~`…`\x1b[201~`) and followed by a carriage return, so a multi-line
+  message arrives as one prompt instead of one submission per line.
+- **Liveness** — `internal/terminal`, `Service.Live`: whether a card has a PTY
+  behind it right now.
+- **CLI** — `internal/cli`: argument parsing and the RPC client. It answers
+  before `main` opens the database or takes the log file, so a command never
+  races the lich it is talking to. `dispatch` is the seam its tests use: a
+  client built by `Run` resolves the runtime file of the lich actually running,
+  and a test that reached it would deliver into a real session.
+- **Finding a lich from outside** — `internal/singleton`, `Read`: the runtime
+  file the CLI falls back to when the environment carries no coordinates.
+- **MCP server** — `internal/cli/mcp.go`: the stdio transport, the tool table
+  and the handshake. Adding a tool is one entry in `mcpTools`, which is what
+  registering once buys — every tool lich grows later reaches every provider
+  that took the registration, with no further per-provider work.
+- **Registration** — `internal/terminal`, `providerArgs` / `mcpArgs`, beside
+  `nameArgs` and `resumeArgs`; which providers accept one is
+  `providers.AcceptsMCPServer`. The names it registers under
+  (`relay.MCPServerName`, `relay.MCPSubcommand`, `relay.ToolReply`) live in the
+  relay because both this and the composed message need them, and only that
+  direction closes no import cycle.
+- **Env** — `internal/terminal`, `Service.sessionEnv`: exports `LICH_BIN`
+  alongside the hook coordinates.
+
+## Known ceilings
+
+- **A relayed prompt carries the sender's reach, not the user's.** It is typed
+  at the target's prompt and submitted, so the receiving agent acts on it under
+  its own permissions — in a session running without permission prompts, that is
+  every tool it has. This does not widen lich's trust boundary (`LICH_TOKEN` is
+  already in every PTY, and any process in one can already write to any
+  session), but it is the first feature that uses it, and there is no switch.
+- **The tools cost context in every session, used or not.** Four tool
+  definitions are in the prompt of every Claude Code and Codex session lich
+  spawns, whether or not that session ever talks to another one. The command
+  line costs nothing until it is called; the tools are what buy discovery, and
+  this is the price. Anything added to `mcpTools` raises it for everyone.
+- **Registration is silent and there is no switch.** A session lich spawns is
+  handed the server without being asked. This does not widen the trust boundary
+  — `LICH_TOKEN` was already in every PTY — but it does mean a user who never
+  wanted this has no way to say so short of the provider's own MCP settings.
+- **Only live sessions are addressable.** A parked or never-opened card is
+  invisible to `sessions` and unreachable by `send`. Spawning one on demand
+  would mean lifting spawn state out of the frontend, which owns it.
+- **Delivery is proven, receipt is not.** `send` knows the bytes reached the
+  PTY. Whether the target's TUI queued them, and whether its agent ever runs the
+  reply command, is what the wait and the ticket are for. A provider that does
+  not honour bracketed paste would read the message's newlines as submissions.
+- **A busy target is written to anyway.** Every provider lich spawns queues text
+  typed mid-turn and submits it when the turn ends, so the message waits its
+  turn rather than interrupting one.
+- **The answer is the agent's summary, not the transcript.** Nothing reads the
+  target's output, so what comes back is exactly what that agent chose to type
+  into `lich reply` — and an agent that never runs it is indistinguishable from
+  one still working.

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -51,6 +51,10 @@ Neither addresses anything in lich and no hook reads them — they exist for the
 project's own setup script and commands (`PORT=$LICH_WORKTREE_PORT pnpm dev`,
 `cp --reflink=auto -r "$LICH_PROJECT_DIR/node_modules" .`).
 
+`LICH_BIN` is the fourth: the path of the lich this session belongs to, which
+the agent in the PTY calls to reach the sessions beside it. That surface has its
+own contract in [cli.md](../cli.md).
+
 ## Client rules (all hooks)
 
 - Missing env vars → no-op, exit 0.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,0 +1,363 @@
+// Package cli is the `lich` command line — the surface a provider CLI running
+// inside a lich session uses to reach the sessions beside it.
+//
+// It exists because an agent has a shell and nothing else: no lich window, no
+// RPC client, no knowledge of this app. Every command here reads the loopback
+// coordinates lich already exports into each PTY (LICH_PORT / LICH_TOKEN /
+// LICH_SESSION_ID, see docs/hooks/README.md) and talks to the running lich over
+// the same listener the window uses.
+//
+// It also works from any other shell on the machine — a script, a scheduled
+// job, the user's own terminal. With no coordinates in the environment it reads
+// them from the running instance's runtime file (internal/singleton), the same
+// one install.sh uses to reach a running lich for /restart. Such a caller has
+// no session of its own, and the message it relays says so.
+//
+// The contract is docs/cli.md; the lich-plugin slash commands are written
+// against it, so a flag or an output line that moves here breaks a repo this
+// one cannot see.
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/omartelo/lich/internal/relay"
+	"github.com/omartelo/lich/internal/singleton"
+)
+
+// NotACommand is returned when the arguments name no lich subcommand at all,
+// which is how main tells "the user ran a command" apart from "the user opened
+// the app" (and from `lich -- <chromium flags>`).
+const NotACommand = -1
+
+// callSlack is how much longer than the wait it asked for the client gives the
+// request. The relay answers a pending errand on its own deadline; this only
+// has to outlast that answer's trip back.
+const callSlack = 30 * time.Second
+
+// shortCall bounds the commands that do not wait on another session.
+const shortCall = 10 * time.Second
+
+const usage = `lich talks to the sessions open in the running lich window.
+
+  lich sessions [--json]
+      List the live sessions that can be reached.
+
+  lich send [--project <name>] [--timeout <seconds>] [--json] <session> <prompt>
+      Put <prompt> at <session>'s prompt and wait for its agent to answer.
+      Prints the answer. If the wait runs out first it prints a ticket to
+      pick the answer up with.
+
+  lich wait [--timeout <seconds>] [--json] <ticket>
+      Wait again on a ticket a previous send handed back.
+
+  lich reply <ticket> <answer>
+      Send <answer> back to whoever is waiting on <ticket>. This is what a
+      relayed message asks you to run when you are done.
+
+  lich mcp
+      Serve the commands above as MCP tools over stdio. lich registers this
+      itself for the providers that support it; you only run it by hand to
+      point another MCP client at lich.
+
+Run inside a lich session these address the sessions beside it. Run anywhere
+else on the machine they find the running lich on their own, and what they
+relay is attributed to the command line rather than to a session.
+`
+
+// Run executes one subcommand and returns the process exit code, or
+// NotACommand when args name none. env reads the process environment.
+func Run(args []string, env func(string) string, stdout, stderr io.Writer) int {
+	return dispatch(args, &client{
+		env: env, stdin: os.Stdin, stdout: stdout, stderr: stderr, running: runningLich,
+	})
+}
+
+// dispatch is Run with the client already built. It is the seam the tests use:
+// a client built here can be pointed at a fake instance, where one built by Run
+// would find the lich actually running on the machine and deliver into it.
+func dispatch(args []string, c *client) int {
+	if len(args) == 0 {
+		return NotACommand
+	}
+	switch args[0] {
+	case "sessions":
+		return c.run(c.sessions, args[1:])
+	case "send":
+		return c.run(c.send, args[1:])
+	case "wait":
+		return c.run(c.wait, args[1:])
+	case "reply":
+		return c.run(c.reply, args[1:])
+	case "mcp":
+		return c.run(c.serveMCP, args[1:])
+	case "help", "--help", "-h":
+		fmt.Fprint(c.stdout, usage)
+		return 0
+	}
+	return NotACommand
+}
+
+type client struct {
+	env func(string) string
+	// stdin carries the MCP server's incoming messages; nil for every other
+	// command, none of which reads anything.
+	stdin  io.Reader
+	stdout io.Writer
+	stderr io.Writer
+	// running finds the lich instance to talk to when the environment carries
+	// no coordinates, i.e. when this is not running inside a lich PTY.
+	running func() (*singleton.Info, error)
+}
+
+// run reports a subcommand's failure the way a command line does — one line on
+// stderr, a non-zero exit — so an agent reading the output is told what went
+// wrong instead of being handed an empty answer.
+func (c *client) run(fn func([]string) error, args []string) int {
+	if err := fn(args); err != nil {
+		fmt.Fprintf(c.stderr, "lich: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+func (c *client) sessions(args []string) error {
+	flags := newFlagSet("sessions")
+	asJSON := flags.Bool("json", false, "print the result as JSON")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	var peers []relay.Peer
+	if err := c.call("relay.Peers", []any{c.sessionID()}, shortCall, &peers); err != nil {
+		return err
+	}
+	if peers == nil {
+		// Decoding a JSON null leaves the slice nil, and a script reading --json
+		// should never have to tell that apart from an empty roster.
+		peers = []relay.Peer{}
+	}
+	if *asJSON {
+		return c.emit(peers)
+	}
+	if len(peers) == 0 {
+		fmt.Fprintln(c.stdout, "No other live sessions.")
+		return nil
+	}
+	fmt.Fprintln(c.stdout, "session\tproject\tprovider")
+	for _, p := range peers {
+		fmt.Fprintf(c.stdout, "%s\t%s\t%s\n", p.Label, p.Project, p.Kind)
+	}
+	return nil
+}
+
+func (c *client) send(args []string) error {
+	flags := newFlagSet("send")
+	project := flags.String("project", "", "narrow the target to one project when the label is ambiguous")
+	timeout := flags.Int("timeout", 0, "seconds to wait for an answer before handing back a ticket")
+	asJSON := flags.Bool("json", false, "print the result as JSON")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 2 {
+		return fmt.Errorf("usage: lich send [--project <name>] [--timeout <seconds>] [--json] <session> <prompt>")
+	}
+
+	var result relay.Result
+	call := []any{c.sessionID(), flags.Arg(0), *project, flags.Arg(1), *timeout}
+	if err := c.call("relay.Send", call, waitBudget(*timeout), &result); err != nil {
+		return err
+	}
+	return c.report(result, *asJSON)
+}
+
+func (c *client) wait(args []string) error {
+	flags := newFlagSet("wait")
+	timeout := flags.Int("timeout", 0, "seconds to wait before handing the ticket back again")
+	asJSON := flags.Bool("json", false, "print the result as JSON")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 1 {
+		return fmt.Errorf("usage: lich wait [--timeout <seconds>] [--json] <ticket>")
+	}
+
+	var result relay.Result
+	if err := c.call("relay.Wait", []any{flags.Arg(0), *timeout}, waitBudget(*timeout), &result); err != nil {
+		return err
+	}
+	return c.report(result, *asJSON)
+}
+
+func (c *client) reply(args []string) error {
+	flags := newFlagSet("reply")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 2 {
+		return fmt.Errorf("usage: lich reply <ticket> <answer>")
+	}
+	if err := c.call("relay.Reply", []any{flags.Arg(0), flags.Arg(1)}, shortCall, nil); err != nil {
+		return err
+	}
+	fmt.Fprintln(c.stdout, "Answer sent.")
+	return nil
+}
+
+// report prints a Send or Wait outcome. An answer goes to stdout on its own so
+// it can be read as the command's output; a wait that ran out says what to run
+// next, because an agent handed a bare ticket would have to guess.
+func (c *client) report(result relay.Result, asJSON bool) error {
+	if asJSON {
+		return c.emit(result)
+	}
+	if result.Status == relay.StatusAnswered {
+		fmt.Fprintln(c.stdout, result.Answer)
+		return nil
+	}
+	fmt.Fprintf(c.stdout,
+		"%s has not answered yet. The message was delivered; wait for it with:\n  lich wait %s\n",
+		result.Target, result.Ticket,
+	)
+	return nil
+}
+
+// emit writes one JSON line — the shape a script reads instead of the prose
+// above, which is what makes these commands usable from an automation.
+func (c *client) emit(payload any) error {
+	if err := json.NewEncoder(c.stdout).Encode(payload); err != nil {
+		return fmt.Errorf("encode the result: %w", err)
+	}
+	return nil
+}
+
+// call posts one RPC to the lich this session belongs to.
+func (c *client) call(method string, args []any, timeout time.Duration, out any) error {
+	endpoint, err := c.endpoint(method)
+	if err != nil {
+		return err
+	}
+	body, err := json.Marshal(args)
+	if err != nil {
+		return fmt.Errorf("encode arguments: %w", err)
+	}
+
+	httpClient := &http.Client{Timeout: timeout}
+	resp, err := httpClient.Post(endpoint, "application/json", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("reach lich: %w", err)
+	}
+	defer resp.Body.Close()
+
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read the reply: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s", failureOf(payload, resp.Status))
+	}
+	if out == nil {
+		return nil
+	}
+	if err := json.Unmarshal(payload, out); err != nil {
+		return fmt.Errorf("decode the reply: %w", err)
+	}
+	return nil
+}
+
+// endpoint builds the RPC URL for one call.
+func (c *client) endpoint(method string) (string, error) {
+	port, token, err := c.coordinates()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf(
+		"http://127.0.0.1:%s/rpc/%s?token=%s",
+		url.PathEscape(port), method, url.QueryEscape(token),
+	), nil
+}
+
+// coordinates finds the lich to talk to: the one that spawned this PTY when
+// there is one, otherwise the instance running on this machine.
+//
+// The environment comes first on purpose. A session belongs to the lich that
+// spawned it, and on a machine running a daily driver beside a `task dev`
+// build, the runtime file names only one of them — answering to the wrong lich
+// would put a message in a window the caller cannot see.
+func (c *client) coordinates() (string, string, error) {
+	if port, token := c.env("LICH_PORT"), c.env("LICH_TOKEN"); port != "" && token != "" {
+		return port, token, nil
+	}
+	if c.running == nil {
+		return "", "", fmt.Errorf("no lich is running")
+	}
+	info, err := c.running()
+	if err != nil {
+		return "", "", err
+	}
+	if info == nil || info.Port == 0 || info.Token == "" {
+		return "", "", fmt.Errorf("no lich is running — open lich, or run this inside one of its sessions")
+	}
+	return strconv.Itoa(info.Port), info.Token, nil
+}
+
+// runningLich reads the loopback coordinates of the lich running on this
+// machine. It is the same runtime file install.sh reads to reach a running lich
+// from outside a session, and LICH_DEV selects the dev instance's own file just
+// as it does everywhere else.
+func runningLich() (*singleton.Info, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve config directory: %w", err)
+	}
+	return singleton.Read(dir)
+}
+
+// sessionID is which card this command runs in, empty for a caller that has no
+// session — a script, a scheduled job, a plain shell. The relay words the
+// message it delivers differently for those, so an empty sender is a fact to
+// pass on rather than an error.
+func (c *client) sessionID() string {
+	return c.env("LICH_SESSION_ID")
+}
+
+// failureOf unwraps the RPC's {"error": "..."} envelope, falling back to the
+// HTTP status for a body that is not one.
+func failureOf(payload []byte, status string) string {
+	var envelope struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(payload, &envelope); err == nil && envelope.Error != "" {
+		return envelope.Error
+	}
+	return status
+}
+
+// waitBudget is how long the client gives a call that blocks on another
+// session: the wait it asked for, plus room for the answer's trip back. A zero
+// timeout means the relay's own default.
+func waitBudget(seconds int) time.Duration {
+	if seconds <= 0 {
+		return relay.DefaultWait + callSlack
+	}
+	return time.Duration(seconds)*time.Second + callSlack
+}
+
+// newFlagSet builds a subcommand's flags. Its own reporting is silenced: a
+// parse error comes back as an error and is printed once, by run, on the
+// stderr the caller passed rather than on the process's.
+func newFlagSet(name string) *flag.FlagSet {
+	flags := flag.NewFlagSet(name, flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.Usage = func() {}
+	return flags
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,447 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/relay"
+	"github.com/omartelo/lich/internal/singleton"
+)
+
+// recorded is one RPC the fake lich received.
+type recorded struct {
+	method string
+	token  string
+	args   []any
+}
+
+// fakeLich stands in for the running app: it answers /rpc/<method> with a
+// canned body and records what was asked.
+type fakeLich struct {
+	server *httptest.Server
+	calls  []recorded
+	status int
+	body   string
+}
+
+func newFakeLich(t *testing.T, body string) *fakeLich {
+	t.Helper()
+	f := &fakeLich{status: http.StatusOK, body: body}
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		payload, _ := io.ReadAll(r.Body)
+		var args []any
+		_ = json.Unmarshal(payload, &args)
+		f.calls = append(f.calls, recorded{
+			method: strings.TrimPrefix(r.URL.Path, "/rpc/"),
+			token:  r.URL.Query().Get("token"),
+			args:   args,
+		})
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(f.status)
+		_, _ = io.WriteString(w, f.body)
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+// env is the session environment lich exports into every PTY, pointed at the
+// fake.
+func (f *fakeLich) env(key string) string {
+	switch key {
+	case "LICH_PORT":
+		return strconv.Itoa(f.server.Listener.Addr().(*net.TCPAddr).Port)
+	case "LICH_TOKEN":
+		return "tok en"
+	case "LICH_SESSION_ID":
+		return "s1"
+	}
+	return ""
+}
+
+func (f *fakeLich) only(t *testing.T) recorded {
+	t.Helper()
+	if len(f.calls) != 1 {
+		t.Fatalf("got %d calls, want 1", len(f.calls))
+	}
+	return f.calls[0]
+}
+
+// run executes one command against a fake lich and returns its streams. It
+// never goes through Run: that would resolve the runtime file of the lich
+// actually running on this machine, and a test that reached it would deliver a
+// message into a real session.
+func run(t *testing.T, f *fakeLich, args ...string) (int, string, string) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	code := dispatch(args, &client{env: f.env, stdout: &stdout, stderr: &stderr, running: noInstance})
+	return code, stdout.String(), stderr.String()
+}
+
+// noInstance is a machine with no lich recorded — the fallback finds nothing,
+// so only the environment can point a command anywhere.
+func noInstance() (*singleton.Info, error) { return nil, nil }
+
+func TestUnknownArgumentsAreNotACommand(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	for _, args := range [][]string{{}, {"--"}, {"--", "--ozone-platform=wayland"}, {"nonsense"}} {
+		if code, _, _ := run(t, f, args...); code != NotACommand {
+			t.Errorf("Run(%q) = %d, want NotACommand", args, code)
+		}
+	}
+	if len(f.calls) != 0 {
+		t.Errorf("a non-command reached the app: %+v", f.calls)
+	}
+}
+
+func TestHelpPrintsEveryCommand(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	code, stdout, _ := run(t, f, "help")
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	for _, want := range []string{"lich sessions", "lich send", "lich wait", "lich reply"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("help does not document %q", want)
+		}
+	}
+}
+
+func TestSessionsListsPeers(t *testing.T) {
+	f := newFakeLich(t, `[{"label":"docs","project":"lich","kind":"codex"},
+	                      {"label":"api","project":"revu","kind":"crush"}]`)
+
+	code, stdout, stderr := run(t, f, "sessions")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+
+	call := f.only(t)
+	if call.method != "relay.Peers" {
+		t.Errorf("method = %q", call.method)
+	}
+	if call.token != "tok en" {
+		t.Errorf("token = %q — it must survive URL encoding", call.token)
+	}
+	if len(call.args) != 1 || call.args[0] != "s1" {
+		t.Errorf("args = %v, want the caller's own session id", call.args)
+	}
+	for _, want := range []string{"docs\tlich\tcodex", "api\trevu\tcrush"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("output is missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestSessionsSaysWhenThereAreNone(t *testing.T) {
+	f := newFakeLich(t, `[]`)
+
+	code, stdout, _ := run(t, f, "sessions")
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(stdout, "No other live sessions.") {
+		t.Errorf("empty roster printed %q", stdout)
+	}
+}
+
+func TestSendPrintsTheAnswer(t *testing.T) {
+	f := newFakeLich(t, `{"ticket":"a1b2c3d4","target":"docs","status":"answered","answer":"3 failures"}`)
+
+	code, stdout, stderr := run(t, f, "send", "docs", "run the tests")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+
+	call := f.only(t)
+	if call.method != "relay.Send" {
+		t.Errorf("method = %q", call.method)
+	}
+	want := []any{"s1", "docs", "", "run the tests", float64(0)}
+	if len(call.args) != len(want) {
+		t.Fatalf("args = %v, want %v", call.args, want)
+	}
+	for i := range want {
+		if call.args[i] != want[i] {
+			t.Errorf("argument %d = %v, want %v", i, call.args[i], want[i])
+		}
+	}
+	if strings.TrimSpace(stdout) != "3 failures" {
+		t.Errorf("stdout = %q, want the answer alone", stdout)
+	}
+}
+
+func TestSendPassesProjectAndTimeout(t *testing.T) {
+	f := newFakeLich(t, `{"ticket":"a1b2c3d4","target":"api","status":"answered","answer":"ok"}`)
+
+	code, _, stderr := run(t, f, "send", "--project", "revu", "--timeout", "5", "api", "hello")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+
+	call := f.only(t)
+	if call.args[2] != "revu" {
+		t.Errorf("project = %v", call.args[2])
+	}
+	if call.args[4] != float64(5) {
+		t.Errorf("timeout = %v", call.args[4])
+	}
+}
+
+func TestSendPointsAtTheTicketWhenTheWaitRunsOut(t *testing.T) {
+	f := newFakeLich(t, `{"ticket":"a1b2c3d4","target":"docs","status":"pending","answer":""}`)
+
+	code, stdout, _ := run(t, f, "send", "docs", "long errand")
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	for _, want := range []string{"docs has not answered yet", "lich wait a1b2c3d4"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("output is missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestWaitPicksUpAnAnswer(t *testing.T) {
+	f := newFakeLich(t, `{"ticket":"a1b2c3d4","target":"docs","status":"answered","answer":"late but here"}`)
+
+	code, stdout, _ := run(t, f, "wait", "a1b2c3d4")
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+
+	call := f.only(t)
+	if call.method != "relay.Wait" {
+		t.Errorf("method = %q", call.method)
+	}
+	if call.args[0] != "a1b2c3d4" {
+		t.Errorf("ticket = %v", call.args[0])
+	}
+	if strings.TrimSpace(stdout) != "late but here" {
+		t.Errorf("stdout = %q", stdout)
+	}
+}
+
+func TestReplySendsTheAnswerHome(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	code, stdout, stderr := run(t, f, "reply", "a1b2c3d4", "3 failures in foo_test")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+
+	call := f.only(t)
+	if call.method != "relay.Reply" {
+		t.Errorf("method = %q", call.method)
+	}
+	if call.args[0] != "a1b2c3d4" || call.args[1] != "3 failures in foo_test" {
+		t.Errorf("args = %v", call.args)
+	}
+	if !strings.Contains(stdout, "Answer sent.") {
+		t.Errorf("stdout = %q", stdout)
+	}
+}
+
+func TestWrongArgumentCountsFailWithUsage(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	tests := [][]string{
+		{"send", "docs"},
+		{"send", "docs", "a prompt", "extra"},
+		{"wait"},
+		{"reply", "a1b2c3d4"},
+	}
+	for _, args := range tests {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			code, _, stderr := run(t, f, args...)
+			if code != 1 {
+				t.Fatalf("exit = %d, want 1", code)
+			}
+			if !strings.Contains(stderr, "usage: lich "+args[0]) {
+				t.Errorf("stderr = %q, want the subcommand's usage", stderr)
+			}
+		})
+	}
+	if len(f.calls) != 0 {
+		t.Errorf("a malformed command reached the app: %+v", f.calls)
+	}
+}
+
+func TestAnUnknownFlagFailsWithoutCallingTheApp(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	code, _, stderr := run(t, f, "send", "--nonsense", "docs", "hello")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr, "lich: ") {
+		t.Errorf("stderr = %q, want the failure on one line", stderr)
+	}
+	if len(f.calls) != 0 {
+		t.Errorf("a rejected command reached the app: %+v", f.calls)
+	}
+}
+
+func TestTheAppsErrorReachesTheUser(t *testing.T) {
+	f := newFakeLich(t, `{"error":"no live session named \"ghost\""}`)
+	f.status = http.StatusInternalServerError
+
+	code, _, stderr := run(t, f, "send", "ghost", "hello")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr, `no live session named "ghost"`) {
+		t.Errorf("stderr = %q, want the app's own message", stderr)
+	}
+}
+
+func TestAFailureWithNoEnvelopeFallsBackToTheStatus(t *testing.T) {
+	f := newFakeLich(t, `<html>gateway</html>`)
+	f.status = http.StatusBadGateway
+
+	code, _, stderr := run(t, f, "sessions")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr, "502") {
+		t.Errorf("stderr = %q, want the HTTP status", stderr)
+	}
+}
+
+func TestWithNoLichAnywhereEveryCommandSaysSo(t *testing.T) {
+	bare := func(string) string { return "" }
+
+	for _, args := range [][]string{
+		{"sessions"},
+		{"send", "docs", "hello"},
+		{"wait", "a1b2c3d4"},
+		{"reply", "a1b2c3d4", "done"},
+	} {
+		t.Run(args[0], func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			c := &client{env: bare, stdout: &stdout, stderr: &stderr, running: noInstance}
+			if code := dispatch(args, c); code != 1 {
+				t.Fatalf("exit = %d, want 1", code)
+			}
+			if !strings.Contains(stderr.String(), "no lich is running") {
+				t.Errorf("stderr = %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestOutsideASessionTheRuntimeFileIsUsed(t *testing.T) {
+	f := newFakeLich(t, `[{"label":"docs","project":"lich","kind":"codex"}]`)
+	port := f.server.Listener.Addr().(*net.TCPAddr).Port
+
+	var stdout, stderr bytes.Buffer
+	c := &client{
+		env:     func(string) string { return "" },
+		stdout:  &stdout,
+		stderr:  &stderr,
+		running: func() (*singleton.Info, error) { return &singleton.Info{Port: port, Token: "tok"}, nil },
+	}
+	if code := dispatch([]string{"sessions"}, c); code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+
+	call := f.only(t)
+	if call.token != "tok" {
+		t.Errorf("token = %q, want the one from the runtime file", call.token)
+	}
+	if len(call.args) != 1 || call.args[0] != "" {
+		t.Errorf("args = %v, want an empty sender: this caller has no session", call.args)
+	}
+	if !strings.Contains(stdout.String(), "docs") {
+		t.Errorf("stdout = %q", stdout.String())
+	}
+}
+
+func TestTheEnvironmentWinsOverTheRuntimeFile(t *testing.T) {
+	session := newFakeLich(t, `[]`)
+	other := newFakeLich(t, `[]`)
+	otherPort := other.server.Listener.Addr().(*net.TCPAddr).Port
+
+	var stdout, stderr bytes.Buffer
+	c := &client{
+		env:     session.env,
+		stdout:  &stdout,
+		stderr:  &stderr,
+		running: func() (*singleton.Info, error) { return &singleton.Info{Port: otherPort, Token: "other"}, nil },
+	}
+	if code := dispatch([]string{"sessions"}, c); code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+
+	if len(session.calls) != 1 {
+		t.Errorf("the session's own lich got %d calls, want 1", len(session.calls))
+	}
+	if len(other.calls) != 0 {
+		t.Errorf("a session answered to the wrong lich: %+v", other.calls)
+	}
+}
+
+func TestTheRuntimeFileFailureIsReported(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	c := &client{
+		env:     func(string) string { return "" },
+		stdout:  &stdout,
+		stderr:  &stderr,
+		running: func() (*singleton.Info, error) { return nil, errors.New("permission denied") },
+	}
+	if code := dispatch([]string{"sessions"}, c); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "permission denied") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestJSONOutputIsMachineReadable(t *testing.T) {
+	peers := newFakeLich(t, `[{"label":"docs","project":"lich","kind":"codex"}]`)
+	code, stdout, stderr := run(t, peers, "sessions", "--json")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	var got []relay.Peer
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("sessions --json is not JSON: %v (%q)", err, stdout)
+	}
+	if len(got) != 1 || got[0].Label != "docs" {
+		t.Errorf("peers = %+v", got)
+	}
+
+	answered := newFakeLich(t, `{"ticket":"a1b2c3d4","target":"docs","status":"answered","answer":"3 failures"}`)
+	code, stdout, stderr = run(t, answered, "send", "--json", "docs", "hello")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	var result relay.Result
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("send --json is not JSON: %v (%q)", err, stdout)
+	}
+	if result.Answer != "3 failures" || result.Ticket != "a1b2c3d4" {
+		t.Errorf("result = %+v", result)
+	}
+}
+
+func TestEmptyPeersAreAnEmptyJSONArray(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	code, stdout, _ := run(t, f, "sessions", "--json")
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if strings.TrimSpace(stdout) != "[]" {
+		t.Errorf("stdout = %q, want [] — a script should not have to handle null", stdout)
+	}
+}

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -1,0 +1,329 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/omartelo/lich/internal/relay"
+)
+
+// `lich mcp` is the same surface as the commands beside it, offered as MCP
+// tools instead of as argv. It exists because a command line only helps an
+// agent that already knows the command exists: a slash command has to be typed,
+// a documented flag has to be read. An MCP tool is in the agent's own tool list
+// from the first turn, so nobody has to be told anything — which is the whole
+// point, since the person who would need telling is the one who does not read
+// release notes.
+//
+// It speaks the stdio transport: one JSON-RPC 2.0 message per line on stdin and
+// stdout. stdout therefore carries protocol and nothing else — anything this
+// package would print for a human goes to stderr, which the host logs.
+//
+// Registration is stdio rather than HTTP for one reason: the config lich passes
+// at spawn lands in the provider's argv, and /proc/<pid>/cmdline is readable by
+// any user on the machine while /proc/<pid>/environ is not. A URL registration
+// would put ?token= in argv. A stdio one carries no secret at all — the server
+// inherits the coordinates from the PTY's environment, where they already were.
+
+// mcpProtocolVersion is what this server advertises when a client asks for
+// nothing. A client that names its own version gets that version back: this
+// implements the tools subset, which every revision of the protocol carries
+// unchanged, so agreeing with the client costs nothing and refusing it would
+// only lose a working session over a date.
+const mcpProtocolVersion = "2025-06-18"
+
+// mcpServerName is the name the tools are namespaced under in a client's tool
+// list (`mcp__lich__send_to_session` in Claude Code). It is also the key lich
+// registers itself under at spawn.
+const mcpServerName = "lich"
+
+// jsonRPC frames one message in either direction. ID is absent on a
+// notification, which is answered with nothing at all.
+type jsonRPC struct {
+	Version string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  any             `json:"result,omitempty"`
+	Error   *jsonRPCError   `json:"error,omitempty"`
+}
+
+type jsonRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// JSON-RPC error codes this server can emit.
+const (
+	codeMethodNotFound = -32601
+	codeInvalidParams  = -32602
+)
+
+// mcpTool is one entry in the tool list. run returns the text the agent sees;
+// an error it returns is reported as a failed tool call rather than as a
+// protocol error, so the agent reads what went wrong and can act on it.
+type mcpTool struct {
+	Name        string
+	Description string
+	Schema      map[string]any
+	Run         func(c *client, args mcpArgs) (string, error)
+}
+
+// serveMCP runs the stdio server until its input ends.
+func (c *client) serveMCP(args []string) error {
+	flags := newFlagSet("mcp")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if c.stdin == nil {
+		return fmt.Errorf("no input to serve")
+	}
+
+	decoder := json.NewDecoder(c.stdin)
+	encoder := json.NewEncoder(c.stdout)
+	for {
+		var request jsonRPC
+		if err := decoder.Decode(&request); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return fmt.Errorf("read message: %w", err)
+		}
+		response, answer := c.handleMCP(request)
+		if !answer {
+			continue
+		}
+		if err := encoder.Encode(response); err != nil {
+			return fmt.Errorf("write message: %w", err)
+		}
+	}
+}
+
+// handleMCP answers one message. The second return is false for a notification,
+// which the protocol says gets no reply — answering one is a protocol error on
+// this side, not a courtesy.
+func (c *client) handleMCP(request jsonRPC) (jsonRPC, bool) {
+	if len(request.ID) == 0 {
+		return jsonRPC{}, false
+	}
+	response := jsonRPC{Version: "2.0", ID: request.ID}
+
+	switch request.Method {
+	case "initialize":
+		response.Result = mcpHandshake(request.Params)
+	case "tools/list":
+		response.Result = map[string]any{"tools": mcpToolList()}
+	case "tools/call":
+		response.Result, response.Error = c.callMCPTool(request.Params)
+	case "ping":
+		response.Result = map[string]any{}
+	default:
+		response.Error = &jsonRPCError{Code: codeMethodNotFound, Message: "unknown method " + request.Method}
+	}
+	return response, true
+}
+
+// mcpHandshake answers initialize, echoing the client's protocol version when
+// it named one (see mcpProtocolVersion).
+func mcpHandshake(params json.RawMessage) map[string]any {
+	var asked struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	_ = json.Unmarshal(params, &asked)
+	version := asked.ProtocolVersion
+	if version == "" {
+		version = mcpProtocolVersion
+	}
+	return map[string]any{
+		"protocolVersion": version,
+		"capabilities":    map[string]any{"tools": map[string]any{}},
+		"serverInfo":      map[string]any{"name": mcpServerName, "version": "1"},
+	}
+}
+
+// callMCPTool runs one tool. A tool that fails answers with isError so the
+// agent sees the reason; only an unknown tool or unreadable arguments are
+// protocol errors.
+func (c *client) callMCPTool(params json.RawMessage) (any, *jsonRPCError) {
+	var call struct {
+		Name      string  `json:"name"`
+		Arguments mcpArgs `json:"arguments"`
+	}
+	if err := json.Unmarshal(params, &call); err != nil {
+		return nil, &jsonRPCError{Code: codeInvalidParams, Message: err.Error()}
+	}
+	for _, tool := range mcpTools {
+		if tool.Name != call.Name {
+			continue
+		}
+		text, err := tool.Run(c, call.Arguments)
+		if err != nil {
+			return mcpText(err.Error(), true), nil
+		}
+		return mcpText(text, false), nil
+	}
+	return nil, &jsonRPCError{Code: codeInvalidParams, Message: "unknown tool " + call.Name}
+}
+
+// mcpText is a tool result: MCP carries them as content blocks, and everything
+// here is text.
+func mcpText(text string, failed bool) map[string]any {
+	result := map[string]any{"content": []any{map[string]any{"type": "text", "text": text}}}
+	if failed {
+		result["isError"] = true
+	}
+	return result
+}
+
+func mcpToolList() []map[string]any {
+	list := make([]map[string]any, 0, len(mcpTools))
+	for _, tool := range mcpTools {
+		list = append(list, map[string]any{
+			"name":        tool.Name,
+			"description": tool.Description,
+			"inputSchema": tool.Schema,
+		})
+	}
+	return list
+}
+
+// mcpArgs is one tool call's arguments, read leniently: a model that sends a
+// number as a string, or omits an optional field, should not lose its turn to a
+// type error.
+type mcpArgs map[string]any
+
+func (a mcpArgs) text(key string) string {
+	switch v := a[key].(type) {
+	case string:
+		return v
+	case nil:
+		return ""
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func (a mcpArgs) seconds(key string) int {
+	switch v := a[key].(type) {
+	case float64:
+		return int(v)
+	case string:
+		var n int
+		_, _ = fmt.Sscanf(v, "%d", &n)
+		return n
+	default:
+		return 0
+	}
+}
+
+// schema builds an inputSchema from named properties and the subset of them
+// that is required.
+func schema(properties map[string]any, required ...string) map[string]any {
+	if required == nil {
+		required = []string{}
+	}
+	return map[string]any{
+		"type":       "object",
+		"properties": properties,
+		"required":   required,
+	}
+}
+
+func property(kind, description string) map[string]any {
+	return map[string]any{"type": kind, "description": description}
+}
+
+// mcpTools is the whole tool surface. Adding one is an entry here — the reason
+// registering MCP once buys every tool lich grows later, on every provider,
+// with no further per-provider work.
+var mcpTools = []mcpTool{
+	{
+		Name: "list_sessions",
+		Description: "List the other lich sessions that are live right now and can be given work. " +
+			"Returns each session's label (how it is addressed), its project, and which agent runs in it.",
+		Schema: schema(map[string]any{}),
+		Run: func(c *client, _ mcpArgs) (string, error) {
+			var peers []relay.Peer
+			if err := c.call("relay.Peers", []any{c.sessionID()}, shortCall, &peers); err != nil {
+				return "", err
+			}
+			if len(peers) == 0 {
+				return "No other live sessions.", nil
+			}
+			out, err := json.Marshal(peers)
+			if err != nil {
+				return "", err
+			}
+			return string(out), nil
+		},
+	},
+	{
+		Name: "send_to_session",
+		Description: "Give another lich session a task and wait for its agent to answer. " +
+			"The task is put at that session's prompt as if typed there. Returns its answer, " +
+			"or a ticket to pick the answer up with wait_for_answer if it takes too long.",
+		Schema: schema(map[string]any{
+			"session": property("string", "Label of the target session, as returned by list_sessions."),
+			"prompt":  property("string", "What to ask that session's agent to do."),
+			"project": property("string", "Project name, needed only when two live sessions share a label."),
+			"timeout_seconds": property("number",
+				"How long to wait for an answer. Defaults to 100; the call returns a ticket rather than failing if it runs out."),
+		}, "session", "prompt"),
+		Run: func(c *client, args mcpArgs) (string, error) {
+			var result relay.Result
+			timeout := args.seconds("timeout_seconds")
+			call := []any{c.sessionID(), args.text("session"), args.text("project"), args.text("prompt"), timeout}
+			if err := c.call("relay.Send", call, waitBudget(timeout), &result); err != nil {
+				return "", err
+			}
+			return mcpOutcome(result), nil
+		},
+	},
+	{
+		Name: "wait_for_answer",
+		Description: "Wait again on a ticket that send_to_session handed back because its wait ran out. " +
+			"The task was already delivered; this only waits for the answer.",
+		Schema: schema(map[string]any{
+			"ticket":          property("string", "The ticket send_to_session returned."),
+			"timeout_seconds": property("number", "How long to wait. Defaults to 100."),
+		}, "ticket"),
+		Run: func(c *client, args mcpArgs) (string, error) {
+			var result relay.Result
+			timeout := args.seconds("timeout_seconds")
+			if err := c.call("relay.Wait", []any{args.text("ticket"), timeout}, waitBudget(timeout), &result); err != nil {
+				return "", err
+			}
+			return mcpOutcome(result), nil
+		},
+	},
+	{
+		Name: "reply_to_session",
+		Description: "Answer a task another session gave you. Call this when a message at your prompt " +
+			"came from lich and carried a ticket; whoever asked is blocked until you do.",
+		Schema: schema(map[string]any{
+			"ticket": property("string", "The ticket from the message you were given."),
+			"answer": property("string", "Your answer, in full — nothing else is sent back."),
+		}, "ticket", "answer"),
+		Run: func(c *client, args mcpArgs) (string, error) {
+			if err := c.call("relay.Reply", []any{args.text("ticket"), args.text("answer")}, shortCall, nil); err != nil {
+				return "", err
+			}
+			return "Answer sent.", nil
+		},
+	},
+}
+
+// mcpOutcome words a Send or Wait result for an agent: the answer alone when
+// there is one, otherwise what to call next. A bare ticket would leave the
+// agent guessing what it is for.
+func mcpOutcome(result relay.Result) string {
+	if result.Status == relay.StatusAnswered {
+		return result.Answer
+	}
+	return fmt.Sprintf(
+		"%s has not answered yet. The task was delivered; call wait_for_answer with ticket %q.",
+		result.Target, result.Ticket,
+	)
+}

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -1,0 +1,317 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// speak runs the MCP server over one scripted conversation and returns the
+// responses in order. Every message is one line, which is the stdio transport.
+func speak(t *testing.T, f *fakeLich, messages ...string) []jsonRPC {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	c := &client{
+		env:     f.env,
+		stdin:   strings.NewReader(strings.Join(messages, "\n") + "\n"),
+		stdout:  &stdout,
+		stderr:  &stderr,
+		running: noInstance,
+	}
+	if code := dispatch([]string{"mcp"}, c); code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+
+	var replies []jsonRPC
+	decoder := json.NewDecoder(&stdout)
+	for decoder.More() {
+		var reply jsonRPC
+		if err := decoder.Decode(&reply); err != nil {
+			t.Fatalf("undecodable response: %v", err)
+		}
+		replies = append(replies, reply)
+	}
+	return replies
+}
+
+// resultOf re-decodes a response's result into v, which is how a test reads a
+// map[string]any the server built.
+func resultOf(t *testing.T, reply jsonRPC, v any) {
+	t.Helper()
+	raw, err := json.Marshal(reply.Result)
+	if err != nil {
+		t.Fatalf("marshal result: %v", err)
+	}
+	if err := json.Unmarshal(raw, v); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+}
+
+// textOf pulls the text out of a tool result's content blocks.
+func textOf(t *testing.T, reply jsonRPC) (string, bool) {
+	t.Helper()
+	var result struct {
+		Content []struct {
+			Type string `json:"type"`
+			Text string `json:"text"`
+		} `json:"content"`
+		IsError bool `json:"isError"`
+	}
+	resultOf(t, reply, &result)
+	if len(result.Content) != 1 || result.Content[0].Type != "text" {
+		t.Fatalf("want one text block, got %+v", result.Content)
+	}
+	return result.Content[0].Text, result.IsError
+}
+
+func TestMCPHandshakeAdvertisesTools(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26"}}`)
+	if len(replies) != 1 {
+		t.Fatalf("got %d replies, want 1", len(replies))
+	}
+
+	var result struct {
+		ProtocolVersion string `json:"protocolVersion"`
+		Capabilities    struct {
+			Tools *struct{} `json:"tools"`
+		} `json:"capabilities"`
+		ServerInfo struct {
+			Name string `json:"name"`
+		} `json:"serverInfo"`
+	}
+	resultOf(t, replies[0], &result)
+
+	if result.ProtocolVersion != "2025-03-26" {
+		t.Errorf("protocolVersion = %q, want the client's own", result.ProtocolVersion)
+	}
+	if result.Capabilities.Tools == nil {
+		t.Error("the server did not advertise tools")
+	}
+	if result.ServerInfo.Name != "lich" {
+		t.Errorf("serverInfo.name = %q", result.ServerInfo.Name)
+	}
+}
+
+func TestMCPHandshakeFallsBackToItsOwnVersion(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
+	var result struct {
+		ProtocolVersion string `json:"protocolVersion"`
+	}
+	resultOf(t, replies[0], &result)
+	if result.ProtocolVersion != mcpProtocolVersion {
+		t.Errorf("protocolVersion = %q, want %q", result.ProtocolVersion, mcpProtocolVersion)
+	}
+}
+
+func TestMCPNotificationsGetNoReply(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	replies := speak(t, f,
+		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
+		`{"jsonrpc":"2.0","id":1,"method":"ping"}`,
+	)
+	if len(replies) != 1 {
+		t.Fatalf("got %d replies, want 1 — a notification must be answered with nothing", len(replies))
+	}
+	if string(replies[0].ID) != "1" {
+		t.Errorf("the one reply answered id %s", replies[0].ID)
+	}
+}
+
+func TestMCPListsEveryTool(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/list"}`)
+	var result struct {
+		Tools []struct {
+			Name        string `json:"name"`
+			Description string `json:"description"`
+			InputSchema struct {
+				Type       string                     `json:"type"`
+				Properties map[string]json.RawMessage `json:"properties"`
+				Required   []string                   `json:"required"`
+			} `json:"inputSchema"`
+		} `json:"tools"`
+	}
+	resultOf(t, replies[0], &result)
+
+	want := map[string][]string{
+		"list_sessions":    {},
+		"send_to_session":  {"session", "prompt"},
+		"wait_for_answer":  {"ticket"},
+		"reply_to_session": {"ticket", "answer"},
+	}
+	if len(result.Tools) != len(want) {
+		t.Fatalf("got %d tools, want %d", len(result.Tools), len(want))
+	}
+	for _, tool := range result.Tools {
+		required, known := want[tool.Name]
+		if !known {
+			t.Errorf("unexpected tool %q", tool.Name)
+			continue
+		}
+		if tool.Description == "" {
+			t.Errorf("%s has no description — it is all the agent has to go on", tool.Name)
+		}
+		if tool.InputSchema.Type != "object" {
+			t.Errorf("%s schema type = %q", tool.Name, tool.InputSchema.Type)
+		}
+		if len(tool.InputSchema.Required) != len(required) {
+			t.Errorf("%s required = %v, want %v", tool.Name, tool.InputSchema.Required, required)
+		}
+		for _, name := range required {
+			if _, ok := tool.InputSchema.Properties[name]; !ok {
+				t.Errorf("%s requires %q but does not declare it", tool.Name, name)
+			}
+		}
+	}
+}
+
+func TestMCPSendToSessionReturnsTheAnswer(t *testing.T) {
+	f := newFakeLich(t, `{"ticket":"a1b2c3d4","target":"docs","status":"answered","answer":"3 failures"}`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"send_to_session","arguments":{"session":"docs","prompt":"run the tests","timeout_seconds":20}}}`)
+
+	text, failed := textOf(t, replies[0])
+	if failed {
+		t.Fatalf("tool reported a failure: %s", text)
+	}
+	if text != "3 failures" {
+		t.Errorf("text = %q, want the answer alone", text)
+	}
+
+	call := f.only(t)
+	if call.method != "relay.Send" {
+		t.Fatalf("method = %q", call.method)
+	}
+	want := []any{"s1", "docs", "", "run the tests", float64(20)}
+	for i := range want {
+		if call.args[i] != want[i] {
+			t.Errorf("argument %d = %v, want %v", i, call.args[i], want[i])
+		}
+	}
+}
+
+func TestMCPSendPointsAtTheTicketWhenItRunsOut(t *testing.T) {
+	f := newFakeLich(t, `{"ticket":"a1b2c3d4","target":"docs","status":"pending","answer":""}`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"send_to_session","arguments":{"session":"docs","prompt":"long errand"}}}`)
+
+	text, failed := textOf(t, replies[0])
+	if failed {
+		t.Fatalf("a delivered-but-unanswered task was reported as a failure: %s", text)
+	}
+	for _, want := range []string{"wait_for_answer", "a1b2c3d4"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("text is missing %q: %s", want, text)
+		}
+	}
+}
+
+func TestMCPListSessionsReturnsThemAsJSON(t *testing.T) {
+	f := newFakeLich(t, `[{"label":"docs","project":"lich","kind":"codex"}]`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"list_sessions","arguments":{}}}`)
+
+	text, failed := textOf(t, replies[0])
+	if failed {
+		t.Fatalf("tool reported a failure: %s", text)
+	}
+	var peers []struct {
+		Label string `json:"label"`
+	}
+	if err := json.Unmarshal([]byte(text), &peers); err != nil {
+		t.Fatalf("list_sessions did not return JSON: %v (%q)", err, text)
+	}
+	if len(peers) != 1 || peers[0].Label != "docs" {
+		t.Errorf("peers = %+v", peers)
+	}
+}
+
+func TestMCPReplyToSession(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"reply_to_session","arguments":{"ticket":"a1b2c3d4","answer":"done"}}}`)
+
+	if text, failed := textOf(t, replies[0]); failed {
+		t.Fatalf("tool reported a failure: %s", text)
+	}
+	call := f.only(t)
+	if call.method != "relay.Reply" || call.args[0] != "a1b2c3d4" || call.args[1] != "done" {
+		t.Errorf("call = %+v", call)
+	}
+}
+
+func TestMCPAFailedCallIsAToolErrorNotAProtocolError(t *testing.T) {
+	f := newFakeLich(t, `{"error":"no live session named \"ghost\""}`)
+	f.status = 500
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"send_to_session","arguments":{"session":"ghost","prompt":"hello"}}}`)
+
+	if replies[0].Error != nil {
+		t.Fatalf("a tool failure came back as a protocol error: %+v", replies[0].Error)
+	}
+	text, failed := textOf(t, replies[0])
+	if !failed {
+		t.Error("the tool result was not marked isError")
+	}
+	if !strings.Contains(text, `no live session named "ghost"`) {
+		t.Errorf("text = %q, want the app's own message", text)
+	}
+}
+
+func TestMCPRejectsUnknownMethodsAndTools(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	replies := speak(t, f,
+		`{"jsonrpc":"2.0","id":1,"method":"resources/list"}`,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"delete_everything","arguments":{}}}`,
+	)
+	if len(replies) != 2 {
+		t.Fatalf("got %d replies, want 2", len(replies))
+	}
+	if replies[0].Error == nil || replies[0].Error.Code != codeMethodNotFound {
+		t.Errorf("unknown method answered %+v", replies[0])
+	}
+	if replies[1].Error == nil || replies[1].Error.Code != codeInvalidParams {
+		t.Errorf("unknown tool answered %+v", replies[1])
+	}
+	if len(f.calls) != 0 {
+		t.Errorf("a rejected message reached the app: %+v", f.calls)
+	}
+}
+
+func TestMCPReadsLooseArgumentTypes(t *testing.T) {
+	f := newFakeLich(t, `{"ticket":"a1b2c3d4","target":"docs","status":"answered","answer":"ok"}`)
+
+	// A model that sends the timeout as a string should not lose its turn.
+	speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"send_to_session","arguments":{"session":"docs","prompt":"hi","timeout_seconds":"15"}}}`)
+
+	if got := f.only(t).args[4]; got != float64(15) {
+		t.Errorf("timeout = %v, want 15", got)
+	}
+}
+
+func TestMCPStopsCleanlyAtEndOfInput(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	var stdout, stderr bytes.Buffer
+	c := &client{env: f.env, stdin: strings.NewReader(""), stdout: &stdout, stderr: &stderr, running: noInstance}
+	if code := dispatch([]string{"mcp"}, c); code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("an empty conversation produced output: %q", stdout.String())
+	}
+}

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"bytes"
+	"net"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/omartelo/lich/internal/relay"
+	"github.com/omartelo/lich/internal/rpc"
+	"github.com/omartelo/lich/internal/store"
+)
+
+// The tests above answer the CLI with canned JSON, which proves what it prints
+// but not that the app understands what it asks. These drive the real
+// dispatcher over a real socket, so an argument that moves position or changes
+// type fails here rather than in a terminal.
+
+type wiredSessions struct{}
+
+func (wiredSessions) LoadState() ([]store.Project, error) {
+	return []store.Project{{ID: "p1", Name: "lich", Sessions: []store.Session{
+		{ID: "s1", Label: "sender", Kind: "claude"},
+		{ID: "s2", Label: "docs", Kind: "codex"},
+	}}}, nil
+}
+
+type wiredTerminal struct {
+	mu    sync.Mutex
+	typed string
+}
+
+// Pointer receiver like Write's: a value receiver would copy the mutex beside
+// it on every call, which is a race the moment the two are used together.
+func (*wiredTerminal) Live(string) bool { return true }
+
+func (w *wiredTerminal) Write(_, data string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.typed += data
+	return nil
+}
+
+func (w *wiredTerminal) message() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.typed
+}
+
+// wiredLich serves the relay behind the real RPC dispatcher and returns the
+// session environment a PTY would carry, plus the terminal it types into.
+func wiredLich(t *testing.T) (func(string) string, *wiredTerminal) {
+	t.Helper()
+	term := &wiredTerminal{}
+	dispatcher := rpc.New()
+	dispatcher.Register("relay", relay.New(wiredSessions{}, term))
+
+	server := httptest.NewServer(dispatcher)
+	t.Cleanup(server.Close)
+
+	port := strconv.Itoa(server.Listener.Addr().(*net.TCPAddr).Port)
+	return func(key string) string {
+		switch key {
+		case "LICH_PORT":
+			return port
+		case "LICH_TOKEN":
+			return "tok"
+		case "LICH_SESSION_ID":
+			return "s1"
+		}
+		return ""
+	}, term
+}
+
+func TestSessionsOverTheRealDispatcher(t *testing.T) {
+	env, _ := wiredLich(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"sessions"}, env, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "docs\tlich\tcodex") {
+		t.Errorf("stdout = %q", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "sender") {
+		t.Errorf("the caller listed itself: %q", stdout.String())
+	}
+}
+
+func TestSendAndReplyOverTheRealDispatcher(t *testing.T) {
+	env, term := wiredLich(t)
+
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- Run([]string{"send", "--timeout", "20", "docs", "run the tests"}, env, &stdout, &stderr)
+	}()
+
+	ticketID := ticketFrom(term)
+	if ticketID == "" {
+		t.Fatal("the message never reached the target's terminal")
+	}
+
+	var replyOut, replyErr bytes.Buffer
+	if code := Run([]string{"reply", ticketID, "3 failures"}, env, &replyOut, &replyErr); code != 0 {
+		t.Fatalf("reply exit = %d, stderr = %q", code, replyErr.String())
+	}
+	if code := <-done; code != 0 {
+		t.Fatalf("send exit = %d, stderr = %q", code, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != "3 failures" {
+		t.Errorf("send printed %q, want the answer the other session typed", stdout.String())
+	}
+}
+
+// ticketFrom pulls the ticket out of the message the relay typed at the target,
+// which is the only place the receiving agent ever learns it.
+func ticketFrom(term *wiredTerminal) string {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		_, after, found := strings.Cut(term.message(), `"$LICH_BIN" reply `)
+		if found {
+			id, _, _ := strings.Cut(after, " ")
+			return id
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return ""
+}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -48,6 +48,20 @@ func Known(id string) bool {
 	return false
 }
 
+// AcceptsMCPServer reports whether a provider can be handed an MCP server on
+// its own command line, so lich can register one for a session it spawns
+// without editing config that belongs to the user or to their repository.
+//
+// Claude Code takes `--mcp-config` with a JSON string; Codex takes `-c`
+// overrides for its `mcp_servers` table. opencode, oh-my-pi and Crush have no
+// such flag — Crush's whole flag list is cwd, data-dir, session and debug — so
+// registering for those means writing a config file lich does not own, and lich
+// does not. Their sessions reach the other sessions through the `lich` command
+// line instead (docs/cli.md).
+func AcceptsMCPServer(id string) bool {
+	return id == Claude || id == Codex
+}
+
 // DefaultBinary returns a provider's preferred executable name, or "" for an
 // unknown id.
 func DefaultBinary(id string) string {

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -1,0 +1,454 @@
+// Package relay lets one lich session hand a prompt to another and get an
+// answer back, for the providers whose own CLI has no cross-session channel of
+// its own. Claude Code has one; Codex, OpenCode and Crush do not, and this
+// works the same for all four.
+//
+// The delivery is deliberately dumb: lich types the message at the target's
+// prompt and submits it, exactly as the user would. What it never does is read
+// the answer off the terminal — a TUI's output is boxes, spinners and ANSI, and
+// parsing it would mean a parser per provider, each hostage to a release.
+// Instead the message it types asks the agent to report back by running
+// `lich reply <ticket>`, so the answer is *written by the agent that produced
+// it*. That is what keeps this provider-agnostic: anything that can run a shell
+// command can answer.
+package relay
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/store"
+)
+
+const (
+	// DefaultWait is how long Send blocks before handing the caller a ticket to
+	// come back with. It sits under the 120s an agent's shell tool typically
+	// allows a command, so a long errand ends in an answer this side chose —
+	// "still working, wait on this ticket" — instead of a killed process and no
+	// way back to the conversation.
+	DefaultWait = 100 * time.Second
+	// MaxWait bounds an explicit timeout. Past this the caller should be
+	// polling with Wait, not holding a socket.
+	MaxWait = 30 * time.Minute
+	// ticketTTL is how long an unanswered ticket stays waitable. A target that
+	// never replies would otherwise leak one entry per attempt for the life of
+	// the process.
+	ticketTTL = time.Hour
+	// promptLimit bounds one relayed prompt. The message is typed into a TUI a
+	// character at a time; a megabyte of it is a hang, not a prompt.
+	promptLimit = 8192
+	// answerLimit bounds one reply. Generous — an answer is a summary, and the
+	// caller reads it as command output.
+	answerLimit = 64 * 1024
+)
+
+// How lich's own MCP server (internal/cli) is registered and what it calls its
+// tools. They live here rather than beside the server because two other places
+// need them and neither may depend on that one: the message this package
+// composes has to name the reply tool, and the spawn path (internal/terminal)
+// has to name the command to register. The server itself already depends on
+// this package, so this is the only direction that closes no cycle.
+const (
+	// MCPServerName namespaces the tools in a client's list
+	// (`mcp__lich__send_to_session` in Claude Code) and is the key lich
+	// registers itself under.
+	MCPServerName = "lich"
+	// MCPSubcommand is the `lich` subcommand that serves them.
+	MCPSubcommand = "mcp"
+	// ToolReply answers a relayed message. It is the one tool named in prose,
+	// because the receiving agent is told what to call.
+	ToolReply = "reply_to_session"
+)
+
+// Status values a Result carries.
+const (
+	// StatusAnswered means the target's agent replied and Answer holds it.
+	StatusAnswered = "answered"
+	// StatusPending means the message was delivered and the wait ran out first.
+	// The ticket is still live: Wait picks the same answer up later.
+	StatusPending = "pending"
+)
+
+// Sessions is the persistence the relay reads: every open session, so a label
+// can be resolved to the session it names and the caller can be told what it
+// may address. The store implements it.
+type Sessions interface {
+	LoadState() ([]store.Project, error)
+}
+
+// Terminal is the PTY side: whether a session has a process running right now,
+// and how to type at it. The terminal service implements it.
+type Terminal interface {
+	Live(id string) bool
+	Write(id, data string) error
+}
+
+// Peer is one session a caller may address: the label it is addressed by, the
+// project it belongs to (labels are unique within a project, not across them),
+// and what is running in it.
+type Peer struct {
+	Label   string `json:"label"`
+	Project string `json:"project"`
+	Kind    string `json:"kind"`
+}
+
+// Result is what a caller gets back from Send or Wait. Answer is empty unless
+// Status is StatusAnswered.
+type Result struct {
+	Ticket string `json:"ticket"`
+	Target string `json:"target"`
+	Status string `json:"status"`
+	Answer string `json:"answer"`
+}
+
+// ticket is one outstanding errand. answer is written once, before done is
+// closed, so every waiter reads it safely after the close.
+type ticket struct {
+	target  string
+	created time.Time
+	done    chan struct{}
+	answer  string
+}
+
+// Service relays prompts between sessions. Tickets live in memory only: one
+// exists for as long as its errand does, and a lich that restarted has no PTY
+// left to answer into anyway.
+type Service struct {
+	mu      sync.Mutex
+	tickets map[string]*ticket
+
+	sessions Sessions
+	term     Terminal
+	now      func() time.Time
+}
+
+// New returns a relay reading its roster from sessions and typing through term.
+func New(sessions Sessions, term Terminal) *Service {
+	return &Service{
+		tickets:  make(map[string]*ticket),
+		sessions: sessions,
+		term:     term,
+		now:      time.Now,
+	}
+}
+
+// Peers lists the live sessions fromID may address, in the order the sidebar
+// shows them. A session with no PTY running is left out: there is nothing there
+// to type at, and offering it would only produce a message nobody ever reads.
+func (s *Service) Peers(fromID string) ([]Peer, error) {
+	found, err := s.roster(fromID)
+	if err != nil {
+		return nil, err
+	}
+	peers := make([]Peer, 0, len(found))
+	for _, c := range found {
+		peers = append(peers, c.Peer)
+	}
+	return peers, nil
+}
+
+// Send types prompt at the prompt of the session labelled target and waits for
+// its agent to answer. project narrows the search when the same label exists in
+// more than one project; empty searches them all. waitSeconds bounds the wait —
+// 0 uses DefaultWait.
+//
+// The wait running out is not a failure: the message was delivered, and the
+// returned ticket is what picks the answer up later.
+func (s *Service) Send(fromID, target, project, prompt string, waitSeconds int) (Result, error) {
+	prompt = sanitize(prompt)
+	if strings.TrimSpace(prompt) == "" {
+		return Result{}, fmt.Errorf("nothing to send: the prompt is empty")
+	}
+	if len(prompt) > promptLimit {
+		return Result{}, fmt.Errorf("prompt is %d characters, over the %d limit", len(prompt), promptLimit)
+	}
+
+	dest, err := s.resolve(fromID, target, project)
+	if err != nil {
+		return Result{}, err
+	}
+	sender := s.labelOf(fromID)
+
+	id, err := newTicketID()
+	if err != nil {
+		return Result{}, err
+	}
+	t := &ticket{target: dest.Peer.Label, created: s.now(), done: make(chan struct{})}
+	s.mu.Lock()
+	s.sweep()
+	s.tickets[id] = t
+	s.mu.Unlock()
+
+	if err := s.term.Write(dest.ID, paste(compose(sender, id, prompt, dest.Peer.Kind))); err != nil {
+		s.mu.Lock()
+		delete(s.tickets, id)
+		s.mu.Unlock()
+		return Result{}, fmt.Errorf("deliver to %q: %w", dest.Peer.Label, err)
+	}
+	return s.await(id, t, waitSeconds), nil
+}
+
+// Wait blocks on an already-delivered ticket for another round, so a caller
+// whose first wait ran out can come back without sending the message twice.
+func (s *Service) Wait(ticketID string, waitSeconds int) (Result, error) {
+	s.mu.Lock()
+	s.sweep()
+	t, ok := s.tickets[ticketID]
+	s.mu.Unlock()
+	if !ok {
+		return Result{}, fmt.Errorf("unknown ticket %q — it was answered long ago, or expired", ticketID)
+	}
+	return s.await(ticketID, t, waitSeconds), nil
+}
+
+// Reply hands an answer back to whoever is waiting on ticketID. It is what the
+// message composed by Send asks the receiving agent to run.
+func (s *Service) Reply(ticketID, answer string) error {
+	answer = sanitize(answer)
+	if len(answer) > answerLimit {
+		answer = answer[:answerLimit]
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	t, ok := s.tickets[ticketID]
+	if !ok {
+		return fmt.Errorf("unknown ticket %q — it was answered already, or expired", ticketID)
+	}
+	select {
+	case <-t.done:
+		return fmt.Errorf("ticket %q was already answered", ticketID)
+	default:
+	}
+	t.answer = answer
+	close(t.done)
+	return nil
+}
+
+// await blocks on one ticket until it is answered or the wait runs out. An
+// answered ticket is dropped here rather than in Reply: the answer has to
+// outlive the reply long enough for the waiter to read it, and a caller whose
+// wait expired needs the ticket to still be there.
+func (s *Service) await(id string, t *ticket, waitSeconds int) Result {
+	timer := time.NewTimer(waitFor(waitSeconds))
+	defer timer.Stop()
+
+	select {
+	case <-t.done:
+		s.mu.Lock()
+		delete(s.tickets, id)
+		s.mu.Unlock()
+		return Result{Ticket: id, Target: t.target, Status: StatusAnswered, Answer: t.answer}
+	case <-timer.C:
+		return Result{Ticket: id, Target: t.target, Status: StatusPending}
+	}
+}
+
+// waitFor clamps a caller's requested wait into the supported range.
+func waitFor(seconds int) time.Duration {
+	if seconds <= 0 {
+		return DefaultWait
+	}
+	if d := time.Duration(seconds) * time.Second; d < MaxWait {
+		return d
+	}
+	return MaxWait
+}
+
+// sweep drops tickets nobody answered in time. Called under s.mu on the paths
+// that already take it, which is often enough for a map that grows one entry
+// per errand.
+func (s *Service) sweep() {
+	cutoff := s.now().Add(-ticketTTL)
+	for id, t := range s.tickets {
+		if t.created.Before(cutoff) {
+			delete(s.tickets, id)
+		}
+	}
+}
+
+// candidate is a resolved peer together with the session id behind it, which
+// callers never see: they address a session by the label on its card.
+type candidate struct {
+	ID   string
+	Peer Peer
+}
+
+// roster returns every live session except the caller's own.
+func (s *Service) roster(fromID string) ([]candidate, error) {
+	projects, err := s.sessions.LoadState()
+	if err != nil {
+		return nil, fmt.Errorf("read sessions: %w", err)
+	}
+	var found []candidate
+	for _, p := range projects {
+		for _, sess := range p.Sessions {
+			if sess.ID == fromID || !s.term.Live(sess.ID) {
+				continue
+			}
+			found = append(found, candidate{
+				ID:   sess.ID,
+				Peer: Peer{Label: sess.Label, Project: p.Name, Kind: sess.Kind},
+			})
+		}
+	}
+	return found, nil
+}
+
+// resolve finds the single live session named by target, optionally narrowed to
+// one project. An ambiguous label is an error naming every match, because
+// guessing which session a prompt lands in is the one mistake this feature must
+// not make.
+func (s *Service) resolve(fromID, target, project string) (candidate, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return candidate{}, fmt.Errorf("no target session given")
+	}
+	found, err := s.roster(fromID)
+	if err != nil {
+		return candidate{}, err
+	}
+
+	var matches []candidate
+	for _, c := range found {
+		if !strings.EqualFold(c.Peer.Label, target) {
+			continue
+		}
+		if project != "" && !strings.EqualFold(c.Peer.Project, project) {
+			continue
+		}
+		matches = append(matches, c)
+	}
+
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return candidate{}, fmt.Errorf("no live session named %q%s", target, inProject(project))
+	default:
+		return candidate{}, fmt.Errorf(
+			"%q names %d live sessions (%s) — narrow it with the project",
+			target, len(matches), projectsOf(matches),
+		)
+	}
+}
+
+// labelOf names the sending session for the message it is about to deliver.
+// An empty id is a caller with no session at all — the CLI run from a plain
+// shell or a script — and stays empty, which compose words differently. A
+// caller lich has no record of still gets to send: the receiving agent is told
+// the sender is unknown rather than told nothing at all.
+func (s *Service) labelOf(id string) string {
+	if id == "" {
+		return ""
+	}
+	projects, err := s.sessions.LoadState()
+	if err != nil {
+		return "unknown"
+	}
+	for _, p := range projects {
+		for _, sess := range p.Sessions {
+			if sess.ID == id {
+				return sess.Label
+			}
+		}
+	}
+	return "unknown"
+}
+
+func inProject(project string) string {
+	if project == "" {
+		return ""
+	}
+	return fmt.Sprintf(" in project %q", project)
+}
+
+func projectsOf(matches []candidate) string {
+	names := make([]string, 0, len(matches))
+	for _, c := range matches {
+		names = append(names, c.Peer.Project)
+	}
+	return strings.Join(names, ", ")
+}
+
+// compose is the message typed at the target's prompt. It names where the
+// request came from so the receiving agent knows this did not come from the
+// person in front of it, and carries the exact command that sends an answer
+// home — the reply path only exists because this text describes it, so the
+// agent needs no prior knowledge of the feature.
+func compose(sender, ticketID, prompt, targetKind string) string {
+	return fmt.Sprintf(
+		"[lich] %s, not from your own prompt.\n\n%s\n\n%s",
+		origin(sender), prompt, replyInstruction(targetKind, ticketID),
+	)
+}
+
+// replyInstruction tells the receiving agent how to answer. Every agent has a
+// shell, so the command is always named; a provider lich registers its MCP
+// server with is offered the tool first, because a session that withholds shell
+// access would otherwise have no way to answer at all.
+func replyInstruction(kind, ticketID string) string {
+	command := fmt.Sprintf(
+		"  \"$LICH_BIN\" reply %s \"<your answer>\"\nWhoever asked is blocked waiting on it.",
+		ticketID,
+	)
+	if !providers.AcceptsMCPServer(kind) {
+		return "When you have an answer, send it back by running:\n" + command
+	}
+	return fmt.Sprintf(
+		"When you have an answer, send it back with the lich tool `%s` (ticket %s), or by running:\n%s",
+		ToolReply, ticketID, command,
+	)
+}
+
+// origin describes the sender in the message's first line. An empty sender is
+// the lich CLI run outside any session — a script, a scheduled job, the user's
+// own shell — which is a different thing to be told than "another agent".
+func origin(sender string) string {
+	if sender == "" {
+		return "Message relayed by the lich command line"
+	}
+	return fmt.Sprintf("Message from session %q", sender)
+}
+
+// paste wraps text in bracketed paste and submits it, which is how a multi-line
+// message reaches a TUI prompt as one prompt instead of as one submission per
+// newline. Every provider lich spawns runs a TUI that enables bracketed paste;
+// one that did not would read the newlines as submissions.
+func paste(text string) string {
+	return "\x1b[200~" + text + "\x1b[201~\r"
+}
+
+// sanitize strips the control characters that would either break out of the
+// bracketed paste framing or drive the target's terminal, keeping the
+// whitespace a prompt legitimately contains. ESC is the one that matters: text
+// carrying "\x1b[201~" would end the paste early and leave the rest of itself
+// running as keystrokes.
+func sanitize(text string) string {
+	return strings.Map(func(r rune) rune {
+		if r == '\n' || r == '\t' {
+			return r
+		}
+		if r < 0x20 || r == 0x7f {
+			return -1
+		}
+		return r
+	}, text)
+}
+
+// ticketIDBytes is the length of a ticket id before hex encoding. Short enough
+// to read back off a terminal, wide enough that two live errands never collide.
+const ticketIDBytes = 4
+
+func newTicketID() (string, error) {
+	raw := make([]byte, ticketIDBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate ticket id: %w", err)
+	}
+	return hex.EncodeToString(raw), nil
+}

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -1,0 +1,468 @@
+package relay
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/omartelo/lich/internal/store"
+)
+
+// fakeSessions is the persisted workspace a test declares inline.
+type fakeSessions struct {
+	projects []store.Project
+	err      error
+}
+
+func (f fakeSessions) LoadState() ([]store.Project, error) { return f.projects, f.err }
+
+// fakeTerminal records what was typed at which session, and answers Live from
+// an explicit set so a test can park a session without a PTY.
+type fakeTerminal struct {
+	mu       sync.Mutex
+	live     map[string]bool
+	writes   map[string]string
+	writeErr error
+}
+
+func newFakeTerminal(live ...string) *fakeTerminal {
+	t := &fakeTerminal{live: map[string]bool{}, writes: map[string]string{}}
+	for _, id := range live {
+		t.live[id] = true
+	}
+	return t
+}
+
+func (f *fakeTerminal) Live(id string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.live[id]
+}
+
+func (f *fakeTerminal) Write(id, data string) error {
+	if f.writeErr != nil {
+		return f.writeErr
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.writes[id] += data
+	return nil
+}
+
+func (f *fakeTerminal) written(id string) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.writes[id]
+}
+
+// workspace is the roster most tests run against: two projects, one label
+// ("api") deliberately repeated across them.
+func workspace() fakeSessions {
+	return fakeSessions{projects: []store.Project{
+		{ID: "p1", Name: "lich", Sessions: []store.Session{
+			{ID: "s1", Label: "sender", Kind: "claude"},
+			{ID: "s2", Label: "docs", Kind: "codex"},
+			{ID: "s3", Label: "api", Kind: "opencode"},
+			{ID: "s4", Label: "parked", Kind: "claude"},
+		}},
+		{ID: "p2", Name: "revu", Sessions: []store.Session{
+			{ID: "s5", Label: "api", Kind: "crush"},
+		}},
+	}}
+}
+
+func TestPeersListsLiveSessionsWithoutTheCaller(t *testing.T) {
+	svc := New(workspace(), newFakeTerminal("s1", "s2", "s3", "s5"))
+
+	peers, err := svc.Peers("s1")
+	if err != nil {
+		t.Fatalf("Peers: %v", err)
+	}
+
+	want := []Peer{
+		{Label: "docs", Project: "lich", Kind: "codex"},
+		{Label: "api", Project: "lich", Kind: "opencode"},
+		{Label: "api", Project: "revu", Kind: "crush"},
+	}
+	if len(peers) != len(want) {
+		t.Fatalf("got %d peers %v, want %d", len(peers), peers, len(want))
+	}
+	for i := range want {
+		if peers[i] != want[i] {
+			t.Errorf("peer %d = %+v, want %+v", i, peers[i], want[i])
+		}
+	}
+}
+
+func TestPeersReportsAStoreFailure(t *testing.T) {
+	svc := New(fakeSessions{err: errors.New("database is locked")}, newFakeTerminal())
+
+	if _, err := svc.Peers("s1"); err == nil {
+		t.Fatal("want an error when the workspace cannot be read")
+	}
+}
+
+func TestSendDeliversAndReplyAnswers(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := New(workspace(), term)
+
+	var (
+		got Result
+		err error
+		wg  sync.WaitGroup
+	)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		got, err = svc.Send("s1", "docs", "", "run the tests", 30)
+	}()
+
+	ticketID := waitForTicket(svc)
+	if err := svc.Reply(ticketID, "3 failures in foo_test"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	wg.Wait()
+
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got.Status != StatusAnswered {
+		t.Errorf("status = %q, want %q", got.Status, StatusAnswered)
+	}
+	if got.Answer != "3 failures in foo_test" {
+		t.Errorf("answer = %q", got.Answer)
+	}
+	if got.Target != "docs" {
+		t.Errorf("target = %q, want %q", got.Target, "docs")
+	}
+
+	typed := term.written("s2")
+	if !strings.HasPrefix(typed, "\x1b[200~") || !strings.HasSuffix(typed, "\x1b[201~\r") {
+		t.Errorf("message was not bracketed-pasted and submitted: %q", typed)
+	}
+	for _, want := range []string{`"sender"`, "run the tests", `"$LICH_BIN" reply ` + ticketID} {
+		if !strings.Contains(typed, want) {
+			t.Errorf("typed message is missing %q:\n%s", want, typed)
+		}
+	}
+	if other := term.written("s1"); other != "" {
+		t.Errorf("the sender's own session was typed at: %q", other)
+	}
+}
+
+func TestAMessageFromOutsideLichIsAttributedToTheCommandLine(t *testing.T) {
+	term := newFakeTerminal("s2")
+	svc := New(workspace(), term)
+
+	go func() { _ = svc.Reply(waitForTicket(svc), "ok") }()
+	if _, err := svc.Send("", "docs", "", "hello", 30); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	typed := term.written("s2")
+	if !strings.Contains(typed, "Message relayed by the lich command line") {
+		t.Errorf("a caller with no session was announced as one:\n%s", typed)
+	}
+	if strings.Contains(typed, "unknown") {
+		t.Errorf("an external caller was named as an unknown session:\n%s", typed)
+	}
+}
+
+// TestReplyInstructionOffersTheToolOnlyWhereItExists proves the message names
+// the MCP tool exactly for the providers lich registers its server with, and
+// always names the command — an agent whose shell is locked down could
+// otherwise have no way to answer at all.
+func TestReplyInstructionOffersTheToolOnlyWhereItExists(t *testing.T) {
+	tests := []struct {
+		kind string
+		tool bool
+	}{
+		{"claude", true},
+		{"codex", true},
+		{"opencode", false},
+		{"crush", false},
+		{"omp", false},
+		{"shell", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			got := replyInstruction(tt.kind, "a1b2c3d4")
+			if !strings.Contains(got, `"$LICH_BIN" reply a1b2c3d4`) {
+				t.Errorf("the command is missing:\n%s", got)
+			}
+			if named := strings.Contains(got, ToolReply); named != tt.tool {
+				t.Errorf("names the %s tool = %v, want %v:\n%s", ToolReply, named, tt.tool, got)
+			}
+		})
+	}
+}
+
+func TestSendRefusesAnAmbiguousLabel(t *testing.T) {
+	svc := New(workspace(), newFakeTerminal("s1", "s3", "s5"))
+
+	_, err := svc.Send("s1", "api", "", "hello", 30)
+	if err == nil {
+		t.Fatal("want an error for a label two live sessions answer to")
+	}
+	for _, want := range []string{"lich", "revu"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should name project %q: %v", want, err)
+		}
+	}
+}
+
+func TestSendNarrowsAnAmbiguousLabelByProject(t *testing.T) {
+	term := newFakeTerminal("s1", "s3", "s5")
+	svc := New(workspace(), term)
+
+	go func() {
+		ticketID := waitForTicket(svc)
+		_ = svc.Reply(ticketID, "ok")
+	}()
+	got, err := svc.Send("s1", "api", "revu", "hello", 30)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got.Answer != "ok" {
+		t.Fatalf("answer = %q", got.Answer)
+	}
+	if term.written("s5") == "" {
+		t.Error("the revu session was never typed at")
+	}
+	if term.written("s3") != "" {
+		t.Error("the lich session was typed at despite the project narrowing")
+	}
+}
+
+func TestSendRejectsUnreachableTargets(t *testing.T) {
+	svc := New(workspace(), newFakeTerminal("s1", "s2"))
+
+	tests := []struct {
+		name   string
+		target string
+	}{
+		{"no such session", "ghost"},
+		{"session with no pty", "parked"},
+		{"the caller itself", "sender"},
+		{"empty target", "  "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := svc.Send("s1", tt.target, "", "hello", 30); err == nil {
+				t.Fatalf("want an error for target %q", tt.target)
+			}
+		})
+	}
+}
+
+func TestSendReportsADeliveryFailure(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	term.writeErr = errors.New("pty closed")
+	svc := New(workspace(), term)
+
+	if _, err := svc.Send("s1", "docs", "", "hello", 30); err == nil {
+		t.Fatal("want an error when the message cannot be typed")
+	}
+	svc.mu.Lock()
+	open := len(svc.tickets)
+	svc.mu.Unlock()
+	if open != 0 {
+		t.Errorf("a ticket outlived its undelivered message: %d open", open)
+	}
+}
+
+func TestSendPendsWhenTheWaitRunsOutAndWaitPicksItUp(t *testing.T) {
+	svc := New(workspace(), newFakeTerminal("s1", "s2"))
+
+	got, err := svc.Send("s1", "docs", "", "long errand", 1)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got.Status != StatusPending {
+		t.Fatalf("status = %q, want %q", got.Status, StatusPending)
+	}
+	if got.Answer != "" {
+		t.Errorf("a pending result carried an answer: %q", got.Answer)
+	}
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		_ = svc.Reply(got.Ticket, "late but here")
+	}()
+	again, err := svc.Wait(got.Ticket, 30)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if again.Status != StatusAnswered || again.Answer != "late but here" {
+		t.Errorf("Wait returned %+v", again)
+	}
+}
+
+func TestReplyRefusesUnknownAndRepeatedTickets(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := New(workspace(), term)
+
+	if err := svc.Reply("deadbeef", "hello"); err == nil {
+		t.Error("want an error replying to a ticket that never existed")
+	}
+
+	done := make(chan Result, 1)
+	go func() {
+		got, _ := svc.Send("s1", "docs", "", "hello", 30)
+		done <- got
+	}()
+	ticketID := waitForTicket(svc)
+	if err := svc.Reply(ticketID, "first"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	got := <-done
+	if got.Answer != "first" {
+		t.Fatalf("answer = %q", got.Answer)
+	}
+	if err := svc.Reply(ticketID, "second"); err == nil {
+		t.Error("want an error replying to an answered ticket")
+	}
+}
+
+func TestWaitRefusesAnUnknownTicket(t *testing.T) {
+	svc := New(workspace(), newFakeTerminal())
+
+	if _, err := svc.Wait("deadbeef", 1); err == nil {
+		t.Fatal("want an error waiting on a ticket that never existed")
+	}
+}
+
+func TestExpiredTicketsAreSweptAway(t *testing.T) {
+	svc := New(workspace(), newFakeTerminal("s1", "s2"))
+	svc.tickets["stale"] = &ticket{
+		target:  "docs",
+		created: time.Now().Add(-2 * time.Hour),
+		done:    make(chan struct{}),
+	}
+
+	if _, err := svc.Wait("missing", 1); err == nil {
+		t.Fatal("want an error, and the sweep it triggers")
+	}
+	svc.mu.Lock()
+	_, still := svc.tickets["stale"]
+	svc.mu.Unlock()
+	if still {
+		t.Error("an hours-old ticket survived the sweep")
+	}
+}
+
+func TestSendBoundsThePrompt(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := New(workspace(), term)
+
+	if _, err := svc.Send("s1", "docs", "", "", 30); err == nil {
+		t.Error("want an error for an empty prompt")
+	}
+	if _, err := svc.Send("s1", "docs", "", "\x1b\x07", 30); err == nil {
+		t.Error("want an error for a prompt that is only control characters")
+	}
+	if _, err := svc.Send("s1", "docs", "", strings.Repeat("a", 8193), 30); err == nil {
+		t.Error("want an error for a prompt of 8193 characters")
+	}
+
+	go func() {
+		ticketID := waitForTicket(svc)
+		_ = svc.Reply(ticketID, "ok")
+	}()
+	if _, err := svc.Send("s1", "docs", "", strings.Repeat("a", 8192), 30); err != nil {
+		t.Errorf("a prompt of 8192 characters was refused: %v", err)
+	}
+}
+
+func TestReplyTruncatesAnOversizedAnswer(t *testing.T) {
+	svc := New(workspace(), newFakeTerminal("s1", "s2"))
+
+	done := make(chan Result, 1)
+	go func() {
+		got, _ := svc.Send("s1", "docs", "", "hello", 30)
+		done <- got
+	}()
+	ticketID := waitForTicket(svc)
+	if err := svc.Reply(ticketID, strings.Repeat("a", 65537)); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+
+	if got := <-done; len(got.Answer) != 65536 {
+		t.Errorf("answer is %d characters, want it capped at 65536", len(got.Answer))
+	}
+}
+
+func TestSanitizeKeepsWhitespaceAndDropsEscapes(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"keeps newlines and tabs", "one\ntwo\tthree", "one\ntwo\tthree"},
+		{"drops the paste terminator", "before\x1b[201~after", "before[201~after"},
+		{"drops a carriage return", "no\rsubmit", "nosubmit"},
+		{"drops the bell", "ding\x07", "ding"},
+		{"keeps unicode", "não — ok", "não — ok"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitize(tt.in); got != tt.want {
+				t.Errorf("sanitize(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWaitForClampsTheRequestedWait(t *testing.T) {
+	tests := []struct {
+		name    string
+		seconds int
+		want    time.Duration
+	}{
+		{"zero falls back to the default", 0, DefaultWait},
+		{"negative falls back to the default", -5, DefaultWait},
+		{"a plain wait is honoured", 42, 42 * time.Second},
+		{"an over-long wait is capped", 4000, MaxWait},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := waitFor(tt.seconds); got != tt.want {
+				t.Errorf("waitFor(%d) = %v, want %v", tt.seconds, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTicketIDsAreDistinct(t *testing.T) {
+	seen := map[string]bool{}
+	for range 100 {
+		id, err := newTicketID()
+		if err != nil {
+			t.Fatalf("newTicketID: %v", err)
+		}
+		if seen[id] {
+			t.Fatalf("ticket id %q was handed out twice", id)
+		}
+		seen[id] = true
+	}
+}
+
+// waitForTicket blocks until Send has registered its ticket and returns its id.
+// Send delivers the message before it starts waiting, so a test that replies
+// has to let it get that far first.
+func waitForTicket(svc *Service) string {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		svc.mu.Lock()
+		for id := range svc.tickets {
+			svc.mu.Unlock()
+			return id
+		}
+		svc.mu.Unlock()
+		time.Sleep(time.Millisecond)
+	}
+	// Timed out: the caller's own assertion is what reports it.
+	return ""
+}

--- a/internal/terminal/command.go
+++ b/internal/terminal/command.go
@@ -1,9 +1,13 @@
 package terminal
 
 import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/relay"
 )
 
 // What a session's PTY runs: which binary, and with which arguments. Every
@@ -29,6 +33,14 @@ const (
 // roster — the list its cross-session messaging addresses, and what
 // `/list-agents` prints.
 const claudeNameFlag = "--name"
+
+// How each provider is handed an MCP server on its command line: Claude Code
+// takes a JSON string, Codex takes config overrides for its `mcp_servers`
+// table. Which providers accept one at all is providers.AcceptsMCPServer.
+const (
+	claudeMCPFlag   = "--mcp-config"
+	codexConfigFlag = "-c"
+)
 
 // resolveCommand picks the binary a session runs: the user's shell for "shell"
 // sessions, otherwise the provider binary for the session's kind.
@@ -69,6 +81,74 @@ func nameArgs(kind, name string) []string {
 		return nil
 	}
 	return []string{claudeNameFlag, name}
+}
+
+// providerArgs assembles the whole argument list for one spawn. Ordering is
+// decided here rather than by appending in call order, because the two
+// providers constrain it in opposite directions: Codex spells resume as a
+// subcommand, so its global options have to come first, while Claude Code's
+// --mcp-config is variadic and reads everything after it as another config
+// path, so it has to come last.
+func providerArgs(kind, name, resume, lichBin string) []string {
+	mcp := mcpArgs(kind, lichBin)
+	args := append([]string{}, nameArgs(kind, name)...)
+	args = append(args, resumeArgs(kind, resume)...)
+	if kind == providers.Codex {
+		return append(mcp, args...)
+	}
+	return append(args, mcp...)
+}
+
+// mcpArgs registers lich's own MCP server with the provider being spawned, so
+// the agent in that session finds tools for reaching the sessions beside it in
+// its own tool list — without the user having to know the feature exists, and
+// without lich editing any config the user owns.
+//
+// The registration is stdio and carries no secret: it names the lich binary and
+// its `mcp` subcommand, and the server inherits the loopback coordinates from
+// this PTY's environment. A URL registration would have put the token in argv,
+// which any user on the machine can read out of /proc/<pid>/cmdline.
+//
+// Empty when lich cannot name its own binary, or when the provider has no way
+// to be told at spawn — never --strict-mcp-config, which would drop the user's
+// own MCP servers for the sake of lich's.
+func mcpArgs(kind, lichBin string) []string {
+	if lichBin == "" || !providers.AcceptsMCPServer(kind) {
+		return nil
+	}
+	switch kind {
+	case providers.Claude:
+		config := claudeMCPConfig(lichBin)
+		if config == "" {
+			return nil
+		}
+		return []string{claudeMCPFlag, config}
+	case providers.Codex:
+		return []string{
+			codexConfigFlag, fmt.Sprintf("mcp_servers.%s.command=%q", relay.MCPServerName, lichBin),
+			codexConfigFlag, fmt.Sprintf("mcp_servers.%s.args=[%q]", relay.MCPServerName, relay.MCPSubcommand),
+		}
+	}
+	return nil
+}
+
+// claudeMCPConfig is the JSON string Claude Code's --mcp-config accepts in
+// place of a file, which is what keeps this registration off the disk entirely.
+func claudeMCPConfig(lichBin string) string {
+	config := map[string]any{
+		"mcpServers": map[string]any{
+			relay.MCPServerName: map[string]any{
+				"command": lichBin,
+				"args":    []string{relay.MCPSubcommand},
+			},
+		},
+	}
+	raw, err := json.Marshal(config)
+	if err != nil {
+		slog.Warn("mcp registration skipped", "err", err)
+		return ""
+	}
+	return string(raw)
 }
 
 // resumeArgs returns the arguments that reopen a provider conversation, or nil

--- a/internal/terminal/respawn_test.go
+++ b/internal/terminal/respawn_test.go
@@ -153,7 +153,7 @@ func respawn(t *testing.T, svc *Service, id string) *session {
 // shell.
 func TestRespawnedSessionIsNotToldItExited(t *testing.T) {
 	hub, rec := newProbeHub(t)
-	svc := New(stubBins{bin: "/bin/cat"}, nil, hub)
+	svc := New(stubBins{bin: echoBin(t)}, nil, hub)
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
 	respawn(t, svc, "s1")
@@ -171,7 +171,7 @@ func TestRespawnedSessionIsNotToldItExited(t *testing.T) {
 // evicts only its own PTY, so after Close+Start under one id that id still
 // resolves to the new PTY and input still reaches it.
 func TestRespawnedSessionKeepsItsPTY(t *testing.T) {
-	svc := New(stubBins{bin: "/bin/cat"}, nil, events.New())
+	svc := New(stubBins{bin: echoBin(t)}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
 	respawn(t, svc, "s1")

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -238,10 +238,11 @@ func (s *Service) SetRestart(fn func() error) {
 //
 // LICH_PROJECT_DIR and LICH_WORKTREE_PORT belong to the checkout rather than to
 // the transport, so they are exported even when the transport failed to start.
-// The loopback coordinates are the transport's: with none there is nowhere to
-// report, so a hook spawned in this PTY sees no LICH_PORT and no-ops.
+// The rest are the transport's: with none there is nowhere to report, so a hook
+// spawned in this PTY sees no LICH_PORT and no-ops, and the `lich` CLI it would
+// have called has nothing to call.
 func (s *Service) sessionEnv(id, projectID, cwd string) []string {
-	env := make([]string, len(s.env), len(s.env)+5)
+	env := make([]string, len(s.env), len(s.env)+6)
 	copy(env, s.env)
 	if dir := s.store.ProjectPath(projectID); dir != "" {
 		env = append(env, "LICH_PROJECT_DIR="+dir)
@@ -252,12 +253,32 @@ func (s *Service) sessionEnv(id, projectID, cwd string) []string {
 	if s.ws == nil {
 		return env
 	}
-	return append(env,
+	env = append(env,
 		"LICH_PORT="+strconv.Itoa(s.ws.port),
 		"LICH_TOKEN="+s.ws.token,
 		"LICH_SESSION_ID="+id,
 	)
+	if bin := lichBin(); bin != "" {
+		env = append(env, "LICH_BIN="+bin)
+	}
+	return env
 }
+
+// lichBin is the path of the running lich binary, exported as LICH_BIN so a
+// session can call the `lich` CLI back (internal/cli) — which is how one
+// session reaches another. The path rather than the name: an installed lich is
+// on $PATH and a `task dev` build is not, and on a machine running both, the
+// name would resolve to whichever came first rather than to the lich this
+// session belongs to. Empty when the path cannot be resolved; nothing is
+// exported then and a caller falls back to $PATH.
+var lichBin = sync.OnceValue(func() string {
+	exe, err := os.Executable()
+	if err != nil {
+		slog.Warn("resolve executable — LICH_BIN unset in sessions", "err", err)
+		return ""
+	}
+	return exe
+})
 
 // readBufSize is the chunk size read from a session's PTY per iteration.
 const readBufSize = 32 * 1024
@@ -320,9 +341,16 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 		cwd = home
 	}
 
+	// The MCP registration is withheld without a transport for the same reason
+	// the hook coordinates are: the server it points at would have nothing to
+	// talk to, so the session would carry tools that can only fail.
+	mcpBin := ""
+	if s.ws != nil {
+		mcpBin = lichBin()
+	}
 	spec := ptySpec{
 		bin:  resolveCommand(kind, s.store.ProviderBin(kind, projectID), userShell()),
-		args: append(nameArgs(kind, name), resumeArgs(kind, resume)...),
+		args: providerArgs(kind, name, resume, mcpBin),
 		dir:  cwd,
 		env:  s.sessionEnv(id, projectID, cwd),
 		cols: cols,
@@ -476,6 +504,14 @@ func (s *Service) Close(id string) error {
 		return nil
 	}
 	return sess.pty.Close()
+}
+
+// Live reports whether a session has a process running right now. It is the
+// difference between a card and a PTY: a session the user has never opened in
+// this page has a row in the store and nothing behind it to type at, so it can
+// be listed but never addressed (internal/relay).
+func (s *Service) Live(id string) bool {
+	return s.ptyOf(id) != nil
 }
 
 // ptyOf returns the PTY for a session, or nil if it is not running.

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -7,6 +7,7 @@
 package terminal
 
 import (
+	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -16,6 +17,7 @@ import (
 	"time"
 
 	"github.com/omartelo/lich/internal/events"
+	"github.com/omartelo/lich/internal/providers"
 	"github.com/omartelo/lich/internal/shquote"
 )
 
@@ -320,6 +322,19 @@ func stayAliveBin(t *testing.T) string {
 	return path
 }
 
+// echoBin writes a script that echoes its input like cat and ignores whatever
+// arguments it is spawned with. A session spawn carries flags of lich's own now
+// (the MCP registration), and plain /bin/cat would read those as file names,
+// fail, and exit before the test could inspect the session.
+func echoBin(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-claude")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexec cat\n"), 0o755); err != nil {
+		t.Fatalf("write stub bin: %v", err)
+	}
+	return path
+}
+
 // spawnedArgs returns the argv of a session's spawned process. It reaches
 // through the seam to the Unix implementation — these tests only run where a
 // real PTY exists, and argv is not part of the ptyHandle contract.
@@ -347,9 +362,12 @@ func TestStartPassesResumeToTheProcess(t *testing.T) {
 	got := spawnedArgs(t, svc, "s1")
 	svc.mu.Unlock()
 
-	want := []string{bin, "--resume", "abc-123"}
-	if !slices.Equal(got, want) {
-		t.Errorf("spawned argv = %v, want %v", got, want)
+	// A spawn also registers lich's MCP server, whose content
+	// TestProviderArgsRegistersTheMCPServer pins; this test owns the resume id
+	// reaching argv ahead of it.
+	want := []string{bin, "--resume", "abc-123", "--mcp-config"}
+	if len(got) != len(want)+1 || !slices.Equal(got[:len(want)], want) {
+		t.Errorf("spawned argv = %v, want %v followed by one config", got, want)
 	}
 }
 
@@ -368,8 +386,12 @@ func TestStartWithoutResumeSpawnsBare(t *testing.T) {
 	got := spawnedArgs(t, svc, "s1")
 	svc.mu.Unlock()
 
-	if !slices.Equal(got, []string{bin}) {
-		t.Errorf("spawned argv = %v, want %v", got, []string{bin})
+	// A claude spawn is never bare now: it carries lich's MCP registration,
+	// whose content TestProviderArgsRegistersTheMCPServer pins. What this test
+	// owns is that no resume flag was invented alongside it.
+	want := []string{bin, "--mcp-config"}
+	if len(got) != len(want)+1 || !slices.Equal(got[:len(want)], want) {
+		t.Errorf("spawned argv = %v, want %v followed by one config", got, want)
 	}
 }
 
@@ -414,8 +436,11 @@ func TestStartWithSetupButNoScriptSpawnsBare(t *testing.T) {
 	got := spawnedArgs(t, svc, "s1")
 	svc.mu.Unlock()
 
-	if !slices.Equal(got, []string{bin}) {
-		t.Errorf("spawned argv = %v, want %v", got, []string{bin})
+	// As above: the registration is expected, an sh indirection is not — argv
+	// still starts at the provider binary itself.
+	want := []string{bin, "--mcp-config"}
+	if len(got) != len(want)+1 || !slices.Equal(got[:len(want)], want) {
+		t.Errorf("spawned argv = %v, want %v followed by one config", got, want)
 	}
 }
 
@@ -524,9 +549,10 @@ func TestStartPassesNameToTheProcess(t *testing.T) {
 	got := spawnedArgs(t, svc, "s1")
 	svc.mu.Unlock()
 
-	want := []string{bin, "--name", "lich-4f2a"}
-	if !slices.Equal(got, want) {
-		t.Errorf("spawned argv = %v, want %v", got, want)
+	// As above: the registration follows, pinned by its own test.
+	want := []string{bin, "--name", "lich-4f2a", "--mcp-config"}
+	if len(got) != len(want)+1 || !slices.Equal(got[:len(want)], want) {
+		t.Errorf("spawned argv = %v, want %v followed by one config", got, want)
 	}
 }
 
@@ -633,6 +659,119 @@ func TestSessionEnvInjectsCoordinates(t *testing.T) {
 	}
 	if len(s.env) != 1 || s.env[0] != "A=1" {
 		t.Fatalf("shared base env was mutated: %v", s.env)
+	}
+}
+
+// TestProviderArgsRegistersTheMCPServer proves each provider that can be handed
+// an MCP server at spawn is handed lich's, spelled its own way.
+func TestProviderArgsRegistersTheMCPServer(t *testing.T) {
+	const bin = "/usr/bin/lich"
+
+	claude := providerArgs(providers.Claude, "", "", bin)
+	if len(claude) != 2 || claude[0] != "--mcp-config" {
+		t.Fatalf("claude args = %v", claude)
+	}
+	var config struct {
+		MCPServers map[string]struct {
+			Command string   `json:"command"`
+			Args    []string `json:"args"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal([]byte(claude[1]), &config); err != nil {
+		t.Fatalf("--mcp-config value is not JSON: %v (%q)", err, claude[1])
+	}
+	server, ok := config.MCPServers["lich"]
+	if !ok {
+		t.Fatalf("no lich server in %q", claude[1])
+	}
+	if server.Command != bin || !slices.Equal(server.Args, []string{"mcp"}) {
+		t.Errorf("server = %+v, want %q mcp", server, bin)
+	}
+	if strings.Contains(claude[1], "token") {
+		t.Errorf("a secret reached the argv, which /proc exposes: %q", claude[1])
+	}
+
+	codex := providerArgs(providers.Codex, "", "", bin)
+	want := []string{
+		"-c", `mcp_servers.lich.command="/usr/bin/lich"`,
+		"-c", `mcp_servers.lich.args=["mcp"]`,
+	}
+	if !slices.Equal(codex, want) {
+		t.Errorf("codex args = %v, want %v", codex, want)
+	}
+}
+
+// TestProviderArgsOrdersEachProvidersConstraint pins the two orderings that are
+// not interchangeable: Claude Code's --mcp-config is variadic and swallows what
+// follows it, and Codex reads resume as a subcommand that every global option
+// must precede.
+func TestProviderArgsOrdersEachProvidersConstraint(t *testing.T) {
+	claude := providerArgs(providers.Claude, "lich-4f2a", "conv-1", "/usr/bin/lich")
+	if claude[len(claude)-2] != "--mcp-config" {
+		t.Errorf("--mcp-config is not last, so it eats what follows: %v", claude)
+	}
+	for _, want := range []string{"--name", "--resume"} {
+		if !slices.Contains(claude, want) {
+			t.Errorf("claude args lost %q: %v", want, claude)
+		}
+	}
+
+	codex := providerArgs(providers.Codex, "", "conv-1", "/usr/bin/lich")
+	resume := slices.Index(codex, "resume")
+	if resume < 0 {
+		t.Fatalf("codex args lost the resume subcommand: %v", codex)
+	}
+	if last := slices.Index(codex, "-c"); last > resume {
+		t.Errorf("a global option follows the subcommand: %v", codex)
+	}
+	if codex[len(codex)-1] != "conv-1" {
+		t.Errorf("codex args = %v, want the conversation id last", codex)
+	}
+}
+
+// TestProviderArgsWithoutARegistration proves the providers with no way to be
+// told at spawn are spawned exactly as before, and that a lich which cannot
+// name its own binary registers nothing rather than something broken.
+func TestProviderArgsWithoutARegistration(t *testing.T) {
+	tests := []struct {
+		name string
+		kind string
+		bin  string
+	}{
+		{"opencode has no flag for it", providers.OpenCode, "/usr/bin/lich"},
+		{"crush has no flag for it", providers.Crush, "/usr/bin/lich"},
+		{"oh-my-pi has no flag for it", providers.OMP, "/usr/bin/lich"},
+		{"a shell session is not a provider", KindShell, "/usr/bin/lich"},
+		{"no binary to point at", providers.Claude, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if args := providerArgs(tt.kind, "", "", tt.bin); len(args) != 0 {
+				t.Errorf("args = %v, want none", args)
+			}
+		})
+	}
+}
+
+// TestSessionEnvExportsTheBinary proves a session is told where the lich it
+// belongs to lives. Its agent calls that path back to reach another session
+// (internal/cli), and on a machine running an installed lich beside a dev build
+// the bare name would resolve to the wrong one.
+func TestSessionEnvExportsTheBinary(t *testing.T) {
+	exe, err := os.Executable()
+	if err != nil {
+		t.Skipf("no executable path on this platform: %v", err)
+	}
+	s := &Service{env: []string{"A=1"}, store: stubBins{}, ws: &transport{port: 4321, token: "tok"}}
+
+	var got string
+	for _, e := range s.sessionEnv("sess", "p1", "") {
+		if path, ok := strings.CutPrefix(e, "LICH_BIN="); ok {
+			got = path
+		}
+	}
+	if got != exe {
+		t.Fatalf("LICH_BIN = %q, want the running binary %q", got, exe)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/omartelo/lich/internal/agentplugin"
 	"github.com/omartelo/lich/internal/appupdate"
 	"github.com/omartelo/lich/internal/chromium"
+	"github.com/omartelo/lich/internal/cli"
 	"github.com/omartelo/lich/internal/drop"
 	"github.com/omartelo/lich/internal/events"
 	"github.com/omartelo/lich/internal/fonts"
@@ -20,6 +21,7 @@ import (
 	"github.com/omartelo/lich/internal/patchnotes"
 	"github.com/omartelo/lich/internal/project"
 	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/relay"
 	"github.com/omartelo/lich/internal/restart"
 	"github.com/omartelo/lich/internal/rpc"
 	"github.com/omartelo/lich/internal/singleton"
@@ -52,6 +54,15 @@ const defaultListenPort = "47821"
 var version = "dev"
 
 func main() {
+	// `lich <subcommand>` is the CLI a session's agent calls to reach the
+	// sessions beside it (internal/cli). It answers before anything else here:
+	// it must not open the database, take the log file or race the singleton
+	// bind of the lich it is talking to. Anything that is not a subcommand —
+	// including `lich -- <chromium flags>` — falls through and opens the app.
+	if code := cli.Run(os.Args[1:], os.Getenv, os.Stdout, os.Stderr); code != cli.NotACommand {
+		os.Exit(code)
+	}
+
 	// Snapshot before any env tweaks: spawned terminal sessions must inherit
 	// what the user launched lich with (see terminal.childEnv). ResolveShellEnv
 	// recovers the rc-exported vars a GUI launch misses (see its doc).
@@ -114,6 +125,9 @@ func main() {
 	dispatcher.Register("store", db)
 	dispatcher.Register("system", system.New(env, logPath, version))
 	dispatcher.Register("providers", providers.New())
+	// The relay is the only service whose caller is not the window: the `lich`
+	// CLI running inside a session reaches it over the same listener.
+	dispatcher.Register("relay", relay.New(db, term))
 	dispatcher.Register("themes", themes.New())
 	dispatcher.Deny("store.Close")
 	// The dropped file's bytes are the request body, so the upload is its own


### PR DESCRIPTION
A lich session could not reach the session beside it unless its provider shipped a messaging channel of its own. Claude Code has one; Codex, opencode, oh-my-pi and Crush do not.

lich now relays: it types a task at the target's prompt and waits. It never reads the answer off the terminal — a TUI's output is boxes, spinners and ANSI, and parsing it would mean a parser per provider, each hostage to that provider's next release. The message it types **asks the agent to report back**, so the answer is written by the agent that produced it. That is what makes this work on every provider: anything that can run a shell command can answer.

## The surface is offered twice

**As MCP tools**, registered by lich itself at spawn. A command only helps an agent that has been told it exists, and the person who would need telling is the one who does not read release notes; a tool is in the agent's own list from the first turn.

| Provider | How | Registered |
|---|---|---|
| Claude Code | `--mcp-config` with a JSON string, no file on disk | yes |
| Codex | `-c mcp_servers.lich.command=…` / `…args=["mcp"]` | yes |
| opencode · oh-my-pi · Crush | no flag for it — Crush's whole flag list is cwd, data-dir, session, debug | no |

**As the `lich` command**, which needs nothing registered. It is the whole surface for the three providers above, it is the reply path that still works where a server failed to load, and it runs from any shell on the machine — so lich is scriptable without a provider in the loop (`--json`, and a caller with no session is attributed to the command line rather than posing as one).

## Two decisions worth reviewing

**stdio, not HTTP.** lich already serves HTTP on the loopback listener and registering a URL would have been less code. But the registration lands in the provider's **argv**, and `/proc/<pid>/cmdline` is readable by any user on the machine while `/proc/<pid>/environ` is not. A URL registration means `?token=` in argv. The stdio one names a binary and a subcommand and carries no secret at all.

**Never `--strict-mcp-config`.** It would make Claude Code ignore every other MCP configuration — the user's own servers dropped for the sake of lich's. Proven below that the default merges.

## Verified, not assumed

| | Result |
|---|---|
| Claude Code loads the server | real session with the exact JSON lich passes → `mcp__lich__{list_sessions,send_to_session,wait_for_answer,reply_to_session}` |
| It does not replace the user's servers | same session without `--strict`: `servers visible: ['ai-memory', 'lich']` |
| Codex loads the server | real Codex 0.144.5 handshake captured on disk: `initialize` → `notifications/initialized` → `tools/list`, answered with all four tools |
| The CLI works outside a session | with no `LICH_*` in the environment it found the running lich through `runtime.json` and authenticated |
| No secret reaches argv | a test fails if `token` appears in the `--mcp-config` value |

## Tests that changed, and why

The contract changed: a spawn now also registers the MCP server, so four argv assertions had to move. Their exact pinning is kept — prefix compared literally, and exactly one further argument allowed — with the registration's own content pinned by `TestProviderArgsRegistersTheMCPServer`.

Two respawn tests used `/bin/cat` as the fake provider binary. Given arguments it does not understand, cat reads them as file names and exits, so the respawned session died before the assertion. They now use a fake that ignores argv and echoes; `stayAliveBin`'s own comment already warned about exactly this.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` — 25 packages, no failures
- [x] `go test -race ./internal/...` clean
- [x] Cross-compile loop: `build` + `vet` green for linux, darwin, windows
- [x] `pnpm` biome + tsc clean (no frontend changes)
- [x] Coverage: relay 94.7%, cli 87.3%, terminal 86.1%, providers 90.0%
- [ ] `ci:os` — backend suite on real Windows and macOS runners. Worth watching: the registration JSON carries a Windows path, and argv assembly is shared with the ConPTY spawn.

## Known ceilings (documented in `docs/cli.md`)

- Four tool definitions sit in every Claude Code and Codex session lich spawns, used or not. The command line costs nothing until called; the tools are what buy discovery, and this is the price.
- Registration is silent and there is no switch. It does not widen the trust boundary — `LICH_TOKEN` was already in every PTY — but it is the first feature to use it.
- Only live sessions are addressable; a card whose terminal was never opened has nothing to type at.
- Delivery is proven, receipt is not: an agent that never runs the reply is indistinguishable from one still working, which is what the wait and the ticket are for.

## Not in this PR

- **No UI.** Nothing in the window mentions any of this yet.
- **opencode, oh-my-pi, Crush** get no MCP registration — closing that means writing a config file lich does not own.