### PR TITLE
feat: install the plugin into opencode and Crush from Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **opencode and Crush install the lich plugin from Settings, like the other
+  two.** Their sessions could already report what they were doing, but only for
+  someone willing to place the files by hand — neither harness has a plugin CLI
+  or a marketplace to install from, so the offer stopped at Claude Code and
+  Codex. **Settings › lich plugin** now lists all four, and installs and updates
+  the released version into each: opencode gets its module written into its
+  plugin directory, Crush gets the hook scripts plus two lines added to its
+  `crushrc`. Everything else in that file — every line and every comment you
+  wrote — is left exactly where it was, and an update replaces only what lich
+  put there.
+
+  Two things worth knowing before clicking. **Crush needs 0.88.0 or newer**: the
+  older ones read the file lich writes and ignore it without a word, so lich
+  refuses the install and says which version you have instead of leaving you
+  with a plugin that never reports. And **Crush reports two of the four things**
+  — its session id and the git-status refresh — because `PreToolUse` is the only
+  hook event it has: its cards show no status and keep their own name until it
+  ships an end-of-turn event.
+
 - **A task nobody picks up says so, instead of being waited out.** Handing work
   to another session proved only that the text reached its terminal — and a
   terminal can have something else on it: a provider still starting, a dialog

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,3 +117,9 @@ nobody knows it and that the call site never shows. The mechanism and the histor
   the running window (best-effort, untested against a real window) and exits 0.
 - **Reordering rides dnd-kit's pointer sensors** (`frontend/src/lib/use-sortable-list.ts`); the activation distance
   is load-bearing — without it plain clicks stop selecting a session.
+- **Installing the plugin writes into two harnesses' own directories**
+  (`internal/agentplugin`): Claude Code and Codex are driven through their plugin CLI, but opencode and Crush have
+  none, so lich writes the released files itself — a module into opencode's plugin dir, hook scripts plus a
+  delimited block in Crush's `crushrc`. Neither harness records what is installed, so the version lives in a marker
+  line lich wrote; edit the file by hand and lich reads it as not installed. Crush below 0.88.0 ignores those lines
+  in silence, which is why the install asks its version first.

--- a/frontend/src/components/settings/PluginSetting.tsx
+++ b/frontend/src/components/settings/PluginSetting.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import { ProviderIcon } from "@/components/ProviderIcon"
 import { SettingBlock } from "./SettingBlock"
 import { AgentPlugin } from "@/lib/rpc"
-import { CODEX_TRUST_HINT, RESTART_HINT } from "@/lib/update/plugin-gate"
+import { CODEX_TRUST_HINT, CRUSH_SCOPE_HINT, RESTART_HINT } from "@/lib/update/plugin-gate"
 import { runWithToast } from "@/lib/toast-async"
 import type { PluginStatus } from "@/lib/api-types"
 
@@ -45,6 +45,7 @@ export function PluginSetting({ statuses, onRefresh }: PluginSettingProps) {
 
   const spinner = <LoaderCircle className="size-4 animate-spin" />
   const showTrustHint = statuses?.some((s) => s.provider === "codex" && s.installed)
+  const showCrushHint = statuses?.some((s) => s.provider === "crush" && s.installed)
 
   return (
     <SettingBlock
@@ -103,6 +104,9 @@ export function PluginSetting({ statuses, onRefresh }: PluginSettingProps) {
         ))}
         {showTrustHint && (
           <p className="text-xs text-muted-foreground">Codex: {CODEX_TRUST_HINT}</p>
+        )}
+        {showCrushHint && (
+          <p className="text-xs text-muted-foreground">Crush: {CRUSH_SCOPE_HINT}</p>
         )}
         <div className="flex items-center gap-3 pt-1">
           <Button size="sm" variant="outline" onClick={() => void check()} disabled={busy}>

--- a/frontend/src/lib/update/plugin-gate.ts
+++ b/frontend/src/lib/update/plugin-gate.ts
@@ -22,6 +22,12 @@ export const RESTART_HINT = "restart your sessions to apply."
 // this, and the user would see a plugin that reports nothing.
 export const CODEX_TRUST_HINT = "run /hooks in a Codex session to trust the plugin's hooks."
 
+// Crush has one hook event, so two of the four reports have nowhere to ride.
+// Said here because the gap is invisible otherwise: a card that never shows a
+// spinner reads as a broken install rather than as the harness's own limit.
+export const CRUSH_SCOPE_HINT =
+  "reports its session id and refreshes git status. It has no end-of-turn event, so its cards show no status and keep their own name."
+
 // PluginAction is what the gate should do: an install prompt listing the
 // providers it can install into, an update prompt (with the target version and
 // the providers it covers), or nothing.

--- a/internal/agentplugin/agentplugin.go
+++ b/internal/agentplugin/agentplugin.go
@@ -1,10 +1,19 @@
 // Package agentplugin manages the lich companion plugin inside the provider
