### PR TITLE
fix: hold a relayed message back while the user is typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A relayed message no longer sends the sentence you were typing with it.** A
+  peer's answer or task arriving while you had a half-written prompt was pasted
+  onto your line and submitted with it, and your half was gone. lich now waits
+  for the prompt to be free — you send your line, or you leave it alone for a
+  minute — before typing anything into it. Same for every provider: it is the
+  session's terminal that is watched, not the agent running in it.
+
 - **A session card being dragged stays visible, and stays a card.** Dragged past
   the end of its group the card slid under the edge that clips the group and
   disappeared; short of that it read as if it were dissolving into its

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -53,6 +53,14 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   prompt and in `/proc/<pid>/cmdline`. Codex, opencode and Crush get nothing there — none has a per-spawn append
   flag, so for those three the point exists only in lich's MCP instructions, and behaviour between providers
   differs by that much.
+- **A prompt in use is recognised from the bytes going in, never from the line itself**
+  (`internal/terminal/draft.go`): a relayed message pastes at the prompt and sends an Enter behind it, so lich
+  holds the delivery back while the user has unsent input there. What it counts is printable input since the last
+  Enter, escape sequences skipped — it cannot see the line, so an edit that leaves it empty by another route
+  (Ctrl+W, a click into the middle of it) reads as a draft that is still there, and a delivery waits out
+  `draftIdle` for nothing. The stale-draft release is what keeps that a delay instead of a wedged relay. Two gaps
+  stay open: input arriving in the ~150ms between the paste and its Enter (`defaultSubmitDelay`) still rides along,
+  and a provider that takes keystrokes through anything other than this PTY is invisible here.
 - **Installing the plugin writes into three harnesses' own directories** (`internal/agentplugin`): Claude Code and
   Codex are driven through their plugin CLI, but opencode, oh-my-pi and Crush have none, so lich writes the
   released files itself. None of them records what is installed, so the version lives in a marker line lich wrote —

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -46,14 +46,14 @@ const (
 	// expiry an hour later.
 	defaultReceiptWindow = 30 * time.Second
 	// defaultDeliveryLimit is how long a queued task waits for its target to
-	// reach a prompt before the errand is reported undelivered (see
-	// queueDelivery). A worktree setup script that installs dependencies and
-	// warms a build runs minutes on a cold cache, so the number has to be
-	// generous; past it the checkout is broken or waiting on a person, and
-	// neither ends by itself. It is well inside ticketTTL on purpose: the sender
-	// hears a failure it can act on rather than watching a ticket expire an hour
-	// later with nothing said.
-	defaultDeliveryLimit = 10 * time.Minute
+	// reach a free prompt before the errand is reported undelivered (see
+	// queueDelivery and awaitFree). A worktree setup script that installs
+	// dependencies and warms a build runs minutes on a cold cache, so the number
+	// has to be generous; past it the checkout is broken or waiting on a person,
+	// and neither ends by itself. It is well inside ticketTTL on purpose: the
+	// sender hears a failure it can act on rather than watching a ticket expire
+	// an hour later with nothing said.
+	defaultDeliveryLimit = 5 * time.Minute
 	// promptLimit bounds one relayed prompt. The message is typed into a TUI a
 	// character at a time; a megabyte of it is a hang, not a prompt.
 	promptLimit = 8192
@@ -540,13 +540,43 @@ func (s *Service) failDelivery(id string, t *ticket, cause error) {
 
 // deliver puts message at a session's prompt and sends it — two writes, a beat
 // apart, because the Enter has to arrive after the prompt has taken the paste
-// (see defaultSubmitDelay).
+// (see defaultSubmitDelay). It waits for a prompt that is free first: this
+// Enter sends everything on the line, including whatever the person at that
+// session had started typing.
 func (s *Service) deliver(sessionID, message string) error {
+	if err := s.awaitFree(sessionID); err != nil {
+		return err
+	}
 	if err := s.term.Write(sessionID, paste(message)); err != nil {
 		return err
 	}
 	time.Sleep(s.submitDelay)
 	return s.term.Write(sessionID, submit)
+}
+
+// awaitFree blocks while a session's prompt belongs to somebody else — the
+// checkout's setup script, or the user mid-sentence at it, both of which
+// terminal.Ready answers. Every write this package makes goes through deliver,
+// so this one gate covers the task, the nudge and the retry alike; a check at
+// each call site would be three places to forget it in and would still leave
+// the window between the check and the write open.
+//
+// It is bounded by the same budget a queued delivery gets and, in practice,
+// cannot spend it: unsent input goes stale on its own well inside that
+// (terminal.draftIdle), so somebody who walked away mid-word costs a delivery
+// its delay, never its outcome.
+func (s *Service) awaitFree(sessionID string) error {
+	deadline := s.now().Add(s.deliveryLimit)
+	for !s.term.Ready(sessionID) {
+		if !s.term.Live(sessionID) {
+			return fmt.Errorf("session stopped before its prompt was free")
+		}
+		if s.now().After(deadline) {
+			return fmt.Errorf("prompt was still not free after %s", s.deliveryLimit)
+		}
+		time.Sleep(readyPoll)
+	}
+	return nil
 }
 
 // awaitReady blocks until a target's agent is the program reading its PTY, and

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -27,9 +27,12 @@ type fakeTerminal struct {
 	// the worktree setup script rather than the agent.
 	live      map[string]bool
 	settingUp map[string]bool
-	writes    map[string][]string
-	writeErr  error
-	refused   int
+	// typing is whether the person at that session has a half-written line at its
+	// prompt, which the terminal service reports through the same Ready.
+	typing   map[string]bool
+	writes   map[string][]string
+	writeErr error
+	refused  int
 	// onWrite runs after a write is recorded, outside the fake's own lock, so a
 	// test can make the target report state from inside a delivery.
 	onWrite func(id, data string)
@@ -37,7 +40,8 @@ type fakeTerminal struct {
 
 func newFakeTerminal(live ...string) *fakeTerminal {
 	t := &fakeTerminal{
-		live: map[string]bool{}, writes: map[string][]string{}, settingUp: map[string]bool{},
+		live: map[string]bool{}, writes: map[string][]string{},
+		settingUp: map[string]bool{}, typing: map[string]bool{},
 	}
 	for _, id := range live {
 		t.live[id] = true
@@ -52,12 +56,20 @@ func (f *fakeTerminal) Live(id string) bool {
 }
 
 // Ready defaults to "as ready as it is live": most tests are about delivery and
-// answers, not about a checkout that is still installing its dependencies. The
-// ones that are set settingUp.
+// answers, not about a checkout that is still installing its dependencies, nor
+// about a prompt its own user is typing at. The ones that are set settingUp or
+// typing.
 func (f *fakeTerminal) Ready(id string) bool {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return f.live[id] && !f.settingUp[id]
+	return f.live[id] && !f.settingUp[id] && !f.typing[id]
+}
+
+// typeAt marks a session as having the user's own unsent line at its prompt.
+func (f *fakeTerminal) typeAt(id string, drafting bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.typing[id] = drafting
 }
 
 // setUp marks a session as still running its worktree setup script: live, and
@@ -2086,6 +2098,32 @@ func TestANudgeThatNeverLandedIsSentAgain(t *testing.T) {
 	svc.Observe("s1", stateDone)
 	if !awaitWritten(term, "s1", "[lich]") {
 		t.Fatalf("a nudge that failed to land was never sent again: %q", term.writesTo("s1"))
+	}
+}
+
+// Every write this package makes is a paste with an Enter behind it, and that
+// Enter sends the whole line — so one landing while the person at that session
+// is mid-sentence submits their half-written text along with lich's, and their
+// half is gone. The nudge is the path that has no other gate: it is typed at an
+// idle sender, which is exactly the session somebody is sitting at.
+func TestNothingIsTypedIntoAPromptItsUserIsHolding(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, nil)
+	term.typeAt("s1", true)
+	plant(svc, "t1", "s1", "s2", "docs")
+
+	if err := svc.Reply("t1", "all green"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	// Long enough for the nudge's debounce to have fired and typed.
+	time.Sleep(50 * time.Millisecond)
+	if typed := term.written("s1"); typed != "" {
+		t.Fatalf("typed into a prompt its user was using: %q", typed)
+	}
+
+	term.typeAt("s1", false)
+	if !awaitWritten(term, "s1", "[lich]") {
+		t.Fatalf("the prompt came free and nothing was delivered: %q", term.writesTo("s1"))
 	}
 }
 

--- a/internal/terminal/draft.go
+++ b/internal/terminal/draft.go
@@ -1,0 +1,100 @@
+package terminal
+
+import "time"
+
+// What the user has typed at a prompt and not sent yet, and why lich has to
+// know: a relayed message is pasted straight into that prompt and an Enter is
+// sent behind it (internal/relay, deliver), so one landing mid-sentence sends
+// lich's text and the user's half-written one as a single submission. The
+// user's half is gone — it was never in a scrollback, and no provider offers a
+// way to get it back.
+//
+// Only the frontend's keystrokes reach here; what the relay itself types goes
+// in through Write. The two paths were already separate, which is what makes
+// this answerable at all — and answerable the same way for every provider,
+// because it is asked of the PTY rather than of the TUI drawing on it.
+
+const (
+	// draftIdle is how long unsent input keeps a prompt to itself. It bounds a
+	// heuristic that cannot be exact: what is on the line is the TUI's business
+	// and lich only sees the bytes going in, so an edit lich cannot read as one —
+	// Ctrl+W, a click into the middle of the line — would otherwise leave a draft
+	// that never clears and a relay that never delivers into that session again,
+	// silently. Long enough to cover a pause mid-sentence, short against the
+	// budget a held-back delivery has to wait it out (relay's deliveryLimit).
+	draftIdle = time.Minute
+
+	esc   = 0x1b
+	ctrlC = 0x03
+	// maxEscape bounds what is held waiting for the rest of a sequence. The
+	// longest one a terminal sends is a mouse report at around a dozen bytes; an
+	// ESC that never ends is not a sequence at all, and holding it would swallow
+	// everything typed after it.
+	maxEscape = 32
+)
+
+// noteInput records whether the user is composing something at this session's
+// prompt right now, so a relayed message is not pasted into the middle of it
+// (see Ready). Unknown sessions are a no-op.
+func (s *Service) noteInput(id string, data []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[id]
+	if !ok {
+		return
+	}
+	if len(sess.escPending) > 0 {
+		data = append(sess.escPending, data...)
+		sess.escPending = nil
+	}
+	for i := 0; i < len(data); i++ {
+		switch b := data[i]; {
+		case b == esc:
+			n, done := escapeSpan(data[i:])
+			if !done {
+				// The rest of it is in the next write. Held rather than counted:
+				// its parameters are digits, and digits read as typing.
+				if n <= maxEscape {
+					sess.escPending = append([]byte(nil), data[i:]...)
+				}
+				return
+			}
+			i += n - 1
+		case b == '\r' || b == '\n' || b == ctrlC:
+			// Sent, or thrown away. Either way the line is the user's no longer.
+			sess.draftAt = time.Time{}
+		case b >= 0x20:
+			sess.draftAt = time.Now()
+		}
+	}
+}
+
+// escapeSpan is how many bytes the escape sequence starting at data[0] takes
+// up, and whether it ended inside data at all — a PTY write can split one, and
+// what arrives first has to be recognised as a beginning rather than as text.
+//
+// Sequences are skipped rather than interpreted: arrow keys arrive as input,
+// and with mouse tracking on (?1003h) so does every pointer movement over the
+// terminal. Counting the printable bytes inside those as typing would leave a
+// session whose prompt never looks free again.
+func escapeSpan(data []byte) (int, bool) {
+	if len(data) < 2 {
+		return len(data), false
+	}
+	if data[1] != '[' && data[1] != 'O' {
+		return 2, true // ESC + one key, which is how Alt+<key> arrives.
+	}
+	for i := 2; i < len(data); i++ {
+		// A CSI runs to its final byte; everything before it is parameters.
+		if data[i] >= 0x40 && data[i] <= 0x7e {
+			return i + 1, true
+		}
+	}
+	return len(data), false
+}
+
+// drafting is whether the user has unsent input at this prompt as of now.
+// Called under the service's mu.
+func (sess *session) drafting(now time.Time) bool {
+	return !sess.draftAt.IsZero() && now.Sub(sess.draftAt) < draftIdle
+}

--- a/internal/terminal/draft_test.go
+++ b/internal/terminal/draft_test.go
@@ -1,0 +1,133 @@
+package terminal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/omartelo/lich/internal/events"
+)
+
+// settled is a session that has finished drawing itself: ready for work, unless
+// the person at it has the prompt.
+func settled(t *testing.T) (*Service, *session) {
+	t.Helper()
+	svc := New(nil, nil, events.New())
+	sess := &session{lastOut: time.Now().Add(-time.Second)}
+	svc.mu.Lock()
+	svc.sessions["s1"] = sess
+	svc.mu.Unlock()
+	if !svc.Ready("s1") {
+		t.Fatal("a settled session was not ready to begin with")
+	}
+	return svc, sess
+}
+
+// The bug this exists for: a relayed message is pasted at the prompt and an
+// Enter is sent behind it, so one arriving while the user is mid-sentence sends
+// both halves as one submission and the user's half is gone.
+func TestTypingTakesThePromptBackFromTheRelay(t *testing.T) {
+	svc, _ := settled(t)
+
+	svc.noteInput("s1", []byte("what about the"))
+	if svc.Ready("s1") {
+		t.Error("a prompt with the user's own half-written line was offered work")
+	}
+
+	svc.noteInput("s1", []byte("\r"))
+	if !svc.Ready("s1") {
+		t.Error("the line was sent and the prompt stayed held")
+	}
+}
+
+// Ctrl+C throws the line away rather than sending it. Either way it is not the
+// user's anymore, and a prompt held by a draft nobody has is a relay that never
+// delivers here again.
+func TestAnAbandonedLineReleasesThePrompt(t *testing.T) {
+	svc, _ := settled(t)
+
+	svc.noteInput("s1", []byte("half a thought"))
+	svc.noteInput("s1", []byte{ctrlC})
+	if !svc.Ready("s1") {
+		t.Error("a line thrown away with Ctrl+C still held the prompt")
+	}
+}
+
+// With mouse tracking on, every pointer movement over the terminal arrives as
+// input, and the digits inside those reports are printable. Read as typing they
+// would hold the prompt forever without anybody touching a key.
+func TestPointerAndCursorInputIsNotADraft(t *testing.T) {
+	svc, _ := settled(t)
+
+	svc.noteInput("s1", []byte("\x1b[<35;42;7M\x1b[<35;43;7M"))
+	svc.noteInput("s1", []byte("\x1b[A\x1b[B\x1bOP"))
+	if !svc.Ready("s1") {
+		t.Error("moving the mouse over a terminal took its prompt away")
+	}
+
+	// The same report split across two PTY writes, which is how a long one
+	// arrives: neither half may be counted as typing.
+	svc.noteInput("s1", []byte("\x1b[<35;10"))
+	svc.noteInput("s1", []byte(";5M"))
+	if !svc.Ready("s1") {
+		t.Error("a mouse report split across two writes was read as typing")
+	}
+}
+
+// The prompt cannot be held indefinitely: lich sees the bytes going in, never
+// the line itself, so an edit it cannot read as one would wedge the relay
+// silently. A draft nobody has touched goes stale and gives the prompt back.
+func TestAStaleDraftGivesThePromptBack(t *testing.T) {
+	svc, sess := settled(t)
+
+	svc.mu.Lock()
+	sess.draftAt = time.Now().Add(-59 * time.Second)
+	svc.mu.Unlock()
+	if svc.Ready("s1") {
+		t.Error("a draft under a minute old was already treated as abandoned")
+	}
+
+	svc.mu.Lock()
+	sess.draftAt = time.Now().Add(-61 * time.Second)
+	svc.mu.Unlock()
+	if !svc.Ready("s1") {
+		t.Error("a draft nobody touched for over a minute still held the prompt")
+	}
+}
+
+func TestEscapeSpan(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want int
+		done bool
+	}{
+		{"csi arrow", "\x1b[A", 3, true},
+		{"csi mouse report", "\x1b[<35;42;7M", 11, true},
+		{"csi with a tail after it", "\x1b[Bx", 3, true},
+		{"ss3 function key", "\x1bOP", 3, true},
+		{"alt and a letter", "\x1bv", 2, true},
+		{"truncated csi", "\x1b[<35;10", 8, false},
+		{"escape alone", "\x1b", 1, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, done := escapeSpan([]byte(c.in))
+			if got != c.want || done != c.done {
+				t.Errorf("escapeSpan(%q) = %d, %v; want %d, %v", c.in, got, done, c.want, c.done)
+			}
+		})
+	}
+}
+
+// An ESC that never ends is not a sequence: what comes after it is typing, and
+// holding it back forever would leave the relay pasting into a line that has a
+// paragraph of the user's on it.
+func TestAnEscapeThatNeverEndsDoesNotSwallowTyping(t *testing.T) {
+	svc, _ := settled(t)
+
+	svc.noteInput("s1", []byte("\x1b[0123456789012345678901234567890123456789"))
+	svc.noteInput("s1", []byte("and then a real sentence"))
+	if svc.Ready("s1") {
+		t.Error("typing after an unterminated escape was discarded")
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -130,6 +130,13 @@ type session struct {
 	// is waiting on input. Both guarded by the service's mu.
 	lastOut time.Time
 	ready   bool
+	// draftAt is when the user last typed something at this prompt without
+	// sending it, and zero when there is nothing of theirs on the line.
+	// escPending is the beginning of an escape sequence a PTY write split, held
+	// until the rest of it arrives. Both guarded by the service's mu. See
+	// draft.go.
+	draftAt    time.Time
+	escPending []byte
 }
 
 // Store is the persistence the terminal service depends on: the binary to spawn
@@ -253,6 +260,7 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 	}
 	ws, err := newTransport(
 		func(id string, data []byte) {
+			s.noteInput(id, data)
 			if err := s.writeBytes(id, data); err != nil {
 				slog.Warn("terminal: input write failed", "session", id, "err", err)
 			}
@@ -710,8 +718,9 @@ func (sess *session) setupEnded(chunk []byte) bool {
 }
 
 // Ready reports whether a session can be given work — whether what reads this
-// PTY is the provider rather than the project's setup script. False for a
-// session that is not running at all.
+// PTY is the provider rather than the project's setup script, and whether the
+// prompt is free rather than half-filled by the person sitting at it. False for
+// a session that is not running at all.
 //
 // Live is not this question. A session whose checkout is still installing its
 // dependencies has a PTY, appears in the roster, and accepts writes that go
@@ -723,6 +732,12 @@ func (s *Service) Ready(id string) bool {
 	defer s.mu.Unlock()
 	sess, ok := s.sessions[id]
 	if !ok || sess.settingUp {
+		return false
+	}
+	// Unlike the rest of this, being ready is not a state a session reaches and
+	// keeps: the user starts typing and the prompt is theirs again until they
+	// send it (see draft.go).
+	if sess.drafting(time.Now()) {
 		return false
 	}
 	if sess.ready {


### PR DESCRIPTION
## The bug

A relayed message — a task from a peer, or the nudge saying results are waiting — is pasted at the target's prompt with an Enter behind it, and that Enter sends the whole line. Arriving while somebody was mid-sentence at that session, it submitted their half-written text together with lich's: both went into the same turn and the user's half was gone, in a place nothing keeps a copy of.

Reported against Claude Code, oh-my-pi and Codex alike, which is what the fix answers to: the mechanism is lich's own paste-and-Enter, so it belongs on the PTY, not per provider.

## The fix

- **`internal/terminal/draft.go`** (new) tracks whether the user has unsent input at a prompt, from the bytes going in: printable input since the last Enter marks a draft, `\r`/`\n`/Ctrl+C clears it. Escape sequences are skipped — with mouse tracking on, every pointer movement arrives as input and its parameters are digits, which read as typing would hold a prompt forever. A sequence split across two PTY writes is carried rather than counted. Only the frontend's keystrokes come through here; what the relay types goes in through `Write`, and the two paths were already separate.
- **`Ready`** answers this alongside the setup-script question it already answered. Unlike the rest of it, this part is not a latch: the prompt goes back to being the user's every time they type.
- **`deliver`** waits for a free prompt before its two writes. Every write this package makes goes through it, so one gate covers the task, the nudge and the retry — and unlike a check per call site, it leaves no window open between the check and the write.
- A draft lich cannot see cleared **goes stale after a minute**. Without that, an edit it cannot read as one (Ctrl+W, a click into the middle of the line) would wedge the relay into that session silently. With it, the worst case is a delayed delivery, never a failed one — and `defaultDeliveryLimit` drops from 10 to 5 minutes, still an order above what a stale draft can spend.

`docs/ceilings.md` carries the two gaps that stay open: input arriving in the ~150ms between the paste and its Enter still rides along, and a provider taking keystrokes through anything other than this PTY is invisible here.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test ./...` — 1574 pass
- [x] `go test -race -count=20` on the new tests — no flakes
- [x] `for os in linux darwin windows` build + vet loop clean
- [x] Coverage of the touched packages at 93%
- [x] Type at a session's prompt, have a peer answer, and watch the delivery wait for the Enter