### PR TITLE
feat: say whether lich would start here with lich doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now opens with a notice that the previous run ended unexpectedly, and a button
   onto the log folder where that run's log sits. Closing the window as usual
   says nothing, and neither does the relaunch an in-place update performs.
+- **`lich doctor` says whether lich would start here, and what stops it.** A
+  window that never opens is the one failure lich could not report, because
+  everything it uses to report one is behind that window. The command walks the
+  same boot a launch walks — the config directory, the log file, the pinned
+  loopback port, the workspace database, the browser, the provider CLIs on PATH
+  — and prints a verdict and a timing for each step, ending with whether a
+  launch would get through. A port held by the lich you already have open reads
+  as the single-instance lock working, not as a failure; a port held by anything
+  else, a missing Chromium-family browser or a database that will not open are
+  the three that stop a launch, and the command exits non-zero so a script can
+  read the same answer. It needs no window, no running instance and no network,
+  and it never opens the database behind an instance that is running.
 - **`lich rage` packs a bug report you can actually attach.** Reporting a
   problem meant being walked through it: find the log folder, notice that the
   rotated generation beside it is usually the one holding the crash, say which

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -13,6 +13,7 @@ Pick your system:
 - [macOS (experimental)](#macos-experimental)
 - [Windows (experimental)](#windows-experimental)
 - [Verifying checksums](#verifying-checksums)
+- [If it does not start](#if-it-does-not-start)
 
 **Runtime dependencies** — lich opens its window in a Chromium-family browser;
 none is bundled. On Linux any of `chromium`, `google-chrome`, `helium-browser` or `brave`
@@ -137,3 +138,28 @@ sha256sum -c --ignore-missing checksums.txt
 
 `install.sh` (the [one-liner in the README](README.md#install)) does this
 verification automatically before installing.
+
+## If it does not start
+
+No window is the one failure lich cannot report through its own settings, so it
+reports it from the terminal instead:
+
+```bash
+lich doctor
+```
+
+It walks the same boot a launch walks — the config directory, the log file, the
+pinned loopback port, the workspace database, the browser, the provider CLIs on
+PATH — and says which step would stop it, exiting non-zero when one does. A port
+already held by the lich you have open is not a failure; a port held by
+something else is, and so is a missing Chromium-family browser.
+
+When you file the issue, attach the bundle:
+
+```bash
+lich rage
+```
+
+That collects the same facts plus your logs into one `lich-rage-*.tar.gz`, with
+values named like a token, key or password reported only as present or absent.
+Nothing is uploaded — read it, then attach it.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ version is in [CHANGELOG.md](CHANGELOG.md).
   git the moment it writes a file.
   Settings › Help opens the log folder and a pre-filled bug report; `lich rage`
   packs the whole report — versions, browser, providers, plugin state, logs,
-  secrets masked — into one archive, and works when no window opened at all.
+  secrets masked — into one archive, and `lich doctor` says whether lich would
+  start on this machine at all. Both work when no window opened.
 
 <div align="center">
   <img src="docs/media/pulls-list.png" alt="The pull request list: every open pull request with its author, age and check status, narrowed by a filter box" width="900" />

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,9 +9,10 @@ It is not only for agents. The same commands run from any shell on the machine �
 a script, a scheduled job, the user's own terminal — which is what makes lich
 automatable without a provider in the loop. `--json` is there for exactly that.
 
-One command is about lich itself rather than about the sessions: `lich rage`
-collects a bug report from the machine, and is the surface for the failure where
-there is no window to ask through.
+Two commands are about lich itself rather than about the sessions: `lich doctor`
+says whether lich would start on this machine and what would stop it, and
+`lich rage` collects a bug report from the same facts plus the logs. Both are
+the surface for the failure where there is no window to ask through.
 
 Agents mostly do not run it as a command. lich registers the same operations as
 **MCP tools** for the providers that can be told at spawn, so they are in the
@@ -44,8 +45,8 @@ channel of their own: anything that can run a shell command can answer.
 
 Every command that addresses a session reads the coordinates lich already
 injects into each PTY (see the hooks [README](hooks/README.md)) and posts to the
-same loopback listener the window uses. `lich rage` is the exception: it reads
-the file system and nothing else.
+same loopback listener the window uses. `lich doctor` and `lich rage` are the
+exceptions: they read the machine, not a running lich.
 
 | Var               | Purpose                                          |
 |-------------------|--------------------------------------------------|
@@ -203,6 +204,43 @@ user attaches it to one they wrote. The loopback token is masked wherever it
 appeared — by value for the running instance, and by the `token=` query shape
 for every earlier one. The Chromium profile, the workspace database and its
 directories are named but never read.
+
+### `lich doctor`
+
+Walks the boot a launch walks and says whether lich would start here:
+
+```
+lich v0.25.0 — linux/amd64
+
+  ok    home          1ms  /home/u/.config/lich is writable
+  ok    log          <1ms  /home/u/.config/lich/lich.log
+  ok    listener     <1ms  port 47821 is held by the running lich (pid 4242)
+  skip  store        <1ms  held by the running lich (pid 4242)
+  ok    browser       2ms  /usr/bin/chromium
+  ok    providers     3ms  4 of 5 on PATH: claude, codex, opencode, crush
+        total         6ms
+
+lich starts here — nothing is in the way.
+```
+
+The checks are in boot order, and each carries its own verdict:
+
+| Check | Fails when | Warns when |
+|-------|-----------|------------|
+| `home` | `<config-dir>/lich` cannot be created or written to. | It is writable but the probe file could not be removed. |
+| `log` | — | The log file will not open; lich would run on stderr only. |
+| `listener` | The pinned port (`LICH_LISTEN_PORT`, else 47821) cannot be bound and no live lich holds it. | — |
+| `store` | The workspace database will not open or migrate. Skipped while an instance is running — a second process migrating the store is not a price a diagnosis may charge. | It will not close cleanly. |
+| `browser` | No Chromium-family browser resolves. lich would run and show nothing. | — |
+| `providers` | — | None on PATH: the window opens, but no session can spawn. |
+
+A `fail` exits 1 and a clean run exits 0, which is the automation surface here —
+there is no `--json`. It needs no TTY, no running instance and no network.
+
+Two things it does on purpose, because a launch does them too: it creates
+`<config-dir>/lich` and an empty log file if they are missing, and — only when
+no instance is running — it opens the workspace database, creating it on a
+first run.
 
 ## Registration
 
@@ -402,6 +440,14 @@ whoever asked.
   the database — a second process migrating it is not a price a bug report may
   charge — so no project, session or cost is in the bundle, only that the file
   exists and how big it is. What a session was doing has to be asked for.
+- **`doctor` proves the port for an instant, not for the launch.** It binds the
+  pinned port to prove it is free and releases it immediately, exactly as the
+  worktree port reservation does: anything on the machine can take it between
+  the check and the launch that follows.
+- **A green `doctor` is not a green window.** It goes as far as resolving the
+  browser binary; whether that browser opens under this compositor, this
+  display server or this sandbox is not something a check can answer without
+  becoming the launch.
 - **The answer is the agent's summary, not the transcript.** Nothing reads the
   target's output, so what comes back is exactly what that agent chose to type
   into `lich reply` — and an agent that never runs it is indistinguishable from

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -37,6 +37,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/omartelo/lich/internal/doctor"
 	"github.com/omartelo/lich/internal/rage"
 	"github.com/omartelo/lich/internal/relay"
 	"github.com/omartelo/lich/internal/singleton"
@@ -82,6 +83,11 @@ const usage = `lich talks to the sessions open in the running lich window.
       the logs, with secrets masked — into one .tar.gz to attach to an issue.
       Nothing is uploaded, and it works with no lich running.
 
+  lich doctor
+      Walk the boot lich walks — config dir, log, the pinned port, the
+      workspace database, the browser, the providers — and say whether it
+      would start here. Exits non-zero when something would stop it.
+
 Run inside a lich session these address the sessions beside it. Run anywhere
 else on the machine they find the running lich on their own, and what they
 relay is attributed to the command line rather than to a session.
@@ -117,6 +123,11 @@ func dispatch(args []string, c *client) int {
 		return c.run(c.serveMCP, args[1:])
 	case "rage":
 		return c.run(c.rage, args[1:])
+	case "doctor":
+		// Not through run: this command's failure is the report it just
+		// printed, and a second "lich: …" line on stderr would only say it
+		// again, worse.
+		return c.doctor(args[1:])
 	case "help", "--help", "-h":
 		fmt.Fprint(c.stdout, usage)
 		return 0
@@ -141,6 +152,10 @@ type client struct {
 	// test overrides it because collecting scans PATH, runs the provider CLIs
 	// and asks GitHub for the plugin's latest release.
 	bundle func(w io.Writer, root string) (rage.Report, error)
+	// diagnose walks the boot; nil takes the real one. A test overrides it for
+	// the same reason bundle exists — the real walk binds the pinned port and
+	// opens the workspace database.
+	diagnose func() ([]doctor.Check, error)
 }
 
 // run reports a subcommand's failure the way a command line does — one line on
@@ -278,6 +293,44 @@ func (c *client) rage(args []string) error {
 	fmt.Fprintf(c.stdout, "lich %s on %s, %s.\n", report.Version, report.Platform, report.Instance)
 	fmt.Fprintln(c.stdout, "Read it before you attach it: it carries absolute paths, project and branch names.")
 	return nil
+}
+
+// doctor prints the boot report and returns the process exit code directly: a
+// launch-stopping check is a non-zero exit, which is what a script reads.
+func (c *client) doctor(args []string) int {
+	flags := newFlagSet("doctor")
+	if err := flags.Parse(args); err != nil {
+		fmt.Fprintf(c.stderr, "lich: %v\n", err)
+		return 1
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintln(c.stderr, "lich: usage: lich doctor")
+		return 1
+	}
+
+	run := c.diagnose
+	if run == nil {
+		run = c.runDoctor
+	}
+	checks, err := run()
+	if err != nil {
+		fmt.Fprintf(c.stderr, "lich: %v\n", err)
+		return 1
+	}
+	doctor.Render(c.stdout, c.version, checks)
+	if doctor.Failed(checks) {
+		return 1
+	}
+	return 0
+}
+
+// runDoctor is the real boot walk, reached when no seam replaced it.
+func (c *client) runDoctor() ([]doctor.Check, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve config directory: %w", err)
+	}
+	return doctor.New(dir, c.env).Run(), nil
 }
 
 // collectRage is the real collector, reached when no seam replaced it.

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,0 +1,109 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/doctor"
+)
+
+// doctorClient runs `lich doctor` against a canned walk: the real one binds the
+// pinned port and opens the workspace database, neither of which a unit test may
+// do to the machine it runs on.
+func doctorClient(t *testing.T, checks []doctor.Check, err error) (*client, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	var stdout, stderr bytes.Buffer
+	return &client{
+		env:      func(string) string { return "" },
+		version:  "v1.2.3",
+		stdout:   &stdout,
+		stderr:   &stderr,
+		diagnose: func() ([]doctor.Check, error) { return checks, err },
+	}, &stdout, &stderr
+}
+
+func TestDoctorPrintsTheReportAndExitsZeroWhenNothingStopsALaunch(t *testing.T) {
+	c, stdout, stderr := doctorClient(t, []doctor.Check{
+		{Name: "home", Status: doctor.OK, Detail: "/home/u/.config/lich is writable"},
+		{Name: "store", Status: doctor.Skip, Detail: "held by the running lich (pid 42)"},
+	}, nil)
+
+	if code := dispatch([]string{"doctor"}, c); code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	for _, want := range []string{"lich v1.2.3", "home", "store", "nothing is in the way"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Errorf("report is missing %q: %q", want, stdout.String())
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("a healthy report wrote to stderr: %q", stderr.String())
+	}
+}
+
+func TestDoctorExitsNonZeroOnACheckThatStopsALaunch(t *testing.T) {
+	c, stdout, stderr := doctorClient(t, []doctor.Check{
+		{Name: "browser", Status: doctor.Fail, Detail: "no chromium-family browser found"},
+	}, nil)
+
+	if code := dispatch([]string{"doctor"}, c); code != 1 {
+		t.Fatalf("exit = %d, want 1 — a script reads this", code)
+	}
+	if !strings.Contains(stdout.String(), "no chromium-family browser found") {
+		t.Errorf("stdout = %q", stdout.String())
+	}
+	// The report already said it. Saying it again on stderr, worse, is the
+	// reason this command does not go through run().
+	if stderr.Len() != 0 {
+		t.Errorf("the failure was repeated on stderr: %q", stderr.String())
+	}
+}
+
+func TestDoctorReportsAWalkItCouldNotStart(t *testing.T) {
+	c, stdout, stderr := doctorClient(t, nil, errors.New("resolve config directory: no home"))
+
+	if code := dispatch([]string{"doctor"}, c); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "no home") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("a walk that never ran still printed a report: %q", stdout.String())
+	}
+}
+
+func TestDoctorTakesNoArguments(t *testing.T) {
+	c, stdout, stderr := doctorClient(t, []doctor.Check{{Name: "home", Status: doctor.OK}}, nil)
+
+	if code := dispatch([]string{"doctor", "--everything"}, c); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "lich: ") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("a rejected command still printed a report: %q", stdout.String())
+	}
+
+	c, stdout, stderr = doctorClient(t, []doctor.Check{{Name: "home", Status: doctor.OK}}, nil)
+	if code := dispatch([]string{"doctor", "everything"}, c); code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "usage: lich doctor") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("a rejected command still printed a report: %q", stdout.String())
+	}
+}
+
+func TestDoctorIsInTheHelp(t *testing.T) {
+	f := newFakeLich(t, `null`)
+	_, stdout, _ := run(t, f, "help")
+	if !strings.Contains(stdout, "lich doctor") {
+		t.Errorf("help does not document doctor: %q", stdout)
+	}
+}

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,0 +1,232 @@
+// Package doctor answers "would lich start on this machine, and why not". It
+// walks the same boot the app walks — config dir, log file, the pinned listener,
+// the workspace database, the browser, the providers — and reports each step
+// with a verdict and how long it took.
+//
+// It is a command line because the failure it diagnoses is a window that never
+// opened: there is no Settings › Help behind a window that is not there. It
+// needs no TTY and no running instance, and it exits non-zero when a check that
+// would stop a launch fails, so it works as a smoke test in a script.
+package doctor
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/omartelo/lich/internal/chromium"
+	"github.com/omartelo/lich/internal/logging"
+	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/singleton"
+	"github.com/omartelo/lich/internal/store"
+)
+
+// Status is one check's verdict.
+type Status string
+
+const (
+	// OK: this step of a launch would succeed.
+	OK Status = "ok"
+	// Warn: lich starts, but something it offers will not work.
+	Warn Status = "warn"
+	// Fail: a launch stops here. Any Fail exits non-zero.
+	Fail Status = "fail"
+	// Skip: the check could not run without disturbing the instance already
+	// running — reported rather than guessed at.
+	Skip Status = "skip"
+)
+
+// Check is one step of the boot, as the report prints it.
+type Check struct {
+	Name   string
+	Status Status
+	Detail string
+	Took   time.Duration
+}
+
+// bindProbe holds the pinned port for as long as it takes to prove it is free.
+// Nothing is served on it: a launch seconds later has to be able to take it.
+func bindProbe(port int) error {
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		return err
+	}
+	return listener.Close()
+}
+
+// Doctor runs the checks. Every probe that reaches the machine is a field, so a
+// test decides what this machine has without touching PATH, the port or the
+// database.
+type Doctor struct {
+	configDir string
+	port      int
+
+	bind     func(port int) error
+	instance func() (*singleton.Info, bool)
+	browser  func() (string, error)
+	detect   func() []providers.Detected
+	store    func() (io.Closer, error)
+}
+
+// New returns a Doctor for this machine. configDir is the OS config dir, and
+// getenv resolves the listener port exactly as a launch would.
+func New(configDir string, getenv func(string) string) *Doctor {
+	return &Doctor{
+		configDir: configDir,
+		port:      singleton.Port(getenv),
+		bind:      bindProbe,
+		instance: func() (*singleton.Info, bool) {
+			info, err := singleton.Read(configDir)
+			if err != nil || info == nil {
+				return nil, false
+			}
+			return info, singleton.Ping(info.Port, info.Token)
+		},
+		browser: func() (string, error) { return chromium.FindBrowser(exec.LookPath) },
+		detect: func() []providers.Detected {
+			found, err := providers.New().Detect()
+			if err != nil {
+				return nil
+			}
+			return found
+		},
+		store: func() (io.Closer, error) { return store.New() },
+	}
+}
+
+// Run walks the boot in order and returns one Check per step. The instance is
+// probed once for the whole run: two checks need the answer, and a stale
+// runtime file costs a timeout to find out.
+func (d *Doctor) Run() []Check {
+	info, alive := d.instance()
+	running := alive && info != nil
+
+	steps := []struct {
+		name string
+		run  func() (Status, string)
+	}{
+		{"home", d.checkHome},
+		{"log", d.checkLog},
+		{"listener", func() (Status, string) { return d.checkListener(info, running) }},
+		{"store", func() (Status, string) { return d.checkStore(info, running) }},
+		{"browser", d.checkBrowser},
+		{"providers", d.checkProviders},
+	}
+
+	checks := make([]Check, 0, len(steps))
+	for _, step := range steps {
+		started := time.Now()
+		status, detail := step.run()
+		checks = append(checks, Check{
+			Name: step.name, Status: status, Detail: detail, Took: time.Since(started),
+		})
+	}
+	return checks
+}
+
+// checkHome proves lich's config directory can be created and written to. It is
+// first because every step below it writes there.
+func (d *Doctor) checkHome() (Status, string) {
+	dir := filepath.Join(d.configDir, "lich")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return Fail, fmt.Sprintf("%s cannot be created: %v", dir, err)
+	}
+	probe := filepath.Join(dir, ".doctor-probe")
+	if err := os.WriteFile(probe, []byte("lich doctor"), 0o600); err != nil {
+		return Fail, fmt.Sprintf("%s is not writable: %v", dir, err)
+	}
+	if err := os.Remove(probe); err != nil {
+		return Warn, fmt.Sprintf("%s is writable, but %s could not be removed", dir, probe)
+	}
+	return OK, dir + " is writable"
+}
+
+// checkLog opens the log the way startup does, minus the rotation: rotating
+// here would move the generation a bug report is about to attach.
+func (d *Doctor) checkLog() (Status, string) {
+	path := logging.Path(filepath.Join(d.configDir, "lich"))
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return Warn, fmt.Sprintf("no log file — lich would run on stderr only: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		return Warn, fmt.Sprintf("%s does not close cleanly: %v", path, err)
+	}
+	return OK, path
+}
+
+// checkListener asks the question a failed launch poses: is the pinned port
+// free, held by the lich already running (which is the single-instance lock
+// working), or taken by something else that will not hand it over.
+func (d *Doctor) checkListener(info *singleton.Info, running bool) (Status, string) {
+	err := d.bind(d.port)
+	if err == nil {
+		return OK, fmt.Sprintf("port %d is free", d.port)
+	}
+	if running && info.Port == d.port {
+		return OK, fmt.Sprintf("port %d is held by the running lich (pid %d)", d.port, info.PID)
+	}
+	// Not "taken": the same bind refuses a privileged port the same way, and a
+	// diagnosis that names the wrong cause sends the reader after the wrong fix.
+	return Fail, fmt.Sprintf("port %d cannot be bound: %v", d.port, err)
+}
+
+// checkStore opens and migrates the workspace database, which is what a launch
+// does — but never while an instance is running: a second process migrating the
+// store is not a price a diagnosis may charge.
+func (d *Doctor) checkStore(info *singleton.Info, running bool) (Status, string) {
+	if running {
+		return Skip, fmt.Sprintf("held by the running lich (pid %d)", info.PID)
+	}
+	db, err := d.store()
+	if err != nil {
+		return Fail, fmt.Sprintf("the workspace database will not open: %v", err)
+	}
+	if err := db.Close(); err != nil {
+		return Warn, fmt.Sprintf("the workspace database does not close cleanly: %v", err)
+	}
+	return OK, "the workspace database opens and its schema is current"
+}
+
+// checkBrowser resolves the Chromium-family binary the window is. Its absence
+// is the one failure where lich runs perfectly and shows nothing.
+func (d *Doctor) checkBrowser() (Status, string) {
+	path, err := d.browser()
+	if err != nil {
+		return Fail, err.Error()
+	}
+	return OK, path
+}
+
+// checkProviders counts the harnesses a session could spawn. None is not a
+// launch failure — the window opens on an empty workspace — so it warns.
+func (d *Doctor) checkProviders() (Status, string) {
+	found := d.detect()
+	var installed []string
+	for _, p := range found {
+		if p.Installed {
+			installed = append(installed, p.ID)
+		}
+	}
+	if len(installed) == 0 {
+		return Warn, "none on PATH — lich opens, but no session can spawn"
+	}
+	return OK, fmt.Sprintf("%d of %d on PATH: %s",
+		len(installed), len(found), strings.Join(installed, ", "))
+}
+
+// Failed reports whether any check would stop a launch, which is what the exit
+// code carries to a script.
+func Failed(checks []Check) bool {
+	for _, c := range checks {
+		if c.Status == Fail {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -1,0 +1,260 @@
+package doctor
+
+import (
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/singleton"
+)
+
+// healthy builds a Doctor over a temp config dir with every probe answering the
+// way a working machine does, so each test breaks exactly one thing.
+func healthy(t *testing.T) *Doctor {
+	t.Helper()
+	t.Setenv("LICH_DEV", "")
+	d := New(t.TempDir(), func(string) string { return "" })
+	d.bind = func(int) error { return nil }
+	d.instance = func() (*singleton.Info, bool) { return nil, false }
+	d.browser = func() (string, error) { return "/usr/bin/chromium", nil }
+	d.detect = func() []providers.Detected {
+		return []providers.Detected{
+			{ID: "claude", Installed: true, Path: "/usr/bin/claude"},
+			{ID: "codex"},
+		}
+	}
+	d.store = func() (io.Closer, error) { return io.NopCloser(nil), nil }
+	return d
+}
+
+func statuses(checks []Check) map[string]Check {
+	out := make(map[string]Check, len(checks))
+	for _, c := range checks {
+		out[c.Name] = c
+	}
+	return out
+}
+
+func TestAHealthyMachineWalksTheWholeBoot(t *testing.T) {
+	checks := healthy(t).Run()
+
+	var names []string
+	for _, c := range checks {
+		names = append(names, c.Name)
+	}
+	want := []string{"home", "log", "listener", "store", "browser", "providers"}
+	if strings.Join(names, ",") != strings.Join(want, ",") {
+		t.Errorf("checks ran as %v, want the boot order %v", names, want)
+	}
+	for _, c := range checks {
+		if c.Status != OK {
+			t.Errorf("%s = %s (%s), want ok", c.Name, c.Status, c.Detail)
+		}
+	}
+	if Failed(checks) {
+		t.Error("a healthy machine reports a launch-stopping failure")
+	}
+}
+
+func TestTheListenerTellsTheRunningLichFromAStranger(t *testing.T) {
+	t.Run("held by the running lich", func(t *testing.T) {
+		d := healthy(t)
+		d.bind = func(int) error { return errors.New("address already in use") }
+		d.instance = func() (*singleton.Info, bool) {
+			return &singleton.Info{PID: 4242, Port: singleton.DefaultPort, Token: "t"}, true
+		}
+
+		got := statuses(d.Run())["listener"]
+
+		if got.Status != OK {
+			t.Errorf("listener = %s (%s), want ok — the lock working is not a failure", got.Status, got.Detail)
+		}
+		if !strings.Contains(got.Detail, "4242") {
+			t.Errorf("detail does not name the instance holding it: %q", got.Detail)
+		}
+	})
+
+	t.Run("held by something else", func(t *testing.T) {
+		d := healthy(t)
+		d.bind = func(int) error { return errors.New("address already in use") }
+
+		checks := d.Run()
+		got := statuses(checks)["listener"]
+
+		if got.Status != Fail {
+			t.Errorf("listener = %s (%s), want fail", got.Status, got.Detail)
+		}
+		if !Failed(checks) {
+			t.Error("a port lich cannot bind is not reported as launch-stopping")
+		}
+	})
+
+	t.Run("a dead instance on another port is not a holder", func(t *testing.T) {
+		d := healthy(t)
+		d.bind = func(int) error { return errors.New("address already in use") }
+		// A live dev instance on its own port does not explain the daily
+		// driver's port being busy.
+		d.instance = func() (*singleton.Info, bool) {
+			return &singleton.Info{PID: 1, Port: singleton.DefaultPort + 1, Token: "t"}, true
+		}
+
+		if got := statuses(d.Run())["listener"]; got.Status != Fail {
+			t.Errorf("listener = %s (%s), want fail", got.Status, got.Detail)
+		}
+	})
+}
+
+func TestTheStoreIsNeverOpenedBehindARunningInstance(t *testing.T) {
+	d := healthy(t)
+	d.instance = func() (*singleton.Info, bool) {
+		return &singleton.Info{PID: 4242, Port: singleton.DefaultPort, Token: "t"}, true
+	}
+	opened := false
+	d.store = func() (io.Closer, error) {
+		opened = true
+		return io.NopCloser(nil), nil
+	}
+
+	got := statuses(d.Run())["store"]
+
+	if opened {
+		t.Error("doctor opened the database a running lich holds — a second migration is not its to run")
+	}
+	if got.Status != Skip || !strings.Contains(got.Detail, "4242") {
+		t.Errorf("store = %s (%s), want skip naming the instance", got.Status, got.Detail)
+	}
+}
+
+func TestADatabaseThatWillNotOpenStopsALaunch(t *testing.T) {
+	d := healthy(t)
+	d.store = func() (io.Closer, error) { return nil, errors.New("file is not a database") }
+
+	checks := d.Run()
+
+	if got := statuses(checks)["store"]; got.Status != Fail || !strings.Contains(got.Detail, "not a database") {
+		t.Errorf("store = %s (%s), want fail carrying the cause", got.Status, got.Detail)
+	}
+	if !Failed(checks) {
+		t.Error("a database that will not open is not reported as launch-stopping")
+	}
+}
+
+func TestAMissingBrowserStopsALaunchAndMissingProvidersDoNot(t *testing.T) {
+	d := healthy(t)
+	d.browser = func() (string, error) { return "", errors.New("no chromium-family browser found") }
+	d.detect = func() []providers.Detected { return []providers.Detected{{ID: "claude"}} }
+
+	checks := statuses(d.Run())
+
+	if checks["browser"].Status != Fail {
+		t.Errorf("browser = %s, want fail — lich runs and shows nothing", checks["browser"].Status)
+	}
+	if checks["providers"].Status != Warn {
+		t.Errorf("providers = %s, want warn — the window still opens", checks["providers"].Status)
+	}
+	if !strings.Contains(checks["providers"].Detail, "no session can spawn") {
+		t.Errorf("providers detail = %q", checks["providers"].Detail)
+	}
+}
+
+func TestAnUnwritableHomeStopsALaunch(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root writes through a read-only mode bit")
+	}
+	configDir := t.TempDir()
+	if err := os.Chmod(configDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(configDir, 0o700) })
+
+	d := healthy(t)
+	d.configDir = configDir
+
+	checks := statuses(d.Run())
+
+	if checks["home"].Status != Fail {
+		t.Errorf("home = %s (%s), want fail", checks["home"].Status, checks["home"].Detail)
+	}
+	// The log lives under the same directory, so it cannot be opened either —
+	// and that is a warning, because lich still runs on stderr.
+	if checks["log"].Status != Warn {
+		t.Errorf("log = %s (%s), want warn", checks["log"].Status, checks["log"].Detail)
+	}
+}
+
+func TestTheLogIsOpenedWithoutRotatingIt(t *testing.T) {
+	d := healthy(t)
+	dir := filepath.Join(d.configDir, "lich")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "lich.log")
+	if err := os.WriteFile(path, []byte("the line a bug report is about to quote\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got := statuses(d.Run())["log"]
+
+	if got.Status != OK || got.Detail != path {
+		t.Errorf("log = %s (%s), want ok naming %s", got.Status, got.Detail, path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "about to quote") {
+		t.Error("doctor moved or truncated the log it was only meant to open")
+	}
+	if _, err := os.Stat(path + ".old"); err == nil {
+		t.Error("doctor rotated the log, taking the generation a bug report attaches")
+	}
+}
+
+func TestBindProbeGivesThePortStraightBack(t *testing.T) {
+	taken, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := taken.Addr().(*net.TCPAddr).Port
+
+	if err := bindProbe(port); err == nil {
+		t.Error("the probe called a port free while something was listening on it")
+	}
+	if err := taken.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := bindProbe(port); err != nil {
+		t.Errorf("the probe refused a free port: %v", err)
+	}
+	// The launch comes seconds later and has to be able to take it: a probe
+	// that kept the port would diagnose the machine into the failure it reports.
+	after, err := net.Listen("tcp", "127.0.0.1:"+strconv.Itoa(port))
+	if err != nil {
+		t.Fatalf("the probe held the port it proved free: %v", err)
+	}
+	_ = after.Close()
+}
+
+func TestThePortComesFromTheEnvironmentTheLaunchWouldRead(t *testing.T) {
+	d := New(t.TempDir(), func(key string) string {
+		if key == "LICH_LISTEN_PORT" {
+			return "1234"
+		}
+		return ""
+	})
+	if d.port != 1234 {
+		t.Errorf("port = %d, want the pinned override", d.port)
+	}
+	if plain := New(t.TempDir(), func(string) string { return "" }); plain.port != singleton.DefaultPort {
+		t.Errorf("port = %d, want singleton.DefaultPort", plain.port)
+	}
+	if nonsense := New(t.TempDir(), func(string) string { return "not-a-port" }); nonsense.port != singleton.DefaultPort {
+		t.Errorf("port = %d, want the default when the override is not a number", nonsense.port)
+	}
+}

--- a/internal/doctor/render.go
+++ b/internal/doctor/render.go
@@ -1,0 +1,63 @@
+package doctor
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+	"time"
+)
+
+// Render writes the report: a header naming the build, one line per check in
+// boot order, the total, and a verdict. The verdict is the whole point of
+// reading it — a table of six lines that never says whether lich would start
+// leaves the reader to add it up.
+func Render(w io.Writer, version string, checks []Check) {
+	fmt.Fprintf(w, "lich %s — %s/%s\n\n", version, runtime.GOOS, runtime.GOARCH)
+
+	var total time.Duration
+	for _, c := range checks {
+		total += c.Took
+		fmt.Fprintf(w, "  %-5s %-10s %7s  %s\n", c.Status, c.Name, took(c.Took), c.Detail)
+	}
+	fmt.Fprintf(w, "  %-5s %-10s %7s\n\n", "", "total", took(total))
+	fmt.Fprintln(w, verdict(checks))
+}
+
+// verdict is the one line a reader can act on. Failures win over warnings:
+// there is no point telling someone a provider is missing when the window will
+// not open at all.
+func verdict(checks []Check) string {
+	failed, warned := 0, 0
+	for _, c := range checks {
+		switch c.Status {
+		case Fail:
+			failed++
+		case Warn:
+			warned++
+		}
+	}
+	switch {
+	case failed == 1:
+		return "1 check above stops a launch here. Fix it first."
+	case failed > 1:
+		return fmt.Sprintf("%d checks above stop a launch here. Fix them first.", failed)
+	case warned == 1:
+		return "lich starts. 1 warning above limits something it offers."
+	case warned > 1:
+		return fmt.Sprintf("lich starts. %d warnings above limit something it offers.", warned)
+	default:
+		// Not "every check passed": one of them may have been skipped, and a
+		// verdict that overstates what was measured is the one thing a
+		// diagnosis may never do.
+		return "lich starts here — nothing is in the way."
+	}
+}
+
+// took renders a duration for a human scanning a column: whole milliseconds,
+// and anything faster as a floor rather than a misleading "0s".
+func took(d time.Duration) string {
+	if d < time.Millisecond {
+		return "<1ms"
+	}
+	return d.Round(time.Millisecond).String()
+}

--- a/internal/doctor/render_test.go
+++ b/internal/doctor/render_test.go
@@ -1,0 +1,100 @@
+package doctor
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func rendered(t *testing.T, checks []Check) string {
+	t.Helper()
+	var buf bytes.Buffer
+	Render(&buf, "v1.2.3", checks)
+	return buf.String()
+}
+
+func TestRenderNamesTheBuildEveryCheckAndTheTotal(t *testing.T) {
+	page := rendered(t, []Check{
+		{Name: "home", Status: OK, Detail: "/home/u/.config/lich is writable", Took: 2 * time.Millisecond},
+		{Name: "store", Status: Skip, Detail: "held by the running lich (pid 42)", Took: 300 * time.Microsecond},
+	})
+
+	for _, want := range []string{
+		"lich v1.2.3 — ",
+		"ok    home",
+		"/home/u/.config/lich is writable",
+		"skip  store",
+		"2ms",
+		"<1ms", // faster than a millisecond, and never printed as 0s
+		"total",
+	} {
+		if !strings.Contains(page, want) {
+			t.Errorf("report is missing %q:\n%s", want, page)
+		}
+	}
+	if strings.Contains(page, " 0s") {
+		t.Errorf("a sub-millisecond check printed as 0s:\n%s", page)
+	}
+}
+
+func TestTheVerdictIsWhatTheReaderActsOn(t *testing.T) {
+	cases := []struct {
+		name   string
+		checks []Check
+		want   string
+	}{
+		{"all clear", []Check{{Status: OK}}, "lich starts here — nothing is in the way."},
+		{
+			"a skip is not a pass",
+			[]Check{{Status: OK}, {Status: Skip}},
+			"lich starts here — nothing is in the way.",
+		},
+		{
+			"one warning",
+			[]Check{{Status: OK}, {Status: Warn}},
+			"lich starts. 1 warning above limits something it offers.",
+		},
+		{
+			"two warnings",
+			[]Check{{Status: Warn}, {Status: Warn}},
+			"lich starts. 2 warnings above limit something it offers.",
+		},
+		{"one failure", []Check{{Status: Fail}}, "1 check above stops a launch here. Fix it first."},
+		{
+			"two failures",
+			[]Check{{Status: Fail}, {Status: Fail}},
+			"2 checks above stop a launch here. Fix them first.",
+		},
+		{
+			"a failure outranks a warning",
+			[]Check{{Status: Warn}, {Status: Fail}},
+			"1 check above stops a launch here. Fix it first.",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := verdict(tc.checks); got != tc.want {
+				t.Errorf("verdict = %q, want %q", got, tc.want)
+			}
+			if !strings.Contains(rendered(t, tc.checks), tc.want) {
+				t.Error("the verdict never reached the rendered report")
+			}
+		})
+	}
+}
+
+func TestTookRendersWholeMilliseconds(t *testing.T) {
+	cases := map[time.Duration]string{
+		0:                       "<1ms",
+		999 * time.Microsecond:  "<1ms",
+		time.Millisecond:        "1ms",
+		1500 * time.Microsecond: "2ms",
+		2 * time.Second:         "2s",
+	}
+	for d, want := range cases {
+		if got := took(d); got != want {
+			t.Errorf("took(%v) = %q, want %q", d, got, want)
+		}
+	}
+}

--- a/internal/singleton/singleton.go
+++ b/internal/singleton/singleton.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 )
 
@@ -30,6 +31,23 @@ type Info struct {
 // pingTimeout bounds the liveness probe: a loopback GET answers in microseconds,
 // so a slow one means the recorded instance is gone and the file is stale.
 const pingTimeout = time.Second
+
+// DefaultPort is the loopback port lich pins when LICH_LISTEN_PORT does not
+// override it. It lives here because binding it is the single-instance lock,
+// and because the page's localStorage (lich.* settings) is keyed by the origin
+// it forms — a moved port is a wiped settings store.
+const DefaultPort = 47821
+
+// Port is the listener port this launch pins: LICH_LISTEN_PORT when it holds a
+// number, DefaultPort otherwise. getenv reads the environment (os.Getenv in
+// production), so a caller diagnosing a launch resolves the same port the
+// launch would.
+func Port(getenv func(string) string) int {
+	if port, err := strconv.Atoi(getenv("LICH_LISTEN_PORT")); err == nil && port > 0 {
+		return port
+	}
+	return DefaultPort
+}
 
 // path resolves runtime.json. LICH_DEV (set by `task dev`) selects a separate
 // file, mirroring the store's database split: the dev shell records itself on

--- a/internal/singleton/singleton_test.go
+++ b/internal/singleton/singleton_test.go
@@ -86,6 +86,37 @@ func TestUncleanExit(t *testing.T) {
 	})
 }
 
+// TestDefaultPortIsPinned spells the number out rather than reading the
+// constant: the page's localStorage (lich.* settings) is keyed by the origin
+// this port forms, so moving it wipes every user's preferences. A test that
+// followed the constant would let that move through green.
+func TestDefaultPortIsPinned(t *testing.T) {
+	if DefaultPort != 47821 {
+		t.Fatalf("DefaultPort = %d, want 47821 — moving it wipes the page's localStorage", DefaultPort)
+	}
+}
+
+func TestPortReadsTheOverride(t *testing.T) {
+	cases := map[string]int{
+		"":           DefaultPort,
+		"0":          DefaultPort,
+		"-1":         DefaultPort,
+		"not-a-port": DefaultPort,
+		"1234":       1234,
+	}
+	for value, want := range cases {
+		got := Port(func(key string) string {
+			if key != "LICH_LISTEN_PORT" {
+				t.Errorf("Port read %q, not the listener variable", key)
+			}
+			return value
+		})
+		if got != want {
+			t.Errorf("Port(LICH_LISTEN_PORT=%q) = %d, want %d", value, got, want)
+		}
+	}
+}
+
 func TestDetect(t *testing.T) {
 	const want = 47821
 	seed := func(t *testing.T, port int, token string) string {

--- a/main.go
+++ b/main.go
@@ -43,11 +43,6 @@ var assets embed.FS
 //go:embed CHANGELOG.md
 var changelog string
 
-// defaultListenPort pins the loopback listener so the page origin — and with
-// it the frontend's localStorage (lich.* settings) — survives restarts.
-// LICH_LISTEN_PORT overrides (not LICH_PORT, the per-session hook variable).
-const defaultListenPort = "47821"
-
 // version is the running build's version, injected at build time via
 // -ldflags "-X main.version=<git tag>" (see Taskfile.yml). Unset in dev builds
 // ("dev"), which the update check treats as "not a release".
@@ -86,8 +81,11 @@ func main() {
 		defer closer.Close()
 	}
 
+	// Pinned in the environment, not just resolved: the restart successor and
+	// every spawned session inherit it, so they all agree on the origin the
+	// page's localStorage is keyed by (singleton.DefaultPort).
 	if os.Getenv("LICH_LISTEN_PORT") == "" {
-		if err := os.Setenv("LICH_LISTEN_PORT", defaultListenPort); err != nil {
+		if err := os.Setenv("LICH_LISTEN_PORT", strconv.Itoa(singleton.DefaultPort)); err != nil {
 			slog.Error("set LICH_LISTEN_PORT", "err", err)
 			os.Exit(1)
 		}


### PR DESCRIPTION
## What

`lich doctor` walks the boot a launch walks and says whether lich would start on
this machine:

```
lich v0.25.0 — linux/amd64

  ok    home          1ms  /home/u/.config/lich is writable
  ok    log          <1ms  /home/u/.config/lich/lich.log
  ok    listener     <1ms  port 47821 is held by the running lich (pid 4242)
  skip  store        <1ms  held by the running lich (pid 4242)
  ok    browser       2ms  /usr/bin/chromium
  ok    providers     3ms  4 of 5 on PATH: claude, codex, opencode, crush
        total         6ms

lich starts here — nothing is in the way.
```

| Check | Fails when | Warns when |
|-------|-----------|------------|
| `home` | `<config-dir>/lich` cannot be created or written to. | The probe file could not be removed. |
| `log` | — | The log file will not open; lich would run on stderr only. |
| `listener` | The pinned port cannot be bound and no live lich holds it. | — |
| `store` | The workspace database will not open or migrate. | It will not close cleanly. |
| `browser` | No Chromium-family browser resolves. | — |
| `providers` | — | None on PATH: the window opens, no session can spawn. |

## Why

A window that never opens is the one failure lich could not report: everything
it reports with — Settings › Help, the bug-report form, `Open log folder` — is
behind that window. #210 gave that case a bundle to attach; this gives it an
answer to read.

The port check is the one that earns the command: a failed launch cannot say
whether the pinned port is free, held by the lich already open (the
single-instance lock working, which is not a failure) or held by a stranger. It
answers exactly that, mirroring `handleBindFailure`.

Idea taken from `ante doctor` (AntigmaLabs/ante), scoped to lich's own boot.

## Deliberate limits

- **The store is never opened behind a running instance** — a second process
  migrating the workspace is not a price a diagnosis may charge. It reports
  `skip` and names the instance holding it.
- **The log is opened, never rotated** — rotating here would move the generation
  a bug report is about to attach.
- **The port is proven for an instant, not held** — the same ceiling
  `LICH_WORKTREE_PORT` already has, now recorded for this too in `docs/cli.md`.
- **A green run is not a green window** — it resolves the browser binary; whether
  that browser opens under this compositor is not answerable without becoming the
  launch. Recorded as a ceiling.
- **No `--json`** — the exit code is the automation surface: 1 when a check would
  stop a launch, 0 otherwise. No TTY, no window, no running instance, no network.

## Incidental

`singleton` gains `DefaultPort` and `Port()`. The pinned port was a `const` in
`main`, and doctor has to resolve the same port a launch would rather than carry
a second copy of the number. Its own test spells `47821` out literally rather
than reading the constant: the page's localStorage is keyed by the origin that
port forms, so a moved port wipes every user's preferences, and a test that
followed the constant would let that through green.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` — green; `internal/doctor`
      covers every verdict (the three listener outcomes, the skip behind a running
      instance, browser vs providers severity, an unwritable home, the log opened
      without rotating, the bind probe releasing the port it proved).
- [x] `go test -race` on the touched packages.
- [x] Cross-compile loop for linux/darwin/windows (build + vet).
- [x] `pnpm check`, `vitest`, `tsc --noEmit` — green.
- [x] Ran it for real: healthy machine exits 0; with `LICH_LISTEN_PORT=22` and
      with an isolated config dir and no browser on `PATH`, the failing checks are
      named and it exits 1.