-// CLIs that can run it (Claude Code, Codex): whether it is installed, whether a
-// newer release exists, and installing or updating it. Both harnesses ship the
-// same plugin from the same repository, and both are driven through their own
-// CLI — the supported interface — so lich never edits a harness's plugin state
-// files by hand. What differs per provider (the subcommands, and where the
-// installed version is read from) lives in claude.go and codex.go.
+// CLIs that can run it: whether it is installed, whether a newer release
+// exists, and installing or updating it. All four ship the same plugin from the
+// same repository; what differs per provider — the subcommands, where the
+// installed version is read from, and whether there is a CLI at all — lives in
+// claude.go, codex.go, opencode.go and crush.go.
+//
+// Two install shapes, decided by the harness rather than by lich:
+//
+//   - Claude Code and Codex are driven through their own plugin CLI, the
+//     supported interface, so lich never edits their state files by hand.
+//   - opencode and Crush have no plugin CLI, so lich writes the files the
+//     release published: a module into opencode's plugin directory, and hook
+//     scripts plus a delimited block of `hook add` lines into Crush's crushrc.
+//     Both carry a marker naming the version, which is the only record of what
+//     is installed where the harness keeps none.
 package agentplugin
 
 import (
@@ -30,6 +39,12 @@ const (
 	// target, and key in their installed-plugin state.
 	pluginKey        = pluginName + "@" + marketplaceName
 	latestReleaseURL = "https://api.github.com/repos/" + marketplaceRepo + "/releases/latest"
+	// rawBaseURL serves the repository's files at a tag, for the harnesses lich
+	// installs by writing files rather than by calling a CLI.
+	rawBaseURL = "https://raw.githubusercontent.com/" + marketplaceRepo
+	// markerName labels the lines lich writes into a harness's files, so an
+	// update can find what a previous install left there.
+	markerName = marketplaceName
 
 	// cmdTimeout bounds a plugin mutation; a marketplace add clones the repo,
 	// which Claude Code itself caps at 120s. readTimeout bounds the status
@@ -40,10 +55,10 @@ const (
 	httpTimeout = 5 * time.Second
 )
 
-// supported is every provider whose CLI can run the plugin, in the order the UI
+// supported is every provider that can run the plugin, in the order the UI
 // lists them. A provider outside this list has no plugin to offer, so it never
 // reaches a status or an install.
-var supported = []string{providers.Claude, providers.Codex}
+var supported = []string{providers.Claude, providers.Codex, providers.OpenCode, providers.Crush}
 
 // BinResolver supplies the binary to shell out to for a provider. The store
 // implements it; the empty project id asks for the global value, and an empty
@@ -59,6 +74,9 @@ type Service struct {
 	// latestURL is the release endpoint to poll; a field so tests can point it
 	// at a local server.
 	latestURL string
+	// rawBase serves the plugin repository's files at a tag; a field so tests
+	// can point it at a local server.
+	rawBase string
 	// lookPath resolves a binary on PATH, injected so tests decide which
 	// provider CLIs the machine has.
 	lookPath func(string) (string, error)
@@ -70,6 +88,7 @@ func New(bins BinResolver) *Service {
 		bins:      bins,
 		http:      &http.Client{Timeout: httpTimeout},
 		latestURL: latestReleaseURL,
+		rawBase:   rawBaseURL,
 		lookPath:  exec.LookPath,
 	}
 }
@@ -137,25 +156,36 @@ func computeStatus(id string, available, installed bool, installedVer, latestVer
 	}
 }
 
-// Install adds the marketplace and installs the plugin into a provider's CLI.
+// Install puts the plugin into a provider: through its plugin CLI where there
+// is one, by writing the released files where there is not.
 func (s *Service) Install(provider string) error {
 	switch provider {
 	case providers.Claude:
 		return s.claudeInstall()
 	case providers.Codex:
 		return s.codexInstall()
+	case providers.OpenCode:
+		return s.opencodeInstall()
+	case providers.Crush:
+		return s.crushInstall()
 	}
 	return fmt.Errorf("no lich plugin for provider %q", provider)
 }
 
-// Update pulls the latest released version into a provider's CLI. Both apply it
-// on the next session (a restart is required, which the UI signals).
+// Update pulls the latest released version into a provider. Every one applies
+// it on the next session (a restart is required, which the UI signals). For the
+// file-shipped harnesses an update is the same write as an install — the files
+// are replaced wholesale — so they share one path.
 func (s *Service) Update(provider string) error {
 	switch provider {
 	case providers.Claude:
 		return s.claudeUpdate()
 	case providers.Codex:
 		return s.codexUpdate()
+	case providers.OpenCode:
+		return s.opencodeInstall()
+	case providers.Crush:
+		return s.crushInstall()
 	}
 	return fmt.Errorf("no lich plugin for provider %q", provider)
 }
@@ -168,6 +198,10 @@ func (s *Service) installedVersion(provider string) (string, bool) {
 		return claudeInstalledVersion()
 	case providers.Codex:
 		return s.codexInstalledVersion()
+	case providers.OpenCode:
+		return s.opencodeInstalledVersion()
+	case providers.Crush:
+		return s.crushInstalledVersion()
 	}
 	return "", false
 }

--- a/internal/agentplugin/agentplugin_test.go
+++ b/internal/agentplugin/agentplugin_test.go
@@ -282,8 +282,8 @@ func TestStatus(t *testing.T) {
 }
 
 // TestStatusListsEveryHarness proves the report covers the providers that can
