### PR TITLE
feat: terminal keeps a 4px left gutter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   arguments the app itself takes are unchanged: bare `lich` opens it, and
   `lich -- <chromium flags>` still passes them through.
 
+- **The terminal keeps a 4px left gutter.** Text used to start flush against the
+  panel seam. The grid fit now reserves the 4px on the left before dividing the
+  rest into cells, so the fix costs no column.
+
 ### Fixed
 
 - **A task nothing read is typed in once more before being given up on.** A

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Every `lich` command explains itself.** `lich send --help` used to answer
+  `lich: flag: help requested` on stderr and exit 1 — the command line telling
+  someone asking how to run it that they had failed. Each command now prints
+  what it does, how it is spelled and every flag it takes with the description
+  that flag was declared with, so the help cannot drift from what the command
+  parses. `lich help <command>` reaches the same page, and `lich version` prints
+  the running build.
+
+### Changed
+
+- **A mistyped command no longer opens the app.** `lich sesions` used to name no
+  subcommand, and anything that named none launched the whole window — an answer
+  that says nothing about the command that was run. It is now refused with
+  `lich: unknown command "sesions" — did you mean "sessions"?` and exit 1. The
+  arguments the app itself takes are unchanged: bare `lich` opens it, and
+  `lich -- <chromium flags>` still passes them through.
+
 ### Fixed
 
 - **A task nothing read is typed in once more before being given up on.** A

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,8 +83,16 @@ relayed message spells the reply command that way.
 ## Commands
 
 Every command prints its result on stdout and its failure as one `lich: …` line
-on stderr, exiting 0 or 1. Anything that is not a subcommand below — including
-`lich -- <chromium flags>` — opens the app instead.
+on stderr, exiting 0 or 1.
+
+`lich help` lists every command below; `lich <command> --help` prints that one's
+own description and every flag it takes, generated from the flags the command
+actually parses. `lich version` prints the running build.
+
+A word that names no subcommand is refused with `lich: unknown command "…"`, a
+guess at the one it resembles, and exit 1 — a typo does not open a window.
+Arguments the app itself takes still do: bare `lich`, and `lich --` with the
+Chromium flags behind it.
 
 `--json` on `sessions`, `send`, `wait`, `open`, `close` and `worktrees` replaces
 the prose with one JSON line: the peer array, the result object and the session

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -60,6 +60,10 @@ const REFIT_DEBOUNCE_MS = 100
 const COPY_DEBOUNCE_MS = 150
 const SCROLLBACK_LINES = 5000
 
+// Left gutter so the first column doesn't sit flush against the sidebar/panel
+// seam. Subtracted before the grid fit (below) so it doesn't cost a column.
+const TERMINAL_PADDING_LEFT = 4
+
 // Search match styling. Passing decorations is also what makes xterm's
 // SearchAddon compute the match count (onDidChangeResults reports -1 without
 // them); it highlights every match too, not just the active one. Amber reads on
@@ -99,16 +103,20 @@ function mouseEncoding(term: Terminal): string | undefined {
     ?.coreMouseService?.activeEncoding
 }
 
