### PR TITLE
feat: one skip-permissions ladder, for every provider that has a flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Skipping the permission prompts is no longer a Claude Code privilege.** The
+  two switches that spawn an agent with its "run every tool without asking"
+  flag — one for the project's own checkout, one for worktrees — are now offered
+  for Codex, opencode and Crush as well, each wired to that provider's own
+  spelling of the flag, which is named in the setting's description. The setting
+  was always stored per provider; only Claude Code's was ever read. oh-my-pi is
+  the exception and shows no switch: its spelling has not been confirmed against
+  the binary, and a guessed flag is a session that dies before it opens.
+
 - **The shortcuts are readable without going looking for them, and there are
   more of them.** `Ctrl/Cmd + /` opens a list of every keyboard shortcut lich
   has — the rebindable ones with the combos *this* install has them on, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Skipping the permission prompts is no longer a Claude Code privilege.** The
-  two switches that spawn an agent with its "run every tool without asking"
-  flag — one for the project's own checkout, one for worktrees — are now offered
-  for Codex, opencode and Crush as well, each wired to that provider's own
-  spelling of the flag, which is named in the setting's description. The setting
-  was always stored per provider; only Claude Code's was ever read. oh-my-pi is
-  the exception and shows no switch: its spelling has not been confirmed against
-  the binary, and a guessed flag is a session that dies before it opens.
+- **Skipping the permission prompts is no longer a Claude Code privilege, and it
+  is now one control instead of two.** Every provider lich has a spelling for —
+  Claude Code, Codex, opencode, Crush — gets the setting, wired to that
+  provider's own flag, which the description names. It was always stored per
+  provider; only Claude Code's was ever read. oh-my-pi shows nothing: its
+  spelling has not been confirmed against the binary, and a guessed flag is a
+  session that dies before it opens.
+
+  The pair of switches is now a ladder — **Never · Worktrees only ·
+  Everywhere** — with a line under it saying what the chosen rung leaves asking.
+  Two independent switches could express a fourth state that is the inversion of
+  the reason the setting exists: free rein in the tree you work in while the
+  throwaway checkout still stops to ask. That combination is no longer
+  reachable, and one already saved reads as *Everywhere* — what it already did
+  to the checkout you work in.
 
 - **The shortcuts are readable without going looking for them, and there are
   more of them.** `Ctrl/Cmd + /` opens a list of every keyboard shortcut lich

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,12 @@ Chromium, Edge or Brave are looked up as `.app` bundles under `/Applications`
 Edge or Brave are found via their conventional install paths (Edge ships with
 Windows) and the folder picker is native.
 
+**Agent versions** — lich names each Claude Code session with `--name` at spawn,
+a flag added in Claude Code 2.1.76. An older build exits with
+`error: unknown option '--name'` before the session exists, which reads as lich
+failing to start it; upgrade Claude Code. Nothing lich passes the other
+providers unprompted is that recent.
+
 ## Debian / Ubuntu
 
 Download the `.deb` from the releases page, then install it — apt resolves the

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -1,15 +1,44 @@
 import { useEffect, useState } from "react"
 import { Store } from "@/lib/rpc"
 import { useProjects } from "@/providers/projects"
-import { binKey, skipPermissionFlags, skipPermissionsKey } from "@/lib/providers-store"
+import {
+  binKey,
+  skipLevel,
+  skipLevelPair,
+  skipPermissionFlags,
+  skipPermissionsKey,
+  type SkipLevel,
+} from "@/lib/providers-store"
 import { useSettings } from "@/providers/settings"
 import { setCostReadout } from "@/lib/cost-readout-store"
 import { useCostReadout } from "@/lib/use-cost-readout"
 import { Input } from "@/components/ui/input"
 import { Switch } from "@/components/ui/switch"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { SettingBlock } from "./SettingBlock"
 
 const GLOBAL_SCOPE = ""
