### PR TITLE
feat: parallel work opens lich sessions, not invisible subagents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Asking for work to be fanned out opens lich sessions, not invisible
+  subagents.** Every coding agent lich runs also has subagents of its own, and
+  its harness describes those to it at length, from its first turn — so "spin
+  these three tasks up in worktrees" produced three processes with no checkout,
+  no card, and nothing to open, read or take over. lich now says the one thing
+  that was missing: sessions it opens are visible and steerable and subagents
+  are not, so parallel work belongs in sessions. Claude Code and oh-my-pi are
+  told at spawn (both take `--append-system-prompt`); the rest read the same
+  point in lich's own MCP instructions, since none of them has a flag that
+  appends to a system prompt and lich will not rewrite config that belongs to
+  the user. Opening a worker also got cheaper: `open_session` now takes the task
+  itself, so fanning work out costs one call per worker instead of two, and the
+  task waits for that session's agent to come up rather than landing in a setup
+  script.
+
 - **opencode and Crush sessions resume.** A restored card running either of them
   used to start a fresh conversation every time, even though lich had been
   storing the id of the one it ran before. Both now offer the same resume prompt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,14 @@ nobody knows it and that the call site never shows. The mechanism and the histor
   the running window (best-effort, untested against a real window) and exits 0.
 - **Reordering rides dnd-kit's pointer sensors** (`frontend/src/lib/use-sortable-list.ts`); the activation distance
   is load-bearing — without it plain clicks stop selecting a session.
+- **lich appends to the agent's system prompt, for two providers only**
+  (`internal/terminal/command.go`, `briefingFlags` → `relay.SpawnBriefing`): Claude Code and oh-my-pi
+  are spawned with `--append-system-prompt` carrying lich's own briefing, so text the user never
+  wrote is in every session's prompt and in `/proc/<pid>/cmdline`. Codex, opencode and Crush get
+  nothing there — none has an append (Codex's `model_instructions_file` *replaces* the base
+  instructions; the other two are config keys, not flags), so for them the same point exists only in
+  lich's MCP instructions, and behaviour between providers differs by that much.
+
 - **Installing the plugin writes into three harnesses' own directories**
   (`internal/agentplugin`): Claude Code and Codex are driven through their plugin CLI, but opencode, oh-my-pi and
   Crush have none, so lich writes the released files itself — a module into opencode's plugin dir, another into

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -299,7 +299,7 @@ at lich.
 | `send_to_session` | `session`, `prompt`, optional `project` and `timeout_seconds`. |
 | `wait_for_answer` | optional `ticket` and `timeout_seconds` — with a ticket, `lich wait <ticket>`; without one, the collect: everything ready at once. |
 | `reply_to_session` | `ticket`, `answer` — what a relayed message asks for. |
-| `open_session` | optional `project`, `kind`, `worktree`, `base`, `model` — `lich open`. |
+| `open_session` | optional `project`, `kind`, `worktree`, `base`, `model` — `lich open` — plus optional `prompt`, which hands the new session that task in the same call (`lich open` then `lich send`, in one). |
 | `close_session` | `session`, optional `project`, `worktree` (`keep`/`remove`), `force`. |
 | `list_worktrees` | optional `project` — the checkouts, as JSON. |
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -17,6 +17,13 @@ import (
 	"github.com/omartelo/lich/internal/spawn"
 )
 
