### PR TITLE
fix: close a session's ConPTY once, not twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Closing a session on Windows no longer takes the app down with it.** The
+  service closed the session's ConPTY and its output reader, freed by that very
+  close, then closed the same one again — a repeat the Unix PTY absorbs and
+  ConPTY does not: it releases the pseudoconsole and six handles unconditionally,
+  so the second pass acted on handle values Windows had already reissued to
+  whatever the app opened next. Whichever one it hit went with it — the loopback
+  listener, another session's pipes, the log file — leaving a window whose
+  terminals had stopped answering and no crash, error or log line to say why.
+  The PTY now closes once, and a reap that arrives after it is the no-op it was
+  always assumed to be.
+
 - **A launch that loses its port now tells you, instead of dying into a log
   file.** When the loopback listener cannot bind and no running lich explains
   it, the app used to exit with nothing but a log line — which a double-click

--- a/internal/terminal/pty_windows.go
+++ b/internal/terminal/pty_windows.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"sync"
 
 	"github.com/UserExistsError/conpty"
 	"golang.org/x/sys/windows"
@@ -26,7 +27,8 @@ func startPTY(spec ptySpec) (ptyHandle, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &windowsPTY{cpty}, nil
+	waitCtx, cancelWait := context.WithCancel(context.Background())
+	return &windowsPTY{ConPty: cpty, waitCtx: waitCtx, cancelWait: cancelWait}, nil
 }
 
 // commandLine turns bin+args into the single quoted command line
@@ -42,13 +44,51 @@ func commandLine(bin string, args []string) (string, error) {
 }
 
 // windowsPTY adapts a ConPTY to the seam. The embedded type already carries
-// Read, Write, Close (which terminates the child) and a same-shape Resize;
-// only Wait needs its context-and-exit-code signature narrowed.
+// Read, Write and a same-shape Resize; Wait and Close are wrapped because
+// conpty's cannot be called twice or overlap each other.
+//
+// conpty's Close is not idempotent: it calls ClosePseudoConsole on the HPCON
+// and CloseHandle on six handles unconditionally, and its Wait reads the
+// process handle among them. A second Close therefore hands CloseHandle values
+// Windows has already reissued to whatever this process opened next — the
+// loopback listener's socket, the log file, another session's pipes — and the
+// app stops answering with nothing panicking and nothing logged. Every
+// user-driven close reaches that second call: Service.Close closes the PTY and
+// the read loop, freed by the same close, reaps it again (see stream). The
+// Unix seam is *os.File, whose repeat Close is the harmless no-op stream's
+// comment describes; this one has to be made into it.
 type windowsPTY struct {
 	*conpty.ConPty
+	waitCtx    context.Context
+	cancelWait context.CancelFunc
+
+	mu     sync.Mutex
+	closed bool
 }
 
+// Wait reaps the child, or returns immediately once Close has taken the handles
+// it would read.
 func (p *windowsPTY) Wait() error {
-	_, err := p.ConPty.Wait(context.Background())
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return nil
+	}
+	_, err := p.ConPty.Wait(p.waitCtx)
 	return err
+}
+
+// Close hangs up and terminates the child, once. The pending Wait is cancelled
+// before the lock is taken because it only returns when the child exits, and
+// the child exits because of this very call — conpty polls the process handle
+// on a one-second tick, so that is the longest a close waits for it.
+func (p *windowsPTY) Close() error {
+	p.cancelWait()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed {
+		return nil
+	}
+	p.closed = true
+	return p.ConPty.Close()
 }

