### PR TITLE
fix: relocate a project whose directory moved instead of deleting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A project whose directory moved is relocated, not deleted.** Reopening a
+  closed project whose folder had been renamed or moved used to drop it from the
+  workspace on the spot — the project, its sessions and the conversations parked
+  with them, gone with one click and no way back. Those rows now say so before
+  they are clicked: the reopen menu and the command palette mark them
+  `relocate`, and picking one opens the directory chooser instead of the
+  project. Choose where the folder went and the project comes back with its
+  identity intact — same sessions, same worktrees, the name following the new
+  directory. Cancel and nothing changes; the entry is still there to try again.
+  Choosing a directory another project already sits on is refused by name,
+  rather than leaving the workspace with two projects on one folder.
 - **Building lich from source now needs Go 1.26.6.** The pin is exact so that
   every release binary carries the current toolchain's own security fixes, and
   the module is what CI reads its Go version from. `GOTOOLCHAIN=auto` — the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,8 +131,9 @@ nobody knows it and that the call site never shows. The mechanism and the histor
 - **Persistence is hybrid**: UI prefs in the page's localStorage (`lich.*` keys — the reason the listener port is
   pinned at 47821; `LICH_LISTEN_PORT` overrides it, `LICH_PORT` is the distinct per-session hook variable), the
   workspace in SQLite (`<config-dir>/lich/lich.db`, `internal/store`). Closing a session deletes its row; keeping a
-  worktree parks its session for a later resume; closing a project hides it, but reopening one whose directory is
-  gone silently deletes it and its sessions. Only the 25 most recent closes are offered back
+  worktree parks its session for a later resume; closing a project hides it, and reopening one whose directory is
+  gone relocates it instead (`project.Relocate`, which keeps the stored id — the identity its sessions and its
+  worktree directory hang off, so it no longer hashes its own path). Only the 25 most recent closes are offered back
   (`recentLimit`, `internal/store/store.go`) — the row survives, but past that a project is reachable only through
   the directory picker, and neither the menu nor the palette says so.
 - **Hidden sessions are serialized and destroyed**: 2MB replay rings on both sides

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react"
 import { useNavigate } from "react-router-dom"
-import { Folder, MessageSquareText } from "lucide-react"
+import { Folder, FolderX, MessageSquareText } from "lucide-react"
 import { useProjects } from "@/providers/projects"
 import { useSettings } from "@/providers/settings"
 import { useHotkey } from "@/lib/use-hotkey"
