### PR TITLE
feat: say when a task reached a terminal that never read it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A task nobody picks up says so, instead of being waited out.** Handing work
+  to another session proved only that the text reached its terminal — and a
+  terminal can have something else on it: a provider still starting, a dialog
+  left open, Claude Code asking whether it should trust a directory it has never
+  seen. The task went into that and was gone, silently, and whoever sent it sat
+  on a ticket nobody had been asked to answer until it expired an hour later.
+  lich now watches whether the session actually starts working on what it was
+  given, and says within half a minute when it does not — naming the session to
+  open and what is usually on its screen. It reads that silence only for the
+  agents that report what they are doing (the lich plugin); the others were
+  always silent, and silence has to mean something before it can be read as
+  anything.
+
 - **An agent can open a session, and give it its own worktree.** Until now every
   session was opened by hand: an agent could hand work to the sessions beside it
   but not create one, so a task that deserved its own checkout waited for

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -128,6 +128,14 @@ Types `<prompt>` at `<session>`'s prompt, submits it, and waits.
 - Not answered in time: the message was still delivered, so it says so and hands
   back a ticket, exit 0. **The answer is not lost by giving up on it** — see
   below.
+- **Never read**: the task was typed at the target's prompt and nothing there
+  picked it up — the session never started working. What has that terminal is
+  usually a question of the provider's own (see the ceiling on trust prompts
+  below), and lich cannot see it. The ticket is dropped rather than left open,
+  and the output sends a person to that card: nothing is queued, so the task has
+  to be sent again once the screen is clear. Only reported for providers that
+  report their state at all (the plugin, `docs/hooks/`) — silence has to mean
+  something before it can be read as anything.
 - **Answered somewhere else**: the target worked through the request and ended
   its turn without replying here — it answered over its provider's own channel,
   or out loud to whoever was watching. The wait ends there rather than running
@@ -516,12 +524,15 @@ whoever asked.
 - **A provider may open on a question of its own.** Claude Code asks whether a
   directory is trusted the first time it runs in one, and a session sitting on
   that prompt looks exactly like one waiting at its own: quiet, live, ready. The
-  first task sent to it answers the trust prompt instead of being read. It
-  applies to a directory the provider has never seen, so the worktrees of a
-  project already in use are unaffected — but the first worktree of a new one,
-  on a machine where nobody has answered it yet, needs a human at that card
-  once. lich cannot see it without reading the screen, which is the one thing
-  this feature does not do.
+  first task sent to it answers the trust prompt instead of being read. lich
+  cannot see that without reading the screen, which is the one thing this
+  feature does not do — what it does instead is notice that nothing was picked
+  up and say so (the `unread` result above), so the wait ends in half a minute
+  with somewhere to look rather than at the ticket's expiry an hour later.
+  Measured: the prompt is answered once per **project**, not per worktree — the
+  second checkout of a repository never asks — and the session's own
+  `session-start` hook fires while it sits there, so the report that a session
+  exists is no evidence that anything in it is listening.
 - **Delivery is proven, receipt is not.** `send` knows the bytes reached the
   PTY. Whether the target's TUI queued them, and whether its agent ever runs the
   reply command, is what the wait and the ticket are for. A provider that does

--- a/internal/agentplugin/agentplugin.go
+++ b/internal/agentplugin/agentplugin.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"net/http"
 	"os/exec"
+	"slices"
 	"strings"
 	"time"
 
@@ -105,6 +106,21 @@ func (s *Service) Status() []Status {
 		out = append(out, computeStatus(id, available, installed, version, latest))
 	}
 	return out
+}
+
+// Installed reports whether the lich plugin is installed for a provider — that
+// its sessions report what they are doing (docs/hooks/). The relay asks before
+// reading a session's silence as an answer: a provider that never reports is
+// silent whatever happens in it.
+//
+// It shells out to the provider's CLI, so it is not for a hot path. The relay
+// calls it once per errand.
+func (s *Service) Installed(provider string) bool {
+	if !slices.Contains(supported, provider) || !s.available(provider) {
+		return false
+	}
+	_, installed := s.installedVersion(provider)
+	return installed
 }
 
 // computeStatus is the pure decision: an update needs the plugin installed, a

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -427,6 +427,10 @@ func (c *client) report(result relay.Result, asJSON bool) error {
 		fmt.Fprintln(c.stdout, unansweredText(result.Target))
 		return nil
 	}