+// answer is one method's canned reply: an RPC failure is a 4xx/5xx carrying
+// {"error"}, so a test that exercises one has to set both (internal/rpc).
+type answer struct {
+	status int
+	body   string
+}
+
 // recorded is one RPC the fake lich received.
 type recorded struct {
 	method string
@@ -31,6 +38,10 @@ type fakeLich struct {
 	calls  []recorded
 	status int
 	body   string
+	// answers overrides the canned reply for one RPC method, which is what a
+	// conversation making more than one call needs: a tool that opens a session
+	// and then hands it a task reads two different shapes back.
+	answers map[string]answer
 	// token, when set, is the only one this listener accepts — every other is
 	// refused the way the real transport refuses it (internal/terminal:
 	// mount answers 403). Empty accepts anything, which is what every test
@@ -54,9 +65,13 @@ func newFakeLich(t *testing.T, body string) *fakeLich {
 			http.Error(w, "forbidden", http.StatusForbidden)
 			return
 		}
+		status, body := f.status, f.body
+		if override, ok := f.answers[strings.TrimPrefix(r.URL.Path, "/rpc/")]; ok {
+			status, body = override.status, override.body
+		}
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(f.status)
-		_, _ = io.WriteString(w, f.body)
+		w.WriteHeader(status)
+		_, _ = io.WriteString(w, body)
 	}))
 	t.Cleanup(f.server.Close)
 	return f

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -492,10 +492,14 @@ var mcpTools = []mcpTool{
 //
 // It is not a wait for an answer. The worker was created seconds ago and its
 // task is minutes of work, so a ticket is the expected outcome and the sender
-// carries on. It is short because opening may already have spent up to openCall
-// seconds on a worktree, and the two together have to stay under the 120 seconds
-// past which the client stops waiting and detaches the call (see mcpMaxWait).
-const deliverWait = 30
+// carries on.
+//
+// The number is what is left of the call's budget. Opening can spend openCall
+// (60s) before this starts, and the client detaches anything still running at
+// 120s (see mcpMaxWait) — so the delivery gets 20, plus the callSlack the HTTP
+// timeout adds for the trip back, and the worst case lands at 110 rather than
+// on the line.
+const deliverWait = 20
 
 // handOver gives a just-opened session its first task, wording the outcome the
 // way send_to_session words it — the caller should not have to learn two

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -90,7 +90,7 @@ type mcpTool struct {
 // that never realizes it could.
 const mcpInstructions = `lich runs coding-agent sessions side by side in one window; these tools are how this session works with the others.
 
-Delegate in parallel: for work that can run beside yours, open a worker session in its own git worktree (open_session with worktree) so it gets its own checkout, then hand it the task with send_to_session. Check list_worktrees first — a branch already checked out is opened, not created. Workers are full sessions on the user's screen: visible, steerable, and yours to close (close_session) when the work is done.
+Delegate in parallel: for work that can run beside yours, open a worker session in its own git worktree (open_session with worktree) so it gets its own checkout, then hand it the task with send_to_session. Check list_worktrees first — a branch already checked out is opened, not created. Workers are full sessions on the user's screen: visible, steerable, and yours to close (close_session) when the work is done. That is the difference from the subagents your own harness runs, and it is what the user is asking for when they say to fan work out across branches or worktrees: a subagent has no checkout of its own and no card they can open, read or take over mid-task. Reach for one of those to read something and throw it away, not to run the implementation somebody asked to see.
 
 Never poll for results. A send that outlives its wait hands back a ticket and you carry on with your own work; when results are ready, one short [lich] note arrives at your prompt — collect everything at once with wait_for_answer (no ticket). Polling in a loop burns the tokens this design exists to save.
 
@@ -370,12 +370,13 @@ var mcpTools = []mcpTool{
 	},
 	{
 		Name: "open_session",
-		Description: "Open a new lich session and start it, so it can be given work with " +
-			"send_to_session. Optionally creates a git worktree first and roots the new " +
-			"session in it, which is how you give a task its own checkout instead of " +
-			"sharing yours. Returns the names the new session is addressed by. " +
-			"It starts empty and idle — nobody has asked it anything yet — and its agent " +
-			"takes a few seconds to come up, so send it work as a separate step.",
+		Description: "Open a new lich session and start it. Optionally creates a git worktree " +
+			"first and roots the new session in it, which is how you give a task its own " +
+			"checkout instead of sharing yours — and optionally hands it the task in the same " +
+			"call, so fanning work out costs one call per worker instead of two. Returns the " +
+			"names the new session is addressed by, and, when a task came with it, that task's " +
+			"outcome: the answer if it was quick, otherwise a ticket to carry on from, exactly " +
+			"as send_to_session returns one.",
 		Schema: schema(map[string]any{
 			"project": property("string",
 				"Project to open the session in, by name. Defaults to your own project."),
@@ -392,6 +393,9 @@ var mcpTools = []mcpTool{
 					"--model flag takes it — the name or alias, never a lich name for it. Omit "+
 					"to leave the provider on its default. Crush and shell sessions cannot be "+
 					"given one."),
+			"prompt": property("string",
+				"Task to hand the new session as soon as its agent is up. Omit to open it idle "+
+					"and send later."),
 		}),
 		Run: func(c *client, args mcpArgs) (string, error) {
 			var opened spawn.Session
@@ -402,7 +406,11 @@ var mcpTools = []mcpTool{
 			if err := c.call("spawn.Open", call, openCall, &opened); err != nil {
 				return "", err
 			}
-			return openedText(opened), nil
+			prompt := args.text("prompt")
+			if prompt == "" {
+				return openedText(opened), nil
+			}
+			return openedText(opened) + "\n" + c.handOver(opened, prompt), nil
 		},
 	},
 	{
@@ -476,6 +484,39 @@ var mcpTools = []mcpTool{
 			return "Answer sent.", nil
 		},
 	},
+}
+
+// deliverWait bounds handing a task to a session that was opened a moment ago:
+// how long the delivery waits for that session's agent to be the program reading
+// its PTY (relay.awaitReady).
+//
+// It is not a wait for an answer. The worker was created seconds ago and its
+// task is minutes of work, so a ticket is the expected outcome and the sender
+// carries on. It is short because opening may already have spent up to openCall
+// seconds on a worktree, and the two together have to stay under the 120 seconds
+// past which the client stops waiting and detaches the call (see mcpMaxWait).
+const deliverWait = 30
+
+// handOver gives a just-opened session its first task, wording the outcome the
+// way send_to_session words it — the caller should not have to learn two
+// spellings of one answer.
+//
+// A delivery that fails is reported beside the opened session rather than as a
+// failed call. The session exists either way, and a failed call would read as if
+// nothing had happened — leaving an agent that opens three workers convinced it
+// has none.
+func (c *client) handOver(opened spawn.Session, prompt string) string {
+	var result relay.Result
+	call := []any{c.sessionID(), opened.Label, opened.Project, prompt, deliverWait}
+	if err := c.call("relay.Send", call, waitBudget(deliverWait), &result); err != nil {
+		return fmt.Sprintf(
+			"The task did not reach it: %v. The session is open and idle, so send the task "+
+				"with send_to_session — a fresh worktree runs the project's setup script "+
+				"before its agent, and that can outlast this call.",
+			err,
+		)
+	}
+	return mcpOutcome(result)
 }
 
 // mcpOutcome words a Send or Wait result for an agent: the answer alone when

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -537,6 +537,66 @@ func TestMCPOpenSessionReturnsTheNamesItIsAddressedBy(t *testing.T) {
 	}
 }
 
+// A worker opened for a task is opened and given it in one call — the whole
+// point of the prompt argument, since two calls per worker is what made the
+// harness's own subagents the cheaper thing to reach for.
+func TestMCPOpenSessionHandsOverTheTaskItCameWith(t *testing.T) {
+	f := newFakeLich(t, `{"id":"9f8e","projectId":"p1","project":"lich","label":"auth-fix",
+		"name":"auth-fix-9f8e","kind":"claude","path":"/wt/auth-fix","nextSeq":5}`)
+	f.answers = map[string]answer{
+		"relay.Send": {status: 200, body: `{"ticket":"a1b2c3d4","target":"auth-fix","status":"pending"}`},
+	}
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"open_session","arguments":{"worktree":"auth-fix","prompt":"port the parser"}}}`)
+
+	text, failed := textOf(t, replies[0])
+	if failed {
+		t.Fatalf("tool reported a failure: %s", text)
+	}
+	if len(f.calls) != 2 || f.calls[0].method != "spawn.Open" || f.calls[1].method != "relay.Send" {
+		t.Fatalf("calls = %+v, want spawn.Open then relay.Send", f.calls)
+	}
+	// The new session is addressed by the label lich just gave it, in its own
+	// project — the sender cannot have been told either one yet.
+	want := []any{"s1", "auth-fix", "lich", "port the parser", float64(deliverWait)}
+	if len(f.calls[1].args) != len(want) {
+		t.Fatalf("send args = %v, want %v", f.calls[1].args, want)
+	}
+	for i := range want {
+		if f.calls[1].args[i] != want[i] {
+			t.Errorf("send argument %d = %v, want %v", i, f.calls[1].args[i], want[i])
+		}
+	}
+	if !strings.Contains(text, "a1b2c3d4") {
+		t.Errorf("result carries no ticket to collect the work with:\n%s", text)
+	}
+}
+
+// The session outlives a delivery that failed, so saying so is the whole
+// answer: reporting a failed call would leave an agent that opened three
+// workers believing it has none.
+func TestMCPOpenSessionKeepsTheSessionWhenTheTaskDoesNotLand(t *testing.T) {
+	f := newFakeLich(t, `{"id":"9f8e","projectId":"p1","project":"lich","label":"auth-fix",
+		"name":"auth-fix-9f8e","kind":"claude","path":"/wt/auth-fix","nextSeq":5}`)
+	f.answers = map[string]answer{
+		"relay.Send": {status: 500, body: `{"error":"the setup script is still running"}`},
+	}
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"open_session","arguments":{"worktree":"auth-fix","prompt":"port the parser"}}}`)
+
+	text, failed := textOf(t, replies[0])
+	if failed {
+		t.Fatalf("the open was reported as a failure, but the session exists: %s", text)
+	}
+	for _, phrase := range []string{"auth-fix", "the setup script is still running", "send_to_session"} {
+		if !strings.Contains(text, phrase) {
+			t.Errorf("result is missing %q:\n%s", phrase, text)
+		}
+	}
+}
+
 func TestMCPOpenSessionDefaultsEveryArgument(t *testing.T) {
 	f := newFakeLich(t, `{"id":"9f8e","projectId":"p1","project":"lich","label":"Session 4",
 		"name":"lich-9f8e","kind":"claude","path":"","nextSeq":5}`)

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -97,7 +97,13 @@ func TestMCPHandshakeAdvertisesTools(t *testing.T) {
 	// The instructions are the one place the whole journey — fan out, carry
 	// on, collect — is told as one; clients inject them into the system
 	// prompt, so an empty field is an agent that never learns it can delegate.
-	for _, want := range []string{"open_session", "send_to_session", "wait_for_answer", "worktree"} {
+	// "subagent" is in the list because the instructions are the only place the
+	// providers with no --append-system-prompt (Codex, opencode, Crush) are told
+	// the one thing they get wrong on their own: that fanning work out means
+	// these sessions and not the subagents their own harness offers.
+	for _, want := range []string{
+		"open_session", "send_to_session", "wait_for_answer", "worktree", "subagent",
+	} {
 		if !strings.Contains(result.Instructions, want) {
 			t.Errorf("instructions are missing %q:\n%s", want, result.Instructions)
 		}
@@ -558,8 +564,12 @@ func TestMCPOpenSessionHandsOverTheTaskItCameWith(t *testing.T) {
 		t.Fatalf("calls = %+v, want spawn.Open then relay.Send", f.calls)
 	}
 	// The new session is addressed by the label lich just gave it, in its own
-	// project — the sender cannot have been told either one yet.
-	want := []any{"s1", "auth-fix", "lich", "port the parser", float64(deliverWait)}
+	// project — the sender cannot have been told either one yet. The wait is
+	// spelled out rather than read from deliverWait: what has to hold is that
+	// opening (up to openCall) and delivering together stay under the 120s at
+	// which the client detaches the call, and a constant this test follows
+	// could be raised past that with the suite still green.
+	want := []any{"s1", "auth-fix", "lich", "port the parser", float64(20)}
 	if len(f.calls[1].args) != len(want) {
 		t.Fatalf("send args = %v, want %v", f.calls[1].args, want)
 	}

--- a/internal/relay/compose.go
+++ b/internal/relay/compose.go
@@ -11,6 +11,41 @@ import (
 // this text: the words are the whole protocol, which is what lets a provider
 // lich has never heard of answer a relayed request.
 
+// SpawnBriefing is what a provider is told about lich when lich starts it: two
+// sentences appended to its system prompt, for the providers whose command line
+// accepts one (internal/terminal, briefingFlags).
+//
+// It exists because the agent's own harness offers subagents of its own, and
+// those are described to it at length, in its system prompt, from its first
+// turn. lich's tools are described in a server block far below that — so an
+// agent asked to "fan this out across worktrees" reaches for the subagent it was
+// told about, and the user watches work they meant to supervise disappear into a
+// process they cannot open, on a checkout that does not exist. Reported twice by
+// the same user before this text existed.
+//
+// It draws the line rather than forbidding anything: a subagent is still the
+// right tool for a throwaway read. What it fixes is the one case the agent
+// cannot get right on its own, because nothing in its prompt says lich sessions
+// are visible and steerable and subagents are not.
+//
+// hasTools is whether this provider was handed lich's MCP server at spawn. The
+// command line works everywhere and is named for the ones that were not, on the
+// same rule replyInstruction follows: naming a tool a session does not have is
+// worse than naming the command.
+func SpawnBriefing(hasTools bool) string {
+	route := "Open one with `lich open --worktree <branch>`, then hand it the task with " +
+		"`lich send <session> \"<task>\"`."
+	if hasTools {
+		route = "The lich tools in your list open one and hand it the task."
+	}
+	return "You are running inside lich, which runs coding-agent sessions side by side and can " +
+		"open more of them beside this one — each a card the user watches and can take over " +
+		"mid-task, in its own git worktree when the work needs its own checkout. When work is " +
+		"to be fanned out — several tasks at once, one per branch or checkout — those sessions " +
+		"are what to open, not the subagents your own harness runs: a subagent has no checkout, " +
+		"no card, and nothing the user can steer or resume. " + route
+}
+
 // compose is the message typed at the target's prompt. It names where the
 // request came from so the receiving agent knows this did not come from the
 // person in front of it, and carries the exact command that sends an answer