+
+// The ladder as the user reads it: the rung's label, and what the rung leaves
+// asking. The second line is the half of the answer the two switches made
+// people assemble in their heads.
+const SKIP_LEVELS: { level: SkipLevel; label: string; consequence: string }[] = [
+  {
+    level: "never",
+    label: "Never",
+    consequence: "Every edit and command waits for you, in every checkout.",
+  },
+  {
+    level: "worktrees",
+    label: "Worktrees only",
+    consequence: "Sessions in the project directory keep asking.",
+  },
+  {
+    level: "everywhere",
+    label: "Everywhere",
+    consequence: "Including the tree you work in. Nothing will ask.",
+  },
+]
 
 // useSkipPermissions is the stored "run without permission prompts" flag for one
 // checkout scope: read once, written through on every toggle. It reads off until
@@ -56,6 +85,17 @@ export function ProviderBinSettings({
   const [skipHere, setSkipHere] = useSkipPermissions(providerId, false)
   const [skipInWorktrees, setSkipInWorktrees] = useSkipPermissions(providerId, true)
   const skipFlag = skipPermissionFlags[providerId]
+  const level = skipLevel(skipHere, skipInWorktrees)
+  const consequence = SKIP_LEVELS.find((rung) => rung.level === level)?.consequence ?? ""
+
+  // One rung writes both keys, always: the pair is the storage, the rung is the
+  // choice. Writing only the one that changed would leave the other holding an
+  // answer to a question the user is no longer being asked.
+  const setLevel = (next: SkipLevel) => {
+    const pair = skipLevelPair(next)
+    setSkipHere(pair.here)
+    setSkipInWorktrees(pair.worktrees)
+  }
 
   useEffect(() => {
     void Store.GetSetting(key, GLOBAL_SCOPE).then(setGlobalBin)
@@ -166,34 +206,33 @@ export function ProviderBinSettings({
         </>
       )}
 
-      {/* Both off unless the user says otherwise, and separate on purpose: a
-          worktree is a checkout you can throw away, the project directory is
-          the one you work in. Absent for a provider whose flag lich has no
-          spelling for — the switch would store a setting nothing reads. */}
+      {/* Never unless the user says otherwise. A worktree is its own rung
+          because it is a checkout you can throw away, while the project
+          directory is the one you work in. Absent for a provider whose flag
+          lich has no spelling for — the control would store a setting nothing
+          reads. */}
       {skipFlag && (
-        <>
-          <SettingBlock
-            title="Skip permission prompts"
-            description={`Spawn ${providerName} with ${skipFlag} in this project's own checkout. It edits files, runs commands and installs things without asking first, and whatever it gets wrong lands in the tree you work in.`}
+        <SettingBlock
+          title="Skip permission prompts"
+          description={`How far ${providerName} runs without asking: it edits files, runs commands and installs things unconfirmed, and lich spawns it with ${skipFlag}.`}
+        >
+          <ToggleGroup
+            value={[level]}
+            // An empty array is the pressed rung being pressed again. There is
+            // no fourth answer to fall back to, so it stays where it was.
+            onValueChange={(next) => next[0] && setLevel(next[0] as SkipLevel)}
+            spacing={1}
+            aria-label={`How far ${providerName} runs without asking`}
+            className="border border-border p-[3px]"
           >
-            <Switch
-              checked={skipHere}
-              onCheckedChange={setSkipHere}
-              aria-label="Skip permission prompts in the project directory"
-            />
-          </SettingBlock>
-
-          <SettingBlock
-            title="Skip permission prompts in worktrees"
-            description="The same flag for sessions started in a git worktree. That checkout is separate from your working tree, so a mistake stays in the branch until you merge it."
-          >
-            <Switch
-              checked={skipInWorktrees}
-              onCheckedChange={setSkipInWorktrees}
-              aria-label="Skip permission prompts in worktree sessions"
-            />
-          </SettingBlock>
-        </>
+            {SKIP_LEVELS.map((rung) => (
+              <ToggleGroupItem key={rung.level} value={rung.level} size="sm">
+                {rung.label}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+          <p className="mt-2 text-xs text-muted-foreground">{consequence}</p>
+        </SettingBlock>
       )}
     </>
   )

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react"
 import { Store } from "@/lib/rpc"
 import { useProjects } from "@/providers/projects"
-import { binKey, skipPermissionsKey } from "@/lib/providers-store"
+import { binKey, skipPermissionFlags, skipPermissionsKey } from "@/lib/providers-store"
 import { useSettings } from "@/providers/settings"
 import { setCostReadout } from "@/lib/cost-readout-store"
 import { useCostReadout } from "@/lib/use-cost-readout"
@@ -36,9 +36,11 @@ function useSkipPermissions(providerId: string, worktree: boolean) {
 // provider's own name on $PATH. Same keys the Go store resolves (see binKey).
 export function ProviderBinSettings({
   providerId,
+  providerName,
   projectId,
 }: {
   providerId: string
+  providerName: string
   projectId?: string
 }) {
   const { projects } = useProjects()
@@ -53,6 +55,7 @@ export function ProviderBinSettings({
   const [budget, setBudget] = useState(() => (costBudget > 0 ? String(costBudget) : ""))
   const [skipHere, setSkipHere] = useSkipPermissions(providerId, false)
   const [skipInWorktrees, setSkipInWorktrees] = useSkipPermissions(providerId, true)
+  const skipFlag = skipPermissionFlags[providerId]
 
   useEffect(() => {
     void Store.GetSetting(key, GLOBAL_SCOPE).then(setGlobalBin)
@@ -160,13 +163,18 @@ export function ProviderBinSettings({
               />
             </SettingBlock>
           )}
+        </>
+      )}
 
-          {/* Both off unless the user says otherwise, and separate on purpose:
-              a worktree is a checkout you can throw away, the project directory
-              is the one you work in. */}
+      {/* Both off unless the user says otherwise, and separate on purpose: a
+          worktree is a checkout you can throw away, the project directory is
+          the one you work in. Absent for a provider whose flag lich has no
+          spelling for — the switch would store a setting nothing reads. */}
+      {skipFlag && (
+        <>
           <SettingBlock
             title="Skip permission prompts"
-            description="Spawn Claude Code with --dangerously-skip-permissions in this project's own checkout. It edits files, runs commands and installs things without asking first, and whatever it gets wrong lands in the tree you work in."
+            description={`Spawn ${providerName} with ${skipFlag} in this project's own checkout. It edits files, runs commands and installs things without asking first, and whatever it gets wrong lands in the tree you work in.`}
           >
             <Switch
               checked={skipHere}

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -72,7 +72,9 @@ export function Settings() {
     id: `provider-${provider.id}`,
     label: provider.name,
     group: "provider",
-    render: (id) => <ProviderBinSettings providerId={provider.id} projectId={id} />,
+    render: (id) => (
+      <ProviderBinSettings providerId={provider.id} providerName={provider.name} projectId={id} />
+    ),
   }))
   const sections = [...BASE_SECTIONS, ...providerSections, ...FOOTER_SECTIONS]
 

--- a/frontend/src/components/ui/toggle-group.tsx
+++ b/frontend/src/components/ui/toggle-group.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import * as React from "react"
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
+import { ToggleGroup as ToggleGroupPrimitive } from "@base-ui/react/toggle-group"
+import { type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { toggleVariants } from "@/components/ui/toggle"
+
+const ToggleGroupContext = React.createContext<
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }
+>({
+  size: "default",
+  variant: "default",
+  spacing: 2,
+  orientation: "horizontal",
+})
+
+function ToggleGroup({
+  className,
+  variant,
+  size,
+  spacing = 2,
+  orientation = "horizontal",
+  children,
+  ...props
+}: ToggleGroupPrimitive.Props &
+  VariantProps<typeof toggleVariants> & {
+    spacing?: number
+    orientation?: "horizontal" | "vertical"
+  }) {
+  return (
+    <ToggleGroupPrimitive
+      data-slot="toggle-group"
+      data-variant={variant}
+      data-size={size}
+      data-spacing={spacing}
+      data-orientation={orientation}
+      style={{ "--gap": spacing } as React.CSSProperties}
+      className={cn(
+        "group/toggle-group flex w-fit flex-row items-center gap-[--spacing(var(--gap))] rounded-md data-[spacing=0]:data-[variant=outline]:shadow-xs data-vertical:flex-col data-vertical:items-stretch",
+        className,
+      )}
+      {...props}
+    >
+      <ToggleGroupContext.Provider value={{ variant, size, spacing, orientation }}>
+        {children}
+      </ToggleGroupContext.Provider>
+    </ToggleGroupPrimitive>
+  )
+}
+
+function ToggleGroupItem({
+  className,
+  children,
+  variant = "default",
+  size = "default",
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  const context = React.useContext(ToggleGroupContext)
+
+  return (
+    <TogglePrimitive
+      data-slot="toggle-group-item"
+      data-variant={context.variant || variant}
+      data-size={context.size || size}
+      data-spacing={context.spacing}
+      className={cn(
+        "shrink-0 group-data-[spacing=0]/toggle-group:rounded-none group-data-[spacing=0]/toggle-group:px-2 group-data-[spacing=0]/toggle-group:shadow-none focus:z-10 focus-visible:z-10 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-end]:pr-1.5 group-data-[spacing=0]/toggle-group:has-data-[icon=inline-start]:pl-1.5 group-data-horizontal/toggle-group:data-[spacing=0]:first:rounded-l-md group-data-vertical/toggle-group:data-[spacing=0]:first:rounded-t-md group-data-horizontal/toggle-group:data-[spacing=0]:last:rounded-r-md group-data-vertical/toggle-group:data-[spacing=0]:last:rounded-b-md data-[state=on]:bg-accent data-[state=on]:text-accent-foreground group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:border-l-0 group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:border-t-0 group-data-horizontal/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-l group-data-vertical/toggle-group:data-[spacing=0]:data-[variant=outline]:first:border-t",
+        toggleVariants({
+          variant: context.variant || variant,
+          size: context.size || size,
+        }),
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </TogglePrimitive>
+  )
+}
+
+export { ToggleGroup, ToggleGroupItem }

--- a/frontend/src/components/ui/toggle.tsx
+++ b/frontend/src/components/ui/toggle.tsx
@@ -1,0 +1,46 @@
+import { Toggle as TogglePrimitive } from "@base-ui/react/toggle"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+// Adapted to DESIGN.md before first use: an option is a ghost at rest and
+// selection is a flat accent fill — no shadow, no ring, no border of its own.
+// The enclosure belongs to the track around the group, not to the options.
+const toggleVariants = cva(
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-md text-sm font-medium whitespace-nowrap text-muted-foreground transition-[color,box-shadow] outline-none hover:bg-accent/50 hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-accent aria-pressed:text-accent-foreground dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border border-input bg-transparent hover:bg-accent/50",
+      },
+      size: {
+        default:
+          "h-9 min-w-9 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+        sm: "h-8 min-w-8 px-2.5 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5",
+        lg: "h-10 min-w-10 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+)
+
+function Toggle({
+  className,
+  variant = "default",
+  size = "default",
+  ...props
+}: TogglePrimitive.Props & VariantProps<typeof toggleVariants>) {
+  return (
+    <TogglePrimitive
+      data-slot="toggle"
+      className={cn(toggleVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Toggle, toggleVariants }

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -7,6 +7,8 @@ import {
   enabledProviders,
   readEnabled,
   resolveDefaultProvider,
+  skipLevel,
+  skipLevelPair,
   skipPermissionFlags,
   skipPermissionsKey,
   type ProviderState,
@@ -41,6 +43,36 @@ describe("provider setting keys", () => {
     expect(skipPermissionFlags.opencode).toBe("--auto")
     expect(skipPermissionFlags.crush).toBe("--yolo")
     expect(skipPermissionFlags.omp).toBeUndefined()
+  })
+})
+
+describe("the skip-permissions ladder", () => {
+  it("folds the stored pair into a rung", () => {
+    expect(skipLevel(false, false)).toBe("never")
+    expect(skipLevel(false, true)).toBe("worktrees")
+    expect(skipLevel(true, true)).toBe("everywhere")
+  })
+
+  // The pair nothing offers any more: free rein in the tree you work in while
+  // the throwaway checkout still asks. It has to read as the rung it already
+  // behaved like in the project directory, not as the safer one above it.
+  it("reads the pair no rung writes as everywhere", () => {
+    expect(skipLevel(true, false)).toBe("everywhere")
+  })
+
+  it("writes both keys for the chosen rung", () => {
+    expect(skipLevelPair("never")).toEqual({ here: false, worktrees: false })
+    expect(skipLevelPair("worktrees")).toEqual({ here: false, worktrees: true })
+    expect(skipLevelPair("everywhere")).toEqual({ here: true, worktrees: true })
+  })
+
+  // A round trip through the control must not move a setting the user did not
+  // touch — opening the section and choosing what is already chosen is a no-op.
+  it("round-trips every rung", () => {
+    for (const level of ["never", "worktrees", "everywhere"] as const) {
+      const pair = skipLevelPair(level)
+      expect(skipLevel(pair.here, pair.worktrees)).toBe(level)
+    }
   })
 })
 

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -7,6 +7,7 @@ import {
   enabledProviders,
   readEnabled,
   resolveDefaultProvider,
+  skipPermissionFlags,
   skipPermissionsKey,
   type ProviderState,
 } from "./providers-store"
@@ -28,6 +29,18 @@ describe("provider setting keys", () => {
   it("keys the skip-permissions flag per provider and checkout scope", () => {
     expect(skipPermissionsKey("claude", false)).toBe("provider.claude.skip-permissions")
     expect(skipPermissionsKey("claude", true)).toBe("provider.claude.skip-permissions.worktree")
+  })
+
+  // Pinned literals, not a read-back of the map: this string is printed to the
+  // user beside the switch that hands an agent the machine, and it has to be
+  // the flag the Go spawn actually passes that provider. oh-my-pi has no
+  // confirmed spelling, so it must stay absent — that is what hides the switch.
+  it("spells the skip-permissions flag per provider, and only where one is wired", () => {
+    expect(skipPermissionFlags.claude).toBe("--dangerously-skip-permissions")
+    expect(skipPermissionFlags.codex).toBe("--dangerously-bypass-approvals-and-sandbox")
+    expect(skipPermissionFlags.opencode).toBe("--auto")
+    expect(skipPermissionFlags.crush).toBe("--yolo")
+    expect(skipPermissionFlags.omp).toBeUndefined()
   })
 })
 

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -38,6 +38,17 @@ export function skipPermissionsKey(id: string, worktree: boolean): string {
   return `provider.${id}.skip-permissions${worktree ? ".worktree" : ""}`
 }
 
+// skipPermissionFlags mirrors terminal.skipPermissionFlags in Go: how each
+// provider spells "run every tool without asking". Settings offers the switch
+// only for a provider listed here, so the UI cannot promise a flag the spawn
+// has no spelling for — which is what oh-my-pi's absence means.
+export const skipPermissionFlags: Record<string, string> = {
+  claude: "--dangerously-skip-permissions",
+  codex: "--dangerously-bypass-approvals-and-sandbox",
+  opencode: "--auto",
+  crush: "--yolo",
+}
+
 // readEnabled interprets the stored flag: Claude is enabled by default (it was
 // always offered before the providers feature), every other provider is opt-in.
 // An explicit "1"/"0" overrides the default.

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -49,6 +49,29 @@ export const skipPermissionFlags: Record<string, string> = {
   crush: "--yolo",
 }
 
+// How far a provider runs without asking, as one ladder ordered by risk. The
+// two settings keys stay exactly as they are — this is the shape the user
+// chooses in, not the shape lich stores.
+export type SkipLevel = "never" | "worktrees" | "everywhere"
+
+// skipLevel folds the stored pair into a rung. The fourth combination — skip in
+// the working tree, ask in worktrees — is the inversion of the whole argument
+// for the setting, and reads as "everywhere": it is what that pair already did
+// to the checkout the user works in.
+export function skipLevel(here: boolean, worktrees: boolean): SkipLevel {
+  if (here) {
+    return "everywhere"
+  }
+  return worktrees ? "worktrees" : "never"
+}
+
+// skipLevelPair is the inverse: the pair a chosen rung writes back. Composing
+// it with skipLevel is the identity on all three rungs, which is what keeps a
+// round trip through the control from moving a setting the user did not touch.
+export function skipLevelPair(level: SkipLevel): { here: boolean; worktrees: boolean } {
+  return { here: level === "everywhere", worktrees: level !== "never" }
+}
+
 // readEnabled interprets the stored flag: Claude is enabled by default (it was
 // always offered before the providers feature), every other provider is opt-in.
 // An explicit "1"/"0" overrides the default.

--- a/internal/terminal/command.go
+++ b/internal/terminal/command.go
@@ -34,11 +34,22 @@ const (
 // `/list-agents` prints.
 const claudeNameFlag = "--name"
 
-// claudeSkipPermissionsFlag runs Claude Code without its permission prompts:
-// every edit and every command goes through unconfirmed. Off unless the user
-// turned it on for this checkout's scope in Settings › Providers, which is what
-// store.SkipPermissions answers.
-const claudeSkipPermissionsFlag = "--dangerously-skip-permissions"
+// skipPermissionFlags is how each provider spells "run every tool without
+// asking": every edit and every command goes through unconfirmed. Off unless the
+// user turned it on for this checkout's scope in Settings › Providers, which is
+// what store.SkipPermissions answers.
+//
+// Each spelling was read off that provider's own `--help` — they agree on
+// nothing, and a flag guessed from a sibling is a spawn that dies before the
+// session exists. oh-my-pi is absent because its spelling was never confirmed
+// against the binary; a provider missing here gets no flag rather than
+// somebody else's.
+var skipPermissionFlags = map[string]string{
+	providers.Claude:   "--dangerously-skip-permissions",
+	providers.Codex:    "--dangerously-bypass-approvals-and-sandbox",
+	providers.OpenCode: "--auto",
+	providers.Crush:    "--yolo",
+}
 
 // How each provider is handed an MCP server on its command line: Claude Code
 // takes a JSON string, Codex takes config overrides for its `mcp_servers`
@@ -107,14 +118,15 @@ func providerArgs(kind, name, resume, lichBin string, skipPermissions bool) []st
 }
 
 // skipPermissionArgs returns the flag that drops a provider's permission
-// prompts, or nil. Claude Code is the only spelling wired: the others each word
-// it differently, and none of them is turned on by a setting that says Claude —
-// a stray true must not reach a shell or opencode/crush either.
+// prompts, or nil when it is off or the provider has no spelling wired — a
+// stray true must not reach a shell either. The setting is stored per provider,
+// so the true that arrives here was ticked for this kind and no other.
 func skipPermissionArgs(kind string, skip bool) []string {
-	if !skip || kind != providers.Claude {
+	flag, ok := skipPermissionFlags[kind]
+	if !skip || !ok {
 		return nil
 	}
-	return []string{claudeSkipPermissionsFlag}
+	return []string{flag}
 }
 
 // mcpArgs registers lich's own MCP server with the provider being spawned, so

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -538,9 +538,11 @@ func TestNameArgs(t *testing.T) {
 	}
 }
 
-// TestSkipPermissionArgs proves the setting only ever arms Claude Code's flag,
-// and only when it is on: the other providers word it differently, so a true
-// meant for Claude must not be spelled at a shell or at opencode/crush.
+// TestSkipPermissionArgs proves each provider gets its own spelling and only
+// when the setting is on. The literals are pinned rather than read back from
+// skipPermissionFlags: this is the flag that hands an agent the machine, and a
+// test that follows the map would keep passing while the map handed opencode
+// Claude Code's flag. A kind with no spelling — a shell, oh-my-pi — gets none.
 func TestSkipPermissionArgs(t *testing.T) {
 	cases := []struct {
 		name, kind string
@@ -549,8 +551,11 @@ func TestSkipPermissionArgs(t *testing.T) {
 	}{
 		{"claude off", "claude", false, nil},
 		{"claude on", "claude", true, []string{"--dangerously-skip-permissions"}},
-		{"codex is not wired", "codex", true, nil},
-		{"opencode is not wired", "opencode", true, nil},
+		{"codex off", "codex", false, nil},
+		{"codex on", "codex", true, []string{"--dangerously-bypass-approvals-and-sandbox"}},
+		{"opencode on", "opencode", true, []string{"--auto"}},
+		{"crush on", "crush", true, []string{"--yolo"}},
+		{"oh-my-pi is not wired", "omp", true, nil},
 		{"shell is never wired", KindShell, true, nil},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## What

Two things, in order:

1. The skip-permissions setting reaches **every provider lich has a flag spelling for**, not only Claude Code.
2. The **two switches become one ladder** — `Never · Worktrees only · Everywhere`.

The setting was always keyed per provider (`provider.<id>.skip-permissions`), but `skipPermissionArgs` returned nil for anything that was not Claude, and Settings only drew the switches inside the Claude Code section. The storage was general; the feature was not.

## The flags

Read off each binary's own `--help` on a machine that has them, rather than guessed from a sibling:

| provider | flag | measured against |
| --- | --- | --- |
| Claude Code | `--dangerously-skip-permissions` | 2.1.228 |
| Codex | `--dangerously-bypass-approvals-and-sandbox` | codex-cli 0.144.5 (accepted after `resume <id>` too) |
| opencode | `--auto` | 1.18.16 |
| Crush | `-y` / `--yolo` | v0.88.0 |

oh-my-pi is absent: its spelling was never confirmed against the binary, and a flag a CLI does not know is a session that dies before it opens (`claude --bogus` exits immediately with `error: unknown option`). The absence is load-bearing — Settings offers the control only for a provider in the map, so the UI can never store a preference the spawn has no way to honour. The description names the flag it will pass.

## Why one control

Two independent booleans express four states. One of them is the inversion of the argument the setting exists for — skip in the working tree, ask in the worktree — and two clicks reached it with nothing saying it was the worst of the four.

The ladder is ordered by risk and carries a line under it naming what the chosen rung leaves asking. Storage does not move: the rung writes the same two keys, so the Go spawn is untouched and there is no migration. A saved fourth state reads as *Everywhere*, which is what that pair already did to the checkout the user works in.

`ToggleGroup` came from `shadcn add toggle-group` (base-ui) — the segmented control was specified in DESIGN.md with no implementation — and was adapted to the idiom before first use: ghost options in a bordered track, selection a flat `bg-accent` fill, no shadow. Pressing the pressed rung clears a base-ui toggle group, so the empty selection is ignored.

## Also

`INSTALL.md` gains the version floor that was implied and never written down: lich passes Claude Code `--name`, added in 2.1.76, so an older build exits with an unknown-option error that reads as lich failing to start the session.

## Test plan

- [x] `go test ./...` — 28 packages ok, real exit code read unproxied
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] Cross-compile loop: `GOOS=linux|darwin|windows go build ./... && go vet ./...` all ok
- [x] `vitest run` — 824 tests, 75 files; `biome check` clean; `tsc --noEmit` clean; `vite build` ok
- [x] `TestSkipPermissionArgs` extended with pinned literals per provider (and the two that must yield nothing: oh-my-pi, shell); the frontend flag map pinned the same way rather than read back from itself
- [x] Ladder mapping unit-tested both ways, including the round trip and the unreachable pair
- [x] Smoked headless in a real window (isolated `XDG_CONFIG_HOME`, CDP): the group renders, selection moves, the consequence line follows, the rung survives a full reload off the store, and pressing the pressed rung leaves it pressed