### PR TITLE
feat: open a session, and its worktree, from the CLI and MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **An agent can open a session, and give it its own worktree.** Until now every
+  session was opened by hand: an agent could hand work to the sessions beside it
+  but not create one, so a task that deserved its own checkout waited for
+  someone to click New Session. `lich open` — and the `open_session` tool beside
+  it — opens one in any project, running any provider lich knows, optionally on
+  a fresh git worktree branched off whatever branch you name. The new card
+  appears in the sidebar without stealing your view, and its terminal is already
+  running: it can be given work straight away, whether or not anybody opens it.
 - **Closing a project asks when an agent is still working.** The tab's × took a
   project's terminals down with it, killing whatever was mid-turn — with a
   spinner on that very tab as the only warning, and no undo. Closing a project

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,7 +3,7 @@
 An agent running in a lich session has a shell and nothing else — no window, no
 RPC client, no knowledge of this app. The `lich` command is the surface it uses
 to reach the sessions beside it: list them, hand one a task, answer one that
-handed it a task.
+handed it a task, open a new one.
 
 It is not only for agents. The same commands run from any shell on the machine —
 a script, a scheduled job, the user's own terminal — which is what makes lich
@@ -51,6 +51,7 @@ window uses:
 
 ```
 POST http://127.0.0.1:${LICH_PORT}/rpc/relay.<Method>?token=${LICH_TOKEN}
+POST http://127.0.0.1:${LICH_PORT}/rpc/spawn.<Method>?token=${LICH_TOKEN}
 ```
 
 **Outside a session** those are absent, and the command finds the running lich
@@ -79,10 +80,10 @@ Every command prints its result on stdout and its failure as one `lich: …` lin
 on stderr, exiting 0 or 1. Anything that is not a subcommand below — including
 `lich -- <chromium flags>` — opens the app instead.
 
-`--json` on `sessions`, `send` and `wait` replaces the prose with one JSON line:
-the peer array and the result object exactly as this document describes them.
-An empty roster is `[]`, never `null` — a script should not have to tell those
-apart.
+`--json` on `sessions`, `send`, `wait` and `open` replaces the prose with one
+JSON line: the peer array, the result object and the session object exactly as
+this document describes them. An empty roster is `[]`, never `null` — a script
+should not have to tell those apart.
 
 ### `lich sessions [--json]`
 
@@ -150,6 +151,46 @@ This is what a relayed message asks the receiving agent to run. An answer is
 capped at 64 KiB. Replying twice to one ticket is an error — the first answer
 already went home.
 
+### `lich open [--project <name>] [--kind <provider>] [--worktree <branch>] [--base <branch>]`
+
+Opens a new session, starts it, and prints the two names it is addressed by:
+
+```
+Opened session "auth-fix" (claude) in project "lich", in worktree /home/you/.local/share/lich/worktrees/1a2b/auth-fix.
+It answers to "auth-fix" and to "auth-fix-9f8e". It is still starting up — give it a moment before you send it work.
+```
+
+- `--project` names the project it lands in; the default is the caller's own.
+  **Outside a session there is no default** and the project must be named — the
+  error lists what is open.
+- `--kind` is what the session runs: any provider id (`claude`, `codex`,
+  `opencode`, `omp`, `crush`) or `shell`. The default is the caller's own
+  provider, so an agent opening a worker gets another of itself; a caller that
+  is not a session at all gets Claude Code.
+- `--worktree` is the **branch name** of a new git worktree, created off
+  `--base` (the project's current branch by default) under the app data dir. The
+  session is rooted there and labelled after it, and the project's worktree
+  setup script (Settings › Project) runs in its terminal before the provider,
+  exactly as when the window creates one. Without it the session opens in the
+  project's own directory, beside the caller's.
+- `--base` is checked against the repository's branches — local, remote
+  (`origin/…`, fetched and tracked), or one another worktree already holds. A
+  base that is not a branch is refused rather than resolved: git would happily
+  branch off a typo that names a revision, leaving a checkout nobody asked for.
+- A session without a worktree is labelled from the project's own counter
+  (`Session 4`), continuing the numbering the window uses.
+
+The card appears in the sidebar **without taking focus** — nobody in front of
+the window asked for this session — and its PTY is started by lich itself rather
+than by the first person to look at the card. That is what makes it addressable:
+`lich sessions` lists only sessions with a process in them, so a session nobody
+opened would be one nobody could send to.
+
+Failure is one line on stderr and exit 1. A worktree that could not be created
+leaves nothing behind — no row, no card. A session whose *terminal* failed to
+start keeps both, and says so, because the card is the only place its error can
+be read.
+
 ### `lich mcp`
 
 Serves the commands above as MCP tools over stdio: one JSON-RPC 2.0 message per
@@ -166,6 +207,7 @@ at lich.
 | `send_to_session` | `session`, `prompt`, optional `project` and `timeout_seconds`. |
 | `wait_for_answer` | `ticket`, optional `timeout_seconds`. |
 | `reply_to_session` | `ticket`, `answer` — what a relayed message asks for. |
+| `open_session` | optional `project`, `kind`, `worktree`, `base` — `lich open`. |
 
 A tool that fails answers with `isError` and the reason as text, not a JSON-RPC
 error: the agent should read what went wrong and act on it, not lose the turn.
@@ -260,6 +302,18 @@ receiving agent only because this text describes it.
 
 ## lich server side
 
+- **Spawn** — `internal/spawn`: opens a session for a caller that is not the
+  window. It is the one place that does all four things a session is at once —
+  the worktree (`internal/project`), the row (`internal/store`), the PTY
+  (`internal/terminal`) and the card (the `session-opened` event) — because no
+  existing package owns more than one of them. The window does the same four in
+  `frontend/src/providers/projects.tsx`, in its own order.
+- **The card** — `session-opened` carries the whole session
+  (`{id, projectId, project, label, name, kind, path, nextSeq}`) rather than an
+  id to look up: the row is already written and the PTY is already running, so
+  the window has nothing to fetch and nothing to spawn. `adoptSession`
+  (`frontend/src/lib/session/sessions.ts`) appends it **without focusing it** —
+  an agent opening three workers must not drag the view along three times.
 - **Relay** — `internal/relay`: resolves a label to a live session, composes the
   message above, types it through the terminal service, and holds the ticket the
   answer comes back on. Tickets live in memory: one exists for as long as its
@@ -342,7 +396,7 @@ whoever asked.
   every tool it has. This does not widen lich's trust boundary (`LICH_TOKEN` is
   already in every PTY, and any process in one can already write to any
   session), but it is the first feature that uses it, and there is no switch.
-- **The tools cost context in every session, used or not.** Four tool
+- **The tools cost context in every session, used or not.** Five tool
   definitions are in the prompt of every Claude Code and Codex session lich
   spawns, whether or not that session ever talks to another one. The command
   line costs nothing until it is called; the tools are what buy discovery, and
@@ -355,8 +409,25 @@ whoever asked.
   their ticket and the ticket lives in memory, so a finished request leaves no
   trace and a reload starts blank — the same ceiling the status readout has.
 - **Only live sessions are addressable.** A parked or never-opened card is
-  invisible to `sessions` and unreachable by `send`. Spawning one on demand
-  would mean lifting spawn state out of the frontend, which owns it.
+  invisible to `sessions` and unreachable by `send` — the window spawns a
+  session's terminal on its first view and nothing here changes that. `open` is
+  the exception, and only for the session it creates: it starts that PTY itself,
+  which is why the card it leaves behind is one you can send to unseen.
+- **A session is addressable before its agent can read.** `open` returns when
+  the PTY exists, not when the provider inside it has finished starting — there
+  is no signal for the latter that every provider gives. A message sent in that
+  window is written into a TUI that may not be reading yet, and lich cannot tell
+  that apart from a delivered one (delivery is proven, receipt is not). Hence
+  the line the command prints; opening and sending are two steps on purpose.
+- **`open` starts the PTY at 80×24.** Nothing is watching it, so there is no
+  terminal to measure. The window resizes it the first time the card is viewed,
+  and a TUI that drew itself into the smaller grid redraws — but output produced
+  before that view was wrapped for 80 columns, and the replayed scrollback keeps
+  those wraps.
+- **An opened session takes the project's active slot.** The row is written the
+  way the window writes one, so the project's `active_session_id` moves to it —
+  the card is not focused now, but a reload lands on it. Two of them and the
+  last one wins.
 - **Delivery is proven, receipt is not.** `send` knows the bytes reached the
   PTY. Whether the target's TUI queued them, and whether its agent ever runs the
   reply command, is what the wait and the ticket are for. A provider that does

