### PR TITLE
chore: cut v0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.33.0] - 2026-08-14
 
 ### Added
 
@@ -2552,7 +2552,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.32.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.33.0...HEAD
+[0.33.0]: https://github.com/omartelo/lich/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/omartelo/lich/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/omartelo/lich/compare/v0.30.0...v0.31.0
 [0.30.0]: https://github.com/omartelo/lich/compare/v0.29.0...v0.30.0


### PR DESCRIPTION
Nine commits since v0.32.0, and the release notes read from this section, so the heading has to exist before the tag.

Every user-visible one already has its entry — the roster's `state` column (#278), `lich open --prompt` (#279), fan-out landing in sessions rather than subagents (#277), opencode and Crush resuming (#273), the band a session shows when its process ends and the confirmation for closing one mid-turn (#274), the queued hand-off to a session still running its setup script (#280), the token retry for a helper that outlived a restart (#275), and the macOS cask (#272). The tenth commit (#276) only changed how a test measures readiness and earns no entry.

- `[Unreleased]` becomes `[0.33.0] - 2026-08-14`.
- Compare links: `[Unreleased]` now starts at v0.33.0, and `[0.33.0]` spans v0.32.0...v0.33.0.

Minor, not patch: the section adds features.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test -race ./...` green
- [x] `pnpm check` clean, `vitest run` green (886 tests, cache cleared first)
- [x] `tsc && vite build` succeeds
- [x] Cross-compile loop (build + vet for linux, darwin, windows) clean
- [ ] Tag `v0.33.0` after this merges