### PR TITLE
fix: keep the theme selection in the workspace, not only the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Your theme survives an update.** The theme and terminal theme you picked
+  were kept only in the app window's own storage — the Chromium profile — and a
+  profile whose storage comes back damaged is one Chromium empties and starts
+  again, taking both selections with it. On Windows that was the ordinary end of
+  an update until v0.29.0, because the window was killed rather than asked to
+  close, so an update was the likeliest moment to open lich on the default theme
+  with the theme you had imported still sitting in the list. Both selections now
+  live in the workspace database, beside the projects and sessions that already
+  survive anything the window does; the window's copy stays as the cache the
+  first frame paints from, so nothing about starting up changed, and an install
+  that had a theme picked before this keeps it.
+
 - **A task sent to a session stopped on a permission prompt is no longer
   reported as never read.** The target's `waiting` report was read as "not
   working", so thirty seconds of a human not answering the permission dialog

--- a/frontend/src/lib/themes.test.ts
+++ b/frontend/src/lib/themes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import type { ThemeDefinition } from "./api-types"
 import {
+  adoptStoredSelections,
   APP_COLOR_TOKENS,
   applyAppTheme,
   BUNDLED_THEMES,
@@ -120,6 +121,44 @@ describe("themes", () => {
     expect(
       reconcileThemeSelections({ theme: "dark", terminalTheme: "light" }, BUNDLED_THEMES),
     ).toEqual({ theme: "dark", terminalTheme: "light" })
+  })
+
+  it("prefers the stored selections over the boot cache", () => {
+    expect(
+      adoptStoredSelections(
+        { theme: "dracula", terminalTheme: "dark" },
+        { theme: SYSTEM_THEME, terminalTheme: DEFAULT_TERMINAL_THEME },
+      ),
+    ).toEqual({
+      selections: { theme: "dracula", terminalTheme: "dark" },
+      persist: false,
+    })
+  })
+
+  it("adopts the boot cache and asks for a write-back when nothing is stored", () => {
+    expect(
+      adoptStoredSelections(
+        { theme: "", terminalTheme: "" },
+        { theme: "dracula", terminalTheme: "light" },
+      ),
+    ).toEqual({
+      selections: { theme: "dracula", terminalTheme: "light" },
+      persist: true,
+    })
+  })
+
+  // The two keys are written together but read apart: an install that stored one
+  // selection before the other must not have the missing one left unwritten.
+  it("writes back when only one selection is stored", () => {
+    expect(
+      adoptStoredSelections(
+        { theme: "dracula", terminalTheme: "" },
+        { theme: SYSTEM_THEME, terminalTheme: "light" },
+      ),
+    ).toEqual({
+      selections: { theme: "dracula", terminalTheme: "light" },
+      persist: true,
+    })
   })
 
   it("resets only selections that use a removed theme", () => {

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -142,6 +142,25 @@ export function reconcileThemeSelections(
   }
 }
 
+// adoptStoredSelections resolves the selections a launch starts from against
+// the workspace copy, which is the durable one: the boot cache lives in the
+// Chromium profile, and a profile Chromium recreates comes back empty while the
+// workspace database survives. A setting that was never written reads as "" —
+// an install whose cache is still the only record — so the cache is adopted and
+// written back once, which is what `persist` reports.
+export function adoptStoredSelections(
+  stored: ThemeSelections,
+  cached: ThemeSelections,
+): { selections: ThemeSelections; persist: boolean } {
+  return {
+    selections: {
+      theme: stored.theme || cached.theme,
+      terminalTheme: stored.terminalTheme || cached.terminalTheme,
+    },
+    persist: !stored.theme || !stored.terminalTheme,
+  }
+}
+
 export function selectionsAfterThemeRemoval(
   removedID: string,
   selections: ThemeSelections,

--- a/frontend/src/providers/settings.tsx
+++ b/frontend/src/providers/settings.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react"
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
 import type { ReactNode } from "react"
 import {
   DEFAULT_HOTKEYS,
@@ -17,8 +17,9 @@ import {
   readPref,
   writePref,
 } from "@/lib/prefs"
-import { Themes as ThemeRPC } from "@/lib/rpc"
+import { Store, Themes as ThemeRPC } from "@/lib/rpc"
 import {
+  adoptStoredSelections,
   applyAppTheme,
   BUNDLED_THEMES,
   DARK_THEME_SCHEME,
@@ -47,6 +48,18 @@ const CONTEXT_USAGE_STORAGE_KEY = "lich.footer.contextUsage"
 const COST_BUDGET_STORAGE_KEY = "lich.footer.costBudget"
 const DESKTOP_NOTIFICATIONS_STORAGE_KEY = "lich.notifications.desktop"
 const FINISHED_TURN_NOTIFICATIONS_STORAGE_KEY = "lich.notifications.finishedTurn"
+
+// The workspace keys the two theme selections actually live under. The
+// localStorage pair above keeps them too, but only as the cache the first frame
+// paints from: it sits in the Chromium profile, which Chromium recreates from
+// scratch when its storage comes back damaged — a window killed rather than
+// closed (#209) is how that happened — taking every `lich.*` pref with it
+// (#236). The database is the same store the sessions survive in, and it is
+// where the "what's new" flag went for the same reason (#199).
+const THEME_SETTING_KEY = "appearance.theme"
+const TERMINAL_THEME_SETTING_KEY = "appearance.terminalTheme"
+// The selections answer for this install, not for a project.
+const GLOBAL_SCOPE = ""
 
 // DEFAULT_FONT is the bundled FiraCode Nerd Font Mono. It is not installed via
 // fontconfig, so it must be offered explicitly alongside the system fonts.
@@ -200,6 +213,62 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     readFinishedTurnNotifications,
   )
 
+  // A selection the user (or a reconcile) has already written must not be
+  // overwritten by the stored one still in flight, so the load below stands down
+  // once anything has been persisted.
+  const selectionsTouched = useRef(false)
+
+  const persistTheme = useCallback((next: Theme) => {
+    selectionsTouched.current = true
+    writePref(THEME_STORAGE_KEY, next)
+    // A failed write costs the selection only if the profile is later recreated
+    // — the cache answers every ordinary launch — so it stays quiet.
+    void Store.SetSetting(THEME_SETTING_KEY, GLOBAL_SCOPE, next).catch(() => {})
+  }, [])
+
+  const persistTerminalTheme = useCallback((next: TerminalTheme) => {
+    selectionsTouched.current = true
+    writePref(TERMINAL_THEME_STORAGE_KEY, next)
+    void Store.SetSetting(TERMINAL_THEME_SETTING_KEY, GLOBAL_SCOPE, next).catch(() => {})
+  }, [])
+
+  // The stored selections land after the first paint, which the cache has
+  // already answered for: a theme that is only in the database repaints once,
+  // and a custom one waits for the theme list either way.
+  useEffect(() => {
+    let cancelled = false
+    const cached = { theme: readTheme(), terminalTheme: readTerminalTheme() }
+    Promise.all([
+      Store.GetSetting(THEME_SETTING_KEY, GLOBAL_SCOPE),
+      Store.GetSetting(TERMINAL_THEME_SETTING_KEY, GLOBAL_SCOPE),
+    ])
+      .then(([storedTheme, storedTerminalTheme]) => {
+        if (cancelled || selectionsTouched.current) return
+        const { selections, persist } = adoptStoredSelections(
+          { theme: storedTheme, terminalTheme: storedTerminalTheme },
+          cached,
+        )
+        if (selections.theme !== cached.theme) {
+          setThemeState(selections.theme)
+          writePref(THEME_STORAGE_KEY, selections.theme)
+        }
+        if (selections.terminalTheme !== cached.terminalTheme) {
+          setTerminalThemeState(selections.terminalTheme)
+          writePref(TERMINAL_THEME_STORAGE_KEY, selections.terminalTheme)
+        }
+        if (persist) {
+          persistTheme(selections.theme)
+          persistTerminalTheme(selections.terminalTheme)
+        }
+      })
+      .catch((error) => {
+        console.warn("[settings] failed to load the stored theme selections", error)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [persistTheme, persistTerminalTheme])
+
   useEffect(() => {
     let cancelled = false
     ThemeRPC.List()
@@ -222,13 +291,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     const reconciled = reconcileThemeSelections({ theme, terminalTheme }, themes)
     if (reconciled.theme !== theme) {
       setThemeState(reconciled.theme)
-      writePref(THEME_STORAGE_KEY, reconciled.theme)
+      persistTheme(reconciled.theme)
     }
     if (reconciled.terminalTheme !== terminalTheme) {
       setTerminalThemeState(reconciled.terminalTheme)
-      writePref(TERMINAL_THEME_STORAGE_KEY, reconciled.terminalTheme)
+      persistTerminalTheme(reconciled.terminalTheme)
     }
-  }, [theme, terminalTheme, themes, themesLoaded])
+  }, [theme, terminalTheme, themes, themesLoaded, persistTheme, persistTerminalTheme])
 
   const setFont = useCallback((next: string) => {
     setFontState(next)
@@ -241,10 +310,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     writePref(TERMINAL_FONT_SIZE_STORAGE_KEY, clamped)
   }, [])
 
-  const setTheme = useCallback((next: Theme) => {
-    setThemeState(next)
-    writePref(THEME_STORAGE_KEY, next)
-  }, [])
+  const setTheme = useCallback(
+    (next: Theme) => {
+      setThemeState(next)
+      persistTheme(next)
+    },
+    [persistTheme],
+  )
 
   // Neither of these persists: the zoom is mirrored to localStorage by the
   // effect that applies it, so the one updater that has to be functional (see
@@ -259,10 +331,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     setZoomState((prev) => clampZoom(prev + delta))
   }, [])
 
-  const setTerminalTheme = useCallback((next: TerminalTheme) => {
-    setTerminalThemeState(next)
-    writePref(TERMINAL_THEME_STORAGE_KEY, next)
-  }, [])
+  const setTerminalTheme = useCallback(
+    (next: TerminalTheme) => {
+      setTerminalThemeState(next)
+      persistTerminalTheme(next)
+    },
+    [persistTerminalTheme],
+  )
 
   const importTheme = useCallback(
     async (path: string, overwrite: boolean) => {
@@ -316,14 +391,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       const next = selectionsAfterThemeRemoval(id, { theme, terminalTheme })
       if (next.theme !== theme) {
         setThemeState(next.theme)
-        writePref(THEME_STORAGE_KEY, next.theme)
+        persistTheme(next.theme)
       }
       if (next.terminalTheme !== terminalTheme) {
         setTerminalThemeState(next.terminalTheme)
-        writePref(TERMINAL_THEME_STORAGE_KEY, next.terminalTheme)
+        persistTerminalTheme(next.terminalTheme)
       }
     },
-    [theme, terminalTheme],
+    [theme, terminalTheme, persistTheme, persistTerminalTheme],
   )
 
   const setHotkey = useCallback((id: HotkeyId, combo: Combo) => {


### PR DESCRIPTION
Closes #236.

## What broke

The theme and terminal theme selections were kept only in `localStorage`, which lives in the Chromium profile lich launches its window against. When that profile's storage comes back damaged, Chromium empties it and starts again — every `lich.*` pref goes with it. The reporter's screenshots show the shape of it precisely: the imported Dracula theme is still installed and still listed, the workspace is intact, and only the *selection* is back on `System`.

On Windows that was the ordinary end of an update until v0.29.0: the self-apply flow runs `AppUpdate.Apply()` → `AppUpdate.Restart()`, and the restart killed the window outright rather than asking it to close (fixed in #209). An update was therefore the likeliest moment to lose the selection — which is exactly when #236 was reported.

#209 stops new damage; it cannot give back what a recreated profile already dropped, and it leaves the selections single-copy in a store that has been observed emptying itself. The "what's new" flag hit the same wall in #199 and moved to the database. The theme is the most visible pref still exposed to it.

## What changed

- `appearance.theme` and `appearance.terminalTheme` now live in the `settings` table (global scope), read at startup through `store.GetSetting`.
- `localStorage` stays as the boot cache the first frame paints from — startup is unchanged, and a custom theme waits for the theme list either way. Every write goes to both.
- A first launch after this copies the cache into the database, so an install that already had a theme picked keeps it.
- The stored load stands down if a selection was persisted while it was in flight, so a pick made in the first milliseconds is not overwritten by a late arrival.

No Go changes: `store.GetSetting`/`SetSetting` are already registered.

## Test plan

- [x] `adoptStoredSelections` unit-tested in `frontend/src/lib/themes.test.ts`: stored wins, empty stored adopts the cache and asks for the write-back, one-of-two stored still writes back.
- [x] Frontend gate: `biome check` clean, `tsc -b --noEmit` clean, `vitest run` 858 passed, `vite build` ok.
- [x] Backend gate: `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green (untouched).
- [x] Headless smoke against an isolated config dir (write path): opening Settings › Appearance and picking `Dark` with real mouse events left `store.GetSetting("appearance.theme", "")` reading `"dark"`.
- [x] Headless smoke (the #236 regression): with `light` stored and the OS scheme dark, `localStorage.clear()` + reload — the profile coming back empty — brought the app back on the light theme and rewrote the cache. Before this change that reload landed on `System`.