### PR TITLE
fix: Ctrl+Click opens a terminal link in every session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Ctrl+Click opens a link in every session again, not only where the agent
+  opens it for you.** Since the fix for the duplicated browser tab, lich stood
+  down from any session whose app reads the mouse — which left the click dead
+  wherever that app ignores links (opencode, among others): the URL underlined
+  on hover and nothing happened. Now lich keeps the click out of the session
+  instead of standing down, so one Ctrl+Click (Cmd+Click on macOS) opens one
+  tab, in every provider.
+
 - **A launch that loses its port now tells you, instead of dying into a log
   file.** When the loopback listener cannot bind and no running lich explains
   it, the app used to exit with nothing but a log line — which a double-click

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   instead of standing down, so one Ctrl+Click (Cmd+Click on macOS) opens one
   tab, in every provider.
 
+- **A hyperlink printed by a tool opens like any other link.** Output that
+  carries its URL as a terminal hyperlink rather than as plain text (`gh`,
+  `eza`, and anything else speaking OSC 8) was left to xterm's own fallback: a
+  browser-style "do you want to navigate to…" prompt, outside lich's opener.
+  Now Ctrl+Click serves both kinds of link the same way.
+
 - **A launch that loses its port now tells you, instead of dying into a log
   file.** When the loopback listener cannot bind and no running lich explains
   it, the app used to exit with nothing but a log line — which a double-click

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -306,12 +306,25 @@ export function TerminalView({
     })
     const serialize = new SerializeAddon()
     term.loadAddon(serialize)
+    // Tracks the pointer sitting on a URL, so the mousedown listener below only
+    // swallows a click the link layer is about to serve.
+    let linkHovered = false
     term.loadAddon(
-      new WebLinksAddon((event, uri) => {
-        if (linkClickIsOurs(event, term.modes.mouseTrackingMode)) {
-          void System.OpenExternal(uri)
-        }
-      }),
+      new WebLinksAddon(
+        (event, uri) => {
+          if (linkClickIsOurs(event)) {
+            void System.OpenExternal(uri)
+          }
+        },
+        {
+          hover: () => {
+            linkHovered = true
+          },
+          leave: () => {
+            linkHovered = false
+          },
+        },
+      ),
     )
     // After the web-links addon, and load-bearing: xterm asks its providers in
     // registration order and drops a later provider's link where an earlier
