### PR TITLE
fix: harden the RPC dispatch surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **The RPC surface no longer exposes lich's own wiring.** Three methods that
+  exist for lich to call itself — the hooks' session-state stream and two
+  startup wiring calls — answered a request from the page like any other
+  service method. A call to the first could close another session's pending
+  delegations; a call to either of the others could unwire the relay's plugin
+  lookup or a project's gh account while the app was running. They are now
+  refused. Discarding a file is guarded the same way: a path that names the
+  repository root instead of a file is rejected, where before it would have
+  emptied the whole index.
+
 ## [0.31.0] - 2026-08-13
 
 ### Added

--- a/internal/relpath/relpath.go
+++ b/internal/relpath/relpath.go
@@ -12,11 +12,15 @@ import (
 	"strings"
 )
 
-// Validate rejects rooted paths and parent-directory escapes, so joining rel
-// onto a work-tree root can never leave it.
+// Validate rejects rooted paths, parent-directory escapes and the work-tree
+// root itself, so joining rel onto a work-tree root can never leave it — and
+// can never name the whole tree. The root is refused because a caller that
+// means one file is handed every file instead: `git rm -f --cached -- .`
+// empties the index (see project.DiscardFile). It is also what an empty path
+// cleans to, so a missing argument stops here rather than at the git call.
 func Validate(rel string) error {
 	clean := filepath.Clean(rel)
-	if isRooted(clean) || clean == ".." ||
+	if clean == "." || isRooted(clean) || clean == ".." ||
 		strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
 		return fmt.Errorf("invalid repository path %q", rel)
 	}

--- a/internal/relpath/relpath_test.go
+++ b/internal/relpath/relpath_test.go
@@ -33,6 +33,17 @@ func TestValidateRejectsTraversal(t *testing.T) {
 	}
 }
 
