### PR TITLE
feat: a delegated session keeps saying where it came from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A delegated session keeps saying where it came from.** A card opened by
+  another session used to show that only while the request was still open: the
+  moment the worker answered, the mark came down and three workers of a fan-out
+  looked like three unrelated cards. The card now carries a quiet `from <the
+  session that asked>` line for as long as it exists, under everything the card
+  has to say about what is happening right now — so it surfaces exactly when the
+  session goes quiet, which is when you are trying to work out where a card came
+  from. It survives a reload and a restart, follows the parent through a rename,
+  and keeps naming it after it is closed: the delegation happened, whatever
+  became of the session that asked. Sessions opened from the window have no
+  origin and show nothing.
+
 - **The session roster says what each session is doing.** `lich sessions` grew a
   `state` column and the `list_sessions` tool a `state` field, carrying what that
   session last reported: `busy` mid-turn, `done` at a prompt and free, and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -280,8 +280,13 @@ absent without `--prompt`, so a reader that branches on it is never handed an
 empty one to interpret:
 
 ```json
-{"id":"9f8e","projectId":"p1","project":"lich","label":"auth-fix","name":"auth-fix-9f8e","kind":"claude","path":"/wt/auth-fix","nextSeq":5,"delivery":{"ticket":"a1b2c3d4","target":"auth-fix","status":"pending","answer":""}}
+{"id":"9f8e","projectId":"p1","project":"lich","label":"auth-fix","name":"auth-fix-9f8e","kind":"claude","path":"/wt/auth-fix","nextSeq":5,"originSessionId":"3c4d","originLabel":"planner","delivery":{"ticket":"a1b2c3d4","target":"auth-fix","status":"pending","answer":""}}
 ```
+
+`originSessionId` and `originLabel` name the session this one was opened from —
+the id it answers to, and the label its card carried at that moment. Both are
+`""` when `lich open` runs outside a session, which is the normal case for the
+command line.
 
 The card appears in the sidebar **without taking focus** — nobody in front of
 the window asked for this session — and its PTY is started by lich itself rather
@@ -561,7 +566,8 @@ receiving agent only because this text describes it.
   existing package owns more than one of them. The window does the same four in
   `frontend/src/providers/projects.tsx`, in its own order.
 - **The card** — `session-opened` carries the whole session
