### PR TITLE
feat: pack a bug report into one archive with lich rage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`lich rage` packs a bug report you can actually attach.** Reporting a
+  problem meant being walked through it: find the log folder, notice that the
+  rotated generation beside it is usually the one holding the crash, say which
+  browser and which provider CLIs the machine has, remember the version. One
+  command now collects all of it — versions and build, platform, whether an
+  instance is running and answering, the browser it found, the providers on
+  PATH, the plugin's state in each of them, the config directory, the
+  environment lich was launched with and both log generations — into a single
+  `.tar.gz` beside you. Values named like a token, key, secret or password are
+  reported as present or absent rather than printed, and lich's own loopback
+  token is masked wherever it had been written. Nothing is uploaded and no issue
+  is filed: the archive stays on disk until you attach it to one you wrote. It
+  reads the file system only, so it still works when the window never opened —
+  the case where there was no Settings › Help to ask through.
+
 - **Closing a project asks when an agent is still working.** The tab's × took a
   project's terminals down with it, killing whatever was mid-turn — with a
   spinner on that very tab as the only warning, and no undo. Closing a project

--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ version is in [CHANGELOG.md](CHANGELOG.md).
   [lich plugin](https://github.com/omartelo/lich-plugin) installed — in Claude
   Code, in Codex, or in both — a session also titles its own card and refreshes
   git the moment it writes a file.
-  Settings › Help opens the log folder and a pre-filled bug report.
+  Settings › Help opens the log folder and a pre-filled bug report; `lich rage`
+  packs the whole report — versions, browser, providers, plugin state, logs,
+  secrets masked — into one archive, and works when no window opened at all.
 
 <div align="center">
   <img src="docs/media/pulls-list.png" alt="The pull request list: every open pull request with its author, age and check status, narrowed by a filter box" width="900" />
@@ -169,7 +171,8 @@ backend is a token-authenticated loopback listener, and nothing leaves
 `localhost` except the update check: a version ping to GitHub Releases at startup
 and hourly. Updates apply in place on Windows/macOS and through the AUR on Arch.
 Settings › Help says what the log file carries — paths, project and branch names,
-your gh login, never a session token — before you attach it to a bug report.
+your gh login, never a session token — before you attach it to a bug report, and
+`lich rage` collects that report into one archive without uploading any of it.
 
 ## Build from source
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,6 +9,10 @@ It is not only for agents. The same commands run from any shell on the machine �
 a script, a scheduled job, the user's own terminal — which is what makes lich
 automatable without a provider in the loop. `--json` is there for exactly that.
 
+One command is about lich itself rather than about the sessions: `lich rage`
+collects a bug report from the machine, and is the surface for the failure where
+there is no window to ask through.
+
 Agents mostly do not run it as a command. lich registers the same operations as
 **MCP tools** for the providers that can be told at spawn, so they are in the
 agent's own tool list without anybody being told anything — see
@@ -38,9 +42,10 @@ channel of their own: anything that can run a shell command can answer.
 
 ## Transport
 
-Every command reads the coordinates lich already injects into each PTY (see the
-hooks [README](hooks/README.md)) and posts to the same loopback listener the
-window uses:
+Every command that addresses a session reads the coordinates lich already
+injects into each PTY (see the hooks [README](hooks/README.md)) and posts to the
+same loopback listener the window uses. `lich rage` is the exception: it reads
+the file system and nothing else.
 
 | Var               | Purpose                                          |
 |-------------------|--------------------------------------------------|
@@ -169,6 +174,35 @@ at lich.
 
 A tool that fails answers with `isError` and the reason as text, not a JSON-RPC
 error: the agent should read what went wrong and act on it, not lose the turn.
+
+### `lich rage [--output <path>]`
+
+The one command here that talks to no session — and to no lich. It collects a
+bug report from this machine into `./lich-rage-<timestamp>.tar.gz` (or
+`--output`'s path) and prints where it went:
+
+```
+Wrote lich-rage-20260810-150405.tar.gz
+lich v0.25.0 on linux/amd64, running (pid 4242, port 47821).
+Read it before you attach it: it carries absolute paths, project and branch names.
+```
+
+It exists for the failure lich cannot report on itself: a window that never
+opened has no Settings › Help to ask through. So it needs no running instance —
+whether one is running, and whether it still answers, is one of the facts it
+reports.
+
+| Entry | What it holds |
+|-------|---------------|
+| `report.md` | Version and build, platform, instance state, browser, providers on PATH, plugin state per provider, and the config directory one level deep. |
+| `env.txt` | Every `LICH_*` variable plus a fixed allowlist (`SHELL`, `PATH`, `EDITOR`, the desktop ones). Anything named like a token, key, secret or password is `<SET>` / `<UNSET>`, never a value. |
+| `logs/` | `lich.log` and the rotated `lich.log.old`, each carrying at most its last 4 MiB. |
+
+Nothing is uploaded and no issue is filed: the archive sits on disk until the
+user attaches it to one they wrote. The loopback token is masked wherever it
+appeared — by value for the running instance, and by the `token=` query shape
+for every earlier one. The Chromium profile, the workspace database and its
+directories are named but never read.
 
 ## Registration
 
@@ -364,6 +398,10 @@ whoever asked.
 - **A busy target is written to anyway.** Every provider lich spawns queues text
   typed mid-turn and submits it when the turn ends, so the message waits its
   turn rather than interrupting one.
+- **A bug report knows nothing about the workspace.** `lich rage` never opens
+  the database — a second process migrating it is not a price a bug report may
+  charge — so no project, session or cost is in the bundle, only that the file
+  exists and how big it is. What a session was doing has to be asked for.
 - **The answer is the agent's summary, not the transcript.** Nothing reads the
   target's output, so what comes back is exactly what that agent chose to type
   into `lich reply` — and an agent that never runs it is indistinguishable from

--- a/frontend/src/components/settings/HelpSettings.tsx
+++ b/frontend/src/components/settings/HelpSettings.tsx
@@ -23,7 +23,7 @@ export function HelpSettings() {
       <SettingBlock
         icon={<Bug className="size-4" />}
         title="Report a bug"
-        description="Opens the bug form in your browser with the version and platform filled in. lich does not file the issue — you write it and attach the log yourself."
+        description="Opens the bug form in your browser with the version and platform filled in. lich does not file the issue — you write it yourself. Run `lich rage` in a terminal to pack the log, the versions and what lich found on this machine into one archive to attach."
       >
         <Button
           size="sm"

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -13,6 +13,11 @@
 // one install.sh uses to reach a running lich for /restart. Such a caller has
 // no session of its own, and the message it relays says so.
 //
+// One command is not about the other sessions at all: `lich rage` collects a
+// bug report from this machine, and answers to the failure where there is no
+// window to ask through (internal/rage). It is here because it is part of the
+// same command line, and because it must work when nothing else does.
+//
 // The contract is docs/cli.md; the lich-plugin slash commands are written
 // against it, so a flag or an output line that moves here breaks a repo this
 // one cannot see.
@@ -27,9 +32,12 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/omartelo/lich/internal/rage"
 	"github.com/omartelo/lich/internal/relay"
 	"github.com/omartelo/lich/internal/singleton"
 )
@@ -69,16 +77,23 @@ const usage = `lich talks to the sessions open in the running lich window.
       itself for the providers that support it; you only run it by hand to
       point another MCP client at lich.
 
+  lich rage [--output <path>]
+      Collect a bug report — versions, browser, providers, plugin state and
+      the logs, with secrets masked — into one .tar.gz to attach to an issue.
+      Nothing is uploaded, and it works with no lich running.
+
 Run inside a lich session these address the sessions beside it. Run anywhere
 else on the machine they find the running lich on their own, and what they
 relay is attributed to the command line rather than to a session.
 `
 
 // Run executes one subcommand and returns the process exit code, or
-// NotACommand when args name none. env reads the process environment.
-func Run(args []string, env func(string) string, stdout, stderr io.Writer) int {
+// NotACommand when args name none. env reads the process environment, and
+// version is the running build's, which only the bug report needs.
+func Run(args []string, version string, env func(string) string, stdout, stderr io.Writer) int {
 	return dispatch(args, &client{
-		env: env, stdin: os.Stdin, stdout: stdout, stderr: stderr, running: runningLich,
+		env: env, version: version, stdin: os.Stdin,
+		stdout: stdout, stderr: stderr, running: runningLich,
 	})
 }
 
@@ -100,6 +115,8 @@ func dispatch(args []string, c *client) int {
 		return c.run(c.reply, args[1:])
 	case "mcp":
 		return c.run(c.serveMCP, args[1:])
+	case "rage":
+		return c.run(c.rage, args[1:])
 	case "help", "--help", "-h":
 		fmt.Fprint(c.stdout, usage)
 		return 0
@@ -109,6 +126,9 @@ func dispatch(args []string, c *client) int {
 
 type client struct {
 	env func(string) string
+	// version is the running build's, reported by the bug report and by nothing
+	// else: every other command talks to a lich that knows its own.
+	version string
 	// stdin carries the MCP server's incoming messages; nil for every other
 	// command, none of which reads anything.
 	stdin  io.Reader
@@ -117,6 +137,10 @@ type client struct {
 	// running finds the lich instance to talk to when the environment carries
 	// no coordinates, i.e. when this is not running inside a lich PTY.
 	running func() (*singleton.Info, error)
+	// bundle writes the bug report archive; nil takes the real collector. A
+	// test overrides it because collecting scans PATH, runs the provider CLIs
+	// and asks GitHub for the plugin's latest release.
+	bundle func(w io.Writer, root string) (rage.Report, error)
 }
 
 // run reports a subcommand's failure the way a command line does — one line on
@@ -211,6 +235,66 @@ func (c *client) reply(args []string) error {
 	}
 	fmt.Fprintln(c.stdout, "Answer sent.")
 	return nil
+}
+
+// rage writes the bug report bundle to a file and says what it wrote. It talks
+// to no lich: the report it collects is most needed exactly when there is none
+// running to ask.
+func (c *client) rage(args []string) error {
+	flags := newFlagSet("rage")
+	output := flags.String("output", "", "write the bundle here instead of ./lich-rage-<timestamp>.tar.gz")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 0 {
+		return fmt.Errorf("usage: lich rage [--output <path>]")
+	}
+
+	path := *output
+	if path == "" {
+		path = rage.DefaultBase(time.Now()) + ".tar.gz"
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return fmt.Errorf("create the bundle: %w", err)
+	}
+
+	collect := c.bundle
+	if collect == nil {
+		collect = c.collectRage
+	}
+	report, err := collect(file, archiveRoot(path))
+	if closeErr := file.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		// A half-written archive is worse than none: it opens, it looks like a
+		// report, and it is missing the part that mattered.
+		_ = os.Remove(path)
+		return err
+	}
+
+	fmt.Fprintf(c.stdout, "Wrote %s\n", path)
+	fmt.Fprintf(c.stdout, "lich %s on %s, %s.\n", report.Version, report.Platform, report.Instance)
+	fmt.Fprintln(c.stdout, "Read it before you attach it: it carries absolute paths, project and branch names.")
+	return nil
+}
+
+// collectRage is the real collector, reached when no seam replaced it.
+func (c *client) collectRage(w io.Writer, root string) (rage.Report, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return rage.Report{}, fmt.Errorf("resolve config directory: %w", err)
+	}
+	return rage.New(dir, c.version, os.Environ()).Bundle(w, root)
+}
+
+// archiveRoot is the directory the bundle's entries sit under: the archive's
+// own name, so two extracted side by side stay apart.
+func archiveRoot(path string) string {
+	base := filepath.Base(path)
+	base = strings.TrimSuffix(base, ".gz")
+	return strings.TrimSuffix(base, ".tar")
 }
 
 // report prints a Send or Wait outcome. An answer goes to stdout on its own so

--- a/internal/cli/rage_test.go
+++ b/internal/cli/rage_test.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/rage"
+)
+
+// rageClient runs `lich rage` against a stub collector: the real one scans
+// PATH, runs the provider CLIs and asks GitHub for the plugin release, none of
+// which a unit test may do. roots records the archive root it was asked for.
+func rageClient(t *testing.T, err error, roots *[]string) (*client, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	c := &client{
+		env:    func(string) string { return "" },
+		stdout: &stdout,
+		stderr: &stderr,
+		bundle: func(w io.Writer, root string) (rage.Report, error) {
+			*roots = append(*roots, root)
+			_, _ = io.WriteString(w, "archive bytes")
+			return rage.Report{Version: "v1.2.3", Platform: "linux/amd64", Instance: "not running"}, err
+		},
+	}
+	return c, &stdout, &stderr
+}
+
+func TestRageWritesATimestampedBundleAndSaysWhatItHolds(t *testing.T) {
+	t.Chdir(t.TempDir())
+	var roots []string
+	c, stdout, stderr := rageClient(t, nil, &roots)
+
+	if code := dispatch([]string{"rage"}, c); code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+
+	written := bundlesIn(t, ".")
+	if len(written) != 1 {
+		t.Fatalf("wrote %v, want one lich-rage-<timestamp>.tar.gz", written)
+	}
+	if !strings.HasPrefix(written[0], "lich-rage-") {
+		t.Errorf("bundle is named %q", written[0])
+	}
+	if len(roots) != 1 || roots[0]+".tar.gz" != written[0] {
+		t.Errorf("archive root %v does not match the file name %q", roots, written[0])
+	}
+	for _, want := range []string{written[0], "v1.2.3", "linux/amd64", "not running", "Read it before you attach it"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("stdout does not mention %q: %q", want, stdout.String())
+		}
+	}
+}
+
+func TestRageWritesWhereItWasTold(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.tar.gz")
+	var roots []string
+	c, _, stderr := rageClient(t, nil, &roots)
+
+	if code := dispatch([]string{"rage", "--output", path}, c); code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read the bundle: %v", err)
+	}
+	if string(data) != "archive bytes" {
+		t.Errorf("bundle = %q", data)
+	}
+	if len(roots) != 1 || roots[0] != "report" {
+		t.Errorf("archive root = %v, want the file's own name", roots)
+	}
+}
+
+func TestRageLeavesNoHalfWrittenBundleBehind(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.tar.gz")
+	var roots []string
+	c, _, stderr := rageClient(t, errors.New("disk full"), &roots)
+
+	if code := dispatch([]string{"rage", "--output", path}, c); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "disk full") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("a failed collection left an archive that opens and is missing the part that mattered")
+	}
+}
+
+func TestRageTakesNoArguments(t *testing.T) {
+	t.Chdir(t.TempDir())
+	var roots []string
+	c, _, stderr := rageClient(t, nil, &roots)
+
+	if code := dispatch([]string{"rage", "everything"}, c); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "usage: lich rage") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+	if written := bundlesIn(t, "."); len(written) != 0 {
+		t.Errorf("a rejected command still wrote %v", written)
+	}
+}
+
+func TestRageIsInTheHelp(t *testing.T) {
+	f := newFakeLich(t, `null`)
+	_, stdout, _ := run(t, f, "help")
+	if !strings.Contains(stdout, "lich rage") {
+		t.Errorf("help does not document rage: %q", stdout)
+	}
+}
+
+func TestArchiveRootStripsBothExtensions(t *testing.T) {
+	cases := map[string]string{
+		"lich-rage-20260810-150405.tar.gz": "lich-rage-20260810-150405",
+		"/tmp/report.tar.gz":               "report",
+		"/tmp/report.tar":                  "report",
+		"bundle":                           "bundle",
+	}
+	for path, want := range cases {
+		if got := archiveRoot(path); got != want {
+			t.Errorf("archiveRoot(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+func bundlesIn(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out []string
+	for _, e := range entries {
+		out = append(out, e.Name())
+	}
+	return out
+}

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -82,7 +82,7 @@ func TestSessionsOverTheRealDispatcher(t *testing.T) {
 	env, _ := wiredLich(t)
 
 	var stdout, stderr bytes.Buffer
-	if code := Run([]string{"sessions"}, env, &stdout, &stderr); code != 0 {
+	if code := Run([]string{"sessions"}, "test", env, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "docs\tlich\tcodex") {
@@ -99,7 +99,7 @@ func TestSendAndReplyOverTheRealDispatcher(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	done := make(chan int, 1)
 	go func() {
-		done <- Run([]string{"send", "--timeout", "20", "docs", "run the tests"}, env, &stdout, &stderr)
+		done <- Run([]string{"send", "--timeout", "20", "docs", "run the tests"}, "test", env, &stdout, &stderr)
 	}()
 
 	ticketID := ticketFrom(term)
@@ -108,7 +108,7 @@ func TestSendAndReplyOverTheRealDispatcher(t *testing.T) {
 	}
 
 	var replyOut, replyErr bytes.Buffer
-	if code := Run([]string{"reply", ticketID, "3 failures"}, env, &replyOut, &replyErr); code != 0 {
+	if code := Run([]string{"reply", ticketID, "3 failures"}, "test", env, &replyOut, &replyErr); code != 0 {
 		t.Fatalf("reply exit = %d, stderr = %q", code, replyErr.String())
 	}
 	if code := <-done; code != 0 {

--- a/internal/rage/rage.go
+++ b/internal/rage/rage.go
@@ -1,0 +1,300 @@
+// Package rage collects what a lich bug report needs into one archive: the
+// facts that decide whether a report is actionable (version, platform, browser,
+// provider and plugin state), the environment lich was launched with, and the
+// log generations — with the loopback token masked wherever it appeared.
+//
+// It exists for the failure lich cannot report on itself: no window means no
+// Settings › Help, so this runs from the command line and needs no running
+// instance. Nothing is uploaded and nothing is filed — the archive stays on
+// disk until the user attaches it to an issue they wrote themselves.
+package rage
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"runtime/debug"
+	"time"
+
+	"github.com/omartelo/lich/internal/agentplugin"
+	"github.com/omartelo/lich/internal/chromium"
+	"github.com/omartelo/lich/internal/logging"
+	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/singleton"
+)
+
+// maxLogBytes bounds each log generation in the archive. Rotation caps the file
+// at startup only, so a long-running session at debug level can outgrow it
+// while running — such a file is carried by its tail, which is the half that
+// holds what just went wrong.
+const maxLogBytes = 4 << 20
+
+// Report is what report.md renders: every fact gathered about this machine,
+// and none that identify the loopback session. The token is deliberately
+// absent — the file outlives the instance it would name.
+type Report struct {
+	Version   string
+	GoVersion string
+	// Revision is the VCS stamp Go embeds when a build comes from a checkout,
+	// suffixed "-dirty" for a modified tree. It is what identifies a build the
+	// reporter compiled themselves, where Version says only "dev".
+	Revision  string
+	Platform  string
+	Instance  string
+	ConfigDir string
+	LogPath   string
+	Browser   string
+	Providers []providers.Detected
+	Plugin    []agentplugin.Status
+	Entries   []Entry
+}
+
+// Entry is one item in the lich config directory, reported by name and size so
+// a missing database or an empty theme folder is visible without shipping any
+// of their contents.
+type Entry struct {
+	Name string
+	Size int64
+	Dir  bool
+}
+
+// Collector gathers a Report. The four probes are fields because each one
+// reaches the machine — PATH, the provider CLIs, the network, the running
+// instance — and a test must answer for all of them.
+type Collector struct {
+	configDir string
+	version   string
+	environ   []string
+
+	browser func() (string, error)
+	detect  func() []providers.Detected
+	plugin  func() []agentplugin.Status
+	probe   func() (*singleton.Info, bool)
+}
+
+// New returns a Collector reading the real machine. configDir is the OS config
+// dir (os.UserConfigDir), the parent of lich's own directory, because that is
+// what the runtime file and the log path are both resolved from.
+func New(configDir, version string, environ []string) *Collector {
+	return &Collector{
+		configDir: configDir,
+		version:   version,
+		environ:   environ,
+		browser:   func() (string, error) { return chromium.FindBrowser(exec.LookPath) },
+		detect: func() []providers.Detected {
+			found, err := providers.New().Detect()
+			if err != nil {
+				return nil
+			}
+			return found
+		},
+		plugin: func() []agentplugin.Status { return agentplugin.New(pathBins{}).Status() },
+		probe: func() (*singleton.Info, bool) {
+			info, err := singleton.Read(configDir)
+			if err != nil || info == nil {
+				return nil, false
+			}
+			return info, singleton.Ping(info.Port, info.Token)
+		},
+	}
+}
+
+// pathBins resolves every provider to its default name on PATH. The real
+// resolver is the workspace database, and rage never opens it: the database
+// belongs to the running instance, and a bug report must not be the second
+// process to migrate it.
+type pathBins struct{}
+
+func (pathBins) ProviderBin(_, _ string) string { return "" }
+
+// Bundle writes the gzipped tar to w and returns the report it carries. root is
+// the directory every entry sits under, so extracting two bundles side by side
+// does not merge them.
+func (c *Collector) Bundle(w io.Writer, root string) (Report, error) {
+	report, token := c.collect()
+
+	gz := gzip.NewWriter(w)
+	archive := tar.NewWriter(gz)
+
+	files := []bundleFile{
+		{"report.md", []byte(render(report))},
+		{"env.txt", []byte(renderEnv(c.environ, token))},
+	}
+	files = append(files, logFiles(report.LogPath, token)...)
+
+	for _, f := range files {
+		if err := writeEntry(archive, root+"/"+f.name, f.data); err != nil {
+			return report, err
+		}
+	}
+	if err := archive.Close(); err != nil {
+		return report, fmt.Errorf("close the archive: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return report, fmt.Errorf("compress the archive: %w", err)
+	}
+	return report, nil
+}
+
+// bundleFile is one entry of the archive, held in memory: the whole bundle is
+// two rendered pages and at most two capped log generations.
+type bundleFile struct {
+	name string
+	data []byte
+}
+
+// logFiles reads the log generations the archive carries — the live one and the
+// rotated *.old, which is often the one holding the crash. An unreadable
+// generation is skipped rather than failing the bundle: a report missing one log
+// still beats no report.
+func logFiles(logPath, token string) []bundleFile {
+	if logPath == "" {
+		return nil
+	}
+	var out []bundleFile
+	for _, path := range []string{logPath, logPath + ".old"} {
+		data, err := readTail(path, maxLogBytes)
+		if err != nil {
+			continue
+		}
+		out = append(out, bundleFile{"logs/" + filepath.Base(path), scrub(data, token)})
+	}
+	return out
+}
+
+// collect gathers every fact, and returns the running instance's token beside
+// the report rather than inside it: the token is needed to mask the copies of
+// itself that may sit in the log, and must reach nothing else.
+func (c *Collector) collect() (Report, string) {
+	lichDir := filepath.Join(c.configDir, "lich")
+	report := Report{
+		Version:   c.version,
+		GoVersion: runtime.Version(),
+		Revision:  revision(),
+		Platform:  runtime.GOOS + "/" + runtime.GOARCH,
+		ConfigDir: lichDir,
+		LogPath:   logging.Path(lichDir),
+		Providers: c.detect(),
+		Plugin:    c.plugin(),
+		Entries:   entries(lichDir),
+	}
+	if _, err := os.Stat(report.LogPath); err != nil {
+		// A path that was never written would send the reporter looking for a
+		// file that does not exist, and the archive carries no logs section.
+		report.LogPath = ""
+	}
+
+	browser, err := c.browser()
+	report.Browser = browser
+	if err != nil {
+		report.Browser = err.Error()
+	}
+
+	token := ""
+	info, alive := c.probe()
+	switch {
+	case info == nil:
+		report.Instance = "not running"
+	case alive:
+		token = info.Token
+		report.Instance = fmt.Sprintf("running (pid %d, port %d)", info.PID, info.Port)
+	default:
+		// The file outlives a crash, so a recorded instance that does not answer
+		// is itself a finding: lich died without closing its window.
+		report.Instance = fmt.Sprintf("recorded but not answering (pid %d, port %d)", info.PID, info.Port)
+	}
+	return report, token
+}
+
+// entries lists the lich config directory one level deep. Directories are named
+// but never descended into: below them are the Chromium profile's cookies and
+// the workspace database, neither of which belongs in a bug report.
+func entries(dir string) []Entry {
+	found, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	out := make([]Entry, 0, len(found))
+	for _, e := range found {
+		entry := Entry{Name: e.Name(), Dir: e.IsDir()}
+		if info, err := e.Info(); err == nil {
+			entry.Size = info.Size()
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// readTail reads the last max bytes of a file, marking the cut so a reader does
+// not take a mid-line start for a corrupt log.
+func readTail(path string, max int64) ([]byte, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	info, err := file.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if info.Size() <= max {
+		return io.ReadAll(file)
+	}
+	if _, err := file.Seek(info.Size()-max, io.SeekStart); err != nil {
+		return nil, err
+	}
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return nil, err
+	}
+	head := fmt.Sprintf("[lich rage: %d earlier bytes omitted, this is the tail]\n", info.Size()-max)
+	return append([]byte(head), data...), nil
+}
+
+// writeEntry adds one file to the archive, 0600 like everything else lich
+// writes: the bundle carries paths and project names.
+func writeEntry(archive *tar.Writer, name string, data []byte) error {
+	header := &tar.Header{Name: name, Mode: 0o600, Size: int64(len(data))}
+	if err := archive.WriteHeader(header); err != nil {
+		return fmt.Errorf("write %s: %w", name, err)
+	}
+	if _, err := archive.Write(data); err != nil {
+		return fmt.Errorf("write %s: %w", name, err)
+	}
+	return nil
+}
+
+// DefaultBase is the bundle's name without an extension: the archive file is
+// this plus ".tar.gz", and the directory inside it is this exactly.
+func DefaultBase(now time.Time) string {
+	return "lich-rage-" + now.Format("20060102-150405")
+}
+
+// revision reads the VCS stamp Go embeds at build time, empty when the binary
+// was not built from a checkout.
+func revision() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	var rev string
+	dirty := false
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			rev = setting.Value
+		case "vcs.modified":
+			dirty = setting.Value == "true"
+		}
+	}
+	if rev != "" && dirty {
+		return rev + "-dirty"
+	}
+	return rev
+}

--- a/internal/rage/rage_test.go
+++ b/internal/rage/rage_test.go
@@ -1,0 +1,277 @@
+package rage
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/omartelo/lich/internal/agentplugin"
+	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/singleton"
+)
+
+// liveToken is the loopback credential of the fake running instance: long
+// enough that scrub masks it, and distinctive enough that finding it anywhere
+// in the bundle is a failure.
+const liveToken = "s3cr3t-loopback-token"
+
+// collector builds a Collector over a temp config dir with every probe
+// answered, so no test reaches PATH, a provider CLI or the network.
+func collector(t *testing.T, configDir string, info *singleton.Info, alive bool) *Collector {
+	t.Helper()
+	c := New(configDir, "v1.2.3", []string{"SHELL=/bin/zsh", "LICH_TOKEN=" + liveToken, "LICH_DEV=1"})
+	c.browser = func() (string, error) { return "/usr/bin/chromium", nil }
+	c.detect = func() []providers.Detected {
+		return []providers.Detected{{ID: "claude", Name: "Claude Code", Installed: true, Path: "/usr/bin/claude"}}
+	}
+	c.plugin = func() []agentplugin.Status {
+		return []agentplugin.Status{{Provider: "claude", Name: "Claude Code", Available: true, Installed: true, InstalledVersion: "0.2.0"}}
+	}
+	c.probe = func() (*singleton.Info, bool) { return info, alive }
+	return c
+}
+
+// lichDir prepares a config dir holding both log generations, and returns the
+// OS-level config dir to hand the collector.
+func lichDir(t *testing.T, live, old string) string {
+	t.Helper()
+	configDir := t.TempDir()
+	dir := filepath.Join(configDir, "lich")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// The collector resolves the log through logging.Path, which reads LICH_DEV.
+	t.Setenv("LICH_DEV", "")
+	if err := os.WriteFile(filepath.Join(dir, "lich.log"), []byte(live), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if old != "" {
+		if err := os.WriteFile(filepath.Join(dir, "lich.log.old"), []byte(old), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return configDir
+}
+
+// unpack reads the whole bundle back as name → contents.
+func unpack(t *testing.T, data []byte) map[string]string {
+	t.Helper()
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("gzip: %v", err)
+	}
+	out := map[string]string{}
+	archive := tar.NewReader(gz)
+	for {
+		header, err := archive.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("tar: %v", err)
+		}
+		body, err := io.ReadAll(archive)
+		if err != nil {
+			t.Fatalf("read %s: %v", header.Name, err)
+		}
+		out[header.Name] = string(body)
+	}
+	return out
+}
+
+func bundle(t *testing.T, c *Collector, root string) (map[string]string, Report) {
+	t.Helper()
+	var buf bytes.Buffer
+	report, err := c.Bundle(&buf, root)
+	if err != nil {
+		t.Fatalf("Bundle: %v", err)
+	}
+	return unpack(t, buf.Bytes()), report
+}
+
+func TestBundleCarriesTheReportTheEnvAndBothLogs(t *testing.T) {
+	configDir := lichDir(t, "live line\n", "older line\n")
+	c := collector(t, configDir, &singleton.Info{PID: 42, Port: 47821, Token: liveToken}, true)
+
+	files, report := bundle(t, c, "lich-rage-x")
+
+	for _, want := range []string{
+		"lich-rage-x/report.md",
+		"lich-rage-x/env.txt",
+		"lich-rage-x/logs/lich.log",
+		"lich-rage-x/logs/lich.log.old",
+	} {
+		if _, ok := files[want]; !ok {
+			t.Errorf("bundle has no %s (got %v)", want, keys(files))
+		}
+	}
+	if !strings.Contains(files["lich-rage-x/logs/lich.log"], "live line") {
+		t.Error("the live log generation is not the one that was copied")
+	}
+	if report.Version != "v1.2.3" || !strings.Contains(report.Instance, "pid 42") {
+		t.Errorf("report = %+v", report)
+	}
+}
+
+func TestBundleNeverCarriesTheLoopbackToken(t *testing.T) {
+	configDir := lichDir(t,
+		"time=x msg=\"chromium shell opening\" url=http://127.0.0.1:47821/?token="+liveToken+" more=1\n"+
+			"time=y msg=stale url=http://127.0.0.1:47821/?token=an-older-instances-token\n", "")
+	c := collector(t, configDir, &singleton.Info{PID: 42, Port: 47821, Token: liveToken}, true)
+
+	files, _ := bundle(t, c, "r")
+
+	for name, body := range files {
+		if strings.Contains(body, liveToken) {
+			t.Errorf("%s leaks the live token", name)
+		}
+		if strings.Contains(body, "an-older-instances-token") {
+			t.Errorf("%s leaks an earlier instance's token", name)
+		}
+	}
+	log := files["r/logs/lich.log"]
+	if !strings.Contains(log, "more=1") {
+		t.Errorf("masking ate what followed the token: %q", log)
+	}
+	if !strings.Contains(files["r/env.txt"], "LICH_TOKEN=<SET>") {
+		t.Errorf("env.txt does not report the token as present: %q", files["r/env.txt"])
+	}
+}
+
+func TestBundleCarriesTheTailOfAnOversizedLog(t *testing.T) {
+	head := strings.Repeat("a", maxLogBytes)
+	configDir := lichDir(t, head+"the end\n", "")
+	c := collector(t, configDir, nil, false)
+
+	files, _ := bundle(t, c, "r")
+
+	log := files["r/logs/lich.log"]
+	if !strings.Contains(log, "the end") {
+		t.Error("the tail — the half that holds what just went wrong — was dropped")
+	}
+	if !strings.Contains(log, "earlier bytes omitted") {
+		t.Errorf("a truncated log does not say so: %q", log[:80])
+	}
+	if len(log) > maxLogBytes+200 {
+		t.Errorf("log entry is %d bytes, want the cap plus its marker", len(log))
+	}
+}
+
+func TestReportNamesEveryInstanceState(t *testing.T) {
+	cases := []struct {
+		name  string
+		info  *singleton.Info
+		alive bool
+		want  string
+	}{
+		{"none recorded", nil, false, "not running"},
+		{"answering", &singleton.Info{PID: 7, Port: 47821, Token: liveToken}, true, "running (pid 7, port 47821)"},
+		{"stale file", &singleton.Info{PID: 7, Port: 47821, Token: liveToken}, false, "recorded but not answering (pid 7, port 47821)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := collector(t, lichDir(t, "x\n", ""), tc.info, tc.alive)
+			_, report := bundle(t, c, "r")
+			if report.Instance != tc.want {
+				t.Errorf("instance = %q, want %q", report.Instance, tc.want)
+			}
+		})
+	}
+}
+
+func TestBundleSurvivesAConfigDirWithNoLog(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("LICH_DEV", "")
+	c := collector(t, configDir, nil, false)
+
+	files, report := bundle(t, c, "r")
+
+	if report.LogPath != "" {
+		t.Errorf("log path = %q, want empty when no file was ever written", report.LogPath)
+	}
+	for name := range files {
+		if strings.HasPrefix(name, "r/logs/") {
+			t.Errorf("bundle carries %s with no log on disk", name)
+		}
+	}
+	if !strings.Contains(files["r/report.md"], "stderr only") {
+		t.Error("report.md does not say the log is missing")
+	}
+}
+
+func TestReportListsTheConfigDirectoryWithoutDescending(t *testing.T) {
+	configDir := lichDir(t, "x\n", "")
+	dir := filepath.Join(configDir, "lich")
+	if err := os.MkdirAll(filepath.Join(dir, "chromium-profile", "Default"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "chromium-profile", "Default", "Cookies"), []byte("secret"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "lich.db"), []byte("sqlite"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	c := collector(t, configDir, nil, false)
+
+	files, report := bundle(t, c, "r")
+
+	var names []string
+	for _, e := range report.Entries {
+		names = append(names, e.Name)
+	}
+	for _, want := range []string{"lich.db", "chromium-profile"} {
+		if !contains(names, want) {
+			t.Errorf("entries %v do not list %s", names, want)
+		}
+	}
+	if contains(names, "Default") || contains(names, "Cookies") {
+		t.Errorf("entries descended into a directory: %v", names)
+	}
+	if strings.Contains(files["r/report.md"], "Cookies") {
+		t.Error("report.md names a file inside the Chromium profile")
+	}
+}
+
+func TestDefaultBaseNamesTheMoment(t *testing.T) {
+	got := DefaultBase(time.Date(2026, 8, 10, 15, 4, 5, 0, time.UTC))
+	if got != "lich-rage-20260810-150405" {
+		t.Errorf("DefaultBase = %q", got)
+	}
+}
+
+func keys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func contains(list []string, want string) bool {
+	for _, s := range list {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestBundleReportsAWriteFailure pins that a broken destination is an error the
+// caller can act on, not a silent half-archive.
+func TestBundleReportsAWriteFailure(t *testing.T) {
+	c := collector(t, lichDir(t, "x\n", ""), nil, false)
+	if _, err := c.Bundle(failingWriter{}, "r"); err == nil {
+		t.Fatal("Bundle succeeded against a writer that fails every write")
+	}
+}
+
+type failingWriter struct{}
+
+func (failingWriter) Write([]byte) (int, error) { return 0, fmt.Errorf("disk full") }

--- a/internal/rage/report.go
+++ b/internal/rage/report.go
@@ -1,0 +1,217 @@
+package rage
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// reported is every environment variable the bundle carries besides LICH_*.
+// An allowlist, not a filter: a machine's environment holds cloud credentials,
+// provider API keys and whatever the user exports in their rc, and none of that
+// belongs in an archive headed for a public issue. These are the ones that
+// answer a lich bug — which shell resolved the env, which desktop the window
+// opened on, which PATH the provider detection scanned.
+var reported = []string{
+	"APPDATA", "BROWSER", "DESKTOP_SESSION", "DISPLAY", "EDITOR",
+	"GH_CONFIG_DIR", "GH_TOKEN", "GITHUB_TOKEN", "LANG", "PATH",
+	"PROCESSOR_ARCHITECTURE", "SHELL", "TERM", "TERM_PROGRAM", "VISUAL",
+	"WAYLAND_DISPLAY", "XDG_CURRENT_DESKTOP", "XDG_SESSION_TYPE",
+}
+
+// secretish matches the names whose value is never printed, only its presence.
+// It runs over the allowlist above and over LICH_*, so a false positive costs a
+// value the reporter can still name by hand.
+var secretish = regexp.MustCompile(`(?i)token|key|secret|password|passwd|credential`)
+
+// tokenQuery masks the loopback token wherever it was written as a query
+// parameter, which is the one shape it takes outside the environment. It backs
+// up the exact-value scrub for a token from an earlier run: that instance's
+// value is gone, its log line is not.
+var tokenQuery = regexp.MustCompile(`(?i)(token=)[^\s&"'` + "`" + `]+`)
+
+// redacted is what replaces a masked value, spelled so a reader can grep the
+// bundle for what was removed.
+const redacted = "<REDACTED>"
+
+// render writes report.md — the page a maintainer reads first, so the facts
+// that decide whether a report is actionable come before anything else.
+func render(r Report) string {
+	var b strings.Builder
+	b.WriteString("# lich bug report\n\n")
+	b.WriteString("Collected by `lich rage`. Nothing here was uploaded — read it before you attach it.\n\n")
+
+	b.WriteString("| Fact | Value |\n|---|---|\n")
+	row(&b, "lich", r.Version)
+	row(&b, "build", buildLine(r))
+	row(&b, "platform", r.Platform)
+	row(&b, "instance", r.Instance)
+	row(&b, "config dir", r.ConfigDir)
+	row(&b, "log", logLine(r.LogPath))
+	row(&b, "browser", r.Browser)
+
+	b.WriteString("\n## Providers\n\n")
+	b.WriteString("| Provider | On PATH | Resolved to |\n|---|---|---|\n")
+	for _, p := range r.Providers {
+		fmt.Fprintf(&b, "| %s | %s | %s |\n", p.Name, yesNo(p.Installed), dash(p.Path))
+	}
+	if len(r.Providers) == 0 {
+		b.WriteString("| — | — | detection failed |\n")
+	}
+
+	b.WriteString("\n## lich plugin\n\n")
+	b.WriteString("| Provider | CLI | Installed | Version | Latest |\n|---|---|---|---|---|\n")
+	for _, p := range r.Plugin {
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s |\n",
+			p.Name, yesNo(p.Available), yesNo(p.Installed),
+			dash(p.InstalledVersion), dash(p.LatestVersion))
+	}
+	if len(r.Plugin) == 0 {
+		b.WriteString("| — | — | — | — | — |\n")
+	}
+
+	b.WriteString("\n## Config directory\n\n")
+	b.WriteString("| Entry | Size |\n|---|---|\n")
+	for _, e := range r.Entries {
+		name := e.Name
+		size := humanSize(e.Size)
+		if e.Dir {
+			name += "/"
+			size = "directory"
+		}
+		fmt.Fprintf(&b, "| %s | %s |\n", name, size)
+	}
+	if len(r.Entries) == 0 {
+		b.WriteString("| — | the config directory could not be read |\n")
+	}
+
+	b.WriteString(notice)
+	return b.String()
+}
+
+// notice closes the report with what the bundle holds and what it never does.
+// It is addressed to the reporter, not to the maintainer: they are the one
+// deciding whether to attach this to a public issue.
+const notice = `
+## What this bundle carries
+
+- ` + "`report.md`" + ` — this page.
+- ` + "`env.txt`" + ` — the LICH_* variables and a fixed list of shell/desktop ones.
+  Anything named like a token, key, secret or password is reported as set or
+  unset, never by value.
+- ` + "`logs/`" + ` — the log file and the rotated generation before it, each
+  capped at its last 4 MiB. They hold absolute paths, project and branch names,
+  and your gh login.
+
+Never collected: your Chromium profile, the workspace database, and any
+conversation transcript — lich stores none. The loopback token is masked
+wherever it appeared.
+`
+
+func row(b *strings.Builder, name, value string) {
+	fmt.Fprintf(b, "| %s | %s |\n", name, dash(value))
+}
+
+// buildLine names the toolchain and, for a binary built from a checkout, the
+// commit — the only thing that identifies a build whose version is "dev".
+func buildLine(r Report) string {
+	if r.Revision == "" {
+		return r.GoVersion
+	}
+	return r.GoVersion + ", revision " + r.Revision
+}
+
+func logLine(path string) string {
+	if path == "" {
+		return "none — lich logged to stderr only"
+	}
+	return path
+}
+
+// renderEnv writes env.txt: every allowlisted name, then whatever LICH_*
+// variables this process was launched with, values masked by name and scrubbed
+// of the live token.
+func renderEnv(environ []string, token string) string {
+	values := make(map[string]string, len(environ))
+	var lich []string
+	for _, kv := range environ {
+		key, value, found := strings.Cut(kv, "=")
+		if !found {
+			continue
+		}
+		values[key] = value
+		if strings.HasPrefix(key, "LICH_") {
+			lich = append(lich, key)
+		}
+	}
+	sort.Strings(lich)
+
+	var b strings.Builder
+	b.WriteString("# Values are masked by name: anything token/key/secret/password-shaped\n")
+	b.WriteString("# is reported as <SET> or <UNSET> only.\n\n")
+	for _, key := range reported {
+		writeEnvLine(&b, key, values, token)
+	}
+	b.WriteString("\n")
+	for _, key := range lich {
+		writeEnvLine(&b, key, values, token)
+	}
+	return b.String()
+}
+
+func writeEnvLine(b *strings.Builder, key string, values map[string]string, token string) {
+	value, set := values[key]
+	switch {
+	case secretish.MatchString(key):
+		value = "<UNSET>"
+		if set {
+			value = "<SET>"
+		}
+	case !set:
+		value = "<UNSET>"
+	default:
+		value = string(scrub([]byte(value), token))
+	}
+	fmt.Fprintf(b, "%s=%s\n", key, value)
+}
+
+// scrub masks the loopback token in bytes headed for the bundle. The exact
+// value covers the running instance, whose token is known; the query form
+// covers every earlier one, whose value is not. A short token is ignored —
+// masking a two-character string would gut the log.
+func scrub(data []byte, token string) []byte {
+	if len(token) >= 8 {
+		data = []byte(strings.ReplaceAll(string(data), token, redacted))
+	}
+	return tokenQuery.ReplaceAll(data, []byte("${1}"+redacted))
+}
+
+func yesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}
+
+func dash(s string) string {
+	if s == "" {
+		return "—"
+	}
+	return s
+}
+
+// humanSize renders a byte count for a human reading a table, not for a
+// machine: one decimal, binary units.
+func humanSize(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	value, exp := float64(n)/unit, 0
+	for value >= unit && exp < 2 {
+		value /= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %s", value, [...]string{"KiB", "MiB", "GiB"}[exp])
+}

--- a/internal/rage/report_test.go
+++ b/internal/rage/report_test.go
@@ -1,0 +1,146 @@
+package rage
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/agentplugin"
+	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/singleton"
+)
+
+func TestRenderSaysSoWhenAProbeFoundNothing(t *testing.T) {
+	page := render(Report{Version: "dev", GoVersion: "go1.25.0", Revision: "abc1234-dirty"})
+
+	for _, want := range []string{
+		"detection failed",      // no providers came back
+		"| — | — | — | — | — |", // no plugin row
+		"the config directory could not be read",
+		"go1.25.0, revision abc1234-dirty", // the only id a dev build has
+		"none — lich logged to stderr only",
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("report.md is missing %q:\n%s", want, page)
+		}
+	}
+}
+
+func TestRenderNamesTheProvidersAndThePlugin(t *testing.T) {
+	page := render(Report{
+		Providers: []providers.Detected{
+			{ID: "claude", Name: "Claude Code", Installed: true, Path: "/usr/bin/claude"},
+			{ID: "crush", Name: "Crush"},
+		},
+		Plugin: []agentplugin.Status{
+			{Provider: "claude", Name: "Claude Code", Available: true, LatestVersion: "0.3.0"},
+		},
+		Entries: []Entry{{Name: "lich.db", Size: 2048}, {Name: "themes", Dir: true}},
+	})
+
+	for _, want := range []string{
+		"| Claude Code | yes | /usr/bin/claude |",
+		"| Crush | no | — |",
+		"| Claude Code | yes | no | — | 0.3.0 |",
+		"| lich.db | 2.0 KiB |",
+		"| themes/ | directory |",
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("report.md is missing %q:\n%s", want, page)
+		}
+	}
+}
+
+func TestEnvMasksBySecretNameAndReportsWhatIsUnset(t *testing.T) {
+	env := renderEnv([]string{
+		"SHELL=/bin/zsh",
+		"GH_TOKEN=ghp_realvalue",
+		"LICH_LISTEN_PORT=47821",
+		"LICH_TOKEN=" + liveToken,
+		"AWS_SECRET_ACCESS_KEY=nobody-asked",
+		"malformed",
+	}, liveToken)
+
+	for _, want := range []string{
+		"SHELL=/bin/zsh",
+		"GH_TOKEN=<SET>",
+		"GITHUB_TOKEN=<UNSET>",
+		"EDITOR=<UNSET>",
+		"LICH_LISTEN_PORT=47821",
+		"LICH_TOKEN=<SET>",
+	} {
+		if !strings.Contains(env, want) {
+			t.Errorf("env.txt is missing %q:\n%s", want, env)
+		}
+	}
+	for _, never := range []string{"ghp_realvalue", liveToken, "AWS_SECRET_ACCESS_KEY", "malformed"} {
+		if strings.Contains(env, never) {
+			t.Errorf("env.txt carries %q, which is outside the allowlist or is a value:\n%s", never, env)
+		}
+	}
+}
+
+func TestScrubLeavesAShortTokenAlone(t *testing.T) {
+	// A two-character token would match half the log; masking by exact value is
+	// only safe once the value is distinctive.
+	got := string(scrub([]byte("a session ran at path/to/a"), "a"))
+	if got != "a session ran at path/to/a" {
+		t.Errorf("scrub(%q) = %q", "a", got)
+	}
+}
+
+func TestHumanSizeScalesToTheUnit(t *testing.T) {
+	cases := map[int64]string{
+		0:       "0 B",
+		512:     "512 B",
+		1536:    "1.5 KiB",
+		5 << 20: "5.0 MiB",
+		3 << 30: "3.0 GiB",
+	}
+	for size, want := range cases {
+		if got := humanSize(size); got != want {
+			t.Errorf("humanSize(%d) = %q, want %q", size, got, want)
+		}
+	}
+}
+
+func TestPathBinsAsksForTheDefaultBinary(t *testing.T) {
+	// The empty string is agentplugin's "the provider's default name on PATH";
+	// anything else would be rage opening the workspace database.
+	if got := (pathBins{}).ProviderBin("claude", "p1"); got != "" {
+		t.Errorf("ProviderBin = %q, want the default", got)
+	}
+}
+
+func TestNewProbesTheConfigDirItWasGiven(t *testing.T) {
+	configDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(configDir, "lich"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LICH_DEV", "")
+	recorded, err := json.Marshal(singleton.Info{PID: 99, Port: 1, Token: liveToken})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "lich", "runtime.json"), recorded, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	c := New(configDir, "v9", nil)
+	info, alive := c.probe()
+
+	if info == nil || info.PID != 99 {
+		t.Fatalf("probe read %+v, want the runtime file under the given config dir", info)
+	}
+	if alive {
+		t.Error("probe called a recorded instance alive with nothing listening on its port")
+	}
+	if _, err := c.browser(); err != nil && !strings.Contains(err.Error(), "no chromium-family browser") {
+		t.Errorf("browser probe failed for an unexpected reason: %v", err)
+	}
+	if len(c.detect()) == 0 {
+		t.Error("provider detection returned no rows at all — every known provider should be listed")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -59,7 +59,7 @@ func main() {
 	// it must not open the database, take the log file or race the singleton
 	// bind of the lich it is talking to. Anything that is not a subcommand —
 	// including `lich -- <chromium flags>` — falls through and opens the app.
-	if code := cli.Run(os.Args[1:], os.Getenv, os.Stdout, os.Stderr); code != cli.NotACommand {
+	if code := cli.Run(os.Args[1:], version, os.Getenv, os.Stdout, os.Stderr); code != cli.NotACommand {
 		os.Exit(code)
 	}
 


### PR DESCRIPTION
## What

`lich rage` collects a bug report from the machine into one
`lich-rage-<timestamp>.tar.gz` (or `--output`'s path) and prints where it went:

```
Wrote lich-rage-20260810-190320.tar.gz
lich v0.25.0 on linux/amd64, running (pid 4242, port 47821).
Read it before you attach it: it carries absolute paths, project and branch names.
```

| Entry | What it holds |
|-------|---------------|
| `report.md` | Version and build (VCS revision when the binary came from a checkout), platform, instance state, browser, providers on PATH, plugin state per provider, the config directory one level deep. |
| `env.txt` | Every `LICH_*` variable plus a fixed allowlist (`SHELL`, `PATH`, `EDITOR`, the desktop ones). |
| `logs/` | `lich.log` and the rotated `lich.log.old`, each carrying at most its last 4 MiB, marked where the cut is. |

## Why

Today a reporter is walked through it by hand: find the log folder, notice that
the rotated generation beside it is usually the one holding the crash, say which
browser and which provider CLIs the machine has, remember the version. lich is
built for strangers to use, and a stranger does not know which of those matters.

It reads the file system and talks to no lich, on purpose: the failure it
answers to is the one where the window never opened, so there was no
Settings › Help to ask through. Whether an instance is running — and whether the
recorded one still answers — is itself one of the facts it reports.

Idea taken from `ante rage` (AntigmaLabs/ante), scoped down to what lich's own
design already bounds: log rotation caps the generations at two, so there is no
`--since` window and no file-count budget to spend.

## Redaction

The bundle is headed for a public issue, so it is a trust boundary:

- A value whose name matches `token|key|secret|password|credential` is reported
  as `<SET>` / `<UNSET>`, never printed — over the allowlist and over `LICH_*`.
- The loopback token is masked by exact value for the running instance, and by
  the `token=` query shape for every earlier one whose value is gone.
- Never read: the Chromium profile, the workspace database (a bug report may not
  be the second process to migrate the store), and any conversation transcript —
  lich stores none. Directories are named and never descended into.

Nothing is uploaded and no issue is filed; the archive sits on disk until the
user attaches it to one they wrote.

## Notes

- No UI button. Settings › Help gains one line naming the command; a real button
  is a UI change that goes through a mockup first, and it can call the same
  package when it does.
- Ceiling recorded in `docs/cli.md`: the bundle knows nothing about the
  workspace — only that the database exists and how big it is.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` — green; `internal/rage` at
      92.3% statements, `internal/cli` covers the command (default name,
      `--output`, no half-written archive on failure, argument rejection).
- [x] Cross-compile loop for linux/darwin/windows (build + vet).
- [x] `pnpm check`, `vitest` (784), `tsc --noEmit` — green.
- [x] Ran it for real: 37.7 KB bundle, three entries, the machine's own
      `LICH_TOKEN` grepped for in the extracted tree and absent.