### PR TITLE
feat: lich open can hand the new session its task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nothing shows `-` (`""` in `--json`), which means "not reported" and never
   "idle".
 
+- **`lich open` can hand the new session its task.** `--prompt "<task>"` opens a
+  session and gives it that task in one command, which is what the `open_session`
+  tool has been doing and the command line could not. It matters for the agents
+  that reach lich through a shell rather than through tools — opencode, Crush,
+  anything spawned without lich's MCP server — where fanning work out cost two
+  commands per worker, and the second one was the one an agent forgot. The task
+  is queued for a worker still running its setup script, exactly as `lich send`
+  queues one, and the outcome is printed under the session's own lines in the
+  words `send` uses, ticket included. `--json` still prints one object: the
+  session, plus a `delivery` key with the send's result when a task came with it.
+
 - **Asking for work to be fanned out opens lich sessions, not invisible
   subagents.** Every coding agent lich runs also has subagents of its own, and
   its harness describes those to it at length, from its first turn — so "spin

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -89,7 +89,8 @@ on stderr, exiting 0 or 1. Anything that is not a subcommand below — including
 `--json` on `sessions`, `send`, `wait`, `open`, `close` and `worktrees` replaces
 the prose with one JSON line: the peer array, the result object and the session
 object exactly as this document describes them. An empty roster is `[]`, never
-`null` — a script should not have to tell those apart.
+`null` — a script should not have to tell those apart. One line is the contract:
+`open --prompt` does two things and still prints one object (see below).
 
 ### `lich sessions [--json]`
 
@@ -215,7 +216,7 @@ This is what a relayed message asks the receiving agent to run. An answer is
 capped at 64 KiB. Replying twice to one ticket is an error — the first answer
 already went home.
 
-### `lich open [--project <name>] [--kind <provider>] [--worktree <branch>] [--base <branch>] [--model <model>]`
+### `lich open [--project <name>] [--kind <provider>] [--worktree <branch>] [--base <branch>] [--model <model>] [--prompt <task>]`
 
 Opens a new session, starts it, and prints the two names it is addressed by:
 
@@ -252,8 +253,35 @@ It answers to "auth-fix" and to "auth-fix-9f8e". Its agent may still be starting
   for it would silently give you a session on the default. The model is
   recorded on the session, so every later spawn of it — a page reload, a
   respawn, the resume of a parked worktree session — starts on the same model.
+- `--prompt` hands the new session that task as soon as its agent is up, so
+  opening a worker *for* a task is one command rather than `open` then `send`.
+  It is the same delivery `lich send` makes — a worker still running its setup
+  script is queued for, not written to — with the wait fixed at **20 seconds**
+  and no flag to raise it: the worker was created a moment ago and its task is
+  minutes of work, so a ticket is the expected outcome and the caller carries
+  on. Waiting for the answer is `lich wait`'s job, and it takes the timeout.
 - A session without a worktree is labelled from the project's own counter
   (`Session 4`), continuing the numbering the window uses.
+
+With `--prompt` the hand-off is printed under the session's own lines, in the
+words `send` words it with, ticket included:
+
+```
+Opened session "auth-fix" (claude) in project "lich", in worktree /home/you/.local/share/lich/worktrees/1a2b/auth-fix.
+It answers to "auth-fix" and to "auth-fix-9f8e". …
+auth-fix is still working. The message was delivered; a note will be typed at the
+sending session's prompt when its result is ready. To hold the line for it instead:
+  lich wait a1b2c3d4
+```
+
+`--json` prints **one object** either way: the session exactly as above, plus a
+`delivery` key carrying the same result object `send --json` prints. The key is
+absent without `--prompt`, so a reader that branches on it is never handed an
+empty one to interpret:
+
+```json
+{"id":"9f8e","projectId":"p1","project":"lich","label":"auth-fix","name":"auth-fix-9f8e","kind":"claude","path":"/wt/auth-fix","nextSeq":5,"delivery":{"ticket":"a1b2c3d4","target":"auth-fix","status":"pending","answer":""}}
+```
 
 The card appears in the sidebar **without taking focus** — nobody in front of
 the window asked for this session — and its PTY is started by lich itself rather
