### PR TITLE
fix: "Waiting on you" only when somebody is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   target that is merely busy is unchanged: the task queues at its prompt and it
   answers a turn later.
 
+- **"Waiting on you" now means somebody is actually waiting on you.** Claude Code
+  raises one and the same notification when it needs a permission decision and
+  when a session has simply been sitting at its prompt with nothing to do, and
+  lich read both as a session blocked on a human: a worker that had just finished
+  its task and reported back lit up the amber bell on its card and threw a toast
+  that took you there, to find nothing to answer. lich now tells the two apart by
+  the turn — a permission can only be asked inside one — so the bell and the
+  toast are raised only while a turn is genuinely stuck on you. A session idling
+  at its prompt keeps whatever its card already showed: the finished turn, its
+  results waiting to be collected, or nothing at all.
+
 - **A helper that outlives a lich restart can talk to lich again.** The `lich`
   command line and lich's own MCP tools read the loopback coordinates the session
   they run in was given, and the connect token behind them is minted fresh every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,7 +100,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the turn — a permission can only be asked inside one — so the bell and the
   toast are raised only while a turn is genuinely stuck on you. A session idling
   at its prompt keeps whatever its card already showed: the finished turn, its
-  results waiting to be collected, or nothing at all.
+  results waiting to be collected, or nothing at all. The session roster an agent
+  reads gets the same correction: a session at an idle prompt no longer tells its
+  peers it is waiting on a human, which read as "do not send work here" about the
+  one session most able to take it.
 
 - **A helper that outlives a lich restart can talk to lich again.** The `lich`
   command line and lich's own MCP tools read the loopback coordinates the session

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -151,10 +151,15 @@ a broken script could do was lose a status report.
   desktop notification. The card keeps whatever it was already showing (the
   finished turn, an inbox count, nothing), which is what an unchanged session
   should show. `waiting` itself is not recorded: it interrupts a turn rather than
-  replacing it, so two permission prompts in one turn are two blocks. The relay
-  (`internal/relay`, `Observe`) reads the same stream raw and makes the same
-  distinction from its own record, for a different question — which turn an
-  errand belongs to.
+  replacing it, so two permission prompts in one turn are two blocks.
+- **The peer roster** — `internal/relay`, `Observe` and `roster.go`: reads the
+  same stream raw, for two questions of its own. Which turn an errand belongs to
+  is one (`s.state`, where a mid-turn `waiting` has to keep reading as `busy`).
+  What each session is doing, published to an agent listing its peers
+  (`Peer.State`, `lich list`, `list_sessions`), is the other — and it applies the
+  same rule as `turnLog`: a `waiting` inside a turn is published, because it is
+  the state that means "do not send work here", and one outside a turn is not,
+  because a session idle at its prompt is the most available it will ever be.
 - **Store** — `frontend/src/lib/session/session-status-store.ts`: one subscription taken
   at page load keeps the last state of every session, keyed by id. The card
   cannot hold it: the sidebar only renders cards for the active project, so

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -70,12 +70,14 @@ registers this contract on the three harnesses that can close it, and a Crush
 card carries no indicator. The day Crush ships `Stop` (its `docs/hooks/FUTURE.md`
 tracks the request, not the event), the column fills in from the existing script.
 
-`Notification` fires when Claude needs a permission decision or has been idle
-waiting for input — both mean "your turn"; lich shows a toast (see below) only
-for `waiting`. Codex has no `Notification`: the same meaning arrives as
-`PermissionRequest`, where a hook exiting `2` would *deny* the request — which
-is why the contract's client rules (silent, always exit 0) are load-bearing
-there and not merely polite.
+`Notification` fires when Claude needs a permission decision **or** when the
+session has simply been sitting at its prompt with nothing to do. Only the first
+of those blocks a human, and the client cannot tell them apart — the event
+carries the same shape either way — so it reports `waiting` for both and **lich
+decides which one arrived** (see `turnLog` below). Codex has no `Notification`:
+the permission half arrives as `PermissionRequest`, where a hook exiting `2`
+would *deny* the request — which is why the contract's client rules (silent,
+always exit 0) are load-bearing there and not merely polite.
 
 `SessionEnd → idle` clears the card's indicator (no spinner/check/bell). It
 fires when the Claude session ends or is reset, so a stale state does not linger
