### PR TITLE
fix: give a toast with a description its own button row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The crash notice is readable again.** The toast that reports a previous run
+  ending unexpectedly is the only one carrying a description, and sonner lays a
+  toast out as a single row — so its two buttons squeezed the wording into a
+  third of the width. Toasts with a description now put their buttons on a row
+  of their own, and the notice no longer spells out where the log is when the
+  button beside it already says so.
+
 - **A task sent to a session stopped on a permission prompt is no longer
   reported as never read.** The target's `waiting` report was read as "not
   working", so thirty seconds of a human not answering the permission dialog

--- a/frontend/src/components/UncleanExitGate.tsx
+++ b/frontend/src/components/UncleanExitGate.tsx
@@ -25,8 +25,7 @@ export function UncleanExitGate() {
 // the user is reading a session is a toast they never saw.
 const prompt = () => {
   toast.warning("lich's previous run ended unexpectedly", {
-    description:
-      "Your sessions were restored, but whatever they were running stopped with it. That run's log is in the log folder.",
+    description: "Your sessions were restored, but whatever they were running stopped with it.",
     duration: Infinity,
     action: {
       label: "Open log folder",

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -236,6 +236,31 @@
   border-radius: 3px;
 }
 
+/* sonner lays a toast out as a single row — icon, text, then the buttons — so a
+   toast carrying a description leaves its copy in a sliver of the 356px width.
+   Keyed on the description, so the title-only toasts keep their buttons inline.
+   Every rule here has to out-specify sonner's own, which the Toaster injects
+   into the head after this stylesheet — hence the `[data-styled]` repeat. */
+[data-sonner-toast][data-styled="true"]:has([data-description]) {
+  flex-wrap: wrap;
+  row-gap: 12px;
+  align-items: flex-start;
+}
+/* Wide enough that no button can share the first row (the icon and the gap are
+   23px; the rest is slack against a future padding change), and it grows back
+   over whatever slack is left. */
+[data-sonner-toast][data-styled="true"]:has([data-description]) [data-content] {
+  flex: 1 1 calc(100% - 32px);
+}
+/* sonner gives every button `margin-left: auto`, which on a row of their own
+   would spread them apart instead of grouping them at the right edge. */
+[data-sonner-toast][data-styled="true"]:has([data-description]) [data-button] {
+  margin-left: 0;
+}
+[data-sonner-toast][data-styled="true"]:has([data-description]) [data-button]:first-of-type {
+  margin-left: auto;
+}
+
 /* Desktop app: the page itself never scrolls. Without this, Chromium's
    classic (width-taking, dark) scrollbars appear the moment anything
    overflows 100vw/100vh by a pixel — w-screen includes the scrollbar width,


### PR DESCRIPTION
## What

The unclean-exit notice is the only toast in lich that carries a description, and sonner lays every toast out as a single row — icon, text, then the buttons. The result was the copy squeezed into about a third of the 356px width: a two-line title and a five-line description in a sliver beside `Dismiss` and `Open log folder`.

Described toasts now wrap: the text keeps the full width, the buttons group at the right edge of a row of their own, and the icon lines up with the title.

## How

- `frontend/src/index.css` — the rule is keyed on `[data-description]`, so the seven title-only toasts keep their buttons inline. Every selector repeats `[data-styled]` to out-specify sonner's own, which the Toaster injects into the head *after* this stylesheet — a tie goes to sonner (that is exactly how the first attempt lost `align-items`). sonner also puts `margin-left: auto` on every button, which on a shared row spreads the pair apart instead of grouping it, so the second button's is cleared.
- `frontend/src/components/UncleanExitGate.tsx` — the description drops its last sentence, which named the log folder that the button beside it already opens.

## Test plan

- [x] `pnpm exec biome check .`, `vitest run` (855 passed), `tsc --noEmit`, `vite build`
- [x] Rendered against sonner's own runtime stylesheet in a headless Chromium, both themes — the frontend suite runs in node and cannot render, so the layout was measured (`getBoundingClientRect`) rather than eyeballed
- [x] Seen in the app: needs a real unclean exit (kill lich, relaunch)