-  (`{id, projectId, project, label, name, kind, path, nextSeq}`) rather than an
+  (`{id, projectId, project, label, name, kind, path, nextSeq, originSessionId,
+  originLabel}`) rather than an
   id to look up: the row is already written and the PTY is already running, so
   the window has nothing to fetch and nothing to spawn. `adoptSession`
   (`frontend/src/lib/session/sessions.ts`) appends it **without focusing it** —

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -5,6 +5,7 @@ import {
   ArrowLeft,
   ArrowRight,
   CircleQuestionMark,
+  CornerDownLeft,
   GitBranch,
   GitPullRequestArrow,
   Inbox,
@@ -52,6 +53,9 @@ import { SessionTargetPicker } from "./SessionTargetPicker"
 interface SessionCardProps {
   session: Session
   path: string
+  // The session this one was opened from, named as it is called now; "" for a
+  // session nobody delegated, which is most of them (sessionOrigin).
+  origin: string
   active: boolean
   onSelect: () => void
   onClose: () => void
@@ -76,6 +80,7 @@ interface SessionCardProps {
 export function SessionCard({
   session,
   path,
+  origin,
   active,
   onSelect,
   onClose,
@@ -254,18 +259,23 @@ export function SessionCard({
                   </span>
                 </span>
               )}
-              {/* One line, four rungs: an open request, then a session blocked
+              {/* One line, five rungs: an open request, then a session blocked
                   on the user, then results waiting to be collected, then the
-                  tool. A request in flight explains the whole turn — a card
-                  working because another session asked it to, or one stalled
-                  waiting on a card elsewhere in the list. A block outranks the
-                  rest for the reason it needs words at all: the amber ring
-                  differs from the emerald one by hue alone, so nothing else on
-                  the card says the session wants an answer. The inbox sits
-                  under those and over the tool: mid-turn the live tool is the
-                  news, and the count takes the rung when the card goes quiet —
-                  the same rule the relay's own nudge follows. Only one rung
-                  ever draws, so the card grows by one row at most. */}
+                  tool, then where the session came from. A request in flight
+                  explains the whole turn — a card working because another
+                  session asked it to, or one stalled waiting on a card
+                  elsewhere in the list. A block outranks the rest for the
+                  reason it needs words at all: the amber ring differs from the
+                  emerald one by hue alone, so nothing else on the card says the
+                  session wants an answer. The inbox sits under those and over
+                  the tool: mid-turn the live tool is the news, and the count
+                  takes the rung when the card goes quiet — the same rule the
+                  relay's own nudge follows. The origin is last precisely
+                  because it is never news: it says something that has been true
+                  since the card was created, so it surfaces only once the card
+                  is quiet, which is when somebody scanning the sidebar is
+                  working out where a card came from. Only one rung ever draws,
+                  so the card grows by one row at most. */}
               {relay ? (
                 <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">
                   {relay.direction === "out" ? (
@@ -293,17 +303,29 @@ export function SessionCard({
                     {inbox === 1 ? "1 result ready" : `${inbox} results ready`}
                   </span>
                 </span>
+              ) : tool ? (
+                <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">
+                  {ToolGlyph && <ToolGlyph className="size-3 shrink-0" />}
+                  <span className="shrink-0 font-medium text-foreground">{tool.name}</span>
+                  {tool.detail && (
+                    <>
+                      <span className="shrink-0 opacity-50">·</span>
+                      <span className="truncate font-mono">{tool.detail}</span>
+                    </>
+                  )}
+                </span>
               ) : (
-                tool && (
+                // Quieter than the rungs above it, on purpose: muted throughout
+                // and at normal weight, where an open request puts its peer in
+                // text-foreground. The word "from" earns its place — an arrow
+                // and a name alone read as traffic happening now, which is the
+                // confusion this rung exists to end. Not a link either: the
+                // parent may be closed, and a dead link is worse than a
+                // sentence.
+                origin && (
                   <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">
-                    {ToolGlyph && <ToolGlyph className="size-3 shrink-0" />}
-                    <span className="shrink-0 font-medium text-foreground">{tool.name}</span>
-                    {tool.detail && (
-                      <>
-                        <span className="shrink-0 opacity-50">·</span>
-                        <span className="truncate font-mono">{tool.detail}</span>
-                      </>
-                    )}
+                    <CornerDownLeft className="size-3 shrink-0" />
+                    <span className="truncate">from {origin}</span>
                   </span>
                 )
               )}

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -6,7 +6,7 @@ import { dragStyle, useSortableList, verticalAxis } from "@/lib/use-sortable-lis
 import { cn } from "@/lib/utils"
 import { checkoutLabel } from "@/lib/git/checkout-label"
 import type { DelegateGroup } from "@/lib/session/delegate-targets"
-import type { Session } from "@/lib/session/sessions"
+import { type Session, sessionOrigin } from "@/lib/session/sessions"
 import { useProjects } from "@/providers/projects"
 import { SessionCard } from "./SessionCard"
 import { PullRequestCard } from "./PullRequestCard"
@@ -77,7 +77,13 @@ export function SessionGroup({
   onClosePulls,
   delegateGroups,
 }: SessionGroupProps) {
-  const { activateSession, renameSession, pinSession, newSession } = useProjects()
+  const {
+    sessions: workspace,
+    activateSession,
+    renameSession,
+    pinSession,
+    newSession,
+  } = useProjects()
   const navigate = useNavigate()
   const ids = sessions.map((session) => session.id)
   const { sensors, onDragEnd } = useSortableList(ids, onReorder)
@@ -130,6 +136,10 @@ export function SessionGroup({
                 key={session.id}
                 session={session}
                 path={projectPath}
+                // Resolved here rather than in the card: the parent can be a
+                // session in another project, which only the workspace-wide
+                // state knows about.
+                origin={sessionOrigin(workspace, session)}
                 active={session.id === activeId}
                 onSelect={() => select(session.id)}
                 onClose={() => onClose(session)}

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -277,6 +277,10 @@ export interface StoredSession {
   path: string
   providerSessionId: string
   pinned: boolean
+  /** The session that asked for this one, "" for a session nobody delegated. */
+  originSessionId: string
+  /** What that session was called at the time; all that survives its close. */
+  originLabel: string
 }
 
 /** internal/terminal.TranscriptMatch — a session whose conversation mentions a

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -278,6 +278,32 @@ export const Store = {
     path: string,
     nextSeq: number,
   ) => call<null>("store.AddSession", [projectID, sessionID, label, kind, path, nextSeq]),
+  /**
+   * AddSession for a session that was opened by delegation: originID is the
+   * session that asked for it and originLabel what that one was called then.
+   * The window only ever uses it to re-create a row it already had — an origin
+   * is minted backend-side, in internal/spawn.
+   */
+  AddSessionFrom: (
+    projectID: string,
+    sessionID: string,
+    label: string,
+    kind: string,
+    path: string,
+    nextSeq: number,
+    originID: string,
+    originLabel: string,
+  ) =>
+    call<null>("store.AddSessionFrom", [
+      projectID,
+      sessionID,
+      label,
+      kind,
+      path,
+      nextSeq,
+      originID,
+      originLabel,
+    ]),
   DeleteSession: (projectID: string, sessionID: string, activeID: string) =>
     call<null>("store.DeleteSession", [projectID, sessionID, activeID]),
   /** Park a session (keep its row for a later resume) instead of deleting it. */

--- a/frontend/src/lib/session/session-events.test.ts
+++ b/frontend/src/lib/session/session-events.test.ts
@@ -271,6 +271,8 @@ describe("toOpenedSession", () => {
     kind: "claude",
     path: "/wt/auth-fix",
     nextSeq: 5,
+    originSessionId: "s1",
+    originLabel: "planner",
   }
 
   it("narrows a session opened outside the window", () => {
@@ -281,7 +283,17 @@ describe("toOpenedSession", () => {
       kind: "claude",
       path: "/wt/auth-fix",
       nextSeq: 5,
+      originSessionId: "s1",
+      originLabel: "planner",
     })
+  })
+
+  // A session opened from the window, or by `lich open` from a plain shell, has
+  // no origin at all — absent is the normal case, not a malformed payload.
+  it("keeps a session that nobody delegated", () => {
+    const opened = toOpenedSession({ ...payload, originSessionId: undefined, originLabel: 4 })
+    expect(opened?.originSessionId).toBe("")
+    expect(opened?.originLabel).toBe("")
   })
 
   it("keeps a session in the project's own directory", () => {

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -197,6 +197,10 @@ export interface OpenedSession {
   kind: SessionKind
   path: string
   nextSeq: number
+  // The session that asked for this one, and what it was called at the time.
+  // Both "" when the opener was not a session — `lich open` from a plain shell.
+  originSessionId: string
+  originLabel: string
 }
 
 // toOpenedSession narrows a session-opened payload, or null when it names
@@ -208,12 +212,14 @@ export function toOpenedSession(data: unknown): OpenedSession | null {
   if (!isIdEvent(data)) {
     return null
   }
-  const { projectId, label, kind, path, nextSeq } = data as {
+  const { projectId, label, kind, path, nextSeq, originSessionId, originLabel } = data as {
     projectId?: unknown
     label?: unknown
     kind?: unknown
     path?: unknown
     nextSeq?: unknown
+    originSessionId?: unknown
+    originLabel?: unknown
   }
   if (typeof projectId !== "string" || projectId === "" || typeof label !== "string") {
     return null
@@ -228,6 +234,8 @@ export function toOpenedSession(data: unknown): OpenedSession | null {
     kind,
     path: typeof path === "string" ? path : "",
     nextSeq: typeof nextSeq === "number" ? nextSeq : 1,
+    originSessionId: typeof originSessionId === "string" ? originSessionId : "",
+    originLabel: typeof originLabel === "string" ? originLabel : "",
   }
 }
 

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -21,6 +21,7 @@ import {
   reorderSubset,
   restoreSession,
   resumableSession,
+  sessionOrigin,
   sessionsOf,
   setActiveSession,
   setSessionPinned,
@@ -719,6 +720,52 @@ describe("adoptSession", () => {
     const before = buildState(5)
     const state = adoptSession(before, P, opened, 2)
     expect(state[P].nextSeq).toBe(before[P].nextSeq)
+  })
+})
+
+describe("sessionOrigin", () => {
+  // The child of s1, as the backend hands it over: the id of the session that
+  // asked for it, plus the name that session went by at the time.
+  const child: Session = {
+    id: "worker",
+    label: "auth-fix",
+    kind: "claude",
+    originSessionId: "s1",
+    originLabel: "Session 1",
+  }
+
+  it("names nothing for a session nobody delegated", () => {
+    const state = buildState(2)
+    expect(sessionOrigin(state, state[P].sessions[0])).toBe("")
+  })
+
+  // The whole reason the id is stored beside the label: a renamed parent is
+  // still the parent, and the card has to say what it is called now.
+  it("follows a rename of the parent", () => {
+    const state = renameSession(adoptSession(buildState(2), P, child, 3), P, "s1", "planner")
+    expect(sessionOrigin(state, child)).toBe("planner")
+  })
+
+  // And the whole reason the label is stored beside the id: the delegation
+  // happened, and a closed parent does not make that untrue.
+  it("falls back to the name the parent had when it is gone", () => {
+    const state = closeSession(adoptSession(buildState(2), P, child, 3), P, "s1")
+    expect(sessionOrigin(state, child)).toBe("Session 1")
+  })
+
+  // Delegation crosses projects, so the lookup has to: the sidebar shows one
+  // project at a time and the parent can be in any of them.
+  it("finds a parent in another project", () => {
+    const state = adoptSession(addSession(buildState(2), "other", "o1"), "other", child, 2)
+    expect(sessionOrigin(state, state.other.sessions[1])).toBe("Session 1")
+  })
+
+  // An origin whose parent is gone and that never carried a name draws nothing
+  // rather than an empty "from".
+  it("names nothing when neither half resolves", () => {
+    expect(
+      sessionOrigin(buildState(1), { ...child, originSessionId: "ghost", originLabel: "" }),
+    ).toBe("")
   })
 })
 

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -38,6 +38,13 @@ export interface Session {
   providerSessionId?: string
   // Kept at the head of the project's list and refused a close until unpinned.
   pinned?: boolean
+  // The session that asked for this one, when it was opened by delegation:
+  // absent for every session opened from the window. The id is the live half —
+  // it resolves to whatever that session is called now — and the label is the
+  // name the delegation happened under, which is what is left once the parent
+  // is closed. Read them through sessionOrigin, never on their own.
+  originSessionId?: string
+  originLabel?: string
 }
 
 export interface ProjectSessions {
@@ -473,6 +480,24 @@ export function isLastWorktreeSession(sessions: Session[], session: Session): bo
 // closed — React unmounts a terminal for reasons of its own.
 export function hasSession(state: SessionState, sessionId: string): boolean {
   return projectOfSession(state, sessionId) !== ""
+}
+
+// sessionOrigin names the session a card was opened from, as the sidebar should
+// spell it now: the label the parent answers to at this moment, so a rename
+// shows through without a reload, falling back to the name it had when the
+// delegation happened. "" for a session nobody delegated — the usual case — and
+// for one whose parent is gone without a name ever having been recorded.
+//
+// The lookup spans every project because delegation does: a card can hand work
+// to a session in another project, and its own project alone would answer "" for
+// a parent that plainly exists.
+export function sessionOrigin(state: SessionState, session: Session): string {
+  if (!session.originSessionId) {
+    return ""
+  }
+  const projectId = projectOfSession(state, session.originSessionId)
+  const parent = state[projectId]?.sessions.find((s) => s.id === session.originSessionId)
+  return parent?.label ?? session.originLabel ?? ""
 }
 
 export function activeSessionId(state: SessionState, projectId: string): string {

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -136,6 +136,9 @@ function buildSessionState(loaded: StoreProject[]): SessionState {
       ...(s.path ? { path: s.path } : {}),
       ...(s.providerSessionId ? { providerSessionId: s.providerSessionId } : {}),
       ...(s.pinned ? { pinned: true } : {}),
+      ...(s.originSessionId
+        ? { originSessionId: s.originSessionId, originLabel: s.originLabel }
+        : {}),
     }))
     state[p.id] = {
       sessions,
@@ -247,8 +250,14 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       if (!opened) {
         return
       }
-      const { id, projectId, label, kind, path, nextSeq } = opened
-      const session: Session = { id, label, kind, ...(path ? { path } : {}) }
+      const { id, projectId, label, kind, path, nextSeq, originSessionId, originLabel } = opened
+      const session: Session = {
+        id,
+        label,
+        kind,
+        ...(path ? { path } : {}),
+        ...(originSessionId ? { originSessionId, originLabel } : {}),
+      }
       const next = adoptSession(sessionsRef.current, projectId, session, nextSeq)
       if (next !== sessionsRef.current) {
         setSessions(next)
@@ -392,6 +401,9 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
         kind: isSessionKind(restored.kind) ? restored.kind : "claude",
         path: restored.path,
         ...(restored.providerSessionId ? { providerSessionId: restored.providerSessionId } : {}),
+        ...(restored.originSessionId
+          ? { originSessionId: restored.originSessionId, originLabel: restored.originLabel }
+          : {}),
       }
       setSessions(restoreSession(sessionsRef.current, projectId, session))
     },
@@ -440,8 +452,25 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       }
       setSessions(next)
       const order = sessionsOf(next, projectId).map((s) => s.id)
-      const { id, label, kind, path = "", providerSessionId } = session
-      void Store.AddSession(projectId, id, label, kind, path, nextSeq)
+      const {
+        id,
+        label,
+        kind,
+        path = "",
+        providerSessionId,
+        originSessionId = "",
+        originLabel = "",
+      } = session
+      void Store.AddSessionFrom(
+        projectId,
+        id,
+        label,
+        kind,
+        path,
+        nextSeq,
+        originSessionId,
+        originLabel,
+      )
         .then(() => providerSessionId && Store.SetProviderSession(id, providerSessionId))
         // AddSession appends: the slot the card went back to is a reorder.
         .then(() => Store.ReorderSessions(projectId, order))

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -153,7 +153,7 @@ func (*spawnStore) LoadState() ([]store.Project, error) {
 	}}}, nil
 }
 
-func (s *spawnStore) AddSession(_, _, _, _, _ string, _ int) error {
+func (s *spawnStore) AddSessionFrom(_, _, _, _, _ string, _ int, _, _ string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.rows++

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -70,7 +70,9 @@ const (
 // a later resume. The store implements it.
 type Sessions interface {
 	LoadState() ([]store.Project, error)
-	AddSession(projectID, sessionID, label, kind, path string, nextSeq int) error
+	AddSessionFrom(
+		projectID, sessionID, label, kind, path string, nextSeq int, originID, originLabel string,
+	) error
 	SetSessionModel(sessionID, model string) error
 	DeleteSession(projectID, sessionID, activeID string) error
 	CloseSession(projectID, sessionID, activeID string) error
@@ -111,16 +113,19 @@ type Events interface {
 // name on its card. Both address it (see internal/relay). Path is the worktree
 // the session lives in, empty for a session in the project's own directory —
 // the store's own spelling. NextSeq is the project's label counter after this
-// session took its number.
+// session took its number. OriginSessionID and OriginLabel name the session that
+// asked for this one — empty when the caller was not a session at all.
 type Session struct {
-	ID        string `json:"id"`
-	ProjectID string `json:"projectId"`
-	Project   string `json:"project"`
-	Label     string `json:"label"`
-	Name      string `json:"name"`
-	Kind      string `json:"kind"`
-	Path      string `json:"path"`
-	NextSeq   int    `json:"nextSeq"`
+	ID              string `json:"id"`
+	ProjectID       string `json:"projectId"`
+	Project         string `json:"project"`
+	Label           string `json:"label"`
+	Name            string `json:"name"`
+	Kind            string `json:"kind"`
+	Path            string `json:"path"`
+	NextSeq         int    `json:"nextSeq"`
+	OriginSessionID string `json:"originSessionId"`
+	OriginLabel     string `json:"originLabel"`
 }
 
 // Service opens sessions on behalf of a caller outside the window.
@@ -145,7 +150,10 @@ func New(sessions Sessions, worktrees Worktrees, term Terminal, events Events) *
 // fromID is the session the caller runs in, empty for the command line run
 // outside one. It decides two defaults: the project the session lands in and the
 // provider it runs, both taken from the caller unless named. A caller with no
-// session of its own must name the project — there is nothing to inherit.
+// session of its own must name the project — there is nothing to inherit. It is
+// also recorded on the row as the new session's origin, which outlives the
+// request that created it: the card says where it came from for as long as it
+// exists.
 //
 // worktree, when given, is the branch name of a new git worktree created off
 // base (the project's current branch when base is empty); the session is rooted
@@ -224,17 +232,22 @@ func (s *Service) Open(fromID, projectName, kind, worktree, base, model string) 
 	if err != nil {
 		return Session{}, err
 	}
+	originID, originLabel := originOf(projects, fromID)
 	opened := Session{
-		ID:        id,
-		ProjectID: target.ID,
-		Project:   target.Name,
-		Label:     label,
-		Name:      relay.RosterName(cwd, id),
-		Kind:      kind,
-		Path:      stored,
-		NextSeq:   target.NextSeq + 1,
+		ID:              id,
+		ProjectID:       target.ID,
+		Project:         target.Name,
+		Label:           label,
+		Name:            relay.RosterName(cwd, id),
+		Kind:            kind,
+		Path:            stored,
+		NextSeq:         target.NextSeq + 1,
+		OriginSessionID: originID,
+		OriginLabel:     originLabel,
 	}
-	if err := s.sessions.AddSession(target.ID, id, label, kind, stored, opened.NextSeq); err != nil {
+	if err := s.sessions.AddSessionFrom(
+		target.ID, id, label, kind, stored, opened.NextSeq, originID, originLabel,
+	); err != nil {
 		return Session{}, err
 	}
 	// Announced before the spawn, and regardless of how it goes: the row exists
@@ -367,6 +380,24 @@ func resolveKind(projects []store.Project, fromID, kind string) (string, error) 
 		}
 	}
 	return providers.Claude, nil
+}
+
+// originOf names the session that asked for this one: its id, and the label it
+// answers to at this moment. A fromID that names no session in the workspace —
+// the command line run outside one, or a caller whose card has since gone — is
+// no origin at all, because there would be nothing to draw for it.
+func originOf(projects []store.Project, fromID string) (string, string) {
+	if fromID == "" {
+		return "", ""
+	}
+	for _, p := range projects {
+		for _, sess := range p.Sessions {
+			if sess.ID == fromID {
+				return fromID, sess.Label
+			}
+		}
+	}
+	return "", ""
 }
 
 // labelTaken reports whether a project already holds a session under a label.

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -12,12 +12,14 @@ import (
 
 // added is one session row the fake store was asked to write.
 type added struct {
-	projectID string
-	sessionID string
-	label     string
-	kind      string
-	path      string
-	nextSeq   int
+	projectID   string
+	sessionID   string
+	label       string
+	kind        string
+	path        string
+	nextSeq     int
+	originID    string
+	originLabel string
 }
 
 type fakeSessions struct {
@@ -61,11 +63,15 @@ func (f *fakeSessions) LoadState() ([]store.Project, error) {
 	return f.projects, f.loadErr
 }
 
-func (f *fakeSessions) AddSession(projectID, sessionID, label, kind, path string, nextSeq int) error {
+func (f *fakeSessions) AddSessionFrom(
+	projectID, sessionID, label, kind, path string, nextSeq int, originID, originLabel string,
+) error {
 	if f.addErr != nil {
 		return f.addErr
 	}
-	f.rows = append(f.rows, added{projectID, sessionID, label, kind, path, nextSeq})
+	f.rows = append(f.rows, added{
+		projectID, sessionID, label, kind, path, nextSeq, originID, originLabel,
+	})
 	// The counter moves with the write, as it does in the store: a fake that kept
 	// answering the old number would hide two sessions taking one label.
 	for i := range f.projects {
@@ -228,7 +234,7 @@ func TestOpenLandsInTheCallersProject(t *testing.T) {
 		t.Fatalf("wrote %d rows, want 1", len(sessions.rows))
 	}
 	row := sessions.rows[0]
-	if row != (added{"p1", opened.ID, "Session 4", "codex", "", 5}) {
+	if row != (added{"p1", opened.ID, "Session 4", "codex", "", 5, "s1", "Session 3"}) {
 		t.Errorf("row = %+v", row)
 	}
 	if len(term.spawns) != 1 {
@@ -380,6 +386,55 @@ func TestOpenWithoutAModelWritesNone(t *testing.T) {
 	}
 	if len(sessions.models) != 0 {
 		t.Errorf("wrote %v, want the model column left alone", sessions.models)
+	}
+}
+
+// The origin is the caller, not the project: a session opened into another
+// project still came from the card that asked for it, and the label written
+// beside the id is the one that caller answers to right now.
+func TestOpenRecordsTheCallerAsTheOrigin(t *testing.T) {
+	svc, sessions, _, _, events := newService(t)
+
+	opened, err := svc.Open("s1", "revu", "shell", "", "", "")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	row := sessions.rows[0]
+	if row.originID != "s1" || row.originLabel != "Session 3" {
+		t.Errorf("row origin = (%q, %q), want (s1, Session 3)", row.originID, row.originLabel)
+	}
+	// The window draws the rung off the event, so an origin only on the row is
+	// one that appears a reload late.
+	if opened.OriginSessionID != "s1" || opened.OriginLabel != "Session 3" {
+		t.Errorf("announced origin = (%q, %q), want (s1, Session 3)",
+			opened.OriginSessionID, opened.OriginLabel)
+	}
+	if events.events[0].data != any(opened) {
+		t.Errorf("the window was told %+v, the caller %+v", events.events[0].data, opened)
+	}
+}
+
+// No caller, no origin: `lich open` from a plain shell opens a session nobody
+// delegated, and a card that claims a parent it never had is worse than a quiet
+// one. A fromID that names no session in the workspace is the same case — there
+// is nothing left to name.
+func TestOpenWithoutACallerRecordsNoOrigin(t *testing.T) {
+	for _, from := range []string{"", "gone"} {
+		t.Run("from="+from, func(t *testing.T) {
+			svc, sessions, _, _, _ := newService(t)
+
+			opened, err := svc.Open(from, "lich", "", "", "", "")
+			if err != nil {
+				t.Fatalf("Open: %v", err)
+			}
+			row := sessions.rows[0]
+			if row.originID != "" || row.originLabel != "" {
+				t.Errorf("row origin = (%q, %q), want none", row.originID, row.originLabel)
+			}
+			if opened.OriginSessionID != "" || opened.OriginLabel != "" {
+				t.Errorf("announced origin = %+v, want none", opened)
+			}
+		})
 	}
 }
 

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -82,14 +82,28 @@ func (s *Service) DeleteProject(id string) error {
 // The session takes the position after the project's last one, so it appends to
 // the card list even once the user has dragged the others around.
 func (s *Service) AddSession(projectID, sessionID, label, kind, path string, nextSeq int) error {
+	return s.AddSessionFrom(projectID, sessionID, label, kind, path, nextSeq, "", "")
+}
+
+// AddSessionFrom is AddSession for a session opened by delegation: originID is
+// the session that asked for it and originLabel what that session was called at
+// the time. Both are written with the row rather than after it, so a card can
+// never exist without the origin it was created with.
+//
+// It is a second entry point rather than two more arguments on AddSession
+// because the window — the only caller reaching this over RPC — never has an
+// origin to pass. Only internal/spawn does.
+func (s *Service) AddSessionFrom(
+	projectID, sessionID, label, kind, path string, nextSeq int, originID, originLabel string,
+) error {
 	if kind == "" {
 		kind = providers.Claude
 	}
 	return s.tx(func(tx *sql.Tx) error {
 		if _, err := tx.Exec(
-			`INSERT INTO sessions (id, project_id, label, kind, path, position)
-			 VALUES (?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
-			sessionID, projectID, label, kind, path, projectID,
+			`INSERT INTO sessions (id, project_id, label, kind, path, origin_session_id, origin_label, position)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
+			sessionID, projectID, label, kind, path, originID, originLabel, projectID,
 		); err != nil {
 			return fmt.Errorf("insert session %q: %w", sessionID, err)
 		}
@@ -133,7 +147,7 @@ func (s *Service) CloseSession(projectID, sessionID, activeID string) error {
 // ReopenWorktreeSession resumes a parked worktree session. It finds the parked
 // (is_open = 0) session for the worktree at path and re-adds it to the workspace
 // under a fresh id (newSessionID), carrying over the old label, kind, provider
-// session id and label_auto flag. The fresh id is deliberate: it makes the frontend treat the card
+// session id, label_auto flag and origin. The fresh id is deliberate: it makes the frontend treat the card
 // as never-spawned, so its resume prompt fires and the provider conversation
 // continues instead of starting cold. Returns nil when nothing is parked at path
 // — the caller then opens a brand-new session.
@@ -146,13 +160,16 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 		// stomp the chosen name, breaking SetSessionTitle's contract.
 		var labelAuto int
 		row := tx.QueryRow(
-			`SELECT id, label, kind, provider_session_id, label_auto
+			`SELECT id, label, kind, provider_session_id, label_auto, origin_session_id, origin_label
 			   FROM sessions
 			  WHERE project_id = ? AND path = ? AND is_open = 0
 			  ORDER BY rowid DESC LIMIT 1`,
 			projectID, path,
 		)
-		if err := row.Scan(&old.ID, &old.Label, &old.Kind, &old.ProviderSessionID, &labelAuto); err != nil {
+		if err := row.Scan(
+			&old.ID, &old.Label, &old.Kind, &old.ProviderSessionID, &labelAuto,
+			&old.OriginSessionID, &old.OriginLabel,
+		); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return nil // nothing parked here; caller creates a new session
 			}
@@ -169,9 +186,12 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 			return fmt.Errorf("drop parked session %q: %w", old.ID, err)
 		}
 		if _, err := tx.Exec(
-			`INSERT INTO sessions (id, project_id, label, kind, path, provider_session_id, label_auto, position)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
-			newSessionID, projectID, old.Label, old.Kind, path, old.ProviderSessionID, labelAuto, projectID,
+			`INSERT INTO sessions
+			   (id, project_id, label, kind, path, provider_session_id, label_auto,
+			    origin_session_id, origin_label, position)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
+			newSessionID, projectID, old.Label, old.Kind, path, old.ProviderSessionID, labelAuto,
+			old.OriginSessionID, old.OriginLabel, projectID,
 		); err != nil {
 			return fmt.Errorf("reinsert session %q: %w", newSessionID, err)
 		}
@@ -181,7 +201,15 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 		if err := setActiveSession(tx, projectID, newSessionID); err != nil {
 			return err
 		}
-		restored = &Session{ID: newSessionID, Label: old.Label, Kind: old.Kind, Path: path, ProviderSessionID: old.ProviderSessionID}
+		restored = &Session{
+			ID:                newSessionID,
+			Label:             old.Label,
+			Kind:              old.Kind,
+			Path:              path,
+			ProviderSessionID: old.ProviderSessionID,
+			OriginSessionID:   old.OriginSessionID,
+			OriginLabel:       old.OriginLabel,
+		}
 		return nil
 	})
 	if err != nil {

--- a/internal/store/origin_test.go
+++ b/internal/store/origin_test.go
@@ -1,0 +1,99 @@
+package store
+
+import "testing"
+
+// TestSessionOriginPersistsAndDefaults pins the two halves of the origin: the id
+// of the session that asked for this one, and the label it was called at the
+// time. Both come back from LoadState, and a session nobody delegated carries
+// neither — absent is the normal case.
+func TestSessionOriginPersistsAndDefaults(t *testing.T) {
+	svc := newTestStore(t)
+	if err := svc.AddProject("p1", "alpha", "/tmp/alpha"); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+	if err := svc.AddSession("p1", "parent", "planner", "claude", "", 2); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+	if err := svc.AddSessionFrom("p1", "child", "worker", "claude", "/wt/a", 3, "parent", "planner"); err != nil {
+		t.Fatalf("AddSessionFrom: %v", err)
+	}
+
+	projects, err := svc.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if len(projects) != 1 || len(projects[0].Sessions) != 2 {
+		t.Fatalf("state = %+v", projects)
+	}
+	if parent := projects[0].Sessions[0]; parent.OriginSessionID != "" || parent.OriginLabel != "" {
+		t.Errorf("parent origin = %+v, want none", parent)
+	}
+	child := projects[0].Sessions[1]
+	if child.OriginSessionID != "parent" || child.OriginLabel != "planner" {
+		t.Errorf("child origin = (%q, %q), want (parent, planner)", child.OriginSessionID, child.OriginLabel)
+	}
+}
+
+// TestSessionOriginSurvivesARenameOfTheParent proves the shape does what a
+// single stored name could not: the id is what carries the rename, so the row
+// keeps naming the parent no matter what the parent is called now. The label
+// stored beside it is the fallback for a parent that is gone, and is deliberately
+// the name the delegation happened under.
+func TestSessionOriginSurvivesARenameOfTheParent(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "parent", "planner", "claude", "", 2)
+	_ = svc.AddSessionFrom("p1", "child", "worker", "claude", "", 3, "parent", "planner")
+
+	if err := svc.RenameSession("parent", "the boss"); err != nil {
+		t.Fatalf("RenameSession: %v", err)
+	}
+	projects, err := svc.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	sessions := projects[0].Sessions
+	if sessions[0].Label != "the boss" {
+		t.Errorf("parent label = %q, want the boss", sessions[0].Label)
+	}
+	if sessions[1].OriginSessionID != "parent" {
+		t.Errorf("child origin id = %q, want it to still name the parent", sessions[1].OriginSessionID)
+	}
+}
+
+// TestReopenWorktreeSessionCarriesTheOrigin proves a parked worktree session
+// comes back knowing where it came from. The resume reinserts the row under a
+// fresh id, so anything not copied across is lost — and the origin is identity,
+// which must outlive a park exactly as the label and the conversation id do.
+func TestReopenWorktreeSessionCarriesTheOrigin(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "parent", "planner", "claude", "", 2)
+	_ = svc.AddSessionFrom("p1", "child", "worker", "claude", "/wt/a", 3, "parent", "planner")
+	_ = svc.CloseSession("p1", "child", "parent")
+
+	restored, err := svc.ReopenWorktreeSession("p1", "/wt/a", "child2")
+	if err != nil {
+		t.Fatalf("ReopenWorktreeSession: %v", err)
+	}
+	if restored == nil {
+		t.Fatal("ReopenWorktreeSession = nil, want the parked session")
+	}
+	if restored.OriginSessionID != "parent" || restored.OriginLabel != "planner" {
+		t.Errorf("restored origin = (%q, %q), want (parent, planner)",
+			restored.OriginSessionID, restored.OriginLabel)
+	}
+	projects, err := svc.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	var reloaded Session
+	for _, s := range projects[0].Sessions {
+		if s.ID == "child2" {
+			reloaded = s
+		}
+	}
+	if reloaded.OriginSessionID != "parent" || reloaded.OriginLabel != "planner" {
+		t.Errorf("reloaded origin = %+v, want the parent it was opened from", reloaded)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -48,7 +48,13 @@ CREATE TABLE IF NOT EXISTS sessions (
     is_open             INTEGER NOT NULL DEFAULT 1,
     position            INTEGER NOT NULL DEFAULT 0,
     pinned              INTEGER NOT NULL DEFAULT 0,
-    model               TEXT NOT NULL DEFAULT ''
+    model               TEXT NOT NULL DEFAULT '',
+    -- The session that asked for this one, when it was opened by delegation.
+    -- Two columns rather than a foreign key: the id resolves to whatever the
+    -- parent is called now, and the label is what it was called when the
+    -- delegation happened — which is all that survives the parent being closed.
+    origin_session_id   TEXT NOT NULL DEFAULT '',
+    origin_label        TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
 
@@ -91,7 +97,10 @@ type Service struct {
 // sessions), it is the key for features that need to reach a session's
 // transcript or resume it. Only Claude Code reports one today. Pinned keeps a
 // session at the head of its project's list and withholds its close affordances
-// until it is unpinned.
+// until it is unpinned. OriginSessionID and OriginLabel record the session that
+// asked for this one, empty for a session nobody delegated: the id names the
+// parent while it is still in the workspace, the label is what that parent was
+// called at the time and is all that is left once it is closed.
 type Session struct {
 	ID                string `json:"id"`
 	Label             string `json:"label"`
@@ -99,6 +108,8 @@ type Session struct {
 	Path              string `json:"path"`
 	ProviderSessionID string `json:"providerSessionId"`
 	Pinned            bool   `json:"pinned"`
+	OriginSessionID   string `json:"originSessionId"`
+	OriginLabel       string `json:"originLabel"`
 }
 
 // Project is a persisted project together with its restorable session state.
@@ -162,6 +173,8 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN model TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN origin_session_id TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN origin_label TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN closed_seq INTEGER NOT NULL DEFAULT 0`,
 	}
@@ -307,7 +320,7 @@ func (s *Service) ProjectPath(projectID string) string {
 // the frontend would have no order left to put an unpinned card back into.
 func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	rows, err := s.db.Query(
-		`SELECT id, label, kind, path, provider_session_id, pinned
+		`SELECT id, label, kind, path, provider_session_id, pinned, origin_session_id, origin_label
 		   FROM sessions WHERE project_id = ? AND is_open = 1 ORDER BY position, rowid`,
 		projectID,
 	)
@@ -321,6 +334,7 @@ func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 		var sess Session
 		if err := rows.Scan(
 			&sess.ID, &sess.Label, &sess.Kind, &sess.Path, &sess.ProviderSessionID, &sess.Pinned,
+			&sess.OriginSessionID, &sess.OriginLabel,
 		); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -720,6 +720,21 @@ CREATE TABLE sessions (
 	if model := svc.SessionModel("s1"); model != "opus" {
 		t.Errorf("migrated session model = %q, want opus", model)
 	}
+	// So did the origin columns, and a workspace carried over from the previous
+	// version keeps its sessions: the ones already there simply have no origin.
+	if s := got[0].Sessions[0]; s.OriginSessionID != "" || s.OriginLabel != "" {
+		t.Errorf("migrated session origin = %+v, want none", s)
+	}
+	if err := svc.AddSessionFrom("p1", "s2", "worker", "shell", "", 3, "s1", "mellow-otter"); err != nil {
+		t.Fatalf("AddSessionFrom on a migrated database: %v", err)
+	}
+	after, err := svc.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if s := after[0].Sessions[1]; s.OriginSessionID != "s1" || s.OriginLabel != "mellow-otter" {
+		t.Errorf("origin on a migrated database = %+v", s)
+	}
 }
 
 // TestOpenRenamesClaudeSessionColumn proves the multi-provider rename carries


### PR DESCRIPTION
A session opened by delegation showed `← <the card that asked>` only while the request was open. The
relay takes that mark down when the errand closes — correctly, nothing is in flight — and the card was
then left saying nothing about being part of a delegation at all: three workers of a fan-out read as
three unrelated cards.

Two facts were riding one mark. "I have an open request from X" is transient. "I was opened by X" is
identity, and lich already knew it and threw it away: `spawn.Open` takes `fromID`.

## What changed

**Backend.** `sessions` grows `origin_session_id` and `origin_label` (plain `ADD COLUMN` migrations,
like every column before them — a workspace from the previous version opens with its sessions intact
and simply no origin). `spawn.Open` records the caller it already resolves, `LoadState` reads both back,
and the `session-opened` event carries them so the card draws the rung without a reload. A parked
worktree session carries its origin through the resume, and an undone close writes it back.

`store.AddSessionFrom` is a second entry point rather than two more arguments on `AddSession`: the
window — the only caller that reaches the store over RPC — never has an origin to pass, and writing it
with the row rather than after it means a card can never exist without the origin it was created with.

**The shape, and why.** Two columns, not one, and not a foreign key:

- The **id** is the live half. Nothing is denormalised through it — `sessionOrigin` resolves it against
  the workspace at render time, so a renamed parent shows its new name immediately, with no reload and
  no write anywhere near the child's row. The lookup spans every project, because delegation does.
- The **label** is the historical half: the name the parent went by when the delegation happened. It is
  all that survives the parent being closed, and it is deliberately frozen — the delegation is a fact
  about the past, and that is the reading the task asked for ("the history is true").

The consequence worth naming: rename a parent and its children say the new name; close that parent
afterwards and they fall back to the name it had at delegation time. Keeping the snapshot current
instead would mean fanning a write out to every child on every rename — and on every ai-title, which
fires each turn — plus mirroring that fan-out in the reducer for cross-project parents. Not worth it
for a tail case, but it is a visible flip, so it is a call to make rather than a detail to bury.

A foreign key was the other option and buys nothing here: `ON DELETE SET NULL` loses exactly the fact
worth keeping, and `RESTRICT` would make a closed parent un-closable.

**Frontend.** A fifth rung on the ladder `SessionCard` documents, below the tool: open request → blocked
on you → results ready → tool → origin. Only one ever draws, so the card still grows by one row at most.
Origin is last because it is never news — it surfaces when the card goes quiet, which is when someone
scanning the sidebar is working out where a card came from. `CornerDownLeft` at `size-3` and the text
`from <parent>`, all `text-muted-foreground` at normal weight: deliberately quieter than the open-request
rung, which uses an incoming arrow and `text-foreground`. The word "from" is load-bearing — an arrow and
a name alone read as traffic happening now. Not clickable in either case; a dead link to a closed parent
is worse than a plain sentence.

Both lucide candidates were built and looked at side by side at 12px: `Undo2`'s arc reads as a soft hook
and loses its arrowhead, `CornerDownLeft`'s elbow stays crisp and reads as "came from". Hence the pick.

## Gate

`gofmt`, `go vet`, `go test ./...` (and `-race` on the three touched packages) green, run directly with
`LICH_LISTEN_PORT=` empty. Cross-compile loop green for linux/darwin/windows. Frontend: `pnpm check`
clean, vitest green, `pnpm build` green.

New tests: origin persistence, defaults, rename-does-not-move-the-id and the park/resume carry
(`internal/store/origin_test.go`); the pre-migration database now also asserts the origin columns
arrived and are usable; spawn records the caller across projects and records nothing for a caller that
is not a session (`""` and a stale id both); `sessionOrigin` covers the rename, the closed parent, the
cross-project parent and the neither-half-resolves case; `toOpenedSession` covers the payload with no
origin.

## What I saw in the running app

The frontend suite is node-only, so I ran it: isolated `XDG_CONFIG_HOME`, own port and Chromium profile,
one project with a `Session 1` and a worker opened from it through the real `spawn.Open` path.

- Worker card draws `↵ from Session 1`; the parent card draws nothing. ✅
- `lich send` from the parent into the worker: the origin rung is displaced by `← Session 1` while the
  request is open (and the parent card shows `→ Session 2`). `lich reply <ticket>` closes the errand and
  `from Session 1` comes straight back — the rung survives the answer. ✅
- Rename the parent to `planner` through its context menu: the worker card says `from planner`
  immediately, no reload. ✅
- Full page reload: still `from planner` — it comes from the row, not from memory. ✅
- Close the parent: the worker card falls back to `from Session 1`, the name at delegation time (the
  flip described above). ✅
