### PR TITLE
feat: show cross-session work in the window, and return its answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The sidebar says which session is waiting on which.** One session handing
+  work to another used to happen entirely off screen: the card that asked looked
+  like any card running a tool, and the card doing the work spun with no hint of
+  why. Both now name the other end while the request is open — `→ docs` on the
+  one waiting, `← auth` on the one that was asked — and go back to normal the
+  moment the answer lands. A request from a script rather than a session says so
+  instead of borrowing a name.
+- **A session answers to either of its names.** Every session has two: the label
+  on its card, and the name Claude Code lists it under. Handing work to one used
+  to work with the first and fail with the second, which was enough to make an
+  agent try both channels at once and lose the answer between them. Both names
+  now reach the same session, and both are listed wherever lich names one.
+- **An answer finds you even if you stopped waiting.** A task handed to another
+  session can take minutes, which is longer than an agent can hold a tool call
+  open. So it no longer has to: when the answer comes back and nobody is waiting
+  on it, lich types it at the prompt of the session that asked, exactly as it
+  typed the request at the other one. Ask, carry on, and the answer turns up.
+
+- **A request stops waiting when the answer went elsewhere.** If the session you
+  asked works through the request and then answers in its own window instead of
+  back through lich, the wait ends right there saying so, and a notification
+  opens that session so you can read what it wrote — instead of running out a
+  five-minute clock on an answer that already exists.
+
+- **Delegate to session, from the card menu.** Right-click the session you are
+  in and pick another to hand work to; lich writes the request at your own
+  prompt and leaves the cursor there, so you read it before it is sent. What it
+  writes depends on what your agent has: Claude Code and Codex get it in plain
+  words and reach for the tool themselves, everything else gets the `lich send`
+  command spelled out — which for opencode, oh-my-pi and Crush is the only way
+  they would learn it exists.
+
 - **One session can hand work to another, whatever it is running.** Claude Code
   sessions can already message each other; Codex, OpenCode and Crush cannot, and
   nothing in lich reached across a card. Every session now carries a `lich`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -102,19 +102,34 @@ type at.
 
 Types `<prompt>` at `<session>`'s prompt, submits it, and waits.
 
-- `<session>` is the label on the card. Labels are unique within a project, not
-  across them: a label two live sessions answer to is an error naming both, and
-  `--project` is what narrows it. Guessing which session a prompt lands in is
-  the one mistake this must not make.
+- `<session>` is the label on the card, **or** the name that session answers to
+  in Claude Code's peer roster (`myrepo-a1b2`, the one lich passes as `--name`
+  and a mention writes at a prompt). Both name the same session and both are
+  accepted, because an agent holding one of them should never have to know which
+  door it is standing at — offering one name and accepting the other is what
+  once made an agent treat a single session as two and use both channels at
+  once. The label wins a tie.
+- Labels are unique within a project, not across them: a label two live sessions
+  answer to is an error naming both, and `--project` is what narrows it.
+  Guessing which session a prompt lands in is the one mistake this must not
+  make. A name that matches nothing comes back with every live session's two
+  names, so a miss is one step from a hit.
 - `--timeout` bounds the wait in seconds. Default 100 — under the 120s an
   agent's shell tool typically allows a command, so the wait ends in an answer
   this side controls rather than a killed process. Capped at 30 minutes.
 - Answered: prints the answer alone, exit 0.
-- Not answered in time: the message was still delivered, so it prints the ticket
-  and the command that picks the answer up later, exit 0.
+- Not answered in time: the message was still delivered, so it says so and hands
+  back a ticket, exit 0. **The answer is not lost by giving up on it** — see
+  below.
+- **Answered somewhere else**: the target worked through the request and ended
+  its turn without replying here — it answered over its provider's own channel,
+  or out loud to whoever was watching. The wait ends there rather than running
+  its clock out, and says the answer is in that session and has to be read
+  there. The window raises a toast that opens the card.
 
 ```
-docs has not answered yet. The message was delivered; wait for it with:
+docs is still working. The message was delivered; its answer will be typed at
+the sending session's prompt when it arrives. To hold the line for it instead:
   lich wait a1b2c3d4
 ```
 
@@ -192,6 +207,28 @@ the machine while `/proc/<pid>/environ` is not. A URL registration means
 secret at all — the server inherits the coordinates from the PTY's environment,
 where they already were.
 
