### PR TITLE
fix: isolate the Crush install test from the real config directory

### DIFF
--- a/internal/agentplugin/files_test.go
+++ b/internal/agentplugin/files_test.go
@@ -191,13 +191,37 @@ func crushCLI(t *testing.T, s *Service, configDir, version string) {
 	s.bins = stubBin(self)
 }
 
+// lichConfigHome redirects os.UserConfigDir — where lich keeps the scripts it
+// installs for Crush — into a temporary directory, and returns what it will
+// answer.
+//
+// Setting XDG_CONFIG_HOME alone is a Linux-only isolation: os.UserConfigDir
+// reads it there, but $HOME/Library/Application Support on macOS and %AppData%
+// on Windows. A test that sets only XDG therefore looks for the scripts in its
+// temporary directory while the install writes them into the real user's config
+// directory — failing on those two, and leaving files behind on a machine it was
+// never supposed to touch. All three variables are set so the redirect holds
+// wherever the suite runs, and the answer is read back from the standard library
+// rather than rebuilt here, because the per-OS layout is its rule, not lich's.
+func lichConfigHome(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+	t.Setenv("AppData", root)
+	t.Setenv("HOME", root)
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("resolve config directory: %v", err)
+	}
+	return dir
+}
+
 // installCrush runs an install against temporary directories and returns the
 // crushrc it wrote and the directory the scripts went to.
 func installCrush(t *testing.T, s *Service, existingRC string) (string, string) {
 	t.Helper()
 	configDir := t.TempDir()
-	lichConfig := t.TempDir()
-	t.Setenv("XDG_CONFIG_HOME", lichConfig)
+	lichConfig := lichConfigHome(t)
 	crushCLI(t, s, configDir, "0.88.1")
 
 	rc := filepath.Join(configDir, "crushrc")

--- a/internal/agentplugin/files_test.go
+++ b/internal/agentplugin/files_test.go
@@ -259,7 +259,9 @@ func TestCrushInstallWritesScriptsAndHooks(t *testing.T) {
 			t.Fatalf("stat %s: %v", path, err)
 		}
 		// Crush dispatches a shebang'd script through os/exec, which needs the bit.
-		if info.Mode().Perm()&0o111 == 0 {
+		// Windows has no POSIX mode to carry it — a file written 0o755 stats as
+		// -rw-rw-rw- there — so the bit is asserted where it decides anything.
+		if runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
 			t.Errorf("%s is not executable (mode %v)", path, info.Mode().Perm())
 		}
 		if !strings.Contains(rc, hook.name) {


### PR DESCRIPTION
`main` has been red on macOS and Windows since #220 — four merges ago. The `os-tests` job only arms on a push to `main` or on a PR labelled `ci:os`, so every one of those merges was green on its own PR and red the moment it landed.

```
failure 9118d14  #223 (docs only — inherited)
failure 90c1bd8  #222
failure aae1ace  #219
failure a29f1f3  #220  ← broke here
success b77df6e  #221
```

One test, both OSes: `TestCrushInstallWritesScriptsAndHooks`.

## Root cause

The test set `XDG_CONFIG_HOME` and looked for the installed scripts under it. That isolation is Linux-only — `os.UserConfigDir` reads `XDG_CONFIG_HOME` there, but `$HOME/Library/Application Support` on macOS and `%AppData%` on Windows:

```
files_test.go:235: stat …/002/lich/plugin/hooks/report-session-start.sh: no such file or directory
```

So on those two the install wrote into **the runner's real config directory** while the assertion looked in a temporary one. The failure is the visible half; the leak is the other one — a test writing outside its `TempDir` on a developer's own machine.

## The fix

The test asserted something the contract never promised: that `XDG_CONFIG_HOME` governs where lich keeps its copy of the plugin scripts. `os.UserConfigDir` is the right call for the product — `lich.db`, themes and pricing all live there — so the product is untouched.

`lichConfigHome(t)` now sets all three variables and reads the answer back from the standard library, pinning only the `lich/plugin/hooks` suffix that `crushScriptDir` actually promises. Four tests route through it, so all four stop writing outside their temp dir, not just the one that failed.

## Verification

- `internal/agentplugin` green locally, `-count=1`.
- `gofmt -l` clean; `go build` + `go vet` for linux, darwin and windows.
- Test binary cross-compiles for darwin and windows (`go test -c`).
- Labelled `ci:os` — the real macOS and Windows runners are the proof, and cross-compiling is not.

## Worth a decision, not in this PR

The label rule is "`ci:os` only when a PR touches an OS seam", and by that rule #220 was labelled correctly: it added no build tags. It did add code whose *path* differs per OS, which the rule does not describe. Either the rule widens to "anything reading a per-OS location", or `os-tests` stops being opt-in for PRs that touch `internal/agentplugin`, `internal/store`, `internal/themes` or `internal/pricing` — every package that calls `os.UserConfigDir`.