--- a/frontend/src/lib/session/session-events.test.ts
+++ b/frontend/src/lib/session/session-events.test.ts
@@ -9,6 +9,7 @@ import {
   isTitleEvent,
   isUsageEvent,
   shouldToastAttention,
+  toOpenedSession,
   toSessionStatus,
 } from "./session-events"
 import { addSession, setActiveSession, type SessionState } from "./sessions"
@@ -256,5 +257,49 @@ describe("decideStatusNotice", () => {
   // a second thing to answer, so a repeat "waiting" is not collapsed.
   it("notifies again for a repeated waiting report", () => {
     expect(decideStatusNotice("waiting", "waiting", false, BOTH_ON)).toBe("notify")
+  })
+})
+
+describe("toOpenedSession", () => {
+  const payload = {
+    id: "agent-1",
+    projectId: "p1",
+    project: "lich",
+    label: "auth-fix",
+    name: "auth-fix-agen",
+    kind: "claude",
+    path: "/wt/auth-fix",
+    nextSeq: 5,
+  }
+
+  it("narrows a session opened outside the window", () => {
+    expect(toOpenedSession(payload)).toEqual({
+      id: "agent-1",
+      projectId: "p1",
+      label: "auth-fix",
+      kind: "claude",
+      path: "/wt/auth-fix",
+      nextSeq: 5,
+    })
+  })
+
+  it("keeps a session in the project's own directory", () => {
+    const opened = toOpenedSession({ ...payload, path: "", label: "Session 4" })
+    expect(opened?.path).toBe("")
+    expect(opened?.label).toBe("Session 4")
+  })
+
+  it("rejects a payload with nothing to place the card by", () => {
+    expect(toOpenedSession({ ...payload, id: undefined })).toBeNull()
+    expect(toOpenedSession({ ...payload, projectId: "" })).toBeNull()
+    expect(toOpenedSession({ ...payload, label: 4 })).toBeNull()
+    expect(toOpenedSession(null)).toBeNull()
+  })
+
+  // A provider a newer backend knows and this build cannot spawn: the row is
+  // written either way and the next load reads it, so dropping the card costs
+  // less than adopting one whose terminal can never start.
+  it("rejects a kind this build does not know", () => {
+    expect(toOpenedSession({ ...payload, kind: "gemini" })).toBeNull()
   })
 })

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -5,7 +5,7 @@
 // alone. Kept pure (no bindings, no React) so the provider and the card only
 // wire it up.
 
-import { projectOfSession, type SessionState } from "./sessions"
+import { isSessionKind, projectOfSession, type SessionKind, type SessionState } from "./sessions"
 
 // Global event carrying a session's Claude Code processing state (see
 // terminal.statusEventName). Payload: { id, state }. Global rather than
@@ -47,6 +47,12 @@ export const USAGE_EVENT = "session-usage"
 // request runs. An empty direction clears it: the request is over, answered or
 // expired.
 export const RELAY_EVENT = "session-relay"
+
+// Global event the backend emits when a session was opened outside the window —
+// an agent running `lich open` or its MCP tool (see spawn.OpenedEventName).
+// Payload: the whole session, because the card is drawn from it rather than
+// looked up: the row is already written and its PTY is already running.
+export const OPENED_EVENT = "session-opened"
 
 // Global event the backend emits when a request's target ended its turn without
 // answering through lich (see relay.StalledEventName). Payload:
@@ -158,6 +164,49 @@ export function statusTool(data: unknown): SessionTool | null {
     return null
   }
   return { name: tool, detail: typeof detail === "string" ? detail : "" }