--- a/internal/relay/compose.go
+++ b/internal/relay/compose.go
@@ -32,9 +32,16 @@ import (
 // command line works everywhere and is named for the ones that were not, on the
 // same rule replyInstruction follows: naming a tool a session does not have is
 // worse than naming the command.
+//
+// The example spells its placeholders in capitals and quotes with ' rather than
+// the usual <angle brackets> and ": this string is passed as one argv entry, and
+// a provider shipped as a .cmd is spawned through `cmd.exe /c`
+// (internal/terminal, wrapArgv). Windows escapes a double quote as \" for
+// CommandLineToArgvW, cmd.exe does not read that as an escape, and the < and >
+// left outside quotes by it are redirection.
 func SpawnBriefing(hasTools bool) string {
-	route := "Open one with `lich open --worktree <branch>`, then hand it the task with " +
-		"`lich send <session> \"<task>\"`."
+	route := "Open one with `lich open --worktree BRANCH`, then hand it the task with " +
+		"`lich send SESSION 'the task'`."
 	if hasTools {
 		route = "The lich tools in your list open one and hand it the task."
 	}

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -2103,3 +2103,31 @@ func TestTheNudgeNamesTheToolOnlyWhereItExists(t *testing.T) {
 		})
 	}
 }
+
+// TestSpawnBriefingNamesTheRouteThisSpawnGave pins the same rule the reply
+// instruction follows: a session handed lich's MCP server is pointed at the
+// tools, and one that was not is pointed at the command line every provider
+// has. Naming tools that are not in the list would leave that session believing
+// it has no way to open anything.
+func TestSpawnBriefingNamesTheRouteThisSpawnGave(t *testing.T) {
+	withTools, withCommand := SpawnBriefing(true), SpawnBriefing(false)
+
+	if strings.Contains(withTools, "lich open") {
+		t.Errorf("a session with the tools is sent to the command line:\n%s", withTools)
+	}
+	if !strings.Contains(withTools, "tools in your list") {
+		t.Errorf("the tool route is missing:\n%s", withTools)
+	}
+	for _, want := range []string{"lich open --worktree", "lich send"} {
+		if !strings.Contains(withCommand, want) {
+			t.Errorf("the command route is missing %q:\n%s", want, withCommand)
+		}
+	}
+	// The distinction is the whole reason this text is spawned with: without it
+	// the agent reaches for the subagents its own harness describes at length.
+	for _, briefing := range []string{withTools, withCommand} {
+		if !strings.Contains(briefing, "subagent") {
+			t.Errorf("the briefing draws no line against a subagent:\n%s", briefing)
+		}
+	}
+}

