### PR TITLE
chore: cut v0.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.0] - 2026-08-16
+
 ### Added
 
 - **A project's usual provider can differ from the global default.** Settings now
@@ -2737,7 +2739,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.34.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.35.0...HEAD
+[0.35.0]: https://github.com/omartelo/lich/compare/v0.34.0...v0.35.0
 [0.34.0]: https://github.com/omartelo/lich/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/omartelo/lich/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/omartelo/lich/compare/v0.31.0...v0.32.0

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <p><a href="https://omartelo.github.io/lich/"><strong>omartelo.github.io/lich</strong></a></p>
   <p>
     <a href="https://github.com/omartelo/lich/releases"><img alt="Release" src="https://img.shields.io/github/v/release/omartelo/lich?color=4285F4&label=release" /></a>
-    <img alt="Go" src="https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white" />
+    <img alt="Go" src="https://img.shields.io/badge/Go-1.26-00ADD8?logo=go&logoColor=white" />
     <img alt="Shell" src="https://img.shields.io/badge/shell-Chromium%20--app-4285F4?logo=googlechrome&logoColor=white" />
     <img alt="Platform" src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-333" />
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-AGPL--3.0-blue" /></a>
@@ -85,7 +85,8 @@ notarization/signing ship. Homebrew installs sidestep the Gatekeeper prompt;
 a download from the Releases page needs its quarantine flag cleared by hand.
 On macOS the cask installs `Lich.app`, so lich has its own icon in
 `/Applications`; the Dock, while it runs, shows the browser that owns the
-window.
+window. Upgrading from the old formula needs `brew uninstall lich` first —
+[INSTALL.md](INSTALL.md) says why.
 
 ## Getting started
 
@@ -146,7 +147,7 @@ TypeScript / Vite frontend over a token-authenticated loopback listener (HTTP RP
 + WebSockets). Terminals are xterm.js with the WebGL addon; the code and diff
 surfaces are CodeMirror 6. The Chromium shell is a decision record:
 [`docs/chromium-shell.md`](docs/chromium-shell.md). Prerequisites are **Go
-1.25+**, **Node + pnpm** and **[Task](https://taskfile.dev)** — no C toolchain,
+1.26.6+**, **Node + pnpm** and **[Task](https://taskfile.dev)** — no C toolchain,
 no system dev libraries.
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,7 +15,7 @@
   </p>
   <p>
     <a href="https://github.com/omartelo/lich/releases"><img alt="Release" src="https://img.shields.io/github/v/release/omartelo/lich?color=4285F4&label=release" /></a>
-    <img alt="Go" src="https://img.shields.io/badge/Go-1.25-00ADD8?logo=go&logoColor=white" />
+    <img alt="Go" src="https://img.shields.io/badge/Go-1.26-00ADD8?logo=go&logoColor=white" />
     <img alt="Shell" src="https://img.shields.io/badge/shell-Chromium%20--app-4285F4?logo=googlechrome&logoColor=white" />
     <img alt="Platform" src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-333" />
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-AGPL--3.0-blue" /></a>
@@ -86,14 +86,19 @@ Homebrew 安装可以绕开 Gatekeeper 的提示；从 Releases 页面下载的�
 2. **打开一个项目** —— 标签栏里的 `+` 会列出你最近关掉的项目，也能调起系统的文件夹
    选择器；指向一个 git 仓库即可。
 3. **把 lich 指向你的智能体** —— 首次启动会列出在你机器上找到的智能体；之后可以在
-   设置 › Providers 里设置各自的二进制文件路径，并改掉新会话默认用哪一个。
-4. **开一个会话** —— *New Session* 会在项目里启动一个跑着你的智能体的终端。
+   全局设置 › Providers 里设置各自的二进制文件路径，并选定默认用哪一个。项目可以沿用
+   这个默认，也可以在项目设置 › Providers 里选另一个 provider。
+4. **开一个会话** —— *New Session* 会在项目里启动一个跑着你的智能体的终端。每个
+   checkout 的标题栏也有一个 `+` 菜单，可以在那个 checkout 里直接打开任意已启用的
+   provider 或一个纯终端；点标题栏本身则会折叠或展开它下面的会话。
 5. **分出一个 worktree**（可选）—— 从任意基础分支创建一个；lich 会为它播种文件，并把你
    带进一个新的会话。
 
 ## 配置
 
-- **智能体** —— 在设置里为每个 provider 设定二进制文件路径，并选定新会话默认用哪一个。
+- **智能体** —— 在全局设置 › Providers 里为每个 provider 设定二进制文件路径，并选定
+  全局默认。项目设置 › Providers 可以为单个项目覆盖这个选择；**Use default** 会移除
+  这层覆盖，之后全局默认的变化便会自动流过来。
   Claude Code 那一节还管着底栏的上下文圆环和费用读数 —— 费用默认关闭，因为只有当你按
   token 计费时这个数字才有意义。
 - **Worktree** —— 项目仓库里的 `.lich/setup-worktree.sh` 会在新 worktree 的终端里


### PR DESCRIPTION
Move the `[Unreleased]` entries under a `v0.35.0` heading and refresh the compare links.

The READMEs still advertised Go 1.25: #296 pinned the module to 1.26.6, so the badge and the build-from-source prerequisite now say so. #294 changed how a project picks its provider and gave every checkout header its own `+` menu, which the English README described and the zh-CN translation did not; both now match. The English README also gained the formula-to-cask upgrade note the translation already carried.

## Test plan

- [x] `gofmt -l .`, `go vet ./...` clean
- [x] `go test -race ./...` green (1560 tests)
- [x] `biome check .` clean, `vitest run` green (926 tests)
- [x] `tsc && vite build` succeeds