### PR TITLE
fix: a task handed to a session that is not up yet is queued, not lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A task handed to a session that is not up yet is queued, not lost.** Giving
+  a task to a session on a fresh worktree meant racing that checkout's setup
+  script: the install runs in the same terminal the agent will use, it can take
+  minutes, and a task typed into it is read by `pnpm install` and dropped. lich
+  refused to type into it — but the refusal came back as a failed send with the
+  task gone, and it fell on whoever sent it to guess when to try again. That is
+  the main path of a fan-out, where every worker is a checkout nobody has
+  installed yet. Now the sender gets its ticket immediately and the task goes in
+  the moment that session's agent is the program reading its terminal, however
+  long the setup takes. A queue that can never end — the session ends, or ten
+  minutes pass with nothing at a prompt — comes back as a reported failure at
+  the sender's own prompt, saying the task is gone rather than waiting
+  somewhere, instead of a ticket that hangs until it expires an hour later. A
+  target that is merely busy is unchanged: the task queues at its prompt and it
+  answers a turn later.
+
 - **A helper that outlives a lich restart can talk to lich again.** The `lich`
   command line and lich's own MCP tools read the loopback coordinates the session
   they run in was given, and the connect token behind them is minted fresh every

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -139,6 +139,12 @@ Types `<prompt>` at `<session>`'s prompt, submits it, and waits.
   to be sent again once the screen is clear. Only reported for providers that
   report their state at all (the plugin, `docs/hooks/`) — silence has to mean
   something before it can be read as anything.
+- **Never delivered**: the task was held for a session that never reached a
+  prompt — it ended, or whatever had its terminal outlasted the queue (10
+  minutes). The ticket is dropped rather than left to expire, and the output
+  says the task is gone rather than waiting anywhere: it has to be sent again
+  once that card shows what happened. A sender that had already stopped waiting
+  finds it in its inbox, like any other outcome.
 - **Answered somewhere else**: the target worked through the request and ended
   its turn without replying here — it answered over its provider's own channel,
   or out loud to whoever was watching. The wait ends there rather than running
@@ -149,8 +155,9 @@ Types `<prompt>` at `<session>`'s prompt, submits it, and waits.
   is that news.
 
 ```
-docs is still working. The message was delivered; a note will be typed at the
-sending session's prompt when its result is ready. To hold the line for it instead:
+docs is still working. The errand is open — a message that session was not ready
+for is held until it is — and a note will be typed at the sending session's
+prompt when its result is ready. To hold the line for it instead:
   lich wait a1b2c3d4
 ```
 
@@ -158,13 +165,16 @@ A prompt is capped at 8192 bytes and stripped of control characters — the text
 is typed into a terminal, and an escape sequence inside it would stop being
 text.
 
-**A target still running its setup script is waited for, not written to.** The
-wait shares the caller's own `--timeout` with the wait for the answer — one
-budget covers the whole call, so `send` never blocks past what was asked.
-Running out is an error saying nothing was sent, never a ticket — an errand
-nobody can answer would otherwise be waited out in full. `internal/terminal` tells the two apart by a marker the
-setup wrapper prints between the script and the provider (`setupDone`): the PTY
-and the pid are the same across the `exec`, so nothing else can.
+**A target still running its setup script is queued for, not written to.** The
+ticket comes back at once and the message goes in when that session's agent is
+the program reading its PTY — a fresh worktree installs its dependencies before
+its agent, which routinely outlasts the caller's own `--timeout`, and losing the
+task there is exactly what a fan-out cannot afford. `send` never blocks past
+what was asked. A queue that can never end — the session dies, or 10 minutes
+pass — is reported as a failure the sender can act on, never a ticket left to
+expire. `internal/terminal` tells the setup script and the agent apart by a
+marker the setup wrapper prints between them (`setupDone`): the PTY and the pid
+are the same across the `exec`, so nothing else can.
 
 ### `lich wait [--timeout <seconds>] [<ticket>]`
 
@@ -617,8 +627,8 @@ whoever asked.
 - **A session is addressable before its agent can read.** `open` returns when
   the PTY exists, not when the provider inside it has finished starting. The one
   stretch lich *can* see is the project's worktree setup script, which owns that
-  PTY before the provider and can run for minutes: `send` waits it out rather
-  than typing into it (see below), because a message handed to a running
+  PTY before the provider and can run for minutes: `send` queues the task for it
+  rather than typing into it (see below), because a message handed to a running
   `pnpm install` is read and discarded, and the sender then waits out a ticket
   nobody was ever asked to answer. What is left is the second or two the
   provider's own TUI takes to start reading. lich waits that out as quiet — a

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -548,9 +548,14 @@ func (c *client) report(result relay.Result, asJSON bool) error {
 		fmt.Fprintln(c.stdout, unreadText(result.Target))
 		return nil
 	}
