### PR TITLE
fix: keep a dragged session card visible, and whole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A session card being dragged stays visible, and stays a card.** Dragged past
+  the end of its group the card slid under the edge that clips the group and
+  disappeared; short of that it read as if it were dissolving into its
+  neighbour, because a card in flight had no background of its own and the
+  labels underneath showed straight through it. A dragged card now carries a
+  raised surface and stops at the ends of the list it is being reordered in —
+  the same for checkout groups and project tabs.
+
 ## [0.35.0] - 2026-08-16
 
 ### Added

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -204,7 +204,15 @@ export function SessionCard({
     <div
       ref={setNodeRef}
       style={dragStyle(transform, transition)}
-      className={cn("relative", isDragging && "pointer-events-none z-10 rounded-lg shadow-md")}
+      // A card in flight floats over its neighbours, so it carries a background
+      // of its own: the card's own fill is transparent until it is hovered or
+      // active, and without one the labels underneath read straight through the
+      // card being dragged.
+      className={cn(
+        "relative",
+        isDragging &&
+          "pointer-events-none z-10 rounded-lg bg-popover shadow-lg ring-1 ring-foreground/10",
+      )}
       {...attributes}
       {...listeners}
     >

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -2,7 +2,7 @@ import { useState, useSyncExternalStore } from "react"
 import { useNavigate } from "react-router-dom"
 import { DndContext, closestCenter } from "@dnd-kit/core"
 import { SortableContext, useSortable, verticalListSortingStrategy } from "@dnd-kit/sortable"
-import { dragStyle, useSortableList, verticalAxis } from "@/lib/use-sortable-list"
+import { dragStyle, useSortableList, verticalAxis, withinList } from "@/lib/use-sortable-list"
 import { cn } from "@/lib/utils"
 import { checkoutLabel } from "@/lib/git/checkout-label"
 import type { ProviderState } from "@/lib/providers-store"
@@ -148,7 +148,7 @@ export function SessionGroup({
           <DndContext
             sensors={sensors}
             collisionDetection={closestCenter}
-            modifiers={[verticalAxis]}
+            modifiers={[verticalAxis, withinList]}
             onDragEnd={onDragEnd}
           >
             <SortableContext items={ids} strategy={verticalListSortingStrategy}>

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -33,7 +33,7 @@ import {
   type Session,
   type SidebarGroup,
 } from "@/lib/session/sessions"
-import { useSortableList, verticalAxis } from "@/lib/use-sortable-list"
+import { useSortableList, verticalAxis, withinList } from "@/lib/use-sortable-list"
 import { WorktreeCloseDialogs } from "./WorktreeCloseDialogs"
 import { SessionGroup } from "./SessionGroup"
 import { WorktreeDialog } from "./WorktreeDialog"
@@ -238,7 +238,7 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
-          modifiers={[verticalAxis]}
+          modifiers={[verticalAxis, withinList]}
           onDragEnd={onDragEnd}
         >
           <SortableContext items={dragKeys} strategy={verticalListSortingStrategy}>

--- a/frontend/src/components/tabs/ProjectTabs.tsx
+++ b/frontend/src/components/tabs/ProjectTabs.tsx
@@ -15,7 +15,7 @@ import { openPullsList } from "@/lib/pulls-list-card-store"
 import { useSettings } from "@/providers/settings"
 import { useHotkey } from "@/lib/use-hotkey"
 import { NotificationsButton } from "./NotificationsButton"
-import { horizontalAxis, useSortableList } from "@/lib/use-sortable-list"
+import { horizontalAxis, useSortableList, withinList } from "@/lib/use-sortable-list"
 import { ProjectTab } from "./ProjectTab"
 import { HomeTab } from "./HomeTab"
 import { OpenProjectMenu } from "./OpenProjectMenu"
@@ -85,7 +85,7 @@ export function ProjectTabs() {
           <DndContext
             sensors={sensors}
             collisionDetection={closestCenter}
-            modifiers={[horizontalAxis]}
+            modifiers={[horizontalAxis, withinList]}
             onDragEnd={onDragEnd}
           >
             <SortableContext items={ids} strategy={horizontalListSortingStrategy}>

--- a/frontend/src/lib/use-sortable-list.test.ts
+++ b/frontend/src/lib/use-sortable-list.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+import type { Modifier } from "@dnd-kit/core"
+import { withinList } from "./use-sortable-list"
+
+type Args = Parameters<Modifier>[0]
+
+const rect = (top: number, height: number, left = 0, width = 200) => ({
+  top,
+  left,
+  width,
+  height,
+  right: left + width,
+  bottom: top + height,
+})
+
+// A list of three 100px rows starting at y=100, and the middle one dragged.
+const args = (
+  transform: { x: number; y: number },
+  dragged = rect(200, 100),
+  container = rect(100, 300),
+) =>
+  ({
+    containerNodeRect: container,
+    draggingNodeRect: dragged,
+    transform: { ...transform, scaleX: 1, scaleY: 1 },
+  }) as unknown as Args
+
+describe("withinList", () => {
+  it("leaves a drag that stays inside the list untouched", () => {
+    expect(withinList(args({ x: 0, y: 50 }))).toMatchObject({ x: 0, y: 50 })
+    expect(withinList(args({ x: 0, y: -50 }))).toMatchObject({ x: 0, y: -50 })
+  })
+
+  it("stops a drag at the end of the list instead of letting it leave", () => {
+    // The row's bottom (300) reaches the container's (400) after 100px.
+    expect(withinList(args({ x: 0, y: 400 }))).toMatchObject({ y: 100 })
+    // And its top (200) reaches the container's (100) after -100px.
+    expect(withinList(args({ x: 0, y: -400 }))).toMatchObject({ y: -100 })
+  })
+
+  it("clamps horizontally too, for the tab strip", () => {
+    // A 100px tab sitting at x=300 in a strip that runs from 0 to 600.
+    const strip = rect(0, 40, 0, 600)
+    const tab = rect(0, 40, 300, 100)
+    expect(withinList(args({ x: 500, y: 0 }, tab, strip))).toMatchObject({ x: 200 })
+    expect(withinList(args({ x: -500, y: 0 }, tab, strip))).toMatchObject({ x: -300 })
+  })
+
+  it("passes the transform through before the rects are measured", () => {
+    const unmeasured = {
+      containerNodeRect: null,
+      draggingNodeRect: null,
+      transform: { x: 4, y: 900, scaleX: 1, scaleY: 1 },
+    } as unknown as Args
+    expect(withinList(unmeasured)).toMatchObject({ x: 4, y: 900 })
+  })
+})

--- a/frontend/src/lib/use-sortable-list.ts
+++ b/frontend/src/lib/use-sortable-list.ts
@@ -17,6 +17,31 @@ const DRAG_THRESHOLD_PX = 5
 export const horizontalAxis: Modifier = ({ transform }) => ({ ...transform, y: 0 })
 export const verticalAxis: Modifier = ({ transform }) => ({ ...transform, x: 0 })
 
+// Holds a dragged node inside the list it is being reordered in. Every list
+// here is clipped by an ancestor — the group's collapse animation needs
+// overflow-hidden, the tab strip scrolls — so a node dragged past either end
+// slides under that edge and vanishes mid-drag. Reordering cannot follow the
+// pointer out there anyway: the drop it would land is the end of this list.
+export const withinList: Modifier = ({ containerNodeRect, draggingNodeRect, transform }) => {
+  if (!containerNodeRect || !draggingNodeRect) {
+    return transform
+  }
+  const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max)
+  return {
+    ...transform,
+    x: clamp(
+      transform.x,
+      containerNodeRect.left - draggingNodeRect.left,
+      containerNodeRect.right - draggingNodeRect.right,
+    ),
+    y: clamp(
+      transform.y,
+      containerNodeRect.top - draggingNodeRect.top,
+      containerNodeRect.bottom - draggingNodeRect.bottom,
+    ),
+  }
+}
+
 // The style every sortable node wears while it moves. Translate, never
 // Transform: dnd-kit's transform also carries the scale needed to match the
 // item being displaced, so a card dragged past a taller neighbour would stretch


### PR DESCRIPTION
Dragging a session card had two things wrong with it, both visible in the same gesture.

**It disappeared.** The cards of a group live inside the wrapper that animates the group's collapse, which is `overflow-hidden`. A card dragged past the end of the list slid under that edge and was gone until the pointer came back.

**It dissolved into its neighbour.** `isDragging` only added a shadow, and a card's own fill is transparent until it is hovered or active — so the card in flight let the labels underneath show through, and the two read as one card with two headers.

## What changed

- `withinList` (new modifier in `lib/use-sortable-list.ts`) clamps a dragged node to its container's rect on both axes. Reordering cannot follow the pointer out of the list anyway: the drop out there is the end of this list. Wired into all three sortable surfaces — session cards, checkout groups, project tabs.
- A card in flight now carries a raised surface (`bg-popover shadow-lg ring-1 ring-foreground/10`) instead of a shadow over nothing.

## Test plan

- `use-sortable-list.test.ts` covers the clamp: inside the list untouched, both ends stopped, horizontal clamp for the tab strip, and the pass-through before the rects are measured.
- Measured by hand in the headless CDP rig (real `Input.dispatchMouseEvent` drags, reading each card's transform and rect per step): at +200px the dragged card used to end up outside the clipped area; it now stops at +184px, the exact end of the list, fully visible. Tab reordering re-checked in the same rig — the strip still reorders and its wider container leaves the tab's travel unchanged.
- Frontend gate green: biome, tsc, 930 tests, `vite build`. Backend untouched (`gofmt`, `go vet` clean).