### PR TITLE
feat: close a session, and its worktree, from the CLI and MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **An agent can close a session, and decide what happens to its worktree.** It
+  could open one and hand it work, but never tidy up: every checkout an agent
+  made stayed until somebody removed it by hand. `lich close` — and the
+  `close_session` tool — closes a session by either of its names, and closing the
+  last one in a worktree asks what the checkout is for: keep it, and the session
+  is parked so opening that branch again resumes its conversation, or remove it
+  and the checkout goes with it. A checkout with uncommitted work is only removed
+  when the caller says so explicitly, and no session can close itself. `lich
+  worktrees` (and `list_worktrees`) is the other half: what each checkout is
+  called, whether anything in it is uncommitted, and which sessions are open in
+  it. Opening a session on a branch that is already checked out now opens that
+  checkout instead of failing.
+
 - **A task nobody picks up says so, instead of being waited out.** Handing work
   to another session proved only that the text reached its terminal — and a
   terminal can have something else on it: a provider still starting, a dialog

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -212,6 +212,48 @@ leaves nothing behind — no row, no card. A session whose *terminal* failed to
 start keeps both, and says so, because the card is the only place its error can
 be read.
 
+### `lich close [--project <name>] [--worktree keep|remove] [--force] <session>`
+
+Closes a session, addressed by either of its names, and settles what happens to
+the checkout it was the last one in.
+
+```
+Closed "auth-fix". Its worktree /home/you/.local/share/lich/worktrees/1a2b/auth-fix is still
+there, and the session is parked: opening a session on that branch again picks its
+conversation back up.
+```
+
+- **`--worktree` is required when this is the checkout's last session**, and only
+  then. `keep` leaves it on disk and parks the row — the provider conversation
+  goes with it, and `open --worktree <branch>` on that branch resumes it. `remove`
+  deletes the checkout, the row, and any parked rows pointing at it. Without the
+  flag it is an error naming the two answers rather than a guess: the window asks
+  this in a dialog, and there is nobody here to ask.
+- **`--force` is needed to remove a checkout with uncommitted work**, which is
+  the second question the window asks. What it discards is in no commit and on no
+  remote.
+- A session sharing its checkout with another, or living in the project's own
+  directory, has nothing at stake and closes on the spot.
+- **A session cannot close itself.** The answer would have nowhere to go.
+- Unlike `sessions`, this reaches a card whose terminal was never opened: it is
+  still a session, and closing it is the one thing you can do with it.
+
+### `lich worktrees [--project <name>] [--json]`
+
+Lists a project's git worktrees — what each is called, whether it holds
+uncommitted work, and which sessions are open in it:
+
+```
+worktree	state	sessions
+auth-fix	uncommitted	auth-fix
+idle	clean	-
+```
+
+The sessions column is what makes it actionable: a checkout with one session is
+one whose fate that session's close decides, and a checkout with none is one
+nobody is working in. The project's own directory is not listed — it is the
+checkout every project has and the one that cannot be removed.
+
 ### `lich mcp`
 
 Serves the commands above as MCP tools over stdio: one JSON-RPC 2.0 message per
@@ -229,6 +271,8 @@ at lich.
 | `wait_for_answer` | `ticket`, optional `timeout_seconds`. |
 | `reply_to_session` | `ticket`, `answer` — what a relayed message asks for. |
 | `open_session` | optional `project`, `kind`, `worktree`, `base` — `lich open`. |
+| `close_session` | `session`, optional `project`, `worktree` (`keep`/`remove`), `force`. |
+| `list_worktrees` | optional `project` — the checkouts, as JSON. |
 
 A tool that fails answers with `isError` and the reason as text, not a JSON-RPC
 error: the agent should read what went wrong and act on it, not lose the turn.
@@ -389,8 +433,8 @@ receiving agent only because this text describes it.
 
 ## lich server side
 
-- **Spawn** — `internal/spawn`: opens a session for a caller that is not the
-  window. It is the one place that does all four things a session is at once —
+- **Spawn** — `internal/spawn`: opens, lists and closes for a caller that is not
+  the window. It is the one place that does all four things a session is at once —
   the worktree (`internal/project`), the row (`internal/store`), the PTY
   (`internal/terminal`) and the card (the `session-opened` event) — because no
   existing package owns more than one of them. The window does the same four in
@@ -477,13 +521,21 @@ whoever asked.
 
 ## Known ceilings
 
+- **Closing has no undo.** The window offers one for ten seconds after a close;
+  nothing here does. A removed checkout is gone from disk, and a deleted session
+  row with it. `--force` on a dirty checkout is the only step that asks for
+  anything extra, and it asks the agent, not the user.
+- **Nothing says whose session it is.** Any session can close any other in the
+  workspace, its own excepted. That does not widen lich's trust boundary — every
+  PTY already holds the token — but an agent told to "clean up the worktrees"
+  can close cards a person was working in.
 - **A relayed prompt carries the sender's reach, not the user's.** It is typed
   at the target's prompt and submitted, so the receiving agent acts on it under
   its own permissions — in a session running without permission prompts, that is
   every tool it has. This does not widen lich's trust boundary (`LICH_TOKEN` is
   already in every PTY, and any process in one can already write to any
   session), but it is the first feature that uses it, and there is no switch.
-- **The tools cost context in every session, used or not.** Five tool
+- **The tools cost context in every session, used or not.** Seven tool
   definitions are in the prompt of every Claude Code and Codex session lich
   spawns, whether or not that session ever talks to another one. The command
   line costs nothing until it is called; the tools are what buy discovery, and

--- a/frontend/src/lib/session/session-events.test.ts
+++ b/frontend/src/lib/session/session-events.test.ts
@@ -9,6 +9,7 @@ import {
   isTitleEvent,
   isUsageEvent,
   shouldToastAttention,
+  toClosedSession,
   toOpenedSession,
   toSessionStatus,
 } from "./session-events"
@@ -301,5 +302,28 @@ describe("toOpenedSession", () => {
   // less than adopting one whose terminal can never start.
   it("rejects a kind this build does not know", () => {
     expect(toOpenedSession({ ...payload, kind: "gemini" })).toBeNull()
+  })
+})
+
+describe("toClosedSession", () => {
+  it("narrows a session closed outside the window", () => {
+    expect(toClosedSession({ id: "s2", projectId: "p1", activeId: "s3" })).toEqual({
+      id: "s2",
+      projectId: "p1",
+      activeId: "s3",
+    })
+  })
+
+  // An empty active session is the project having none left, not a missing
+  // field: the last card of a project closes to nothing.
+  it("keeps an empty active session", () => {
+    expect(toClosedSession({ id: "s2", projectId: "p1", activeId: "" })?.activeId).toBe("")
+    expect(toClosedSession({ id: "s2", projectId: "p1" })?.activeId).toBe("")
+  })
+
+  it("rejects a payload with nothing to place the card by", () => {
+    expect(toClosedSession({ projectId: "p1" })).toBeNull()
+    expect(toClosedSession({ id: "s2", projectId: "" })).toBeNull()
+    expect(toClosedSession(null)).toBeNull()
   })
 })

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -54,6 +54,12 @@ export const RELAY_EVENT = "session-relay"
 // looked up: the row is already written and its PTY is already running.
 export const OPENED_EVENT = "session-opened"
 
+// Global event the backend emits when a session was closed outside the window —
+// an agent running `lich close` or its MCP tool (see spawn.ClosedEventName).
+// Payload: { id, projectId, activeId } — the session that left, its project,
+// and which card is active now, decided by the row that is already written.
+export const CLOSED_EVENT = "session-closed"
+
 // Global event the backend emits when a request's target ended its turn without
 // answering through lich (see relay.StalledEventName). Payload:
 // { id, targetId, target } — who asked ("" when it was the command line rather
@@ -207,6 +213,25 @@ export function toOpenedSession(data: unknown): OpenedSession | null {
     path: typeof path === "string" ? path : "",
     nextSeq: typeof nextSeq === "number" ? nextSeq : 1,
   }