@@ -265,6 +293,12 @@ Failure is one line on stderr and exit 1. A worktree that could not be created
 leaves nothing behind — no row, no card. A session whose *terminal* failed to
 start keeps both, and says so, because the card is the only place its error can
 be read.
+
+**A `--prompt` that never reached the session does not undo the open.** The
+session is printed as usual — prose or JSON, on stdout — and the failure is that
+same `lich: …` line and exit 1, naming the `lich send` that tries again. The
+`delivery` key stays absent rather than growing a shape for the failure: what
+went wrong is one send, and the exit code is what says so.
 
 ### `lich close [--project <name>] [--worktree keep|remove] [--force] [--json] <session>`
 
@@ -324,7 +358,7 @@ at lich.
 | `send_to_session` | `session`, `prompt`, optional `project` and `timeout_seconds`. |
 | `wait_for_answer` | optional `ticket` and `timeout_seconds` — with a ticket, `lich wait <ticket>`; without one, the collect: everything ready at once. |
 | `reply_to_session` | `ticket`, `answer` — what a relayed message asks for. |
-| `open_session` | optional `project`, `kind`, `worktree`, `base`, `model` — `lich open` — plus optional `prompt`, which hands the new session that task in the same call (`lich open` then `lich send`, in one). |
+| `open_session` | optional `project`, `kind`, `worktree`, `base`, `model` — `lich open` — plus optional `prompt` — `lich open --prompt`, the same hand-off in the same call. |
 | `close_session` | `session`, optional `project`, `worktree` (`keep`/`remove`), `force`. |
 | `list_worktrees` | optional `project` — the checkouts, as JSON. |
 

--- a/frontend/src/lib/session/delegate-prompt.test.ts
+++ b/frontend/src/lib/session/delegate-prompt.test.ts
@@ -33,11 +33,14 @@ describe("delegateWorktreePrompt", () => {
     expect(delegateWorktreePrompt("codex")).toBe("Delegate to a new worktree session: ")
   })
 
