### PR TITLE
fix: bill the cache write by its lifetime and count sub-agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   session parked with its worktree. The exit banner's **Restart** is a fresh
   spawn with no conversation behind it, so it still gets the derived name.
 
+- **The cost readout was billing about a quarter of a session too little.** Two
+  things went uncounted. A cached prompt is priced by how long the cache entry
+  is kept, and Claude Code keeps its entries for an hour — the dearer of the two
+  rates — while lich billed every cache write at the five-minute price. And a
+  sub-agent now runs its own transcript beside the conversation that spawned it,
+  where its tokens used to be written into the parent's, so everything delegated
+  to one was missing from the total. Measured across 30 real transcripts and the
+  107 sub-agent transcripts beside them, the readout moved from $1417.18 to
+  $1757.81 — 24.0% of the bill it was not showing. A model whose hour-long rate
+  the price table has never published keeps the readout absent rather than
+  cheap, which is the rule the number has always answered to.
+
 ### Changed
 
 - **Building lich from source now needs Go 1.26.6.** The pin is exact so that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,8 @@ nobody knows it and that the call site never shows. The mechanism and the histor
 - **The cost readout is priced from a table, not from the provider** (`internal/pricing`): an unpriced model makes
   the readout go *absent* rather than wrong, and billing is per `(session, transcript)` — a conversation forked
   inside the PTY bills its copied history twice. lich's own resume continues the same transcript and is unaffected.
+  A conversation is more than one transcript: each sub-agent writes its own beside it and is counted in
+  (`claudeSubagentPaths`), so one unreadable or unpriceable sub-agent withholds the whole session's number.
 - **A dropped file has no path, so lich guesses it** (`internal/drop`): Chromium never hands the page a path, so a
   drop is matched by name + size + mtime under the session directory, then home. Twins resolve to nothing; a file
   in neither tree is *copied*, so an agent told to edit it edits the copy — and that copy is deleted 3 days on,

--- a/internal/pricing/prices.json
+++ b/internal/pricing/prices.json
@@ -3,13 +3,15 @@
     "input": 3e-06,
     "output": 1.5e-05,
     "cacheRead": 3e-07,