+	if result.Status == relay.StatusUndelivered {
+		fmt.Fprintln(c.stdout, undeliveredText(result.Target))
+		return nil
+	}
 	fmt.Fprintf(c.stdout,
-		"%s is still working. The message was delivered; a note will be typed at the "+
-			"sending session's prompt when its result is ready. To hold the line for it instead:\n"+
+		"%s is still working. The errand is open — a message that session was not ready "+
+			"for is held until it is — and a note will be typed at the sending session's "+
+			"prompt when its result is ready. To hold the line for it instead:\n"+
 			"  lich wait %s\n",
 		result.Target, result.Ticket,
 	)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -709,6 +709,26 @@ func TestSendSaysWhenTheTaskWasNeverPickedUp(t *testing.T) {
 	}
 }
 
+func TestSendSaysWhenTheTaskNeverReachedAPrompt(t *testing.T) {
+	f := newFakeLich(t, `{"ticket":"a1b2c3d4","target":"docs","status":"undelivered"}`)
+
+	code, stdout, stderr := run(t, f, "send", "docs", "run the tests")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	// A queued task that never landed reads as a delivery to anyone who is not
+	// told otherwise, so the output has to say the task is gone rather than
+	// waiting somewhere.
+	for _, phrase := range []string{"never reached", "Nothing is queued anymore", "again"} {
+		if !strings.Contains(stdout, phrase) {
+			t.Errorf("output is missing %q:\n%s", phrase, stdout)
+		}
+	}
+	if strings.Contains(stdout, "lich wait") {
+		t.Errorf("offered a ticket to wait on for a task that was never delivered:\n%s", stdout)
+	}
+}
+
 func TestCloseSaysWhatWentWithTheSession(t *testing.T) {
 	kept := newFakeLich(t, `{"id":"9f8e","projectId":"p1","project":"lich","label":"auth-fix",
 		"worktree":"/wt/auth-fix","kept":true}`)

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -311,7 +311,9 @@ var mcpTools = []mcpTool{
 	{
 		Name: "send_to_session",
 		Description: "Give another lich session a task. The task is put at that session's prompt " +
-			"as if typed there. Returns the answer when it comes back quickly; for anything " +
+			"as if typed there, or held and delivered when it gets to one — a session on a " +
+			"fresh worktree runs the project's setup script before its agent, and the task " +
+			"waits that out rather than being lost. Returns the answer when it comes back quickly; for anything " +
 			"slower you get a ticket and carry on — when the result is ready, a short note " +
 			"arrives at your own prompt and wait_for_answer collects it, so you never poll. " +
 			"Sessions are addressed by the label on their lich card — call list_sessions for " +
@@ -486,13 +488,14 @@ var mcpTools = []mcpTool{
 	},
 }
 
-// deliverWait bounds handing a task to a session that was opened a moment ago:
-// how long the delivery waits for that session's agent to be the program reading
-// its PTY (relay.awaitReady).
+// deliverWait bounds holding the line when a task is handed to a session that
+// was opened a moment ago.
 //
-// It is not a wait for an answer. The worker was created seconds ago and its
-// task is minutes of work, so a ticket is the expected outcome and the sender
-// carries on.
+// It is not a wait for an answer, and no longer a wait for the session to come
+// up either: a task sent to a session that is still running its worktree setup
+// script is queued and delivered when its agent is there (relay.queueDelivery).
+// The worker was created seconds ago and its task is minutes of work, so a
+// ticket is the expected outcome and the sender carries on.
 //
 // The number is what is left of the call's budget. Opening can spend openCall
 // (60s) before this starts, and the client detaches anything still running at
@@ -514,9 +517,8 @@ func (c *client) handOver(opened spawn.Session, prompt string) string {
 	call := []any{c.sessionID(), opened.Label, opened.Project, prompt, deliverWait}
 	if err := c.call("relay.Send", call, waitBudget(deliverWait), &result); err != nil {
 		return fmt.Sprintf(
-			"The task did not reach it: %v. The session is open and idle, so send the task "+
-				"with send_to_session — a fresh worktree runs the project's setup script "+
-				"before its agent, and that can outlast this call.",
+			"The task did not reach it: %v. The session is open, so hand it the task with "+
+				"send_to_session once whatever that says is dealt with.",
 			err,
 		)
 	}
@@ -534,9 +536,12 @@ func mcpOutcome(result relay.Result) string {
 		return unansweredText(result.Target)
 	case relay.StatusUnread:
 		return unreadText(result.Target)
+	case relay.StatusUndelivered:
+		return undeliveredText(result.Target)
 	}
 	return fmt.Sprintf(
-		"%s is still working. The task was delivered; when its result is ready a short note "+
+		"%s is still working. The errand is open — if that session was not at a prompt yet, "+
+			"the task is held and goes in when it is. When its result is ready a short note "+
 			"will arrive at your own prompt, so carry on — there is nothing to poll. Collect "+
 			"it with wait_for_answer (ticket %q, or no ticket for everything at once).",
 		result.Target, result.Ticket,
@@ -560,6 +565,8 @@ func collectedText(collected relay.Collected) string {
 			parts = append(parts, unreadText(result.Target))
 		case relay.StatusUnanswered:
 			parts = append(parts, unansweredText(result.Target))
+		case relay.StatusUndelivered:
+			parts = append(parts, undeliveredText(result.Target))
 		}
 	}
 	if len(collected.Open) > 0 {
@@ -586,6 +593,22 @@ func unreadText(target string) string {
 			"directory is trusted the first time it runs in one). Nothing is queued and "+
 			"nothing was answered. Tell the user to open the %q card and clear what is "+
 			"on it; the task has to be sent again after that.",
+		target, target,
+	)
+}
+
+// undeliveredText is what both surfaces say about a task that was held for a
+// session that never reached a prompt. It is the one outcome where nothing was
+// read and nothing was typed, so the reader has to hear that the task is gone
+// rather than queued somewhere — and that the session itself is what needs
+// looking at before it is sent again.
+func undeliveredText(target string) string {
+	return fmt.Sprintf(
+		"The task never reached the %q session: it was held back because that terminal "+
+			"was not at a prompt — a worktree setup script still running, a provider that "+
+			"never came up — and the session ended or stayed that way for too long. Nothing "+
+			"is queued anymore and nothing was answered. Tell the user to open the %q card "+
+			"to see what happened there; the task has to be sent again after that.",
 		target, target,
 	)
 }

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -645,6 +645,26 @@ func TestMCPSendReportsATaskNobodyRead(t *testing.T) {
 	}
 }
 
+func TestMCPSendReportsATaskThatNeverReachedAPrompt(t *testing.T) {
+	f := newFakeLich(t, `{"ticket":"a1b2c3d4","target":"docs","status":"undelivered"}`)
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"send_to_session","arguments":{"session":"docs","prompt":"run the tests"}}}`)
+
+	text, failed := textOf(t, replies[0])
+	if failed {
+		t.Fatalf("tool reported a failure: %s", text)
+	}
+	if !strings.Contains(text, "never reached") {
+		t.Errorf("text = %q, want it to say the task was never delivered", text)
+	}
+	// The ticket is gone with the errand; an agent told to collect it would be
+	// waiting on nothing.
+	if strings.Contains(text, "wait_for_answer") {
+		t.Errorf("pointed at a ticket for a task that never landed: %q", text)
+	}
+}
+
 func TestMCPCloseSessionPassesTheWorktreeAnswer(t *testing.T) {
 	f := newFakeLich(t, `{"id":"9f8e","projectId":"p1","project":"lich","label":"auth-fix",
 		"worktree":"/wt/auth-fix","removed":true}`)

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -17,6 +17,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -44,6 +45,15 @@ const (
 	// enough that the sender learns in one tool call rather than at the ticket's
 	// expiry an hour later.
 	defaultReceiptWindow = 30 * time.Second
+	// defaultDeliveryLimit is how long a queued task waits for its target to
+	// reach a prompt before the errand is reported undelivered (see
+	// queueDelivery). A worktree setup script that installs dependencies and
+	// warms a build runs minutes on a cold cache, so the number has to be
+	// generous; past it the checkout is broken or waiting on a person, and
+	// neither ends by itself. It is well inside ticketTTL on purpose: the sender
+	// hears a failure it can act on rather than watching a ticket expire an hour
+	// later with nothing said.
+	defaultDeliveryLimit = 10 * time.Minute
 	// promptLimit bounds one relayed prompt. The message is typed into a TUI a
 	// character at a time; a megabyte of it is a hang, not a prompt.
 	promptLimit = 8192
@@ -92,6 +102,10 @@ const (
 	// session's own terminal and nowhere lich can read it — which is what
 	// happens when an agent answers over a channel of its provider's own.
 	StatusUnanswered = "unanswered"
+	// StatusUndelivered means the task never reached a prompt: it was held back
+	// for a session that was not at one, and that session died or stayed busy
+	// past defaultDeliveryLimit. Nothing is queued anymore and nothing was read.
+	StatusUndelivered = "undelivered"
 )
 
 // Session states the relay watches, spelled as the hook contract reports them
@@ -227,6 +241,9 @@ type ticket struct {
 	// unread closes when the target never reacted to the task at all. See
 	// watchReceipt.
 	unread chan struct{}
+	// undelivered closes when the message never got into the target's PTY at
+	// all. See queueDelivery.
+	undelivered chan struct{}
 	// sawBusy is whether the target has been working since this ticket's turn
 	// began; a turn that ends without it never started here.
 	sawBusy bool
@@ -278,6 +295,9 @@ type Service struct {
 	// receiptWindow is how long a delivered task has to be picked up before it
 	// is called unread (see watchReceipt). A field for the same reason.
 	receiptWindow time.Duration
+	// deliveryLimit is how long a queued task waits for a prompt to reach
+	// (defaultDeliveryLimit). A field for the same reason.
+	deliveryLimit time.Duration
 	// nudgeDelay is the debounce before a nudge is typed (defaultNudgeDelay).
 	// A field for the same reason.
 	nudgeDelay time.Duration
@@ -318,6 +338,7 @@ func New(sessions Sessions, term Terminal, events Events) *Service {
 		now:           time.Now,
 		submitDelay:   defaultSubmitDelay,
 		receiptWindow: defaultReceiptWindow,
+		deliveryLimit: defaultDeliveryLimit,
 		nudgeDelay:    defaultNudgeDelay,
 	}
 }
@@ -350,8 +371,10 @@ func (s *Service) Peers(fromID string) ([]Peer, error) {
 // more than one project; empty searches them all. waitSeconds bounds the wait —
 // 0 uses DefaultWait.
 //
-// The wait running out is not a failure: the message was delivered, and the
-// returned ticket is what picks the answer up later.
+// The wait running out is not a failure: the errand is open, and the returned
+// ticket is what picks its outcome up later. A target that is not at a prompt
+// yet is not a failure either — the task is queued and delivered when it is
+// (see queueDelivery).
 func (s *Service) Send(fromID, target, project, prompt string, waitSeconds int) (Result, error) {
 	prompt = sanitize(prompt)
 	if strings.TrimSpace(prompt) == "" {
@@ -372,53 +395,68 @@ func (s *Service) Send(fromID, target, project, prompt string, waitSeconds int) 
 		return Result{}, err
 	}
 	t := &ticket{
-		fromID:   fromID,
-		sender:   sender,
-		targetID: dest.ID,
-		target:   dest.Peer.Label,
-		created:  s.now(),
-		done:     make(chan struct{}),
-		stalled:  make(chan struct{}),
-		unread:   make(chan struct{}),
+		fromID:      fromID,
+		sender:      sender,
+		targetID:    dest.ID,
+		target:      dest.Peer.Label,
+		created:     s.now(),
+		done:        make(chan struct{}),
+		stalled:     make(chan struct{}),
+		unread:      make(chan struct{}),
+		undelivered: make(chan struct{}),
 	}
 	s.mu.Lock()
 	expired, senders := s.sweep()
-	busy := s.state[dest.ID] == stateBusy
-	if busy {
-		t.skipTurns = 1
-	}
 	s.tickets[id] = t
 	s.mu.Unlock()
 	s.clearAll(expired)
 	s.announceInboxAll(senders)
 
-	// One deadline covers the whole call: the setup wait and the answer wait
-	// spend the same budget. Each taking a full waitFor of its own would let a
-	// Send block for twice what the caller asked — past the HTTP client's own
-	// budget (internal/cli, waitBudget), which would report a timeout on a
-	// message that was in fact delivered.
-	deadline := s.now().Add(waitFor(waitSeconds))
-	if err := s.awaitReady(dest, deadline); err != nil {
-		s.mu.Lock()
-		delete(s.tickets, id)
-		s.mu.Unlock()
-		return Result{}, err
-	}
 	message := compose(sender, id, prompt, s.offersTools(dest.Peer.Kind))
+	if s.term.Ready(dest.ID) {
+		// A target that is at a prompt is written to on the caller's own
+		// goroutine, so a PTY that refuses the write is the error this call
+		// returns rather than an outcome mailed to the sender later.
+		if err := s.handOff(id, t, dest.Peer.Kind, message); err != nil {
+			s.mu.Lock()
+			delete(s.tickets, id)
+			s.mu.Unlock()
+			return Result{}, err
+		}
+	} else {
+		go s.queueDelivery(id, t, dest, message)
+	}
+	// The caller's own wait bounds this call and nothing else: the errand
+	// outlives it either way, and blocking past what was asked would run past
+	// the HTTP client's own budget (internal/cli, waitBudget) and report a
+	// timeout on an errand that is running perfectly well.
+	return s.await(id, t, waitFor(waitSeconds)), nil
+}
+
+// handOff puts a composed message in the target's PTY and starts everything
+// that watches what becomes of it. Called once per ticket, either on the
+// caller's goroutine or, for a target that was not at a prompt yet, on the one
+// holding the message back.
+func (s *Service) handOff(id string, t *ticket, kind, message string) error {
+	s.mu.Lock()
+	// Read here rather than at Send: a queued message can wait out a whole setup
+	// script, and what the target was doing back then decides nothing about the
+	// turn this message lands in.
+	busy := s.state[t.targetID] == stateBusy
+	if busy {
+		t.skipTurns = 1
+	}
 	// Stamped before the write, not after: a delivery is two writes a beat apart
 	// (see deliver), and turn accounting ignores an undelivered ticket. A target
 	// reporting inside that beat would be lost — its busy report, and the ticket
 	// is closed unread with the message queued and the reply that follows landing
 	// on nothing; its done, and the skip meant for the turn already running is
 	// spent on the turn that carries the answer.
-	s.mu.Lock()
 	t.delivered = s.now()
 	s.mu.Unlock()
-	if err := s.deliver(dest.ID, message); err != nil {
-		s.mu.Lock()
-		delete(s.tickets, id)
-		s.mu.Unlock()
-		return Result{}, fmt.Errorf("deliver to %q: %w", dest.Peer.Label, err)
+
+	if err := s.deliver(t.targetID, message); err != nil {
+		return fmt.Errorf("deliver to %q: %w", t.target, err)
 	}
 	// Announced only once the message is actually in the PTY: a mark raised
 	// before the write would survive a delivery that never happened.
@@ -427,10 +465,59 @@ func (s *Service) Send(fromID, target, project, prompt string, waitSeconds int) 
 	// A target that was already working is not checked: it will read this at the
 	// end of the turn it is in, whenever that is, and its provider is busy the
 	// whole time — there is nothing here to tell apart.
-	if !busy && s.reportsState(dest.Peer.Kind) {
+	if !busy && s.reportsState(kind) {
 		go s.watchReceipt(id, t)
 	}
-	return s.await(id, t, deadline.Sub(s.now())), nil
+	return nil
+}
+
+// queueDelivery holds a task back until its target is at a prompt, then hands
+// it over.
+//
+// A session opened on a fresh worktree runs the project's setup script in that
+// PTY first, and the script routinely outlasts the budget of the call that
+// sent the task — that is the main path of a fan-out, where every worker is a
+// checkout that has never been installed. Failing there loses the task
+// outright and leaves the sender guessing when to try again, so the wait moved
+// off the caller: it gets its ticket, and the message goes in when there is
+// something there to read it.
+//
+// A wait that can never end is reported rather than left open. The sender
+// hears it the way it hears any other outcome — through the inbox, or on the
+// ticket it is still holding — because a promise of news at your prompt has to
+// be kept by the failures too.
+func (s *Service) queueDelivery(id string, t *ticket, dest candidate, message string) {
+	err := s.awaitReady(dest, s.now().Add(s.deliveryLimit))
+	if err == nil {
+		err = s.handOff(id, t, dest.Peer.Kind, message)
+	}
+	if err != nil {
+		s.failDelivery(id, t, err)
+	}
+}
+
+// failDelivery closes an errand whose message never reached a prompt, and tells
+// the sender: the one still holding the ticket hears it from its own wait,
+// anyone who has moved on finds it in the inbox. The ticket is checked to be
+// the live one first — a delivery that failed after the message went in races
+// Observe, which may have closed the same errand from the other side.
+func (s *Service) failDelivery(id string, t *ticket, cause error) {
+	slog.Warn("relay: task never reached a prompt", "target", t.target, "err", cause)
+	s.mu.Lock()
+	current, live := s.tickets[id]
+	if !live || current != t {
+		s.mu.Unlock()
+		return
+	}
+	delete(s.tickets, id)
+	close(t.undelivered)
+	unattended := t.attended == 0
+	s.mu.Unlock()
+
+	s.clear(t)
+	if unattended {
+		s.stash(id, t, StatusUndelivered, "")
+	}
 }
 
 // deliver puts message at a session's prompt and sends it — two writes, a beat
@@ -444,7 +531,9 @@ func (s *Service) deliver(sessionID, message string) error {
 	return s.term.Write(sessionID, submit)
 }
 
-// awaitReady blocks until a target's agent is the program reading its PTY.
+// awaitReady blocks until a target's agent is the program reading its PTY, and
+// errors when that will never happen: the session stopped, or it is still not
+// at a prompt by deadline.
 //
 // A session opened on a fresh worktree runs the project's setup script in that
 // PTY first, and the script can take minutes. It is live the whole time, and a
@@ -452,15 +541,10 @@ func (s *Service) deliver(sessionID, message string) error {
 // so the request never existed, and the sender waits out a ticket nobody was
 // asked to answer. Seen on the first real run of a worktree session.
 //
-// Waiting is bounded by the caller's own deadline — the same one the answer is
-// waited on, so setup and answer spend one budget between them: there is no
-// point holding a message for a setup that outlasts the errand. Running out is
-// an error rather than a delivery, because a message nobody can be given is not
-// one that was sent.
+// What comes back is a cause for a log line and for the status the sender is
+// given, not prose for a person: whoever reads about this reads it in the
+// window or at an agent's prompt, where internal/cli words it.
 func (s *Service) awaitReady(dest candidate, deadline time.Time) error {
-	if s.term.Ready(dest.ID) {
-		return nil
-	}
 	for {
 		time.Sleep(readyPoll)
 		if s.term.Ready(dest.ID) {
@@ -470,17 +554,11 @@ func (s *Service) awaitReady(dest candidate, deadline time.Time) error {
 			return fmt.Errorf("%q stopped before its agent started", dest.Peer.Label)
 		}
 		if s.now().After(deadline) {
-			// Which of the two it is, lich cannot see from here, and naming only
-			// the setup script sent whoever read this hunting a script the
-			// project may not even have. What is certain is on that session's own
-			// screen, so the message says to go and look.
 			return fmt.Errorf(
-				"%q has not stopped drawing, so lich cannot tell what is reading its "+
-					"terminal: the project's worktree setup script may still be running in "+
-					"it, or its provider may still be starting up. Nothing was sent — open "+
-					"that session to see what is on its screen, and try again once it is at "+
-					"a prompt",
-				dest.Peer.Label,
+				"%q was still not at a prompt after %s: whatever holds that terminal — "+
+					"the project's worktree setup script, a provider that never came up — "+
+					"outlasted the wait",
+				dest.Peer.Label, s.deliveryLimit,
 			)
 		}
 	}
@@ -636,6 +714,9 @@ func (s *Service) await(id string, t *ticket, wait time.Duration) Result {
 	case <-t.unread:
 		s.leave(t)
 		return Result{Ticket: id, Target: t.target, Status: StatusUnread}
+	case <-t.undelivered:
+		s.leave(t)
+		return Result{Ticket: id, Target: t.target, Status: StatusUndelivered}
 	case <-timer.C:
 		return Result{Ticket: id, Target: t.target, Status: s.giveUp(id, t)}
 	}
@@ -655,8 +736,9 @@ func (s *Service) leave(t *ticket) {
 // had already stopped listening. Whoever leaves last owns what is left behind.
 //
 // A reply is stashed for the sender, because an answer outlives the wait it
-// missed. The receipt window closing the ticket unread — and a turn ending
-// with no answer — are told to the caller instead: it is still here to hear
+// missed. The three ways an errand ends without one — the receipt window
+// closing it unread, a turn ending with no answer, a message that never
+// reached a prompt — are told to the caller instead: it is still here to hear
 // them, and the alternative is reporting the errand as still in progress, on a
 // ticket already out of the map.
 func (s *Service) giveUp(id string, t *ticket) string {
@@ -664,7 +746,7 @@ func (s *Service) giveUp(id string, t *ticket) string {
 	t.attended--
 	last := t.attended == 0
 	orphaned := t.answered && last
-	unread, stalled := false, false
+	unread, stalled, undelivered := false, false, false
 	if last && !t.answered {
 		select {
 		case <-t.unread:
@@ -674,6 +756,11 @@ func (s *Service) giveUp(id string, t *ticket) string {
 		select {
 		case <-t.stalled:
 			stalled = true
+		default:
+		}
+		select {
+		case <-t.undelivered:
+			undelivered = true
 		default:
 		}
 	}
@@ -686,6 +773,9 @@ func (s *Service) giveUp(id string, t *ticket) string {
 	}
 	if stalled {
 		return StatusUnanswered
+	}
+	if undelivered {
+		return StatusUndelivered
 	}
 	return StatusPending
 }
@@ -738,8 +828,9 @@ func (s *Service) Observe(sessionID, state string) {
 		}
 	case stateIdle:
 		// SessionEnd needs no turn to have run: the CLI has left the PTY and
-		// nothing there can answer anymore. An undelivered ticket is left for
-		// awaitReady, which sees the session die and fails the Send itself.
+		// nothing there can answer anymore. A ticket still queued is left for
+		// awaitReady, which sees the session die and reports it undelivered —
+		// a different thing to be told, and its own message to be told it in.
 		for id, t := range s.tickets {
 			if t.targetID == sessionID && !t.delivered.IsZero() {
 				delete(s.tickets, id)

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -1404,9 +1404,11 @@ func waitForTicket(svc *Service) string {
 // read a message: the script owns the PTY until it execs the provider. Writing
 // into it loses the request outright — `pnpm install` reads the bytes and drops
 // them — and the sender then waits out a ticket nobody was ever asked to
-// answer, which is how this was found.
+// answer, which is how this was found. So the task is queued instead: the
+// sender gets its ticket now, and the message goes in when there is something
+// there to read it.
 
-func TestSendWaitsForTheSetupScriptToFinish(t *testing.T) {
+func TestSendDeliversOnceTheSetupScriptFinishes(t *testing.T) {
 	term := newFakeTerminal("s1", "s2")
 	term.setUp("s2", true)
 	svc := newRelay(workspace(), term, nil)
@@ -1416,8 +1418,8 @@ func TestSendWaitsForTheSetupScriptToFinish(t *testing.T) {
 		term.setUp("s2", false)
 	}()
 
-	// One second covers both waits here: the setup finishes in 20ms, and nobody
-	// answers, so the errand ends pending on purpose.
+	// One second is long enough for the setup to finish and the delivery to
+	// land inside the call; nobody answers, so the errand ends pending.
 	result, err := svc.Send("s1", "docs", "", "run the tests", 1)
 	if err != nil {
 		t.Fatalf("Send = %v, want the message held until the agent was up", err)
@@ -1430,19 +1432,87 @@ func TestSendWaitsForTheSetupScriptToFinish(t *testing.T) {
 	}
 }
 
-func TestSendRefusesRatherThanTypingIntoASetupScript(t *testing.T) {
+// TestSendQueuesForASessionThatIsNotAtAPromptYet is the case the whole feature
+// exists for: a fan-out hands a task to a worktree that has never been
+// installed, and the setup script outlasts the caller's own budget. What used
+// to happen was a failed Send with the task gone; what has to happen is a
+// ticket now and a delivery later, on an errand that still answers.
+func TestSendQueuesForASessionThatIsNotAtAPromptYet(t *testing.T) {
 	term := newFakeTerminal("s1", "s2")
 	term.setUp("s2", true)
 	svc := newRelay(workspace(), term, nil)
 
-	_, err := svc.Send("s1", "docs", "", "run the tests", 1)
-	if err == nil {
-		t.Fatal("sent a message into a checkout that was still installing")
+	result, err := svc.Send("s1", "docs", "", "run the tests", 1)
+	if err != nil {
+		t.Fatalf("Send = %v, want a ticket for a task that is queued", err)
 	}
-	// The sender has to know nothing was delivered: a ticket here would be an
-	// errand nobody can answer, waited out in full.
-	if !strings.Contains(err.Error(), "Nothing was sent") {
-		t.Errorf("error = %q, want it to say the message was not delivered", err)
+	if result.Status != StatusPending {
+		t.Errorf("status = %q, want the errand open", result.Status)
+	}
+	if len(term.writesTo("s2")) != 0 {
+		t.Errorf("typed %v into the setup script", term.writesTo("s2"))
+	}
+
+	term.setUp("s2", false)
+	if !awaitWritten(term, "s2", "run the tests") {
+		t.Fatal("the queued task never reached the target once its agent was up")
+	}
+
+	// The ticket the caller left with is the one that answers: an errand
+	// delivered late is not a different errand.
+	if err := svc.Reply(result.Ticket, "green"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	answered, err := svc.Wait(result.Ticket, 1)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if answered.Status != StatusAnswered || answered.Answer != "green" {
+		t.Errorf("wait = %+v, want the answer to the queued task", answered)
+	}
+}
+
+// TestSendDoesNotBlockOnASessionThatIsNotReady pins the caller's wait bounding
+// the call and nothing else. Blocking past it would run past the HTTP client's
+// own timeout (internal/cli, waitBudget) and report a failure on an errand that
+// is running perfectly well.
+func TestSendDoesNotBlockOnASessionThatIsNotReady(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	term.setUp("s2", true)
+	svc := newRelay(workspace(), term, nil)
+
+	start := time.Now()
+	result, err := svc.Send("s1", "docs", "", "run the tests", 1)
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("Send = %v, want a ticket", err)
+	}
+	if result.Status != StatusPending {
+		t.Errorf("status = %q, want the errand still open", result.Status)
+	}
+	if elapsed > 1500*time.Millisecond {
+		t.Errorf("Send blocked %v on a 1s wait — the readiness wait is spending the caller's budget", elapsed)
+	}
+}
+
+// A queued delivery that can never happen is an outcome, not a ticket left to
+// expire: the sender is told, on the ticket it is still holding or in its
+// inbox, and told that nothing is queued anymore.
+
+func TestQueuedTaskGivesUpWhenTheTargetNeverReachesAPrompt(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	term.setUp("s2", true)
+	svc := newRelay(workspace(), term, nil)
+	// A tenth of the caller's own wait, so the give-up lands while it is still
+	// holding the line and is what it hears.
+	svc.deliveryLimit = 100 * time.Millisecond
+
+	result, err := svc.Send("s1", "docs", "", "run the tests", 1)
+	if err != nil {
+		t.Fatalf("Send = %v, want a ticket", err)
+	}
+	if result.Status != StatusUndelivered {
+		t.Errorf("status = %q, want the sender told the task never reached a prompt", result.Status)
 	}
 	if len(term.writesTo("s2")) != 0 {
 		t.Errorf("typed %v into the setup script", term.writesTo("s2"))
@@ -1451,59 +1521,46 @@ func TestSendRefusesRatherThanTypingIntoASetupScript(t *testing.T) {
 	open := len(svc.tickets)
 	svc.mu.Unlock()
 	if open != 0 {
-		t.Errorf("left %d tickets open for a message that was never delivered", open)
+		t.Errorf("left %d tickets open for a task that was never delivered", open)
 	}
 }
 
-// TestSendSpendsOneBudgetAcrossSetupAndAnswer pins the deadline being shared:
-// a setup that eats most of the wait leaves only the remainder for the answer,
-// instead of a fresh full wait on top. Two full budgets would block past the
-// HTTP client's own timeout (internal/cli, waitBudget) and report a failure on
-// a message that was in fact delivered.
-func TestSendSpendsOneBudgetAcrossSetupAndAnswer(t *testing.T) {
+func TestQueuedTaskReportsTheTargetDyingToTheInbox(t *testing.T) {
 	term := newFakeTerminal("s1", "s2")
 	term.setUp("s2", true)
-	svc := newRelay(workspace(), term, nil)
+	events := &fakeEvents{}
+	svc := newRelay(workspace(), term, events)
 
-	go func() {
-		time.Sleep(750 * time.Millisecond)
-		term.setUp("s2", false)
-	}()
-
-	start := time.Now()
+	// The wait runs out with the task still queued: the sender has moved on, so
+	// the news has to reach it the way an answer would.
 	result, err := svc.Send("s1", "docs", "", "run the tests", 1)
-	elapsed := time.Since(start)
 	if err != nil {
-		t.Fatalf("Send = %v, want the message delivered", err)
+		t.Fatalf("Send = %v, want a ticket", err)
 	}
 	if result.Status != StatusPending {
-		t.Errorf("status = %q, want the errand still open", result.Status)
+		t.Fatalf("status = %q, want the errand still queued", result.Status)
 	}
-	// The old shape waited the setup out and then a full second more, ending
-	// past 1.75s. The shared budget ends the call at the one second asked for.
-	if elapsed > 1500*time.Millisecond {
-		t.Errorf("Send blocked %v on a 1s wait — the setup and the answer each spent a full budget", elapsed)
+
+	term.mu.Lock()
+	term.live["s2"] = false
+	term.mu.Unlock()
+
+	if !awaitWritten(term, "s1", "[lich]") {
+		t.Fatal("the sender was never told its queued task died with the target")
 	}
-}
-
-func TestSendGivesUpWhenTheTargetDiesDuringSetup(t *testing.T) {
-	term := newFakeTerminal("s1", "s2")
-	term.setUp("s2", true)
-	svc := newRelay(workspace(), term, nil)
-
-	go func() {
-		time.Sleep(20 * time.Millisecond)
-		term.mu.Lock()
-		term.live["s2"] = false
-		term.mu.Unlock()
-	}()
-
-	_, err := svc.Send("s1", "docs", "", "run the tests", 30)
-	if err == nil {
-		t.Fatal("waited on a session that is gone")
+	collected, err := svc.Collect("s1", 1)
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
 	}
-	if !strings.Contains(err.Error(), "stopped before its agent started") {
-		t.Errorf("error = %q", err)
+	if len(collected.Results) != 1 || collected.Results[0].Status != StatusUndelivered {
+		t.Fatalf("collected = %+v, want one undelivered result", collected.Results)
+	}
+	if collected.Results[0].Ticket != result.Ticket {
+		t.Errorf("ticket = %q, want the one the sender left with (%q)",
+			collected.Results[0].Ticket, result.Ticket)
+	}
+	if counts := events.inboxCounts("s1"); len(counts) == 0 || counts[len(counts)-1] != 0 {
+		t.Errorf("inbox counts = %v, want the card to have said one result and then none", counts)
 	}
 }
 


### PR DESCRIPTION
## The problem

`relay.Send` waited for the target's agent to be the program reading its PTY (`awaitReady`), on the caller's own budget. A session opened on a fresh worktree runs the project's setup script in that PTY first — minutes of `pnpm install`, which reads a typed message and discards it — and an MCP delivery has 20 seconds (`deliverWait`). When the budget ran out the Send failed and the task was simply gone, leaving the sender to guess when to retry. That is the main path of a fan-out, where every worker is a checkout nobody has installed yet.

## What ships

- **The task is queued, the caller is not.** A target already at a prompt is written to inline, exactly as before. One that is not gets its message held by `queueDelivery`, which delivers as soon as that session's agent is reading its PTY, however long the setup takes. `Send` comes back with a ticket at once and the errand answers on that same ticket later — no second tool, nothing to poll, and the caller's own wait still bounds the call.
- **A queue that can never end is reported, never left to hang.** The session ending, or `defaultDeliveryLimit` (10 minutes) with nothing at a prompt, closes the errand as the new `undelivered` status. A sender still holding the ticket hears it from its own wait; one that moved on finds it in the inbox and gets the usual nudge. Both surfaces word it as a task that is *gone* rather than one waiting somewhere, and send the reader to that session's card.
- **A busy target is unchanged.** It is written to, its provider queues the text, and it answers a turn later.
- **Delivery-time facts are read at delivery.** `handOff` decides `skipTurns` and whether to arm the receipt check from the state the target is in when the message goes in — what it was doing when the task was *sent* says nothing about the turn a queued message lands in.

## The ceiling

10 minutes. A worktree setup script that installs dependencies and warms a build runs minutes on a cold cache, so the number has to be generous; past it the checkout is broken or waiting on a person, and neither ends by itself. It sits well inside the 1h `ticketTTL` on purpose — the sender hears a failure it can act on instead of watching a ticket expire with nothing said.

## Tests

Two tests changed contract *with the product*, and it is the contract that moved:

- `TestSendRefusesRatherThanTypingIntoASetupScript` → `TestSendQueuesForASessionThatIsNotAtAPromptYet`: a setup that outlasts the wait is no longer a failed Send. It still proves nothing is typed into the script, and now also that the delivery lands after readiness and the original ticket answers.
- `TestSendGivesUpWhenTheTargetDiesDuringSetup` → `TestQueuedTaskReportsTheTargetDyingToTheInbox`: the death is reported to the sender (inbox entry, nudge, card count) instead of returned as an error.

New: `TestQueuedTaskGivesUpWhenTheTargetNeverReachesAPrompt` (the ceiling, on the ticket the caller is still holding), `TestSendDoesNotBlockOnASessionThatIsNotReady`, plus the `undelivered` wording on both the CLI and MCP surfaces.

## Test plan

- [x] `gofmt -l .`, `go vet ./...` clean
- [x] `go test ./...` green (`LICH_LISTEN_PORT=` empty), relay with `-race`
- [x] New tests `-count=20 -race`, no flakes
- [x] Coverage: relay 94.0%, cli 87.1%
- [x] Cross-compile loop for linux/darwin/windows (build + vet)
- [x] CHANGELOG `[Unreleased]` entry, docs/cli.md updated