-  it("names both commands for every other sender — nothing else would", () => {
+  it("names the one command for every other sender — nothing else would", () => {
     for (const kind of ["opencode", "crush", "omp", "shell", "something-new"]) {
       const prompt = delegateWorktreePrompt(kind)
       expect(prompt).toContain("lich open --worktree")
-      expect(prompt).toContain("lich send")
+      // Opening and handing over is one command now, so sending the agent to a
+      // second one would spend a turn it no longer needs.
+      expect(prompt).toContain("--prompt")
+      expect(prompt).not.toContain("lich send")
       expect(prompt.endsWith(": ")).toBe(true)
     }
   })

--- a/frontend/src/lib/session/delegate-prompt.ts
+++ b/frontend/src/lib/session/delegate-prompt.ts
@@ -46,16 +46,15 @@ export function delegatePrompt(senderKind: SessionKind | string, target: string)
  * opens a worktree session and hands it the task, picking the branch name
  * itself — it knows the task, and the user typed only the task.
  *
- * Prose for every kind, because a two-command errand cannot be one fill-in
- * command the way `lich send` can. A sender without lich's tools is told the
- * commands by name — nothing else would tell it they exist.
+ * Prose for every kind, because the branch name is the agent's to pick and it
+ * sits before the task in the command — so this cannot be one fill-in command
+ * the way `lich send` can, even now that one command carries both. A sender
+ * without lich's tools is told the command by name — nothing else would tell it
+ * it exists.
  */
 export function delegateWorktreePrompt(senderKind: SessionKind | string): string {
   if (TOOL_KINDS.includes(senderKind)) {
     return "Delegate to a new worktree session: "
   }
-  return (
-    "Delegate to a new worktree session (run `lich open --worktree <branch>`, " +
-    "then `lich send` the task to the session it opens): "
-  )
+  return "Delegate to a new worktree session (run `lich open --worktree <branch> --prompt <task>`): "
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -64,6 +64,23 @@ const shortCall = 10 * time.Second
 // surfaces.
 const openCall = 60 * time.Second
 
+// deliverWait bounds holding the line when a task is handed to a session that
+// was opened a moment ago.
+//
+// It is not a wait for an answer, and no longer a wait for the session to come
+// up either: a task sent to a session that is still running its worktree setup
+// script is queued and delivered when its agent is there (relay.queueDelivery).
+// The worker was created seconds ago and its task is minutes of work, so a
+// ticket is the expected outcome and the sender carries on.
+//
+// The number is what is left of an MCP call's budget, and the command line
+// shares it rather than growing a timeout of its own: opening can spend openCall
+// (60s) before this starts, and the client detaches anything still running at
+// 120s (see mcpMaxWait) — so the delivery gets 20, plus the callSlack the HTTP
+// timeout adds for the trip back, and the worst case lands at 110 rather than
+// on the line.
+const deliverWait = 20
+
 const usage = `lich talks to the sessions open in the running lich window.
 
   lich sessions [--json]
@@ -83,11 +100,13 @@ const usage = `lich talks to the sessions open in the running lich window.
       relayed message asks you to run when you are done.
 
   lich open [--project <name>] [--kind <provider>] [--worktree <branch>]
-            [--base <branch>] [--model <model>] [--json]
+            [--base <branch>] [--model <model>] [--prompt <task>] [--json]
       Open a new session and start it. --worktree creates a git worktree of
       that branch name first and roots the session in it. --model runs the
-      provider on that model, in the provider's own spelling. Prints the name
-      the new session is addressed by.
+      provider on that model, in the provider's own spelling. --prompt hands
+      the new session that task as soon as its agent is up, so opening a
+      worker for a task is one command rather than two. Prints the name the
+      new session is addressed by.
 
   lich close [--project <name>] [--worktree keep|remove] [--force] [--json] <session>
       Close a session. Closing the last one in a worktree needs --worktree to
@@ -315,6 +334,7 @@ func (c *client) open(args []string) error {
 	worktree := flags.String("worktree", "", "branch name of a new git worktree to root the session in")
 	base := flags.String("base", "", "branch the worktree starts from; defaults to the project's current branch")
 	model := flags.String("model", "", "model the provider runs, in the provider's own spelling")
+	prompt := flags.String("prompt", "", "task to hand the new session as soon as its agent is up")
 	asJSON := flags.Bool("json", false, "print the result as JSON")
 	if err := flags.Parse(args); err != nil {
 		return err
@@ -322,7 +342,7 @@ func (c *client) open(args []string) error {
 	if flags.NArg() != 0 {
 		return fmt.Errorf(
 			"usage: lich open [--project <name>] [--kind <provider>] [--worktree <branch>] " +
-				"[--base <branch>] [--json]")
+				"[--base <branch>] [--model <model>] [--prompt <task>] [--json]")
 	}
 
 	var opened spawn.Session
@@ -330,11 +350,63 @@ func (c *client) open(args []string) error {
 	if err := c.call("spawn.Open", call, openCall, &opened); err != nil {
 		return err
 	}
+	delivered, failure := c.handOff(opened, *prompt)
 	if *asJSON {
-		return c.emit(opened)
+		if err := c.emit(opening{Session: opened, Delivery: delivered}); err != nil {
+			return err
+		}
+		return failure
 	}
 	fmt.Fprint(c.stdout, openedText(opened))
-	return nil
+	if failure != nil {
+		return failure
+	}
+	if delivered == nil {
+		return nil
+	}
+	return c.report(*delivered, false)
+}
+
+// opening is what `lich open --json` prints. The session's fields stay at the
+// top level, where every reader of this command has always found them, and the
+// hand-off rides beside them under one key — absent unless --prompt asked for
+// one. Two objects, or two lines, would make a script tell the flags apart
+// before it could read the output; --json promises one line and one shape.
+//
+// A hand-off that failed leaves the key absent and exits non-zero: the session
+// is real and printing it is the point, but a script that read exit 0 would
+// believe the task landed.
+type opening struct {
+	spawn.Session
+	Delivery *relay.Result `json:"delivery,omitempty"`
+}
+
+// handOff gives a just-opened session its first task, and nothing at all when
+// no task came with it. The failure it returns names the session, because the
+// session outlives it: what went wrong is one send, not the open.
+func (c *client) handOff(opened spawn.Session, prompt string) (*relay.Result, error) {
+	if prompt == "" {
+		return nil, nil
+	}
+	result, err := c.deliver(opened, prompt)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"the session is open, but the task did not reach it: %w — hand it the task with "+
+				"`lich send %q '<task>'` once whatever that says is dealt with",
+			err, opened.Label,
+		)
+	}
+	return &result, nil
+}
+
+// deliver hands a just-opened session its first task, on both surfaces: the
+// command line's --prompt and the open_session tool's, which differ in how they
+// word the outcome and in nothing else.
+func (c *client) deliver(opened spawn.Session, prompt string) (relay.Result, error) {
+	var result relay.Result
+	call := []any{c.sessionID(), opened.Label, opened.Project, prompt, deliverWait}
+	err := c.call("relay.Send", call, waitBudget(deliverWait), &result)
+	return result, err
 }
 
 // openedText words a new session for whoever asked for one. It names both of

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -678,6 +678,125 @@ func TestOpenJSONIsMachineReadable(t *testing.T) {
 	if opened.Label != "auth-fix" || opened.Name != "auth-fix-9f8e" || opened.Path != "/wt/auth-fix" {
 		t.Errorf("opened = %+v", opened)
 	}
+	// Nothing was handed over, so nothing is reported: a reader that branches on
+	// the key must not find an empty one to interpret.
+	if strings.Contains(stdout, "delivery") {
+		t.Errorf("an open with no --prompt carries a delivery:\n%s", stdout)
+	}
+}
+
+// The whole point of the flag: opening a worker for a task is one command
+// rather than two, exactly as the open_session tool has been.
+func TestOpenHandsOverTheTaskItCameWith(t *testing.T) {
+	f := newFakeLich(t, openedBody)
+	f.answers = map[string]answer{
+		"relay.Send": {status: 200, body: `{"ticket":"a1b2c3d4","target":"auth-fix","status":"pending"}`},
+	}
+
+	code, stdout, stderr := run(t, f, "open", "--worktree", "auth-fix", "--prompt", "port the parser")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+
+	if len(f.calls) != 2 || f.calls[0].method != "spawn.Open" || f.calls[1].method != "relay.Send" {
+		t.Fatalf("calls = %+v, want spawn.Open then relay.Send", f.calls)
+	}
+	// The new session is addressed by the label lich just gave it, in its own
+	// project — the caller cannot have been told either one yet. The wait is
+	// spelled out rather than read from deliverWait, which could be raised past
+	// what the surfaces sharing it allow with the suite still green.
+	want := []any{"s1", "auth-fix", "lich", "port the parser", float64(20)}
+	if len(f.calls[1].args) != len(want) {
+		t.Fatalf("send args = %v, want %v", f.calls[1].args, want)
+	}
+	for i := range want {
+		if f.calls[1].args[i] != want[i] {
+			t.Errorf("send argument %d = %v, want %v", i, f.calls[1].args[i], want[i])
+		}
+	}
+	// Both halves are reported: the session's names, then what became of the
+	// task — and the next step is this command line's own, not the tool's.
+	for _, phrase := range []string{`"auth-fix-9f8e"`, "lich wait a1b2c3d4"} {
+		if !strings.Contains(stdout, phrase) {
+			t.Errorf("output is missing %q:\n%s", phrase, stdout)
+		}
+	}
+}
+
+func TestOpenJSONCarriesTheHandOffBesideTheSession(t *testing.T) {
+	f := newFakeLich(t, openedBody)
+	f.answers = map[string]answer{
+		"relay.Send": {status: 200, body: `{"ticket":"a1b2c3d4","target":"auth-fix","status":"pending"}`},
+	}
+
+	code, stdout, stderr := run(t, f, "open", "--json", "--worktree", "auth-fix", "--prompt", "port the parser")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+
+	if lines := strings.Count(strings.TrimSpace(stdout), "\n"); lines != 0 {
+		t.Fatalf("--json printed %d extra lines — the contract is one line:\n%s", lines, stdout)
+	}
+	var got struct {
+		spawn.Session
+		Delivery *relay.Result `json:"delivery"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("open --json is not JSON: %v (%q)", err, stdout)
+	}
+	// The session's fields stay where a reader of this command has always found
+	// them; only the hand-off is new, and it is under one key.
+	if got.Label != "auth-fix" || got.Name != "auth-fix-9f8e" {
+		t.Errorf("session = %+v", got.Session)
+	}
+	if got.Delivery == nil {
+		t.Fatalf("no delivery reported for a task that was handed over:\n%s", stdout)
+	}
+	if got.Delivery.Ticket != "a1b2c3d4" || got.Delivery.Status != "pending" {
+		t.Errorf("delivery = %+v", got.Delivery)
+	}
+}
+
+// The session outlives a delivery that failed, so it is still printed — but the
+// exit code has to say the task did not land, or a script reading 0 believes it
+// did.
+func TestOpenKeepsTheSessionWhenTheTaskDoesNotLand(t *testing.T) {
+	f := newFakeLich(t, openedBody)
+	f.answers = map[string]answer{
+		"relay.Send": {status: 500, body: `{"error":"the setup script is still running"}`},
+	}
+
+	code, stdout, stderr := run(t, f, "open", "--worktree", "auth-fix", "--prompt", "port the parser")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 — the task never reached the session", code)
+	}
+	if !strings.Contains(stdout, `"auth-fix"`) {
+		t.Errorf("the session that was opened is not reported:\n%s", stdout)
+	}
+	for _, phrase := range []string{"the setup script is still running", `lich send "auth-fix"`} {
+		if !strings.Contains(stderr, phrase) {
+			t.Errorf("stderr is missing %q:\n%s", phrase, stderr)
+		}
+	}
+
+	// In JSON the same failure leaves the key absent rather than inventing a
+	// shape for it: the reader branches on the exit code, then on the key.
+	asJSON := newFakeLich(t, openedBody)
+	asJSON.answers = f.answers
+	code, stdout, _ = run(t, asJSON, "open", "--json", "--worktree", "auth-fix", "--prompt", "port the parser")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	var got map[string]any
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("open --json is not JSON: %v (%q)", err, stdout)
+	}
+	if got["label"] != "auth-fix" {
+		t.Errorf("the session that was opened is not in the JSON: %v", got)
+	}
+	if _, reported := got["delivery"]; reported {
+		t.Errorf("a delivery that failed is reported as one: %v", got)
+	}
 }
 
 func TestOpenReportsTheAppsRefusal(t *testing.T) {

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -494,22 +494,6 @@ var mcpTools = []mcpTool{
 	},
 }
 
-// deliverWait bounds holding the line when a task is handed to a session that
-// was opened a moment ago.
-//
-// It is not a wait for an answer, and no longer a wait for the session to come
-// up either: a task sent to a session that is still running its worktree setup
-// script is queued and delivered when its agent is there (relay.queueDelivery).
-// The worker was created seconds ago and its task is minutes of work, so a
-// ticket is the expected outcome and the sender carries on.
-//
-// The number is what is left of the call's budget. Opening can spend openCall
-// (60s) before this starts, and the client detaches anything still running at
-// 120s (see mcpMaxWait) — so the delivery gets 20, plus the callSlack the HTTP
-// timeout adds for the trip back, and the worst case lands at 110 rather than
-// on the line.
-const deliverWait = 20
-
 // handOver gives a just-opened session its first task, wording the outcome the
 // way send_to_session words it — the caller should not have to learn two
 // spellings of one answer.
@@ -519,9 +503,8 @@ const deliverWait = 20
 // nothing had happened — leaving an agent that opens three workers convinced it
 // has none.
 func (c *client) handOver(opened spawn.Session, prompt string) string {
-	var result relay.Result
-	call := []any{c.sessionID(), opened.Label, opened.Project, prompt, deliverWait}
-	if err := c.call("relay.Send", call, waitBudget(deliverWait), &result); err != nil {
+	result, err := c.deliver(opened, prompt)
+	if err != nil {
 		return fmt.Sprintf(
 			"The task did not reach it: %v. The session is open, so hand it the task with "+
 				"send_to_session once whatever that says is dealt with.",

--- a/internal/relay/compose.go
+++ b/internal/relay/compose.go
@@ -40,8 +40,8 @@ import (
 // CommandLineToArgvW, cmd.exe does not read that as an escape, and the < and >
 // left outside quotes by it are redirection.
 func SpawnBriefing(hasTools bool) string {
-	route := "Open one with `lich open --worktree BRANCH`, then hand it the task with " +
-		"`lich send SESSION 'the task'`."
+	route := "Open one with `lich open --worktree BRANCH --prompt 'the task'`, which opens the " +
+		"session and hands it the task in one command."
 	if hasTools {
 		route = "The lich tools in your list open one and hand it the task."
 	}

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -2218,7 +2218,10 @@ func TestSpawnBriefingNamesTheRouteThisSpawnGave(t *testing.T) {
 	if !strings.Contains(withTools, "tools in your list") {
 		t.Errorf("the tool route is missing:\n%s", withTools)
 	}
-	for _, want := range []string{"lich open --worktree", "lich send"} {
+	// One command, not two: the tool route opens a worker and hands it the task
+	// in one call, and a command route that cost two is what made the harness's
+	// own subagents the cheaper thing to reach for.
+	for _, want := range []string{"lich open --worktree", "--prompt"} {
 		if !strings.Contains(withCommand, want) {
 			t.Errorf("the command route is missing %q:\n%s", want, withCommand)
 		}


### PR DESCRIPTION
`lich open --prompt "<task>"` opens a session and hands it that task in one
command — what the `open_session` MCP tool has been doing since it grew a
`prompt`, and what the command line could not.

It matters for the agents that reach lich through a shell rather than through
tools (opencode, Crush, anything spawned without lich's MCP server): fanning
work out cost them `open` then `send`, and the second command is the one an
agent forgets. `relay.SpawnBriefing` and the delegate prompt in the sidebar
both pointed at that two-command route; they now name the one.

## How

`handOver`'s path, not a second copy of it. The RPC half moved out into
`client.deliver`, shared by both surfaces; what stays per-surface is the
wording of the outcome — `lich wait <ticket>` on the command line, the
`wait_for_answer` sentence in the tool. `deliverWait` (20s) moved beside
`openCall` with its reason updated: the command line shares the MCP call's
budget rather than growing a timeout of its own, since the hand-off waits for
the agent to come up, never for an answer.

## `--json` with both

One object, still one line:

```json
{"id":"9f8e","project":"lich","label":"auth-fix","name":"auth-fix-9f8e","kind":"claude","path":"/wt/auth-fix","nextSeq":5,"delivery":{"ticket":"a1b2c3d4","target":"auth-fix","status":"pending","answer":""}}
```

The session's fields stay exactly where every reader of this command has found
them; the send's result rides under `delivery`, the same shape `send --json`
prints, and the key is **absent** without `--prompt` — a reader that branches
on it is never handed an empty one to interpret. Two objects, or two lines,
would make a script tell the flags apart before it could read the output.

A hand-off that fails does not undo the open: the session is printed as usual
on stdout, the failure is the usual `lich: …` line on stderr with exit 1
naming the `lich send` that tries again, and `delivery` stays absent rather
than growing a shape for a failed send. Exit 1 is deliberate — a script
reading 0 would believe the task landed.

## Test plan

- [x] `go test ./...` green (`LICH_LISTEN_PORT=` empty), `gofmt -l .` clean, `go vet ./...` clean
- [x] `pnpm check`, `vitest run` (886 tests), `tsc`, `vite build`
- [x] New: the flag delivers (two RPCs, `spawn.Open` then `relay.Send` with the
      new session's own label, project and the 20s wait), the `--json` shape
      with and without a task, and the open surviving a delivery that failed
- [x] Smoke in a real window: `lich open --worktree x --prompt "…"` from a
      Crush session

docs/cli.md moves with it — the flag, the printed hand-off, the `--json` shape
and the failure — plus a `CHANGELOG.md` `[Unreleased]` entry.