-// fitTerminal resizes the grid to fill the container edge to edge (replacing
-// xterm's FitAddon, which reserves a scrollbar gutter on the right — see
-// term-fit.ts). No-op when metrics or size aren't ready, or the grid already
-// fits.
+// fitTerminal resizes the grid to fill the container edge to edge on the
+// right/bottom (replacing xterm's FitAddon, which reserves a scrollbar
+// gutter on the right — see term-fit.ts), minus the fixed left gutter above.
+// No-op when metrics or size aren't ready, or the grid already fits.
 function fitTerminal(term: Terminal, container: HTMLElement): void {
   const cell = cellDimensions(term)
   if (!cell) {
     return
   }
-  const grid = computeGrid(container.clientWidth, container.clientHeight, cell)
+  const grid = computeGrid(
+    container.clientWidth - TERMINAL_PADDING_LEFT,
+    container.clientHeight,
+    cell,
+  )
   if (grid && (grid.cols !== term.cols || grid.rows !== term.rows)) {
     term.resize(grid.cols, grid.rows)
   }
@@ -842,7 +850,10 @@ export function TerminalView({
       <div
         ref={containerRef}
         className="h-full w-full"
-        style={{ backgroundColor: terminalColors.background }}
+        style={{
+          backgroundColor: terminalColors.background,
+          paddingLeft: TERMINAL_PADDING_LEFT,
+        }}
       />
       {dropping && (
         <div className="pointer-events-none absolute inset-0 z-10 flex items-end justify-center bg-accent/10 pb-6 ring-2 ring-inset ring-ring">

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -26,6 +26,7 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -81,61 +82,6 @@ const openCall = 60 * time.Second
 // on the line.
 const deliverWait = 20
 
-const usage = `lich talks to the sessions open in the running lich window.
-
-  lich sessions [--json]
-      List the live sessions that can be reached.
-
-  lich send [--project <name>] [--timeout <seconds>] [--json] <session> <prompt>
-      Put <prompt> at <session>'s prompt and wait for its agent to answer.
-      Prints the answer. If the wait runs out first it prints a ticket to
-      pick the answer up with.
-
-  lich wait [--timeout <seconds>] [--json] [<ticket>]
-      With a ticket, wait again on that errand. Without one, collect every
-      result that is ready — and when none is, wait for the next.
-
-  lich reply <ticket> <answer>
-      Send <answer> back to whoever is waiting on <ticket>. This is what a
-      relayed message asks you to run when you are done.
-
-  lich open [--project <name>] [--kind <provider>] [--worktree <branch>]
-            [--base <branch>] [--model <model>] [--prompt <task>] [--json]
-      Open a new session and start it. --worktree creates a git worktree of
-      that branch name first and roots the session in it. --model runs the
-      provider on that model, in the provider's own spelling. --prompt hands
-      the new session that task as soon as its agent is up, so opening a
-      worker for a task is one command rather than two. Prints the name the
-      new session is addressed by.
-
-  lich close [--project <name>] [--worktree keep|remove] [--force] [--json] <session>
-      Close a session. Closing the last one in a worktree needs --worktree to
-      say whether the checkout stays; removing a dirty one needs --force.
-
-  lich worktrees [--project <name>] [--json]
-      List a project's git worktrees: what is uncommitted in each and which
-      sessions are open in it.
-
-  lich mcp
-      Serve the commands above as MCP tools over stdio. lich registers this
-      itself for the providers that support it; you only run it by hand to
-      point another MCP client at lich.
-
-  lich rage [--output <path>]
-      Collect a bug report — versions, browser, providers, plugin state and
-      the logs, with secrets masked — into one .tar.gz to attach to an issue.
-      Nothing is uploaded, and it works with no lich running.
-
-  lich doctor
-      Walk the boot lich walks — config dir, log, the pinned port, the
-      workspace database, the browser, the providers — and say whether it
-      would start here. Exits non-zero when something would stop it.
-
-Run inside a lich session these address the sessions beside it. Run anywhere
-else on the machine they find the running lich on their own, and what they
-relay is attributed to the command line rather than to a session.
-`
-
 // Run executes one subcommand and returns the process exit code, or
 // NotACommand when args name none. env reads the process environment, and
 // version is the running build's, which only the bug report needs.
@@ -178,10 +124,30 @@ func dispatch(args []string, c *client) int {
 		// again, worse.
 		return c.doctor(args[1:])
 	case "help", "--help", "-h":
+		// `lich help <command>` is the command's own help, which is the flags
+		// and not just the paragraph the list above shows.
+		if len(args) > 1 {
+			return dispatch([]string{args[1], "--help"}, c)
+		}
 		fmt.Fprint(c.stdout, usage)
 		return 0
+	case "version", "--version", "-v":
+		fmt.Fprintf(c.stdout, "lich %s\n", c.version)
+		return 0
 	}
-	return NotACommand
+	// A word that names no subcommand is a typo, and opening the whole app for
+	// one is an answer nobody reads: the window it puts on screen says nothing
+	// about the command that was run. A leading dash is not a typo — that is
+	// `lich --` and the Chromium flags behind it, which the app still takes.
+	if strings.HasPrefix(args[0], "-") {
+		return NotACommand
+	}
+	fmt.Fprintf(c.stderr, "lich: unknown command %q", args[0])
+	if near := nearest(args[0]); near != "" {
+		fmt.Fprintf(c.stderr, " — did you mean %q?", near)
+	}
+	fmt.Fprint(c.stderr, "\nRun `lich help` for the list.\n")
+	return 1
 }
 
 type client struct {
@@ -207,25 +173,44 @@ type client struct {
 	diagnose func() ([]doctor.Check, error)
 }
 
+// errHelpShown ends a subcommand that was asked for its help rather than for
+// its work. It travels the error path because that is the only way out of a
+// parse, and is the one error run does not report: the help is already printed,
+// and asking for it succeeded.
+var errHelpShown = errors.New("help printed")
+
 // run reports a subcommand's failure the way a command line does — one line on
 // stderr, a non-zero exit — so an agent reading the output is told what went
 // wrong instead of being handed an empty answer.
 func (c *client) run(fn func([]string) error, args []string) int {
-	if err := fn(args); err != nil {
-		fmt.Fprintf(c.stderr, "lich: %v\n", err)
-		return 1
+	err := fn(args)
+	if err == nil || errors.Is(err, errHelpShown) {
+		return 0
 	}
-	return 0
+	fmt.Fprintf(c.stderr, "lich: %v\n", err)
+	return 1
+}
+
+// parse reads a subcommand's flags, answering -h/--help with that command's own
+// help. Without this the flag package's "flag: help requested" is what a user
+// asking how to run something is handed, on stderr, as a failure.
+func (c *client) parse(flags *flag.FlagSet, args []string) error {
+	err := flags.Parse(args)
+	if errors.Is(err, flag.ErrHelp) {
+		printHelp(c.stdout, flags)
+		return errHelpShown
+	}
+	return err
 }
 
 func (c *client) sessions(args []string) error {
 	flags := newFlagSet("sessions")
 	asJSON := flags.Bool("json", false, "print the result as JSON")
-	if err := flags.Parse(args); err != nil {
+	if err := c.parse(flags, args); err != nil {
 		return err
 	}
 	if flags.NArg() != 0 {
-		return fmt.Errorf("usage: lich sessions [--json]")
+		return usageError("sessions")
 	}
 
 	var peers []relay.Peer
@@ -267,11 +252,11 @@ func (c *client) send(args []string) error {
 	project := flags.String("project", "", "narrow the target to one project when the label is ambiguous")
 	timeout := flags.Int("timeout", 0, "seconds to wait for an answer before handing back a ticket")
 	asJSON := flags.Bool("json", false, "print the result as JSON")
-	if err := flags.Parse(args); err != nil {
+	if err := c.parse(flags, args); err != nil {
 		return err
 	}
 	if flags.NArg() != 2 {
-		return fmt.Errorf("usage: lich send [--project <name>] [--timeout <seconds>] [--json] <session> <prompt>")
+		return usageError("send")
 	}
 
 	var result relay.Result
@@ -286,11 +271,11 @@ func (c *client) wait(args []string) error {
 	flags := newFlagSet("wait")
 	timeout := flags.Int("timeout", 0, "seconds to wait before handing the ticket back again")
 	asJSON := flags.Bool("json", false, "print the result as JSON")
-	if err := flags.Parse(args); err != nil {
+	if err := c.parse(flags, args); err != nil {
 		return err
 	}
 	if flags.NArg() > 1 {
-		return fmt.Errorf("usage: lich wait [--timeout <seconds>] [--json] [<ticket>]")
+		return usageError("wait")
 	}
 
 	if flags.NArg() == 0 {
@@ -314,11 +299,11 @@ func (c *client) wait(args []string) error {
 
 func (c *client) reply(args []string) error {
 	flags := newFlagSet("reply")
-	if err := flags.Parse(args); err != nil {
+	if err := c.parse(flags, args); err != nil {
 		return err
 	}
 	if flags.NArg() != 2 {
-		return fmt.Errorf("usage: lich reply <ticket> <answer>")
+		return usageError("reply")
 	}
 	if err := c.call("relay.Reply", []any{flags.Arg(0), flags.Arg(1)}, shortCall, nil); err != nil {
 		return err
@@ -336,13 +321,11 @@ func (c *client) open(args []string) error {
 	model := flags.String("model", "", "model the provider runs, in the provider's own spelling")
 	prompt := flags.String("prompt", "", "task to hand the new session as soon as its agent is up")
 	asJSON := flags.Bool("json", false, "print the result as JSON")
-	if err := flags.Parse(args); err != nil {
+	if err := c.parse(flags, args); err != nil {
 		return err
 	}
 	if flags.NArg() != 0 {
-		return fmt.Errorf(
-			"usage: lich open [--project <name>] [--kind <provider>] [--worktree <branch>] " +
-				"[--base <branch>] [--model <model>] [--prompt <task>] [--json]")
+		return usageError("open")
 	}
 
 	var opened spawn.Session
@@ -438,11 +421,11 @@ func openedText(opened spawn.Session) string {
 func (c *client) rage(args []string) error {
 	flags := newFlagSet("rage")
 	output := flags.String("output", "", "write the bundle here instead of ./lich-rage-<timestamp>.tar.gz")
-	if err := flags.Parse(args); err != nil {
+	if err := c.parse(flags, args); err != nil {
 		return err
 	}
 	if flags.NArg() != 0 {
-		return fmt.Errorf("usage: lich rage [--output <path>]")
+		return usageError("rage")
 	}
 
 	path := *output
@@ -479,12 +462,15 @@ func (c *client) rage(args []string) error {
 // launch-stopping check is a non-zero exit, which is what a script reads.
 func (c *client) doctor(args []string) int {
 	flags := newFlagSet("doctor")
-	if err := flags.Parse(args); err != nil {
+	if err := c.parse(flags, args); err != nil {
+		if errors.Is(err, errHelpShown) {
+			return 0
+		}
 		fmt.Fprintf(c.stderr, "lich: %v\n", err)
 		return 1
 	}
 	if flags.NArg() != 0 {
-		fmt.Fprintln(c.stderr, "lich: usage: lich doctor")
+		fmt.Fprintf(c.stderr, "lich: %v\n", usageError("doctor"))
 		return 1
 	}
 
@@ -537,12 +523,11 @@ func (c *client) close(args []string) error {
 		"what to do with the checkout when this is its last session: keep or remove")
 	force := flags.Bool("force", false, "remove a checkout that still has uncommitted work")
 	asJSON := flags.Bool("json", false, "print the result as JSON")
-	if err := flags.Parse(args); err != nil {
+	if err := c.parse(flags, args); err != nil {
 		return err
 	}
 	if flags.NArg() != 1 {
-		return fmt.Errorf(
-			"usage: lich close [--project <name>] [--worktree keep|remove] [--force] [--json] <session>")
+		return usageError("close")
 	}
 
 	var closed spawn.Closed
@@ -578,11 +563,11 @@ func (c *client) worktrees(args []string) error {
 	flags := newFlagSet("worktrees")
 	project := flags.String("project", "", "project to list; defaults to the caller's own")
 	asJSON := flags.Bool("json", false, "print the result as JSON")
-	if err := flags.Parse(args); err != nil {
+	if err := c.parse(flags, args); err != nil {
 		return err
 	}
 	if flags.NArg() != 0 {
-		return fmt.Errorf("usage: lich worktrees [--project <name>] [--json]")
+		return usageError("worktrees")
 	}
 
 	var checkouts []spawn.Checkout

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -99,6 +99,11 @@ func (f *fakeLich) only(t *testing.T) recorded {
 	return f.calls[0]
 }
 
+// testVersion is what the build under test calls itself. Pinned as a literal
+// rather than read from anywhere, so a command that prints the wrong string
+// fails here.
+const testVersion = "v9.9.9-test"
+
 // run executes one command against a fake lich and returns its streams. It
 // never goes through Run: that would resolve the runtime file of the lich
 // actually running on this machine, and a test that reached it would deliver a
@@ -106,7 +111,10 @@ func (f *fakeLich) only(t *testing.T) recorded {
 func run(t *testing.T, f *fakeLich, args ...string) (int, string, string) {
 	t.Helper()
 	var stdout, stderr bytes.Buffer
-	code := dispatch(args, &client{env: f.env, stdout: &stdout, stderr: &stderr, running: noInstance})
+	code := dispatch(args, &client{
+		env: f.env, version: testVersion,
+		stdout: &stdout, stderr: &stderr, running: noInstance,
+	})
 	return code, stdout.String(), stderr.String()
 }
 
@@ -114,16 +122,109 @@ func run(t *testing.T, f *fakeLich, args ...string) (int, string, string) {
 // so only the environment can point a command anywhere.
 func noInstance() (*singleton.Info, error) { return nil, nil }
 
-func TestUnknownArgumentsAreNotACommand(t *testing.T) {
+// The app's own arguments still fall through to it. A word that is not a
+// subcommand no longer does — see TestAnUnknownCommandDoesNotOpenTheApp.
+func TestTheAppsOwnArgumentsAreNotACommand(t *testing.T) {
 	f := newFakeLich(t, `null`)
 
-	for _, args := range [][]string{{}, {"--"}, {"--", "--ozone-platform=wayland"}, {"nonsense"}} {
+	for _, args := range [][]string{
+		{}, {"--"}, {"--", "--ozone-platform=wayland"}, {"--ozone-platform=wayland"},
+	} {
 		if code, _, _ := run(t, f, args...); code != NotACommand {
 			t.Errorf("Run(%q) = %d, want NotACommand", args, code)
 		}
 	}
 	if len(f.calls) != 0 {
 		t.Errorf("a non-command reached the app: %+v", f.calls)
+	}
+}
+
+// A mistyped subcommand used to return NotACommand, which opened the whole app:
+// a window that says nothing about the command that was run is not an answer to
+// a typo.
+func TestAnUnknownCommandDoesNotOpenTheApp(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	code, _, stderr := run(t, f, "sesions")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	for _, want := range []string{`unknown command "sesions"`, `did you mean "sessions"`, "lich help"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr = %q, want it to carry %q", stderr, want)
+		}
+	}
+
+	// Nothing close enough to guess at is still refused, without a guess.
+	code, _, stderr = run(t, f, "xyzzy")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if strings.Contains(stderr, "did you mean") {
+		t.Errorf("stderr = %q, want no guess for a word that resembles no command", stderr)
+	}
+	if len(f.calls) != 0 {
+		t.Errorf("an unknown command reached the app: %+v", f.calls)
+	}
+}
+
+func TestVersionPrintsTheBuild(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	for _, args := range [][]string{{"version"}, {"--version"}, {"-v"}} {
+		code, stdout, _ := run(t, f, args...)
+		if code != 0 {
+			t.Errorf("Run(%q) = %d, want 0", args, code)
+		}
+		if !strings.Contains(stdout, testVersion) {
+			t.Errorf("Run(%q) printed %q, want the running version", args, stdout)
+		}
+	}
+}
+
+// Every command answers --help with its own help rather than with the flag
+// package's "flag: help requested" on stderr, which is what a user asking how to
+// run something used to be handed — as a failure, exit 1.
+func TestEveryCommandPrintsItsOwnHelp(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	for _, cmd := range commands {
+		t.Run(cmd.name, func(t *testing.T) {
+			for _, args := range [][]string{{cmd.name, "--help"}, {cmd.name, "-h"}, {"help", cmd.name}} {
+				code, stdout, stderr := run(t, f, args...)
+				if code != 0 {
+					t.Fatalf("Run(%q) = %d (stderr %q), want 0", args, code, stderr)
+				}
+				if !strings.Contains(stdout, "usage: "+cmd.line()) {
+					t.Errorf("Run(%q) printed %q, want the command's usage line", args, stdout)
+				}
+			}
+		})
+	}
+	if len(f.calls) != 0 {
+		t.Errorf("asking for help reached the app: %+v", f.calls)
+	}
+}
+
+// The help lists a flag with the description it was declared with, so the two
+// cannot drift: a flag added to a command shows up here without anyone editing
+// prose.
+func TestPerCommandHelpListsTheFlags(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	_, stdout, _ := run(t, f, "send", "--help")
+	for _, want := range []string{
+		"--project string", "narrow the target to one project",
+		"--timeout int", "--json",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("send --help = %q, want it to carry %q", stdout, want)
+		}
+	}
+	// One dash is what flag.PrintDefaults would have written, and every lich
+	// surface documents two.
+	if strings.Contains(stdout, "\n  -project") {
+		t.Errorf("send --help spells a flag with one dash: %q", stdout)
 	}
 }
 

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -1,0 +1,212 @@
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// command is one subcommand as the help describes it. The spelling lives here
+// and nowhere else: the general help, the per-command help and the "usage: …"
+// line a malformed call is answered with all read this table, so a flag that
+// moves is wrong in one place rather than right on one surface and stale on the
+// other two.
+type command struct {
+	name string
+	// args is everything after the name. Written on as many lines as it reads
+	// well on; whitespace is collapsed wherever it has to be one line.
+	args string
+	// about is what the command does, in the words the general help lists it
+	// with.
+	about string
+}
+
+var commands = []command{
+	{
+		name:  "sessions",
+		args:  "[--json]",
+		about: "List the live sessions that can be reached.",
+	},
+	{
+		name: "send",
+		args: "[--project <name>] [--timeout <seconds>] [--json] <session> <prompt>",
+		about: "Put <prompt> at <session>'s prompt and wait for its agent to answer.\n" +
+			"Prints the answer. If the wait runs out first it prints a ticket to\n" +
+			"pick the answer up with.",
+	},
+	{
+		name: "wait",
+		args: "[--timeout <seconds>] [--json] [<ticket>]",
+		about: "With a ticket, wait again on that errand. Without one, collect every\n" +
+			"result that is ready — and when none is, wait for the next.",
+	},
+	{
+		name: "reply",
+		args: "<ticket> <answer>",
+		about: "Send <answer> back to whoever is waiting on <ticket>. This is what a\n" +
+			"relayed message asks you to run when you are done.",
+	},
+	{
+		name: "open",
+		args: "[--project <name>] [--kind <provider>] [--worktree <branch>]\n" +
+			"            [--base <branch>] [--model <model>] [--prompt <task>] [--json]",
+		about: "Open a new session and start it. --worktree creates a git worktree of\n" +
+			"that branch name first and roots the session in it. --model runs the\n" +
+			"provider on that model, in the provider's own spelling. --prompt hands\n" +
+			"the new session that task as soon as its agent is up, so opening a\n" +
+			"worker for a task is one command rather than two. Prints the name the\n" +
+			"new session is addressed by.",
+	},
+	{
+		name: "close",
+		args: "[--project <name>] [--worktree keep|remove] [--force] [--json] <session>",
+		about: "Close a session. Closing the last one in a worktree needs --worktree to\n" +
+			"say whether the checkout stays; removing a dirty one needs --force.",
+	},
+	{
+		name: "worktrees",
+		args: "[--project <name>] [--json]",
+		about: "List a project's git worktrees: what is uncommitted in each and which\n" +
+			"sessions are open in it.",
+	},
+	{
+		name: "mcp",
+		args: "",
+		about: "Serve the commands above as MCP tools over stdio. lich registers this\n" +
+			"itself for the providers that support it; you only run it by hand to\n" +
+			"point another MCP client at lich.",
+	},
+	{
+		name: "rage",
+		args: "[--output <path>]",
+		about: "Collect a bug report — versions, browser, providers, plugin state and\n" +
+			"the logs, with secrets masked — into one .tar.gz to attach to an issue.\n" +
+			"Nothing is uploaded, and it works with no lich running.",
+	},
+	{
+		name: "doctor",
+		args: "",
+		about: "Walk the boot lich walks — config dir, log, the pinned port, the\n" +
+			"workspace database, the browser, the providers — and say whether it\n" +
+			"would start here. Exits non-zero when something would stop it.",
+	},
+}
+
+const helpHeader = "lich talks to the sessions open in the running lich window.\n\n"
+
+const helpFooter = `
+  lich version
+      Print the running build's version.
+
+Every command takes --help for its own flags.
+
+Run inside a lich session these address the sessions beside it. Run anywhere
+else on the machine they find the running lich on their own, and what they
+relay is attributed to the command line rather than to a session.
+`
+
+// usage is the general help, built from the table so it cannot drift from the
+// flags the commands actually parse.
+var usage = buildUsage()
+
+func buildUsage() string {
+	var b strings.Builder
+	b.WriteString(helpHeader)
+	for _, cmd := range commands {
+		b.WriteString("  " + cmd.spelling() + "\n")
+		for _, line := range strings.Split(cmd.about, "\n") {
+			b.WriteString("      " + line + "\n")
+		}
+		b.WriteString("\n")
+	}
+	b.WriteString(strings.TrimPrefix(helpFooter, "\n"))
+	return b.String()
+}
+
+// spelling is the command as the general help lists it, keeping the line breaks
+// the table wrote into a long argument list.
+func (c command) spelling() string {
+	if c.args == "" {
+		return "lich " + c.name
+	}
+	return "lich " + c.name + " " + c.args
+}
+
+// line is the command on one line, which is what an error has room for.
+func (c command) line() string {
+	return strings.Join(strings.Fields(c.spelling()), " ")
+}
+
+// lookup finds a command by name. A miss is impossible from the call sites here
+// — every one passes a name the dispatch table already matched — so the zero
+// value is enough of an answer.
+func lookup(name string) command {
+	for _, cmd := range commands {
+		if cmd.name == name {
+			return cmd
+		}
+	}
+	return command{name: name}
+}
+
+// usageError is what a call with the wrong arguments is answered with. It is
+// the same line the command's own help prints, so the two cannot disagree.
+func usageError(name string) error {
+	return fmt.Errorf("usage: %s", lookup(name).line())
+}
+
+// printHelp writes one command's own help: what it does, how it is spelled, and
+// every flag it takes with the description it was declared with.
+func printHelp(w io.Writer, flags *flag.FlagSet) {
+	cmd := lookup(flags.Name())
+	if cmd.about != "" {
+		fmt.Fprintf(w, "%s\n\n", cmd.about)
+	}
+	fmt.Fprintf(w, "usage: %s\n", cmd.line())
+	// Not flag.PrintDefaults: it spells every flag with one dash, and lich's
+	// documented spelling — the one the plugin's tool calls use — is two.
+	flags.VisitAll(func(f *flag.Flag) {
+		kind, description := flag.UnquoteUsage(f)
+		name := "  --" + f.Name
+		if kind != "" {
+			name += " " + kind
+		}
+		fmt.Fprintf(w, "%s\n        %s\n", name, description)
+	})
+}
+
+// nearest is the command a word that named none was probably meant to be, or
+// empty when nothing is close enough to be worth guessing at. Three edits apart
+// is a different word, not a typo.
+func nearest(word string) string {
+	best, bestDistance := "", 4
+	for _, cmd := range commands {
+		if d := distance(word, cmd.name); d < bestDistance {
+			best, bestDistance = cmd.name, d
+		}
+	}
+	return best
+}
+
+// distance is the Levenshtein distance between two words, over two rows rather
+// than the full matrix — the words here are one short command name each.
+func distance(a, b string) int {
+	previous := make([]int, len(b)+1)
+	current := make([]int, len(b)+1)
+	for j := range previous {
+		previous[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		current[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			current[j] = min(previous[j]+1, current[j-1]+1, previous[j-1]+cost)
+		}
+		previous, current = current, previous
+	}
+	return previous[len(b)]
+}

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -99,7 +99,7 @@ When a [lich] message carrying a ticket arrives at YOUR prompt, you are the work
 // serveMCP runs the stdio server until its input ends.
 func (c *client) serveMCP(args []string) error {
 	flags := newFlagSet("mcp")
-	if err := flags.Parse(args); err != nil {
+	if err := c.parse(flags, args); err != nil {
 		return err
 	}
 	if c.stdin == nil {


### PR DESCRIPTION
## Summary
- Terminal text sat flush against the panel seam; adds a fixed 4px left gutter.
- `fitTerminal` subtracts the gutter from the container width before dividing into cells, so it costs no column and doesn't desync the PTY's COLS from what actually renders.

## Test plan
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec biome check`
- [x] `pnpm exec vitest run src/lib/terminal`
- [ ] eyeball in `task dev`