### PR TITLE
docs: the briefing ceiling says why three providers are out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,9 +146,16 @@ nobody knows it and that the call site never shows. The mechanism and the histor
   (`internal/terminal/command.go`, `briefingFlags` → `relay.SpawnBriefing`): Claude Code and oh-my-pi
   are spawned with `--append-system-prompt` carrying lich's own briefing, so text the user never
   wrote is in every session's prompt and in `/proc/<pid>/cmdline`. Codex, opencode and Crush get
-  nothing there — none has an append (Codex's `model_instructions_file` *replaces* the base
-  instructions; the other two are config keys, not flags), so for them the same point exists only in
-  lich's MCP instructions, and behaviour between providers differs by that much.
+  nothing there — none has an append flag, and their only static channels (Codex's
+  `model_instructions_file`, opencode's `instructions`, Crush's `system_prompt_prefix`) are
+  machine-wide config that cannot ask whether it is running inside lich, so a briefing written there
+  would lie to every session started outside it. The channels that *can* ask are the plugin's hooks —
+  Codex's `SessionStart` and opencode's `experimental.chat.system.transform` both take text at
+  session start, while Crush has only `PreToolUse` and no session-start hook at all — so for those
+  three the point exists only in lich's MCP instructions, and behaviour between providers differs by
+  that much. Claude Code also takes a `--append-system-prompt-file` that would keep the briefing out
+  of argv, but it is absent from `--help` (measured on 2.1.233), so lich passes the text flag rather
+  than bet a spawn on an undocumented one.
 
 - **Installing the plugin writes into three harnesses' own directories**
   (`internal/agentplugin`): Claude Code and Codex are driven through their plugin CLI, but opencode, oh-my-pi and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,16 +146,9 @@ nobody knows it and that the call site never shows. The mechanism and the histor
   (`internal/terminal/command.go`, `briefingFlags` → `relay.SpawnBriefing`): Claude Code and oh-my-pi
   are spawned with `--append-system-prompt` carrying lich's own briefing, so text the user never
   wrote is in every session's prompt and in `/proc/<pid>/cmdline`. Codex, opencode and Crush get
-  nothing there — none has an append flag, and their only static channels (Codex's
-  `model_instructions_file`, opencode's `instructions`, Crush's `system_prompt_prefix`) are
-  machine-wide config that cannot ask whether it is running inside lich, so a briefing written there
-  would lie to every session started outside it. The channels that *can* ask are the plugin's hooks —
-  Codex's `SessionStart` and opencode's `experimental.chat.system.transform` both take text at
-  session start, while Crush has only `PreToolUse` and no session-start hook at all — so for those
-  three the point exists only in lich's MCP instructions, and behaviour between providers differs by
-  that much. Claude Code also takes a `--append-system-prompt-file` that would keep the briefing out
-  of argv, but it is absent from `--help` (measured on 2.1.233), so lich passes the text flag rather
-  than bet a spawn on an undocumented one.
+  nothing there — none has an append flag, and their config keys are machine-wide, so a briefing
+  written into one would lie to every session started outside lich. For those three the point exists
+  only in lich's MCP instructions, and behaviour between providers differs by that much.
 
 - **Installing the plugin writes into three harnesses' own directories**
   (`internal/agentplugin`): Claude Code and Codex are driven through their plugin CLI, but opencode, oh-my-pi and