+## The answer comes back the way the request went out
+
+A relayed task can take minutes; a tool call cannot sit still that long (Claude
+Code detaches one that runs past 120 seconds). So waiting is optional here.
+
+When the answer lands and **nobody is still holding the line**, lich types it at
+the sending session's own prompt and submits it — the same bracketed paste, the
+same delay, the same submit that carried the request to the target:
+
+```
+[lich] Answer from session "docs", to the request you sent it:
+
+3 failures in foo_test
+```
+
+That is what makes a long errand work without polling: the asker carries on, and
+the answer arrives when it exists. A caller that *is* still waiting carries the
+answer out itself and nothing is typed — delivering both would deliver twice.
+
+A sender that is not a session — the `lich` command from a script — has no
+prompt to answer at. Such a caller waits, or does without.
+
 ## The message a target receives
 
 ```
@@ -227,6 +264,23 @@ receiving agent only because this text describes it.
   message above, types it through the terminal service, and holds the ticket the
   answer comes back on. Tickets live in memory: one exists for as long as its
   errand does, and a lich that restarted has no PTY left to answer into.
+- **UI push** — the relay emits the global app event `session-relay`
+  (`{id, peer, direction}`) for **both** ends when a message lands in a PTY, and
+  again with an empty direction for both when the errand closes. It is raised
+  after the write, never before: a mark that outlived a delivery which never
+  happened would be a card claiming something untrue. A caller with no session
+  of its own gets no mark — there is no card to put one on — and the target's
+  `peer` is then empty, which the card words as the command line.
+- **Store and card** — `frontend/src/lib/session/session-relay-store.ts`, keyed
+  by session id, read by `SessionCard`. The row outranks the tool line while a
+  request is open: it explains the whole turn, and the tool comes back when the
+  errand closes. The store also clears on `idle` (SessionEnd), which the relay's
+  own clear cannot reach — a session that ended can answer nothing, and its
+  ticket would otherwise hold the mark for an hour.
+- **Delegating from the window** — `delegate-targets.ts` lists every other
+  session, `delegate-prompt.ts` decides what is typed: a plain request where the
+  sender has lich's tools, the spelled-out command where it has none. That split
+  mirrors `providers.AcceptsMCPServer` and has to keep mirroring it.
 - **Delivery** — `internal/terminal`, `Service.Write`: the same PTY write the
   window's keyboard input takes. The message is wrapped in bracketed paste
   (`\x1b[200~`…`\x1b[201~`) and followed by a carriage return, so a multi-line
@@ -253,6 +307,33 @@ receiving agent only because this text describes it.
 - **Env** — `internal/terminal`, `Service.sessionEnv`: exports `LICH_BIN`
   alongside the hook coordinates.
 
+## Two channels, one address space
+
+A Claude Code session can reach another one twice over: through its own peer
+messaging, and through lich. That is not a conflict to be settled by a setting —
+it became one only because the two named the same sessions differently, so an
+agent handed a name could not tell which door it was standing at. On the first
+real run one hedged and used both at once: it delivered over its own channel and
+then waited on a lich ticket nobody would ever close.
+
+Three things keep that from repeating, and none of them asks the user to choose:
+
+1. **One address space.** The relay answers to the card label *and* to the peer
+   roster name (`internal/relay/rostername.go`, the Go half of
+   `frontend/src/lib/session/peer-name.ts` — a divergence there delivers a
+   message to the wrong terminal). A mention that slips into lich's tool works
+   instead of erroring.
+2. **Both names travel.** `list_sessions` and every miss report the label and
+   the roster name together, so an agent sees one session with two names.
+3. **One route home.** The relayed message says the ticket is the only way back
+   and that an answer sent any other way is lost; `reply_to_session` says the
+   same.
+
+When all three fail anyway, the fourth catches it: the target's own turn ending
+closes the wait and points the user at that session. That path is the exception,
+not a supported mode — an answer that goes there is one lich cannot hand to
+whoever asked.
+
 ## Known ceilings
 
 - **A relayed prompt carries the sender's reach, not the user's.** It is typed
@@ -270,6 +351,9 @@ receiving agent only because this text describes it.
   handed the server without being asked. This does not widen the trust boundary
   — `LICH_TOKEN` was already in every PTY — but it does mean a user who never
   wanted this has no way to say so short of the provider's own MCP settings.
+- **The card shows what is in flight, never what happened.** Marks live with
+  their ticket and the ticket lives in memory, so a finished request leaves no
+  trace and a reload starts blank — the same ceiling the status readout has.
 - **Only live sessions are addressable.** A parked or never-opened card is
   invisible to `sessions` and unreachable by `send`. Spawning one on demand
   would mean lifting spawn state out of the frontend, which owns it.

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -2,6 +2,8 @@ import { useEffect, useRef, useState } from "react"
 import type { KeyboardEvent } from "react"
 import {
   ArrowDown,
+  ArrowLeft,
+  ArrowRight,
   AtSign,
   GitBranch,
   GitPullRequestArrow,
@@ -21,6 +23,7 @@ import { peerMention, peerName } from "@/lib/session/peer-name"
 import { useSessionStatus, useSessionStatusAge } from "@/lib/session/use-session-status"
 import { useSessionCwd } from "@/lib/session/use-session-cwd"
 import { useSessionAgent } from "@/lib/session/use-session-agent"
+import { useSessionRelay } from "@/lib/session/use-session-relay"
 import { useSessionTool } from "@/lib/session/use-session-tool"
 import { toolGlyph } from "@/lib/session/tool-glyph"
 import { useGitStatus } from "@/lib/git/use-git-status"
@@ -44,6 +47,8 @@ import {
 } from "@/components/ui/context-menu"
 import { Terminal as TerminalService } from "@/lib/rpc"
 import type { MentionGroup } from "@/lib/session/mention-targets"
+import type { DelegateGroup } from "@/lib/session/delegate-targets"
+import { delegatePrompt } from "@/lib/session/delegate-prompt"
 import { bracketedPaste } from "@/lib/terminal/bracketed-paste"
 import { requestTerminalFocus } from "@/lib/terminal/focus-request"
 
@@ -68,6 +73,10 @@ interface SessionCardProps {
   // that terminal's prompt, so any other card would be writing somewhere the
   // user cannot see.
   mentionGroups: MentionGroup[]
+  // Sessions this one can hand work to, grouped by project. Offered by the card
+  // on screen for the reason the mention is: the request is written at that
+  // terminal's prompt, and any other card would be writing out of sight.
+  delegateGroups: DelegateGroup[]
 }
 
 // The card itself is the drag grip for reordering the list — no separate handle.
@@ -82,6 +91,7 @@ export function SessionCard({
   onOpenTerminal,
   onPulls,
   mentionGroups,
+  delegateGroups,
 }: SessionCardProps) {
   const pinned = !!session.pinned
   const pathRef = useRef<HTMLSpanElement>(null)
@@ -105,6 +115,10 @@ export function SessionCard({
   // hook: null outside a tool call, which is what keeps the card its usual size
   // whenever nothing is happening in it.
   const tool = useSessionTool(session.id)
+  // The request this session has open with another, reported by the relay when
+  // a message lands in a PTY and cleared when it is answered. null the rest of
+  // the time, which is nearly always.
+  const relay = useSessionRelay(session.id)
   const ToolGlyph = tool && toolGlyph(tool.name)
   // The live working directory the backend's cwd watcher reports ("" until it
   // does): a `cd` in the terminal moves the card with it. Falls back to the
@@ -133,7 +147,18 @@ export function SessionCard({
     requestTerminalFocus(session.id)
   }
 
+  // Write the request at this session's own prompt and hand the cursor back.
+  // lich stops here too: what it types is a request, and the agent reading it
+  // decides whether to reach for the tool or the command (delegatePrompt).
+  const delegate = (label: string) => {
+    void TerminalService.Write(session.id, bracketedPaste(delegatePrompt(session.kind, label)))
+    requestTerminalFocus(session.id)
+  }
+
   const canMention = active && session.kind === "claude" && mentionGroups.length > 0
+  // Every provider can delegate: the relay types at the target's prompt, so
+  // none of this depends on the sender's own messaging channel.
+  const canDelegate = active && delegateGroups.length > 0
 
   const commit = (value: string) => {
     setEditing(false)
@@ -225,20 +250,40 @@ export function SessionCard({
                   </span>
                 </span>
               )}
-              {/* Under the label, so the card reads name → what it is doing →
-                  where. It is the only row that comes and goes with the turn,
-                  which is the cost of putting it where the eye already is. */}
-              {tool && (
+              {/* An open request outranks the tool on the same line. While one
+                  is in flight it explains the whole turn — a card working
+                  because another session asked it to, or one stalled waiting on
+                  a card elsewhere in the list — and the tool line comes back the
+                  moment the errand closes. Only one of the two ever draws, so
+                  the card grows by one row at most. */}
+              {relay ? (
                 <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">
-                  {ToolGlyph && <ToolGlyph className="size-3 shrink-0" />}
-                  <span className="shrink-0 font-medium text-foreground">{tool.name}</span>
-                  {tool.detail && (
-                    <>
-                      <span className="shrink-0 opacity-50">·</span>
-                      <span className="truncate font-mono">{tool.detail}</span>
-                    </>
+                  {relay.direction === "out" ? (
+                    <ArrowRight className="size-3 shrink-0" />
+                  ) : (
+                    <ArrowLeft className="size-3 shrink-0" />
+                  )}
+                  {relay.peer ? (
+                    <span className="truncate font-medium text-foreground">{relay.peer}</span>
+                  ) : (
+                    // Not a session, so not a label: the other end is the `lich`
+                    // command run from a script or a shell (docs/cli.md).
+                    <span className="truncate italic">command line</span>
                   )}
                 </span>
+              ) : (
+                tool && (
+                  <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">
+                    {ToolGlyph && <ToolGlyph className="size-3 shrink-0" />}
+                    <span className="shrink-0 font-medium text-foreground">{tool.name}</span>
+                    {tool.detail && (
+                      <>
+                        <span className="shrink-0 opacity-50">·</span>
+                        <span className="truncate font-mono">{tool.detail}</span>
+                      </>
+                    )}
+                  </span>
+                )
               )}
               {/* rtl anchors the tail (project folder) to the right so overflow is
                 clipped on the left; the leading LRM keeps "~/" in logical order
@@ -403,6 +448,30 @@ export function SessionCard({
                         <span className="ml-auto pl-3 font-mono text-xs text-muted-foreground">
                           {target.name}
                         </span>
+                      </ContextMenuItem>
+                    ))}
+                  </ContextMenuGroup>
+                ))}
+              </ContextMenuSubContent>
+            </ContextMenuSub>
+          )}
+          {canDelegate && (
+            <ContextMenuSub>
+              <ContextMenuSubTrigger>
+                <ArrowRight />
+                Delegate to session
+              </ContextMenuSubTrigger>
+              <ContextMenuSubContent>
+                {delegateGroups.map((group) => (
+                  <ContextMenuGroup key={group.projectId}>
+                    {/* The project only earns a heading when there is more than
+                        one to tell apart. */}
+                    {delegateGroups.length > 1 && (
+                      <ContextMenuLabel>{group.projectName}</ContextMenuLabel>
+                    )}
+                    {group.targets.map((target) => (
+                      <ContextMenuItem key={target.id} onClick={() => delegate(target.label)}>
+                        <span className="truncate">{target.label}</span>
                       </ContextMenuItem>
                     ))}
                   </ContextMenuGroup>

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -6,6 +6,7 @@ import { dragStyle, useSortableList, verticalAxis } from "@/lib/use-sortable-lis
 import { cn } from "@/lib/utils"
 import { checkoutLabel } from "@/lib/git/checkout-label"
 import type { MentionGroup } from "@/lib/session/mention-targets"
+import type { DelegateGroup } from "@/lib/session/delegate-targets"
 import { groupKey, type Session } from "@/lib/session/sessions"
 import { useProjects } from "@/providers/projects"
 import { SessionCard } from "./SessionCard"
@@ -41,6 +42,7 @@ interface SessionGroupProps {
   // the Claude sessions the active one can be pointed at, across every open
   // project.
   mentionGroups: MentionGroup[]
+  delegateGroups: DelegateGroup[]
 }
 
 // SessionGroup renders one worktree's sessions under a static divider titled
@@ -67,6 +69,7 @@ export function SessionGroup({
   onPulls,
   onClosePulls,
   mentionGroups,
+  delegateGroups,
 }: SessionGroupProps) {
   const { activateSession, renameSession, pinSession, newSession } = useProjects()
   const navigate = useNavigate()
@@ -129,6 +132,7 @@ export function SessionGroup({
                 onOpenTerminal={(cwd) => newSession(projectId, "shell", cwd)}
                 onPulls={onPulls}
                 mentionGroups={mentionGroups}
+                delegateGroups={delegateGroups}
               />
             ))}
           </div>

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -7,6 +7,7 @@ import { ProjectService } from "@/lib/rpc"
 import { closeSettings, isSettingsOpen, subscribeSettingsCard } from "@/lib/settings-card-store"
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
 import { mentionTargets } from "@/lib/session/mention-targets"
+import { delegateTargets } from "@/lib/session/delegate-targets"
 import {
   closePullsList,
   isPullsListOpen,
@@ -117,6 +118,7 @@ export function SessionSidebar() {
   // Resolved once here, not per group: the list spans every open project, so
   // it is the same for every card in the sidebar.
   const mentionGroups = mentionTargets(projects, sessions, realActiveId)
+  const delegateGroups = delegateTargets(projects, sessions, realActiveId)
   // No session card highlights while a full-screen route (Settings, Pulls) owns
   // the view; its own sidebar entry reads as active instead.
   const activeId = onSettings || onPullsRoute ? "" : realActiveId
@@ -263,6 +265,7 @@ export function SessionSidebar() {
                     }
                   }}
                   mentionGroups={mentionGroups}
+                  delegateGroups={delegateGroups}
                 />
               )
             })}

--- a/frontend/src/components/ui/context-menu.tsx
+++ b/frontend/src/components/ui/context-menu.tsx
@@ -117,7 +117,9 @@ function ContextMenuSubTrigger({
       data-slot="context-menu-sub-trigger"
       data-inset={inset}
       className={cn(
-        "flex cursor-default items-center rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-8 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        // gap-2 matches ContextMenuItem: stock shadcn omits it here, which glues
+        // a leading glyph to the label on every submenu trigger.
+        "flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-inset:pl-8 data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
       {...props}

--- a/frontend/src/lib/session/delegate-prompt.test.ts
+++ b/frontend/src/lib/session/delegate-prompt.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+import { delegatePrompt } from "./delegate-prompt"
+
+describe("delegatePrompt", () => {
+  it("asks in plain words where the sender has lich's tools", () => {
+    expect(delegatePrompt("claude", "docs")).toBe('Ask the "docs" session to ')
+    expect(delegatePrompt("codex", "docs")).toBe('Ask the "docs" session to ')
+  })
+
+  it("spells the command where the sender has none", () => {
+    for (const kind of ["opencode", "crush", "omp", "shell"]) {
+      expect(delegatePrompt(kind, "docs")).toBe('lich send "docs" "')
+    }
+  })
+
+  it("treats a kind it does not know as having no tools", () => {
+    // A provider from a newer build: the command works everywhere, so guessing
+    // it has tools is the only guess that can leave the agent stuck.
+    expect(delegatePrompt("something-new", "docs")).toBe('lich send "docs" "')
+  })
+
+  it("carries the label through verbatim", () => {
+    expect(delegatePrompt("claude", "fix login 2")).toBe('Ask the "fix login 2" session to ')
+    expect(delegatePrompt("crush", "fix login 2")).toBe('lich send "fix login 2" "')
+  })
+})

--- a/frontend/src/lib/session/delegate-prompt.ts
+++ b/frontend/src/lib/session/delegate-prompt.ts
@@ -1,0 +1,31 @@
+// What lich writes at the sender's own prompt when the user picks a session to
+// hand work to. lich never carries the request itself: it puts the words there
+// and hands the cursor back, and the agent reading that prompt is what acts.
+
+import type { SessionKind } from "./sessions"
+
+// The providers lich registers its MCP server with at spawn. Mirrors
+// providers.AcceptsMCPServer on the Go side — the two have to agree, because an
+// agent offered a tool it does not have would answer the user with an error.
+//
+// The session's declared kind, never the live agent readout: a shell card
+// running `claude` by hand was spawned without the registration, so it has the
+// command and not the tools.
+const TOOL_KINDS: readonly string[] = ["claude", "codex"]
+
+/**
+ * The text to type at a sender of this kind, addressing the session labelled
+ * target.
+ *
+ * An agent that has lich's tools is given the request in its own language and
+ * picks the tool itself; one that has none is given the command, because
+ * nothing else would tell it the command exists. The quote is left open on
+ * purpose there — the user types the task inside it, which is where the cursor
+ * lands.
+ */
+export function delegatePrompt(senderKind: SessionKind | string, target: string): string {
+  if (TOOL_KINDS.includes(senderKind)) {
+    return `Ask the "${target}" session to `
+  }
+  return `lich send "${target}" "`
+}

--- a/frontend/src/lib/session/delegate-targets.test.ts
+++ b/frontend/src/lib/session/delegate-targets.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest"
+import { delegateTargets } from "./delegate-targets"
+import type { SessionState } from "./sessions"
+
+const PROJECTS = [
+  { id: "p1", name: "lich", path: "/home/me/code/lich" },
+  { id: "p2", name: "revu", path: "/home/me/code/revu" },
+]
+
+const state: SessionState = {
+  p1: {
+    activeId: "aaaa1111",
+    nextSeq: 4,
+    sessions: [
+      { id: "aaaa1111", label: "auth", kind: "claude" },
+      { id: "bbbb2222", label: "docs", kind: "codex" },
+      { id: "cccc3333", label: "api", kind: "crush" },
+    ],
+  },
+  p2: {
+    activeId: "",
+    nextSeq: 2,
+    sessions: [{ id: "dddd4444", label: "web", kind: "opencode" }],
+  },
+}
+
+describe("delegateTargets", () => {
+  it("offers every other session, whatever provider it runs", () => {
+    const groups = delegateTargets(PROJECTS, state, "aaaa1111")
+
+    expect(groups.map((group) => group.projectName)).toEqual(["lich", "revu"])
+    expect(groups[0].targets.map((target) => target.label)).toEqual(["docs", "api"])
+    expect(groups[1].targets.map((target) => target.label)).toEqual(["web"])
+  })
+
+  it("never offers the session doing the sending", () => {
+    const labels = delegateTargets(PROJECTS, state, "bbbb2222")
+      .flatMap((group) => group.targets)
+      .map((target) => target.label)
+
+    expect(labels).not.toContain("docs")
+    expect(labels).toEqual(["auth", "api", "web"])
+  })
+
+  it("drops a project with nothing left to offer", () => {
+    const alone: SessionState = {
+      p1: { activeId: "", nextSeq: 1, sessions: [] },
+      p2: state.p2,
+    }
+    expect(delegateTargets(PROJECTS, alone, "dddd4444")).toEqual([])
+  })
+
+  it("is empty when this is the only session open", () => {
+    const alone: SessionState = {
+      p1: { activeId: "aaaa1111", nextSeq: 2, sessions: [state.p1.sessions[0]] },
+    }
+    expect(delegateTargets(PROJECTS, alone, "aaaa1111")).toEqual([])
+  })
+})

--- a/frontend/src/lib/session/delegate-targets.ts
+++ b/frontend/src/lib/session/delegate-targets.ts
@@ -1,0 +1,51 @@
+// The sessions the one on screen can hand work to, grouped by the project they
+// belong to. Distinct from mention-targets, which is Claude's own peer roster:
+// this one addresses a session by the label on its card, and every provider can
+// be a target because the relay types at the target's prompt rather than using
+// any messaging channel of its own (docs/cli.md).
+//
+// The list spans every open project, because the sidebar shows one project at a
+// time and walking to another would change which session is sending.
+//
+// A card whose terminal was never opened is listed like any other. It has no
+// PTY, so the relay refuses it — and says so, in the session that asked. Hiding
+// it here would mean tracking spawn state outside the component that owns it,
+// for a case the sender is told about anyway.
+
+import type { Project } from "@/lib/api-types"
+import type { SessionState } from "./sessions"
+import { sessionsOf } from "./sessions"
+
+export interface DelegateTarget {
+  id: string
+  /** The label on the card, which is also how the relay addresses it. */
+  label: string
+}
+
+export interface DelegateGroup {
+  projectId: string
+  projectName: string
+  targets: DelegateTarget[]
+}
+
+/**
+ * Every session across every open project except the one doing the sending, in
+ * project order. A project with nothing to offer is left out, so an empty
+ * result means there is nobody to hand work to.
+ */
+export function delegateTargets(
+  projects: readonly Project[],
+  sessions: SessionState,
+  sourceId: string,
+): DelegateGroup[] {
+  const groups: DelegateGroup[] = []
+  for (const project of projects) {
+    const targets = sessionsOf(sessions, project.id)
+      .filter((session) => session.id !== sourceId)
+      .map((session) => ({ id: session.id, label: session.label }))
+    if (targets.length > 0) {
+      groups.push({ projectId: project.id, projectName: project.name, targets })
+    }
+  }
+  return groups
+}

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -41,6 +41,63 @@ export const AGENT_EVENT = "session-agent"
 // the session has a known price. Its absence is the answer, not a zero.
 export const USAGE_EVENT = "session-usage"
 
+// Global event the backend emits while one session has a request open with
+// another (see relay.RelayEventName). Payload: { id, peer, direction } — the
+// session whose card changes, the label at the other end, and which way the
+// request runs. An empty direction clears it: the request is over, answered or
+// expired.
+export const RELAY_EVENT = "session-relay"
+
+// Global event the backend emits when a request's target ended its turn without
+// answering through lich (see relay.StalledEventName). Payload:
+// { id, targetId, target } — who asked ("" when it was the command line rather
+// than a session), and the session holding whatever was produced.
+export const RELAY_STALLED_EVENT = "session-relay-stalled"
+
+// One request whose answer, if there is one, is only in the target's terminal.
+export interface RelayStalled {
+  id: string
+  targetId: string
+  target: string
+}
+
+export function isRelayStalledEvent(data: unknown): data is RelayStalled {
+  if (!isIdEvent(data)) {
+    return false
+  }
+  const { targetId, target } = data as { targetId?: unknown; target?: unknown }
+  return typeof targetId === "string" && targetId !== "" && typeof target === "string"
+}
+
+// Which way an open request runs, from the marked card's side: "out" is waiting
+// on someone, "in" is owing someone an answer.
+const RELAY_DIRECTIONS = ["out", "in"] as const
+
+export type RelayDirection = (typeof RELAY_DIRECTIONS)[number]
+
+// One session's open request. peer is the label at the other end, empty when
+// that end is not a session at all — the `lich` command run from a script or a
+// plain shell, which the card names in its own words.
+export interface SessionRelay {
+  peer: string
+  direction: RelayDirection
+}
+
+// toSessionRelay narrows a relay payload to an open request, or null when there
+// is none: the clearing empty direction, and equally a direction from a newer
+// backend that this build cannot draw. Both mean "show nothing", which is
+// safer than stranding a mark no event will ever take down.
+export function toSessionRelay(data: unknown): SessionRelay | null {
+  const { peer, direction } = (data ?? {}) as { peer?: unknown; direction?: unknown }
+  if (typeof direction !== "string") {
+    return null
+  }
+  if (!(RELAY_DIRECTIONS as readonly string[]).includes(direction)) {
+    return null
+  }
+  return { peer: typeof peer === "string" ? peer : "", direction: direction as RelayDirection }
+}
+
 // A session's context-window occupancy as the footer shows it, and what the
 // session has cost so far. costUsd is null whenever the backend sent no number:
 // the setting is off (the case on a subscription, where the figure is noise) or

--- a/frontend/src/lib/session/session-relay-store.test.ts
+++ b/frontend/src/lib/session/session-relay-store.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest"
+import { isRelayStalledEvent } from "./session-events"
+import { createSessionRelayStore } from "./session-relay-store"
+
+describe("isRelayStalledEvent", () => {
+  it("accepts a request whose target holds the answer", () => {
+    expect(isRelayStalledEvent({ id: "s1", targetId: "s2", target: "docs" })).toBe(true)
+  })
+
+  it("accepts one with no sender — the command line has no card", () => {
+    expect(isRelayStalledEvent({ id: "", targetId: "s2", target: "docs" })).toBe(true)
+  })
+
+  it("refuses one with no target, which is the only thing the toast can open", () => {
+    expect(isRelayStalledEvent({ id: "s1", targetId: "", target: "docs" })).toBe(false)
+    expect(isRelayStalledEvent({ id: "s1", target: "docs" })).toBe(false)
+    expect(isRelayStalledEvent(null)).toBe(false)
+  })
+})
+
+// A hand-driven event source: the test emits, the store reacts.
+function source() {
+  const handlers: Array<(data: unknown) => void> = []
+  return {
+    subscribe: (handler: (data: unknown) => void) => {
+      handlers.push(handler)
+      return () => {}
+    },
+    emit: (data: unknown) => {
+      for (const handler of handlers) {
+        handler(data)
+      }
+    },
+  }
+}
+
+function build() {
+  const relay = source()
+  const status = source()
+  const store = createSessionRelayStore(relay.subscribe, status.subscribe)
+  return { relay, status, store }
+}
+
+describe("createSessionRelayStore", () => {
+  it("is empty until something is reported", () => {
+    const { store } = build()
+    expect(store.get("s1")).toBeNull()
+  })
+
+  it("marks both ends of one request independently", () => {
+    const { relay, store } = build()
+
+    relay.emit({ id: "s1", peer: "docs", direction: "out" })
+    relay.emit({ id: "s2", peer: "auth", direction: "in" })
+
+    expect(store.get("s1")).toEqual({ peer: "docs", direction: "out" })
+    expect(store.get("s2")).toEqual({ peer: "auth", direction: "in" })
+  })
+
+  it("clears on the empty direction the backend sends when the errand closes", () => {
+    const { relay, store } = build()
+
+    relay.emit({ id: "s1", peer: "docs", direction: "out" })
+    relay.emit({ id: "s1", peer: "", direction: "" })
+
+    expect(store.get("s1")).toBeNull()
+  })
+
+  it("keeps a request with no peer label — the other end is the command line", () => {
+    const { relay, store } = build()
+
+    relay.emit({ id: "s2", peer: "", direction: "in" })
+
+    expect(store.get("s2")).toEqual({ peer: "", direction: "in" })
+  })
+
+  it("shows nothing for a direction this build cannot draw", () => {
+    const { relay, store } = build()
+
+    relay.emit({ id: "s1", peer: "docs", direction: "sideways" })
+
+    expect(store.get("s1")).toBeNull()
+  })
+
+  it("ignores a payload with no session id", () => {
+    const { relay, store } = build()
+
+    relay.emit({ peer: "docs", direction: "out" })
+    relay.emit(null)
+    relay.emit("nonsense")
+
+    expect(store.get("s1")).toBeNull()
+  })
+
+  it("clears when the session ends, which the relay's own clear would not reach", () => {
+    const { relay, status, store } = build()
+
+    relay.emit({ id: "s2", peer: "auth", direction: "in" })
+    status.emit({ id: "s2", state: "idle" })
+
+    expect(store.get("s2")).toBeNull()
+  })
+
+  it("survives every other state: a busy session is still owed an answer", () => {
+    const { relay, status, store } = build()
+
+    relay.emit({ id: "s2", peer: "auth", direction: "in" })
+    for (const state of ["busy", "done", "waiting"]) {
+      status.emit({ id: "s2", state })
+    }
+
+    expect(store.get("s2")).toEqual({ peer: "auth", direction: "in" })
+  })
+
+  it("does not notify subscribers when a repeat report changes nothing", () => {
+    const { relay, store } = build()
+    let notifications = 0
+    store.subscribe("s1", () => {
+      notifications += 1
+    })
+
+    relay.emit({ id: "s1", peer: "docs", direction: "out" })
+    relay.emit({ id: "s1", peer: "docs", direction: "out" })
+
+    expect(notifications).toBe(1)
+  })
+})

--- a/frontend/src/lib/session/session-relay-store.ts
+++ b/frontend/src/lib/session/session-relay-store.ts
@@ -1,0 +1,46 @@
+import { createKeyedStore, type ReadableKeyedStore } from "@/lib/keyed-store"
+import { isIdEvent, toSessionRelay, type SessionRelay } from "./session-events"
+
+// A subscription to one of the global session events, injected so the store is
+// testable without standing up the /events socket. Returns its unsubscribe.
+export type RelayEventSource = (handler: (data: unknown) => void) => () => void
+
+// Two marks are the same when both fields match. The store rebuilds the object
+// on every event, so without this a repeat report would hand
+// useSyncExternalStore a new reference and re-render the card for nothing.
+function sameRelay(a: SessionRelay | null, b: SessionRelay | null): boolean {
+  if (a === null || b === null) {
+    return a === b
+  }
+  return a.peer === b.peer && a.direction === b.direction
+}
+
+// createSessionRelayStore keeps the request each session has open with another,
+// keyed by session id, fed by the relay event (see internal/relay). The backend
+// raises a mark on both ends when a message lands in a PTY and takes both down
+// when the errand closes, so this store only follows what it is told.
+//
+// It also clears on "idle": that is SessionEnd, the CLI leaving the PTY. A
+// session that ended can no longer answer anything, and the mark would
+// otherwise sit on a dead card until its next spawn — the relay's own clear
+// only comes when someone answers or the ticket expires an hour later.
+export function createSessionRelayStore(
+  relaySource: RelayEventSource,
+  statusSource: RelayEventSource,
+): ReadableKeyedStore<SessionRelay | null> {
+  const store = createKeyedStore<SessionRelay | null>(null, sameRelay)
+
+  relaySource((data) => {
+    if (isIdEvent(data)) {
+      store.set(data.id, toSessionRelay(data))
+    }
+  })
+
+  statusSource((data) => {
+    if (isIdEvent(data) && (data as { state?: unknown }).state === "idle") {
+      store.set(data.id, null)
+    }
+  })
+
+  return store
+}

--- a/frontend/src/lib/session/use-session-relay.ts
+++ b/frontend/src/lib/session/use-session-relay.ts
@@ -1,0 +1,19 @@
+import { useKeyedStore } from "@/lib/use-keyed-store"
+import { onAppEvent } from "@/lib/app-events"
+import { RELAY_EVENT, STATUS_EVENT, type SessionRelay } from "./session-events"
+import { createSessionRelayStore } from "./session-relay-store"
+
+// Subscribed at import rather than on first use: that opens the /events socket
+// at page load, so a request opened before any card mounts still lands.
+const store = createSessionRelayStore(
+  (handler) => onAppEvent(RELAY_EVENT, handler),
+  (handler) => onAppEvent(STATUS_EVENT, handler),
+)
+
+// useSessionRelay reads the request a session has open with another from the
+// shared store (see session-relay-store), which retains it across the card's
+// unmount. Returns null while the session is on its own — the usual case, and
+// what keeps the card its normal size.
+export function useSessionRelay(id: string): SessionRelay | null {
+  return useKeyedStore(store, id)
+}

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
 import type { ReactNode } from "react"
 import { toast } from "sonner"
-import { Bell, Folder } from "lucide-react"
+import { Bell, Folder, MessageSquareDashed } from "lucide-react"
 import { useMatch, useNavigate } from "react-router-dom"
 import type { Project, RecentProject } from "@/lib/api-types"
 import type { StoredProject as StoreProject } from "@/lib/api-types"
@@ -29,15 +29,17 @@ import { applyOrder, pinFirst } from "@/lib/reorder"
 import { displayPath } from "@/lib/paths"
 import { defaultProviderKind } from "@/lib/providers-store"
 import {
+  RELAY_STALLED_EVENT,
+  STATUS_EVENT,
+  TITLE_EVENT,
+  TOUCHED_EVENT,
   decideStatusNotice,
   isIdEvent,
+  isRelayStalledEvent,
   isStatusEvent,
   isTitleEvent,
   shouldToastAttention,
-  STATUS_EVENT,
-  TITLE_EVENT,
   toSessionStatus,
-  TOUCHED_EVENT,
   type SessionStatus,
 } from "@/lib/session/session-events"
 import { NotificationsOptIn } from "@/components/NotificationsOptIn"
@@ -509,6 +511,49 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     window.addEventListener("keydown", onKey, true)
     return () => window.removeEventListener("keydown", onKey, true)
   }, [activeProjectId, newSession, activateSession, hotkeys])
