### PR TITLE
chore: cut v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.31.0] - 2026-08-13
 
 ### Changed
 
@@ -2234,7 +2234,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.30.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.31.0...HEAD
+[0.31.0]: https://github.com/omartelo/lich/compare/v0.30.0...v0.31.0
 [0.30.0]: https://github.com/omartelo/lich/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/omartelo/lich/compare/v0.28.0...v0.29.0
 [0.28.0]: https://github.com/omartelo/lich/compare/v0.27.0...v0.28.0


### PR DESCRIPTION
Cuts v0.31.0: the `[Unreleased]` entries move under a `## [0.31.0] - 2026-08-13`
heading and the compare links gain the new tag.

Four PRs landed since v0.30.0 — #250, #251, #252 and #253 — and all six of their
user-visible changes already carry a CHANGELOG entry, so nothing had to be added
after the fact. The claims were re-read against the code: the one-hour ticket
TTL and the 2s nudge debounce (`internal/relay/relay.go`), the `instructions`
handshake and the `readOnlyHint` annotations (`internal/cli/mcp.go`), the OSC 8
link handler (`frontend/src/components/TerminalView.tsx`) and the bind dialog
naming `LICH_LISTEN_PORT` (`main.go`).

The READMEs need no change: no user-facing surface they describe moved in this
window, and the Chinese one is still in sync with the English one as of the
v0.30.0 cut.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test -race ./...` green (1321 tests, 30 packages)
- [x] `biome check .` clean, `tsc --noEmit` clean
- [x] `vitest run` green (866 tests, 77 files)
- [x] `vite build` succeeds
- [x] cross-compile loop: `GOOS=linux|darwin|windows go build ./... && go vet ./...` all green