### PR TITLE
fix: a helper that outlives a lich restart can reach lich again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A helper that outlives a lich restart can talk to lich again.** The `lich`
+  command line and lich's own MCP tools read the loopback coordinates the session
+  they run in was given, and the connect token behind them is minted fresh every
+  time lich starts. Anything still holding the old one — a background agent the
+  coding agent parked outside the session, a `nohup`, a detached pane — got
+  `403 Forbidden` on every call from then on, with nothing saying why, and the
+  only cure was starting it over. A refused call now retries once with the token
+  the running lich recorded, so the helper simply keeps working. It is retried
+  only against the same port: a machine can run an installed lich beside a
+  development build, and a message delivered to the wrong one lands in a window
+  its sender cannot see — so that case, and every other refusal, now says what
+  happened instead of printing the status code.
+
 - **lich is an application on macOS.** The Homebrew install shipped a bare
   command-line binary, so nothing landed in `/Applications`: lich was absent
   from Launchpad, from Spotlight and from the Finder, and had no icon anywhere.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -578,7 +578,7 @@ func (c *client) emit(payload any) error {
 
 // call posts one RPC to the lich this session belongs to.
 func (c *client) call(method string, args []any, timeout time.Duration, out any) error {
-	endpoint, err := c.endpoint(method)
+	port, token, err := c.coordinates()
 	if err != nil {
 		return err
 	}
@@ -588,18 +588,24 @@ func (c *client) call(method string, args []any, timeout time.Duration, out any)
 	}
 
 	httpClient := &http.Client{Timeout: timeout}
-	resp, err := httpClient.Post(endpoint, "application/json", bytes.NewReader(body))
+	status, payload, err := post(httpClient, endpoint(port, token, method), body)
 	if err != nil {
-		return fmt.Errorf("reach lich: %w", err)
+		return err
 	}
-	defer resp.Body.Close()
-
-	payload, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("read the reply: %w", err)
+	// A refused token is not this caller's mistake — the coordinates it was given
+	// can have gone stale under it (see reissued). Retried once, on the same port,
+	// with the token the running instance recorded.
+	if status == http.StatusForbidden || status == http.StatusUnauthorized {
+		token, err = c.reissued(port, token)
+		if err != nil {
+			return err
+		}
+		if status, payload, err = post(httpClient, endpoint(port, token, method), body); err != nil {
+			return err
+		}
 	}
-	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("%s", failureOf(payload, resp.Status))
+	if status != http.StatusOK {
+		return fmt.Errorf("%s", failureOf(payload, status))
 	}
 	if out == nil {
 		return nil
@@ -610,16 +616,78 @@ func (c *client) call(method string, args []any, timeout time.Duration, out any)
 	return nil
 }
 
-// endpoint builds the RPC URL for one call.
-func (c *client) endpoint(method string) (string, error) {
-	port, token, err := c.coordinates()
+// post sends one RPC and reads the whole reply. The body is read here rather
+// than returned open because a refused call is sent a second time, and the
+// first response has to be finished with before the second one starts.
+func post(httpClient *http.Client, endpoint string, body []byte) (int, []byte, error) {
+	resp, err := httpClient.Post(endpoint, "application/json", bytes.NewReader(body))
 	if err != nil {
-		return "", err
+		return 0, nil, fmt.Errorf("reach lich: %w", err)
 	}
+	defer resp.Body.Close()
+	payload, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, fmt.Errorf("read the reply: %w", err)
+	}
+	return resp.StatusCode, payload, nil
+}
+
+// endpoint builds the RPC URL for one call.
+func endpoint(port, token, method string) string {
 	return fmt.Sprintf(
 		"http://127.0.0.1:%s/rpc/%s?token=%s",
 		url.PathEscape(port), method, url.QueryEscape(token),
-	), nil
+	)
+}
+
+// reissued answers a listener that refused this call's token, with the token the
+// lich on that same port recorded — or with why there is none to try.
+//
+// The connect token is minted per launch and lives only in memory, so a lich
+// closed and opened again answers on the pinned port with a token no older
+// process can know. The coordinates in a PTY's environment are that older
+// process's, and a caller that outlives the session it was started in keeps
+// them: a background agent the harness parks in its own daemon, a nohup, a
+// detached pane. Every call it makes 403s from then on, forever, with nothing
+// on screen saying why — measured on a Claude Code background agent whose
+// `lich mcp` outlived a restart of the lich that spawned it.
+//
+// Only the same port is retried. The runtime file names one instance, and a
+// machine running a daily driver beside a `task dev` build has two: answering to
+// the other one would put this message in a window the caller cannot see, which
+// is the rule coordinates() follows too.
+func (c *client) reissued(port, refused string) (string, error) {
+	stale := fmt.Sprintf(
+		"lich refused this token on port %s: the coordinates in this environment "+
+			"were exported by an earlier lich, and the one running now cannot be "+
+			"reached with them", port,
+	)
+	if c.running == nil {
+		return "", fmt.Errorf("%s. Run this from a session of the running lich", stale)
+	}
+	info, err := c.running()
+	if err != nil {
+		return "", fmt.Errorf("%s, and the running instance could not be read: %w", stale, err)
+	}
+	if info == nil || info.Token == "" {
+		return "", fmt.Errorf("%s, and no running instance is recorded to ask instead", stale)
+	}
+	if strconv.Itoa(info.Port) != port {
+		return "", fmt.Errorf(
+			"%s. The lich recorded on this machine listens on port %d, and a message "+
+				"sent there would land in a window this caller cannot see — start it "+
+				"again from a session of that lich",
+			stale, info.Port,
+		)
+	}
+	if info.Token == refused {
+		return "", fmt.Errorf(
+			"lich refused this token on port %s, and it is the token the running "+
+				"instance recorded — so something other than lich is answering there",
+			port,
+		)
+	}
+	return info.Token, nil
 }
 
 // coordinates finds the lich to talk to: the one that spawned this PTY when
