### PR TITLE
fix: macOS install lands an application, not a bare binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,12 +198,19 @@ jobs:
       - name: Build macOS binaries
         run: task build:mac
 
+      # Two assets per arch: the .app the cask installs, and the bare binary the
+      # in-app self-update and hand installs still download.
       - name: Assemble macOS assets
         run: |
           cd bin
           tag="${GITHUB_REF_NAME//\//-}"
-          mv lich-darwin-arm64 "lich-${tag}-darwin-arm64"
-          mv lich-darwin-amd64 "lich-${tag}-darwin-amd64"
+          for arch in arm64 amd64; do
+            ../build/darwin/bundle.sh "lich-darwin-${arch}" "${tag#v}" "stage-${arch}"
+            # ditto, not zip: it is the archiver that keeps a bundle's symlinks,
+            # permissions and signature intact for Homebrew Cask to unpack.
+            ditto -c -k --keepParent "stage-${arch}/Lich.app" "lich-${tag}-darwin-${arch}.zip"
+            mv "lich-darwin-${arch}" "lich-${tag}-darwin-${arch}"
+          done
           ls -la lich-${tag}-*
 
       - name: Upload macOS assets
@@ -280,7 +287,7 @@ jobs:
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}
           commit_message: "Update to ${{ github.ref_name }}"
 
-  # The formula pins the macOS assets by checksum, so it can only be rendered
+  # The cask pins the macOS assets by checksum, so it can only be rendered
   # once `release` has published them and their checksums.txt.
   # HOMEBREW_TAP_SSH_KEY is a deploy key with write access on
   # omartelo/homebrew-tap — GITHUB_TOKEN is scoped to this repository and cannot
@@ -292,7 +299,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Render formula
+      - name: Render cask
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -301,9 +308,9 @@ jobs:
           sum() {
             awk -v file="$1" '$2 == file { print $1 }' checksums.txt
           }
-          arm64="$(sum "lich-v${version}-darwin-arm64")"
-          amd64="$(sum "lich-v${version}-darwin-amd64")"
-          # An empty checksum would publish a formula that fails every install.
+          arm64="$(sum "lich-v${version}-darwin-arm64.zip")"
+          amd64="$(sum "lich-v${version}-darwin-amd64.zip")"
+          # An empty checksum would publish a cask that fails every install.
           if [ -z "$arm64" ] || [ -z "$amd64" ]; then
             echo "missing darwin checksums in checksums.txt" >&2
             cat checksums.txt >&2
@@ -328,15 +335,18 @@ jobs:
           # and getting rejected before this one is tried.
           export GIT_SSH_COMMAND="ssh -i $key -o IdentitiesOnly=yes -o UserKnownHostsFile=$known"
           git clone --depth 1 git@github.com:omartelo/homebrew-tap.git tap
-          mkdir -p tap/Formula
-          cp lich.rb tap/Formula/lich.rb
+          mkdir -p tap/Casks
+          cp lich.rb tap/Casks/lich.rb
           cd tap
           git config user.name omartelo
           git config user.email meopedevts@proton.me
-          git add Formula/lich.rb
-          # A re-run of the same tag renders an identical formula; nothing to push.
+          # The formula shipped a bare CLI and the cask supersedes it; leaving
+          # both in the tap makes `brew install omartelo/tap/lich` ambiguous.
+          git rm -q --ignore-unmatch Formula/lich.rb
+          git add Casks/lich.rb
+          # A re-run of the same tag renders an identical cask; nothing to push.
           if git diff --cached --quiet; then
-            echo "formula already up to date"
+            echo "cask already up to date"
             exit 0
           fi
           git commit -m "lich: update to ${GITHUB_REF_NAME}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from Launchpad, from Spotlight and from the Finder, and had no icon anywhere.
   The tap now publishes a cask that installs `Lich.app` under its own icon and
   keeps `lich` on `PATH` as before. The Dock still shows the browser while lich