--- a/internal/terminal/command.go
+++ b/internal/terminal/command.go
@@ -80,6 +80,23 @@ func SupportsModel(kind string) bool {
 	return ok
 }
 
+// briefingFlags is how each provider spells "append this to your system
+// prompt", for the two that spell it at all: Claude Code and oh-my-pi share
+// --append-system-prompt (read off both `--help`, like every other table here).
+//
+// The other three are absent because none of them has an append. Codex takes
+// `model_instructions_file`, which *replaces* its base instructions — swapping
+// the whole system prompt of a provider for a file lich wrote is not a thing
+// lich does for one paragraph. opencode's `instructions` and Crush's
+// `system_prompt_prefix` are config keys, not flags, so using them means writing
+// a file the user owns — the line lich already draws at MCP registration
+// (providers.AcceptsMCPServer). Those three read the same point in lich's MCP
+// instructions instead, which costs nothing and needs no file.
+var briefingFlags = map[string]string{
+	providers.Claude: "--append-system-prompt",
+	providers.OMP:    "--append-system-prompt",
+}
+
 // How each provider is handed an MCP server on its command line: Claude Code
 // takes a JSON string, Codex takes config overrides for its `mcp_servers`
 // table. Which providers accept one at all is providers.AcceptsMCPServer.
@@ -154,6 +171,7 @@ func providerArgs(kind, name, resume, model, lichBin string, skipPermissions boo
 	args = append(args, resumeArgs(kind, resume)...)
 	args = append(args, skipPermissionArgs(kind, skipPermissions)...)
 	args = append(args, modelArgs(kind, model)...)
+	args = append(args, briefingArgs(kind)...)
 	if kind == providers.Codex {
 		return append(mcp, args...)
 	}
@@ -174,6 +192,19 @@ func modelArgs(kind, model string) []string {
 		return nil
 	}
 	return []string{flag, model}
+}
+
+// briefingArgs returns the arguments that append lich's own briefing to a
+// provider's system prompt, or nil for a provider with no spelling for it. The
+// briefing is worded for what this spawn actually registered: a provider handed
+// lich's MCP server is pointed at the tools, everyone else at the command line
+// (relay.SpawnBriefing).
+func briefingArgs(kind string) []string {
+	flag, ok := briefingFlags[kind]
+	if !ok {
+		return nil
+	}
+	return []string{flag, relay.SpawnBriefing(providers.AcceptsMCPServer(kind))}
 }
 
 // skipPermissionArgs returns the flag that drops a provider's permission

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -386,9 +386,7 @@ func TestStartPassesResumeToTheProcess(t *testing.T) {
 	// TestProviderArgsRegistersTheMCPServer pins; this test owns the resume id
 	// reaching argv ahead of it.
 	want := []string{bin, "--resume", "abc-123", "--mcp-config"}
-	if len(got) != len(want)+1 || !slices.Equal(got[:len(want)], want) {
-		t.Errorf("spawned argv = %v, want %v followed by one config", got, want)
-	}
+	spawnPins(t, got, want...)
 }
 
 // TestStartWithoutResumeSpawnsBare proves a session with no id to resume spawns
