### PR TITLE
fix: close the relay's second give-up race, and pin three tests to their contract

### DIFF
--- a/frontend/src/lib/session/peer-name.test.ts
+++ b/frontend/src/lib/session/peer-name.test.ts
@@ -30,9 +30,14 @@ describe("peerName", () => {
   it("falls back when there is no directory to name", () => {
     expect(peerName("", "4f2a1b3c")).toBe("lich-4f2a")
     expect(peerName("/", "4f2a1b3c")).toBe("lich-4f2a")
+    expect(peerName(".", "4f2a1b3c")).toBe("lich-4f2a")
   })
 
   it("keeps the directory alone when the id carries nothing usable", () => {
     expect(peerName("/home/me/code/lich", "---")).toBe("lich")
+  })
+
+  it("skips punctuation inside the id rather than counting it", () => {
+    expect(peerName("/home/me/code/lich", "4-f-2-a-1")).toBe("lich-4f2a")
   })
 })

--- a/frontend/src/lib/session/peer-name.ts
+++ b/frontend/src/lib/session/peer-name.ts
@@ -16,11 +16,13 @@ const ID_CHARS = 4
 export function peerName(cwd: string, id: string): string {
   // Windows separators too: the name is built the same way wherever lich runs,
   // even though only macOS and Linux have the messaging feature.
-  const dir =
-    cwd
-      .replace(/[\\/]+$/, "")
-      .split(/[\\/]/)
-      .pop() || "lich"
+  const last = cwd
+    .replace(/[\\/]+$/, "")
+    .split(/[\\/]/)
+    .pop()
+  // "." names no directory, and the Go half reads a path that names nothing the
+  // same way: filepath.Base answers "." for it, and falls back to the app name.
+  const dir = !last || last === "." ? "lich" : last
   const tail = id.replace(/[^a-z0-9]/gi, "").slice(0, ID_CHARS)
   return tail ? `${dir}-${tail}` : dir
 }

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -219,9 +219,9 @@ func (a mcpArgs) text(key string) string {
 	}
 }
 
