### PR TITLE
fix: keep the "what's new" dismissal in the workspace database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   neighbour's size, smearing its text until the drop. Cards, session groups and
   project tabs now only move while dragging, never resize.
 
+- **"What's new" stays dismissed.** The popup after an update remembered your
+  click in the window's own storage, so a browser profile that had stopped
+  accepting writes — and kept answering reads with what it last loaded — greeted
+  you with the same release notes on every launch, with no way to make it stop.
+  The dismissed release is now kept in the workspace database beside everything
+  else that has to survive a restart.
+
 ## [0.28.0] - 2026-08-09
 
 ### Added

--- a/frontend/src/components/PatchNotesGate.tsx
+++ b/frontend/src/components/PatchNotesGate.tsx
@@ -1,9 +1,16 @@
 import { useEffect, useState } from "react"
 import { PatchNotesDialog } from "./PatchNotesDialog"
-import { decidePatchNotes, PATCH_NOTES_SEEN_KEY } from "@/lib/update/patch-notes-gate"
-import { PatchNotes } from "@/lib/rpc"
-import { readPref, writePref } from "@/lib/prefs"
+import {
+  decidePatchNotes,
+  LEGACY_PATCH_NOTES_SEEN_KEY,
+  PATCH_NOTES_SEEN_KEY,
+} from "@/lib/update/patch-notes-gate"
+import { PatchNotes, Store } from "@/lib/rpc"
+import { readPref } from "@/lib/prefs"
 import type { PatchNotes as PatchNotesData } from "@/lib/api-types"
+
+// The setting is the app's, not a project's — it answers for this install.
+const GLOBAL_SCOPE = ""
 
 // PatchNotesGate shows lich's "what's new" popup once per release, right after
 // an update. On startup it fetches this build's changelog section and decides:
@@ -14,12 +21,14 @@ export function PatchNotesGate() {
 
   useEffect(() => {
     let alive = true
-    void PatchNotes.Current()
-      .then((current) => {
+    void Promise.all([PatchNotes.Current(), Store.GetSetting(PATCH_NOTES_SEEN_KEY, GLOBAL_SCOPE)])
+      .then(([current, seen]) => {
         if (!alive) return
-        const action = decidePatchNotes(current, readPref(PATCH_NOTES_SEEN_KEY))
+        // A setting that was never written reads as "": the gate wants null for
+        // it, so a first run records rather than shows.
+        const action = decidePatchNotes(current, seen || readPref(LEGACY_PATCH_NOTES_SEEN_KEY))
         if (action.kind === "record") {
-          writePref(PATCH_NOTES_SEEN_KEY, action.version)
+          record(action.version)
         } else if (action.kind === "show") {
           setNotes(action.notes)
         }
@@ -33,9 +42,15 @@ export function PatchNotesGate() {
   if (!notes) return null
 
   const close = () => {
-    writePref(PATCH_NOTES_SEEN_KEY, notes.version)
+    record(notes.version)
     setNotes(null)
   }
 
   return <PatchNotesDialog notes={notes} onClose={close} />
+}
+
+// record remembers the version whose notes have been seen. A failed write only
+// costs the popup one extra appearance, so it stays silent like the read.
+function record(version: string): void {
+  void Store.SetSetting(PATCH_NOTES_SEEN_KEY, GLOBAL_SCOPE, version).catch(() => {})
 }

--- a/frontend/src/lib/update/patch-notes-gate.ts
+++ b/frontend/src/lib/update/patch-notes-gate.ts
@@ -6,8 +6,18 @@
 import type { PatchNotes } from "@/lib/api-types"
 
 // Stores the version whose notes were last shown (or silently recorded on first
-// run), so a given release's popup fires exactly once.
-export const PATCH_NOTES_SEEN_KEY = "lich.patchNotesSeen"
+// run), so a given release's popup fires exactly once. It is a workspace
+// setting rather than a localStorage pref: a Chromium profile whose Local
+// Storage stops accepting writes keeps serving the value it loaded at startup,
+// which leaves the popup returning on every launch with no click able to stop
+// it (#199). The database is the same store the sessions themselves survive in.
+export const PATCH_NOTES_SEEN_KEY = "update.patchNotesSeen"
+
+// The localStorage key the same state used before it moved into the database.
+// Read once as a fallback so an install that already dismissed a release is not
+// treated as a first run — which would swallow the popup for the very release
+// that moves it. Never written; it ages out with the profile.
+export const LEGACY_PATCH_NOTES_SEEN_KEY = "lich.patchNotesSeen"
 
 // PatchNotesAction is what the gate should do:
 // - show: open the popup for this version's notes.


### PR DESCRIPTION
Closes #199 — pending the reporter's confirmation of the profile diagnosis; the change stands on its own either way.

## The report

The "what's new" popup returns on every launch, `v0.28.0` both times, dismissal ignored (Windows, 0.28.0).

## What the gate does

`decidePatchNotes` is correct, and the reported behaviour pins down which half is broken:

- nothing recorded → `record`, silent, no popup;
- popup on screen ⟹ the stored value is **non-null and different** from the running version.

So the read works and the write does not stick. Every "the storage was wiped" explanation (a session-only cookie policy, a recreated profile, an in-memory fallback) predicts the opposite of the report: a silent `record` and no popup at all. What is left is a Chromium profile whose `Local Storage` LevelDB keeps serving the snapshot it loaded and fails every commit — a corrupt database, or a profile directory that stopped being writable.

lich cannot fix somebody's browser profile, but it does not have to depend on it: the dismissal is the one localStorage pref where a lost write is unrecoverable by the user, because the popup it silences is the thing in the way.

## The change

`update.patchNotesSeen` moves to the settings table (`store.GetSetting`/`SetSetting`, global scope) — the same store the sessions survive in. The old `lich.patchNotesSeen` key is read once as a fallback so an install that already dismissed a release is not treated as a first run, which would swallow the popup for the release that carries this change.

Frontend only; the settings RPC already exists.

## Also found, not fixed here

`internal/restart/restart_windows.go` terminates the window with `p.Kill()`, where Unix sends SIGTERM precisely so Chromium exits cleanly. Chromium batches localStorage commits (~5s) and only guarantees a flush on a graceful shutdown, so every restart and self-apply update on Windows drops whatever prefs were written just before it. The reporter's log carries 10 of those kills. Separate PR, and it needs `ci:os`.

## Test plan

- [x] `pnpm check`, `tsc --noEmit`, `vitest run` (784 pass), `vite build`
- [x] `gofmt -l .`, `go vet ./...`, `go test ./...`