### PR TITLE
fix: bail out of hopeless binds and surface the failure in a dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **A launch that loses its port now tells you, instead of dying into a log
+  file.** When the loopback listener cannot bind and no running lich explains
+  it, the app used to exit with nothing but a log line — which a double-click
+  launch never shows, so the window simply failed to appear. Now it raises a
+  native error dialog carrying the port, the OS error and the
+  `LICH_LISTEN_PORT` override, so a taken port is something the user can fix
+  without hunting down the log.
+
+- **A bind that can never succeed fails at once, with its real error.** The
+  launch retry loop treated every bind failure as the transient
+  port-still-releasing race and retried it for the full two seconds — so a
+  misconfigured `LICH_LISTEN_PORT` (say, a port past 65535) burned the whole
+  budget before reporting `invalid port` wrapped in "after 11 attempts". Now
+  only "address in use" earns a retry; any other bind error surfaces
+  immediately, undiluted.
+
 ## [0.30.0] - 2026-08-12
 
 ### Added

--- a/internal/terminal/bind_unix.go
+++ b/internal/terminal/bind_unix.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package terminal
+
+import (
+	"errors"
+	"syscall"
+)
+
+// addrInUse reports whether a bind failed because the port is taken — the one
+// error worth retrying, since only a taken port can free itself.
+func addrInUse(err error) bool {
+	return errors.Is(err, syscall.EADDRINUSE)
+}

--- a/internal/terminal/bind_windows.go
+++ b/internal/terminal/bind_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package terminal
+
+import (
+	"errors"
+
+	"golang.org/x/sys/windows"
+)
+
+// addrInUse reports whether a bind failed because the port is taken — the one
+// error worth retrying, since only a taken port can free itself. Windows
+// surfaces this as WSAEADDRINUSE, which syscall.Errno.Is does not map to the
+// portable syscall.EADDRINUSE, so the check names the real constant.
+func addrInUse(err error) bool {
+	return errors.Is(err, windows.WSAEADDRINUSE)
+}

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -201,6 +201,11 @@ func listen(addr string) (net.Listener, error) {
 			}
 			return l, nil
 		}
+		// Only a taken port can free itself; anything else (invalid port,
+		// permission denied) fails the same way every time, so surface it now.
+		if !addrInUse(err) {
+			return nil, err
+		}
 		if time.Now().After(deadline) {
 			return nil, fmt.Errorf("after %d attempts over %s: %w", attempts, time.Since(start).Round(time.Millisecond), err)
 		}

--- a/internal/terminal/transport_restart_test.go
+++ b/internal/terminal/transport_restart_test.go
@@ -110,6 +110,21 @@ func TestListenGivesUpAfterBindTimeoutWithoutWaitMarker(t *testing.T) {
 	}
 }
 
+func TestListenBailsOutFastOnUnretryableError(t *testing.T) {
+	// An out-of-range port can never free itself; retrying it only delays the
+	// real error (seen in the field as LICH_LISTEN_PORT=321654 burning the
+	// whole bindTimeout before reporting "invalid port").
+	start := time.Now()
+	l, err := listen("127.0.0.1:321654")
+	if err == nil {
+		_ = l.Close()
+		t.Fatal("listen() = nil error on an invalid port, want immediate failure")
+	}
+	if elapsed := time.Since(start); elapsed >= bindRetryInterval {
+		t.Fatalf("listen() took %s on an unretryable error, want a bail-out before the first retry (%s)", elapsed, bindRetryInterval)
+	}
+}
+
 func TestListenRetriesUntilPortFreesWithoutWaitMarker(t *testing.T) {
 	busy, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/ncruces/zenity"
 	"github.com/omartelo/lich/internal/agentplugin"
 	"github.com/omartelo/lich/internal/appupdate"
 	"github.com/omartelo/lich/internal/chromium"
@@ -252,6 +253,17 @@ func handleBindFailure(configDir string, cause error) {
 	// No "is the port free?" here: on Windows the answer is regularly yes and
 	// the bind still fails, so the OS error is the message.
 	slog.Error("loopback listener failed to start", "port", port, "err", cause)
+	// The window never opens on this path, so a double-click launch dies in
+	// silence with only the log to explain — and nothing on screen says a log
+	// exists. The dialog is the one surface left. Best effort: where no dialog
+	// backend answers, the log line above still has the story.
+	_ = zenity.Error(fmt.Sprintf(
+		"lich could not listen on 127.0.0.1:%s.\n\n%v\n\n"+
+			"If another program is holding the port, set the LICH_LISTEN_PORT "+
+			"environment variable to a free one and launch lich again.\n\n"+
+			"Log: %s",
+		port, cause, logging.Path(filepath.Join(configDir, "lich"))),
+		zenity.Title("lich"))
 	os.Exit(1)
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #245, driven by a field report: a Windows user's lich still would not open after v0.30.0, and the log showed the retry budget being burned on errors that can never heal.

- **Retry only what can change.** `listen()` retried every bind failure as if it were the transient port-still-releasing race — a misconfigured `LICH_LISTEN_PORT` (the reporter tried `321654`, past 65535) spent the whole 2s budget before surfacing `invalid port` wrapped in "after 11 attempts". Now only *address in use* earns a retry; any other bind error returns on the first attempt, undiluted.
- **Per-OS seam for the check.** Windows reports `WSAEADDRINUSE`, and `syscall.Errno.Is` does not map it to the portable `syscall.EADDRINUSE` — a naive `errors.Is` check would have killed the #245 retry exactly on the platform it was written for. `bind_unix.go` / `bind_windows.go` (via `golang.org/x/sys/windows`, already a dependency) name the right constant per OS.
- **A lost bind now tells the user.** When the bind fails for good and no running lich explains it, the window simply never appeared: exit 1 and a log line no double-click launch ever shows. `handleBindFailure` now raises a native error dialog (ncruces/zenity, already a dependency) carrying the port, the OS error and the `LICH_LISTEN_PORT` override — the same escape hatch that unblocked the reporter's machine.

## Test plan

- [x] New `TestListenBailsOutFastOnUnretryableError` pins the field case (port 321654) and requires the failure before the first retry interval
- [x] Existing `TestListen*` retry/give-up suite still green (the in-use path still retries on both budgets)
- [x] `go test ./...` — 1305 passed, 30 packages
- [x] `gofmt`, `go vet`, cross-compile + vet for linux/darwin/windows
- [x] Dialog smoke on a real Windows machine (no hardware here — `ci:os` runs the suite on Windows/macOS runners)