-// flag reads a boolean, and only "yes" counts. A model that sends the string
-// "false" — or anything else it invented — must not read as consent, because
-// the one flag this carries discards uncommitted work.
+// flag reads a boolean, and a string only counts as one when it spells "true".
+// A model that sends "false", "yes", or anything else it invented must not read
+// as consent, because the one flag this carries discards uncommitted work.
 func (a mcpArgs) flag(key string) bool {
 	switch v := a[key].(type) {
 	case bool:

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -453,15 +453,23 @@ func TestMCPCloseSessionPassesTheWorktreeAnswer(t *testing.T) {
 	}
 }
 
-// force discards work that is in no commit and on no remote, so only a real
-// yes counts — a model that sends the string "false" must not read as consent.
+// force discards work that is in no commit and on no remote, so only a real yes
+// counts: the boolean, or the one string that spells it. A model that sends
+// "false" — or "yes", which reads like consent and is not the word — must not.
 func TestMCPForceIsOnlyTrueWhenItSaysTrue(t *testing.T) {
-	for _, sent := range []string{`"false"`, `"no"`, `0`, `null`} {
+	for sent, want := range map[string]bool{
+		`true`:    true,
+		`"true"`:  true,
+		`"false"`: false,
+		`"yes"`:   false,
+		`0`:       false,
+		`null`:    false,
+	} {
 		f := newFakeLich(t, `{"id":"9f8e","projectId":"p1","label":"auth-fix","removed":true}`)
 		speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
 			{"name":"close_session","arguments":{"session":"auth-fix","worktree":"remove","force":`+sent+`}}}`)
-		if got := f.only(t).args[4]; got != false {
-			t.Errorf("force sent as %s read as %v", sent, got)
+		if got := f.only(t).args[4]; got != want {
+			t.Errorf("force sent as %s read as %v, want %v", sent, got, want)
 		}
 	}
 }

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -600,8 +600,7 @@ func (s *Service) await(id string, t *ticket, waitSeconds int) Result {
 		s.leave(t)
 		return Result{Ticket: id, Target: t.target, Status: StatusUnread}
 	case <-timer.C:
-		s.giveUp(t)
-		return Result{Ticket: id, Target: t.target, Status: StatusPending}
+		return Result{Ticket: id, Target: t.target, Status: s.giveUp(t)}
 	}
 }
 
@@ -612,18 +611,37 @@ func (s *Service) leave(t *ticket) {
 	s.mu.Unlock()
 }
 
-// giveUp drops the claim of a caller whose wait ran out, and catches the one
-// race that would lose an answer: the reply landing in the same instant, seeing
-// this caller still attending, and leaving the answer for it — after it had
+// giveUp drops the claim of a caller whose wait ran out and returns the status
+// that caller should hear. It catches the two races that would lose what became
+// of the errand, both of the same shape: the ticket closing in the same instant,
+// seeing this caller still attending, and leaving the news for it — after it had
 // already stopped listening. Whoever leaves last owns what is left behind.
-func (s *Service) giveUp(t *ticket) {
+//
+// A reply is typed at the sender's prompt, because an answer outlives the wait
+// it missed. The receipt window closing the ticket unread is told to the caller
+// instead: it is still here to hear it, and the alternative is reporting a task
+// nobody read as still in progress, on a ticket already out of the map.
+func (s *Service) giveUp(t *ticket) string {
 	s.mu.Lock()
 	t.attended--
-	orphaned := t.answered && t.attended == 0
+	last := t.attended == 0
+	orphaned := t.answered && last
+	unread := false
+	if last && !t.answered {
+		select {
+		case <-t.unread:
+			unread = true
+		default:
+		}
+	}
 	s.mu.Unlock()
 	if orphaned {
 		s.returnAnswer(t)
 	}
+	if unread {
+		return StatusUnread
+	}
+	return StatusPending
 }
 
 // Observe takes one session-state report from the hooks the provider already

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -957,16 +957,22 @@ func TestSanitizeKeepsWhitespaceAndDropsEscapes(t *testing.T) {
 	}
 }
 
+// The numbers are spelled out rather than read from DefaultWait and MaxWait:
+// derived from the constants the test says only that waitFor returns them, and
+// stays green when they move. What the contract promises is these values — 100s
+// under the 120s an agent's shell tool allows, and a 30 minute ceiling — so the
+// cap is pinned from both sides of the boundary rather than from far away.
 func TestWaitForClampsTheRequestedWait(t *testing.T) {
 	tests := []struct {
 		name    string
 		seconds int
 		want    time.Duration
 	}{
-		{"zero falls back to the default", 0, DefaultWait},
-		{"negative falls back to the default", -5, DefaultWait},
+		{"zero falls back to the default", 0, 100 * time.Second},
+		{"negative falls back to the default", -5, 100 * time.Second},
 		{"a plain wait is honoured", 42, 42 * time.Second},
-		{"an over-long wait is capped", 4000, MaxWait},
+		{"a wait just under the cap is honoured", 1799, 1799 * time.Second},
+		{"a wait past the cap is capped", 1801, 30 * time.Minute},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1205,6 +1211,27 @@ func TestTheSenderIsToldAtItsPromptWhenNobodyWasWaiting(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	t.Errorf("the sender was never told: %v", term.writesTo("s1"))
+}
+
+// The two can also land together: the window closes the ticket while the sender
+// is still counted as waiting, so nobody types the news at its prompt, and the
+// sender's own wait runs out a moment later. The waiter that leaves last owns
+// what is left behind — without that it hears "still working" about a task
+// nothing read, on a ticket already gone from the map.
+func TestAWaiterGivingUpAsTheTaskGoesUnreadHearsSo(t *testing.T) {
+	svc := withReceipts(newFakeTerminal("s1", "s2"))
+	tk := &ticket{
+		target:   "docs",
+		done:     make(chan struct{}),
+		stalled:  make(chan struct{}),
+		unread:   make(chan struct{}),
+		attended: 1,
+	}
+	close(tk.unread)
+
+	if got := svc.giveUp(tk); got != StatusUnread {
+		t.Errorf("status = %q, want the sender told nothing read it", got)
+	}
 }
 
 // Which providers carry lich's operations stopped being a fact about the

--- a/internal/relay/rostername_test.go
+++ b/internal/relay/rostername_test.go
@@ -44,6 +44,12 @@ func TestRosterNameOfMatchesTheFrontend(t *testing.T) {
 			want: "lich-4f2a",
 		},
 		{
+			name: "here is not a name either",
+			cwd:  ".",
+			id:   "4f2a1b3c",
+			want: "lich-4f2a",
+		},
+		{
 			name: "id carries nothing usable",
 			cwd:  "/home/me/code/lich",
 			id:   "---",


### PR DESCRIPTION
The low-severity half of the `[Unreleased]` review (v0.28.0..HEAD). The high and medium findings are on their own branches; nothing here overlaps them beyond `internal/relay/relay.go`, where this touches only `giveUp` and `await`'s timer branch.

## The race

`giveUp` exists to catch one empty race: a reply landing in the same instant a waiter gives up, seeing that waiter still counted, and leaving the answer for someone who stopped listening. The receipt window has the same tie and nobody held it — `watchReceipt` closes the ticket unread, reads `attended` with the waiter still counted, and stays quiet; the waiter's timer branch only looked at `answered` and returned `pending`. The sender is told its task is in progress when nothing read it, and the ticket is already out of the map, so a later `lich wait` answers "unknown ticket".

`giveUp` now owns both ties and returns the status the caller should hear. An answer is still typed at the sender's prompt — it outlives the wait it missed — but the receipt goes straight back to the caller, which is still there to hear it.

## Tests, and which reason each one changed

All three asserted something the contract never promised:

- **The wait clamp** derived its expectations from `DefaultWait`/`MaxWait`, so it only said `waitFor` returns the constants. Pinned to 100s and 30min, and the cap is probed from both sides of the boundary (1799/1801) instead of from 4000, which survives a cap moved to 10 minutes.
- **The peer-name mirror** pinned `4-f-2-a-1` on the Go side only — exactly the case where the two implementations differ in shape (filter-while-scanning vs. strip-then-slice). Both halves carry it now. The halves also disagreed on a path that names nothing (`.` → `lich` in Go, `.` in TypeScript); unreachable today since `cwd` arrives absolute, fixed anyway because the mirror exists to rule that out rather than make it unlikely.
- **`force`** pinned the refusals and never the acceptance, so a `flag` that took any string at all stayed green. Its comment also claimed only `"yes"` counts where the code takes `"true"` — the code is right (this flag discards uncommitted work), the sentence was wrong.

## Left alone, deliberately

- **`SessionCard.tsx` (513 lines).** Under the 800 ceiling and cohesive. The tooltip body needs six values, the context menu around fourteen; both extractions trade a long file for a long parameter list, which is the worse of the two.
- **`spawn.go:174`'s `setup = false`.** Redundant, but it sits opposite the branch that sets `true`, and which branch runs the setup script is the whole point of the pair.

Nothing here is visible to a user of a published version, so no `CHANGELOG.md` entry.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`
- [x] `go test ./...` (`LICH_LISTEN_PORT=` empty)
- [x] `biome check .`, `tsc -b --noEmit`, `vite build`, `vitest run` (803 tests)