+}
+
+// A session closed outside the window: which card goes, and which one the
+// project falls back to.
+export interface ClosedSession {
+  id: string
+  projectId: string
+  activeId: string
+}
+
+export function toClosedSession(data: unknown): ClosedSession | null {
+  if (!isIdEvent(data)) {
+    return null
+  }
+  const { projectId, activeId } = data as { projectId?: unknown; activeId?: unknown }
+  if (typeof projectId !== "string" || projectId === "") {
+    return null
+  }
+  return { id: data.id, projectId, activeId: typeof activeId === "string" ? activeId : "" }
 }
 
 export function isTitleEvent(data: unknown): data is { id: string; label: string } {

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -5,6 +5,7 @@ import {
   addSession,
   adoptSession,
   closeSession,
+  dropClosedSession,
   groupByWorktree,
   hasSession,
   isLastWorktreeSession,
@@ -643,5 +644,27 @@ describe("hasSession", () => {
     expect(hasSession(state, "s2")).toBe(false)
     expect(hasSession(state, "never-existed")).toBe(false)
     expect(hasSession({}, "s1")).toBe(false)
+  })
+})
+
+describe("dropClosedSession", () => {
+  it("removes the card and takes the active session the row recorded", () => {
+    const state = dropClosedSession(buildState(3), P, "s2", "s3")
+    expect(sessionsOf(state, P).map((s) => s.id)).toEqual(["s1", "s3"])
+    expect(activeSessionId(state, P)).toBe("s3")
+  })
+
+  // The backend picked the neighbour when it wrote the row; picking a different
+  // one here would put the window and the next launch on different sessions.
+  it("takes an empty active session as the project having none left", () => {
+    const state = dropClosedSession(addSession({}, P, "only"), P, "only", "")
+    expect(sessionsOf(state, P)).toEqual([])
+    expect(activeSessionId(state, P)).toBe("")
+  })
+
+  it("ignores a session or project it does not hold", () => {
+    const before = buildState(2)
+    expect(dropClosedSession(before, P, "ghost", "s1")).toBe(before)
+    expect(dropClosedSession(before, "other", "s1", "")).toBe(before)
   })
 })

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -117,6 +117,31 @@ export function adoptSession(
   }
 }
 
