### PR TITLE
feat: announce relayed answers with a nudge and collect them in batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **A worker's answer no longer floods the orchestrator's prompt — it is
+  announced, and collected.** A session fanning work out to others used to get
+  every answer typed back at its prompt in full, and every arrival restarted
+  its turn with the whole text left in its context window: orchestrating N
+  workers cost that N times over. Now an unattended result goes to the
+  sender's inbox, and what is typed is one short `[lich]` note — results
+  landing within a couple of seconds share it, and a sender mid-turn hears
+  nothing until its turn ends. `wait_for_answer` with no ticket (or a bare
+  `lich wait`) collects everything at once, inside a turn the sender chose,
+  and reports who still owes an answer. Uncollected results expire with the
+  ticket TTL, one hour.
+
+- **lich's MCP server now briefs the agent on the whole journey.** The
+  `initialize` handshake carries `instructions` — how to fan work out into
+  worktree sessions, that answers announce themselves so polling is waste, and
+  that a relayed reply should be a concise report, not a transcript. Clients
+  inject it into the agent's system prompt, so an agent no longer has to
+  reverse-engineer the orchestration flow from seven tool descriptions. The
+  relayed message asks for the concise report too, and `list_sessions` /
+  `list_worktrees` are annotated read-only so clients may auto-allow them.
+
 ### Fixed
 
 - **A launch that loses its port now tells you, instead of dying into a log

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -149,8 +149,8 @@ Types `<prompt>` at `<session>`'s prompt, submits it, and waits.
   is that news.
 
 ```
-docs is still working. The message was delivered; its answer will be typed at
-the sending session's prompt when it arrives. To hold the line for it instead:
+docs is still working. The message was delivered; a note will be typed at the
+sending session's prompt when its result is ready. To hold the line for it instead:
   lich wait a1b2c3d4
 ```
 
@@ -166,11 +166,22 @@ nobody can answer would otherwise be waited out in full. `internal/terminal` tel
 setup wrapper prints between the script and the provider (`setupDone`): the PTY
 and the pid are the same across the `exec`, so nothing else can.
 
-### `lich wait [--timeout <seconds>] <ticket>`
+### `lich wait [--timeout <seconds>] [<ticket>]`
 
-Waits again on a ticket a previous `send` handed back. Same output as `send`.
-A ticket that was answered, or that nobody answered within an hour, is gone and
-waiting on it is an error.
+With a ticket: waits again on that errand. Same output as `send`. A result that
+already came back unattended is handed over on the spot — it sits in the
+sender's inbox (see below) until collected or expired. A ticket that was
+collected already, or that nobody answered within an hour, is gone and waiting
+on it is an error.
+
+Without a ticket: **collects**. Every result waiting for this session is
+printed at once, oldest first, each in the same words a single wait uses;
+sessions still owing an answer are listed after (`Still working: "docs"`).
+When nothing is ready and errands are open, it holds the line for the next
+result; when nothing is open either, it says so and returns at once. This is
+the command the nudge at a sender's prompt names, and it needs a session of
+its own — run from a plain shell it is an error, because there is no inbox to
+drain.
 
 ### `lich reply <ticket> <answer>`
 
@@ -275,7 +286,7 @@ at lich.
 |------|--------------|
 | `list_sessions` | The live sessions that can be given work, as JSON. |
 | `send_to_session` | `session`, `prompt`, optional `project` and `timeout_seconds`. |
-| `wait_for_answer` | `ticket`, optional `timeout_seconds`. |
+| `wait_for_answer` | optional `ticket` and `timeout_seconds` — with a ticket, `lich wait <ticket>`; without one, the collect: everything ready at once. |
 | `reply_to_session` | `ticket`, `answer` — what a relayed message asks for. |
 | `open_session` | optional `project`, `kind`, `worktree`, `base` — `lich open`. |
 | `close_session` | `session`, optional `project`, `worktree` (`keep`/`remove`), `force`. |
@@ -283,6 +294,13 @@ at lich.
 
 A tool that fails answers with `isError` and the reason as text, not a JSON-RPC
 error: the agent should read what went wrong and act on it, not lose the turn.
+
+`initialize` also carries `instructions` — the server's own briefing, which
+clients inject into the agent's system prompt. It is the one place the whole
+journey (fan out into worktree sessions, carry on, collect) is told as one;
+the tool descriptions each only explain their own door. `list_sessions` and
+`list_worktrees` are annotated `readOnlyHint`, so a client may auto-allow
+them.
 
 ### `lich rage [--output <path>]`
 
@@ -396,27 +414,36 @@ the machine while `/proc/<pid>/environ` is not. A URL registration means
 secret at all — the server inherits the coordinates from the PTY's environment,
 where they already were.
 
-## The answer comes back the way the request went out
+## The answer is announced, and collected
 
 A relayed task can take minutes; a tool call cannot sit still that long (Claude
 Code detaches one that runs past 120 seconds). So waiting is optional here.
 
-When the answer lands and **nobody is still holding the line**, lich types it at
-the sending session's own prompt and submits it — the same bracketed paste, the
-same delay, the same submit that carried the request to the target:
+When a result lands and **nobody is still holding the line**, it goes to the
+sender's **inbox**, and what is typed at the sender's prompt is one short
+nudge — never the result itself:
 
 ```
-[lich] Answer from session "docs", to the request you sent it:
-
-3 failures in foo_test
+[lich] The task you sent "docs" has its result ready. To collect everything at
+once, call the lich tool `wait_for_answer` with no ticket, or run:
+  "$LICH_BIN" wait
 ```
 
-That is what makes a long errand work without polling: the asker carries on, and
-the answer arrives when it exists. A caller that *is* still waiting carries the
-answer out itself and nothing is typed — delivering both would deliver twice.
+The nudge is the whole delivery on purpose. Typing the results themselves was
+the first shape this had, and it is what made orchestrating expensive: every
+arrival is a prompt submission, every submission restarts the sender's turn,
+and the full text stays in its context window — an orchestrator fanning out to
+N workers paid all of that N times. The nudge costs one line, arrives once per
+batch (results landing within a couple of seconds share it, and a sender
+mid-turn hears nothing until its turn ends), and the text comes back through
+the collect call, inside a turn the sender chose. A result nobody collects
+expires with its ticket's TTL, one hour.
 
-A sender that is not a session — the `lich` command from a script — has no
-prompt to answer at. Such a caller waits, or does without.
+A caller that *is* still waiting carries the result out itself and nothing is
+typed — delivering both would deliver twice.
+
+A sender that is not a session — the `lich` command from a script — is never
+nudged: its result waits in the inbox for `lich wait <ticket>`, or expires.
 
 ## The message a target receives
 
@@ -427,7 +454,12 @@ prompt to answer at. Such a caller waits, or does without.
 
 When you have an answer, send it back by running:
   "$LICH_BIN" reply <ticket> "<your answer>"
-Whoever asked is blocked waiting on that command.
+
+That ticket is the only way back: whoever asked is blocked on it and is
+reading nothing else. Do not answer by messaging a peer session — an answer
+sent any other way is lost. Keep the answer a concise report — what was done,
+where, and what remains — never a transcript: the sender pays to read every
+byte, and the detail is in your commits and files anyway.
 ```
 
 A caller with no session of its own — the CLI run from a script or a plain

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -74,8 +74,9 @@ const usage = `lich talks to the sessions open in the running lich window.
       Prints the answer. If the wait runs out first it prints a ticket to
       pick the answer up with.
 
-  lich wait [--timeout <seconds>] [--json] <ticket>
-      Wait again on a ticket a previous send handed back.
+  lich wait [--timeout <seconds>] [--json] [<ticket>]
+      With a ticket, wait again on that errand. Without one, collect every
+      result that is ready — and when none is, wait for the next.
 
   lich reply <ticket> <answer>
       Send <answer> back to whoever is waiting on <ticket>. This is what a