-  runs — the window belongs to it, and macOS offers nothing like the window
-  class Linux matches against the launcher — so the app deliberately claims no
-  Dock tile of its own rather than flashing one that vanishes a second later.
-  Upgrading from the old formula means `brew uninstall lich` first; INSTALL.md
-  says so.
+  runs: the window belongs to it, and macOS offers nothing like the window
+  class Linux matches against the launcher, so the lich icon is the one you
+  launch from rather than the one you switch to. Upgrading from the old formula
+  means `brew uninstall lich` first; INSTALL.md says so.
 
 ## [0.32.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **lich is an application on macOS.** The Homebrew install shipped a bare
+  command-line binary, so nothing landed in `/Applications`: lich was absent
+  from Launchpad, from Spotlight and from the Finder, and had no icon anywhere.
+  The tap now publishes a cask that installs `Lich.app` under its own icon and
+  keeps `lich` on `PATH` as before. The Dock still shows the browser while lich
+  runs — the window belongs to it, and macOS offers nothing like the window
+  class Linux matches against the launcher — so the app deliberately claims no
+  Dock tile of its own rather than flashing one that vanishes a second later.
+  Upgrading from the old formula means `brew uninstall lich` first; INSTALL.md
+  says so.
+
 ## [0.32.0] - 2026-08-13
 
 ### Added

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -100,17 +100,41 @@ From the [tap](https://github.com/omartelo/homebrew-tap) — Apple Silicon and
 Intel both:
 
 ```bash
-brew install omartelo/tap/lich
+brew install --cask omartelo/tap/lich
 ```
 
-The formula installs the release binary, so `brew upgrade` tracks new versions
-and lich's own update button steps aside on a Homebrew install.
+The cask installs `Lich.app` into `/Applications` — Launchpad, Spotlight and
+the Finder list it under its own icon — and symlinks the same binary onto
+`PATH` as `lich`, so the app and the command are one install. `brew upgrade
+--cask omartelo/tap/lich` tracks new versions, and lich's own update button
+steps aside on a Homebrew install.
 
-Without Homebrew, download `lich-*-darwin-arm64` (Apple Silicon) or
-`lich-*-darwin-amd64` (Intel) from the releases page and install it by hand.
-The binary is unsigned, so a browser or `curl` download carries a quarantine
-flag Gatekeeper refuses to run — clear it after verifying the checksum (see
-below):
+The Dock, while lich runs, shows the icon of the Chromium-family browser: the
+window belongs to that browser, and macOS has no equivalent of the window class
+Linux matches against the lich launcher. The lich icon is the one you launch
+from, not the one you switch to.
+
+**Upgrading from the old formula** — releases up to v0.32.0 shipped a bare CLI
+as `Formula/lich.rb`. Homebrew refuses to install the cask over it (both want
+`lich` on `PATH`), so remove the formula first:
+
+```bash
+brew uninstall lich
+brew install --cask omartelo/tap/lich
+```
+
+Without Homebrew, download `lich-*-darwin-arm64.zip` (Apple Silicon) or
+`lich-*-darwin-amd64.zip` (Intel) from the releases page, unzip it and drag
+`Lich.app` into `/Applications`. It is ad-hoc signed and not notarized, so
+after verifying the checksum (see below) clear the quarantine flag Gatekeeper
+would otherwise refuse:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/Lich.app
+```
+
+The bare `lich-*-darwin-arm64` and `lich-*-darwin-amd64` binaries are still
+published for a CLI-only install by hand:
 
 ```bash
 install -m755 lich-*-darwin-arm64 ~/.local/bin/lich

--- a/README.md
+++ b/README.md
@@ -76,14 +76,16 @@ curl -fsSL https://raw.githubusercontent.com/omartelo/lich/main/install.sh | sh
 | Platform | Get it | Needs at runtime |
 | --- | --- | --- |
 | **Linux** | `install.sh` above, or AUR [`lich-bin`](https://aur.archlinux.org/packages/lich-bin) (`yay -S lich-bin`) | chromium / google-chrome / brave on `PATH`, plus `zenity` |
-| **macOS** *(experimental)* | `brew install omartelo/tap/lich` | Chrome / Chromium / Edge / Brave in `/Applications` |
+| **macOS** *(experimental)* | `brew install --cask omartelo/tap/lich` | Chrome / Chromium / Edge / Brave in `/Applications` |
 | **Windows** *(experimental)* | installer from [Releases](https://github.com/omartelo/lich/releases) | Chrome / Edge / Brave |
 
 Manual per-distro packages and the static binary: [INSTALL.md](INSTALL.md). The
 macOS and Windows binaries are unsigned — Gatekeeper and SmartScreen warn until
 notarization/signing ship. Homebrew installs sidestep the Gatekeeper prompt;
-a binary downloaded from the Releases page needs its quarantine flag cleared by
-hand.
+a download from the Releases page needs its quarantine flag cleared by hand.
+On macOS the cask installs `Lich.app`, so lich has its own icon in
+`/Applications`; the Dock, while it runs, shows the browser that owns the
+window.
 
 ## Getting started
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -56,6 +56,14 @@ tasks:
       - cmd: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build {{.GO_BUILD_FLAGS}} -o {{.BIN_DIR}}/{{.APP_NAME}}-darwin-arm64 .
       - cmd: CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build {{.GO_BUILD_FLAGS}} -o {{.BIN_DIR}}/{{.APP_NAME}}-darwin-amd64 .
 
+  bundle:mac:
+    desc: Wrap the macOS binary in bin/Lich.app (macOS host only)
+    deps: [build:mac]
+    cmds:
+      # The binary cross-compiles from anywhere; the bundle needs Apple's sips
+      # and iconutil for the icon, so this task only runs on a Mac.
+      - cmd: build/darwin/bundle.sh {{.BIN_DIR}}/{{.APP_NAME}}-darwin-{{ARCH}} {{.VERSION}} {{.BIN_DIR}}
+
   run:
     desc: Build and run
     deps: [build]

--- a/build/darwin/Info.plist.tpl
+++ b/build/darwin/Info.plist.tpl
@@ -2,12 +2,13 @@
 <!--
   Rendered by build/darwin/bundle.sh (@VERSION@ -> the release version).
 
-  LSUIElement is the measured answer, not a preference: lich is a pure-Go
-  binary that never touches AppKit, so macOS shows its Dock tile only while
-  LaunchServices is starting it and drops the tile as soon as the process
-  fails to register with the window server. Without this key the user watches
-  an icon appear and vanish; with it the app lives in /Applications, Launchpad
-  and Spotlight, and the Dock shows only the browser that owns the window.
+  lich is a pure-Go binary that never touches AppKit, so it never registers
+  with the window server: macOS shows a Dock tile while LaunchServices starts
+  it and drops that tile once the window belongs to the browser instead.
+  Measured on a Mac, LSUIElement does not suppress that launch tile — it is
+  here because an app that owns no window of its own has no business in the
+  Dock or in Cmd-Tab once it is running. The icon that matters is the one in
+  /Applications, Launchpad and Spotlight.
 -->
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/build/darwin/Info.plist.tpl
+++ b/build/darwin/Info.plist.tpl
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Rendered by build/darwin/bundle.sh (@VERSION@ -> the release version).
+
+  LSUIElement is the measured answer, not a preference: lich is a pure-Go
+  binary that never touches AppKit, so macOS shows its Dock tile only while
+  LaunchServices is starting it and drops the tile as soon as the process
+  fails to register with the window server. Without this key the user watches
+  an icon appear and vanish; with it the app lives in /Applications, Launchpad
+  and Spotlight, and the Dock shows only the browser that owns the window.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>lich</string>
+  <key>CFBundleIdentifier</key>
+  <string>com.github.omartelo.lich</string>
+  <key>CFBundleName</key>
+  <string>lich</string>
+  <key>CFBundleDisplayName</key>
+  <string>lich</string>
+  <key>CFBundleIconFile</key>
+  <string>lich</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>@VERSION@</string>
+  <key>CFBundleVersion</key>
+  <string>@VERSION@</string>
+  <key>LSMinimumSystemVersion</key>
+  <string>11.0</string>
+  <key>LSUIElement</key>
+  <true/>
+  <key>NSHighResolutionCapable</key>
+  <true/>
+</dict>
+</plist>

--- a/build/darwin/bundle.sh
+++ b/build/darwin/bundle.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+# Wraps an already-built darwin binary in Lich.app — the bundle is what puts
+# lich in /Applications, Launchpad and Spotlight and gives it its icon; a bare
+# binary on PATH appears in none of them.
+#
+#   build/darwin/bundle.sh bin/lich-darwin-arm64 0.30.0 bin
+#
+# macOS host only: sips and iconutil are Apple's, so the icon is generated at
+# build time from build/appicon.png instead of committing an .icns — one source
+# of the mark for every platform. Cross-compiling the binary still works
+# anywhere (task build:mac); only this wrapping step needs a Mac.
+set -eu
+
+bin="${1:?usage: bundle.sh <binary> <version> <outdir>}"
+version="${2:?usage: bundle.sh <binary> <version> <outdir>}"
+outdir="${3:?usage: bundle.sh <binary> <version> <outdir>}"
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+app="$outdir/Lich.app"
+
+rm -rf "$app"
+mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
+cp "$bin" "$app/Contents/MacOS/lich"
+chmod +x "$app/Contents/MacOS/lich"
+
+sed "s/@VERSION@/${version}/g" "$root/build/darwin/Info.plist.tpl" \
+  > "$app/Contents/Info.plist"
+
+iconset="$(mktemp -d)/lich.iconset"
+mkdir -p "$iconset"
+for size in 16 32 128 256 512; do
+  sips -z "$size" "$size" "$root/build/appicon.png" \
+    --out "$iconset/icon_${size}x${size}.png" >/dev/null
+  sips -z "$((size * 2))" "$((size * 2))" "$root/build/appicon.png" \
+    --out "$iconset/icon_${size}x${size}@2x.png" >/dev/null
+done
+iconutil -c icns "$iconset" -o "$app/Contents/Resources/lich.icns"
+rm -rf "$(dirname "$iconset")"
+
+# Ad-hoc signature: arm64 refuses to run an executable carrying none, and a
+# bundle whose seal does not cover Info.plist and the icon reads as damaged.
+# This is not notarization — Gatekeeper still calls the developer unidentified.
+codesign --force --sign - "$app"
+
+echo "built $app"

--- a/build/darwin/homebrew/lich.rb.tpl
+++ b/build/darwin/homebrew/lich.rb.tpl
@@ -1,39 +1,45 @@
 # Rendered by .github/workflows/release.yml (@VERSION@ -> tag, checksums from the
-# release's checksums.txt) and pushed to the omartelo/homebrew-tap repository —
-# edit this template, never the tap copy.
-class Lich < Formula
+# release's checksums.txt) and pushed to the omartelo/homebrew-tap repository as
+# Casks/lich.rb — edit this template, never the tap copy.
+#
+# A cask, not a formula: only a cask installs an .app into /Applications, which
+# is what puts lich in Launchpad, in Spotlight and behind its own icon. The
+# binary stanza keeps `lich` on PATH, so the one install still serves both.
+cask "lich" do
+  arch arm: "arm64", intel: "amd64"
+
+  version "@VERSION@"
+  sha256 arm: "@SHA_ARM64@", intel: "@SHA_AMD64@"
+
+  url "https://github.com/omartelo/lich/releases/download/v#{version}/lich-v#{version}-darwin-#{arch}.zip"
+  name "lich"
   desc "Personal harness for AI-assisted development"
   homepage "https://github.com/omartelo/lich"
-  version "@VERSION@"
-  license "AGPL-3.0-only"
 
-  on_macos do
-    on_arm do
-      url "https://github.com/omartelo/lich/releases/download/v#{version}/lich-v#{version}-darwin-arm64"
-      sha256 "@SHA_ARM64@"
-    end
+  depends_on macos: ">= :big_sur"
 
-    on_intel do
-      url "https://github.com/omartelo/lich/releases/download/v#{version}/lich-v#{version}-darwin-amd64"
-      sha256 "@SHA_AMD64@"
-    end
+  app "Lich.app"
+  binary "#{appdir}/Lich.app/Contents/MacOS/lich"
+
+  # lich is ad-hoc signed and never notarized, so Gatekeeper refuses a
+  # quarantined copy outright. The archive is pinned by the checksums above and
+  # comes from the project's own release — that is the trust this trades on.
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "#{appdir}/Lich.app"]
   end
 
-  def install
-    # The release ships bare binaries, so the staged file keeps the asset name.
-    bin.install Dir["lich-v#{version}-darwin-*"].first => "lich"
-  end
+  caveats <<~EOS
+    lich opens its window in a Chromium-family browser and bundles none: install
+    Google Chrome, Chromium, Microsoft Edge or Brave under /Applications.
 
-  def caveats
-    <<~EOS
-      lich opens its window in a Chromium-family browser and bundles none: install
-      Google Chrome, Chromium, Microsoft Edge or Brave under /Applications.
+    That window belongs to the browser, so the Dock shows the browser's icon
+    while lich is running; the lich icon is the one in /Applications.
 
-      macOS support is experimental — see the project README.
-    EOS
-  end
+    macOS support is experimental — see the project README.
+  EOS
 
-  test do
-    assert_predicate bin/"lich", :executable?
-  end
+  zap trash: [
+    "~/Library/Application Support/lich",
+  ]
 end

--- a/internal/appupdate/appupdate.go
+++ b/internal/appupdate/appupdate.go
@@ -31,9 +31,9 @@ const (
 
 	// aurPackage is the AUR name Arch users update through their helper.
 	aurPackage = "lich-bin"
-	// brewFormula is the tap-qualified formula name Homebrew users update
-	// through; brew owns the Cellar copy, so lich never swaps it itself.
-	brewFormula = "omartelo/tap/lich"
+	// brewPackage is the tap-qualified name Homebrew users update through; brew
+	// owns its copy, so lich never swaps it itself.
+	brewPackage = "omartelo/tap/lich"
 	// installScript is the deb/rpm/other-distro update path: install.sh detects
 	// the distro, installs the matching package, and POSTs /restart itself.
 	installScript = "curl -fsSL https://raw.githubusercontent.com/" + repo + "/main/install.sh | sh"
@@ -207,7 +207,7 @@ func canSelfApply(goos, exePath string) bool {
 	if exePath == "" {
 		return false
 	}
-	if brewOwned(exePath) {
+	if brewOwned(exePath) || bundled(exePath) {
 		return false
 	}
 	return dirWritable(filepath.Dir(exePath))
@@ -227,15 +227,27 @@ func brewOwned(exePath string) bool {
 	return slices.Contains(strings.Split(resolved, string(filepath.Separator)), "Cellar")
 }
 
+// bundled reports whether exePath is the executable inside lich's macOS .app —
+// what the Homebrew cask installs into /Applications. Swapping that binary
+// would invalidate the bundle's code signature and leave an app macOS reads as
+// damaged, so a bundled install updates through Homebrew rather than the
+// button.
+func bundled(exePath string) bool {
+	return strings.Contains(filepath.ToSlash(exePath), ".app/Contents/MacOS/")
+}
+
 // installCommand is the shell command the UI pastes to update this install, or
 // "" on the self-apply platforms (they swap the binary through the button).
 // Arch goes through its AUR helper plus an explicit restart — yay knows nothing
 // about lich's /restart — while every other distro uses install.sh, which
 // restarts itself. A Homebrew install is package-manager owned like Arch's, on
-// whichever platform it runs.
+// whichever platform it runs, and macOS ships as a cask.
 func (s *Service) installCommand() string {
+	if bundled(s.exePath) {
+		return "brew upgrade --cask " + brewPackage + restartChain
+	}
 	if brewOwned(s.exePath) {
-		return "brew upgrade " + brewFormula + restartChain
+		return "brew upgrade " + brewPackage + restartChain
 	}
 	if s.goos != "linux" {
 		return ""

--- a/internal/appupdate/appupdate_test.go
+++ b/internal/appupdate/appupdate_test.go
@@ -67,6 +67,7 @@ func TestCanSelfApply(t *testing.T) {
 		{"no exe path", "darwin", "", false},
 		{"unwritable dir", "darwin", filepath.Join("/nonexistent-abc123", "lich"), false},
 		{"homebrew cellar is brew's", "darwin", cellarExe(t), false},
+		{"app bundle keeps its signature", "darwin", bundleExe(t), false},
 	}
 	for _, tc := range tests {
 		if got := canSelfApply(tc.goos, tc.exePath); got != tc.want {
@@ -81,6 +82,18 @@ func TestCanSelfApply(t *testing.T) {
 func cellarExe(t *testing.T) string {
 	t.Helper()
 	dir := filepath.Join(t.TempDir(), "Cellar", "lich", "0.21.1", "bin")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(dir, "lich")
+}
+
+// bundleExe returns a writable path shaped like the cask install
+// (/Applications/Lich.app/Contents/MacOS/lich), so the bundle is the only
+// reason canSelfApply can refuse it.
+func bundleExe(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "Lich.app", "Contents", "MacOS")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -199,6 +212,7 @@ func TestStatus(t *testing.T) {
 func TestInstallCommand(t *testing.T) {
 	arch := "yay -S lich-bin" + restartChain
 	brew := "brew upgrade omartelo/tap/lich" + restartChain
+	cask := "brew upgrade --cask omartelo/tap/lich" + restartChain
 
 	tests := []struct {
 		name      string
@@ -210,6 +224,7 @@ func TestInstallCommand(t *testing.T) {
 		{"windows self-apply", "windows", "", "", ""},
 		{"darwin self-apply", "darwin", "", "", ""},
 		{"homebrew install", "darwin", cellarExe(t), "", brew},
+		{"cask install", "darwin", bundleExe(t), "", cask},
 		{"arch by ID", "linux", "", "ID=arch\n", arch},
 		{"arch quoted ID", "linux", "", "ID=\"arch\"\n", arch},
 		{"arch derivative via ID_LIKE", "linux", "", "ID=manjaro\nID_LIKE=arch\n", arch},


### PR DESCRIPTION
## Problem

`brew install omartelo/tap/lich` installed a bare CLI into Homebrew's `bin`, which is all a formula can do. Nothing reached `/Applications`, so lich was absent from Launchpad, from Spotlight and from the Finder, had no icon anywhere, and could only be started by typing `lich` in a terminal.

## Change

- `build/darwin/Info.plist.tpl` + `build/darwin/bundle.sh` assemble `Lich.app` around a darwin binary. The icon is generated at build time from `build/appicon.png` with `sips` + `iconutil`, so no `.icns` is committed and `appicon.png` stays the single source of the mark on every platform. The bundle is ad-hoc signed: arm64 refuses an executable carrying no signature, and a bundle whose seal misses `Info.plist` and the icon reads as damaged.
- The release publishes `lich-vX.Y.Z-darwin-<arch>.zip` next to the bare binaries, which the self-update path and hand installs still use.
- The tap moves from `Formula/lich.rb` to `Casks/lich.rb` — only a cask installs into `/Applications` — with a `binary` stanza so `lich` stays on `PATH`. The publish step removes the formula: two artifacts with the same token make `brew install omartelo/tap/lich` ambiguous.
- `internal/appupdate`: inside a bundle the update button steps aside and points at `brew upgrade --cask`, because swapping the executable invalidates the signature the bundle is sealed with.
- `task bundle:mac` builds the same bundle locally (macOS host only).

## What was measured, on a real Mac

The bundle registers, shows its icon in `/Applications` and Launchpad, and launches. The Dock tile appears while LaunchServices starts the app and drops once the browser owns the window — `LSUIElement` does not suppress that, which the second commit corrects in the comment and the changelog. The key stays because an app with no window of its own belongs in neither the Dock nor Cmd-Tab.

The Dock icon while lich runs is the browser's and stays that way: the window belongs to the browser, and macOS has no counterpart to the window class Linux matches against the `.desktop` launcher. A native shell would need CGO, which the pure-Go invariant rules out. README and INSTALL.md say this rather than leaving it to be discovered.

## Note for review

The cask strips the quarantine attribute in `postflight`. lich is ad-hoc signed and never notarized, so Gatekeeper refuses a quarantined copy outright; the archive is pinned by checksum and comes from this project's own release. Say the word and it comes out, at the cost of sending every user through "Open Anyway".

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` (1447 passing), cross-compile loop for linux/darwin/windows.
- [x] Bundle built and launched on a Mac from the branch's own `Info.plist` and `bundle.sh`, round-tripped through `ditto` the way the release archives it.
- [ ] Cask install end to end — only provable once a release publishes the zips and the tap.