### PR TITLE
chore: cut v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.30.0] - 2026-08-12
 
 ### Added
 
@@ -225,6 +225,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   retry the restart handoff always had, and a retry that pays off is logged —
   a race that resolves on its own left no trace before, so a failure a few
   launches later looked unrelated to the ones that quietly won.
+
+- **The footer's attach button wears the same glyph as the dock's.** Attaching a
+  file from the footer showed a `+` while the same action beside the diff shows a
+  paperclip, so one action had two icons depending on where you reached it. Both
+  are the paperclip now.
 
 ## [0.29.0] - 2026-08-11
 
@@ -2161,7 +2166,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.29.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.30.0...HEAD
+[0.30.0]: https://github.com/omartelo/lich/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/omartelo/lich/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/omartelo/lich/compare/v0.27.0...v0.28.0
 [0.27.0]: https://github.com/omartelo/lich/compare/v0.26.1...v0.27.0

--- a/README.md
+++ b/README.md
@@ -110,10 +110,11 @@ hand.
 - **Version control** — a project can name the GitHub account `gh` runs as
   (Settings › Version Control), for a repository only one of your accounts can
   see. It governs what lich reads from GitHub, not what git pushes.
-- **Appearance & hotkeys** — themes, fonts and key combos in Settings; UI
-  preferences persist in `localStorage` under `lich.*` keys (inside lich's
-  Chromium profile at `~/.config/lich/chromium-profile`), imported themes as JSON
-  under `<config-dir>/lich/themes`.
+- **Appearance & hotkeys** — themes, fonts and key combos in Settings; the theme
+  you pick persists in the workspace database, the rest of the UI preferences in
+  `localStorage` under `lich.*` keys (inside lich's Chromium profile at
+  `~/.config/lich/chromium-profile`), and imported themes as JSON under
+  `<config-dir>/lich/themes`.
 - **Workspace** — projects and sessions persist in SQLite at
   `<config-dir>/lich/lich.db`. Closing a session does not delete it.
 - **Session hooks** — with the

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,9 +99,9 @@ Homebrew 安装可以绕开 Gatekeeper 的提示；从 Releases 页面下载的�
 - **版本控制** —— 一个项目可以指定 `gh` 以哪个 GitHub 账号运行（设置 › Version
   Control），用于只有你其中一个账号看得见的仓库。它管的是 lich 从 GitHub 读到什么，
   而不是 git 推送时用谁的身份。
-- **外观与快捷键** —— 主题、字体和组合键都在设置里；UI 偏好以 `lich.*` 为键持久化在
-  `localStorage`（位于 lich 的 Chromium 配置目录 `~/.config/lich/chromium-profile`），
-  导入的主题则以 JSON 存在 `<config-dir>/lich/themes` 下。
+- **外观与快捷键** —— 主题、字体和组合键都在设置里；你选定的主题持久化在工作区数据库里，
+  其余 UI 偏好以 `lich.*` 为键持久化在 `localStorage`（位于 lich 的 Chromium 配置目录
+  `~/.config/lich/chromium-profile`），导入的主题则以 JSON 存在 `<config-dir>/lich/themes` 下。
 - **工作区** —— 项目和会话持久化在 SQLite 里，路径为 `<config-dir>/lich/lich.db`。
   关闭一个会话并不会删除它。
 - **会话钩子** —— 在设置里装上 [lich 插件](https://github.com/omartelo/lich-plugin)


### PR DESCRIPTION
Release prep for v0.30.0.

- `CHANGELOG.md`: `[Unreleased]` becomes `## [0.30.0] - 2026-08-12`, compare links refreshed.
- One user-visible change shipped without an entry (`35bc40c`, the footer's attach glyph) — added under Fixed.
- Both READMEs said UI preferences persist in `localStorage`; the theme selection moved into the workspace database in #248, so the Appearance bullet now splits the two.

Everything else in `[Unreleased]` was checked against `git log v0.29.0..HEAD`: every commit in the range has an entry, and every entry has a commit.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `biome check .` clean (14 pre-existing warnings, exit 0)
- [x] `tsc --noEmit` clean, `vite build` succeeds
- [x] `go test ./...` — 1304 tests, 30 packages, green; `-race` green
- [x] `vitest run` — 867 tests, 77 files, green
- [x] cross-compile loop: linux / darwin / windows build + vet OK