### PR TITLE
feat: a session's path follows the shell you started inside it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A session's path now follows the shell you started inside it.** The
+  directory on a card was read from the process lich spawned in the PTY, so a
+  `cd` made inside a nested shell — `sh`, `su`, `nix develop` — moved nothing:
+  the path line, the git status beside it and the tree a dropped file is
+  searched for all went on naming the directory that shell was launched from.
+  lich now reads the terminal's foreground process group, which is where that
+  `cd` happened, on Linux and macOS; Windows still tracks the process it
+  spawned. A session running a coding agent reads the same as before, and
+  deliberately: the subprocesses an agent runs for a tool call have no terminal
+  of their own, so a `cd /tmp && …` inside one no longer risks dragging the card
+  along with it. A shell hosted somewhere else — tmux, ssh, a container — is
+  still beyond reach, and keeps reporting the directory the session started in.
 - **A deleted project no longer leaves its settings behind for the next one.**
   A project whose directory is gone is dropped from the workspace, but its
   per-project settings — provider, gh account, binary paths — stayed in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,15 +88,11 @@ Deliberate limits and shortcuts. A bullet earns its place by naming a trap — s
 nobody knows it and that the call site never shows. The mechanism and the history stay in the code and
 `CHANGELOG.md`.
 
-- **Session cwd is polled, and anything that re-hosts the shell reports the wrong directory in silence**
-  (`internal/terminal/cwd.go`, per-OS readers behind build tags): a failed read degrades to the session's start
-  directory. Linux and macOS follow the terminal's foreground process group, so a nested shell's `cd` moves the
-  card; Windows still tracks the direct child, so the same `cd` moves nothing there. Neither reaches tmux/screen
-  (the server is not in the process tree), ssh (the directory is on another machine) or docker (another mount
-  namespace) — the readout keeps naming a real local directory that is not where the user is, and nothing on
-  screen says so. A root shell (`sudo -i`, `su`) freezes it at its last value. What consumes the wrong answer:
-  the card's path line, its git status and PR badge, and `internal/drop`'s search root — that last one silently
-  *copies* the dropped file when the tree is wrong.
+- **Session cwd is polled** from the terminal's foreground process group (`internal/terminal/cwd.go`, per-OS
+  readers behind build tags); a failed read degrades to the session's start directory, and Windows tracks the
+  PTY child instead, where the same nested-shell `cd` moves nothing. A shell hosted elsewhere — tmux, ssh, a
+  container — is beyond all of them: the readout goes on naming a real local directory that is not where the
+  user is, with nothing on screen saying so.
 - **A project's gh account governs gh, not git**: `vcs.account` (`internal/project/ghaccount.go`) puts one
   account's token in `GH_TOKEN` for every gh call lich makes for that project. A push still rides the remote's
   ssh key and signs with the global `user.email`, so a PR can be *read* by one account and its commits *land*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,8 +88,15 @@ Deliberate limits and shortcuts. A bullet earns its place by naming a trap — s
 nobody knows it and that the call site never shows. The mechanism and the history stay in the code and
 `CHANGELOG.md`.
 
-- **Session cwd is polled** from the PTY child (`internal/terminal/cwd.go`, per-OS readers behind build tags); a
-  failed read degrades to the session's start directory. Tracks the direct child only, not nested shells.
+- **Session cwd is polled, and anything that re-hosts the shell reports the wrong directory in silence**
+  (`internal/terminal/cwd.go`, per-OS readers behind build tags): a failed read degrades to the session's start
+  directory. Linux and macOS follow the terminal's foreground process group, so a nested shell's `cd` moves the
+  card; Windows still tracks the direct child, so the same `cd` moves nothing there. Neither reaches tmux/screen
+  (the server is not in the process tree), ssh (the directory is on another machine) or docker (another mount
+  namespace) — the readout keeps naming a real local directory that is not where the user is, and nothing on
+  screen says so. A root shell (`sudo -i`, `su`) freezes it at its last value. What consumes the wrong answer:
+  the card's path line, its git status and PR badge, and `internal/drop`'s search root — that last one silently
+  *copies* the dropped file when the tree is wrong.
 - **A project's gh account governs gh, not git**: `vcs.account` (`internal/project/ghaccount.go`) puts one
   account's token in `GH_TOKEN` for every gh call lich makes for that project. A push still rides the remote's
   ssh key and signs with the global `user.email`, so a PR can be *read* by one account and its commits *land*

