### PR TITLE
feat: let Claude Code sessions skip their permission prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Claude Code can be spawned with its permission prompts off.** In a checkout
+  you intend to throw away, confirming every edit and every command is ceremony
+  — but the flag that drops the prompts could only be reached by pointing lich
+  at a launcher script of your own, which then applied to every session it ever
+  spawned. Settings › Providers › Claude Code now carries the switch, twice:
+  once for sessions in the project's own directory, once for sessions in a
+  worktree, so an agent can be let loose in the branch you can delete while the
+  tree you work in keeps asking. Both are off until you turn them on, and what
+  they turn on is `--dangerously-skip-permissions`: the agent then edits files,
+  runs commands and installs things without asking first.
+
 - **A task nobody picks up says so, instead of being waited out.** Handing work
   to another session proved only that the text reached its terminal — and a
   terminal can have something else on it: a provider still starting, a dialog

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import { Store } from "@/lib/rpc"
 import { useProjects } from "@/providers/projects"
-import { binKey } from "@/lib/providers-store"
+import { binKey, skipPermissionsKey } from "@/lib/providers-store"
 import { useSettings } from "@/providers/settings"
 import { setCostReadout } from "@/lib/cost-readout-store"
 import { useCostReadout } from "@/lib/use-cost-readout"
@@ -10,6 +10,25 @@ import { Switch } from "@/components/ui/switch"
 import { SettingBlock } from "./SettingBlock"
 
 const GLOBAL_SCOPE = ""
+
+// useSkipPermissions is the stored "run without permission prompts" flag for one
+// checkout scope: read once, written through on every toggle. It reads off until
+// the value arrives — this is the switch that hands an agent the machine, so the
+// unknown state must never be drawn as the permissive one.
+function useSkipPermissions(providerId: string, worktree: boolean) {
+  const key = skipPermissionsKey(providerId, worktree)
+  const [on, setOn] = useState(false)
+
+  useEffect(() => {
+    void Store.GetSetting(key, GLOBAL_SCOPE).then((value) => setOn(value === "true"))
+  }, [key])
+
+  const toggle = (next: boolean) => {
+    setOn(next)
+    void Store.SetSetting(key, GLOBAL_SCOPE, String(next))
+  }
+  return [on, toggle] as const
+}
 
 // ProviderBinSettings is the config section a provider gets when enabled: the
 // custom path to its binary or launcher script, as a global default plus an
@@ -32,6 +51,8 @@ export function ProviderBinSettings({
   // The field keeps the raw string so a half-typed "1." survives the keystroke;
   // the stored budget is the parsed value, and an emptied field is no budget.
   const [budget, setBudget] = useState(() => (costBudget > 0 ? String(costBudget) : ""))
+  const [skipHere, setSkipHere] = useSkipPermissions(providerId, false)
+  const [skipInWorktrees, setSkipInWorktrees] = useSkipPermissions(providerId, true)
 
   useEffect(() => {
     void Store.GetSetting(key, GLOBAL_SCOPE).then(setGlobalBin)
@@ -139,6 +160,31 @@ export function ProviderBinSettings({
               />
             </SettingBlock>
           )}
+
+          {/* Both off unless the user says otherwise, and separate on purpose:
+              a worktree is a checkout you can throw away, the project directory
+              is the one you work in. */}
+          <SettingBlock
+            title="Skip permission prompts"
+            description="Spawn Claude Code with --dangerously-skip-permissions in this project's own checkout. It edits files, runs commands and installs things without asking first, and whatever it gets wrong lands in the tree you work in."
+          >
+            <Switch
+              checked={skipHere}
+              onCheckedChange={setSkipHere}
+              aria-label="Skip permission prompts in the project directory"
+            />
+          </SettingBlock>
+
+          <SettingBlock
+            title="Skip permission prompts in worktrees"
+            description="The same flag for sessions started in a git worktree. That checkout is separate from your working tree, so a mistake stays in the branch until you merge it."
+          >
+            <Switch
+              checked={skipInWorktrees}
+              onCheckedChange={setSkipInWorktrees}
+              aria-label="Skip permission prompts in worktree sessions"
+            />
+          </SettingBlock>
         </>
       )}
     </>

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -7,6 +7,7 @@ import {
   enabledProviders,
   readEnabled,
   resolveDefaultProvider,
+  skipPermissionsKey,
   type ProviderState,
 } from "./providers-store"
 
@@ -19,6 +20,14 @@ describe("provider setting keys", () => {
     expect(binKey("claude")).toBe("claude.bin")
     expect(binKey("codex")).toBe("provider.codex.bin")
     expect(binKey("opencode")).toBe("provider.opencode.bin")
+  })
+
+  // The two scopes are separate rows in the settings table, and the Go spawn
+  // reads these exact strings — a rename on either side silently re-arms the
+  // wrong checkout, or none.
+  it("keys the skip-permissions flag per provider and checkout scope", () => {
+    expect(skipPermissionsKey("claude", false)).toBe("provider.claude.skip-permissions")
+    expect(skipPermissionsKey("claude", true)).toBe("provider.claude.skip-permissions.worktree")
   })
 })
 

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -29,6 +29,15 @@ export function binKey(id: string): string {
   return id === "claude" ? "claude.bin" : `provider.${id}.bin`
 }
 
