### PR TITLE
feat: say a session is waiting on you, in words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **A session blocked on you says so in words.** Being asked a question looked
+  the same as being finished — a 22px ring differing from the emerald one by
+  hue alone, and nothing naming what the session wanted. A card stopped on a
+  prompt now reads `Waiting on you` in amber, so a sidebar of running agents
+  says which one to answer instead of leaving you to read the hue. It takes the
+  line the running tool was using rather than a new one, so no card grows, and
+  the ring is unchanged.
+
 ## [0.29.0] - 2026-08-11
 
 ### Added

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -5,6 +5,7 @@ import {
   ArrowLeft,
   ArrowRight,
   AtSign,
+  CircleQuestionMark,
   GitBranch,
   GitPullRequestArrow,
   Pencil,
@@ -250,12 +251,17 @@ export function SessionCard({
                   </span>
                 </span>
               )}
-              {/* An open request outranks the tool on the same line. While one
-                  is in flight it explains the whole turn — a card working
-                  because another session asked it to, or one stalled waiting on
-                  a card elsewhere in the list — and the tool line comes back the
-                  moment the errand closes. Only one of the two ever draws, so
-                  the card grows by one row at most. */}
+              {/* One line, three rungs: an open request, then a session blocked
+                  on the user, then the tool. A request in flight explains the
+                  whole turn — a card working because another session asked it
+                  to, or one stalled waiting on a card elsewhere in the list. A
+                  block outranks the tool for the reason it needs words at all:
+                  the amber ring differs from the emerald one by hue alone, so
+                  nothing else on the card says the session wants an answer. It
+                  costs no tool line either — a state other than busy clears the
+                  reported tool (session-tool-store), so by the time a card is
+                  blocked there is nothing left on that rung anyway. Only one
+                  rung ever draws, so the card grows by one row at most. */}
               {relay ? (
                 <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">
                   {relay.direction === "out" ? (
@@ -270,6 +276,11 @@ export function SessionCard({
                     // command run from a script or a shell (docs/cli.md).
                     <span className="truncate italic">command line</span>
                   )}
+                </span>
+              ) : status === "waiting" ? (
+                <span className="flex w-full min-w-0 items-center gap-1 text-xs">
+                  <CircleQuestionMark className="size-3 shrink-0 text-amber-500" />
+                  <span className="truncate font-medium text-amber-500">Waiting on you</span>
                 </span>
               ) : (
                 tool && (


### PR DESCRIPTION
A session blocked on a permission prompt said so with one thing: the amber ring
around its provider glyph — 22px, and a hue apart from the emerald ring a
finished session wears. Nothing on the card named what it wanted. With five
agents in the sidebar, finding the one to answer first meant comparing colours.

The card now says it in words: `Waiting on you`, amber, under the label.

## What it takes

The line the running tool was using, not a new one. That line already had a
precedence chain — an open relay request outranks the tool, because a request
in flight explains the whole turn — and this adds the middle rung:
**relay > waiting > tool**. Only one ever draws, so no card grows a row, and
the comment above the chain now explains three rungs instead of two.

## The tool name is not on that line, and cannot be

The original ask was to keep the tool after a `·` separator
(`Waiting on you · Bash · rm -rf dist`) so you can see what the session is
asking about. That branch would be dead code: `session-tool-store` clears the
reported tool on **any** state other than `busy` — `waiting` included — which
is the documented rule in `docs/hooks/session-state.md` ("drops it on `done`,
`waiting` and `idle`"), and the rule that keeps `PostToolUse` from blinking the
line off between every two tools. A card blocked on a prompt therefore has no
tool to name.

Showing it would mean changing that clearing rule (keep the last tool through
`waiting`, drop it on `done`/`idle`), its contract paragraph and its store
tests — a separate change to a shared contract, not a render branch. Happy to
do it as a follow-up if the readout is worth it.

## Idiom

`DESIGN.md`: text + glyph, no pill, no border, semantic amber only. `size-3`
lucide `CircleQuestionMark` (the canonical name of `CircleHelp` in lucide v1 —
same icon; the message-bubble variant loses its `?` at 12px), `font-medium` to
match the weight the relay peer and tool name already use. The ring is
unchanged, and no store, event or backend field was added — this is a branch
over `useSessionStatus`, which the card already reads.

## Test plan

- [x] `pnpm check`, `pnpm exec vitest run` (803 passed), `tsc -b` + `vite build`
- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` (backend untouched)
- [x] Verified by hand in an isolated headless lich: a seeded session driven to
      `waiting` over the real `/hook` endpoint, beside a `busy` card showing
      `Bash · go test ./...` and a `done` one — **dark and light theme both**.
      The waiting line replaces the tool line; the card keeps its height.