### PR TITLE
fix: type a task in again before calling it unread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **A task nothing read is typed in once more before being given up on.** A
+  session opened with a task in the same call could lose it: lich types a task
+  in once the terminal has been quiet for a beat, and a provider that pauses
+  mid-startup — opencode does — passes for one at a prompt, then flushes what
+  was typed at it when it takes the terminal for real. The sender was told the
+  task went unread and had to send it again by hand. The relay now does that
+  itself: when the receipt window closes with nothing having read the task, it
+  is typed in a second time — same ticket, one retry — and only silence after
+  that is reported as unread.
+
 ## [0.33.0] - 2026-08-14
 
 ### Added

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -248,6 +248,9 @@ type ticket struct {
 	// unread closes when the target never reacted to the task at all. See
 	// watchReceipt.
 	unread chan struct{}
+	// redelivered is whether the task was already typed in a second time, which
+	// is what bounds watchReceipt's retry at one.
+	redelivered bool
 	// undelivered closes when the message never got into the target's PTY at
 	// all. See queueDelivery.
 	undelivered chan struct{}
@@ -448,9 +451,10 @@ func (s *Service) Send(fromID, target, project, prompt string, waitSeconds int) 
 }
 
 // handOff puts a composed message in the target's PTY and starts everything
-// that watches what becomes of it. Called once per ticket, either on the
-// caller's goroutine or, for a target that was not at a prompt yet, on the one
-// holding the message back.
+// that watches what becomes of it. Called either on the caller's goroutine or,
+// for a target that was not at a prompt yet, on the one holding the message
+// back — and once more from watchReceipt, when the first write reached a
+// terminal nothing was reading.
 func (s *Service) handOff(id string, t *ticket, kind, message string) error {
 	s.mu.Lock()
 	// Read here rather than at Send: a queued message can wait out a whole setup
@@ -480,7 +484,7 @@ func (s *Service) handOff(id string, t *ticket, kind, message string) error {
 	// end of the turn it is in, whenever that is, and its provider is busy the
 	// whole time — there is nothing here to tell apart.
 	if !busy && s.reportsState(kind) {
-		go s.watchReceipt(id, t)
+		go s.watchReceipt(id, t, kind, message)
 	}
 	return nil
 }
@@ -605,7 +609,17 @@ func (s *Service) offersTools(kind string) bool {
 // so the absence of that report inside the window is the answer. It is only
 // asked of providers that report at all — the rest have always been silent, and
 // silence has to mean something to be read as anything.
-func (s *Service) watchReceipt(id string, t *ticket) {
+//
+// Before the errand is written off, the task is typed in once more. The
+// commonest thing under an unread write is a provider that was still taking
+// over the tty when Ready's quiet heuristic cleared — opencode's startup pauses
+// long enough mid-splash to pass for a prompt, then flushes what was typed at
+// it — and by the time the window has run out that same provider has been
+// sitting at its real prompt for most of it. The second write is the manual
+// resend automated, it carries the same ticket, and it costs nothing new: a
+// terminal that swallows it was going to be reported unread anyway, and one
+// mid-dialog got the first write already.
+func (s *Service) watchReceipt(id string, t *ticket, kind, message string) {
 	timer := time.NewTimer(s.receiptWindow)
 	defer timer.Stop()
 	select {
@@ -621,6 +635,21 @@ func (s *Service) watchReceipt(id string, t *ticket) {
 	if !live || current != t || t.sawBusy {
 		s.mu.Unlock()
 		return
+	}
+	if !t.redelivered && s.term.Ready(t.targetID) {
+		t.redelivered = true
+		s.mu.Unlock()
+		slog.Warn("relay: task was typed and nothing read it, typing it again", "target", t.target)
+		if err := s.handOff(id, t, kind, message); err == nil {
+			return
+		}
+		// The second write was refused — the session died under it. Nothing read
+		// the task, which is what unread says.
+		s.mu.Lock()
+		if current, live = s.tickets[id]; !live || current != t || t.sawBusy {
+			s.mu.Unlock()
+			return
+		}
 	}
 	delete(s.tickets, id)
 	close(t.unread)

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -1675,6 +1675,69 @@ func TestATaskNobodyPicksUpComesBackUnread(t *testing.T) {
 	if open != 0 {
 		t.Errorf("left %d tickets open on a task that was never read", open)
 	}
+	// Typed in twice — the retry — and no more: paste and Enter, then paste and
+	// Enter again. A third pair would be the retry retrying itself.
+	if got := len(term.writesTo("s2")); got != 4 {
+		t.Errorf("target got %d writes, want 4: the task typed in exactly twice", got)
+	}
+}
+
+// A task typed into a terminal nothing was reading yet is typed in again before
+// the errand is written off: what sat under the first write is a provider still
+// taking over the tty, and by the end of the receipt window it is at its real
+// prompt. The second write is the manual resend automated — seen with opencode,
+// whose startup goes quiet long enough to pass for a prompt.
+func TestATaskNobodyReadIsTypedInAgain(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := withReceipts(term)
+
+	// The target reads the second delivery: it reports busy on its Enter.
+	var submits int
+	term.onWrite = func(id, data string) {
+		if id != "s2" || data != submit {
+			return
+		}
+		submits++
+		if submits == 2 {
+			svc.Observe("s2", stateBusy)
+		}
+	}
+
+	result, err := svc.Send("s1", "docs", "", "run the tests", 1)
+	if err != nil {
+		t.Fatalf("Send = %v, want nil", err)
+	}
+	if result.Status == StatusUnread {
+		t.Error("a task the target picked up on the second write was reported unread")
+	}
+	if result.Status != StatusPending {
+		t.Errorf("status = %q, want the errand still open", result.Status)
+	}
+}
+
+// The retry is only worth typing at a terminal whose agent is there to read it;
+// one that is no longer ready — the provider died back to a setup script, the
+// session ended — gets the unread verdict without a second write into whatever
+// holds it now.
+func TestNoRetryIntoATerminalThatIsNotReady(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := withReceipts(term)
+	term.onWrite = func(id, data string) {
+		if id == "s2" && data == submit {
+			term.setUp("s2", true)
+		}
+	}
+
+	result, err := svc.Send("s1", "docs", "", "run the tests", 5)
+	if err != nil {
+		t.Fatalf("Send = %v, want nil", err)
+	}
+	if result.Status != StatusUnread {
+		t.Errorf("status = %q, want unread", result.Status)
+	}
+	if got := len(term.writesTo("s2")); got != 2 {
+		t.Errorf("target got %d writes, want 2: no retry into a terminal that is not ready", got)
+	}
 }
 
 func TestATaskTheTargetStartsWorkingOnIsNotUnread(t *testing.T) {


### PR DESCRIPTION
## What

A session opened with a task in the same `open_session` call could lose the task. `Ready`'s quiet heuristic (`readySettle`, 600ms, measured against Claude Code) clears mid-startup on a provider that pauses while taking over the tty — opencode does — so the paste + Enter land in a terminal nothing is reading yet and are flushed when the TUI comes up for real. The receipt check (`watchReceipt`) already detected exactly this, thirty seconds later, but only reported the task unread and told the sender to resend by hand — which worked, because by then the provider had long been at its real prompt.

## How

`watchReceipt` now types the task in once more before writing the errand off: same ticket, one retry, only into a terminal that is still ready. Only the second silence is reported as unread. It is the manual resend automated, at the single choke point every delivery routes through, so it covers every provider that reports state — including the Claude Code trust-dialog case, where the first Enter dismisses the dialog and the retry delivers the task.

Providers without the companion plugin are unchanged: no receipt signal, no retry, as before.

## Test plan

- [x] New: a task nobody read is typed in again, and the errand stays open when the target picks the second write up
- [x] New: no retry into a terminal that is no longer ready — straight to unread, two writes only
- [x] Existing unread test now pins exactly two deliveries (four writes), so the retry cannot retry itself
- [x] `go test -race -count=30` on the receipt tests, green
- [x] Local gate: gofmt, go vet, `go test -race ./...` green