### PR TITLE
feat: a shortcuts overlay, six more bindings, and a hotkeys pane that scales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **The shortcuts are readable without going looking for them.** `Ctrl/Cmd + /`
-  opens a list of every keyboard shortcut lich has — the rebindable ones with
-  the combos *this* install has them on, and the chords lich rewrites on the way
-  to the agent's TUI: attaching a clipboard image, inserting a newline without
-  sending, erasing the previous word. The last three were only ever written down
-  in the source, and the rest lived on the one screen you have to already know
-  about to reach. The overlay itself edits nothing and says where to rebind; its
-  own shortcut is rebindable like the others.
+- **The shortcuts are readable without going looking for them, and there are
+  more of them.** `Ctrl/Cmd + /` opens a list of every keyboard shortcut lich
+  has — the rebindable ones with the combos *this* install has them on, and the
+  chords lich rewrites on the way to the agent's TUI: attaching a clipboard
+  image, inserting a newline without sending, erasing the previous word. The
+  last three were only ever written down in the source, and the rest lived on
+  the one screen you have to already know about to reach. The overlay edits
+  nothing and says where to rebind.
+
+  Six more actions the app already performed are now on the keyboard: walk the
+  project tabs (`Ctrl/Cmd + Shift + ←/→`, the sideways twin of the session
+  pair), toggle the right dock (`Ctrl/Cmd + Shift + D`), put the cursor back in
+  the active session's terminal from wherever you are (`Ctrl/Cmd + Shift +
+  Enter`), open Settings (`Ctrl/Cmd + ,`) and the repository's pull requests
+  (`Ctrl/Cmd + Shift + P`). Every default was chosen against what the terminal
+  underneath does with it: each one was pressed into a live session first, and
+  the only chords taken are ones the TUI either never receives or receives as a
+  duplicate of a key you still have.
+
+  Settings › Hotkeys is now one dense list grouped by what it acts on —
+  sessions, view, app — with the passed-through chords listed read-only at the
+  bottom. Bind two actions to the same combo and both rows say so, naming the
+  other action: lich stores the binding either way, but only one of the two will
+  answer to it, and now you can see which pair to fix.
 
 ## [0.29.0] - 2026-08-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The shortcuts are readable without going looking for them.** `Ctrl/Cmd + /`
+  opens a list of every keyboard shortcut lich has — the rebindable ones with
+  the combos *this* install has them on, and the chords lich rewrites on the way
+  to the agent's TUI: attaching a clipboard image, inserting a newline without
+  sending, erasing the previous word. The last three were only ever written down
+  in the source, and the rest lived on the one screen you have to already know
+  about to reach. The overlay itself edits nothing and says where to rebind; its
+  own shortcut is rebindable like the others.
+
 ## [0.29.0] - 2026-08-11
 
 ### Added

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import { PatchNotesGate } from "@/components/PatchNotesGate"
 import { ProviderSetupGate } from "@/components/ProviderSetupGate"
 import { UncleanExitGate } from "@/components/UncleanExitGate"
 import { CommandPalette } from "@/components/CommandPalette"
+import { ShortcutsOverlay } from "@/components/ShortcutsOverlay"
 
 // Layout is persistent across navigation: the project tabs, session sidebar and
 // TerminalHost stay mounted while the Outlet swaps screens (Home, Settings) on
@@ -92,6 +93,9 @@ function App() {
           {/* Global quick switcher; also needs the provider (sessions/projects)
               and the router (navigation). */}
           <CommandPalette />
+          {/* Read-only list of what is bound; beside the palette because both
+              are app-wide overlays opened by a shortcut. */}
+          <ShortcutsOverlay />
         </ProjectsProvider>
       </HashRouter>
       {/* Holds its prompt until a provider has been chosen, so a first launch

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { HashRouter, Outlet, Route, Routes } from "react-router-dom"
-import { SettingsProvider } from "@/providers/settings"
+import { SettingsProvider, useSettings } from "@/providers/settings"
+import { useHotkey } from "@/lib/use-hotkey"
 import { ProjectsProvider } from "@/providers/projects"
 import { ProjectTabs } from "@/components/tabs/ProjectTabs"
 import { SessionSidebar } from "@/components/sidebar/SessionSidebar"
@@ -24,8 +25,18 @@ import { ShortcutsOverlay } from "@/components/ShortcutsOverlay"
 // TerminalHost stay mounted while the Outlet swaps screens (Home, Settings) on
 // top of the terminals.
 function Layout() {
+  const { hotkeys } = useSettings()
   const [dock, setDock] = useState<DockTab | null>(null)
   const toggleDock = (tab: DockTab) => setDock((cur) => (cur === tab ? null : tab))
+  // The shortcut toggles the dock as a whole, so it reopens on the tab it was
+  // last showing — the two tabs have their own footer buttons.
+  const lastTab = useRef<DockTab>("files")
+  useEffect(() => {
+    if (dock) {
+      lastTab.current = dock
+    }
+  }, [dock])
+  useHotkey(hotkeys.toggleDock, () => setDock((cur) => (cur ? null : lastTab.current)))
   return (
     <div className="flex h-screen w-screen flex-col bg-background">
       <ProjectTabs />

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -14,6 +14,7 @@ import {
   type PaletteSession,
 } from "@/lib/session/command-palette"
 import { useTranscriptSearch } from "@/lib/session/use-transcript-search"
+import { Keys } from "@/components/common/Keys"
 import type { Project } from "@/lib/api-types"
 import { cn } from "@/lib/utils"
 
@@ -337,12 +338,7 @@ function Hint({ keys, children }: { keys: string[]; children: React.ReactNode })
     <span className="inline-flex items-center gap-1.5">
       <span className="inline-flex gap-1">
         {keys.map((k) => (
-          <kbd
-            key={k}
-            className="rounded border border-b-2 bg-muted px-1.5 py-0.5 font-mono text-[0.625rem] leading-none text-muted-foreground"
-          >
-            {k}
-          </kbd>
+          <Keys key={k}>{k}</Keys>
         ))}
       </span>
       {children}

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from "react-router-dom"
 import { CornerDownLeft, Folder, MessageSquareText, Search } from "lucide-react"
 import { useProjects } from "@/providers/projects"
 import { useSettings } from "@/providers/settings"
-import { isRecordingTarget, matchesCombo } from "@/lib/hotkeys"
+import { useHotkey } from "@/lib/use-hotkey"
 import { useSessionStatus } from "@/lib/session/use-session-status"
 import { SessionStatusIcon } from "@/components/sidebar/SessionStatusIcon"
 import {
@@ -34,22 +34,11 @@ export function CommandPalette() {
   const [query, setQuery] = useState("")
   const [selected, setSelected] = useState(0)
 
-  useEffect(() => {
-    const onKey = (event: KeyboardEvent) => {
-      if (isRecordingTarget(event)) {
-        return
-      }
-      if (matchesCombo(event, hotkeys.commandPalette)) {
-        event.preventDefault()
-        event.stopPropagation()
-        setOpen((v) => !v)
-        setQuery("")
-        setSelected(0)
-      }
-    }
-    window.addEventListener("keydown", onKey, true)
-    return () => window.removeEventListener("keydown", onKey, true)
-  }, [hotkeys])
+  useHotkey(hotkeys.commandPalette, () => {
+    setOpen((v) => !v)
+    setQuery("")
+    setSelected(0)
+  })
 
   const all = useMemo(() => paletteSessions(projects, sessions), [projects, sessions])
   const results = useMemo(() => filterPalette(query, all, projects), [query, all, projects])

--- a/frontend/src/components/ShortcutsOverlay.tsx
+++ b/frontend/src/components/ShortcutsOverlay.tsx
@@ -3,11 +3,9 @@ import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
 import { useSettings } from "@/providers/settings"
 import { useHotkey } from "@/lib/use-hotkey"
 import { shortcutGroups } from "@/lib/shortcuts"
+import { isMac, isWindows } from "@/lib/platform"
+import { ShortcutLine } from "@/components/common/ShortcutLine"
 import { Keys } from "@/components/common/Keys"
-
-// Same signal HotkeysSettings and TerminalView read: the OS lich runs on.
-const IS_MAC = navigator.platform.toLowerCase().includes("mac")
-const IS_WINDOWS = navigator.platform.toLowerCase().includes("win")
 
 // ShortcutsOverlay lists what is already bound and edits nothing — the one
 // screen naming the shortcuts is Settings › Hotkeys, which is where a binding is
@@ -23,7 +21,7 @@ export function ShortcutsOverlay() {
 
   useHotkey(hotkeys.shortcuts, () => setOpen((v) => !v))
 
-  const groups = useMemo(() => shortcutGroups(hotkeys, IS_MAC, IS_WINDOWS), [hotkeys])
+  const groups = useMemo(() => shortcutGroups(hotkeys, isMac, isWindows), [hotkeys])
 
   return (
     <DialogPrimitive.Root open={open} onOpenChange={setOpen}>
@@ -41,13 +39,7 @@ export function ShortcutsOverlay() {
                   {group.title}
                 </div>
                 {group.rows.map((row) => (
-                  <div
-                    key={row.label}
-                    className="flex items-center gap-4 rounded-md px-3 py-2 hover:bg-accent/50"
-                  >
-                    <span className="flex-1 truncate text-sm">{row.label}</span>
-                    <Keys>{row.keys}</Keys>
-                  </div>
+                  <ShortcutLine key={row.label} label={row.label} keys={row.keys} />
                 ))}
               </div>
             ))}

--- a/frontend/src/components/ShortcutsOverlay.tsx
+++ b/frontend/src/components/ShortcutsOverlay.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
 import { useSettings } from "@/providers/settings"
-import { isRecordingTarget, matchesCombo } from "@/lib/hotkeys"
+import { useHotkey } from "@/lib/use-hotkey"
 import { shortcutGroups } from "@/lib/shortcuts"
+import { Keys } from "@/components/common/Keys"
 
 // Same signal HotkeysSettings and TerminalView read: the OS lich runs on.
 const IS_MAC = navigator.platform.toLowerCase().includes("mac")
@@ -20,20 +21,7 @@ export function ShortcutsOverlay() {
   const { hotkeys } = useSettings()
   const [open, setOpen] = useState(false)
 
-  useEffect(() => {
-    const onKey = (event: KeyboardEvent) => {
-      if (isRecordingTarget(event)) {
-        return
-      }
-      if (matchesCombo(event, hotkeys.shortcuts)) {
-        event.preventDefault()
-        event.stopPropagation()
-        setOpen((v) => !v)
-      }
-    }
-    window.addEventListener("keydown", onKey, true)
-    return () => window.removeEventListener("keydown", onKey, true)
-  }, [hotkeys])
+  useHotkey(hotkeys.shortcuts, () => setOpen((v) => !v))
 
   const groups = useMemo(() => shortcutGroups(hotkeys, IS_MAC, IS_WINDOWS), [hotkeys])
 
@@ -41,7 +29,7 @@ export function ShortcutsOverlay() {
     <DialogPrimitive.Root open={open} onOpenChange={setOpen}>
       <DialogPrimitive.Portal>
         <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-black/50 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
-        <DialogPrimitive.Popup className="fixed left-1/2 top-[14vh] z-50 flex max-h-[70vh] w-full max-w-[34rem] -translate-x-1/2 flex-col overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-2xl ring-1 ring-foreground/10 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0">
+        <DialogPrimitive.Popup className="fixed left-1/2 top-[9vh] z-50 flex max-h-[82vh] w-full max-w-[34rem] -translate-x-1/2 flex-col overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-2xl ring-1 ring-foreground/10 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0">
           <DialogPrimitive.Title className="border-b px-4 py-3 text-sm">
             Keyboard shortcuts
           </DialogPrimitive.Title>
@@ -75,13 +63,5 @@ export function ShortcutsOverlay() {
         </DialogPrimitive.Popup>
       </DialogPrimitive.Portal>
     </DialogPrimitive.Root>
-  )
-}
-
-function Keys({ children }: { children: React.ReactNode }) {
-  return (
-    <kbd className="shrink-0 rounded border border-b-2 bg-muted px-1.5 py-0.5 font-mono text-[0.625rem] leading-none text-muted-foreground">
-      {children}
-    </kbd>
   )
 }

--- a/frontend/src/components/ShortcutsOverlay.tsx
+++ b/frontend/src/components/ShortcutsOverlay.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useMemo, useState } from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+import { useSettings } from "@/providers/settings"
+import { isRecordingTarget, matchesCombo } from "@/lib/hotkeys"
+import { shortcutGroups } from "@/lib/shortcuts"
+
+// Same signal HotkeysSettings and TerminalView read: the OS lich runs on.
+const IS_MAC = navigator.platform.toLowerCase().includes("mac")
+const IS_WINDOWS = navigator.platform.toLowerCase().includes("win")
+
+// ShortcutsOverlay lists what is already bound and edits nothing — the one
+// screen naming the shortcuts is Settings › Hotkeys, which is where a binding is
+// changed, not where it is found. Mounted once at the app root; it renders
+// nothing until opened.
+//
+// The trigger is caught in the window capture phase (like the palette) so it
+// beats the shell chord it shadows; while open, focus is trapped in the dialog
+// and keys never reach the terminal.
+export function ShortcutsOverlay() {
+  const { hotkeys } = useSettings()
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (isRecordingTarget(event)) {
+        return
+      }
+      if (matchesCombo(event, hotkeys.shortcuts)) {
+        event.preventDefault()
+        event.stopPropagation()
+        setOpen((v) => !v)
+      }
+    }
+    window.addEventListener("keydown", onKey, true)
+    return () => window.removeEventListener("keydown", onKey, true)
+  }, [hotkeys])
+
+  const groups = useMemo(() => shortcutGroups(hotkeys, IS_MAC, IS_WINDOWS), [hotkeys])
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={setOpen}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Backdrop className="fixed inset-0 z-50 bg-black/50 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0" />
+        <DialogPrimitive.Popup className="fixed left-1/2 top-[14vh] z-50 flex max-h-[70vh] w-full max-w-[34rem] -translate-x-1/2 flex-col overflow-hidden rounded-xl border bg-popover text-popover-foreground shadow-2xl ring-1 ring-foreground/10 outline-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0">
+          <DialogPrimitive.Title className="border-b px-4 py-3 text-sm">
+            Keyboard shortcuts
+          </DialogPrimitive.Title>
+
+          <div className="flex-1 overflow-y-auto p-1.5">
+            {groups.map((group) => (
+              <div key={group.title}>
+                <div className="px-3 pb-1 pt-3 text-[0.65625rem] font-semibold uppercase tracking-wider text-muted-foreground">
+                  {group.title}
+                </div>
+                {group.rows.map((row) => (
+                  <div
+                    key={row.label}
+                    className="flex items-center gap-4 rounded-md px-3 py-2 hover:bg-accent/50"
+                  >
+                    <span className="flex-1 truncate text-sm">{row.label}</span>
+                    <Keys>{row.keys}</Keys>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-4 border-t bg-black/10 px-4 py-2 text-xs text-muted-foreground">
+            <span>Rebind in Settings › Hotkeys</span>
+            <span className="ml-auto inline-flex items-center gap-1.5">
+              <Keys>esc</Keys>
+              close
+            </span>
+          </div>
+        </DialogPrimitive.Popup>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  )
+}
+
+function Keys({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="shrink-0 rounded border border-b-2 bg-muted px-1.5 py-0.5 font-mono text-[0.625rem] leading-none text-muted-foreground">
+      {children}
+    </kbd>
+  )
+}

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -28,6 +28,7 @@ import {
   resolveDroppedFiles,
 } from "@/lib/terminal/drop-files"
 import { useSettings } from "@/providers/settings"
+import { isWindows } from "@/lib/platform"
 import type { SessionKind } from "@/lib/session/sessions"
 import "@xterm/xterm/css/xterm.css"
 
@@ -62,12 +63,6 @@ const SEARCH_DECORATIONS = {
   matchOverviewRuler: "#e3b341",
   activeMatchColorOverviewRuler: "#f59e0b",
 }
-
-// Claude Code's clipboard-image-paste chord is Ctrl+V on Linux/macOS but Alt+V
-// on Windows (see term-keys.ts); the host OS is the machine lich runs on.
-// navigator.platform is "Win32" on Windows Chromium — same signal HotkeysSettings
-// uses for isMac.
-const IS_WINDOWS = navigator.platform.toLowerCase().includes("win")
 
 // cellDimensions reads the renderer's measured cell size — the same private
 // API FitAddon relies on ("TODO: Remove reliance" upstream). Null before the
@@ -322,7 +317,9 @@ export function TerminalView({
         closeSearch()
         return false
       }
-      const seq = chordSequence(event, IS_WINDOWS)
+      // Platform-dependent because Claude Code's clipboard-image-paste chord is
+      // Ctrl+V on Linux/macOS but Alt+V on Windows (term-keys.ts).
+      const seq = chordSequence(event, isWindows)
       if (seq === null) {
         return true
       }
@@ -444,7 +441,7 @@ export function TerminalView({
     }
     void (async () => {
       const { paths, skipped } = await resolveDroppedFiles(cwd, dropped)
-      const paste = composeDroppedPaths(paths, IS_WINDOWS)
+      const paste = composeDroppedPaths(paths, isWindows)
       if (paste !== "") {
         writeInput(paste)
         liveRef.current?.term.focus()

--- a/frontend/src/components/common/Keys.tsx
+++ b/frontend/src/components/common/Keys.tsx
@@ -1,0 +1,10 @@
+// A key combo as printed text — the one <kbd> in the app, shared by the
+// shortcuts overlay and the Hotkeys settings pane so a chord never reads two
+// ways in two places.
+export function Keys({ children }: { children: React.ReactNode }) {
+  return (
+    <kbd className="shrink-0 rounded border border-b-2 bg-muted px-1.5 py-0.5 font-mono text-[0.625rem] leading-none text-muted-foreground">
+      {children}
+    </kbd>
+  )
+}

--- a/frontend/src/components/common/ShortcutLine.tsx
+++ b/frontend/src/components/common/ShortcutLine.tsx
@@ -1,0 +1,13 @@
+import { Keys } from "@/components/common/Keys"
+
+// One listed shortcut: what it does on the left, the chord on the right. Shared
+// by the shortcuts overlay and the read-only half of Settings › Hotkeys so the
+// same row cannot drift into two shapes.
+export function ShortcutLine({ label, keys }: { label: string; keys: string }) {
+  return (
+    <div className="flex items-center gap-4 rounded-md px-3 py-1.5 hover:bg-accent/50">
+      <span className="min-w-0 flex-1 truncate text-sm">{label}</span>
+      <Keys>{keys}</Keys>
+    </div>
+  )
+}

--- a/frontend/src/components/settings/HotkeysSettings.tsx
+++ b/frontend/src/components/settings/HotkeysSettings.tsx
@@ -1,24 +1,48 @@
 import { useState } from "react"
-import { RotateCcw } from "lucide-react"
+import { RotateCcw, TriangleAlert } from "lucide-react"
 import { useSettings } from "@/providers/settings"
 import {
   comboFromEvent,
   DEFAULT_HOTKEYS,
   formatCombo,
+  hotkeyConflicts,
   HOTKEY_ACTIONS,
+  HOTKEY_GROUPS,
   sameCombo,
   type HotkeyAction,
+  type HotkeyId,
 } from "@/lib/hotkeys"
+import { PASSTHROUGH_TITLE, passthroughRows } from "@/lib/shortcuts"
 import { Button } from "@/components/ui/button"
+import { Keys } from "@/components/common/Keys"
 import { cn } from "@/lib/utils"
-import { SettingBlock } from "./SettingBlock"
 
-const isMac = typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac")
+const platform = typeof navigator === "undefined" ? "" : navigator.platform.toLowerCase()
+const isMac = platform.includes("mac")
+const isWindows = platform.includes("win")
+
+const LABELS = Object.fromEntries(HOTKEY_ACTIONS.map((a) => [a.id, a.label])) as Record<
+  HotkeyId,
+  string
+>
+
+// A dense list rather than one setting block per action: eleven bindings read as
+// a table of rows, and a block each would be a column of near-empty cards.
+function Group({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <section className="pt-8 first:pt-0">
+      <h2 className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </h2>
+      {children}
+    </section>
+  )
+}
 
 // HotkeyRow shows the current combo as a capture button: click to record, press
 // the new combo to save, Escape to cancel. Key events are swallowed while
 // recording so they do not also trigger the very shortcut being rebound.
-function HotkeyRow({ action }: { action: HotkeyAction }) {
+function HotkeyRow({ action, conflicts }: { action: HotkeyAction; conflicts?: HotkeyId[] }) {
   const { hotkeys, setHotkey, resetHotkey } = useSettings()
   const [recording, setRecording] = useState(false)
   const combo = hotkeys[action.id]
@@ -40,7 +64,18 @@ function HotkeyRow({ action }: { action: HotkeyAction }) {
   }
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-4 rounded-md px-2 py-1.5 hover:bg-accent/50">
+      <div className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-sm text-foreground">{action.label}</span>
+        {conflicts && (
+          // Amber because it is a state, not a failure: the binding was stored,
+          // and whichever listener runs first is the one that will answer to it.
+          <span className="mt-0.5 inline-flex items-center gap-1 text-xs text-amber-500">
+            <TriangleAlert className="size-3 shrink-0" />
+            Also bound to {conflicts.map((id) => LABELS[id]).join(", ")}
+          </span>
+        )}
+      </div>
       <button
         type="button"
         data-hotkey-capturing={recording ? "" : undefined}
@@ -48,10 +83,11 @@ function HotkeyRow({ action }: { action: HotkeyAction }) {
         onKeyDown={onKeyDown}
         onBlur={() => setRecording(false)}
         className={cn(
-          "min-w-40 rounded-md border px-3 py-1.5 text-left text-sm tabular-nums outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
+          "min-w-36 shrink-0 rounded-md border px-3 py-1 text-left text-sm tabular-nums outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
           recording
             ? "border-ring text-muted-foreground"
             : "border-border text-foreground hover:bg-accent",
+          conflicts && !recording && "border-amber-500/60",
         )}
       >
         {recording ? "Press keys…" : formatCombo(combo, isMac)}
@@ -70,13 +106,33 @@ function HotkeyRow({ action }: { action: HotkeyAction }) {
 }
 
 export function HotkeysSettings() {
+  const { hotkeys } = useSettings()
+  const conflicts = hotkeyConflicts(hotkeys)
+
   return (
     <>
-      {HOTKEY_ACTIONS.map((action) => (
-        <SettingBlock key={action.id} title={action.label}>
-          <HotkeyRow action={action} />
-        </SettingBlock>
+      {HOTKEY_GROUPS.map((group) => (
+        <Group key={group.id} label={group.label}>
+          {HOTKEY_ACTIONS.filter((action) => action.group === group.id).map((action) => (
+            <HotkeyRow key={action.id} action={action} conflicts={conflicts[action.id]} />
+          ))}
+        </Group>
       ))}
+      <Group label={PASSTHROUGH_TITLE}>
+        <p className="mb-2 max-w-prose text-xs text-muted-foreground">
+          lich rewrites these on their way to the agent's terminal, so they are fixed rather than
+          rebindable.
+        </p>
+        {passthroughRows(isWindows).map((row) => (
+          <div
+            key={row.label}
+            className="flex items-center gap-4 rounded-md px-2 py-1.5 hover:bg-accent/50"
+          >
+            <span className="min-w-0 flex-1 truncate text-sm text-foreground">{row.label}</span>
+            <Keys>{row.keys}</Keys>
+          </div>
+        ))}
+      </Group>
     </>
   )
 }

--- a/frontend/src/components/settings/HotkeysSettings.tsx
+++ b/frontend/src/components/settings/HotkeysSettings.tsx
@@ -6,6 +6,7 @@ import {
   DEFAULT_HOTKEYS,
   formatCombo,
   hotkeyConflicts,
+  hotkeyLabel,
   HOTKEY_ACTIONS,
   HOTKEY_GROUPS,
   sameCombo,
@@ -14,17 +15,9 @@ import {
 } from "@/lib/hotkeys"
 import { PASSTHROUGH_TITLE, passthroughRows } from "@/lib/shortcuts"
 import { Button } from "@/components/ui/button"
-import { Keys } from "@/components/common/Keys"
+import { ShortcutLine } from "@/components/common/ShortcutLine"
+import { isMac, isWindows } from "@/lib/platform"
 import { cn } from "@/lib/utils"
-
-const platform = typeof navigator === "undefined" ? "" : navigator.platform.toLowerCase()
-const isMac = platform.includes("mac")
-const isWindows = platform.includes("win")
-
-const LABELS = Object.fromEntries(HOTKEY_ACTIONS.map((a) => [a.id, a.label])) as Record<
-  HotkeyId,
-  string
->
 
 // A dense list rather than one setting block per action: eleven bindings read as
 // a table of rows, and a block each would be a column of near-empty cards.
@@ -72,7 +65,7 @@ function HotkeyRow({ action, conflicts }: { action: HotkeyAction; conflicts?: Ho
           // and whichever listener runs first is the one that will answer to it.
           <span className="mt-0.5 inline-flex items-center gap-1 text-xs text-amber-500">
             <TriangleAlert className="size-3 shrink-0" />
-            Also bound to {conflicts.map((id) => LABELS[id]).join(", ")}
+            Also bound to {conflicts.map(hotkeyLabel).join(", ")}
           </span>
         )}
       </div>
@@ -124,13 +117,7 @@ export function HotkeysSettings() {
           rebindable.
         </p>
         {passthroughRows(isWindows).map((row) => (
-          <div
-            key={row.label}
-            className="flex items-center gap-4 rounded-md px-2 py-1.5 hover:bg-accent/50"
-          >
-            <span className="min-w-0 flex-1 truncate text-sm text-foreground">{row.label}</span>
-            <Keys>{row.keys}</Keys>
-          </div>
+          <ShortcutLine key={row.label} label={row.label} keys={row.keys} />
         ))}
       </Group>
     </>

--- a/frontend/src/components/tabs/ProjectTabs.tsx
+++ b/frontend/src/components/tabs/ProjectTabs.tsx
@@ -12,6 +12,8 @@ import { runningSessions } from "@/lib/session/use-session-status"
 import type { Project } from "@/lib/api-types"
 import { openSettings } from "@/lib/settings-card-store"
 import { openPullsList } from "@/lib/pulls-list-card-store"
+import { useSettings } from "@/providers/settings"
+import { useHotkey } from "@/lib/use-hotkey"
 import { NotificationsButton } from "./NotificationsButton"
 import { horizontalAxis, useSortableList } from "@/lib/use-sortable-list"
 import { ProjectTab } from "./ProjectTab"
@@ -52,6 +54,14 @@ export function ProjectTabs() {
     openPullsList(activeProjectId)
     navigate(`/projects/${activeProjectId}/pulls/all`)
   }
+  // Both shortcuts open exactly what their toolbar button opens, and decline the
+  // press when that button would be disabled — with no project there is nothing
+  // to configure and no repository to read. The pull request screen speaks for
+  // itself when the project has no repository or no open pull request.
+  const { hotkeys } = useSettings()
+  useHotkey(hotkeys.settings, () => (activeProjectId ? openProjectSettings() : false))
+  useHotkey(hotkeys.pulls, () => (activeProjectId ? openProjectPulls() : false))
+
   const requestClose = (project: Project) => {
     const running = runningSessions(sessionsOf(sessions, project.id).map((s) => s.id))
     if (running.length === 0) {

--- a/frontend/src/lib/hotkeys.test.ts
+++ b/frontend/src/lib/hotkeys.test.ts
@@ -97,6 +97,14 @@ describe("mergeHotkeys", () => {
     expect(mergeHotkeys(override).commandPalette).toEqual(DEFAULT_HOTKEYS.commandPalette)
   })
 
+  it("defaults an action absent from stored settings, keeping the rest", () => {
+    // What an install predating a new action has on disk.
+    const stored = { newSession: { mod: true, shift: false, alt: true, key: "n" } }
+    const merged = mergeHotkeys(stored)
+    expect(merged.newSession).toEqual(stored.newSession)
+    expect(merged.shortcuts).toEqual(DEFAULT_HOTKEYS.shortcuts)
+  })
+
   it("ignores ids that are no longer actions (the old zoom hotkeys)", () => {
     expect(mergeHotkeys({ zoomIn: { mod: true, shift: false, alt: false, key: "+" } })).toEqual(
       DEFAULT_HOTKEYS,

--- a/frontend/src/lib/hotkeys.test.ts
+++ b/frontend/src/lib/hotkeys.test.ts
@@ -106,6 +106,16 @@ describe("mergeHotkeys", () => {
     expect(merged.shortcuts).toEqual(DEFAULT_HOTKEYS.shortcuts)
   })
 
+  it("normalizes a stored key, so an uppercase one still fires", () => {
+    // Well formed enough to survive validation, but matchesCombo compares
+    // against a normalized event key: kept as "T" the shortcut would be dead.
+    const merged = mergeHotkeys({ newSession: { mod: true, shift: true, alt: false, key: "T" } })
+    expect(merged.newSession.key).toBe("t")
+    expect(matchesCombo(key({ ctrlKey: true, shiftKey: true, key: "T" }), merged.newSession)).toBe(
+      true,
+    )
+  })
+
   it("ignores ids that are no longer actions (the old zoom hotkeys)", () => {
     expect(mergeHotkeys({ zoomIn: { mod: true, shift: false, alt: false, key: "+" } })).toEqual(
       DEFAULT_HOTKEYS,

--- a/frontend/src/lib/hotkeys.test.ts
+++ b/frontend/src/lib/hotkeys.test.ts
@@ -3,6 +3,7 @@ import {
   comboFromEvent,
   DEFAULT_HOTKEYS,
   formatCombo,
+  hotkeyConflicts,
   matchesCombo,
   mergeHotkeys,
   sameCombo,
@@ -115,6 +116,39 @@ describe("mergeHotkeys", () => {
     expect(mergeHotkeys({ newSession: { mod: 1, key: "" } })).toEqual(DEFAULT_HOTKEYS)
     expect(mergeHotkeys(null)).toEqual(DEFAULT_HOTKEYS)
     expect(mergeHotkeys("nope")).toEqual(DEFAULT_HOTKEYS)
+  })
+})
+
+describe("hotkeyConflicts", () => {
+  it("reports nothing when every action holds its own combo", () => {
+    expect(hotkeyConflicts(DEFAULT_HOTKEYS)).toEqual({})
+  })
+
+  it("names the other action on both sides of a collision", () => {
+    const clashing = { ...DEFAULT_HOTKEYS, newSession: DEFAULT_HOTKEYS.commandPalette }
+    const conflicts = hotkeyConflicts(clashing)
+    expect(conflicts.newSession).toEqual(["commandPalette"])
+    expect(conflicts.commandPalette).toEqual(["newSession"])
+    expect(conflicts.nextSession).toBeUndefined()
+  })
+
+  it("names both others when three actions share a combo", () => {
+    const combo: Combo = { mod: true, shift: true, alt: false, key: "j" }
+    const conflicts = hotkeyConflicts({
+      ...DEFAULT_HOTKEYS,
+      newSession: combo,
+      nextSession: combo,
+      prevSession: combo,
+    })
+    expect(conflicts.nextSession).toEqual(["newSession", "prevSession"])
+  })
+
+  it("treats combos differing only in a modifier as distinct", () => {
+    const conflicts = hotkeyConflicts({
+      ...DEFAULT_HOTKEYS,
+      newSession: { ...DEFAULT_HOTKEYS.commandPalette, alt: true },
+    })
+    expect(conflicts).toEqual({})
   })
 })
 

--- a/frontend/src/lib/hotkeys.ts
+++ b/frontend/src/lib/hotkeys.ts
@@ -8,7 +8,27 @@ import { readPref, writePref } from "@/lib/prefs"
 // Zoom is deliberately absent: those chords shadow Chromium's own accelerators,
 // which are bound to physical keys, so they are matched on event.code in
 // zoom-keys.ts instead of being character combos a user can rebind.
-export type HotkeyId = "commandPalette" | "newSession" | "nextSession" | "prevSession" | "shortcuts"
+export type HotkeyId =
+  | "commandPalette"
+  | "newSession"
+  | "nextSession"
+  | "prevSession"
+  | "focusTerminal"
+  | "nextProject"
+  | "prevProject"
+  | "toggleDock"
+  | "settings"
+  | "pulls"
+  | "shortcuts"
+
+/** Which part of the app an action acts on — the grouping both UIs read. */
+export type HotkeyGroup = "sessions" | "view" | "app"
+
+export const HOTKEY_GROUPS: readonly { id: HotkeyGroup; label: string }[] = [
+  { id: "sessions", label: "Sessions" },
+  { id: "view", label: "View" },
+  { id: "app", label: "App" },
+]
 
 export interface Combo {
   mod: boolean
@@ -20,39 +40,99 @@ export interface Combo {
 export interface HotkeyAction {
   id: HotkeyId
   label: string
+  group: HotkeyGroup
   combo: Combo
 }
 
-// HOTKEY_ACTIONS drives the defaults and the settings UI list.
+// Every default here is a key taken away from the TUI underneath: the chord is
+// caught in the window capture phase and never reaches the PTY. What each one
+// costs was measured by pressing it into `cat -v` in a live session:
+//
+// - Ctrl+letter is a control code the shell and Claude Code already bind
+//   (Ctrl+R search, Ctrl+U kill, Ctrl+W erase word) — never take one.
+// - Ctrl+Shift+letter reaches the PTY as *nothing at all*: xterm's control-code
+//   mapping requires Shift to be up, so no TUI can bind it and the chord is free.
+//   It is the family to reach for, minus the letters Chromium keeps for itself.
+// - Ctrl+Shift+arrow arrives as a real sequence (CSI 1;6A…D), so it does cost
+//   the TUI something. It is spent only where the direction *is* the meaning.
+// - Ctrl+Alt+arrow is the desktop's workspace switch on Linux and would never
+//   arrive; Ctrl+Tab and Ctrl+PageUp/Down are Chromium's own tab accelerators.
+//
+// HOTKEY_ACTIONS drives the defaults, the settings list and the shortcuts
+// overlay, in this order.
 export const HOTKEY_ACTIONS: readonly HotkeyAction[] = [
-  {
-    id: "commandPalette",
-    label: "Command palette",
-    combo: { mod: true, shift: false, alt: false, key: "k" },
-  },
   {
     id: "newSession",
     label: "New session",
+    group: "sessions",
     combo: { mod: true, shift: true, alt: false, key: "t" },
   },
-  // Down/up because the sidebar list is vertical. Two modifiers plus an arrow is
-  // the one shape nothing downstream wants: any Ctrl+letter is a control code a
-  // shell or Claude Code already binds, Chromium's own switching accelerators are
-  // Ctrl+Tab and Ctrl+PageUp/Down, and Ctrl+Alt+arrow is the desktop's
-  // workspace switch on Linux — it would never reach the page.
+  // Down/up because the sidebar list is vertical; the project pair below is the
+  // same shape turned sideways, because the tab strip is horizontal.
   {
     id: "nextSession",
     label: "Next session",
+    group: "sessions",
     combo: { mod: true, shift: true, alt: false, key: "ArrowDown" },
   },
   {
     id: "prevSession",
     label: "Previous session",
+    group: "sessions",
     combo: { mod: true, shift: true, alt: false, key: "ArrowUp" },
+  },
+  // The cheapest chord in the app to take: Ctrl+Shift+Enter reaches the PTY as a
+  // plain CR, indistinguishable from Enter, so nothing downstream can bind it
+  // apart from Enter itself — which the user still has.
+  {
+    id: "focusTerminal",
+    label: "Focus the session terminal",
+    group: "sessions",
+    combo: { mod: true, shift: true, alt: false, key: "Enter" },
+  },
+  {
+    id: "nextProject",
+    label: "Next project",
+    group: "view",
+    combo: { mod: true, shift: true, alt: false, key: "ArrowRight" },
+  },
+  {
+    id: "prevProject",
+    label: "Previous project",
+    group: "view",
+    combo: { mod: true, shift: true, alt: false, key: "ArrowLeft" },
+  },
+  {
+    id: "toggleDock",
+    label: "Toggle the right dock",
+    group: "view",
+    combo: { mod: true, shift: true, alt: false, key: "d" },
+  },
+  {
+    id: "commandPalette",
+    label: "Command palette",
+    group: "app",
+    combo: { mod: true, shift: false, alt: false, key: "k" },
+  },
+  // Ctrl+, is what every other app opens preferences with, and the terminal
+  // encodes no control code for it — a rare case where the familiar chord is
+  // also the free one.
+  {
+    id: "settings",
+    label: "Settings",
+    group: "app",
+    combo: { mod: true, shift: false, alt: false, key: "," },
+  },
+  {
+    id: "pulls",
+    label: "Pull requests",
+    group: "app",
+    combo: { mod: true, shift: true, alt: false, key: "p" },
   },
   {
     id: "shortcuts",
     label: "Keyboard shortcuts",
+    group: "app",
     combo: { mod: true, shift: false, alt: false, key: "/" },
   },
 ]
@@ -120,6 +200,28 @@ export function isRecordingTarget(event: Event): boolean {
 
 export function sameCombo(a: Combo, b: Combo): boolean {
   return a.mod === b.mod && a.shift === b.shift && a.alt === b.alt && a.key === b.key
+}
+
+// hotkeyConflicts reports, for every action sharing its combo with another, the
+// other actions holding it — in HOTKEY_ACTIONS order. Recording a taken combo is
+// allowed (lich does not veto the user's choice), but with two listeners on one
+// chord whichever runs first wins and the other action silently stops working,
+// so both rows say so.
+export function hotkeyConflicts(hotkeys: Hotkeys): Partial<Record<HotkeyId, HotkeyId[]>> {
+  const byCombo = new Map<string, HotkeyId[]>()
+  for (const action of HOTKEY_ACTIONS) {
+    const combo = hotkeys[action.id]
+    const key = `${combo.mod}|${combo.shift}|${combo.alt}|${combo.key}`
+    byCombo.set(key, [...(byCombo.get(key) ?? []), action.id])
+  }
+  const conflicts: Partial<Record<HotkeyId, HotkeyId[]>> = {}
+  for (const ids of byCombo.values()) {
+    if (ids.length < 2) continue
+    for (const id of ids) {
+      conflicts[id] = ids.filter((other) => other !== id)
+    }
+  }
+  return conflicts
 }
 
 function formatKey(key: string): string {

--- a/frontend/src/lib/hotkeys.ts
+++ b/frontend/src/lib/hotkeys.ts
@@ -8,7 +8,7 @@ import { readPref, writePref } from "@/lib/prefs"
 // Zoom is deliberately absent: those chords shadow Chromium's own accelerators,
 // which are bound to physical keys, so they are matched on event.code in
 // zoom-keys.ts instead of being character combos a user can rebind.
-export type HotkeyId = "commandPalette" | "newSession" | "nextSession" | "prevSession"
+export type HotkeyId = "commandPalette" | "newSession" | "nextSession" | "prevSession" | "shortcuts"
 
 export interface Combo {
   mod: boolean
@@ -49,6 +49,11 @@ export const HOTKEY_ACTIONS: readonly HotkeyAction[] = [
     id: "prevSession",
     label: "Previous session",
     combo: { mod: true, shift: true, alt: false, key: "ArrowUp" },
+  },
+  {
+    id: "shortcuts",
+    label: "Keyboard shortcuts",
+    combo: { mod: true, shift: false, alt: false, key: "/" },
   },
 ]
 

--- a/frontend/src/lib/hotkeys.ts
+++ b/frontend/src/lib/hotkeys.ts
@@ -202,6 +202,17 @@ export function sameCombo(a: Combo, b: Combo): boolean {
   return a.mod === b.mod && a.shift === b.shift && a.alt === b.alt && a.key === b.key
 }
 
+// A combo's identity as a map key, so many can be bucketed in one pass where
+// sameCombo only compares two. The separator cannot collide: a key is either a
+// single character or a name like "ArrowDown", and neither contains "|".
+function comboKey(combo: Combo): string {
+  return `${combo.mod}|${combo.shift}|${combo.alt}|${combo.key}`
+}
+
+export function hotkeyLabel(id: HotkeyId): string {
+  return HOTKEY_ACTIONS.find((action) => action.id === id)?.label ?? id
+}
+
 // hotkeyConflicts reports, for every action sharing its combo with another, the
 // other actions holding it — in HOTKEY_ACTIONS order. Recording a taken combo is
 // allowed (lich does not veto the user's choice), but with two listeners on one
@@ -210,9 +221,13 @@ export function sameCombo(a: Combo, b: Combo): boolean {
 export function hotkeyConflicts(hotkeys: Hotkeys): Partial<Record<HotkeyId, HotkeyId[]>> {
   const byCombo = new Map<string, HotkeyId[]>()
   for (const action of HOTKEY_ACTIONS) {
-    const combo = hotkeys[action.id]
-    const key = `${combo.mod}|${combo.shift}|${combo.alt}|${combo.key}`
-    byCombo.set(key, [...(byCombo.get(key) ?? []), action.id])
+    const key = comboKey(hotkeys[action.id])
+    const held = byCombo.get(key)
+    if (held) {
+      held.push(action.id)
+    } else {
+      byCombo.set(key, [action.id])
+    }
   }
   const conflicts: Partial<Record<HotkeyId, HotkeyId[]>> = {}
   for (const ids of byCombo.values()) {
@@ -253,12 +268,18 @@ function isCombo(value: unknown): value is Combo {
 
 // mergeHotkeys layers validated overrides over the defaults, dropping anything
 // malformed. Keeps unknown/corrupt persisted data from breaking shortcuts.
+//
+// The stored key is normalized on the way in, not only on the way out of
+// comboFromEvent: a combo hand-edited into localStorage as "T" is well-formed,
+// so it survives validation, but matchesCombo compares against a normalized
+// event key and would never fire it — a shortcut dead with nothing on screen
+// saying why.
 export function mergeHotkeys(overrides: unknown): Hotkeys {
   const result: Hotkeys = { ...DEFAULT_HOTKEYS }
   if (overrides && typeof overrides === "object") {
     for (const id of Object.keys(DEFAULT_HOTKEYS) as HotkeyId[]) {
       const value = (overrides as Record<string, unknown>)[id]
-      if (isCombo(value)) result[id] = value
+      if (isCombo(value)) result[id] = { ...value, key: normalizeKey(value.key) }
     }
   }
   return result

--- a/frontend/src/lib/platform.ts
+++ b/frontend/src/lib/platform.ts
@@ -1,0 +1,8 @@
+// The OS lich itself runs on. navigator.platform is deprecated, but it is what
+// the app already read — in three places, each with its own spelling and its own
+// guard — and the three must never disagree about which chord a user is shown.
+// Read once here instead: "Win32" on Windows Chromium, "MacIntel" on macOS.
+const platform = typeof navigator === "undefined" ? "" : navigator.platform.toLowerCase()
+
+export const isMac = platform.includes("mac")
+export const isWindows = platform.includes("win")

--- a/frontend/src/lib/project-order.test.ts
+++ b/frontend/src/lib/project-order.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import type { Project } from "./api-types"
+import { neighborProjectId } from "./project-order"
+
+const project = (id: string): Project => ({ id, name: id, path: `/tmp/${id}` }) as Project
+
+// Home is stored last here on purpose: it is appended when it is missing, and the
+// tab strip still draws it first.
+const projects = [project("a"), project("b"), project("home")]
+
+describe("neighborProjectId", () => {
+  it("walks the strip's order, Home first", () => {
+    expect(neighborProjectId(projects, "home", "home", 1)).toBe("a")
+    expect(neighborProjectId(projects, "home", "a", 1)).toBe("b")
+  })
+
+  it("wraps at both ends", () => {
+    expect(neighborProjectId(projects, "home", "b", 1)).toBe("home")
+    expect(neighborProjectId(projects, "home", "home", -1)).toBe("b")
+  })
+
+  it("has nowhere to go with a single tab", () => {
+    expect(neighborProjectId([project("home")], "home", "home", 1)).toBe("")
+    expect(neighborProjectId([], "home", undefined, 1)).toBe("")
+  })
+
+  it("lands on the end the step comes from when nothing is active", () => {
+    expect(neighborProjectId(projects, "home", undefined, 1)).toBe("home")
+    expect(neighborProjectId(projects, "home", undefined, -1)).toBe("b")
+  })
+
+  it("keeps the stored order when there is no Home", () => {
+    expect(neighborProjectId(projects, null, "b", 1)).toBe("home")
+    expect(neighborProjectId(projects, null, "a", -1)).toBe("home")
+  })
+})

--- a/frontend/src/lib/project-order.ts
+++ b/frontend/src/lib/project-order.ts
@@ -1,0 +1,25 @@
+import type { Project } from "@/lib/api-types"
+
+// neighborProjectId returns the project one step from `activeId` in the order the
+// tab strip draws — Home pinned first, the rest in their stored order — wrapping
+// at both ends. "" means there is nowhere to go (a single tab, or none), and the
+// caller leaves the screen alone.
+export function neighborProjectId(
+  projects: readonly Project[],
+  homeId: string | null,
+  activeId: string | undefined,
+  step: 1 | -1,
+): string {
+  const home = projects.filter((project) => project.id === homeId)
+  const ids = [...home, ...projects.filter((project) => project.id !== homeId)].map((p) => p.id)
+  if (ids.length < 2) {
+    return ""
+  }
+  const index = activeId ? ids.indexOf(activeId) : -1
+  // Nowhere to step from (the landing screen, or a tab just closed): the press
+  // still moves, onto the end the step comes from.
+  if (index === -1) {
+    return step === 1 ? ids[0] : ids[ids.length - 1]
+  }
+  return ids[(index + step + ids.length) % ids.length]
+}

--- a/frontend/src/lib/shortcuts.test.ts
+++ b/frontend/src/lib/shortcuts.test.ts
@@ -1,16 +1,35 @@
 import { describe, expect, it } from "vitest"
-import { DEFAULT_HOTKEYS, HOTKEY_ACTIONS } from "./hotkeys"
-import { shortcutGroups } from "./shortcuts"
+import { DEFAULT_HOTKEYS, HOTKEY_ACTIONS, HOTKEY_GROUPS } from "./hotkeys"
+import { PASSTHROUGH_TITLE, shortcutGroups } from "./shortcuts"
 
-const rowFor = (group: { rows: { label: string; keys: string }[] }, label: string) =>
-  group.rows.find((row) => row.label === label)
+const groupTitled = (
+  groups: { title: string; rows: { label: string; keys: string }[] }[],
+  title: string,
+) => {
+  const group = groups.find((g) => g.title === title)
+  if (!group) throw new Error(`no group titled ${title}`)
+  return group
+}
+const keysFor = (
+  groups: { title: string; rows: { label: string; keys: string }[] }[],
+  label: string,
+) => groups.flatMap((g) => g.rows).find((row) => row.label === label)?.keys
 
 describe("shortcutGroups", () => {
-  it("lists every rebindable action under lich", () => {
-    const [lich] = shortcutGroups(DEFAULT_HOTKEYS, false, false)
-    expect(lich.title).toBe("lich")
-    expect(lich.rows.map((row) => row.label)).toEqual(HOTKEY_ACTIONS.map((a) => a.label))
-    expect(rowFor(lich, "Command palette")?.keys).toBe("Ctrl+K")
+  it("lists every rebindable action, grouped the way the actions declare", () => {
+    const groups = shortcutGroups(DEFAULT_HOTKEYS, false, false)
+    expect(groups.map((g) => g.title)).toEqual([
+      ...HOTKEY_GROUPS.map((g) => g.label),
+      PASSTHROUGH_TITLE,
+    ])
+    const listed = groups.slice(0, -1).flatMap((g) => g.rows.map((row) => row.label))
+    expect(listed).toEqual(HOTKEY_ACTIONS.map((a) => a.label))
+    expect(groupTitled(groups, "Sessions").rows.map((r) => r.label)).toContain("New session")
+  })
+
+  it("formats each binding for the platform", () => {
+    expect(keysFor(shortcutGroups(DEFAULT_HOTKEYS, false, false), "Command palette")).toBe("Ctrl+K")
+    expect(keysFor(shortcutGroups(DEFAULT_HOTKEYS, true, false), "Command palette")).toBe("⌘K")
   })
 
   it("shows the user's binding, not the default", () => {
@@ -18,25 +37,18 @@ describe("shortcutGroups", () => {
       ...DEFAULT_HOTKEYS,
       commandPalette: { mod: true, shift: false, alt: true, key: "p" },
     }
-    const [lich] = shortcutGroups(rebound, false, false)
-    expect(rowFor(lich, "Command palette")?.keys).toBe("Ctrl+Alt+P")
-  })
-
-  it("formats the lich bindings for macOS", () => {
-    const [lich] = shortcutGroups(DEFAULT_HOTKEYS, true, false)
-    expect(rowFor(lich, "Command palette")?.keys).toBe("⌘K")
+    expect(keysFor(shortcutGroups(rebound, false, false), "Command palette")).toBe("Ctrl+Alt+P")
   })
 
   it("splits the image-paste chord by platform", () => {
-    const agentOn = (isWindows: boolean) => shortcutGroups(DEFAULT_HOTKEYS, false, isWindows)[1]
-    expect(rowFor(agentOn(false), "Attach an image from the clipboard")?.keys).toBe("Ctrl+V")
-    expect(rowFor(agentOn(true), "Attach an image from the clipboard")?.keys).toBe("Alt+V")
+    const on = (isWindows: boolean) => shortcutGroups(DEFAULT_HOTKEYS, false, isWindows)
+    expect(keysFor(on(false), "Attach an image from the clipboard")).toBe("Ctrl+V")
+    expect(keysFor(on(true), "Attach an image from the clipboard")).toBe("Alt+V")
   })
 
   it("keeps the platform-independent chords as Control, macOS included", () => {
-    const agent = shortcutGroups(DEFAULT_HOTKEYS, true, false)[1]
-    expect(agent.title).toBe("Passed through to the agent")
-    expect(rowFor(agent, "Erase the previous word")?.keys).toBe("Ctrl+Backspace")
-    expect(rowFor(agent, "Insert a newline without sending")?.keys).toBe("Shift+Enter")
+    const groups = shortcutGroups(DEFAULT_HOTKEYS, true, false)
+    expect(keysFor(groups, "Erase the previous word")).toBe("Ctrl+Backspace")
+    expect(keysFor(groups, "Insert a newline without sending")).toBe("Shift+Enter")
   })
 })

--- a/frontend/src/lib/shortcuts.test.ts
+++ b/frontend/src/lib/shortcuts.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import { DEFAULT_HOTKEYS, HOTKEY_ACTIONS } from "./hotkeys"
+import { shortcutGroups } from "./shortcuts"
+
+const rowFor = (group: { rows: { label: string; keys: string }[] }, label: string) =>
+  group.rows.find((row) => row.label === label)
+
+describe("shortcutGroups", () => {
+  it("lists every rebindable action under lich", () => {
+    const [lich] = shortcutGroups(DEFAULT_HOTKEYS, false, false)
+    expect(lich.title).toBe("lich")
+    expect(lich.rows.map((row) => row.label)).toEqual(HOTKEY_ACTIONS.map((a) => a.label))
+    expect(rowFor(lich, "Command palette")?.keys).toBe("Ctrl+K")
+  })
+
+  it("shows the user's binding, not the default", () => {
+    const rebound = {
+      ...DEFAULT_HOTKEYS,
+      commandPalette: { mod: true, shift: false, alt: true, key: "p" },
+    }
+    const [lich] = shortcutGroups(rebound, false, false)
+    expect(rowFor(lich, "Command palette")?.keys).toBe("Ctrl+Alt+P")
+  })
+
+  it("formats the lich bindings for macOS", () => {
+    const [lich] = shortcutGroups(DEFAULT_HOTKEYS, true, false)
+    expect(rowFor(lich, "Command palette")?.keys).toBe("⌘K")
+  })
+
+  it("splits the image-paste chord by platform", () => {
+    const agentOn = (isWindows: boolean) => shortcutGroups(DEFAULT_HOTKEYS, false, isWindows)[1]
+    expect(rowFor(agentOn(false), "Attach an image from the clipboard")?.keys).toBe("Ctrl+V")
+    expect(rowFor(agentOn(true), "Attach an image from the clipboard")?.keys).toBe("Alt+V")
+  })
+
+  it("keeps the platform-independent chords as Control, macOS included", () => {
+    const agent = shortcutGroups(DEFAULT_HOTKEYS, true, false)[1]
+    expect(agent.title).toBe("Passed through to the agent")
+    expect(rowFor(agent, "Erase the previous word")?.keys).toBe("Ctrl+Backspace")
+    expect(rowFor(agent, "Insert a newline without sending")?.keys).toBe("Shift+Enter")
+  })
+})

--- a/frontend/src/lib/shortcuts.ts
+++ b/frontend/src/lib/shortcuts.ts
@@ -1,8 +1,8 @@
-import { formatCombo, HOTKEY_ACTIONS, type Hotkeys } from "@/lib/hotkeys"
+import { formatCombo, HOTKEY_ACTIONS, HOTKEY_GROUPS, type Hotkeys } from "@/lib/hotkeys"
 
-// The rows the shortcuts overlay lists. Two sources: the rebindable actions,
-// read from the user's current bindings, and the chords lich rewrites on the
-// way to the PTY.
+// The rows the shortcuts overlay lists, and the read-only half of the Hotkeys
+// settings pane. Two sources: the rebindable actions, read from the user's
+// current bindings, and the chords lich rewrites on the way to the PTY.
 
 export interface ShortcutRow {
   label: string
@@ -14,10 +14,12 @@ export interface ShortcutGroup {
   rows: ShortcutRow[]
 }
 
-// The passthrough chords are spelled out rather than built from a Combo: they
-// are matched on event.ctrlKey (term-keys.ts), so the modifier is Control on
-// macOS too and formatCombo's `mod` — which prints ⌘ there — would lie.
-function passthroughRows(isWindows: boolean): ShortcutRow[] {
+export const PASSTHROUGH_TITLE = "Passed through to the agent"
+
+// These are spelled out rather than built from a Combo: they are matched on
+// event.ctrlKey (term-keys.ts), so the modifier is Control on macOS too and
+// formatCombo's `mod` — which prints ⌘ there — would lie.
+export function passthroughRows(isWindows: boolean): ShortcutRow[] {
   return [
     // Claude Code reads the clipboard itself on this one; Windows binds it to
     // Alt+V, so the chord lich sends differs by platform (term-keys.ts).
@@ -32,14 +34,12 @@ export function shortcutGroups(
   isMac: boolean,
   isWindows: boolean,
 ): ShortcutGroup[] {
-  return [
-    {
-      title: "lich",
-      rows: HOTKEY_ACTIONS.map((action) => ({
-        label: action.label,
-        keys: formatCombo(hotkeys[action.id], isMac),
-      })),
-    },
-    { title: "Passed through to the agent", rows: passthroughRows(isWindows) },
-  ]
+  const bound = HOTKEY_GROUPS.map((group) => ({
+    title: group.label,
+    rows: HOTKEY_ACTIONS.filter((action) => action.group === group.id).map((action) => ({
+      label: action.label,
+      keys: formatCombo(hotkeys[action.id], isMac),
+    })),
+  }))
+  return [...bound, { title: PASSTHROUGH_TITLE, rows: passthroughRows(isWindows) }]
 }

--- a/frontend/src/lib/shortcuts.ts
+++ b/frontend/src/lib/shortcuts.ts
@@ -1,0 +1,45 @@
+import { formatCombo, HOTKEY_ACTIONS, type Hotkeys } from "@/lib/hotkeys"
+
+// The rows the shortcuts overlay lists. Two sources: the rebindable actions,
+// read from the user's current bindings, and the chords lich rewrites on the
+// way to the PTY.
+
+export interface ShortcutRow {
+  label: string
+  keys: string
+}
+
+export interface ShortcutGroup {
+  title: string
+  rows: ShortcutRow[]
+}
+
+// The passthrough chords are spelled out rather than built from a Combo: they
+// are matched on event.ctrlKey (term-keys.ts), so the modifier is Control on
+// macOS too and formatCombo's `mod` — which prints ⌘ there — would lie.
+function passthroughRows(isWindows: boolean): ShortcutRow[] {
+  return [
+    // Claude Code reads the clipboard itself on this one; Windows binds it to
+    // Alt+V, so the chord lich sends differs by platform (term-keys.ts).
+    { label: "Attach an image from the clipboard", keys: isWindows ? "Alt+V" : "Ctrl+V" },
+    { label: "Insert a newline without sending", keys: "Shift+Enter" },
+    { label: "Erase the previous word", keys: "Ctrl+Backspace" },
+  ]
+}
+
+export function shortcutGroups(
+  hotkeys: Hotkeys,
+  isMac: boolean,
+  isWindows: boolean,
+): ShortcutGroup[] {
+  return [
+    {
+      title: "lich",
+      rows: HOTKEY_ACTIONS.map((action) => ({
+        label: action.label,
+        keys: formatCombo(hotkeys[action.id], isMac),
+      })),
+    },
+    { title: "Passed through to the agent", rows: passthroughRows(isWindows) },
+  ]
+}

--- a/frontend/src/lib/use-hotkey.ts
+++ b/frontend/src/lib/use-hotkey.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react"
+import { isRecordingTarget, matchesCombo, type Combo } from "@/lib/hotkeys"
+
+// One place for what every global shortcut has to get right: the listener sits
+// in the window capture phase so the chord is seen before the terminal that has
+// focus, and the event is stopped there so the PTY never receives it — a hotkey
+// that reached the shell would run a command as well as its action. Recording a
+// rebind in Settings bails out, so pressing a combo to store it does not also
+// fire the action it is being stored for.
+//
+// The handler may decline by returning false, for the shortcuts whose action is
+// unavailable right now (no project open): the chord then behaves as if lich had
+// never bound it and falls through to whatever is underneath.
+export function useHotkey(combo: Combo, handler: () => unknown): void {
+  // The handler is read through a ref so a caller may pass an inline closure
+  // without re-subscribing the listener on every render.
+  const latest = useRef(handler)
+  latest.current = handler
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (isRecordingTarget(event) || !matchesCombo(event, combo)) {
+        return
+      }
+      if (latest.current() === false) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+    }
+    window.addEventListener("keydown", onKey, true)
+    return () => window.removeEventListener("keydown", onKey, true)
+  }, [combo])
+}

--- a/frontend/src/lib/use-hotkey.ts
+++ b/frontend/src/lib/use-hotkey.ts
@@ -11,7 +11,7 @@ import { isRecordingTarget, matchesCombo, type Combo } from "@/lib/hotkeys"
 // The handler may decline by returning false, for the shortcuts whose action is
 // unavailable right now (no project open): the chord then behaves as if lich had
 // never bound it and falls through to whatever is underneath.
-export function useHotkey(combo: Combo, handler: () => unknown): void {
+export function useHotkey(combo: Combo, handler: () => void | false): void {
   // The handler is read through a ref so a caller may pass an inline closure
   // without re-subscribing the listener on every render.
   const latest = useRef(handler)

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -51,7 +51,9 @@ import {
 import { NotificationsOptIn } from "@/components/NotificationsOptIn"
 import { refreshGitStatus } from "@/lib/git/use-git-status"
 import { markSessionSeen } from "@/lib/session/use-session-status"
-import { isRecordingTarget, matchesCombo } from "@/lib/hotkeys"
+import { useHotkey } from "@/lib/use-hotkey"
+import { neighborProjectId } from "@/lib/project-order"
+import { requestTerminalFocus } from "@/lib/terminal/focus-request"
 import { useSettings } from "./settings"
 
 interface ProjectsValue {
@@ -514,49 +516,52 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
   }, [])
 
   // The session shortcuts act on the active project: one opens a session
-  // (mirroring the "+" button), the other two walk its sidebar list. They fire
-  // even with terminal focus, so they stay reachable while working in a terminal
-  // — the capture-phase listener sees the chord before the terminal does and
-  // stops propagation so the PTY never receives it. Bails while a hotkey is
-  // being recorded so rebinding does not trigger it.
-  useEffect(() => {
-    if (!activeProjectId) {
-      return
+  // (mirroring the "+" button), two walk its sidebar list, and one puts the
+  // cursor back in the active session's terminal. They fire even with terminal
+  // focus — see useHotkey for how the chord is kept out of the PTY. A press with
+  // no project open is declined, so the chord falls through instead of being
+  // swallowed for nothing.
+  useHotkey(hotkeys.newSession, () => {
+    if (!activeProjectId) return false
+    newSession(activeProjectId)
+  })
+
+  const stepSession = (step: 1 | -1) => {
+    if (!activeProjectId) return false
+    // Swallowed even with nowhere to go: the chord belongs to lich, so a project
+    // with a single session must not leak it into that session's PTY.
+    const current = sessionsRef.current
+    const target = neighborSessionId(
+      current,
+      activeProjectId,
+      activeSessionId(current, activeProjectId),
+      step,
+    )
+    if (target) {
+      activateSession(activeProjectId, target)
     }
-    const onKey = (event: KeyboardEvent) => {
-      if (isRecordingTarget(event)) return
-      if (matchesCombo(event, hotkeys.newSession)) {
-        event.preventDefault()
-        event.stopPropagation()
-        newSession(activeProjectId)
-        return
-      }
-      const step = matchesCombo(event, hotkeys.nextSession)
-        ? 1
-        : matchesCombo(event, hotkeys.prevSession)
-          ? -1
-          : 0
-      if (step === 0) {
-        return
-      }
-      // Swallowed even with nowhere to go: the chord belongs to lich, so a
-      // project with a single session must not leak it into that session's PTY.
-      event.preventDefault()
-      event.stopPropagation()
-      const current = sessionsRef.current
-      const target = neighborSessionId(
-        current,
-        activeProjectId,
-        activeSessionId(current, activeProjectId),
-        step,
-      )
-      if (target) {
-        activateSession(activeProjectId, target)
-      }
-    }
-    window.addEventListener("keydown", onKey, true)
-    return () => window.removeEventListener("keydown", onKey, true)
-  }, [activeProjectId, newSession, activateSession, hotkeys])
+  }
+  useHotkey(hotkeys.nextSession, () => stepSession(1))
+  useHotkey(hotkeys.prevSession, () => stepSession(-1))
+
+  // Settings and the pull requests render over the terminals rather than beside
+  // them, so handing focus to a session that is behind one of those screens would
+  // type into something the user cannot see: leave the screen first.
+  useHotkey(hotkeys.focusTerminal, () => {
+    if (!activeProjectId) return false
+    const target = activeSessionId(sessionsRef.current, activeProjectId)
+    if (!target) return false
+    navigate(`/projects/${activeProjectId}`)
+    requestTerminalFocus(target)
+  })
+
+  const stepProject = (step: 1 | -1) => {
+    const target = neighborProjectId(projectsRef.current, homeIdRef.current, activeProjectId, step)
+    if (!target) return false
+    navigate(`/projects/${target}`)
+  }
+  useHotkey(hotkeys.nextProject, () => stepProject(1))
+  useHotkey(hotkeys.prevProject, () => stepProject(-1))
 
   // A request whose target worked and then answered somewhere lich cannot read
   // — its provider's own peer channel, or simply out loud to whoever is watching


### PR DESCRIPTION
## What

Three things, on top of each other:

1. **A read-only shortcuts overlay** — `Ctrl/Cmd + /` lists every keyboard
   shortcut lich has. Until now the only screen that named any of them was
   Settings › Hotkeys, where you go to *change* a binding rather than to find
   one, and the chords lich rewrites on the way to the agent's TUI were written
   down nowhere outside `lib/terminal/term-keys.ts`.
2. **Six more bindings**, for actions the app already performed.
3. **A Hotkeys pane that survives eleven rows**, with collision detection.

## The bindings

| Action | Default | What it costs the TUI |
| --- | --- | --- |
| Next / previous project | `Ctrl+Shift+→` / `←` | CSI `1;6C`/`1;6D` — a real sequence |
| Toggle the right dock | `Ctrl+Shift+D` | nothing |
| Focus the session terminal | `Ctrl+Shift+Enter` | a plain CR, i.e. a duplicate of Enter |
| Settings | `Ctrl+,` | nothing |
| Pull requests | `Ctrl+Shift+P` | nothing |

Every default was measured, not guessed: each candidate was pressed into
`cat -v` in a live session and the replay ring read back. Two findings drove the
choices — `Ctrl+Shift+<letter>` reaches the PTY as **nothing at all** (xterm's
control-code mapping requires Shift to be up), and `Ctrl+Shift+Enter` reaches it
as a plain CR, so no TUI can bind it distinctly from Enter. `Ctrl+Shift+arrow`
*is* a real sequence, so it is spent only where the direction is the meaning:
the tab strip is horizontal the way the session list is vertical, which is the
existing `nextSession`/`prevSession` shape turned sideways. The rule is recorded
in the comment above `HOTKEY_ACTIONS`.

Nothing new was invented: each shortcut calls the function its button already
calls, and **declines the press when that button would be disabled** — with no
project open the chord falls through instead of being swallowed for nothing.
`Ctrl+Shift+P` opens exactly what the tab strip's pull-request button opens; a
project with no repository gets that screen's own explanation rather than a
silent no-op.

Nothing was dropped for lack of a safe shape.

## Settings › Hotkeys

One dense list grouped by area (sessions / view / app) instead of one
`SettingBlock` per action: borderless rows, hover `bg-accent/50`, the hairline
only on the capture control itself. The passed-through chords are listed
read-only at the bottom, built from the same `lib/shortcuts.ts` the overlay
reads — one source, so a binding cannot render one way in one place and another
in the other.

**Collisions.** Recording a combo another action already holds is still allowed
— lich does not veto the user's choice — but with two listeners on one chord
whichever runs first wins and the other action silently stops working. Both rows
now say so in amber, naming the other action, and `Reset` is right there.
`hotkeyConflicts` is a pure function in `lib/hotkeys.ts` with tests.

## Also

`useHotkey` (`lib/use-hotkey.ts`) is now the one place the capture-phase contract
lives: window capture so the chord beats the terminal that has focus,
`preventDefault` + `stopPropagation` so the PTY never receives it, and a bail
while a rebind is being recorded. The palette, the overlay and the session
shortcuts moved onto it.

New pure logic, all tested in the node suite: `lib/shortcuts.ts` (list building,
platform split), `lib/hotkeys.ts` `hotkeyConflicts`, `lib/project-order.ts`
(`neighborProjectId` — Home pinned first, wrapping at both ends).

## Test plan

- [x] `pnpm check` (0), `pnpm exec vitest run` (818 passed, 0), `tsc -b
      --noEmit` (0), `vite build` (0) — binaries run directly, exit codes read.
- [x] Smoked by hand in a headless instance, both themes, with focus inside the
      terminal for every press: each of the eleven bindings did its thing (dock
      opened and closed, route changed for Settings / pull requests / project
      walk, active session moved, palette and overlay opened, a session was
      created, and `Ctrl+Shift+Enter` from the Settings screen both left the
      screen and put the cursor in the terminal) — and **none of them reached
      the PTY**: the session was running `cat -v` throughout and every chord
      landed between its markers with nothing in between.
- [x] Collision marking verified live: binding the palette to the new-session
      chord marks both rows ("Also bound to …").

Note: the sibling branch `feat/waiting-on-you` also adds an `[Unreleased]`
entry, so expect a trivial CHANGELOG conflict on whichever of the two merges
second.