+// dropClosedSession removes a session the backend already closed — one an agent
+// closed through the CLI or its MCP tools — and focuses whichever card that
+// write recorded as the project's active one. Nothing is persisted from here:
+// the row is gone, and choosing a different card than the row names would put
+// the window and the next launch on different sessions.
+export function dropClosedSession(
+  state: SessionState,
+  projectId: string,
+  sessionId: string,
+  activeId: string,
+): SessionState {
+  const current = state[projectId]
+  if (!current || !current.sessions.some((s) => s.id === sessionId)) {
+    return state
+  }
+  return {
+    ...state,
+    [projectId]: {
+      ...current,
+      sessions: current.sessions.filter((s) => s.id !== sessionId),
+      activeId,
+    },
+  }
+}
+
 // closeSession removes a session. When the active one is closed, focus moves to
 // a neighbor. The project entry is kept even when empty so nextSeq survives: a
 // project emptied and then reopened keeps counting labels up.

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -12,6 +12,7 @@ import {
   addSession,
   adoptSession,
   closeSession as removeSession,
+  dropClosedSession,
   isSessionKind,
   neighborSessionId,
   projectOfSession,
@@ -30,6 +31,7 @@ import { applyOrder, pinFirst } from "@/lib/reorder"
 import { displayPath } from "@/lib/paths"
 import { defaultProviderKind } from "@/lib/providers-store"
 import {
+  CLOSED_EVENT,
   OPENED_EVENT,
   RELAY_STALLED_EVENT,
   STATUS_EVENT,
@@ -41,6 +43,7 @@ import {
   isStatusEvent,
   isTitleEvent,
   shouldToastAttention,
+  toClosedSession,
   toOpenedSession,
   toSessionStatus,
   type SessionStatus,
@@ -245,6 +248,27 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       const { id, projectId, label, kind, path, nextSeq } = opened
       const session: Session = { id, label, kind, ...(path ? { path } : {}) }
       const next = adoptSession(sessionsRef.current, projectId, session, nextSeq)
+      if (next !== sessionsRef.current) {
+        setSessions(next)
+      }
+    })
+    return () => off()
+  }, [])
+
+  // A session an agent closed through the CLI or its MCP tools: the row is
+  // already gone and its PTY with it, so only the card is taken down here.
+  useEffect(() => {
+    const off = onAppEvent(CLOSED_EVENT, (data) => {
+      const closed = toClosedSession(data)
+      if (!closed) {
+        return
+      }
+      const next = dropClosedSession(
+        sessionsRef.current,
+        closed.projectId,
+        closed.id,
+        closed.activeId,
+      )
       if (next !== sessionsRef.current) {
         setSessions(next)
       }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -87,6 +87,14 @@ const usage = `lich talks to the sessions open in the running lich window.
       that branch name first and roots the session in it. Prints the name the
       new session is addressed by.
 
+  lich close [--project <name>] [--worktree keep|remove] [--force] [--json] <session>
+      Close a session. Closing the last one in a worktree needs --worktree to
+      say whether the checkout stays; removing a dirty one needs --force.
+
+  lich worktrees [--project <name>] [--json]
+      List a project's git worktrees: what is uncommitted in each and which
+      sessions are open in it.
+
   lich mcp
       Serve the commands above as MCP tools over stdio. lich registers this
       itself for the providers that support it; you only run it by hand to
@@ -135,6 +143,10 @@ func dispatch(args []string, c *client) int {
 		return c.run(c.reply, args[1:])
 	case "open":
 		return c.run(c.open, args[1:])
+	case "close":
+		return c.run(c.close, args[1:])
+	case "worktrees":
+		return c.run(c.worktrees, args[1:])
 	case "mcp":
 		return c.run(c.serveMCP, args[1:])
 	case "rage":
@@ -410,6 +422,87 @@ func archiveRoot(path string) string {
 	base := filepath.Base(path)
 	base = strings.TrimSuffix(base, ".gz")
 	return strings.TrimSuffix(base, ".tar")
+}
+
+func (c *client) close(args []string) error {
+	flags := newFlagSet("close")
+	project := flags.String("project", "", "narrow the target to one project when the label is ambiguous")
+	worktree := flags.String("worktree", "",
+		"what to do with the checkout when this is its last session: keep or remove")
+	force := flags.Bool("force", false, "remove a checkout that still has uncommitted work")
+	asJSON := flags.Bool("json", false, "print the result as JSON")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if flags.NArg() != 1 {
+		return fmt.Errorf(
+			"usage: lich close [--project <name>] [--worktree keep|remove] [--force] [--json] <session>")
+	}
+
+	var closed spawn.Closed
+	call := []any{c.sessionID(), flags.Arg(0), *project, *worktree, *force}
+	if err := c.call("spawn.Close", call, openCall, &closed); err != nil {
+		return err
+	}
+	if *asJSON {
+		return c.emit(closed)
+	}
+	fmt.Fprint(c.stdout, closedText(closed))
+	return nil
+}
+
+// closedText says what is gone and what is not. A checkout that was kept is the
+// one outcome with something left to come back to, so it says how.
+func closedText(closed spawn.Closed) string {
+	switch {
+	case closed.Removed:
+		return fmt.Sprintf("Closed %q and removed its worktree %s.\n", closed.Label, closed.Worktree)
+	case closed.Kept:
+		return fmt.Sprintf(
+			"Closed %q. Its worktree %s is still there, and the session is parked: opening a "+
+				"session on that branch again picks its conversation back up.\n",
+			closed.Label, closed.Worktree,
+		)
+	default:
+		return fmt.Sprintf("Closed %q.\n", closed.Label)
+	}
+}
+
+func (c *client) worktrees(args []string) error {
+	flags := newFlagSet("worktrees")
+	project := flags.String("project", "", "project to list; defaults to the caller's own")
+	asJSON := flags.Bool("json", false, "print the result as JSON")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	var checkouts []spawn.Checkout
+	if err := c.call("spawn.Worktrees", []any{c.sessionID(), *project}, shortCall, &checkouts); err != nil {
+		return err
+	}
+	if checkouts == nil {
+		checkouts = []spawn.Checkout{}
+	}
+	if *asJSON {
+		return c.emit(checkouts)
+	}
+	if len(checkouts) == 0 {
+		fmt.Fprintln(c.stdout, "No worktrees.")
+		return nil
+	}
+	fmt.Fprintln(c.stdout, "worktree\tstate\tsessions")
+	for _, wt := range checkouts {
+		state := "clean"
+		if wt.Dirty {
+			state = "uncommitted"
+		}
+		sessions := "-"
+		if len(wt.Sessions) > 0 {
+			sessions = strings.Join(wt.Sessions, ", ")
+		}
+		fmt.Fprintf(c.stdout, "%s\t%s\t%s\n", wt.Name, state, sessions)
+	}
+	return nil
 }
 
 // report prints a Send or Wait outcome. An answer goes to stdout on its own so

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -110,7 +110,10 @@ func TestHelpPrintsEveryCommand(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d", code)
 	}
-	for _, want := range []string{"lich sessions", "lich send", "lich wait", "lich reply", "lich open"} {
+	for _, want := range []string{
+		"lich sessions", "lich send", "lich wait", "lich reply", "lich open",
+		"lich close", "lich worktrees",
+	} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("help does not document %q", want)
 		}
@@ -556,5 +559,96 @@ func TestSendSaysWhenTheTaskWasNeverPickedUp(t *testing.T) {
 	}
 	if strings.Contains(stdout, "lich wait") {
 		t.Errorf("offered a ticket to wait on for a task nobody read:\n%s", stdout)
+	}
+}
+
+func TestCloseSaysWhatWentWithTheSession(t *testing.T) {
+	kept := newFakeLich(t, `{"id":"9f8e","projectId":"p1","project":"lich","label":"auth-fix",
+		"worktree":"/wt/auth-fix","kept":true}`)
+	code, stdout, stderr := run(t, kept, "close", "--worktree", "keep", "auth-fix")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	call := kept.only(t)
+	if call.method != "spawn.Close" {
+		t.Errorf("method = %q", call.method)
+	}
+	want := []any{"s1", "auth-fix", "", "keep", false}
+	if len(call.args) != len(want) {
+		t.Fatalf("args = %v, want %v", call.args, want)
+	}
+	for i := range want {
+		if call.args[i] != want[i] {
+			t.Errorf("argument %d = %v, want %v", i, call.args[i], want[i])
+		}
+	}
+	// A kept checkout is the one outcome with something to come back to.
+	if !strings.Contains(stdout, "/wt/auth-fix") || !strings.Contains(stdout, "parked") {
+		t.Errorf("output does not say what was kept:\n%s", stdout)
+	}
+
+	removed := newFakeLich(t, `{"id":"9f8e","projectId":"p1","project":"lich","label":"auth-fix",
+		"worktree":"/wt/auth-fix","removed":true}`)
+	code, stdout, _ = run(t, removed, "close", "--worktree", "remove", "--force", "auth-fix")
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if removed.only(t).args[4] != true {
+		t.Errorf("force was not passed through: %v", removed.only(t).args)
+	}
+	if !strings.Contains(stdout, "removed its worktree") {
+		t.Errorf("output = %q", stdout)
+	}
+}
+
+func TestCloseReportsTheRefusalToDecideForYou(t *testing.T) {
+	f := newFakeLich(t, `{"error":"\"auth-fix\" is the last session in the worktree /wt/auth-fix"}`)
+	f.status = 400
+
+	code, stdout, stderr := run(t, f, "close", "auth-fix")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if stdout != "" {
+		t.Errorf("stdout = %q, want nothing for a close that did not happen", stdout)
+	}
+	if !strings.Contains(stderr, "last session in the worktree") {
+		t.Errorf("stderr = %q", stderr)
+	}
+}
+
+func TestWorktreesListsWhatIsInEach(t *testing.T) {
+	f := newFakeLich(t, `[{"name":"auth-fix","path":"/wt/auth-fix","dirty":true,"sessions":["auth-fix"]},
+	                      {"name":"idle","path":"/wt/idle","dirty":false,"sessions":[]}]`)
+
+	code, stdout, stderr := run(t, f, "worktrees")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	if f.only(t).method != "spawn.Worktrees" {
+		t.Errorf("method = %q", f.only(t).method)
+	}
+	for _, want := range []string{"auth-fix\tuncommitted\tauth-fix", "idle\tclean\t-"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("output is missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestWorktreesSaysWhenThereAreNone(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	code, stdout, _ := run(t, f, "worktrees")
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(stdout, "No worktrees.") {
+		t.Errorf("stdout = %q", stdout)
+	}
+
+	empty := newFakeLich(t, `null`)
+	_, jsonOut, _ := run(t, empty, "worktrees", "--json")
+	if strings.TrimSpace(jsonOut) != "[]" {
+		t.Errorf("json = %q, want [] — a script should not have to handle null", jsonOut)
 	}
 }

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -219,6 +219,20 @@ func (a mcpArgs) text(key string) string {
 	}
 }
 
+// flag reads a boolean, and only "yes" counts. A model that sends the string
+// "false" — or anything else it invented — must not read as consent, because
+// the one flag this carries discards uncommitted work.
+func (a mcpArgs) flag(key string) bool {
+	switch v := a[key].(type) {
+	case bool:
+		return v
+	case string:
+		return v == "true"
+	default:
+		return false
+	}
+}
+
 // seconds reads a wait from the arguments, clamped to what an MCP call may
 // block for (see mcpMaxWait). A caller asking for longer gets the cap, not the
 // detachment it was heading for.
@@ -356,6 +370,62 @@ var mcpTools = []mcpTool{
 				return "", err
 			}
 			return openedText(opened), nil
+		},
+	},
+	{
+		Name: "close_session",
+		Description: "Close a session opened in lich. Closing the last session in a git " +
+			"worktree decides what happens to that checkout, so it needs the worktree " +
+			"argument: keep it on disk (the session is parked, and opening a session on " +
+			"that branch again resumes its conversation) or remove it. A checkout with " +
+			"uncommitted work is only removed with force, because what that discards is in " +
+			"no commit and on no remote. You cannot close the session you are running in.",
+		Schema: schema(map[string]any{
+			"session": property("string",
+				"The session to close, by the label on its card or the name it answers to."),
+			"project": property("string",
+				"Project to narrow to, when the same label exists in more than one."),
+			"worktree": property("string",
+				"Required when this is the last session in a worktree: \"keep\" leaves the "+
+					"checkout on disk, \"remove\" deletes it."),
+			"force": property("boolean",
+				"Remove a checkout that still has uncommitted work. Ask the user first."),
+		}, "session"),
+		Run: func(c *client, args mcpArgs) (string, error) {
+			var closed spawn.Closed
+			call := []any{
+				c.sessionID(), args.text("session"), args.text("project"),
+				args.text("worktree"), args.flag("force"),
+			}
+			if err := c.call("spawn.Close", call, openCall, &closed); err != nil {
+				return "", err
+			}
+			return closedText(closed), nil
+		},
+	},
+	{
+		Name: "list_worktrees",
+		Description: "The git worktrees of a project: what each is called, whether it has " +
+			"uncommitted work, and which sessions are open in it. Use it before opening a " +
+			"session on a branch (one that is already checked out is opened, not created) " +
+			"and before closing one (the last session in a checkout decides its fate).",
+		Schema: schema(map[string]any{
+			"project": property("string", "Project to list. Defaults to your own."),
+		}),
+		Run: func(c *client, args mcpArgs) (string, error) {
+			var checkouts []spawn.Checkout
+			call := []any{c.sessionID(), args.text("project")}
+			if err := c.call("spawn.Worktrees", call, shortCall, &checkouts); err != nil {
+				return "", err
+			}
+			if checkouts == nil {
+				checkouts = []spawn.Checkout{}
+			}
+			out, err := json.Marshal(checkouts)
+			if err != nil {
+				return "", fmt.Errorf("encode the worktrees: %w", err)
+			}
+			return string(out), nil
 		},
 	},
 	{

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -143,6 +143,8 @@ func TestMCPListsEveryTool(t *testing.T) {
 	want := map[string][]string{
 		"list_sessions":    {},
 		"open_session":     {},
+		"close_session":    {"session"},
+		"list_worktrees":   {},
 		"send_to_session":  {"session", "prompt"},
 		"wait_for_answer":  {"ticket"},
 		"reply_to_session": {"ticket", "answer"},
@@ -426,5 +428,63 @@ func TestMCPSendReportsATaskNobodyRead(t *testing.T) {
 	// An agent told to wait on this would poll a ticket that no longer exists.
 	if strings.Contains(text, "wait_for_answer") {
 		t.Errorf("pointed at a ticket for a task nobody read: %q", text)
+	}
+}
+
+func TestMCPCloseSessionPassesTheWorktreeAnswer(t *testing.T) {
+	f := newFakeLich(t, `{"id":"9f8e","projectId":"p1","project":"lich","label":"auth-fix",
+		"worktree":"/wt/auth-fix","removed":true}`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"close_session","arguments":{"session":"auth-fix","worktree":"remove","force":true}}}`)
+
+	if text, failed := textOf(t, replies[0]); failed {
+		t.Fatalf("tool reported a failure: %s", text)
+	}
+	call := f.only(t)
+	want := []any{"s1", "auth-fix", "", "remove", true}
+	if len(call.args) != len(want) {
+		t.Fatalf("args = %v, want %v", call.args, want)
+	}
+	for i := range want {
+		if call.args[i] != want[i] {
+			t.Errorf("argument %d = %v, want %v", i, call.args[i], want[i])
+		}
+	}
+}
+
+// force discards work that is in no commit and on no remote, so only a real
+// yes counts — a model that sends the string "false" must not read as consent.
+func TestMCPForceIsOnlyTrueWhenItSaysTrue(t *testing.T) {
+	for _, sent := range []string{`"false"`, `"no"`, `0`, `null`} {
+		f := newFakeLich(t, `{"id":"9f8e","projectId":"p1","label":"auth-fix","removed":true}`)
+		speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+			{"name":"close_session","arguments":{"session":"auth-fix","worktree":"remove","force":`+sent+`}}}`)
+		if got := f.only(t).args[4]; got != false {
+			t.Errorf("force sent as %s read as %v", sent, got)
+		}
+	}
+}
+
+func TestMCPListWorktreesReturnsThemAsJSON(t *testing.T) {
+	f := newFakeLich(t, `[{"name":"auth-fix","path":"/wt/auth-fix","dirty":true,"sessions":["auth-fix"]}]`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"list_worktrees","arguments":{}}}`)
+
+	text, failed := textOf(t, replies[0])
+	if failed {
+		t.Fatalf("tool reported a failure: %s", text)
+	}
+	var checkouts []struct {
+		Name     string   `json:"name"`
+		Dirty    bool     `json:"dirty"`
+		Sessions []string `json:"sessions"`
+	}
+	if err := json.Unmarshal([]byte(text), &checkouts); err != nil {
+		t.Fatalf("list_worktrees did not return JSON: %v (%q)", err, text)
+	}
+	if len(checkouts) != 1 || !checkouts[0].Dirty || len(checkouts[0].Sessions) != 1 {
+		t.Errorf("checkouts = %+v", checkouts)
 	}
 }

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -157,6 +157,17 @@ func (s *spawnStore) AddSession(_, _, _, _, _ string, _ int) error {
 	return nil
 }
 
+func (s *spawnStore) DeleteSession(_, _, _ string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.rows--
+	return nil
+}
+
+func (*spawnStore) CloseSession(_, _, _ string) error { return nil }
+
+func (*spawnStore) PurgeWorktreeSessions(_, _ string) error { return nil }
+
 // spawnGit refuses every worktree: the wire is what these tests prove, and
 // running git would prove something else in a temporary directory.
 type spawnGit struct{}
@@ -169,16 +180,30 @@ func (spawnGit) CreateWorktree(_, _, _, _ string, _ bool) (*project.Worktree, er
 	return nil, errors.New("no git here")
 }
 
+func (spawnGit) ListCheckouts(string) ([]project.Worktree, error) { return nil, nil }
+
+func (spawnGit) RemoveWorktree(_, _ string, _ bool) error { return errors.New("no git here") }
+
+func (spawnGit) WorktreeDirty(string) (bool, error) { return false, nil }
+
 type spawnTerminal struct {
-	mu   sync.Mutex
-	kind string
-	cwd  string
+	mu     sync.Mutex
+	kind   string
+	cwd    string
+	closed string
 }
 
 func (s *spawnTerminal) Start(_, _, cwd, kind, _, _ string, _ bool, _, _ int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.cwd, s.kind = cwd, kind
+	return nil
+}
+
+func (s *spawnTerminal) Close(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = id
 	return nil
 }
 

--- a/internal/spawn/close.go
+++ b/internal/spawn/close.go
@@ -1,0 +1,246 @@
+package spawn
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/omartelo/lich/internal/relay"
+	"github.com/omartelo/lich/internal/store"
+)
+
+// What a caller may do with the checkout a session was the last one in. The
+// window asks the same question with a dialog; a caller outside it has nobody
+// to ask, so it has to say up front.
+const (
+	// KeepWorktree leaves the checkout on disk and parks the session's row, so
+	// its conversation can be resumed later — the window's "keep" answer.
+	KeepWorktree = "keep"
+	// RemoveWorktree deletes the checkout and the session with it.
+	RemoveWorktree = "remove"
+)
+
+// Closed is what a caller is told about the session it closed.
+type Closed struct {
+	ID        string `json:"id"`
+	ProjectID string `json:"projectId"`
+	Project   string `json:"project"`
+	Label     string `json:"label"`
+	// Worktree is the checkout the session lived in, empty for a session in the
+	// project's own directory.
+	Worktree string `json:"worktree"`
+	// Kept is whether the checkout was left on disk (and the session parked for
+	// a later resume) rather than removed. Meaningless without a Worktree.
+	Kept bool `json:"kept"`
+	// Removed is whether the checkout was deleted.
+	Removed bool `json:"removed"`
+}
+
+// Close closes a session, and settles what happens to the checkout it was the
+// last one in.
+//
+// The window asks about that in a dialog, twice over when the checkout has
+// uncommitted work. Nobody can be asked here, so the answer is an argument:
+// closing the last session of a worktree without one is an error naming the
+// choice rather than a guess. Removing a checkout that is dirty needs force on
+// top, because what it discards exists in no other place — not in a commit, not
+// on a remote, not in the session that was working on it.
+//
+// A session that shares its checkout with another, or lives in the project's own
+// directory, has nothing at stake and closes on the spot.
+func (s *Service) Close(fromID, target, projectName, worktree string, force bool) (Closed, error) {
+	if worktree != "" && worktree != KeepWorktree && worktree != RemoveWorktree {
+		return Closed{}, fmt.Errorf(
+			"%q is not something to do with a worktree — %q keeps the checkout, %q deletes it",
+			worktree, KeepWorktree, RemoveWorktree,
+		)
+	}
+
+	projects, err := s.sessions.LoadState()
+	if err != nil {
+		return Closed{}, fmt.Errorf("read the workspace: %w", err)
+	}
+	found, err := findSession(projects, fromID, target, projectName)
+	if err != nil {
+		return Closed{}, err
+	}
+
+	closed := Closed{
+		ID:        found.session.ID,
+		ProjectID: found.project.ID,
+		Project:   found.project.Name,
+		Label:     found.session.Label,
+		Worktree:  found.session.Path,
+	}
+	last := found.session.Path != "" && lastInWorktree(found.project, found.session)
+	if last && worktree == "" {
+		return Closed{}, fmt.Errorf(
+			"%q is the last session in the worktree %s, so closing it decides that checkout's "+
+				"fate: say %q to leave it on disk (the session is parked and can be resumed) "+
+				"or %q to delete it",
+			found.session.Label, found.session.Path, KeepWorktree, RemoveWorktree,
+		)
+	}
+
+	active := neighborOf(found.project, found.session.ID)
+	if last && worktree == KeepWorktree {
+		if err := s.sessions.CloseSession(found.project.ID, found.session.ID, active); err != nil {
+			return Closed{}, err
+		}
+		closed.Kept = true
+		s.finish(found, active)
+		return closed, nil
+	}
+	if last && worktree == RemoveWorktree {
+		if err := s.removeCheckout(found, active, force); err != nil {
+			return Closed{}, err
+		}
+		closed.Removed = true
+		s.finish(found, active)
+		return closed, nil
+	}
+
+	if err := s.sessions.DeleteSession(found.project.ID, found.session.ID, active); err != nil {
+		return Closed{}, err
+	}
+	s.finish(found, active)
+	return closed, nil
+}
+
+// removeCheckout takes a worktree off disk together with the session that was
+// the last one in it.
+//
+// The order is the window's, and it is load-bearing: the PTY dies before git is
+// asked to remove the directory it is running in, and the parked rows go before
+// the checkout does — one left behind would offer a resume into a directory that
+// no longer exists.
+func (s *Service) removeCheckout(found located, active string, force bool) error {
+	dirty, err := s.worktrees.WorktreeDirty(found.session.Path)
+	if err == nil && dirty && !force {
+		return fmt.Errorf(
+			"the worktree %s has uncommitted work, and removing it discards what is in no "+
+				"commit and on no remote. Force it only if that is what you mean",
+			found.session.Path,
+		)
+	}
+	if err := s.term.Close(found.session.ID); err != nil {
+		return fmt.Errorf("close the session's terminal: %w", err)
+	}
+	if err := s.sessions.DeleteSession(found.project.ID, found.session.ID, active); err != nil {
+		return err
+	}
+	if err := s.sessions.PurgeWorktreeSessions(found.project.ID, found.session.Path); err != nil {
+		return err
+	}
+	return s.worktrees.RemoveWorktree(found.project.Path, found.session.Path, force)
+}
+
+// finish takes down the PTY and the card. The terminal close is repeated for
+// the paths that already made it (removeCheckout) because it is a no-op the
+// second time, and skipping it on the others would leave an agent running in a
+// session nobody can reach.
+func (s *Service) finish(found located, active string) {
+	if err := s.term.Close(found.session.ID); err != nil {
+		// The row is already gone, so there is nothing to undo and nothing the
+		// caller could do about it. The window's own close ignores this too.
+		return
+	}
+	if s.events != nil {
+		s.events.Emit(ClosedEventName, ClosedEvent{
+			ID: found.session.ID, ProjectID: found.project.ID, ActiveID: active,
+		})
+	}
+}
+
+// located is a session together with the project holding it.
+type located struct {
+	project store.Project
+	session store.Session
+}
+
+// findSession resolves a session by the label on its card or the name it answers
+// to in the peer roster, exactly as the relay does — an agent holding either
+// should not have to know which one it has.
+//
+// Unlike the relay it looks past the live ones: a card whose terminal was never
+// opened is still a session, and closing it is the one thing you can do with it.
+func findSession(projects []store.Project, fromID, target, projectName string) (located, error) {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return located{}, fmt.Errorf("no session given to close")
+	}
+
+	var matches []located
+	for _, p := range projects {
+		if projectName != "" && !strings.EqualFold(p.Name, projectName) {
+			continue
+		}
+		for _, sess := range p.Sessions {
+			cwd := sess.Path
+			if cwd == "" {
+				cwd = p.Path
+			}
+			if strings.EqualFold(sess.Label, target) ||
+				strings.EqualFold(relay.RosterName(cwd, sess.ID), target) {
+				matches = append(matches, located{project: p, session: sess})
+			}
+		}
+	}
+
+	switch len(matches) {
+	case 1:
+		if matches[0].session.ID == fromID {
+			return located{}, fmt.Errorf(
+				"%q is this session — closing it would take down the agent asking for it",
+				target,
+			)
+		}
+		return matches[0], nil
+	case 0:
+		where := ""
+		if projectName != "" {
+			where = fmt.Sprintf(" in project %q", projectName)
+		}
+		return located{}, fmt.Errorf("no session named %q%s", target, where)
+	default:
+		return located{}, fmt.Errorf(
+			"%q names %d sessions — narrow it with the project", target, len(matches),
+		)
+	}
+}
+
+// lastInWorktree reports whether a session is the only one left in its checkout,
+// which is what makes closing it a decision about that checkout.
+func lastInWorktree(p store.Project, sess store.Session) bool {
+	for _, other := range p.Sessions {
+		if other.ID != sess.ID && other.Path == sess.Path {
+			return false
+		}
+	}
+	return true
+}
+
+// neighborOf picks the session that takes the closed one's place as the
+// project's active card: the one that fills its slot, else the one before it,
+// else none. The same rule the window applies (sessions.ts, neighborId) — the
+// row it writes is the one the window reads back on the next launch.
+func neighborOf(p store.Project, id string) string {
+	index := -1
+	for i, sess := range p.Sessions {
+		if sess.ID == id {
+			index = i
+			break
+		}
+	}
+	if index == -1 {
+		return p.ActiveSessionID
+	}
+	left := append([]store.Session{}, p.Sessions[:index]...)
+	left = append(left, p.Sessions[index+1:]...)
+	if len(left) == 0 {
+		return ""
+	}
+	if index < len(left) {
+		return left[index].ID
+	}
+	return left[index-1].ID
+}