--- a/internal/terminal/pty_windows_test.go
+++ b/internal/terminal/pty_windows_test.go
@@ -19,7 +19,10 @@ func TestWindowsPTYCloseIsSingleShot(t *testing.T) {
 	p, err := startPTY(ptySpec{
 		bin:  "cmd.exe",
 		args: []string{"/c", "pause"},
-		dir:  t.TempDir(),
+		// Not t.TempDir(): the child holds its working directory open for as
+		// long as it takes Windows to tear it down after the close, and the
+		// cleanup that cannot delete it fails the test for the wrong reason.
+		dir:  os.TempDir(),
 		cols: 80,
 		rows: 24,
 	})

--- a/internal/terminal/pty_windows_test.go
+++ b/internal/terminal/pty_windows_test.go
@@ -1,0 +1,48 @@
+//go:build windows
+
+package terminal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWindowsPTYCloseIsSingleShot pins the guard windowsPTY puts over conpty's
+// Close, which the service relies on: stream reaps a PTY the user-driven Close
+// already released. A second call reaching ConPty.Close would run
+// ClosePseudoConsole on a freed HPCON and CloseHandle on six values this
+// process may have reissued since — the witness file is opened between the two
+// closes for that reason, holding a fresh handle of the kind a stale one gets
+// reused as.
+func TestWindowsPTYCloseIsSingleShot(t *testing.T) {
+	p, err := startPTY(ptySpec{
+		bin:  "cmd.exe",
+		args: []string{"/c", "pause"},
+		dir:  t.TempDir(),
+		cols: 80,
+		rows: 24,
+	})
+	if err != nil {
+		t.Fatalf("startPTY: %v", err)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+
+	witness, err := os.Create(filepath.Join(t.TempDir(), "witness"))
+	if err != nil {
+		t.Fatalf("open witness: %v", err)
+	}
+	defer witness.Close()
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	if _, err := witness.WriteString("still open"); err != nil {
+		t.Fatalf("second Close took another handle: %v", err)
+	}
+	if err := p.Wait(); err != nil {
+		t.Fatalf("Wait after Close: %v", err)
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -498,8 +498,9 @@ func (s *Service) stream(id string, sess *session) {
 	}
 	_ = p.Wait()
 	// Release the PTY handle: on a natural child exit nobody else closes it
-	// (Close only reaps sessions still in the map), and the user-driven Close
-	// path tolerates this as a no-op double close.
+	// (Close only reaps sessions still in the map), and after a user-driven
+	// Close this is the second one — a no-op each seam has to make safe, since
+	// the handles are already gone (see windowsPTY, where they are reissued).
 	_ = p.Close()
 	// Flush any batched output and wait for it to be delivered before the exit
 	// event, so the frontend always sees the final bytes ahead of the exit


### PR DESCRIPTION
On Windows, closing a live session could take the whole app down: the window
stayed up while its terminals stopped answering, new sessions failed to start,
and nothing panicked, errored or reached `lich.log`.

## Cause

Closing a live session runs two closes on the same PTY:

1. `Service.Close` closes it (`terminal.go`), which kills the child and its pipes;
2. the read loop, freed by exactly that, breaks out and reaps the same PTY —
   `p.Wait()` then `p.Close()` (`stream`).

That second close is documented in `stream` as a tolerated no-op, and on Unix it
is: the seam is `*os.File`, whose repeat `Close` returns `ErrClosed` without
touching a recycled fd. The Windows seam is `conpty.ConPty`, whose `Close` is
not idempotent — it calls `ClosePseudoConsole` on the HPCON and `CloseHandle` on
six handles unconditionally, and its `Wait` reads the process handle among them.

Windows reissues handle values eagerly, and between the two closes the app opens
plenty: RPC and WebSocket sockets, SQLite files, log writes, the next PTY. The
second pass closes whichever of those inherited the stale values. That is the
whole symptom list — the loopback listener's socket (fetches fail), another
session's pipes (terminals go quiet), the log file (the log simply stops).
`CloseHandle` raises nothing, so there is no crash to report.

## Fix

`windowsPTY.Close` is single-shot, and `Wait` returns once it has run rather
than reading a handle `Close` released. `Close` cancels a pending `Wait` before
taking the lock — `Wait` only returns when the child exits, and the child exits
because of that very `Close`; conpty polls on a one-second tick, so that is the
longest a close waits for it.

## Test plan

- [x] `gofmt -l .`, `go vet ./...` clean
- [x] `GOOS=linux|darwin|windows go build ./... && go vet ./...` clean
- [x] `go test ./internal/terminal/` green (347)
- [x] `TestWindowsPTYCloseIsSingleShot` on the Windows runner — closes twice with
      a freshly opened file in between and asserts that file survives, the shape
      of what the second close was taking. No Windows hardware here; CI is the
      answer to trust.