-    "cacheWrite": 3.75e-06
+    "cacheWrite": 3.75e-06,
+    "cacheWrite1h": 6e-06
   },
   "claude-3-haiku-20240307": {
     "input": 2.5e-07,
     "output": 1.25e-06,
     "cacheRead": 3e-08,
-    "cacheWrite": 3e-07
+    "cacheWrite": 3e-07,
+    "cacheWrite1h": 6e-06
   },
   "claude-3-opus-20240229": {
     "input": 1.5e-05,
@@ -33,114 +35,133 @@
     "input": 1e-05,
     "output": 5e-05,
     "cacheRead": 1e-06,
-    "cacheWrite": 1.25e-05
+    "cacheWrite": 1.25e-05,
+    "cacheWrite1h": 2e-05
   },
   "claude-haiku-4-5": {
     "input": 1e-06,
     "output": 5e-06,
     "cacheRead": 1e-07,
-    "cacheWrite": 1.25e-06
+    "cacheWrite": 1.25e-06,
+    "cacheWrite1h": 2e-06
   },
   "claude-haiku-4-5-20251001": {
     "input": 1e-06,
     "output": 5e-06,
     "cacheRead": 1e-07,
-    "cacheWrite": 1.25e-06
+    "cacheWrite": 1.25e-06,
+    "cacheWrite1h": 2e-06
   },
   "claude-opus-4-1": {
     "input": 1.5e-05,
     "output": 7.5e-05,
     "cacheRead": 1.5e-06,
-    "cacheWrite": 1.875e-05
+    "cacheWrite": 1.875e-05,
+    "cacheWrite1h": 3e-05
   },
   "claude-opus-4-1-20250805": {
     "input": 1.5e-05,
     "output": 7.5e-05,
     "cacheRead": 1.5e-06,
-    "cacheWrite": 1.875e-05
+    "cacheWrite": 1.875e-05,
+    "cacheWrite1h": 3e-05
   },
   "claude-opus-4-20250514": {
     "input": 1.5e-05,
     "output": 7.5e-05,
     "cacheRead": 1.5e-06,
-    "cacheWrite": 1.875e-05
+    "cacheWrite": 1.875e-05,
+    "cacheWrite1h": 3e-05
   },
   "claude-opus-4-5": {
     "input": 5e-06,
     "output": 2.5e-05,
     "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06
+    "cacheWrite": 6.25e-06,
+    "cacheWrite1h": 1e-05
   },
   "claude-opus-4-5-20251101": {
     "input": 5e-06,
     "output": 2.5e-05,
     "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06
+    "cacheWrite": 6.25e-06,
+    "cacheWrite1h": 1e-05
   },
   "claude-opus-4-6": {
     "input": 5e-06,
     "output": 2.5e-05,
     "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06
+    "cacheWrite": 6.25e-06,
+    "cacheWrite1h": 1e-05
   },
   "claude-opus-4-6-20260205": {
     "input": 5e-06,
     "output": 2.5e-05,
     "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06
+    "cacheWrite": 6.25e-06,
+    "cacheWrite1h": 1e-05
   },
   "claude-opus-4-7": {
     "input": 5e-06,
     "output": 2.5e-05,
     "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06
+    "cacheWrite": 6.25e-06,
+    "cacheWrite1h": 1e-05
   },
   "claude-opus-4-7-20260416": {
     "input": 5e-06,
     "output": 2.5e-05,
     "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06
+    "cacheWrite": 6.25e-06,
+    "cacheWrite1h": 1e-05
   },
   "claude-opus-4-8": {
     "input": 5e-06,
     "output": 2.5e-05,
     "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06
+    "cacheWrite": 6.25e-06,
+    "cacheWrite1h": 1e-05
   },
   "claude-opus-5": {
     "input": 5e-06,
     "output": 2.5e-05,
     "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06
+    "cacheWrite": 6.25e-06,
+    "cacheWrite1h": 1e-05
   },
   "claude-sonnet-4-20250514": {
     "input": 3e-06,
     "output": 1.5e-05,
     "cacheRead": 3e-07,
-    "cacheWrite": 3.75e-06
+    "cacheWrite": 3.75e-06,
+    "cacheWrite1h": 6e-06
   },
   "claude-sonnet-4-5": {
     "input": 3e-06,
     "output": 1.5e-05,
     "cacheRead": 3e-07,
-    "cacheWrite": 3.75e-06
+    "cacheWrite": 3.75e-06,
+    "cacheWrite1h": 6e-06
   },
   "claude-sonnet-4-5-20250929": {
     "input": 3e-06,
     "output": 1.5e-05,
     "cacheRead": 3e-07,
-    "cacheWrite": 3.75e-06
+    "cacheWrite": 3.75e-06,
+    "cacheWrite1h": 6e-06
   },
   "claude-sonnet-4-6": {
     "input": 3e-06,
     "output": 1.5e-05,
     "cacheRead": 3e-07,
-    "cacheWrite": 3.75e-06
+    "cacheWrite": 3.75e-06,
+    "cacheWrite1h": 6e-06
   },
   "claude-sonnet-5": {
     "input": 2e-06,
     "output": 1e-05,
     "cacheRead": 2e-07,
-    "cacheWrite": 2.5e-06
+    "cacheWrite": 2.5e-06,
+    "cacheWrite1h": 4e-06
   }
 }

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -46,29 +46,48 @@ const (
 )
 
 // Rate is one model's price per token, in USD, split the way a provider bills
-// them: fresh input, generated output, a cache hit, and writing the cache.
+// them: fresh input, generated output, a cache hit, and writing the cache —
+// which is two prices, because a cache entry is priced by how long it is kept.
+// CacheWrite is the short-lived entry (five minutes); CacheWrite1h is the hour
+// one, and it is the more expensive of the two.
 type Rate struct {
-	Input      float64 `json:"input"`
-	Output     float64 `json:"output"`
-	CacheRead  float64 `json:"cacheRead"`
-	CacheWrite float64 `json:"cacheWrite"`
+	Input        float64 `json:"input"`
+	Output       float64 `json:"output"`
+	CacheRead    float64 `json:"cacheRead"`
+	CacheWrite   float64 `json:"cacheWrite"`
+	CacheWrite1h float64 `json:"cacheWrite1h"`
 }
 
 // Tokens is a turn's (or a whole conversation's) token counts, named after the
-// four counters a provider transcript reports.
+// counters a provider transcript reports, with the cache write split by the
+// entry's lifetime the way the bill is.
 type Tokens struct {
-	Input      int
-	Output     int
-	CacheRead  int
-	CacheWrite int
+	Input        int
+	Output       int
+	CacheRead    int
+	CacheWrite   int
+	CacheWrite1h int
 }
 
