### PR TITLE
docs: opencode reports waiting for any prompt, not one event

### DIFF
--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -39,7 +39,7 @@ Both sides test against the payloads in
 | `UserPromptSubmit` | `UserPromptSubmit`  | `session.status` (`busy`) | —          | `busy`    |
 | `PreToolUse`       | `PreToolUse`        | `tool.execute.before`    | —          | `busy` + `tool` |
 | `PostToolUse`      | `PostToolUse`       | `tool.execute.after`     | —          | `busy`    |
-| `Notification`     | `PermissionRequest` | `permission.asked`       | —          | `waiting` |
+| `Notification`     | `PermissionRequest` | any `*.asked`            | —          | `waiting` |
 | `Stop`             | `Stop`              | `session.status` (`idle`) | —          | `done`    |
 | `SessionEnd`       | —                   | —                        | —          | `idle`    |
 
@@ -48,6 +48,15 @@ opencode is the one harness that reports a state rather than an event: its
 same payload. Its `idle` means the turn ended, which is lich's `done` — not
 lich's `idle`, which says the CLI itself has left. Nothing in opencode's event
 list says that, so like Codex it never reports `idle`.
+
+**opencode's `waiting` is a rule, not an event name.** It asks the user in more
+than one way — a permission decision and an interactive question, each with a
+`.v2.` spelling published alongside — so the client reports `waiting` for any
+event type ending in `.asked` rather than for a list of names. Its catalogue is
+not exhaustive to enumerate against: a real run emits types (`server.heartbeat`)
+that the 94 event schemas its own `/doc` publishes do not list. Nothing is
+registered for the answer: replying raises `session.status busy` and dismissing
+raises `session.status idle`, each within ~100ms, so the card re-arms itself.
 
 **Crush reports no state at all.** Its only hook event is `PreToolUse`, and a
 `busy` with nothing that can end it would leave a spinner on the card until the
@@ -172,6 +181,14 @@ a broken script could do was lose a status report.
   not clear when the session leaves `waiting` (user handled it in the terminal).
   Fix path: track the toast id per session and dismiss it on the next
   busy/done.
+- **Two `waiting` reports for one prompt are two toasts and two desktop
+  notifications.** The toast reads the raw event by design (a repeat state is no
+  change to the store, which would swallow the second one), and
+  `decideStatusNotice` weighs `previous` for `done` but never for `waiting` — a
+  session already waiting notifies again. Harmless while a harness raises one
+  event per prompt, which every one of them does today; it is the cost a client
+  pays for reporting the same block twice, and the reason to dedupe on the
+  client rather than here.
 - `PostToolUse → busy` recovers from `waiting` only when Claude runs a tool. Deny
   a permission and let Claude end the turn without another tool and the card
   stays `waiting` until `Stop → done`. Rare, and it self-corrects on the next


### PR DESCRIPTION
The opencode column of the state table named `permission.asked` — which was the whole client, until an opencode session asking an interactive question turned up waiting behind a card that showed a spinner. A question rides an event of its own (`question.asked`), and enumerating names is how it went unreported.

[lich-plugin#14](https://github.com/omartelo/lich-plugin/pull/14) fixed the client (shipped in v0.9.1); this writes the rule where the contract is canonical.

## Why a rule instead of two names

opencode asks in four spellings today — `permission.asked`, `question.asked`, and a `.v2.` variant of each — and its catalogue is not exhaustive enough to enumerate against: a real `opencode serve` 1.18.16 run emits `server.heartbeat`, which appears in none of the 94 event schemas its own `/doc` publishes.

Measured on that run, and why the answer needs no event of its own:

```
ask     + 1665ms question.asked   …then 45s of silence, no status at all
reply   question.replied  → session.status busy   (+129ms)
reject  question.rejected → session.status idle   (+81ms)
```

## No contract change

`waiting` is an existing state, the payload is unchanged, `fixtures/` is untouched — so per the versioning rule in `README.md` this is a change *within* a contract: plugin-only release, no lich code. That is also why the plugin release could land first without breaking the lockstep the rule reserves for changes *to* a contract.

## One ceiling the audit turned up

Two `waiting` reports for one prompt are **two toasts and two desktop notifications**. The toast reads the raw event deliberately (`projects.tsx` — a repeat state is no change to the store, which would swallow the second one), and `decideStatusNotice` (`session-events.ts:346`) weighs `previous` for `done` but never for `waiting`.

Nothing raises it today — every harness sends one event per prompt — but the suffix rule makes a duplicate cheaper to hit than a named list did, so the ceiling names where it has to be dropped: the client, not here. No behaviour change in this PR.

## Gate

`gofmt -l` clean · `go vet ./...` clean · `go test ./...` green (30 packages). Docs-only, no frontend file touched.