### PR TITLE
feat: say when a dropped file was pasted as a copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   project-level menu. Clicking the checkout header collapses or expands all of
   its cards when the sidebar needs less noise.
 
+- **A dropped file that became a copy now says so.** When lich cannot find a
+  dropped file under the session's directory or your home, it keeps a copy of
+  it and pastes the copy's path — the agent then edits the copy, your own file
+  never changes, and three days later the path stops resolving because the copy
+  is deleted. Nothing in the window ever said which of the two you got. A drop
+  that took that route now raises a notice naming the files and what it means.
+
 ### Fixed
 
 - **A deleted project no longer leaves its settings behind for the next one.**

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -30,6 +30,7 @@ import { createSessionLinkProvider } from "@/lib/terminal/session-link-provider"
 import { sessionLinkTargets } from "@/lib/terminal/session-links"
 import {
   composeDroppedPaths,
+  KEEP_DROPPED_DAYS,
   readDroppedFiles,
   resolveDroppedFiles,
 } from "@/lib/terminal/drop-files"
@@ -566,7 +567,7 @@ export function TerminalView({
       return
     }
     void (async () => {
-      const { paths, skipped } = await resolveDroppedFiles(cwd, dropped)
+      const { paths, skipped, copied } = await resolveDroppedFiles(cwd, dropped)
       const paste = composeDroppedPaths(paths, isWindows)
       if (paste !== "") {
         writeInput(paste)
@@ -574,6 +575,13 @@ export function TerminalView({
       }
       if (skipped.length > 0) {
         toast.error(`Not attached: ${skipped.join(", ")}`)
+      }
+      // Nothing failed here — the path pasted is simply a copy's, and the two
+      // read alike at the prompt.
+      if (copied.length > 0) {
+        toast.info(`Pasted as a copy: ${copied.join(", ")}`, {
+          description: `Not found under this session or your home, so edits land on the copy, not on your file — and the copy is deleted after ${KEEP_DROPPED_DAYS} days.`,
+        })
       }
     })()
   }

--- a/frontend/src/lib/terminal/drop-files.test.ts
+++ b/frontend/src/lib/terminal/drop-files.test.ts
@@ -1,5 +1,24 @@
-import { describe, expect, it } from "vitest"
-import { composeDroppedPaths } from "./drop-files"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { composeDroppedPaths, type DroppedFile, resolveDroppedFiles } from "./drop-files"
+
+// The backend is the boundary: the lookup is an RPC and the upload its own
+// endpoint, so both are stubbed and the test asserts which branch each entry
+// took — the whole point of the copied list.
+const resolve = vi.fn()
+vi.mock("@/lib/rpc", () => ({
+  DropService: {
+    Resolve: (root: string, items: unknown[]) => resolve(root, items),
+  },
+  endpoint: () => ({ base: "http://127.0.0.1:47821", token: "t" }),
+}))
+
+const file = (name: string): DroppedFile => ({
+  name,
+  size: 3,
+  mtime: 1,
+  dir: false,
+  blob: new Blob(["abc"]),
+})
 
 const PASTE_START = "\x1b[200~"
 const PASTE_END = "\x1b[201~"
@@ -48,5 +67,76 @@ describe("composeDroppedPaths", () => {
     expect(composeDroppedPaths(["C:\\Program Files\\a.ts"], true)).toBe(
       `${PASTE_START}"C:\\Program Files\\a.ts" ${PASTE_END}`,
     )
+  })
+})
+
+describe("resolveDroppedFiles", () => {
+  const upload = vi.fn()
+
+  beforeEach(() => {
+    resolve.mockReset()
+    upload.mockReset()
+    upload.mockResolvedValue({
+      ok: true,
+      json: async () => ({ path: "/cfg/lich/dropped/b.png" }),
+    })
+    vi.stubGlobal("fetch", upload)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("reports no copy for a file the tree holds", async () => {
+    resolve.mockResolvedValue(["/home/u/a.ts"])
+
+    const result = await resolveDroppedFiles("/home/u", [file("a.ts")])
+
+    expect(result).toEqual({ paths: ["/home/u/a.ts"], skipped: [], copied: [] })
+    expect(upload).not.toHaveBeenCalled()
+  })
+
+  // The path pasted for b.png is a copy's, and only this list says so.
+  it("names the entries pasted as a copy", async () => {
+    resolve.mockResolvedValue(["/home/u/a.ts", ""])
+
+    const result = await resolveDroppedFiles("/home/u", [file("a.ts"), file("b.png")])
+
+    expect(result).toEqual({
+      paths: ["/home/u/a.ts", "/cfg/lich/dropped/b.png"],
+      skipped: [],
+      copied: ["b.png"],
+    })
+  })
+
+  // A copy that was never written has no path to warn about.
+  it("leaves a failed upload out of the copies", async () => {
+    resolve.mockResolvedValue([""])
+    upload.mockResolvedValue({ ok: false, status: 500 })
+
+    const result = await resolveDroppedFiles("/home/u", [file("b.png")])
+
+    expect(result).toEqual({ paths: [], skipped: ["b.png"], copied: [] })
+  })
+
+  // A directory has no bytes to copy, so it is skipped, never listed as one.
+  it("does not call a missing folder a copy", async () => {
+    resolve.mockResolvedValue([""])
+    const folder: DroppedFile = { name: "docs", size: 0, mtime: 1, dir: true, blob: null }
+
+    const result = await resolveDroppedFiles("/home/u", [folder])
+
+    expect(result.copied).toEqual([])
+    expect(result.skipped).toHaveLength(1)
+    expect(upload).not.toHaveBeenCalled()
+  })
+
+  it("answers an empty drop without touching the backend", async () => {
+    expect(await resolveDroppedFiles("/home/u", [])).toEqual({
+      paths: [],
+      skipped: [],
+      copied: [],
+    })
+    expect(resolve).not.toHaveBeenCalled()
   })
 })

--- a/frontend/src/lib/terminal/drop-files.ts
+++ b/frontend/src/lib/terminal/drop-files.ts
@@ -18,6 +18,10 @@ import { bracketedPaste } from "./bracketed-paste"
 // mis-drag, and the backend refuses it anyway.
 const MAX_UPLOAD_BYTES = 32 << 20
 
+// Matches internal/drop's keepDropped: how long a copy outlives its drop, which
+// is the half of the notice the user cannot find out any other way.
+export const KEEP_DROPPED_DAYS = 3
+
 /** One dropped entry: what the page can say about it, plus its bytes. */
 export interface DroppedFile extends DropItem {
   /** Null for a directory — the page has no bytes to upload for one. */
@@ -57,6 +61,12 @@ export interface DropResult {
   paths: string[]
   /** Names of entries that yielded no path, with why. */
   skipped: string[]
+  /**
+   * Names of entries neither tree held, whose path is a copy's — an edit there
+   * never reaches the user's file, and the copy expires. Nothing else in the UI
+   * distinguishes those paths from the real ones.
+   */
+  copied: string[]
 }
 
 /**
@@ -69,8 +79,9 @@ export async function resolveDroppedFiles(
 ): Promise<DropResult> {
   const paths: string[] = []
   const skipped: string[] = []
+  const copied: string[] = []
   if (dropped.length === 0) {
-    return { paths, skipped }
+    return { paths, skipped, copied }
   }
   const items = dropped.map(({ name, size, mtime, dir }) => ({ name, size, mtime, dir }))
   const found = await DropService.Resolve(cwd, items)
@@ -92,11 +103,12 @@ export async function resolveDroppedFiles(
     }
     try {
       paths.push(await uploadDroppedFile(entry.name, entry.blob))
+      copied.push(entry.name)
     } catch {
       skipped.push(entry.name)
     }
   }
-  return { paths, skipped }
+  return { paths, skipped, copied }
 }
 
 // uploadDroppedFile stores one file's bytes on the backend and answers with the


### PR DESCRIPTION
## What

A file dropped on a terminal that lich cannot find under the session's directory or under home is copied into `<config-dir>/lich/dropped`, and the path pasted at the prompt is the copy's. Nothing in the window said so — the agent edits the copy, the user's own file never changes, and 3 days later `Prune` deletes the copy so the path pasted into a prompt stops resolving.

`resolveDroppedFiles` already knew exactly which entries took the upload branch and dropped that knowledge on the floor. It now reports them.

- `DropResult` gains `copied: string[]` — the names of entries whose path is a copy's.
- `TerminalView` raises a plain `toast.info` for them. Not `toast.error`: nothing failed.
- `KEEP_DROPPED_DAYS = 3` mirrors `internal/drop`'s `keepDropped`, the same way `MAX_UPLOAD_BYTES` mirrors `maxUpload`, with a comment pointing at the Go constant.

The resolve heuristic, the expiry and the skipped/error path are untouched.

## The notice

> **Pasted as a copy: shot.png**
> Not found under this session or your home, so edits land on the copy, not on your file — and the copy is deleted after 3 days.

## Test plan

- [x] `drop-files.test.ts` extended over `resolveDroppedFiles`: found file reports no copy, an uploaded entry is named in `copied`, a failed upload is skipped and not counted a copy, a missing folder is skipped and never uploaded, an empty drop never reaches the backend.
- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green.
- [x] `frontend`: `biome check .` (exit 0, standing a11y warnings only), `vitest run` 897 passed, `pnpm build` green.