### PR TITLE
test: keep the unwritable-home doctor check off Windows

### DIFF
--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -163,31 +163,6 @@ func TestAMissingBrowserStopsALaunchAndMissingProvidersDoNot(t *testing.T) {
 	}
 }
 
-func TestAnUnwritableHomeStopsALaunch(t *testing.T) {
-	if os.Getuid() == 0 {
-		t.Skip("root writes through a read-only mode bit")
-	}
-	configDir := t.TempDir()
-	if err := os.Chmod(configDir, 0o500); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { _ = os.Chmod(configDir, 0o700) })
-
-	d := healthy(t)
-	d.configDir = configDir
-
-	checks := statuses(d.Run())
-
-	if checks["home"].Status != Fail {
-		t.Errorf("home = %s (%s), want fail", checks["home"].Status, checks["home"].Detail)
-	}
-	// The log lives under the same directory, so it cannot be opened either —
-	// and that is a warning, because lich still runs on stderr.
-	if checks["log"].Status != Warn {
-		t.Errorf("log = %s (%s), want warn", checks["log"].Status, checks["log"].Detail)
-	}
-}
-
 func TestTheLogIsOpenedWithoutRotatingIt(t *testing.T) {
 	d := healthy(t)
 	dir := filepath.Join(d.configDir, "lich")

--- a/internal/doctor/doctor_unix_test.go
+++ b/internal/doctor/doctor_unix_test.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package doctor
+
+import (
+	"os"
+	"testing"
+)
+
+// Windows has no equivalent: os.Chmod there only toggles the read-only
+// attribute, which Windows ignores when creating files inside a directory, so
+// the probe in checkHome would find the directory writable and be right.
+func TestAnUnwritableHomeStopsALaunch(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root writes through a read-only mode bit")
+	}
+	configDir := t.TempDir()
+	if err := os.Chmod(configDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(configDir, 0o700) })
+
+	d := healthy(t)
+	d.configDir = configDir
+
+	checks := statuses(d.Run())
+
+	if checks["home"].Status != Fail {
+		t.Errorf("home = %s (%s), want fail", checks["home"].Status, checks["home"].Detail)
+	}
+	// The log lives under the same directory, so it cannot be opened either —
+	// and that is a warning, because lich still runs on stderr.
+	if checks["log"].Status != Warn {
+		t.Errorf("log = %s (%s), want warn", checks["log"].Status, checks["log"].Detail)
+	}
+}


### PR DESCRIPTION
`main` has been red since #212 merged: `os-tests (windows-latest)` fails on one test.

```
doctor_test.go:182: home = ok (...\\lich is writable), want fail
--- FAIL: TestAnUnwritableHomeStopsALaunch
```

`TestAnUnwritableHomeStopsALaunch` makes its temp config dir unwritable with `os.Chmod(dir, 0o500)` and expects `checkHome` to fail. On Windows `os.Chmod` only toggles the read-only attribute, and Windows ignores that attribute when creating a file *inside* a directory — so the directory stays writable, `checkHome`'s probe writes successfully, and `ok` is the truthful answer. The `os.Getuid() == 0` guard does not catch this either: `Getuid` returns -1 on Windows.

The product is right; the test asserted something the contract never promised — that `chmod 0500` yields an unwritable directory, which is POSIX, not a promise `doctor` makes. So the test moves to `doctor_unix_test.go` behind `//go:build !windows`, matching how this repo already selects OS-specific code. The assertions are unchanged, and it still runs on Linux and macOS.

No Windows counterpart: making a directory unwritable there needs ACL work, and it would only re-test the same OS-agnostic probe.

No CHANGELOG entry: nothing a user of a release can see changes.

## Test plan

- [x] `go test ./...` green locally (27 packages, exit 0)
- [x] `GOOS={linux,darwin,windows} go build ./... && go vet ./...` all clean
- [x] `GOOS=windows go test -c ./internal/doctor/` compiles, with the test excluded
- [x] `os-tests (windows-latest)` green on this PR — the point of the `ci:os` label