### PR TITLE
fix: name a session at birth, never on resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   database, and a project identifies itself by its path: recreating a checkout
   where a deleted one stood silently handed the new project the dead one's
   overrides. They are now deleted with it.
+- **`/rename` inside a Claude Code session now survives being resumed.** lich
+  passed the name it derives (`myrepo-a1b2`) on every spawn, including a resume
+  — and Claude Code takes that flag over the name in its transcript, so
+  reopening a session silently undid a `/rename` the user had typed inside it.
+  lich now names a session only when it is born; one that resumes keeps whatever
+  it is called, which is a decision that belongs to the session, not to the
+  harness. This is the Resume answer on a restored card, and the reopening of a
+  session parked with its worktree. The exit banner's **Restart** is a fresh
+  spawn with no conversation behind it, so it still gets the derived name.
+
+### Removed
+
+- **The session tooltip no longer prints an `@name` line.** It showed the name
+  lich derives at spawn rather than the one the session answers to, and the two
+  part company the moment anyone runs `/rename` — so the one place that named a
+  session for cross-session messaging was also the one place that could name it
+  wrong. `/list-agents`, inside the session, is where that name is true.
 
 ## [0.34.0] - 2026-08-14
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,17 @@ nobody knows it and that the call site never shows. The mechanism and the histor
   (`internal/project/setup.go`, read again at every setup spawn): running a stranger's PR must not run a
   stranger's `.lich/setup-worktree.sh`. The flip side is the trap — improve the script on a feature branch
   and fresh worktrees keep running the old one until the change reaches the checkout the project points at.
+- **A session is named at birth, never on resume** (`internal/terminal/command.go`, `nameArgs`): Claude Code's
+  peer-roster name goes out as `--name` only on a spawn with no resume id. It then lives in the transcript (a
+  `custom-title` record, and an `agent-name` one per `/rename`) and is restored on `--resume` — but an explicit
+  `--name` overrides what was restored, measured both ways, so naming a resuming session would erase a
+  `/rename` typed inside it. Note which spawns are which: the Resume answer and a parked worktree's session
+  carry a resume id and keep their name, while the exit banner's Restart is deliberately a fresh spawn
+  (`TerminalView.tsx`, `resume` passed as `""`) and is named again. The trap is that lich still *derives* that
+  name (`internal/relay/rostername.go`, its page-side half `frontend/src/lib/session/peer-name.ts`) for the
+  relay to resolve against, and the derived string goes stale the moment anyone renames: it then addresses a
+  session that no longer answers to it. Nothing reads the real name back — no hook reports it — so
+  `/list-agents` inside the session is the only place it is true.
 - **git status is polled** — one shared poller per repository path (`frontend/src/lib/git/git-status-store.ts`); the
   lich plugin's `session-touched` hook nudges an immediate refresh.
 - **lich fetches on its own** — the base-branch readout (`internal/project/basestatus.go`) runs

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -136,13 +136,17 @@ hook (`docs/hooks/session-state.md`), and it is the same thing its card shows:
 
 Types `<prompt>` at `<session>`'s prompt, submits it, and waits.
 
-- `<session>` is the label on the card, **or** the name that session answers to
-  in Claude Code's peer roster (`myrepo-a1b2`, the one lich passes as `--name`
-  and a mention writes at a prompt). Both name the same session and both are
-  accepted, because an agent holding one of them should never have to know which
-  door it is standing at — offering one name and accepting the other is what
-  once made an agent treat a single session as two and use both channels at
-  once. The label wins a tie.
+- `<session>` is the label on the card, **or** the roster name lich derived for
+  it at spawn (`myrepo-a1b2`, the one passed as `--name` and written at a prompt
+  by a mention). Both name the same session and both are accepted, because an
+  agent holding one of them should never have to know which door it is standing
+  at — offering one name and accepting the other is what once made an agent
+  treat a single session as two and use both channels at once. The label wins a
+  tie. lich derives the roster name rather than reading it back, so a `/rename`
+  typed inside a Claude Code session moves the name *that* roster answers to and
+  not this one: the derived string keeps reaching the session here, and stops
+  reaching it through Claude Code's own messaging. `/list-agents`, in the
+  session, is what prints the name that side is using.
 - Labels are unique within a project, not across them: a label two live sessions
   answer to is an error naming both, and `--project` is what narrows it.
   Guessing which session a prompt lands in is the one mistake this must not