@@ -258,8 +259,20 @@ func (c *client) wait(args []string) error {
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
-	if flags.NArg() != 1 {
-		return fmt.Errorf("usage: lich wait [--timeout <seconds>] [--json] <ticket>")
+	if flags.NArg() > 1 {
+		return fmt.Errorf("usage: lich wait [--timeout <seconds>] [--json] [<ticket>]")
+	}
+
+	if flags.NArg() == 0 {
+		var collected relay.Collected
+		if err := c.call("relay.Collect", []any{c.sessionID(), *timeout}, waitBudget(*timeout), &collected); err != nil {
+			return err
+		}
+		if *asJSON {
+			return c.emit(collected)
+		}
+		fmt.Fprintln(c.stdout, collectedText(collected))
+		return nil
 	}
 
 	var result relay.Result
@@ -529,8 +542,8 @@ func (c *client) report(result relay.Result, asJSON bool) error {
 		return nil
 	}
 	fmt.Fprintf(c.stdout,
-		"%s is still working. The message was delivered; its answer will be typed at the "+
-			"sending session's prompt when it arrives. To hold the line for it instead:\n"+
+		"%s is still working. The message was delivered; a note will be typed at the "+
+			"sending session's prompt when its result is ready. To hold the line for it instead:\n"+
 			"  lich wait %s\n",
 		result.Target, result.Ticket,
 	)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -244,6 +244,32 @@ func TestWaitPicksUpAnAnswer(t *testing.T) {
 	}
 }
 
+// Without a ticket, wait collects everything that is ready — the command the
+// nudge at a sender's prompt names.
+func TestWaitWithoutATicketCollectsEverything(t *testing.T) {
+	f := newFakeLich(t, `{"results":[
+		{"ticket":"t1","target":"auth","status":"answered","answer":"all green"}],
+		"open":["docs"]}`)
+
+	code, stdout, _ := run(t, f, "wait")
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+
+	call := f.only(t)
+	if call.method != "relay.Collect" {
+		t.Fatalf("method = %q, want relay.Collect", call.method)
+	}
+	if call.args[0] != "s1" {
+		t.Errorf("session = %v", call.args[0])
+	}
+	for _, want := range []string{`Answer from "auth" (ticket t1):`, "all green", `Still working: "docs"`} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("output is missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
 func TestReplySendsTheAnswerHome(t *testing.T) {
 	f := newFakeLich(t, `null`)
 
@@ -270,7 +296,7 @@ func TestWrongArgumentCountsFailWithUsage(t *testing.T) {
 	tests := [][]string{
 		{"send", "docs"},
 		{"send", "docs", "a prompt", "extra"},
-		{"wait"},
+		{"wait", "a1b2c3d4", "extra"},
 		{"reply", "a1b2c3d4"},
 	}
 	for _, args := range tests {

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/omartelo/lich/internal/relay"
 	"github.com/omartelo/lich/internal/spawn"
@@ -73,12 +74,27 @@ const (
 // mcpTool is one entry in the tool list. run returns the text the agent sees;
 // an error it returns is reported as a failed tool call rather than as a
 // protocol error, so the agent reads what went wrong and can act on it.
+// ReadOnly marks the tools that change nothing, which a client may auto-allow.
 type mcpTool struct {
 	Name        string
 	Description string
 	Schema      map[string]any
+	ReadOnly    bool
 	Run         func(c *client, args mcpArgs) (string, error)
 }
+
+// mcpInstructions is the server's own briefing, injected into the client's
+// system prompt at initialize. The tool descriptions each explain one door;
+// this is the only place the whole journey — fan out, carry on, collect — is
+// told as one, and the difference between an agent that orchestrates and one
+// that never realizes it could.
+const mcpInstructions = `lich runs coding-agent sessions side by side in one window; these tools are how this session works with the others.
+
+Delegate in parallel: for work that can run beside yours, open a worker session in its own git worktree (open_session with worktree) so it gets its own checkout, then hand it the task with send_to_session. Check list_worktrees first — a branch already checked out is opened, not created. Workers are full sessions on the user's screen: visible, steerable, and yours to close (close_session) when the work is done.
+
+Never poll for results. A send that outlives its wait hands back a ticket and you carry on with your own work; when results are ready, one short [lich] note arrives at your prompt — collect everything at once with wait_for_answer (no ticket). Polling in a loop burns the tokens this design exists to save.
+
+When a [lich] message carrying a ticket arrives at YOUR prompt, you are the worker: do the task, then answer with ` + relay.ToolReply + ` — a concise report (what was done, where, what remains), never a transcript.`
 
 // serveMCP runs the stdio server until its input ends.
 func (c *client) serveMCP(args []string) error {
@@ -149,6 +165,7 @@ func mcpHandshake(params json.RawMessage) map[string]any {
 		"protocolVersion": version,
 		"capabilities":    map[string]any{"tools": map[string]any{}},
 		"serverInfo":      map[string]any{"name": relay.MCPServerName, "version": "1"},
+		"instructions":    mcpInstructions,
 	}
 }
 
@@ -189,11 +206,15 @@ func mcpText(text string, failed bool) map[string]any {
 func mcpToolList() []map[string]any {
 	list := make([]map[string]any, 0, len(mcpTools))
 	for _, tool := range mcpTools {
-		list = append(list, map[string]any{
+		entry := map[string]any{
 			"name":        tool.Name,
 			"description": tool.Description,
 			"inputSchema": tool.Schema,
-		})
+		}
+		if tool.ReadOnly {
+			entry["annotations"] = map[string]any{"readOnlyHint": true}
+		}
+		list = append(list, entry)
 	}
 	return list
 }
@@ -270,7 +291,8 @@ var mcpTools = []mcpTool{
 		Name: "list_sessions",
 		Description: "List the other lich sessions that are live right now and can be given work. " +
 			"Returns each session's label (how it is addressed), its project, and which agent runs in it.",
-		Schema: schema(map[string]any{}),
+		Schema:   schema(map[string]any{}),
+		ReadOnly: true,
 		Run: func(c *client, _ mcpArgs) (string, error) {
 			var peers []relay.Peer
 			if err := c.call("relay.Peers", []any{c.sessionID()}, shortCall, &peers); err != nil {
@@ -290,8 +312,8 @@ var mcpTools = []mcpTool{
 		Name: "send_to_session",
 		Description: "Give another lich session a task. The task is put at that session's prompt " +
 			"as if typed there. Returns the answer when it comes back quickly; for anything " +
-			"slower the answer is delivered to your own prompt as soon as it exists, so you can " +
-			"carry on and do not need to poll. " +
+			"slower you get a ticket and carry on — when the result is ready, a short note " +
+			"arrives at your own prompt and wait_for_answer collects it, so you never poll. " +
 			"Sessions are addressed by the label on their lich card — call list_sessions for " +
 			"the labels. If you were given a name like `myrepo-a1b2`, that is a peer-roster " +
 			"name from your own cross-session messaging, not a lich label: reach it with your " +
@@ -318,21 +340,32 @@ var mcpTools = []mcpTool{
 	},
 	{
 		Name: "wait_for_answer",
-		Description: "Hold the line again on a ticket send_to_session handed back. Optional: the " +
-			"answer reaches your prompt on its own whether or not you call this. Use it only when " +
-			"you have nothing else to do and want the answer inside this turn.",
+		Description: "Collect the results of tasks you sent with send_to_session. Without a " +
+			"ticket it returns every result that is ready — the one call to make when a " +
+			"[lich] note says results are waiting — and, when none is, holds the line for " +
+			"the next one. With a ticket it waits on that one errand. Use it to pick " +
+			"results up, or when you have nothing to do but wait; results announce " +
+			"themselves at your prompt either way, so there is never a reason to poll.",
 		Schema: schema(map[string]any{
-			"ticket": property("string", "The ticket send_to_session returned."),
+			"ticket": property("string",
+				"A ticket send_to_session returned. Omit to collect everything that is ready."),
 			"timeout_seconds": property("number",
-				"Seconds to wait, at most 90. Call this again with the same ticket for longer."),
-		}, "ticket"),
+				"Seconds to hold the line when nothing is ready yet, at most 90. Call again for longer."),
+		}),
 		Run: func(c *client, args mcpArgs) (string, error) {
-			var result relay.Result
 			timeout := args.seconds("timeout_seconds")
-			if err := c.call("relay.Wait", []any{args.text("ticket"), timeout}, waitBudget(timeout), &result); err != nil {
+			if ticket := args.text("ticket"); ticket != "" {
+				var result relay.Result
+				if err := c.call("relay.Wait", []any{ticket, timeout}, waitBudget(timeout), &result); err != nil {
+					return "", err
+				}
+				return mcpOutcome(result), nil
+			}
+			var collected relay.Collected
+			if err := c.call("relay.Collect", []any{c.sessionID(), timeout}, waitBudget(timeout), &collected); err != nil {
 				return "", err
 			}
-			return mcpOutcome(result), nil
+			return collectedText(collected), nil
 		},
 	},
 	{
@@ -407,6 +440,7 @@ var mcpTools = []mcpTool{
 		Schema: schema(map[string]any{
 			"project": property("string", "Project to list. Defaults to your own."),
 		}),
+		ReadOnly: true,
 		Run: func(c *client, args mcpArgs) (string, error) {
 			var checkouts []spawn.Checkout
 			call := []any{c.sessionID(), args.text("project")}
@@ -455,11 +489,42 @@ func mcpOutcome(result relay.Result) string {
 		return unreadText(result.Target)
 	}
 	return fmt.Sprintf(
-		"%s is still working. The task was delivered and its answer will be put at your own "+
-			"prompt when it arrives, so carry on — there is nothing to poll. Ticket %q, if you "+
-			"want to hold the line for it with wait_for_answer instead.",
+		"%s is still working. The task was delivered; when its result is ready a short note "+
+			"will arrive at your own prompt, so carry on — there is nothing to poll. Collect "+
+			"it with wait_for_answer (ticket %q, or no ticket for everything at once).",
 		result.Target, result.Ticket,
 	)
+}
+
+// collectedText words a drain: each result in the order it arrived, then who
+// still owes one. Statuses reuse the same words a single wait answers with —
+// the reader should not meet two spellings of one outcome.
+func collectedText(collected relay.Collected) string {
+	if len(collected.Results) == 0 && len(collected.Open) == 0 {
+		return "Nothing to collect: no results are waiting and no errand of yours is open."
+	}
+	var parts []string
+	for _, result := range collected.Results {
+		switch result.Status {
+		case relay.StatusAnswered:
+			parts = append(parts, fmt.Sprintf(
+				"Answer from %q (ticket %s):\n%s", result.Target, result.Ticket, result.Answer))
+		case relay.StatusUnread:
+			parts = append(parts, unreadText(result.Target))
+		case relay.StatusUnanswered:
+			parts = append(parts, unansweredText(result.Target))
+		}
+	}
+	if len(collected.Open) > 0 {
+		quoted := make([]string, 0, len(collected.Open))
+		for _, label := range collected.Open {
+			quoted = append(quoted, fmt.Sprintf("%q", label))
+		}
+		parts = append(parts, fmt.Sprintf(
+			"Still working: %s. Their results will announce themselves at your prompt.",
+			strings.Join(quoted, ", ")))
+	}
+	return strings.Join(parts, "\n\n")
 }
 
 // unreadText is what both surfaces say about a task that reached the terminal

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -81,6 +81,7 @@ func TestMCPHandshakeAdvertisesTools(t *testing.T) {
 		ServerInfo struct {
 			Name string `json:"name"`
 		} `json:"serverInfo"`
+		Instructions string `json:"instructions"`
 	}
 	resultOf(t, replies[0], &result)
 
@@ -92,6 +93,14 @@ func TestMCPHandshakeAdvertisesTools(t *testing.T) {
 	}
 	if result.ServerInfo.Name != "lich" {
 		t.Errorf("serverInfo.name = %q", result.ServerInfo.Name)
+	}
+	// The instructions are the one place the whole journey — fan out, carry
+	// on, collect — is told as one; clients inject them into the system
+	// prompt, so an empty field is an agent that never learns it can delegate.
+	for _, want := range []string{"open_session", "send_to_session", "wait_for_answer", "worktree"} {
+		if !strings.Contains(result.Instructions, want) {
+			t.Errorf("instructions are missing %q:\n%s", want, result.Instructions)
+		}
 	}
 }
 
@@ -136,6 +145,9 @@ func TestMCPListsEveryTool(t *testing.T) {
 				Properties map[string]json.RawMessage `json:"properties"`
 				Required   []string                   `json:"required"`
 			} `json:"inputSchema"`
+			Annotations *struct {
+				ReadOnlyHint bool `json:"readOnlyHint"`
+			} `json:"annotations"`
 		} `json:"tools"`
 	}
 	resultOf(t, replies[0], &result)
@@ -146,9 +158,12 @@ func TestMCPListsEveryTool(t *testing.T) {
 		"close_session":    {"session"},
 		"list_worktrees":   {},
 		"send_to_session":  {"session", "prompt"},
-		"wait_for_answer":  {"ticket"},
+		"wait_for_answer":  {},
 		"reply_to_session": {"ticket", "answer"},
 	}
+	// The read-only ones, which a client may auto-allow. wait_for_answer is
+	// not among them: collecting drains the inbox.
+	readOnly := map[string]bool{"list_sessions": true, "list_worktrees": true}
 	if len(result.Tools) != len(want) {
 		t.Fatalf("got %d tools, want %d", len(result.Tools), len(want))
 	}
@@ -171,6 +186,9 @@ func TestMCPListsEveryTool(t *testing.T) {
 			if _, ok := tool.InputSchema.Properties[name]; !ok {
 				t.Errorf("%s requires %q but does not declare it", tool.Name, name)
 			}
+		}
+		if marked := tool.Annotations != nil && tool.Annotations.ReadOnlyHint; marked != readOnly[tool.Name] {
+			t.Errorf("%s readOnlyHint = %v, want %v", tool.Name, marked, readOnly[tool.Name])
 		}
 	}
 }
@@ -215,6 +233,72 @@ func TestMCPSendPointsAtTheTicketWhenItRunsOut(t *testing.T) {
 		if !strings.Contains(text, want) {
 			t.Errorf("text is missing %q: %s", want, text)
 		}
+	}
+}
+
+// Without a ticket, wait_for_answer is the drain: one call collects every
+// result the nudge announced, over relay.Collect.
+func TestMCPWaitWithoutATicketCollectsEverything(t *testing.T) {
+	f := newFakeLich(t, `{"results":[
+		{"ticket":"t1","target":"auth","status":"answered","answer":"all green"},
+		{"ticket":"t2","target":"api","status":"unanswered","answer":""}],
+		"open":["docs"]}`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"wait_for_answer","arguments":{"timeout_seconds":20}}}`)
+
+	text, failed := textOf(t, replies[0])
+	if failed {
+		t.Fatalf("tool reported a failure: %s", text)
+	}
+	call := f.only(t)
+	if call.method != "relay.Collect" {
+		t.Fatalf("method = %q, want relay.Collect", call.method)
+	}
+	if call.args[0] != "s1" || call.args[1] != float64(20) {
+		t.Errorf("args = %v", call.args)
+	}
+	for _, want := range []string{
+		`Answer from "auth" (ticket t1):`, "all green",
+		`The "api" session finished its turn`,
+		`Still working: "docs"`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("text is missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestMCPWaitWithNothingToCollectSaysSo(t *testing.T) {
+	f := newFakeLich(t, `{"results":[],"open":[]}`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"wait_for_answer","arguments":{}}}`)
+
+	text, failed := textOf(t, replies[0])
+	if failed {
+		t.Fatalf("tool reported a failure: %s", text)
+	}
+	if !strings.Contains(text, "Nothing to collect") {
+		t.Errorf("text = %q, want it to say there is nothing", text)
+	}
+}
+
+func TestMCPWaitWithATicketWaitsOnIt(t *testing.T) {
+	f := newFakeLich(t, `{"ticket":"a1b2c3d4","target":"docs","status":"answered","answer":"done"}`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"wait_for_answer","arguments":{"ticket":"a1b2c3d4"}}}`)
+
+	text, failed := textOf(t, replies[0])
+	if failed {
+		t.Fatalf("tool reported a failure: %s", text)
+	}
+	if text != "done" {
+		t.Errorf("text = %q, want the answer alone", text)
+	}
+	if call := f.only(t); call.method != "relay.Wait" {
+		t.Errorf("method = %q, want relay.Wait", call.method)
 	}
 }
 

--- a/internal/relay/compose.go
+++ b/internal/relay/compose.go
@@ -45,35 +45,39 @@ func replyInstruction(hasTools bool, ticketID string) string {
 	}
 	return route + "\n\nThat ticket is the only way back: whoever asked is blocked on it and " +
 		"is reading nothing else. Do not answer by messaging a peer session — an answer " +
-		"sent any other way is lost."
+		"sent any other way is lost. Keep the answer a concise report — what was done, " +
+		"where, and what remains — never a transcript: the sender pays to read every byte, " +
+		"and the detail is in your commits and files anyway."
 }
 
-// unreadNotice is what a sender who stopped waiting is told, typed at its own
-// prompt the way an answer would be. It has to be actionable on its own: the
-// sender cannot see the other screen, and what is usually on it is a question
-// only a person can answer.
-func unreadNotice(target string) string {
-	return fmt.Sprintf(
-		"[lich] The %q session never picked up the task you sent it. It was typed at "+
-			"that prompt and nothing read it, so something else has that terminal — a "+
-			"provider still starting, or a question of its own on screen. Nothing is "+
-			"queued and nothing was answered.",
-		target,
-	)
+// nudgeNotice is the one line typed at a sender's prompt when results are
+// waiting and nobody is holding the line for them. It replaces typing the
+// results themselves: N results landing as N prompt submissions each restart
+// the sender's turn and leave the full text sitting in its context window,
+// while one short line lets the agent drain everything in a single tool call.
+// count and targets cover everything waiting, not only what this nudge is the
+// first to mention — the reader acts on the total.
+func nudgeNotice(count int, targets []string, hasTools bool) string {
+	what := fmt.Sprintf("Results from %d tasks you sent are ready (%s)", count, quotedList(targets))
+	if count == 1 {
+		what = fmt.Sprintf("The task you sent %s has its result ready", quotedList(targets))
+	}
+	route := "run:\n  \"$LICH_BIN\" wait"
+	if hasTools {
+		route = fmt.Sprintf(
+			"call the lich tool `%s` with no ticket, or run:\n  \"$LICH_BIN\" wait", ToolCollect,
+		)
+	}
+	return fmt.Sprintf("[lich] %s. To collect everything at once, %s", what, route)
 }
 
-// stalledNotice is what a sender who stopped waiting is told when the target
-// ended its turn without replying through lich, typed at its own prompt the way
-// an answer would be. The pending result promised that prompt an answer, so the
-// promise has to be withdrawn the same way it would have been kept — whatever
-// the target produced is on its own screen, which only a person can go read.
-func stalledNotice(target string) string {
-	return fmt.Sprintf(
-		"[lich] The %q session finished its turn without answering through lich. "+
-			"Nothing more is coming back on that ticket — whatever it produced is on "+
-			"that session's own screen, so ask the user to open the %q card to read it.",
-		target, target,
-	)
+// quotedList words a list of session labels for a message.
+func quotedList(labels []string) string {
+	quoted := make([]string, 0, len(labels))
+	for _, label := range labels {
+		quoted = append(quoted, fmt.Sprintf("%q", label))
+	}
+	return strings.Join(quoted, ", ")
 }
 
 // origin describes the sender in the message's first line. An empty sender is

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -18,6 +18,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -73,7 +74,15 @@ const (
 	// ToolReply answers a relayed message. It is the one tool named in prose,
 	// because the receiving agent is told what to call.
 	ToolReply = "reply_to_session"
+	// ToolCollect drains the results waiting for a sender. Named in prose too:
+	// the nudge typed at a sender's prompt is what tells it the tool exists.
+	ToolCollect = "wait_for_answer"
 )
+
+// defaultNudgeDelay is how long a result sits before the nudge naming it is
+// typed. Parallel workers finish in bursts — a fan-out answered within seconds
+// of itself would otherwise cost one nudge, and one restarted turn, per worker.
+const defaultNudgeDelay = 2 * time.Second
 
 // Status values a Result carries.
 const (
@@ -186,6 +195,33 @@ type Result struct {
 	Answer string `json:"answer"`
 }
 
+// Collected is what a drain returns: every outcome that was waiting for the
+// caller, oldest first, and the labels of the sessions still owing one.
+type Collected struct {
+	Results []Result `json:"results"`
+	Open    []string `json:"open"`
+}
+
+// inboxEntry is one finished errand whose outcome nobody was holding the line
+// for. The result is kept here until the sender collects it instead of being
+// typed at the sender's prompt in full: N results arriving as N prompt
+// submissions each restart the sender's turn and leave the whole text in its
+// context window — exactly the cost an orchestrating session cannot pay per
+// worker. What is typed instead is one short nudge (nudgeNotice), debounced so
+// a burst of workers finishing together costs one.
+type inboxEntry struct {
+	ticket string
+	fromID string
+	target string
+	status string
+	answer string
+	ready  time.Time
+	// nudged is whether a notice naming this entry was already typed. One nudge
+	// per entry: re-nudging on every turn end would start a turn per nudge,
+	// forever, for a sender that chose not to collect.
+	nudged bool
+}
+
 // ticket is one outstanding errand. answer is written once, before done is
 // closed, so every waiter reads it safely after the close.
 //
@@ -246,6 +282,15 @@ type Service struct {
 	// about appear; an unknown one is treated as not working, which is what a
 	// session with no hooks installed looks like.
 	state map[string]string
+	// ready is the inbox: finished errands waiting to be collected, keyed by
+	// ticket so a Wait on the original ticket still finds its outcome.
+	ready map[string]*inboxEntry
+	// collectors is who is blocked in Collect right now, per sender. A result
+	// stashed while one is registered wakes it instead of arming a nudge.
+	collectors map[string][]chan struct{}
+	// nudgeTimer is the armed debounce per sender, so a burst of results costs
+	// one nudge rather than one per result.
+	nudgeTimer map[string]*time.Timer
 
 	sessions Sessions
 	term     Terminal
@@ -258,6 +303,9 @@ type Service struct {
 	// receiptWindow is how long a delivered task has to be picked up before it
 	// is called unread (see watchReceipt). A field for the same reason.
 	receiptWindow time.Duration
+	// nudgeDelay is the debounce before a nudge is typed (defaultNudgeDelay).
+	// A field for the same reason.
+	nudgeDelay time.Duration
 	// plugins answers what a provider's sessions can do, which depends on state
 	// this package has none of: whether the companion plugin is installed there,
 	// and whether it is new enough to carry lich's own operations. Nil — the
@@ -285,12 +333,16 @@ func New(sessions Sessions, term Terminal, events Events) *Service {
 	return &Service{
 		tickets:       make(map[string]*ticket),
 		state:         make(map[string]string),
+		ready:         make(map[string]*inboxEntry),
+		collectors:    make(map[string][]chan struct{}),
+		nudgeTimer:    make(map[string]*time.Timer),
 		sessions:      sessions,
 		term:          term,
 		events:        events,
 		now:           time.Now,
 		submitDelay:   defaultSubmitDelay,
 		receiptWindow: defaultReceiptWindow,
+		nudgeDelay:    defaultNudgeDelay,
 	}
 }
 
@@ -502,15 +554,22 @@ func (s *Service) watchReceipt(id string, t *ticket) {
 
 	s.clear(t)
 	if unattended {
-		s.tellSender(t, unreadNotice(t.target))
+		s.stash(id, t, StatusUnread, "")
 	}
 }
 
 // Wait blocks on an already-delivered ticket for another round, so a caller
 // whose first wait ran out can come back without sending the message twice.
+// An outcome already sitting in the inbox is handed over on the spot.
 func (s *Service) Wait(ticketID string, waitSeconds int) (Result, error) {
 	s.mu.Lock()
 	expired := s.sweep()
+	if e, ok := s.ready[ticketID]; ok {
+		delete(s.ready, ticketID)
+		s.mu.Unlock()
+		s.clearAll(expired)
+		return Result{Ticket: e.ticket, Target: e.target, Status: e.status, Answer: e.answer}, nil
+	}
 	t, ok := s.tickets[ticketID]
 	s.mu.Unlock()
 	s.clearAll(expired)
@@ -518,6 +577,106 @@ func (s *Service) Wait(ticketID string, waitSeconds int) (Result, error) {
 		return Result{}, fmt.Errorf("unknown ticket %q — it was answered long ago, or expired", ticketID)
 	}
 	return s.await(ticketID, t, waitFor(waitSeconds)), nil
+}
+
+// Collect drains every outcome waiting for fromID, oldest first. With nothing
+// ready and errands still open it holds the line for the next one; with
+// nothing ready and nothing open it returns empty at once. It is the batch
+// half of the nudge: one call picks up what any number of workers produced.
+func (s *Service) Collect(fromID string, waitSeconds int) (Collected, error) {
+	if fromID == "" {
+		return Collected{}, fmt.Errorf(
+			"collecting needs a session of your own — outside one, wait on the ticket instead: lich wait <ticket>")
+	}
+	deadline := s.now().Add(waitFor(waitSeconds))
+	for {
+		s.mu.Lock()
+		expired := s.sweep()
+		results := s.drainLocked(fromID)
+		open := s.openLocked(fromID)
+		if len(results) > 0 || len(open) == 0 {
+			s.mu.Unlock()
+			s.clearAll(expired)
+			return Collected{Results: results, Open: open}, nil
+		}
+		wake := make(chan struct{}, 1)
+		s.collectors[fromID] = append(s.collectors[fromID], wake)
+		s.mu.Unlock()
+		s.clearAll(expired)
+
+		remaining := deadline.Sub(s.now())
+		if remaining <= 0 {
+			s.unregister(fromID, wake)
+			return Collected{Results: []Result{}, Open: open}, nil
+		}
+		timer := time.NewTimer(remaining)
+		select {
+		case <-wake:
+			timer.Stop()
+			s.unregister(fromID, wake)
+		case <-timer.C:
+			s.unregister(fromID, wake)
+			// One last look: the result may have landed in the same instant.
+			s.mu.Lock()
+			results := s.drainLocked(fromID)
+			open := s.openLocked(fromID)
+			s.mu.Unlock()
+			return Collected{Results: results, Open: open}, nil
+		}
+	}
+}
+
+// drainLocked empties fromID's inbox, oldest first. Called under s.mu. It
+// never returns nil: a JSON null where a script expects a list is a bug it
+// should not have to defend against.
+func (s *Service) drainLocked(fromID string) []Result {
+	var found []*inboxEntry
+	for id, e := range s.ready {
+		if e.fromID != fromID {
+			continue
+		}
+		delete(s.ready, id)
+		found = append(found, e)
+	}
+	sort.Slice(found, func(i, j int) bool { return found[i].ready.Before(found[j].ready) })
+	results := make([]Result, 0, len(found))
+	for _, e := range found {
+		results = append(results, Result{Ticket: e.ticket, Target: e.target, Status: e.status, Answer: e.answer})
+	}
+	return results
+}
+
+// openLocked is the labels still owing fromID an answer, deduplicated and
+// sorted. Called under s.mu.
+func (s *Service) openLocked(fromID string) []string {
+	seen := map[string]bool{}
+	for _, t := range s.tickets {
+		if t.fromID == fromID {
+			seen[t.target] = true
+		}
+	}
+	labels := make([]string, 0, len(seen))
+	for label := range seen {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	return labels
+}
+
+// unregister drops one Collect call's wake channel.
+func (s *Service) unregister(fromID string, wake chan struct{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	list := s.collectors[fromID]
+	for i, ch := range list {
+		if ch == wake {
+			s.collectors[fromID] = append(list[:i], list[i+1:]...)
+			break
+		}
+	}
+	if len(s.collectors[fromID]) == 0 {
+		delete(s.collectors, fromID)
+	}
 }
 
 // Reply hands an answer back to whoever is waiting on ticketID. It is what the
@@ -554,39 +713,85 @@ func (s *Service) Reply(ticketID, answer string) error {
 
 	s.clear(t)
 	if unattended {
-		s.returnAnswer(t)
+		s.stash(ticketID, t, StatusAnswered, answer)
 	}
 	return nil
 }
 
-// returnAnswer types the answer at the sender's own prompt, the same way the
-// request reached the target. It runs when nobody is blocked on the ticket
-// anymore, which is the normal case for anything that took longer than a tool
-// call may sit still: the answer arrives when it arrives, in the session that
-// asked, instead of being lost because the asker stopped listening.
-//
-// A sender that is not a session at all — the `lich` command from a script —
-// has no prompt to type at. Such a caller waits or does without.
-func (s *Service) returnAnswer(t *ticket) {
-	if t.answer == "" {
+// stash puts one finished errand's outcome in the inbox and decides how the
+// sender hears about it: a Collect already holding the line is woken, a busy
+// sender is left alone until its turn ends (Observe flushes then), and an idle
+// one gets a nudge after the debounce. A sender that is not a session — the
+// `lich` command from a script — is never nudged; its entry waits to be asked
+// for with `lich wait <ticket>`.
+func (s *Service) stash(id string, t *ticket, status, answer string) {
+	s.mu.Lock()
+	s.ready[id] = &inboxEntry{
+		ticket: id, fromID: t.fromID, target: t.target,
+		status: status, answer: answer, ready: s.now(),
+	}
+	woke := false
+	for _, wake := range s.collectors[t.fromID] {
+		select {
+		case wake <- struct{}{}:
+		default:
+		}
+		woke = true
+	}
+	nudgeable := !woke && t.fromID != "" && s.state[t.fromID] != stateBusy
+	if nudgeable && s.nudgeTimer[t.fromID] == nil {
+		fromID := t.fromID
+		s.nudgeTimer[fromID] = time.AfterFunc(s.nudgeDelay, func() { s.flushNudge(fromID) })
+	}
+	s.mu.Unlock()
+}
+
+// flushNudge types one nudge naming everything waiting for fromID, if any of
+// it has not been nudged before. Ran by the debounce timer and by Observe when
+// the sender's turn ends — a delivery mid-turn would queue as its own turn,
+// which is the cost this whole path exists to avoid.
+func (s *Service) flushNudge(fromID string) {
+	s.mu.Lock()
+	if timer := s.nudgeTimer[fromID]; timer != nil {
+		timer.Stop()
+		delete(s.nudgeTimer, fromID)
+	}
+	if s.state[fromID] == stateBusy {
+		// The prompt is not free; the end of this turn flushes instead.
+		s.mu.Unlock()
 		return
 	}
-	s.tellSender(t, fmt.Sprintf(
-		"[lich] Answer from session %q, to the request you sent it:\n\n%s",
-		t.target, t.answer,
-	))
+	fresh := 0
+	count := 0
+	targets := map[string]bool{}
+	for _, e := range s.ready {
+		if e.fromID != fromID {
+			continue
+		}
+		if !e.nudged {
+			fresh++
+			e.nudged = true
+		}
+		count++
+		targets[e.target] = true
+	}
+	s.mu.Unlock()
+	if fresh == 0 {
+		return
+	}
+	labels := make([]string, 0, len(targets))
+	for label := range targets {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	s.tellSender(fromID, nudgeNotice(count, labels, s.offersTools(s.kindOf(fromID))))
 }
 
 // tellSender types one line of news at the prompt of whoever asked, the same
-// way their request reached the target. A sender that is not a session at all —
-// the `lich` command from a script — has no prompt to type at, and hears this
-// only if it is still waiting.
-func (s *Service) tellSender(t *ticket, message string) {
-	if t.fromID == "" {
-		return
-	}
-	if err := s.deliver(t.fromID, message); err != nil {
-		slog.Warn("relay: news not delivered", "session", t.fromID, "err", err)
+// way their request reached the target.
+func (s *Service) tellSender(fromID, message string) {
+	if err := s.deliver(fromID, message); err != nil {
+		slog.Warn("relay: news not delivered", "session", fromID, "err", err)
 	}
 }
 
@@ -623,7 +828,7 @@ func (s *Service) await(id string, t *ticket, wait time.Duration) Result {
 		s.leave(t)
 		return Result{Ticket: id, Target: t.target, Status: StatusUnread}
 	case <-timer.C:
-		return Result{Ticket: id, Target: t.target, Status: s.giveUp(t)}
+		return Result{Ticket: id, Target: t.target, Status: s.giveUp(id, t)}
 	}
 }
 
@@ -640,12 +845,12 @@ func (s *Service) leave(t *ticket) {
 // seeing this caller still attending, and leaving the news for it — after it
 // had already stopped listening. Whoever leaves last owns what is left behind.
 //
-// A reply is typed at the sender's prompt, because an answer outlives the wait
-// it missed. The receipt window closing the ticket unread — and a turn ending
+// A reply is stashed for the sender, because an answer outlives the wait it
+// missed. The receipt window closing the ticket unread — and a turn ending
 // with no answer — are told to the caller instead: it is still here to hear
 // them, and the alternative is reporting the errand as still in progress, on a
 // ticket already out of the map.
-func (s *Service) giveUp(t *ticket) string {
+func (s *Service) giveUp(id string, t *ticket) string {
 	s.mu.Lock()
 	t.attended--
 	last := t.attended == 0
@@ -665,7 +870,7 @@ func (s *Service) giveUp(t *ticket) string {
 	}
 	s.mu.Unlock()
 	if orphaned {
-		s.returnAnswer(t)
+		s.stash(id, t, StatusAnswered, t.answer)
 	}
 	if unread {
 		return StatusUnread
@@ -708,7 +913,11 @@ func (s *Service) Observe(sessionID, state string) {
 		s.state[sessionID] = state
 	}
 
-	var ended []*ticket
+	type endedErrand struct {
+		id string
+		t  *ticket
+	}
+	var ended []endedErrand
 	switch state {
 	case stateBusy:
 		for _, t := range s.tickets {
@@ -726,39 +935,43 @@ func (s *Service) Observe(sessionID, state string) {
 			if t.targetID == sessionID && !t.delivered.IsZero() {
 				delete(s.tickets, id)
 				close(t.stalled)
-				ended = append(ended, t)
+				ended = append(ended, endedErrand{id, t})
 			}
 		}
 	case stateDone:
 		if id, t := s.turnErrand(sessionID); t != nil {
 			delete(s.tickets, id)
 			close(t.stalled)
-			ended = append(ended, t)
+			ended = append(ended, endedErrand{id, t})
 		}
 	}
 	// A waiter still holding the line carries the news out through its own
-	// select; an errand nobody is attending has to reach the sender's prompt
-	// instead, the way an answer or an unread notice would. Without it the
-	// promise a pending result makes — "the answer will arrive at your prompt"
-	// — is silently never kept.
-	var quiet []*ticket
-	for _, t := range ended {
-		if t.attended == 0 {
-			quiet = append(quiet, t)
+	// select; an errand nobody is attending is stashed for the sender instead,
+	// the way an answer would be. Without it the promise a pending result makes
+	// — "news will arrive at your prompt" — is silently never kept.
+	var quiet []endedErrand
+	for _, e := range ended {
+		if e.t.attended == 0 {
+			quiet = append(quiet, e)
 		}
 	}
 	s.mu.Unlock()
 
-	s.clearAll(ended)
-	for _, t := range ended {
+	for _, e := range ended {
+		s.clear(e.t)
 		if s.events != nil {
 			s.events.Emit(StalledEventName, StalledEvent{
-				ID: t.fromID, TargetID: t.targetID, Target: t.target,
+				ID: e.t.fromID, TargetID: e.t.targetID, Target: e.t.target,
 			})
 		}
 	}
-	for _, t := range quiet {
-		s.tellSender(t, stalledNotice(t.target))
+	for _, e := range quiet {
+		s.stash(e.id, e.t, StatusUnanswered, "")
+	}
+	// This session as a sender: its turn ending frees its prompt, which is what
+	// a nudge held back during the turn was waiting for.
+	if state == stateDone {
+		s.flushNudge(sessionID)
 	}
 }
 
@@ -832,9 +1045,11 @@ func waitFor(seconds int) time.Duration {
 }
 
 // sweep drops tickets nobody answered in time and returns them, so the caller
-// can take their marks down after releasing s.mu. Called under the lock on the
-// paths that already hold it, which is often enough for a map that grows one
-// entry per errand.
+// can take their marks down after releasing s.mu. Inbox entries nobody
+// collected age out on the same TTL — a sender that never drains would
+// otherwise grow the inbox by one entry per errand for the life of the
+// process. Called under the lock on the paths that already hold it, which is
+// often enough for a map that grows one entry per errand.
 func (s *Service) sweep() []*ticket {
 	var expired []*ticket
 	cutoff := s.now().Add(-ticketTTL)
@@ -842,6 +1057,11 @@ func (s *Service) sweep() []*ticket {
 		if t.created.Before(cutoff) {
 			delete(s.tickets, id)
 			expired = append(expired, t)
+		}
+	}
+	for id, e := range s.ready {
+		if e.ready.Before(cutoff) {
+			delete(s.ready, id)
 		}
 	}
 	return expired

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -147,12 +147,28 @@ func (f *fakeEvents) awaitMark(id, direction string) bool {
 	return false
 }
 
-// newRelay is New with the paste-to-Enter delay dropped: the fakes have no TUI
-// to settle, and paying it in every test would buy nothing.
+// newRelay is New with the paste-to-Enter delay dropped — the fakes have no
+// TUI to settle, and paying it in every test would buy nothing — and the nudge
+// debounce shrunk for the same reason.
 func newRelay(sessions Sessions, term Terminal, events Events) *Service {
 	svc := New(sessions, term, events)
 	svc.submitDelay = 0
+	svc.nudgeDelay = time.Millisecond
 	return svc
+}
+
+// awaitWritten blocks until want shows up in what a session was typed, and
+// returns whether it did. The nudge rides a debounce timer, so a test asserting
+// on it has to wait it out rather than race it.
+func awaitWritten(term *fakeTerminal, id, want string) bool {
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(term.written(id), want) {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return false
 }
 
 // workspace is the roster most tests run against: two projects, one label
@@ -314,6 +330,11 @@ func TestReplyInstructionOffersTheToolOnlyWhereItExists(t *testing.T) {
 			}
 			if !strings.Contains(got, "Do not answer by messaging a peer session") {
 				t.Errorf("the instruction does not rule out the peer channel:\n%s", got)
+			}
+			// The sender pays to read the answer, so the instruction pins the
+			// shape: a report, not a transcript.
+			if !strings.Contains(got, "concise report") {
+				t.Errorf("the instruction does not ask for a concise report:\n%s", got)
 			}
 		})
 	}
@@ -559,8 +580,8 @@ func TestATurnThatEndsWithoutAnAnswerEndsTheWait(t *testing.T) {
 
 // The sender usually stops waiting long before the target's turn ends: it took
 // a ticket and moved on, on the promise that news would reach its prompt. A
-// turn that ends with no reply is that news, and it has to arrive the same way
-// an answer would.
+// turn that ends with no reply is that news — what arrives is the short nudge,
+// and the outcome itself is collected, not typed.
 func TestTheSenderIsToldAtItsPromptWhenTheTargetStallsUnattended(t *testing.T) {
 	term := newFakeTerminal("s1", "s2")
 	svc := newRelay(workspace(), term, nil)
@@ -576,12 +597,18 @@ func TestTheSenderIsToldAtItsPromptWhenTheTargetStallsUnattended(t *testing.T) {
 	svc.Observe("s2", "busy")
 	svc.Observe("s2", "done")
 
-	typed := term.written("s1")
-	if !strings.Contains(typed, "finished its turn without answering") {
-		t.Errorf("the sender was never told the errand stalled: %q", typed)
+	if !awaitWritten(term, "s1", "[lich]") {
+		t.Fatalf("the sender was never nudged: %q", term.written("s1"))
 	}
-	if _, err := svc.Wait(got.Ticket, 1); err == nil {
-		t.Error("the ticket outlived the turn that closed it")
+	if typed := term.written("s1"); !strings.Contains(typed, `"docs"`) {
+		t.Errorf("the nudge does not name who the news is from: %q", typed)
+	}
+	res, err := svc.Wait(got.Ticket, 1)
+	if err != nil {
+		t.Fatalf("Wait on the stalled ticket: %v", err)
+	}
+	if res.Status != StatusUnanswered {
+		t.Errorf("status = %q, want %q collected off the inbox", res.Status, StatusUnanswered)
 	}
 }
 
@@ -601,7 +628,7 @@ func TestAWaiterGivingUpAsTheErrandStallsHearsSo(t *testing.T) {
 	}
 	close(tk.stalled)
 
-	if got := svc.giveUp(tk); got != StatusUnanswered {
+	if got := svc.giveUp("tk1", tk); got != StatusUnanswered {
 		t.Errorf("status = %q, want the caller told the target answered elsewhere", got)
 	}
 }
@@ -834,10 +861,12 @@ func TestAnotherSessionsTurnLeavesTheTicketAlone(t *testing.T) {
 	}
 }
 
-// TestAnAnswerNobodyWaitedForIsTypedAtTheSendersPrompt proves the path that
-// makes a long errand work at all: the asker stops holding the line, the answer
-// arrives later, and it comes back the same way the request went out.
-func TestAnAnswerNobodyWaitedForIsTypedAtTheSendersPrompt(t *testing.T) {
+// TestAnAnswerNobodyWaitedForIsStashedAndNudged proves the path that makes a
+// long errand work at all: the asker stops holding the line, the answer
+// arrives later — and what reaches its prompt is one short nudge, never the
+// answer itself. The full text comes back through Collect, inside a turn the
+// sender chose, instead of restarting its turn as a prompt submission.
+func TestAnAnswerNobodyWaitedForIsStashedAndNudged(t *testing.T) {
 	term := newFakeTerminal("s1", "s2")
 	svc := newRelay(workspace(), term, nil)
 
@@ -856,18 +885,37 @@ func TestAnAnswerNobodyWaitedForIsTypedAtTheSendersPrompt(t *testing.T) {
 		t.Fatalf("Reply: %v", err)
 	}
 
+	if !awaitWritten(term, "s1", "[lich]") {
+		t.Fatalf("the sender was never nudged: %q", term.written("s1"))
+	}
 	writes := term.writesTo("s1")
 	if len(writes) != 2 {
 		t.Fatalf("got %d writes to the sender, want the paste and the submit: %q", len(writes), writes)
 	}
 	if writes[1] != "\r" {
-		t.Errorf("the answer was left sitting at the prompt: %q", writes)
+		t.Errorf("the nudge was left sitting at the prompt: %q", writes)
 	}
 	typed := term.written("s1")
-	for _, want := range []string{`Answer from session "docs"`, "3 failures in foo_test"} {
-		if !strings.Contains(typed, want) {
-			t.Errorf("returned answer is missing %q:\n%s", want, typed)
-		}
+	if strings.Contains(typed, "3 failures in foo_test") {
+		t.Errorf("the full answer was typed at the prompt instead of held for Collect:\n%s", typed)
+	}
+	if !strings.Contains(typed, `"docs"`) {
+		t.Errorf("the nudge does not name who answered: %q", typed)
+	}
+
+	collected, err := svc.Collect("s1", 1)
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(collected.Results) != 1 {
+		t.Fatalf("collected %d results, want the one answer: %+v", len(collected.Results), collected)
+	}
+	res := collected.Results[0]
+	if res.Status != StatusAnswered || res.Answer != "3 failures in foo_test" || res.Ticket != got.Ticket {
+		t.Errorf("collected %+v, want the stashed answer under its own ticket", res)
+	}
+	if len(collected.Open) != 0 {
+		t.Errorf("collect reports %v still open, want none", collected.Open)
 	}
 }
 
@@ -1471,8 +1519,9 @@ func TestSilenceIsOnlyReadWhereTheProviderReports(t *testing.T) {
 	}
 }
 
-// The sender usually stops waiting long before this: it took a ticket and moved
-// on, so the news has to reach its prompt, exactly as an answer would.
+// The sender usually stops waiting long before this: it took a ticket and
+// moved on, so the news has to reach its prompt — as a nudge, with the unread
+// outcome itself waiting in the inbox.
 func TestTheSenderIsToldAtItsPromptWhenNobodyWasWaiting(t *testing.T) {
 	term := newFakeTerminal("s1", "s2")
 	svc := withReceipts(term)
@@ -1487,14 +1536,16 @@ func TestTheSenderIsToldAtItsPromptWhenNobodyWasWaiting(t *testing.T) {
 	if result.Status != StatusPending {
 		t.Fatalf("status = %q, want the sender to have given up first", result.Status)
 	}
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if strings.Contains(strings.Join(term.writesTo("s1"), ""), "never picked up") {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
+	if !awaitWritten(term, "s1", "[lich]") {
+		t.Fatalf("the sender was never nudged: %v", term.writesTo("s1"))
 	}
-	t.Errorf("the sender was never told: %v", term.writesTo("s1"))
+	collected, err := svc.Collect("s1", 1)
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(collected.Results) != 1 || collected.Results[0].Status != StatusUnread {
+		t.Errorf("collected %+v, want the unread outcome", collected)
+	}
 }
 
 // The two can also land together: the window closes the ticket while the sender
@@ -1513,7 +1564,7 @@ func TestAWaiterGivingUpAsTheTaskGoesUnreadHearsSo(t *testing.T) {
 	}
 	close(tk.unread)
 
-	if got := svc.giveUp(tk); got != StatusUnread {
+	if got := svc.giveUp("tk1", tk); got != StatusUnread {
 		t.Errorf("status = %q, want the sender told nothing read it", got)
 	}
 }
@@ -1566,5 +1617,242 @@ func TestWithoutAPluginCheckTheMessageNamesTheCommand(t *testing.T) {
 	}
 	if typed := strings.Join(term.writesTo("s2"), ""); strings.Contains(typed, ToolReply) {
 		t.Errorf("assumed a tool with nothing to ask:\n%s", typed)
+	}
+}
+
+// The inbox: a result nobody was holding the line for is stashed and announced
+// with one short nudge, and the text itself comes back through Collect — never
+// typed at the sender's prompt, where every arrival restarts a turn.
+
+// plant registers one delivered errand directly, so inbox tests need not spend
+// real seconds waiting out a Send's own timeout first.
+func plant(svc *Service, id, fromID, targetID, target string) {
+	svc.mu.Lock()
+	svc.tickets[id] = &ticket{
+		fromID: fromID, targetID: targetID, target: target,
+		created:   time.Now(),
+		delivered: time.Now(),
+		done:      make(chan struct{}),
+		stalled:   make(chan struct{}),
+		unread:    make(chan struct{}),
+	}
+	svc.mu.Unlock()
+}
+
+// A fan-out's workers finish in bursts. One nudge per result would restart the
+// sender's turn once per worker — the debounce folds the burst into one line
+// naming everything that is waiting.
+func TestABurstOfAnswersCoalescesIntoOneNudge(t *testing.T) {
+	term := newFakeTerminal("s1", "s2", "s3")
+	svc := newRelay(workspace(), term, nil)
+	svc.nudgeDelay = 20 * time.Millisecond
+	plant(svc, "t1", "s1", "s2", "docs")
+	plant(svc, "t2", "s1", "s3", "api")
+
+	if err := svc.Reply("t1", "done here"); err != nil {
+		t.Fatalf("Reply t1: %v", err)
+	}
+	if err := svc.Reply("t2", "done there"); err != nil {
+		t.Fatalf("Reply t2: %v", err)
+	}
+
+	if !awaitWritten(term, "s1", "[lich]") {
+		t.Fatalf("no nudge arrived: %q", term.writesTo("s1"))
+	}
+	// Long enough for a second nudge to have fired if one were coming.
+	time.Sleep(50 * time.Millisecond)
+	writes := term.writesTo("s1")
+	if len(writes) != 2 {
+		t.Fatalf("got %d writes, want one nudge (paste and submit): %q", len(writes), writes)
+	}
+	typed := term.written("s1")
+	for _, want := range []string{"2 tasks", `"docs"`, `"api"`} {
+		if !strings.Contains(typed, want) {
+			t.Errorf("the nudge is missing %q:\n%s", want, typed)
+		}
+	}
+}
+
+// A delivery mid-turn queues as its own turn, which is the cost this whole
+// path exists to avoid — a busy sender hears nothing until its turn ends.
+func TestABusySenderIsNudgedOnlyWhenItsTurnEnds(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, nil)
+	svc.Observe("s1", stateBusy)
+	plant(svc, "t1", "s1", "s2", "docs")
+
+	if err := svc.Reply("t1", "all green"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	time.Sleep(20 * time.Millisecond)
+	if typed := term.written("s1"); typed != "" {
+		t.Fatalf("nudged a sender mid-turn: %q", typed)
+	}
+
+	svc.Observe("s1", stateDone)
+	if !awaitWritten(term, "s1", "[lich]") {
+		t.Fatalf("the turn ended and no nudge came: %q", term.writesTo("s1"))
+	}
+}
+
+// One nudge per result. A sender that read the nudge and chose not to collect
+// must not be nudged again at every turn end — each nudge starts a turn, and
+// two of them chasing each other is a loop with a token bill.
+func TestANudgeIsNotRepeatedOnLaterTurnEnds(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, nil)
+	plant(svc, "t1", "s1", "s2", "docs")
+	if err := svc.Reply("t1", "all green"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	if !awaitWritten(term, "s1", "[lich]") {
+		t.Fatalf("no nudge arrived: %q", term.writesTo("s1"))
+	}
+
+	svc.Observe("s1", stateBusy)
+	svc.Observe("s1", stateDone)
+	time.Sleep(20 * time.Millisecond)
+	if writes := term.writesTo("s1"); len(writes) != 2 {
+		t.Errorf("an uncollected result was nudged again: %q", writes)
+	}
+}
+
+func TestCollectHoldsTheLineForTheNextResult(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, nil)
+	plant(svc, "t1", "s1", "s2", "docs")
+
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		_ = svc.Reply("t1", "all green")
+	}()
+	collected, err := svc.Collect("s1", 2)
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(collected.Results) != 1 || collected.Results[0].Answer != "all green" {
+		t.Fatalf("collected %+v, want the answer", collected)
+	}
+	// The collector carried the result out itself; a nudge on top would deliver
+	// the news twice.
+	time.Sleep(20 * time.Millisecond)
+	if typed := term.written("s1"); typed != "" {
+		t.Errorf("a result a collector carried out was also nudged: %q", typed)
+	}
+}
+
+func TestCollectReportsWhoStillOwes(t *testing.T) {
+	term := newFakeTerminal("s1", "s2", "s3")
+	svc := newRelay(workspace(), term, nil)
+	plant(svc, "t1", "s1", "s2", "docs")
+	plant(svc, "t2", "s1", "s3", "api")
+	if err := svc.Reply("t1", "all green"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+
+	collected, err := svc.Collect("s1", 1)
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(collected.Results) != 1 || collected.Results[0].Target != "docs" {
+		t.Fatalf("collected %+v, want the one finished errand", collected)
+	}
+	if len(collected.Open) != 1 || collected.Open[0] != "api" {
+		t.Errorf("open = %v, want the session still owing", collected.Open)
+	}
+}
+
+func TestCollectWithNothingOpenReturnsAtOnce(t *testing.T) {
+	svc := newRelay(workspace(), newFakeTerminal("s1"), nil)
+
+	start := time.Now()
+	collected, err := svc.Collect("s1", 30)
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(collected.Results) != 0 || len(collected.Open) != 0 {
+		t.Errorf("collected %+v from a caller with no errands", collected)
+	}
+	if time.Since(start) > time.Second {
+		t.Error("Collect held the line with no errand to wait for")
+	}
+}
+
+func TestCollectRefusesACallerWithNoSession(t *testing.T) {
+	svc := newRelay(workspace(), newFakeTerminal(), nil)
+
+	if _, err := svc.Collect("", 1); err == nil {
+		t.Fatal("collected for a caller that has no prompt to be nudged at")
+	}
+}
+
+func TestWaitPicksAStashedOutcomeUp(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, nil)
+	plant(svc, "t1", "s1", "s2", "docs")
+	if err := svc.Reply("t1", "all green"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+
+	res, err := svc.Wait("t1", 1)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if res.Status != StatusAnswered || res.Answer != "all green" {
+		t.Fatalf("result = %+v, want the stashed answer", res)
+	}
+	if _, err := svc.Wait("t1", 1); err == nil {
+		t.Error("the same outcome was handed out twice")
+	}
+}
+
+func TestAnUncollectedResultExpiresWithItsTTL(t *testing.T) {
+	svc := newRelay(workspace(), newFakeTerminal("s1"), nil)
+	svc.mu.Lock()
+	svc.ready["old"] = &inboxEntry{
+		ticket: "old", fromID: "s1", target: "docs",
+		status: StatusAnswered, answer: "stale",
+		ready: time.Now().Add(-2 * time.Hour),
+	}
+	svc.mu.Unlock()
+
+	collected, err := svc.Collect("s1", 1)
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(collected.Results) != 0 {
+		t.Errorf("an hour-old result was still handed over: %+v", collected.Results)
+	}
+}
+
+func TestTheNudgeNamesTheToolOnlyWhereItExists(t *testing.T) {
+	tests := []struct {
+		name  string
+		tools bool
+	}{
+		{"a sender with lich's tools", true},
+		{"a sender with none", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			term := newFakeTerminal("s1", "s2")
+			svc := newRelay(workspace(), term, nil)
+			svc.SetPlugins(fakePlugins{installed: true, tools: tt.tools})
+			plant(svc, "t1", "s1", "s2", "docs")
+			if err := svc.Reply("t1", "all green"); err != nil {
+				t.Fatalf("Reply: %v", err)
+			}
+
+			if !awaitWritten(term, "s1", "[lich]") {
+				t.Fatalf("no nudge arrived: %q", term.writesTo("s1"))
+			}
+			typed := term.written("s1")
+			if named := strings.Contains(typed, ToolCollect); named != tt.tools {
+				t.Errorf("names %s = %v, want %v:\n%s", ToolCollect, named, tt.tools, typed)
+			}
+			if !strings.Contains(typed, `"$LICH_BIN" wait`) {
+				t.Errorf("the command route is missing:\n%s", typed)
+			}
+		})
 	}
 }

--- a/internal/relay/roster.go
+++ b/internal/relay/roster.go
@@ -110,6 +110,27 @@ func (s *Service) labelOf(id string) string {
 	return "unknown"
 }
 
+// kindOf is what the session runs, read from the workspace so a nudge can
+// offer the tool only where it exists. Empty when lich has no record of it,
+// which offersTools reads as "name the command".
+func (s *Service) kindOf(id string) string {
+	if id == "" {
+		return ""
+	}
+	projects, err := s.sessions.LoadState()
+	if err != nil {
+		return ""
+	}
+	for _, p := range projects {
+		for _, sess := range p.Sessions {
+			if sess.ID == id {
+				return sess.Kind
+			}
+		}
+	}
+	return ""
+}
+
 // matching returns the candidates whose name — read out by naming — is target,
 // narrowed to one project when one was given.
 func matching(found []candidate, target, project string, naming func(candidate) string) []candidate {


### PR DESCRIPTION
## Why

Orchestrating other sessions through lich's MCP was expensive at the orchestrator's end. Every worker answer that arrived after the sender stopped waiting was typed at the sender's prompt **in full**: each arrival is a prompt submission, each submission restarts the orchestrator's turn, and the whole answer text stays in its context window forever. Fanning out to N workers paid all of that N times — the window filled up fast and most of those turns were spent saying "still waiting on the others".

And the journey itself was invisible: the agent had to infer "I can fan out into worktree sessions" from seven separate tool descriptions, because the server sent no `instructions` at initialize.

## What

**The inbox and the nudge** (`internal/relay`). An unattended result — answer, unread, or stalled — is stashed in a per-sender inbox instead of typed. The prompt gets one short note:

```
[lich] Results from 2 tasks you sent are ready ("wt-auth", "wt-api"). To collect
everything at once, call the lich tool `wait_for_answer` with no ticket, or run:
  "$LICH_BIN" wait
```

- Debounced (2s): a fan-out finishing in a burst shares one nudge.
- A sender mid-turn hears nothing until its turn ends (the hooks' state reports already tell the relay); a delivery mid-turn would just queue as its own turn.
- One nudge per result — an ignored nudge is not repeated at every turn end, so there is no nudge/turn loop.
- A `Collect` call already holding the line is woken instead; no double delivery.
- Uncollected results expire with the ticket TTL (1h). CLI-from-script senders are never nudged; their result waits for `lich wait <ticket>`.

**Batch collect.** `wait_for_answer` without a ticket (and a bare `lich wait`) drains everything ready in one call — oldest first, same wording per outcome as a single wait — and reports who still owes (`Still working: "docs"`). With nothing ready it holds the line for the next result; with nothing open it returns at once. `relay.Wait` on a specific ticket also finds outcomes already in the inbox, so the old flow keeps working.

**MCP inference** (`internal/cli/mcp.go`):
- `initialize` now carries `instructions` — the whole journey (fan out with `open_session`+worktree, carry on, collect, and how to behave as the worker: concise report, never a transcript). Clients inject it into the system prompt.
- `list_sessions` / `list_worktrees` annotated `readOnlyHint`, so clients may auto-allow them.
- `send_to_session` / `wait_for_answer` descriptions rewritten around announce-and-collect.

**Report discipline** (`internal/relay/compose.go`): the relayed message now asks the worker for a concise report — what was done, where, what remains — since the sender pays to read every byte.

Contract docs (`docs/cli.md`) updated to match; the plugin-facing `lich wait <ticket>` line in the pending output is unchanged.

## Tests

Three tests moved with the contract (the unattended answer/unread/stall paths now assert the nudge + collect instead of the full-text injection — the injection is the behavior this PR removes). New coverage: burst coalescing, busy-sender hold + flush on done, no re-nudge, collect drain/hold/still-owing/empty/no-session, Wait-from-inbox, inbox TTL, tool-vs-command nudge wording, MCP drain formatting, handshake instructions, annotations, CLI no-arg wait.

- `gofmt -l` clean, `go vet ./...` clean
- `go test ./...` green; `-race` on `internal/relay` + `internal/cli`; new tests stable at `-race -count=20`
- frontend untouched; `biome check`, `vitest run` (867), `tsc --noEmit`, `vite build` all green