--- a/internal/terminal/command.go
+++ b/internal/terminal/command.go
@@ -84,14 +84,24 @@ func SupportsModel(kind string) bool {
 // prompt", for the two that spell it at all: Claude Code and oh-my-pi share
 // --append-system-prompt (read off both `--help`, like every other table here).
 //
-// The other three are absent because none of them has an append. Codex takes
-// `model_instructions_file`, which *replaces* its base instructions — swapping
-// the whole system prompt of a provider for a file lich wrote is not a thing
-// lich does for one paragraph. opencode's `instructions` and Crush's
-// `system_prompt_prefix` are config keys, not flags, so using them means writing
-// a file the user owns — the line lich already draws at MCP registration
-// (providers.AcceptsMCPServer). Those three read the same point in lich's MCP
-// instructions instead, which costs nothing and needs no file.
+// They do not mean the same thing by the value. omp's flag takes text *or* a
+// file, and picks between them by looking for a newline: a value without one is
+// opened as a path, and a read that fails falls back to the literal string. The
+// briefing is a single line, so on omp it takes the file branch, fails
+// ENAMETOOLONG on a 600-byte "path" and arrives as text — right by fallback
+// rather than by design (measured on 17.3.4). Give the briefing a newline and it
+// takes the literal branch instead, which lands the same text; what must not
+// happen is a briefing short enough to name a real file.
+//
+// The other three are absent because none of them has an append flag. Codex
+// takes `model_instructions_file`, which *replaces* its base instructions —
+// swapping the whole system prompt of a provider for a file lich wrote is not a
+// thing lich does for one paragraph. opencode's `instructions` and Crush's
+// `system_prompt_prefix` are config keys read by every run of that provider on
+// the machine, and static config cannot ask whether it is running inside lich: a
+// briefing written there would tell a session started outside lich that it is
+// inside one. Those three read the same point in lich's MCP instructions
+// instead, which costs nothing and is true only where it is read.
 var briefingFlags = map[string]string{
 	providers.Claude: "--append-system-prompt",
 	providers.OMP:    "--append-system-prompt",

--- a/internal/terminal/command.go
+++ b/internal/terminal/command.go
@@ -84,6 +84,14 @@ func SupportsModel(kind string) bool {
 // prompt", for the two that spell it at all: Claude Code and oh-my-pi share
 // --append-system-prompt (read off both `--help`, like every other table here).
 //
+// Claude Code also has an `--append-system-prompt-file`, which would keep the
+// briefing out of argv and out of /proc/<pid>/cmdline — it works (measured on
+// 2.1.233), and it is absent from `--help`, named only inside `--bare`'s own
+// description. That is the whole reason lich still passes the text flag: an
+// undocumented flag that goes away is a spawn that dies before the session
+// exists, which is the rule skipPermissionFlags states above. Revisit when it
+// appears in `--help`; the briefing has two variants, so it is two files.
+//
 // They do not mean the same thing by the value. omp's flag takes text *or* a
 // file, and picks between them by looking for a newline: a value without one is
 // opened as a path, and a read that fails falls back to the literal string. The
@@ -102,6 +110,14 @@ func SupportsModel(kind string) bool {
 // briefing written there would tell a session started outside lich that it is
 // inside one. Those three read the same point in lich's MCP instructions
 // instead, which costs nothing and is true only where it is read.
+//
+// What could ask, if the gap is ever worth closing, is the plugin's own hooks —
+// they run code and can read LICH_SESSION_ID. Two of the three have somewhere to
+// put it: Codex's SessionStart returns `additionalContext` (0.144.5) and
+// opencode's plugin API has `experimental.chat.system.transform`, which mutates
+// the system messages (1.18.18). Crush has neither: `PreToolUse` is its only
+// event (0.88.0), so its briefing would arrive at the first tool call, and a
+// turn that answers without one would never see it at all.
 var briefingFlags = map[string]string{
 	providers.Claude: "--append-system-prompt",
 	providers.OMP:    "--append-system-prompt",


### PR DESCRIPTION
## What

The Known Ceilings bullet about lich's spawn briefing said Codex, opencode and Crush get nothing because their channels are config keys rather than flags. True, but not the reason — and the reason is what a maintainer needs before reaching for one of those keys.

Measured against the installed binaries (2026-08-14): `model_instructions_file`, `instructions` and `system_prompt_prefix` are all **machine-wide static config that cannot ask whether it is running inside lich**. A briefing written there would tell a session started outside lich that it is inside one. The channels that *can* ask are the plugin's hooks, because they run code and can read `LICH_SESSION_ID` — and two of the three have one:

| provider | version | session-start channel that can carry text |
|---|---|---|
| Codex | 0.144.5 | `SessionStart` → `hookSpecificOutput.additionalContext` (string, in its own JSON schema) |
| opencode | 1.18.18 | plugin hook `experimental.chat.system.transform`, which mutates the system-message array |
| Crush | 0.88.0 | none — `PreToolUse` is its only hook event |

That is why the gap is where it is, and it now says so.

Two measurements are pinned alongside it so nobody repeats them:

- **Claude Code 2.1.233 does take `--append-system-prompt-file`**, which would keep the 539-byte briefing out of `/proc/<pid>/cmdline`. It is absent from `--help` (named only inside `--bare`'s description). Betting a spawn on an undocumented flag is what `skipPermissionFlags`' own comment forbids — a flag that disappears is a session that dies before it exists — so lich keeps passing the text one, deliberately.
- **omp's `--append-system-prompt` takes text *or* a file**, choosing by whether the value holds a newline: no newline means it is opened as a path, and a failed read falls back to the literal string. The briefing is a single line, so on omp it takes the file branch, fails `ENAMETOOLONG` on a 600-byte "path", and arrives as text — right by fallback rather than by design. Proved without a model turn: pointing the flag at a directory logs `Could not read append system prompt file … Directories cannot be read like files`.

Split follows CLAUDE.md's own criterion: the ceiling bullet carries the trap, the mechanism lives in the code comment at `briefingFlags`.

## What this is not

No behaviour change. Every line touched in `internal/terminal/command.go` is a comment (`git diff -U0 … | grep -v '^[+-]//'` is empty). No argv→file move, no Codex hook work, no `CHANGELOG.md` entry — nothing a user of a published version lives changes here.

## Test plan

- [x] `gofmt -l .` — no output
- [x] `go vet ./...` — exit 0, no output
- [ ] Reviewer reads the bullet and agrees it names the trap rather than restating the mechanism