+// skipPermissionsKey holds the flag that spawns a provider without its
+// permission prompts, in one of two scopes (mirrors store.skipPermissionsKey in
+// Go, which is what the spawn reads). Two keys because a worktree is a throwaway
+// checkout: letting an agent loose there while the main working tree keeps
+// asking is a position a single flag cannot express.
+export function skipPermissionsKey(id: string, worktree: boolean): string {
+  return `provider.${id}.skip-permissions${worktree ? ".worktree" : ""}`
+}
+
 // readEnabled interprets the stored flag: Claude is enabled by default (it was
 // always offered before the providers feature), every other provider is opt-in.
 // An explicit "1"/"0" overrides the default.

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"path/filepath"
 
 	"github.com/omartelo/lich/internal/providers"
 )
@@ -73,6 +74,38 @@ func (s *Service) ProviderBin(providerID, projectID string) string {
 		return ""
 	}
 	return bin
+}
+
+// skipPermissionsKey is the settings key that spawns a provider with its
+// permission prompts turned off, in one of two scopes: the project's own
+// checkout, and a worktree. Global only, and on only for the literal "true" —
+// this hands the agent the machine, so anything else (absent, unreadable, a
+// value from some other feature) has to mean no.
+//
+// Two keys rather than one because a worktree is a throwaway checkout: giving an
+// agent free rein there while keeping the prompts in the main working tree is
+// the answer most users want, and a single flag cannot express it.
+func skipPermissionsKey(providerID string, worktree bool) string {
+	key := "provider." + providerID + ".skip-permissions"
+	if worktree {
+		key += ".worktree"
+	}
+	return key
+}
+
+// SkipPermissions reports whether a session of this provider, starting in cwd,
+// runs without its permission prompts. cwd picks the scope: anything but the
+// project's own directory is a worktree. A project whose path cannot be read
+// falls back to the main-checkout setting — a session lich cannot place is not
+// one to answer for with the more permissive of two flags.
+func (s *Service) SkipPermissions(providerID, projectID, cwd string) bool {
+	root := s.ProjectPath(projectID)
+	worktree := root != "" && filepath.Clean(cwd) != filepath.Clean(root)
+	value, err := s.GetSetting(skipPermissionsKey(providerID, worktree), globalScope)
+	if err != nil {
+		return false
+	}
+	return value == "true"
 }
 
 // ghAccountKey is the settings key holding the gh account a project's GitHub

--- a/internal/store/settings_test.go
+++ b/internal/store/settings_test.go
@@ -127,6 +127,50 @@ func TestProviderBinResolution(t *testing.T) {
 	}
 }
 
