### PR TITLE
feat: collapse the session sidebar into a rail of status rings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Pinned sessions get a block of their own.** A pin used to lift a card to the
+  top of the list and, with it, the whole worktree block it belonged to — so
+  pinning one session quietly reordered a group you had arranged by hand. Now
+  the pinned cards gather under a `Pinned` divider above everything else, in the
+  same shape as the worktree dividers beside it, and their old blocks stay put.
+  Each card still names its own directory and branch, so a pin never costs you
+  the checkout it belongs to, and unpinning still drops the card back among the
+  neighbours it was lifted over. `Ctrl/Cmd + Shift + ↓/↑` walks the new order,
+  and dragging inside one block no longer moves the blocks around it.
+
 - **The session sidebar collapses to a rail.** `Ctrl/Cmd + Shift + S`, or the
   button beside New Session, narrows the list to a 3rem column: one provider
   glyph per session, each still wearing the status ring it wears on its card, in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   glyph per session, each still wearing the status ring it wears on its card, in
   the same order and under the same worktree grouping — a hairline where the
   open sidebar draws a titled divider, since a checkout's name does not fit.
-  Hover names the session and its directory.
+  Hover gives you the card's own tooltip, unabridged — directory, the name the
+  session answers to, branch, pull request, diff and how it stands against its
+  base — because at that width the tooltip is where the card's words go.
 
   The rail selects a session and starts one, and that is deliberately all of it:
   renaming, closing, pinning, reordering and the worktree menus all aim at a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The session sidebar collapses to a rail.** `Ctrl/Cmd + Shift + S`, or the
+  button beside New Session, narrows the list to a 3rem column: one provider
+  glyph per session, each still wearing the status ring it wears on its card, in
+  the same order and under the same worktree grouping — a hairline where the
+  open sidebar draws a titled divider, since a checkout's name does not fit.
+  Hover names the session and its directory.
+
+  The rail selects a session and starts one, and that is deliberately all of it:
+  renaming, closing, pinning, reordering and the worktree menus all aim at a
+  32px target for something the open sidebar already does better, so the rail
+  sends you back to it rather than growing a poorer copy of the card. Collapsed
+  is never *gone* — the rings are what a list of running agents is read for, and
+  hiding them to win the width would be the wrong trade. Whether it is open or
+  railed survives a restart.
+
 - **The shortcuts are readable without going looking for them, and there are
   more of them.** `Ctrl/Cmd + /` opens a list of every keyboard shortcut lich
   has — the rebindable ones with the combos *this* install has them on, and the

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,9 +2,11 @@ import { useEffect, useRef, useState } from "react"
 import { HashRouter, Outlet, Route, Routes } from "react-router-dom"
 import { SettingsProvider, useSettings } from "@/providers/settings"
 import { useHotkey } from "@/lib/use-hotkey"
+import { parseBoolPref, readPref, writePref } from "@/lib/prefs"
 import { ProjectsProvider } from "@/providers/projects"
 import { ProjectTabs } from "@/components/tabs/ProjectTabs"
 import { SessionSidebar } from "@/components/sidebar/SessionSidebar"
+import { SidebarRail } from "@/components/sidebar/SidebarRail"
 import { TerminalHost } from "@/components/TerminalHost"
 import { RightDock, type DockTab } from "@/components/dock/RightDock"
 import { FooterBar } from "@/components/FooterBar"
@@ -21,12 +23,24 @@ import { UncleanExitGate } from "@/components/UncleanExitGate"
 import { CommandPalette } from "@/components/CommandPalette"
 import { ShortcutsOverlay } from "@/components/ShortcutsOverlay"
 
