### PR TITLE
feat: open a session on a named model, and wire oh-my-pi's yolo flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **A session can be opened on a specific model.** `lich open --model <model>`
+  and the `open_session` MCP tool's `model` argument start the new session's
+  provider on the model you name, in that provider's own spelling — Claude Code,
+  Codex, opencode and oh-my-pi each take the name their own `--model` accepts. Fanning work out to a worktree can now put the cheap model on the
+  mechanical half of the job and keep the expensive one where it earns its
+  price. The model is recorded on the session, so a reload, a respawn or the
+  resume of a parked worktree session all come back on it. Crush and `shell`
+  sessions are refused rather than silently opened on the default: Crush spells
+  `--model` only on its non-interactive `run` subcommand, so the TUI lich spawns
+  has nowhere to receive one.
+
+- **oh-my-pi can run without permission prompts.** Settings › Providers now
+  offers oh-my-pi the same "run without asking" ladder as the other providers,
+  spawning it with `--auto-approve`. It was the one provider left out, because
+  its spelling had never been checked against the binary.
+
 ## [0.31.0] - 2026-08-13
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -190,7 +190,7 @@ This is what a relayed message asks the receiving agent to run. An answer is
 capped at 64 KiB. Replying twice to one ticket is an error — the first answer
 already went home.
 
-### `lich open [--project <name>] [--kind <provider>] [--worktree <branch>] [--base <branch>]`
+### `lich open [--project <name>] [--kind <provider>] [--worktree <branch>] [--base <branch>] [--model <model>]`
 
 Opens a new session, starts it, and prints the two names it is addressed by:
 
@@ -216,6 +216,17 @@ It answers to "auth-fix" and to "auth-fix-9f8e". Its agent may still be starting
   (`origin/…`, fetched and tracked), or one another worktree already holds. A
   base that is not a branch is refused rather than resolved: git would happily
   branch off a typo that names a revision, leaving a checkout nobody asked for.
+- `--model` is the model the session's provider starts on. The value is whatever
+  that provider's own `--model` takes — an alias, a full name, a
+  `provider/model` pair — and lich passes it through unchecked: the accepted
+  names differ per provider and change with every release, so a wrong one fails
+  in the provider's own error rather than against a list kept here (and no list
+  here could go stale into a session on the wrong model). **Crush and `shell`
+  are refused**: Crush spells `--model` on its non-interactive `run` subcommand
+  only, so the TUI lich spawns has nowhere to receive one, and naming a model
+  for it would silently give you a session on the default. The model is
+  recorded on the session, so every later spawn of it — a page reload, a
+  respawn, the resume of a parked worktree session — starts on the same model.
 - A session without a worktree is labelled from the project's own counter
   (`Session 4`), continuing the numbering the window uses.
 
@@ -288,7 +299,7 @@ at lich.
 | `send_to_session` | `session`, `prompt`, optional `project` and `timeout_seconds`. |
 | `wait_for_answer` | optional `ticket` and `timeout_seconds` — with a ticket, `lich wait <ticket>`; without one, the collect: everything ready at once. |
 | `reply_to_session` | `ticket`, `answer` — what a relayed message asks for. |
