### PR TITLE
feat: filter the dock's file tree, and stop collapsing it on Back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The dock's file tree has a filter, and it keeps its place.** A field above
+  the tree narrows it to the paths matching what you type — every token has to
+  appear, so a directory name is a search too, and what it matches comes back
+  already expanded. Opening a file no longer collapses the tree behind it: the
+  preview covers the tree instead of replacing it, so Back lands on the folders
+  you opened, scrolled where you left them, with the file you were reading
+  marked.
+
 - **Skipping the permission prompts is no longer a Claude Code privilege, and it
   is now one control instead of two.** Every provider lich has a spelling for —
   Claude Code, Codex, opencode, Crush — gets the setting, wired to that

--- a/frontend/src/components/FileTree.tsx
+++ b/frontend/src/components/FileTree.tsx
@@ -19,6 +19,10 @@ interface FileTreeProps {
   /** Start folders expanded — a pull request's changed files, where every row
    * is part of the review. The repo browser starts collapsed instead. */
   defaultOpen?: boolean
+  /** Hold every folder open, whatever was toggled by hand — a filtered tree,
+   * where a match has to be visible without opening its ancestors first. The
+   * toggles are only suspended, so clearing the filter restores the browse. */
+  expandAll?: boolean
   /** Per-file diff counts keyed by path; a row with an entry shows its +/-. */
   stats?: Map<string, DiffFile>
   /** Right-click → Open in editor. Absent = no file context menu, which is the
@@ -36,6 +40,7 @@ export function FileTree({
   tree,
   active = null,
   defaultOpen = false,
+  expandAll = false,
   stats,
   onEditor,
   className,
@@ -44,7 +49,7 @@ export function FileTree({
   // The set holds the rows toggled *away* from defaultOpen, so a folder's state
   // survives its parent closing and reopening.
   const [toggled, setToggled] = useState<Set<string>>(new Set())
-  const isOpen = (path: string) => toggled.has(path) !== defaultOpen
+  const isOpen = (path: string) => expandAll || toggled.has(path) !== defaultOpen
 
   const toggle = (path: string) =>
     setToggled((prev) => {

--- a/frontend/src/components/dock/FilesPanel.tsx
+++ b/frontend/src/components/dock/FilesPanel.tsx
@@ -2,6 +2,7 @@ import { ChevronLeft } from "lucide-react"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { createPortal } from "react-dom"
 import { Notice } from "@/components/common/Notice"
+import { SearchInput } from "@/components/common/SearchInput"
 import { CommentBatch } from "@/components/diff/CommentBatch"
 import { InjectMenu } from "@/components/diff/InjectMenu"
 import { type Composer, ReviewSlot } from "@/components/diff/ReviewSlots"
@@ -10,6 +11,7 @@ import { threadSlots, type SlotElements } from "@/lib/codemirror-threads"
 import { formatLineRef, parseDiff, type DiffFile } from "@/lib/git/diff"
 import { buildTree, type TreeNode } from "@/lib/git/file-tree"
 import { COMPOSER_KEY } from "@/lib/pulls/review-slots"
+import { matchesQuery } from "@/lib/session/command-palette"
 import { addReviewComment } from "@/lib/review-comments"
 import { queuePaste } from "@/lib/terminal/paste-queue"
 import { useProjects } from "@/providers/projects"
@@ -34,10 +36,14 @@ export function FilesPanel() {
   const { newSession, activateSession } = useProjects()
   const inject = useInject(sessionId)
   const status = useGitStatus(path)
-  const [tree, setTree] = useState<TreeNode[] | null>(null)
+  const [files, setFiles] = useState<string[] | null>(null)
   const [stats, setStats] = useState<Map<string, DiffFile>>(new Map())
   const [failed, setFailed] = useState(false)
   const [open, setOpen] = useState<string | null>(null)
+  // Outlives the preview: after Back the tree still marks the file just read,
+  // which is where the eye left off.
+  const [selected, setSelected] = useState<string | null>(null)
+  const [query, setQuery] = useState("")
 
   const refresh = useCallback(async () => {
     if (!path) {
@@ -50,15 +56,22 @@ export function FilesPanel() {
         ProjectService.Tree(path),
         ProjectService.DiffText(path).catch(() => ""),
       ])
-      setTree(buildTree(files ?? []))
+      setFiles(files ?? [])
       setStats(diffStatsByPath(parseDiff(diffText)))
       setFailed(false)
     } catch {
-      setTree([])
+      setFiles([])
       setStats(new Map())
       setFailed(true)
     }
   }, [path])
+
+  // The filter reads the whole repo-relative path, so a directory name narrows
+  // the tree to what is under it — one field for both halves of "find a file".
+  const tree = useMemo(
+    () => (files === null ? null : buildTree(files.filter((file) => matchesQuery(file, query)))),
+    [files, query],
+  )
 
   // Same invalidation as the diff panel: the git-status poll doubles as the
   // signal, so a new or removed file shows up without a watcher.
@@ -66,9 +79,11 @@ export function FilesPanel() {
     void refresh()
   }, [refresh, status?.files, status?.added, status?.deleted])
 
-  // A worktree switch changes path; drop any preview from the old tree.
+  // A worktree switch changes path; drop any preview and filter from the old tree.
   useEffect(() => {
     setOpen(null)
+    setSelected(null)
+    setQuery("")
   }, [path])
 
   if (!projectId) {
@@ -97,23 +112,44 @@ export function FilesPanel() {
 
   return (
     <div className="flex h-full flex-col">
-      <div className="flex flex-1 flex-col overflow-hidden">
-        {open !== null ? (
-          <FilePreview
-            path={path}
-            rel={open}
-            onBack={() => setOpen(null)}
-            onInject={inject}
-            onComment={(lines, text) => addReviewComment(path, open, lines, text)}
-          />
-        ) : (
+      {/* The preview covers the tree instead of replacing it: the folders that
+          were opened to reach a file — and the scroll that got there — are the
+          tree's own state, and unmounting it throws both away on every Back. */}
+      <div className="relative flex flex-1 flex-col overflow-hidden">
+        <div className="flex h-full flex-col overflow-hidden">
+          <div className="shrink-0 border-b border-border p-1.5">
+            <SearchInput
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Filter by name"
+              aria-label="Filter files by name"
+              spellCheck={false}
+              className="h-7 text-xs"
+            />
+          </div>
           <TreeBody
             tree={tree}