+	if result.Status == relay.StatusUnread {
+		fmt.Fprintln(c.stdout, unreadText(result.Target))
+		return nil
+	}
 	fmt.Fprintf(c.stdout,
 		"%s is still working. The message was delivered; its answer will be typed at the "+
 			"sending session's prompt when it arrives. To hold the line for it instead:\n"+

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -539,3 +539,22 @@ func TestOpenReportsTheAppsRefusal(t *testing.T) {
 		t.Errorf("stderr = %q", stderr)
 	}
 }
+
+func TestSendSaysWhenTheTaskWasNeverPickedUp(t *testing.T) {
+	f := newFakeLich(t, `{"ticket":"a1b2c3d4","target":"docs","status":"unread"}`)
+
+	code, stdout, stderr := run(t, f, "send", "docs", "run the tests")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	// The sender cannot see that screen, so the output has to send a person to
+	// it rather than suggest waiting or retrying the same thing.
+	for _, phrase := range []string{"never picked the task up", "open the", "again"} {
+		if !strings.Contains(stdout, phrase) {
+			t.Errorf("output is missing %q:\n%s", phrase, stdout)
+		}
+	}
+	if strings.Contains(stdout, "lich wait") {
+		t.Errorf("offered a ticket to wait on for a task nobody read:\n%s", stdout)
+	}
+}

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -386,12 +386,30 @@ func mcpOutcome(result relay.Result) string {
 		return result.Answer
 	case relay.StatusUnanswered:
 		return unansweredText(result.Target)
+	case relay.StatusUnread:
+		return unreadText(result.Target)
 	}
 	return fmt.Sprintf(
 		"%s is still working. The task was delivered and its answer will be put at your own "+
 			"prompt when it arrives, so carry on — there is nothing to poll. Ticket %q, if you "+
 			"want to hold the line for it with wait_for_answer instead.",
 		result.Target, result.Ticket,
+	)
+}
+
+// unreadText is what both surfaces say about a task that reached the terminal
+// and nothing read: the session never started working on it. What is usually
+// there is a question only a person can answer, so this has to send the reader
+// to that card rather than suggest waiting or trying the same thing again.
+func unreadText(target string) string {
+	return fmt.Sprintf(
+		"The %q session never picked the task up: it was typed at that prompt and "+
+			"nothing read it, so something else has that terminal — a provider still "+
+			"starting, or a question of its own on screen (Claude Code asks whether a "+
+			"directory is trusted the first time it runs in one). Nothing is queued and "+
+			"nothing was answered. Tell the user to open the %q card and clear what is "+
+			"on it; the task has to be sent again after that.",
+		target, target,
 	)
 }
 

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -409,3 +409,22 @@ func TestMCPOpenSessionDefaultsEveryArgument(t *testing.T) {
 		}
 	}
 }