--- a/internal/spawn/close_test.go
+++ b/internal/spawn/close_test.go
@@ -1,0 +1,228 @@
+package spawn
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/project"
+	"github.com/omartelo/lich/internal/store"
+)
+
+// closable is a workspace with the three shapes a close has to tell apart: a
+// session in the project's own directory, two sharing one checkout, and one
+// alone in another.
+func closable() []store.Project {
+	return []store.Project{{
+		ID: "p1", Name: "lich", Path: "/src/lich", NextSeq: 9,
+		ActiveSessionID: "s1",
+		Sessions: []store.Session{
+			{ID: "s1", Label: "Session 1", Kind: "claude"},
+			{ID: "s2", Label: "shared-a", Kind: "claude", Path: "/wt/shared"},
+			{ID: "s3", Label: "shared-b", Kind: "claude", Path: "/wt/shared"},
+			{ID: "s4", Label: "alone", Kind: "claude", Path: "/wt/alone"},
+		},
+	}}
+}
+
+func closer(t *testing.T) (*Service, *fakeSessions, *fakeWorktrees, *fakeTerminal, *fakeEvents) {
+	t.Helper()
+	sessions := &fakeSessions{projects: closable()}
+	worktrees := &fakeWorktrees{
+		checkouts: []project.Worktree{
+			{Name: "shared", Path: "/wt/shared"},
+			{Name: "alone", Path: "/wt/alone"},
+		},
+		dirty: map[string]bool{},
+	}
+	term := &fakeTerminal{}
+	events := &fakeEvents{}
+	return New(sessions, worktrees, term, events), sessions, worktrees, term, events
+}
+
+func TestCloseTakesDownASessionWithNothingAtStake(t *testing.T) {
+	svc, sessions, worktrees, term, events := closer(t)
+
+	closed, err := svc.Close("s1", "shared-a", "", "", false)
+	if err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if closed.Kept || closed.Removed {
+		t.Errorf("closed = %+v, want the checkout untouched — another session is in it", closed)
+	}
+	if len(sessions.deleted) != 1 || sessions.deleted[0].sessionID != "s2" {
+		t.Errorf("deleted = %+v", sessions.deleted)
+	}
+	if len(worktrees.removed) != 0 {
+		t.Errorf("removed a checkout another session is working in: %+v", worktrees.removed)
+	}
+	if len(term.closed) == 0 {
+		t.Error("left the PTY running for a session that is gone from the workspace")
+	}
+	if len(events.events) != 1 || events.events[0].name != ClosedEventName {
+		t.Errorf("events = %+v, want the card taken down", events.events)
+	}
+}
+
+// The last session in a checkout is the thing holding it, so closing it is a
+// decision about that checkout — and there is nobody here to ask.
+func TestCloseRefusesToDecideAWorktreesFateOnItsOwn(t *testing.T) {
+	svc, sessions, _, _, _ := closer(t)
+
+	_, err := svc.Close("s1", "alone", "", "", false)
+	if err == nil {
+		t.Fatal("closed the last session of a worktree without being told what to do with it")
+	}
+	for _, want := range []string{KeepWorktree, RemoveWorktree} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want it to name %q", err, want)
+		}
+	}
+	if len(sessions.deleted) != 0 || len(sessions.parked) != 0 {
+		t.Error("wrote something for a close that was refused")
+	}
+}
+
+func TestCloseKeepingAWorktreeParksTheSession(t *testing.T) {
+	svc, sessions, worktrees, _, _ := closer(t)
+
+	closed, err := svc.Close("s1", "alone", "", KeepWorktree, false)
+	if err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !closed.Kept || closed.Removed {
+		t.Errorf("closed = %+v, want the checkout kept", closed)
+	}
+	// Parked, not deleted: the row is what carries the provider conversation
+	// that opening a session on that branch again resumes.
+	if len(sessions.parked) != 1 || sessions.parked[0].sessionID != "s4" {
+		t.Errorf("parked = %+v, want the session kept for a resume", sessions.parked)
+	}
+	if len(sessions.deleted) != 0 {
+		t.Errorf("deleted a session that was meant to be parked: %+v", sessions.deleted)
+	}
+	if len(worktrees.removed) != 0 {
+		t.Errorf("removed a checkout that was meant to stay: %+v", worktrees.removed)
+	}
+}
+
+func TestCloseRemovingAWorktreeTakesTheCheckoutWithIt(t *testing.T) {
+	svc, sessions, worktrees, term, _ := closer(t)
+
+	closed, err := svc.Close("s1", "alone", "", RemoveWorktree, false)
+	if err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if !closed.Removed || closed.Kept {
+		t.Errorf("closed = %+v, want the checkout removed", closed)
+	}
+	if len(worktrees.removed) != 1 || worktrees.removed[0].path != "/wt/alone" {
+		t.Errorf("removed = %+v", worktrees.removed)
+	}
+	// The parked rows go with it: one left behind would offer a resume into a
+	// directory that no longer exists.
+	if len(sessions.purged) != 1 || sessions.purged[0] != "/wt/alone" {
+		t.Errorf("purged = %+v, want the parked rows for that checkout", sessions.purged)
+	}
+	if len(term.closed) == 0 || term.closed[0] != "s4" {
+		t.Errorf("closed = %+v, want the PTY down before git is asked to remove its directory", term.closed)
+	}
+}
+
+// What an uncommitted change loses is in no commit and on no remote, so it is
+// the one thing here that needs saying twice.
+func TestCloseRefusesToRemoveADirtyCheckout(t *testing.T) {
+	svc, sessions, worktrees, term, _ := closer(t)
+	worktrees.dirty["/wt/alone"] = true
+
+	_, err := svc.Close("s1", "alone", "", RemoveWorktree, false)
+	if err == nil {
+		t.Fatal("removed a checkout with uncommitted work")
+	}
+	if !strings.Contains(err.Error(), "uncommitted") {
+		t.Errorf("error = %q, want it to name what would be lost", err)
+	}
+	if len(worktrees.removed) != 0 || len(sessions.deleted) != 0 || len(term.closed) != 0 {
+		t.Error("a refused removal still took something down")
+	}
+}
+
+func TestCloseRemovesADirtyCheckoutWhenForced(t *testing.T) {
+	svc, _, worktrees, _, _ := closer(t)
+	worktrees.dirty["/wt/alone"] = true
+
+	if _, err := svc.Close("s1", "alone", "", RemoveWorktree, true); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if len(worktrees.removed) != 1 || !worktrees.removed[0].force {
+		t.Errorf("removed = %+v, want git told to force it", worktrees.removed)
+	}
+}
+
+// An agent closing itself would take down the thing making the request, and the
+// answer would never reach anyone.
+func TestCloseRefusesTheCallersOwnSession(t *testing.T) {
+	svc, sessions, _, _, _ := closer(t)
+
+	_, err := svc.Close("s2", "shared-a", "", "", false)
+	if err == nil {
+		t.Fatal("a session closed itself")
+	}
+	if len(sessions.deleted) != 0 {
+		t.Error("deleted the caller's own session")
+	}
+}
+
+func TestCloseRefusesAnUnknownSession(t *testing.T) {
+	svc, _, _, _, _ := closer(t)
+
+	if _, err := svc.Close("s1", "ghost", "", "", false); err == nil {
+		t.Fatal("closed a session that does not exist")
+	}
+}
+
+func TestCloseRefusesAnUnknownWorktreeAnswer(t *testing.T) {
+	svc, sessions, _, _, _ := closer(t)
+
+	_, err := svc.Close("s1", "alone", "", "delete", false)
+	if err == nil {
+		t.Fatal("accepted an answer that is neither keeping nor removing")
+	}
+	if len(sessions.deleted) != 0 || len(sessions.parked) != 0 {
+		t.Error("acted on an answer it did not understand")
+	}
+}
+
+// The row that records which card is active is written by the close itself, so
+// the window and the next launch land on the same session.
+func TestCloseHandsTheProjectToTheNeighbour(t *testing.T) {
+	svc, sessions, _, _, events := closer(t)
+
+	if _, err := svc.Close("s1", "shared-a", "", "", false); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := sessions.deleted[0].activeID; got != "s3" {
+		t.Errorf("active session = %q, want the card that filled the closed slot", got)
+	}
+	closed, ok := events.events[0].data.(ClosedEvent)
+	if !ok {
+		t.Fatalf("event payload = %T", events.events[0].data)
+	}
+	if closed.ActiveID != "s3" {
+		t.Errorf("the window was told %q is active, the row says s3", closed.ActiveID)
+	}
+}
+
+func TestCloseTheLastSessionOfAProjectLeavesNoneActive(t *testing.T) {
+	sessions := &fakeSessions{projects: []store.Project{{
+		ID: "p1", Name: "lich", Path: "/src/lich",
+		Sessions: []store.Session{{ID: "only", Label: "Session 1", Kind: "claude"}},
+	}}}
+	svc := New(sessions, &fakeWorktrees{dirty: map[string]bool{}}, &fakeTerminal{}, nil)
+
+	if _, err := svc.Close("", "Session 1", "", "", false); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := sessions.deleted[0].activeID; got != "" {
+		t.Errorf("active session = %q, want none left", got)
+	}
+}

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -37,6 +37,19 @@ import (
 // is the workspace state, which outlives any one card.
 const OpenedEventName = "session-opened"
 
+// ClosedEventName carries a session closed outside the window, so the card goes
+// away without a reload. Its payload is ClosedEvent.
+const ClosedEventName = "session-closed"
+
+// ClosedEvent is the payload of ClosedEventName: which session left, the project
+// it left, and which of that project's sessions is active now — the window has
+// no say in the choice, because the row that records it is already written.
+type ClosedEvent struct {
+	ID        string `json:"id"`
+	ProjectID string `json:"projectId"`
+	ActiveID  string `json:"activeId"`
+}
+
 // The size a session opened here starts at: none of its own, which the terminal
 // service reads as "whatever size the window last reported" (terminal.sizeFor).
 //
@@ -51,24 +64,33 @@ const (
 	startRows = 0
 )
 
-// Sessions is the persistence this needs: the workspace to resolve a project in,
-// and the write that adds a session to one. The store implements it.
+// Sessions is the persistence this needs: the workspace to resolve a project
+// in, and the writes that add a session to one, take one away, and park one for
+// a later resume. The store implements it.
 type Sessions interface {
 	LoadState() ([]store.Project, error)
 	AddSession(projectID, sessionID, label, kind, path string, nextSeq int) error
+	DeleteSession(projectID, sessionID, activeID string) error
+	CloseSession(projectID, sessionID, activeID string) error
+	PurgeWorktreeSessions(projectID, path string) error
 }
 
 // Worktrees is the git side. The project service implements it.
 type Worktrees interface {
 	Branch(path string) string
 	ListBranches(path string) (project.Branches, error)
+	ListCheckouts(path string) ([]project.Worktree, error)
 	CreateWorktree(projectPath, projectID, name, base string, baseIsRemote bool) (*project.Worktree, error)
+	RemoveWorktree(projectPath, wtPath string, force bool) error
+	WorktreeDirty(wtPath string) (bool, error)
 }
 
 // Terminal is the PTY side: the same spawn the window asks for when a card is
-// first viewed. The terminal service implements it.
+// first viewed, and the same close it asks for when a card goes away. The
+// terminal service implements it.
 type Terminal interface {
 	Start(id, projectID, cwd, kind, resume, name string, setup bool, cols, rows int) error
+	Close(id string) error
 }
 
 // Events is where an opened session is announced to the window. A nil one leaves
@@ -143,11 +165,27 @@ func (s *Service) Open(fromID, projectName, kind, worktree, base string) (Sessio
 	label := fmt.Sprintf("Session %d", target.NextSeq)
 	setup := false
 	if worktree != "" {
-		wt, err := s.addWorktree(target, worktree, base)
-		if err != nil {
-			return Session{}, err
+		// An existing checkout is opened, not created: asking for a worktree by
+		// the branch it holds is asking to work on that branch, and a caller
+		// that cannot see the repository has no way to know which of the two it
+		// is asking for. Only a fresh one runs the setup script — the checkout
+		// that is already there ran it when it was made.
+		if path, ok := s.checkoutAt(target, worktree); ok {
+			cwd, stored, setup = path, path, false
+		} else {
+			wt, err := s.addWorktree(target, worktree, base)
+			if err != nil {
+				return Session{}, err
+			}
+			cwd, stored, setup = wt.Path, wt.Path, true
 		}
-		cwd, stored, label, setup = wt.Path, wt.Path, wt.Name, true
+		// The card is named after the checkout, as the window names it — unless
+		// a session there already took that name. Two live sessions answering to
+		// one label is the one thing `lich send` cannot resolve, so the second
+		// falls back to the project's own counter.
+		if !labelTaken(target, worktree) {
+			label = worktree
+		}
 	}
 
 	id, err := newSessionID()
@@ -288,6 +326,16 @@ func resolveKind(projects []store.Project, fromID, kind string) (string, error) 
 		}
 	}
 	return providers.Claude, nil
+}
+
+// labelTaken reports whether a project already holds a session under a label.
+func labelTaken(p store.Project, label string) bool {
+	for _, sess := range p.Sessions {
+		if strings.EqualFold(sess.Label, label) {
+			return true
+		}
+	}
+	return false
 }
 
 func knownProjects(projects []store.Project) string {

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -24,6 +24,33 @@ type fakeSessions struct {
 	loadErr  error
 	rows     []added
 	addErr   error
+	// deleted/parked/purged record what a close asked the store to do, and
+	// against which active session it left the project.
+	deleted []closedRow
+	parked  []closedRow
+	purged  []string
+}
+
+// closedRow is one session the store was asked to take out of the workspace.
+type closedRow struct {
+	projectID string
+	sessionID string
+	activeID  string
+}
+
+func (f *fakeSessions) DeleteSession(projectID, sessionID, activeID string) error {
+	f.deleted = append(f.deleted, closedRow{projectID, sessionID, activeID})
+	return nil
+}
+
+func (f *fakeSessions) CloseSession(projectID, sessionID, activeID string) error {
+	f.parked = append(f.parked, closedRow{projectID, sessionID, activeID})
+	return nil
+}
+
+func (f *fakeSessions) PurgeWorktreeSessions(_, path string) error {
+	f.purged = append(f.purged, path)
+	return nil
 }
 
 func (f *fakeSessions) LoadState() ([]store.Project, error) {
@@ -54,6 +81,30 @@ type fakeWorktrees struct {
 	listErr   error
 	created   []createdWorktree
 	createErr error
+	// checkouts is what ListCheckouts answers, dirty which of them hold
+	// uncommitted work, and removed what RemoveWorktree was asked to delete.
+	checkouts []project.Worktree
+	dirty     map[string]bool
+	removed   []removedWorktree
+	removeErr error
+}
+
+type removedWorktree struct {
+	path  string
+	force bool
+}
+
+func (f *fakeWorktrees) ListCheckouts(string) ([]project.Worktree, error) {
+	return f.checkouts, f.listErr
+}
+
+func (f *fakeWorktrees) WorktreeDirty(path string) (bool, error) {
+	return f.dirty[path], nil
+}
+
+func (f *fakeWorktrees) RemoveWorktree(_, path string, force bool) error {
+	f.removed = append(f.removed, removedWorktree{path, force})
+	return f.removeErr
 }
 
 func (f *fakeWorktrees) Branch(string) string { return f.branch }
@@ -87,6 +138,12 @@ type started struct {
 type fakeTerminal struct {
 	spawns []started
 	err    error
+	closed []string
+}
+
+func (f *fakeTerminal) Close(id string) error {
+	f.closed = append(f.closed, id)
+	return nil
 }
 
 func (f *fakeTerminal) Start(

--- a/internal/spawn/worktrees.go
+++ b/internal/spawn/worktrees.go
@@ -1,0 +1,90 @@
+package spawn
+
+import (
+	"fmt"
+
+	"github.com/omartelo/lich/internal/store"
+)
+
+// Checkout is one of a project's git worktrees, as a caller outside the window
+// needs to see it: what it is called, where it is, whether anything in it is
+// uncommitted, and which sessions are open in it.
+//
+// Sessions is what makes the list actionable rather than informational. A
+// checkout with none is one nobody is working in; the last session in one is the
+// thing whose closing decides whether the checkout stays (see Close).
+type Checkout struct {
+	Name     string   `json:"name"`
+	Path     string   `json:"path"`
+	Dirty    bool     `json:"dirty"`
+	Sessions []string `json:"sessions"`
+}
+
+// Worktrees lists a project's checkouts. project names it; empty takes the
+// caller's own, exactly as Open does.
+//
+// The project's own directory is not one of them: it is the checkout every
+// project has, it cannot be removed, and offering it in a list whose point is
+// "what can be opened or closed" would invite exactly that.
+func (s *Service) Worktrees(fromID, projectName string) ([]Checkout, error) {
+	projects, err := s.sessions.LoadState()
+	if err != nil {
+		return nil, fmt.Errorf("read the workspace: %w", err)
+	}
+	target, err := resolveProject(projects, fromID, projectName)
+	if err != nil {
+		return nil, err
+	}
+
+	found, err := s.worktrees.ListCheckouts(target.Path)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]Checkout, 0, len(found))
+	for _, wt := range found {
+		// git lists the repository itself among the worktrees. It is the one
+		// checkout that cannot be removed and the one no session records a path
+		// for, so offering it in a list whose point is "what can be opened or
+		// closed" would only invite trying.
+		if wt.Path == target.Path {
+			continue
+		}
+		// A failed read reports clean rather than refusing the whole list: the
+		// answer is advisory here, and removing a checkout asks git again.
+		dirty, _ := s.worktrees.WorktreeDirty(wt.Path)
+		out = append(out, Checkout{
+			Name:     wt.Name,
+			Path:     wt.Path,
+			Dirty:    dirty,
+			Sessions: sessionsIn(target, wt.Path),
+		})
+	}
+	return out, nil
+}
+
+// sessionsIn names the open sessions rooted at a checkout, in the order the
+// sidebar shows them.
+func sessionsIn(p store.Project, path string) []string {
+	labels := []string{}
+	for _, sess := range p.Sessions {
+		if sess.Path == path {
+			labels = append(labels, sess.Label)
+		}
+	}
+	return labels
+}
+
+// checkoutAt finds an existing worktree by branch name, so opening a session in
+// one is not the same operation as creating it.
+func (s *Service) checkoutAt(target store.Project, name string) (string, bool) {
+	found, err := s.worktrees.ListCheckouts(target.Path)
+	if err != nil {
+		return "", false
+	}
+	for _, wt := range found {
+		if wt.Name == name {
+			return wt.Path, true
+		}
+	}
+	return "", false
+}

--- a/internal/spawn/worktrees_test.go
+++ b/internal/spawn/worktrees_test.go
@@ -1,0 +1,108 @@
+package spawn
+
+import (
+	"testing"
+
+	"github.com/omartelo/lich/internal/project"
+)
+
+func TestWorktreesReportsWhatIsInEachCheckout(t *testing.T) {
+	svc, _, worktrees, _, _ := closer(t)
+	worktrees.dirty["/wt/alone"] = true
+	// git lists the repository itself; it is not a checkout anything here can
+	// act on, so it must not reach the caller.
+	worktrees.checkouts = append(
+		[]project.Worktree{{Name: "main", Path: "/src/lich"}}, worktrees.checkouts...,
+	)
+
+	found, err := svc.Worktrees("s1", "")
+	if err != nil {
+		t.Fatalf("Worktrees: %v", err)
+	}
+	if len(found) != 2 {
+		t.Fatalf("got %d checkouts, want 2", len(found))
+	}
+
+	// The sessions are what make the list actionable: a checkout with one
+	// session is a checkout whose fate that session's close decides.
+	shared, alone := found[0], found[1]
+	if shared.Name != "shared" || len(shared.Sessions) != 2 {
+		t.Errorf("shared = %+v, want both its sessions named", shared)
+	}
+	if shared.Dirty {
+		t.Errorf("shared reported as dirty")
+	}
+	if alone.Name != "alone" || !alone.Dirty {
+		t.Errorf("alone = %+v, want the uncommitted work reported", alone)
+	}
+	if len(alone.Sessions) != 1 || alone.Sessions[0] != "alone" {
+		t.Errorf("alone sessions = %v", alone.Sessions)
+	}
+}
+
+func TestWorktreesNamesAnEmptyCheckoutAsEmpty(t *testing.T) {
+	svc, _, worktrees, _, _ := closer(t)
+	worktrees.checkouts = []project.Worktree{{Name: "parked", Path: "/wt/parked"}}
+
+	found, err := svc.Worktrees("s1", "")
+	if err != nil {
+		t.Fatalf("Worktrees: %v", err)
+	}
+	// Empty, never null: a caller reading this as JSON should not have to tell
+	// "no sessions" apart from "no answer".
+	if len(found) != 1 || found[0].Sessions == nil || len(found[0].Sessions) != 0 {
+		t.Errorf("found = %+v, want one checkout with an empty session list", found)
+	}
+}
+
+func TestWorktreesRefusesAProjectItCannotResolve(t *testing.T) {
+	svc, _, _, _, _ := closer(t)
+
+	if _, err := svc.Worktrees("", ""); err == nil {
+		t.Fatal("listed the worktrees of no project in particular")
+	}
+}
+
+// A session asking for a branch that is already checked out is asking to work
+// on that branch: the checkout is opened, not created a second time.
+func TestOpenUsesACheckoutThatIsAlreadyThere(t *testing.T) {
+	svc, sessions, worktrees, term, _ := closer(t)
+
+	opened, err := svc.Open("s1", "", "", "shared", "")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if len(worktrees.created) != 0 {
+		t.Errorf("created a worktree that was already there: %+v", worktrees.created)
+	}
+	if opened.Path != "/wt/shared" || term.spawns[0].cwd != "/wt/shared" {
+		t.Errorf("opened = %+v, spawn cwd = %q; want the existing checkout", opened, term.spawns[0].cwd)
+	}
+	// The setup script belongs to a fresh checkout. This one ran it when it was
+	// made, and running it again would reinstall over a working tree.
+	if term.spawns[0].setup {
+		t.Error("ran the setup script again in a checkout that already exists")
+	}
+	// Nothing in the project answers to "shared" — the sessions there are
+	// "shared-a" and "shared-b" — so the card takes the checkout's own name.
+	if opened.Label != "shared" {
+		t.Errorf("label = %q, want the checkout's name", opened.Label)
+	}
+	if len(sessions.rows) != 1 || sessions.rows[0].path != "/wt/shared" {
+		t.Errorf("row = %+v", sessions.rows)
+	}
+}
+
+// Two live sessions answering to one label is the single thing `lich send`
+// cannot resolve, so a name already in use is given up rather than repeated.
+func TestOpenFallsBackWhenTheBranchNameIsAlreadyACard(t *testing.T) {
+	svc, _, _, _, _ := closer(t)
+
+	opened, err := svc.Open("s1", "", "", "alone", "")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if opened.Label != "Session 9" {
+		t.Errorf("label = %q, want the project's counter — a session is already called \"alone\"", opened.Label)
+	}
+}


### PR DESCRIPTION
An agent could open a session and hand it work, but never tidy up: every checkout
it made stayed until a person removed it by hand. This is the other end of that
cycle, plus the listing that makes it safe to use.

## `lich close` / `close_session`

Takes a session by either of its names. Closing the **last session in a worktree**
is a decision about that checkout — the window makes it with a dialog, and twice
over when the checkout is dirty — so here it is an argument:

- `keep` leaves the checkout on disk and **parks** the row, so `open --worktree
  <branch>` on that branch resumes its conversation.
- `remove` deletes the checkout, the row, and any parked rows pointing at it.
- Neither given: an error naming both, never a guess.
- `--force` is required to remove a checkout with uncommitted work.

A session sharing its checkout, or living in the project's own directory, has
nothing at stake and closes on the spot. **A session cannot close itself** — the
answer would have nowhere to go.

The order inside `removeCheckout` is the window's, and load-bearing: the PTY dies
before git is asked to remove the directory it runs in, and parked rows go before
the checkout, since one left behind would offer a resume into a directory that is
gone.

## `lich worktrees` / `list_worktrees`

What each checkout is called, whether it holds uncommitted work, and which
sessions are open in it. The sessions column is what makes the list actionable: a
checkout with one session is one whose fate that session's close decides. The
repository itself is filtered out — git lists it, but it is the checkout that
cannot be removed.

## `open` on a branch that already exists

Previously this failed on `git worktree add` (the branch exists). It now opens
that checkout instead: asking for a worktree by the branch it holds is asking to
work on that branch, and a caller that cannot see the repository has no way to
tell the two apart. Only a fresh checkout runs the setup script — running it
again would reinstall over a working tree. The card falls back to the project's
counter when the branch name is already a live label, because two cards under one
name is the single thing `lich send` cannot resolve.

## Ceilings, documented in `docs/cli.md`

- **Closing has no undo.** The window offers one for ten seconds; nothing here
  does. `--force` is the only step that asks for anything extra, and it asks the
  agent, not the user.
- **Nothing says whose session it is.** Any session can close any other, its own
  excepted. It does not widen the trust boundary — every PTY already holds the
  token — but an agent told to "clean up the worktrees" can close cards a person
  was working in.

## Test plan

- [x] `internal/spawn`: closing with nothing at stake; the refusal to decide a checkout's fate; keep parks rather than deletes; remove takes the checkout, the parked rows and the PTY, in that order; a dirty checkout is refused and then forced; the caller's own session and an unknown one are refused; the active session handed to the neighbour matches the row (and is empty when the project empties). 88.5% coverage.
- [x] `internal/spawn`: the listing reports sessions and dirtiness, filters the repository, and answers `[]` rather than null; `open` reuses an existing checkout without re-running setup, and falls back on a taken label.
- [x] `internal/cli`: both surfaces, including that `force` only reads as consent when it is literally true — a model sending the string `"false"` must not discard someone's work.
- [x] `go test ./...`, `go vet ./...`, gofmt; `pnpm test`, `pnpm check`, `tsc --noEmit`; cross-compile `build` + `vet` for linux/darwin/windows.
- [x] **Live instance, the whole cycle**: two worktree sessions opened, listed, one closed with `keep` (checkout still on disk, session parked), the other dirtied and refused, then removed with `--force` (checkout gone from disk), and finally a new session opened on the kept checkout — which reused it instead of creating a second.