+// TestValidateRejectsTheRoot proves the work-tree root itself is not a path to
+// a file. Every one of these cleans to "." — the empty string included — and a
+// caller that takes it for one file operates on the whole repository.
+func TestValidateRejectsTheRoot(t *testing.T) {
+	for _, rel := range []string{".", "", "./", "a/.."} {
+		if err := Validate(rel); err == nil {
+			t.Errorf("Validate(%q): want error, got nil", rel)
+		}
+	}
+}
+
 // TestValidateAcceptsWorkTreePaths proves the ordinary shapes still pass —
 // including a traversal that stays inside the root.
 func TestValidateAcceptsWorkTreePaths(t *testing.T) {

--- a/internal/terminal/transport_auth_test.go
+++ b/internal/terminal/transport_auth_test.go
@@ -1,0 +1,63 @@
+package terminal
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// The token check mount applies is the whole of lich's authentication: the RPC
+// dispatcher, the event socket and every hook endpoint are reached through it.
+// Nothing else asserts it from the outside, so an inverted condition there
+// would open the entire surface and still pass this package's suite.
+
+// probe answers 200 to anything that reaches it, so the status code out here is
+// the gate's verdict and nothing else.
+var probe = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusOK)
+})
+
+func mountedTransport(t *testing.T) *transport {
+	t.Helper()
+	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+	tr.mount("/gated", probe)
+	tr.mountPublic("/open", probe)
+	return tr
+}
+
+func status(t *testing.T, tr *transport, path, token string) int {
+	t.Helper()
+	url := fmt.Sprintf("http://127.0.0.1:%d%s", tr.port, path)
+	if token != "" {
+		url += "?token=" + token
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	return resp.StatusCode
+}
+
+func TestMountRequiresTheToken(t *testing.T) {
+	tr := mountedTransport(t)
+	if code := status(t, tr, "/gated", ""); code != http.StatusForbidden {
+		t.Errorf("no token: want 403, got %d", code)
+	}
+	if code := status(t, tr, "/gated", "wrong"); code != http.StatusForbidden {
+		t.Errorf("wrong token: want 403, got %d", code)
+	}
+	if code := status(t, tr, "/gated", tr.token); code != http.StatusOK {
+		t.Errorf("with the token: want 200, got %d", code)
+	}
+}
+
+func TestMountPublicServesWithoutTheToken(t *testing.T) {
+	tr := mountedTransport(t)
+	if code := status(t, tr, "/open", ""); code != http.StatusOK {
+		t.Errorf("public without token: want 200, got %d", code)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -145,11 +145,7 @@ func main() {
 	// the PTY here rather than waiting for someone to click the card.
 	dispatcher.Register("spawn", spawn.New(db, proj, term, hub))
 	dispatcher.Register("themes", themes.New())
-	dispatcher.Deny("store.Close")
-	// The dropped file's bytes are the request body, so the upload is its own
-	// endpoint: the RPC envelope is a JSON argument array with a 1MB bound.
-	dispatcher.Deny("drop.Upload")
-	dispatcher.Deny("drop.Save")
+	denyInternal(dispatcher)
 	term.Mount("/rpc/", dispatcher)
 	term.Mount("/drop", http.HandlerFunc(drops.Upload))
 	term.Mount("/events", hub)
@@ -167,6 +163,33 @@ func main() {
 	term.SetRestart(coord.Do)
 
 	runChromium(term, configDir, coord)
+}
+
+// denyInternal hides the methods that exist for Go callers inside this process
+// but must never answer a page POST. Registration exposes every exported method
+// of a service (internal/rpc), so each of these is one /rpc/ path away from the
+// window:
+//
+//   - store.Close ends the database the whole app is still using.
+//   - drop.Upload and drop.Save take the dropped file's bytes as the request
+//     body, so the upload is its own endpoint — the RPC envelope is a JSON
+//     argument array with a 1MB bound.
+//   - relay.Observe is the hooks' session-state stream, which arrives over
+//     /hook: forging a SessionEnd here closes another session's errands.
+//   - relay.SetPlugins and project.SetAccounts are startup wiring. Called with
+//     [null] they silently nil what they wired (encoding/json leaves a func or
+//     pointer alone on null), and the write races the readers already serving.
+func denyInternal(d *rpc.Handler) {
+	for _, method := range []string{
+		"store.Close",
+		"drop.Upload",
+		"drop.Save",
+		"relay.Observe",
+		"relay.SetPlugins",
+		"project.SetAccounts",
+	} {
+		d.Deny(method)
+	}
 }
 
 // runChromium serves the embedded frontend on the loopback listener and opens

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/drop"
+	"github.com/omartelo/lich/internal/project"
+	"github.com/omartelo/lich/internal/relay"
+	"github.com/omartelo/lich/internal/rpc"
+	"github.com/omartelo/lich/internal/store"
+)
+
+// denied spells out denyInternal's list a second time, and names the type each
+// entry belongs to. Reading the list under test would prove only that Go can
+// range over a slice; written out here, an entry dropped from denyInternal
+// fails TestDeniedMethodsAreUnreachable and an entry that names nothing —
+// Deny takes any string — fails TestDeniedMethodsExist.
+var denied = map[string]reflect.Type{
+	"store.Close":         reflect.TypeFor[*store.Service](),
+	"drop.Upload":         reflect.TypeFor[*drop.Service](),
+	"drop.Save":           reflect.TypeFor[*drop.Service](),
+	"relay.Observe":       reflect.TypeFor[*relay.Service](),
+	"relay.SetPlugins":    reflect.TypeFor[*relay.Service](),
+	"project.SetAccounts": reflect.TypeFor[*project.Service](),
+}
+
+// stubService stands in for the four registered services: dispatch resolves a
+// method by name alone, and the real ones want a database, a config directory
+// and a running terminal.
+type stubService struct{}
+
+func (stubService) Close() error       { return nil }
+func (stubService) Upload() error      { return nil }
+func (stubService) Save() error        { return nil }
+func (stubService) Observe() error     { return nil }
+func (stubService) SetPlugins() error  { return nil }
+func (stubService) SetAccounts() error { return nil }
+func (stubService) Allowed() error     { return nil }
+
+func denyingDispatcher() *rpc.Handler {
+	d := rpc.New()
+	for _, service := range []string{"store", "drop", "relay", "project"} {
+		d.Register(service, stubService{})
+	}
+	denyInternal(d)
+	return d
+}
+
+func post(t *testing.T, d *rpc.Handler, method string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/rpc/"+method, strings.NewReader("[]"))
+	rec := httptest.NewRecorder()
+	d.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestDeniedMethodsAreUnreachable(t *testing.T) {
+	d := denyingDispatcher()
+	for method := range denied {
+		if rec := post(t, d, method); rec.Code != http.StatusNotFound {
+			t.Errorf("POST /rpc/%s: want 404, got %d", method, rec.Code)
+		}
+	}
+	// The control: the same registration answers everything else, so the 404s
+	// above are the deny list and not a service that was never registered.
+	if rec := post(t, d, "relay.Allowed"); rec.Code != http.StatusOK {
+		t.Errorf("POST /rpc/relay.Allowed: want 200, got %d", rec.Code)
+	}
+}
+
+func TestDeniedMethodsExist(t *testing.T) {
+	for name, service := range denied {
+		_, method, _ := strings.Cut(name, ".")
+		if _, ok := service.MethodByName(method); !ok {
+			t.Errorf("%s: %s has no method %s — the Deny entry hides nothing", name, service, method)
+		}
+	}
+}


### PR DESCRIPTION
## What

Three service methods that exist for lich to call on itself are now denied on the RPC dispatcher, the repo-relative path guard refuses the work-tree root, and the token gate the whole RPC surface hangs on gets its first test.

## Why

`rpc.Register` exposes **every** exported method of a service, so anything the page can POST to `/rpc/<service>.<Method>` is reachable unless it is explicitly denied.

## Findings addressed

1. **`main.go:138-152` — internal wiring reachable from the page.**
   - `relay.Observe` is the hooks' session-state stream; the real reports arrive over `/hook`, so a POST here forges a `SessionEnd` and closes the target session's errands.
   - `relay.SetPlugins` and `project.SetAccounts` are startup wiring. Called with `[null]` they silently nil what they wired (`encoding/json` leaves a func or pointer alone on `null`), and the write is unlocked while readers are already serving.
   The three joined `store.Close` / `drop.Upload` / `drop.Save` in a new `denyInternal` helper, which holds the list and the reason for each entry.

2. **`internal/relpath/relpath.go:17-24` — `Validate` accepted `"."`** (and `""`, which `filepath.Clean` turns into `"."`). `internal/project/discard.go:26` then ran `git rm -f --cached -- .`, emptying the whole index instead of unstaging one file. The root is not a path to a file, so it is refused in the one place every caller routes through.

3. **`internal/terminal/transport.go:294-310` / `terminal.go:276-290` — the token gate had no test.** It authenticates every RPC call, every hook post and the event socket; an inverted condition there would open all of it and still pass the suite.

## Test plan

- `internal/relpath/relpath_test.go`: `TestValidateRejectsTheRoot` — `"."`, `""`, `"./"`, `"a/.."` all rejected. Existing tests untouched.
- `main_test.go` (new): `TestDeniedMethodsAreUnreachable` posts each denied method at a dispatcher wired by `denyInternal` and expects 404, with a permitted method as the control so the 404s cannot come from a missing registration. `TestDeniedMethodsExist` pins each entry to a real method on the real service type — `Deny` takes any string, so a misspelled entry would hide nothing. The list is spelled out in the test rather than read from `denyInternal`.
- `internal/terminal/transport_auth_test.go` (new file, so sibling PRs touching the existing test files do not conflict): `mount` answers 403 without a token and 403 with a wrong one, 200 with the token; `mountPublic` answers 200 without a token. Verified against a mutant — inverting the condition in `mount` fails both assertions.
- Gate green: `gofmt -l .` empty, `go vet ./...`, `go test ./...` (backend suite), and `go build ./...` + `go vet ./...` for linux, darwin and windows.

No existing test was changed or weakened.