@@ -140,6 +142,19 @@ a broken script could do was lose a status report.
 - **UI push** — `internal/terminal/terminal.go`: emits the global app event
   `session-status` (`{id, state, tool, detail}`). Global rather than per-session
   because its consumers outlive any one card.
+- **What `waiting` meant** — `internal/terminal/hookstate.go`, `turnLog`: the one
+  report lich does not pass through as sent. A permission decision only ever
+  happens inside a turn, so the report before it settles which `Notification`
+  arrived: after `busy` a human is blocking an open turn and the report is
+  published; after `done`, after `idle`, or after nothing at all, the session is
+  merely idle at its prompt and **nothing is emitted** — no bell, no toast, no
+  desktop notification. The card keeps whatever it was already showing (the
+  finished turn, an inbox count, nothing), which is what an unchanged session
+  should show. `waiting` itself is not recorded: it interrupts a turn rather than
+  replacing it, so two permission prompts in one turn are two blocks. The relay
+  (`internal/relay`, `Observe`) reads the same stream raw and makes the same
+  distinction from its own record, for a different question — which turn an
+  errand belongs to.
 - **Store** — `frontend/src/lib/session/session-status-store.ts`: one subscription taken
   at page load keeps the last state of every session, keyed by id. The card
   cannot hold it: the sidebar only renders cards for the active project, so
@@ -194,6 +209,12 @@ a broken script could do was lose a status report.
   event per prompt, which every one of them does today; it is the cost a client
   pays for reporting the same block twice, and the reason to dedupe on the
   client rather than here.
