### PR TITLE
feat: give pinned sessions a block of their own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Pinned sessions get a block of their own.** A pin used to lift a card to the
+  top of the list and, with it, the whole worktree block it belonged to — so
+  pinning one session quietly reordered a group you had arranged by hand. Now
+  the pinned cards gather under a `Pinned` divider above everything else, in the
+  same shape as the worktree dividers beside it, and their old blocks stay put.
+  Each card still names its own directory and branch, so a pin never costs you
+  the checkout it belongs to, and unpinning still drops the card back among the
+  neighbours it was lifted over. `Ctrl/Cmd + Shift + ↓/↑` walks the new order,
+  and dragging inside one block no longer moves the blocks around it.
+
 - **The session sidebar collapses to a rail.** `Ctrl/Cmd + Shift + S`, or the
   button beside New Session, narrows the list to a 3rem column: one provider
   glyph per session, each still wearing the status ring it wears on its card, in

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils"
 import { checkoutLabel } from "@/lib/git/checkout-label"
 import type { MentionGroup } from "@/lib/session/mention-targets"
 import type { DelegateGroup } from "@/lib/session/delegate-targets"
-import { groupKey, type Session } from "@/lib/session/sessions"
+import type { Session } from "@/lib/session/sessions"
 import { useProjects } from "@/providers/projects"
 import { SessionCard } from "./SessionCard"
 import { PullRequestCard } from "./PullRequestCard"
