### PR TITLE
fix: pin the config-dir redirect the tests rely on

### DIFF
--- a/internal/agentplugin/files_test.go
+++ b/internal/agentplugin/files_test.go
@@ -213,6 +213,13 @@ func lichConfigHome(t *testing.T) string {
 	if err != nil {
 		t.Fatalf("resolve config directory: %v", err)
 	}
+	// Asserted, not assumed: a redirect that misses a platform's variable leaves
+	// this answering the real config directory — which the install then writes
+	// into, agreeing with the assertions and staying green while leaking files
+	// onto the machine. The failure has to be the redirect, not the leak.
+	if !strings.HasPrefix(dir, root) {
+		t.Fatalf("config dir %q is outside the test's temp dir %q", dir, root)
+	}
 	return dir
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/omartelo/lich/internal/providers"
@@ -307,11 +308,26 @@ func TestDatabasePathDev(t *testing.T) {
 
 func TestNewCreatesDatabaseUnderConfigDir(t *testing.T) {
 	tmp := t.TempDir()
-	// Redirect the OS config dir to tmp: XDG_CONFIG_HOME wins on Linux, HOME on
-	// macOS. Either way New writes under the test's temp directory, not the real
-	// user config.
+	// Redirect the OS config dir to tmp. os.UserConfigDir reads a different
+	// variable on each of the three: XDG_CONFIG_HOME on Linux, HOME on macOS
+	// ($HOME/Library/Application Support), AppData on Windows. Miss one and this
+	// test creates the real user's lich.db on that OS.
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("HOME", tmp)
+	t.Setenv("AppData", tmp)
+
+	// Asserted before New, not after: databasePath is the same call New makes, so
+	// the two agree on the real config directory just as well as on the temporary
+	// one — which is how a redirect that covers only some platforms stays green
+	// while writing outside the test. Checked first so a redirect that slipped
+	// fails the test instead of creating the developer's own lich.db.
+	want, err := databasePath()
+	if err != nil {
+		t.Fatalf("databasePath: %v", err)
+	}
+	if !strings.HasPrefix(want, tmp) {
+		t.Fatalf("database path %q is outside the test's temp dir %q", want, tmp)
+	}
 
 	svc, err := New()
 	if err != nil {
@@ -319,10 +335,6 @@ func TestNewCreatesDatabaseUnderConfigDir(t *testing.T) {
 	}
 	defer svc.Close()
 
-	want, err := databasePath()
-	if err != nil {
-		t.Fatalf("databasePath: %v", err)
-	}
 	if _, err := os.Stat(want); err != nil {
 		t.Errorf("database not created at %q: %v", want, err)
 	}


### PR DESCRIPTION
Follow-up to #224, which fixed the one test that *failed*. This is the same defect where it stayed green.

`TestNewCreatesDatabaseUnderConfigDir` redirects `XDG_CONFIG_HOME` and `HOME` — its comment names Linux and macOS and stops there. On Windows `os.UserConfigDir` reads `%AppData%`, so the test **creates the real user's `lich.db`**. It passes there: it derives the expected path from `databasePath()`, the same call `New` made, and the two agree on the real config directory exactly as well as on a temporary one.

## What changed

- `AppData` completes the redirect in both places.
- Both helpers now **assert the answer lands under the test's temp dir**. That assertion is the actual fix: a missing variable has to fail as a broken redirect, not pass while writing outside the test.
- In the store the check runs *before* `New()`, so a redirect that slipped fails the test instead of touching the developer's own workspace.

## Proved by mutation

Dropping the two variables Linux honours (leaving only `AppData`, the shape of a platform-incomplete redirect):

```
store_test.go:332: database path "/home/…/.config/lich/lich.db" is outside
                   the test's temp dir "/tmp/TestNewCreates…/001"
```

Before this PR that run created the database there and reported success.

## Audit of the rest

Every other config-dir test was read, not assumed:

- **agentplugin, XDG-only tests** — all target opencode, whose plugin dir is xdg-basedir on every OS *by design* (`opencode.go:75`). Correct as they are.
- **themes** — `TestDefaultDirSeparatesDevThemes` only compares the last two path segments and writes nothing. Portable.
- **pricing, cli** — never exercise their `os.UserConfigDir` paths in a test.
- **project, agentplugin (HOME/USERPROFILE)** — those target `os.UserHomeDir`, whose Windows variable is `USERPROFILE`, and set both.

A whole-suite run with `HOME`/`XDG_CONFIG_HOME`/`AppData` pointed at an empty directory writes no `lich/` anywhere on Linux — the leak is only reachable on the two platforms CI reaches, which is why this carries `ci:os`.

## Gate

`gofmt -l` clean · `go test ./...` green, exit 0 · `go vet` + `go test -c` for darwin and windows.