-| `open_session` | optional `project`, `kind`, `worktree`, `base` — `lich open`. |
+| `open_session` | optional `project`, `kind`, `worktree`, `base`, `model` — `lich open`. |
 | `close_session` | `session`, optional `project`, `worktree` (`keep`/`remove`), `force`. |
 | `list_worktrees` | optional `project` — the checkouts, as JSON. |
 

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -35,14 +35,15 @@ describe("provider setting keys", () => {
 
   // Pinned literals, not a read-back of the map: this string is printed to the
   // user beside the switch that hands an agent the machine, and it has to be
-  // the flag the Go spawn actually passes that provider. oh-my-pi has no
-  // confirmed spelling, so it must stay absent — that is what hides the switch.
+  // the flag the Go spawn actually passes that provider. A provider with no
+  // confirmed spelling stays absent — that is what hides the switch.
   it("spells the skip-permissions flag per provider, and only where one is wired", () => {
     expect(skipPermissionFlags.claude).toBe("--dangerously-skip-permissions")
     expect(skipPermissionFlags.codex).toBe("--dangerously-bypass-approvals-and-sandbox")
     expect(skipPermissionFlags.opencode).toBe("--auto")
+    expect(skipPermissionFlags.omp).toBe("--auto-approve")
     expect(skipPermissionFlags.crush).toBe("--yolo")
-    expect(skipPermissionFlags.omp).toBeUndefined()
+    expect(skipPermissionFlags.shell).toBeUndefined()
   })
 })
 

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -41,11 +41,12 @@ export function skipPermissionsKey(id: string, worktree: boolean): string {
 // skipPermissionFlags mirrors terminal.skipPermissionFlags in Go: how each
 // provider spells "run every tool without asking". Settings offers the switch
 // only for a provider listed here, so the UI cannot promise a flag the spawn
-// has no spelling for — which is what oh-my-pi's absence means.
+// has no spelling for.
 export const skipPermissionFlags: Record<string, string> = {
   claude: "--dangerously-skip-permissions",
   codex: "--dangerously-bypass-approvals-and-sandbox",
   opencode: "--auto",
+  omp: "--auto-approve",
   crush: "--yolo",
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -83,10 +83,11 @@ const usage = `lich talks to the sessions open in the running lich window.
       relayed message asks you to run when you are done.
 
   lich open [--project <name>] [--kind <provider>] [--worktree <branch>]
-            [--base <branch>] [--json]
+            [--base <branch>] [--model <model>] [--json]
       Open a new session and start it. --worktree creates a git worktree of
-      that branch name first and roots the session in it. Prints the name the
-      new session is addressed by.
+      that branch name first and roots the session in it. --model runs the
+      provider on that model, in the provider's own spelling. Prints the name
+      the new session is addressed by.
 
   lich close [--project <name>] [--worktree keep|remove] [--force] [--json] <session>
       Close a session. Closing the last one in a worktree needs --worktree to
@@ -303,13 +304,14 @@ func (c *client) open(args []string) error {
 	kind := flags.String("kind", "", "what the session runs; defaults to the caller's own provider")
 	worktree := flags.String("worktree", "", "branch name of a new git worktree to root the session in")
 	base := flags.String("base", "", "branch the worktree starts from; defaults to the project's current branch")
+	model := flags.String("model", "", "model the provider runs, in the provider's own spelling")
 	asJSON := flags.Bool("json", false, "print the result as JSON")
 	if err := flags.Parse(args); err != nil {
 		return err
 	}
 
 	var opened spawn.Session
-	call := []any{c.sessionID(), *project, *kind, *worktree, *base}
+	call := []any{c.sessionID(), *project, *kind, *worktree, *base, *model}
 	if err := c.call("spawn.Open", call, openCall, &opened); err != nil {
 		return err
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -502,7 +502,7 @@ func TestOpenNamesBothWaysToAddressTheNewSession(t *testing.T) {
 	if call.method != "spawn.Open" {
 		t.Errorf("method = %q", call.method)
 	}
-	want := []any{"s1", "", "", "auth-fix", ""}
+	want := []any{"s1", "", "", "auth-fix", "", ""}
 	if len(call.args) != len(want) {
 		t.Fatalf("args = %v, want %v", call.args, want)
 	}
@@ -525,13 +525,17 @@ func TestOpenPassesEveryFlagThrough(t *testing.T) {
 	f := newFakeLich(t, openedBody)
 
 	code, _, stderr := run(t, f,
-		"open", "--project", "revu", "--kind", "codex", "--worktree", "hotfix", "--base", "origin/main")
+		"open", "--project", "revu", "--kind", "codex", "--worktree", "hotfix",
+		"--base", "origin/main", "--model", "gpt-5.2")
 	if code != 0 {
 		t.Fatalf("exit = %d, stderr = %q", code, stderr)
 	}
 
 	call := f.only(t)
-	want := []any{"s1", "revu", "codex", "hotfix", "origin/main"}
+	want := []any{"s1", "revu", "codex", "hotfix", "origin/main", "gpt-5.2"}
+	if len(call.args) != len(want) {
+		t.Fatalf("args = %v, want %v", call.args, want)
+	}
 	for i := range want {
 		if call.args[i] != want[i] {
 			t.Errorf("argument %d = %v, want %v", i, call.args[i], want[i])

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -387,12 +387,17 @@ var mcpTools = []mcpTool{
 					"session in the project's own directory, beside yours."),
 			"base": property("string",
 				"Branch the new worktree starts from. Defaults to the project's current branch."),
+			"model": property("string",
+				"Model the new session's provider runs, spelled exactly as that provider's own "+
+					"--model flag takes it — the name or alias, never a lich name for it. Omit "+
+					"to leave the provider on its default. Crush and shell sessions cannot be "+
+					"given one."),
 		}),
 		Run: func(c *client, args mcpArgs) (string, error) {
 			var opened spawn.Session
 			call := []any{
 				c.sessionID(), args.text("project"), args.text("kind"),
-				args.text("worktree"), args.text("base"),
+				args.text("worktree"), args.text("base"), args.text("model"),
 			}
 			if err := c.call("spawn.Open", call, openCall, &opened); err != nil {
 				return "", err

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -449,7 +449,8 @@ func TestMCPOpenSessionReturnsTheNamesItIsAddressedBy(t *testing.T) {
 		"name":"auth-fix-9f8e","kind":"claude","path":"/wt/auth-fix","nextSeq":5}`)
 
 	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
-		{"name":"open_session","arguments":{"worktree":"auth-fix","base":"main","kind":"codex"}}}`)
+		{"name":"open_session","arguments":{"worktree":"auth-fix","base":"main","kind":"codex",
+		"model":"gpt-5.2"}}}`)
 
 	text, failed := textOf(t, replies[0])
 	if failed {
@@ -459,7 +460,7 @@ func TestMCPOpenSessionReturnsTheNamesItIsAddressedBy(t *testing.T) {
 	if call.method != "spawn.Open" {
 		t.Errorf("method = %q", call.method)
 	}
-	want := []any{"s1", "", "codex", "auth-fix", "main"}
+	want := []any{"s1", "", "codex", "auth-fix", "main", "gpt-5.2"}
 	if len(call.args) != len(want) {
 		t.Fatalf("args = %v, want %v", call.args, want)
 	}

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -141,8 +141,9 @@ func ticketFrom(term *wiredTerminal) string {
 
 // spawnStore is the workspace `lich open` writes into, over the real dispatcher.
 type spawnStore struct {
-	mu   sync.Mutex
-	rows int
+	mu    sync.Mutex
+	rows  int
+	model string
 }
 
 func (*spawnStore) LoadState() ([]store.Project, error) {
@@ -154,6 +155,13 @@ func (s *spawnStore) AddSession(_, _, _, _, _ string, _ int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.rows++
+	return nil
+}
+
+func (s *spawnStore) SetSessionModel(_, model string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.model = model
 	return nil
 }
 
@@ -207,7 +215,7 @@ func (s *spawnTerminal) Close(id string) error {
 	return nil
 }
 
-// TestOpenOverTheRealDispatcher proves the five arguments `lich open` posts land
+// TestOpenOverTheRealDispatcher proves the six arguments `lich open` posts land
 // on spawn.Open in the order it declares them — a positional mismatch here would
 // otherwise open a session in a project named after a provider.
 func TestOpenOverTheRealDispatcher(t *testing.T) {
@@ -232,7 +240,8 @@ func TestOpenOverTheRealDispatcher(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	if code := Run([]string{"open", "--kind", "codex"}, "test", env, &stdout, &stderr); code != 0 {
+	args := []string{"open", "--kind", "codex", "--model", "gpt-5.2"}
+	if code := Run(args, "test", env, &stdout, &stderr); code != 0 {
 		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), `"Session 4"`) {
@@ -243,5 +252,8 @@ func TestOpenOverTheRealDispatcher(t *testing.T) {
 	}
 	if term.kind != "codex" || term.cwd != "/src/lich" {
 		t.Errorf("started %q in %q, want codex in the project directory", term.kind, term.cwd)
+	}
+	if rows.model != "gpt-5.2" {
+		t.Errorf("row model = %q, want the one the flag named", rows.model)
 	}
 }

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -70,6 +70,7 @@ const (
 type Sessions interface {
 	LoadState() ([]store.Project, error)
 	AddSession(projectID, sessionID, label, kind, path string, nextSeq int) error
+	SetSessionModel(sessionID, model string) error
 	DeleteSession(projectID, sessionID, activeID string) error
 	CloseSession(projectID, sessionID, activeID string) error
 	PurgeWorktreeSessions(projectID, path string) error
@@ -144,7 +145,10 @@ func New(sessions Sessions, worktrees Worktrees, term Terminal, events Events) *
 // base (the project's current branch when base is empty); the session is rooted
 // there, labelled after it, and runs the project's worktree setup script before
 // its provider, exactly as the window's own worktree flow does.
-func (s *Service) Open(fromID, projectName, kind, worktree, base string) (Session, error) {
+//
+// model, when given, is the model the provider is spawned on, in that provider's
+// own spelling. It is recorded on the row so every later spawn repeats it.
+func (s *Service) Open(fromID, projectName, kind, worktree, base, model string) (Session, error) {
 	projects, err := s.sessions.LoadState()
 	if err != nil {
 		return Session{}, fmt.Errorf("read the workspace: %w", err)
@@ -156,6 +160,13 @@ func (s *Service) Open(fromID, projectName, kind, worktree, base string) (Sessio
 	kind, err = resolveKind(projects, fromID, kind)
 	if err != nil {
 		return Session{}, err
+	}
+	model = strings.TrimSpace(model)
+	if model != "" && !terminal.SupportsModel(kind) {
+		return Session{}, fmt.Errorf(
+			"%s cannot be told which model to run when lich starts it — open the session without a model and pick one inside it",
+			kindName(kind),
+		)
 	}
 
 	// cwd is where the PTY starts; stored is what the row records, which is
@@ -204,6 +215,11 @@ func (s *Service) Open(fromID, projectName, kind, worktree, base string) (Sessio
 	}
 	if err := s.sessions.AddSession(target.ID, id, label, kind, stored, opened.NextSeq); err != nil {
 		return Session{}, err
+	}
+	if model != "" {
+		if err := s.sessions.SetSessionModel(id, model); err != nil {
+			return Session{}, err
+		}
 	}
 	// Announced before the spawn, and regardless of how it goes: the row exists
 	// either way, so the card has to exist either way too — a session only the
@@ -347,6 +363,17 @@ func knownProjects(projects []store.Project) string {
 		names = append(names, p.Name)
 	}
 	return "Open projects: " + strings.Join(names, ", ") + "."
+}
+
+// kindName is what a provider is called in an error the user reads, falling
+// back to the kind itself — which is what a shell session has.
+func kindName(kind string) string {
+	for _, p := range providers.Registry {
+		if p.ID == kind {
+			return p.Name
+		}
+	}
+	return kind
 }
 
 func knownKinds() string {

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -24,6 +24,8 @@ type fakeSessions struct {
 	loadErr  error
 	rows     []added
 	addErr   error
+	// models records the model written on each session row, keyed by session id.
+	models map[string]string
 	// deleted/parked/purged record what a close asked the store to do, and
 	// against which active session it left the project.
 	deleted []closedRow
@@ -62,6 +64,14 @@ func (f *fakeSessions) AddSession(projectID, sessionID, label, kind, path string
 		return f.addErr
 	}
 	f.rows = append(f.rows, added{projectID, sessionID, label, kind, path, nextSeq})
+	return nil
+}
+
+func (f *fakeSessions) SetSessionModel(sessionID, model string) error {
+	if f.models == nil {
+		f.models = map[string]string{}
+	}
+	f.models[sessionID] = model
 	return nil
 }
 
@@ -187,7 +197,7 @@ func newService(t *testing.T) (*Service, *fakeSessions, *fakeWorktrees, *fakeTer
 func TestOpenLandsInTheCallersProject(t *testing.T) {
 	svc, sessions, _, term, events := newService(t)
 
-	opened, err := svc.Open("s1", "", "", "", "")
+	opened, err := svc.Open("s1", "", "", "", "", "")
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -241,7 +251,7 @@ func TestOpenLandsInTheCallersProject(t *testing.T) {
 func TestOpenInheritsTheCallersKind(t *testing.T) {
 	svc, _, _, term, _ := newService(t)
 
-	if _, err := svc.Open("s1", "", "", "", ""); err != nil {
+	if _, err := svc.Open("s1", "", "", "", "", ""); err != nil {
 		t.Fatalf("Open: %v", err)
 	}
 	if got := term.spawns[0].kind; got != "codex" {
@@ -252,7 +262,7 @@ func TestOpenInheritsTheCallersKind(t *testing.T) {
 func TestOpenTakesANamedProjectAndKind(t *testing.T) {
 	svc, sessions, _, term, _ := newService(t)
 
-	opened, err := svc.Open("s1", "revu", "shell", "", "")
+	opened, err := svc.Open("s1", "revu", "shell", "", "", "")
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -273,7 +283,7 @@ func TestOpenTakesANamedProjectAndKind(t *testing.T) {
 func TestOpenWithoutASessionOrAProjectSaysWhatToDo(t *testing.T) {
 	svc, _, _, term, _ := newService(t)
 
-	_, err := svc.Open("", "", "", "", "")
+	_, err := svc.Open("", "", "", "", "", "")
 	if err == nil {
 		t.Fatal("opened a session with nothing to open it in")
 	}
@@ -290,7 +300,7 @@ func TestOpenWithoutASessionOrAProjectSaysWhatToDo(t *testing.T) {
 func TestOpenRefusesAnUnknownProject(t *testing.T) {
 	svc, sessions, _, _, _ := newService(t)
 
-	if _, err := svc.Open("s1", "nope", "", "", ""); err == nil {
+	if _, err := svc.Open("s1", "nope", "", "", "", ""); err == nil {
 		t.Fatal("opened a session in a project that is not open")
 	}
 	if len(sessions.rows) != 0 {
@@ -301,7 +311,7 @@ func TestOpenRefusesAnUnknownProject(t *testing.T) {
 func TestOpenRefusesAnUnknownKind(t *testing.T) {
 	svc, sessions, _, _, _ := newService(t)
 
-	_, err := svc.Open("s1", "", "gemini", "", "")
+	_, err := svc.Open("s1", "", "gemini", "", "", "")
 	if err == nil {
 		t.Fatal("opened a session running a provider lich does not know")
 	}
@@ -313,10 +323,60 @@ func TestOpenRefusesAnUnknownKind(t *testing.T) {
 	}
 }
 
+// The model is written on the row rather than only handed to the spawn: the
+// terminal service reads it back on every later spawn of this session, so a
+// model that never reached the row is a reload away from the default.
+func TestOpenRecordsTheModelOnTheRow(t *testing.T) {
+	svc, sessions, _, _, _ := newService(t)
+
+	opened, err := svc.Open("s1", "", "claude", "", "", "opus")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if got := sessions.models[opened.ID]; got != "opus" {
+		t.Errorf("row model = %q, want opus", got)
+	}
+}
+
+// A session opened with no model leaves the column alone: "" is what every
+// session the window opens carries, and what leaves the provider on its default.
+func TestOpenWithoutAModelWritesNone(t *testing.T) {
+	svc, sessions, _, _, _ := newService(t)
+
+	if _, err := svc.Open("s1", "", "claude", "", "", ""); err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if len(sessions.models) != 0 {
+		t.Errorf("wrote %v, want the model column left alone", sessions.models)
+	}
+}
+
+// Crush and a shell cannot be told which model to run when lich starts them, so
+// a caller that names one is told — silently dropping it would hand back a
+// session that looks like the one asked for and runs a different model.
+func TestOpenRefusesAModelTheProviderCannotBeTold(t *testing.T) {
+	for _, kind := range []string{"crush", "shell"} {
+		t.Run(kind, func(t *testing.T) {
+			svc, sessions, _, term, _ := newService(t)
+
+			_, err := svc.Open("s1", "", kind, "", "", "opus")
+			if err == nil {
+				t.Fatal("opened a session on a model its provider never sees")
+			}
+			if !strings.Contains(err.Error(), "model") {
+				t.Errorf("error = %q, want it to name the model", err)
+			}
+			if len(sessions.rows) != 0 || len(term.spawns) != 0 {
+				t.Error("the refusal still created something")
+			}
+		})
+	}
+}
+
 func TestOpenOnAWorktreeBranchesOffTheCurrentBranch(t *testing.T) {
 	svc, sessions, worktrees, term, _ := newService(t)
 
-	opened, err := svc.Open("s1", "", "", "auth-fix", "")
+	opened, err := svc.Open("s1", "", "", "auth-fix", "", "")
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -351,7 +411,7 @@ func TestOpenTracksARemoteBase(t *testing.T) {
 		Remote: []string{"origin/release"},
 	}
 
-	if _, err := svc.Open("s1", "", "", "hotfix", "origin/release"); err != nil {
+	if _, err := svc.Open("s1", "", "", "hotfix", "origin/release", ""); err != nil {
 		t.Fatalf("Open: %v", err)
 	}
 	if got := worktrees.created[0]; !got.remote || got.base != "origin/release" {
@@ -368,7 +428,7 @@ func TestOpenBranchesOffABranchAnotherWorktreeHolds(t *testing.T) {
 		Worktrees: []project.Worktree{{Name: "amber-otter", Path: "/wt/amber-otter"}},
 	}
 
-	if _, err := svc.Open("s1", "", "", "follow-up", "amber-otter"); err != nil {
+	if _, err := svc.Open("s1", "", "", "follow-up", "amber-otter", ""); err != nil {
 		t.Fatalf("Open: %v", err)
 	}
 	if got := worktrees.created[0]; got.base != "amber-otter" || got.remote {
@@ -382,7 +442,7 @@ func TestOpenRefusesABaseThatIsNoBranch(t *testing.T) {
 
 	// git would branch off any revision this happened to resolve to, leaving a
 	// checkout nobody asked for; a name that is not a branch is a typo.
-	_, err := svc.Open("s1", "", "", "hotfix", "mian")
+	_, err := svc.Open("s1", "", "", "hotfix", "mian", "")
 	if err == nil {
 		t.Fatal("created a worktree off a base that is not a branch")
 	}
@@ -395,7 +455,7 @@ func TestOpenLeavesNoSessionWhenTheWorktreeFails(t *testing.T) {
 	svc, sessions, worktrees, term, events := newService(t)
 	worktrees.createErr = errors.New("branch already exists")
 
-	if _, err := svc.Open("s1", "", "", "auth-fix", ""); err == nil {
+	if _, err := svc.Open("s1", "", "", "auth-fix", "", ""); err == nil {
 		t.Fatal("opened a session on a worktree that was never created")
 	}
 	if len(sessions.rows) != 0 || len(term.spawns) != 0 || len(events.events) != 0 {
@@ -409,7 +469,7 @@ func TestOpenKeepsTheCardWhenTheTerminalFails(t *testing.T) {
 	svc, sessions, _, term, events := newService(t)
 	term.err = errors.New("claude: not found")
 
-	_, err := svc.Open("s1", "", "", "", "")
+	_, err := svc.Open("s1", "", "", "", "", "")
 	if err == nil {
 		t.Fatal("reported success for a terminal that never started")
 	}
@@ -428,7 +488,7 @@ func TestOpenWithoutAnEventsSinkStillOpens(t *testing.T) {
 	sessions := &fakeSessions{projects: workspace()}
 	svc := New(sessions, &fakeWorktrees{branch: "main"}, &fakeTerminal{}, nil)
 
-	if _, err := svc.Open("s1", "", "", "", ""); err != nil {
+	if _, err := svc.Open("s1", "", "", "", "", ""); err != nil {
 		t.Fatalf("Open: %v", err)
 	}
 	if len(sessions.rows) != 1 {
@@ -440,7 +500,7 @@ func TestOpenRefusesADetachedHeadWithoutABase(t *testing.T) {
 	svc, _, worktrees, _, _ := newService(t)
 	worktrees.branch = ""
 
-	_, err := svc.Open("s1", "", "", "auth-fix", "")
+	_, err := svc.Open("s1", "", "", "auth-fix", "", "")
 	if err == nil {
 		t.Fatal("created a worktree off nothing")
 	}
@@ -453,7 +513,7 @@ func TestSessionIDsDoNotRepeat(t *testing.T) {
 	svc, sessions, _, _, _ := newService(t)
 
 	for range 2 {
-		if _, err := svc.Open("s1", "", "", "", ""); err != nil {
+		if _, err := svc.Open("s1", "", "", "", "", ""); err != nil {
 			t.Fatalf("Open: %v", err)
 		}
 	}

--- a/internal/spawn/worktrees_test.go
+++ b/internal/spawn/worktrees_test.go
@@ -68,7 +68,7 @@ func TestWorktreesRefusesAProjectItCannotResolve(t *testing.T) {
 func TestOpenUsesACheckoutThatIsAlreadyThere(t *testing.T) {
 	svc, sessions, worktrees, term, _ := closer(t)
 
-	opened, err := svc.Open("s1", "", "", "shared", "")
+	opened, err := svc.Open("s1", "", "", "shared", "", "")
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestOpenUsesACheckoutThatIsAlreadyThere(t *testing.T) {
 func TestOpenFallsBackWhenTheBranchNameIsAlreadyACard(t *testing.T) {
 	svc, _, _, _, _ := closer(t)
 
-	opened, err := svc.Open("s1", "", "", "alone", "")
+	opened, err := svc.Open("s1", "", "", "alone", "", "")
 	if err != nil {
 		t.Fatalf("Open: %v", err)
 	}

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -253,6 +253,37 @@ func (s *Service) SetSessionTitle(sessionID, title string) (bool, error) {
 	return n > 0, nil
 }
 
+// SetSessionModel records the model a session's provider was asked to run, so
+// every later spawn of that session repeats the flag: a reload, a respawn, and
+// the resume of a parked worktree session all go through the same path, and a
+// model that only survived the first spawn would silently become the provider's
+// default on the second.
+//
+// It is written once, right after the row is created. A session whose row is
+// gone matches nothing and is not an error.
+func (s *Service) SetSessionModel(sessionID, model string) error {
+	if _, err := s.db.Exec(
+		`UPDATE sessions SET model = ? WHERE id = ?`, model, sessionID,
+	); err != nil {
+		return fmt.Errorf("set model on %q: %w", sessionID, err)
+	}
+	return nil
+}
+
+// SessionModel returns the model recorded for a session, or "" for none — which
+// is what a session opened from the window has, and what leaves the provider on
+// its own default. A read failure answers "" for the same reason: the model is
+// an override, and the provider's default is the safe thing to fall back to.
+func (s *Service) SessionModel(sessionID string) string {
+	var model sql.NullString
+	if err := s.db.QueryRow(
+		`SELECT model FROM sessions WHERE id = ?`, sessionID,
+	).Scan(&model); err != nil {
+		return ""
+	}
+	return model.String
+}
+
 // SetProviderSession records the provider conversation id running inside a lich
 // session's PTY, reported by the provider's session-start hook. A session whose
 // row does not exist yet (the hook racing session persistence) matches nothing

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -43,7 +43,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     label_auto          INTEGER NOT NULL DEFAULT 1,
     is_open             INTEGER NOT NULL DEFAULT 1,
     position            INTEGER NOT NULL DEFAULT 0,
-    pinned              INTEGER NOT NULL DEFAULT 0
+    pinned              INTEGER NOT NULL DEFAULT 0,
+    model               TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
 
@@ -155,6 +156,7 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN is_open INTEGER NOT NULL DEFAULT 1`,
 		`ALTER TABLE sessions ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE sessions ADD COLUMN model TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN closed_seq INTEGER NOT NULL DEFAULT 0`,
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -131,6 +131,40 @@ func TestSetProviderSessionPersistsAndDefaults(t *testing.T) {
 	}
 }
 
+// TestSessionModelRoundTrips pins the pair the terminal service spawns off: the
+// model written when the session was opened is what every later spawn reads
+// back, a session opened without one reads "", and so does a session that is not
+// there at all — the read has no error to report with, and the provider's own
+// default is what "" means.
+func TestSessionModelRoundTrips(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "s1", "Session 1", "claude", "", 2)
+	_ = svc.AddSession("p1", "s2", "Session 2", "claude", "", 3)
+
+	if err := svc.SetSessionModel("s1", "opus"); err != nil {
+		t.Fatalf("SetSessionModel: %v", err)
+	}
+	if got := svc.SessionModel("s1"); got != "opus" {
+		t.Errorf("SessionModel(s1) = %q, want opus", got)
+	}
+	if got := svc.SessionModel("s2"); got != "" {
+		t.Errorf("SessionModel(s2) = %q, want empty", got)
+	}
+	if got := svc.SessionModel("ghost"); got != "" {
+		t.Errorf("SessionModel(ghost) = %q, want empty", got)
+	}
+}
+
+// A model reported for a session whose row is gone matches nothing and is not an
+// error, exactly as the provider session id is.
+func TestSetSessionModelUnknownSessionNoop(t *testing.T) {
+	svc := newTestStore(t)
+	if err := svc.SetSessionModel("ghost", "opus"); err != nil {
+		t.Errorf("SetSessionModel unknown = %v, want nil", err)
+	}
+}
+
 // TestSetProviderSessionUnknownSessionNoop proves reporting for a session whose
 // row does not exist (the hook racing persistence) is not an error.
 func TestSetProviderSessionUnknownSessionNoop(t *testing.T) {
@@ -667,6 +701,14 @@ CREATE TABLE sessions (
 	}
 	if s := got[0].Sessions[0]; s.Kind != "shell" || s.Path != "/data/wt" {
 		t.Errorf("migrated session = %+v, want kind=shell path=/data/wt", s)
+	}
+	// The model column arrived by migration too, and a database that never had it
+	// is exactly the one a spawn reads on the next launch.
+	if err := svc.SetSessionModel("s1", "opus"); err != nil {
+		t.Fatalf("SetSessionModel on a migrated database: %v", err)
+	}
+	if model := svc.SessionModel("s1"); model != "opus" {
+		t.Errorf("migrated session model = %q, want opus", model)
 	}
 }
 

--- a/internal/terminal/command.go
+++ b/internal/terminal/command.go
@@ -41,14 +41,39 @@ const claudeNameFlag = "--name"
 //
 // Each spelling was read off that provider's own `--help` — they agree on
 // nothing, and a flag guessed from a sibling is a spawn that dies before the
-// session exists. oh-my-pi is absent because its spelling was never confirmed
-// against the binary; a provider missing here gets no flag rather than
-// somebody else's.
+// session exists. A provider missing here gets no flag rather than somebody
+// else's.
 var skipPermissionFlags = map[string]string{
 	providers.Claude:   "--dangerously-skip-permissions",
 	providers.Codex:    "--dangerously-bypass-approvals-and-sandbox",
 	providers.OpenCode: "--auto",
+	providers.OMP:      "--auto-approve",
 	providers.Crush:    "--yolo",
+}
+
+// modelFlags is how each provider is told which model to run, for a session
+// opened with one named (internal/spawn). Read off each provider's own `--help`,
+// like skipPermissionFlags, and every one of them takes the value as a separate
+// argument.
+//
+// Crush is absent and stays absent: its `-m` lives on the non-interactive `run`
+// subcommand only, and the TUI lich spawns has no model flag at all (measured
+// against 0.88.0). Naming a model there would mean writing the config file the
+// user owns, which is the same line lich already draws for MCP registration.
+var modelFlags = map[string]string{
+	providers.Claude:   "--model",
+	providers.Codex:    "--model",
+	providers.OpenCode: "--model",
+	providers.OMP:      "--model",
+}
+
+// SupportsModel reports whether a provider can be told which model to run when
+// lich spawns it. It is what rejects `--model` for a kind that would silently
+// drop it, so the caller hears about it instead of getting a session on the
+// wrong model.
+func SupportsModel(kind string) bool {
+	_, ok := modelFlags[kind]
+	return ok
 }
 
 // How each provider is handed an MCP server on its command line: Claude Code
@@ -106,15 +131,32 @@ func nameArgs(kind, name string) []string {
 // subcommand, so its global options have to come first, while Claude Code's
 // --mcp-config is variadic and reads everything after it as another config
 // path, so it has to come last.
-func providerArgs(kind, name, resume, lichBin string, skipPermissions bool) []string {
+func providerArgs(kind, name, resume, model, lichBin string, skipPermissions bool) []string {
 	mcp := mcpArgs(kind, lichBin)
 	args := append([]string{}, nameArgs(kind, name)...)
 	args = append(args, resumeArgs(kind, resume)...)
 	args = append(args, skipPermissionArgs(kind, skipPermissions)...)
+	args = append(args, modelArgs(kind, model)...)
 	if kind == providers.Codex {
 		return append(mcp, args...)
 	}
 	return append(args, mcp...)
+}
+
+// modelArgs returns the arguments that pick the model a provider runs, or nil
+// when none was named or the provider has no flag for it. The name is passed
+// through unchecked — every provider spells its own model names, they change
+// with each release, and a list kept here would reject a model that works. A
+// wrong one dies in the provider's own error message, which is the one the user
+// can act on. A value that would be read as a flag is dropped instead, as it is
+// for a session name.
+func modelArgs(kind, model string) []string {
+	flag, ok := modelFlags[kind]
+	model = strings.TrimSpace(model)
+	if !ok || model == "" || strings.HasPrefix(model, "-") {
+		return nil
+	}
+	return []string{flag, model}
 }
 
 // skipPermissionArgs returns the flag that drops a provider's permission

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -124,6 +124,7 @@ type Store interface {
 	SetWorktreePort(path string, port int) error
 	SetProviderSession(sessionID, providerSessionID string) error
 	ProviderSession(sessionID string) (string, error)
+	SessionModel(sessionID string) string
 	SetSessionTitle(sessionID, title string) (bool, error)
 	CostReadout() bool
 	CostLedger(sessionID, transcriptID string) (int64, string, float64, error)
@@ -436,9 +437,12 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 		mcpBin = lichBin()
 	}
 	skipPermissions := s.store.SkipPermissions(kind, projectID, cwd)
+	// The model is read from the row rather than passed in, so it survives every
+	// spawn this session ever gets: the window's first view, a respawn after a
+	// reload, and the resume of a parked worktree session all arrive here.
 	spec := ptySpec{
 		bin:  resolveCommand(kind, s.store.ProviderBin(kind, projectID), userShell()),
-		args: providerArgs(kind, name, resume, mcpBin, skipPermissions),
+		args: providerArgs(kind, name, resume, s.store.SessionModel(id), mcpBin, skipPermissions),
 		dir:  cwd,
 		env:  s.sessionEnv(id, projectID, cwd),
 		cols: cols,

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -38,6 +38,7 @@ type stubBins struct {
 	projectPath     string
 	providerSession string
 	providerErr     error
+	model           string
 	skipPerms       bool
 	costOn          bool
 	ledgers         map[string]stubLedger
@@ -64,6 +65,7 @@ func (s stubBins) ProviderBin(_, _ string) string       { return s.bin }
 func (s stubBins) SkipPermissions(_, _, _ string) bool  { return s.skipPerms }
 func (s stubBins) ProjectPath(_ string) string          { return s.projectPath }
 func (s stubBins) WorktreeSetup(_ string) string        { return s.setup }
+func (s stubBins) SessionModel(_ string) string         { return s.model }
 func (s stubBins) SetProviderSession(_, _ string) error { return nil }
 
 func (s stubBins) WorktreePorts() map[string]int {
@@ -542,7 +544,7 @@ func TestNameArgs(t *testing.T) {
 // when the setting is on. The literals are pinned rather than read back from
 // skipPermissionFlags: this is the flag that hands an agent the machine, and a
 // test that follows the map would keep passing while the map handed opencode
-// Claude Code's flag. A kind with no spelling — a shell, oh-my-pi — gets none.
+// Claude Code's flag. A kind with no spelling — a shell — gets none.
 func TestSkipPermissionArgs(t *testing.T) {
 	cases := []struct {
 		name, kind string
@@ -555,7 +557,8 @@ func TestSkipPermissionArgs(t *testing.T) {
 		{"codex on", "codex", true, []string{"--dangerously-bypass-approvals-and-sandbox"}},
 		{"opencode on", "opencode", true, []string{"--auto"}},
 		{"crush on", "crush", true, []string{"--yolo"}},
-		{"oh-my-pi is not wired", "omp", true, nil},
+		{"oh-my-pi off", "omp", false, nil},
+		{"oh-my-pi on", "omp", true, []string{"--auto-approve"}},
 		{"shell is never wired", KindShell, true, nil},
 	}
 	for _, tc := range cases {
@@ -610,6 +613,82 @@ func TestStartPassesNameToTheProcess(t *testing.T) {
 
 	// As above: the registration follows, pinned by its own test.
 	want := []string{bin, "--name", "lich-4f2a", "--mcp-config"}
+	if len(got) != len(want)+1 || !slices.Equal(got[:len(want)], want) {
+		t.Errorf("spawned argv = %v, want %v followed by one config", got, want)
+	}
+}
+
+// TestModelArgs pins each provider's own flag, and the two kinds that must never
+// be handed one: Crush spells --model only on its non-interactive `run`
+// subcommand, and a shell is not a provider. The flag literals are pinned rather
+// than read back from modelFlags, for the same reason skipPermissionArgs' test
+// pins its own — a test that follows the map cannot see the map hand a provider
+// somebody else's flag.
+//
+// The model values are only carriers for the passthrough rule: an alias, a full
+// name and a provider/model pair all reach the argv untouched. lich knows no
+// model names, so none of these is a catalogue entry to keep up to date.
+func TestModelArgs(t *testing.T) {
+	cases := []struct {
+		name, kind, model string
+		want              []string
+	}{
+		{"claude, an alias", providers.Claude, "opus", []string{"--model", "opus"}},
+		{"codex, a full name", providers.Codex, "gpt-5.2", []string{"--model", "gpt-5.2"}},
+		{"opencode, a provider/model pair", providers.OpenCode, "openai/gpt-5.2",
+			[]string{"--model", "openai/gpt-5.2"}},
+		{"oh-my-pi, a fuzzy match", providers.OMP, "opus", []string{"--model", "opus"}},
+		{"crush takes none at spawn", providers.Crush, "opus", nil},
+		{"a shell is not a provider", KindShell, "opus", nil},
+		{"no model named", providers.Claude, "", nil},
+		{"blank model", providers.Claude, "   ", nil},
+		{"model trimmed", providers.Claude, " opus ", []string{"--model", "opus"}},
+		{"flag-like model", providers.Claude, "--dangerously-skip-permissions", nil},
+	}
+	for _, tc := range cases {
+		got := modelArgs(tc.kind, tc.model)
+		if !slices.Equal(got, tc.want) {
+			t.Errorf("%s: modelArgs(%q, %q) = %v, want %v", tc.name, tc.kind, tc.model, got, tc.want)
+		}
+	}
+}
+
+// TestSupportsModel pins what the spawn service rejects on: a caller that names
+// a model for a provider lich cannot pass one to hears about it instead of
+// getting a session quietly running the provider's default.
+func TestSupportsModel(t *testing.T) {
+	for _, kind := range []string{providers.Claude, providers.Codex, providers.OpenCode, providers.OMP} {
+		if !SupportsModel(kind) {
+			t.Errorf("SupportsModel(%q) = false, want true", kind)
+		}
+	}
+	for _, kind := range []string{providers.Crush, KindShell, "gemini"} {
+		if SupportsModel(kind) {
+			t.Errorf("SupportsModel(%q) = true, want false", kind)
+		}
+	}
+}
+
+// TestStartPassesTheStoredModelToTheProcess proves the model recorded on the row
+// reaches the spawned binary's argv. It is read from the store rather than
+// passed to Start precisely so it survives a respawn, and this is the wiring
+// that carries it there.
+func TestStartPassesTheStoredModelToTheProcess(t *testing.T) {
+	bin := stayAliveBin(t)
+	svc := New(stubBins{bin: bin, model: "opus"}, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1") })
+
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+
+	svc.mu.Lock()
+	got := spawnedArgs(t, svc, "s1")
+	svc.mu.Unlock()
+
+	// Ahead of the registration, as every other flag is: --mcp-config reads what
+	// follows it as another config path, so a model behind it is a model lost.
+	want := []string{bin, "--model", "opus", "--mcp-config"}
 	if len(got) != len(want)+1 || !slices.Equal(got[:len(want)], want) {
 		t.Errorf("spawned argv = %v, want %v followed by one config", got, want)
 	}
@@ -726,7 +805,7 @@ func TestSessionEnvInjectsCoordinates(t *testing.T) {
 func TestProviderArgsRegistersTheMCPServer(t *testing.T) {
 	const bin = "/usr/bin/lich"
 
-	claude := providerArgs(providers.Claude, "", "", bin, false)
+	claude := providerArgs(providers.Claude, "", "", "", bin, false)
 	if len(claude) != 2 || claude[0] != "--mcp-config" {
 		t.Fatalf("claude args = %v", claude)
 	}
@@ -750,7 +829,7 @@ func TestProviderArgsRegistersTheMCPServer(t *testing.T) {
 		t.Errorf("a secret reached the argv, which /proc exposes: %q", claude[1])
 	}
 
-	codex := providerArgs(providers.Codex, "", "", bin, false)
+	codex := providerArgs(providers.Codex, "", "", "", bin, false)
 	want := []string{
 		"-c", `mcp_servers.lich.command="/usr/bin/lich"`,
 		"-c", `mcp_servers.lich.args=["mcp"]`,
@@ -765,7 +844,7 @@ func TestProviderArgsRegistersTheMCPServer(t *testing.T) {
 // follows it, and Codex reads resume as a subcommand that every global option
 // must precede.
 func TestProviderArgsOrdersEachProvidersConstraint(t *testing.T) {
-	claude := providerArgs(providers.Claude, "lich-4f2a", "conv-1", "/usr/bin/lich", true)
+	claude := providerArgs(providers.Claude, "lich-4f2a", "conv-1", "", "/usr/bin/lich", true)
 	if claude[len(claude)-2] != "--mcp-config" {
 		t.Errorf("--mcp-config is not last, so it eats what follows: %v", claude)
 	}
@@ -775,7 +854,7 @@ func TestProviderArgsOrdersEachProvidersConstraint(t *testing.T) {
 		}
 	}
 
-	codex := providerArgs(providers.Codex, "", "conv-1", "/usr/bin/lich", false)
+	codex := providerArgs(providers.Codex, "", "conv-1", "", "/usr/bin/lich", false)
 	resume := slices.Index(codex, "resume")
 	if resume < 0 {
 		t.Fatalf("codex args lost the resume subcommand: %v", codex)
@@ -785,6 +864,16 @@ func TestProviderArgsOrdersEachProvidersConstraint(t *testing.T) {
 	}
 	if codex[len(codex)-1] != "conv-1" {
 		t.Errorf("codex args = %v, want the conversation id last", codex)
+	}
+
+	// The model is the one flag Codex takes on both sides of the subcommand
+	// (`codex resume --help` lists it), and it goes after: a flag the resumed
+	// conversation's own parser accepts is one less thing riding on where the
+	// global options end.
+	resumed := providerArgs(providers.Codex, "", "conv-1", "gpt-5.2", "/usr/bin/lich", false)
+	model := slices.Index(resumed, "--model")
+	if model < 0 || model < slices.Index(resumed, "resume") {
+		t.Errorf("codex args = %v, want --model after the resume subcommand", resumed)
 	}
 }
 
@@ -805,7 +894,7 @@ func TestProviderArgsWithoutARegistration(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if args := providerArgs(tt.kind, "", "", tt.bin, false); len(args) != 0 {
+			if args := providerArgs(tt.kind, "", "", "", tt.bin, false); len(args) != 0 {
 				t.Errorf("args = %v, want none", args)
 			}
 		})


### PR DESCRIPTION
## What

`lich open --model <model>` and the `open_session` MCP tool's `model` argument start a new session's provider on the model you name. It is what lets a fan-out put the cheap model on the mechanical half of the work and keep the expensive one where it earns its price — the orchestrator picks per worker, without touching anyone's config.

Also wires oh-my-pi into `skipPermissionFlags` with `--auto-approve`: it was the one provider left out of Settings › Providers' "run without asking" ladder, for want of a spelling confirmed against the binary.

## Which providers, and how it was measured

Every flag was read off that provider's own `--help` on this machine, never guessed from a sibling:

| provider | version | model flag on the interactive spawn |
|---|---|---|
| Claude Code | 2.1.231 | `--model <alias\|full name>` |
| Codex | — | `-m, --model` (root **and** `codex resume`) |
| opencode | — | `-m, --model provider/model` |
| oh-my-pi | 17.3.0 | `--model` (fuzzy match) |
| Crush | 0.88.0 | **none** — `-m` exists only on the non-interactive `run` subcommand |

Crush and `shell` are **refused** rather than silently opened on the default: a session that looks like the one asked for and runs a different model is worse than an error. Same line lich already draws for MCP registration — naming a model for Crush would mean writing the config file the user owns.

The value itself is passed through unchecked. Accepted names differ per provider and change with every release, so a wrong one fails in the provider's own error instead of against a list here that could go stale into a session on the wrong model.

## Why the model lives on the row

It is recorded on the session and read back at spawn rather than passed to `terminal.Start`. Every later spawn goes through that same path — a page reload, a respawn, the resume of a parked worktree session — and a model that only survived the first spawn would quietly become the provider's default on the second. `Start`'s signature is unchanged as a result.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./internal/...` green (1334), and `-race` on the four touched packages
- [x] Cross-compile loop for linux/darwin/windows: `go build` + `go vet` clean on each
- [x] `pnpm exec biome check src`, `pnpm exec tsc --noEmit`, `vitest run` (874) and `vite build` green
- [x] New coverage: per-provider flag literals pinned (not read back from the map), `--model` ordering against Codex's `resume` subcommand and Claude Code's variadic `--mcp-config`, the stored model reaching the spawned PTY's argv, store round-trip, the column arriving by migration on an old database, the refusal for Crush/shell, and the six arguments landing over the real RPC dispatcher

## Notes

- The window still opens sessions on the provider's default; this is CLI/MCP only. A model picker on the card is a separate change.
- No per-provider default setting (`provider.<id>.model`). Worth adding when "every worktree of mine starts on opus" comes up; the per-session argument covers the delegate case today.