### PR TITLE
fix: log why the loopback listener would not bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   neighbour's size, smearing its text until the drop. Cards, session groups and
   project tabs now only move while dragging, never resize.
 
+- **A lich that will not open says why.** When the loopback listener could not
+  take its port, the log asked whether the port was free and dropped the system
+  error that knew the answer — leaving the one launch failure that shows no
+  window with nothing to go on. It now records the error itself, which is what
+  separates a port another program holds from a port the system refuses to hand
+  over with nothing listening on it (a Windows habit).
+
 ## [0.28.0] - 2026-08-09
 
 ### Added

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -131,6 +131,12 @@ type Service struct {
 	// ws is the local WebSocket transport for terminal I/O (see transport.go);
 	// nil when it failed to start, leaving /events and the RPC as the path.
 	ws *transport
+	// wsErr is why ws is nil. Kept because a failed bind of the pinned port is
+	// how the app fails to launch at all, and the OS error is the only thing
+	// telling a port somebody else holds apart from a port the OS refuses to
+	// hand over — Windows answers WSAEACCES for a port inside an excluded
+	// range, with nothing listening on it.
+	wsErr error
 	// prices resolves what a session's tokens cost. Nil disables the cost
 	// readout outright — the state a test that builds a bare Service is in.
 	prices rateSource
@@ -203,9 +209,7 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 			hub.Emit(touchedEventName, touchedEvent{ID: id})
 		},
 	)
-	if err == nil {
-		s.ws = ws
-	}
+	s.ws, s.wsErr = ws, err
 	return s
 }
 

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -591,6 +591,13 @@ type TransportInfo struct {
 	Token string `json:"token"`
 }
 
+// TransportError reports why the transport is absent, nil when it started. It
+// stays out of TransportInfo on purpose: the page has no use for an OS error,
+// and the launch-failure log is the only caller.
+func (s *Service) TransportError() error {
+	return s.wsErr
+}
+
 // Transport returns the WebSocket endpoint for terminal I/O.
 func (s *Service) Transport() TransportInfo {
 	if s.ws == nil {

--- a/internal/terminal/transport_test.go
+++ b/internal/terminal/transport_test.go
@@ -6,13 +6,17 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/coder/websocket"
+
+	"github.com/omartelo/lich/internal/events"
 )
 
 // TestMain drops LICH_LISTEN_PORT so every transport in this package binds a
@@ -752,5 +756,27 @@ func TestTransportInfoZeroWithoutTransport(t *testing.T) {
 	s := &Service{}
 	if info := s.Transport(); info.Port != 0 || info.Token != "" {
 		t.Fatalf("expected zero TransportInfo, got %+v", info)
+	}
+}
+
+// A launch that cannot bind the pinned port has the OS error as its only
+// diagnosis, so New must keep it rather than only reporting the absent port.
+func TestTransportErrorKeepsBindFailure(t *testing.T) {
+	busy, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("occupy a port: %v", err)
+	}
+	defer busy.Close()
+	t.Setenv("LICH_LISTEN_PORT", strconv.Itoa(busy.Addr().(*net.TCPAddr).Port))
+
+	// A nil store, not the suite's stub: that one is Unix-only, and this test
+	// earns its keep on Windows. Nothing here spawns a session, so the store is
+	// never reached.
+	s := New(nil, nil, events.New())
+	if info := s.Transport(); info.Port != 0 {
+		t.Fatalf("transport bound %d, want the busy port to refuse it", info.Port)
+	}
+	if s.TransportError() == nil {
+		t.Fatal("TransportError is nil after a failed bind")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -168,7 +168,7 @@ func main() {
 func runChromium(term *terminal.Service, configDir string, coord *restart.Coordinator) {
 	info := term.Transport()
 	if info.Port == 0 {
-		handleBindFailure(configDir) // never returns
+		handleBindFailure(configDir, term.TransportError()) // never returns
 	}
 
 	// The runtime file lets install.sh reach a running lich for /restart when it
@@ -220,8 +220,9 @@ func runChromium(term *terminal.Service, configDir string, coord *restart.Coordi
 
 // handleBindFailure runs when the pinned listener would not bind, and never
 // returns. It gathers the two inputs the decision needs, asks
-// singleton.BindFailureVerdict what they mean, and performs the effects.
-func handleBindFailure(configDir string) {
+// singleton.BindFailureVerdict what they mean, and performs the effects. cause
+// is the bind error, carried into the log for the launches that end here.
+func handleBindFailure(configDir string, cause error) {
 	port := os.Getenv("LICH_LISTEN_PORT")
 	restartWait := os.Getenv(restart.WaitEnv)
 	// A restart successor never probes: the verdict is already decided, and the
@@ -237,7 +238,9 @@ func handleBindFailure(configDir string) {
 		focusRunning(configDir, running)
 		os.Exit(0)
 	}
-	slog.Error("loopback listener failed to start — is the port free?", "port", port)
+	// No "is the port free?" here: on Windows the answer is regularly yes and
+	// the bind still fails, so the OS error is the message.
+	slog.Error("loopback listener failed to start", "port", port, "err", cause)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
Reported from a Windows install where lich simply does not open. The log said
only this, on every launch:

```
level=ERROR msg="loopback listener failed to start — is the port free?" port=47821
```

That is the entire diagnosis available for the one failure mode that shows no
window, and it is a guess — the system error that knew the answer was thrown
away one layer down.

## What was wrong

`terminal.New` dropped `newTransport`'s error:

```go
if err == nil {
    s.ws = ws
}
```

`main.go` then saw a zero port and printed a question it could not answer.

The question also misleads on Windows. Hyper-V, WSL and Docker reserve blocks
of TCP ports that move between boots; a port inside one refuses the bind with
`WSAEACCES` while nothing is listening on it. It is free by every check the
user can run, and unbindable. That is a different problem from a port another
process holds, and it wants a different fix — but both print the same line
today.

## What changed

- The `Service` keeps the bind error and exposes it as `TransportError()`.
  Deliberately not part of `TransportInfo`: the page has no use for an OS
  error, and the launch-failure log is the only caller.
- `handleBindFailure` takes the cause and logs it. The `— is the port free?`
  is gone, because the honest answer is often yes.
- The duplicate-launch path is untouched: `singleton.Detect` still runs first,
  so a second launch focuses the running window instead of reporting an error.

The log now reads:

```
level=ERROR msg="loopback listener failed to start" port=47821
  err="failed to listen for transport on 127.0.0.1:47821: listen tcp 127.0.0.1:47821: bind: ..."
```

`Only one usage of each socket address` — the port is taken.
`An attempt was made to access a socket in a way forbidden by its access
permissions` — an excluded range, and the port is free.

This is diagnosis only. lich still exits when it cannot bind; whether it
should fall back to another port depends on which of the two the report turns
out to be, and the fallback costs the frontend's `localStorage` (it is keyed
to the origin, which is why the port is pinned at all).

## Test plan

- [x] `TestTransportErrorKeepsBindFailure` — occupies a port, pins it via
      `LICH_LISTEN_PORT`, asserts the transport reports both an absent port and
      the error. It fails if the error is swallowed again.
- [x] `gofmt -l .`, `go vet ./...`, `go test ./...`
- [x] `for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done`

Frontend untouched.