### PR TITLE
feat: version control settings name the commit identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the select still shows the resolved global provider, and follows later changes
   to the global choice.
 
+- **The GitHub account picker now says who your commits are authored as.** The
+  account it selects governs what lich asks gh — reading pull requests, checks,
+  PR checkouts — and nothing else: a push rides the remote's ssh key and signs
+  with `git user.email`, so a PR read by one account can land commits under
+  another with no error anywhere. Version control settings now name that second
+  identity under the picker, saying when it comes from the repository's own
+  config rather than your global one, and when the checkout has none at all and
+  git will refuse the commit. Both facts, no comparison between them: noreply
+  addresses, vanity domains and org aliases make a mismatch warning a
+  false-positive farm, and the two values side by side tell you more than a
+  guess would. lich never writes `user.email`.
+
 - **Every visible checkout group can open another session in place.** Its `+`
   menu offers every enabled coding provider and a plain terminal, rooted in that
   exact project directory or worktree instead of requiring a trip through the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,9 @@ nobody knows it and that the call site never shows. The mechanism and the histor
 - **A project's gh account governs gh, not git**: `vcs.account` (`internal/project/ghaccount.go`) puts one
   account's token in `GH_TOKEN` for every gh call lich makes for that project. A push still rides the remote's
   ssh key and signs with the global `user.email`, so a PR can be *read* by one account and its commits *land*
-  under another, with no error anywhere.
+  under another, with no error anywhere. The Version Control settings print the second identity beside the
+  picker (`internal/project/commitidentity.go`) — both facts, never a comparison: noreply forms, vanity domains
+  and org aliases make a mismatch warning a false-positive farm. lich never writes `user.email`.
 - **`LICH_WORKTREE_PORT` is reserved, never held** (`internal/terminal/worktreeport.go`, table `worktree_ports`):
   the number is checked against the other checkouts and bound once to prove it is free, then released — the dev
   server starts minutes later, after the setup script, and anything on the machine can take the port in between.

--- a/frontend/src/components/settings/VersionControlSettings.tsx
+++ b/frontend/src/components/settings/VersionControlSettings.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react"
+import type { CommitIdentity } from "@/lib/api-types"
 import { ProjectService, Store } from "@/lib/rpc"
+import { commitIdentityRow } from "@/lib/commit-identity"
 import { accountLabel, accountSelectItems, upgradeAccount } from "@/lib/gh-account"
 import { GH_ACCOUNT_KEY } from "@/lib/project-settings"
 import { errorText } from "@/lib/utils"