+- **A block lich never heard start is not read as a block.** `turnLog` lives in
+  memory, so a `waiting` arriving with no `busy` on record for that session — the
+  first report after lich restarts under a session already mid-turn — is read as
+  an idle prompt and shows nothing. Every provider opens a turn before it can ask
+  for a permission, so the normal path never hits this; the card catches up on
+  the session's next report either way.
 - `PostToolUse → busy` recovers from `waiting` only when Claude runs a tool. Deny
   a permission and let Claude end the turn without another tool and the card
   stays `waiting` until `Stop → done`. Rare, and it self-corrects on the next

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -828,9 +828,19 @@ func (s *Service) Observe(sessionID, state string) {
 	// The roster publishes the report itself rather than the turn state above:
 	// waiting is exactly what a caller has to see, and idle drops the row for
 	// the same reason it does there — an ended session reports nothing more.
-	if state == stateIdle {
+	switch {
+	case state == stateIdle:
 		delete(s.reported, sessionID)
-	} else {
+	case state == stateWaiting && s.state[sessionID] != stateBusy:
+		// Except when that waiting is not a block at all. One Notification
+		// means both "I need a permission decision" and "I have been sitting at
+		// my prompt" (docs/hooks/session-state.md, and internal/terminal's
+		// turnLog, which keeps the card honest about the same pair). Only the
+		// first is a session a caller must not send work into; the second is
+		// the most available a session ever is, and publishing it as waiting
+		// tells every peer to hold off. The turn state above is what tells them
+		// apart, and it is left standing here.
+	default:
 		s.reported[sessionID] = state
 	}
 

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -310,6 +310,32 @@ func TestPeersCarryTheStateEachSessionReported(t *testing.T) {
 	}
 }
 
+// The other half of that pair: a waiting reported after the turn ended is the
+// provider saying "your turn" to nobody in particular, not a session stuck on a
+// human. Published as waiting it would tell every caller reading the roster to
+// hold off from the one session most able to take work.
+func TestPeersDoNotCallAnIdlePromptWaiting(t *testing.T) {
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2", "s3"), nil)
+
+	svc.Observe("s2", "busy")
+	svc.Observe("s2", "done")
+	svc.Observe("s2", "waiting")
+	// One that never reported a turn at all: its first word is the notification.
+	svc.Observe("s3", "waiting")
+
+	peers, err := svc.Peers("s1")
+	if err != nil {
+		t.Fatalf("Peers: %v", err)
+	}
+	want := map[string]string{"lich-s2": "done", "lich-s3": ""}
+	for _, p := range peers {
+		state, watched := want[p.Name]
+		if watched && p.State != state {
+			t.Errorf("%s state = %q, want %q", p.Name, p.State, state)
+		}
+	}
+}
+
 func TestPeersReportsAStoreFailure(t *testing.T) {
 	svc := newRelay(fakeSessions{err: errors.New("database is locked")}, newFakeTerminal(), nil)
 

--- a/internal/terminal/hookstate.go
+++ b/internal/terminal/hookstate.go
@@ -1,0 +1,60 @@
+package terminal
+
+import "sync"
+
+// turnLog is the memory behind the one distinction the session-state contract
+// cannot make on its own (docs/hooks/session-state.md): Claude Code raises the
+// same `Notification` — reported as `waiting` — for a permission prompt and for
+// a session that has simply been sitting at its own prompt with nothing to do.
+// The card draws `waiting` as "Waiting on you" and the window toasts it, so a
+// session nobody was blocked on wore the badge that says a human is.
+//
+// A permission decision only ever happens inside a turn, so the report before it
+// tells the two apart: after `busy` a turn is open and something in it is
+// blocked on a human; after `done`, or after nothing at all, there is no turn to
+// block and the notification is the provider's "your turn" nudge. It is the same
+// reading internal/relay makes of the pair (see relay.Observe), from its own
+// record: that one answers for which turn an errand belongs to, this one for
+// what the window is told.
+//
+// The zero value is ready to use.
+type turnLog struct {
+	mu   sync.Mutex
+	open map[string]bool
+}
+
+// report takes one session-state report and answers whether the window should
+// hear it. Only an idle-prompt `waiting` is held back, and it is dropped rather
+// than published under a state of its own: the card then keeps whatever it was
+// already showing — the finished turn, an inbox count, nothing — which is what a
+// session nobody is blocked on should show.
+func (l *turnLog) report(id, state string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	switch state {
+	case statusWaiting:
+		// Recorded neither way: `waiting` interrupts a turn rather than replacing
+		// it, so the report after it still has to be read against the turn it
+		// interrupted. Two permission prompts in one turn are two blocks.
+		return l.open[id]
+	case statusBusy:
+		if l.open == nil {
+			l.open = make(map[string]bool)
+		}
+		l.open[id] = true
+	default:
+		// `done` ends the turn; `idle` (SessionEnd) ends the session, and a row
+		// per dead session would grow for the life of the process. Absent reads
+		// as "no turn open", which is what both of them mean here.
+		delete(l.open, id)
+	}
+	return true
+}
+
+// forget drops a session's turn, so a PTY respawned under the same id is read
+// against its own reports rather than against those of the provider that left.
+func (l *turnLog) forget(id string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.open, id)
+}

--- a/internal/terminal/hookstate_test.go
+++ b/internal/terminal/hookstate_test.go
@@ -1,0 +1,133 @@
+package terminal
+
+import (
+	"fmt"
+	"net/http"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// The two readings of one `waiting` report, which is the whole point of
+// turnLog: inside a turn a human is blocking it, outside one the session is
+// merely sitting at its prompt.
+func TestTurnLogTellsBlockedFromIdle(t *testing.T) {
+	tests := []struct {
+		name   string
+		before []string
+		want   bool
+	}{
+		{"permission prompt inside a turn", []string{statusBusy}, true},
+		{"a tool ran first", []string{statusBusy, statusBusy}, true},
+		{"a second prompt in the same turn", []string{statusBusy, statusWaiting}, true},
+		{"the turn resumed after the first prompt", []string{statusBusy, statusWaiting, statusBusy}, true},
+		{"idle at the prompt after a finished turn", []string{statusBusy, statusDone}, false},
+		{"nothing was ever reported", nil, false},
+		{"the session ended", []string{statusBusy, statusIdle}, false},
+		{"a turn that ended and one that never started", []string{statusBusy, statusDone, statusWaiting}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var log turnLog
+			for _, state := range tc.before {
+				log.report("s1", state)
+			}
+			if got := log.report("s1", statusWaiting); got != tc.want {
+				t.Fatalf("waiting after %v published = %v, want %v", tc.before, got, tc.want)
+			}
+		})
+	}
+}
+
+// Every state but `waiting` reaches the window as sent — the filter is one
+// distinction, not a gate on the stream.
+func TestTurnLogPublishesEveryOtherState(t *testing.T) {
+	var log turnLog
+	for _, state := range []string{statusBusy, statusDone, statusIdle, statusBusy} {
+		if !log.report("s1", state) {
+			t.Fatalf("%q was held back from the window", state)
+		}
+	}
+}
+
+// One session's turn says nothing about another's: a permission prompt in a
+// busy session must not vouch for an idle one.
+func TestTurnLogKeepsSessionsApart(t *testing.T) {
+	var log turnLog
+	log.report("busy-one", statusBusy)
+	if log.report("idle-one", statusWaiting) {
+		t.Fatal("an idle session was published as blocked because another one was busy")
+	}
+	if !log.report("busy-one", statusWaiting) {
+		t.Fatal("the busy session's permission prompt was held back")
+	}
+}
+
+// A PTY respawned under the same id starts from nothing: the turn the previous
+// provider left open died with it, and reading the new one against it would
+// badge its first idle notification as a block.
+func TestTurnLogForgetsARespawnedSession(t *testing.T) {
+	var log turnLog
+	log.report("s1", statusBusy)
+	log.forget("s1")
+	if log.report("s1", statusWaiting) {
+		t.Fatal("the respawned session inherited the dead provider's open turn")
+	}
+}
+
+// The end of the wire the user sees: a report reaches the window through the
+// hook endpoint and the /events socket, or it does not reach it at all. The
+// same run covers both directions, because the second `waiting` is the one the
+// author saw badge a worker that had just answered.
+func TestHookPublishesOnlyABlockingWait(t *testing.T) {
+	hub, rec := newProbeHub(t)
+	svc := New(hookStore{}, nil, hub)
+	if svc.wsErr != nil {
+		t.Fatalf("transport: %v", svc.wsErr)
+	}
+
+	// A turn with a permission prompt in it, then a turn that ends and leaves
+	// the session sitting at its prompt.
+	for _, state := range []string{"busy", "waiting", "busy", "done", "waiting"} {
+		postHook(t, svc, "s1", state)
+	}
+
+	// Every emit is written to the socket before its POST answers, and the
+	// socket is FIFO, so a sentinel coming back proves the whole stream has
+	// landed — including a fifth report that should not be in it. Asserting on a
+	// count would pass on the first four and never see the one this test is for.
+	hub.Emit(probeReadyEvent, nil)
+	waitFor(t, func() bool { return slices.Contains(rec.snapshot(), probeReadyEvent) },
+		"the window to be told about both turns")
+
+	want := []string{"busy", "waiting", "busy", "done"}
+	got := rec.statesOf("s1")
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("the window was told %v, want %v", got, want)
+	}
+}
+
+// hookStore answers the one question a status report asks of the store: every
+// non-idle report refreshes the context readout, which looks up the session's
+// provider conversation. An empty one ends that lookup there. The rest of the
+// interface is embedded and nil, so a path that starts using it panics loudly
+// rather than being quietly stubbed out here.
+type hookStore struct{ Store }
+
+func (hookStore) ProviderSession(string) (string, error) { return "", nil }
+
+// postHook reports one state the way the companion plugin does, and fails the
+// test unless lich accepted it (docs/hooks/session-state.md).
+func postHook(t *testing.T, svc *Service, id, state string) {
+	t.Helper()
+	url := fmt.Sprintf("http://127.0.0.1:%d/hook?token=%s", svc.ws.port, svc.ws.token)
+	body := fmt.Sprintf(`{"session_id":%q,"state":%q}`, id, state)
+	resp, err := http.Post(url, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("post %q: %v", state, err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("hook %q: status = %d, want 204", state, resp.StatusCode)
+	}
+}

--- a/internal/terminal/probehub_test.go
+++ b/internal/terminal/probehub_test.go
@@ -1,0 +1,160 @@
+// A hub with a real /events client on the other end, so a test can assert on
+// what the service actually pushed to the window rather than on the call it
+// made. No PTY is involved, so this runs everywhere the suite does.
+
+package terminal
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/omartelo/lich/internal/events"
+)
+
+// probeReadyEvent is the sentinel newProbeHub emits until its client is
+// attached. The hub drops events while nobody is connected, so one coming back
+// is the only proof, from outside the events package, that the socket is live.
+const probeReadyEvent = "probe-ready"
+
+// eventRecorder collects, in order, the name of every event the hub pushed to
+// its client, plus the payload each name last carried.
+type eventRecorder struct {
+	mu       sync.Mutex
+	names    []string
+	payloads map[string]any
+	// states is every session-status payload in the order it arrived, which is
+	// what a test about the status stream asserts on: payloads keeps only the
+	// last one per name, and a report that should never have been pushed is
+	// exactly the one the next report would hide.
+	states []statusEvent
+}
+
+func (r *eventRecorder) add(name string, data any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.names = append(r.names, name)
+	if r.payloads == nil {
+		r.payloads = make(map[string]any)
+	}
+	r.payloads[name] = data
+	if name == statusEventName {
+		r.states = append(r.states, decodeStatus(data))
+	}
+}
+
+// decodeStatus reads a status payload back off the wire, where it arrived as
+// the generic JSON object every envelope carries.
+func decodeStatus(data any) statusEvent {
+	fields, _ := data.(map[string]any)
+	text := func(key string) string {
+		value, _ := fields[key].(string)
+		return value
+	}
+	return statusEvent{ID: text("id"), State: text("state"), Tool: text("tool"), Detail: text("detail")}
+}
+
+// payloadOf returns the payload of the last event pushed under this name, and
+// whether any was pushed at all.
+func (r *eventRecorder) payloadOf(name string) (any, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	data, ok := r.payloads[name]
+	return data, ok
+}
+
+func (r *eventRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return slices.Clone(r.names)
+}
+
+// statesOf returns the states pushed for one session, in order.
+func (r *eventRecorder) statesOf(id string) []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var states []string
+	for _, event := range r.states {
+		if event.ID == id {
+			states = append(states, event.State)
+		}
+	}
+	return states
+}
+
+func (r *eventRecorder) reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.names = nil
+	r.payloads = nil
+	r.states = nil
+}
+
+// newProbeHub returns a hub with a real websocket client attached plus a
+// recorder of every event name that client received, so a test can assert on
+// what the service actually pushed to the window. The record starts empty: the
+// socket is FIFO, so one last sentinel coming back proves every straggler from
+// the attach loop was already recorded when the reset ran.
+func newProbeHub(t *testing.T) (*events.Hub, *eventRecorder) {
+	t.Helper()
+	hub := events.New()
+	server := httptest.NewServer(hub)
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+	conn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(server.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial probe hub: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.CloseNow() })
+
+	rec := &eventRecorder{}
+	go func() {
+		for {
+			_, payload, err := conn.Read(context.Background())
+			if err != nil {
+				return
+			}
+			var envelope events.Envelope
+			if err := json.Unmarshal(payload, &envelope); err != nil {
+				return
+			}
+			rec.add(envelope.Name, envelope.Data)
+		}
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for len(rec.snapshot()) == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("probe hub client never attached")
+		}
+		hub.Emit(probeReadyEvent, nil)
+		time.Sleep(time.Millisecond)
+	}
+	settled := len(rec.snapshot())
+	hub.Emit(probeReadyEvent, nil)
+	waitFor(t, func() bool { return len(rec.snapshot()) > settled }, "the probe hub to settle")
+	rec.reset()
+	return hub, rec
+}
+
+// waitFor polls cond until it holds, failing the test if it never does. Every
+// wait in these tests is for something that must happen, never for a duration.
+func waitFor(t *testing.T, cond func() bool, what string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", what)
+}

