### PR TITLE
feat: fetch the base every 30 seconds, not every 2 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the module is what CI reads its Go version from. `GOTOOLCHAIN=auto` — the
   default — fetches 1.26.6 on its own; a build pinned to `local` on anything
   older will refuse the module.
+- **A card notices sooner that its base moved.** The behind count and the
+  conflict list beside a branch refresh at most every 30 seconds, not every 2
+  minutes.
 
 ### Removed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,9 +123,9 @@ nobody knows it and that the call site never shows. The mechanism and the histor
 - **git status is polled** — one shared poller per repository path (`frontend/src/lib/git/git-status-store.ts`); the
   lich plugin's `session-touched` hook nudges an immediate refresh.
 - **lich fetches on its own** — the base-branch readout (`internal/project/basestatus.go`) runs
-  `git fetch --no-tags origin` in the background, at most once every 2 minutes per repository, for as long as a
-  card is on screen. It is the only git write lich makes outside the worktree flows, nothing in the UI announces
-  it, and it moves remote refs in the user's own repository.
+  `git fetch --no-tags origin` in the background, at most once every 30 seconds per repository, for as long as a
+  card is on screen. It is the only git write lich makes outside the worktree flows, nothing announces it, and it
+  moves remote refs in the user's own repository.
 - **Persistence is hybrid**: UI prefs in the page's localStorage (`lich.*` keys — the reason the listener port is
   pinned at 47821; `LICH_LISTEN_PORT` overrides it, `LICH_PORT` is the distinct per-session hook variable), the
   workspace in SQLite (`<config-dir>/lich/lich.db`, `internal/store`). Closing a session deletes its row; keeping a

--- a/internal/project/basestatus.go
+++ b/internal/project/basestatus.go
@@ -25,7 +25,9 @@ type BaseStatus struct {
 // else in lich fetches after a worktree is created, and a branch lands on the
 // forge, not here — so without this the readout would answer from refs frozen at
 // creation time and never notice the very thing it exists to report.
-const baseFetchInterval = 2 * time.Minute
+// The interval is a network round trip per repository with a card on screen,
+// all day, so it is a cost as much as a cadence.
+const baseFetchInterval = 30 * time.Second
 
 // baseFetchTimeout caps the fetch subprocess. It already runs off the poll, but
 // an ssh key prompt with nowhere to prompt would sit there for the app's life.


### PR DESCRIPTION
The behind count and the conflict list beside a branch are computed from remote refs that only move when lich fetches for them. At two minutes a commit landing on the base could go unnoticed for the whole time somebody sat looking at the card.

`baseFetchInterval` in `internal/project/basestatus.go`: 2 minutes to 30 seconds. Nothing else changes — same throttle, same per-repository key, same poll.

Gate: gofmt, `go vet ./...`, `LICH_LISTEN_PORT= go test ./...` (29 packages) all clean.