### PR TITLE
fix: loop writeBytes so ConPTY's short writes don't drop the tail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   line the running tool was using rather than a new one, so no card grows, and
   the ring is unchanged.
 
+### Fixed
+
+- **A long message typed into a session on Windows could land with no Enter
+  behind it.** Input reached a PTY through one write call, which is safe on
+  Unix — `*os.File` always writes everything or fails — but not on Windows:
+  ConPTY's input pipe can hand back fewer bytes than it was given, and ports
+  the code was trusting to loop already were not. A paste that landed on that
+  boundary lost its tail, closing bracket included, so the terminal was still
+  mid-paste when the Enter arrived a moment later and read it as more pasted
+  text instead of a submission — visible as a message sitting typed and unsent
+  until someone opened the session and pressed Enter themselves.
+
 ## [0.29.0] - 2026-08-11
 
 ### Added

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -535,13 +535,28 @@ func (s *Service) Write(id, data string) error {
 // writeBytes delivers input bytes to a session's PTY; unknown sessions are a
 // no-op. It is the shared sink for the RPC Write and the WebSocket
 // transport's input frames.
+//
+// It loops until every byte is written. A single call is not enough:
+// ConPTY's input pipe (pty_windows.go) is a plain Windows anonymous pipe, and
+// WriteFile on one can legitimately return fewer bytes than given rather than
+// blocking for the rest — the caller is documented to retry. A large paste
+// landing exactly on that boundary lost its tail silently, closing bracket
+// and all, so bracketed paste never closed and the Enter that followed
+// landed inside it instead of submitting it. Unix's *os.File already loops
+// internally, so this is a no-op extra check there.
 func (s *Service) writeBytes(id string, data []byte) error {
 	p := s.ptyOf(id)
 	if p == nil {
 		return nil
 	}
-	_, err := p.Write(data)
-	return err
+	for len(data) > 0 {
+		n, err := p.Write(data)
+		if err != nil {
+			return err
+		}
+		data = data[n:]
+	}
+	return nil
 }
 
 // SetVisible tells the session's output coalescer whether its terminal is on

--- a/internal/terminal/write_test.go
+++ b/internal/terminal/write_test.go
@@ -1,0 +1,45 @@
+package terminal
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/omartelo/lich/internal/events"
+)
+
+// shortWritePTY accepts at most chunk bytes per Write call, the way a Windows
+// anonymous pipe can when its buffer is fuller than the write is long (see
+// writeBytes). Everything past Write is unused by this test.
+type shortWritePTY struct {
+	chunk    int
+	received bytes.Buffer
+}
+
+func (p *shortWritePTY) Write(b []byte) (int, error) {
+	n := min(len(b), p.chunk)
+	p.received.Write(b[:n])
+	return n, nil
+}
+
+func (p *shortWritePTY) Read([]byte) (int, error) { return 0, nil }
+func (p *shortWritePTY) Resize(int, int) error    { return nil }
+func (p *shortWritePTY) Pid() int                 { return 0 }
+func (p *shortWritePTY) Wait() error              { return nil }
+func (p *shortWritePTY) Close() error             { return nil }
+
+// TestWriteBytesSurvivesShortWrites proves a PTY that only ever accepts part
+// of a write still receives every byte: writeBytes has to loop rather than
+// trust the first call, which is what a large paste needs on Windows.
+func TestWriteBytesSurvivesShortWrites(t *testing.T) {
+	fake := &shortWritePTY{chunk: 3}
+	s := New(nil, nil, events.New())
+	s.sessions["s1"] = &session{pty: fake}
+
+	payload := "\x1b[200~a message longer than the fake pipe's chunk size\x1b[201~\r"
+	if err := s.Write("s1", payload); err != nil {
+		t.Fatalf("Write = %v, want nil", err)
+	}
+	if got := fake.received.String(); got != payload {
+		t.Errorf("PTY received %q, want %q", got, payload)
+	}
+}


### PR DESCRIPTION
## Summary
- `writeBytes` wrote a session's input to its PTY with one `Write` call and discarded the byte count, which is safe on Unix (`*os.File.Write` always writes everything or fails) but not on Windows: ConPTY's input pipe is a plain Windows anonymous pipe, and `WriteFile` on one can legitimately hand back fewer bytes than given, with no error.
- A large paste landing on that boundary lost its tail — closing bracket of the bracketed-paste sequence included — so the terminal was still mid-paste when the Enter written a moment later arrived, and read it as more pasted text instead of a submission. Reported as: cross-session message relayed to a Codex session on Windows pasted the text but never submitted it.
- Fix: `writeBytes` now loops until every byte is written, the same contract `io.Writer` documents and `*os.File` already honors on Unix.

## Test plan
- [x] `internal/terminal/write_test.go`: new test with a fake `ptyHandle` that only accepts part of a write per call, proving `writeBytes` now receives every byte across multiple short writes — fails without the fix, passes with it.
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean, plus the `GOOS=linux/darwin/windows` build+vet cross-compile loop (this PR touches the PTY write seam)
- [x] `go test ./...` green
- [x] `CHANGELOG.md` `[Unreleased]` entry added