### PR TITLE
fix: make a session an agent opens actually usable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it — opens one in any project, running any provider lich knows, optionally on
   a fresh git worktree branched off whatever branch you name. The new card
   appears in the sidebar without stealing your view, and its terminal is already
-  running: it can be given work straight away, whether or not anybody opens it.
+  running, so the session can be given work whether or not anybody opens it — a
+  task sent while the checkout is still running the project's setup script is
+  held until its agent is up, rather than typed into the script.
 - **lich says when its last run ended badly.** A crash, a kill, or a machine
   that went down took the sessions with it — and the next launch restored the
   workspace looking exactly as it does after a deliberate close, so the turn an

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -144,6 +144,13 @@ A prompt is capped at 8192 characters and stripped of control characters — the
 text is typed into a terminal, and an escape sequence inside it would stop being
 text.
 
+**A target still running its setup script is waited for, not written to.** The
+wait is bounded by the caller's own `--timeout`; running out is an error saying
+nothing was sent, never a ticket — an errand nobody can answer would otherwise
+be waited out in full. `internal/terminal` tells the two apart by a marker the
+setup wrapper prints between the script and the provider (`setupDone`): the PTY
+and the pid are the same across the `exec`, so nothing else can.
+
 ### `lich wait [--timeout <seconds>] <ticket>`
 
 Waits again on a ticket a previous `send` handed back. Same output as `send`.
@@ -486,11 +493,15 @@ whoever asked.
   the exception, and only for the session it creates: it starts that PTY itself,
   which is why the card it leaves behind is one you can send to unseen.
 - **A session is addressable before its agent can read.** `open` returns when
-  the PTY exists, not when the provider inside it has finished starting — there
-  is no signal for the latter that every provider gives. A message sent in that
-  window is written into a TUI that may not be reading yet, and lich cannot tell
-  that apart from a delivered one (delivery is proven, receipt is not). Hence
-  the line the command prints; opening and sending are two steps on purpose.
+  the PTY exists, not when the provider inside it has finished starting. The one
+  stretch lich *can* see is the project's worktree setup script, which owns that
+  PTY before the provider and can run for minutes: `send` waits it out rather
+  than typing into it (see below), because a message handed to a running
+  `pnpm install` is read and discarded, and the sender then waits out a ticket
+  nobody was ever asked to answer. What is left is the second or two the
+  provider's own TUI takes to start reading, which no provider signals and lich
+  cannot tell apart from a delivered message (delivery is proven, receipt is
+  not).
 - **`open` starts the PTY at the size the window last reported**, because there
   is no terminal at this end to measure (`terminal.sizeFor`); 80×24 only when no
   window has ever measured one. It is a copy, not a subscription: a window

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -499,9 +499,9 @@ whoever asked.
   than typing into it (see below), because a message handed to a running
   `pnpm install` is read and discarded, and the sender then waits out a ticket
   nobody was ever asked to answer. What is left is the second or two the
-  provider's own TUI takes to start reading, which no provider signals and lich
-  cannot tell apart from a delivered message (delivery is proven, receipt is
-  not).
+  provider's own TUI takes to start reading. lich waits that out as quiet — a
+  PTY that has stopped drawing has taken the terminal — which is a heuristic and
+  not a signal: no provider offers one.
 - **`open` starts the PTY at the size the window last reported**, because there
   is no terminal at this end to measure (`terminal.sizeFor`); 80×24 only when no
   window has ever measured one. It is a copy, not a subscription: a window
@@ -513,6 +513,15 @@ whoever asked.
   way the window writes one, so the project's `active_session_id` moves to it —
   the card is not focused now, but a reload lands on it. Two of them and the
   last one wins.
+- **A provider may open on a question of its own.** Claude Code asks whether a
+  directory is trusted the first time it runs in one, and a session sitting on
+  that prompt looks exactly like one waiting at its own: quiet, live, ready. The
+  first task sent to it answers the trust prompt instead of being read. It
+  applies to a directory the provider has never seen, so the worktrees of a
+  project already in use are unaffected — but the first worktree of a new one,
+  on a machine where nobody has answered it yet, needs a human at that card
+  once. lich cannot see it without reading the screen, which is the one thing
+  this feature does not do.
 - **Delivery is proven, receipt is not.** `send` knows the bytes reached the
   PTY. Whether the target's TUI queued them, and whether its agent ever runs the
   reply command, is what the wait and the ticket are for. A provider that does

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -491,11 +491,13 @@ whoever asked.
   window is written into a TUI that may not be reading yet, and lich cannot tell
   that apart from a delivered one (delivery is proven, receipt is not). Hence
   the line the command prints; opening and sending are two steps on purpose.
-- **`open` starts the PTY at 80×24.** Nothing is watching it, so there is no
-  terminal to measure. The window resizes it the first time the card is viewed,
-  and a TUI that drew itself into the smaller grid redraws — but output produced
-  before that view was wrapped for 80 columns, and the replayed scrollback keeps
-  those wraps.
+- **`open` starts the PTY at the size the window last reported**, because there
+  is no terminal at this end to measure (`terminal.sizeFor`); 80×24 only when no
+  window has ever measured one. It is a copy, not a subscription: a window
+  resized between the spawn and the first view of the card leaves that session
+  drawn for the old grid, and the first view resizes it — at which point the TUI
+  repaints and the conversation it had already written is gone from the screen,
+  though not from the provider. The same seam a hidden session's replay has.
 - **An opened session takes the project's active slot.** The row is written the
   way the window writes one, so the project's `active_session_id` moves to it —
   the card is not focused now, but a reload lands on it. Two of them and the

--- a/frontend/src/components/TerminalHost.tsx
+++ b/frontend/src/components/TerminalHost.tsx
@@ -5,7 +5,7 @@ import { TerminalView } from "./TerminalView"
 import { ResumeSessionDialog } from "./ResumeSessionDialog"
 import { Terminal as TerminalService } from "@/lib/rpc"
 import { useProjects } from "@/providers/projects"