-// Cost is what these tokens cost at this rate, in USD.
-func (r Rate) Cost(t Tokens) float64 {
+// Cost is what these tokens cost at this rate, in USD. ok is false when the
+// tokens include hour-long cache writes and the rate carries no price for them:
+// billing them at the five-minute price is a total that is quietly too small,
+// and this package's whole rule is that a number it cannot stand behind is not
+// reported at all.
+//
+// A rate can miss that price because the source table never published one for
+// the model. The next refresh any unknown model triggers overlays the whole
+// remote table, so this heals on its own if the price appears there — it is not
+// worth a refresh of its own.
+func (r Rate) Cost(t Tokens) (float64, bool) {
+	if t.CacheWrite1h > 0 && r.CacheWrite1h == 0 {
+		return 0, false
+	}
 	return r.Input*float64(t.Input) +
 		r.Output*float64(t.Output) +
 		r.CacheRead*float64(t.CacheRead) +
-		r.CacheWrite*float64(t.CacheWrite)
+		r.CacheWrite*float64(t.CacheWrite) +
+		r.CacheWrite1h*float64(t.CacheWrite1h), true
 }
 
 // Table resolves model ids to rates. The zero value is not usable — call New.
@@ -240,10 +259,11 @@ func (t *Table) fetch() (map[string]Rate, error) {
 // remoteEntry is the subset of a LiteLLM table entry lich reads. Its other forty
 // fields are ignored, so a change to any of them cannot break this.
 type remoteEntry struct {
-	Input      float64 `json:"input_cost_per_token"`
-	Output     float64 `json:"output_cost_per_token"`
-	CacheRead  float64 `json:"cache_read_input_token_cost"`
-	CacheWrite float64 `json:"cache_creation_input_token_cost"`
+	Input        float64 `json:"input_cost_per_token"`
+	Output       float64 `json:"output_cost_per_token"`
+	CacheRead    float64 `json:"cache_read_input_token_cost"`
+	CacheWrite   float64 `json:"cache_creation_input_token_cost"`
+	CacheWrite1h float64 `json:"cache_creation_input_token_cost_above_1hr"`
 }
 
 // parseRemote converts the remote table to lich's shape, dropping every entry
@@ -260,10 +280,11 @@ func parseRemote(data []byte) (map[string]Rate, error) {
 			continue
 		}
 		rates[model] = Rate{
-			Input:      entry.Input,
-			Output:     entry.Output,
-			CacheRead:  entry.CacheRead,
-			CacheWrite: entry.CacheWrite,
+			Input:        entry.Input,
+			Output:       entry.Output,
+			CacheRead:    entry.CacheRead,
+			CacheWrite:   entry.CacheWrite,
+			CacheWrite1h: entry.CacheWrite1h,
 		}
 	}
 	return rates, nil

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -18,6 +18,7 @@ const remoteBody = `{
     "output_cost_per_token": 5e-05,
     "cache_read_input_token_cost": 1e-06,
     "cache_creation_input_token_cost": 1.25e-05,
+    "cache_creation_input_token_cost_above_1hr": 2e-05,
     "litellm_provider": "anthropic",
     "supports_pdf_input": true
   },
@@ -137,7 +138,7 @@ func TestRefreshTeachesAModelReleasedAfterTheBuild(t *testing.T) {
 	if !ok {
 		t.Fatal("Rate after refresh: want the freshly published price")
 	}
-	if rate.Input != 1e-05 || rate.CacheWrite != 1.25e-05 {
+	if rate.Input != 1e-05 || rate.CacheWrite != 1.25e-05 || rate.CacheWrite1h != 2e-05 {
 		t.Errorf("Rate = %+v, want the remote opus-9 rates", rate)
 	}
 	if got := hits.Load(); got != 1 {
@@ -282,18 +283,58 @@ func TestARefreshWithNothingPricedChangesNothing(t *testing.T) {
 	}
 }
 
-// TestCostBillsEveryCounterSeparately proves the four counters are priced at
-// their own rates — a cache read is an order of magnitude cheaper than fresh
-// input, and folding them together would overstate a long session badly.
+// TestCostBillsEveryCounterSeparately proves each counter is priced at its own
+// rate — a cache read is an order of magnitude cheaper than fresh input, an
+// hour-long cache write dearer than a five-minute one, and folding any of them
+// together misreads a long session badly. The total is written out rather than
+// rebuilt from the rates, so a counter that starts billing at a neighbour's
+// price fails here instead of agreeing with itself.
 func TestCostBillsEveryCounterSeparately(t *testing.T) {
+	rate := Rate{Input: 1e-05, Output: 5e-05, CacheRead: 1e-06, CacheWrite: 1.25e-05, CacheWrite1h: 2e-05}
+
+	got, ok := rate.Cost(Tokens{Input: 100, Output: 200, CacheRead: 300, CacheWrite: 400, CacheWrite1h: 500})
+
+	if !ok {
+		t.Fatal("Cost: want a priced total, every counter has a rate")
+	}
+	if !nearly(got, 0.0263) {
+		t.Errorf("Cost = %v, want 0.0263", got)
+	}
+}
+
+// TestAnHourCacheWriteWithNoHourPriceIsUnpriced is the money rule reaching the
+// counter that arrived last: a table that never learnt what an hour-long cache
+// write costs must not bill it at the five-minute price, which is the cheaper
+// one and would report a total that is quietly too small.
+func TestAnHourCacheWriteWithNoHourPriceIsUnpriced(t *testing.T) {
 	rate := Rate{Input: 1e-05, Output: 5e-05, CacheRead: 1e-06, CacheWrite: 1.25e-05}
 
-	got := rate.Cost(Tokens{Input: 100, Output: 200, CacheRead: 300, CacheWrite: 400})
-
-	want := 100*1e-05 + 200*5e-05 + 300*1e-06 + 400*1.25e-05
-	if got != want {
-		t.Errorf("Cost = %v, want %v", got, want)
+	if cost, ok := rate.Cost(Tokens{Input: 100, CacheWrite1h: 500}); ok {
+		t.Errorf("Cost = %v, want no total while the hour rate is unknown", cost)
 	}
+	// Without those tokens the same rate still answers: the miss is about what
+	// the line asks to be priced, not about the rate being incomplete.
+	if _, ok := rate.Cost(Tokens{Input: 100, CacheWrite: 500}); !ok {
+		t.Error("Cost: want a total for a line with no hour-long write on it")
+	}
+}
+
+// TestEveryBakedHourRateOutpricesItsFiveMinute guards the generated table: an
+// entry kept longer cannot cost less, so a row that says otherwise came from a
+// broken source row and would underbill every session running that model.
+func TestEveryBakedHourRateOutpricesItsFiveMinute(t *testing.T) {
+	for model, rate := range parseRates(bakedPrices) {
+		if rate.CacheWrite1h != 0 && rate.CacheWrite1h < rate.CacheWrite {
+			t.Errorf("baked rate for %q = %+v, want the hour write to cost at least the five-minute one", model, rate)
+		}
+	}
+}
+
+// nearly compares two dollar amounts built from float multiplications, where
+// the last bits of a sum are not worth asserting on.
+func nearly(got, want float64) bool {
+	diff := got - want
+	return diff < 1e-12 && diff > -1e-12
 }
 
 // TestEveryBakedRateIsPriced guards the generated table itself: an entry that

--- a/internal/terminal/transcript.go
+++ b/internal/terminal/transcript.go
@@ -42,6 +42,26 @@ func claudeTranscriptPath(providerSessionID string) (string, bool) {
 	return globTranscript(base, "projects", "*", providerSessionID+".jsonl")
 }
 
+// claudeSubagentPaths locates the transcripts of the sub-agents a Claude
+// conversation spawned. A sub-agent's conversation is a file of its own beside
+// the parent's — projects/<slug>/<id>/subagents/agent-<id>.jsonl — where it used
+// to be sidechain lines written into the parent itself, and its tokens are
+// billed to the same account. Empty for a conversation that spawned none, which
+// is most of them.
+func claudeSubagentPaths(providerSessionID string) []string {
+	base, ok := harnessDir("CLAUDE_CONFIG_DIR", ".claude")
+	if !ok {
+		return nil
+	}
+	matches, err := filepath.Glob(
+		filepath.Join(base, "projects", "*", providerSessionID, "subagents", "*.jsonl"),
+	)
+	if err != nil {
+		return nil
+	}
+	return matches
+}
+
 // codexTranscriptPath locates a Codex rollout by its UUID under $CODEX_HOME,
 // else ~/.codex. Codex files a rollout by the date it started —
 // sessions/<yyyy>/<mm>/<dd>/rollout-<timestamp>-<uuid>.jsonl.

--- a/internal/terminal/usage.go
+++ b/internal/terminal/usage.go
@@ -1,6 +1,9 @@
 package terminal
 
-import "log/slog"
+import (
+	"log/slog"
+	"path/filepath"
+)
 
 // usageEventName carries a session's context-window usage ({id, percent, tokens}),
 // emitted after a turn ends. Global like the other session events: the card that
@@ -80,6 +83,11 @@ func (s *Service) sessionUsage(id string) (usageEvent, bool) {
 // table knows — see scanTranscriptCost for why an unpriced line stops the count
 // instead of being skipped.
 //
+// A conversation is more than one file: what its sub-agents spent is billed to
+// the same account and written to transcripts of their own, so each is counted
+// into the same session. One of them falling short withholds the whole number,
+// for the same reason a single unpriced line does.
+//
 // The accounting is persisted per transcript, so it survives both a `/clear`
 // (a new conversation under the same session, counted into its own row) and a
 // restart of lich itself.
@@ -91,26 +99,13 @@ func (s *Service) sessionCost(id, providerSessionID string) (float64, bool) {
 	if !ok {
 		return 0, false
 	}
-	offset, lastMessage, cost, err := s.store.CostLedger(id, providerSessionID)
-	if err != nil {
-		slog.Warn("terminal: read cost ledger", "session", id, "err", err)
+	if !s.countTranscript(id, providerSessionID, path) {
 		return 0, false
 	}
-	from := costLedger{offset: offset, lastMessage: lastMessage, cost: cost}
-	ledger, complete, ok := scanTranscriptCost(path, from, s.prices)
-	if !ok {
-		return 0, false
-	}
-	if ledger != from {
-		if err := s.store.SaveCostLedger(
-			id, providerSessionID, ledger.offset, ledger.lastMessage, ledger.cost,
-		); err != nil {
-			slog.Warn("terminal: save cost ledger", "session", id, "err", err)
+	for _, sub := range claudeSubagentPaths(providerSessionID) {
+		if !s.countTranscript(id, providerSessionID+"/"+filepath.Base(sub), sub) {
 			return 0, false
 		}
-	}
-	if !complete {
-		return 0, false
 	}
 	total, err := s.store.SessionCost(id)
 	if err != nil {
@@ -118,4 +113,34 @@ func (s *Service) sessionCost(id, providerSessionID string) (float64, bool) {
 		return 0, false
 	}
 	return total, true
+}
+
+// countTranscript folds one transcript into the session's ledger, resuming from
+// where the last turn stopped and saving how far this one got. false is "this
+// file has no total to contribute yet" — it could not be read, its accounting
+// could not be stored, or the scan stopped at a line it cannot price.
+//
+// transcriptID is what the ledger row is keyed by, which is the provider's
+// conversation id for the conversation itself and that id plus the file name for
+// each sub-agent beside it: one row per file, so a re-read resumes per file.
+func (s *Service) countTranscript(id, transcriptID, path string) bool {
+	offset, lastMessage, cost, err := s.store.CostLedger(id, transcriptID)
+	if err != nil {
+		slog.Warn("terminal: read cost ledger", "session", id, "err", err)
+		return false
+	}
+	from := costLedger{offset: offset, lastMessage: lastMessage, cost: cost}
+	ledger, complete, ok := scanTranscriptCost(path, from, s.prices)
+	if !ok {
+		return false
+	}
+	if ledger != from {
+		if err := s.store.SaveCostLedger(
+			id, transcriptID, ledger.offset, ledger.lastMessage, ledger.cost,
+		); err != nil {
+			slog.Warn("terminal: save cost ledger", "session", id, "err", err)
+			return false
+		}
+	}
+	return complete
 }

--- a/internal/terminal/usage_cost.go
+++ b/internal/terminal/usage_cost.go
@@ -27,9 +27,12 @@ type costLedger struct {
 }
 
 // costLine is the one transcript line the cost scan cares about: an assistant
-// message with the four token counters a provider bills. Unlike the context
-// read, a sidechain line counts — a Task sub-agent's tokens are billed to the
-// same account as the turn that spawned it.
+// message with the token counters a provider bills. Unlike the context read,
+// nothing here is filtered out for belonging to a sub-agent: its tokens are
+// billed to the same account as the turn that spawned it. Where a sub-agent's
+// lines live has moved — a Claude conversation now files them in transcripts of
+// their own (see claudeSubagentPaths), and the scan is pointed at those too —
+// but a run that still writes them inline is counted the same way.
 type costLine struct {
 	messageID string
 	model     string
@@ -99,7 +102,13 @@ func accumulate(r *bufio.Reader, ledger costLedger, rates rateSource) (costLedge
 		if !priced {
 			return ledger, false
 		}
-		ledger.cost += rate.Cost(entry.tokens)
+		// A rate that cannot price every counter on the line is the same miss as
+		// no rate at all — see Rate.Cost for the counter that can be missing.
+		cost, complete := rate.Cost(entry.tokens)
+		if !complete {
+			return ledger, false
+		}
+		ledger.cost += cost
 		ledger.lastMessage = entry.messageID
 		ledger.offset += int64(len(line))
 	}
@@ -120,6 +129,13 @@ func parseCostLine(line []byte) (costLine, bool) {
 				Output      int `json:"output_tokens"`
 				CacheRead   int `json:"cache_read_input_tokens"`
 				CacheCreate int `json:"cache_creation_input_tokens"`
+				// CacheCreate is the whole cache write; this names the share of
+				// it held for an hour, which is billed at its own higher rate.
+				// Absent on a transcript written before the provider reported
+				// the split, which reads as the short-lived write it used to be.
+				ByLifetime struct {
+					Hour int `json:"ephemeral_1h_input_tokens"`
+				} `json:"cache_creation"`
 			} `json:"usage"`
 		} `json:"message"`
 	}
@@ -130,11 +146,16 @@ func parseCostLine(line []byte) (costLine, bool) {
 		return costLine{}, false
 	}
 	u := entry.Message.Usage
+	// The hour share is taken out of the total rather than read from its own
+	// five-minute counter: whatever the provider adds to the split later, the
+	// tokens still add up to the total it bills.
+	hour := min(u.ByLifetime.Hour, u.CacheCreate)
 	tokens := pricing.Tokens{
-		Input:      u.Input,
-		Output:     u.Output,
-		CacheRead:  u.CacheRead,
-		CacheWrite: u.CacheCreate,
+		Input:        u.Input,
+		Output:       u.Output,
+		CacheRead:    u.CacheRead,
+		CacheWrite:   u.CacheCreate - hour,
+		CacheWrite1h: hour,
 	}
 	if tokens == (pricing.Tokens{}) {
 		return costLine{}, false

--- a/internal/terminal/usage_cost_test.go
+++ b/internal/terminal/usage_cost_test.go
@@ -24,9 +24,11 @@ func (f fixedRates) Rate(model string) (pricing.Rate, bool) {
 }
 
 // testRate is round enough to read totals off by eye: 1 unit of anything is
-// $0.001, except output at $0.01.
+// $0.001, except output at $0.01 and the hour-long cache write at $0.002 — the
+// two cache writes are deliberately different, so a total billed at one rate for
+// both is visible in the number.
 var testRate = fixedRates{
-	modelOpus: {Input: 0.001, Output: 0.01, CacheRead: 0.001, CacheWrite: 0.001},
+	modelOpus: {Input: 0.001, Output: 0.01, CacheRead: 0.001, CacheWrite: 0.001, CacheWrite1h: 0.002},
 }
 
 // costLine renders an assistant transcript line with an explicit message id and
@@ -37,6 +39,17 @@ func costLineJSON(id, model string, input, output, cacheRead, cacheCreate int) s
 		`,"output_tokens":` + itoa(output) +
 		`,"cache_read_input_tokens":` + itoa(cacheRead) +
 		`,"cache_creation_input_tokens":` + itoa(cacheCreate) + `}}}`
+}
+
+// cacheLineJSON renders an assistant line whose whole bill is one cache write,
+// split the way the provider reports it: a total, and the share of that total
+// held for an hour.
+func cacheLineJSON(id, model string, cacheCreate, hour int) string {
+	return `{"type":"assistant","message":{"id":"` + id + `","model":"` + model +
+		`","usage":{"input_tokens":0,"output_tokens":0,"cache_read_input_tokens":0` +
+		`,"cache_creation_input_tokens":` + itoa(cacheCreate) +
+		`,"cache_creation":{"ephemeral_5m_input_tokens":` + itoa(cacheCreate-hour) +
+		`,"ephemeral_1h_input_tokens":` + itoa(hour) + `}}}}`
 }
 
 func itoa(n int) string {
@@ -208,9 +221,70 @@ func TestASyntheticLineIsNotAModelToPrice(t *testing.T) {
 	}
 }
 
+// TestACacheWriteIsPricedByHowLongItIsKept is the split the bill makes and the
+// counter hides: cache_creation_input_tokens is the whole write, and the hour
+// share of it costs more than the five-minute one. Billing the total at a single
+// rate reads a session as cheaper than it was. The wants are written out, not
+// rebuilt from testRate, so a rate applied to the wrong counter fails here.
+func TestACacheWriteIsPricedByHowLongItIsKept(t *testing.T) {
+	tests := []struct {
+		name        string
+		cacheCreate int
+		hour        int
+		want        float64
+	}{
+		{"every token held for an hour", 1000, 1000, 2.0},
+		{"a write split across both lifetimes", 1000, 600, 1.6},
+		{"nothing held for an hour", 1000, 0, 1.0},
+		// A transcript from before the provider reported the split says nothing
+		// about lifetimes, and the whole write reads as the five-minute one.
+		{"a transcript with no split at all", 1000, -1, 1.0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			line := cacheLineJSON("m1", modelOpus, tc.cacheCreate, tc.hour)
+			if tc.hour < 0 {
+				line = costLineJSON("m1", modelOpus, 0, 0, 0, tc.cacheCreate)
+			}
+			ledger, complete, ok := scanTranscriptCost(writeFile(t, line+"\n"), costLedger{}, testRate)
+
+			if !ok || !complete {
+				t.Fatalf("scan: ok=%v complete=%v, want both true", ok, complete)
+			}
+			if !nearly(ledger.cost, tc.want) {
+				t.Errorf("cost = %v, want %v", ledger.cost, tc.want)
+			}
+		})
+	}
+}
+
+// TestAnUnpricedCacheLifetimeStopsTheCount carries the unpriced-model rule down
+// to the counter: a model whose hour-long write has no published price cannot be
+// billed at the five-minute one, because that total is wrong in the direction
+// that flatters the bill.
+func TestAnUnpricedCacheLifetimeStopsTheCount(t *testing.T) {
+	fiveMinuteOnly := fixedRates{modelOpus: {Input: 0.001, Output: 0.01, CacheRead: 0.001, CacheWrite: 0.001}}
+	path := writeFile(t, cacheLineJSON("m1", modelOpus, 1000, 1000)+"\n")
+
+	ledger, complete, ok := scanTranscriptCost(path, costLedger{}, fiveMinuteOnly)
+
+	if !ok {
+		t.Fatal("scan: want ok")
+	}
+	if complete {
+		t.Error("complete = true, want false — an hour-long write with no price must withhold the total")
+	}
+	if ledger.cost != 0 {
+		t.Errorf("cost = %v, want nothing counted past the line it cannot price", ledger.cost)
+	}
+}
+
 // TestASubAgentsTokensAreBilled is where cost parts ways with the context