@@ -410,9 +408,7 @@ func TestStartWithoutResumeSpawnsBare(t *testing.T) {
 	// whose content TestProviderArgsRegistersTheMCPServer pins. What this test
 	// owns is that no resume flag was invented alongside it.
 	want := []string{bin, "--mcp-config"}
-	if len(got) != len(want)+1 || !slices.Equal(got[:len(want)], want) {
-		t.Errorf("spawned argv = %v, want %v followed by one config", got, want)
-	}
+	spawnPins(t, got, want...)
 }
 
 // TestStartWithSetupWrapsTheSpawn proves the setup flag reroutes the spawn
@@ -459,9 +455,7 @@ func TestStartWithSetupButNoScriptSpawnsBare(t *testing.T) {
 	// As above: the registration is expected, an sh indirection is not — argv
 	// still starts at the provider binary itself.
 	want := []string{bin, "--mcp-config"}
-	if len(got) != len(want)+1 || !slices.Equal(got[:len(want)], want) {
-		t.Errorf("spawned argv = %v, want %v followed by one config", got, want)
-	}
+	spawnPins(t, got, want...)
 }
 
 // TestResolveBin proves an empty custom path falls back to the provider's
@@ -611,9 +605,7 @@ func TestStartPassesSkipPermissionsToTheProcess(t *testing.T) {
 	// has to land ahead of it — --mcp-config reads everything after it as another
 	// config path.
 	want := []string{bin, "--dangerously-skip-permissions", "--mcp-config"}
-	if len(got) != len(want)+1 || !slices.Equal(got[:len(want)], want) {
-		t.Errorf("spawned argv = %v, want %v followed by one config", got, want)
-	}
+	spawnPins(t, got, want...)
 }
 
 // TestStartPassesNameToTheProcess proves the peer name reaches the spawned
