### PR TITLE
fix: ask the Windows window to close instead of killing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   neighbour's size, smearing its text until the drop. Cards, session groups and
   project tabs now only move while dragging, never resize.
 
+- **A restart on Windows no longer costs you the settings you just changed.**
+  Where Linux and macOS ask the window to close, Windows killed it outright —
+  and the window is where your interface settings are written, on their way to
+  disk a few seconds later. Anything changed just before an update or a restart
+  went with it: a theme, a panel width, a dialog you had dismissed. The window
+  is now asked to close on Windows too, and only killed if it cannot be.
+
 - **"What's new" stays dismissed.** The popup after an update remembered your
   click in the window's own storage, so a browser profile that had stopped
   accepting writes — and kept answering reads with what it last loaded — greeted

--- a/internal/restart/restart.go
+++ b/internal/restart/restart.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"sync"
 )
 
@@ -83,4 +84,18 @@ func (c *Coordinator) Do() error {
 // successorEnv is env plus the wait marker, on a fresh slice.
 func successorEnv(env []string) []string {
 	return append(append([]string(nil), env...), WaitEnv+"=1")
+}
+
+// closeWindowCommand is how Windows asks a GUI process to close: taskkill
+// without /F posts WM_CLOSE to the process's windows rather than ending it
+// where it stands. It is resolved under SystemRoot instead of through PATH —
+// what this command reaches decides whether somebody's window is closed or
+// killed, and PATH is the user's to rearrange. Kept out of the build-tagged
+// file so the pure logic tests on any OS, like chromium.windowsBrowserCandidates.
+func closeWindowCommand(getenv func(string) string, pid int) (string, []string) {
+	exe := "taskkill.exe"
+	if root := getenv("SystemRoot"); root != "" {
+		exe = root + `\System32\taskkill.exe`
+	}
+	return exe, []string{"/PID", strconv.Itoa(pid)}
 }

--- a/internal/restart/restart_test.go
+++ b/internal/restart/restart_test.go
@@ -36,6 +36,36 @@ func TestSuccessorEnvAppendsWaitMarker(t *testing.T) {
 	}
 }
 
+func TestCloseWindowCommand(t *testing.T) {
+	// /F is the whole point: with it taskkill ends the process, and Chromium
+	// never flushes the profile the close exists to save.
+	t.Run("asks rather than forces", func(t *testing.T) {
+		_, args := closeWindowCommand(func(string) string { return `C:\Windows` }, 4321)
+		if slices.Contains(args, "/F") {
+			t.Fatalf("args = %v, must not force the kill", args)
+		}
+		if !slices.Equal(args, []string{"/PID", "4321"}) {
+			t.Fatalf("args = %v, want [/PID 4321]", args)
+		}
+	})
+
+	t.Run("resolved under SystemRoot", func(t *testing.T) {
+		exe, _ := closeWindowCommand(func(string) string { return `C:\Windows` }, 1)
+		if exe != `C:\Windows\System32\taskkill.exe` {
+			t.Fatalf("exe = %q, want the SystemRoot path", exe)
+		}
+	})
+
+	// No SystemRoot is a broken environment, not a reason to skip the close:
+	// the bare name still resolves through PATH on every Windows.
+	t.Run("falls back to the bare name", func(t *testing.T) {
+		exe, _ := closeWindowCommand(func(string) string { return "" }, 1)
+		if exe != "taskkill.exe" {
+			t.Fatalf("exe = %q, want taskkill.exe", exe)
+		}
+	})
+}
+
 func TestDoSpawnsThenTerminates(t *testing.T) {
 	var (
 		spawnedEnv []string

--- a/internal/restart/restart_windows.go
+++ b/internal/restart/restart_windows.go
@@ -3,6 +3,7 @@
 package restart
 
 import (
+	"log/slog"
 	"os"
 	"os/exec"
 	"syscall"
@@ -22,8 +23,26 @@ func startDetached(exe string, env []string) error {
 	return cmd.Start()
 }
 
-// terminateProcess ends the window process. Windows has no graceful signal to a
-// GUI child here, so this is a hard kill.
+// terminateProcess asks the window to close, the way restart_unix.go's SIGTERM
+// does, so Chromium clears its profile lock and flushes it. That flush is the
+// point: the page's prefs live in the profile's localStorage, which Chromium
+// commits to disk lazily, so a window that is killed rather than closed loses
+// whatever was written in the seconds before the restart — a dismissed dialog
+// coming back on the next launch (#199) is what that looks like.
+//
+// Windows has no signal to send, so the close is posted as WM_CLOSE by taskkill
+// without /F. The hard kill stays as the fallback for when there is no window to
+// post to (a restart in the moment before it opens): the successor is already
+// waiting on the pinned port, and nothing may be left holding it.
 func terminateProcess(p *os.Process) error {
-	return p.Kill()
+	exe, args := closeWindowCommand(os.Getenv, p.Pid)
+	cmd := exec.Command(exe, args...)
+	// lich is built for the GUI subsystem (-H=windowsgui); without this the
+	// console helper flashes a window over the app on its way out.
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NO_WINDOW}
+	if err := cmd.Run(); err != nil {
+		slog.Warn("close window gracefully, killing instead", "err", err)
+		return p.Kill()
+	}
+	return nil
 }


### PR DESCRIPTION
Follow-up to #207, from the same log in #199.

## The bug

`internal/restart/restart_windows.go` ended the window with `p.Kill()`. Its Unix sibling sends SIGTERM, with a comment saying why: so Chromium clears its profile lock and exits cleanly. Chromium commits localStorage to disk lazily, so a killed window never flushes, and everything the page wrote in the seconds before the restart is gone — a theme, a panel width, a dismissed dialog.

The self-apply update on Windows drives this same path, which makes an update the likeliest moment to lose a pref. The reporter's log in #199 carries 10 of these kills (`chromium shell" err="exit status 1"` followed ~150ms later by the successor's `chromium shell opening`).

## The change

Windows has no signal to send, so the close is posted as WM_CLOSE — `taskkill /PID <pid>` without `/F`, resolved under `SystemRoot` rather than through PATH, since what this command reaches decides whether a window is closed or killed. `CREATE_NO_WINDOW` keeps the console helper from flashing over a `-H=windowsgui` binary.

`p.Kill()` stays as the fallback for the one case that has no window to post to — a restart fired in the moment before it opens. The successor is already blocked on the pinned port by then, so nothing may be left holding it.

`closeWindowCommand` lives in the untagged file (the `chromium.windowsBrowserCandidates` precedent), so the part that decides close-vs-kill is covered on any OS.

## What this does not claim

Whether it is #199's root cause. My reading there is a profile whose Local Storage stopped accepting writes altogether, which no shutdown change can fix, and the reporter's answer is still pending. This is a bug either way and worth fixing on its own.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...`
- [x] Cross-compile loop: `GOOS=linux|darwin|windows go build ./... && go vet ./...`
- [x] `closeWindowCommand`: no `/F`, SystemRoot path, bare-name fallback
- [ ] Real Windows: `ci:os` — a restart closes the window, and a pref changed a second before it survives
- [ ] Real Windows: a restart before the window opens still frees the port (kill fallback)