-// gauge: a Task sub-agent's sidechain lines are excluded from the window the
-// user sees, but they are billed to the same account.
+// gauge: a sub-agent's sidechain lines are excluded from the window the user
+// sees, but they are billed to the same account. This is the shape a Claude
+// conversation used to have — the lines inline in the parent — and it is still
+// counted; where the same tokens live now is
+// TestASubAgentTranscriptIsBilledIntoTheSession.
 func TestASubAgentsTokensAreBilled(t *testing.T) {
 	sidechain := `{"type":"assistant","isSidechain":true,"message":{"id":"m2","model":"` + modelOpus +
 		`","usage":{"input_tokens":100,"output_tokens":0,"cache_read_input_tokens":0,"cache_creation_input_tokens":0}}}`
@@ -304,6 +378,47 @@ func TestTheCostIsAbsentWhileAModelIsUnpriced(t *testing.T) {
 	}
 	if got.CostUSD != nil {
 		t.Errorf("CostUSD = %v, want absent while a model has no price", *got.CostUSD)
+	}
+}
+
+// TestASubAgentTranscriptIsBilledIntoTheSession is the file the conversation
+// does not contain: a sub-agent runs its own transcript, and its tokens are
+// billed to the account that spawned it. Counting only the parent bills a
+// session for delegating the work and not for doing it.
+func TestASubAgentTranscriptIsBilledIntoTheSession(t *testing.T) {
+	writeTranscript(t, "uuid-cost", costLineJSON("m1", modelOpus, 100, 0, 0, 0)+"\n")
+	writeSubagentTranscript(t, "uuid-cost", "agent-one", costLineJSON("m2", modelOpus, 300, 0, 0, 0)+"\n")
+	writeSubagentTranscript(t, "uuid-cost", "agent-two", costLineJSON("m3", modelOpus, 600, 0, 0, 0)+"\n")
+	svc := New(newCostStore("uuid-cost"), nil, events.New())
+	svc.prices = testRate
+
+	got, ok := svc.sessionUsage("s1")
+
+	if !ok {
+		t.Fatal("sessionUsage: want ok")
+	}
+	if got.CostUSD == nil || !nearly(*got.CostUSD, 1.0) {
+		t.Errorf("CostUSD = %v, want 1.0 — both sub-agents count into the session", got.CostUSD)
+	}
+}
+
+// TestAnUnpricedSubAgentWithholdsTheTotal carries the money rule across files: a
+// session's cost is only as reportable as the least readable transcript behind
+// it, and a total missing one sub-agent is wrong in the flattering direction.
+func TestAnUnpricedSubAgentWithholdsTheTotal(t *testing.T) {
+	writeTranscript(t, "uuid-cost", costLineJSON("m1", modelOpus, 100, 0, 0, 0)+"\n")
+	writeSubagentTranscript(t, "uuid-cost", "agent-one",
+		costLineJSON("m2", "model-from-the-future", 300, 0, 0, 0)+"\n")
+	svc := New(newCostStore("uuid-cost"), nil, events.New())
+	svc.prices = testRate
+
+	got, ok := svc.sessionUsage("s1")
+
+	if !ok {
+		t.Fatal("sessionUsage: want ok — the context readout is unaffected")
+	}
+	if got.CostUSD != nil {
+		t.Errorf("CostUSD = %v, want absent while a sub-agent has an unpriced model", *got.CostUSD)
 	}
 }
 

