### PR TITLE
ci: run the OS suites on every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,10 @@
 name: ci
 
-# Fast per-PR gate: format/vet + both suites, with pass/fail counts and
-# coverage rendered into the job summary. A PR runs the linux path only, for
-# quick feedback; the windows and macOS suites ride the os-tests job below.
+# Per-PR gate: format/vet + both suites on linux, with pass/fail counts and
+# coverage rendered into the job summary, plus the backend suite on windows and
+# macOS in parallel (os-tests below).
 on:
   pull_request:
-    # labeled: adding `ci:os` to an open PR is what arms the os-tests job, so the
-    # label has to be an event, not just a state read on the next push.
-    types: [opened, synchronize, reopened, labeled]
   push:
     branches: [main]
 
@@ -16,10 +13,6 @@ permissions:
 
 jobs:
   test:
-    # A `labeled` event exists only to arm os-tests below — any label, on any PR,
-    # fires one. This suite already ran on the push that brought the SHA in, and
-    # its check stays attached to it, so re-running it here buys nothing.
-    if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -92,13 +85,12 @@ jobs:
   # as relative on Windows, and the tag's release build was the first thing to
   # say so.
   #
-  # Always after a merge to main, so a regression is caught before a tag is ever
-  # pushed; on a PR only when it carries the `ci:os` label, so touching an OS seam
-  # can be checked before the merge without slowing every other PR down.
+  # On every PR and every merge, because opting in never worked: it asked the
+  # author to know which code reads a per-OS location, and the one who did not
+  # left main red for four merges (#220 → #224). It costs about ten seconds —
+  # this runs beside the linux job, which takes longer than either of these — and
+  # the runners are free on a public repository.
   os-tests:
-    if: >-
-      github.event_name == 'push' ||
-      contains(github.event.pull_request.labels.*.name, 'ci:os')
     strategy:
       # One red OS still reports the other, rather than cancelling it.
       fail-fast: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,8 @@ feature history lives in `CHANGELOG.md` — don't duplicate it here.
   are read from there, so an entry written later is an entry that missed its release.
 - Touched an OS seam or a `_test.go` build tag? Run the same cross-compile loop CI runs:
   `for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done`
-  Cross-compiling only proves it builds — label the PR `ci:os` to run the backend suite on real Windows and macOS
-  runners before the merge.
+  Cross-compiling only proves it builds; the backend suite runs on real Windows and macOS runners on every PR,
+  and that is the answer to trust.
 
 ## Hard Invariants
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,9 @@ Then:
   entry in the same pull request. Release notes are read from that file, so an
   entry written later is an entry that missed its release.
 - **Touched OS-specific code or a `_test.go` build tag?** Run the cross-compile
-  loop, then label the pull request `ci:os` so the backend suite runs on real
-  Windows and macOS runners:
+  loop — CI runs the backend suite on real Windows and macOS runners for every
+  pull request, so that is where the answer comes from; this only saves you a
+  round trip:
   ```bash
   for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done
   ```


### PR DESCRIPTION
`os-tests` was opt-in: a PR had to carry the `ci:os` label, while a push to `main` ran it unconditionally. So a PR could be green and the merge red — which is what happened. `main` was broken from #220 to #224, four merges, and nobody was told, because every one of those PRs passed.

## Why not the two options in #224

Both keep the failure mode and only move the trigger for it.

- **Widening the label rule** asks the author to know which code reads a per-OS location. #220 added no build tag and was labelled *correctly* by the rule as written; what it added was a call whose *path* differs per OS (`os.UserConfigDir`). The rule failed by requiring knowledge that was missing — widening it requires more of the same.
- **A paths filter** at least doesn't depend on memory, but it is a list that goes stale the day a new package calls `os.UserConfigDir`, and the failure is identical and just as quiet.

## The premise was cost, and it does not hold

`os-tests` runs *beside* the linux job, not after it:

| job | duration |
|---|---|
| `test` (linux) | ~2m30 |
| `os-tests` macOS | 1m38 |
| `os-tests` windows | 2m41 |

Critical path moves ~2m30 → ~2m41. **About ten seconds.** The repository is public, so the runners are free.

## What is deleted

- the `if:` on `os-tests`
- the `labeled` trigger on `pull_request`
- the `if: github.event.action != 'labeled'` on `test`, which existed only to stop a label event from re-running the linux suite
- the instructions to apply the label, in `CLAUDE.md` and `CONTRIBUTING.md`

The `ci:os` label itself is left in the repository rather than deleted — old PRs still carry it, and it now means nothing rather than something wrong.

## Trade-off, stated

A flake on Windows or macOS now blocks any PR instead of only `main`. By this project's own rule a flake is a bug with a root cause, not something to re-run — and a flake that only shows up on the push already blocks `main`, which is the worst place to find it. Runner **queue** time is not in the numbers above (`startedAt` is post-queue); if it ever hurts, a paths filter is the fallback.

This PR is its own proof: it carries no label, and the OS suites ran.