### PR TITLE
feat: opencode and Crush sessions resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **opencode and Crush sessions resume.** A restored card running either of them
+  used to start a fresh conversation every time, even though lich had been
+  storing the id of the one it ran before. Both now offer the same resume prompt
+  Claude Code, Codex and oh-my-pi have: accept and the conversation continues
+  where it stopped. lich still only offers a resume it can honour — the two keep
+  their conversations in a database rather than one file per session, so it asks
+  that database whether the conversation is still there, read-only. Crush files
+  its own per checkout, so a card resumes the conversation belonging to its own
+  worktree.
+
 ### Fixed
 
 - **lich is an application on macOS.** The Homebrew install shipped a bare

--- a/docs/hooks/session-start.md
+++ b/docs/hooks/session-start.md
@@ -120,8 +120,10 @@ cares when the id arrived, only which conversation it names.
   `omp config path` applies). opencode and Crush file no per-session transcript,
   so the proof is a row in their own SQLite database instead
   (`internal/terminal/sessiondb.go`): `SELECT 1` on the `id` of `session` in
-  `$XDG_DATA_HOME/opencode/opencode.db`, and of `sessions` in
-  `<cwd>/.crush/crush.db`. Every layout is internal to the provider — a database
+  `$XDG_DATA_HOME/opencode/opencode.db` (`~/.local/share` when the variable is
+  unset, on every platform — opencode applies xdg-basedir rather than the
+  OS-native data location), and of `sessions` in `<cwd>/.crush/crush.db`. Every
+  layout is internal to the provider — a database
   that moved, a table that was renamed, a directory that changed — and all of
   them make a restored card start fresh instead of erroring, which is the
   direction this fails in.

--- a/docs/hooks/session-start.md
+++ b/docs/hooks/session-start.md
@@ -4,7 +4,7 @@ Reports the provider conversation id running inside a lich session's PTY, so
 lich can persist the link between its own session (the card) and the provider's
 session. That id is what lets a restored card offer to resume the conversation
 it ran before the last restart, and the key for later features that need to
-reach a session's transcript. Claude Code and Codex report one today.
+reach a session's transcript. Every provider lich registers reports one.
 
 See [README.md](README.md) for the shared transport (`LICH_PORT` / `LICH_TOKEN`
 / `LICH_SESSION_ID`) and the client rules every hook follows.
@@ -88,8 +88,7 @@ cares when the id arrived, only which conversation it names.
   frontend session (`resumableSession` in `frontend/src/lib/session/sessions.ts`), and
   the first time a restored card is opened `TerminalHost` asks before spawning:
   accepting passes the id to `terminal.Start`, which spawns the kind's resume
-  invocation (`resumeArgs` in `internal/terminal/command.go`: `claude --resume
-  <id>`, `codex resume <id>`).
+  invocation (`resumeArgs` in `internal/terminal/command.go`).
 
 ## Known ceilings
 
@@ -104,33 +103,40 @@ cares when the id arrived, only which conversation it names.
 - **Not the transcript path.** The path is reconstructable from the id and cwd;
   storing it too is a contract change — add a field only when a feature needs
   it, per the versioning note in the README.