-// run the plugin and nothing else: opencode and Crush have none, so an entry for
-// one would put an install button on a CLI that cannot use it.
+// run the plugin and nothing else: oh-my-pi has none, so an entry for it would
+// put an install button on a CLI that cannot use one.
 func TestStatusListsEveryHarness(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 	s := serveBody(t, http.StatusOK, `{"tag_name":"v0.2.0"}`)
@@ -293,8 +293,9 @@ func TestStatusListsEveryHarness(t *testing.T) {
 	for _, entry := range s.Status() {
 		got = append(got, entry.Provider)
 	}
-	if !slices.Equal(got, []string{providers.Claude, providers.Codex}) {
-		t.Fatalf("Status() covers %v, want claude and codex", got)
+	want := []string{providers.Claude, providers.Codex, providers.OpenCode, providers.Crush}
+	if !slices.Equal(got, want) {
+		t.Fatalf("Status() covers %v, want %v", got, want)
 	}
 }
 
@@ -326,12 +327,12 @@ func TestStatusNotInstalled(t *testing.T) {
 }
 
 // TestUnknownProviderIsRefused proves a provider with no plugin never reaches a
-// CLI: opencode has no marketplace to add, and spawning one with the plugin's
-// arguments would be nonsense.
+// CLI or a file: oh-my-pi has no marketplace to add and no plugin directory to
+// write into, so spawning it with the plugin's arguments would be nonsense.
 func TestUnknownProviderIsRefused(t *testing.T) {
 	s, calls := fakeCLI(t, "")
 	for _, run := range []func(string) error{s.Install, s.Update} {
-		if err := run(providers.OpenCode); err == nil {
+		if err := run(providers.OMP); err == nil {
 			t.Error("want an error for a provider with no plugin, got nil")
 		}
 	}
@@ -349,6 +350,10 @@ const (
 	fakeCLIGuard = "LICH_TEST_FAKE_CLI"
 	fakeCLILog   = "LICH_TEST_FAKE_CLI_LOG"
 	fakeCLIFail  = "LICH_TEST_FAKE_CLI_FAIL"
+	// The two questions lich asks Crush rather than tells it, answered from the
+	// environment so a test decides what the machine's Crush says.
+	fakeCLIDirs    = "LICH_TEST_FAKE_CLI_DIRS"
+	fakeCLIVersion = "LICH_TEST_FAKE_CLI_VERSION"
 )
 
 func TestMain(m *testing.M) {
@@ -369,6 +374,16 @@ func TestMain(m *testing.M) {
 	if failOn := os.Getenv(fakeCLIFail); failOn != "" && strings.Contains(strings.Join(os.Args[1:], " "), failOn) {
 		fmt.Fprintln(os.Stderr, "fake cli: refusing "+failOn)
 		os.Exit(1)
+	}
+	switch strings.Join(os.Args[1:], " ") {
+	case "dirs":
+		if dirs := os.Getenv(fakeCLIDirs); dirs != "" {
+			fmt.Println(dirs)
+		}
+	case "--version":
+		if v := os.Getenv(fakeCLIVersion); v != "" {
+			fmt.Println("crush version v" + v)
+		}
 	}
 	os.Exit(0)
 }

--- a/internal/agentplugin/crush.go
+++ b/internal/agentplugin/crush.go
@@ -1,0 +1,244 @@
+package agentplugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/semver"
+	"github.com/omartelo/lich/internal/shquote"
+)
+
+// The Crush side. Crush has no plugin system at all: its hooks are entries in
+// the user's own config, and the scripts they name have to already be somewhere
+// on disk. So an install here is two writes — the scripts into lich's own
+// directory, and a block of `hook add` lines into Crush's `crushrc`.
+//
+// `crushrc` rather than `crush.json` because it is a script, not a document:
+// lich appends its own lines and removes them by their markers, leaving every
+// other line — and every comment — exactly as the user wrote it. Rewriting the
+// JSON would reformat a file lich does not own.
+//
+// Only two of the four reports are registered, because `PreToolUse` is the only
+// event Crush has (docs/hooks/).
+
+const (
+	// crushMinVersion is the first Crush release whose crushrc understands
+	// `hook add` (v0.88.0). Older ones read the file, ignore the lines and say
+	// nothing — the install would look done and report nothing forever — so the
+	// version is checked before anything is written.
+	crushMinVersion = "0.88.0"
+
+	// crushHookEvent is Crush's single event; every hook here rides it.
+	crushHookEvent = "PreToolUse"
+	// crushWriteTools matches the tools that change files, anchored because
+	// Crush's tool names are whole lower-case words.
+	crushWriteTools = "^(edit|write|multiedit|bash)$"
+
+	// shComment is how the marker lines hide from the shell that runs crushrc.
+	shComment = "#"
+	// blockOpen and blockClose delimit lich's lines inside crushrc, so an update
+	// replaces exactly what a previous install wrote.
+	blockOpen  = shComment + " >>> " + markerName + " v%s >>>"
+	blockClose = shComment + " <<< " + markerName + " <<<"
+)
+
+// crushHooks is what lich registers, one entry per report Crush can honour:
+// the script from the plugin repository, the argument it takes, the name the
+// hook is stored under, and the tools it matches ("" for every tool).
+var crushHooks = []struct {
+	script  string
+	arg     string
+	name    string
+	matcher string
+}{
+	{script: "hooks/report-session-start.sh", arg: providers.Crush, name: "lich-session-id"},
+	{script: "hooks/report-touched.sh", name: "lich-touched", matcher: crushWriteTools},
+}
+
+func (s *Service) crushInstall() error {
+	if err := s.crushSupportsHooks(); err != nil {
+		return err
+	}
+	version, err := s.releaseVersion()
+	if err != nil {
+		return err
+	}
+	dir, err := crushScriptDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", dir, err)
+	}
+	for _, hook := range crushHooks {
+		data, err := s.fetchFile(version, hook.script)
+		if err != nil {
+			return err
+		}
+		// Executable: Crush dispatches a shebang'd script through os/exec, which
+		// needs the bit the way any other shell would.
+		path := filepath.Join(dir, filepath.Base(hook.script))
+		if err := os.WriteFile(path, data, 0o755); err != nil {
+			return fmt.Errorf("write %s: %w", path, err)
+		}
+	}
+	return s.writeCrushrc(version, dir)
+}
+
+// writeCrushrc replaces lich's block in Crush's crushrc, creating the file when
+// it is not there yet. Everything outside the markers is carried over verbatim.
+func (s *Service) writeCrushrc(version, scriptDir string) error {
+	path, err := s.crushrcPath()
+	if err != nil {
+		return err
+	}
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(path), err)
+	}
+	body := replaceBlock(string(existing), crushrcBlock(version, scriptDir))
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// crushrcBlock is the block lich owns: its markers, a line saying who wrote it,
+// and one `hook add` per report.
+func crushrcBlock(version, scriptDir string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, blockOpen+"\n", version)
+	fmt.Fprintf(&b, "%s Managed by lich. Edit through Settings, not by hand.\n", shComment)
+	for _, hook := range crushHooks {
+		// Two layers of quoting, and both are load-bearing: the inner one makes
+		// the script path survive as one word inside the command Crush runs, the
+		// outer one makes that whole command survive as one argument to the
+		// crushrc builtin reading this line.
+		command := shquote.Quote(filepath.Join(scriptDir, filepath.Base(hook.script)))
+		if hook.arg != "" {
+			command += " " + hook.arg
+		}
+		fmt.Fprintf(&b, "hook add %s --name %s", crushHookEvent, hook.name)
+		if hook.matcher != "" {
+			fmt.Fprintf(&b, " --matcher %s", shquote.Quote(hook.matcher))
+		}
+		fmt.Fprintf(&b, " --command %s --timeout 5\n", shquote.Quote(command))
+	}
+	b.WriteString(blockClose + "\n")
+	return b.String()
+}
+
+// replaceBlock returns existing with lich's block replaced by block — appended
+// when there is none, and left where it was when there is. A file whose opening
+// marker lost its close is treated as having no block: appending is recoverable,
+// eating the rest of the file is not.
+func replaceBlock(existing, block string) string {
+	start := indexOfOpenMarker(existing)
+	if start < 0 {
+		return appendBlock(existing, block)
+	}
+	end := strings.Index(existing[start:], blockClose)
+	if end < 0 {
+		return appendBlock(existing, block)
+	}
+	end += start + len(blockClose)
+	// The block always ends in a newline, so the one that followed the old close
+	// would otherwise become a blank line on every reinstall.
+	rest := strings.TrimPrefix(existing[end:], "\n")
+	return existing[:start] + block + rest
+}
+
+// indexOfOpenMarker finds lich's opening marker whatever version it names.
+func indexOfOpenMarker(existing string) int {
+	prefix, _, _ := strings.Cut(blockOpen, "%s")
+	return strings.Index(existing, prefix)
+}
+
+// appendBlock puts the block at the end, on its own line and after a blank one
+// when the file already has content.
+func appendBlock(existing, block string) string {
+	if strings.TrimSpace(existing) == "" {
+		return block
+	}
+	return strings.TrimRight(existing, "\n") + "\n\n" + block
+}
+
+// crushInstalledVersion reads the version off the block lich wrote into
+// crushrc, or ("", false) when there is none.
+func (s *Service) crushInstalledVersion() (string, bool) {
+	path, err := s.crushrcPath()
+	if err != nil {
+		return "", false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	return versionOf(data, shComment+" >>>")
+}
+
+// crushSupportsHooks refuses an install onto a Crush too old to read the lines
+// it would write. A version lich cannot read at all is allowed through: a
+// refusal there would be lich guessing, and the failure it prevents is one the
+// user can see and undo.
+func (s *Service) crushSupportsHooks() error {
+	out, err := s.read(providers.Crush, "--version")
+	if err != nil {
+		return fmt.Errorf("crush --version: %w: %s", err, strings.TrimSpace(out))
+	}
+	version := parseCrushVersion(out)
+	if version == "" || !semver.Less(version, crushMinVersion) {
+		return nil
+	}
+	return fmt.Errorf(
+		"Crush %s cannot load hooks from crushrc — update to %s or newer",
+		version, crushMinVersion)
+}
+
+// parseCrushVersion pulls the bare version out of `crush --version`, whose
+// output is "crush version v0.88.1". Empty when the shape is not that.
+func parseCrushVersion(out string) string {
+	fields := strings.Fields(strings.TrimSpace(out))
+	if len(fields) == 0 {
+		return ""
+	}
+	version := strings.TrimPrefix(fields[len(fields)-1], "v")
+	if version == "" || version[0] < '0' || version[0] > '9' {
+		return ""
+	}
+	return version
+}
+
+// crushrcPath resolves the global crushrc: the sibling of Crush's global
+// config, in the directory `crush dirs` prints first. Asking the CLI rather
+// than rebuilding its path rule keeps lich right when that rule differs per OS
+// or moves.
+func (s *Service) crushrcPath() (string, error) {
+	out, err := s.read(providers.Crush, "dirs")
+	if err != nil {
+		return "", fmt.Errorf("crush dirs: %w: %s", err, strings.TrimSpace(out))
+	}
+	dir, _, _ := strings.Cut(strings.TrimSpace(out), "\n")
+	dir = strings.TrimSpace(dir)
+	if dir == "" {
+		return "", fmt.Errorf("crush dirs printed no config directory")
+	}
+	return filepath.Join(dir, "crushrc"), nil
+}
+
+// crushScriptDir is where lich keeps the hook scripts it installs: its own
+// config directory, not Crush's. They are lich's copy of another repository's
+// files, and a harness that never installed them should not be carrying them.
+func crushScriptDir() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve config directory: %w", err)
+	}
+	return filepath.Join(dir, "lich", "plugin", "hooks"), nil
+}

