### PR TITLE
fix: make lich close read a name the way lich send does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Crush has no flag for. It goes away with the same uninstall, and nothing
   outside lich's markers is touched.
 
-### Added
-
 - **An agent can close a session, and decide what happens to its worktree.** It
   could open one and hand it work, but never tidy up: every checkout an agent
   made stayed until somebody removed it by hand. `lich close` — and the

--- a/frontend/src/lib/session/delegate-prompt.test.ts
+++ b/frontend/src/lib/session/delegate-prompt.test.ts
@@ -7,7 +7,7 @@ describe("delegatePrompt", () => {
     expect(delegatePrompt("codex", "docs")).toBe('Ask the "docs" session to ')
   })
 
-  it("spells the command where the sender has none", () => {
+  it("spells the command for every other sender", () => {
     for (const kind of ["opencode", "crush", "omp", "shell"]) {
       expect(delegatePrompt(kind, "docs")).toBe('lich send "docs" "')
     }

--- a/frontend/src/lib/session/delegate-prompt.ts
+++ b/frontend/src/lib/session/delegate-prompt.ts
@@ -4,9 +4,16 @@
 
 import type { SessionKind } from "./sessions"
 
-// The providers lich registers its MCP server with at spawn. Mirrors
-// providers.AcceptsMCPServer on the Go side — the two have to agree, because an
-// agent offered a tool it does not have would answer the user with an error.
+// The providers whose sessions are handed lich's tools on their own command
+// line at spawn (providers.AcceptsMCPServer). The kind alone answers it, and
+// that answer cannot go stale.
+//
+// opencode and Crush sessions can have the same tools from the companion plugin
+// (agentplugin.HasTools), and are still given the command here on purpose. What
+// the plugin reports is a fact about what is installed now, not about a session
+// started before the install — it only reaches one on its next restart — and an
+// agent offered a tool it does not have answers the user with an error. The
+// command works in all four and costs nothing.
 //
 // The session's declared kind, never the live agent readout: a shell card
 // running `claude` by hand was spawned without the registration, so it has the

--- a/internal/agentplugin/agentplugin.go
+++ b/internal/agentplugin/agentplugin.go
@@ -159,8 +159,10 @@ func (s *Service) HasTools(provider string) bool {
 // reading a session's silence as an answer: a provider that never reports is
 // silent whatever happens in it.
 //
-// It shells out to the provider's CLI, so it is not for a hot path. The relay
-// calls it once per errand.
+// It reads the provider's own plugin state — a file for Claude Code and
+// opencode, a CLI call for Codex and Crush — so it is not for a hot path. The
+// relay asks it once per errand, and HasTools once more before that; neither
+// question is cached, so each one pays for itself.
 func (s *Service) Installed(provider string) bool {
 	if !slices.Contains(supported, provider) || !s.available(provider) {
 		return false

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -35,11 +35,6 @@ import (
 // only lose a working session over a date.
 const mcpProtocolVersion = "2025-06-18"
 
-// mcpServerName is the name the tools are namespaced under in a client's tool
-// list (`mcp__lich__send_to_session` in Claude Code). It is also the key lich
-// registers itself under at spawn.
-const mcpServerName = "lich"
-
 // mcpMaxWait caps how long any tool here blocks, whatever the caller asks for.
 //
 // Claude Code moves an MCP call that runs past 120 seconds into the background
@@ -153,7 +148,7 @@ func mcpHandshake(params json.RawMessage) map[string]any {
 	return map[string]any{
 		"protocolVersion": version,
 		"capabilities":    map[string]any{"tools": map[string]any{}},
-		"serverInfo":      map[string]any{"name": mcpServerName, "version": "1"},
+		"serverInfo":      map[string]any{"name": relay.MCPServerName, "version": "1"},
 	}
 }
 

--- a/internal/spawn/close.go
+++ b/internal/spawn/close.go
@@ -114,6 +114,10 @@ func (s *Service) Close(fromID, target, projectName, worktree string, force bool
 // the checkout does — one left behind would offer a resume into a directory that
 // no longer exists.
 func (s *Service) removeCheckout(found located, active string, force bool) error {
+	// A check that cannot answer costs the message, never the work: `git worktree
+	// remove` without --force refuses a dirty checkout on its own
+	// (project.RemoveWorktree), so an unreadable status ends in git's own refusal
+	// instead of the sentence written for this case.
 	dirty, err := s.worktrees.WorktreeDirty(found.session.Path)
 	if err == nil && dirty && !force {
 		return fmt.Errorf(
@@ -159,7 +163,10 @@ type located struct {
 
 // findSession resolves a session by the label on its card or the name it answers
 // to in the peer roster, exactly as the relay does — an agent holding either
-// should not have to know which one it has.
+// should not have to know which one it has. The label is tried first and wins a
+// tie against another session's roster name, because that is how `lich send`
+// reads the same name (relay.resolve); one product cannot disagree with itself
+// about which session a name addresses.
 //
 // Unlike the relay it looks past the live ones: a card whose terminal was never
 // opened is still a session, and closing it is the one thing you can do with it.
@@ -169,7 +176,7 @@ func findSession(projects []store.Project, fromID, target, projectName string) (
 		return located{}, fmt.Errorf("no session given to close")
 	}
 
-	var matches []located
+	var byLabel, byName []located
 	for _, p := range projects {
 		if projectName != "" && !strings.EqualFold(p.Name, projectName) {
 			continue
@@ -179,11 +186,17 @@ func findSession(projects []store.Project, fromID, target, projectName string) (
 			if cwd == "" {
 				cwd = p.Path
 			}
-			if strings.EqualFold(sess.Label, target) ||
-				strings.EqualFold(relay.RosterName(cwd, sess.ID), target) {
-				matches = append(matches, located{project: p, session: sess})
+			switch {
+			case strings.EqualFold(sess.Label, target):
+				byLabel = append(byLabel, located{project: p, session: sess})
+			case strings.EqualFold(relay.RosterName(cwd, sess.ID), target):
+				byName = append(byName, located{project: p, session: sess})
 			}
 		}
+	}
+	matches := byLabel
+	if len(matches) == 0 {
+		matches = byName
 	}
 
 	switch len(matches) {

--- a/internal/spawn/close_test.go
+++ b/internal/spawn/close_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/omartelo/lich/internal/project"
+	"github.com/omartelo/lich/internal/relay"
 	"github.com/omartelo/lich/internal/store"
 )
 
@@ -169,6 +170,35 @@ func TestCloseRefusesTheCallersOwnSession(t *testing.T) {
 	}
 	if len(sessions.deleted) != 0 {
 		t.Error("deleted the caller's own session")
+	}
+}
+
+// One string can be a card's label and another session's roster name at the
+// same time, and the two surfaces that resolve it — `lich send` and `lich
+// close` — have to land on the same session. relay.resolve gives the label the
+// tie; so does this.
+func TestCloseResolvesALabelBeforeAnotherSessionsRosterName(t *testing.T) {
+	// The roster name s5 answers to: its project's directory, then four
+	// characters of its id.
+	const name = "lich-s5"
+	if got := relay.RosterName("/src/lich", "s5"); got != name {
+		t.Fatalf("roster name = %q, want %q — the collision this test needs is gone", got, name)
+	}
+	sessions := &fakeSessions{projects: []store.Project{{
+		ID: "p1", Name: "lich", Path: "/src/lich",
+		Sessions: []store.Session{
+			{ID: "s5", Label: "Session 5", Kind: "claude"},
+			{ID: "s6", Label: name, Kind: "claude"},
+		},
+	}}}
+	svc := New(sessions, &fakeWorktrees{}, &fakeTerminal{}, &fakeEvents{})
+
+	closed, err := svc.Close("s1", name, "", "", false)
+	if err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if closed.ID != "s6" {
+		t.Errorf("closed %q, want s6 — the session %q is the label of", closed.ID, name)
 	}
 }
 


### PR DESCRIPTION
Six of the seven medium findings from the `[Unreleased]` changelog review. The relay split (`internal/relay/relay.go` is 992 lines against the project's 800 ceiling) is deliberately left out — it is a large no-logic diff and it collides with work in flight on that file, so it comes as its own PR.

## What changes

**`lich close` resolves a name the way `lich send` does.** `findSession` matched a card's label and a session's roster name in one pass. A workspace where one string is both — a label on one card, another session's roster name — answered `"foo" names 2 sessions` and closed nothing, while `lich send foo` resolved it fine: `relay.resolve` tries the labels first and only falls back to the roster names when none matched, giving the label the tie on purpose. Two surfaces of one product disagreeing about which session a name addresses. Now the same two passes, with a test pinning the collision.

**The skipped `WorktreeDirty` error is documented instead of silent.** No data is at stake — `git worktree remove` without `--force` refuses a dirty checkout on its own — so a status git cannot read costs lich's own wording and nothing else. The comment says so.

**One constant for the MCP server name.** `internal/cli` declared its own `"lich"` beside `relay.MCPServerName`, which exists precisely because more than one package needs it.

**Three comments that had stopped being true:**

- `agentplugin.Installed` claimed to shell out to a CLI and to be asked once per errand. It reads a file for Claude Code and opencode, runs a CLI for Codex and Crush, and the relay asks `HasTools` before delivering plus `Installed` after — two uncached questions per errand. Collapsing them into one would change the relay's `Plugins` interface to save a call nobody has measured, so the comment is what changes.
- `delegate-prompt`'s kind list claimed to mirror `providers.AcceptsMCPServer`. Since #222 that is no longer the same question: the plugin carries lich's operations into opencode and Crush too. The menu keeps the fixed list deliberately — what the plugin reports is true of an install, not of a session started before it, and the shell command works in all four — and the comment now says that rather than pointing at a mirror that moved. No behaviour change, so no changelog entry; its test's name carried the same stale claim and was reworded, assertions untouched.
- `CHANGELOG.md`'s `[Unreleased]` had two `### Added` headings. The release job copies the section verbatim, so the published notes would have shown both. Merged; entries and their order unchanged.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` green (new: `TestCloseResolvesALabelBeforeAnotherSessionsRosterName`)
- [x] `biome check .`, `vitest run` (802 tests), `tsc --noEmit`, `vite build` all green