+}
+
+// A session opened outside the window, as the workspace needs it: the card to
+// draw and the project's label counter after that card took its number.
+export interface OpenedSession {
+  id: string
+  projectId: string
+  label: string
+  kind: SessionKind
+  path: string
+  nextSeq: number
+}
+
+// toOpenedSession narrows a session-opened payload, or null when it names
+// nothing this window can place: no project id, no label, or a kind this build
+// does not know (a provider added by a newer backend). Dropping it costs the
+// card until the next load, which reads the row that is already written —
+// adopting a session whose kind cannot spawn would cost more.
+export function toOpenedSession(data: unknown): OpenedSession | null {
+  if (!isIdEvent(data)) {
+    return null
+  }
+  const { projectId, label, kind, path, nextSeq } = data as {
+    projectId?: unknown
+    label?: unknown
+    kind?: unknown
+    path?: unknown
+    nextSeq?: unknown
+  }
+  if (typeof projectId !== "string" || projectId === "" || typeof label !== "string") {
+    return null
+  }
+  if (typeof kind !== "string" || !isSessionKind(kind)) {
+    return null
+  }
+  return {
+    id: data.id,
+    projectId,
+    label,
+    kind,
+    path: typeof path === "string" ? path : "",
+    nextSeq: typeof nextSeq === "number" ? nextSeq : 1,
+  }
 }
 
 export function isTitleEvent(data: unknown): data is { id: string; label: string } {

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -3,6 +3,7 @@ import {
   activeSessionId,
   activeTarget,
   addSession,
+  adoptSession,
   closeSession,
   groupByWorktree,
   isLastWorktreeSession,
@@ -588,5 +589,39 @@ describe("orderGroups", () => {
   // drops the whole stale order instead of taking its sessions with it.
   it("contributes nothing for a key naming no group", () => {
     expect(orderGroups(groups, ["/wt/gone"])).toEqual([])
+  })
+})
+
+describe("adoptSession", () => {
+  const opened: Session = { id: "agent-1", label: "auth-fix", kind: "claude", path: "/wt/auth-fix" }
+
+  it("appends a session the backend already created", () => {
+    const state = adoptSession(buildState(2), P, opened, 4)
+    expect(sessionsOf(state, P).map((s) => s.id)).toEqual(["s1", "s2", "agent-1"])
+    expect(state[P].nextSeq).toBe(4)
+  })
+
+  it("leaves focus where the user left it", () => {
+    const before = buildState(2)
+    const state = adoptSession(before, P, opened, 4)
+    expect(activeSessionId(state, P)).toBe(activeSessionId(before, P))
+  })
+
+  it("ignores a session that is already there", () => {
+    const once = adoptSession(buildState(2), P, opened, 4)
+    expect(adoptSession(once, P, opened, 4)).toBe(once)
+  })
+
+  it("ignores a project the window does not hold", () => {
+    const before = buildState(2)
+    expect(adoptSession(before, "other", opened, 4)).toBe(before)
+  })
+
+  // The row was written with the backend's counter; a page that had already
+  // moved past it must not walk the number back and mint a duplicate label.
+  it("never lowers the label counter", () => {
+    const before = buildState(5)
+    const state = adoptSession(before, P, opened, 2)
+    expect(state[P].nextSeq).toBe(before[P].nextSeq)
   })
 })

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -87,6 +87,36 @@ export function addSession(
   }
 }
 
+// adoptSession takes in a session the backend already created and persisted —
+// one an agent opened through the `lich` CLI or its MCP tools — and appends its
+// card, carrying the project's label counter forward to the value the row was
+// written with.
+//
+// It deliberately does not focus what it adds, which is the whole difference
+// from addSession: nobody in front of the window asked for this session, and a
+// meta-agent opening three of them would otherwise drag the view along three
+// times while the user is working. An unknown project is ignored — its cards are
+// not on screen to add to, and the next load reads the row anyway.
+export function adoptSession(
+  state: SessionState,
+  projectId: string,
+  session: Session,
+  nextSeq: number,
+): SessionState {
+  const current = state[projectId]
+  if (!current || current.sessions.some((s) => s.id === session.id)) {
+    return state
+  }
+  return {
+    ...state,
+    [projectId]: {
+      ...current,
+      sessions: [...current.sessions, session],
+      nextSeq: Math.max(current.nextSeq, nextSeq),
+    },
+  }
+}
+
 // closeSession removes a session. When the active one is closed, focus moves to
 // a neighbor. The project entry is kept even when empty so nextSeq survives: a
 // project emptied and then reopened keeps counting labels up.

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -10,6 +10,7 @@ import { onAppEvent } from "@/lib/app-events"
 import {
   activeSessionId,
   addSession,
+  adoptSession,
   closeSession as removeSession,
   isSessionKind,
   neighborSessionId,
@@ -29,6 +30,7 @@ import { applyOrder, pinFirst } from "@/lib/reorder"
 import { displayPath } from "@/lib/paths"
 import { defaultProviderKind } from "@/lib/providers-store"
 import {
+  OPENED_EVENT,
   RELAY_STALLED_EVENT,
   STATUS_EVENT,
   TITLE_EVENT,
@@ -39,6 +41,7 @@ import {
   isStatusEvent,
   isTitleEvent,
   shouldToastAttention,
+  toOpenedSession,
   toSessionStatus,
   type SessionStatus,
 } from "@/lib/session/session-events"
@@ -223,6 +226,25 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
         return
       }
       const next = relabelSession(sessionsRef.current, projectId, id, label)
+      if (next !== sessionsRef.current) {
+        setSessions(next)
+      }
+    })
+    return () => off()
+  }, [])
+
+  // A session an agent opened through the CLI or its MCP tools: the backend
+  // wrote the row and started the PTY, so nothing is persisted or spawned here
+  // — only the card is added, unfocused, to the project it belongs to.
+  useEffect(() => {
+    const off = onAppEvent(OPENED_EVENT, (data) => {
+      const opened = toOpenedSession(data)
+      if (!opened) {
+        return
+      }
+      const { id, projectId, label, kind, path, nextSeq } = opened
+      const session: Session = { id, label, kind, ...(path ? { path } : {}) }
+      const next = adoptSession(sessionsRef.current, projectId, session, nextSeq)
       if (next !== sessionsRef.current) {
         setSessions(next)
       }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/omartelo/lich/internal/relay"
 	"github.com/omartelo/lich/internal/singleton"
+	"github.com/omartelo/lich/internal/spawn"
 )
 
 // NotACommand is returned when the arguments name no lich subcommand at all,
@@ -46,6 +47,13 @@ const callSlack = 30 * time.Second
 
 // shortCall bounds the commands that do not wait on another session.
 const shortCall = 10 * time.Second
+
+// openCall bounds opening a session. It is not a wait on anyone — it is git:
+// a worktree off a remote branch fetches first, and a cold fetch of a large
+// repository is not a ten-second operation. It stays under the 90 seconds an
+// MCP tool call may block for (see mcpMaxWait), so the same budget serves both
+// surfaces.
+const openCall = 60 * time.Second
 
 const usage = `lich talks to the sessions open in the running lich window.
 
@@ -63,6 +71,12 @@ const usage = `lich talks to the sessions open in the running lich window.
   lich reply <ticket> <answer>
       Send <answer> back to whoever is waiting on <ticket>. This is what a
       relayed message asks you to run when you are done.
+
+  lich open [--project <name>] [--kind <provider>] [--worktree <branch>]
+            [--base <branch>] [--json]
+      Open a new session and start it. --worktree creates a git worktree of
+      that branch name first and roots the session in it. Prints the name the
+      new session is addressed by.
 
   lich mcp
       Serve the commands above as MCP tools over stdio. lich registers this
@@ -98,6 +112,8 @@ func dispatch(args []string, c *client) int {
 		return c.run(c.wait, args[1:])
 	case "reply":
 		return c.run(c.reply, args[1:])
+	case "open":
+		return c.run(c.open, args[1:])
 	case "mcp":
 		return c.run(c.serveMCP, args[1:])
 	case "help", "--help", "-h":
@@ -211,6 +227,46 @@ func (c *client) reply(args []string) error {
 	}
 	fmt.Fprintln(c.stdout, "Answer sent.")
 	return nil
+}
+
+func (c *client) open(args []string) error {
+	flags := newFlagSet("open")
+	project := flags.String("project", "", "project to open the session in; defaults to the caller's own")
+	kind := flags.String("kind", "", "what the session runs; defaults to the caller's own provider")
+	worktree := flags.String("worktree", "", "branch name of a new git worktree to root the session in")
+	base := flags.String("base", "", "branch the worktree starts from; defaults to the project's current branch")
+	asJSON := flags.Bool("json", false, "print the result as JSON")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	var opened spawn.Session
+	call := []any{c.sessionID(), *project, *kind, *worktree, *base}
+	if err := c.call("spawn.Open", call, openCall, &opened); err != nil {
+		return err
+	}
+	if *asJSON {
+		return c.emit(opened)
+	}
+	fmt.Fprint(c.stdout, openedText(opened))
+	return nil
+}
+
+// openedText words a new session for whoever asked for one. It names both of
+// its names, because the caller's next move is to address it and either one
+// reaches it, and it says the session is still starting: the PTY exists the
+// moment this prints, and the provider inside it does not.
+func openedText(opened spawn.Session) string {
+	where := fmt.Sprintf("project %q", opened.Project)
+	if opened.Path != "" {
+		where = fmt.Sprintf("%s, in worktree %s", where, opened.Path)
+	}
+	return fmt.Sprintf(
+		"Opened session %q (%s) in %s.\n"+
+			"It answers to %q and to %q. It is still starting up — give it a moment "+
+			"before you send it work.\n",
+		opened.Label, opened.Kind, where, opened.Label, opened.Name,
+	)
 }
 
 // report prints a Send or Wait outcome. An answer goes to stdout on its own so

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/omartelo/lich/internal/relay"
 	"github.com/omartelo/lich/internal/singleton"
+	"github.com/omartelo/lich/internal/spawn"
 )
 
 // recorded is one RPC the fake lich received.
@@ -109,7 +110,7 @@ func TestHelpPrintsEveryCommand(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d", code)
 	}
-	for _, want := range []string{"lich sessions", "lich send", "lich wait", "lich reply"} {
+	for _, want := range []string{"lich sessions", "lich send", "lich wait", "lich reply", "lich open"} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("help does not document %q", want)
 		}
@@ -450,5 +451,91 @@ func TestEmptyPeersAreAnEmptyJSONArray(t *testing.T) {
 	}
 	if strings.TrimSpace(stdout) != "[]" {
 		t.Errorf("stdout = %q, want [] — a script should not have to handle null", stdout)
+	}
+}
+
+// openedBody is what spawn.Open answers with: a worktree session, the case that
+// exercises every field the CLI prints.
+const openedBody = `{"id":"9f8e","projectId":"p1","project":"lich","label":"auth-fix",
+	"name":"auth-fix-9f8e","kind":"claude","path":"/wt/auth-fix","nextSeq":5}`
+
+func TestOpenNamesBothWaysToAddressTheNewSession(t *testing.T) {
+	f := newFakeLich(t, openedBody)
+
+	code, stdout, stderr := run(t, f, "open", "--worktree", "auth-fix")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+
+	call := f.only(t)
+	if call.method != "spawn.Open" {
+		t.Errorf("method = %q", call.method)
+	}
+	want := []any{"s1", "", "", "auth-fix", ""}
+	if len(call.args) != len(want) {
+		t.Fatalf("args = %v, want %v", call.args, want)
+	}
+	for i := range want {
+		if call.args[i] != want[i] {
+			t.Errorf("argument %d = %v, want %v", i, call.args[i], want[i])
+		}
+	}
+	// The label and the roster name both address the session (docs/cli.md), and
+	// the caller's next move is to address it — printing one of them would send
+	// half the callers to `sessions` to find the other.
+	for _, phrase := range []string{`"auth-fix"`, `"auth-fix-9f8e"`, "/wt/auth-fix", "lich"} {
+		if !strings.Contains(stdout, phrase) {
+			t.Errorf("output is missing %q:\n%s", phrase, stdout)
+		}
+	}
+}
+
+func TestOpenPassesEveryFlagThrough(t *testing.T) {
+	f := newFakeLich(t, openedBody)
+
+	code, _, stderr := run(t, f,
+		"open", "--project", "revu", "--kind", "codex", "--worktree", "hotfix", "--base", "origin/main")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+
+	call := f.only(t)
+	want := []any{"s1", "revu", "codex", "hotfix", "origin/main"}
+	for i := range want {
+		if call.args[i] != want[i] {
+			t.Errorf("argument %d = %v, want %v", i, call.args[i], want[i])
+		}
+	}
+}
+
+func TestOpenJSONIsMachineReadable(t *testing.T) {
+	f := newFakeLich(t, openedBody)
+
+	code, stdout, stderr := run(t, f, "open", "--json")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	var opened spawn.Session
+	if err := json.Unmarshal([]byte(stdout), &opened); err != nil {
+		t.Fatalf("open --json is not JSON: %v (%q)", err, stdout)
+	}
+	if opened.Label != "auth-fix" || opened.Name != "auth-fix-9f8e" || opened.Path != "/wt/auth-fix" {
+		t.Errorf("opened = %+v", opened)
+	}
+}
+
+func TestOpenReportsTheAppsRefusal(t *testing.T) {
+	f := newFakeLich(t, `{"error":"no open project named \"nope\""}`)
+	f.status = 400
+
+	code, stdout, stderr := run(t, f, "open", "--project", "nope")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if stdout != "" {
+		t.Errorf("stdout = %q, want nothing printed for a session that was not opened", stdout)
+	}
+	if !strings.Contains(stderr, `no open project named "nope"`) {
+		t.Errorf("stderr = %q", stderr)
 	}
 }

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/omartelo/lich/internal/relay"
+	"github.com/omartelo/lich/internal/spawn"
 )
 
 // `lich mcp` is the same surface as the commands beside it, offered as MCP