@@ -633,9 +625,7 @@ func TestStartPassesNameToTheProcess(t *testing.T) {
 
 	// As above: the registration follows, pinned by its own test.
 	want := []string{bin, "--name", "lich-4f2a", "--mcp-config"}
-	if len(got) != len(want)+1 || !slices.Equal(got[:len(want)], want) {
-		t.Errorf("spawned argv = %v, want %v followed by one config", got, want)
-	}
+	spawnPins(t, got, want...)
 }
 
 // TestModelArgs pins each provider's own flag, and the two kinds that must never
@@ -709,9 +699,7 @@ func TestStartPassesTheStoredModelToTheProcess(t *testing.T) {
 	// Ahead of the registration, as every other flag is: --mcp-config reads what
 	// follows it as another config path, so a model behind it is a model lost.
 	want := []string{bin, "--model", "opus", "--mcp-config"}
-	if len(got) != len(want)+1 || !slices.Equal(got[:len(want)], want) {
-		t.Errorf("spawned argv = %v, want %v followed by one config", got, want)
-	}
+	spawnPins(t, got, want...)
 }
 
 // TestPTYEcho proves the core assumption of the service: a process spawns
@@ -820,13 +808,38 @@ func TestSessionEnvInjectsCoordinates(t *testing.T) {
 	}
 }
 