--- a/frontend/src/components/sidebar/SessionTooltip.tsx
+++ b/frontend/src/components/sidebar/SessionTooltip.tsx
@@ -1,6 +1,5 @@
-import { AtSign, GitBranch, GitPullRequestArrow, TriangleAlert } from "lucide-react"
+import { GitBranch, GitPullRequestArrow, TriangleAlert } from "lucide-react"
 import type { Session } from "@/lib/session/sessions"
-import { peerName } from "@/lib/session/peer-name"
 import { useSessionCwd } from "@/lib/session/use-session-cwd"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { baseReadout } from "@/lib/git/base-status"
@@ -15,11 +14,15 @@ interface SessionTooltipProps {
   path: string
 }
 
-// Everything a session card knows, in words — its directory, the name it
-// answers to, its branch and how that branch stands against its base. Shared by
-// the card and the rail rather than each writing its own: collapsing the
-// sidebar takes the card's text away, so this is where the text goes, and two
-// versions of it would mean the rail quietly telling you less.
+// Everything a session card knows, in words — its directory, its branch and how
+// that branch stands against its base. Shared by the card and the rail rather
+// than each writing its own: collapsing the sidebar takes the card's text away,
+// so this is where the text goes, and two versions of it would mean the rail
+// quietly telling you less.
+//
+// The peer-roster name is deliberately not among them: lich derives it at spawn
+// and never reads it back, so a /rename typed in the session leaves the derived
+// one naming nobody. `/list-agents` is where that name is true.
 //
 // It resolves its own readouts instead of taking them as props. The stores
 // behind them are keyed by path and shared (one git poller per repository), so