@@ -323,6 +324,38 @@ var mcpTools = []mcpTool{
 				return "", err
 			}
 			return mcpOutcome(result), nil
+		},
+	},
+	{
+		Name: "open_session",
+		Description: "Open a new lich session and start it, so it can be given work with " +
+			"send_to_session. Optionally creates a git worktree first and roots the new " +
+			"session in it, which is how you give a task its own checkout instead of " +
+			"sharing yours. Returns the names the new session is addressed by. " +
+			"It starts empty and idle — nobody has asked it anything yet — and its agent " +
+			"takes a few seconds to come up, so send it work as a separate step.",
+		Schema: schema(map[string]any{
+			"project": property("string",
+				"Project to open the session in, by name. Defaults to your own project."),
+			"kind": property("string",
+				"What the session runs: claude, codex, opencode, omp, crush, or shell. "+
+					"Defaults to the same agent you are."),
+			"worktree": property("string",
+				"Branch name for a new git worktree to root the session in. Omit to open the "+
+					"session in the project's own directory, beside yours."),
+			"base": property("string",
+				"Branch the new worktree starts from. Defaults to the project's current branch."),
+		}),
+		Run: func(c *client, args mcpArgs) (string, error) {
+			var opened spawn.Session
+			call := []any{
+				c.sessionID(), args.text("project"), args.text("kind"),
+				args.text("worktree"), args.text("base"),
+			}
+			if err := c.call("spawn.Open", call, openCall, &opened); err != nil {
+				return "", err
+			}
+			return openedText(opened), nil
 		},
 	},
 	{

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -142,6 +142,7 @@ func TestMCPListsEveryTool(t *testing.T) {
 
 	want := map[string][]string{
 		"list_sessions":    {},
+		"open_session":     {},
 		"send_to_session":  {"session", "prompt"},
 		"wait_for_answer":  {"ticket"},
 		"reply_to_session": {"ticket", "answer"},
@@ -354,5 +355,57 @@ func TestMCPStopsCleanlyAtEndOfInput(t *testing.T) {
 	}
 	if stdout.Len() != 0 {
 		t.Errorf("an empty conversation produced output: %q", stdout.String())
+	}
+}
+
+func TestMCPOpenSessionReturnsTheNamesItIsAddressedBy(t *testing.T) {
+	f := newFakeLich(t, `{"id":"9f8e","projectId":"p1","project":"lich","label":"auth-fix",
+		"name":"auth-fix-9f8e","kind":"claude","path":"/wt/auth-fix","nextSeq":5}`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"open_session","arguments":{"worktree":"auth-fix","base":"main","kind":"codex"}}}`)
+
+	text, failed := textOf(t, replies[0])
+	if failed {
+		t.Fatalf("tool reported a failure: %s", text)
+	}
+	call := f.only(t)
+	if call.method != "spawn.Open" {
+		t.Errorf("method = %q", call.method)
+	}
+	want := []any{"s1", "", "codex", "auth-fix", "main"}
+	if len(call.args) != len(want) {
+		t.Fatalf("args = %v, want %v", call.args, want)
+	}
+	for i := range want {
+		if call.args[i] != want[i] {
+			t.Errorf("argument %d = %v, want %v", i, call.args[i], want[i])
+		}
+	}
+	// send_to_session is the next call the agent makes, and it addresses the
+	// session by one of these two names.
+	for _, phrase := range []string{`"auth-fix"`, `"auth-fix-9f8e"`} {
+		if !strings.Contains(text, phrase) {
+			t.Errorf("result is missing %q:\n%s", phrase, text)
+		}
+	}
+}
+
+func TestMCPOpenSessionDefaultsEveryArgument(t *testing.T) {
+	f := newFakeLich(t, `{"id":"9f8e","projectId":"p1","project":"lich","label":"Session 4",
+		"name":"lich-9f8e","kind":"claude","path":"","nextSeq":5}`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"open_session","arguments":{}}}`)
+
+	if text, failed := textOf(t, replies[0]); failed {
+		t.Fatalf("tool reported a failure: %s", text)
+	}
+	call := f.only(t)
+	want := []any{"s1", "", "", "", ""}
+	for i := range want {
+		if call.args[i] != want[i] {
+			t.Errorf("argument %d = %v, want %v", i, call.args[i], want[i])
+		}
 	}
 }

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"net"
 	"net/http/httptest"
 	"strconv"
@@ -10,8 +11,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/omartelo/lich/internal/project"
 	"github.com/omartelo/lich/internal/relay"
 	"github.com/omartelo/lich/internal/rpc"
+	"github.com/omartelo/lich/internal/spawn"
 	"github.com/omartelo/lich/internal/store"
 )
 
@@ -132,4 +135,86 @@ func ticketFrom(term *wiredTerminal) string {
 		time.Sleep(time.Millisecond)
 	}
 	return ""