+// spawnPins asserts a spawn's argv: it starts with the binary, carries these
+// flags in this order, and ends with the MCP registration plus its one config
+// value.
+//
+// lich's own briefing is dropped before the comparison. Every Claude Code spawn
+// carries it, and each of these tests owns one flag of its own — pinning the
+// briefing's presence six more times would only mean six failures the day its
+// wording moves. What it says is pinned once, by
+// TestTheBriefingGoesToTheProvidersThatTakeOne.
+func spawnPins(t *testing.T, got []string, want ...string) {
+	t.Helper()
+	trimmed := make([]string, 0, len(got))
+	for i := 0; i < len(got); i++ {
+		if got[i] == "--append-system-prompt" {
+			i++ // and the text it carries
+			continue
+		}
+		trimmed = append(trimmed, got[i])
+	}
+	if len(trimmed) != len(want)+1 || !slices.Equal(trimmed[:len(want)], want) {
+		t.Errorf("spawned argv = %v, want %v followed by one config", got, want)
+	}
+}
+
 // TestProviderArgsRegistersTheMCPServer proves each provider that can be handed
 // an MCP server at spawn is handed lich's, spelled its own way.
 func TestProviderArgsRegistersTheMCPServer(t *testing.T) {
 	const bin = "/usr/bin/lich"
 
 	claude := providerArgs(providers.Claude, "", "", "", bin, false)
-	if len(claude) != 2 || claude[0] != "--mcp-config" {
+	at := slices.Index(claude, "--mcp-config")
+	if at < 0 || at+1 >= len(claude) {
 		t.Fatalf("claude args = %v", claude)
 	}
 	var config struct {
@@ -835,18 +848,18 @@ func TestProviderArgsRegistersTheMCPServer(t *testing.T) {
 			Args    []string `json:"args"`
 		} `json:"mcpServers"`
 	}
-	if err := json.Unmarshal([]byte(claude[1]), &config); err != nil {
-		t.Fatalf("--mcp-config value is not JSON: %v (%q)", err, claude[1])
+	if err := json.Unmarshal([]byte(claude[at+1]), &config); err != nil {
+		t.Fatalf("--mcp-config value is not JSON: %v (%q)", err, claude[at+1])
 	}
 	server, ok := config.MCPServers["lich"]
 	if !ok {
-		t.Fatalf("no lich server in %q", claude[1])
+		t.Fatalf("no lich server in %q", claude[at+1])
 	}
 	if server.Command != bin || !slices.Equal(server.Args, []string{"mcp"}) {
 		t.Errorf("server = %+v, want %q mcp", server, bin)
 	}
-	if strings.Contains(claude[1], "token") {
-		t.Errorf("a secret reached the argv, which /proc exposes: %q", claude[1])
+	if strings.Contains(claude[at+1], "token") {
+		t.Errorf("a secret reached the argv, which /proc exposes: %q", claude[at+1])
 	}
 
 	codex := providerArgs(providers.Codex, "", "", "", bin, false)
@@ -900,22 +913,66 @@ func TestProviderArgsOrdersEachProvidersConstraint(t *testing.T) {
 // TestProviderArgsWithoutARegistration proves the providers with no way to be
 // told at spawn are spawned exactly as before, and that a lich which cannot
 // name its own binary registers nothing rather than something broken.
+//
+// bare is the stronger claim: nothing at all on the command line. It does not
+// hold for the two that take a briefing without taking an MCP server — for
+// those, what is proven is that no registration rode along with it.
 func TestProviderArgsWithoutARegistration(t *testing.T) {
 	tests := []struct {
 		name string
 		kind string
 		bin  string
+		bare bool
 	}{
-		{"opencode has no flag for it", providers.OpenCode, "/usr/bin/lich"},
-		{"crush has no flag for it", providers.Crush, "/usr/bin/lich"},
-		{"oh-my-pi has no flag for it", providers.OMP, "/usr/bin/lich"},
-		{"a shell session is not a provider", KindShell, "/usr/bin/lich"},
-		{"no binary to point at", providers.Claude, ""},
+		{"opencode has no flag for it", providers.OpenCode, "/usr/bin/lich", true},
+		{"crush has no flag for it", providers.Crush, "/usr/bin/lich", true},
+		{"a shell session is not a provider", KindShell, "/usr/bin/lich", true},
+		{"oh-my-pi takes a briefing but no server", providers.OMP, "/usr/bin/lich", false},
+		{"no binary to point at", providers.Claude, "", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if args := providerArgs(tt.kind, "", "", "", tt.bin, false); len(args) != 0 {
+			args := providerArgs(tt.kind, "", "", "", tt.bin, false)
+			if tt.bare && len(args) != 0 {
 				t.Errorf("args = %v, want none", args)
+			}
+			for _, flag := range []string{claudeMCPFlag, codexConfigFlag} {
+				if slices.Contains(args, flag) {
+					t.Errorf("args = %v, want no MCP registration", args)
+				}
+			}
+		})
+	}
+}
+
+// TestTheBriefingGoesToTheProvidersThatTakeOne proves the two halves of the
+// briefing: who is handed it at all, and that its wording follows what this
+// spawn registered — a provider given no MCP server is pointed at the command
+// line, because naming a tool it does not have is the one thing that leaves it
+// with no route at all.
+func TestTheBriefingGoesToTheProvidersThatTakeOne(t *testing.T) {
+	briefed := map[string]string{
+		providers.Claude: "tools in your list",
+		providers.OMP:    "lich open --worktree",
+	}
+	for kind, want := range briefed {
+		t.Run(kind, func(t *testing.T) {
+			args := providerArgs(kind, "", "", "", "/usr/bin/lich", false)
+			flag := slices.Index(args, "--append-system-prompt")
+			if flag < 0 || flag+1 >= len(args) {
+				t.Fatalf("args = %v, want a briefing", args)
+			}
+			if !strings.Contains(args[flag+1], want) {
+				t.Errorf("briefing = %q, want it to name %q", args[flag+1], want)
+			}
+		})
+	}
+
+	for _, kind := range []string{providers.Codex, providers.OpenCode, providers.Crush, KindShell} {
+		t.Run(kind+" takes none", func(t *testing.T) {
+			args := providerArgs(kind, "", "", "", "/usr/bin/lich", false)
+			if slices.Contains(args, "--append-system-prompt") {
+				t.Errorf("args = %v, want no briefing: %s has no flag that appends one", args, kind)
 			}
 		})
 	}

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -411,6 +411,32 @@ func TestStartWithoutResumeSpawnsBare(t *testing.T) {
 	spawnPins(t, got, want...)
 }
 
+// TestStartCarriesTheBriefingIntoTheSpawn proves lich's briefing reaches the
+// process itself, and not only providerArgs. Every argv assertion around it
+// goes through spawnPins, which drops the briefing before comparing — so
+// nothing else here would notice it being lost between the two.
+func TestStartCarriesTheBriefingIntoTheSpawn(t *testing.T) {
+	bin := stayAliveBin(t)
+	svc := New(stubBins{bin: bin}, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1") })
+
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+
+	svc.mu.Lock()
+	got := spawnedArgs(t, svc, "s1")
+	svc.mu.Unlock()
+
+	flag := slices.Index(got, "--append-system-prompt")
+	if flag < 0 || flag+1 >= len(got) {
+		t.Fatalf("spawned argv = %v, want a briefing", got)
+	}
+	if !strings.Contains(got[flag+1], "subagent") {
+		t.Errorf("briefing = %q, want the line it exists to draw", got[flag+1])
+	}
+}
+
 // TestStartWithSetupWrapsTheSpawn proves the setup flag reroutes the spawn
 // through sh -c with the project's script ahead of the exec'd provider — the
 // wiring wrapSetup's unit test cannot see.


### PR DESCRIPTION
## The problem

Every coding agent lich runs also has subagents of its own, described at length in its system prompt from the first turn. lich's tools are described in a server block far below that. So "spin these three tasks up in worktrees" produces three processes with no checkout, no card, and nothing the user can open, read or take over — work they had planned *in order to* supervise it, running where they cannot look.

Reported twice by the same user, in the same week.

## What each provider can actually be told

Measured against the installed binaries — none of it inferred:

| provider | mechanism | form |
|---|---|---|
| Claude Code | `--append-system-prompt` | flag at spawn |
| oh-my-pi | `--append-system-prompt` | flag at spawn |
| Codex | `model_instructions_file` | **replaces** the base instructions |
| opencode | `instructions: [...]` | config key |
| Crush | `system_prompt_prefix`, `context_paths` | config key |

Two can be told at spawn. Codex's key would swap its whole system prompt for a file lich wrote, which is not a thing lich does for one paragraph. opencode's and Crush's are config keys, not flags — using them means writing a file the user owns, the line lich already draws at MCP registration (`providers.AcceptsMCPServer`).

## What changed

- `relay.SpawnBriefing` — the text, wording the route this spawn actually gave the session: the tools when lich registered its MCP server, `lich open --worktree` / `lich send` when it did not. Same rule `replyInstruction` follows, for the same reason: naming a tool a session does not have leaves it with no route at all.
- `briefingFlags` (`internal/terminal/command.go`) — Claude Code and oh-my-pi, in the shape of the tables beside it. The other three read the same point in the MCP `instructions`, which costs nothing and needs no file.
- `open_session` takes `prompt` — fanning work out is one call per worker instead of two. Delivery goes through the relay, so the task waits for that session's agent (`awaitReady`) rather than landing in a setup script, and `deliverWait` is 30s so `openCall` + delivery stays under the 120s past which the client detaches the call.
- A delivery that fails is reported beside the opened session, not as a failed call: the session exists either way, and an error would leave an agent that opened three workers believing it has none.

`lich open --prompt` was left out on purpose: `--json` would have to carry two shapes in one stream, and every provider without the tools already has the two-command path the briefing names.

## Test plan

- [x] `go test ./...` green (exit code read directly, not through a pipe); `gofmt -l .` and `go vet ./...` clean.
- [x] Cross-compile loop for linux/darwin/windows — build and vet.
- [x] New: who gets a briefing and who does not; that its wording follows the registration; that `open_session` hands the task over with the right session, project and wait; that a failed delivery keeps the session.
- [x] Six spawn tests that pinned argv positionally now assert through `spawnPins`, which drops the briefing — each of them owns one flag of its own, and the briefing's wording is pinned once.
- [x] The effect itself — an agent asked to fan work out reaching for lich — is a judgement call in a live session, not something a test can hold.