--- a/internal/terminal/respawn_test.go
+++ b/internal/terminal/respawn_test.go
@@ -5,21 +5,16 @@
 package terminal
 
 import (
-	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
-	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
-	"sync"
 	"syscall"
 	"testing"
 	"time"
 
-	"github.com/coder/websocket"
 	"github.com/omartelo/lich/internal/events"
 )
 
@@ -29,114 +24,6 @@ import (
 // magnitude wider than it needs — wide enough that a slow runner cannot turn
 // these assertions into a coin flip.
 const reapSettle = 250 * time.Millisecond
-
-// probeReadyEvent is the sentinel newProbeHub emits until its client is
-// attached. The hub drops events while nobody is connected, so one coming back
-// is the only proof, from outside the events package, that the socket is live.
-const probeReadyEvent = "probe-ready"
-
-// eventRecorder collects, in order, the name of every event the hub pushed to
-// its client, plus the payload each name last carried.
-type eventRecorder struct {
-	mu       sync.Mutex
-	names    []string
-	payloads map[string]any
-}
-
-func (r *eventRecorder) add(name string, data any) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.names = append(r.names, name)
-	if r.payloads == nil {
-		r.payloads = make(map[string]any)
-	}
-	r.payloads[name] = data
-}
-
-// payloadOf returns the payload of the last event pushed under this name, and
-// whether any was pushed at all.
-func (r *eventRecorder) payloadOf(name string) (any, bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	data, ok := r.payloads[name]
-	return data, ok
-}
-
-func (r *eventRecorder) snapshot() []string {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	return slices.Clone(r.names)
-}
-
-func (r *eventRecorder) reset() {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.names = nil
-	r.payloads = nil
-}
-
-// newProbeHub returns a hub with a real websocket client attached plus a
-// recorder of every event name that client received, so a test can assert on
-// what the service actually pushed to the window. The record starts empty: the
-// socket is FIFO, so one last sentinel coming back proves every straggler from
-// the attach loop was already recorded when the reset ran.
-func newProbeHub(t *testing.T) (*events.Hub, *eventRecorder) {
-	t.Helper()
-	hub := events.New()
-	server := httptest.NewServer(hub)
-	t.Cleanup(server.Close)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	t.Cleanup(cancel)
-	conn, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(server.URL, "http"), nil)
-	if err != nil {
-		t.Fatalf("dial probe hub: %v", err)
-	}
-	t.Cleanup(func() { _ = conn.CloseNow() })
-
-	rec := &eventRecorder{}
-	go func() {
-		for {
-			_, payload, err := conn.Read(context.Background())
-			if err != nil {
-				return
-			}
-			var envelope events.Envelope
-			if err := json.Unmarshal(payload, &envelope); err != nil {
-				return
-			}
-			rec.add(envelope.Name, envelope.Data)
-		}
-	}()
-
-	deadline := time.Now().Add(5 * time.Second)
-	for len(rec.snapshot()) == 0 {
-		if time.Now().After(deadline) {
-			t.Fatal("probe hub client never attached")
-		}
-		hub.Emit(probeReadyEvent, nil)
-		time.Sleep(time.Millisecond)
-	}
-	settled := len(rec.snapshot())
-	hub.Emit(probeReadyEvent, nil)
-	waitFor(t, func() bool { return len(rec.snapshot()) > settled }, "the probe hub to settle")
-	rec.reset()
-	return hub, rec
-}
-
-// waitFor polls cond until it holds, failing the test if it never does. Every
-// wait in these tests is for something that must happen, never for a duration.
-func waitFor(t *testing.T, cond func() bool, what string) {
-	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		if cond() {
-			return
-		}
-		time.Sleep(time.Millisecond)
-	}
-	t.Fatalf("timed out waiting for %s", what)
-}
 
 // respawn runs the lifecycle both tests need — start a session, close it,
 // start it again under the same id — and returns the session whose PTY died,

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -183,6 +183,12 @@ type Service struct {
 	// without answering (internal/relay). Guarded by mu: wired after the
 	// transport is already serving.
 	onState func(id, state string)
+	// turns is which sessions have a turn open right now, which is what tells a
+	// `waiting` report that a human is blocking from one that only says the
+	// session is sitting at its prompt (see turnLog). It carries its own lock:
+	// nothing else about a report needs mu, and a hook must never queue behind a
+	// PTY spawn.
+	turns turnLog
 	// lastCols/lastRows is the last terminal size the window reported, and the
 	// size a session spawned with none of its own is started at. See
 	// sizeFor. Guarded by mu.
@@ -252,12 +258,19 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 			}
 		},
 		func(req hookRequest) {
-			hub.Emit(statusEventName, statusEvent{
-				ID:     req.SessionID,
-				State:  req.State,
-				Tool:   req.Tool,
-				Detail: req.Detail,
-			})
+			// The window is told what the report means, not what it said: a
+			// `waiting` outside a turn is a session idle at its prompt, and the
+			// card would draw it as a human being blocked (see turnLog).
+			if s.turns.report(req.SessionID, req.State) {
+				hub.Emit(statusEventName, statusEvent{
+					ID:     req.SessionID,
+					State:  req.State,
+					Tool:   req.Tool,
+					Detail: req.Detail,
+				})
+			}
+			// The relay reads the stream raw: it keeps its own turn accounting,
+			// and a report held back from the window still moves an errand.
 			if watch := s.stateWatcher(); watch != nil {
 				watch(req.SessionID, req.State)
 			}
@@ -446,6 +459,9 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 	if _, running := s.sessions[id]; running {
 		return nil, "", nil
 	}
+	// Whatever the previous provider left open under this id died with its PTY,
+	// and the first report of the new one has to be read against its own turn.
+	s.turns.forget(id)
 	cols, rows = s.sizeFor(cols, rows)
 
 	if cwd == "" {


### PR DESCRIPTION
## The bug

A card said **"Waiting on you"** when nobody was waiting on anybody. Reproduced on a real delegated
session: a worker finished its task, answered through the relay, and its card then wore the amber rung
(`SessionCard.tsx:287`) and fired the attention toast. Nothing was blocked.

The cause is in the contract, not in a component. Claude Code raises the same `Notification` when it needs
a permission decision **and** when a session has simply been sitting at its prompt with nothing to do. The
hook client cannot tell them apart — the event carries the same shape either way — so it reports `waiting`
for both, and lich published that raw. `waiting` is the state that means "a human is blocking this".

## The fix

lich already makes the distinction internally: `relay.Observe` reads a `waiting` mid-turn as a permission
prompt with the turn still open, and a `waiting` after `done` as the provider's "your turn" nudge. A
permission decision only ever happens inside a turn, so the previous report settles it.

This publishes that distinction instead of the raw state. `turnLog` (`internal/terminal/hookstate.go`)
records whether a session has a turn open and gates the `session-status` emit on it, at the one funnel every
hook report passes through:

- `busy` → `waiting` — a human is blocking an open turn. Published, exactly as before.
- `done` / `idle` / nothing on record → `waiting` — the session is idle at its prompt. **Nothing is
  emitted**: no bell, no toast, no desktop notification.

Dropped rather than republished under a state of its own, so the card keeps whatever it was already
showing — the finished turn, an inbox count, nothing. Both surfaces in scope read that single event, so the
rung and the toast are fixed at the source and the frontend re-derives no rule: there is no frontend change
in this PR.

`waiting` is not recorded either way, since it interrupts a turn rather than replacing it — two permission
prompts in one turn are still two blocks. A respawned PTY forgets the turn its predecessor left open.

### Second commit: the same claim, on the roster

#278 landed while this was in review and added a third consumer of the raw state: the peer roster publishes
what each session last reported (`Peer.State`, `lich list`, `list_sessions`), where `waiting` is documented
as the one state meaning *do not send work into this session*. Fed the same ambiguous `Notification`, a
session idle at its prompt told every peer agent to stay away from the session most able to take work —
the same bug, on the surface agents read rather than the one people look at.

`Observe` already holds the turn state that tells the two apart, so the roster now applies the same rule:
a `waiting` inside a turn is published, one outside a turn leaves the last report standing. The turn state
itself (`s.state`) is untouched — a delivery landing mid-permission still queues behind the turn it is in,
which `TestPeersCarryTheStateEachSessionReported` keeps pinned.

Flagging it as a scope call: it was not in the original brief, because the surface did not exist when the
brief was written. Happy to split it out if you would rather it travelled on its own.

## The plugin needs nothing

The hooks send exactly what they sent; only lich's reading of it changed. **No `lich-plugin` release is
required.** `docs/hooks/session-state.md` moves in this PR anyway, because it is where the wrong reading was
written down: the `Notification` paragraph now says the client cannot tell the two apart and lich decides,
the server-side list gains a `turnLog` bullet and a peer-roster bullet, and a new known ceiling records that
a `waiting` with no `busy` on record reads as idle.

## Tests

Both directions, at the rule and through the real wire:

- `TestTurnLogTellsBlockedFromIdle` — table over what precedes the `waiting`: inside a turn (including a
  second prompt in the same turn) it publishes; after `done`, after `idle`, after nothing, it does not.
- `TestTurnLogKeepsSessionsApart`, `TestTurnLogForgetsARespawnedSession`, `TestTurnLogPublishesEveryOtherState`.
- `TestHookPublishesOnlyABlockingWait` — posts `busy, waiting, busy, done, waiting` to the real `/hook`
  endpoint and reads what came back over a real `/events` socket: the window is told `busy, waiting, busy,
  done`. A sentinel closes the stream first, so a fifth report cannot slip past a count check.
- `TestPeersDoNotCallAnIdlePromptWaiting` — the roster half, against
  `TestPeersCarryTheStateEachSessionReported` which pins the blocking direction.

Verified by mutation: `return l.open[id]` → `return true` fails all four terminal tests, the end-to-end one
included; disabling the roster's new case fails the roster test.

The probe hub (`newProbeHub`, `eventRecorder`, `waitFor`) moves out of the `!windows`-tagged `respawn_test.go`
into `probehub_test.go`: it drives no PTY, so the new test runs on every OS the suite does.

## Test plan

- [x] `gofmt -l .` clean · `go vet ./...` clean
- [x] `go test ./...` green; `go test -race` green on `internal/terminal` and `internal/relay`
- [x] `go test -count=50` on the new tests — no flake
- [x] Cross-compile loop `linux`/`darwin`/`windows`: `go build ./...` + `go vet ./...` all clean
- [x] `pnpm check` clean (14 standing a11y warnings), `vitest run` 886 passed, `pnpm build` succeeds
- [x] CI green after rebase: `test`, `os-tests (windows-latest)`, `os-tests (macos-latest)`