### PR TITLE
chore: cut v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-08-14
+
 ### Added
 
 - **Every `lich` command explains itself.** `lich send --help` used to answer
@@ -2630,7 +2632,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.33.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.34.0...HEAD
+[0.34.0]: https://github.com/omartelo/lich/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/omartelo/lich/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/omartelo/lich/compare/v0.31.0...v0.32.0
 [0.31.0]: https://github.com/omartelo/lich/compare/v0.30.0...v0.31.0

--- a/README.md
+++ b/README.md
@@ -106,9 +106,10 @@ window.
   new sessions default to. Claude Code's section also holds the footer's context
   ring and its cost readout — the cost one off by default, since the figure only
   means something when you are billed per token.
-- **Worktrees** — a per-project setup script (Settings › Worktree) runs in a new
-  worktree's terminal ahead of the agent; a `.worktreeinclude` file tunes which
-  gitignored files get copied over.
+- **Worktrees** — `.lich/setup-worktree.sh` in the project checkout runs in a
+  new worktree's terminal ahead of the agent; the New worktree dialog shows it
+  and offers a detected suggestion when the repo ships none. A
+  `.worktreeinclude` file tunes which gitignored files get copied over.
 - **Version control** — a project can name the GitHub account `gh` runs as
   (Settings › Version Control), for a repository only one of your accounts can
   see. It governs what lich reads from GitHub, not what git pushes.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -96,8 +96,9 @@ Homebrew 安装可以绕开 Gatekeeper 的提示；从 Releases 页面下载的�
 - **智能体** —— 在设置里为每个 provider 设定二进制文件路径，并选定新会话默认用哪一个。
   Claude Code 那一节还管着底栏的上下文圆环和费用读数 —— 费用默认关闭，因为只有当你按
   token 计费时这个数字才有意义。
-- **Worktree** —— 按项目配置的初始化脚本（设置 › Worktree）会在新 worktree 的终端里
-  先于智能体运行；`.worktreeinclude` 文件用来调整哪些被 gitignore 的文件会被复制过去。
+- **Worktree** —— 项目仓库里的 `.lich/setup-worktree.sh` 会在新 worktree 的终端里
+  先于智能体运行；New worktree 对话框会展示这个脚本，若仓库没有则给出检测到的建议。
+  `.worktreeinclude` 文件用来调整哪些被 gitignore 的文件会被复制过去。
 - **版本控制** —— 一个项目可以指定 `gh` 以哪个 GitHub 账号运行（设置 › Version
   Control），用于只有你其中一个账号看得见的仓库。它管的是 lich 从 GitHub 读到什么，
   而不是 git 推送时用谁的身份。


### PR DESCRIPTION
## Summary
- Move `[Unreleased]` entries under a `v0.34.0` heading, refresh compare links.
- README + README.zh-CN: fix stale `Worktree` bullet still pointing at the removed Settings › Worktree field; #292 moved that to `.lich/setup-worktree.sh`.

## Test plan
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` (1532 passed)
- [x] `pnpm check` (biome, no errors)
- [x] `pnpm test` (892 passed)
- [x] `pnpm build` (tsc + vite)