--- a/internal/terminal/usage_test.go
+++ b/internal/terminal/usage_test.go
@@ -30,6 +30,22 @@ func writeTranscript(t *testing.T, providerSessionID, body string) {
 	t.Setenv("CLAUDE_CONFIG_DIR", dir)
 }
 
+// writeSubagentTranscript plants the transcript of one sub-agent beside the
+// conversation that spawned it. It writes into the directory writeTranscript
+// pointed CLAUDE_CONFIG_DIR at, so the parent is planted first.
+func writeSubagentTranscript(t *testing.T, providerSessionID, agent, body string) {
+	t.Helper()
+	dir := filepath.Join(
+		os.Getenv("CLAUDE_CONFIG_DIR"), "projects", "-home-user-repo", providerSessionID, "subagents",
+	)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, agent+".jsonl"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // TestSessionUsageReportsTheTranscriptTail proves the whole read the card's
 // context gauge rides on: session id → recorded provider session → transcript →
 // the event's numbers.


### PR DESCRIPTION
The per-session cost readout was showing about a quarter of the bill as missing. Two causes, both invisible at the call site because the transcript agrees with itself either way.

## The cache write has two prices

A cached prompt is billed by how long its entry is kept. Claude Code keeps entries for an hour — the dearer rate — and the scan billed the whole of `cache_creation_input_tokens` at the five-minute one. Measured over 30 real transcripts: 116,386,535 cache-write tokens, **100% of them** in `usage.cache_creation.ephemeral_1h_input_tokens`, none in the five-minute counter.

The split is read now (`parseCostLine`), and the rate comes from the price table's own source, which publishes it as `cache_creation_input_token_cost_above_1hr`. `Rate.Cost` reports no total at all when a line carries hour-long writes and the rate has no price for them: billing them at the five-minute rate is wrong in the direction that flatters the bill, and this package's rule has always been absent over cheap. The baked table takes the published value, and drops a row that prices the hour write below the five-minute one — a cache kept longer cannot cost less, so that row is a broken source row, not a price.

## A conversation is more than one transcript

A sub-agent's tokens are billed to the account that spawned it. Its conversation used to be sidechain lines inside the parent transcript — where the scan read them — and is now a transcript of its own under `<id>/subagents/`. Measured: 0 sidechain assistant lines in 14,239 assistant lines of those 30 transcripts, and 107 sub-agent transcripts beside them carrying real tokens. `claudeSubagentPaths` finds them and each gets its own ledger row, so the incremental resume still reads only what was appended, per file.

The comment claiming sidechain lines are counted from the parent said the opposite of what the code did; it is corrected, and the `CLAUDE.md` ceiling now names that one unpriceable sub-agent withholds the whole session's number.

## Measured, same transcripts before and after

Same 30 transcripts, the shipped scan, old behaviour reproduced by pricing both cache writes at one rate:

| | total |
|---|---|
| before | $1417.18 |
| lifetime split only | $1578.27 (+11.4%) |
| sub-agents counted | $1757.81 (**+24.0%**) |

## Test plan

- [x] `go test -race ./...` green; `gofmt -l .` and `go vet ./...` clean
- [x] cross-compile loop for linux/darwin/windows (build + vet) clean
- [x] Mutation check: billing the hour write at the five-minute rate again fails `TestCostBillsEveryCounterSeparately`, `TestAnHourCacheWriteWithNoHourPriceIsUnpriced`, `TestACacheWriteIsPricedByHowLongItIsKept` and `TestAnUnpricedCacheLifetimeStopsTheCount`. The totals in those tests are written out, not rebuilt from the rates