+// Named here like every other `lich.*` pref rather than spelled at the call
+// site. Unlike the dock — opened for a task and closed after it — a hidden
+// sidebar is a layout choice, so it survives a restart.
+const SIDEBAR_KEY = "lich.sidebar.open"
+
 // Layout is persistent across navigation: the project tabs, session sidebar and
 // TerminalHost stay mounted while the Outlet swaps screens (Home, Settings) on
 // top of the terminals.
 function Layout() {
   const { hotkeys } = useSettings()
   const [dock, setDock] = useState<DockTab | null>(null)
+  const [sidebar, setSidebar] = useState(() => parseBoolPref(readPref(SIDEBAR_KEY), true))
+  const toggleSidebar = () => {
+    const open = !sidebar
+    setSidebar(open)
+    writePref(SIDEBAR_KEY, open)
+  }
+  useHotkey(hotkeys.toggleSidebar, toggleSidebar)
   const toggleDock = (tab: DockTab) => setDock((cur) => (cur === tab ? null : tab))
   // The shortcut toggles the dock as a whole, so it reopens on the tab it was
   // last showing — the two tabs have their own footer buttons.
@@ -41,7 +55,14 @@ function Layout() {
     <div className="flex h-screen w-screen flex-col bg-background">
       <ProjectTabs />
       <div className="flex flex-1 overflow-hidden">
-        <SessionSidebar />
+        {/* Collapsed is a rail, never nothing: the status rings are what a list
+            of running agents is read for, and hiding them to win 12rem of
+            terminal is a trade the width alone does not pay for. */}
+        {sidebar ? (
+          <SessionSidebar onCollapse={toggleSidebar} />
+        ) : (
+          <SidebarRail onExpand={toggleSidebar} />
+        )}
         <main className="flex flex-1 flex-col overflow-hidden">
           {/* relative: RightDock overlays this area when in full screen. */}
           <div className="relative flex flex-1 overflow-hidden">

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -20,7 +20,7 @@ import { cn } from "@/lib/utils"
 import { dragStyle } from "@/lib/use-sortable-list"
 import { displayPath } from "@/lib/paths"
 import type { Session } from "@/lib/session/sessions"
-import { peerMention, peerName } from "@/lib/session/peer-name"
+import { peerMention } from "@/lib/session/peer-name"
 import { useSessionStatus, useSessionStatusAge } from "@/lib/session/use-session-status"
 import { useSessionCwd } from "@/lib/session/use-session-cwd"
 import { useSessionAgent } from "@/lib/session/use-session-agent"
@@ -33,7 +33,8 @@ import { usePullRequest } from "@/lib/pulls/use-pull-request"
 import { CloseButton } from "@/components/common/CloseButton"
 import { DiffStat } from "@/components/DiffStat"
 import { SessionStatusIcon } from "./SessionStatusIcon"
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { SessionTooltip } from "./SessionTooltip"
+import { Tooltip, TooltipTrigger } from "@/components/ui/tooltip"
 import {
   ContextMenu,
   ContextMenuContent,
@@ -381,62 +382,7 @@ export function SessionCard({
               )}
             </span>
           </ContextMenuTrigger>
-          <TooltipContent
-            side="right"
-            className="max-w-xs border border-border bg-card text-foreground"
-          >
-            <div className="flex flex-col gap-1.5">
-              <span className="font-medium">{session.label}</span>
-              <span className="break-all font-mono text-muted-foreground">{shownPath}</span>
-              {/* The name this session answers to when another Claude Code
-                  session messages it. Built from the start path, not the shown
-                  one: a `cd` in the terminal never renames a running session. */}
-              {session.kind === "claude" && (
-                <span className="flex items-center gap-1 font-mono text-muted-foreground">
-                  <AtSign className="size-3 shrink-0" />
-                  {peerName(session.path || path, session.id)}
-                </span>
-              )}
-              {git?.branch && (
-                <span className="flex flex-wrap items-center gap-2 text-muted-foreground">
-                  <span className="flex items-center gap-1">
-                    <GitBranch className="size-3 shrink-0" />
-                    {git.branch}
-                  </span>
-                  {pr && (
-                    <span className="flex items-center gap-1">
-                      <GitPullRequestArrow className="size-3 shrink-0" />#{pr.number}
-                    </span>
-                  )}
-                  {git.files > 0 && (
-                    <span className="flex items-center gap-1.5">
-                      <DiffStat added={git.added} deleted={git.deleted} />
-                    </span>
-                  )}
-                </span>
-              )}
-              {/* The base standing spelled out — the card itself has room for a
-                  glyph and a number, and this is the only place the branch it
-                  measures against is named. */}
-              {base?.behind && <span className="text-muted-foreground">{base.behind}</span>}
-              {base?.conflict && (
-                <span className="flex items-center gap-1 text-amber-500">
-                  <TriangleAlert className="size-3 shrink-0" />
-                  {base.conflict}
-                </span>
-              )}
-              {base && base.paths.length > 0 && (
-                <span className="flex flex-col gap-0.5 pl-4 text-muted-foreground">
-                  {base.paths.map((file) => (
-                    <span key={file} className="break-all font-mono">
-                      {file}
-                    </span>
-                  ))}
-                  {base.more > 0 && <span>+{base.more} more</span>}
-                </span>
-              )}
-            </div>
-          </TooltipContent>
+          <SessionTooltip session={session} path={path} />
         </Tooltip>
         <ContextMenuContent>
           {canMention && (

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils"
 import { checkoutLabel } from "@/lib/git/checkout-label"
 import type { MentionGroup } from "@/lib/session/mention-targets"
 import type { DelegateGroup } from "@/lib/session/delegate-targets"
-import { groupKey, type Session } from "@/lib/session/sessions"
+import type { Session } from "@/lib/session/sessions"
 import { useProjects } from "@/providers/projects"
 import { SessionCard } from "./SessionCard"
 import { PullRequestCard } from "./PullRequestCard"
@@ -15,7 +15,15 @@ import { isPullsOpen, subscribePullsCard } from "@/lib/pulls-card-store"
 
 interface SessionGroupProps {
   projectId: string
-  // "" for the project's own root, else the worktree checkout path.
+  // This block's sortable id — the checkout path, or a stand-in for the two
+  // blocks that have none (the project root, the pinned sessions).
+  sortId: string
+  // The block of pinned sessions, gathered from every checkout: titled after
+  // the pin rather than a worktree, no pull request of its own, and never
+  // dragged — it is always the first block.
+  pinned: boolean
+  // "" for the project's own root or the pinned block, else the worktree
+  // checkout path.
   path: string
   sessions: Session[]
   projectPath: string
@@ -58,6 +66,8 @@ interface SessionGroupProps {
 // sidebar, which keeps only the ones carrying its own state.
 export function SessionGroup({
   projectId,
+  sortId,
+  pinned,
   path,
   sessions,
   projectPath,
@@ -75,8 +85,8 @@ export function SessionGroup({
   const navigate = useNavigate()
   const ids = sessions.map((session) => session.id)
   const { sensors, onDragEnd } = useSortableList(ids, onReorder)
-  const name = checkoutLabel(path, projectPath, projectId)
-  const group = useSortable({ id: groupKey(path), disabled: !showHeader })
+  const name = pinned ? "Pinned" : checkoutLabel(path, projectPath, projectId)
+  const group = useSortable({ id: sortId, disabled: !showHeader || pinned })
   // The PR card keys off the group's real checkout — the project root for the
   // root group (empty path), else the worktree — so a root project on a feature
   // branch parks its card too, not only worktrees.
@@ -101,7 +111,7 @@ export function SessionGroup({
     >
       {showHeader && (
         <div
-          className="flex cursor-grab items-center gap-2 px-1 pb-0.5 pt-1.5"
+          className={cn("flex items-center gap-2 px-1 pb-0.5 pt-1.5", !pinned && "cursor-grab")}
           {...group.attributes}
           {...group.listeners}
         >
@@ -138,7 +148,9 @@ export function SessionGroup({
           </div>
         </SortableContext>
       </DndContext>
-      {pullsOpen && (
+      {/* The pinned block spans every checkout, so no single pull request
+          belongs under it — the card stays with the worktree's own block. */}
+      {!pinned && pullsOpen && (
         <PullRequestCard
           path={checkout}
           active={pullsActive}

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -31,11 +31,12 @@ import { useProjects } from "@/providers/projects"
 import { queueSetup } from "@/lib/terminal/setup-queue"
 import {
   activeSessionId,
-  groupByWorktree,
-  groupKey,
   orderGroups,
+  reorderSubset,
   sessionsOf,
-  sortPinned,
+  sidebarGroups,
+  type Session,
+  type SidebarGroup,
 } from "@/lib/session/sessions"
 import { useSortableList, verticalAxis } from "@/lib/use-sortable-list"
 import { CloseWorktreeDialog, ForceRemoveWorktreeDialog } from "./CloseWorktreeDialog"
@@ -103,16 +104,20 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   })
   const [worktreeOpen, setWorktreeOpen] = useState(false)
   // Resolved ahead of the no-project bail below: hooks cannot sit behind it.
-  // Pinned first, which also carries their worktree group to the top of the
-  // sidebar — groupByWorktree buckets by first appearance.
-  const list = sortPinned(sessionsOf(sessions, projectId ?? ""))
+  const list = sessionsOf(sessions, projectId ?? "")
   const worktreeClose = useWorktreeClose(projectId ?? "", path, list)
-  const groups = groupByWorktree(list)
-  // Dragging a group moves its whole block of sessions inside the flat list the
-  // groups are read back from — there is no separate group order to store.
-  const { sensors, onDragEnd } = useSortableList(
-    groups.map((group) => groupKey(group.path)),
-    (keys) => reorderSessions(projectId ?? "", orderGroups(groups, keys)),
+  const groups = sidebarGroups(list)
+  // The pinned block is out of the drag list entirely: it is always first, and
+  // the worktree blocks reorder among themselves. Dragging one moves its whole
+  // block of ids inside the flat list the groups are read back from — there is
+  // no separate group order to store — leaving the pinned sessions where they
+  // sit in it, so unpinning still drops a card among its old neighbours.
+  const dragKeys = groups.filter((group) => !group.pinned).map((group) => group.key)
+  const { sensors, onDragEnd } = useSortableList(dragKeys, (keys) =>
+    reorderSessions(
+      projectId ?? "",
+      reorderSubset(list, orderGroups(groups, keys), (session) => !session.pinned),
+    ),
   )
 
   if (!projectId) {
@@ -128,14 +133,14 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   // the view; its own sidebar entry reads as active instead.
   const activeId = onSettings || onPullsRoute ? "" : realActiveId
 
-  // A drag reorders one group only; splice its new order back into the flat list
-  // in group order and persist the whole thing. reorderSessions bails on any
-  // id-set mismatch, so a close that raced the drop drops the stale order.
-  const commitGroupOrder = (groupPath: string, ids: string[]) => {
-    const flat = groups.flatMap((group) =>
-      group.path === groupPath ? ids : group.sessions.map((session) => session.id),
-    )
-    reorderSessions(projectId, flat)
+  // A drag reorders one block only; hand its new order to that block's own
+  // sessions inside the flat list and persist the whole thing. reorderSessions
+  // bails on any id-set mismatch, so a close that raced the drop drops the
+  // stale order.
+  const commitGroupOrder = (group: SidebarGroup, ids: string[]) => {
+    const member = (session: Session) =>
+      group.pinned ? !!session.pinned : !session.pinned && (session.path ?? "") === group.path
+    reorderSessions(projectId, reorderSubset(list, ids, member))
   }
 
   const createWorktree = async (name: string, base: string, baseIsRemote: boolean) => {
@@ -249,24 +254,24 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
           modifiers={[verticalAxis]}
           onDragEnd={onDragEnd}
         >
-          <SortableContext
-            items={groups.map((group) => groupKey(group.path))}
-            strategy={verticalListSortingStrategy}
-          >
+          <SortableContext items={dragKeys} strategy={verticalListSortingStrategy}>
             {groups.map((group) => {
               const groupActive = group.sessions.some((s) => s.id === realActiveId)
               return (
                 <SessionGroup
-                  key={groupKey(group.path)}
+                  key={group.key}
+                  sortId={group.key}
+                  pinned={group.pinned}
                   projectId={projectId}
                   path={group.path}
                   sessions={group.sessions}
                   projectPath={path}
                   activeId={activeId}
-                  // The divider only earns its place once a worktree splits the
-                  // list; a lone group keeps the old flat, header-less look.
+                  // The divider only earns its place once a worktree — or a pin
+                  // — splits the list; a lone group keeps the old flat,
+                  // header-less look.
                   showHeader={groups.length > 1}
-                  onReorder={(ids) => commitGroupOrder(group.path, ids)}
+                  onReorder={(ids) => commitGroupOrder(group, ids)}
                   onClose={worktreeClose.requestClose}
                   pullsActive={onPullsRoute && groupActive}
                   onPulls={() => {

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -2,7 +2,7 @@ import { useState, useSyncExternalStore } from "react"
 import { useMatch, useNavigate } from "react-router-dom"
 import { DndContext, closestCenter } from "@dnd-kit/core"
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable"
-import { GitBranch, GitPullRequestArrow, Plus, Terminal } from "lucide-react"
+import { GitBranch, GitPullRequestArrow, PanelLeftClose, Plus, Terminal } from "lucide-react"
 import { ProjectService } from "@/lib/rpc"
 import { closeSettings, isSettingsOpen, subscribeSettingsCard } from "@/lib/settings-card-store"
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
@@ -53,6 +53,11 @@ const MIN_REM = 12
 const MAX_REM = 30
 const DEFAULT_REM = 15
 
+interface SessionSidebarProps {
+  // Collapses the sidebar to its rail (SidebarRail), which carries the way back.
+  onCollapse: () => void
+}
+
 // SessionSidebar lists the active project's sessions and can be drag-resized
 // within a fixed pixel range. Width persists across restarts. It renders nothing
 // when no project is active (Home, Settings), so it never competes with those
@@ -60,7 +65,7 @@ const DEFAULT_REM = 15
 //
 // Resizing only changes this element's width; the terminal keeps its PTY in sync
 // on its own via a ResizeObserver, so the sidebar does not need to know about it.
-export function SessionSidebar() {
+export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   const {
     projects,
     sessions,
@@ -153,45 +158,56 @@ export function SessionSidebar() {
       className="relative flex shrink-0 flex-col border-r border-border bg-sidebar p-2"
       style={{ width: `${width}rem` }}
     >
-      <DropdownMenu>
-        <DropdownMenuTrigger
-          title="New session"
-          aria-label="New session"
-          render={
-            <Button
-              variant="ghost"
-              className="mb-2 w-full justify-start gap-2 text-foreground hover:bg-accent aria-expanded:bg-accent"
-            />
-          }
-        >
-          <Plus className="size-4 text-muted-foreground" />
-          New Session
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="max-w-56">
-          <DropdownMenuGroup>
-            {enabled.map((provider) => (
-              <DropdownMenuItem
-                key={provider.id}
-                onClick={() => newSession(projectId, provider.id)}
-              >
-                <ProviderIcon kind={provider.id} />
-                {provider.name}
+      <div className="mb-2 flex items-center gap-1">
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            title="New session"
+            aria-label="New session"
+            render={
+              <Button
+                variant="ghost"
+                className="w-full flex-1 justify-start gap-2 text-foreground hover:bg-accent aria-expanded:bg-accent"
+              />
+            }
+          >
+            <Plus className="size-4 text-muted-foreground" />
+            New Session
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="max-w-56">
+            <DropdownMenuGroup>
+              {enabled.map((provider) => (
+                <DropdownMenuItem
+                  key={provider.id}
+                  onClick={() => newSession(projectId, provider.id)}
+                >
+                  <ProviderIcon kind={provider.id} />
+                  {provider.name}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuItem onClick={() => newSession(projectId, "shell")}>
+                <Terminal />
+                Terminal
               </DropdownMenuItem>
-            ))}
-          </DropdownMenuGroup>
-          <DropdownMenuSeparator />
-          <DropdownMenuGroup>
-            <DropdownMenuItem onClick={() => newSession(projectId, "shell")}>
-              <Terminal />
-              Terminal
-            </DropdownMenuItem>
-            <DropdownMenuItem disabled={!git?.branch} onClick={() => setWorktreeOpen(true)}>
-              <GitBranch />
-              Worktree
-            </DropdownMenuItem>
-          </DropdownMenuGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
+              <DropdownMenuItem disabled={!git?.branch} onClick={() => setWorktreeOpen(true)}>
+                <GitBranch />
+                Worktree
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <Button
+          variant="ghost"
+          title="Collapse sidebar"
+          aria-label="Collapse sidebar"
+          onClick={onCollapse}
+          className="size-8 shrink-0 justify-center px-0 text-muted-foreground hover:bg-accent hover:text-foreground"
+        >
+          <PanelLeftClose className="size-4" />
+        </Button>
+      </div>
       {/* The scrollbar takes width, so it rides the aside's own padding (-mr-2)
           and the padding is re-applied inside — a gap between thumb and card
           when it shows, no shift in card width when it doesn't. */}

--- a/frontend/src/components/sidebar/SessionTooltip.tsx
+++ b/frontend/src/components/sidebar/SessionTooltip.tsx
@@ -1,0 +1,88 @@
+import { AtSign, GitBranch, GitPullRequestArrow, TriangleAlert } from "lucide-react"
+import type { Session } from "@/lib/session/sessions"
+import { peerName } from "@/lib/session/peer-name"
+import { useSessionCwd } from "@/lib/session/use-session-cwd"
+import { useGitStatus } from "@/lib/git/use-git-status"
+import { baseReadout } from "@/lib/git/base-status"
+import { usePullRequest } from "@/lib/pulls/use-pull-request"
+import { DiffStat } from "@/components/DiffStat"
+import { TooltipContent } from "@/components/ui/tooltip"
+
+interface SessionTooltipProps {
+  session: Session
+  // The project's own directory: the fallback for a session with neither a
+  // checkout of its own nor a reported cwd.
+  path: string
+}
+
+// Everything a session card knows, in words — its directory, the name it
+// answers to, its branch and how that branch stands against its base. Shared by
+// the card and the rail rather than each writing its own: collapsing the
+// sidebar takes the card's text away, so this is where the text goes, and two
+// versions of it would mean the rail quietly telling you less.
+//
+// It resolves its own readouts instead of taking them as props. The stores
+// behind them are keyed by path and shared (one git poller per repository), so
+// the second reader costs a subscription, not a second poll.
+export function SessionTooltip({ session, path }: SessionTooltipProps) {
+  const liveCwd = useSessionCwd(session.id)
+  const shownPath = liveCwd || session.path || path
+  const git = useGitStatus(shownPath)
+  const pr = usePullRequest(shownPath, git?.branch ?? "", git?.head ?? "")
+  const base = baseReadout(git?.base ?? null)
+  return (
+    <TooltipContent side="right" className="max-w-xs border border-border bg-card text-foreground">
+      <div className="flex flex-col gap-1.5">
+        <span className="font-medium">{session.label}</span>
+        <span className="break-all font-mono text-muted-foreground">{shownPath}</span>
+        {/* The name this session answers to when another Claude Code session
+            messages it. Built from the start path, not the shown one: a `cd` in
+            the terminal never renames a running session. */}
+        {session.kind === "claude" && (
+          <span className="flex items-center gap-1 font-mono text-muted-foreground">
+            <AtSign className="size-3 shrink-0" />
+            {peerName(session.path || path, session.id)}
+          </span>
+        )}
+        {git?.branch && (
+          <span className="flex flex-wrap items-center gap-2 text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <GitBranch className="size-3 shrink-0" />
+              {git.branch}
+            </span>
+            {pr && (
+              <span className="flex items-center gap-1">
+                <GitPullRequestArrow className="size-3 shrink-0" />#{pr.number}
+              </span>
+            )}
+            {git.files > 0 && (
+              <span className="flex items-center gap-1.5">
+                <DiffStat added={git.added} deleted={git.deleted} />
+              </span>
+            )}
+          </span>
+        )}
+        {/* The base standing spelled out — the card itself has room for a glyph
+            and a number, and this is the only place the branch it measures
+            against is named. */}
+        {base?.behind && <span className="text-muted-foreground">{base.behind}</span>}
+        {base?.conflict && (
+          <span className="flex items-center gap-1 text-amber-500">
+            <TriangleAlert className="size-3 shrink-0" />
+            {base.conflict}
+          </span>
+        )}
+        {base && base.paths.length > 0 && (
+          <span className="flex flex-col gap-0.5 pl-4 text-muted-foreground">
+            {base.paths.map((file) => (
+              <span key={file} className="break-all font-mono">
+                {file}
+              </span>
+            ))}
+            {base.more > 0 && <span>+{base.more} more</span>}
+          </span>
+        )}
+      </div>
+    </TooltipContent>
+  )
+}

--- a/frontend/src/components/sidebar/SidebarRail.tsx
+++ b/frontend/src/components/sidebar/SidebarRail.tsx
@@ -11,9 +11,9 @@ import {
   type Session,
 } from "@/lib/session/sessions"
 import { useSessionAgent } from "@/lib/session/use-session-agent"
-import { useSessionCwd } from "@/lib/session/use-session-cwd"
 import { useSessionStatus } from "@/lib/session/use-session-status"
 import { SessionStatusIcon } from "./SessionStatusIcon"
+import { SessionTooltip } from "./SessionTooltip"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 
 interface RailSessionProps {
@@ -29,10 +29,11 @@ interface RailSessionProps {
 // mark inside the status ring. The ring is the whole reason the rail exists —
 // collapsing the sidebar must not cost the readout you watch all day — so it is
 // drawn from the same component the card uses, not a second implementation.
+// Same for the tooltip: at this width it is the only place the card's words can
+// go, so it is the card's own tooltip, not a shortened one.
 function RailSession({ session, projectPath, active, onSelect }: RailSessionProps) {
   const status = useSessionStatus(session.id)
   const agent = useSessionAgent(session.id)
-  const cwd = useSessionCwd(session.id)
   return (
     <Tooltip>
       <TooltipTrigger
@@ -50,17 +51,7 @@ function RailSession({ session, projectPath, active, onSelect }: RailSessionProp
       >
         <SessionStatusIcon kind={agent ?? session.kind} status={status} />
       </TooltipTrigger>
-      <TooltipContent
-        side="right"
-        className="max-w-xs border border-border bg-card text-foreground"
-      >
-        <div className="flex flex-col gap-1">
-          <span className="font-medium">{session.label}</span>
-          <span className="break-all font-mono text-muted-foreground">
-            {cwd || session.path || projectPath}
-          </span>
-        </div>
-      </TooltipContent>
+      <SessionTooltip session={session} path={projectPath} />
     </Tooltip>
   )
 }

--- a/frontend/src/components/sidebar/SidebarRail.tsx
+++ b/frontend/src/components/sidebar/SidebarRail.tsx
@@ -1,0 +1,154 @@
+import { useMatch, useNavigate } from "react-router-dom"
+import { PanelLeft, Plus } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { useProjects } from "@/providers/projects"
+import {
+  activeSessionId,
+  groupByWorktree,
+  groupKey,
+  sessionsOf,
+  sortPinned,
+  type Session,
+} from "@/lib/session/sessions"
+import { useSessionAgent } from "@/lib/session/use-session-agent"
+import { useSessionCwd } from "@/lib/session/use-session-cwd"
+import { useSessionStatus } from "@/lib/session/use-session-status"
+import { SessionStatusIcon } from "./SessionStatusIcon"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+
+interface RailSessionProps {
+  session: Session
+  // The project's own directory, the fallback for a session with no path of its
+  // own and no cwd reported yet.
+  projectPath: string
+  active: boolean
+  onSelect: () => void
+}
+
+// One session, reduced to the glyph it already wears on its card: the provider
+// mark inside the status ring. The ring is the whole reason the rail exists —
+// collapsing the sidebar must not cost the readout you watch all day — so it is
+// drawn from the same component the card uses, not a second implementation.
+function RailSession({ session, projectPath, active, onSelect }: RailSessionProps) {
+  const status = useSessionStatus(session.id)
+  const agent = useSessionAgent(session.id)
+  const cwd = useSessionCwd(session.id)
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            onClick={onSelect}
+            aria-label={session.label}
+            className={cn(
+              "flex size-8 shrink-0 items-center justify-center rounded-md transition-colors hover:bg-accent/60",
+              active && "bg-accent text-accent-foreground",
+            )}
+          />
+        }
+      >
+        <SessionStatusIcon kind={agent ?? session.kind} status={status} />
+      </TooltipTrigger>
+      <TooltipContent
+        side="right"
+        className="max-w-xs border border-border bg-card text-foreground"
+      >
+        <div className="flex flex-col gap-1">
+          <span className="font-medium">{session.label}</span>
+          <span className="break-all font-mono text-muted-foreground">
+            {cwd || session.path || projectPath}
+          </span>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}
+
+interface SidebarRailProps {
+  onExpand: () => void
+}
+
+// SidebarRail is the collapsed session sidebar: the same list, the same order,
+// the same worktree grouping — one hairline where the open sidebar draws a
+// titled divider, since a checkout's name does not fit in 3rem.
+//
+// It selects and it creates, and that is all: no close, no rename, no context
+// menu, no drag. Every one of those aims at a 32px target for an action the
+// open sidebar already does better, so the rail sends you back to it instead of
+// growing a second, poorer copy of the card.
+export function SidebarRail({ onExpand }: SidebarRailProps) {
+  const { projects, sessions, newSession, activateSession } = useProjects()
+  const match = useMatch("/projects/:projectId/*")
+  const projectId = match?.params.projectId
+  const navigate = useNavigate()
+
+  if (!projectId) {
+    return null
+  }
+
+  const path = projects.find((p) => p.id === projectId)?.path ?? ""
+  const groups = groupByWorktree(sortPinned(sessionsOf(sessions, projectId)))
+  // Unlike the open sidebar, a full-screen route (Settings, Pulls) does not put
+  // the highlight out: those screens have no card of their own here to carry
+  // it, so dropping it would leave the rail with nothing lit at all.
+  const activeId = activeSessionId(sessions, projectId)
+
+  const select = (id: string) => {
+    activateSession(projectId, id)
+    navigate(`/projects/${projectId}`)
+  }
+
+  return (
+    <aside className="flex w-12 shrink-0 flex-col items-center gap-1 border-r border-border bg-sidebar py-2">
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              onClick={onExpand}
+              aria-label="Expand sidebar"
+              className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
+            />
+          }
+        >
+          <PanelLeft className="size-4" />
+        </TooltipTrigger>
+        <TooltipContent side="right">Expand sidebar</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              onClick={() => newSession(projectId)}
+              aria-label="New session"
+              className="flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent/60 hover:text-foreground"
+            />
+          }
+        >
+          <Plus className="size-4" />
+        </TooltipTrigger>
+        {/* No provider menu at this width: the plus spawns the default provider,
+            the same session the New session shortcut makes. */}
+        <TooltipContent side="right">New session</TooltipContent>
+      </Tooltip>
+      <div className="flex w-full flex-1 flex-col items-center gap-1 overflow-y-auto overflow-x-hidden">
+        {groups.map((group, index) => (
+          <div key={groupKey(group.path)} className="flex w-full flex-col items-center gap-1">
+            {index > 0 && <span className="my-1 h-px w-5 shrink-0 bg-border" />}
+            {group.sessions.map((session) => (
+              <RailSession
+                key={session.id}
+                session={session}
+                projectPath={path}
+                active={session.id === activeId}
+                onSelect={() => select(session.id)}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </aside>
+  )
+}

--- a/frontend/src/components/sidebar/SidebarRail.tsx
+++ b/frontend/src/components/sidebar/SidebarRail.tsx
@@ -2,14 +2,7 @@ import { useMatch, useNavigate } from "react-router-dom"
 import { PanelLeft, Plus } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useProjects } from "@/providers/projects"
-import {
-  activeSessionId,
-  groupByWorktree,
-  groupKey,
-  sessionsOf,
-  sortPinned,
-  type Session,
-} from "@/lib/session/sessions"
+import { activeSessionId, sessionsOf, sidebarGroups, type Session } from "@/lib/session/sessions"
 import { useSessionAgent } from "@/lib/session/use-session-agent"
 import { useSessionStatus } from "@/lib/session/use-session-status"
 import { SessionStatusIcon } from "./SessionStatusIcon"
@@ -79,7 +72,7 @@ export function SidebarRail({ onExpand }: SidebarRailProps) {
   }
 
   const path = projects.find((p) => p.id === projectId)?.path ?? ""
-  const groups = groupByWorktree(sortPinned(sessionsOf(sessions, projectId)))
+  const groups = sidebarGroups(sessionsOf(sessions, projectId))
   // Unlike the open sidebar, a full-screen route (Settings, Pulls) does not put
   // the highlight out: those screens have no card of their own here to carry
   // it, so dropping it would leave the rail with nothing lit at all.
@@ -126,7 +119,7 @@ export function SidebarRail({ onExpand }: SidebarRailProps) {
       </Tooltip>
       <div className="flex w-full flex-1 flex-col items-center gap-1 overflow-y-auto overflow-x-hidden">
         {groups.map((group, index) => (
-          <div key={groupKey(group.path)} className="flex w-full flex-col items-center gap-1">
+          <div key={group.key} className="flex w-full flex-col items-center gap-1">
             {index > 0 && <span className="my-1 h-px w-5 shrink-0 bg-border" />}
             {group.sessions.map((session) => (
               <RailSession

--- a/frontend/src/lib/hotkeys.ts
+++ b/frontend/src/lib/hotkeys.ts
@@ -16,6 +16,7 @@ export type HotkeyId =
   | "focusTerminal"
   | "nextProject"
   | "prevProject"
+  | "toggleSidebar"
   | "toggleDock"
   | "settings"
   | "pulls"
@@ -101,6 +102,12 @@ export const HOTKEY_ACTIONS: readonly HotkeyAction[] = [
     label: "Previous project",
     group: "view",
     combo: { mod: true, shift: true, alt: false, key: "ArrowLeft" },
+  },
+  {
+    id: "toggleSidebar",
+    label: "Toggle the session sidebar",
+    group: "view",
+    combo: { mod: true, shift: true, alt: false, key: "s" },
   },
   {
     id: "toggleDock",

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -12,17 +12,19 @@ import {
   isSessionKind,
   neighborSessionId,
   orderGroups,
+  PINNED_GROUP_KEY,
   projectOfSession,
   ROOT_GROUP_KEY,
   removeProject,
   renameSession,
   reorderSessions,
+  reorderSubset,
   restoreSession,
   resumableSession,
   sessionsOf,
   setActiveSession,
   setSessionPinned,
-  sortPinned,
+  sidebarGroups,
   type Session,
   type SessionKind,
   type SessionState,
@@ -266,25 +268,100 @@ describe("reorderSessions", () => {
   })
 })
 
-describe("sortPinned", () => {
-  it("hoists the pinned sessions, keeping both blocks in order", () => {
+describe("sidebarGroups", () => {
+  const ids = (groups: ReturnType<typeof sidebarGroups>) =>
+    groups.map((group) => [group.key, group.sessions.map((s) => s.id)])
+
+  it("draws one block per worktree when nothing is pinned", () => {
+    let state = addSession({}, P, "s1")
+    state = addSession(state, P, "wt1", "claude", "/wt/a")
+    expect(ids(sidebarGroups(sessionsOf(state, P)))).toEqual([
+      [ROOT_GROUP_KEY, ["s1"]],
+      ["/wt/a", ["wt1"]],
+    ])
+  })
+
+  it("lifts the pinned sessions into a first block, keeping stored order", () => {
     let state = setSessionPinned(buildState(4), P, "s3", true)
     state = setSessionPinned(state, P, "s1", true)
-    expect(sortPinned(sessionsOf(state, P)).map((s) => s.id)).toEqual(["s1", "s3", "s2", "s4"])
+    expect(ids(sidebarGroups(sessionsOf(state, P)))).toEqual([
+      [PINNED_GROUP_KEY, ["s1", "s3"]],
+      [ROOT_GROUP_KEY, ["s2", "s4"]],
+    ])
   })
 
-  it("returns the list untouched when nothing is pinned", () => {
-    const list = sessionsOf(buildState(3), P)
-    expect(sortPinned(list)).toBe(list)
+  // The block gathers cards from every checkout, so it is the one group whose
+  // sessions do not share a path — and it leaves their worktree blocks behind.
+  it("takes pinned sessions out of their worktree blocks", () => {
+    let state = addSession({}, P, "s1")
+    state = addSession(state, P, "a1", "claude", "/wt/a")
+    state = addSession(state, P, "b1", "claude", "/wt/b")
+    state = setSessionPinned(state, P, "a1", true)
+    expect(ids(sidebarGroups(sessionsOf(state, P)))).toEqual([
+      [PINNED_GROUP_KEY, ["a1"]],
+      [ROOT_GROUP_KEY, ["s1"]],
+      ["/wt/b", ["b1"]],
+    ])
   })
 
-  // The hoist is display-only, so unpinning drops a session back among the
+  // The block is display-only, so unpinning drops a session back among the
   // neighbours it was lifted over instead of stranding it on top.
   it("puts an unpinned session back where the stored order has it", () => {
     let state = setSessionPinned(buildState(3), P, "s3", true)
-    expect(sortPinned(sessionsOf(state, P)).map((s) => s.id)).toEqual(["s3", "s1", "s2"])
+    expect(ids(sidebarGroups(sessionsOf(state, P)))).toEqual([
+      [PINNED_GROUP_KEY, ["s3"]],
+      [ROOT_GROUP_KEY, ["s1", "s2"]],
+    ])
     state = setSessionPinned(state, P, "s3", false)
-    expect(sortPinned(sessionsOf(state, P)).map((s) => s.id)).toEqual(["s1", "s2", "s3"])
+    expect(ids(sidebarGroups(sessionsOf(state, P)))).toEqual([[ROOT_GROUP_KEY, ["s1", "s2", "s3"]]])
+  })
+
+  it("marks only the pinned block, and gives it no path", () => {
+    const state = setSessionPinned(buildState(2), P, "s2", true)
+    const groups = sidebarGroups(sessionsOf(state, P))
+    expect(groups.map((g) => [g.pinned, g.path])).toEqual([
+      [true, ""],
+      [false, ""],
+    ])
+  })
+
+  it("has no blocks at all for a project with no sessions", () => {
+    expect(sidebarGroups([])).toEqual([])
+  })
+})
+
+describe("reorderSubset", () => {
+  const s = (id: string, pinned?: boolean): Session => ({
+    id,
+    label: id,
+    kind: "shell",
+    ...(pinned ? { pinned } : {}),
+  })
+  const stored = [s("a"), s("p1", true), s("b"), s("c"), s("p2", true)]
+  const unpinned = (session: Session) => !session.pinned
+
+  it("reorders the subset and leaves every other session in place", () => {
+    expect(reorderSubset(stored, ["c", "a", "b"], unpinned)).toEqual(["c", "p1", "a", "b", "p2"])
+  })
+
+  it("reorders the pinned block without moving the sessions between them", () => {
+    expect(reorderSubset(stored, ["p2", "p1"], (x) => !!x.pinned)).toEqual([
+      "a",
+      "p2",
+      "b",
+      "c",
+      "p1",
+    ])
+  })
+
+  // A short list has to come back with a repeat, not a gap: reorderSessions
+  // rejects an id set that does not match, which is what drops a stale drag.
+  it("repeats rather than drops when the ids run out", () => {
+    expect(reorderSubset(stored, ["c"], unpinned)).toEqual(["c", "p1", "b", "c", "p2"])
+  })
+
+  it("leaves the order alone when the predicate picks nothing", () => {
+    expect(reorderSubset(stored, [], () => false)).toEqual(["a", "p1", "b", "c", "p2"])
   })
 })
 
@@ -301,7 +378,7 @@ describe("neighborSessionId", () => {
     expect(neighborSessionId(state, P, "s1", -1)).toBe("s3")
   })
 
-  // The sidebar draws sortPinned's order, so the walk has to follow it — a
+  // The sidebar draws the pinned block first, so the walk has to follow it — a
   // pinned session sits at the top of the list, not where it was created.
   it("walks the pinned order the sidebar shows", () => {
     const state = setSessionPinned(buildState(3), P, "s3", true) // s3, s1, s2
@@ -569,7 +646,7 @@ describe("orderGroups", () => {
     kind: "shell",
     ...(path ? { path } : {}),
   })
-  const groups = groupByWorktree([
+  const groups = sidebarGroups([
     s("r1"),
     s("r2"),
     s("a1", "/wt/a"),

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -231,16 +231,61 @@ export function renameSession(
   }
 }
 
-// sortPinned hoists the pinned sessions to the head of the list. The partition
-// is stable, so both blocks keep the order the drags gave them.
+// The pinned block's stand-in id, for the same reason ROOT_GROUP_KEY exists: it
+// is not a path. The block gathers sessions from every checkout, so it can
+// collide with no worktree — those paths are absolute.
+export const PINNED_GROUP_KEY = "__pinned__"
+
+// One block of the sidebar: the pinned sessions, or one worktree's.
+export interface SidebarGroup {
+  key: string
+  // True for the pinned block. It is not a checkout — no path of its own, no
+  // pull request, and it never moves: it is always drawn first.
+  pinned: boolean
+  // The checkout root ("" for the project's own directory), empty for pinned.
+  path: string
+  sessions: Session[]
+}
+
+// sidebarGroups splits a project's sessions into the blocks the sidebar draws:
+// the pinned ones first, in one block of their own, then one block per worktree
+// in first-appearance order. Each block keeps the stored (drag) order inside.
 //
-// It sorts for display and never writes the result back into the state: the
-// stored list stays in drag order, which is what lets an unpinned session drop
-// back among its old neighbours instead of being stranded on top. The store
-// hands back that same drag order, so a reload draws what the pin did live.
-export function sortPinned(sessions: Session[]): Session[] {
+// Pinning never rewrites the stored list — it only lifts a card into this first
+// block — which is what lets an unpinned session drop back among its old
+// neighbours instead of being stranded on top. The store hands that same order
+// back, so a reload draws what the pin did live.
+export function sidebarGroups(sessions: Session[]): SidebarGroup[] {
+  const groups: SidebarGroup[] = groupByWorktree(sessions.filter((s) => !s.pinned)).map(
+    (group) => ({
+      key: groupKey(group.path),
+      pinned: false,
+      path: group.path,
+      sessions: group.sessions,
+    }),
+  )
   const pinned = sessions.filter((s) => s.pinned)
-  return pinned.length === 0 ? sessions : [...pinned, ...sessions.filter((s) => !s.pinned)]
+  if (pinned.length === 0) {
+    return groups
+  }
+  return [{ key: PINNED_GROUP_KEY, pinned: true, path: "", sessions: pinned }, ...groups]
+}
+
+// reorderSubset returns the full id order that hands `ids` to the sessions the
+// predicate picks and leaves every other session exactly where it is. A drag
+// inside one block must not move the blocks around it, and the pinned block is
+// not even contiguous in the stored list — it is a filter over it.
+//
+// An `ids` that does not name that subset exactly yields a list with a repeat
+// (or a gap), which reorderSessions rejects wholesale — the same way it rejects
+// an order a close has raced.
+export function reorderSubset(
+  stored: Session[],
+  ids: string[],
+  member: (session: Session) => boolean,
+): string[] {
+  const queue = [...ids]
+  return stored.map((session) => (member(session) ? (queue.shift() ?? session.id) : session.id))
 }
 
 // neighborSessionId returns the session one step from `sessionId` in the order
@@ -252,16 +297,15 @@ export function sortPinned(sessions: Session[]): Session[] {
 // The order is the grouped one, not the stored flat list: a session opened in
 // the project root after a worktree one sits between its own group's cards in
 // the state and under them on screen, so walking the flat list would jump a
-// divider and come back.
+// divider and come back. Pinned cards are walked where they are drawn — in the
+// block at the top, not in the worktree they belong to.
 export function neighborSessionId(
   state: SessionState,
   projectId: string,
   sessionId: string,
   step: 1 | -1,
 ): string {
-  const sessions = groupByWorktree(sortPinned(sessionsOf(state, projectId))).flatMap(
-    (group) => group.sessions,
-  )
+  const sessions = sidebarGroups(sessionsOf(state, projectId)).flatMap((group) => group.sessions)
   if (sessions.length < 2) {
     return ""
   }
@@ -409,8 +453,8 @@ export function groupKey(path: string): string {
 // group means moving its whole block of ids. A key naming no group contributes
 // nothing, which makes the result fail reorderSessions' id-set check rather than
 // silently drop that group's sessions.
-export function orderGroups(groups: SessionGroup[], keys: string[]): string[] {
-  const byKey = new Map(groups.map((group) => [groupKey(group.path), group]))
+export function orderGroups(groups: SidebarGroup[], keys: string[]): string[] {
+  const byKey = new Map(groups.map((group) => [group.key, group]))
   return keys.flatMap((key) => byKey.get(key)?.sessions.map((session) => session.id) ?? [])
 }
 


### PR DESCRIPTION
## What

The session sidebar can be collapsed to a 3rem rail instead of being hidden: one provider glyph per session, each still wearing the status ring its card wears, in the same order and under the same worktree grouping — a hairline where the open sidebar draws a titled divider, since a checkout's name does not fit in 3rem. Hover names the session and its directory.

`Ctrl/Cmd + Shift + S` toggles it (rebindable in Settings › Hotkeys, listed in the `Ctrl/Cmd + /` overlay), and so does the button beside New Session. Whether the sidebar is open or railed is a pref, so it survives a restart.

## Why a rail and not nothing

Hiding the sidebar wins 12rem of terminal and costs the readout the list exists for: with four agents running, the rings are the thing you watch. A rail keeps them, and carries its own way back — a vanished sidebar has no affordance at all, which is what a footer button was standing in for in the first draft.

## What the rail deliberately does not do

It selects a session and starts one. Rename, close, pin, reorder and the worktree menus all aim at a 32px target for something the open sidebar already does better, so the rail sends you back to it rather than growing a second, poorer copy of `SessionCard`. Group order is frozen while collapsed for the same reason: the drag handle is the group header, and the rail has no room for one.

## Notes

- `SidebarRail` reuses `SessionStatusIcon`, so there is exactly one implementation of the ring.
- The rail keeps the active highlight on a full-screen route (Settings, Pulls), unlike the open sidebar — those screens have no card of their own here to carry it, so dropping it would leave nothing lit.
- No provider menu on the rail's `+`: it spawns the default provider, the same session the New session shortcut makes.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` clean (backend untouched, run anyway)
- [x] `pnpm check`, `tsc --noEmit`, `vite build`, `vitest run` (819 tests) green
- [x] Headless smoke over CDP against an isolated instance: 240px → 48px → 240px, four sessions across two groups with one seam, emerald/busy/amber rings from live `/hook` reports, tooltip resolving, zero exceptions or console errors
- [ ] Eyes on it in a real window — the rail with a full list, and how a fresh session lands in it