-import { activeSessionId, resumableSession, sessionsOf } from "@/lib/session/sessions"
+import { activeSessionId, hasSession, resumableSession, sessionsOf } from "@/lib/session/sessions"
 import { spawnDecision, type SpawnProbe } from "@/lib/session/spawn-gate"
 import type { Session } from "@/lib/session/sessions"
 
@@ -146,6 +146,7 @@ export function TerminalHost() {
                 kind={session.kind}
                 resume={resuming[session.id] ?? ""}
                 visible={visible}
+                stillInWorkspace={() => hasSession(sessionsRef.current, session.id)}
               />
             </div>
           )

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -596,6 +596,13 @@ export function TerminalView({
         void Service.Close(sessionId)
         return
       }
+      // Start is a no-op for a session that was already running — one an agent
+      // opened through the CLI or its MCP tools, whose PTY the backend started
+      // without a terminal to measure — and a no-op ignores the size passed to
+      // it. Sending it separately is what stops such a session from drawing
+      // into a grid this terminal does not have. Same size: no SIGWINCH, no
+      // repaint, so the ordinary spawn pays nothing.
+      void Service.Resize(sessionId, live.term.cols, live.term.rows)
       // Deliver any one-shot input queued for this session (the update flow's
       // install command) now that the PTY exists. No trailing newline, so it
       // sits at the prompt for the user to run.

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -156,6 +156,15 @@ export interface TerminalViewProps {
    */
   resume: string
   visible: boolean
+  /**
+   * Whether this session still belongs to the workspace, asked at the moment
+   * this component goes away. Unmounting is not the same event as closing a
+   * session — React unmounts for reasons of its own (StrictMode's double
+   * mount in dev, a hot reload) — and the PTY must only die with the session.
+   * Read through a ref, never as a dependency: the answer is wanted at
+   * teardown, not at render.
+   */
+  stillInWorkspace: () => boolean
 }
 
 interface LiveTerminal {
@@ -179,6 +188,7 @@ export function TerminalView({
   kind,
   resume,
   visible,
+  stillInWorkspace,
 }: TerminalViewProps) {
   const { font, terminalFontSize, resolvedTerminalTheme } = useSettings()
   const terminalColors = resolvedTerminalTheme.terminal
@@ -199,10 +209,12 @@ export function TerminalView({
   const mouseEncodingRef = useRef("")
   const replayRef = useRef(makeReplayBuffer())
   const visibleRef = useRef(visible)
+  const stillInWorkspaceRef = useRef(stillInWorkspace)
   const fontRef = useRef(font)
   const fontSizeRef = useRef(terminalFontSize)
   const themeRef = useRef(terminalColors)
   visibleRef.current = visible
+  stillInWorkspaceRef.current = stillInWorkspace
   fontRef.current = font
   fontSizeRef.current = terminalFontSize
   themeRef.current = terminalColors
@@ -590,10 +602,14 @@ export function TerminalView({
         return
       }
       if (disposed) {
-        // Unmounted during the Start round-trip: the cleanup's Close raced
-        // ahead of the spawn, so close again now that the PTY exists. The
-        // queued paste stays put for the session's next mount.
-        void Service.Close(sessionId)
+        // Unmounted during the Start round-trip. If the session went with it,
+        // the cleanup's Close raced ahead of the spawn, so close again now
+        // that the PTY exists; if the session is still in the workspace this
+        // was React remounting us and the PTY is the one the next mount
+        // attaches to. The queued paste stays put either way.
+        if (!stillInWorkspaceRef.current()) {
+          void Service.Close(sessionId)
+        }
         return
       }
       // Start is a no-op for a session that was already running — one an agent
@@ -625,7 +641,17 @@ export function TerminalView({
       for (const cleanup of cleanups) {
         cleanup()
       }
-      void Service.Close(sessionId)
+      // The PTY dies with the session, never with this component. React
+      // unmounts for reasons that are not a close — StrictMode mounts every
+      // component twice in dev, a hot reload tears the tree down — and a PTY
+      // closed for one of those takes the running agent and its scrollback
+      // with it. That was invisible while every session's PTY was born on
+      // this very mount; a session opened through the CLI or its MCP tools is
+      // already running when the card is first viewed, and the double mount
+      // killed the conversation the user came to read.
+      if (!stillInWorkspaceRef.current()) {
+        void Service.Close(sessionId)
+      }
       liveRef.current?.dispose()
       liveRef.current = null
     }

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -6,6 +6,7 @@ import {
   adoptSession,
   closeSession,
   groupByWorktree,
+  hasSession,
   isLastWorktreeSession,
   isSessionKind,
   neighborSessionId,
@@ -623,5 +624,24 @@ describe("adoptSession", () => {
     const before = buildState(5)
     const state = adoptSession(before, P, opened, 2)
     expect(state[P].nextSeq).toBe(before[P].nextSeq)
+  })
+})
+
+describe("hasSession", () => {
+  it("finds a session under any project", () => {
+    let state = buildState(2)
+    state = addSession(state, "other", "x1")
+    expect(hasSession(state, "s1")).toBe(true)
+    expect(hasSession(state, "x1")).toBe(true)
+  })
+
+  // The question a terminal asks as it goes away: a session that left the
+  // workspace is one whose PTY may die, and a session still in it is a card
+  // React took down for reasons of its own.
+  it("is false for a session that left the workspace", () => {
+    const state = closeSession(buildState(2), P, "s2")
+    expect(hasSession(state, "s2")).toBe(false)
+    expect(hasSession(state, "never-existed")).toBe(false)
+    expect(hasSession({}, "s1")).toBe(false)
   })
 })

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -399,6 +399,14 @@ export function isLastWorktreeSession(sessions: Session[], session: Session): bo
   return !sessions.some((s) => s.id !== session.id && s.path === session.path)
 }
 
+// hasSession reports whether the workspace still holds a session, under any
+// project. It answers one question: whether a card that is going away is going
+// away because its session ended, which is the only reason its PTY may be
+// closed — React unmounts a terminal for reasons of its own.
+export function hasSession(state: SessionState, sessionId: string): boolean {
+  return projectOfSession(state, sessionId) !== ""
+}
+
 export function activeSessionId(state: SessionState, projectId: string): string {
   return state[projectId]?.activeId ?? ""
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -293,8 +293,13 @@ func (c *client) open(args []string) error {
 
 // openedText words a new session for whoever asked for one. It names both of
 // its names, because the caller's next move is to address it and either one
-// reaches it, and it says the session is still starting: the PTY exists the
-// moment this prints, and the provider inside it does not.
+// reaches it.
+//
+// What it no longer does is tell the caller to wait. A session on a fresh
+// worktree runs the project's setup script before its provider, which can take
+// minutes, and no instruction to "give it a moment" survives that. Sending is
+// what waits now (relay.awaitReady), so the honest thing to say is that the
+// message will be held.
 func openedText(opened spawn.Session) string {
 	where := fmt.Sprintf("project %q", opened.Project)
 	if opened.Path != "" {
@@ -302,8 +307,9 @@ func openedText(opened spawn.Session) string {
 	}
 	return fmt.Sprintf(
 		"Opened session %q (%s) in %s.\n"+
-			"It answers to %q and to %q. It is still starting up — give it a moment "+
-			"before you send it work.\n",
+			"It answers to %q and to %q. Its agent may still be starting — a fresh "+
+			"worktree runs the project's setup script first — so a task you send it "+
+			"is held until the agent is up rather than lost.\n",
 		opened.Label, opened.Kind, where, opened.Label, opened.Name,
 	)
 }

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -41,6 +41,8 @@ type wiredTerminal struct {
 // it on every call, which is a race the moment the two are used together.
 func (*wiredTerminal) Live(string) bool { return true }
 
+func (*wiredTerminal) Ready(string) bool { return true }
+
 func (w *wiredTerminal) Write(_, data string) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -47,6 +47,10 @@ const (
 	// answerLimit bounds one reply. Generous — an answer is a summary, and the
 	// caller reads it as command output.
 	answerLimit = 64 * 1024
+	// readyPoll is how often awaitReady asks whether a target's agent is up. A
+	// setup script runs for tens of seconds at least, so this only has to be
+	// quick against a human's patience, not against the machine.
+	readyPoll = 250 * time.Millisecond
 )
 
 // How lich's own MCP server (internal/cli) is registered and what it calls its
@@ -141,9 +145,11 @@ type Events interface {
 }
 
 // Terminal is the PTY side: whether a session has a process running right now,
+// whether what runs in it is the agent rather than the checkout's setup script,
 // and how to type at it. The terminal service implements it.
 type Terminal interface {
 	Live(id string) bool
+	Ready(id string) bool
 	Write(id, data string) error
 }
 
@@ -307,6 +313,12 @@ func (s *Service) Send(fromID, target, project, prompt string, waitSeconds int) 
 	s.mu.Unlock()
 	s.clearAll(expired)
 
+	if err := s.awaitReady(dest, waitFor(waitSeconds)); err != nil {
+		s.mu.Lock()
+		delete(s.tickets, id)
+		s.mu.Unlock()
+		return Result{}, err
+	}
 	if err := s.deliver(dest.ID, compose(sender, id, prompt, dest.Peer.Kind)); err != nil {
 		s.mu.Lock()
 		delete(s.tickets, id)
@@ -329,6 +341,42 @@ func (s *Service) deliver(sessionID, message string) error {
 	}
 	time.Sleep(s.submitDelay)
 	return s.term.Write(sessionID, submit)
+}
+
+// awaitReady blocks until a target's agent is the program reading its PTY.
+//
+// A session opened on a fresh worktree runs the project's setup script in that
+// PTY first, and the script can take minutes. It is live the whole time, and a
+// message typed into it reaches `pnpm install`, which reads and discards it —
+// so the request never existed, and the sender waits out a ticket nobody was
+// asked to answer. Seen on the first real run of a worktree session.
+//
+// Waiting is bounded by the caller's own wait: there is no point holding a
+// message for a setup that outlasts the errand. Running out is an error rather
+// than a delivery, because a message nobody can be given is not one that was
+// sent.
+func (s *Service) awaitReady(dest candidate, wait time.Duration) error {
+	if s.term.Ready(dest.ID) {
+		return nil
+	}
+	deadline := s.now().Add(wait)
+	for {
+		time.Sleep(readyPoll)
+		if s.term.Ready(dest.ID) {
+			return nil
+		}
+		if !s.term.Live(dest.ID) {
+			return fmt.Errorf("%q stopped before its agent started", dest.Peer.Label)
+		}
+		if s.now().After(deadline) {
+			return fmt.Errorf(
+				"%q is still preparing its checkout — the project's worktree setup script "+
+					"is running in it and its agent has not started yet. Nothing was sent. "+
+					"Try again once it is up; lich sessions lists it as soon as it can take work",
+				dest.Peer.Label,
+			)
+		}
+	}
 }
 
 // Wait blocks on an already-delivered ticket for another round, so a caller

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -21,14 +21,19 @@ func (f fakeSessions) LoadState() ([]store.Project, error) { return f.projects, 
 // fakeTerminal records what was typed at which session, and answers Live from
 // an explicit set so a test can park a session without a PTY.
 type fakeTerminal struct {
-	mu       sync.Mutex
-	live     map[string]bool
-	writes   map[string][]string
-	writeErr error
+	mu sync.Mutex
+	// live is whether a PTY exists; settingUp is whether what reads it is still
+	// the worktree setup script rather than the agent.
+	live      map[string]bool
+	settingUp map[string]bool
+	writes    map[string][]string
+	writeErr  error
 }
 
 func newFakeTerminal(live ...string) *fakeTerminal {
-	t := &fakeTerminal{live: map[string]bool{}, writes: map[string][]string{}}
+	t := &fakeTerminal{
+		live: map[string]bool{}, writes: map[string][]string{}, settingUp: map[string]bool{},
+	}
 	for _, id := range live {
 		t.live[id] = true
 	}
@@ -39,6 +44,23 @@ func (f *fakeTerminal) Live(id string) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return f.live[id]
+}
+
+// Ready defaults to "as ready as it is live": most tests are about delivery and
+// answers, not about a checkout that is still installing its dependencies. The
+// ones that are set settingUp.
+func (f *fakeTerminal) Ready(id string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.live[id] && !f.settingUp[id]
+}
+
+// setUp marks a session as still running its worktree setup script: live, and
+// with nothing on the other end that could read a message.
+func (f *fakeTerminal) setUp(id string, running bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.settingUp[id] = running
 }
 
 func (f *fakeTerminal) Write(id, data string) error {
@@ -989,4 +1011,80 @@ func waitForTicket(svc *Service) string {
 	}
 	// Timed out: the caller's own assertion is what reports it.
 	return ""
+}
+
+// A session running its worktree setup script is live and has nothing that can
+// read a message: the script owns the PTY until it execs the provider. Writing
+// into it loses the request outright — `pnpm install` reads the bytes and drops
+// them — and the sender then waits out a ticket nobody was ever asked to
+// answer, which is how this was found.
+
+func TestSendWaitsForTheSetupScriptToFinish(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	term.setUp("s2", true)
+	svc := newRelay(workspace(), term, nil)
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		term.setUp("s2", false)
+	}()
+
+	// One second covers both waits here: the setup finishes in 20ms, and nobody
+	// answers, so the errand ends pending on purpose.
+	result, err := svc.Send("s1", "docs", "", "run the tests", 1)
+	if err != nil {
+		t.Fatalf("Send = %v, want the message held until the agent was up", err)
+	}
+	if result.Status != StatusPending {
+		t.Errorf("status = %q, want the errand open", result.Status)
+	}
+	if len(term.writesTo("s2")) == 0 {
+		t.Error("nothing was typed at the target once its agent started")
+	}
+}
+
+func TestSendRefusesRatherThanTypingIntoASetupScript(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	term.setUp("s2", true)
+	svc := newRelay(workspace(), term, nil)
+
+	_, err := svc.Send("s1", "docs", "", "run the tests", 1)
+	if err == nil {
+		t.Fatal("sent a message into a checkout that was still installing")
+	}
+	// The sender has to know nothing was delivered: a ticket here would be an
+	// errand nobody can answer, waited out in full.
+	if !strings.Contains(err.Error(), "Nothing was sent") {
+		t.Errorf("error = %q, want it to say the message was not delivered", err)
+	}
+	if len(term.writesTo("s2")) != 0 {
+		t.Errorf("typed %v into the setup script", term.writesTo("s2"))
+	}
+	svc.mu.Lock()
+	open := len(svc.tickets)
+	svc.mu.Unlock()
+	if open != 0 {
+		t.Errorf("left %d tickets open for a message that was never delivered", open)
+	}
+}
+
+func TestSendGivesUpWhenTheTargetDiesDuringSetup(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	term.setUp("s2", true)
+	svc := newRelay(workspace(), term, nil)
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		term.mu.Lock()
+		term.live["s2"] = false
+		term.mu.Unlock()
+	}()
+
+	_, err := svc.Send("s1", "docs", "", "run the tests", 30)
+	if err == nil {
+		t.Fatal("waited on a session that is gone")
+	}
+	if !strings.Contains(err.Error(), "stopped before its agent started") {
+		t.Errorf("error = %q", err)
+	}
 }

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -37,12 +37,18 @@ import (
 // is the workspace state, which outlives any one card.
 const OpenedEventName = "session-opened"
 
-// The size a session's PTY starts at. Nothing is watching it yet — the window
-// resizes it to the real terminal the first time the card is viewed — so this
-// only has to be a shape a TUI can draw itself into meanwhile.
+// The size a session opened here starts at: none of its own, which the terminal
+// service reads as "whatever size the window last reported" (terminal.sizeFor).
+//
+// There is no terminal to measure at this end — that is what opening a session
+// for an agent means — and naming a shape here was wrong rather than arbitrary.
+// The provider drew its whole conversation into a grid the window did not have;
+// the first view of the card resized the PTY, the TUI repainted, and everything
+// it had written was gone from the screen. Copying the window's size costs
+// nothing and leaves the card readable.
 const (
-	startCols = 80
-	startRows = 24
+	startCols = 0
+	startRows = 0
 )
 
 // Sessions is the persistence this needs: the workspace to resolve a project in,

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -161,8 +161,12 @@ func TestOpenLandsInTheCallersProject(t *testing.T) {
 	if spawn.setup {
 		t.Error("ran the worktree setup script for a session that opened no worktree")
 	}
-	if spawn.cols != startCols || spawn.rows != startRows {
-		t.Errorf("spawn sized %dx%d, want %dx%d", spawn.cols, spawn.rows, startCols, startRows)
+	// No size of its own — pinned as the literal zero rather than read off the
+	// constants, because the zero is the contract: it is what makes the terminal
+	// service start this session at the size the window is actually showing,
+	// instead of a shape chosen here that the first view would have to repaint.
+	if spawn.cols != 0 || spawn.rows != 0 {
+		t.Errorf("spawn sized %dx%d, want no size of its own", spawn.cols, spawn.rows)
 	}
 	if spawn.name != opened.Name {
 		t.Errorf("spawned as %q but reported %q — the roster name has to be one name", spawn.name, opened.Name)

--- a/internal/terminal/setup.go
+++ b/internal/terminal/setup.go
@@ -26,7 +26,28 @@ func wrapSetup(spec ptySpec, script, goos string) ptySpec {
 	spec.bin = "sh"
 	spec.args = []string{
 		"-c",
-		"(\n" + script + "\n) || echo \"[lich] worktree setup failed (exit $?)\"; exec " + strings.Join(argv, " "),
+		"(\n" + script + "\n) || echo \"[lich] worktree setup failed (exit $?)\"; " +
+			"printf '" + setupDoneEscaped + "'; exec " + strings.Join(argv, " "),
 	}
 	return spec
 }
+
+// setupDone is what the wrapper emits between the script and the provider, and
+// the only way lich can tell the two apart from outside: the PTY is the same,
+// the process is the same (exec replaces the image, keeping the pid), and the
+// output of a setup script looks like the output of anything else.
+//
+// It matters because a session running its setup is not a session an agent can
+// be given work in. lich types a relayed message at the prompt, and during the
+// setup the thing reading that PTY is the script — a message handed over then
+// goes to `pnpm install`, which discards it, and the agent that finally starts
+// never sees the request. Nothing reports a failure: the sender waits for an
+// answer nobody was ever asked for.
+//
+// An OSC sequence with a private code carries it. Terminals ignore an OSC they
+// do not know — xterm.js parses and drops it — so the marker never reaches the
+// screen the user is watching.
+const (
+	setupDone        = "\x1b]6969;lich-setup-done\x07"
+	setupDoneEscaped = "\\033]6969;lich-setup-done\\007"
+)

--- a/internal/terminal/setup_test.go
+++ b/internal/terminal/setup_test.go
@@ -44,3 +44,35 @@ func TestWrapSetup(t *testing.T) {
 		t.Errorf("wrap changed dir/size: %+v", got)
 	}
 }
+
+// TestSetupWrapperMarksItsEnd pins the marker the wrapper prints between the
+// script and the provider. It is the only thing that tells lich the two apart —
+// the PTY and the pid are the same across the exec — and a session still
+// running its setup must not be handed work (see Service.Ready).
+func TestSetupWrapperMarksItsEnd(t *testing.T) {
+	spec := wrapSetup(ptySpec{bin: "claude", args: []string{"--name", "x"}}, "pnpm install", "linux")
+
+	script := spec.args[1]
+	marker := strings.Index(script, `printf '\033]6969;lich-setup-done\007'`)
+	if marker == -1 {
+		t.Fatalf("the wrapper prints no end marker: %q", script)
+	}
+	// Before the exec, and after the script: a marker on the wrong side of
+	// either would report an agent that has not started, or never report one.
+	if exec := strings.Index(script, "exec "); exec < marker {
+		t.Errorf("the marker is printed after the exec that replaces this shell: %q", script)
+	}
+	if install := strings.Index(script, "pnpm install"); install > marker {
+		t.Errorf("the marker is printed before the script runs: %q", script)
+	}
+}
+
+// The escaped form printf receives has to produce the bytes the service scans
+// for; two spellings of one sequence would mean a marker nobody ever matches.
+func TestSetupMarkerSpellingsAgree(t *testing.T) {
+	unescaped := strings.ReplaceAll(setupDoneEscaped, `\033`, "\x1b")
+	unescaped = strings.ReplaceAll(unescaped, `\007`, "\x07")
+	if unescaped != setupDone {
+		t.Errorf("printf writes %q, the service watches for %q", unescaped, setupDone)
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 
 	"github.com/omartelo/lich/internal/events"
@@ -94,6 +95,10 @@ type session struct {
 	done   chan struct{}
 	replay *replayBuffer
 	outbox *outbox
+	// settingUp is true while the project's worktree setup script still owns
+	// this PTY, before the provider it execs into. Cleared by the marker the
+	// wrapper prints (see setupDone). Guarded by the service's mu.
+	settingUp bool
 }
 
 // Store is the persistence the terminal service depends on: the binary to spawn
@@ -440,11 +445,12 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 	}, outboxDepth)
 	out := newCoalescer(box.push, visibleFlushInterval, hiddenFlushInterval)
 	sess := &session{
-		pty:    p,
-		out:    out,
-		done:   make(chan struct{}),
-		replay: newReplayBuffer(replayCapBytes),
-		outbox: box,
+		pty:       p,
+		out:       out,
+		done:      make(chan struct{}),
+		replay:    newReplayBuffer(replayCapBytes),
+		outbox:    box,
+		settingUp: spec.bin == "sh" && setup,
 	}
 	s.sessions[id] = sess
 	go s.stream(id, sess)
@@ -462,6 +468,7 @@ func (s *Service) stream(id string, sess *session) {
 	for {
 		n, err := p.Read(buf)
 		if n > 0 {
+			s.noteOutput(sess, buf[:n])
 			sess.replay.append(buf[:n])
 			sess.out.Write(buf[:n])
 		}
@@ -563,6 +570,33 @@ func (s *Service) Resize(id string, cols, rows int) error {
 		return nil
 	}
 	return p.Resize(cols, rows)
+}
+
+// noteOutput reads one chunk of a session's output for the one thing lich has
+// to know about it from outside: whether the worktree setup script is still the
+// program on the other end of this PTY (see setupDone).
+func (s *Service) noteOutput(sess *session, chunk []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if sess.settingUp && strings.Contains(string(chunk), setupDone) {
+		sess.settingUp = false
+	}
+}
+
+// Ready reports whether a session can be given work — whether what reads this
+// PTY is the provider rather than the project's setup script. False for a
+// session that is not running at all.
+//
+// Live is not this question. A session whose checkout is still installing its
+// dependencies has a PTY, appears in the roster, and accepts writes that go
+// straight into `pnpm install`'s stdin and are discarded before the provider
+// ever starts. It looked delivered to everyone involved: the sender waited out
+// its ticket on an agent that was never asked anything.
+func (s *Service) Ready(id string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[id]
+	return ok && !sess.settingUp
 }
 
 // Close terminates a session's shell, if any.

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/omartelo/lich/internal/events"
 	"github.com/omartelo/lich/internal/pricing"
@@ -99,6 +100,11 @@ type session struct {
 	// this PTY, before the provider it execs into. Cleared by the marker the
 	// wrapper prints (see setupDone). Guarded by the service's mu.
 	settingUp bool
+	// lastOut is when this PTY last produced output, and ready records that it
+	// has since gone quiet once — that its program finished drawing itself and
+	// is waiting on input. Both guarded by the service's mu.
+	lastOut time.Time
+	ready   bool
 }
 
 // Store is the persistence the terminal service depends on: the binary to spawn
@@ -155,6 +161,13 @@ type Service struct {
 	// sizeFor. Guarded by mu.
 	lastCols, lastRows int
 }
+
+// readySettle is how long a session's PTY must stay quiet before lich hands it
+// work: long enough that a provider drawing its opening screen is not mistaken
+// for one waiting at a prompt, short enough to sit inside the wait an agent
+// gives a tool call. Measured against Claude Code, whose splash lands in
+// several bursts.
+const readySettle = 600 * time.Millisecond
 
 // The size a session is started at when nothing has ever measured a terminal —
 // no window has opened yet, so there is no real one to copy. A conventional
@@ -451,6 +464,10 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 		replay:    newReplayBuffer(replayCapBytes),
 		outbox:    box,
 		settingUp: spec.bin == "sh" && setup,
+		// Timed from the spawn, so a program that never writes anything still
+		// becomes ready once: quiet is the signal, and silence from the start
+		// is quiet too.
+		lastOut: time.Now(),
 	}
 	s.sessions[id] = sess
 	go s.stream(id, sess)
@@ -578,8 +595,12 @@ func (s *Service) Resize(id string, cols, rows int) error {
 func (s *Service) noteOutput(sess *session, chunk []byte) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	sess.lastOut = time.Now()
 	if sess.settingUp && strings.Contains(string(chunk), setupDone) {
 		sess.settingUp = false
+		// The provider starts drawing from here, so the quiet this waits for is
+		// measured from the exec, not from the setup script's last line.
+		sess.ready = false
 	}
 }
 
@@ -596,7 +617,26 @@ func (s *Service) Ready(id string) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	sess, ok := s.sessions[id]
-	return ok && !sess.settingUp
+	if !ok || sess.settingUp {
+		return false
+	}
+	if sess.ready {
+		return true
+	}
+	// A TUI that has stopped drawing is one that has taken the terminal and is
+	// waiting on input. Before that, a message is written into a program still
+	// setting the tty up, which discards what it finds there — the bracketed
+	// paste then lands on screen as literal text, ahead of a prompt that never
+	// received it.
+	//
+	// Asked once: after the first quiet the session stays ready. A busy agent
+	// draws continuously, and a target mid-turn has always been written to —
+	// its provider queues the input and answers a turn later.
+	if !sess.lastOut.IsZero() && time.Since(sess.lastOut) >= readySettle {
+		sess.ready = true
+		return true
+	}
+	return false
 }
 
 // Close terminates a session's shell, if any.

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -145,6 +145,43 @@ type Service struct {
 	// without answering (internal/relay). Guarded by mu: wired after the
 	// transport is already serving.
 	onState func(id, state string)
+	// lastCols/lastRows is the last terminal size the window reported, and the
+	// size a session spawned with none of its own is started at. See
+	// sizeFor. Guarded by mu.
+	lastCols, lastRows int
+}
+
+// The size a session is started at when nothing has ever measured a terminal —
+// no window has opened yet, so there is no real one to copy. A conventional
+// terminal, which every TUI draws itself into.
+const (
+	fallbackCols = 80
+	fallbackRows = 24
+)
+
+// sizeFor resolves the size to start a PTY at. A caller that measured a
+// terminal passes it and gets it back; one that has no terminal to measure
+// (internal/spawn, opening a session for an agent) passes zero and gets the
+// last size the window reported.
+//
+// Copying that size is what keeps such a session readable. Its provider draws
+// its whole conversation into whatever grid it is given, and the window replays
+// those exact bytes into the terminal it builds when somebody finally opens the
+// card. Started at a size the window does not have, the session is redrawn on
+// the first view — at which point the TUI repaints and what it had already
+// written is gone from the screen. The conversation survives in the provider,
+// not on the screen the user came to read.
+//
+// Called under s.mu.
+func (s *Service) sizeFor(cols, rows int) (int, int) {
+	if cols > 0 && rows > 0 {
+		s.lastCols, s.lastRows = cols, rows
+		return cols, rows
+	}
+	if s.lastCols > 0 && s.lastRows > 0 {
+		return s.lastCols, s.lastRows
+	}
+	return fallbackCols, fallbackRows
 }
 
 // New returns a ready-to-use terminal service that resolves the binary to spawn
@@ -361,6 +398,7 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 	if _, running := s.sessions[id]; running {
 		return nil, "", nil
 	}
+	cols, rows = s.sizeFor(cols, rows)
 
 	if cwd == "" {
 		home, err := os.UserHomeDir()
@@ -512,6 +550,14 @@ func (s *Service) Replay(id string) (string, error) {
 // the visible terminal; a hidden terminal is resized on the next time it is
 // shown.
 func (s *Service) Resize(id string, cols, rows int) error {
+	// Recorded even when the session it names is gone: it is the window's own
+	// terminal being measured, and the next session spawned without one starts
+	// at that size (see sizeFor).
+	if cols > 0 && rows > 0 {
+		s.mu.Lock()
+		s.lastCols, s.lastRows = cols, rows
+		s.mu.Unlock()
+	}
 	p := s.ptyOf(id)
 	if p == nil {
 		return nil

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -981,12 +981,59 @@ func TestReadyWaitsForTheSetupScript(t *testing.T) {
 	svc.mu.Unlock()
 	svc.noteOutput(sess, []byte("Progress: resolved 551"+setupDone))
 
+	// The marker is the exec, not the prompt: the provider draws its opening
+	// screen from here, and a message written into that is the one that landed
+	// on screen as literal paste markers.
+	if svc.Ready("s1") {
+		t.Error("work was offered the instant the setup script exec'd the provider")
+	}
+	time.Sleep(readySettle + 100*time.Millisecond)
 	if !svc.Ready("s1") {
-		t.Error("the session stayed unready after its setup script finished")
+		t.Error("the session stayed unready after its provider settled")
 	}
 }
 
-func TestReadyIsImmediateWithoutASetupScript(t *testing.T) {
+// TestReadyWaitsForTheProviderToStopDrawing covers the spawn with no setup
+// script at all: the provider still takes the terminal over, and a message
+// written before it does is lost the same way.
+func TestReadyWaitsForTheProviderToStopDrawing(t *testing.T) {
+	svc := New(stubBins{}, nil, events.New())
+	sess := &session{}
+
+	svc.noteOutput(sess, []byte("Claude Code v2.1.227"))
+	svc.mu.Lock()
+	svc.sessions["s1"] = sess
+	svc.mu.Unlock()
+
+	if svc.Ready("s1") {
+		t.Error("a session still drawing its opening screen was offered work")
+	}
+	time.Sleep(readySettle + 100*time.Millisecond)
+	if !svc.Ready("s1") {
+		t.Error("a session that went quiet was not offered work")
+	}
+}
+
+// Once a session has been ready it stays ready: a working agent draws
+// continuously, and a target mid-turn has always been written to — its provider
+// queues the input and answers a turn later.
+func TestReadyStaysTrueThroughABusyTurn(t *testing.T) {
+	svc := New(stubBins{}, nil, events.New())
+	sess := &session{lastOut: time.Now().Add(-time.Second)}
+	svc.mu.Lock()
+	svc.sessions["s1"] = sess
+	svc.mu.Unlock()
+
+	if !svc.Ready("s1") {
+		t.Fatal("a settled session was not ready")
+	}
+	svc.noteOutput(sess, []byte("...thinking..."))
+	if !svc.Ready("s1") {
+		t.Error("a session that started working again stopped accepting work")
+	}
+}
+
+func TestReadyWaitsOnlyTheSettleWithoutASetupScript(t *testing.T) {
 	bin := stayAliveBin(t)
 	svc := New(stubBins{bin: bin}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
@@ -994,6 +1041,9 @@ func TestReadyIsImmediateWithoutASetupScript(t *testing.T) {
 	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
+	// No setup script to wait out, but the provider still has to take the
+	// terminal: readiness is the quiet after it draws, never the spawn itself.
+	time.Sleep(readySettle + 100*time.Millisecond)
 	if !svc.Ready("s1") {
 		t.Error("a session with no setup script to wait for was held back")
 	}

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -957,3 +957,52 @@ func TestStartWithoutASizeCopiesTheWindow(t *testing.T) {
 		t.Errorf("the agent's session moved the window's size to %dx%d", cols, rows)
 	}
 }
+
+// TestReadyWaitsForTheSetupScript drives the whole seam: a session spawned with
+// the project's setup script is live but has nothing on the other end that can
+// read a message, until the wrapper's marker comes through its own output.
+func TestReadyWaitsForTheSetupScript(t *testing.T) {
+	bin := stayAliveBin(t)
+	svc := New(stubBins{bin: bin, setup: "echo installing"}, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1") })
+
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", true, 80, 24); err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+	if !svc.Live("s1") {
+		t.Fatal("the session is not live")
+	}
+	if svc.Ready("s1") {
+		t.Fatal("a session still running its setup script was offered work")
+	}
+
+	svc.mu.Lock()
+	sess := svc.sessions["s1"]
+	svc.mu.Unlock()
+	svc.noteOutput(sess, []byte("Progress: resolved 551"+setupDone))
+
+	if !svc.Ready("s1") {
+		t.Error("the session stayed unready after its setup script finished")
+	}
+}
+
+func TestReadyIsImmediateWithoutASetupScript(t *testing.T) {
+	bin := stayAliveBin(t)
+	svc := New(stubBins{bin: bin}, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1") })
+
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+	if !svc.Ready("s1") {
+		t.Error("a session with no setup script to wait for was held back")
+	}
+}
+
+func TestReadyIsFalseForASessionThatIsNotRunning(t *testing.T) {
+	svc := New(stubBins{}, nil, events.New())
+
+	if svc.Ready("ghost") {
+		t.Error("a session with no PTY was reported ready for work")
+	}
+}

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -873,3 +873,87 @@ func TestSessionStateWithoutAWatcherIsHarmless(t *testing.T) {
 		t.Fatalf("status = %d, want 204", resp.StatusCode)
 	}
 }
+
+// The size a session starts at is a contract with the window, not an
+// implementation detail: a session drawn into a grid the window does not have
+// is repainted on its first view, and whatever its provider had already written
+// is gone from the screen (see sizeFor).
+
+func TestSizeForKeepsAMeasuredSize(t *testing.T) {
+	svc := New(stubBins{}, nil, events.New())
+
+	svc.mu.Lock()
+	cols, rows := svc.sizeFor(174, 51)
+	svc.mu.Unlock()
+
+	if cols != 174 || rows != 51 {
+		t.Errorf("sizeFor(174, 51) = %dx%d, want the caller's own terminal", cols, rows)
+	}
+}
+
+func TestSizeForFallsBackWhenNothingHasBeenMeasured(t *testing.T) {
+	svc := New(stubBins{}, nil, events.New())
+
+	svc.mu.Lock()
+	cols, rows := svc.sizeFor(0, 0)
+	svc.mu.Unlock()
+
+	// Pinned, not read off the constants: a conventional terminal is the whole
+	// reason this number is safe to hand a TUI that nobody is watching yet.
+	if cols != 80 || rows != 24 {
+		t.Errorf("sizeFor(0, 0) with no window = %dx%d, want 80x24", cols, rows)
+	}
+}
+
+func TestSizeForCopiesTheWindowsLastSize(t *testing.T) {
+	svc := New(stubBins{}, nil, events.New())
+
+	svc.mu.Lock()
+	svc.sizeFor(174, 51)
+	cols, rows := svc.sizeFor(0, 0)
+	svc.mu.Unlock()
+
+	if cols != 174 || rows != 51 {
+		t.Errorf("sizeFor(0, 0) = %dx%d, want the window's own 174x51", cols, rows)
+	}
+}
+
+// A resize is the window measuring its terminal, which is the freshest size
+// lich has — including for the session an agent opens next, whose own PTY
+// nobody is looking at.
+func TestResizeRecordsTheWindowsSize(t *testing.T) {
+	svc := New(stubBins{}, nil, events.New())
+
+	if err := svc.Resize("ghost", 174, 51); err != nil {
+		t.Fatalf("Resize = %v, want nil", err)
+	}
+
+	svc.mu.Lock()
+	cols, rows := svc.sizeFor(0, 0)
+	svc.mu.Unlock()
+	if cols != 174 || rows != 51 {
+		t.Errorf("a session spawned after the resize starts at %dx%d, want 174x51", cols, rows)
+	}
+}
+
+// TestStartWithoutASizeCopiesTheWindow drives the whole path: a card the window
+// measured, then a session opened with no terminal of its own.
+func TestStartWithoutASizeCopiesTheWindow(t *testing.T) {
+	bin := stayAliveBin(t)
+	svc := New(stubBins{bin: bin}, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1"); _ = svc.Close("s2") })
+
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 174, 51); err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+	if err := svc.Start("s2", "p1", t.TempDir(), "claude", "", "", false, 0, 0); err != nil {
+		t.Fatalf("Start without a size = %v, want nil", err)
+	}
+
+	svc.mu.Lock()
+	cols, rows := svc.lastCols, svc.lastRows
+	svc.mu.Unlock()
+	if cols != 174 || rows != 51 {
+		t.Errorf("the agent's session moved the window's size to %dx%d", cols, rows)
+	}
+}


### PR DESCRIPTION
Found in homologation, one bug at a time, each hiding the next. All three sit on
the path from "the backend started this PTY" to "the agent works and the user can
read what happened".

## 1. A task sent to a fresh worktree was silently thrown away

A session opened on a new worktree runs the project's setup script **in its PTY,
before the provider it execs into** — `pnpm install`, minutes of it. The session
is live that whole time: the roster lists it, writes succeed. So the relayed task
went into the setup script's stdin, which read it and dropped it. The agent that
finally started had never been asked anything, and the sender sat on a ticket
nobody could answer — five minutes of an orchestrator polling for an answer to a
question that no longer existed.

Live and ready are different questions, so the terminal service answers both.
Nothing outside the PTY can tell the script from the provider — the pid survives
the `exec`, and output looks like output — so the setup wrapper prints a marker
between the two (a private OSC, which terminals ignore) and the stream clears the
flag when it goes by. `send` waits for that, bounded by the caller's own timeout;
running out is an error naming the setup script, **never a ticket**, because an
errand that was never delivered must not be waited out as if it had been.

## 2. The terminal died with the component

`TerminalView` closed the PTY from its effect cleanup, which reads as "the card
went away, so the process should go too". Unmounting is not that event: React
unmounts for reasons of its own — `StrictMode`'s double mount in dev, a hot
reload — and the PTY died with each. Invisible while every PTY was born on the
very mount that would kill it (dev spawned each session twice and nobody could
tell); fatal for a session that was **already running** when its card is first
viewed, which is exactly what `lich open` produces.

Measured — `Close` then `Start`, what the double mount does:

| | PTY pid | replay |
|---|---|---|
| before | 421914 | 3379 bytes, conversation present |
| after | 422720 | 1026 bytes, conversation gone |

The PTY now dies with the session, not with the component: the host answers
whether the session still belongs to the workspace (`hasSession`), and only a
teardown that is a real close reaches `Close`.

## 3. The PTY was started at a size the window does not have

No terminal at this end to measure, so it started at a hardcoded 80×24. The
provider drew the conversation into that grid; the first view of the card resized
the PTY, the TUI repainted, and what it had written was gone from the screen.
`terminal.sizeFor` now starts such a session at the last size the window
reported, keeping 80×24 as the fallback for when no window ever measured one.

| Resize | Bytes emitted |
|---|---|
| to the same size | **0** — no SIGWINCH, no repaint |
| to a different size | 1161 — the repaint that wiped the card |

## No CHANGELOG entry

`lich open` has not been released — it sits under `[Unreleased]`, so no user of a
published version met any of these. The entry that ships describes the fixed
behaviour, and `docs/cli.md` carries the contract: what `send` waits for, and
what is left of the window where a provider is still starting.

## Test plan

- [x] `internal/relay`: a target still in setup is waited for and then written to; a wait that runs out is an error that says nothing was sent and leaves no ticket behind; a target that dies during setup gives up. 95.5% coverage.
- [x] `internal/terminal`: `Ready` is false during setup and true once the marker arrives, immediate without a script, false for a session with no PTY; the marker's two spellings (what `printf` writes, what the service scans for) are pinned against each other; the size contract pinned as literals.
- [x] `hasSession` covered, including the session that left the workspace.
- [x] `go test ./...`, `go vet ./...`, gofmt; `pnpm test` (795), `pnpm check`, `tsc --noEmit`; cross-compile `build` + `vet` for linux/darwin/windows.
- [x] **Live instance, the exact failing scenario**: a project with a 12-second setup script, `lich open --worktree slow`, and `lich send` fired immediately. The message is held for the setup and delivered after it — confirmed by ordering inside the session's own replay — where before it vanished. The marker never reaches the screen.
- [x] **Dev, with StrictMode live** (Vite dev server + headless window over CDP): a real click on the card of a session the agent opened leaves the pid unchanged, the replay intact, and the screenshot shows its scrollback at the window's own width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165ri2wHyhozQQjhFBUV1UB