### PR TITLE
chore: add GitHub Sponsors funding file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: omartelo


### PR DESCRIPTION
Adds `.github/FUNDING.yml` so the repo shows a Sponsor button pointing at the `omartelo` GitHub Sponsors profile.

The button only renders once the Sponsors listing on the account is live — until then GitHub simply doesn't show it, so this file is safe to merge ahead of the account setup.

No CHANGELOG entry: nothing in the app changes.

## Test plan

- [ ] After the Sponsors listing goes live, confirm the Sponsor button appears in the repo header and links to https://github.com/sponsors/omartelo