--- a/internal/agentplugin/fetch.go
+++ b/internal/agentplugin/fetch.go
@@ -1,0 +1,83 @@
+package agentplugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Fetching plugin files directly, for the harnesses that have no CLI to install
+// them: opencode loads a module and Crush runs scripts, and neither ships a
+// command that can put one on disk. Both read the release tag, so a file lich
+// writes is the same file that release published — the version a card reports
+// stays the plugin's, never lich's.
+
+const (
+	// fileBodyLimit caps a fetched plugin file. The largest is a few KiB of
+	// JavaScript; anything past this is malformed or hostile, and lich is about
+	// to write it somewhere a harness executes.
+	fileBodyLimit = 1 << 20
+	// fetchTimeout bounds one file. It belongs to an install the user asked for
+	// and is watching, not to the startup status check the shared client's
+	// timeout is sized for.
+	fetchTimeout = 30 * time.Second
+)
+
+// fetchFile GETs one path from the plugin repository at a released version.
+func (s *Service) fetchFile(version, path string) ([]byte, error) {
+	url := fmt.Sprintf("%s/v%s/%s", strings.TrimSuffix(s.rawBase, "/"), version, path)
+	ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("request %s: %w", url, err)
+	}
+	req.Header.Set("User-Agent", "lich")
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch %s: %s", url, resp.Status)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, fileBodyLimit))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", url, err)
+	}
+	if len(data) == 0 {
+		return nil, fmt.Errorf("fetch %s: empty file", url)
+	}
+	return data, nil
+}
+
+// releaseVersion is the version an install writes, or an error naming why it
+// could not be known. The install of a file-shipped harness cannot fall back to
+// "whatever is on main": the version is what a card reports and what the next
+// update compares against, so an unknown one has to stop the install rather
+// than write a file lich cannot describe.
+func (s *Service) releaseVersion() (string, error) {
+	if v := s.latestVersion(); v != "" {
+		return v, nil
+	}
+	return "", fmt.Errorf("cannot reach the %s releases — are you online?", marketplaceRepo)
+}
+
+// versionOf pulls the version out of the marker line lich writes above what it
+// installs, given the comment prefix that file's syntax uses.
+func versionOf(data []byte, prefix string) (string, bool) {
+	marker := prefix + " " + markerName + " v"
+	for line := range strings.Lines(string(data)) {
+		rest, ok := strings.CutPrefix(strings.TrimSpace(line), marker)
+		if !ok {
+			continue
+		}
+		if version, _, _ := strings.Cut(rest, " "); version != "" {
+			return version, true
+		}
+	}
+	return "", false
+}