-- **Three providers resume.** The field and the column are provider-agnostic,
-  but each CLI spells resume its own way (`claude --resume <id>`, `codex resume
-  <id>`, `omp -r <id>`), so both `resumeArgs` (`internal/terminal/command.go`)
-  and `resumableSession` (`frontend/src/lib/session/sessions.ts`) list the kinds
-  that have one. A provider outside that list reporting an id has it stored and
-  ignored until its own invocation is wired.
-- **opencode and Crush report an id lich does not resume.** Both spell it
-  (`opencode --session <id>`, `crush --session <id>`), so the invocation is the
-  easy half. The gate is the one below: lich only offers a resume it has proof
-  of, and both keep their conversations in SQLite — `opencode.db` under the data
-  dir, Crush's under its `--data-dir` — where there is no per-session file to
-  glob for. Wiring them means either reading another tool's schema or offering a
-  resume that can die inside the PTY, and neither is worth it for a mark on a
-  card. The id is stored today so the day one of them is wired, the sessions
-  already carry it. oh-my-pi is the counterexample that shows where the line is:
-  it files one JSONL per session, so there is something to glob for, and it
-  resumes.
-- **Resume availability is asked of each provider's transcript directory.**
+- **Every provider resumes; the shell does not.** The field and the column are
+  provider-agnostic, but each CLI spells resume its own way (`claude --resume
+  <id>`, `codex resume <id>`, `omp -r <id>`, `opencode --session <id>`, `crush
+  --session <id>`), so both `resumeArgs` (`internal/terminal/command.go`) and
+  `resumableSession` (`frontend/src/lib/session/sessions.ts`) list the kinds that
+  have one. A shell session that had a provider CLI run inside it by hand carries
+  an id and is still never offered a resume — the shell cannot reopen it.
+- **Resume availability is asked of whatever the provider left on disk.**
   `ResumeAvailable` (`internal/terminal/resume.go`) globs
   `~/.claude/projects/*/<id>.jsonl` for Claude Code,
   `~/.codex/sessions/*/*/*/rollout-*-<id>.jsonl` for Codex and
   `~/.omp/agent/sessions/*/*_<id>.jsonl` for oh-my-pi (`CLAUDE_CONFIG_DIR`,
   `CODEX_HOME` and `OMP_PROFILE`/`PI_CODING_AGENT_DIR` override the roots; a
   named omp profile wins over the explicit override, which is the order
-  `omp config path` applies). Every layout is internal to the provider: one that
-  moves its files makes every restored card start fresh instead of erroring,
-  which is the direction this fails in.
+  `omp config path` applies). opencode and Crush file no per-session transcript,
+  so the proof is a row in their own SQLite database instead
+  (`internal/terminal/sessiondb.go`): `SELECT 1` on the `id` of `session` in
+  `$XDG_DATA_HOME/opencode/opencode.db`, and of `sessions` in
+  `<cwd>/.crush/crush.db`. Every layout is internal to the provider — a database
+  that moved, a table that was renamed, a directory that changed — and all of
+  them make a restored card start fresh instead of erroring, which is the
+  direction this fails in.
+- **Crush resumes per checkout, and never through `--data-dir`.** Crush keeps
+  its database inside the directory it was started in, so `ResumeAvailable`
+  takes the session's cwd and the same id answers differently in another
+  worktree — which is the correct answer, since the conversation belongs to that
+  checkout. A user who runs Crush with `--data-dir` outside lich moves the
+  database somewhere lich does not look; lich itself never passes the flag, so
+  the default is what its own sessions use.
+- **The database is opened read-only, and only for existence.** lich reads one
+  column of one table and never writes: a resume is offered for a row that is
+  there and withheld for one that is not. A lock held by the provider running
+  right now is waited out briefly and then read as absent — the failure that
+  costs a live conversation, which is why the wait exists at all.
 - **The deprecated `claude_session_id` alias stays until the install gate can
   no longer meet a plugin older than v0.3.0.** Dropping it earlier silently
   breaks resume for anyone who has not updated the plugin.

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -103,10 +103,11 @@ export const Terminal = {
    * provable absence closes a session. */
   WorkdirMissing: (cwd: string) => call<boolean>("terminal.WorkdirMissing", [cwd]),
   /** Whether the conversation providerSessionID names can still be reopened —
-   * false once the provider has pruned its transcript, which is the resume the
-   * prompt must not offer. */
-  ResumeAvailable: (kind: string, providerSessionID: string) =>
-    call<boolean>("terminal.ResumeAvailable", [kind, providerSessionID]),
+   * false once the provider has dropped it, which is the resume the prompt must
+   * not offer. cwd is the session's working directory: Crush keeps its
+   * conversations per checkout, so the same id answers differently in another. */
+  ResumeAvailable: (kind: string, providerSessionID: string, cwd: string) =>
+    call<boolean>("terminal.ResumeAvailable", [kind, providerSessionID, cwd]),
   /** resume: a provider session id to reopen (--resume); "" starts fresh.
    * name: what the session answers to in its provider's peer roster (lib/session/peer-name);
    * only Claude Code has one, every other kind ignores it.

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -488,11 +488,20 @@ describe("resumableSession", () => {
     })
   })
 
-  // opencode reports no id and has no resume invocation wired; one arriving
-  // anyway must not raise a prompt lich cannot honour.
-  it("returns null for a provider with no resume wired", () => {
-    const state = withClaudeSession(buildState(2), "s1", "some-id", "opencode")
-    expect(resumableSession(state, P, "s1")).toBeNull()
+  it("returns an opencode session carrying a provider session id", () => {
+    const state = withClaudeSession(buildState(2), "s1", "ses_0031a382dffe", "opencode")
+    expect(resumableSession(state, P, "s1")).toMatchObject({
+      id: "s1",
+      providerSessionId: "ses_0031a382dffe",
+    })
+  })
+
+  it("returns a crush session carrying a provider session id", () => {
+    const state = withClaudeSession(buildState(2), "s1", "18345afc-f497", "crush")
+    expect(resumableSession(state, P, "s1")).toMatchObject({
+      id: "s1",
+      providerSessionId: "18345afc-f497",
+    })
   })
 
   it("returns null for unknown project and session ids", () => {

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -368,10 +368,8 @@ export function removeProject(state: SessionState, projectId: string): SessionSt
 }
 
 // The provider kinds whose CLI can reopen a conversation by id, mirrored from
-// resumeArgs (Go) — keep in sync. opencode and Crush keep their conversations in
-// SQLite with no per-session file to prove one still exists, so an id reported
-// for either is stored and never offered.
-const RESUMABLE_KINDS: readonly SessionKind[] = ["claude", "codex", "omp"]
+// resumeArgs (Go) — keep in sync.
+const RESUMABLE_KINDS: readonly SessionKind[] = ["claude", "codex", "omp", "opencode", "crush"]
 
 // resumableSession returns the session whose PTY should ask before it spawns,
 // because it carries the provider conversation it ran before the last restart.

--- a/frontend/src/lib/session/spawn-gate.test.ts
+++ b/frontend/src/lib/session/spawn-gate.test.ts
@@ -35,6 +35,24 @@ describe("spawnDecision", () => {
     expect(decision).toEqual({ verdict: "fresh", notice: CONVERSATION_GONE })
   })
 
+  // Crush keeps one conversation database per checkout, so the directory is
+  // part of the question: asked without it, every restored Crush card would be
+  // told its conversation is gone.
+  it("asks about the conversation in the session's own directory", async () => {
+    const asked: string[] = []
+    await spawnDecision(
+      "/repo/worktrees/feature",
+      { ...resumable, kind: "crush" },
+      probe({
+        resumeAvailable: (_kind, _id, cwd) => {
+          asked.push(cwd)
+          return Promise.resolve(true)
+        },
+      }),
+    )
+    expect(asked).toEqual(["/repo/worktrees/feature"])
+  })
+
   it("parks when the checkout is gone, without asking about the conversation", async () => {
     let asked = false
     const decision = await spawnDecision(

--- a/frontend/src/lib/session/spawn-gate.ts
+++ b/frontend/src/lib/session/spawn-gate.ts
@@ -18,7 +18,7 @@ export type SpawnDecision =
 /** The two backend checks, injected so the decision is testable without the RPC. */
 export interface SpawnProbe {
   workdirMissing: (cwd: string) => Promise<boolean>
-  resumeAvailable: (kind: string, providerSessionID: string) => Promise<boolean>
+  resumeAvailable: (kind: string, providerSessionID: string, cwd: string) => Promise<boolean>
 }
 
 export const CHECKOUT_GONE =
@@ -50,7 +50,7 @@ export async function spawnDecision(
     return { verdict: "spawn" }
   }
   const available = await probe
-    .resumeAvailable(resumable.kind, resumable.providerSessionId ?? "")
+    .resumeAvailable(resumable.kind, resumable.providerSessionId ?? "", cwd)
     .catch(() => true)
   return available ? { verdict: "ask" } : { verdict: "fresh", notice: CONVERSATION_GONE }
 }

