### PR TITLE
feat: the session roster says what each session is doing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The session roster says what each session is doing.** `lich sessions` grew a
+  `state` column and the `list_sessions` tool a `state` field, carrying what that
+  session last reported: `busy` mid-turn, `done` at a prompt and free, and
+  `waiting` — blocked on a permission prompt only a human can answer. That last
+  one is the point: work handed to a waiting session sits behind that prompt
+  unread for as long as nobody is at the screen, so an agent reading the roster
+  now knows to tell you rather than send into it. Only the providers whose
+  companion plugin reports state have one at all, so a session that reported
+  nothing shows `-` (`""` in `--json`), which means "not reported" and never
+  "idle".
+
 - **Asking for work to be fanned out opens lich sessions, not invisible
   subagents.** Every coding agent lich runs also has subagents of its own, and
   its harness describes those to it at length, from its first turn — so "spin

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -94,19 +94,34 @@ object exactly as this document describes them. An empty roster is `[]`, never
 ### `lich sessions [--json]`
 
 Lists the live sessions the caller can address, tab-separated with a header.
-The last column is the peer-roster name — both names reach a session, and a
-surface that showed only one is what once made an agent treat a single session
-as two. It rides last so a script reading the first columns keeps working:
+The peer-roster name is there because both names reach a session, and a surface
+that showed only one is what once made an agent treat a single session as two.
+New columns are appended rather than inserted, so a script reading the first
+ones keeps working:
 
 ```
-session	project	provider	name
-docs	lich	codex	lich-a1b2
-api	revu	crush	revu-9f8e
+session	project	provider	name	state
+docs	lich	codex	lich-a1b2	busy
+api	revu	crush	revu-9f8e	-
 ```
 
 `No other live sessions.` when there are none. A session is listed only while a
 process is running in it: a card whose terminal was never opened has nothing to
 type at.
+
+The `state` column is what that session last reported through the session-state
+hook (`docs/hooks/session-state.md`), and it is the same thing its card shows:
+
+- `busy` — mid-turn. A message sent now is queued and read when the turn ends.
+- `done` — the turn ended. The session is at a prompt and free.
+- `waiting` — **blocked on a human.** The agent hit a permission prompt and
+  nothing there can move until someone answers it, so this session cannot pick
+  up work at all: say so to the user instead of sending into it. What was typed
+  would sit behind the prompt, unread, for as long as nobody is at that screen.
+- `-` (`""` in `--json`) — **not reported**, which is not the same as idle.
+  Only providers whose companion plugin reports state have one at all (Crush
+  reports none, and a session that has not had a turn yet has said nothing
+  either), so an empty state says nothing about whether that session is free.
 
 ### `lich send [--project <name>] [--timeout <seconds>] <session> <prompt>`
 
@@ -295,7 +310,7 @@ at lich.
 
 | Tool | What it does |
 |------|--------------|
-| `list_sessions` | The live sessions that can be given work, as JSON. |
+| `list_sessions` | The live sessions that can be given work, as JSON — each with the state it last reported, `waiting` among them. |
 | `send_to_session` | `session`, `prompt`, optional `project` and `timeout_seconds`. |
 | `wait_for_answer` | optional `ticket` and `timeout_seconds` — with a ticket, `lich wait <ticket>`; without one, the collect: everything ready at once. |
 | `reply_to_session` | `ticket`, `answer` — what a relayed message asks for. |

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -221,15 +221,26 @@ func (c *client) sessions(args []string) error {
 		fmt.Fprintln(c.stdout, "No other live sessions.")
 		return nil
 	}
-	// The roster name rides last so a script reading the first columns keeps
-	// working. It has to be here at all: both names reach a session, and a
-	// surface that shows only one is what once made an agent treat a single
-	// session as two.
-	fmt.Fprintln(c.stdout, "session\tproject\tprovider\tname")
+	// New columns are appended, never inserted, so a script reading the first
+	// ones keeps working. The roster name has to be here at all: both names
+	// reach a session, and a surface that shows only one is what once made an
+	// agent treat a single session as two.
+	fmt.Fprintln(c.stdout, "session\tproject\tprovider\tname\tstate")
 	for _, p := range peers {
-		fmt.Fprintf(c.stdout, "%s\t%s\t%s\t%s\n", p.Label, p.Project, p.Kind, p.Name)
+		fmt.Fprintf(c.stdout, "%s\t%s\t%s\t%s\t%s\n", p.Label, p.Project, p.Kind, p.Name, sessionState(p.State))
 	}
 	return nil