@@ -22,7 +22,7 @@ import {
 import { useTranscriptSearch } from "@/lib/session/use-transcript-search"
 import { PickerDialog, PickerEmpty, PickerGroup, PickerRow } from "@/components/common/PickerDialog"
 import type { Project, RecentProject } from "@/lib/api-types"
-import { Store } from "@/lib/rpc"
+import { ProjectService, Store } from "@/lib/rpc"
 import { cn } from "@/lib/utils"
 
 // CommandPalette is the app-wide quick switcher: one shortcut (Ctrl/Cmd+K by
@@ -43,6 +43,7 @@ export function CommandPalette() {
   const [tab, setTab] = useState<PaletteTab>("All")
   const [selected, setSelected] = useState(0)
   const [closed, setClosed] = useState<RecentProject[]>([])
+  const [missing, setMissing] = useState<ReadonlySet<string>>(new Set())
 
   useHotkey(hotkeys.commandPalette, () => {
     setOpen((v) => !v)
@@ -53,16 +54,26 @@ export function CommandPalette() {
 
   // The closed projects live in the store, not in the projects state, so they
   // are fetched per opening — a project closed or reopened since the last one
-  // moves in or out of this list.
+  // moves in or out of this list. Their directories are read with them: one
+  // whose folder moved is relocated rather than reopened, and the row says so.
   useEffect(() => {
     if (!open) {
       return
     }
     let live = true
     void Store.RecentProjects().then((rows) => {
-      if (live) {
-        setClosed(rows ?? [])
+      const recents = rows ?? []
+      if (!live) {
+        return
       }
+      setClosed(recents)
+      // Asked for after the rows are up: the mark is what a row says about
+      // itself, and a failed check must not cost the palette its entries.
+      void ProjectService.Missing(recents.map((row) => row.path)).then((gone) => {
+        if (live) {
+          setMissing(new Set(gone ?? []))
+        }
+      })
     })
     return () => {
       live = false
@@ -118,9 +129,9 @@ export function CommandPalette() {
       case "project":
         openProject(row.project.id)
         return
-      // Reopening navigates on its own once the project is adopted, and drops
-      // the row instead when its directory is gone — either way the palette has
-      // nothing left to show.
+      // Reopening navigates on its own once the project is adopted, and asks
+      // for the new directory first when the stored one is gone — either way
+      // the palette has nothing left to show.
       case "closed":
         close()
         void openRecent(row.project)
@@ -198,6 +209,7 @@ export function CommandPalette() {
                 sessionCount={
                   row.kind === "project" ? (sessions[row.project.id]?.sessions.length ?? 0) : 0
                 }
+                missing={row.kind === "closed" && missing.has(row.project.path)}
                 selected={offset + i === active}
                 onSelect={() => setSelected(offset + i)}
                 onRun={() => runIndex(offset + i)}
@@ -259,12 +271,15 @@ function FilterTabs({
 function ListRow({
   row,
   sessionCount,
+  missing,
   selected,
   onSelect,
   onRun,
 }: {
   row: PaletteRow
   sessionCount: number
+  /** Closed projects only: the stored directory is gone, so the row relocates. */
+  missing: boolean
   selected: boolean
   onSelect: () => void
   onRun: () => void
@@ -292,6 +307,7 @@ function ListRow({
       return (
         <ClosedProjectRow
           project={row.project}
+          missing={missing}
           selected={selected}
           onSelect={onSelect}
           onRun={onRun}
@@ -384,26 +400,32 @@ function ProjectRow({
 }
 
 // A closed project has no session to count, so the slot the open ones use for
-// theirs names what Enter does with this one instead.
+// theirs names what Enter does with this one instead — which is not the same
+// thing once the directory has moved: that row asks for the new one first.
 function ClosedProjectRow({
   project,
+  missing,
   selected,
   onSelect,
   onRun,
 }: {
   project: Project
+  missing: boolean
   selected: boolean
   onSelect: () => void
   onRun: () => void
 }) {
+  const Icon = missing ? FolderX : Folder
   return (
     <PickerRow selected={selected} onSelect={onSelect} onRun={onRun}>
-      <Folder className="size-4 shrink-0 text-muted-foreground" />
+      <Icon className="size-4 shrink-0 text-muted-foreground" />
       <span className="flex min-w-0 flex-1 flex-col">
         <span className="truncate text-sm">{project.name}</span>
         <span className="truncate font-mono text-xs text-muted-foreground">{project.path}</span>
       </span>
-      <span className="shrink-0 font-mono text-[0.625rem] text-muted-foreground">reopen</span>
+      <span className="shrink-0 font-mono text-[0.625rem] text-muted-foreground">
+        {missing ? "relocate" : "reopen"}
+      </span>
     </PickerRow>
   )
 }

--- a/frontend/src/components/tabs/OpenProjectMenu.tsx
+++ b/frontend/src/components/tabs/OpenProjectMenu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { Folder, FolderOpen, Plus } from "lucide-react"
+import { Folder, FolderOpen, FolderX, Plus } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -11,7 +11,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import type { RecentProject } from "@/lib/api-types"
 import { displayPath } from "@/lib/paths"
-import { Store } from "@/lib/rpc"
+import { ProjectService, Store } from "@/lib/rpc"
 import { useProjects } from "@/providers/projects"
 
 // MENU_LIMIT is how many closed projects the menu offers. Five is what fits
@@ -27,28 +27,32 @@ const MENU_LIMIT = 5
 export function OpenProjectMenu() {
   const { projects, openProject, openRecent } = useProjects()
   const [recents, setRecents] = useState<RecentProject[]>([])
+  const [missing, setMissing] = useState<ReadonlySet<string>>(new Set())
 
   // The open projects are exactly what the recent ones are not, so the list is
   // refetched whenever they change: closing a tab adds one, opening removes it.
+  // The directories are checked with it, so an entry that moved says what
+  // clicking it will ask for instead of opening a picker out of nowhere.
   useEffect(() => {
     let live = true
     void Store.RecentProjects().then((rows) => {
-      if (live) {
-        setRecents((rows ?? []).slice(0, MENU_LIMIT))
+      const shown = (rows ?? []).slice(0, MENU_LIMIT)
+      if (!live) {
+        return
       }
+      setRecents(shown)
+      // Asked for after the list is up: the mark is what a row says about
+      // itself, and a failed check must not cost the menu its entries.
+      void ProjectService.Missing(shown.map((row) => row.path)).then((gone) => {
+        if (live) {
+          setMissing(new Set(gone ?? []))
+        }
+      })
     })
     return () => {
       live = false
     }
   }, [projects])
-
-  // Picking an entry whose directory is gone drops its row without opening
-  // anything, so the open projects — and the effect above — never move. The
-  // list has to be asked again, or the dead entry stays on offer.
-  const pick = async (recent: RecentProject) => {
-    await openRecent(recent)
-    setRecents(((await Store.RecentProjects()) ?? []).slice(0, MENU_LIMIT))
-  }
 
   if (recents.length === 0) {
     return (
@@ -83,17 +87,30 @@ export function OpenProjectMenu() {
           Recent projects
         </div>
         <DropdownMenuSeparator />
-        {recents.map((recent) => (
-          <DropdownMenuItem key={recent.id} className="gap-2" onClick={() => void pick(recent)}>
-            <Folder className="size-4 shrink-0 text-muted-foreground" />
-            <span className="flex min-w-0 flex-col">
-              <span className="truncate">{recent.name}</span>
-              <span className="truncate text-xs text-muted-foreground">
-                {displayPath(recent.path)}
+        {recents.map((recent) => {
+          const gone = missing.has(recent.path)
+          const Icon = gone ? FolderX : Folder
+          return (
+            <DropdownMenuItem
+              key={recent.id}
+              className="gap-2"
+              onClick={() => void openRecent(recent)}
+            >
+              <Icon className="size-4 shrink-0 text-muted-foreground" />
+              <span className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate">{recent.name}</span>
+                <span className="truncate text-xs text-muted-foreground">
+                  {displayPath(recent.path)}
+                </span>
               </span>
-            </span>
-          </DropdownMenuItem>
-        ))}
+              {gone && (
+                <span className="shrink-0 self-center font-mono text-[0.625rem] text-muted-foreground">
+                  relocate
+                </span>
+              )}
+            </DropdownMenuItem>
+          )
+        })}
         <DropdownMenuSeparator />
         <DropdownMenuItem className="gap-2" onClick={() => void openProject()}>
           <FolderOpen className="size-4 shrink-0 text-muted-foreground" />

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -155,6 +155,12 @@ export const ProjectService = {
   Home: () => call<Project>("project.Home", []),
   /** Whether a stored project's directory is still there, before reopening it. */
   Exists: (path: string) => call<boolean>("project.Exists", [path]),
+  /** Which of these project directories are gone, so the lists that offer them
+   * can mark the rows that need relocating first. */
+  Missing: (paths: string[]) => call<string[]>("project.Missing", [paths]),
+  /** Point a stored project at a new directory, keeping id — hence its sessions
+   * and its worktrees. null when the user cancels the picker. */
+  Relocate: (id: string) => call<Project | null>("project.Relocate", [id]),
   PickFile: (title: string) => call<string>("project.PickFile", [title]),
   /** Native save dialog seeded with defaultName. "" when the user cancels. */
   PickSaveFile: (title: string, defaultName: string) =>
@@ -279,8 +285,6 @@ export const Store = {
   CloseProject: (id: string) => call<null>("store.CloseProject", [id]),
   /** The closed projects offered for reopening, newest first (capped backend-side). */
   RecentProjects: () => call<RecentProject[] | null>("store.RecentProjects", []),
-  /** Drop a project and its sessions for good — the row whose directory is gone. */
-  DeleteProject: (id: string) => call<null>("store.DeleteProject", [id]),
   AddSession: (
     projectID: string,
     sessionID: string,

--- a/frontend/src/providers/projects-context.ts
+++ b/frontend/src/providers/projects-context.ts
@@ -11,7 +11,7 @@ export interface ProjectsValue {
   /** Show the OS directory picker, add the chosen project and navigate to it. */
   openProject: () => Promise<void>
   /** Reopen a closed project without the picker. A project whose directory is
-   * gone is dropped from the store instead, with a toast saying so. */
+   * gone asks for the new one instead, keeping its id and its sessions. */
   openRecent: (recent: RecentProject) => Promise<void>
   /** Ensure a project rooted at $HOME exists (no picker) and return its id — the
    * update flow's install terminal when no project is in view. */

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/lib/session/sessions"
 import { applyOrder, pinFirst } from "@/lib/reorder"
 import { displayPath } from "@/lib/paths"
+import { errorText } from "@/lib/utils"
 import {
   hydrateProjectProviderDefaults,
   loadProviders,
@@ -243,16 +244,27 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
   }, [adopt])
 
   // Reopening skips the picker, so nothing guarantees the directory is still
-  // there — a project whose folder was moved or deleted can never be opened
-  // again, so its row goes with it rather than sitting in the list forever.
+  // there. A project whose folder was moved or renamed is not dropped — the
+  // picker asks where it went and the project is repointed under its own id,
+  // which is what its sessions and its worktree directory hang off. Cancelling
+  // leaves the row exactly as it was, to relocate on the next attempt; a
+  // directory another project already holds is refused backend-side.
   const openRecent = useCallback(
     async (recent: RecentProject) => {
       if (await ProjectService.Exists(recent.path)) {
         await adopt(recent)
         return
       }
-      await Store.DeleteProject(recent.id)
-      toast.error(`Project not found: ${displayPath(recent.path)}`)
+      try {
+        const moved = await ProjectService.Relocate(recent.id)
+        if (!moved) {
+          return
+        }
+        await adopt(moved)
+        toast.success(`${moved.name} now opens ${displayPath(moved.path)}`)
+      } catch (error) {
+        toast.error(`Relocate failed: ${errorText(error)}`)
+      }
     },
     [adopt],
   )

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -43,6 +43,11 @@ type Service struct {
 	// default, and every test that does not wire it) means gh's own active
 	// account. Wired to the store in main (ghaccount.go).
 	accounts accountLookup
+	// projects names the project a directory already belongs to, so Relocate can
+	// refuse one the workspace is holding twice. Wired to the store in main;
+	// nil answers "nobody owns it", which is what a picked directory is until
+	// there is a workspace to ask.
+	projects projectLookup
 	// bases memoises the base-branch readout and throttles the fetch behind it
 	// (basestatus.go). Zero value ready; it holds a mutex, so a Service is
 	// passed by pointer and never copied.
@@ -65,6 +70,44 @@ func (s *Service) Open() (*Project, error) {
 		return nil, nil // cancelled
 	}
 	return newProject(path), nil
+}
+
+// projectLookup names the project already rooted at a directory — its id and
+// its name — or two empty strings when no project is.
+type projectLookup func(path string) (id, name string)
+
+// SetProjects wires the workspace lookup Relocate validates against. Left
+// unset, any picked directory is taken as free.
+func (s *Service) SetProjects(lookup projectLookup) {
+	s.projects = lookup
+}
+
+// Relocate points a stored project at a directory chosen from the picker,
+// keeping id rather than deriving a new one from the path. The id is the
+// project's identity in the store — what its sessions hang off and what names
+// its worktree directory — so a checkout that was moved or renamed keeps both.
+// The name follows the new directory. nil when the user cancels.
+//
+// A directory another project already sits on is refused: the two rows would
+// hold the same path under different ids, and every path-addressed lookup the
+// app makes — which project a checkout belongs to, which account its gh calls
+// run as — answers with whichever row the query reached first.
+func (s *Service) Relocate(id string) (*Project, error) {
+	path, err := s.picker.PickDirectory("Relocate Project")
+	if err != nil {
+		return nil, fmt.Errorf("open dialog failed: %w", err)
+	}
+	if path == "" {
+		return nil, nil // cancelled
+	}
+	if s.projects != nil {
+		if owner, name := s.projects(path); owner != "" && owner != id {
+			return nil, fmt.Errorf("That directory is already the project %q. Open that one instead.", name)
+		}
+	}
+	project := newProject(path)
+	project.ID = id
+	return project, nil
 }
 
 // Home returns a project rooted at the user's home directory, without a picker.
@@ -138,6 +181,19 @@ func parsePullRequest(out []byte) *PullRequest {
 func (s *Service) Exists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && info.IsDir()
+}
+
+// Missing returns the subset of paths whose directory is no longer there. The
+// lists that offer closed projects ask about all their rows at once, so a row
+// that cannot be opened as it stands says so before it is clicked.
+func (s *Service) Missing(paths []string) []string {
+	gone := []string{}
+	for _, path := range paths {
+		if !s.Exists(path) {
+			gone = append(gone, path)
+		}
+	}
+	return gone
 }
 
 // PickFile shows the native file picker and returns the chosen file path, or ""

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -363,3 +363,97 @@ func TestExistsAcceptsOnlyDirectories(t *testing.T) {
 		t.Errorf("Exists(missing) = true, want false")
 	}
 }
+
+// TestMissingNamesOnlyTheGoneDirectories: the answer is what the lists mark, so
+// a path that is still there must never appear in it.
+func TestMissingNamesOnlyTheGoneDirectories(t *testing.T) {
+	svc := New(nil)
+	dir := t.TempDir()
+	gone := filepath.Join(dir, "gone")
+
+	missing := svc.Missing([]string{dir, gone})
+	if len(missing) != 1 || missing[0] != gone {
+		t.Fatalf("Missing = %v, want [%q]", missing, gone)
+	}
+	if got := svc.Missing(nil); len(got) != 0 {
+		t.Errorf("Missing(nil) = %v, want empty", got)
+	}
+}
+
+// TestRelocateKeepsTheProjectIdentity pins the whole point of the call: the id
+// comes from the caller, not from the new path. Deriving it the way Open does
+// would hand back a project the store has never seen, and the sessions and the
+// worktree directory of the one that moved would stay with the dead id.
+func TestRelocateKeepsTheProjectIdentity(t *testing.T) {
+	moved := filepath.Join(t.TempDir(), "renamed")
+	picker := &pickerStub{dirPath: moved}
+	svc := New(picker)
+
+	project, err := svc.Relocate("stored-id")
+	if err != nil {
+		t.Fatalf("Relocate: %v", err)
+	}
+	if project == nil {
+		t.Fatal("Relocate = nil, want the repointed project")
+	}
+	if project.ID != "stored-id" {
+		t.Errorf("id = %q, want the stored one", project.ID)
+	}
+	if project.Path != moved || project.Name != "renamed" {
+		t.Errorf("project = %+v, want path %q named after it", project, moved)
+	}
+	if picker.dirTitle != "Relocate Project" {
+		t.Errorf("dialog title = %q", picker.dirTitle)
+	}
+}
+
+// TestRelocateRefusesADirectoryAnotherProjectHolds: the path comes from a
+// dialog, so it is user input and the workspace is what validates it. Two rows
+// on one directory under different ids is a workspace no path-addressed lookup
+// can read — and no undo puts the sessions back afterwards.
+func TestRelocateRefusesADirectoryAnotherProjectHolds(t *testing.T) {
+	taken := filepath.Join(t.TempDir(), "taken")
+	svc := New(&pickerStub{dirPath: taken})
+	svc.SetProjects(func(path string) (string, string) {
+		if path == taken {
+			return "other-id", "warm-fjord"
+		}
+		return "", ""
+	})
+
+	project, err := svc.Relocate("stored-id")
+	if project != nil {
+		t.Fatalf("Relocate = %+v, want nothing relocated", project)
+	}
+	if err == nil || !strings.Contains(err.Error(), "warm-fjord") {
+		t.Fatalf("Relocate error = %v, want the project holding it named", err)
+	}
+}
+
+// TestRelocateAcceptsTheProjectsOwnDirectory: the guard is about a *second*
+// project on a path. A row pointed at the directory it is already stored with
+// is the relocation being repeated, not a collision, and refusing it would
+// dead-end the only flow that can fix a project.
+func TestRelocateAcceptsTheProjectsOwnDirectory(t *testing.T) {
+	own := filepath.Join(t.TempDir(), "own")
+	svc := New(&pickerStub{dirPath: own})
+	svc.SetProjects(func(string) (string, string) { return "stored-id", "own" })
+
+	project, err := svc.Relocate("stored-id")
+	if err != nil || project == nil || project.Path != own {
+		t.Fatalf("Relocate = %+v, %v; want the project repointed at %q", project, err, own)
+	}
+}
+
+// TestRelocateCancelledChangesNothing: a cancelled dialog must not read as a
+// chosen directory — the caller writes whatever comes back over the stored row.
+func TestRelocateCancelledChangesNothing(t *testing.T) {
+	project, err := New(&pickerStub{}).Relocate("stored-id")
+	if err != nil || project != nil {
+		t.Fatalf("Relocate(cancelled) = %+v, %v; want nil, nil", project, err)
+	}
+
+	if _, err := New(&pickerStub{dirError: errors.New("picker failed")}).Relocate("stored-id"); err == nil {
+		t.Fatal("Relocate error was swallowed")
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -343,6 +343,20 @@ func (s *Service) ProjectPath(projectID string) string {
 	return path
 }
 
+// ProjectAt names the project rooted at path — id and name — or two empty
+// strings when no project is. Closed projects answer too: a row hidden from the
+// tab strip still owns its directory, and relocating another project onto it
+// would be the same collision.
+func (s *Service) ProjectAt(path string) (string, string) {
+	var id, name string
+	if err := s.db.QueryRow(
+		`SELECT id, name FROM projects WHERE path = ?`, path,
+	).Scan(&id, &name); err != nil {
+		return "", ""
+	}
+	return id, name
+}
+
 // sessionsOf returns a project's sessions in the order the user dragged them
 // into, falling back to insertion order for rows never reordered.
 //

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1071,6 +1071,28 @@ func TestProjectPathOfAnUnknownProjectIsEmpty(t *testing.T) {
 	}
 }
 
+// TestProjectAtNamesTheHolderOfADirectory covers what the relocation guard
+// asks: a closed project still holds its path (it is reopened, never gone), and
+// a directory no project sits on has to answer empty rather than name the last
+// row the query happened to read.
+func TestProjectAtNamesTheHolderOfADirectory(t *testing.T) {
+	svc := newTestStore(t)
+	if err := svc.AddProject("p1", "alpha", "/tmp/alpha"); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+	if err := svc.CloseProject("p1"); err != nil {
+		t.Fatalf("CloseProject: %v", err)
+	}
+
+	id, name := svc.ProjectAt("/tmp/alpha")
+	if id != "p1" || name != "alpha" {
+		t.Errorf("ProjectAt(/tmp/alpha) = %q, %q; want p1, alpha", id, name)
+	}
+	if id, name := svc.ProjectAt("/tmp/free"); id != "" || name != "" {
+		t.Errorf("ProjectAt(free path) = %q, %q; want empty", id, name)
+	}
+}
+
 // TestRecentProjectsListsClosedOnesNewestFirst covers the shape of the list:
 // open projects stay out of it and closed ones come back newest first. Well
 // under the cap, so nothing here is dropped — the cap has its own test.

--- a/main.go
+++ b/main.go
@@ -107,6 +107,9 @@ func main() {
 	proj := project.New(project.ZenityPicker{})
 	// gh has one active account per host; a project can name a different one.
 	proj.SetAccounts(db.GHAccountForPath)
+	// Relocating a project is the one flow that can point two rows at the same
+	// directory, so it validates the picked one against the workspace.
+	proj.SetProjects(db.ProjectAt)
 
 	// Every service the frontend uses goes through the loopback RPC
 	// (internal/rpc). store.Close manages the DB lifecycle and stays Go-only.
@@ -176,9 +179,11 @@ func main() {
 //     argument array with a 1MB bound.
 //   - relay.Observe is the hooks' session-state stream, which arrives over
 //     /hook: forging a SessionEnd here closes another session's errands.
-//   - relay.SetPlugins and project.SetAccounts are startup wiring. Called with
-//     [null] they silently nil what they wired (encoding/json leaves a func or
-//     pointer alone on null), and the write races the readers already serving.
+//   - relay.SetPlugins, project.SetAccounts and project.SetProjects are startup
+//     wiring. Called with [null] they silently nil what they wired
+//     (encoding/json leaves a func or pointer alone on null), and the write
+//     races the readers already serving — nilling SetProjects also disarms the
+//     guard that keeps two projects off the same directory.
 func denyInternal(d *rpc.Handler) {
 	for _, method := range []string{
 		"store.Close",
@@ -187,6 +192,7 @@ func denyInternal(d *rpc.Handler) {
 		"relay.Observe",
 		"relay.SetPlugins",
 		"project.SetAccounts",
+		"project.SetProjects",
 	} {
 		d.Deny(method)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -26,6 +26,7 @@ var denied = map[string]reflect.Type{
 	"relay.Observe":       reflect.TypeFor[*relay.Service](),
 	"relay.SetPlugins":    reflect.TypeFor[*relay.Service](),
 	"project.SetAccounts": reflect.TypeFor[*project.Service](),
+	"project.SetProjects": reflect.TypeFor[*project.Service](),
 }
 
 // stubService stands in for the four registered services: dispatch resolves a
@@ -39,6 +40,7 @@ func (stubService) Save() error        { return nil }
 func (stubService) Observe() error     { return nil }
 func (stubService) SetPlugins() error  { return nil }
 func (stubService) SetAccounts() error { return nil }
+func (stubService) SetProjects() error { return nil }
 func (stubService) Allowed() error     { return nil }
 
 func denyingDispatcher() *rpc.Handler {


### PR DESCRIPTION
## The gap

Reopening a closed project whose directory had been renamed or moved deleted it
on the spot — the project row, its sessions and the conversations parked with
them, gone with one click, no warning and no undo. It was a documented ceiling
("reopening one whose directory is gone silently deletes it and its sessions"),
not a bug report, and the delete lived in the frontend: `openRecent` in
`providers/projects.tsx` was the only caller of `store.DeleteProject` in the
repo.

## What this does

A closed project whose folder is gone is now **marked, not dropped**. The reopen
menu and the command palette ask `project.Missing` about the rows they are
about to draw, and a dead one wears `FolderX` and the verb `relocate` where the
others say `reopen`. Picking it opens the directory chooser; choose where the
folder went and the project comes back whole. Cancel and nothing changed — the
entry is still there for the next attempt.

## Why the id is kept

`project.Relocate(id)` takes the id from the caller instead of hashing the
picked path. That id is the project's identity in the store: sessions cascade
from it, and worktrees live at `<data>/lich/worktrees/<projectID>/<branch>`.
Deriving a new one would hand back a project the store has never seen and leave
the sessions and worktrees of the one that moved behind a dead id. The name
follows the new directory; the path is the only other thing that changes, and
`store.AddProject` already upserts both.

The cost is that a relocated project's id is no longer the hash of its own path.
That is now a Known Ceiling in `CLAUDE.md` — the assumption is what a reader
would otherwise carry from `newProject`.

## The picked directory is validated

The path comes from a dialog, so it is user input at a trust boundary. A
directory another project already holds is **refused by name** ("That directory
is already the project "warm-fjord". Open that one instead."), rather than
leaving two rows on one path under different ids — a workspace no path-addressed
lookup can read (`projectIDForPath`, `GHAccountForPath`, the worktree flows all
answer with whichever row the query reached first), and one nothing puts the
sessions back from. Refusing is the cheap half of the choice; adopting the
existing project would change which identity the sessions belong to, and nothing
here asks for that.

The workspace is reached through a lookup seam (`SetProjects`, wired to
`store.ProjectAt` in `main.go`), mirroring `SetAccounts` — and denied from RPC
dispatch for the same reason: a page POST with `[null]` would nil the guard.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test ./...` green; `-race` on `internal/project`, `internal/store` and
      the root package
- [x] `pnpm check` (biome) — only the standing a11y warnings
- [x] `tsc` typecheck, `vitest` 892/892, `vite build`
- [x] New Go tests: id kept and name followed on relocate, cancel and picker
      error, refusal naming the holder, a project's own directory still accepted,
      `Missing` naming only the gone ones, `ProjectAt` answering for closed rows,
      and the deny-list entry for `project.SetProjects`
- [x] Manual smoke in `task dev` — the frontend suite is node-only and renders
      nothing, so the marked row and the picker round trip have not been seen

## Left out (on purpose)

- **A project that is already open when its directory disappears** is not marked
  and cannot be relocated: only the reopen path is covered here.
- **`store.DeleteProject` is now an orphan.** Its frontend binding is gone; the
  Go method and its tests stay for a separate prune, since it is the only way a
  row ever leaves the database.
