### PR TITLE
fix: stop timing the readiness settle from the spawn in tests

### DIFF
--- a/internal/terminal/spawn_test.go
+++ b/internal/terminal/spawn_test.go
@@ -29,10 +29,12 @@ func TestASetupSpawnWithNoScriptIsReadyAnyway(t *testing.T) {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
-	time.Sleep(readySettle + 100*time.Millisecond)
-	if !svc.Ready("s1") {
-		t.Error("a session with no setup script to run was left waiting for its marker")
-	}
+	// Waited for, never slept out: a real shell's prompt is the session's first
+	// byte and it arrives whenever the machine gets to it — on a loaded macOS
+	// runner, /etc/profile alone puts it hundreds of milliseconds past the spawn,
+	// and the settle is measured from that byte, not from Start.
+	waitFor(t, func() bool { return svc.Ready("s1") },
+		"a session with no setup script to run to stop waiting for its marker")
 }
 
 // The other side of the same decision: a project that does have a setup script

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -1153,10 +1153,10 @@ func TestReadyWaitsForTheSetupScript(t *testing.T) {
 	if svc.Ready("s1") {
 		t.Error("work was offered the instant the setup script exec'd the provider")
 	}
-	time.Sleep(readySettle + 100*time.Millisecond)
-	if !svc.Ready("s1") {
-		t.Error("the session stayed unready after its provider settled")
-	}
+	// This session has a real PTY behind it, still writing the script's own
+	// output and marker on its own schedule, so the settle runs from whenever
+	// that last byte lands rather than from here.
+	waitFor(t, func() bool { return svc.Ready("s1") }, "the provider to settle")
 }
 
 // TestReadyWaitsForTheProviderToStopDrawing covers the spawn with no setup


### PR DESCRIPTION
`os-tests (macos-latest)` went red on main at dc81710. The failure:

```
spawn_test.go:34: a session with no setup script to run was left waiting for its marker
--- FAIL: TestASetupSpawnWithNoScriptIsReadyAnyway (0.70s)
```

## Cause

`Ready` is the quiet after the PTY's *last byte* (`readySettle`, 600ms), and
`spawnSession` seeds `lastOut` at the spawn so a program that never writes still
settles once. Two tests slept `readySettle + 100ms` after `Start` and then
asserted readiness — a margin that only holds if the session's first byte lands
within 100ms of the spawn.

On macOS it does not. The failing test spawns an interactive `sh`, which reads
`/etc/profile` (and `path_helper`) before printing its prompt; that first byte
arrives hundreds of milliseconds in, restarts the settle, and the assertion runs
inside it. Linux and Windows never noticed — Windows excludes the file by build
tag, Linux's `sh` prompts immediately.

Nothing is wrong with the service: with no setup script `wrapSetup` returns
`false`, the session is never armed for the marker, and it does become ready —
just later than the sleep allowed.

## Measurement

Disposable probe on Linux, a stub provider that delays its first write, same
`sleep(readySettle + 100ms)` then `Ready`:

| first byte at | ready |
|---|---|
| 0ms | true |
| 200ms | false |
| 500ms | false |

## Fix

The two assertions that a session *must become* ready now poll with the
package's existing `waitFor` instead of sleeping out a duration. The assertions
that a session must *not* be ready keep their fixed sleep — a session still
running `sleep 30` under its setup wrap has nothing that could clear them, so
they are not timing-dependent.

## Test plan

- [x] `go test ./...` green; `go test -race -count=20` on the touched tests green (67s, no failures)
- [x] `gofmt -l .` and `go vet ./...` clean
- [x] cross-compile loop (`GOOS=linux|darwin|windows` build + vet) clean
- [x] `os-tests (macos-latest)` green on this PR — the only check that actually proves it

No CHANGELOG entry: test-only, nothing a user of a published version lived through.