@@ -15,7 +15,15 @@ import { isPullsOpen, subscribePullsCard } from "@/lib/pulls-card-store"
 
 interface SessionGroupProps {
   projectId: string
-  // "" for the project's own root, else the worktree checkout path.
+  // This block's sortable id — the checkout path, or a stand-in for the two
+  // blocks that have none (the project root, the pinned sessions).
+  sortId: string
+  // The block of pinned sessions, gathered from every checkout: titled after
+  // the pin rather than a worktree, no pull request of its own, and never
+  // dragged — it is always the first block.
+  pinned: boolean
+  // "" for the project's own root or the pinned block, else the worktree
+  // checkout path.
   path: string
   sessions: Session[]
   projectPath: string
@@ -58,6 +66,8 @@ interface SessionGroupProps {
 // sidebar, which keeps only the ones carrying its own state.
 export function SessionGroup({
   projectId,
+  sortId,
+  pinned,
   path,
   sessions,
   projectPath,
@@ -75,8 +85,8 @@ export function SessionGroup({
   const navigate = useNavigate()
   const ids = sessions.map((session) => session.id)
   const { sensors, onDragEnd } = useSortableList(ids, onReorder)
-  const name = checkoutLabel(path, projectPath, projectId)
-  const group = useSortable({ id: groupKey(path), disabled: !showHeader })
+  const name = pinned ? "Pinned" : checkoutLabel(path, projectPath, projectId)
+  const group = useSortable({ id: sortId, disabled: !showHeader || pinned })
   // The PR card keys off the group's real checkout — the project root for the
   // root group (empty path), else the worktree — so a root project on a feature
   // branch parks its card too, not only worktrees.
@@ -101,7 +111,7 @@ export function SessionGroup({
     >
       {showHeader && (
         <div
-          className="flex cursor-grab items-center gap-2 px-1 pb-0.5 pt-1.5"
+          className={cn("flex items-center gap-2 px-1 pb-0.5 pt-1.5", !pinned && "cursor-grab")}
           {...group.attributes}
           {...group.listeners}
         >
@@ -138,7 +148,9 @@ export function SessionGroup({
           </div>
         </SortableContext>
       </DndContext>
-      {pullsOpen && (
+      {/* The pinned block spans every checkout, so no single pull request
+          belongs under it — the card stays with the worktree's own block. */}
+      {!pinned && pullsOpen && (
         <PullRequestCard
           path={checkout}
           active={pullsActive}

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -31,11 +31,12 @@ import { useProjects } from "@/providers/projects"
 import { queueSetup } from "@/lib/terminal/setup-queue"
 import {
   activeSessionId,
-  groupByWorktree,
-  groupKey,
   orderGroups,
+  reorderSubset,
   sessionsOf,
-  sortPinned,
+  sidebarGroups,
+  type Session,
+  type SidebarGroup,
 } from "@/lib/session/sessions"
 import { useSortableList, verticalAxis } from "@/lib/use-sortable-list"
 import { CloseWorktreeDialog, ForceRemoveWorktreeDialog } from "./CloseWorktreeDialog"
@@ -103,16 +104,20 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   })
   const [worktreeOpen, setWorktreeOpen] = useState(false)
   // Resolved ahead of the no-project bail below: hooks cannot sit behind it.
-  // Pinned first, which also carries their worktree group to the top of the
-  // sidebar — groupByWorktree buckets by first appearance.
-  const list = sortPinned(sessionsOf(sessions, projectId ?? ""))
+  const list = sessionsOf(sessions, projectId ?? "")
   const worktreeClose = useWorktreeClose(projectId ?? "", path, list)
-  const groups = groupByWorktree(list)
-  // Dragging a group moves its whole block of sessions inside the flat list the
-  // groups are read back from — there is no separate group order to store.
-  const { sensors, onDragEnd } = useSortableList(
-    groups.map((group) => groupKey(group.path)),
-    (keys) => reorderSessions(projectId ?? "", orderGroups(groups, keys)),
+  const groups = sidebarGroups(list)
+  // The pinned block is out of the drag list entirely: it is always first, and
+  // the worktree blocks reorder among themselves. Dragging one moves its whole
+  // block of ids inside the flat list the groups are read back from — there is
+  // no separate group order to store — leaving the pinned sessions where they
+  // sit in it, so unpinning still drops a card among its old neighbours.
+  const dragKeys = groups.filter((group) => !group.pinned).map((group) => group.key)
+  const { sensors, onDragEnd } = useSortableList(dragKeys, (keys) =>
+    reorderSessions(
+      projectId ?? "",
+      reorderSubset(list, orderGroups(groups, keys), (session) => !session.pinned),
+    ),
   )
 
   if (!projectId) {
@@ -128,14 +133,14 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   // the view; its own sidebar entry reads as active instead.
   const activeId = onSettings || onPullsRoute ? "" : realActiveId
 
-  // A drag reorders one group only; splice its new order back into the flat list
-  // in group order and persist the whole thing. reorderSessions bails on any
-  // id-set mismatch, so a close that raced the drop drops the stale order.
-  const commitGroupOrder = (groupPath: string, ids: string[]) => {
-    const flat = groups.flatMap((group) =>
-      group.path === groupPath ? ids : group.sessions.map((session) => session.id),
-    )
-    reorderSessions(projectId, flat)
+  // A drag reorders one block only; hand its new order to that block's own
+  // sessions inside the flat list and persist the whole thing. reorderSessions
+  // bails on any id-set mismatch, so a close that raced the drop drops the
+  // stale order.
+  const commitGroupOrder = (group: SidebarGroup, ids: string[]) => {
+    const member = (session: Session) =>
+      group.pinned ? !!session.pinned : !session.pinned && (session.path ?? "") === group.path
+    reorderSessions(projectId, reorderSubset(list, ids, member))
   }
 
   const createWorktree = async (name: string, base: string, baseIsRemote: boolean) => {
@@ -249,24 +254,24 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
           modifiers={[verticalAxis]}
           onDragEnd={onDragEnd}
         >
-          <SortableContext
-            items={groups.map((group) => groupKey(group.path))}
-            strategy={verticalListSortingStrategy}
-          >
+          <SortableContext items={dragKeys} strategy={verticalListSortingStrategy}>
             {groups.map((group) => {
               const groupActive = group.sessions.some((s) => s.id === realActiveId)
               return (
                 <SessionGroup
-                  key={groupKey(group.path)}
+                  key={group.key}
+                  sortId={group.key}
+                  pinned={group.pinned}
                   projectId={projectId}
                   path={group.path}
                   sessions={group.sessions}
                   projectPath={path}
                   activeId={activeId}
-                  // The divider only earns its place once a worktree splits the
-                  // list; a lone group keeps the old flat, header-less look.
+                  // The divider only earns its place once a worktree — or a pin
+                  // — splits the list; a lone group keeps the old flat,
+                  // header-less look.
                   showHeader={groups.length > 1}
-                  onReorder={(ids) => commitGroupOrder(group.path, ids)}
+                  onReorder={(ids) => commitGroupOrder(group, ids)}
                   onClose={worktreeClose.requestClose}
                   pullsActive={onPullsRoute && groupActive}
                   onPulls={() => {

--- a/frontend/src/components/sidebar/SidebarRail.tsx
+++ b/frontend/src/components/sidebar/SidebarRail.tsx
@@ -2,14 +2,7 @@ import { useMatch, useNavigate } from "react-router-dom"
 import { PanelLeft, Plus } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useProjects } from "@/providers/projects"
-import {
-  activeSessionId,
-  groupByWorktree,
-  groupKey,
-  sessionsOf,
-  sortPinned,
-  type Session,
-} from "@/lib/session/sessions"
+import { activeSessionId, sessionsOf, sidebarGroups, type Session } from "@/lib/session/sessions"
 import { useSessionAgent } from "@/lib/session/use-session-agent"
 import { useSessionCwd } from "@/lib/session/use-session-cwd"
 import { useSessionStatus } from "@/lib/session/use-session-status"
@@ -88,7 +81,7 @@ export function SidebarRail({ onExpand }: SidebarRailProps) {
   }
 
   const path = projects.find((p) => p.id === projectId)?.path ?? ""
-  const groups = groupByWorktree(sortPinned(sessionsOf(sessions, projectId)))
+  const groups = sidebarGroups(sessionsOf(sessions, projectId))
   // Unlike the open sidebar, a full-screen route (Settings, Pulls) does not put
   // the highlight out: those screens have no card of their own here to carry
   // it, so dropping it would leave the rail with nothing lit at all.
@@ -135,7 +128,7 @@ export function SidebarRail({ onExpand }: SidebarRailProps) {
       </Tooltip>
       <div className="flex w-full flex-1 flex-col items-center gap-1 overflow-y-auto overflow-x-hidden">
         {groups.map((group, index) => (
-          <div key={groupKey(group.path)} className="flex w-full flex-col items-center gap-1">
+          <div key={group.key} className="flex w-full flex-col items-center gap-1">
             {index > 0 && <span className="my-1 h-px w-5 shrink-0 bg-border" />}
             {group.sessions.map((session) => (
               <RailSession

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -12,17 +12,19 @@ import {
   isSessionKind,
   neighborSessionId,
   orderGroups,
+  PINNED_GROUP_KEY,
   projectOfSession,
   ROOT_GROUP_KEY,
   removeProject,
   renameSession,
   reorderSessions,
+  reorderSubset,
   restoreSession,
   resumableSession,
   sessionsOf,
   setActiveSession,
   setSessionPinned,
-  sortPinned,
+  sidebarGroups,
   type Session,
   type SessionKind,
   type SessionState,
@@ -266,25 +268,100 @@ describe("reorderSessions", () => {
   })
 })
 
-describe("sortPinned", () => {
-  it("hoists the pinned sessions, keeping both blocks in order", () => {
+describe("sidebarGroups", () => {
+  const ids = (groups: ReturnType<typeof sidebarGroups>) =>
+    groups.map((group) => [group.key, group.sessions.map((s) => s.id)])
+
+  it("draws one block per worktree when nothing is pinned", () => {
+    let state = addSession({}, P, "s1")
+    state = addSession(state, P, "wt1", "claude", "/wt/a")
+    expect(ids(sidebarGroups(sessionsOf(state, P)))).toEqual([
+      [ROOT_GROUP_KEY, ["s1"]],
+      ["/wt/a", ["wt1"]],
+    ])
+  })
+
+  it("lifts the pinned sessions into a first block, keeping stored order", () => {
     let state = setSessionPinned(buildState(4), P, "s3", true)
     state = setSessionPinned(state, P, "s1", true)
-    expect(sortPinned(sessionsOf(state, P)).map((s) => s.id)).toEqual(["s1", "s3", "s2", "s4"])
+    expect(ids(sidebarGroups(sessionsOf(state, P)))).toEqual([
+      [PINNED_GROUP_KEY, ["s1", "s3"]],
+      [ROOT_GROUP_KEY, ["s2", "s4"]],
+    ])
   })
 
-  it("returns the list untouched when nothing is pinned", () => {
-    const list = sessionsOf(buildState(3), P)
-    expect(sortPinned(list)).toBe(list)
+  // The block gathers cards from every checkout, so it is the one group whose
+  // sessions do not share a path — and it leaves their worktree blocks behind.
+  it("takes pinned sessions out of their worktree blocks", () => {
+    let state = addSession({}, P, "s1")
+    state = addSession(state, P, "a1", "claude", "/wt/a")
+    state = addSession(state, P, "b1", "claude", "/wt/b")
+    state = setSessionPinned(state, P, "a1", true)
+    expect(ids(sidebarGroups(sessionsOf(state, P)))).toEqual([
+      [PINNED_GROUP_KEY, ["a1"]],
+      [ROOT_GROUP_KEY, ["s1"]],
+      ["/wt/b", ["b1"]],
+    ])
   })
 
-  // The hoist is display-only, so unpinning drops a session back among the
+  // The block is display-only, so unpinning drops a session back among the
   // neighbours it was lifted over instead of stranding it on top.
   it("puts an unpinned session back where the stored order has it", () => {
     let state = setSessionPinned(buildState(3), P, "s3", true)
-    expect(sortPinned(sessionsOf(state, P)).map((s) => s.id)).toEqual(["s3", "s1", "s2"])
+    expect(ids(sidebarGroups(sessionsOf(state, P)))).toEqual([
+      [PINNED_GROUP_KEY, ["s3"]],
+      [ROOT_GROUP_KEY, ["s1", "s2"]],
+    ])
     state = setSessionPinned(state, P, "s3", false)
-    expect(sortPinned(sessionsOf(state, P)).map((s) => s.id)).toEqual(["s1", "s2", "s3"])
+    expect(ids(sidebarGroups(sessionsOf(state, P)))).toEqual([[ROOT_GROUP_KEY, ["s1", "s2", "s3"]]])
+  })
+
+  it("marks only the pinned block, and gives it no path", () => {
+    const state = setSessionPinned(buildState(2), P, "s2", true)
+    const groups = sidebarGroups(sessionsOf(state, P))
+    expect(groups.map((g) => [g.pinned, g.path])).toEqual([
+      [true, ""],
+      [false, ""],
+    ])
+  })
+
+  it("has no blocks at all for a project with no sessions", () => {
+    expect(sidebarGroups([])).toEqual([])
+  })
+})
+
+describe("reorderSubset", () => {
+  const s = (id: string, pinned?: boolean): Session => ({
+    id,
+    label: id,
+    kind: "shell",
+    ...(pinned ? { pinned } : {}),
+  })
+  const stored = [s("a"), s("p1", true), s("b"), s("c"), s("p2", true)]
+  const unpinned = (session: Session) => !session.pinned
+
+  it("reorders the subset and leaves every other session in place", () => {
+    expect(reorderSubset(stored, ["c", "a", "b"], unpinned)).toEqual(["c", "p1", "a", "b", "p2"])
+  })
+
+  it("reorders the pinned block without moving the sessions between them", () => {
+    expect(reorderSubset(stored, ["p2", "p1"], (x) => !!x.pinned)).toEqual([
+      "a",
+      "p2",
+      "b",
+      "c",
+      "p1",
+    ])
+  })
+
+  // A short list has to come back with a repeat, not a gap: reorderSessions
+  // rejects an id set that does not match, which is what drops a stale drag.
+  it("repeats rather than drops when the ids run out", () => {
+    expect(reorderSubset(stored, ["c"], unpinned)).toEqual(["c", "p1", "b", "c", "p2"])
+  })
+
+  it("leaves the order alone when the predicate picks nothing", () => {
+    expect(reorderSubset(stored, [], () => false)).toEqual(["a", "p1", "b", "c", "p2"])
   })
 })
 
@@ -301,7 +378,7 @@ describe("neighborSessionId", () => {
     expect(neighborSessionId(state, P, "s1", -1)).toBe("s3")
   })
 
-  // The sidebar draws sortPinned's order, so the walk has to follow it — a
+  // The sidebar draws the pinned block first, so the walk has to follow it — a
   // pinned session sits at the top of the list, not where it was created.
   it("walks the pinned order the sidebar shows", () => {
     const state = setSessionPinned(buildState(3), P, "s3", true) // s3, s1, s2
@@ -569,7 +646,7 @@ describe("orderGroups", () => {
     kind: "shell",
     ...(path ? { path } : {}),
   })
-  const groups = groupByWorktree([
+  const groups = sidebarGroups([
     s("r1"),
     s("r2"),
     s("a1", "/wt/a"),

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -231,16 +231,61 @@ export function renameSession(
   }
 }
 
-// sortPinned hoists the pinned sessions to the head of the list. The partition
-// is stable, so both blocks keep the order the drags gave them.
+// The pinned block's stand-in id, for the same reason ROOT_GROUP_KEY exists: it
+// is not a path. The block gathers sessions from every checkout, so it can
+// collide with no worktree — those paths are absolute.
+export const PINNED_GROUP_KEY = "__pinned__"
+
+// One block of the sidebar: the pinned sessions, or one worktree's.
+export interface SidebarGroup {
+  key: string
+  // True for the pinned block. It is not a checkout — no path of its own, no
+  // pull request, and it never moves: it is always drawn first.
+  pinned: boolean
+  // The checkout root ("" for the project's own directory), empty for pinned.
+  path: string
+  sessions: Session[]
+}
+
+// sidebarGroups splits a project's sessions into the blocks the sidebar draws:
+// the pinned ones first, in one block of their own, then one block per worktree
+// in first-appearance order. Each block keeps the stored (drag) order inside.
 //
-// It sorts for display and never writes the result back into the state: the
-// stored list stays in drag order, which is what lets an unpinned session drop
-// back among its old neighbours instead of being stranded on top. The store
-// hands back that same drag order, so a reload draws what the pin did live.
-export function sortPinned(sessions: Session[]): Session[] {
+// Pinning never rewrites the stored list — it only lifts a card into this first
+// block — which is what lets an unpinned session drop back among its old
+// neighbours instead of being stranded on top. The store hands that same order
+// back, so a reload draws what the pin did live.
+export function sidebarGroups(sessions: Session[]): SidebarGroup[] {
+  const groups: SidebarGroup[] = groupByWorktree(sessions.filter((s) => !s.pinned)).map(
+    (group) => ({
+      key: groupKey(group.path),
+      pinned: false,
+      path: group.path,
+      sessions: group.sessions,
+    }),
+  )
   const pinned = sessions.filter((s) => s.pinned)
-  return pinned.length === 0 ? sessions : [...pinned, ...sessions.filter((s) => !s.pinned)]
+  if (pinned.length === 0) {
+    return groups
+  }
+  return [{ key: PINNED_GROUP_KEY, pinned: true, path: "", sessions: pinned }, ...groups]
+}
+
+// reorderSubset returns the full id order that hands `ids` to the sessions the
+// predicate picks and leaves every other session exactly where it is. A drag
+// inside one block must not move the blocks around it, and the pinned block is
+// not even contiguous in the stored list — it is a filter over it.
+//
+// An `ids` that does not name that subset exactly yields a list with a repeat
+// (or a gap), which reorderSessions rejects wholesale — the same way it rejects
+// an order a close has raced.
+export function reorderSubset(
+  stored: Session[],
+  ids: string[],
+  member: (session: Session) => boolean,
+): string[] {
+  const queue = [...ids]
+  return stored.map((session) => (member(session) ? (queue.shift() ?? session.id) : session.id))
 }
 
 // neighborSessionId returns the session one step from `sessionId` in the order
@@ -252,16 +297,15 @@ export function sortPinned(sessions: Session[]): Session[] {
 // The order is the grouped one, not the stored flat list: a session opened in
 // the project root after a worktree one sits between its own group's cards in
 // the state and under them on screen, so walking the flat list would jump a
-// divider and come back.
+// divider and come back. Pinned cards are walked where they are drawn — in the
+// block at the top, not in the worktree they belong to.
 export function neighborSessionId(
   state: SessionState,
   projectId: string,
   sessionId: string,
   step: 1 | -1,
 ): string {
-  const sessions = groupByWorktree(sortPinned(sessionsOf(state, projectId))).flatMap(
-    (group) => group.sessions,
-  )
+  const sessions = sidebarGroups(sessionsOf(state, projectId)).flatMap((group) => group.sessions)
   if (sessions.length < 2) {
     return ""
   }
@@ -409,8 +453,8 @@ export function groupKey(path: string): string {
 // group means moving its whole block of ids. A key naming no group contributes
 // nothing, which makes the result fail reorderSessions' id-set check rather than
 // silently drop that group's sessions.
-export function orderGroups(groups: SessionGroup[], keys: string[]): string[] {
-  const byKey = new Map(groups.map((group) => [groupKey(group.path), group]))
+export function orderGroups(groups: SidebarGroup[], keys: string[]): string[] {
+  const byKey = new Map(groups.map((group) => [group.key, group]))
   return keys.flatMap((key) => byKey.get(key)?.sessions.map((session) => session.id) ?? [])
 }
 


### PR DESCRIPTION
Stacked on #235 (the rail) — its base flips to `main` when that one merges. The overlap is two lines in `SidebarRail`, which reads the same grouping.

## What

Pinned sessions gather under their own `Pinned` divider above the worktree blocks, in the same shape as the dividers beside them.

## Why

Pinning hoisted a card to the head of the flat list, and `groupByWorktree` buckets by first appearance — so pinning one session carried its **whole worktree block** to the top of the sidebar. A pin is a statement about one card; it was silently reordering a group the user had arranged by hand.

## How

- `sidebarGroups` is now the single place the sidebar's order is decided. The rail and `neighborSessionId` (`Ctrl/Cmd + Shift + ↓/↑`) read it too, so the drawn order and the walked order cannot drift. It replaces `sortPinned`, which had no callers left.
- `reorderSubset` keeps a drag inside one block from moving the blocks around it. The stored list is one flat order shared by every block, and the pinned block is a *filter* over it rather than a contiguous run, so the old splice-by-group no longer describes it. A short id list comes back with a repeat, which `reorderSessions` rejects wholesale — the existing behaviour for an order a close has raced.
- Pinning still writes nothing but the flag, so unpinning drops a card back among the neighbours it was lifted over.
- The pinned block never drags (it is always first) and carries no `PullRequestCard`: it spans every checkout, so no single PR belongs under it.

## Notes

- Cards keep naming their own path and branch, so a pinned session pulled out of its worktree block is still self-identifying.
- With a pinned block on screen every block gets a divider, including the project root — the existing rule (`groups.length > 1`), now reachable without a worktree.

## Test plan

- [x] `pnpm check`, `tsc --noEmit`, `vite build`, `vitest run` (826 tests, 7 new across `sidebarGroups` and `reorderSubset`) green
- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` clean (backend untouched)
- [x] Headless smoke over CDP: three dividers in order (PINNED, GENTLE-COMET, RAPID-QUARTZ), pinned card keeping path and branch, two seams in the collapsed rail, zero exceptions
- [x] Eyes on it in a real window: pin/unpin round trip, and a drag inside a block while something is pinned