--- a/internal/terminal/cwd.go
+++ b/internal/terminal/cwd.go
@@ -1,6 +1,8 @@
 package terminal
 
 import (
+	"bytes"
+	"strconv"
 	"time"
 
 	"github.com/omartelo/lich/internal/events"
@@ -36,6 +38,28 @@ func dosPathRunes(n uint16) int {
 		return 0
 	}
 	return int(n / 2)
+}
+
+// parseTpgid returns the foreground process group of a /proc/<pid>/stat line —
+// tpgid, the sixth field after the comm — and 0 when the line does not carry
+// one. Counting starts at the last ')' because comm sits in parens and may hold
+// spaces and parens of its own ("(sh (deploy))"), which is the whole reason a
+// field split of the raw line is wrong. Kept out of the build-tagged file so
+// the parse tests on any OS (dosPathRunes' pattern).
+func parseTpgid(stat []byte) int {
+	i := bytes.LastIndexByte(stat, ')')
+	if i < 0 {
+		return 0
+	}
+	fields := bytes.Fields(stat[i+1:])
+	if len(fields) < 6 {
+		return 0
+	}
+	pgrp, err := strconv.Atoi(string(fields[5]))
+	if err != nil || pgrp < 0 {
+		return 0
+	}
+	return pgrp
 }
 
 // watchCwd reports the session child's working directory to the frontend

--- a/internal/terminal/cwd_darwin.go
+++ b/internal/terminal/cwd_darwin.go
@@ -5,6 +5,8 @@ import (
 	"syscall"
 	"unsafe"
 	_ "unsafe" // for go:linkname
+
+	"golang.org/x/sys/unix"
 )
 
 const cwdTracked = true
@@ -40,11 +42,25 @@ type procVnodePathInfo struct {
 	Rdir vnodeInfoPath
 }
 