+
+  // A request whose target worked and then answered somewhere lich cannot read
+  // — its provider's own peer channel, or simply out loud to whoever is watching
+  // — leaves the answer on that session's screen and nowhere else. The toast is
+  // the only thing that says where it went, so it carries the way there.
+  //
+  // Meant to be rare: unifying the two names a session answers to, and telling
+  // the target its ticket is the only route home, are what keep it rare. This is
+  // the escape hatch for when neither held.
+  useEffect(() => {
+    const off = onAppEvent(RELAY_STALLED_EVENT, (data) => {
+      if (!isRelayStalledEvent(data)) {
+        return
+      }
+      const { targetId, target } = data
+      const projectId = projectOfSession(sessionsRef.current, targetId)
+      // The target's project was closed meanwhile: there is no card to open, so
+      // the toast would offer a door to nowhere.
+      if (!sessionsRef.current[projectId]) {
+        return
+      }
+      toast(
+        <div className="flex min-w-0 flex-col">
+          <span>{target || UNLABELED_SESSION} answered in its own session</span>
+          <span className="mt-0.5 text-xs text-muted-foreground">
+            It finished without replying through lich — open it to read the answer.
+          </span>
+        </div>,
+        {
+          duration: ATTENTION_TOAST_MS,
+          icon: <MessageSquareDashed className="size-4 text-sky-500" />,
+          action: {
+            label: "Open",
+            onClick: () => {
+              navigate(`/projects/${projectId}`)
+              activateSession(projectId, targetId)
+            },
+          },
+        },
+      )
+    })
+    return () => off()
+  }, [navigate, activateSession])
 
   // A session that needs the user (permission prompt or idle input) raises a
   // global toast that routes to its card — reachable even when the session lives

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -224,8 +224,14 @@ func (c *client) report(result relay.Result, asJSON bool) error {
 		fmt.Fprintln(c.stdout, result.Answer)
 		return nil
 	}
+	if result.Status == relay.StatusUnanswered {
+		fmt.Fprintln(c.stdout, unansweredText(result.Target))
+		return nil
+	}
 	fmt.Fprintf(c.stdout,
-		"%s has not answered yet. The message was delivered; wait for it with:\n  lich wait %s\n",
+		"%s is still working. The message was delivered; its answer will be typed at the "+
+			"sending session's prompt when it arrives. To hold the line for it instead:\n"+
+			"  lich wait %s\n",
 		result.Target, result.Ticket,
 	)
 	return nil

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -204,7 +204,14 @@ func TestSendPointsAtTheTicketWhenTheWaitRunsOut(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d", code)
 	}
-	for _, want := range []string{"docs has not answered yet", "lich wait a1b2c3d4"} {
+	// A wait running out is not a dead end anymore: the answer comes back to the
+	// sending session's prompt on its own, and holding the line again is the
+	// option rather than the instruction.
+	for _, want := range []string{
+		"docs is still working",
+		"typed at the sending session's prompt",
+		"lich wait a1b2c3d4",
+	} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("output is missing %q:\n%s", want, stdout)
 		}

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -39,6 +39,19 @@ const mcpProtocolVersion = "2025-06-18"
 // registers itself under at spawn.
 const mcpServerName = "lich"
 
+// mcpMaxWait caps how long any tool here blocks, whatever the caller asks for.
+//
+// Claude Code moves an MCP call that runs past 120 seconds into the background
+// and delivers its result later as a notification. A tool that waits longer
+// therefore does not wait at all — it detaches, and the agent reports that it is
+// "waiting in the background" while the answer lands somewhere it has stopped
+// looking. Seen on the first real run, at the caller's own request: it asked for
+// 120 seconds and then 180.
+//
+// The ticket is what makes the cap cheap. A wait that ends unanswered costs one
+// more tool call, inside the agent's own turn, instead of a detached task.
+const mcpMaxWait = 90
+
 // jsonRPC frames one message in either direction. ID is absent on a
 // notification, which is answered with nothing at all.
 type jsonRPC struct {
@@ -205,17 +218,21 @@ func (a mcpArgs) text(key string) string {
 	}
 }
 
+// seconds reads a wait from the arguments, clamped to what an MCP call may
+// block for (see mcpMaxWait). A caller asking for longer gets the cap, not the
+// detachment it was heading for.
 func (a mcpArgs) seconds(key string) int {
+	asked := 0
 	switch v := a[key].(type) {
 	case float64:
-		return int(v)
+		asked = int(v)
 	case string:
-		var n int
-		_, _ = fmt.Sscanf(v, "%d", &n)
-		return n
-	default:
-		return 0
+		_, _ = fmt.Sscanf(v, "%d", &asked)
 	}
+	if asked <= 0 || asked > mcpMaxWait {
+		return mcpMaxWait
+	}
+	return asked
 }
 
 // schema builds an inputSchema from named properties and the subset of them
