### PR TITLE
feat: say when the previous run ended unexpectedly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **lich says when its last run ended badly.** A crash, a kill, or a machine
+  that went down took the sessions with it — and the next launch restored the
+  workspace looking exactly as it does after a deliberate close, so the turn an
+  agent never finished was gone with nothing on screen saying so. That launch
+  now opens with a notice that the previous run ended unexpectedly, and a button
+  onto the log folder where that run's log sits. Closing the window as usual
+  says nothing, and neither does the relaunch an in-place update performs.
 - **Closing a project asks when an agent is still working.** The tab's × took a
   project's terminals down with it, killing whatever was mid-turn — with a
   spinner on that very tab as the only warning, and no undo. Closing a project

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { AgentPluginGate } from "@/components/AgentPluginGate"
 import { AppUpdateGate } from "@/components/AppUpdateGate"
 import { PatchNotesGate } from "@/components/PatchNotesGate"
 import { ProviderSetupGate } from "@/components/ProviderSetupGate"
+import { UncleanExitGate } from "@/components/UncleanExitGate"
 import { CommandPalette } from "@/components/CommandPalette"
 
 // Layout is persistent across navigation: the project tabs, session sidebar and
@@ -97,6 +98,9 @@ function App() {
           asks which harnesses you use before offering to install into them. */}
       <AgentPluginGate />
       <PatchNotesGate />
+      {/* A toast, so it shares no surface with the gates around it: the launch
+          after a crash can be the launch that also has a release to announce. */}
+      <UncleanExitGate />
       {/* Last, so that on the one launch where it can coincide with another gate
           it is the dialog on top: choosing a provider comes before reading about
           a release. */}