+
+func TestMCPSendReportsATaskNobodyRead(t *testing.T) {
+	f := newFakeLich(t, `{"ticket":"a1b2c3d4","target":"docs","status":"unread"}`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"send_to_session","arguments":{"session":"docs","prompt":"run the tests"}}}`)
+
+	text, failed := textOf(t, replies[0])
+	if failed {
+		t.Fatalf("tool reported a failure: %s", text)
+	}
+	if !strings.Contains(text, "never picked the task up") {
+		t.Errorf("text = %q, want it to say the task was not read", text)
+	}
+	// An agent told to wait on this would poll a ticket that no longer exists.
+	if strings.Contains(text, "wait_for_answer") {
+		t.Errorf("pointed at a ticket for a task nobody read: %q", text)
+	}
+}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -41,6 +41,12 @@ const (
 	// never replies would otherwise leak one entry per attempt for the life of
 	// the process.
 	ticketTTL = time.Hour
+	// defaultReceiptWindow is how long a task has to be picked up by the agent it
+	// was typed at. A provider that read it reports UserPromptSubmit within a
+	// second or two; this is generous against a machine under load, and short
+	// enough that the sender learns in one tool call rather than at the ticket's
+	// expiry an hour later.
+	defaultReceiptWindow = 30 * time.Second
 	// promptLimit bounds one relayed prompt. The message is typed into a TUI a
 	// character at a time; a megabyte of it is a hang, not a prompt.
 	promptLimit = 8192
@@ -78,6 +84,9 @@ const (
 	// StatusPending means the message was delivered and the wait ran out first.
 	// The ticket is still live: Wait picks the same answer up later.
 	StatusPending = "pending"
+	// StatusUnread means the task was typed at the target's prompt and nothing
+	// there read it: the session never started working. See watchReceipt.
+	StatusUnread = "unread"
 	// StatusUnanswered means the target worked through the request and ended its
 	// turn without replying here. Its answer, if it wrote one, is in that
 	// session's own terminal and nowhere lich can read it — which is what
@@ -208,6 +217,9 @@ type ticket struct {
 	// Observe for how a turn is told apart from the one already running when the
 	// message arrived.
 	stalled chan struct{}
+	// unread closes when the target never reacted to the task at all. See
+	// watchReceipt.
+	unread chan struct{}
 	// sawBusy is whether the target has been working since this ticket's turn
 	// began; a turn that ends without it never started here.
 	sawBusy bool
@@ -238,20 +250,37 @@ type Service struct {
 	// defaultSubmitDelay). A field so the suite can drop it to zero: the fakes
 	// have no TUI to settle, and paying it per test would buy nothing.
 	submitDelay time.Duration
+	// receiptWindow is how long a delivered task has to be picked up before it
+	// is called unread (see watchReceipt). A field for the same reason.
+	receiptWindow time.Duration
+	// hooksInstalled reports whether a provider reports its state to lich at
+	// all, which is what makes a missing report mean something. Nil — the state
+	// a test that does not care is in — reads as "no provider does", and no
+	// delivery is ever checked.
+	hooksInstalled func(kind string) bool
 }
 
 // New returns a relay reading its roster from sessions, typing through term and
 // announcing what is in flight on events.
 func New(sessions Sessions, term Terminal, events Events) *Service {
 	return &Service{
-		tickets:     make(map[string]*ticket),
-		state:       make(map[string]string),
-		sessions:    sessions,
-		term:        term,
-		events:      events,
-		now:         time.Now,
-		submitDelay: defaultSubmitDelay,
+		tickets:       make(map[string]*ticket),
+		state:         make(map[string]string),
+		sessions:      sessions,
+		term:          term,
+		events:        events,
+		now:           time.Now,
+		submitDelay:   defaultSubmitDelay,
+		receiptWindow: defaultReceiptWindow,
 	}
+}
+
+// SetPluginCheck wires the test for whether a provider reports session state to
+// lich (its hooks are installed). Without one, a target that never reacts is
+// indistinguishable from a target lich simply cannot hear, so nothing is
+// checked. Called at startup, before any errand exists.
+func (s *Service) SetPluginCheck(installed func(kind string) bool) {
+	s.hooksInstalled = installed
 }
 
 // Peers lists the live sessions fromID may address, in the order the sidebar
@@ -303,10 +332,12 @@ func (s *Service) Send(fromID, target, project, prompt string, waitSeconds int) 
 		created:  s.now(),
 		done:     make(chan struct{}),
 		stalled:  make(chan struct{}),
+		unread:   make(chan struct{}),
 	}
 	s.mu.Lock()
 	expired := s.sweep()
-	if s.state[dest.ID] == stateBusy {
+	busy := s.state[dest.ID] == stateBusy
+	if busy {
 		t.skipTurns = 1
 	}
 	s.tickets[id] = t
@@ -329,6 +360,12 @@ func (s *Service) Send(fromID, target, project, prompt string, waitSeconds int) 
 	// before the write would survive a delivery that never happened.
 	s.announce(t.targetID, t.sender, DirectionIn)
 	s.announce(t.fromID, t.target, DirectionOut)
+	// A target that was already working is not checked: it will read this at the
+	// end of the turn it is in, whenever that is, and its provider is busy the
+	// whole time — there is nothing here to tell apart.
+	if !busy && s.reportsState(dest.Peer.Kind) {
+		go s.watchReceipt(id, t)
+	}
 	return s.await(id, t, waitSeconds), nil
 }
 
@@ -376,6 +413,54 @@ func (s *Service) awaitReady(dest candidate, wait time.Duration) error {
 				dest.Peer.Label,
 			)
 		}
+	}
+}
+
+// reportsState is whether a provider tells lich what it is doing, which is what
+// makes its silence mean something (docs/hooks/session-state.md).
+func (s *Service) reportsState(kind string) bool {
+	return s.hooksInstalled != nil && s.hooksInstalled(kind)
+}
+
+// watchReceipt closes a ticket whose task nobody ever picked up.
+//
+// Delivery has always been provable — the bytes reached the PTY — and receipt
+// never was. Between the two sits everything that can be on a terminal instead
+// of a prompt: Claude Code asking whether a new directory is trusted, a
+// provider still taking over the tty, a dialog left open by whoever was here
+// last. The task is typed into that, and it is gone. Nothing fails: the sender
+// waits out a ticket nobody was asked to answer, and finds out an hour later
+// when it expires, which is how this feature's own first users found it.
+//
+// An agent that reads a prompt reports UserPromptSubmit within a second or two,
+// so the absence of that report inside the window is the answer. It is only
+// asked of providers that report at all — the rest have always been silent, and
+// silence has to mean something to be read as anything.
+func (s *Service) watchReceipt(id string, t *ticket) {
+	timer := time.NewTimer(s.receiptWindow)
+	defer timer.Stop()
+	select {
+	case <-t.done:
+		return
+	case <-t.stalled:
+		return
+	case <-timer.C:
+	}
+
+	s.mu.Lock()
+	current, live := s.tickets[id]
+	if !live || current != t || t.sawBusy {
+		s.mu.Unlock()
+		return
+	}
+	delete(s.tickets, id)
+	close(t.unread)
+	unattended := t.attended == 0
+	s.mu.Unlock()
+
+	s.clear(t)
+	if unattended {
+		s.tellSender(t, unreadNotice(t.target))
 	}
 }
 
@@ -439,15 +524,25 @@ func (s *Service) Reply(ticketID, answer string) error {
 // A sender that is not a session at all — the `lich` command from a script —
 // has no prompt to type at. Such a caller waits or does without.
 func (s *Service) returnAnswer(t *ticket) {
-	if t.fromID == "" || t.answer == "" {
+	if t.answer == "" {
 		return
 	}
-	message := fmt.Sprintf(
+	s.tellSender(t, fmt.Sprintf(
 		"[lich] Answer from session %q, to the request you sent it:\n\n%s",
 		t.target, t.answer,
-	)
+	))
+}
+
+// tellSender types one line of news at the prompt of whoever asked, the same
+// way their request reached the target. A sender that is not a session at all —
+// the `lich` command from a script — has no prompt to type at, and hears this
+// only if it is still waiting.
+func (s *Service) tellSender(t *ticket, message string) {
+	if t.fromID == "" {
+		return
+	}
 	if err := s.deliver(t.fromID, message); err != nil {
-		slog.Warn("relay: answer not returned", "session", t.fromID, "err", err)
+		slog.Warn("relay: news not delivered", "session", t.fromID, "err", err)
 	}
 }
 
@@ -480,6 +575,9 @@ func (s *Service) await(id string, t *ticket, waitSeconds int) Result {
 	case <-t.stalled:
 		s.leave(t)
 		return Result{Ticket: id, Target: t.target, Status: StatusUnanswered}
+	case <-t.unread:
+		s.leave(t)
+		return Result{Ticket: id, Target: t.target, Status: StatusUnread}
 	case <-timer.C:
 		s.giveUp(t)
 		return Result{Ticket: id, Target: t.target, Status: StatusPending}
@@ -789,6 +887,20 @@ func replyInstruction(kind, ticketID string) string {
 	return route + "\n\nThat ticket is the only way back: whoever asked is blocked on it and " +
 		"is reading nothing else. Do not answer by messaging a peer session — an answer " +
 		"sent any other way is lost."
+}
+
+// unreadNotice is what a sender who stopped waiting is told, typed at its own
+// prompt the way an answer would be. It has to be actionable on its own: the
+// sender cannot see the other screen, and what is usually on it is a question
+// only a person can answer.
+func unreadNotice(target string) string {
+	return fmt.Sprintf(
+		"[lich] The %q session never picked up the task you sent it. It was typed at "+
+			"that prompt and nothing read it, so something else has that terminal — a "+
+			"provider still starting, or a question of its own on screen. Nothing is "+
+			"queued and nothing was answered.",
+		target,
+	)
 }
 
 // origin describes the sender in the message's first line. An empty sender is

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -1088,3 +1088,114 @@ func TestSendGivesUpWhenTheTargetDiesDuringSetup(t *testing.T) {
 		t.Errorf("error = %q", err)
 	}
 }
+
+// Delivery was always provable — the bytes reached the PTY — and receipt never
+// was. Between them sits everything that can be on a terminal instead of a
+// prompt: a provider still starting, a dialog left open, Claude Code asking
+// whether a new directory is trusted. The task is typed into that and is gone,
+// and nothing fails: the sender waits out a ticket nobody was asked to answer.
+
+// withReceipts is a relay that checks receipts, on a window a test can outlast.
+func withReceipts(term Terminal) *Service {
+	svc := newRelay(workspace(), term, nil)
+	svc.receiptWindow = 40 * time.Millisecond
+	svc.SetPluginCheck(func(string) bool { return true })
+	return svc
+}
+
+func TestATaskNobodyPicksUpComesBackUnread(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := withReceipts(term)
+
+	result, err := svc.Send("s1", "docs", "", "run the tests", 5)
+	if err != nil {
+		t.Fatalf("Send = %v, want nil", err)
+	}
+	if result.Status != StatusUnread {
+		t.Errorf("status = %q, want the sender told nothing read it", result.Status)
+	}
+	svc.mu.Lock()
+	open := len(svc.tickets)
+	svc.mu.Unlock()
+	if open != 0 {
+		t.Errorf("left %d tickets open on a task that was never read", open)
+	}
+}
+
+func TestATaskTheTargetStartsWorkingOnIsNotUnread(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := withReceipts(term)
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		svc.Observe("s2", stateBusy)
+	}()
+
+	result, err := svc.Send("s1", "docs", "", "run the tests", 1)
+	if err != nil {
+		t.Fatalf("Send = %v, want nil", err)
+	}
+	if result.Status != StatusPending {
+		t.Errorf("status = %q, want the errand still open", result.Status)
+	}
+}
+
+// A target that was already working is not checked at all: its provider queues
+// the message for the next turn and is busy the whole time, so there is nothing
+// here to tell apart.
+func TestABusyTargetIsNotCheckedForReceipt(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := withReceipts(term)
+	svc.Observe("s2", stateBusy)
+
+	result, err := svc.Send("s1", "docs", "", "run the tests", 1)
+	if err != nil {
+		t.Fatalf("Send = %v, want nil", err)
+	}
+	if result.Status == StatusUnread {
+		t.Error("a target that was mid-turn was reported as never having read the task")
+	}
+}
+
+// Without the plugin a session reports nothing whatever happens in it, so its
+// silence says nothing either.
+func TestSilenceIsOnlyReadWhereTheProviderReports(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, nil)
+	svc.receiptWindow = 40 * time.Millisecond
+	svc.SetPluginCheck(func(string) bool { return false })
+
+	result, err := svc.Send("s1", "docs", "", "run the tests", 1)
+	if err != nil {
+		t.Fatalf("Send = %v, want nil", err)
+	}
+	if result.Status == StatusUnread {
+		t.Error("read silence as an answer from a provider that never reports")
+	}
+}
+
+// The sender usually stops waiting long before this: it took a ticket and moved
+// on, so the news has to reach its prompt, exactly as an answer would.
+func TestTheSenderIsToldAtItsPromptWhenNobodyWasWaiting(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := withReceipts(term)
+	// A window the sender's own wait runs out before, which is the ordinary
+	// case: an agent holds a tool call for a fraction of what an errand takes.
+	svc.receiptWindow = 1200 * time.Millisecond
+
+	result, err := svc.Send("s1", "docs", "", "run the tests", 1)
+	if err != nil {
+		t.Fatalf("Send = %v, want nil", err)
+	}
+	if result.Status != StatusPending {
+		t.Fatalf("status = %q, want the sender to have given up first", result.Status)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(strings.Join(term.writesTo("s1"), ""), "never picked up") {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Errorf("the sender was never told: %v", term.writesTo("s1"))
+}

--- a/main.go
+++ b/main.go
@@ -118,7 +118,8 @@ func main() {
 	dispatcher.Register("drop", drops)
 	dispatcher.Register("fonts", fonts.New())
 	dispatcher.Register("project", proj)
-	dispatcher.Register("agentplugin", agentplugin.New(db))
+	plugins := agentplugin.New(db)
+	dispatcher.Register("agentplugin", plugins)
 	dispatcher.Register("appupdate", appupdate.New(version))
 	dispatcher.Register("patchnotes", patchnotes.New(version, changelog))
 	dispatcher.Register("store", db)
@@ -134,6 +135,9 @@ func main() {
 	// answering the request it was given.
 	rl := relay.New(db, term, hub)
 	term.SetSessionState(rl.Observe)
+	// A task nobody picks up can only be told apart from a task in progress
+	// where the provider reports what it is doing, which is the plugin's job.
+	rl.SetPluginCheck(plugins.Installed)
 	dispatcher.Register("relay", rl)
 	// Its caller is not the window either: opening a session for an agent starts
 	// the PTY here rather than waiting for someone to click the card.


### PR DESCRIPTION
Follow-up to #216, closing the gap it documented: handing work to another
session proved only that the text reached its terminal, and a terminal can have
something else on it.

## The gap

A session sitting on a question of its own looks exactly like one waiting at its
prompt: live, quiet, ready. The task is typed into that question and is gone —
no error anywhere — and the sender waits out a ticket nobody was ever asked to
answer, learning nothing until it expires an hour later.

Two facts, both measured, shaped the fix:

- **The `session-start` hook is not a readiness signal.** It fires while Claude
  Code sits on its trust prompt: `provider_session_id` is recorded with the
  dialog still on screen. A session reporting that it exists says nothing about
  anything in it listening.
- **The trust prompt is asked once per project, not per worktree.** The second
  checkout of a repository never asks. That is why this never showed up in
  day-to-day use and did show up on a machine meeting a repository for the first
  time.

## The fix

An agent that reads a prompt reports `UserPromptSubmit` within a second or two,
so the absence of that report is the answer. A task that draws no reaction
within 30 seconds comes back **unread**: the ticket is dropped rather than left
open, and both surfaces send the reader to that card — what is usually on it is
a question only a person can answer.

Asked only of providers that report their state at all (`internal/agentplugin`
answers who). The rest have always been silent, and silence has to mean
something before it can be read as anything.

Left alone on purpose: a target that was **already working** (its provider
queues the task for the next turn and is busy throughout — nothing to tell
apart), and one that answers or ends its turn first, which closes the ticket on
its own.

No screen is read to do any of this. Parsing a TUI would mean a parser per
provider, each hostage to the next release — the reason the relay asks agents to
write their own answers in the first place.

## Test plan

- [x] `internal/relay`: a task nobody picks up comes back unread and leaves no ticket; a target that starts working keeps its errand open; a target that was already busy is never checked; a provider that does not report is never read as silent; a sender that stopped waiting is told at its own prompt.
- [x] `internal/cli`: both surfaces word it as somewhere to look, and neither offers a ticket to wait on.
- [x] `go test ./...`, `go vet ./...`, gofmt; `pnpm test`, `pnpm check`, `tsc --noEmit`; cross-compile `build` + `vet` for linux/darwin/windows.
- [x] **Live instance, the real thing**: a repository Claude Code had never seen, a worktree session opened on it, the session parked on its trust prompt, and a task sent to it. It came back in **31 seconds** naming the card to open — where before it was 100 seconds of waiting followed by an hour of a dead ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165ri2wHyhozQQjhFBUV1UB