### PR TITLE
fix: delegate types a delegation, not a question

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Delegate types a delegation, not a question.** Picking a session in
+  "Delegate to session…" used to put `Ask the "docs" session to ` at the
+  prompt, and whatever you typed next had to bend into "to <verb>" — a
+  question or pasted context read wrong, and "Ask" was not even the button's
+  word. It now types `Delegate to the "docs" session: `, and anything can
+  follow the colon: an order, a question, a dump of context.
+
 - **A worker's answer no longer floods the orchestrator's prompt — it is
   announced, and collected.** A session fanning work out to others used to get
   every answer typed back at its prompt in full, and every arrival restarted

--- a/frontend/src/lib/session/delegate-prompt.test.ts
+++ b/frontend/src/lib/session/delegate-prompt.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest"
 import { delegatePrompt } from "./delegate-prompt"
 
 describe("delegatePrompt", () => {
-  it("asks in plain words where the sender has lich's tools", () => {
-    expect(delegatePrompt("claude", "docs")).toBe('Ask the "docs" session to ')
-    expect(delegatePrompt("codex", "docs")).toBe('Ask the "docs" session to ')
+  it("delegates in plain words where the sender has lich's tools", () => {
+    // A colon, never a preposition: the task typed after it can be an order, a
+    // question or pasted context, and none of them bends into "to <verb>".
+    expect(delegatePrompt("claude", "docs")).toBe('Delegate to the "docs" session: ')
+    expect(delegatePrompt("codex", "docs")).toBe('Delegate to the "docs" session: ')
   })
 
   it("spells the command for every other sender", () => {
@@ -20,7 +22,7 @@ describe("delegatePrompt", () => {
   })
 
   it("carries the label through verbatim", () => {
-    expect(delegatePrompt("claude", "fix login 2")).toBe('Ask the "fix login 2" session to ')
+    expect(delegatePrompt("claude", "fix login 2")).toBe('Delegate to the "fix login 2" session: ')
     expect(delegatePrompt("crush", "fix login 2")).toBe('lich send "fix login 2" "')
   })
 })

--- a/frontend/src/lib/session/delegate-prompt.ts
+++ b/frontend/src/lib/session/delegate-prompt.ts
@@ -29,10 +29,14 @@ const TOOL_KINDS: readonly string[] = ["claude", "codex"]
  * nothing else would tell it the command exists. The quote is left open on
  * purpose there — the user types the task inside it, which is where the cursor
  * lands.
+ *
+ * The prose form ends in a colon, not a preposition: what follows can be an
+ * order, a question, or pasted context, and none of them should have to bend
+ * into "to <verb>". The verb is the UI's own — the button says Delegate.
  */
 export function delegatePrompt(senderKind: SessionKind | string, target: string): string {
   if (TOOL_KINDS.includes(senderKind)) {
-    return `Ask the "${target}" session to `
+    return `Delegate to the "${target}" session: `
   }
   return `lich send "${target}" "`
 }


### PR DESCRIPTION
## Why

Picking a session in "Delegate to session…" pasted this at the sender's prompt:

```
Ask the "docs" session to 
```

Two problems. The task the user types next has to bend into "to <verb>" — a question ("does the auth flow handle expired tokens?") or pasted context reads as broken grammar and mushy intent. And "Ask" is not even the feature's word: the button says **Delegate**.

## What

The prose form now ends in a colon, under the UI's own verb:

```
Delegate to the "docs" session: 
```

Anything follows naturally — an order, a question, a dump of context. The command form for tool-less senders (`lich send "docs" "`) is unchanged, and since #251 the sender's agent carries the MCP `instructions` briefing, so the phrase needs no pedagogy of its own.

One string, its two tests, and a CHANGELOG entry.

## Tests

- `biome check` clean, `vitest run` green (866), `tsc --noEmit` + `vite build` green
- backend untouched