@@ -668,14 +736,14 @@ func (c *client) sessionID() string {
 
 // failureOf unwraps the RPC's {"error": "..."} envelope, falling back to the
 // HTTP status for a body that is not one.
-func failureOf(payload []byte, status string) string {
+func failureOf(payload []byte, status int) string {
 	var envelope struct {
 		Error string `json:"error"`
 	}
 	if err := json.Unmarshal(payload, &envelope); err == nil && envelope.Error != "" {
 		return envelope.Error
 	}
-	return status
+	return fmt.Sprintf("%d %s", status, http.StatusText(status))
 }
 
 // waitBudget is how long the client gives a call that blocks on another

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -31,6 +31,11 @@ type fakeLich struct {
 	calls  []recorded
 	status int
 	body   string
+	// token, when set, is the only one this listener accepts — every other is
+	// refused the way the real transport refuses it (internal/terminal:
+	// mount answers 403). Empty accepts anything, which is what every test
+	// about something else needs.
+	token string
 }
 
 func newFakeLich(t *testing.T, body string) *fakeLich {
@@ -45,6 +50,10 @@ func newFakeLich(t *testing.T, body string) *fakeLich {
 			token:  r.URL.Query().Get("token"),
 			args:   args,
 		})
+		if f.token != "" && r.URL.Query().Get("token") != f.token {
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(f.status)
 		_, _ = io.WriteString(w, f.body)
@@ -433,6 +442,90 @@ func TestTheEnvironmentWinsOverTheRuntimeFile(t *testing.T) {
 	}
 	if len(other.calls) != 0 {
 		t.Errorf("a session answered to the wrong lich: %+v", other.calls)
+	}
+}
+
+// The connect token is minted per launch and never written into a live PTY
+// again, so a caller that outlives the lich that spawned it holds one the
+// listener refuses from then on — measured on a background agent's `lich mcp`,
+// which the harness keeps alive in its own daemon across a lich restart.
+func TestARefusedTokenIsRetriedWithTheRecordedOne(t *testing.T) {
+	f := newFakeLich(t, `[{"label":"docs","project":"lich","kind":"claude"}]`)
+	f.token = "fresh"
+	port := f.server.Listener.Addr().(*net.TCPAddr).Port
+
+	var stdout, stderr bytes.Buffer
+	c := &client{
+		env:     f.env,
+		stdout:  &stdout,
+		stderr:  &stderr,
+		running: func() (*singleton.Info, error) { return &singleton.Info{Port: port, Token: "fresh"}, nil },
+	}
+	if code := dispatch([]string{"sessions"}, c); code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr.String())
+	}
+
+	if len(f.calls) != 2 {
+		t.Fatalf("got %d calls, want the refused one and one retry", len(f.calls))
+	}
+	if f.calls[0].token != "tok en" || f.calls[1].token != "fresh" {
+		t.Errorf(
+			"tokens = %q then %q, want the environment's then the recorded one",
+			f.calls[0].token, f.calls[1].token,
+		)
+	}
+	if !strings.Contains(stdout.String(), "docs") {
+		t.Errorf("stdout = %q, want the retry's answer", stdout.String())
+	}
+}
+
+// The retry is the same lich or nothing: a machine can run a daily driver and a
+// `task dev` build at once, and a message delivered to the wrong one lands in a
+// window this caller cannot see.
+func TestARefusedTokenIsNotRetriedElsewhere(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		running func(port int) *singleton.Info
+		want    string
+	}{
+		{
+			name:    "another instance answers on another port",
+			running: func(port int) *singleton.Info { return &singleton.Info{Port: port + 1, Token: "fresh"} },
+			want:    "cannot see",
+		},
+		{
+			name:    "no instance is recorded at all",
+			running: func(int) *singleton.Info { return nil },
+			want:    "no running instance is recorded",
+		},
+		{
+			name:    "the recorded token is the refused one",
+			running: func(port int) *singleton.Info { return &singleton.Info{Port: port, Token: "tok en"} },
+			want:    "something other than lich is answering",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newFakeLich(t, `[]`)
+			f.token = "fresh"
+			port := f.server.Listener.Addr().(*net.TCPAddr).Port
+
+			var stdout, stderr bytes.Buffer
+			c := &client{
+				env:     f.env,
+				stdout:  &stdout,
+				stderr:  &stderr,
+				running: func() (*singleton.Info, error) { return tc.running(port), nil },
+			}
+			if code := dispatch([]string{"sessions"}, c); code != 1 {
+				t.Fatalf("exit = %d, want 1 — stdout = %q", code, stdout.String())
+			}
+			if len(f.calls) != 1 {
+				t.Errorf("got %d calls, want the refused one and no retry", len(f.calls))
+			}
+			if !strings.Contains(stderr.String(), tc.want) {
+				t.Errorf("stderr = %q, want it to carry %q", stderr.String(), tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## What broke

The connect token is minted per launch and lives only in memory (`internal/terminal/transport.go`), so a lich closed and opened again answers on the pinned port with a token no older process can know. `internal/cli` reads `LICH_PORT` / `LICH_TOKEN` out of the environment and never reasks — which is correct for a session's own PTY, since that dies with the lich that spawned it.

It is not correct for a caller that outlives the session: a background agent the coding agent parks in its own daemon, a `nohup`, a detached pane. Those keep the old coordinates and 403 on every call from then on, forever, with `lich: 403 Forbidden` as the whole explanation. The static assets on `/` answer 200 the entire time (`mountPublic`), so the instance looks alive and only the API looks broken.

Measured on this machine, not reasoned about:

| process | started | `LICH_TOKEN` |
|---|---|---|
| lich (pid 437305, port 47821) | 21:17:32 | `709122…` |
| `claude bg-pty-host` + its `lich mcp` | **20:41:11** | `89373e…` |
| sessions respawned by the new lich | 21:17:44+ | `709122…` |

`lich.log` records the restart in between: `21:17:05 msg="chromium shell" err="signal: killed"`, a fresh listener at `21:17:35`. The PTY sessions were respawned and picked the new token up; the background agent, which lives outside lich's process tree, did not.

## What changed

`call` resolves the coordinates once, and a 401/403 is retried **once** with the token the running instance recorded (`internal/singleton`), so the helper simply keeps working.

The retry is the same port or nothing. A machine can run an installed lich beside a `task dev` build, and delivering a message to the other one puts it in a window the caller cannot see — the rule `coordinates()` already followed for the environment-over-runtime-file preference. Every refusal that is not retried now says what happened: a different port, no instance recorded, or the recorded token being the refused one (something that is not lich answering there).

## Test plan

- [x] `go test ./...` green; `gofmt -l .` and `go vet ./...` clean.
- [x] New: retry succeeds with the recorded token; a table-test pins the three refusals that must **not** retry.
- [x] Mutation check — disabling the retry fails all four; the tests bite.
- [x] End-to-end against the lich running on this machine, with the orphan's real dead token: `/usr/bin/lich sessions` prints `403 Forbidden`, the patched binary lists the sessions.