--- a/internal/terminal/command.go
+++ b/internal/terminal/command.go
@@ -23,11 +23,14 @@ const defaultBin = providers.Claude
 const KindShell = "shell"
 
 // How each provider reopens an existing conversation by id: Claude Code and
-// oh-my-pi take a flag, Codex a subcommand.
+// oh-my-pi take a flag of their own, Codex a subcommand, and opencode and Crush
+// happen to agree on one spelling. Every one of them was read off that CLI's own
+// --help.
 const (
 	claudeResumeFlag  = "--resume"
 	codexResumeSubcmd = "resume"
 	ompResumeFlag     = "-r"
+	sessionResumeFlag = "--session"
 )
 
 // claudeNameFlag sets the name a session answers to in Claude Code's peer
@@ -241,7 +244,7 @@ func claudeMCPConfig(lichBin string) string {
 // when the session must start fresh. Each provider spells resume its own way,
 // and a provider with no spelling here never grows one — the frontend only
 // passes a resume id for a kind it knows resumes, but a stray one must not reach
-// a shell or opencode/crush either.
+// a shell either.
 func resumeArgs(kind, resume string) []string {
 	if resume == "" {
 		return nil
@@ -253,6 +256,8 @@ func resumeArgs(kind, resume string) []string {
 		return []string{codexResumeSubcmd, resume}
 	case providers.OMP:
 		return []string{ompResumeFlag, resume}
+	case providers.OpenCode, providers.Crush:
+		return []string{sessionResumeFlag, resume}
 	}
 	return nil
 }

--- a/internal/terminal/resume.go
+++ b/internal/terminal/resume.go
@@ -8,12 +8,15 @@ import "github.com/omartelo/lich/internal/providers"
 // The session row keeps its provider session id for good, but a provider prunes
 // its own transcripts, so the id outlives the conversation it points at. Resuming
 // one then dies inside the PTY with the provider's error in place of a session —
-// the shortcut Start's doc names. The transcript on disk is what answers the
-// question; this asks it for existence alone.
+// the shortcut Start's doc names. What the provider left on disk is what answers
+// the question; this asks it for existence alone.
+//
+// cwd is the session's working directory, needed only by Crush: it keeps one
+// database per checkout rather than one per machine.
 //
 // False for a provider with no resume wired (resumeArgs): there is nothing to
 // offer where the CLI cannot reopen a conversation by id.
-func (*Service) ResumeAvailable(kind, providerSessionID string) bool {
+func (*Service) ResumeAvailable(kind, providerSessionID, cwd string) bool {
 	if providerSessionID == "" {
 		return false
 	}
@@ -27,6 +30,12 @@ func (*Service) ResumeAvailable(kind, providerSessionID string) bool {
 	case providers.OMP:
 		_, ok := ompTranscriptPath(providerSessionID)
 		return ok
+	case providers.OpenCode:
+		path, ok := opencodeSessionDB()
+		return ok && sessionRowExists(path, opencodeSessionTable, providerSessionID)
+	case providers.Crush:
+		path, ok := crushSessionDB(cwd)
+		return ok && sessionRowExists(path, crushSessionTable, providerSessionID)
 	}
 	return false
 }

--- a/internal/terminal/resume_test.go
+++ b/internal/terminal/resume_test.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"database/sql"
 	"os"
 	"path/filepath"
 	"testing"
@@ -51,32 +52,78 @@ func TestResumeAvailable(t *testing.T) {
 	t.Setenv("OMP_PROFILE", "")
 	t.Setenv("PI_CODING_AGENT_DIR", ompBase)
 
+	// opencode keeps every conversation in one database under its data
+	// directory; Crush keeps one database per checkout. The table names are
+	// spelled out rather than taken from the constants, so renaming a constant
+	// to match a schema lich never measured fails here instead of silently
+	// passing.
+	opencodeBase := t.TempDir()
+	const opencodeLive = "ses_0031a382dffe1QdVbfzi6AZmbs"
+	writeSessionDB(t, filepath.Join(opencodeBase, "opencode", "opencode.db"), "session", opencodeLive)
+	t.Setenv("XDG_DATA_HOME", opencodeBase)
+
+	crushCwd := t.TempDir()
+	const crushLive = "18345afc-f497-4d53-8dfd-f7c4e4d9b313"
+	writeSessionDB(t, filepath.Join(crushCwd, ".crush", "crush.db"), "sessions", crushLive)
+	otherCwd := t.TempDir()
+
 	svc := &Service{}
 	tests := []struct {
 		name              string
 		kind              string
 		providerSessionID string
+		cwd               string
 		want              bool
 	}{
-		{"transcript on disk", providers.Claude, live, true},
-		{"pruned transcript", providers.Claude, "gone-uuid", false},
-		{"no id at all", providers.Claude, "", false},
-		{"shell session", KindShell, live, false},
-		{"codex rollout on disk", providers.Codex, codexLive, true},
-		{"codex rollout deleted", providers.Codex, "019fe876-0000-0000-0000-000000000000", false},
-		{"codex never sees a claude transcript", providers.Codex, live, false},
-		{"omp transcript on disk", providers.OMP, ompLive, true},
-		{"omp transcript deleted", providers.OMP, "019ffb38-0000-0000-0000-000000000000", false},
-		{"omp never sees a codex rollout", providers.OMP, codexLive, false},
-		{"provider with no resume wired", providers.OpenCode, live, false},
+		{"transcript on disk", providers.Claude, live, "", true},
+		{"pruned transcript", providers.Claude, "gone-uuid", "", false},
+		{"no id at all", providers.Claude, "", "", false},
+		{"shell session", KindShell, live, "", false},
+		{"codex rollout on disk", providers.Codex, codexLive, "", true},
+		{"codex rollout deleted", providers.Codex, "019fe876-0000-0000-0000-000000000000", "", false},
+		{"codex never sees a claude transcript", providers.Codex, live, "", false},
+		{"omp transcript on disk", providers.OMP, ompLive, "", true},
+		{"omp transcript deleted", providers.OMP, "019ffb38-0000-0000-0000-000000000000", "", false},
+		{"omp never sees a codex rollout", providers.OMP, codexLive, "", false},
+		{"opencode row in its database", providers.OpenCode, opencodeLive, "", true},
+		{"opencode conversation deleted", providers.OpenCode, "ses_gone", "", false},
+		{"opencode never sees a crush row", providers.OpenCode, crushLive, "", false},
+		{"crush row in the checkout's database", providers.Crush, crushLive, crushCwd, true},
+		{"crush conversation deleted", providers.Crush, "00000000-0000-0000-0000-000000000000", crushCwd, false},
+		// Crush's database lives in the checkout, so the same id proves nothing
+		// about another one — and a session whose cwd lich cannot name has no
+		// database to ask at all.
+		{"crush row belongs to another checkout", providers.Crush, crushLive, otherCwd, false},
+		{"crush without a working directory", providers.Crush, crushLive, "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := svc.ResumeAvailable(tt.kind, tt.providerSessionID); got != tt.want {
-				t.Errorf("ResumeAvailable(%q, %q) = %v, want %v",
-					tt.kind, tt.providerSessionID, got, tt.want)
+			if got := svc.ResumeAvailable(tt.kind, tt.providerSessionID, tt.cwd); got != tt.want {
+				t.Errorf("ResumeAvailable(%q, %q, %q) = %v, want %v",
+					tt.kind, tt.providerSessionID, tt.cwd, got, tt.want)
 			}
 		})
+	}
+}
+
+// writeSessionDB builds the smallest database that answers the existence
+// question the way a provider's own does: one table keyed by a text id, holding
+// one row. The id column is all lich reads, so it is all this creates.
+func writeSessionDB(t *testing.T, path, table, id string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	db, err := sql.Open("sqlite", "file:"+path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec("CREATE TABLE " + table + " (id TEXT PRIMARY KEY, title TEXT)"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec("INSERT INTO "+table+" (id, title) VALUES (?, ?)", id, "a conversation"); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/terminal/resume_test.go
+++ b/internal/terminal/resume_test.go
@@ -127,6 +127,63 @@ func writeSessionDB(t *testing.T, path, table, id string) {
 	}
 }
 
+// TestSessionRowExistsSurvivesAnotherToolsSchema pins the promise that makes
+// reading another tool's database acceptable at all: every shape lich did not
+// measure answers "no conversation" rather than erroring. A card that starts
+// fresh has lost a resume; one that errors has lost the session, inside the PTY,
+// with the provider's message in place of it.
+func TestSessionRowExistsSurvivesAnotherToolsSchema(t *testing.T) {
+	dir := t.TempDir()
+
+	renamed := filepath.Join(dir, "renamed.db")
+	writeSessionDB(t, renamed, "conversations", "live-id")
+	if sessionRowExists(renamed, "session", "live-id") {
+		t.Error("a renamed table answered true; the schema lich reads is not the one on disk")
+	}
+
+	notADatabase := filepath.Join(dir, "corrupt.db")
+	if err := os.WriteFile(notADatabase, []byte("this is not a database"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if sessionRowExists(notADatabase, "session", "live-id") {
+		t.Error("a file that is not a database answered true")
+	}
+
+	if sessionRowExists(filepath.Join(dir, "absent.db"), "session", "live-id") {
+		t.Error("a database that is not there answered true")
+	}
+
+	empty := filepath.Join(dir, "empty-id.db")
+	writeSessionDB(t, empty, "session", "live-id")
+	if sessionRowExists(empty, "session", "") {
+		t.Error("an empty id answered true; every row would match a LIKE, none may match this")
+	}
+}
+
+// TestOpencodeSessionDB pins where opencode's database is looked for. opencode
+// applies the xdg-basedir convention on every platform rather than the
+// OS-native data location, so the fallback is ~/.local/share even where the OS
+// keeps application data elsewhere — resolve it the OS way and every restored
+// opencode card silently starts fresh.
+func TestOpencodeSessionDB(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	override := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", override)
+	want := filepath.Join(override, "opencode", "opencode.db")
+	if got, ok := opencodeSessionDB(); !ok || got != want {
+		t.Errorf("with XDG_DATA_HOME set = (%q,%v), want %q", got, ok, want)
+	}
+
+	t.Setenv("XDG_DATA_HOME", "")
+	want = filepath.Join(home, ".local", "share", "opencode", "opencode.db")
+	if got, ok := opencodeSessionDB(); !ok || got != want {
+		t.Errorf("with XDG_DATA_HOME unset = (%q,%v), want %q", got, ok, want)
+	}
+}
+
 // TestOMPAgentDirPrecedence pins the order `omp config path` was measured to
 // apply: a named profile moves the whole directory and wins over the explicit
 // override, which is the opposite of the way the two read. Get it backwards and

--- a/internal/terminal/sessiondb.go
+++ b/internal/terminal/sessiondb.go
@@ -26,10 +26,6 @@ const (
 	opencodeSessionTable = "session"
 	crushSessionTable    = "sessions"
 
-	// crushDataDir is the directory Crush creates inside the checkout it runs
-	// in — its database is per project, not per machine.
-	crushDataDir = ".crush"
-
 	// sessionDBBusyMS caps the wait for a database the provider is writing to
 	// right now. A read that gives up reads as "no conversation", which costs a
 	// resume that was there, so it is worth waiting out a lock; it is short
@@ -44,25 +40,23 @@ const (
 // (internal/agentplugin/opencode.go) — so os.UserCacheDir and friends would
 // point somewhere opencode never writes.
 func opencodeSessionDB() (string, bool) {
-	base := os.Getenv("XDG_DATA_HOME")
-	if base == "" {
-		home, err := os.UserHomeDir()
-		if err != nil {
-			return "", false
-		}
-		base = filepath.Join(home, ".local", "share")
+	base, ok := harnessDir("XDG_DATA_HOME", filepath.Join(".local", "share"))
+	if !ok {
+		return "", false
 	}
 	return filepath.Join(base, "opencode", "opencode.db"), true
 }
 
 // crushSessionDB is the database Crush keeps in the checkout it was started in.
 // cwd is the session's own working directory, which is the directory lich
-// spawned Crush in.
+// spawned Crush in. False without one: a directory lich cannot name has no
+// database to ask, and answering from the process's own cwd would be asking
+// about somebody else's checkout.
 func crushSessionDB(cwd string) (string, bool) {
 	if cwd == "" {
 		return "", false
 	}
-	return filepath.Join(cwd, crushDataDir, "crush.db"), true
+	return filepath.Join(cwd, ".crush", "crush.db"), true
 }
 
 // sessionRowExists reports whether table in the SQLite database at path holds a

--- a/internal/terminal/sessiondb.go
+++ b/internal/terminal/sessiondb.go
@@ -1,0 +1,95 @@
+package terminal
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	_ "modernc.org/sqlite"
+)
+
+// Where opencode and Crush keep their conversations. Neither files one
+// transcript per session the way Claude Code, Codex and oh-my-pi do, so there is
+// nothing to glob for: the proof a conversation still exists is a row in the
+// provider's own SQLite database. Only the id column of one table is read, and
+// only to answer whether the row is there.
+//
+// This fails in the same direction the transcript globs do, which is what makes
+// it safe to depend on another tool's schema: a database that moved, a table
+// that was renamed, a file that cannot be opened — every one of them answers
+// false, so a restored card starts fresh instead of dying inside the PTY with
+// the provider's error in place of a session.
+const (
+	// opencodeSessionTable is singular and Crush's is plural. Both are keyed by
+	// a text `id`, which is the id the session-start hook reported.
+	opencodeSessionTable = "session"
+	crushSessionTable    = "sessions"
+
+	// crushDataDir is the directory Crush creates inside the checkout it runs
+	// in — its database is per project, not per machine.
+	crushDataDir = ".crush"
+
+	// sessionDBBusyMS caps the wait for a database the provider is writing to
+	// right now. A read that gives up reads as "no conversation", which costs a
+	// resume that was there, so it is worth waiting out a lock; it is short
+	// enough that the spawn gate never feels stuck.
+	sessionDBBusyMS = 500
+)
+
+// opencodeSessionDB is the single database opencode keeps every conversation in,
+// under its data directory. opencode reads that directory through the
+// xdg-basedir convention on every platform rather than the OS-native data
+// location, the same way it resolves the plugin directory
+// (internal/agentplugin/opencode.go) — so os.UserCacheDir and friends would
+// point somewhere opencode never writes.
+func opencodeSessionDB() (string, bool) {
+	base := os.Getenv("XDG_DATA_HOME")
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", false
+		}
+		base = filepath.Join(home, ".local", "share")
+	}
+	return filepath.Join(base, "opencode", "opencode.db"), true
+}
+
+// crushSessionDB is the database Crush keeps in the checkout it was started in.
+// cwd is the session's own working directory, which is the directory lich
+// spawned Crush in.
+func crushSessionDB(cwd string) (string, bool) {
+	if cwd == "" {
+		return "", false
+	}
+	return filepath.Join(cwd, crushDataDir, "crush.db"), true
+}
+
+// sessionRowExists reports whether table in the SQLite database at path holds a
+// row with this id. False for every failure — a missing file, a database held
+// exclusively, a table that is not there any more.
+//
+// The connection is read-only so lich can never write into a database another
+// tool owns, and it is opened per call rather than pooled: this runs once when a
+// restored card is first opened, and holding a handle on a file the provider is
+// migrating would be the more expensive mistake.
+func sessionRowExists(path, table, id string) bool {
+	if id == "" {
+		return false
+	}
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=busy_timeout(%d)", path, sessionDBBusyMS)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = db.Close() }()
+
+	// table is a constant from this file and never anything that arrived from
+	// outside lich; the id is bound.
+	var found int
+	query := "SELECT 1 FROM " + table + " WHERE id = ? LIMIT 1"
+	return db.QueryRow(query, id).Scan(&found) == nil
+}

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -505,9 +505,9 @@ func TestResolveCommand(t *testing.T) {
 }
 
 // TestResumeArgs proves each provider resumes in its own spelling — a flag for
-// Claude Code and oh-my-pi, a subcommand for Codex — and that a provider with
-// none wired never grows one: a shell, opencode or Crush must not be handed a
-// stray id.
+// Claude Code and oh-my-pi, a subcommand for Codex, one they happen to share for
+// opencode and Crush — and that a kind with none wired never grows one: a shell
+// must not be handed a stray id.
 func TestResumeArgs(t *testing.T) {
 	cases := []struct {
 		name, kind, resume string
@@ -519,8 +519,10 @@ func TestResumeArgs(t *testing.T) {
 		{"codex resume", "codex", "abc-123", []string{"resume", "abc-123"}},
 		{"omp fresh", "omp", "", nil},
 		{"omp resume", "omp", "abc-123", []string{"-r", "abc-123"}},
-		{"opencode never resumes", "opencode", "abc-123", nil},
-		{"crush never resumes", "crush", "abc-123", nil},
+		{"opencode fresh", "opencode", "", nil},
+		{"opencode resume", "opencode", "ses_0031a382dffe", []string{"--session", "ses_0031a382dffe"}},
+		{"crush fresh", "crush", "", nil},
+		{"crush resume", "crush", "abc-123", []string{"--session", "abc-123"}},
 		{"shell never resumes", KindShell, "abc-123", nil},
 		{"shell fresh", KindShell, "", nil},
 	}


### PR DESCRIPTION
A restored card running opencode or Crush started a fresh conversation every time. lich had the id of the one it ran before — both providers report it through the session-start hook — and both spell the invocation that reopens it (`--session <id>`). What was missing was the proof: lich only offers a resume it can honour, and neither files a per-session transcript to glob for the way Claude Code, Codex and oh-my-pi do.

## The proof is a row in the provider's own database

`ResumeAvailable` (`internal/terminal/resume.go`) now asks that database directly, through `internal/terminal/sessiondb.go`:

| provider | database | table |
|---|---|---|
| opencode | `$XDG_DATA_HOME/opencode/opencode.db` (one per machine) | `session` |
| Crush | `<cwd>/.crush/crush.db` (one per checkout) | `sessions` |

Both keyed by a text `id`, which is the id the hook reported. The query is `SELECT 1 ... WHERE id = ?` and the connection is read-only — lich reads one column of one table and never writes into a database another tool owns.

Crush keeping its database inside the checkout is why the check now takes the session's working directory: a Crush conversation belongs to one worktree, and the same id answers differently in another. That is the correct answer, not a limitation.

## Why depending on another tool's schema is acceptable here

It fails in the direction the transcript globs already fail in. A database that moved, a table that was renamed, a file that cannot be opened — every one of them answers "no conversation", so the card starts fresh instead of dying inside the PTY with the provider's error in place of a session. Globbing `rollout-*-<uuid>.jsonl` is a dependency on Codex's internal layout in exactly the same way.

The alternatives were measured and are worse:

- `opencode session list | grep <id>` — 1.7s per call, ASCII table output with no `--json`, against 0.01s for the query.
- Spawn optimistically and fall back on failure — 3.3s of opencode booting and dying on screen, plus exit-code plumbing and a timer heuristic to tell "resume died at boot" from "the user quit with an error two hours in".

## Measured

- `opencode --session <bogus>` → `Error: Session not found: <id>`, exit 1. Crush the same. This is the failure the gate exists to prevent.
- `sessionRowExists` against the real `opencode.db` and `.crush/crush.db` on this machine, both with a live WAL: live id `true`, bogus id `false`, 0.01s.
- The opencode plugin reports `properties.info?.id` on `session.created` and the Crush hook reports the payload's `session_id` — the same ids these tables are keyed by.

## Not verified

Crush's end-to-end report (hook payload id → `sessions.id`) was read from the plugin and from the contract, not re-measured against a live Crush session, which would cost a model turn. If it is ever wrong, a Crush card simply never offers a resume — today's behaviour, no regression.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` (backend), `pnpm check`, `vitest run`, `tsc -b`, `vite build` (frontend)
- [x] Cross-compile loop: `GOOS=linux/darwin/windows go build ./... && go vet ./...`
- [x] `TestResumeAvailable` covers both providers: row present, row deleted, an id belonging to another checkout, and a Crush session with no working directory
- [x] `spawnDecision` pins that the session's own directory reaches the check