### PR TITLE
fix: keep the sidebar scrollbar off the session cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The session list's scrollbar no longer sits on the cards.** With enough
+  sessions to scroll, the scrollbar came down flush against the right edge of
+  every card, reading as part of them. It now keeps a gap, and the cards stay
+  the width they were when the list is short enough not to scroll.
+
 - **A dragged card keeps its own shape.** Dragging a session card past a taller
   neighbour — a worktree card with a long title, say — stretched it to that
   neighbour's size, smearing its text until the drop. Cards, session groups and

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -190,7 +190,10 @@ export function SessionSidebar() {
           </DropdownMenuGroup>
         </DropdownMenuContent>
       </DropdownMenu>
-      <div className="flex flex-1 flex-col gap-1.5 overflow-y-auto overflow-x-hidden">
+      {/* The scrollbar takes width, so it rides the aside's own padding (-mr-2)
+          and the padding is re-applied inside — a gap between thumb and card
+          when it shows, no shift in card width when it doesn't. */}
+      <div className="-mr-2 flex flex-1 flex-col gap-1.5 overflow-y-auto overflow-x-hidden pr-2">
         {/* Pinned above the session groups beside Settings, not inside a
             worktree's group: this card belongs to the project, and the screen it
             opens is the repository's, not one checkout's. */}


### PR DESCRIPTION
## What

With enough sessions to scroll, the session list's scrollbar came down flush against the right edge of every card, reading as part of them.

## How

The scroll container rides the `aside`'s own right padding (`-mr-2`) and re-applies it inside (`pr-2`). The 8px scrollbar lands in that gutter, leaving a gap between thumb and card; a list short enough not to scroll keeps the cards at the width they already had, so nothing shifts when the scrollbar comes and goes.

One class change plus its comment, and the `[Unreleased]` entry.

## Test plan

- [x] `biome check .` — warnings only (the standing a11y backlog)
- [x] `vitest run` — 764 passed
- [x] `vite build` (tsc typecheck + build)
- [x] By hand in `task dev`: open enough sessions to overflow the sidebar, confirm the gap; close them again, confirm the cards don't resize