### PR TITLE
feat: delegate into a fresh worktree, and mark uncollected results on the card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Delegate types a delegation, not a question.** Picking a session in
+  "Delegate to session…" used to put `Ask the "docs" session to ` at the
+  prompt, and whatever you typed next had to bend into "to <verb>" — a
+  question or pasted context read wrong, and "Ask" was not even the button's
+  word. It now types `Delegate to the "docs" session: `, and anything can
+  follow the colon: an order, a question, a dump of context.
+
 - **A worker's answer no longer floods the orchestrator's prompt — it is
   announced, and collected.** A session fanning work out to others used to get
   every answer typed back at its prompt in full, and every arrival restarted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Delegate can open the fan-out.** The delegate picker gains a pinned "New
+  worktree session…" row — sticky under the list, never filtered by the
+  query, and offered even when no other session is live, which is exactly
+  when fanning out is most useful. Picking it hands the orchestrator a
+  delegation into a fresh worktree checkout; the agent opens the session and
+  sends the task itself, picking the branch name from the task it was given.
+
+- **The card says when results are back.** A session with uncollected
+  results — answers to tasks it delegated, waiting in the relay's inbox —
+  now says so on its card ("2 results ready"), in the same quiet line the
+  relay marks use. The nudge tells the agent; this tells you. It clears the
+  moment the agent collects, and never interrupts a turn in progress.
+
 ### Changed
 
 - **Delegate types a delegation, not a question.** Picking a session in

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -7,6 +7,7 @@ import {
   CircleQuestionMark,
   GitBranch,
   GitPullRequestArrow,
+  Inbox,
   Pencil,
   Pin,
   PinOff,
@@ -23,6 +24,7 @@ import { useSessionStatus, useSessionStatusAge } from "@/lib/session/use-session
 import { useSessionCwd } from "@/lib/session/use-session-cwd"
 import { useSessionAgent } from "@/lib/session/use-session-agent"
 import { useSessionRelay } from "@/lib/session/use-session-relay"
+import { useSessionInbox } from "@/lib/session/use-session-inbox"
 import { useSessionTool } from "@/lib/session/use-session-tool"
 import { toolGlyph } from "@/lib/session/tool-glyph"
 import { useGitStatus } from "@/lib/git/use-git-status"
@@ -42,7 +44,7 @@ import {
 } from "@/components/ui/context-menu"
 import { Terminal as TerminalService } from "@/lib/rpc"
 import type { DelegateGroup } from "@/lib/session/delegate-targets"
-import { delegatePrompt } from "@/lib/session/delegate-prompt"
+import { delegatePrompt, delegateWorktreePrompt } from "@/lib/session/delegate-prompt"
 import { bracketedPaste } from "@/lib/terminal/bracketed-paste"
 import { requestTerminalFocus } from "@/lib/terminal/focus-request"
 import { SessionTargetPicker } from "./SessionTargetPicker"
@@ -110,6 +112,9 @@ export function SessionCard({
   // a message lands in a PTY and cleared when it is answered. null the rest of
   // the time, which is nearly always.
   const relay = useSessionRelay(session.id)
+  // How many results this session has waiting in the relay's inbox: results of
+  // tasks it delegated, uncollected. Zero — the usual case — draws nothing.
+  const inbox = useSessionInbox(session.id)
   const ToolGlyph = tool && toolGlyph(tool.name)
   // The live working directory the backend's cwd watcher reports ("" until it
   // does): a `cd` in the terminal moves the card with it. Falls back to the
@@ -137,10 +142,15 @@ export function SessionCard({
     void TerminalService.Write(session.id, bracketedPaste(delegatePrompt(session.kind, label)))
     requestTerminalFocus(session.id)
   }
+  const delegateWorktree = () => {
+    void TerminalService.Write(session.id, bracketedPaste(delegateWorktreePrompt(session.kind)))
+    requestTerminalFocus(session.id)
+  }
 
-  // Every provider can delegate: the relay types at the target's prompt, so
-  // none of this depends on the sender's own messaging channel.
-  const canDelegate = active && delegateGroups.length > 0
+  // Every provider can delegate, and no live target is required: the picker's
+  // pinned row delegates into a fresh worktree session, which is most useful
+  // exactly when there is nobody else to hand work to yet.
+  const canDelegate = active
 
   // The picker is only rendered while the card can delegate, so losing that
   // unmounts it — and an open flag left behind would spring the dialog back up
@@ -244,17 +254,18 @@ export function SessionCard({
                   </span>
                 </span>
               )}
-              {/* One line, three rungs: an open request, then a session blocked
-                  on the user, then the tool. A request in flight explains the
-                  whole turn — a card working because another session asked it
-                  to, or one stalled waiting on a card elsewhere in the list. A
-                  block outranks the tool for the reason it needs words at all:
-                  the amber ring differs from the emerald one by hue alone, so
-                  nothing else on the card says the session wants an answer. It
-                  costs no tool line either — a state other than busy clears the
-                  reported tool (session-tool-store), so by the time a card is
-                  blocked there is nothing left on that rung anyway. Only one
-                  rung ever draws, so the card grows by one row at most. */}
+              {/* One line, four rungs: an open request, then a session blocked
+                  on the user, then results waiting to be collected, then the
+                  tool. A request in flight explains the whole turn — a card
+                  working because another session asked it to, or one stalled
+                  waiting on a card elsewhere in the list. A block outranks the
+                  rest for the reason it needs words at all: the amber ring
+                  differs from the emerald one by hue alone, so nothing else on
+                  the card says the session wants an answer. The inbox sits
+                  under those and over the tool: mid-turn the live tool is the
+                  news, and the count takes the rung when the card goes quiet —
+                  the same rule the relay's own nudge follows. Only one rung
+                  ever draws, so the card grows by one row at most. */}
               {relay ? (
                 <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">
                   {relay.direction === "out" ? (
@@ -274,6 +285,13 @@ export function SessionCard({
                 <span className="flex w-full min-w-0 items-center gap-1 text-xs">
                   <CircleQuestionMark className="size-3 shrink-0 text-amber-500" />
                   <span className="truncate font-medium text-amber-500">Waiting on you</span>
+                </span>
+              ) : status !== "busy" && inbox > 0 ? (
+                <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">
+                  <Inbox className="size-3 shrink-0" />
+                  <span className="truncate font-medium text-foreground">
+                    {inbox === 1 ? "1 result ready" : `${inbox} results ready`}
+                  </span>
                 </span>
               ) : (
                 tool && (
@@ -418,6 +436,7 @@ export function SessionCard({
           onOpenChange={setDelegatePickerOpen}
           groups={delegateGroups}
           onPick={(target) => delegate(target.label)}
+          onPickWorktree={delegateWorktree}
         />
       )}
     </div>

--- a/frontend/src/components/sidebar/SessionTargetPicker.tsx
+++ b/frontend/src/components/sidebar/SessionTargetPicker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from "react"
 import type { KeyboardEvent } from "react"
+import { GitBranchPlus } from "lucide-react"
 import { useSessionStatus } from "@/lib/session/use-session-status"
 import { filterTargetRows, flattenTargetGroups, groupTargetRows } from "@/lib/session/target-picker"
 import type { DelegateGroup, DelegateTarget } from "@/lib/session/delegate-targets"
@@ -11,6 +12,8 @@ interface SessionTargetPickerProps {
   onOpenChange: (open: boolean) => void
   groups: readonly DelegateGroup[]
   onPick: (target: DelegateTarget) => void
+  /** Delegate to a session that does not exist yet: a fresh worktree. */
+  onPickWorktree: () => void
 }
 
 const TITLE = "Delegate to session"
@@ -20,11 +23,17 @@ const TITLE = "Delegate to session"
 // open, finding the right one took a scroll and gave no sense of which
 // sessions were busy or waiting. The command palette's own surface
 // (PickerDialog), scoped down to "hand this session's work to another".
+//
+// One row is pinned under the list: a new worktree session. It is an action,
+// not a search hit, so the query never filters it out and a long list scrolls
+// beneath it — and it is what the picker opens onto when no other session is
+// live, which is exactly when fanning out is most useful.
 export function SessionTargetPicker({
   open,
   onOpenChange,
   groups,
   onPick,
+  onPickWorktree,
 }: SessionTargetPickerProps) {
   const [query, setQuery] = useState("")
   const [selected, setSelected] = useState(0)
@@ -40,7 +49,9 @@ export function SessionTargetPicker({
   const results = useMemo(() => filterTargetRows(query, rows), [query, rows])
   const displayGroups = useMemo(() => groupTargetRows(results), [results])
   useEffect(() => setSelected(0), [query])
-  const active = Math.min(selected, Math.max(0, results.length - 1))
+  // The pinned worktree row sits at index results.length, so it is always the
+  // last stop of the arrow keys — and the only one when nothing else is live.
+  const active = Math.min(selected, results.length)
   // A project heading only earns its keep once there is more than one to tell
   // apart — the rule the old flat submenu applied to its own labels.
   const showHeadings = displayGroups.length > 1
@@ -49,16 +60,24 @@ export function SessionTargetPicker({
     onPick(target)
     onOpenChange(false)
   }
+  const pickWorktree = () => {
+    onPickWorktree()
+    onOpenChange(false)
+  }
 
   const onInputKeyDown = (event: KeyboardEvent) => {
     if (event.key === "ArrowDown") {
       event.preventDefault()
-      setSelected(Math.min(active + 1, results.length - 1))
+      setSelected(Math.min(active + 1, results.length))
     } else if (event.key === "ArrowUp") {
       event.preventDefault()
       setSelected(Math.max(active - 1, 0))
     } else if (event.key === "Enter") {
       event.preventDefault()
+      if (active === results.length) {
+        pickWorktree()
+        return
+      }
       const row = results[active]
       if (row) {
         pick(row.target)
@@ -79,25 +98,38 @@ export function SessionTargetPicker({
       onKeyDown={onInputKeyDown}
       actionHint="pick"
     >
-      {results.length === 0 ? (
+      {results.length === 0 && query.trim() !== "" && (
         <PickerEmpty>
           No sessions match <span className="font-mono text-foreground/80">{query.trim()}</span>
         </PickerEmpty>
-      ) : (
-        displayGroups.map((group) => (
-          <PickerGroup key={group.projectId} label={group.projectName} showLabel={showHeadings}>
-            {group.rows.map(({ row, index }) => (
-              <TargetRowView
-                key={row.target.id}
-                target={row.target}
-                selected={index === active}
-                onSelect={() => setSelected(index)}
-                onPick={() => pick(row.target)}
-              />
-            ))}
-          </PickerGroup>
-        ))
       )}
+      {displayGroups.map((group) => (
+        <PickerGroup key={group.projectId} label={group.projectName} showLabel={showHeadings}>
+          {group.rows.map(({ row, index }) => (
+            <TargetRowView
+              key={row.target.id}
+              target={row.target}
+              selected={index === active}
+              onSelect={() => setSelected(index)}
+              onPick={() => pick(row.target)}
+            />
+          ))}
+        </PickerGroup>
+      ))}
+      {/* Sticky, so a long list scrolls under it instead of burying it. It
+          stays inside the listbox because an option outside one is announced
+          to nobody; the negative margins let its ground bleed over the list's
+          own padding while it floats. */}
+      <div className="sticky -bottom-1.5 -mx-1.5 -mb-1.5 mt-1.5 border-t bg-popover p-1.5">
+        <PickerRow
+          selected={active === results.length}
+          onSelect={() => setSelected(results.length)}
+          onRun={pickWorktree}
+        >
+          <GitBranchPlus className="size-4 shrink-0 text-muted-foreground" />
+          <span className="truncate text-sm">New worktree session…</span>
+        </PickerRow>
+      </div>
     </PickerDialog>
   )
 }

--- a/frontend/src/lib/session/delegate-prompt.test.ts
+++ b/frontend/src/lib/session/delegate-prompt.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest"
 import { delegatePrompt } from "./delegate-prompt"
 
 describe("delegatePrompt", () => {
-  it("asks in plain words where the sender has lich's tools", () => {
-    expect(delegatePrompt("claude", "docs")).toBe('Ask the "docs" session to ')
-    expect(delegatePrompt("codex", "docs")).toBe('Ask the "docs" session to ')
+  it("delegates in plain words where the sender has lich's tools", () => {
+    // A colon, never a preposition: the task typed after it can be an order, a
+    // question or pasted context, and none of them bends into "to <verb>".
+    expect(delegatePrompt("claude", "docs")).toBe('Delegate to the "docs" session: ')
+    expect(delegatePrompt("codex", "docs")).toBe('Delegate to the "docs" session: ')
   })
 
   it("spells the command for every other sender", () => {
@@ -20,7 +22,7 @@ describe("delegatePrompt", () => {
   })
 
   it("carries the label through verbatim", () => {
-    expect(delegatePrompt("claude", "fix login 2")).toBe('Ask the "fix login 2" session to ')
+    expect(delegatePrompt("claude", "fix login 2")).toBe('Delegate to the "fix login 2" session: ')
     expect(delegatePrompt("crush", "fix login 2")).toBe('lich send "fix login 2" "')
   })
 })

--- a/frontend/src/lib/session/delegate-prompt.test.ts
+++ b/frontend/src/lib/session/delegate-prompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { delegatePrompt } from "./delegate-prompt"
+import { delegatePrompt, delegateWorktreePrompt } from "./delegate-prompt"
 
 describe("delegatePrompt", () => {
   it("delegates in plain words where the sender has lich's tools", () => {
@@ -24,5 +24,21 @@ describe("delegatePrompt", () => {
   it("carries the label through verbatim", () => {
     expect(delegatePrompt("claude", "fix login 2")).toBe('Delegate to the "fix login 2" session: ')
     expect(delegatePrompt("crush", "fix login 2")).toBe('lich send "fix login 2" "')
+  })
+})
+
+describe("delegateWorktreePrompt", () => {
+  it("stays plain prose where the sender has lich's tools", () => {
+    expect(delegateWorktreePrompt("claude")).toBe("Delegate to a new worktree session: ")
+    expect(delegateWorktreePrompt("codex")).toBe("Delegate to a new worktree session: ")
+  })
+
+  it("names both commands for every other sender — nothing else would", () => {
+    for (const kind of ["opencode", "crush", "omp", "shell", "something-new"]) {
+      const prompt = delegateWorktreePrompt(kind)
+      expect(prompt).toContain("lich open --worktree")
+      expect(prompt).toContain("lich send")
+      expect(prompt.endsWith(": ")).toBe(true)
+    }
   })
 })

--- a/frontend/src/lib/session/delegate-prompt.ts
+++ b/frontend/src/lib/session/delegate-prompt.ts
@@ -40,3 +40,22 @@ export function delegatePrompt(senderKind: SessionKind | string, target: string)
   }
   return `lich send "${target}" "`
 }
+
+/**
+ * The text for delegating to a session that does not exist yet: the agent
+ * opens a worktree session and hands it the task, picking the branch name
+ * itself — it knows the task, and the user typed only the task.
+ *
+ * Prose for every kind, because a two-command errand cannot be one fill-in
+ * command the way `lich send` can. A sender without lich's tools is told the
+ * commands by name — nothing else would tell it they exist.
+ */
+export function delegateWorktreePrompt(senderKind: SessionKind | string): string {
+  if (TOOL_KINDS.includes(senderKind)) {
+    return "Delegate to a new worktree session: "
+  }
+  return (
+    "Delegate to a new worktree session (run `lich open --worktree <branch>`, " +
+    "then `lich send` the task to the session it opens): "
+  )
+}

--- a/frontend/src/lib/session/delegate-prompt.ts
+++ b/frontend/src/lib/session/delegate-prompt.ts
@@ -29,10 +29,14 @@ const TOOL_KINDS: readonly string[] = ["claude", "codex"]
  * nothing else would tell it the command exists. The quote is left open on
  * purpose there — the user types the task inside it, which is where the cursor
  * lands.
+ *
+ * The prose form ends in a colon, not a preposition: what follows can be an
+ * order, a question, or pasted context, and none of them should have to bend
+ * into "to <verb>". The verb is the UI's own — the button says Delegate.
  */
 export function delegatePrompt(senderKind: SessionKind | string, target: string): string {
   if (TOOL_KINDS.includes(senderKind)) {
-    return `Ask the "${target}" session to `
+    return `Delegate to the "${target}" session: `
   }
   return `lich send "${target}" "`
 }

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -140,6 +140,22 @@ export function toSessionStatus(data: unknown): SessionStatus | null {
   return (RENDERED_STATUSES as readonly string[]).includes(data) ? (data as SessionStatus) : null
 }
 
+// Global event the backend emits when a session's relay inbox changes size —
+// results waiting to be collected (see relay.InboxEventName). Payload:
+// { id, count }; zero clears the mark.
+export const INBOX_EVENT = "session-inbox"
+
+// toInboxCount narrows an inbox payload to a drawable count. Anything that is
+// not a positive number — a malformed payload, a shape from another build —
+// reads as zero, which clears the mark rather than stranding a stale one.
+export function toInboxCount(data: unknown): number {
+  const { count } = (data ?? {}) as { count?: unknown }
+  if (typeof count !== "number" || !Number.isFinite(count) || count <= 0) {
+    return 0
+  }
+  return Math.floor(count)
+}
+
 // session-touched carries only a session id.
 export function isIdEvent(data: unknown): data is { id: string } {
   return (

--- a/frontend/src/lib/session/session-inbox-store.test.ts
+++ b/frontend/src/lib/session/session-inbox-store.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest"
+import { toInboxCount } from "./session-events"
+import { createSessionInboxStore } from "./session-inbox-store"
+
+describe("toInboxCount", () => {
+  it("reads a positive count", () => {
+    expect(toInboxCount({ id: "s1", count: 2 })).toBe(2)
+  })
+
+  it("reads anything else as zero, which clears the mark", () => {
+    expect(toInboxCount({ id: "s1", count: 0 })).toBe(0)
+    expect(toInboxCount({ id: "s1", count: -1 })).toBe(0)
+    expect(toInboxCount({ id: "s1", count: "2" })).toBe(0)
+    expect(toInboxCount({ id: "s1" })).toBe(0)
+    expect(toInboxCount(null)).toBe(0)
+  })
+})
+
+// A hand-driven event source: the test emits, the store reacts.
+function source() {
+  const handlers: Array<(data: unknown) => void> = []
+  return {
+    subscribe: (handler: (data: unknown) => void) => {
+      handlers.push(handler)
+      return () => {}
+    },
+    emit: (data: unknown) => {
+      for (const handler of handlers) {
+        handler(data)
+      }
+    },
+  }
+}
+
+function build() {
+  const inbox = source()
+  const status = source()
+  const store = createSessionInboxStore(inbox.subscribe, status.subscribe)
+  return { inbox, status, store }
+}
+
+describe("createSessionInboxStore", () => {
+  it("is zero until something is reported", () => {
+    const { store } = build()
+    expect(store.get("s1")).toBe(0)
+  })
+
+  it("follows the count up and back to zero", () => {
+    const { inbox, store } = build()
+
+    inbox.emit({ id: "s1", count: 2 })
+    expect(store.get("s1")).toBe(2)
+
+    inbox.emit({ id: "s1", count: 0 })
+    expect(store.get("s1")).toBe(0)
+  })
+
+  it("keeps sessions apart", () => {
+    const { inbox, store } = build()
+
+    inbox.emit({ id: "s1", count: 1 })
+    expect(store.get("s2")).toBe(0)
+  })
+
+  it("clears when the session ends — nothing there collects anymore", () => {
+    const { inbox, status, store } = build()
+
+    inbox.emit({ id: "s1", count: 3 })
+    status.emit({ id: "s1", state: "idle" })
+
+    expect(store.get("s1")).toBe(0)
+  })
+})

--- a/frontend/src/lib/session/session-inbox-store.ts
+++ b/frontend/src/lib/session/session-inbox-store.ts
@@ -1,0 +1,34 @@
+import { createKeyedStore, type ReadableKeyedStore } from "@/lib/keyed-store"
+import { isIdEvent, toInboxCount } from "./session-events"
+
+// A subscription to one of the global session events, injected so the store is
+// testable without standing up the /events socket. Returns its unsubscribe.
+export type InboxEventSource = (handler: (data: unknown) => void) => () => void
+
+// createSessionInboxStore keeps how many uncollected results each session has
+// waiting in the relay's inbox, keyed by session id (see relay.InboxEventName).
+// The nudge tells the agent; this is what tells the person, on the card.
+//
+// It clears on "idle" — SessionEnd — the way the relay mark does: a session
+// that ended collects nothing, and the count would otherwise sit on a dead
+// card until the entries expire an hour later.
+export function createSessionInboxStore(
+  inboxSource: InboxEventSource,
+  statusSource: InboxEventSource,
+): ReadableKeyedStore<number> {
+  const store = createKeyedStore<number>(0)
+
+  inboxSource((data) => {
+    if (isIdEvent(data)) {
+      store.set(data.id, toInboxCount(data))
+    }
+  })
+
+  statusSource((data) => {
+    if (isIdEvent(data) && (data as { state?: unknown }).state === "idle") {
+      store.set(data.id, 0)
+    }
+  })
+
+  return store
+}

--- a/frontend/src/lib/session/use-session-inbox.ts
+++ b/frontend/src/lib/session/use-session-inbox.ts
@@ -1,0 +1,17 @@
+import { useKeyedStore } from "@/lib/use-keyed-store"
+import { onAppEvent } from "@/lib/app-events"
+import { INBOX_EVENT, STATUS_EVENT } from "./session-events"
+import { createSessionInboxStore } from "./session-inbox-store"
+
+// Subscribed at import rather than on first use: that opens the /events socket
+// at page load, so a result stashed before any card mounts still lands.
+const store = createSessionInboxStore(
+  (handler) => onAppEvent(INBOX_EVENT, handler),
+  (handler) => onAppEvent(STATUS_EVENT, handler),
+)
+
+// useSessionInbox reads how many uncollected results a session has waiting.
+// Zero — the usual case — draws nothing.
+export function useSessionInbox(id: string): number {
+  return useKeyedStore(store, id)
+}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -122,6 +122,18 @@ const (
 	DirectionIn  = "in"
 )
 
+// InboxEventName carries how many uncollected results a session has waiting,
+// so its card can say so — the nudge tells the agent, and this tells the
+// person. Emitted whenever a sender's inbox changes size; zero clears the
+// mark. Global for the same reason the relay event is.
+const InboxEventName = "session-inbox"
+
+// InboxEvent is the payload of InboxEventName.
+type InboxEvent struct {
+	ID    string `json:"id"`
+	Count int    `json:"count"`
+}
+
 // StalledEventName carries a request whose target ended its turn without
 // answering through lich. The window turns it into a toast that opens the
 // target's card, because the answer — if there is one — is on that screen and
@@ -406,7 +418,7 @@ func (s *Service) Send(fromID, target, project, prompt string, waitSeconds int) 
 		unread:   make(chan struct{}),
 	}
 	s.mu.Lock()
-	expired := s.sweep()
+	expired, inboxEvents := s.sweep()
 	busy := s.state[dest.ID] == stateBusy
 	if busy {
 		t.skipTurns = 1
@@ -414,6 +426,7 @@ func (s *Service) Send(fromID, target, project, prompt string, waitSeconds int) 
 	s.tickets[id] = t
 	s.mu.Unlock()
 	s.clearAll(expired)
+	s.announceInboxAll(inboxEvents)
 
 	// One deadline covers the whole call: the setup wait and the answer wait
 	// spend the same budget. Each taking a full waitFor of its own would let a
@@ -563,16 +576,20 @@ func (s *Service) watchReceipt(id string, t *ticket) {
 // An outcome already sitting in the inbox is handed over on the spot.
 func (s *Service) Wait(ticketID string, waitSeconds int) (Result, error) {
 	s.mu.Lock()
-	expired := s.sweep()
+	expired, inboxEvents := s.sweep()
 	if e, ok := s.ready[ticketID]; ok {
 		delete(s.ready, ticketID)
+		count := s.countLocked(e.fromID)
 		s.mu.Unlock()
 		s.clearAll(expired)
+		s.announceInboxAll(inboxEvents)
+		s.announceInbox(e.fromID, count)
 		return Result{Ticket: e.ticket, Target: e.target, Status: e.status, Answer: e.answer}, nil
 	}
 	t, ok := s.tickets[ticketID]
 	s.mu.Unlock()
 	s.clearAll(expired)
+	s.announceInboxAll(inboxEvents)
 	if !ok {
 		return Result{}, fmt.Errorf("unknown ticket %q — it was answered long ago, or expired", ticketID)
 	}
@@ -591,18 +608,23 @@ func (s *Service) Collect(fromID string, waitSeconds int) (Collected, error) {
 	deadline := s.now().Add(waitFor(waitSeconds))
 	for {
 		s.mu.Lock()
-		expired := s.sweep()
+		expired, inboxEvents := s.sweep()
 		results := s.drainLocked(fromID)
 		open := s.openLocked(fromID)
 		if len(results) > 0 || len(open) == 0 {
 			s.mu.Unlock()
 			s.clearAll(expired)
+			s.announceInboxAll(inboxEvents)
+			if len(results) > 0 {
+				s.announceInbox(fromID, 0)
+			}
 			return Collected{Results: results, Open: open}, nil
 		}
 		wake := make(chan struct{}, 1)
 		s.collectors[fromID] = append(s.collectors[fromID], wake)
 		s.mu.Unlock()
 		s.clearAll(expired)
+		s.announceInboxAll(inboxEvents)
 
 		remaining := deadline.Sub(s.now())
 		if remaining <= 0 {
@@ -621,6 +643,9 @@ func (s *Service) Collect(fromID string, waitSeconds int) (Collected, error) {
 			results := s.drainLocked(fromID)
 			open := s.openLocked(fromID)
 			s.mu.Unlock()
+			if len(results) > 0 {
+				s.announceInbox(fromID, 0)
+			}
 			return Collected{Results: results, Open: open}, nil
 		}
 	}
@@ -730,6 +755,7 @@ func (s *Service) stash(id string, t *ticket, status, answer string) {
 		ticket: id, fromID: t.fromID, target: t.target,
 		status: status, answer: answer, ready: s.now(),
 	}
+	count := s.countLocked(t.fromID)
 	woke := false
 	for _, wake := range s.collectors[t.fromID] {
 		select {
@@ -744,6 +770,33 @@ func (s *Service) stash(id string, t *ticket, status, answer string) {
 		s.nudgeTimer[fromID] = time.AfterFunc(s.nudgeDelay, func() { s.flushNudge(fromID) })
 	}
 	s.mu.Unlock()
+	s.announceInbox(t.fromID, count)
+}
+
+// countLocked is how many results wait for fromID. Called under s.mu.
+func (s *Service) countLocked(fromID string) int {
+	count := 0
+	for _, e := range s.ready {
+		if e.fromID == fromID {
+			count++
+		}
+	}
+	return count
+}
+
+// announceInbox tells the window a sender's inbox changed size. Outside s.mu,
+// like every Emit here.
+func (s *Service) announceInbox(fromID string, count int) {
+	if s.events == nil || fromID == "" {
+		return
+	}
+	s.events.Emit(InboxEventName, InboxEvent{ID: fromID, Count: count})
+}
+
+func (s *Service) announceInboxAll(events []InboxEvent) {
+	for _, e := range events {
+		s.announceInbox(e.ID, e.Count)
+	}
 }
 
 // flushNudge types one nudge naming everything waiting for fromID, if any of
@@ -1050,7 +1103,7 @@ func waitFor(seconds int) time.Duration {
 // otherwise grow the inbox by one entry per errand for the life of the
 // process. Called under the lock on the paths that already hold it, which is
 // often enough for a map that grows one entry per errand.
-func (s *Service) sweep() []*ticket {
+func (s *Service) sweep() ([]*ticket, []InboxEvent) {
 	var expired []*ticket
 	cutoff := s.now().Add(-ticketTTL)
 	for id, t := range s.tickets {
@@ -1059,12 +1112,20 @@ func (s *Service) sweep() []*ticket {
 			expired = append(expired, t)
 		}
 	}
+	touched := map[string]bool{}
 	for id, e := range s.ready {
 		if e.ready.Before(cutoff) {
 			delete(s.ready, id)
+			if e.fromID != "" {
+				touched[e.fromID] = true
+			}
 		}
 	}
-	return expired
+	var inbox []InboxEvent
+	for fromID := range touched {
+		inbox = append(inbox, InboxEvent{ID: fromID, Count: s.countLocked(fromID)})
+	}
+	return expired, inbox
 }
 
 // ticketIDBytes is the length of a ticket id before hex encoding. Short enough

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -91,6 +91,7 @@ type fakeEvents struct {
 	mu    sync.Mutex
 	sent  []RelayEvent
 	halts []StalledEvent
+	inbox []InboxEvent
 }
 
 func (f *fakeEvents) Emit(name string, data any) {
@@ -105,6 +106,10 @@ func (f *fakeEvents) Emit(name string, data any) {
 		if name == StalledEventName {
 			f.halts = append(f.halts, event)
 		}
+	case InboxEvent:
+		if name == InboxEventName {
+			f.inbox = append(f.inbox, event)
+		}
 	}
 }
 
@@ -112,6 +117,19 @@ func (f *fakeEvents) stalled() []StalledEvent {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	return append([]StalledEvent(nil), f.halts...)
+}
+
+// inboxCounts is every inbox size announced for one session, in order.
+func (f *fakeEvents) inboxCounts(id string) []int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	var counts []int
+	for _, e := range f.inbox {
+		if e.ID == id {
+			counts = append(counts, e.Count)
+		}
+	}
+	return counts
 }
 
 func (f *fakeEvents) snapshot() []RelayEvent {
@@ -1822,6 +1840,70 @@ func TestAnUncollectedResultExpiresWithItsTTL(t *testing.T) {
 	}
 	if len(collected.Results) != 0 {
 		t.Errorf("an hour-old result was still handed over: %+v", collected.Results)
+	}
+}
+
+// The window hears the inbox change size, so the card can say results are
+// waiting: the nudge tells the agent, the event tells the person.
+func TestTheInboxSizeIsAnnouncedAsItGrowsAndDrains(t *testing.T) {
+	events := &fakeEvents{}
+	term := newFakeTerminal("s1", "s2", "s3")
+	svc := newRelay(workspace(), term, events)
+	plant(svc, "t1", "s1", "s2", "docs")
+	plant(svc, "t2", "s1", "s3", "api")
+
+	if err := svc.Reply("t1", "one"); err != nil {
+		t.Fatalf("Reply t1: %v", err)
+	}
+	if err := svc.Reply("t2", "two"); err != nil {
+		t.Fatalf("Reply t2: %v", err)
+	}
+	if got := events.inboxCounts("s1"); len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Fatalf("counts = %v, want [1 2]", got)
+	}
+
+	if _, err := svc.Collect("s1", 1); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	counts := events.inboxCounts("s1")
+	if len(counts) != 3 || counts[2] != 0 {
+		t.Errorf("counts = %v, want the drain announced as 0", counts)
+	}
+}
+
+func TestASingleTicketPickupAnnouncesTheSmallerInbox(t *testing.T) {
+	events := &fakeEvents{}
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2"), events)
+	plant(svc, "t1", "s1", "s2", "docs")
+	if err := svc.Reply("t1", "one"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+
+	if _, err := svc.Wait("t1", 1); err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	counts := events.inboxCounts("s1")
+	if len(counts) != 2 || counts[1] != 0 {
+		t.Errorf("counts = %v, want the pickup announced as 0", counts)
+	}
+}
+
+func TestAnExpiredInboxEntryAnnouncesItsAbsence(t *testing.T) {
+	events := &fakeEvents{}
+	svc := newRelay(workspace(), newFakeTerminal("s1"), events)
+	svc.mu.Lock()
+	svc.ready["old"] = &inboxEntry{
+		ticket: "old", fromID: "s1", target: "docs",
+		status: StatusAnswered, ready: time.Now().Add(-2 * time.Hour),
+	}
+	svc.mu.Unlock()
+
+	if _, err := svc.Collect("s1", 1); err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	counts := events.inboxCounts("s1")
+	if len(counts) != 1 || counts[0] != 0 {
+		t.Errorf("counts = %v, want the expiry announced as 0", counts)
 	}
 }
 


### PR DESCRIPTION
> Stacked on #254 (the colon phrasing) — merge that first; GitHub will retarget this to main when the base branch is deleted.

Mockup (both themes, real tokens): the Delegate Journey artifact reviewed in-session.

## 1 · Picker — pinned "New worktree session…" row

The picker only listed *live* sessions, but the journey the MCP instructions teach (#251) is fan-out into fresh worktrees — the UI couldn't delegate to a session that doesn't exist yet.

- The row is **sticky at the foot of the list**: a long roster scrolls beneath it, it never leaves the screen, and the query never filters it out. It stays inside the listbox (an `option` outside one is announced to nobody).
- Arrow keys reach it as the last stop; Enter with no query still lands on the first *session*, so muscle memory keeps.
- The delegate menu item stops requiring live targets (`canDelegate = active`): with nobody else open the picker opens straight onto the row — exactly when fanning out is most useful.
- What it pastes (`delegateWorktreePrompt`): tool-having senders get `Delegate to a new worktree session: `; the rest get the same prose naming `lich open --worktree` and `lich send`, because nothing else would tell them the commands exist. Provider-symmetric on purpose.
- The agent picks the branch name — it knows the task; the user typed only the task.

## 2 · Card — "2 results ready"

The relay inbox (#251) knows when an orchestrator has uncollected results; only the agent heard the nudge. Now the person sees it too.

- Backend: new global event `session-inbox` `{id, count}`, emitted whenever a sender's inbox changes size — stash, batch collect, single-ticket pickup, TTL expiry. Zero clears the mark.
- Frontend: `createKeyedStore` readout (`session-inbox-store`), cleared on SessionEnd like the relay mark.
- The card's one-line rung grows a fourth state, between "Waiting on you" and the tool line: `Inbox` glyph + count, the relay mark's own quiet idiom. Mid-turn the live tool wins — the same rule the nudge follows — and the mark takes the rung when the card goes quiet.
- Ceiling: a page reload forgets the count until the next inbox change; the events channel has no replay, same as the relay mark today.

## Tests

- Go: inbox announcements on grow/drain/pickup/expiry; suite green with `-race`.
- TS: `toInboxCount` narrowing, inbox store (follow/clear/isolate), `delegateWorktreePrompt` both shapes. 874 vitest green; `biome check`, `tsc --noEmit`, `vite build` green.
- Render paths (picker sticky row, card rung) are node-untestable — smoke them in `task dev`: open the picker with a long list (row stays put), collect with `wait_for_answer` (mark clears).