--- a/frontend/src/components/UncleanExitGate.tsx
+++ b/frontend/src/components/UncleanExitGate.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from "react"
+import { toast } from "sonner"
+import { System } from "@/lib/rpc"
+import { runWithToast } from "@/lib/toast-async"
+
+// UncleanExitGate says, once per launch, that the run before this one ended
+// without closing its window — a crash, a kill, a machine that went down. It is
+// the only place the user can learn it: the workspace comes back looking exactly
+// as it does after a deliberate close, so a turn an agent was mid-way through is
+// gone with nothing on screen to say so. The backend consumes the flag, which is
+// what keeps a page reload from reading as a second crash.
+export function UncleanExitGate() {
+  useEffect(() => {
+    void System.TakeUncleanExit()
+      .then((unclean) => {
+        if (unclean) prompt()
+      })
+      .catch(() => {})
+  }, [])
+
+  return null
+}
+
+// Persistent on purpose: this is the one telling, and a toast that expires while
+// the user is reading a session is a toast they never saw.
+const prompt = () => {
+  toast.warning("lich's previous run ended unexpectedly", {
+    description:
+      "Your sessions were restored, but whatever they were running stopped with it. That run's log is in the log folder.",
+    duration: Infinity,
+    action: {
+      label: "Open log folder",
+      onClick: () =>
+        void runWithToast(
+          "Opening log folder…",
+          System.RevealLog,
+          "Log folder opened.",
+          "Could not open the log folder",
+        ),
+    },
+    // sonner closes the toast itself; the handler is only what its type asks for.
+    cancel: { label: "Dismiss", onClick: () => {} },
+  })
+}

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -345,6 +345,9 @@ export const System = {
   Diagnostics: () => call<DiagnosticsData>("system.Diagnostics", []),
   /** Open the log's folder in the platform's file manager, for attaching it. */
   RevealLog: () => call<null>("system.RevealLog", []),
+  /** Whether the run before this one ended without closing its window. Reading
+   * it clears it, so only the first caller of a launch is told. */
+  TakeUncleanExit: () => call<boolean>("system.TakeUncleanExit", []),
   /** Raise a desktop notification: a headline and an optional second line.
    * The caller decides it is warranted — the backend only delivers. */
   Notify: (summary: string, detail: string) => call<null>("system.Notify", [summary, detail]),

--- a/internal/singleton/singleton.go
+++ b/internal/singleton/singleton.go
@@ -61,6 +61,22 @@ func Write(configDir string, port int, token string) (string, error) {
 	return p, nil
 }
 
+// UncleanExit reports whether the run before this one ended without closing its
+// window. Write records the runtime file at startup and the clean window-close
+// exit removes it, so a file still on disk when a fresh launch is about to write
+// its own is the previous run's — it crashed, was killed, or the machine went
+// down under it. Call it before Write, which overwrites the evidence.
+//
+// restartWait is the restart.WaitEnv value: a successor is spawned while its
+// predecessor still holds the file, and that handover is not a crash.
+func UncleanExit(configDir, restartWait string) bool {
+	if restartWait != "" {
+		return false
+	}
+	_, err := os.Stat(path(configDir))
+	return err == nil
+}
+
 // Read loads runtime.json. A missing file returns (nil, nil): no instance
 // recorded, not an error.
 func Read(configDir string) (*Info, error) {

--- a/internal/singleton/singleton_test.go
+++ b/internal/singleton/singleton_test.go
@@ -55,6 +55,37 @@ func TestReadRejectsGarbage(t *testing.T) {
 	}
 }
 
+// TestUncleanExit pins the three cases the launch notice is decided from: the
+// file the clean exit removed, the file it never got to remove, and the file a
+// restart successor finds because its predecessor is still holding it.
+func TestUncleanExit(t *testing.T) {
+	t.Run("no runtime file is a clean exit", func(t *testing.T) {
+		if UncleanExit(writeConfig(t), "") {
+			t.Fatal("UncleanExit with no runtime file = true, want false")
+		}
+	})
+
+	t.Run("a leftover runtime file is an unclean exit", func(t *testing.T) {
+		configDir := writeConfig(t)
+		if _, err := Write(configDir, 47821, "tok"); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		if !UncleanExit(configDir, "") {
+			t.Fatal("UncleanExit with a leftover runtime file = false, want true")
+		}
+	})
+
+	t.Run("a restart successor inherits the file, not a crash", func(t *testing.T) {
+		configDir := writeConfig(t)
+		if _, err := Write(configDir, 47821, "tok"); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		if UncleanExit(configDir, "1") {
+			t.Fatal("UncleanExit for a restart successor = true, want false")
+		}
+	})
+}
+
 func TestDetect(t *testing.T) {
 	const want = 47821
 	seed := func(t *testing.T, port int, token string) string {

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync/atomic"
 
 	"github.com/ncruces/zenity"
 	"github.com/omartelo/lich/internal/relpath"
@@ -27,6 +28,10 @@ type Service struct {
 	logPath string
 	// version is the running build's version, "dev" outside a release.
 	version string
+	// uncleanExit records that the previous run never reached its clean exit
+	// (see singleton.UncleanExit). Consumed by the first reader, so it is
+	// atomic: a page reload calls in again on the same process.
+	uncleanExit atomic.Bool
 	// run launches a detached process; injected in tests, exec in production.
 	run func(name string, args ...string) error
 	// notify posts one desktop notification; injected in tests, zenity in
@@ -34,8 +39,8 @@ type Service struct {
 	notify func(text, title string) error
 }
 
-func New(env []string, logPath, version string) *Service {
-	return &Service{
+func New(env []string, logPath, version string, uncleanExit bool) *Service {
+	s := &Service{
 		env:     env,
 		logPath: logPath,
 		version: version,
@@ -46,6 +51,17 @@ func New(env []string, logPath, version string) *Service {
 			return zenity.Notify(text, zenity.Title(title))
 		},
 	}
+	s.uncleanExit.Store(uncleanExit)
+	return s
+}
+
+// TakeUncleanExit reports whether the run before this one ended without closing
+// its window, and clears the flag. It is consumed rather than read because the
+// notice belongs to the launch that followed the bad exit, not to every page
+// reload of it: the page mounts its gate again on each reload, the process does
+// not start again with it.
+func (s *Service) TakeUncleanExit() bool {
+	return s.uncleanExit.Swap(false)
 }
 
 // Diagnostics is what a bug report opens with: the three facts that decide

--- a/internal/system/system_test.go
+++ b/internal/system/system_test.go
@@ -115,13 +115,33 @@ func TestRevealLogWithoutAFileLaunchesNothing(t *testing.T) {
 }
 
 func TestDiagnosticsReportsTheRunningBuild(t *testing.T) {
-	s := New(nil, "/config/lich/lich.log", "0.23.0")
+	s := New(nil, "/config/lich/lich.log", "0.23.0", false)
 	got := s.Diagnostics()
 	if got.Version != "0.23.0" || got.LogPath != "/config/lich/lich.log" {
 		t.Errorf("Diagnostics() = %+v, want the version and log path it was built with", got)
 	}
 	if want := runtime.GOOS + "/" + runtime.GOARCH; got.Platform != want {
 		t.Errorf("Platform = %q, want %q", got.Platform, want)
+	}
+}
+
+// TestTakeUncleanExitIsConsumed pins the notice to one telling. A page reload
+// asks the same process again, and a second warning about a crash the user has
+// already been told about reads as a second crash.
+func TestTakeUncleanExitIsConsumed(t *testing.T) {
+	s := New(nil, "", "0.23.0", true)
+	if !s.TakeUncleanExit() {
+		t.Fatal("first TakeUncleanExit() = false, want true")
+	}
+	if s.TakeUncleanExit() {
+		t.Error("second TakeUncleanExit() = true, want false — the flag was not consumed")
+	}
+}
+
+func TestTakeUncleanExitAfterACleanExit(t *testing.T) {
+	s := New(nil, "", "0.23.0", false)
+	if s.TakeUncleanExit() {
+		t.Error("TakeUncleanExit() = true after a clean exit, want false")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -123,7 +123,11 @@ func main() {
 	dispatcher.Register("appupdate", appupdate.New(version))
 	dispatcher.Register("patchnotes", patchnotes.New(version, changelog))
 	dispatcher.Register("store", db)
-	dispatcher.Register("system", system.New(env, logPath, version))
+	// Read before runChromium writes this run's runtime file over the previous
+	// run's: a file still there is the only trace a bad exit leaves, and the
+	// restored workspace looks exactly like one closed on purpose.
+	uncleanExit := singleton.UncleanExit(configDir, os.Getenv(restart.WaitEnv))
+	dispatcher.Register("system", system.New(env, logPath, version, uncleanExit))
 	dispatcher.Register("providers", providers.New())
 	// The relay is the only service whose caller is not the window: the `lich`
 	// CLI running inside a session reaches it over the same listener. It watches


### PR DESCRIPTION
## What

A crash, a kill, or a machine that goes down takes lich's sessions with it. The next launch restores the workspace looking exactly as it does after a deliberate close, so the turn an agent never finished is gone with nothing on screen to say a run ended badly at all — the only trace is a log file the user has no reason to open.

The launch after a bad exit now opens with one toast saying so, and a button onto the log folder where that run's rotated log sits. A normal window close says nothing, and neither does the relaunch an in-place update performs.

## How

The evidence already existed. `singleton` writes `runtime.json` at startup and the clean window-close exit removes it, so a file still on disk when a fresh launch is about to write its own belongs to a run that never reached that exit.

- `singleton.UncleanExit(configDir, restartWait)` — reads that file's presence. A restart successor (`restart.WaitEnv`) inherits its predecessor's file while that process still holds it, which is a handover, not a crash.
- `main.go` calls it before `runChromium`, which overwrites the evidence.
- `system.TakeUncleanExit()` — consumed by its first reader (`atomic.Bool.Swap`), not read. The page mounts its gate again on every reload; the process does not start again with it, and a second warning about a crash already reported reads as a second crash.
- `UncleanExitGate` — a persistent toast with "Open log folder" and "Dismiss". A toast rather than a dialog, because the launch after a crash can be the launch that also has a release to announce.

## Trade-offs

Any exit that skips the deferred removal counts: SIGTERM at logout and a power cut are reported the same as a segfault. That is what the copy says — the run ended without closing its window — rather than claiming a crash it cannot prove.

A restart whose predecessor deletes the successor's file loses the signal for one launch (an existing race in `singleton`, unchanged here). It fails silent, never false.

## Test plan

- `singleton.UncleanExit`: no file, leftover file, restart successor with a leftover file.
- `system.TakeUncleanExit`: true once then false; false after a clean exit.
- Full gate: `gofmt`/`go vet` clean, `go test ./...` (1109) green, `pnpm check` clean, `pnpm test` (784) green, `pnpm build` succeeds.
- Real binary, isolated `XDG_CONFIG_HOME` + a chromium shim on port 47921: a stale `runtime.json` makes the RPC answer `true` once and `false` after; no file answers `false`.

No render test for the gate — the frontend suite is node-only, and the branching lives on the backend where it is covered.