@@ -261,15 +278,23 @@ var mcpTools = []mcpTool{
 	},
 	{
 		Name: "send_to_session",
-		Description: "Give another lich session a task and wait for its agent to answer. " +
-			"The task is put at that session's prompt as if typed there. Returns its answer, " +
-			"or a ticket to pick the answer up with wait_for_answer if it takes too long.",
+		Description: "Give another lich session a task. The task is put at that session's prompt " +
+			"as if typed there. Returns the answer when it comes back quickly; for anything " +
+			"slower the answer is delivered to your own prompt as soon as it exists, so you can " +
+			"carry on and do not need to poll. " +
+			"Sessions are addressed by the label on their lich card — call list_sessions for " +
+			"the labels. If you were given a name like `myrepo-a1b2`, that is a peer-roster " +
+			"name from your own cross-session messaging, not a lich label: reach it with your " +
+			"own messaging tool instead of this one.",
 		Schema: schema(map[string]any{
-			"session": property("string", "Label of the target session, as returned by list_sessions."),
+			"session": property("string",
+				"Label of the target session, exactly as list_sessions returns it. Not a peer-roster name."),
 			"prompt":  property("string", "What to ask that session's agent to do."),
 			"project": property("string", "Project name, needed only when two live sessions share a label."),
 			"timeout_seconds": property("number",
-				"How long to wait for an answer. Defaults to 100; the call returns a ticket rather than failing if it runs out."),
+				"Seconds to hold the line for a quick answer, at most 90 — longer is capped, "+
+					"because a call running past 120s is detached by the client and stops being a "+
+					"wait at all. Running out costs nothing: the answer arrives at your prompt."),
 		}, "session", "prompt"),
 		Run: func(c *client, args mcpArgs) (string, error) {
 			var result relay.Result
@@ -283,11 +308,13 @@ var mcpTools = []mcpTool{
 	},
 	{
 		Name: "wait_for_answer",
-		Description: "Wait again on a ticket that send_to_session handed back because its wait ran out. " +
-			"The task was already delivered; this only waits for the answer.",
+		Description: "Hold the line again on a ticket send_to_session handed back. Optional: the " +
+			"answer reaches your prompt on its own whether or not you call this. Use it only when " +
+			"you have nothing else to do and want the answer inside this turn.",
 		Schema: schema(map[string]any{
-			"ticket":          property("string", "The ticket send_to_session returned."),
-			"timeout_seconds": property("number", "How long to wait. Defaults to 100."),
+			"ticket": property("string", "The ticket send_to_session returned."),
+			"timeout_seconds": property("number",
+				"Seconds to wait, at most 90. Call this again with the same ticket for longer."),
 		}, "ticket"),
 		Run: func(c *client, args mcpArgs) (string, error) {
 			var result relay.Result
@@ -301,7 +328,9 @@ var mcpTools = []mcpTool{
 	{
 		Name: "reply_to_session",
 		Description: "Answer a task another session gave you. Call this when a message at your prompt " +
-			"came from lich and carried a ticket; whoever asked is blocked until you do.",
+			"came from lich and carried a ticket; whoever asked is blocked until you do. " +
+			"It is the only route back — a peer message does not reach them, because they are " +
+			"waiting on the ticket and reading nothing else.",
 		Schema: schema(map[string]any{
 			"ticket": property("string", "The ticket from the message you were given."),
 			"answer": property("string", "Your answer, in full — nothing else is sent back."),
@@ -319,11 +348,29 @@ var mcpTools = []mcpTool{
 // there is one, otherwise what to call next. A bare ticket would leave the
 // agent guessing what it is for.
 func mcpOutcome(result relay.Result) string {
-	if result.Status == relay.StatusAnswered {
+	switch result.Status {
+	case relay.StatusAnswered:
 		return result.Answer
+	case relay.StatusUnanswered:
+		return unansweredText(result.Target)
 	}
 	return fmt.Sprintf(
-		"%s has not answered yet. The task was delivered; call wait_for_answer with ticket %q.",
+		"%s is still working. The task was delivered and its answer will be put at your own "+
+			"prompt when it arrives, so carry on — there is nothing to poll. Ticket %q, if you "+
+			"want to hold the line for it with wait_for_answer instead.",
 		result.Target, result.Ticket,
+	)
+}
+
+// unansweredText is what both surfaces say when the target worked through the
+// request and ended its turn without replying here. It has to send the reader
+// to the other session: whatever the agent there produced is on its screen and
+// nowhere lich can reach, so an answer that reads as "nothing happened" would
+// be the one wrong thing to say.
+func unansweredText(target string) string {
+	return fmt.Sprintf(
+		"The %q session finished its turn without answering through lich. "+
+			"Whatever it produced is in that session — tell the user to open the %q card to read it.",
+		target, target,
 	)
 }

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -303,6 +303,47 @@ func TestMCPReadsLooseArgumentTypes(t *testing.T) {
 	}
 }
 
+// TestMCPCapsTheWaitBelowTheClientsBackgroundThreshold pins the ceiling that
+// keeps a wait a wait. Claude Code detaches an MCP call that runs past 120
+// seconds, so a caller asking for more than the cap gets the cap — the first
+// real run asked for 120 and then 180, and both stopped waiting.
+func TestMCPCapsTheWaitBelowTheClientsBackgroundThreshold(t *testing.T) {
+	tests := []struct {
+		name  string
+		asked any
+		want  float64
+	}{
+		{"under the cap is honoured", float64(20), 20},
+		{"the cap itself", float64(90), 90},
+		{"over the cap is clamped", float64(180), 90},
+		{"the client's own threshold is already too long", float64(120), 90},
+		{"omitted falls back to the cap", nil, 90},
+		{"zero falls back to the cap", float64(0), 90},
+		{"negative falls back to the cap", float64(-5), 90},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newFakeLich(t, `{"ticket":"a1b2c3d4","target":"docs","status":"answered","answer":"ok"}`)
+			args := map[string]any{"session": "docs", "prompt": "hi"}
+			if tt.asked != nil {
+				args["timeout_seconds"] = tt.asked
+			}
+			call, err := json.Marshal(map[string]any{
+				"jsonrpc": "2.0", "id": 1, "method": "tools/call",
+				"params": map[string]any{"name": "send_to_session", "arguments": args},
+			})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			speak(t, f, string(call))
+
+			if got := f.only(t).args[4]; got != tt.want {
+				t.Errorf("timeout = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMCPStopsCleanlyAtEndOfInput(t *testing.T) {
 	f := newFakeLich(t, `null`)
 

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -57,7 +57,9 @@ func wiredLich(t *testing.T) (func(string) string, *wiredTerminal) {
 	t.Helper()
 	term := &wiredTerminal{}
 	dispatcher := rpc.New()
-	dispatcher.Register("relay", relay.New(wiredSessions{}, term))
+	// No events sink: these tests are about the wire between the CLI and the
+	// dispatcher, and the window is not on this side of it.
+	dispatcher.Register("relay", relay.New(wiredSessions{}, term, nil))
 
 	server := httptest.NewServer(dispatcher)
 	t.Cleanup(server.Close)

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -17,6 +17,8 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -72,13 +74,70 @@ const (
 	// StatusPending means the message was delivered and the wait ran out first.
 	// The ticket is still live: Wait picks the same answer up later.
 	StatusPending = "pending"
+	// StatusUnanswered means the target worked through the request and ended its
+	// turn without replying here. Its answer, if it wrote one, is in that
+	// session's own terminal and nowhere lich can read it — which is what
+	// happens when an agent answers over a channel of its provider's own.
+	StatusUnanswered = "unanswered"
 )
+
+// Session states the relay watches, spelled as the hook contract reports them
+// (docs/hooks/session-state.md).
+const (
+	stateBusy = "busy"
+	stateDone = "done"
+	stateIdle = "idle"
+)
+
+// RelayEventName carries which session is waiting on which, so the sidebar can
+// say it. Global rather than per-session because its consumer — one store keyed
+// by id — outlives any one card, exactly as the status event's does.
+const RelayEventName = "session-relay"
+
+// Directions a RelayEvent carries. An empty direction clears the mark: the
+// request it named is over, answered or expired.
+const (
+	DirectionOut = "out"
+	DirectionIn  = "in"
+)
+
+// StalledEventName carries a request whose target ended its turn without
+// answering through lich. The window turns it into a toast that opens the
+// target's card, because the answer — if there is one — is on that screen and
+// the person who asked has no other way to know where it went.
+const StalledEventName = "session-relay-stalled"
+
+// StalledEvent is the payload of StalledEventName: who asked ("" when the
+// request came from the command line rather than a session), and the session
+// that has whatever was produced.
+type StalledEvent struct {
+	ID       string `json:"id"`
+	TargetID string `json:"targetId"`
+	Target   string `json:"target"`
+}
+
+// RelayEvent is the payload of RelayEventName: the session whose mark changed,
+// the label at the other end, and which way the request runs. Peer is empty
+// when the other end is not a session at all — the CLI run from a script or a
+// shell — which the card words its own way.
+type RelayEvent struct {
+	ID        string `json:"id"`
+	Peer      string `json:"peer"`
+	Direction string `json:"direction"`
+}
 
 // Sessions is the persistence the relay reads: every open session, so a label
 // can be resolved to the session it names and the caller can be told what it
 // may address. The store implements it.
 type Sessions interface {
 	LoadState() ([]store.Project, error)
+}
+
+// Events is where the relay announces a request in flight. The app's event hub
+// implements it; a nil one leaves the feature working and silent, which is the
+// state a test that only exercises delivery is in.
+type Events interface {
+	Emit(name string, data any)
 }
 
 // Terminal is the PTY side: whether a session has a process running right now,
@@ -89,10 +148,17 @@ type Terminal interface {
 }
 
 // Peer is one session a caller may address: the label it is addressed by, the
-// project it belongs to (labels are unique within a project, not across them),
-// and what is running in it.
+// name it answers to in Claude Code's peer roster, the project it belongs to
+// (labels are unique within a project, not across them), and what is running in
+// it.
+//
+// Both names are published because both reach this session and an agent sees
+// them in different places — the label on the card, the roster name in
+// `/list-agents` and in what a mention writes at a prompt. Showing one and
+// accepting the other is what made an agent treat a single session as two.
 type Peer struct {
 	Label   string `json:"label"`
+	Name    string `json:"name"`
 	Project string `json:"project"`
 	Kind    string `json:"kind"`
 }
@@ -108,11 +174,42 @@ type Result struct {
 
 // ticket is one outstanding errand. answer is written once, before done is
 // closed, so every waiter reads it safely after the close.
+//
+// It carries both ends' ids and labels because the marks raised when it opens
+// have to be taken down when it closes, and by then the roster may have moved
+// on: a session renamed, or closed altogether, would otherwise leave a mark
+// nothing can clear.
 type ticket struct {
-	target  string
-	created time.Time
-	done    chan struct{}
-	answer  string
+	fromID   string
+	sender   string
+	targetID string
+	target   string
+	created  time.Time
+	done     chan struct{}
+	answer   string
+
+	// attended is how many callers are blocked on this ticket right now. An
+	// answer that lands while nobody is waiting has nowhere to be returned, so
+	// it is typed at the sender's prompt instead — the same way the request
+	// reached the target.
+	attended int
+	// answered records that the answer is in, for the waiter that gave up in the
+	// same instant it arrived: it leaves last and has to notice it was the one
+	// holding the ticket.
+	answered bool
+
+	// stalled closes when the target finished a turn without replying here. See
+	// Observe for how a turn is told apart from the one already running when the
+	// message arrived.
+	stalled chan struct{}
+	// sawBusy is whether the target has been working since this ticket's turn
+	// began; a turn that ends without it never started here.
+	sawBusy bool
+	// skipTurns is how many turn endings belong to work that was already running
+	// when the message was delivered. Every provider queues typed input, so a
+	// message handed to a busy session is answered a turn later — and the ending
+	// of the turn in progress says nothing about this request.
+	skipTurns int
 }
 
 // Service relays prompts between sessions. Tickets live in memory only: one
@@ -121,19 +218,33 @@ type ticket struct {
 type Service struct {
 	mu      sync.Mutex
 	tickets map[string]*ticket
+	// state is the last thing each session reported, so a delivery knows whether
+	// it is landing in the middle of a turn. Only sessions the relay has heard
+	// about appear; an unknown one is treated as not working, which is what a
+	// session with no hooks installed looks like.
+	state map[string]string
 
 	sessions Sessions
 	term     Terminal
+	events   Events
 	now      func() time.Time
+	// submitDelay separates the paste from the Enter that sends it (see
+	// defaultSubmitDelay). A field so the suite can drop it to zero: the fakes
+	// have no TUI to settle, and paying it per test would buy nothing.
+	submitDelay time.Duration
 }
 
-// New returns a relay reading its roster from sessions and typing through term.
-func New(sessions Sessions, term Terminal) *Service {
+// New returns a relay reading its roster from sessions, typing through term and
+// announcing what is in flight on events.
+func New(sessions Sessions, term Terminal, events Events) *Service {
 	return &Service{
-		tickets:  make(map[string]*ticket),
-		sessions: sessions,
-		term:     term,
-		now:      time.Now,
+		tickets:     make(map[string]*ticket),
+		state:       make(map[string]string),
+		sessions:    sessions,
+		term:        term,
+		events:      events,
+		now:         time.Now,
+		submitDelay: defaultSubmitDelay,
 	}
 }
 
@@ -178,28 +289,56 @@ func (s *Service) Send(fromID, target, project, prompt string, waitSeconds int) 
 	if err != nil {
 		return Result{}, err
 	}
-	t := &ticket{target: dest.Peer.Label, created: s.now(), done: make(chan struct{})}
+	t := &ticket{
+		fromID:   fromID,
+		sender:   sender,
+		targetID: dest.ID,
+		target:   dest.Peer.Label,
+		created:  s.now(),
+		done:     make(chan struct{}),
+		stalled:  make(chan struct{}),
+	}
 	s.mu.Lock()
-	s.sweep()
+	expired := s.sweep()
+	if s.state[dest.ID] == stateBusy {
+		t.skipTurns = 1
+	}
 	s.tickets[id] = t
 	s.mu.Unlock()
+	s.clearAll(expired)
 
-	if err := s.term.Write(dest.ID, paste(compose(sender, id, prompt, dest.Peer.Kind))); err != nil {
+	if err := s.deliver(dest.ID, compose(sender, id, prompt, dest.Peer.Kind)); err != nil {
 		s.mu.Lock()
 		delete(s.tickets, id)
 		s.mu.Unlock()
 		return Result{}, fmt.Errorf("deliver to %q: %w", dest.Peer.Label, err)
 	}
+	// Announced only once the message is actually in the PTY: a mark raised
+	// before the write would survive a delivery that never happened.
+	s.announce(t.targetID, t.sender, DirectionIn)
+	s.announce(t.fromID, t.target, DirectionOut)
 	return s.await(id, t, waitSeconds), nil
+}
+
+// deliver puts message at a session's prompt and sends it — two writes, a beat
+// apart, because the Enter has to arrive after the prompt has taken the paste
+// (see defaultSubmitDelay).
+func (s *Service) deliver(sessionID, message string) error {
+	if err := s.term.Write(sessionID, paste(message)); err != nil {
+		return err
+	}
+	time.Sleep(s.submitDelay)
+	return s.term.Write(sessionID, submit)
 }
 
 // Wait blocks on an already-delivered ticket for another round, so a caller
 // whose first wait ran out can come back without sending the message twice.
 func (s *Service) Wait(ticketID string, waitSeconds int) (Result, error) {
 	s.mu.Lock()
-	s.sweep()
+	expired := s.sweep()
 	t, ok := s.tickets[ticketID]
 	s.mu.Unlock()
+	s.clearAll(expired)
 	if !ok {
 		return Result{}, fmt.Errorf("unknown ticket %q — it was answered long ago, or expired", ticketID)
 	}
@@ -215,37 +354,185 @@ func (s *Service) Reply(ticketID, answer string) error {
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	t, ok := s.tickets[ticketID]
 	if !ok {
+		s.mu.Unlock()
 		return fmt.Errorf("unknown ticket %q — it was answered already, or expired", ticketID)
 	}
 	select {
 	case <-t.done:
+		s.mu.Unlock()
 		return fmt.Errorf("ticket %q was already answered", ticketID)
 	default:
 	}
 	t.answer = answer
+	t.answered = true
 	close(t.done)
+	// The errand is over the moment the answer lands, whether or not anyone is
+	// still waiting on it: a sender whose wait ran out has moved on, and the
+	// mark on both cards has to go with the ticket rather than with the waiter.
+	delete(s.tickets, ticketID)
+	unattended := t.attended == 0
+	s.mu.Unlock()
+
+	s.clear(t)
+	if unattended {
+		s.returnAnswer(t)
+	}
 	return nil
 }
 
-// await blocks on one ticket until it is answered or the wait runs out. An
-// answered ticket is dropped here rather than in Reply: the answer has to
-// outlive the reply long enough for the waiter to read it, and a caller whose
-// wait expired needs the ticket to still be there.
+// returnAnswer types the answer at the sender's own prompt, the same way the
+// request reached the target. It runs when nobody is blocked on the ticket
+// anymore, which is the normal case for anything that took longer than a tool
+// call may sit still: the answer arrives when it arrives, in the session that
+// asked, instead of being lost because the asker stopped listening.
+//
+// A sender that is not a session at all — the `lich` command from a script —
+// has no prompt to type at. Such a caller waits or does without.
+func (s *Service) returnAnswer(t *ticket) {
+	if t.fromID == "" || t.answer == "" {
+		return
+	}
+	message := fmt.Sprintf(
+		"[lich] Answer from session %q, to the request you sent it:\n\n%s",
+		t.target, t.answer,
+	)
+	if err := s.deliver(t.fromID, message); err != nil {
+		slog.Warn("relay: answer not returned", "session", t.fromID, "err", err)
+	}
+}
+
+// await blocks on one ticket until it is answered or the wait runs out. It only
+// reads: the ticket is dropped by whoever closes it (Reply, or sweep), because
+// a wait that expired leaves an errand that is still open and still has to be
+// waitable, and an answer has to reach a caller who stopped waiting for it too.
 func (s *Service) await(id string, t *ticket, waitSeconds int) Result {
 	timer := time.NewTimer(waitFor(waitSeconds))
 	defer timer.Stop()
 
+	s.mu.Lock()
+	t.attended++
+	s.mu.Unlock()
+
+	// An answer that is already in outranks everything: a target may reply and
+	// end its turn in the same breath, and a select over two ready channels
+	// picks between them at random.
 	select {
 	case <-t.done:
-		s.mu.Lock()
-		delete(s.tickets, id)
-		s.mu.Unlock()
+		s.leave(t)
 		return Result{Ticket: id, Target: t.target, Status: StatusAnswered, Answer: t.answer}
+	default:
+	}
+
+	select {
+	case <-t.done:
+		s.leave(t)
+		return Result{Ticket: id, Target: t.target, Status: StatusAnswered, Answer: t.answer}
+	case <-t.stalled:
+		s.leave(t)
+		return Result{Ticket: id, Target: t.target, Status: StatusUnanswered}
 	case <-timer.C:
+		s.giveUp(t)
 		return Result{Ticket: id, Target: t.target, Status: StatusPending}
+	}
+}
+
+// leave drops this caller's claim on a ticket it is carrying the answer out of.
+func (s *Service) leave(t *ticket) {
+	s.mu.Lock()
+	t.attended--
+	s.mu.Unlock()
+}
+
+// giveUp drops the claim of a caller whose wait ran out, and catches the one
+// race that would lose an answer: the reply landing in the same instant, seeing
+// this caller still attending, and leaving the answer for it — after it had
+// already stopped listening. Whoever leaves last owns what is left behind.
+func (s *Service) giveUp(t *ticket) {
+	s.mu.Lock()
+	t.attended--
+	orphaned := t.answered && t.attended == 0
+	s.mu.Unlock()
+	if orphaned {
+		s.returnAnswer(t)
+	}
+}
+
+// Observe takes one session-state report from the hooks the provider already
+// runs (docs/hooks/session-state.md). It exists for one case: a target that
+// works through a relayed request and then answers somewhere lich cannot read —
+// its provider's own peer channel, or simply out loud to the person watching.
+// Nothing would ever close that ticket, and the sender would sit out the full
+// wait learning nothing.
+//
+// A turn ending is only this request's turn when the target has been working
+// since the request arrived. Every provider queues typed input, so a message
+// handed to a busy session is answered a turn later; the ending of the turn
+// already in progress is skipped rather than mistaken for an answer that never
+// came. Getting that backwards would report "answered elsewhere" about a
+// request the target had not read yet, which is worse than saying nothing.
+func (s *Service) Observe(sessionID, state string) {
+	s.mu.Lock()
+	s.state[sessionID] = state
+
+	var ended []*ticket
+	for id, t := range s.tickets {
+		if t.targetID != sessionID {
+			continue
+		}
+		switch state {
+		case stateBusy:
+			t.sawBusy = true
+		case stateDone, stateIdle:
+			if t.skipTurns > 0 && state == stateDone {
+				// The turn that was already running. Its own busy reports say
+				// nothing about this request either.
+				t.skipTurns--
+				t.sawBusy = false
+				continue
+			}
+			// SessionEnd needs no turn to have run: the CLI has left the PTY and
+			// nothing there can answer anymore.
+			if !t.sawBusy && state != stateIdle {
+				continue
+			}
+			close(t.stalled)
+			delete(s.tickets, id)
+			ended = append(ended, t)
+		}
+	}
+	s.mu.Unlock()
+
+	s.clearAll(ended)
+	for _, t := range ended {
+		if s.events != nil {
+			s.events.Emit(StalledEventName, StalledEvent{
+				ID: t.fromID, TargetID: t.targetID, Target: t.target,
+			})
+		}
+	}
+}
+
+// announce raises or clears one session's mark. Called outside s.mu on every
+// path: Emit blocks on a stalled /events client, and holding the relay's lock
+// across it would stall every other errand behind one unread window.
+func (s *Service) announce(sessionID, peer, direction string) {
+	if s.events == nil || sessionID == "" {
+		return
+	}
+	s.events.Emit(RelayEventName, RelayEvent{ID: sessionID, Peer: peer, Direction: direction})
+}
+
+// clear takes down both ends' marks for a ticket that is over.
+func (s *Service) clear(t *ticket) {
+	s.announce(t.targetID, "", "")
+	s.announce(t.fromID, "", "")
+}
+
+func (s *Service) clearAll(tickets []*ticket) {
+	for _, t := range tickets {
+		s.clear(t)
 	}
 }
 
@@ -260,16 +547,20 @@ func waitFor(seconds int) time.Duration {
 	return MaxWait
 }
 
-// sweep drops tickets nobody answered in time. Called under s.mu on the paths
-// that already take it, which is often enough for a map that grows one entry
-// per errand.
-func (s *Service) sweep() {
+// sweep drops tickets nobody answered in time and returns them, so the caller
+// can take their marks down after releasing s.mu. Called under the lock on the
+// paths that already hold it, which is often enough for a map that grows one
+// entry per errand.
+func (s *Service) sweep() []*ticket {
+	var expired []*ticket
 	cutoff := s.now().Add(-ticketTTL)
 	for id, t := range s.tickets {
 		if t.created.Before(cutoff) {
 			delete(s.tickets, id)
+			expired = append(expired, t)
 		}
 	}
+	return expired
 }
 
 // candidate is a resolved peer together with the session id behind it, which
@@ -291,9 +582,18 @@ func (s *Service) roster(fromID string) ([]candidate, error) {
 			if sess.ID == fromID || !s.term.Live(sess.ID) {
 				continue
 			}
+			cwd := sess.Path
+			if cwd == "" {
+				cwd = p.Path
+			}
 			found = append(found, candidate{
-				ID:   sess.ID,
-				Peer: Peer{Label: sess.Label, Project: p.Name, Kind: sess.Kind},
+				ID: sess.ID,
+				Peer: Peer{
+					Label:   sess.Label,
+					Name:    rosterNameOf(cwd, sess.ID),
+					Project: p.Name,
+					Kind:    sess.Kind,
+				},
 			})
 		}
 	}
@@ -314,22 +614,23 @@ func (s *Service) resolve(fromID, target, project string) (candidate, error) {
 		return candidate{}, err
 	}
 
-	var matches []candidate
-	for _, c := range found {
-		if !strings.EqualFold(c.Peer.Label, target) {
-			continue
-		}
-		if project != "" && !strings.EqualFold(c.Peer.Project, project) {
-			continue
-		}
-		matches = append(matches, c)
+	// The label first, then the roster name. Both address this session, and an
+	// agent may have been handed either — a mention writes the roster name at
+	// the prompt, list_sessions prints both. The label wins a tie because it is
+	// the name the user chose and the one every message and error quotes.
+	matches := matching(found, target, project, func(c candidate) string { return c.Peer.Label })
+	if len(matches) == 0 {
+		matches = matching(found, target, project, func(c candidate) string { return c.Peer.Name })
 	}
 
 	switch len(matches) {
 	case 1:
 		return matches[0], nil
 	case 0:
-		return candidate{}, fmt.Errorf("no live session named %q%s", target, inProject(project))
+		return candidate{}, fmt.Errorf(
+			"no live session named %q%s. %s",
+			target, inProject(project), knownLabels(found),
+		)
 	default:
 		return candidate{}, fmt.Errorf(
 			"%q names %d live sessions (%s) — narrow it with the project",
@@ -359,6 +660,35 @@ func (s *Service) labelOf(id string) string {
 		}
 	}
 	return "unknown"
+}
+
+// matching returns the candidates whose name — read out by naming — is target,
+// narrowed to one project when one was given.
+func matching(found []candidate, target, project string, naming func(candidate) string) []candidate {
+	var matches []candidate
+	for _, c := range found {
+		if !strings.EqualFold(naming(c), target) {
+			continue
+		}
+		if project != "" && !strings.EqualFold(c.Peer.Project, project) {
+			continue
+		}
+		matches = append(matches, c)
+	}
+	return matches
+}
+
+// knownLabels names what is actually reachable, under both names, so a wrong
+// name is one step from a right one rather than a guess.
+func knownLabels(found []candidate) string {
+	if len(found) == 0 {
+		return "No other session is live."
+	}
+	names := make([]string, 0, len(found))
+	for _, c := range found {
+		names = append(names, fmt.Sprintf("%s (%s)", strconv.Quote(c.Peer.Label), c.Peer.Name))
+	}
+	return "Live sessions: " + strings.Join(names, ", ") + "."
 }
 
 func inProject(project string) string {
@@ -392,18 +722,25 @@ func compose(sender, ticketID, prompt, targetKind string) string {
 // shell, so the command is always named; a provider lich registers its MCP
 // server with is offered the tool first, because a session that withholds shell
 // access would otherwise have no way to answer at all.
+//
+// The exclusivity is load-bearing, not emphasis. A Claude Code session has a
+// peer channel of its own and this message names another session, so answering
+// through that channel is the obvious move — and it reaches a sender that is
+// blocked on a ticket instead. That happened on the first real run: the target
+// replied over its own socket and the errand timed out with the answer already
+// written. The ticket is the only route home, and the message has to say so.
 func replyInstruction(kind, ticketID string) string {
-	command := fmt.Sprintf(
-		"  \"$LICH_BIN\" reply %s \"<your answer>\"\nWhoever asked is blocked waiting on it.",
-		ticketID,
-	)
-	if !providers.AcceptsMCPServer(kind) {
-		return "When you have an answer, send it back by running:\n" + command
+	command := fmt.Sprintf("  \"$LICH_BIN\" reply %s \"<your answer>\"", ticketID)
+	route := "When you have an answer, send it back by running:\n" + command
+	if providers.AcceptsMCPServer(kind) {
+		route = fmt.Sprintf(
+			"When you have an answer, send it back with the lich tool `%s` (ticket %s), or by running:\n%s",
+			ToolReply, ticketID, command,
+		)
 	}
-	return fmt.Sprintf(
-		"When you have an answer, send it back with the lich tool `%s` (ticket %s), or by running:\n%s",
-		ToolReply, ticketID, command,
-	)
+	return route + "\n\nThat ticket is the only way back: whoever asked is blocked on it and " +
+		"is reading nothing else. Do not answer by messaging a peer session — an answer " +
+		"sent any other way is lost."
 }
 
 // origin describes the sender in the message's first line. An empty sender is
@@ -416,13 +753,33 @@ func origin(sender string) string {
 	return fmt.Sprintf("Message from session %q", sender)
 }
 
-// paste wraps text in bracketed paste and submits it, which is how a multi-line
-// message reaches a TUI prompt as one prompt instead of as one submission per
-// newline. Every provider lich spawns runs a TUI that enables bracketed paste;
-// one that did not would read the newlines as submissions.
+// paste wraps text in bracketed paste, which is how a multi-line message
+// reaches a TUI prompt as one prompt instead of as one submission per newline.
+// Every provider lich spawns runs a TUI that enables bracketed paste; one that
+// did not would read the newlines as submissions.
+//
+// It does not submit. See submitDelay.
 func paste(text string) string {
-	return "\x1b[200~" + text + "\x1b[201~\r"
+	return "\x1b[200~" + text + "\x1b[201~"
 }
+
+// submit is the Enter that sends what paste put at the prompt.
+const submit = "\r"
+
+// defaultSubmitDelay is how long the relay waits between the paste and the
+// Enter that sends it.
+//
+// Everything else lich pastes into a prompt is left for the user to send, so
+// this is the only place that presses Enter itself — and a carriage return
+// riding in the same write as the paste is swallowed. Claude Code collapses a
+// multi-line paste into a "[Pasted text #2 +7 lines]" placeholder, and the
+// Enter arriving inside that same burst goes into building the placeholder
+// rather than sending it: the message sat unsent at the target's prompt, seen
+// only when someone opened that session by hand. Nothing here can read the
+// target's screen to know when it has settled, so the delay is the instrument,
+// and it is generous on purpose — a tenth of a second nobody notices against a
+// message that otherwise never arrives.
+const defaultSubmitDelay = 150 * time.Millisecond
 
 // sanitize strips the control characters that would either break out of the
 // bracketed paste framing or drive the target's terminal, keeping the

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -23,12 +23,12 @@ func (f fakeSessions) LoadState() ([]store.Project, error) { return f.projects, 
 type fakeTerminal struct {
 	mu       sync.Mutex
 	live     map[string]bool
-	writes   map[string]string
+	writes   map[string][]string
 	writeErr error
 }
 
 func newFakeTerminal(live ...string) *fakeTerminal {
-	t := &fakeTerminal{live: map[string]bool{}, writes: map[string]string{}}
+	t := &fakeTerminal{live: map[string]bool{}, writes: map[string][]string{}}
 	for _, id := range live {
 		t.live[id] = true
 	}
@@ -47,44 +47,122 @@ func (f *fakeTerminal) Write(id, data string) error {
 	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.writes[id] += data
+	f.writes[id] = append(f.writes[id], data)
 	return nil
 }
 
-func (f *fakeTerminal) written(id string) string {
+// writesTo is every write a session received, in order — the submit is its own,
+// so a test can tell "pasted and sent" from "pasted and left sitting there".
+func (f *fakeTerminal) writesTo(id string) []string {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.writes[id]
+	return append([]string(nil), f.writes[id]...)
+}
+
+func (f *fakeTerminal) written(id string) string {
+	return strings.Join(f.writesTo(id), "")
+}
+
+// fakeEvents records what the relay announced to the window, in order.
+type fakeEvents struct {
+	mu    sync.Mutex
+	sent  []RelayEvent
+	halts []StalledEvent
+}
+
+func (f *fakeEvents) Emit(name string, data any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	switch event := data.(type) {
+	case RelayEvent:
+		if name == RelayEventName {
+			f.sent = append(f.sent, event)
+		}
+	case StalledEvent:
+		if name == StalledEventName {
+			f.halts = append(f.halts, event)
+		}
+	}
+}
+
+func (f *fakeEvents) stalled() []StalledEvent {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]StalledEvent(nil), f.halts...)
+}
+
+func (f *fakeEvents) snapshot() []RelayEvent {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]RelayEvent(nil), f.sent...)
+}
+
+// markOf is the last thing announced about one session, which is what its card
+// would be showing.
+func (f *fakeEvents) markOf(id string) (RelayEvent, bool) {
+	events := f.snapshot()
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].ID == id {
+			return events[i], true
+		}
+	}
+	return RelayEvent{}, false
+}
+
+// awaitMark blocks until one session's mark matches want, and returns whether
+// it did. Marks are raised after the message is in the PTY, which is later than
+// the ticket appearing in the map — waiting on the ticket instead would read
+// the marks before they exist.
+func (f *fakeEvents) awaitMark(id, direction string) bool {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if mark, ok := f.markOf(id); ok && mark.Direction == direction {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return false
+}
+
+// newRelay is New with the paste-to-Enter delay dropped: the fakes have no TUI
+// to settle, and paying it in every test would buy nothing.
+func newRelay(sessions Sessions, term Terminal, events Events) *Service {
+	svc := New(sessions, term, events)
+	svc.submitDelay = 0
+	return svc
 }
 
 // workspace is the roster most tests run against: two projects, one label
 // ("api") deliberately repeated across them.
 func workspace() fakeSessions {
 	return fakeSessions{projects: []store.Project{
-		{ID: "p1", Name: "lich", Sessions: []store.Session{
+		{ID: "p1", Name: "lich", Path: "/src/lich", Sessions: []store.Session{
 			{ID: "s1", Label: "sender", Kind: "claude"},
 			{ID: "s2", Label: "docs", Kind: "codex"},
 			{ID: "s3", Label: "api", Kind: "opencode"},
 			{ID: "s4", Label: "parked", Kind: "claude"},
 		}},
-		{ID: "p2", Name: "revu", Sessions: []store.Session{
+		{ID: "p2", Name: "revu", Path: "/src/revu", Sessions: []store.Session{
 			{ID: "s5", Label: "api", Kind: "crush"},
 		}},
 	}}
 }
 
 func TestPeersListsLiveSessionsWithoutTheCaller(t *testing.T) {
-	svc := New(workspace(), newFakeTerminal("s1", "s2", "s3", "s5"))
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2", "s3", "s5"), nil)
 
 	peers, err := svc.Peers("s1")
 	if err != nil {
 		t.Fatalf("Peers: %v", err)
 	}
 
+	// Both names travel: an agent that sees only one of them treats the other
+	// as a different session, which is what sent the first real run down two
+	// channels at once.
 	want := []Peer{
-		{Label: "docs", Project: "lich", Kind: "codex"},
-		{Label: "api", Project: "lich", Kind: "opencode"},
-		{Label: "api", Project: "revu", Kind: "crush"},
+		{Label: "docs", Name: "lich-s2", Project: "lich", Kind: "codex"},
+		{Label: "api", Name: "lich-s3", Project: "lich", Kind: "opencode"},
+		{Label: "api", Name: "revu-s5", Project: "revu", Kind: "crush"},
 	}
 	if len(peers) != len(want) {
 		t.Fatalf("got %d peers %v, want %d", len(peers), peers, len(want))
@@ -97,7 +175,7 @@ func TestPeersListsLiveSessionsWithoutTheCaller(t *testing.T) {
 }
 
 func TestPeersReportsAStoreFailure(t *testing.T) {
-	svc := New(fakeSessions{err: errors.New("database is locked")}, newFakeTerminal())
+	svc := newRelay(fakeSessions{err: errors.New("database is locked")}, newFakeTerminal(), nil)
 
 	if _, err := svc.Peers("s1"); err == nil {
 		t.Fatal("want an error when the workspace cannot be read")
@@ -106,7 +184,7 @@ func TestPeersReportsAStoreFailure(t *testing.T) {
 
 func TestSendDeliversAndReplyAnswers(t *testing.T) {
 	term := newFakeTerminal("s1", "s2")
-	svc := New(workspace(), term)
+	svc := newRelay(workspace(), term, nil)
 
 	var (
 		got Result
@@ -138,10 +216,24 @@ func TestSendDeliversAndReplyAnswers(t *testing.T) {
 		t.Errorf("target = %q, want %q", got.Target, "docs")
 	}
 
-	typed := term.written("s2")
-	if !strings.HasPrefix(typed, "\x1b[200~") || !strings.HasSuffix(typed, "\x1b[201~\r") {
-		t.Errorf("message was not bracketed-pasted and submitted: %q", typed)
+	// Two writes, and in this order. Claude Code collapses a multi-line paste
+	// into a placeholder, and an Enter riding in that same burst is swallowed —
+	// the message then sits at the target's prompt unsent, which is exactly what
+	// the first real runs produced.
+	writes := term.writesTo("s2")
+	if len(writes) != 2 {
+		t.Fatalf("got %d writes, want the paste and the submit apart: %q", len(writes), writes)
 	}
+	if !strings.HasPrefix(writes[0], "\x1b[200~") || !strings.HasSuffix(writes[0], "\x1b[201~") {
+		t.Errorf("the message was not bracketed-pasted: %q", writes[0])
+	}
+	if strings.Contains(writes[0], "\r") {
+		t.Errorf("an Enter rode along with the paste: %q", writes[0])
+	}
+	if writes[1] != "\r" {
+		t.Errorf("second write = %q, want the submit alone", writes[1])
+	}
+	typed := term.written("s2")
 	for _, want := range []string{`"sender"`, "run the tests", `"$LICH_BIN" reply ` + ticketID} {
 		if !strings.Contains(typed, want) {
 			t.Errorf("typed message is missing %q:\n%s", want, typed)
@@ -154,7 +246,7 @@ func TestSendDeliversAndReplyAnswers(t *testing.T) {
 
 func TestAMessageFromOutsideLichIsAttributedToTheCommandLine(t *testing.T) {
 	term := newFakeTerminal("s2")
-	svc := New(workspace(), term)
+	svc := newRelay(workspace(), term, nil)
 
 	go func() { _ = svc.Reply(waitForTicket(svc), "ok") }()
 	if _, err := svc.Send("", "docs", "", "hello", 30); err != nil {
@@ -195,12 +287,444 @@ func TestReplyInstructionOffersTheToolOnlyWhereItExists(t *testing.T) {
 			if named := strings.Contains(got, ToolReply); named != tt.tool {
 				t.Errorf("names the %s tool = %v, want %v:\n%s", ToolReply, named, tt.tool, got)
 			}
+			// The first real run lost an answer to a target that replied over
+			// its provider's own peer channel. Saying the ticket is the only
+			// route is the whole fix, so it is pinned rather than left to taste.
+			if !strings.Contains(got, "only way back") {
+				t.Errorf("the instruction does not say the ticket is exclusive:\n%s", got)
+			}
+			if !strings.Contains(got, "Do not answer by messaging a peer session") {
+				t.Errorf("the instruction does not rule out the peer channel:\n%s", got)
+			}
 		})
 	}
 }
 
+// TestARosterNameReachesTheSameSession proves the two names for one session are
+// one address space now. A mention writes the roster name at a prompt; if the
+// agent hands that to lich instead of to its own messaging, it must land on the
+// session it names rather than on an error — that mismatch is what made an
+// agent use both channels at once on the first real run.
+func TestARosterNameReachesTheSameSession(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, nil)
+
+	go func() { _ = svc.Reply(waitForTicket(svc), "ok") }()
+	got, err := svc.Send("s1", rosterNameOf("/src/lich", "s2"), "", "hello", 30)
+	if err != nil {
+		t.Fatalf("Send by roster name: %v", err)
+	}
+	if got.Target != "docs" {
+		t.Errorf("target = %q, want the card label", got.Target)
+	}
+	if term.written("s2") == "" {
+		t.Error("the session the roster name points at was never typed at")
+	}
+}
+
+// TestTheLabelWinsARosterCollision proves the tie-break: a label is the name the
+// user chose and the one every message quotes, so it outranks a roster name that
+// happens to read the same.
+func TestTheLabelWinsARosterCollision(t *testing.T) {
+	collide := fakeSessions{projects: []store.Project{{
+		ID: "p1", Name: "lich", Path: "/src/lich",
+		Sessions: []store.Session{
+			{ID: "s1", Label: "sender", Kind: "claude"},
+			// s3's roster name is "lich-s3"; s2 carries it as its label.
+			{ID: "s2", Label: "lich-s3", Kind: "codex"},
+			{ID: "s3", Label: "docs", Kind: "codex"},
+		},
+	}}}
+	term := newFakeTerminal("s1", "s2", "s3")
+	svc := newRelay(collide, term, nil)
+
+	go func() { _ = svc.Reply(waitForTicket(svc), "ok") }()
+	if _, err := svc.Send("s1", "lich-s3", "", "hello", 30); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if term.written("s2") == "" {
+		t.Error("the session whose label matched was not the one written to")
+	}
+	if term.written("s3") != "" {
+		t.Error("the roster name won over a label")
+	}
+}
+
+// TestAnUnknownNameNamesWhatIsReachable proves a miss is one step from a hit:
+// both names of every live session come back with the error.
+func TestAnUnknownNameNamesWhatIsReachable(t *testing.T) {
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2"), nil)
+
+	_, err := svc.Send("s1", "ghost", "", "hello", 30)
+	if err == nil {
+		t.Fatal("want an error for an unknown name")
+	}
+	for _, want := range []string{`"docs"`, "lich-s2"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error is missing %q: %v", want, err)
+		}
+	}
+}
+
+// TestWithNothingReachableTheErrorSaysSo proves the empty case reads as a fact
+// about the workspace rather than as a bad name.
+func TestWithNothingReachableTheErrorSaysSo(t *testing.T) {
+	svc := newRelay(workspace(), newFakeTerminal("s1"), nil)
+
+	_, err := svc.Send("s1", "docs", "", "hello", 30)
+	if err == nil {
+		t.Fatal("want an error when nothing is live")
+	}
+	if !strings.Contains(err.Error(), "No other session is live.") {
+		t.Errorf("error = %v", err)
+	}
+}
+
+// TestBothCardsAreMarkedAndCleared proves the sidebar can tell the whole story
+// from one errand: the target learns who asked, the sender learns who it is
+// waiting on, and both marks come down when the answer lands.
+func TestBothCardsAreMarkedAndCleared(t *testing.T) {
+	events := &fakeEvents{}
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2"), events)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = svc.Send("s1", "docs", "", "run the tests", 30)
+	}()
+	ticketID := waitForTicket(svc)
+
+	if !events.awaitMark("s2", DirectionIn) {
+		t.Fatal("the target was never marked as asked")
+	}
+	if !events.awaitMark("s1", DirectionOut) {
+		t.Fatal("the sender was never marked as waiting")
+	}
+	if target, _ := events.markOf("s2"); target.Peer != "sender" {
+		t.Errorf("target mark names %q, want the sender's label", target.Peer)
+	}
+	if sender, _ := events.markOf("s1"); sender.Peer != "docs" {
+		t.Errorf("sender mark names %q, want the target's label", sender.Peer)
+	}
+
+	if err := svc.Reply(ticketID, "3 failures"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	<-done
+
+	for _, id := range []string{"s1", "s2"} {
+		mark, _ := events.markOf(id)
+		if mark.Direction != "" || mark.Peer != "" {
+			t.Errorf("session %q kept the mark %+v after the answer", id, mark)
+		}
+	}
+}
+
+// TestAnExternalSenderMarksOnlyTheTarget proves a caller with no card leaves no
+// mark of its own — there is no session to put one on — while the target still
+// learns a request arrived.
+func TestAnExternalSenderMarksOnlyTheTarget(t *testing.T) {
+	events := &fakeEvents{}
+	svc := newRelay(workspace(), newFakeTerminal("s2"), events)
+
+	go func() {
+		if !events.awaitMark("s2", DirectionIn) {
+			return
+		}
+		_ = svc.Reply(waitForTicket(svc), "ok")
+	}()
+	if _, err := svc.Send("", "docs", "", "hello", 30); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	sent := events.snapshot()
+	if len(sent) == 0 {
+		t.Fatal("the target was never marked")
+	}
+	for _, event := range sent {
+		if event.ID != "s2" {
+			t.Errorf("a session that does not exist was marked: %+v", event)
+		}
+	}
+	// The peer is empty rather than invented: the card is what words it.
+	if sent[0].Direction != DirectionIn || sent[0].Peer != "" {
+		t.Errorf("target mark = %+v, want an inbound one with no peer label", sent[0])
+	}
+}
+
+// TestAnUndeliveredMessageMarksNobody proves the mark follows the bytes: a write
+// that failed leaves no card claiming a request that never arrived.
+func TestAnUndeliveredMessageMarksNobody(t *testing.T) {
+	events := &fakeEvents{}
+	term := newFakeTerminal("s1", "s2")
+	term.writeErr = errors.New("pty closed")
+	svc := newRelay(workspace(), term, events)
+
+	if _, err := svc.Send("s1", "docs", "", "hello", 30); err == nil {
+		t.Fatal("want an error when the message cannot be typed")
+	}
+	if got := events.snapshot(); len(got) != 0 {
+		t.Errorf("an undelivered message marked %+v", got)
+	}
+}
+
+// TestAnExpiredTicketTakesItsMarksDown proves a request nobody ever answered
+// stops claiming both cards once it is swept, rather than marking them for the
+// life of the process.
+func TestAnExpiredTicketTakesItsMarksDown(t *testing.T) {
+	events := &fakeEvents{}
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2"), events)
+	svc.tickets["stale"] = &ticket{
+		fromID:   "s1",
+		sender:   "sender",
+		targetID: "s2",
+		target:   "docs",
+		created:  time.Now().Add(-2 * time.Hour),
+		done:     make(chan struct{}),
+	}
+
+	if _, err := svc.Wait("missing", 1); err == nil {
+		t.Fatal("want an error, and the sweep it triggers")
+	}
+	for _, id := range []string{"s1", "s2"} {
+		mark, ok := events.markOf(id)
+		if !ok {
+			t.Errorf("session %q was never cleared", id)
+			continue
+		}
+		if mark.Direction != "" {
+			t.Errorf("session %q kept the mark %+v after the sweep", id, mark)
+		}
+	}
+}
+
+// TestATurnThatEndsWithoutAnAnswerEndsTheWait proves the exception this feature
+// has to survive: the target worked and then answered somewhere lich cannot
+// read. The wait ends there, saying so, instead of running its full clock out.
+func TestATurnThatEndsWithoutAnAnswerEndsTheWait(t *testing.T) {
+	events := &fakeEvents{}
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2"), events)
+
+	done := make(chan Result, 1)
+	go func() {
+		got, _ := svc.Send("s1", "docs", "", "run the tests", 30)
+		done <- got
+	}()
+	waitForTicket(svc)
+	if !events.awaitMark("s2", DirectionIn) {
+		t.Fatal("the target was never marked, so the message never landed")
+	}
+
+	svc.Observe("s2", "busy")
+	svc.Observe("s2", "done")
+
+	got := <-done
+	if got.Status != StatusUnanswered {
+		t.Fatalf("status = %q, want %q", got.Status, StatusUnanswered)
+	}
+	if got.Answer != "" {
+		t.Errorf("an unanswered result carried an answer: %q", got.Answer)
+	}
+	for _, id := range []string{"s1", "s2"} {
+		if mark, _ := events.markOf(id); mark.Direction != "" {
+			t.Errorf("session %q kept the mark %+v", id, mark)
+		}
+	}
+}
+
+// TestAQueuedRequestIgnoresTheTurnAlreadyRunning proves the guard that keeps
+// this honest. A message handed to a busy session waits its turn, so the ending
+// of the turn in progress says nothing — reporting it as unanswered would
+// accuse a target that had not read the request yet.
+func TestAQueuedRequestIgnoresTheTurnAlreadyRunning(t *testing.T) {
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2"), nil)
+	svc.Observe("s2", "busy")
+
+	done := make(chan Result, 1)
+	go func() {
+		got, _ := svc.Send("s1", "docs", "", "run the tests", 2)
+		done <- got
+	}()
+	ticketID := waitForTicket(svc)
+
+	// The turn that was already running ends. Nothing about this request.
+	svc.Observe("s2", "done")
+	select {
+	case got := <-done:
+		t.Fatalf("the wait ended on someone else's turn: %+v", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Now the queued request runs, and ends without an answer.
+	svc.Observe("s2", "busy")
+	svc.Observe("s2", "done")
+	if got := <-done; got.Status != StatusUnanswered {
+		t.Fatalf("status = %q, want %q", got.Status, StatusUnanswered)
+	}
+	if err := svc.Reply(ticketID, "late"); err == nil {
+		t.Error("the ticket outlived the turn that closed it")
+	}
+}
+
+// TestAnAnsweredTicketIsNotAlsoStalled proves the ordering that matters most: a
+// target that replies and ends its turn in the same breath has answered, and a
+// race between the two must not turn an answer into a shrug.
+func TestAnAnsweredTicketIsNotAlsoStalled(t *testing.T) {
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2"), nil)
+
+	done := make(chan Result, 1)
+	go func() {
+		got, _ := svc.Send("s1", "docs", "", "hello", 30)
+		done <- got
+	}()
+	ticketID := waitForTicket(svc)
+
+	svc.Observe("s2", "busy")
+	if err := svc.Reply(ticketID, "3 failures"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	svc.Observe("s2", "done")
+
+	got := <-done
+	if got.Status != StatusAnswered || got.Answer != "3 failures" {
+		t.Fatalf("result = %+v, want the answer", got)
+	}
+}
+
+// TestASessionThatEndedStopsTheWaitOutright proves SessionEnd needs no turn:
+// the CLI has left the PTY, so nothing there will ever answer.
+func TestASessionThatEndedStopsTheWaitOutright(t *testing.T) {
+	events := &fakeEvents{}
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2"), events)
+
+	done := make(chan Result, 1)
+	go func() {
+		got, _ := svc.Send("s1", "docs", "", "hello", 30)
+		done <- got
+	}()
+	waitForTicket(svc)
+	svc.Observe("s2", "idle")
+
+	if got := <-done; got.Status != StatusUnanswered {
+		t.Fatalf("status = %q, want %q", got.Status, StatusUnanswered)
+	}
+	stalls := 0
+	for _, event := range events.stalled() {
+		if event.TargetID == "s2" && event.ID == "s1" && event.Target == "docs" {
+			stalls++
+		}
+	}
+	if stalls != 1 {
+		t.Errorf("the window was told %d times, want once", stalls)
+	}
+}
+
+// TestAnotherSessionsTurnLeavesTheTicketAlone proves the ticket only answers to
+// its own target: a busy neighbour must not close it.
+func TestAnotherSessionsTurnLeavesTheTicketAlone(t *testing.T) {
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2", "s3"), nil)
+
+	done := make(chan Result, 1)
+	go func() {
+		got, _ := svc.Send("s1", "docs", "", "hello", 1)
+		done <- got
+	}()
+	waitForTicket(svc)
+
+	svc.Observe("s3", "busy")
+	svc.Observe("s3", "done")
+
+	if got := <-done; got.Status != StatusPending {
+		t.Fatalf("status = %q, want %q — a neighbour closed the ticket", got.Status, StatusPending)
+	}
+}
+
+// TestAnAnswerNobodyWaitedForIsTypedAtTheSendersPrompt proves the path that
+// makes a long errand work at all: the asker stops holding the line, the answer
+// arrives later, and it comes back the same way the request went out.
+func TestAnAnswerNobodyWaitedForIsTypedAtTheSendersPrompt(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, nil)
+
+	got, err := svc.Send("s1", "docs", "", "run the tests", 1)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got.Status != StatusPending {
+		t.Fatalf("status = %q, want the wait to run out first", got.Status)
+	}
+	if term.written("s1") != "" {
+		t.Fatalf("the sender was typed at before any answer existed: %q", term.written("s1"))
+	}
+
+	if err := svc.Reply(got.Ticket, "3 failures in foo_test"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+
+	writes := term.writesTo("s1")
+	if len(writes) != 2 {
+		t.Fatalf("got %d writes to the sender, want the paste and the submit: %q", len(writes), writes)
+	}
+	if writes[1] != "\r" {
+		t.Errorf("the answer was left sitting at the prompt: %q", writes)
+	}
+	typed := term.written("s1")
+	for _, want := range []string{`Answer from session "docs"`, "3 failures in foo_test"} {
+		if !strings.Contains(typed, want) {
+			t.Errorf("returned answer is missing %q:\n%s", want, typed)
+		}
+	}
+}
+
+// TestAnAnswerSomeoneIsWaitingForIsNotAlsoTyped proves the other half: a caller
+// still holding the line carries the answer out itself, and typing it at the
+// prompt as well would deliver it twice.
+func TestAnAnswerSomeoneIsWaitingForIsNotAlsoTyped(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, nil)
+
+	done := make(chan Result, 1)
+	go func() {
+		got, _ := svc.Send("s1", "docs", "", "hello", 30)
+		done <- got
+	}()
+	ticketID := waitForTicket(svc)
+	if err := svc.Reply(ticketID, "all green"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+
+	if got := <-done; got.Answer != "all green" {
+		t.Fatalf("the waiter did not get the answer: %+v", got)
+	}
+	if typed := term.written("s1"); typed != "" {
+		t.Errorf("the answer was also typed at a prompt that was already reading it: %q", typed)
+	}
+}
+
+// TestAnExternalSenderHasNoPromptToAnswerAt proves the one case with nowhere to
+// return to: the CLI run from a script is not a session, so an answer nobody
+// waited for is simply not delivered rather than typed at a stranger.
+func TestAnExternalSenderHasNoPromptToAnswerAt(t *testing.T) {
+	term := newFakeTerminal("s2")
+	svc := newRelay(workspace(), term, nil)
+
+	got, err := svc.Send("", "docs", "", "hello", 1)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if err := svc.Reply(got.Ticket, "all green"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+
+	for id, writes := range term.writes {
+		if id != "s2" {
+			t.Errorf("session %q was typed at: %q", id, writes)
+		}
+	}
+}
+
 func TestSendRefusesAnAmbiguousLabel(t *testing.T) {
-	svc := New(workspace(), newFakeTerminal("s1", "s3", "s5"))
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s3", "s5"), nil)
 
 	_, err := svc.Send("s1", "api", "", "hello", 30)
 	if err == nil {
@@ -215,7 +739,7 @@ func TestSendRefusesAnAmbiguousLabel(t *testing.T) {
 
 func TestSendNarrowsAnAmbiguousLabelByProject(t *testing.T) {
 	term := newFakeTerminal("s1", "s3", "s5")
-	svc := New(workspace(), term)
+	svc := newRelay(workspace(), term, nil)
 
 	go func() {
 		ticketID := waitForTicket(svc)
@@ -237,7 +761,7 @@ func TestSendNarrowsAnAmbiguousLabelByProject(t *testing.T) {
 }
 
 func TestSendRejectsUnreachableTargets(t *testing.T) {
-	svc := New(workspace(), newFakeTerminal("s1", "s2"))
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2"), nil)
 
 	tests := []struct {
 		name   string
@@ -260,7 +784,7 @@ func TestSendRejectsUnreachableTargets(t *testing.T) {
 func TestSendReportsADeliveryFailure(t *testing.T) {
 	term := newFakeTerminal("s1", "s2")
 	term.writeErr = errors.New("pty closed")
-	svc := New(workspace(), term)
+	svc := newRelay(workspace(), term, nil)
 
 	if _, err := svc.Send("s1", "docs", "", "hello", 30); err == nil {
 		t.Fatal("want an error when the message cannot be typed")
@@ -274,7 +798,7 @@ func TestSendReportsADeliveryFailure(t *testing.T) {
 }
 
 func TestSendPendsWhenTheWaitRunsOutAndWaitPicksItUp(t *testing.T) {
-	svc := New(workspace(), newFakeTerminal("s1", "s2"))
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2"), nil)
 
 	got, err := svc.Send("s1", "docs", "", "long errand", 1)
 	if err != nil {
@@ -302,7 +826,7 @@ func TestSendPendsWhenTheWaitRunsOutAndWaitPicksItUp(t *testing.T) {
 
 func TestReplyRefusesUnknownAndRepeatedTickets(t *testing.T) {
 	term := newFakeTerminal("s1", "s2")
-	svc := New(workspace(), term)
+	svc := newRelay(workspace(), term, nil)
 
 	if err := svc.Reply("deadbeef", "hello"); err == nil {
 		t.Error("want an error replying to a ticket that never existed")
@@ -327,7 +851,7 @@ func TestReplyRefusesUnknownAndRepeatedTickets(t *testing.T) {
 }
 
 func TestWaitRefusesAnUnknownTicket(t *testing.T) {
-	svc := New(workspace(), newFakeTerminal())
+	svc := newRelay(workspace(), newFakeTerminal(), nil)
 
 	if _, err := svc.Wait("deadbeef", 1); err == nil {
 		t.Fatal("want an error waiting on a ticket that never existed")
@@ -335,7 +859,7 @@ func TestWaitRefusesAnUnknownTicket(t *testing.T) {
 }
 
 func TestExpiredTicketsAreSweptAway(t *testing.T) {
-	svc := New(workspace(), newFakeTerminal("s1", "s2"))
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2"), nil)
 	svc.tickets["stale"] = &ticket{
 		target:  "docs",
 		created: time.Now().Add(-2 * time.Hour),
@@ -355,7 +879,7 @@ func TestExpiredTicketsAreSweptAway(t *testing.T) {
 
 func TestSendBoundsThePrompt(t *testing.T) {
 	term := newFakeTerminal("s1", "s2")
-	svc := New(workspace(), term)
+	svc := newRelay(workspace(), term, nil)
 
 	if _, err := svc.Send("s1", "docs", "", "", 30); err == nil {
 		t.Error("want an error for an empty prompt")
@@ -377,7 +901,7 @@ func TestSendBoundsThePrompt(t *testing.T) {
 }
 
 func TestReplyTruncatesAnOversizedAnswer(t *testing.T) {
-	svc := New(workspace(), newFakeTerminal("s1", "s2"))
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2"), nil)
 
 	done := make(chan Result, 1)
 	go func() {

--- a/internal/relay/rostername.go
+++ b/internal/relay/rostername.go
@@ -1,0 +1,54 @@
+package relay
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// A lich session has two names, and until this file they were two address
+// spaces. The card carries a label the user chose ("docs"); Claude Code's peer
+// roster carries the name lich passes at spawn ("skipo-3939"). Both name the
+// same session, and nothing in an agent's world said so — so an agent handed
+// one of them reached for whichever tool it had and, on the first real run,
+// used both channels at once.
+//
+// The relay therefore answers to either. It can: lich is what mints the roster
+// name, so it can derive it again here. This is the Go half of
+// frontend/src/lib/session/peer-name.ts, and the two have to agree — a name
+// derived differently would address a session that is not the one on the card.
+
+// rosterIDChars is how much of the session id trails the directory name. Four
+// separates the handful of sessions one checkout holds and stays readable in a
+// roster row.
+const rosterIDChars = 4
+
+// rosterNameOf builds the name a session answers to in the peer roster: the
+// last element of its working directory, then four characters of its id. cwd is
+// the session's own directory when it has one (a worktree) and its project's
+// otherwise, matching what the frontend passes at spawn.
+func rosterNameOf(cwd, id string) string {
+	dir := filepath.Base(strings.TrimRight(strings.ReplaceAll(cwd, "\\", "/"), "/"))
+	// filepath.Base answers "." for an empty path and "/" for a bare root;
+	// neither names anything, and Claude Code's own fallback is the app name.
+	if dir == "" || dir == "." || dir == "/" {
+		dir = "lich"
+	}
+
+	tail := make([]rune, 0, rosterIDChars)
+	for _, r := range id {
+		if len(tail) == rosterIDChars {
+			break
+		}
+		if isRosterChar(r) {
+			tail = append(tail, r)
+		}
+	}
+	if len(tail) == 0 {
+		return dir
+	}
+	return dir + "-" + string(tail)
+}
+
+func isRosterChar(r rune) bool {
+	return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z')
+}

--- a/internal/relay/rostername_test.go
+++ b/internal/relay/rostername_test.go
@@ -1,0 +1,76 @@
+package relay
+
+import "testing"
+
+// These cases are the Go half of frontend/src/lib/session/peer-name.test.ts,
+// deliberately the same inputs and the same expected strings. The two
+// implementations address the same sessions, so a divergence here is a message
+// delivered to the wrong terminal — the one failure this feature must not have.
+func TestRosterNameOfMatchesTheFrontend(t *testing.T) {
+	tests := []struct {
+		name string
+		cwd  string
+		id   string
+		want string
+	}{
+		{
+			name: "directory and id tail",
+			cwd:  "/home/me/code/lich",
+			id:   "4f2a1b3c-0000-4000-8000-000000000000",
+			want: "lich-4f2a",
+		},
+		{
+			name: "trailing separator ignored",
+			cwd:  "/home/me/code/lich/",
+			id:   "4f2a1b3c",
+			want: "lich-4f2a",
+		},
+		{
+			name: "windows path",
+			cwd:  `C:\Users\me\code\lich`,
+			id:   "4f2a1b3c",
+			want: "lich-4f2a",
+		},
+		{
+			name: "no directory to name",
+			cwd:  "",
+			id:   "4f2a1b3c",
+			want: "lich-4f2a",
+		},
+		{
+			name: "root is not a name",
+			cwd:  "/",
+			id:   "4f2a1b3c",
+			want: "lich-4f2a",
+		},
+		{
+			name: "id carries nothing usable",
+			cwd:  "/home/me/code/lich",
+			id:   "---",
+			want: "lich",
+		},
+		{
+			name: "punctuation inside the id is skipped, not counted",
+			cwd:  "/home/me/code/lich",
+			id:   "4-f-2-a-1",
+			want: "lich-4f2a",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rosterNameOf(tt.cwd, tt.id); got != tt.want {
+				t.Errorf("rosterNameOf(%q, %q) = %q, want %q", tt.cwd, tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRosterNameSeparatesSessionsSharingACheckout(t *testing.T) {
+	const cwd = "/home/me/code/lich"
+	first := rosterNameOf(cwd, "4f2a1b3c-0000-4000-8000-000000000000")
+	second := rosterNameOf(cwd, "9d8e7f6a-0000-4000-8000-000000000000")
+
+	if first == second {
+		t.Fatalf("two sessions in one checkout share the name %q", first)
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -134,6 +134,11 @@ type Service struct {
 	// prices resolves what a session's tokens cost. Nil disables the cost
 	// readout outright — the state a test that builds a bare Service is in.
 	prices rateSource
+	// onState, when set, receives every session-state report. The relay watches
+	// it to notice a target that worked through a request and ended its turn
+	// without answering (internal/relay). Guarded by mu: wired after the
+	// transport is already serving.
+	onState func(id, state string)
 }
 
 // New returns a ready-to-use terminal service that resolves the binary to spawn
@@ -162,6 +167,9 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 				Tool:   req.Tool,
 				Detail: req.Detail,
 			})
+			if watch := s.stateWatcher(); watch != nil {
+				watch(req.SessionID, req.State)
+			}
 			// Every non-idle state is a point where a fresh assistant usage line
 			// may have landed — a tool call mid-turn (busy), a prompt (waiting),
 			// or the turn's end (done) — so refresh the context window then, and
@@ -218,6 +226,23 @@ func (s *Service) MountPublic(pattern string, handler http.Handler) {
 		return
 	}
 	s.ws.mountPublic(pattern, handler)
+}
+
+// SetSessionState wires fn to every session-state report the hooks deliver.
+// Only one watcher: the relay is the only thing that needs the stream, and the
+// window gets the same reports over its own event channel.
+func (s *Service) SetSessionState(fn func(id, state string)) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.onState = fn
+}
+
+// stateWatcher reads the watcher under the lock, so a report arriving while it
+// is being wired sees one function or none, never a torn read.
+func (s *Service) stateWatcher() func(id, state string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.onState
 }
 
 // SetRestart wires the POST /restart endpoint to fn, the in-place relaunch the

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -8,7 +8,9 @@ package terminal
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
@@ -814,5 +816,60 @@ func TestSessionEnvWithoutProject(t *testing.T) {
 		if strings.HasPrefix(e, "LICH_PROJECT_DIR=") {
 			t.Fatalf("exported %q for a project that does not resolve", e)
 		}
+	}
+}
+
+// TestSessionStateReachesItsWatcher proves the seam the relay hangs off: a hook
+// report must reach SetSessionState, not only the window's event channel.
+// Everything downstream is unit-tested against a fake, so a break here would
+// look exactly like a feature that simply never fires — which is what an
+// unanswered request looked like on the first real run.
+func TestSessionStateReachesItsWatcher(t *testing.T) {
+	svc := New(stubBins{}, nil, events.New())
+	if svc.ws == nil {
+		t.Skip("no transport on this machine")
+	}
+	type report struct{ id, state string }
+	seen := make(chan report, 4)
+	svc.SetSessionState(func(id, state string) { seen <- report{id, state} })
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/hook?token=%s", svc.ws.port, svc.ws.token)
+	for _, state := range []string{"busy", "done"} {
+		body := fmt.Sprintf(`{"session_id":"sess","state":%q}`, state)
+		resp, err := http.Post(url, "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("post %s: %v", state, err)
+		}
+		_ = resp.Body.Close()
+	}
+
+	for _, want := range []report{{"sess", "busy"}, {"sess", "done"}} {
+		select {
+		case got := <-seen:
+			if got != want {
+				t.Fatalf("watcher saw %+v, want %+v", got, want)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatalf("watcher never saw %+v", want)
+		}
+	}
+}
+
+// TestSessionStateWithoutAWatcherIsHarmless proves the default: nothing is wired
+// until main wires it, and a report arriving first must not take the hook down.
+func TestSessionStateWithoutAWatcherIsHarmless(t *testing.T) {
+	svc := New(stubBins{}, nil, events.New())
+	if svc.ws == nil {
+		t.Skip("no transport on this machine")
+	}
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/hook?token=%s", svc.ws.port, svc.ws.token)
+	resp, err := http.Post(url, "application/json", strings.NewReader(`{"session_id":"s","state":"busy"}`))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", resp.StatusCode)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -126,8 +126,12 @@ func main() {
 	dispatcher.Register("system", system.New(env, logPath, version))
 	dispatcher.Register("providers", providers.New())
 	// The relay is the only service whose caller is not the window: the `lich`
-	// CLI running inside a session reaches it over the same listener.
-	dispatcher.Register("relay", relay.New(db, term))
+	// CLI running inside a session reaches it over the same listener. It watches
+	// the hooks' state reports too, to notice a target that ends a turn without
+	// answering the request it was given.
+	rl := relay.New(db, term, hub)
+	term.SetSessionState(rl.Observe)
+	dispatcher.Register("relay", rl)
 	dispatcher.Register("themes", themes.New())
 	dispatcher.Deny("store.Close")
 	// The dropped file's bytes are the request body, so the upload is its own


### PR DESCRIPTION
#203 gave sessions a way to hand each other work. It had no presence in the app, and the first real runs showed it did not actually work end to end. This is both halves: the window, and the three things that were breaking it.

## In the window

**The sidebar says which session is waiting on which.** While a request is open both cards name the other end — `→ docs` on the one waiting, `← auth` on the one that was asked — and go back to normal when the answer lands. A request relayed from a script says so instead of borrowing a name.

**Delegate to session**, in the card's right-click menu, mirroring `Mention session` from #201: it writes the request at your own prompt and leaves the cursor there, so you read it before it is sent. What it writes depends on what your agent has — Claude Code and Codex are asked in plain words and pick the tool themselves; opencode, oh-my-pi and Crush get `lich send` spelled out, which is the only way they would learn it exists.

Also fixes a stock-shadcn omission: `ContextMenuSubTrigger` had no `gap-2`, so a leading glyph was glued to its label on **every** submenu trigger — `Mention session` has looked like that since #201.

## Three things the real runs taught

**The Enter was being swallowed.** lich pasted the message and the carriage return in one write. Claude Code collapses a multi-line paste into a `[Pasted text #2 +7 lines]` placeholder, and the return arriving in that same burst goes into building the placeholder rather than sending it. The message sat unsent at the target's prompt, visible only to someone who opened that session by hand — which is why nothing ever came back. Everything else lich pastes leaves the Enter to the user (`paste-queue.ts` says so in as many words), so nothing had hit this before. Paste and submit are now two writes, a beat apart, and a test fails if a `\r` ever rides along again.

**A session had two addresses.** The card label (`docs`) and the peer-roster name lich passes as `--name` (`skipo-3939`) are the same session, and nothing in an agent's world said so. Handed one of them, an agent used *both* channels at once and lost the answer between them. The relay now answers to either name, publishes both wherever it names a session, and tells a target that its ticket is the only route home. `rostername.go` is the Go half of `peer-name.ts` — same inputs, same expected strings on both sides, because a divergence there delivers a message to the wrong terminal.

**An answer outlived the asker.** A relayed task can take minutes; Claude Code detaches a tool call that runs past 120s, so holding the line is not a strategy. Waiting is now optional: when an answer lands and nobody is waiting, lich types it at the sending session's prompt, exactly as the request reached the target. And when the target instead ends its turn without answering here, the wait stops right there and a toast opens that session — whatever it wrote is only on that screen.

## Not a setting

The two channels were an obvious candidate for a switch, and one was proposed and rejected: a toggle moves the problem onto the user, and writing `crossSessionInbound` into their Claude settings is invasive for an unproven gain. The conflict was never *which channel* — it was two names for one session. Unifying them made the choice not matter. `docs/cli.md` has the reasoning under "Two channels, one address space".

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` — 25 packages, no failures
- [x] `go test -race ./internal/...` clean; the turn-tracking and answer-return paths run 20–30× under `-race`
- [x] Cross-compile loop green for linux, darwin, windows (a first cut broke the Windows vet — a test in an untagged file reached a `!windows` helper)
- [x] `pnpm` vitest / biome / tsc / vite build all clean
- [x] Coverage: relay 95.2%, cli 85.9%
- [x] Exercised by hand in `task dev`, session to session, both directions
- [x] `ci:os` — the backend suite on real Windows and macOS runners

## Known ceilings (in `docs/cli.md`)

- The submit delay is a fixed 150ms. Nothing here can read the target's screen to know when the prompt has settled, so the delay is the instrument.
- Marks live with their ticket and tickets live in memory: a finished request leaves no trace, and a reload starts blank.
- Four tool definitions sit in every Claude Code and Codex session lich spawns, used or not.
- Answering out of band is handled, not supported: lich can point you at that session, never hand you what it says.