+            query={query}
+            active={selected}
             stats={stats}
             failed={failed}
-            onOpen={setOpen}
+            onOpen={(rel) => {
+              setOpen(rel)
+              setSelected(rel)
+            }}
             onEditor={openInEditor}
           />
+        </div>
+        {open !== null && (
+          <div className="absolute inset-0 z-10 bg-sidebar">
+            <FilePreview
+              path={path}
+              rel={open}
+              onBack={() => setOpen(null)}
+              onInject={inject}
+              onComment={(lines, text) => addReviewComment(path, open, lines, text)}
+            />
+          </div>
         )}
       </div>
       {/* Below the tree as well as the preview: a batch written file by file
@@ -139,13 +175,18 @@ function diffStatsByPath(files: DiffFile[]): Map<string, DiffFile> {
 
 interface TreeBodyProps {
   tree: TreeNode[] | null
+  /** The filter the tree was narrowed by; empty means the whole checkout. */
+  query: string
+  /** The file last opened, so Back lands on a row that reads as current. */
+  active: string | null
   stats: Map<string, DiffFile>
   failed: boolean
   onOpen: (rel: string) => void
   onEditor: (rel: string) => void
 }
 
-function TreeBody({ tree, stats, failed, onOpen, onEditor }: TreeBodyProps) {
+function TreeBody({ tree, query, active, stats, failed, onOpen, onEditor }: TreeBodyProps) {
+  const filtering = query.trim() !== ""
   if (failed) {
     return <Notice>Not a git repository</Notice>
   }
@@ -153,11 +194,15 @@ function TreeBody({ tree, stats, failed, onOpen, onEditor }: TreeBodyProps) {
     return <Notice>Loading…</Notice>
   }
   if (tree.length === 0) {
-    return <Notice>No tracked files</Notice>
+    return <Notice>{filtering ? "No file matches" : "No tracked files"}</Notice>
   }
   return (
     <FileTree
       tree={tree}
+      active={active}
+      // Suspended, not replaced: clearing the filter gives back the folders the
+      // browse had open rather than a tree collapsed to the root.
+      expandAll={filtering}
       stats={stats}
       onEditor={onEditor}
       className="h-full overflow-y-auto"


### PR DESCRIPTION
## What

Two things about the Code dock, both about finding a file without spelunking directory by directory.

**A filter.** A field above the tree narrows it to the paths matching what you type. It reuses the command palette's `matchesQuery`, so every whitespace-separated token has to appear in the repo-relative path — `dock files` finds `frontend/src/components/dock/FilesPanel.tsx`, and a directory name is a search too. Matches come back already expanded.

**Back no longer collapses the tree.** Opening a file swapped the tree out for the preview, which unmounted `FileTree` — the expand state lives there, so every Back returned a tree collapsed to the root and scrolled to the top. The preview now covers the tree (`absolute inset-0`) instead of replacing it. The filter suspends the expansion through a new `expandAll` prop rather than remounting, so clearing it gives back the folders that were open by hand. The file last opened stays marked in the tree.

## Test plan

Frontend gate is node-only, so the render path was measured in a headless instance (isolated `XDG_CONFIG_HOME`, CDP driver), dark and light:

- [x] Filtering `dock files` leaves one row: `frontend | src | components | dock | FilesPanel.tsx`
- [x] Expand a folder, filter, clear — tree identical to before the filter (`EXPAND SURVIVED THE FILTER: true`)
- [x] Open a file, Back — tree identical (`SAME TREE AFTER BACK: true`), last file marked, `scrollTop` 400 → 400
- [x] Preview overlay sits on the dock's own tone in both themes; no exception or console error
- [x] `tsc --noEmit`, `biome check` (only the standing a11y warnings), `vitest run` — 824 passed