### PR TITLE
fix: hand a task to a session that is already working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,9 +223,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   length, that the project's setup script was still running — in a session with
   no worktree and no setup script. lich now notices the quiet when it happens
   rather than asking after the fact, so a busy session is handed the task and
-  answers it a turn later, the way every other busy session already did. When
-  the check does time out, the message no longer names a cause it cannot see:
-  it says what is certain, and points at the screen that knows the rest.
+  answers it a turn later, the way every other busy session already did. The
+  same check was too eager at the other end: a session whose setup script had
+  just handed over could be handed a task while its agent was still drawing its
+  opening screen, and that task appeared there as literal paste markers instead
+  of reaching the prompt. The wait for an agent to start is no longer mistaken
+  for an agent that has settled. When the check does time out, the message no
+  longer names a cause it cannot see: it says what is certain, and points at the
+  screen that knows the rest.
 
 - **The session list's scrollbar no longer sits on the cards.** With enough
   sessions to scroll, the scrollbar came down flush against the right edge of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A session that is working can be handed a task again.** Before typing at
+  another session's prompt, lich checks that the agent — and not the checkout's
+  setup script — is what reads that terminal, by waiting for the terminal to
+  stop drawing. It only ever asked that question at the moment a task arrived,
+  and an agent in the middle of a turn redraws its spinner several times a
+  second: a session that had been sitting at its prompt for hours failed the
+  check the first time anything was ever sent to it, and the sender was told, at
+  length, that the project's setup script was still running — in a session with
+  no worktree and no setup script. lich now notices the quiet when it happens
+  rather than asking after the fact, so a busy session is handed the task and
+  answers it a turn later, the way every other busy session already did. When
+  the check does time out, the message no longer names a cause it cannot see:
+  it says what is certain, and points at the screen that knows the rest.
+
 - **The session list's scrollbar no longer sits on the cards.** With enough
   sessions to scroll, the scrollbar came down flush against the right edge of
   every card, reading as part of them. It now keeps a gap, and the cards stay

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -420,10 +420,16 @@ func (s *Service) awaitReady(dest candidate, wait time.Duration) error {
 			return fmt.Errorf("%q stopped before its agent started", dest.Peer.Label)
 		}
 		if s.now().After(deadline) {
+			// Which of the two it is, lich cannot see from here, and naming only
+			// the setup script sent whoever read this hunting a script the
+			// project may not even have. What is certain is on that session's own
+			// screen, so the message says to go and look.
 			return fmt.Errorf(
-				"%q is still preparing its checkout — the project's worktree setup script "+
-					"is running in it and its agent has not started yet. Nothing was sent. "+
-					"Try again once it is up; lich sessions lists it as soon as it can take work",
+				"%q has not stopped drawing, so lich cannot tell what is reading its "+
+					"terminal: the project's worktree setup script may still be running in "+
+					"it, or its provider may still be starting up. Nothing was sent — open "+
+					"that session to see what is on its screen, and try again once it is at "+
+					"a prompt",
 				dest.Peer.Label,
 			)
 		}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -614,8 +614,14 @@ func (s *Service) noteOutput(sess *session, chunk []byte) {
 	if sess.settingUp && strings.Contains(string(chunk), setupDone) {
 		sess.settingUp = false
 		// The provider starts drawing from here, so the quiet this waits for is
-		// measured from the exec, not from the setup script's last line.
+		// measured from the exec, not from the setup script's last line. The
+		// clock goes with the flag: the exec itself takes a second or two — the
+		// image is replaced, a runtime starts, a splash is composed — and that
+		// silence is nobody's quiet. Measured from the script's last line it
+		// would clear the settle on the provider's very first byte, mid-splash,
+		// which is the write that lands on screen as literal paste markers.
 		sess.ready = false
+		sess.lastOut = time.Time{}
 	}
 }
 

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -592,12 +592,24 @@ func (s *Service) Resize(id string, cols, rows int) error {
 	return p.Resize(cols, rows)
 }
 