--- a/internal/agentplugin/files_test.go
+++ b/internal/agentplugin/files_test.go
@@ -1,0 +1,500 @@
+package agentplugin
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// The harnesses lich installs by writing files rather than by calling a CLI.
+// What is asserted here is what the harness will read back: the bytes the
+// release published, the marker that names the version, and — for Crush — that
+// every line the user wrote survives the write.
+
+const testVersion = "0.8.0"
+
+// fileServer serves the plugin repository's files at a tag and records the
+// paths asked for. A path with no body 404s, which is how a test says "this
+// release does not carry that file".
+func fileServer(t *testing.T, files map[string]string) (*Service, func() []string) {
+	t.Helper()
+	var asked []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		asked = append(asked, r.URL.Path)
+		body, ok := files[r.URL.Path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = io.WriteString(w, body)
+	}))
+	t.Cleanup(srv.Close)
+
+	release := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"tag_name":"v`+testVersion+`"}`)
+	}))
+	t.Cleanup(release.Close)
+
+	return &Service{
+		http:      srv.Client(),
+		latestURL: release.URL,
+		rawBase:   srv.URL,
+		bins:      stubBins{},
+		lookPath:  func(name string) (string, error) { return "/usr/bin/" + name, nil },
+	}, func() []string { return asked }
+}
+
+// tagged is the URL path a release file is served at.
+func tagged(path string) string { return "/v" + testVersion + "/" + path }
+
+// ---------------------------------------------------------------- opencode --
+
+func TestOpencodeInstallWritesTheModule(t *testing.T) {
+	config := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", config)
+	s, asked := fileServer(t, map[string]string{
+		tagged(opencodeSource): "export const LichPlugin = async () => ({})\n",
+	})
+
+	if err := s.Install(providers.OpenCode); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+
+	path := filepath.Join(config, "opencode", "plugin", opencodeFile)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read the installed module: %v", err)
+	}
+	body := string(data)
+	if !strings.Contains(body, "export const LichPlugin") {
+		t.Errorf("installed module lost the release's body:\n%s", body)
+	}
+	if !strings.HasPrefix(body, jsComment+" "+markerName+" v"+testVersion+" ") {
+		t.Errorf("installed module has no version marker on its first line:\n%s", body)
+	}
+	if got := asked(); len(got) != 1 || got[0] != tagged(opencodeSource) {
+		t.Errorf("fetched %v, want just %q", got, tagged(opencodeSource))
+	}
+}
+
+// The version has to survive the round trip: Status reads back what Install
+// wrote, and a marker either side spells differently reports nothing installed.
+func TestOpencodeInstalledVersionRoundTrips(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	s, _ := fileServer(t, map[string]string{tagged(opencodeSource): "export const P = async () => ({})\n"})
+
+	if err := s.Install(providers.OpenCode); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	got, ok := s.installedVersion(providers.OpenCode)
+	if !ok || got != testVersion {
+		t.Fatalf("installedVersion = (%q,%v), want (%q,true)", got, ok, testVersion)
+	}
+}
+
+// A module somebody installed by hand carries no marker. Reporting a version
+// for it would offer an update over a file lich never wrote.
+func TestOpencodeInstalledVersionIgnoresAnUnmarkedModule(t *testing.T) {
+	config := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", config)
+	dir := filepath.Join(config, "opencode", "plugin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, opencodeFile), []byte("export const P = async () => ({})\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	s, _ := fileServer(t, nil)
+
+	if got, ok := s.installedVersion(providers.OpenCode); ok || got != "" {
+		t.Fatalf("installedVersion = (%q,%v), want empty/false for a module lich did not write", got, ok)
+	}
+}
+
+func TestOpencodeInstalledVersionMissingModule(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	s, _ := fileServer(t, nil)
+	if got, ok := s.installedVersion(providers.OpenCode); ok || got != "" {
+		t.Fatalf("installedVersion = (%q,%v), want empty/false", got, ok)
+	}
+}
+
+// An update replaces the module wholesale, so the older version must not
+// survive anywhere in the file — Status would otherwise read the first marker
+// it finds and report the version the user just left.
+func TestOpencodeUpdateReplacesTheModule(t *testing.T) {
+	config := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", config)
+	s, _ := fileServer(t, map[string]string{tagged(opencodeSource): "export const P = async () => ({ event: async () => {} })\n"})
+
+	dir := filepath.Join(config, "opencode", "plugin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	old := jsComment + " " + markerName + " v0.1.0 — installed by lich\nexport const P = async () => ({})\n"
+	if err := os.WriteFile(filepath.Join(dir, opencodeFile), []byte(old), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.Update(providers.OpenCode); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, opencodeFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "v0.1.0") {
+		t.Errorf("update left the old version behind:\n%s", data)
+	}
+	if got, ok := s.installedVersion(providers.OpenCode); !ok || got != testVersion {
+		t.Errorf("installedVersion = (%q,%v), want (%q,true)", got, ok, testVersion)
+	}
+}
+
+// A release that does not carry the module must leave nothing behind: a
+// half-written plugin directory is worse than an install the user can retry.
+func TestOpencodeInstallWritesNothingWhenTheFetchFails(t *testing.T) {
+	config := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", config)
+	s, _ := fileServer(t, nil) // every path 404s
+
+	if err := s.Install(providers.OpenCode); err == nil {
+		t.Fatal("Install: want an error when the release has no module, got nil")
+	}
+	if _, err := os.Stat(filepath.Join(config, "opencode", "plugin", opencodeFile)); !os.IsNotExist(err) {
+		t.Errorf("a failed install left a module behind (stat err = %v)", err)
+	}
+}
+
+// ------------------------------------------------------------------- crush --
+
+// crushCLI points a Service at the fake CLI, answering `crush dirs` with
+// configDir and `crush --version` with version.
+func crushCLI(t *testing.T, s *Service, configDir, version string) {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("resolve test binary: %v", err)
+	}
+	t.Setenv(fakeCLIGuard, "1")
+	t.Setenv(fakeCLIDirs, configDir)
+	t.Setenv(fakeCLIVersion, version)
+	s.bins = stubBin(self)
+}
+
+// installCrush runs an install against temporary directories and returns the
+// crushrc it wrote and the directory the scripts went to.
+func installCrush(t *testing.T, s *Service, existingRC string) (string, string) {
+	t.Helper()
+	configDir := t.TempDir()
+	lichConfig := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", lichConfig)
+	crushCLI(t, s, configDir, "0.88.1")
+
+	rc := filepath.Join(configDir, "crushrc")
+	if existingRC != "" {
+		if err := os.WriteFile(rc, []byte(existingRC), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := s.Install(providers.Crush); err != nil {
+		t.Fatalf("Install: %v", err)
+	}
+	data, err := os.ReadFile(rc)
+	if err != nil {
+		t.Fatalf("read crushrc: %v", err)
+	}
+	return string(data), filepath.Join(lichConfig, "lich", "plugin", "hooks")
+}
+
+func crushFiles() map[string]string {
+	files := map[string]string{}
+	for _, hook := range crushHooks {
+		files[tagged(hook.script)] = "#!/bin/sh\n# " + hook.name + "\nexit 0\n"
+	}
+	return files
+}
+
+func TestCrushInstallWritesScriptsAndHooks(t *testing.T) {
+	s, _ := fileServer(t, crushFiles())
+	rc, scriptDir := installCrush(t, s, "")
+
+	for _, hook := range crushHooks {
+		path := filepath.Join(scriptDir, filepath.Base(hook.script))
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		// Crush dispatches a shebang'd script through os/exec, which needs the bit.
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Errorf("%s is not executable (mode %v)", path, info.Mode().Perm())
+		}
+		if !strings.Contains(rc, hook.name) {
+			t.Errorf("crushrc does not register %q:\n%s", hook.name, rc)
+		}
+		if !strings.Contains(rc, filepath.Base(hook.script)) {
+			t.Errorf("crushrc does not name %q:\n%s", hook.script, rc)
+		}
+	}
+	if strings.Count(rc, "hook add "+crushHookEvent) != len(crushHooks) {
+		t.Errorf("crushrc has the wrong number of hook lines:\n%s", rc)
+	}
+	// Only the tools that write: a git-status refresh per read costs more than
+	// the poll it front-runs.
+	if !strings.Contains(rc, crushWriteTools) {
+		t.Errorf("crushrc registers the touched hook without its matcher:\n%s", rc)
+	}
+}
+
+// The block carries the provider argument through, which is what puts Crush's
+// icon on the card rather than Claude's.
+func TestCrushInstallNamesTheProvider(t *testing.T) {
+	s, _ := fileServer(t, crushFiles())
+	rc, _ := installCrush(t, s, "")
+
+	command, ok := commandOf(rc, "lich-session-id")
+	if !ok {
+		t.Fatalf("no session-start hook in crushrc:\n%s", rc)
+	}
+	if !strings.HasSuffix(command, " "+providers.Crush) {
+		t.Errorf("session-start command does not end in the provider: %q", command)
+	}
+}
+
+// The whole reason for crushrc over crush.json: what the user wrote stays.
+func TestCrushInstallKeepsTheUsersLines(t *testing.T) {
+	existing := "# my own notes\nprovider anthropic --api-key $ANTHROPIC_API_KEY\n"
+	s, _ := fileServer(t, crushFiles())
+	rc, _ := installCrush(t, s, existing)
+
+	if !strings.HasPrefix(rc, existing) {
+		t.Errorf("install did not keep the user's lines at the top:\n%s", rc)
+	}
+}
+
+func TestCrushInstalledVersionRoundTrips(t *testing.T) {
+	s, _ := fileServer(t, crushFiles())
+	installCrush(t, s, "")
+
+	got, ok := s.installedVersion(providers.Crush)
+	if !ok || got != testVersion {
+		t.Fatalf("installedVersion = (%q,%v), want (%q,true)", got, ok, testVersion)
+	}
+}
+
+func TestCrushInstalledVersionWithoutABlock(t *testing.T) {
+	s, _ := fileServer(t, nil)
+	configDir := t.TempDir()
+	crushCLI(t, s, configDir, "0.88.1")
+	if err := os.WriteFile(filepath.Join(configDir, "crushrc"), []byte("# just the user's own\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got, ok := s.installedVersion(providers.Crush); ok || got != "" {
+		t.Fatalf("installedVersion = (%q,%v), want empty/false", got, ok)
+	}
+}
+
+// A Crush too old reads the file and ignores the lines, so the install would
+// look done and report nothing forever. Nothing may be written.
+func TestCrushInstallRefusesAnOldCrush(t *testing.T) {
+	s, asked := fileServer(t, crushFiles())
+	configDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	crushCLI(t, s, configDir, "0.77.0")
+
+	err := s.Install(providers.Crush)
+	if err == nil {
+		t.Fatal("Install: want an error on a Crush without crushrc hooks, got nil")
+	}
+	for _, want := range []string{"0.77.0", crushMinVersion} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error %q does not name %q", err, want)
+		}
+	}
+	if _, statErr := os.Stat(filepath.Join(configDir, "crushrc")); !os.IsNotExist(statErr) {
+		t.Errorf("a refused install wrote a crushrc anyway (stat err = %v)", statErr)
+	}
+	if got := asked(); len(got) > 0 {
+		t.Errorf("a refused install fetched %v, want nothing", got)
+	}
+}
+
+// A version lich cannot read is not a version it may refuse on: guessing would
+// block an install that would have worked.
+func TestCrushInstallProceedsOnAnUnreadableVersion(t *testing.T) {
+	s, _ := fileServer(t, crushFiles())
+	configDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	crushCLI(t, s, configDir, "")
+
+	if err := s.Install(providers.Crush); err != nil {
+		t.Fatalf("Install with an unreadable crush version: %v", err)
+	}
+}
+
+func TestParseCrushVersion(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"crush version v0.88.1\n", "0.88.1"},
+		{"crush version 0.88.1", "0.88.1"},
+		{"v1.0.0", "1.0.0"},
+		{"", ""},
+		{"command not found", ""},
+		{"crush version unknown", ""},
+	}
+	for _, tc := range tests {
+		if got := parseCrushVersion(tc.in); got != tc.want {
+			t.Errorf("parseCrushVersion(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// --------------------------------------------------------------- the block --
+
+func TestReplaceBlock(t *testing.T) {
+	block := fmt.Sprintf(blockOpen+"\nhook add X\n"+blockClose+"\n", "2.0.0")
+	old := fmt.Sprintf(blockOpen+"\nhook add OLD\n"+blockClose+"\n", "1.0.0")
+
+	tests := []struct {
+		name     string
+		existing string
+		want     string
+	}{
+		{"empty file takes the block alone", "", block},
+		{"whitespace only is still empty", "\n\n  \n", block},
+		{"appends after the user's lines", "mine\n", "mine\n\n" + block},
+		{"replaces an older block in place", old, block},
+		{"replaces between the user's lines", "before\n\n" + old + "after\n", "before\n\n" + block + "after\n"},
+		{"an unterminated block is appended past, never eaten",
+			"before\n" + fmt.Sprintf(blockOpen, "1.0.0") + "\nhook add OLD\n",
+			"before\n" + fmt.Sprintf(blockOpen, "1.0.0") + "\nhook add OLD\n\n" + block},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := replaceBlock(tc.existing, block); got != tc.want {
+				t.Errorf("replaceBlock(%q) =\n%q\nwant\n%q", tc.existing, got, tc.want)
+			}
+		})
+	}
+}
+
+// Reinstalling must converge: the second write has to equal the first, or a
+// crushrc grows a blank line — or a whole block — on every update.
+func TestReplaceBlockIsIdempotent(t *testing.T) {
+	block := fmt.Sprintf(blockOpen+"\nhook add X\n"+blockClose+"\n", "2.0.0")
+	once := replaceBlock("mine\n", block)
+	twice := replaceBlock(once, block)
+	if once != twice {
+		t.Errorf("a second install changed the file:\n%q\n%q", once, twice)
+	}
+}
+
+// commandOf returns the command a named hook line carries, as Crush reads it:
+// the value of --command with the crushrc line's own quoting removed. Its
+// bounds are the two flags around it, which is what makes the outer quoting
+// visible rather than guessed at.
+func commandOf(block, name string) (string, bool) {
+	for line := range strings.Lines(block) {
+		if !strings.Contains(line, "--name "+name+" ") {
+			continue
+		}
+		_, rest, ok := strings.Cut(line, "--command ")
+		if !ok {
+			return "", false
+		}
+		quoted, _, ok := strings.Cut(rest, " --timeout ")
+		if !ok {
+			return "", false
+		}
+		return shUnquote(quoted), true
+	}
+	return "", false
+}
+
+// shUnquote undoes one layer of single-quoting, the shape shquote.Quote writes.
+func shUnquote(s string) string {
+	s = strings.TrimPrefix(s, "'")
+	s = strings.TrimSuffix(s, "'")
+	return strings.ReplaceAll(s, `'\''`, "'")
+}
+
+// The command lands inside a shell word that Crush then runs through a shell,
+// so both layers of quoting have to hold. A directory with a space is the case
+// that catches a missing one, and running the command is the only way to know
+// it does — a path split in two would run a different file, or none.
+func TestCrushrcBlockSurvivesAPathWithSpaces(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		// The assertion is that a POSIX shell resolves the command to one file;
+		// Crush runs its own embedded one there, which this test cannot borrow.
+		t.Skip("no /bin/sh to run the command through")
+	}
+	dir := filepath.Join(t.TempDir(), "some one")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seen := filepath.Join(t.TempDir(), "args")
+	for _, hook := range crushHooks {
+		script := "#!/bin/sh\nprintf '%s|%s\\n' \"$0\" \"$*\" >> " + seen + "\n"
+		if err := os.WriteFile(filepath.Join(dir, filepath.Base(hook.script)), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	block := crushrcBlock("1.2.3", dir)
+	for _, hook := range crushHooks {
+		command, ok := commandOf(block, hook.name)
+		if !ok {
+			t.Fatalf("no %q hook in the block:\n%s", hook.name, block)
+		}
+		// Exactly what Crush does with the value: run it through a POSIX shell.
+		out, err := exec.Command("/bin/sh", "-c", command).CombinedOutput()
+		if err != nil {
+			t.Fatalf("running %q: %v: %s", command, err, out)
+		}
+	}
+
+	got, err := os.ReadFile(seen)
+	if err != nil {
+		t.Fatalf("no hook ran from a path with a space: %v", err)
+	}
+	for _, hook := range crushHooks {
+		want := filepath.Join(dir, filepath.Base(hook.script)) + "|" + hook.arg
+		if !strings.Contains(string(got), want+"\n") {
+			t.Errorf("hook %q ran as something else:\n%s\nwant a line %q", hook.name, got, want)
+		}
+	}
+}
+
+func TestVersionOf(t *testing.T) {
+	tests := []struct {
+		name   string
+		body   string
+		prefix string
+		want   string
+	}{
+		{"js marker", "// lich-plugin v0.8.0 — installed by lich\ncode\n", jsComment, "0.8.0"},
+		{"crushrc marker", "mine\n# >>> lich-plugin v1.2.3 >>>\nhook add X\n", shComment + " >>>", "1.2.3"},
+		{"no marker", "just code\n", jsComment, ""},
+		{"marker without a version", "// lich-plugin v\ncode\n", jsComment, ""},
+		{"another comment first", "// unrelated\n// lich-plugin v0.9.0 x\n", jsComment, "0.9.0"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := versionOf([]byte(tc.body), tc.prefix)
+			if got != tc.want || ok != (tc.want != "") {
+				t.Errorf("versionOf = (%q,%v), want %q", got, ok, tc.want)
+			}
+		})
+	}
+}

--- a/internal/agentplugin/opencode.go
+++ b/internal/agentplugin/opencode.go
@@ -1,0 +1,85 @@
+package agentplugin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// The opencode side. opencode has no plugin CLI and no marketplace: a plugin
+// there is a JavaScript module its server imports from a directory, so
+// installing one is writing the file and uninstalling one is deleting it.
+//
+// lich writes the module the release published, with a marker line naming the
+// version above it — that line is the only record of what is installed, since
+// opencode keeps no plugin state to ask.
+
+const (
+	// opencodeSource is the module's path inside the plugin repository, and
+	// opencodeFile the name it takes in opencode's plugin directory. The
+	// extension is load-bearing: opencode globs `{plugin,plugins}/*.{ts,js}`, so
+	// a `.mjs` would sit there unread.
+	opencodeSource = "opencode/lich.js"
+	opencodeFile   = "lich.js"
+
+	// jsComment is how the marker line hides from the JavaScript that follows it.
+	jsComment = "//"
+)
+
+func (s *Service) opencodeInstall() error {
+	version, err := s.releaseVersion()
+	if err != nil {
+		return err
+	}
+	data, err := s.fetchFile(version, opencodeSource)
+	if err != nil {
+		return err
+	}
+	dir, err := s.opencodePluginDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", dir, err)
+	}
+	body := fmt.Sprintf("%s %s v%s — installed by lich, replace with the file from %s\n%s",
+		jsComment, markerName, version, marketplaceRepo, data)
+	path := filepath.Join(dir, opencodeFile)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// opencodeInstalledVersion reads the version off the marker line lich wrote, or
+// ("", false) when the module is absent, unreadable, or was not written by lich
+// — a hand-installed copy carries no marker, and reporting a version for it
+// would claim an install lich cannot update.
+func (s *Service) opencodeInstalledVersion() (string, bool) {
+	dir, err := s.opencodePluginDir()
+	if err != nil {
+		return "", false
+	}
+	data, err := os.ReadFile(filepath.Join(dir, opencodeFile))
+	if err != nil {
+		return "", false
+	}
+	return versionOf(data, jsComment)
+}
+
+// opencodePluginDir resolves opencode's global plugin directory. opencode reads
+// it through the xdg-basedir convention — $XDG_CONFIG_HOME, else ~/.config —
+// which it applies on every platform rather than deferring to the OS-native
+// config location, so os.UserConfigDir would point elsewhere on macOS and
+// Windows and the module would land where nothing loads it.
+func (s *Service) opencodePluginDir() (string, error) {
+	base := os.Getenv("XDG_CONFIG_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		base = filepath.Join(home, ".config")
+	}
+	return filepath.Join(base, "opencode", "plugin"), nil
+}


### PR DESCRIPTION
**Settings › lich plugin** now lists all four harnesses and installs into each. opencode and Crush could already report to lich — the plugin has shipped clients for them since lich-plugin#10 — but only for someone willing to place the files by hand.

## Two install shapes

`agentplugin` was built around one interface: shell out to the harness's plugin CLI, never touch its state. Neither new harness has one, so the package grows a second shape beside the first rather than bending the first.

| | how | version read from |
|---|---|---|
| Claude Code, Codex | their plugin CLI (unchanged) | the harness's own plugin state |
| opencode | write `opencode/lich.js` into its plugin dir | a marker line lich wrote |
| Crush | write the hook scripts + two `hook add` lines in `crushrc` | a marker line lich wrote |

**opencode's directory is resolved the way opencode resolves it** — xdg-basedir: `$XDG_CONFIG_HOME`, else `~/.config`, on every platform. `os.UserConfigDir` would land in `~/Library/Application Support` on macOS, where nothing loads it.

**Crush gets `crushrc`, not `crush.json`**, because it is a script rather than a document: lich appends a delimited block and replaces exactly that block on update. Every other line — and every comment — is left where the user wrote it. Rewriting the JSON would reformat a file lich does not own.

Neither harness records what is installed, so the version lives in the marker line, and both round-trip through it. A file *without* a marker reads as not installed: an update must never claim a copy lich did not write.

## The failure this refuses

`hook add` in `crushrc` landed in **Crush 0.88.0**. Older versions read the file, ignore the lines, and say nothing — the install would look done and the card would report nothing, forever. So the install asks `crush --version` before it fetches or writes anything, and refuses with the version it found. A version lich cannot parse is allowed through rather than guessed at: a wrong refusal blocks an install that would have worked.

Settings also gains one line of prose for Crush, because the gap is otherwise invisible: `PreToolUse` is its only event, so its cards show no status and keep their own name. Without saying so, a working install reads as a broken one.

## How it was checked

Against both real CLIs, not against their docs:

- **opencode 1.18.16** — the installed module loads and reports; the marker survives the round trip.
- **Crush 0.88.1** — a generated `crushrc` produced both reports (`/session-start` with `provider: crush`, and `/session-touched`) against a stub listener, including from a directory with a space in its name. That case is what the two layers of quoting in the block are for: one so the path survives as a single word inside the command Crush runs, one so the command survives as a single argument to the crushrc builtin.
- **Crush 0.77.0** — the silent-ignore failure, reproduced. It is the reason for the version gate.

Mutation-checked: dropping a quoting layer fails the spaces test, removing the version gate fails the refusal test, and dropping the marker fails the round trip.

## Test plan

- [x] `go test ./...` — 1244 pass
- [x] `gofmt -l .`, `go vet ./...` clean; cross-compile build+vet green for linux/darwin/windows
- [x] `pnpm check`, `vitest run` (795), `tsc --noEmit`, `vite build` clean
- [ ] Needs lich-plugin **v0.8.0 tagged** before it can install anything: the install reads `releases/latest` and fetches files at that tag, and the newest release today is v0.7.0, which carries neither client