+// TestSkipPermissionsIsScopedByCheckout pins the two scopes apart: the flag a
+// session in the project's own directory reads is not the one a session in a
+// worktree reads, so turning it on for throwaway checkouts leaves the main
+// working tree prompting.
+func TestSkipPermissionsIsScopedByCheckout(t *testing.T) {
+	svc := newTestStore(t)
+	if err := svc.AddProject("p1", "alpha", "/repo/alpha"); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+
+	// Nothing configured: both scopes prompt.
+	if svc.SkipPermissions(providers.Claude, "p1", "/repo/alpha") {
+		t.Error("unconfigured project directory skips permissions, want prompts")
+	}
+	if svc.SkipPermissions(providers.Claude, "p1", "/repo/alpha-feature") {
+		t.Error("unconfigured worktree skips permissions, want prompts")
+	}
+
+	_ = svc.SetSetting("provider.claude.skip-permissions.worktree", globalScope, "true")
+	if !svc.SkipPermissions(providers.Claude, "p1", "/repo/alpha-feature/") {
+		t.Error("worktree does not skip permissions, want it on")
+	}
+	if svc.SkipPermissions(providers.Claude, "p1", "/repo/alpha/") {
+		t.Error("project directory follows the worktree flag, want its own")
+	}
+
+	// A project lich cannot place answers with the main-checkout flag, never the
+	// worktree one it just read as true.
+	if svc.SkipPermissions(providers.Claude, "gone", "/repo/alpha-feature") {
+		t.Error("unknown project reads the worktree flag, want the main-checkout one")
+	}
+
+	_ = svc.SetSetting("provider.claude.skip-permissions", globalScope, "true")
+	if !svc.SkipPermissions(providers.Claude, "p1", "/repo/alpha") {
+		t.Error("project directory does not skip permissions, want it on")
+	}
+
+	// Only the literal "true" arms it — any other stored value prompts.
+	_ = svc.SetSetting("provider.claude.skip-permissions", globalScope, "1")
+	if svc.SkipPermissions(providers.Claude, "p1", "/repo/alpha") {
+		t.Error("value \"1\" skips permissions, want only \"true\" to")
+	}
+}
+
 // TestWorktreeSetupIsProjectScoped pins the setup script the terminal service
 // reads when it spawns the first session of a fresh worktree. Project-scoped
 // only: a global value must never leak into a project that configured none,