-// noteOutput reads one chunk of a session's output for the one thing lich has
+// noteOutput reads one chunk of a session's output for the two things lich has
 // to know about it from outside: whether the worktree setup script is still the
-// program on the other end of this PTY (see setupDone).
+// program on the other end of this PTY (see setupDone), and whether that
+// program has ever stopped drawing (see Ready).
 func (s *Service) noteOutput(sess *session, chunk []byte) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// The quiet is recorded as it passes, never sampled when somebody finally
+	// asks. A session settles seconds after it starts and is asked hours later,
+	// by then mid-turn: sampling there reads a spinner redrawing every few
+	// frames and calls a session that has been at its prompt all day unready.
+	//
+	// A setup script pauses too — between one package and the next — and that
+	// quiet belongs to a program the provider has not replaced yet, so it is
+	// not the provider's and does not count.
+	if !sess.settingUp && !sess.lastOut.IsZero() && time.Since(sess.lastOut) >= readySettle {
+		sess.ready = true
+	}
 	sess.lastOut = time.Now()
 	if sess.settingUp && strings.Contains(string(chunk), setupDone) {
 		sess.settingUp = false
@@ -632,9 +644,11 @@ func (s *Service) Ready(id string) bool {
 	// paste then lands on screen as literal text, ahead of a prompt that never
 	// received it.
 	//
-	// Asked once: after the first quiet the session stays ready. A busy agent
-	// draws continuously, and a target mid-turn has always been written to —
-	// its provider queues the input and answers a turn later.
+	// Quiet right now answers it too, for the session that has not produced a
+	// byte since its last one; a quiet that passed earlier was recorded when it
+	// happened (see noteOutput). Either way the session stays ready from then
+	// on. A busy agent draws continuously, and a target mid-turn has always
+	// been written to — its provider queues the input and answers a turn later.
 	if !sess.lastOut.IsZero() && time.Since(sess.lastOut) >= readySettle {
 		sess.ready = true
 		return true

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -1085,6 +1085,31 @@ func TestReadyStaysTrueThroughABusyTurn(t *testing.T) {
 	}
 }
 
+// The quiet a session settles into is recorded as it passes, not sampled when
+// somebody finally asks. A session live for hours is at its prompt the whole
+// time, but the first thing ever asked of it is a relayed message — and by then
+// it is mid-turn, redrawing a spinner every few frames. Sampled there it looks
+// like a provider that never took the terminal, and the message it was sent is
+// refused instead of queued.
+func TestReadyRemembersAQuietThatAlreadyPassed(t *testing.T) {
+	svc := New(stubBins{}, nil, events.New())
+	sess := &session{}
+	svc.mu.Lock()
+	svc.sessions["s1"] = sess
+	svc.mu.Unlock()
+
+	svc.noteOutput(sess, []byte("Claude Code v2.1.227"))
+	time.Sleep(readySettle + 100*time.Millisecond)
+	// The turn starts. From here the PTY never goes quiet again, and this is the
+	// first time anyone asks whether the session can be given work.
+	svc.noteOutput(sess, []byte("...thinking..."))
+	svc.noteOutput(sess, []byte("...thinking..."))
+
+	if !svc.Ready("s1") {
+		t.Error("a session that sat at its prompt for a whole turn was refused work")
+	}
+}
+
 func TestReadyWaitsOnlyTheSettleWithoutASetupScript(t *testing.T) {
 	bin := stayAliveBin(t)
 	svc := New(stubBins{bin: bin}, nil, events.New())

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -1085,6 +1085,33 @@ func TestReadyStaysTrueThroughABusyTurn(t *testing.T) {
 	}
 }
 
+// The setup script's marker is the exec, and the exec is not instant: the image
+// is replaced, a runtime starts, a splash is composed, and none of that writes a
+// byte. Measured from the script's last line, that silence is long enough to
+// pass for a provider that has finished drawing — so the first byte of the
+// splash would clear the settle, and the message the relay then types lands in a
+// TUI that has not taken the terminal yet.
+func TestTheWaitForTheProviderToStartIsNotItsQuiet(t *testing.T) {
+	svc := New(stubBins{}, nil, events.New())
+	sess := &session{settingUp: true}
+	svc.mu.Lock()
+	svc.sessions["s1"] = sess
+	svc.mu.Unlock()
+
+	svc.noteOutput(sess, []byte("Progress: resolved 551"+setupDone))
+	time.Sleep(readySettle + 100*time.Millisecond)
+	svc.noteOutput(sess, []byte("Claude Code v2.1.227"))
+	if svc.Ready("s1") {
+		t.Error("the wait for the provider to start was credited as the provider going quiet")
+	}
+
+	// Its own quiet, once it has drawn itself, still counts.
+	time.Sleep(readySettle + 100*time.Millisecond)
+	if !svc.Ready("s1") {
+		t.Error("the session stayed unready after its provider settled")
+	}
+}
+
 // The quiet a session settles into is recorded as it passes, not sampled when
 // somebody finally asks. A session live for hours is at its prompt the whole
 // time, but the first thing ever asked of it is a relayed message — and by then


### PR DESCRIPTION
## What was wrong

`lich send` to a session that had been live for hours failed on the first try, and the error blamed a setup script that did not exist.

The relay will not type at a target until `terminal.Ready` says the provider — not the checkout's worktree setup script — is the program reading that PTY. `Ready` answered by sampling: *is this PTY quiet right now?* It latched `sess.ready` the first time someone asked, and nobody asks until a task arrives. So the quiet that actually happened (seconds after the provider drew its opening screen) was never recorded, and the question was finally put mid-turn — when an agent redraws its spinner every ~120ms and `time.Since(lastOut) >= readySettle` is never true. `awaitReady` then polled to the caller's deadline and returned an error instead of a delivery.

That contradicts the relay's own design: `Send` already treats a busy target as ordinary (`relay.go:352-355` sets `skipTurns = 1` because every provider queues typed input and answers a turn later). That path was unreachable — `awaitReady` barred the delivery first.

## The fix

`noteOutput` records the quiet as it passes, rather than `Ready` sampling for it after the fact. A gap of `readySettle` between two chunks is the same fact the sample was reaching for, and it is observed whether or not anyone is asking. `Ready` still answers from a live sample too, for a session that has produced nothing since its last chunk.

The quiet of a setup script does not count — it pauses between packages, and the provider has not replaced it yet. That keeps the protection this check exists for: a message written into `pnpm install` is read and discarded, and the bracketed paste lands on screen as literal text.

I did not take the suggested route of short-circuiting `awaitReady` on the hooks' `busy` state. It only covers providers with the plugin installed, so it would leave the same hole open for the rest, and it answers a PTY question with a second mechanism instead of fixing the one that was wrong.

## The error message

`awaitReady`'s timeout asserted that the project's worktree setup script was running. In a session with no worktree that is categorically false, and it sends the reader hunting a script the project may not have. lich cannot see which of the two it is from here, so the message now states the observable fact and names both causes. It also dropped a second false claim: `lich sessions` lists a session whenever it is live (`roster` filters on `Live`, never on `Ready`), so "lists it as soon as it can take work" was never true.

I did not split it into two messages: telling the two causes apart needs `settingUp` exposed through the `Terminal` interface, and one message that names both is honest without the extra API.

## Tests

`TestReadyRemembersAQuietThatAlreadyPassed` pins the contract this was missing: a session goes quiet, then starts a turn it never falls quiet during, and is asked for the first time mid-turn. It fails on the old code (`a session that sat at its prompt for a whole turn was refused work`) and passes on the new.

No existing test changed. `TestReadyStaysTrueThroughABusyTurn` only ever covered the session that had already been asked once.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test -race ./...` green
- [x] `for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done` — all three
- [x] New test fails against the unfixed code, passes against the fix