+}
+
+// sessionState words a peer's state for the table. A session that has reported
+// nothing gets a dash rather than a blank cell: the column is never empty by
+// accident, and "not reported" is a different thing from a session sitting
+// idle — only the providers whose plugin reports state have one at all.
+func sessionState(state string) string {
+	if state == "" {
+		return "-"
+	}
+	return state
 }
 
 func (c *client) send(args []string) error {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -145,7 +145,7 @@ func TestHelpPrintsEveryCommand(t *testing.T) {
 }
 
 func TestSessionsListsPeers(t *testing.T) {
-	f := newFakeLich(t, `[{"label":"docs","name":"lich-s2","project":"lich","kind":"codex"},
+	f := newFakeLich(t, `[{"label":"docs","name":"lich-s2","project":"lich","kind":"codex","state":"waiting"},
 	                      {"label":"api","name":"revu-s5","project":"revu","kind":"crush"}]`)
 
 	code, stdout, stderr := run(t, f, "sessions")
@@ -164,8 +164,9 @@ func TestSessionsListsPeers(t *testing.T) {
 		t.Errorf("args = %v, want the caller's own session id", call.args)
 	}
 	// Both names travel: a surface that shows only one is what once made an
-	// agent treat a single session as two.
-	for _, want := range []string{"docs\tlich\tcodex\tlich-s2", "api\trevu\tcrush\trevu-s5"} {
+	// agent treat a single session as two. The state travels with them, and a
+	// provider that reports none gets a dash — "not reported", never idle.
+	for _, want := range []string{"docs\tlich\tcodex\tlich-s2\twaiting", "api\trevu\tcrush\trevu-s5\t-"} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("output is missing %q:\n%s", want, stdout)
 		}
@@ -561,7 +562,7 @@ func TestTheRuntimeFileFailureIsReported(t *testing.T) {
 }
 
 func TestJSONOutputIsMachineReadable(t *testing.T) {
-	peers := newFakeLich(t, `[{"label":"docs","project":"lich","kind":"codex"}]`)
+	peers := newFakeLich(t, `[{"label":"docs","project":"lich","kind":"codex","state":"waiting"}]`)
 	code, stdout, stderr := run(t, peers, "sessions", "--json")
 	if code != 0 {
 		t.Fatalf("exit = %d, stderr = %q", code, stderr)
@@ -572,6 +573,11 @@ func TestJSONOutputIsMachineReadable(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].Label != "docs" {
 		t.Errorf("peers = %+v", got)
+	}
+	// The state is what a script decides on — a waiting session is blocked on a
+	// human and can pick nothing up — so it has to survive the round trip.
+	if got[0].State != "waiting" {
+		t.Errorf("state = %q, want waiting", got[0].State)
 	}
 
 	answered := newFakeLich(t, `{"ticket":"a1b2c3d4","target":"docs","status":"answered","answer":"3 failures"}`)

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -290,7 +290,13 @@ var mcpTools = []mcpTool{
 	{
 		Name: "list_sessions",
 		Description: "List the other lich sessions that are live right now and can be given work. " +
-			"Returns each session's label (how it is addressed), its project, and which agent runs in it.",
+			"Returns each session's label (how it is addressed), its project, which agent runs " +
+			"in it, and the state it last reported: `busy` is mid-turn, `done` finished its turn " +
+			"and is free, and `waiting` is blocked on a human — a permission prompt nobody has " +
+			"answered, so that session can take nothing on until someone does. Tell the user a " +
+			"session is waiting instead of sending work into it. An empty state is not reported: " +
+			"only some providers report at all, so it says nothing about whether that session is " +
+			"free.",
 		Schema:   schema(map[string]any{}),
 		ReadOnly: true,
 		Run: func(c *client, _ mcpArgs) (string, error) {

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -368,7 +368,8 @@ func TestMCPWaitWithATicketWaitsOnIt(t *testing.T) {
 }
 
 func TestMCPListSessionsReturnsThemAsJSON(t *testing.T) {
-	f := newFakeLich(t, `[{"label":"docs","project":"lich","kind":"codex"}]`)
+	f := newFakeLich(t, `[{"label":"docs","project":"lich","kind":"codex","state":"waiting"},
+	                      {"label":"api","project":"lich","kind":"crush"}]`)
 
 	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
 		{"name":"list_sessions","arguments":{}}}`)
@@ -379,12 +380,19 @@ func TestMCPListSessionsReturnsThemAsJSON(t *testing.T) {
 	}
 	var peers []struct {
 		Label string `json:"label"`
+		State string `json:"state"`
 	}
 	if err := json.Unmarshal([]byte(text), &peers); err != nil {
 		t.Fatalf("list_sessions did not return JSON: %v (%q)", err, text)
 	}
-	if len(peers) != 1 || peers[0].Label != "docs" {
-		t.Errorf("peers = %+v", peers)
+	if len(peers) != 2 || peers[0].Label != "docs" {
+		t.Fatalf("peers = %+v", peers)
+	}
+	// An orchestrator reads the state to decide where work can go: waiting means
+	// blocked on a human, and a provider that reports nothing carries an empty
+	// state rather than one that reads as free.
+	if peers[0].State != "waiting" || peers[1].State != "" {
+		t.Errorf("states = %q, %q, want waiting and an empty one", peers[0].State, peers[1].State)
 	}
 }
 

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -165,18 +165,25 @@ type Terminal interface {
 
 // Peer is one session a caller may address: the label it is addressed by, the
 // name it answers to in Claude Code's peer roster, the project it belongs to
-// (labels are unique within a project, not across them), and what is running in
-// it.
+// (labels are unique within a project, not across them), what is running in it,
+// and what that session last reported it was doing.
 //
 // Both names are published because both reach this session and an agent sees
 // them in different places — the label on the card, the roster name in
 // `/list-agents` and in what a mention writes at a prompt. Showing one and
 // accepting the other is what made an agent treat a single session as two.
+//
+// State is stateBusy, stateWaiting or stateDone, and empty when the session has
+// reported nothing — which is a provider whose plugin does not report state as
+// much as a session that has not had a turn yet. Empty is "not known", never
+// "idle": guessing the second is how a caller ends up sending work into a
+// session that cannot take it.
 type Peer struct {
 	Label   string `json:"label"`
 	Name    string `json:"name"`
 	Project string `json:"project"`
 	Kind    string `json:"kind"`
+	State   string `json:"state"`
 }
 
 // Result is what a caller gets back from Send or Wait. Answer is empty unless
@@ -251,6 +258,12 @@ type Service struct {
 	// about appear; an unknown one is treated as not working, which is what a
 	// session with no hooks installed looks like.
 	state map[string]string
+	// reported is what each session last said out loud, which is what the roster
+	// publishes. It is not s.state: that one answers "is a turn running", and
+	// there a waiting mid-turn has to keep reading as busy (see Observe). Here
+	// waiting has to read as waiting — it is the one state that means a caller
+	// must not send work in at all.
+	reported map[string]string
 	// ready is the inbox: finished errands waiting to be collected, keyed by
 	// ticket so a Wait on the original ticket still finds its outcome.
 	ready map[string]*inboxEntry
@@ -308,6 +321,7 @@ func New(sessions Sessions, term Terminal, events Events) *Service {
 	return &Service{
 		tickets:       make(map[string]*ticket),
 		state:         make(map[string]string),
+		reported:      make(map[string]string),
 		ready:         make(map[string]*inboxEntry),
 		collectors:    make(map[string][]chan struct{}),
 		nudgeTimer:    make(map[string]*time.Timer),
@@ -720,6 +734,14 @@ func (s *Service) Observe(sessionID, state string) {
 		delete(s.state, sessionID)
 	default:
 		s.state[sessionID] = state
+	}
+	// The roster publishes the report itself rather than the turn state above:
+	// waiting is exactly what a caller has to see, and idle drops the row for
+	// the same reason it does there — an ended session reports nothing more.
+	if state == stateIdle {
+		delete(s.reported, sessionID)
+	} else {
+		s.reported[sessionID] = state
 	}
 
 	type endedErrand struct {

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -273,6 +273,43 @@ func TestPeersListsLiveSessionsWithoutTheCaller(t *testing.T) {
 	}
 }
 
+// The roster carries what each session last said it was doing. waiting is the
+// one that has to travel intact: mid-turn it is a permission prompt stuck on a
+// human, so a caller reading the roster must see that rather than a session it
+// can hand work to. A session that reported nothing carries no state at all —
+// never "idle", which would read as free.
+func TestPeersCarryTheStateEachSessionReported(t *testing.T) {
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2", "s3", "s5"), nil)
+
+	svc.Observe("s2", "busy")
+	svc.Observe("s2", "waiting")
+	svc.Observe("s3", "done")
+
+	peers, err := svc.Peers("s1")
+	if err != nil {
+		t.Fatalf("Peers: %v", err)
+	}
+	want := map[string]string{"lich-s2": "waiting", "lich-s3": "done", "revu-s5": ""}
+	if len(peers) != len(want) {
+		t.Fatalf("got %d peers %+v, want %d", len(peers), peers, len(want))
+	}
+	for _, p := range peers {
+		if p.State != want[p.Name] {
+			t.Errorf("%s state = %q, want %q", p.Name, p.State, want[p.Name])
+		}
+	}
+
+	// And the roster's view of waiting did not become the delivery's: a message
+	// handed to a session mid-permission-prompt still queues behind the turn it
+	// is in, which is what the turn state answers for.
+	svc.mu.Lock()
+	turn := svc.state["s2"]
+	svc.mu.Unlock()
+	if turn != stateBusy {
+		t.Errorf("turn state = %q, want %q — waiting mid-turn is still a turn", turn, stateBusy)
+	}
+}
+
 func TestPeersReportsAStoreFailure(t *testing.T) {
 	svc := newRelay(fakeSessions{err: errors.New("database is locked")}, newFakeTerminal(), nil)
 
@@ -1315,9 +1352,15 @@ func TestAnEndedSessionLeavesNoStateBehind(t *testing.T) {
 
 	svc.mu.Lock()
 	_, kept := svc.state["s2"]
+	_, published := svc.reported["s2"]
 	svc.mu.Unlock()
 	if kept {
 		t.Error("a session that ended still holds a row in the state map")
+	}
+	// Same for what the roster publishes: an ended session is gone, and a stale
+	// "busy" beside it would read as work in progress forever.
+	if published {
+		t.Error("a session that ended still reports a state to the roster")
 	}
 }
 

--- a/internal/relay/roster.go
+++ b/internal/relay/roster.go
@@ -43,11 +43,21 @@ func (s *Service) roster(fromID string) ([]candidate, error) {
 					Name:    RosterName(cwd, sess.ID),
 					Project: p.Name,
 					Kind:    sess.Kind,
+					State:   s.reportedState(sess.ID),
 				},
 			})
 		}
 	}
 	return found, nil
+}
+
+// reportedState is what a session last told lich it was doing, empty when it
+// has told lich nothing. Taken under the lock because reports arrive on the
+// hook handler's own goroutines while a roster is being built.
+func (s *Service) reportedState(id string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.reported[id]
 }
 
 // resolve finds the single live session named by target, optionally narrowed to


### PR DESCRIPTION
## What

`relay.Peer` now carries the state each session last reported, and both callers surface it:

- `lich sessions` grew a `state` column — appended after `name`, so a script reading the first columns keeps working. A session that reported nothing prints `-`.
- `list_sessions` (MCP) returns a `state` field; `--json` on the CLI carries the same one, empty when nothing was reported.

States are the ones the session-state hook contract already defines: `busy`, `done`, `waiting`.

## Why `waiting` is the point

Mid-turn, `waiting` is a permission prompt stuck on a human. A task typed at that prompt sits behind it, unread, for as long as nobody is at that screen — so a session in that state cannot pick work up at all. The tool description and `docs/cli.md` word it so an orchestrator tells the user rather than sending into it.

## Report vs turn state

The relay already tracked a state map, but that one answers "is a turn running": `waiting` there deliberately keeps reading as `busy`, because a delivery mid-permission-prompt queues behind the turn in progress, and reading it as free would arm the receipt check against a target that cannot pick anything up. The roster needs the opposite. So the report is kept beside it (`Service.reported`) rather than folded into it — the two disagree exactly where it matters, and both are right about their own question.

An absent state is "not reported", never "idle": only providers whose companion plugin reports state have one (Crush reports none), and a session that has not had a turn yet has said nothing either. `docs/cli.md` says so.

## Test plan

- `TestPeersCarryTheStateEachSessionReported` — states travel, an unreported session carries none, and the roster's `waiting` did not overwrite the delivery's turn state.
- `TestAnEndedSessionLeavesNoStateBehind` — `idle` drops the published row too, so no stale `busy` outlives a session.
- CLI: the table column (`waiting` and the `-`) and the `--json` round trip.
- MCP: `list_sessions` carries the field, empty for a provider that reports nothing.
- Local gate green: `gofmt -l .`, `go vet ./...`, `go test ./...` (relay + cli also under `-race`).

CHANGELOG `[Unreleased]` entry ships here. Two sibling branches are open, so expect a CHANGELOG conflict at merge — rebase.