@@ -35,15 +38,6 @@ export function SessionTooltip({ session, path }: SessionTooltipProps) {
       <div className="flex flex-col gap-1.5">
         <span className="font-medium">{session.label}</span>
         <span className="break-all font-mono text-muted-foreground">{shownPath}</span>
-        {/* The name this session answers to when another Claude Code session
-            messages it. Built from the start path, not the shown one: a `cd` in
-            the terminal never renames a running session. */}
-        {session.kind === "claude" && (
-          <span className="flex items-center gap-1 font-mono text-muted-foreground">
-            <AtSign className="size-3 shrink-0" />
-            {peerName(session.path || path, session.id)}
-          </span>
-        )}
         {git?.branch && (
           <span className="flex flex-wrap items-center gap-2 text-muted-foreground">
             <span className="flex items-center gap-1">

--- a/internal/terminal/command.go
+++ b/internal/terminal/command.go
@@ -130,13 +130,22 @@ func resolveBin(kind, bin string) string {
 }
 
 // nameArgs returns the arguments that name a session in the provider's peer
-// roster, or nil when the provider keeps no roster or the name is unusable.
-// Claude Code is the only one with a roster, and left to itself it names a
-// session after its working directory — the same directory for every session
-// lich runs in one checkout, which is exactly the set the user has to tell
-// apart. A name that would be read as a flag is dropped rather than passed on.
-func nameArgs(kind, name string) []string {
-	if kind != providers.Claude {
+// roster, or nil when the provider keeps no roster, the session is resuming, or
+// the name is unusable. Claude Code is the only one with a roster, and left to
+// itself it names a session after its working directory — the same directory
+// for every session lich runs in one checkout, which is exactly the set the
+// user has to tell apart. A name that would be read as a flag is dropped rather
+// than passed on.
+//
+// lich names a session at birth only. Claude Code writes the name into the
+// transcript and restores it on --resume, including one the user changed with
+// /rename; passing --name again overrides that silently, so a resume would undo
+// a decision the user made inside their own session. The cost is a transcript
+// carrying no name at all — a spawn whose name flagValue rejected — which
+// resumes into Claude Code's own fallback, the working directory, and that is
+// the same string for every session in one checkout.
+func nameArgs(kind, name, resume string) []string {
+	if kind != providers.Claude || resume != "" {
 		return nil
 	}
 	name, ok := flagValue(name)
@@ -167,7 +176,7 @@ func flagValue(value string) (string, bool) {
 // path, so it has to come last.
 func providerArgs(kind, name, resume, model, lichBin string, skipPermissions bool) []string {
 	mcp := mcpArgs(kind, lichBin)
-	args := append([]string{}, nameArgs(kind, name)...)
+	args := append([]string{}, nameArgs(kind, name, resume)...)
 	args = append(args, resumeArgs(kind, resume)...)
 	args = append(args, skipPermissionArgs(kind, skipPermissions)...)
 	args = append(args, modelArgs(kind, model)...)

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -570,26 +570,30 @@ func TestResumeArgs(t *testing.T) {
 }
 
 // TestNameArgs proves only Claude Code is named — the one provider with a peer
-// roster — and that a name which would be parsed as a flag never reaches argv.
+// roster — that a name which would be parsed as a flag never reaches argv, and
+// that a resuming session is not named at all: Claude Code restores the name
+// from the transcript, and naming it again would overwrite a /rename the user
+// typed inside the session.
 func TestNameArgs(t *testing.T) {
 	cases := []struct {
-		name, kind, peer string
-		want             []string
+		name, kind, peer, resume string
+		want                     []string
 	}{
-		{"claude named", "claude", "lich-4f2a", []string{"--name", "lich-4f2a"}},
-		{"claude unnamed", "claude", "", nil},
-		{"claude blank name", "claude", "   ", nil},
-		{"claude name trimmed", "claude", " lich-4f2a ", []string{"--name", "lich-4f2a"}},
-		{"claude flag-like name", "claude", "--dangerously-skip-permissions", nil},
-		{"codex has no roster", "codex", "lich-4f2a", nil},
-		{"opencode has no roster", "opencode", "lich-4f2a", nil},
-		{"shell has no roster", KindShell, "lich-4f2a", nil},
+		{"claude named", "claude", "lich-4f2a", "", []string{"--name", "lich-4f2a"}},
+		{"claude unnamed", "claude", "", "", nil},
+		{"claude blank name", "claude", "   ", "", nil},
+		{"claude name trimmed", "claude", " lich-4f2a ", "", []string{"--name", "lich-4f2a"}},
+		{"claude flag-like name", "claude", "--dangerously-skip-permissions", "", nil},
+		{"claude resuming keeps its own name", "claude", "lich-4f2a", "conv-1", nil},
+		{"codex has no roster", "codex", "lich-4f2a", "", nil},
+		{"opencode has no roster", "opencode", "lich-4f2a", "", nil},
+		{"shell has no roster", KindShell, "lich-4f2a", "", nil},
 	}
 	for _, tc := range cases {
-		got := nameArgs(tc.kind, tc.peer)
+		got := nameArgs(tc.kind, tc.peer, tc.resume)
 		if !slices.Equal(got, tc.want) {
-			t.Errorf("%s: nameArgs(%q, %q) = %v, want %v",
-				tc.name, tc.kind, tc.peer, got, tc.want)
+			t.Errorf("%s: nameArgs(%q, %q, %q) = %v, want %v",
+				tc.name, tc.kind, tc.peer, tc.resume, got, tc.want)
 		}
 	}
 }
@@ -649,7 +653,7 @@ func TestStartPassesSkipPermissionsToTheProcess(t *testing.T) {
 }
 
 // TestStartPassesNameToTheProcess proves the peer name reaches the spawned
-// binary's argv beside the resume id, in the order claude parses.
+// binary's argv when a session is born, in the order claude parses.
 func TestStartPassesNameToTheProcess(t *testing.T) {
 	bin := stayAliveBin(t)
 	svc := New(stubBins{bin: bin}, nil, events.New())
@@ -921,10 +925,20 @@ func TestProviderArgsOrdersEachProvidersConstraint(t *testing.T) {
 	if claude[len(claude)-2] != "--mcp-config" {
 		t.Errorf("--mcp-config is not last, so it eats what follows: %v", claude)
 	}
-	for _, want := range []string{"--name", "--resume", "--dangerously-skip-permissions"} {
+	for _, want := range []string{"--resume", "--dangerously-skip-permissions"} {
 		if !slices.Contains(claude, want) {
 			t.Errorf("claude args lost %q: %v", want, claude)
 		}
+	}
+
+	// A resuming session is not named (nameArgs), so --name is pinned on the
+	// spawn that carries it: a session being born.
+	born := providerArgs(providers.Claude, "lich-4f2a", "", "", "/usr/bin/lich", true)
+	if born[len(born)-2] != "--mcp-config" {
+		t.Errorf("--mcp-config is not last, so it eats what follows: %v", born)
+	}
+	if !slices.Contains(born, "--name") {
+		t.Errorf("claude args lost --name: %v", born)
 	}
 
 	codex := providerArgs(providers.Codex, "", "conv-1", "", "/usr/bin/lich", false)


### PR DESCRIPTION
## The problem

Running `/rename` inside a Claude Code session made lich's UI lie. The `@name`
line on the session tooltip kept printing `myrepo-a1b2` — the name lich
*derives* — while the session had started answering to something else, so the
one place that named a session for cross-session messaging was also the one
place that could name it wrong.

Investigating it turned up a second, larger half: lich was actively erasing the
rename. It passed `--name` on **every** spawn, including a resume.

## What was measured

Claude Code keeps the roster name in two places readable from outside the
process: `~/.claude/sessions/<pid>.json` (`name`, plus a `formerNames` history)
and the transcript itself — a `custom-title` record for the name lich passed at
spawn, and an `agent-name` record per `/rename`.

Run in an isolated `CLAUDE_CONFIG_DIR` against a copy of a renamed session's
transcript:

| spawn | resulting name |
|---|---|
| `claude --resume <sid>` | `TheFool` — restored from the transcript |
| `claude --name work-dead --resume <sid>` | `work-dead` — the flag wins |

So the name is already durable, and `--name` on a resume is what threw it away.

The same rig showed the derived name was never trustworthy anyway: one measured
session carried three automatic `formerNames` before any manual `/rename` —
Claude Code renames sessions on its own.

## The change

`nameArgs` returns nil for a spawn carrying a resume id. A birth still names,
which is what keeps sessions in one checkout apart. No poller, no new event, no
stored field — the platform already restores it.

Which spawns are which matters, and is now written down in both the changelog
and the ceiling: the **Resume** answer on a restored card and a parked
worktree's session carry a resume id and keep their name, while the exit
banner's **Restart** is deliberately a fresh spawn (`resume` passed as `""`)
and is named again.

The tooltip's `@name` line is **removed** rather than corrected. Reading the
real name back is possible — `sessions/<pid>.json` is keyed by the same child
pid lich already polls for cwd — but with the line gone there is no consumer
left, and a derived string presented as an observed one is what caused this.
`/list-agents` is where that name is true.

`docs/cli.md` gets the same correction where `lich send` describes the roster
name. It is not deleted there: after a `/rename` the derived string still
reaches the session through lich's own relay, and stops reaching it through
Claude Code's messaging — the asymmetry is now stated instead of implied.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` green
- [x] `pnpm check` (biome) clean, `tsc -b` clean, vitest 916 passed
- [x] Cross-compile loop: `GOOS=linux|darwin|windows go build ./... && go vet ./...`
- [x] `TestNameArgs` pins the resume case; `TestProviderArgsOrdersEachProvidersConstraint`
      now pins `--name` on a birth spawn and the ordering on both
- [x] By hand: rename a session, reopen it with **Resume**, confirm `/list-agents`
      still shows the chosen name