@@ -321,6 +334,24 @@ export function TerminalView({
       createSessionLinkProvider(term, linkTargetsRef, activateLink),
     )
     term.open(container)
+
+    // A link click must not also reach the PTY: an app that reads the mouse and
+    // opens the links it prints (Claude Code does) would open the same URL a
+    // second time, one browser tab each. xterm reports the mouse from a listener
+    // on its outer element while the link layer listens on .xterm-screen inside
+    // it, so stopping the event here keeps the click out of the session and
+    // leaves the link working. Focus is xterm's own mousedown job, done here
+    // because that handler no longer runs.
+    term.element
+      ?.querySelector<HTMLElement>(".xterm-screen")
+      ?.addEventListener("mousedown", (event) => {
+        if (!linkHovered || !linkClickIsOurs(event)) {
+          return
+        }
+        event.preventDefault()
+        event.stopPropagation()
+        term.focus()
+      })
 
     const search = new SearchAddon()
     term.loadAddon(search)

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -296,6 +296,26 @@ export function TerminalView({
   // createTerminal builds a live terminal in the container, wired for input,
   // resize and copy-on-select. Shared by mount and every show-after-hide.
   const createTerminal = (container: HTMLDivElement): LiveTerminal => {
+    // Tracks the pointer sitting on a link, so the mousedown listener below only
+    // swallows a click the link layer is about to serve.
+    let linkHovered = false
+    // The two kinds of link answer to one policy: URLs printed as text, found by
+    // the web-links addon's regex, and OSC 8 hyperlinks (gh, eza, bun), which
+    // xterm hands to this handler. Without the handler xterm's own default takes
+    // the OSC 8 click — a confirm() dialog and a window.open lich never opened.
+    const linkActions = {
+      activate: (event: MouseEvent, uri: string) => {
+        if (linkClickIsOurs(event)) {
+          void System.OpenExternal(uri)
+        }
+      },
+      hover: () => {
+        linkHovered = true
+      },
+      leave: () => {
+        linkHovered = false
+      },
+    }
     const term = new Terminal({
       fontSize: fontSizeRef.current,
       fontFamily: `"${fontRef.current}", monospace`,
@@ -303,29 +323,11 @@ export function TerminalView({
       scrollback: SCROLLBACK_LINES,
       allowProposedApi: true,
       theme: themeRef.current,
+      linkHandler: linkActions,
     })
     const serialize = new SerializeAddon()
     term.loadAddon(serialize)
-    // Tracks the pointer sitting on a URL, so the mousedown listener below only
-    // swallows a click the link layer is about to serve.
-    let linkHovered = false
-    term.loadAddon(
-      new WebLinksAddon(
-        (event, uri) => {
-          if (linkClickIsOurs(event)) {
-            void System.OpenExternal(uri)
-          }
-        },
-        {
-          hover: () => {
-            linkHovered = true
-          },
-          leave: () => {
-            linkHovered = false
-          },
-        },
-      ),
-    )
+    term.loadAddon(new WebLinksAddon(linkActions.activate, linkActions))
     // After the web-links addon, and load-bearing: xterm asks its providers in
     // registration order and drops a later provider's link where an earlier
     // one already claimed the cells. A session called "docs" printed inside

--- a/frontend/src/lib/terminal/term-modes.test.ts
+++ b/frontend/src/lib/terminal/term-modes.test.ts
@@ -24,18 +24,12 @@ describe("mouseEncodingSequence", () => {
 })
 
 describe("linkClickIsOurs", () => {
-  it("opens the link when no app is reading the mouse", () => {
-    expect(linkClickIsOurs({ ctrlKey: true, metaKey: false }, "none")).toBe(true)
-    expect(linkClickIsOurs({ ctrlKey: false, metaKey: true }, "none")).toBe(true)
-  })
-
-  it("stands down while an app reads the mouse — it got the same click", () => {
-    for (const mode of ["x10", "vt200", "drag", "any"]) {
-      expect(linkClickIsOurs({ ctrlKey: true, metaKey: false }, mode)).toBe(false)
-    }
+  it("opens the link on Ctrl+Click, and on Cmd+Click for macOS", () => {
+    expect(linkClickIsOurs({ ctrlKey: true, metaKey: false })).toBe(true)
+    expect(linkClickIsOurs({ ctrlKey: false, metaKey: true })).toBe(true)
   })
 
   it("ignores a plain click, which selects rather than opens", () => {
-    expect(linkClickIsOurs({ ctrlKey: false, metaKey: false }, "none")).toBe(false)
+    expect(linkClickIsOurs({ ctrlKey: false, metaKey: false })).toBe(false)
   })
 })

--- a/frontend/src/lib/terminal/term-modes.ts
+++ b/frontend/src/lib/terminal/term-modes.ts
@@ -27,16 +27,11 @@ export function mouseEncodingSequence(encoding: string | undefined): string {
 }
 
 /**
- * Whether a click on a link is ours to open. Only Shift bypasses xterm's mouse
- * reporting, so an app that asked for mouse events gets the Ctrl+Click too —
- * and an app that opens its own links (Claude Code does) then opens the same
- * URL a second time, one browser tab each. The app owns the click; we stand
- * down. The cost is that a mouse-reporting TUI which ignores link clicks makes
- * Ctrl+Click open nothing.
+ * Whether a click on a link is ours to open: Ctrl+Click, or Cmd+Click on macOS.
+ * The click is also swallowed before it reaches the PTY (TerminalView), because
+ * an app that reads the mouse and opens its own links (Claude Code does) would
+ * otherwise serve the same click a second time, one browser tab each.
  */
-export function linkClickIsOurs(
-  event: Pick<MouseEvent, "ctrlKey" | "metaKey">,
-  mouseTrackingMode: string,
-): boolean {
-  return (event.ctrlKey || event.metaKey) && mouseTrackingMode === "none"
+export function linkClickIsOurs(event: Pick<MouseEvent, "ctrlKey" | "metaKey">): boolean {
+  return event.ctrlKey || event.metaKey
 }


### PR DESCRIPTION
## Why

Ctrl+Click on a URL printed by opencode did nothing at all.

The fix for the duplicated browser tab (#143) made lich stand down from any session whose app is reading the mouse: that app got the same click and, in Claude Code's case, opens its own links. opencode turns mouse reporting on at startup (`?1000h ?1002h ?1003h ?1006h`, measured) and ignores link clicks, so the URL underlined on hover and the click fell between the two owners. The cost was named in that PR's comment; this is it happening.

A second, quieter hole in the same area: a URL printed as an **OSC 8 hyperlink** (`gh`, `eza`, `bun`) never reaches the web-links addon's regex. xterm resolves those itself and, with no link handler configured, fell back to its own default — a `confirm()` prompt and a `window.open`, outside `System.OpenExternal` and outside lich's click policy.

## What changed

- **Ctrl+Click stays Ctrl+Click** (Cmd+Click on macOS). Instead of standing down, lich keeps the click out of the session: xterm reports the mouse from a listener on its outer element while the link layer listens on `.xterm-screen` inside it, so a modified `mousedown` over a link is stopped there. The link still activates, the PTY never sees the press or the release, and no app can serve the same click twice. A modified click that is not over a link goes to the app untouched.
- **OSC 8 hyperlinks share the same policy**, through a link handler on the terminal — one set of `activate`/`hover`/`leave` actions used by both link sources.

## Test plan

The frontend gate cannot render, so both halves were measured against a running lich (isolated config, headless Chromium over CDP, an `xdg-open` shim as the opener) driving a shell session with mouse reporting on and `cat -v` as the probe.

Plain-text URL, same click in both trees:

| | opener called | bytes at the PTY |
| --- | --- | --- |
| before | — | `^[[<16;1;1M` `^[[<16;1;1m` (press + release) |
| after | once, with the URL | `^[[<51;1;1M` (motion only) |
| after, plain click | — | `^[[<0;1;1M` `^[[<0;1;1m` (app still gets it) |

OSC 8 hyperlink, same click in both trees:

| | opener called | page |
| --- | --- | --- |
| before | — | hung on xterm's native `confirm()` |
| after | once, with the hyperlink's URL | responsive; PTY saw only the motion report |

- [x] `gofmt -l .` / `go vet ./...` clean (Go untouched)
- [x] `pnpm check` clean
- [x] `pnpm test` — 866 passing
- [x] `pnpm build` succeeds
- [x] `CHANGELOG.md` `[Unreleased]` entries land here