--- a/internal/terminal/command.go
+++ b/internal/terminal/command.go
@@ -34,6 +34,12 @@ const (
 // `/list-agents` prints.
 const claudeNameFlag = "--name"
 
+// claudeSkipPermissionsFlag runs Claude Code without its permission prompts:
+// every edit and every command goes through unconfirmed. Off unless the user
+// turned it on for this checkout's scope in Settings › Providers, which is what
+// store.SkipPermissions answers.
+const claudeSkipPermissionsFlag = "--dangerously-skip-permissions"
+
 // How each provider is handed an MCP server on its command line: Claude Code
 // takes a JSON string, Codex takes config overrides for its `mcp_servers`
 // table. Which providers accept one at all is providers.AcceptsMCPServer.
@@ -89,14 +95,26 @@ func nameArgs(kind, name string) []string {
 // subcommand, so its global options have to come first, while Claude Code's
 // --mcp-config is variadic and reads everything after it as another config
 // path, so it has to come last.
-func providerArgs(kind, name, resume, lichBin string) []string {
+func providerArgs(kind, name, resume, lichBin string, skipPermissions bool) []string {
 	mcp := mcpArgs(kind, lichBin)
 	args := append([]string{}, nameArgs(kind, name)...)
 	args = append(args, resumeArgs(kind, resume)...)
+	args = append(args, skipPermissionArgs(kind, skipPermissions)...)
 	if kind == providers.Codex {
 		return append(mcp, args...)
 	}
 	return append(args, mcp...)
+}
+
+// skipPermissionArgs returns the flag that drops a provider's permission
+// prompts, or nil. Claude Code is the only spelling wired: the others each word
+// it differently, and none of them is turned on by a setting that says Claude —
+// a stray true must not reach a shell or opencode/crush either.
+func skipPermissionArgs(kind string, skip bool) []string {
+	if !skip || kind != providers.Claude {
+		return nil
+	}
+	return []string{claudeSkipPermissionsFlag}
 }
 
 // mcpArgs registers lich's own MCP server with the provider being spawned, so

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -108,7 +108,8 @@ type session struct {
 }
 
 // Store is the persistence the terminal service depends on: the binary to spawn
-// for a provider in a project (empty return spawns the provider's default),
+// for a provider in a project (empty return spawns the provider's default) and
+// whether that spawn drops the provider's permission prompts,
 // that project's own directory, the dev-server port reserved for each checkout,
 // where to record the provider session id a PTY reports through its
 // session-start hook, and the running cost
@@ -116,6 +117,7 @@ type session struct {
 // rest is called). The store implements them all.
 type Store interface {
 	ProviderBin(providerID, projectID string) string
+	SkipPermissions(providerID, projectID, cwd string) bool
 	ProjectPath(projectID string) string
 	WorktreeSetup(projectID string) string
 	WorktreePorts() map[string]int
@@ -433,9 +435,10 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 	if s.ws != nil {
 		mcpBin = lichBin()
 	}
+	skipPermissions := s.store.SkipPermissions(kind, projectID, cwd)
 	spec := ptySpec{
 		bin:  resolveCommand(kind, s.store.ProviderBin(kind, projectID), userShell()),
-		args: providerArgs(kind, name, resume, mcpBin),
+		args: providerArgs(kind, name, resume, mcpBin, skipPermissions),
 		dir:  cwd,
 		env:  s.sessionEnv(id, projectID, cwd),
 		cols: cols,

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -38,6 +38,7 @@ type stubBins struct {
 	projectPath     string
 	providerSession string
 	providerErr     error
+	skipPerms       bool
 	costOn          bool
 	ledgers         map[string]stubLedger
 	ports           map[string]int
@@ -60,6 +61,7 @@ func newCostStore(providerSession string) stubBins {
 }
 
 func (s stubBins) ProviderBin(_, _ string) string       { return s.bin }
+func (s stubBins) SkipPermissions(_, _, _ string) bool  { return s.skipPerms }
 func (s stubBins) ProjectPath(_ string) string          { return s.projectPath }
 func (s stubBins) WorktreeSetup(_ string) string        { return s.setup }
 func (s stubBins) SetProviderSession(_, _ string) error { return nil }
@@ -536,6 +538,56 @@ func TestNameArgs(t *testing.T) {
 	}
 }
 
+// TestSkipPermissionArgs proves the setting only ever arms Claude Code's flag,
+// and only when it is on: the other providers word it differently, so a true
+// meant for Claude must not be spelled at a shell or at opencode/crush.
+func TestSkipPermissionArgs(t *testing.T) {
+	cases := []struct {
+		name, kind string
+		skip       bool
+		want       []string
+	}{
+		{"claude off", "claude", false, nil},
+		{"claude on", "claude", true, []string{"--dangerously-skip-permissions"}},
+		{"codex is not wired", "codex", true, nil},
+		{"opencode is not wired", "opencode", true, nil},
+		{"shell is never wired", KindShell, true, nil},
+	}
+	for _, tc := range cases {
+		got := skipPermissionArgs(tc.kind, tc.skip)
+		if !slices.Equal(got, tc.want) {
+			t.Errorf("%s: skipPermissionArgs(%q, %v) = %v, want %v",
+				tc.name, tc.kind, tc.skip, got, tc.want)
+		}
+	}
+}
+
+// TestStartPassesSkipPermissionsToTheProcess proves the stored setting reaches
+// the spawned binary's argv — the wiring skipPermissionArgs' unit test cannot
+// see, and the one that decides whether a user who ticked the box actually gets
+// an agent that stops asking.
+func TestStartPassesSkipPermissionsToTheProcess(t *testing.T) {
+	bin := stayAliveBin(t)
+	svc := New(stubBins{bin: bin, skipPerms: true}, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1") })
+
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+
+	svc.mu.Lock()
+	got := spawnedArgs(t, svc, "s1")
+	svc.mu.Unlock()
+
+	// As above: the MCP registration follows, pinned by its own test. The flag
+	// has to land ahead of it — --mcp-config reads everything after it as another
+	// config path.
+	want := []string{bin, "--dangerously-skip-permissions", "--mcp-config"}
+	if len(got) != len(want)+1 || !slices.Equal(got[:len(want)], want) {
+		t.Errorf("spawned argv = %v, want %v followed by one config", got, want)
+	}
+}
+
 // TestStartPassesNameToTheProcess proves the peer name reaches the spawned
 // binary's argv beside the resume id, in the order claude parses.
 func TestStartPassesNameToTheProcess(t *testing.T) {
@@ -669,7 +721,7 @@ func TestSessionEnvInjectsCoordinates(t *testing.T) {
 func TestProviderArgsRegistersTheMCPServer(t *testing.T) {
 	const bin = "/usr/bin/lich"
 
-	claude := providerArgs(providers.Claude, "", "", bin)
+	claude := providerArgs(providers.Claude, "", "", bin, false)
 	if len(claude) != 2 || claude[0] != "--mcp-config" {
 		t.Fatalf("claude args = %v", claude)
 	}
@@ -693,7 +745,7 @@ func TestProviderArgsRegistersTheMCPServer(t *testing.T) {
 		t.Errorf("a secret reached the argv, which /proc exposes: %q", claude[1])
 	}
 
-	codex := providerArgs(providers.Codex, "", "", bin)
+	codex := providerArgs(providers.Codex, "", "", bin, false)
 	want := []string{
 		"-c", `mcp_servers.lich.command="/usr/bin/lich"`,
 		"-c", `mcp_servers.lich.args=["mcp"]`,
@@ -708,17 +760,17 @@ func TestProviderArgsRegistersTheMCPServer(t *testing.T) {
 // follows it, and Codex reads resume as a subcommand that every global option
 // must precede.
 func TestProviderArgsOrdersEachProvidersConstraint(t *testing.T) {
-	claude := providerArgs(providers.Claude, "lich-4f2a", "conv-1", "/usr/bin/lich")
+	claude := providerArgs(providers.Claude, "lich-4f2a", "conv-1", "/usr/bin/lich", true)
 	if claude[len(claude)-2] != "--mcp-config" {
 		t.Errorf("--mcp-config is not last, so it eats what follows: %v", claude)
 	}
-	for _, want := range []string{"--name", "--resume"} {
+	for _, want := range []string{"--name", "--resume", "--dangerously-skip-permissions"} {
 		if !slices.Contains(claude, want) {
 			t.Errorf("claude args lost %q: %v", want, claude)
 		}
 	}
 
-	codex := providerArgs(providers.Codex, "", "conv-1", "/usr/bin/lich")
+	codex := providerArgs(providers.Codex, "", "conv-1", "/usr/bin/lich", false)
 	resume := slices.Index(codex, "resume")
 	if resume < 0 {
 		t.Fatalf("codex args lost the resume subcommand: %v", codex)
@@ -748,7 +800,7 @@ func TestProviderArgsWithoutARegistration(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if args := providerArgs(tt.kind, "", "", tt.bin); len(args) != 0 {
+			if args := providerArgs(tt.kind, "", "", tt.bin, false); len(args) != 0 {
 				t.Errorf("args = %v, want none", args)
 			}
 		})


### PR DESCRIPTION
In a checkout you intend to throw away, confirming every edit and every command is ceremony. The flag that drops them exists, but nothing in lich could pass it: the only way through was to point the custom binary path at a launcher script of your own, which then applied to every session lich ever spawned — the main working tree included, which is the one place the prompts are worth keeping.

Settings › Providers › Claude Code now carries the switch twice, once per checkout scope, both off until turned on. Turned on, the session spawns with `--dangerously-skip-permissions`.

## How it resolves

- The scope is decided at spawn from the session's directory: anything but the project's own is a worktree (`store.SkipPermissions`). A project whose path cannot be read falls back to the main-checkout flag rather than the worktree one — a session lich cannot place is not one to answer for with the more permissive of two settings — and only the literal `"true"` arms either.
- Two settings rather than one because the position most people want is not expressible in a single flag: an agent let loose in a branch you can delete, while the tree you work in keeps asking.
- Resolved in the store and read by the spawn, so it covers a session opened from the window and one opened by an agent through `lich open` / `open_session` alike, with no new argument on the RPC.
- Claude Code is the only spelling wired: the other providers each word it differently, and a true meant for Claude must not reach a shell or opencode/crush. The flag lands ahead of `--mcp-config`, which is variadic and reads what follows it as another config path.

## Out of scope

- No per-project override — the two flags are global, like the enabled flag beside them.
- No switch for the other providers.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test ./...` — 1218 pass, including the new store scope test and the argv wiring test
- [x] `pnpm test` (796 pass), `tsc --noEmit`, `vite build`
- [x] `biome check` — only the standing a11y warning backlog
- [x] Exercised in `task dev`: the switches persist, and a session spawned with one on runs without the prompts