+}
+
+// spawnStore is the workspace `lich open` writes into, over the real dispatcher.
+type spawnStore struct {
+	mu   sync.Mutex
+	rows int
+}
+
+func (*spawnStore) LoadState() ([]store.Project, error) {
+	return []store.Project{{ID: "p1", Name: "lich", Path: "/src/lich", NextSeq: 4,
+		Sessions: []store.Session{{ID: "s1", Label: "sender", Kind: "claude"}}}}, nil
+}
+
+func (s *spawnStore) AddSession(_, _, _, _, _ string, _ int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rows++
+	return nil
+}
+
+// spawnGit refuses every worktree: the wire is what these tests prove, and
+// running git would prove something else in a temporary directory.
+type spawnGit struct{}
+
+func (spawnGit) Branch(string) string { return "main" }
+
+func (spawnGit) ListBranches(string) (project.Branches, error) { return project.Branches{}, nil }
+
+func (spawnGit) CreateWorktree(_, _, _, _ string, _ bool) (*project.Worktree, error) {
+	return nil, errors.New("no git here")
+}
+
+type spawnTerminal struct {
+	mu   sync.Mutex
+	kind string
+	cwd  string
+}
+
+func (s *spawnTerminal) Start(_, _, cwd, kind, _, _ string, _ bool, _, _ int) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cwd, s.kind = cwd, kind
+	return nil
+}
+
+// TestOpenOverTheRealDispatcher proves the five arguments `lich open` posts land
+// on spawn.Open in the order it declares them — a positional mismatch here would
+// otherwise open a session in a project named after a provider.
+func TestOpenOverTheRealDispatcher(t *testing.T) {
+	rows := &spawnStore{}
+	term := &spawnTerminal{}
+	dispatcher := rpc.New()
+	dispatcher.Register("spawn", spawn.New(rows, spawnGit{}, term, nil))
+
+	server := httptest.NewServer(dispatcher)
+	t.Cleanup(server.Close)
+	port := strconv.Itoa(server.Listener.Addr().(*net.TCPAddr).Port)
+	env := func(key string) string {
+		switch key {
+		case "LICH_PORT":
+			return port
+		case "LICH_TOKEN":
+			return "tok"
+		case "LICH_SESSION_ID":
+			return "s1"
+		}
+		return ""
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := Run([]string{"open", "--kind", "codex"}, env, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), `"Session 4"`) {
+		t.Errorf("stdout = %q, want the label the project's counter gave it", stdout.String())
+	}
+	if rows.rows != 1 {
+		t.Errorf("wrote %d rows, want 1", rows.rows)
+	}
+	if term.kind != "codex" || term.cwd != "/src/lich" {
+		t.Errorf("started %q in %q, want codex in the project directory", term.kind, term.cwd)
+	}
 }

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -590,7 +590,7 @@ func (s *Service) roster(fromID string) ([]candidate, error) {
 				ID: sess.ID,
 				Peer: Peer{
 					Label:   sess.Label,
-					Name:    rosterNameOf(cwd, sess.ID),
+					Name:    RosterName(cwd, sess.ID),
 					Project: p.Name,
 					Kind:    sess.Kind,
 				},

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -310,7 +310,7 @@ func TestARosterNameReachesTheSameSession(t *testing.T) {
 	svc := newRelay(workspace(), term, nil)
 
 	go func() { _ = svc.Reply(waitForTicket(svc), "ok") }()
-	got, err := svc.Send("s1", rosterNameOf("/src/lich", "s2"), "", "hello", 30)
+	got, err := svc.Send("s1", RosterName("/src/lich", "s2"), "", "hello", 30)
 	if err != nil {
 		t.Fatalf("Send by roster name: %v", err)
 	}

--- a/internal/relay/rostername.go
+++ b/internal/relay/rostername.go
@@ -22,11 +22,15 @@ import (
 // roster row.
 const rosterIDChars = 4
 
-// rosterNameOf builds the name a session answers to in the peer roster: the
-// last element of its working directory, then four characters of its id. cwd is
-// the session's own directory when it has one (a worktree) and its project's
+// RosterName builds the name a session answers to in the peer roster: the last
+// element of its working directory, then four characters of its id. cwd is the
+// session's own directory when it has one (a worktree) and its project's
 // otherwise, matching what the frontend passes at spawn.
-func rosterNameOf(cwd, id string) string {
+//
+// Exported for the one caller outside this package that mints a session rather
+// than resolving one: internal/spawn, which passes the name at spawn the way
+// the window does.
+func RosterName(cwd, id string) string {
 	dir := filepath.Base(strings.TrimRight(strings.ReplaceAll(cwd, "\\", "/"), "/"))
 	// filepath.Base answers "." for an empty path and "/" for a bare root;
 	// neither names anything, and Claude Code's own fallback is the app name.

--- a/internal/relay/rostername_test.go
+++ b/internal/relay/rostername_test.go
@@ -58,8 +58,8 @@ func TestRosterNameOfMatchesTheFrontend(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := rosterNameOf(tt.cwd, tt.id); got != tt.want {
-				t.Errorf("rosterNameOf(%q, %q) = %q, want %q", tt.cwd, tt.id, got, tt.want)
+			if got := RosterName(tt.cwd, tt.id); got != tt.want {
+				t.Errorf("RosterName(%q, %q) = %q, want %q", tt.cwd, tt.id, got, tt.want)
 			}
 		})
 	}
@@ -67,8 +67,8 @@ func TestRosterNameOfMatchesTheFrontend(t *testing.T) {
 
 func TestRosterNameSeparatesSessionsSharingACheckout(t *testing.T) {
 	const cwd = "/home/me/code/lich"
-	first := rosterNameOf(cwd, "4f2a1b3c-0000-4000-8000-000000000000")
-	second := rosterNameOf(cwd, "9d8e7f6a-0000-4000-8000-000000000000")
+	first := RosterName(cwd, "4f2a1b3c-0000-4000-8000-000000000000")
+	second := RosterName(cwd, "9d8e7f6a-0000-4000-8000-000000000000")
 
 	if first == second {
 		t.Fatalf("two sessions in one checkout share the name %q", first)

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -1,0 +1,318 @@
+// Package spawn opens new lich sessions for a caller that is not the window:
+// the `lich` command line and the MCP tools beside it (internal/cli). An agent
+// could already talk to the sessions around it (internal/relay); this is what
+// lets it create one — with a git worktree under it when the work needs its own
+// checkout.
+//
+// It exists as its own service because opening a session is four things at once
+// and no single package owns them: a worktree (internal/project), a row
+// (internal/store), a PTY (internal/terminal) and a card in the window
+// (internal/events). The window does the same four in its own order, in
+// providers/projects.tsx.
+//
+// The PTY is started here rather than left to the window, and that is the whole
+// point of the feature. The window spawns a session's terminal only once
+// somebody has looked at the card, so a session opened for an agent and never
+// clicked would have no process in it — invisible to `lich sessions`,
+// unreachable by `lich send`, useless to whoever asked for it. Starting it here
+// makes it addressable the moment Open returns; the card's first view attaches
+// to the PTY that is already running, exactly as it does after a page reload.
+package spawn
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/omartelo/lich/internal/project"
+	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/relay"
+	"github.com/omartelo/lich/internal/store"
+	"github.com/omartelo/lich/internal/terminal"
+)
+
+// OpenedEventName carries a session opened outside the window, so the card
+// appears without a reload. Global, like every other session event: its consumer
+// is the workspace state, which outlives any one card.
+const OpenedEventName = "session-opened"
+
+// The size a session's PTY starts at. Nothing is watching it yet — the window
+// resizes it to the real terminal the first time the card is viewed — so this
+// only has to be a shape a TUI can draw itself into meanwhile.
+const (
+	startCols = 80
+	startRows = 24
+)
+
+// Sessions is the persistence this needs: the workspace to resolve a project in,
+// and the write that adds a session to one. The store implements it.
+type Sessions interface {
+	LoadState() ([]store.Project, error)
+	AddSession(projectID, sessionID, label, kind, path string, nextSeq int) error
+}
+
+// Worktrees is the git side. The project service implements it.
+type Worktrees interface {
+	Branch(path string) string
+	ListBranches(path string) (project.Branches, error)
+	CreateWorktree(projectPath, projectID, name, base string, baseIsRemote bool) (*project.Worktree, error)
+}
+
+// Terminal is the PTY side: the same spawn the window asks for when a card is
+// first viewed. The terminal service implements it.
+type Terminal interface {
+	Start(id, projectID, cwd, kind, resume, name string, setup bool, cols, rows int) error
+}
+
+// Events is where an opened session is announced to the window. A nil one leaves
+// the feature working and silent — the session runs, its card appears on the
+// next reload.
+type Events interface {
+	Emit(name string, data any)
+}
+
+// Session is one opened session: what the caller is told, and what the window is
+// handed to draw the card. Both read the same struct because both need the same
+// facts — a divergence between them is a card that does not match the session
+// the agent was given.
+//
+// Name is what the session answers to in Claude Code's peer roster; Label is the
+// name on its card. Both address it (see internal/relay). Path is the worktree
+// the session lives in, empty for a session in the project's own directory —
+// the store's own spelling. NextSeq is the project's label counter after this
+// session took its number.
+type Session struct {
+	ID        string `json:"id"`
+	ProjectID string `json:"projectId"`
+	Project   string `json:"project"`
+	Label     string `json:"label"`
+	Name      string `json:"name"`
+	Kind      string `json:"kind"`
+	Path      string `json:"path"`
+	NextSeq   int    `json:"nextSeq"`
+}
+
+// Service opens sessions on behalf of a caller outside the window.
+type Service struct {
+	sessions  Sessions
+	worktrees Worktrees
+	term      Terminal
+	events    Events
+}
+
+func New(sessions Sessions, worktrees Worktrees, term Terminal, events Events) *Service {
+	return &Service{sessions: sessions, worktrees: worktrees, term: term, events: events}
+}
+
+// Open creates a session and starts its PTY.
+//
+// fromID is the session the caller runs in, empty for the command line run
+// outside one. It decides two defaults: the project the session lands in and the
+// provider it runs, both taken from the caller unless named. A caller with no
+// session of its own must name the project — there is nothing to inherit.
+//
+// worktree, when given, is the branch name of a new git worktree created off
+// base (the project's current branch when base is empty); the session is rooted
+// there, labelled after it, and runs the project's worktree setup script before
+// its provider, exactly as the window's own worktree flow does.
+func (s *Service) Open(fromID, projectName, kind, worktree, base string) (Session, error) {
+	projects, err := s.sessions.LoadState()
+	if err != nil {
+		return Session{}, fmt.Errorf("read the workspace: %w", err)
+	}
+	target, err := resolveProject(projects, fromID, projectName)
+	if err != nil {
+		return Session{}, err
+	}
+	kind, err = resolveKind(projects, fromID, kind)
+	if err != nil {
+		return Session{}, err
+	}
+
+	// cwd is where the PTY starts; stored is what the row records, which is
+	// empty for a session in the project's own directory (the store's spelling,
+	// and what the window's grouping reads).
+	cwd, stored := target.Path, ""
+	label := fmt.Sprintf("Session %d", target.NextSeq)
+	setup := false
+	if worktree != "" {
+		wt, err := s.addWorktree(target, worktree, base)
+		if err != nil {
+			return Session{}, err
+		}
+		cwd, stored, label, setup = wt.Path, wt.Path, wt.Name, true
+	}
+
+	id, err := newSessionID()
+	if err != nil {
+		return Session{}, err
+	}
+	opened := Session{
+		ID:        id,
+		ProjectID: target.ID,
+		Project:   target.Name,
+		Label:     label,
+		Name:      relay.RosterName(cwd, id),
+		Kind:      kind,
+		Path:      stored,
+		NextSeq:   target.NextSeq + 1,
+	}
+	if err := s.sessions.AddSession(target.ID, id, label, kind, stored, opened.NextSeq); err != nil {
+		return Session{}, err
+	}
+	// Announced before the spawn, and regardless of how it goes: the row exists
+	// either way, so the card has to exist either way too — a session only the
+	// database knows about is one the user cannot reach to see what went wrong.
+	if s.events != nil {
+		s.events.Emit(OpenedEventName, opened)
+	}
+	if err := s.term.Start(id, target.ID, cwd, kind, "", opened.Name, setup, startCols, startRows); err != nil {
+		return Session{}, fmt.Errorf("session %q was created but its terminal did not start: %w", label, err)
+	}
+	return opened, nil
+}
+
+// addWorktree creates the checkout a worktree session lives in.
+func (s *Service) addWorktree(target store.Project, name, base string) (*project.Worktree, error) {
+	base, remote, err := s.resolveBase(target, base)
+	if err != nil {
+		return nil, err
+	}
+	wt, err := s.worktrees.CreateWorktree(target.Path, target.ID, name, base, remote)
+	if err != nil {
+		return nil, err
+	}
+	return wt, nil
+}
+
+// resolveBase settles what a new worktree branches off, and whether that base is
+// a remote branch — which decides whether it is fetched first and tracked.
+//
+// An empty base is the project's current branch, the one thing a caller with no
+// view of the repository can be assumed to have meant. A named base is looked up
+// rather than trusted: git would happily branch off a typo that happens to be a
+// valid revision, and the worktree it left behind is one nobody asked for.
+func (s *Service) resolveBase(target store.Project, base string) (string, bool, error) {
+	if base == "" {
+		current := s.worktrees.Branch(target.Path)
+		if current == "" {
+			return "", false, fmt.Errorf(
+				"%s has no current branch to start from (detached HEAD) — name one with the base",
+				target.Name,
+			)
+		}
+		return current, false, nil
+	}
+
+	branches, err := s.worktrees.ListBranches(target.Path)
+	if err != nil {
+		return "", false, err
+	}
+	for _, name := range branches.Local {
+		if strings.EqualFold(name, base) {
+			return name, false, nil
+		}
+	}
+	// A branch already checked out in another worktree is reported there rather
+	// than among the local ones, and is still a perfectly good base to branch off.
+	for _, wt := range branches.Worktrees {
+		if strings.EqualFold(wt.Name, base) {
+			return wt.Name, false, nil
+		}
+	}
+	for _, name := range branches.Remote {
+		if strings.EqualFold(name, base) {
+			return name, true, nil
+		}
+	}
+	return "", false, fmt.Errorf("no branch named %q in %s", base, target.Name)
+}
+
+// resolveProject picks the project the session lands in: the one named, or the
+// caller's own when nothing is named.
+func resolveProject(projects []store.Project, fromID, name string) (store.Project, error) {
+	if name == "" {
+		for _, p := range projects {
+			for _, sess := range p.Sessions {
+				if sess.ID == fromID {
+					return p, nil
+				}
+			}
+		}
+		return store.Project{}, fmt.Errorf(
+			"no project given, and this is not running in a lich session — name one. %s",
+			knownProjects(projects),
+		)
+	}
+
+	var matches []store.Project
+	for _, p := range projects {
+		if strings.EqualFold(p.Name, name) {
+			matches = append(matches, p)
+		}
+	}
+	switch len(matches) {
+	case 1:
+		return matches[0], nil
+	case 0:
+		return store.Project{}, fmt.Errorf("no open project named %q. %s", name, knownProjects(projects))
+	default:
+		return store.Project{}, fmt.Errorf(
+			"%q names %d open projects — they cannot be told apart by name", name, len(matches),
+		)
+	}
+}
+
+// resolveKind settles what the new session runs: the provider named, or the
+// caller's own. A caller that is not a session at all falls back to the default
+// provider, which is also what the window opens a session with.
+func resolveKind(projects []store.Project, fromID, kind string) (string, error) {
+	if kind != "" {
+		if !providers.Known(kind) && kind != terminal.KindShell {
+			return "", fmt.Errorf("%q is not a provider lich runs. %s", kind, knownKinds())
+		}
+		return kind, nil
+	}
+	for _, p := range projects {
+		for _, sess := range p.Sessions {
+			if sess.ID == fromID {
+				return sess.Kind, nil
+			}
+		}
+	}
+	return providers.Claude, nil
+}
+
+func knownProjects(projects []store.Project) string {
+	if len(projects) == 0 {
+		return "No project is open."
+	}
+	names := make([]string, 0, len(projects))
+	for _, p := range projects {
+		names = append(names, p.Name)
+	}
+	return "Open projects: " + strings.Join(names, ", ") + "."
+}
+
+func knownKinds() string {
+	kinds := make([]string, 0, len(providers.Registry)+1)
+	for _, p := range providers.Registry {
+		kinds = append(kinds, p.ID)
+	}
+	kinds = append(kinds, terminal.KindShell)
+	return "Known kinds: " + strings.Join(kinds, ", ") + "."
+}
+
+// sessionIDBytes is the length of a session id before hex encoding. The window
+// mints a UUID for the same column; both are opaque to everything that reads
+// them, so this only has to be as unguessable and as unique.
+const sessionIDBytes = 16
+
+func newSessionID() (string, error) {
+	raw := make([]byte, sessionIDBytes)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate session id: %w", err)
+	}
+	return hex.EncodeToString(raw), nil
+}

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -1,0 +1,402 @@
+package spawn
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/project"
+	"github.com/omartelo/lich/internal/store"
+)
+
+// added is one session row the fake store was asked to write.
+type added struct {
+	projectID string
+	sessionID string
+	label     string
+	kind      string
+	path      string
+	nextSeq   int
+}
+
+type fakeSessions struct {
+	projects []store.Project
+	loadErr  error
+	rows     []added
+	addErr   error
+}
+
+func (f *fakeSessions) LoadState() ([]store.Project, error) {
+	return f.projects, f.loadErr
+}
+
+func (f *fakeSessions) AddSession(projectID, sessionID, label, kind, path string, nextSeq int) error {
+	if f.addErr != nil {
+		return f.addErr
+	}
+	f.rows = append(f.rows, added{projectID, sessionID, label, kind, path, nextSeq})
+	return nil
+}
+
+// createdWorktree is one CreateWorktree call, so a test can assert the base the
+// service resolved rather than only the checkout it got back.
+type createdWorktree struct {
+	projectPath string
+	projectID   string
+	name        string
+	base        string
+	remote      bool
+}
+
+type fakeWorktrees struct {
+	branch    string
+	branches  project.Branches
+	listErr   error
+	created   []createdWorktree
+	createErr error
+}
+
+func (f *fakeWorktrees) Branch(string) string { return f.branch }
+
+func (f *fakeWorktrees) ListBranches(string) (project.Branches, error) {
+	return f.branches, f.listErr
+}
+
+func (f *fakeWorktrees) CreateWorktree(
+	projectPath, projectID, name, base string, baseIsRemote bool,
+) (*project.Worktree, error) {
+	f.created = append(f.created, createdWorktree{projectPath, projectID, name, base, baseIsRemote})
+	if f.createErr != nil {
+		return nil, f.createErr
+	}
+	return &project.Worktree{Name: name, Path: "/wt/" + name}, nil
+}
+
+// started is one PTY spawn the fake terminal was asked for.
+type started struct {
+	id        string
+	projectID string
+	cwd       string
+	kind      string
+	name      string
+	setup     bool
+	cols      int
+	rows      int
+}
+
+type fakeTerminal struct {
+	spawns []started
+	err    error
+}
+
+func (f *fakeTerminal) Start(
+	id, projectID, cwd, kind, _, name string, setup bool, cols, rows int,
+) error {
+	f.spawns = append(f.spawns, started{id, projectID, cwd, kind, name, setup, cols, rows})
+	return f.err
+}
+
+type emitted struct {
+	name string
+	data any
+}
+
+type fakeEvents struct{ events []emitted }
+
+func (f *fakeEvents) Emit(name string, data any) {
+	f.events = append(f.events, emitted{name, data})
+}
+
+// workspace is the state most tests open a session into: one project holding
+// the caller's own session, and a second one to name explicitly.
+func workspace() []store.Project {
+	return []store.Project{
+		{ID: "p1", Name: "lich", Path: "/src/lich", NextSeq: 4, Sessions: []store.Session{
+			{ID: "s1", Label: "Session 3", Kind: "codex"},
+		}},
+		{ID: "p2", Name: "revu", Path: "/src/revu", NextSeq: 1},
+	}
+}
+
+func newService(t *testing.T) (*Service, *fakeSessions, *fakeWorktrees, *fakeTerminal, *fakeEvents) {
+	t.Helper()
+	sessions := &fakeSessions{projects: workspace()}
+	worktrees := &fakeWorktrees{branch: "main"}
+	term := &fakeTerminal{}
+	events := &fakeEvents{}
+	return New(sessions, worktrees, term, events), sessions, worktrees, term, events
+}
+
+func TestOpenLandsInTheCallersProject(t *testing.T) {
+	svc, sessions, _, term, events := newService(t)
+
+	opened, err := svc.Open("s1", "", "", "", "")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	if opened.ProjectID != "p1" || opened.Project != "lich" {
+		t.Errorf("opened in %q (%q), want the caller's own project", opened.Project, opened.ProjectID)
+	}
+	// The label continues the project's own counter, exactly as the window's
+	// reducer does — a session that repeats a live label is one `lich send`
+	// cannot address without being told which is which.
+	if opened.Label != "Session 4" || opened.NextSeq != 5 {
+		t.Errorf("label %q, next %d; want Session 4 and 5", opened.Label, opened.NextSeq)
+	}
+	if len(sessions.rows) != 1 {
+		t.Fatalf("wrote %d rows, want 1", len(sessions.rows))
+	}
+	row := sessions.rows[0]
+	if row != (added{"p1", opened.ID, "Session 4", "codex", "", 5}) {
+		t.Errorf("row = %+v", row)
+	}
+	if len(term.spawns) != 1 {
+		t.Fatalf("started %d terminals, want 1", len(term.spawns))
+	}
+	spawn := term.spawns[0]
+	if spawn.id != opened.ID || spawn.cwd != "/src/lich" || spawn.kind != "codex" {
+		t.Errorf("spawn = %+v, want the new session in the project directory", spawn)
+	}
+	if spawn.setup {
+		t.Error("ran the worktree setup script for a session that opened no worktree")
+	}
+	if spawn.cols != startCols || spawn.rows != startRows {
+		t.Errorf("spawn sized %dx%d, want %dx%d", spawn.cols, spawn.rows, startCols, startRows)
+	}
+	if spawn.name != opened.Name {
+		t.Errorf("spawned as %q but reported %q — the roster name has to be one name", spawn.name, opened.Name)
+	}
+	if len(events.events) != 1 || events.events[0].name != OpenedEventName {
+		t.Fatalf("events = %+v, want one %s", events.events, OpenedEventName)
+	}
+	if events.events[0].data != any(opened) {
+		t.Errorf("the window was told %+v, the caller %+v", events.events[0].data, opened)
+	}
+}
+
+// The kind is what an agent inherits without asking: a Codex session opening a
+// worker gets another Codex, not whatever lich defaults to.
+func TestOpenInheritsTheCallersKind(t *testing.T) {
+	svc, _, _, term, _ := newService(t)
+
+	if _, err := svc.Open("s1", "", "", "", ""); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if got := term.spawns[0].kind; got != "codex" {
+		t.Errorf("kind = %q, want the caller's codex", got)
+	}
+}
+
+func TestOpenTakesANamedProjectAndKind(t *testing.T) {
+	svc, sessions, _, term, _ := newService(t)
+
+	opened, err := svc.Open("s1", "revu", "shell", "", "")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if opened.ProjectID != "p2" {
+		t.Errorf("opened in %q, want the named project", opened.ProjectID)
+	}
+	if opened.Label != "Session 1" {
+		t.Errorf("label = %q, want the named project's own counter", opened.Label)
+	}
+	if sessions.rows[0].kind != "shell" || term.spawns[0].kind != "shell" {
+		t.Errorf("row %q / spawn %q, want shell", sessions.rows[0].kind, term.spawns[0].kind)
+	}
+	if term.spawns[0].cwd != "/src/revu" {
+		t.Errorf("cwd = %q, want the named project's directory", term.spawns[0].cwd)
+	}
+}
+
+func TestOpenWithoutASessionOrAProjectSaysWhatToDo(t *testing.T) {
+	svc, _, _, term, _ := newService(t)
+
+	_, err := svc.Open("", "", "", "", "")
+	if err == nil {
+		t.Fatal("opened a session with nothing to open it in")
+	}
+	// The command line outside a session inherits nothing, so the error has to
+	// name what it could have been given instead of only refusing.
+	if !strings.Contains(err.Error(), "lich") || !strings.Contains(err.Error(), "revu") {
+		t.Errorf("error = %q, want the open projects named", err)
+	}
+	if len(term.spawns) != 0 {
+		t.Error("started a terminal for a session that was never created")
+	}
+}
+
+func TestOpenRefusesAnUnknownProject(t *testing.T) {
+	svc, sessions, _, _, _ := newService(t)
+
+	if _, err := svc.Open("s1", "nope", "", "", ""); err == nil {
+		t.Fatal("opened a session in a project that is not open")
+	}
+	if len(sessions.rows) != 0 {
+		t.Error("wrote a row for a project that is not open")
+	}
+}
+
+func TestOpenRefusesAnUnknownKind(t *testing.T) {
+	svc, sessions, _, _, _ := newService(t)
+
+	_, err := svc.Open("s1", "", "gemini", "", "")
+	if err == nil {
+		t.Fatal("opened a session running a provider lich does not know")
+	}
+	if !strings.Contains(err.Error(), "claude") {
+		t.Errorf("error = %q, want the known kinds named", err)
+	}
+	if len(sessions.rows) != 0 {
+		t.Error("wrote a row for an unknown kind")
+	}
+}
+
+func TestOpenOnAWorktreeBranchesOffTheCurrentBranch(t *testing.T) {
+	svc, sessions, worktrees, term, _ := newService(t)
+
+	opened, err := svc.Open("s1", "", "", "auth-fix", "")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	if len(worktrees.created) != 1 {
+		t.Fatalf("created %d worktrees, want 1", len(worktrees.created))
+	}
+	if got := worktrees.created[0]; got != (createdWorktree{"/src/lich", "p1", "auth-fix", "main", false}) {
+		t.Errorf("created = %+v, want it off the project's current branch", got)
+	}
+	// The card is named after the checkout, not numbered — the same thing the
+	// window's worktree flow does, and what makes the session addressable by the
+	// branch whoever asked for it is thinking in.
+	if opened.Label != "auth-fix" {
+		t.Errorf("label = %q, want the worktree's name", opened.Label)
+	}
+	if opened.Path != "/wt/auth-fix" || sessions.rows[0].path != "/wt/auth-fix" {
+		t.Errorf("path %q / row %q, want the checkout", opened.Path, sessions.rows[0].path)
+	}
+	if term.spawns[0].cwd != "/wt/auth-fix" {
+		t.Errorf("spawned in %q, want the checkout", term.spawns[0].cwd)
+	}
+	if !term.spawns[0].setup {
+		t.Error("skipped the worktree setup script on a fresh checkout")
+	}
+}
+
+func TestOpenTracksARemoteBase(t *testing.T) {
+	svc, _, worktrees, _, _ := newService(t)
+	worktrees.branches = project.Branches{
+		Local:  []string{"main"},
+		Remote: []string{"origin/release"},
+	}
+
+	if _, err := svc.Open("s1", "", "", "hotfix", "origin/release"); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if got := worktrees.created[0]; !got.remote || got.base != "origin/release" {
+		t.Errorf("created = %+v, want the remote base fetched and tracked", got)
+	}
+}
+
+// A branch another worktree holds is reported among the checkouts rather than
+// among the local branches, and is still a base a new worktree can branch off.
+func TestOpenBranchesOffABranchAnotherWorktreeHolds(t *testing.T) {
+	svc, _, worktrees, _, _ := newService(t)
+	worktrees.branches = project.Branches{
+		Local:     []string{"main"},
+		Worktrees: []project.Worktree{{Name: "amber-otter", Path: "/wt/amber-otter"}},
+	}
+
+	if _, err := svc.Open("s1", "", "", "follow-up", "amber-otter"); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if got := worktrees.created[0]; got.base != "amber-otter" || got.remote {
+		t.Errorf("created = %+v, want a local base", got)
+	}
+}
+
+func TestOpenRefusesABaseThatIsNoBranch(t *testing.T) {
+	svc, sessions, worktrees, _, _ := newService(t)
+	worktrees.branches = project.Branches{Local: []string{"main"}}
+
+	// git would branch off any revision this happened to resolve to, leaving a
+	// checkout nobody asked for; a name that is not a branch is a typo.
+	_, err := svc.Open("s1", "", "", "hotfix", "mian")
+	if err == nil {
+		t.Fatal("created a worktree off a base that is not a branch")
+	}
+	if len(worktrees.created) != 0 || len(sessions.rows) != 0 {
+		t.Error("wrote something for a base that was refused")
+	}
+}
+
+func TestOpenLeavesNoSessionWhenTheWorktreeFails(t *testing.T) {
+	svc, sessions, worktrees, term, events := newService(t)
+	worktrees.createErr = errors.New("branch already exists")
+
+	if _, err := svc.Open("s1", "", "", "auth-fix", ""); err == nil {
+		t.Fatal("opened a session on a worktree that was never created")
+	}
+	if len(sessions.rows) != 0 || len(term.spawns) != 0 || len(events.events) != 0 {
+		t.Error("a failed checkout left a row, a terminal or a card behind")
+	}
+}
+
+// A spawn that fails is still a session: the row is written and the card has to
+// appear, or the user cannot reach what went wrong.
+func TestOpenKeepsTheCardWhenTheTerminalFails(t *testing.T) {
+	svc, sessions, _, term, events := newService(t)
+	term.err = errors.New("claude: not found")
+
+	_, err := svc.Open("s1", "", "", "", "")
+	if err == nil {
+		t.Fatal("reported success for a terminal that never started")
+	}
+	if !strings.Contains(err.Error(), "Session 4") {
+		t.Errorf("error = %q, want the session it left behind named", err)
+	}
+	if len(sessions.rows) != 1 {
+		t.Errorf("wrote %d rows, want the session kept", len(sessions.rows))
+	}
+	if len(events.events) != 1 {
+		t.Errorf("emitted %d events, want the card announced anyway", len(events.events))
+	}
+}
+
+func TestOpenWithoutAnEventsSinkStillOpens(t *testing.T) {
+	sessions := &fakeSessions{projects: workspace()}
+	svc := New(sessions, &fakeWorktrees{branch: "main"}, &fakeTerminal{}, nil)
+
+	if _, err := svc.Open("s1", "", "", "", ""); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if len(sessions.rows) != 1 {
+		t.Errorf("wrote %d rows, want 1", len(sessions.rows))
+	}
+}
+
+func TestOpenRefusesADetachedHeadWithoutABase(t *testing.T) {
+	svc, _, worktrees, _, _ := newService(t)
+	worktrees.branch = ""
+
+	_, err := svc.Open("s1", "", "", "auth-fix", "")
+	if err == nil {
+		t.Fatal("created a worktree off nothing")
+	}
+	if len(worktrees.created) != 0 {
+		t.Error("reached git with an empty base")
+	}
+}
+
+func TestSessionIDsDoNotRepeat(t *testing.T) {
+	svc, sessions, _, _, _ := newService(t)
+
+	for range 2 {
+		if _, err := svc.Open("s1", "", "", "", ""); err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+	}
+	if sessions.rows[0].sessionID == sessions.rows[1].sessionID {
+		t.Fatal("two sessions took the same id — the second would overwrite the first's row")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/omartelo/lich/internal/restart"
 	"github.com/omartelo/lich/internal/rpc"
 	"github.com/omartelo/lich/internal/singleton"
+	"github.com/omartelo/lich/internal/spawn"
 	"github.com/omartelo/lich/internal/store"
 	"github.com/omartelo/lich/internal/system"
 	"github.com/omartelo/lich/internal/terminal"
@@ -132,6 +133,9 @@ func main() {
 	rl := relay.New(db, term, hub)
 	term.SetSessionState(rl.Observe)
 	dispatcher.Register("relay", rl)
+	// Its caller is not the window either: opening a session for an agent starts
+	// the PTY here rather than waiting for someone to click the card.
+	dispatcher.Register("spawn", spawn.New(db, proj, term, hub))
 	dispatcher.Register("themes", themes.New())
 	dispatcher.Deny("store.Close")
 	// The dropped file's bytes are the request body, so the upload is its own


### PR DESCRIPTION
An agent could already reach the sessions beside it (`lich sessions` / `send`),
but it could not create one — so work that deserved its own checkout waited for
somebody to click New Session. This adds the other half: opening a session, with
a git worktree under it when the task needs its own tree.

```
lich open [--project <name>] [--kind <provider>] [--worktree <branch>] [--base <branch>] [--json]
```

and the same thing as the MCP tool `open_session`, so it is in the tool list of
every provider lich registers the server with, without anybody being told it
exists.

## What it does

- **Project** defaults to the caller's own, **kind** to the caller's own provider
  (a Codex session opening a worker gets another Codex). A caller outside a
  session inherits neither, so it must name the project — the error lists what is
  open.
- **`--worktree`** creates the checkout off `--base` (the project's current
  branch by default) and roots the session in it, labelled after the branch, with
  the project's worktree setup script running in the PTY before the provider —
  the same flow the window's own worktree button performs.
- **`--base` is looked up, not trusted**: local branches, remotes (`origin/…`,
  fetched and tracked) and branches another worktree already holds all resolve; a
  name that is none of those is refused. git would happily branch off a typo that
  resolves to a revision, leaving a checkout nobody asked for.

## Why the backend starts the PTY

The window spawns a session's terminal on the card's **first view**. A session
opened for an agent and never clicked would therefore have no process in it —
invisible to `lich sessions`, unreachable by `lich send`, useless to whoever
asked for it. `internal/spawn` starts it instead, so the session is addressable
the moment the command returns; the card's first view attaches to the PTY that is
already running, exactly as it does after a page reload.

That is also why this is its own package: a session is four things at once — the
worktree (`internal/project`), the row (`internal/store`), the PTY
(`internal/terminal`) and the card (an app event) — and no existing package owns
more than one of them.

The card is announced with the whole session (`session-opened`) and adopted
**without focus**: an agent opening three workers must not drag the user's view
along three times.

## Deliberately out of scope

`open` does not take a prompt. A session is addressable before the agent inside
it has finished starting, and there is no readiness signal every provider gives,
so a task handed over in that window is written into a TUI that may not be
reading yet. Opening and sending stay two steps, and the command says so in its
output. Closing or otherwise managing a session from here is not in this PR
either.

## Known ceilings (documented in `docs/cli.md`)

- A session is addressable before its agent can read.
- The PTY starts at 80×24; the window resizes it on the first view, and
  scrollback produced before that keeps the 80-column wraps.
- An opened session takes the project's active slot, so a reload lands on it.

## Test plan

- [x] `go test ./...` — new `internal/spawn` suite at 90.2% coverage; `internal/cli` at 86.6%.
- [x] `internal/cli/wire_test.go` drives `lich open` over the real RPC dispatcher, so a positional argument that moves fails here rather than in a terminal.
- [x] `pnpm test` (793), `pnpm check`, `tsc --noEmit`, `vite build`.
- [x] Cross-compile: `GOOS=linux|darwin|windows go build ./...`.
- [x] End to end against an isolated instance (own `XDG_CONFIG_HOME`, own port): `lich open` produced a session that `lich sessions` listed as live **without anybody opening its card**; `--worktree feat-x` created the checkout on disk with the session rooted in it; unknown project, non-branch base and no-project-outside-a-session each exit 1 naming the options.
- [ ] The card appearing in a real window — the logic is unit-tested on both sides, but the render path is not covered by the node-only frontend suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165ri2wHyhozQQjhFBUV1UB