@@ -30,7 +32,18 @@ export function VersionControlSettings({ projectId }: { projectId?: string }) {
   const project = projects.find((p) => p.id === projectId)
   const [accounts, setAccounts] = useState<string[]>([])
   const [account, setAccount] = useState("")
+  const [identity, setIdentity] = useState<CommitIdentity | null>(null)
   const [error, setError] = useState("")
+
+  // Read once per project: git's config changes outside lich, but so rarely
+  // that polling the settings page for it would buy nothing.
+  useEffect(() => {
+    const path = project?.path
+    if (!path) {
+      return
+    }
+    void ProjectService.CommitIdentity(path).then(setIdentity)
+  }, [project?.path])
 
   useEffect(() => {
     void ProjectService.GitHubAccounts()
@@ -81,6 +94,9 @@ export function VersionControlSettings({ projectId }: { projectId?: string }) {
   // The configured account survives a gh that no longer lists it, so a stale
   // value is visible (and changeable) instead of silently reading as default.
   const options = Array.from(new Set([...accounts, ...(account ? [account] : [])]))
+  // The account governs what lich asks gh; this says who the commits are
+  // authored as. Both facts, no comparison — see commitIdentityRow.
+  const row = identity && commitIdentityRow(identity)
 
   return (
     <SettingBlock
@@ -88,8 +104,7 @@ export function VersionControlSettings({ projectId }: { projectId?: string }) {
       description={
         "Which account lich runs gh as for this project — pull requests, checks and PR checkouts. " +
         "gh keeps one active account per host, so a repository only another account can see reads " +
-        "as not found. Accounts on an enterprise host are listed with it. Pushes are unaffected: " +
-        "they still ride the remote's ssh key and the git user.email."
+        "as not found. Accounts on an enterprise host are listed with it."
       }
     >
       <p className="mb-2 text-xs text-muted-foreground">{project.path}</p>
@@ -115,6 +130,19 @@ export function VersionControlSettings({ projectId }: { projectId?: string }) {
       {error && (
         <p className="mt-2 text-xs text-destructive">
           Could not list GitHub accounts: {error}. Run `gh auth login` to authenticate.
+        </p>
+      )}
+      {row && (
+        <p className="mt-3 border-t border-border pt-2 text-xs text-muted-foreground">
+          {row.email ? (
+            <>
+              {row.lead} <span className="font-mono">{row.email}</span> {row.note}
+            </>
+          ) : (
+            <>
+              <span className="text-foreground">{row.lead}</span> {row.note}
+            </>
+          )}
         </p>
       )}
     </SettingBlock>

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -279,6 +279,16 @@ export interface WorktreeSetup {
   detected?: string
 }
 
+/** internal/project.CommitIdentity — who the next commit in a checkout would
+ * be authored as, which the project's gh account does not govern. Every field
+ * empty means the checkout has no identity configured. */
+export interface CommitIdentity {
+  name: string
+  email: string
+  /** The email comes from the checkout's own config, not the global one. */
+  local: boolean
+}
+
 /** internal/store.Session — a persisted terminal session (metadata only). */
 export interface StoredSession {
   id: string

--- a/frontend/src/lib/commit-identity.test.ts
+++ b/frontend/src/lib/commit-identity.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+import { commitIdentityRow } from "./commit-identity"
+
+describe("commitIdentityRow", () => {
+  it("names the global identity as the one the account does not govern", () => {
+    expect(
+      commitIdentityRow({ name: "Jane Doe", email: "jane@example.com", local: false }),
+    ).toEqual({
+      lead: "Commits land as Jane Doe",
+      email: "<jane@example.com>",
+      note: "— git user.email, not this account.",
+    })
+  })
+
+  it("says where a repository-local identity came from", () => {
+    expect(
+      commitIdentityRow({ name: "Work Jane", email: "jane@work.example", local: true }),
+    ).toEqual({
+      lead: "Commits land as Work Jane",
+      email: "<jane@work.example>",
+      note: "— set in this repository, overriding your global one.",
+    })
+  })
+
+  it("keeps the sentence whole when only the name is missing", () => {
+    expect(commitIdentityRow({ name: "", email: "jane@example.com", local: false })).toEqual({
+      lead: "Commits land as",
+      email: "<jane@example.com>",
+      note: "— git user.email, not this account.",
+    })
+  })
+
+  // The one state worth flagging, and the only one that is not a comparison
+  // between the two accounts: git refuses the commit outright.
+  it("reports a checkout with no identity at all", () => {
+    expect(commitIdentityRow({ name: "", email: "", local: false })).toEqual({
+      lead: "No git identity in this checkout.",
+      email: "",
+      note: "Commits will be refused until user.email is set.",
+    })
+  })
+
+  it("still reports nothing configured when a name outlives its email", () => {
+    const row = commitIdentityRow({ name: "Jane Doe", email: "", local: false })
+    expect(row.lead).toBe("No git identity in this checkout.")
+    expect(row.email).toBe("")
+  })
+})

--- a/frontend/src/lib/commit-identity.ts
+++ b/frontend/src/lib/commit-identity.ts
@@ -1,0 +1,33 @@
+import type { CommitIdentity } from "./api-types"
+
+/** The three parts of the identity row, so the email can be set in monospace
+ * without the rest of the sentence being assembled in JSX. */
+export interface CommitIdentityRow {
+  lead: string
+  /** "<jane@example.com>"; "" when the checkout has no identity to name. */
+  email: string
+  note: string
+}
+
+/** How a checkout's commit identity reads under the account picker. The two
+ * facts sit side by side and nothing here compares them: noreply forms, vanity
+ * domains and org aliases make an email-to-login check a false-positive farm,
+ * and the person reading owns the conclusion. The one state that is not a
+ * comparison — no identity at all — is a fact about the checkout, and git will
+ * refuse the commit for it. */
+export function commitIdentityRow(identity: CommitIdentity): CommitIdentityRow {
+  if (!identity.email) {
+    return {
+      lead: "No git identity in this checkout.",
+      email: "",
+      note: "Commits will be refused until user.email is set.",
+    }
+  }
+  return {
+    lead: identity.name ? `Commits land as ${identity.name}` : "Commits land as",
+    email: `<${identity.email}>`,
+    note: identity.local
+      ? "— set in this repository, overriding your global one."
+      : "— git user.email, not this account.",
+  }
+}

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -11,6 +11,7 @@ import type {
   BaseStatus,
   BranchRules,
   Branches,
+  CommitIdentity,
   DetectedProvider,
   Diagnostics as DiagnosticsData,
   DiffStats,
@@ -178,6 +179,9 @@ export const ProjectService = {
   /** The logins gh is authenticated as, for the project's account picker;
    * errors when gh is missing or logged out. */
   GitHubAccounts: () => call<string[] | null>("project.GitHubAccounts", []),
+  /** Who the next commit in this checkout would be authored as — the fact the
+   * account picker does not govern. Empty fields = no identity configured. */
+  CommitIdentity: (path: string) => call<CommitIdentity>("project.CommitIdentity", [path]),
   /** Every checkout holding a branch, the project's own directory included —
    * which ListBranches omits, since it cannot be resumed as a worktree. */
   ListCheckouts: (path: string) => call<Worktree[] | null>("project.ListCheckouts", [path]),

--- a/internal/project/commitidentity.go
+++ b/internal/project/commitidentity.go
@@ -1,0 +1,39 @@
+package project
+
+import "strings"
+
+// CommitIdentity is the name and email the next commit in a checkout would be
+// authored with — the fact the project's gh account (ghaccount.go) does not
+// carry, since that one only governs what lich asks gh. Local says the value
+// comes from the checkout's own config rather than the global one.
+//
+// The zero value is a legitimate answer, not a failure: a checkout with no
+// identity configured is one of the states worth showing.
+type CommitIdentity struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+	Local bool   `json:"local"`
+}
+
+// CommitIdentity reads the identity git itself resolves in the checkout at
+// path, so a repository-local override wins over the global config exactly as
+// it would for a commit. A non-repository, an unreadable config or no identity
+// at all answer the zero value — hence the quiet probes (see runGit for why).
+func (s *Service) CommitIdentity(path string) CommitIdentity {
+	identity := CommitIdentity{
+		Name:  gitConfig(path, "user.name"),
+		Email: gitConfig(path, "user.email"),
+	}
+	// The email alone decides "set in this repository": it is the value git
+	// refuses a commit without, and the one the readout shows.
+	identity.Local = identity.Email != "" && gitConfig(path, "--local", "user.email") != ""
+	return identity
+}
+
+// gitConfig reads one config key in the checkout at path — with git's own
+// resolution order, or narrowed to a scope ("--local") when one leads the
+// arguments. "" for every key git declines to answer.
+func gitConfig(path string, args ...string) string {
+	out, _ := gitQuiet(path, append([]string{"config", "--get"}, args...)...)
+	return strings.TrimSpace(out)
+}

--- a/internal/project/commitidentity_test.go
+++ b/internal/project/commitidentity_test.go
@@ -1,0 +1,93 @@
+package project
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// isolateGitConfig points git's global and system config at files this test
+// owns, so what the machine running the suite has configured cannot decide the
+// answer — the whole point here is which scope a value came from.
+func isolateGitConfig(t *testing.T, global string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "gitconfig")
+	if err := os.WriteFile(path, []byte(global), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GIT_CONFIG_GLOBAL", path)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+}
+
+// TestCommitIdentity pins the three answers the settings row renders: the
+// global identity, a repository-local override of it, and no identity at all —
+// which is a state to show, not an error.
+func TestCommitIdentity(t *testing.T) {
+	const global = "[user]\n\tname = Jane Doe\n\temail = jane@example.com\n"
+	tests := []struct {
+		name       string
+		globalConf string
+		local      map[string]string
+		want       CommitIdentity
+	}{
+		{
+			"the global identity, with nothing local to override it",
+			global,
+			nil,
+			CommitIdentity{Name: "Jane Doe", Email: "jane@example.com"},
+		},
+		{
+			"a repository-local identity wins and says so",
+			global,
+			map[string]string{"user.name": "Work Jane", "user.email": "jane@work.example"},
+			CommitIdentity{Name: "Work Jane", Email: "jane@work.example", Local: true},
+		},
+		{
+			// Only the email decides Local: it is the value git refuses a
+			// commit without, so a local name over a global email is still the
+			// global identity being used.
+			"a local name over a global email is not an override",
+			global,
+			map[string]string{"user.name": "Work Jane"},
+			CommitIdentity{Name: "Work Jane", Email: "jane@example.com"},
+		},
+		{
+			"no identity anywhere is the empty answer",
+			"",
+			nil,
+			CommitIdentity{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isolateGitConfig(t, tt.globalConf)
+			repo := initBareRepo(t)
+			for key, value := range tt.local {
+				if out, err := exec.Command("git", "-C", repo, "config", key, value).CombinedOutput(); err != nil {
+					t.Fatalf("git config %s: %v (%s)", key, err, out)
+				}
+			}
+			if got := New(nil).CommitIdentity(repo); got != tt.want {
+				t.Errorf("CommitIdentity() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCommitIdentityOutsideARepositoryStaysSilent covers the path a settings
+// page can always reach — a project directory that is not a checkout. git has
+// no local scope to read there, so the answer must degrade to the global
+// identity without filing a warning for the scope that does not exist.
+func TestCommitIdentityOutsideARepositoryStaysSilent(t *testing.T) {
+	isolateGitConfig(t, "[user]\n\tname = Jane Doe\n\temail = jane@example.com\n")
+	logged := captureLog(t)
+
+	want := CommitIdentity{Name: "Jane Doe", Email: "jane@example.com"}
+	if got := New(nil).CommitIdentity(t.TempDir()); got != want {
+		t.Errorf("CommitIdentity(non-repo) = %+v, want %+v", got, want)
+	}
+	if out := logged(); out != "" {
+		t.Errorf("reading the identity logged:\n%s", out)
+	}
+}


### PR DESCRIPTION
## What

The GitHub account picker names the account that *reads* a repository. It never named the identity that *authors* its commits — the block said so in prose ("Pushes are unaffected…") with no value attached to it. Now the second fact is printed next to the first.

**Backend** — `ProjectService.CommitIdentity(path)` returns `{name, email, local}`: the values git itself resolves in the checkout (`git config --get user.name` / `user.email`, so a repository-local override wins exactly as it would for a commit) plus whether the email came from the repository's own config. The zero value is a legitimate answer, not an error — a checkout with no identity is one of the states worth showing. Quiet probes, like every other polled/probing git read in the package.

**Frontend** — one row under the Select, hairline `border-t`, muted `text-xs`, email in a monospace span. Three states:

- `Commits land as Jane Doe <jane@example.com> — git user.email, not this account.`
- `Commits land as Work Jane <jane@work.example> — set in this repository, overriding your global one.`
- `No git identity in this checkout. Commits will be refused until user.email is set.`

The block description's last sentence is gone — the row now says it with a value in it.

## What this deliberately does not do

No heuristic and no warning comparing the email to the gh login: noreply forms, vanity domains and org aliases make that a false-positive farm. Both facts side by side; the person reading owns the conclusion. The only state that carries a visual flag is "nothing configured", because that one is not a comparison — it is a fact about the checkout, and git refuses the commit for it.

lich never sets `user.email`, never offers to, and never touches the push. No dialog, no badge on the session card, nothing in the PR flow.

## Test plan

- [x] `internal/project`: resolution, local-vs-global (including a local *name* over a global email, which is not an override), the empty answer, and the non-repository path staying silent.
- [x] `frontend/src/lib/commit-identity.test.ts`: the three rendered states plus the name-less and email-less edges.
- [x] Local gate: `gofmt -l .`, `go vet ./...`, `go test ./...`, `pnpm check`, `vitest run` (921 tests), `pnpm build`.