-// processCwd returns pid's current working directory, or "" when it cannot be
-// read (the process exited, or was never ours to inspect). proc_pidinfo
-// returns the number of bytes filled; anything short of the full struct is a
-// failure.
-func processCwd(pid int) string {
+// foregroundPgrp returns the process group that owns pid's controlling
+// terminal, or 0 when pid has no terminal (e_tpgid is -1 then) or the process
+// cannot be read. sysctl answers it from the process itself, the way Linux
+// reads tpgid out of /proc, so no PTY file descriptor has to cross the
+// ptyHandle seam for a directory read — TIOCGPGRP on the master would have
+// forced one. Unlike proc_pidinfo above, this call is exposed by x/sys/unix,
+// so there is no trampoline to write.
+func foregroundPgrp(pid int) int {
+	proc, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil || proc.Eproc.Tpgid < 0 {
+		return 0
+	}
+	return int(proc.Eproc.Tpgid)
+}
+
+// readCwd returns pid's own working directory, or "" when it cannot be read
+// (the process exited, or was never ours to inspect). proc_pidinfo returns the
+// number of bytes filled; anything short of the full struct is a failure.
+func readCwd(pid int) string {
 	var info procVnodePathInfo
 	n, _, _ := syscall_syscall6(
 		libc_proc_pidinfo_trampoline_addr,

--- a/internal/terminal/cwd_foreground_test.go
+++ b/internal/terminal/cwd_foreground_test.go
@@ -1,0 +1,69 @@
+//go:build linux || darwin
+
+package terminal
+
+import (
+	"io"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+// TestProcessCwdFollowsForegroundJob proves the readout moves with the nested
+// shell the user started rather than with the PTY child, which never left the
+// directory it was spawned in. That is the one case the direct-child read
+// cannot answer and the only reason this seam reads a foreground group at all.
+//
+// Driven through a real PTY and the shell's own job control: tpgid on Linux
+// and e_tpgid on macOS are set by a shell handing the terminal to a job, and
+// nothing about that is reachable without one.
+func TestProcessCwdFollowsForegroundJob(t *testing.T) {
+	outer := physical(t, t.TempDir())
+	inner := physical(t, t.TempDir())
+
+	cmd := exec.Command("/bin/sh", "-i")
+	cmd.Dir = outer
+	// A stranger's rc file must not get a say in whether this passes: sh reads
+	// whatever $ENV points at.
+	cmd.Env = []string{"PATH=/bin:/usr/bin", "TERM=dumb", "ENV=", "PS1=$ "}
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		t.Fatalf("pty.Start: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = ptmx.Close()
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	})
+	// A shell whose output has nowhere to go blocks once the PTY buffer fills,
+	// and a blocked shell never reaches the cd being measured.
+	go func() { _, _ = io.Copy(io.Discard, ptmx) }()
+
+	// Typed rather than spawned directly: only a shell's job control puts the
+	// nested shell in its own process group and gives it the terminal. Bytes
+	// typed before the shell is ready wait in the line discipline, so there is
+	// no readiness handshake to get wrong.
+	if _, err := ptmx.WriteString("/bin/sh -i\ncd " + inner + "\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	pid := cmd.Process.Pid
+	deadline := time.Now().Add(20 * time.Second)
+	for {
+		got := processCwd(pid)
+		if got == inner {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("processCwd(%d) = %q, want the nested shell's %q", pid, got, inner)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	// Pins what the pass is worth: the child itself never moved, so this cannot
+	// be a run where both reads happen to agree on the same directory.
+	if got := readCwd(pid); got != outer {
+		t.Fatalf("readCwd(%d) = %q, want the unmoved child's %q", pid, got, outer)
+	}
+}

--- a/internal/terminal/cwd_linux.go
+++ b/internal/terminal/cwd_linux.go
@@ -12,12 +12,25 @@ import (
 // skips the watcher entirely.
 const cwdTracked = true
 
-// processCwd returns pid's current working directory, or "" when it cannot be
-// read (the process exited, or was never ours to inspect).
-func processCwd(pid int) string {
+// readCwd returns pid's own working directory, or "" when it cannot be read.
+func readCwd(pid int) string {
 	cwd, err := os.Readlink("/proc/" + strconv.Itoa(pid) + "/cwd")
 	if err != nil {
 		return ""
 	}
 	return cwd
+}
+
+// foregroundPgrp returns the process group that owns pid's controlling
+// terminal — tpgid, in /proc/<pid>/stat — or 0 when pid has no terminal or its
+// stat cannot be read. Read from the process rather than from the terminal
+// (TIOCGPGRP on the PTY master) so no file descriptor has to cross the
+// ptyHandle seam for a directory read; macOS answers the same question the
+// same way, through sysctl.
+func foregroundPgrp(pid int) int {
+	stat, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return 0
+	}
+	return parseTpgid(stat)
 }

--- a/internal/terminal/cwd_track_test.go
+++ b/internal/terminal/cwd_track_test.go
@@ -62,6 +62,29 @@ func TestDosPathRunesRejectsUnusableLengths(t *testing.T) {
 	}
 }
 
+// TestParseTpgidSurvivesComm proves the foreground group is read past a comm
+// holding the very characters a naive field split trips on, and that a process
+// with no controlling terminal (tpgid -1, what every non-PTY child reports)
+// yields no group rather than a negative pid the cwd read would chase.
+func TestParseTpgidSurvivesComm(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want int
+	}{
+		{"plain", "42 (zsh) S 41 42 42 34816 4242 4194304 ...", 4242},
+		{"comm with spaces and parens", "42 (sh (deploy)) S 41 42 42 34816 4242 0 ...", 4242},
+		{"no controlling terminal", "42 (go) S 41 42 42 0 -1 0 ...", 0},
+		{"truncated", "42 (zsh) S 41 42", 0},
+		{"no comm close", "42 (zsh S 41 42 42 34816 4242 0", 0},
+	}
+	for _, tc := range cases {
+		if got := parseTpgid([]byte(tc.in)); got != tc.want {
+			t.Errorf("%s: parseTpgid = %d, want %d", tc.name, got, tc.want)
+		}
+	}
+}
+
 // TestProcessCwdReadsSelf proves the platform read resolves a live process's
 // working directory — exercised against the test process itself.
 func TestProcessCwdReadsSelf(t *testing.T) {

--- a/internal/terminal/cwd_unix.go
+++ b/internal/terminal/cwd_unix.go
@@ -1,0 +1,47 @@
+//go:build linux || darwin
+
+package terminal
+
+import "golang.org/x/sys/unix"
+
+// processCwd returns the working directory of whatever holds pid's terminal:
+// pid itself while it is the foreground job — an agent, or a shell sitting at
+// its prompt — and the foreground process group's leader once the user started
+// one, which is the case the direct child cannot answer. A nested shell (`sh`,
+// `su`, `nix develop`) does its own `cd`; the child that spawned it never
+// moves, so its directory stops being the one the user means. Returns "" when
+// neither can be read (the process exited, or was never ours to inspect).
+//
+// A tool subprocess is not a foreground job. Every coding agent spawns its own
+// without a controlling terminal, so the agent's directory keeps answering
+// through a `cd /tmp && …` the agent runs — which is why the foreground group
+// is read and not the deepest descendant of the process tree.
+//
+// Each OS brings foregroundPgrp and readCwd (see the cwd_* files). Both are
+// allowed to fail: an unreadable foreground group (a root shell under `sudo`,
+// a leader that just exited) falls back to the direct child, so the readout is
+// never worse than tracking the child alone.
+func processCwd(pid int) string {
+	if fg := foregroundPgrp(pid); fg > 0 && fg != pid && ownsTerminal(pid) {
+		if cwd := readCwd(fg); cwd != "" {
+			return cwd
+		}
+	}
+	return readCwd(pid)
+}
+
+// ownsTerminal reports whether pid leads its own terminal session, which every
+// PTY child does (the spawn calls setsid) and a process merely sharing someone
+// else's terminal does not.
+//
+// Without this the read answers for the wrong terminal: a process started from
+// a login shell reports that shell's foreground job, which is some sibling
+// command in a directory that has nothing to do with it. lich only ever asks
+// about a PTY child, but a function that is wrong when asked about anything
+// else is a trap for whoever calls it next — and it is what makes this seam
+// testable against the test binary itself, which shares the terminal `go test`
+// was typed into.
+func ownsTerminal(pid int) bool {
+	sid, err := unix.Getsid(pid)
+	return err == nil && sid == pid
+}


### PR DESCRIPTION
A session's directory was read from the process lich spawned in the PTY. A `cd`
made inside a nested shell — `sh`, `su`, `nix develop` — moved nothing: the
card's path line, the git status and PR badge beside it, and the tree
`internal/drop` searches a dropped file for all went on naming the directory
that shell was launched from.

`processCwd` now reads the terminal's **foreground process group** and falls
back to the direct child whenever that group is unreadable, so the readout is
never worse than before.

- **Linux** — tpgid, out of `/proc/<pid>/stat`.
- **macOS** — the same fact out of `sysctl kern.proc.pid` (`kinfo_proc.kp_eproc.e_tpgid`,
  reached through `unix.SysctlKinfoProc`). Taken over `TIOCGPGRP` deliberately:
  the ioctl reads the terminal and would have forced an `Fd()` onto `ptyHandle`,
  opening that seam for a directory read. sysctl reads the process, the way
  Linux does, and the seam stays closed. Unlike `proc_pidinfo` next to it, this
  call is exposed by `x/sys/unix`, so there is no trampoline to write.
- **Windows** — unchanged. A console has no foreground process group; it keeps
  tracking the direct child, and that difference is stated in the ceiling rather
  than left as a TODO.

The read is guarded on the pid leading its own terminal session (`getsid(pid) == pid`),
which every PTY child does and a process merely sharing someone else's terminal
does not. Without the guard the function answers for the wrong terminal — and
that is not theoretical: it is what made `go test` fail when the suite is run
from a terminal rather than from a pipe.

## Why not the alternatives

Measured on the author's machine with a throwaway PTY rig (not committed), 639
processes in `/proc`:

- **Deepest descendant of the process tree** — 8.98 ms per poll against 2.27 µs
  for the direct read (**3957×**, ~3% of a core per open session, forever) and,
  worse, it is a regression: watched against a live Claude Code session, the
  walk reported `/tmp` and then `/etc` while the agent's own directory never
  moved, because the agent was running `cd /tmp && …` inside a tool call. The
  card, its git status and the drop search would have followed it there. Fork
  ambiguity showed up in every one of the five agents' startup.
- **OSC 7** — measured, not assumed: **none of the five agents emits it** (Claude
  Code, Codex, opencode, omp, Crush, 8 s each under the rig). Bare `zsh -f`,
  `bash --norc` and fish 4.8.1 emit none either; the only emitter found was
  oh-my-zsh's `termsupport.zsh`, i.e. a framework the user installed. It would
  have made correctness a property of somebody's dotfiles.

The foreground-group read costs 7.89 µs per poll (3.5× the direct read).

## Ceiling

Still polled, still degrades to the session's start directory. Anything that
re-hosts the shell elsewhere still reports the wrong directory in silence —
tmux/screen (the server is not in the process tree, and it consumes OSC 7
rather than forwarding it), ssh (the directory is on another machine), docker
(another mount namespace). A root shell freezes the readout at its last value.
All four reproduced; `CLAUDE.md`'s bullet is rewritten to say so, including the
Windows/Unix split.

## Test plan

- `TestProcessCwdFollowsForegroundJob` (new, `linux || darwin`) drives a real PTY
  and real job control: a nested `sh -i` `cd`s, and the readout has to follow it
  while the PTY child itself is pinned to the directory it never left. Verified
  it fails without the change (20 s deadline, wrong directory) and passes 200/200
  runs with it.
- `TestParseTpgidSurvivesComm` pins the `/proc` parse against a comm holding
  spaces and parens, and tpgid `-1`.
- `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green with
  `LICH_LISTEN_PORT=` empty, `-race` green on `internal/terminal`, and the full
  `GOOS=linux|darwin|windows` build+vet loop clean. Frontend is untouched and
  proved so: biome clean, vitest 926/926.
- **macOS cannot be exercised here** — there is no hardware for it. The
  cross-compile proves only that it builds; CI's macOS runner running
  `TestProcessCwdFollowsForegroundJob` is the only real signal that the sysctl
  path works.
