### PR TITLE
fix: close the gaps a backend audit turned up

### DIFF
--- a/internal/agentplugin/omp.go
+++ b/internal/agentplugin/omp.go
@@ -65,18 +65,13 @@ func (s *Service) ompInstall() error {
 	}
 	body := fmt.Sprintf("%s %s v%s — installed by lich, replace with the file from %s\n%s",
 		jsComment, markerName, version, marketplaceRepo, data)
-	path := filepath.Join(extensions, ompFile)
-	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
-		return fmt.Errorf("write %s: %w", path, err)
+	if err := writeFile(filepath.Join(extensions, ompFile), []byte(body), 0o644); err != nil {
+		return err
 	}
 	if registration == nil {
 		return nil
 	}
-	mcp := filepath.Join(dir, ompMCPFile)
-	if err := os.WriteFile(mcp, registration, 0o644); err != nil {
-		return fmt.Errorf("write %s: %w", mcp, err)
-	}
-	return nil
+	return writeFile(filepath.Join(dir, ompMCPFile), registration, 0o644)
 }
 
 // ompInstalledVersion reads the version off the marker line lich wrote, or

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -822,9 +822,18 @@ func failureOf(payload []byte, status int) string {
 // waitBudget is how long the client gives a call that blocks on another
 // session: the wait it asked for, plus room for the answer's trip back. A zero
 // timeout means the relay's own default.
+//
+// It is capped at the relay's own bound, and capped in seconds rather than in
+// Duration for the reason relay.waitFor gives: a number past about 9.2e9
+// overflows into a negative Duration, which http.Client reads as a deadline
+// already past — the POST fails on the spot and reports the send as unreachable
+// while the task it carried is being delivered.
 func waitBudget(seconds int) time.Duration {
 	if seconds <= 0 {
 		return relay.DefaultWait + callSlack
+	}
+	if seconds > relay.MaxWaitSeconds {
+		seconds = relay.MaxWaitSeconds
 	}
 	return time.Duration(seconds)*time.Second + callSlack
 }

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -257,7 +257,10 @@ func (t *Table) fetch() (map[string]Rate, error) {
 }
 
 // remoteEntry is the subset of a LiteLLM table entry lich reads. Its other forty
-// fields are ignored, so a change to any of them cannot break this.
+// fields are ignored, so a change to any of them cannot break this. It exists
+// beside Rate only for the JSON names, so its fields are Rate's in order and
+// parseRemote converts rather than copies — a price added to Rate then has one
+// place to be added, not two.
 type remoteEntry struct {
 	Input        float64 `json:"input_cost_per_token"`
 	Output       float64 `json:"output_cost_per_token"`
@@ -279,13 +282,7 @@ func parseRemote(data []byte) (map[string]Rate, error) {
 		if entry.Input == 0 && entry.Output == 0 {
 			continue
 		}
-		rates[model] = Rate{
-			Input:        entry.Input,
-			Output:       entry.Output,
-			CacheRead:    entry.CacheRead,
-			CacheWrite:   entry.CacheWrite,
-			CacheWrite1h: entry.CacheWrite1h,
-		}
+		rates[model] = Rate(entry)
 	}
 	return rates, nil
 }

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -1024,15 +1024,27 @@ func (s *Service) clearAll(tickets []*ticket) {
 	}
 }
 
+// MaxWaitSeconds is MaxWait in the unit every caller states a wait in. Exported
+// because the clamp has to happen before the multiplication that would overflow
+// it, which means every surface taking a number of seconds needs the bound
+// itself rather than the Duration (internal/cli, waitBudget).
+const MaxWaitSeconds = int(MaxWait / time.Second)
+
 // waitFor clamps a caller's requested wait into the supported range.
+//
+// The seconds are clamped before they become a Duration, not after: a Duration
+// is int64 nanoseconds, so a number past about 9.2e9 overflows into a negative
+// one — which reads as shorter than MaxWait and hands back a timer that has
+// already fired, answering a caller that asked to wait longer by not waiting at
+// all.
 func waitFor(seconds int) time.Duration {
 	if seconds <= 0 {
 		return DefaultWait
 	}
-	if d := time.Duration(seconds) * time.Second; d < MaxWait {
-		return d
+	if seconds > MaxWaitSeconds {
+		return MaxWait
 	}
-	return MaxWait
+	return time.Duration(seconds) * time.Second
 }
 
 // sweep drops tickets nobody answered in time and returns them, so the caller

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -205,26 +205,13 @@ func (s *Service) Open(fromID, projectName, kind, worktree, base, model string) 
 	label := fmt.Sprintf("Session %d", target.NextSeq)
 	setup := false
 	if worktree != "" {
-		// An existing checkout is opened, not created: asking for a worktree by
-		// the branch it holds is asking to work on that branch, and a caller
-		// that cannot see the repository has no way to know which of the two it
-		// is asking for. Only a fresh one runs the setup script — the checkout
-		// that is already there ran it when it was made.
-		if path, ok := s.checkoutAt(target, worktree); ok {
-			cwd, stored, setup = path, path, false
-		} else {
-			wt, err := s.addWorktree(target, worktree, base)
-			if err != nil {
-				return Session{}, err
-			}
-			cwd, stored, setup = wt.Path, wt.Path, true
+		found, err := s.resolveCheckout(target, worktree, base)
+		if err != nil {
+			return Session{}, err
 		}
-		// The card is named after the checkout, as the window names it — unless
-		// a session there already took that name. Two live sessions answering to
-		// one label is the one thing `lich send` cannot resolve, so the second
-		// falls back to the project's own counter.
-		if !labelTaken(target, worktree) {
-			label = worktree
+		cwd, stored, setup = found.path, found.path, found.fresh
+		if found.label != "" {
+			label = found.label
 		}
 	}
 
@@ -258,17 +245,66 @@ func (s *Service) Open(fromID, projectName, kind, worktree, base, model string) 
 	}
 	// After the card, for that same reason: the model is an override on a row
 	// that already exists, so a write that fails must not be what hides the
-	// session. The spawn below reads the model back from the row, so a failure
-	// here costs the provider's default and nothing else.
+	// session — and must not cost it its terminal either. A card with no PTY
+	// behind it is invisible to `lich sessions` and unreachable by `lich send`,
+	// which is the state this package exists to prevent; the spawn below reads
+	// the model back from the row, so the session starts on the provider's own
+	// default and the failure is reported once it is running.
+	var modelErr error
 	if model != "" {
 		if err := s.sessions.SetSessionModel(id, model); err != nil {
-			return Session{}, err
+			modelErr = fmt.Errorf(
+				"session %q is open, but the model could not be recorded, so it runs on the "+
+					"provider's own default: %w",
+				label, err,
+			)
 		}
 	}
 	if err := s.term.Start(id, target.ID, cwd, kind, "", opened.Name, setup, startCols, startRows); err != nil {
 		return Session{}, fmt.Errorf("session %q was created but its terminal did not start: %w", label, err)
 	}
+	if modelErr != nil {
+		return Session{}, modelErr
+	}
 	return opened, nil
+}
+
+// checkout is the worktree a session is being opened in: where it lives,
+// whether it was just created, and what the card should be called — empty when
+// the branch's name is already taken and the caller should fall back to the
+// project's own counter.
+type checkout struct {
+	path  string
+	fresh bool
+	label string
+}
+
+// resolveCheckout settles the worktree a session is opened in: the one already
+// holding that branch, or a new one created off base.
+//
+// An existing checkout is opened, not created: asking for a worktree by the
+// branch it holds is asking to work on that branch, and a caller that cannot
+// see the repository has no way to know which of the two it is asking for. Only
+// a fresh one runs the setup script — the checkout that is already there ran it
+// when it was made.
+//
+// The card is named after the checkout, as the window names it — unless a
+// session there already took that name. Two live sessions answering to one
+// label is the one thing `lich send` cannot resolve, so the second is left
+// unnamed here and takes the project's counter instead.
+func (s *Service) resolveCheckout(target store.Project, worktree, base string) (checkout, error) {
+	label := worktree
+	if labelTaken(target, worktree) {
+		label = ""
+	}
+	if path, ok := s.checkoutAt(target, worktree); ok {
+		return checkout{path: path, label: label}, nil
+	}
+	wt, err := s.addWorktree(target, worktree, base)
+	if err != nil {
+		return checkout{}, err
+	}
+	return checkout{path: wt.Path, fresh: true, label: label}, nil
 }
 
 // addWorktree creates the checkout a worktree session lives in.

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -360,9 +360,11 @@ func TestOpenRecordsTheModelOnTheRow(t *testing.T) {
 // The model is written after the card is announced, and this is why: a row with
 // no card is a session the user cannot reach to see what went wrong, so the one
 // write that can fail after the row exists must not be what hides it. The model
-// is an override — losing it costs the provider's default and nothing more.
+// is an override — losing it costs the provider's default and nothing more,
+// which means the terminal still starts: a card with no PTY behind it is
+// invisible to `lich sessions` and unreachable by `lich send`.
 func TestOpenAnnouncesTheCardEvenWhenTheModelCannotBeRecorded(t *testing.T) {
-	svc, sessions, _, _, events := newService(t)
+	svc, sessions, _, term, events := newService(t)
 	sessions.modelErr = errors.New("database is locked")
 
 	if _, err := svc.Open("s1", "", "claude", "", "", "opus"); err == nil {
@@ -373,6 +375,14 @@ func TestOpenAnnouncesTheCardEvenWhenTheModelCannotBeRecorded(t *testing.T) {
 	}
 	if len(events.events) != 1 || events.events[0].name != OpenedEventName {
 		t.Errorf("events = %+v, want the card announced for the row that exists", events.events)
+	}
+	if len(term.spawns) != 1 {
+		t.Fatalf("spawned %d terminals, want the session started on the provider's default",
+			len(term.spawns))
+	}
+	if term.spawns[0].id != sessions.rows[0].sessionID {
+		t.Errorf("spawned %q, want the session that was written (%q)",
+			term.spawns[0].id, sessions.rows[0].sessionID)
 	}
 }
 

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -74,17 +74,23 @@ func (s *Service) CloseProject(id string) error {
 // binary overrides with nothing in the UI saying where they came from. An empty
 // id is refused for the same reason — it is the global scope, and deleting a
 // project must never take every global setting with it.
+//
+// Both deletes are one transaction: the settings are only orphaned once the
+// project they belong to is gone, so a failure between them would leave the row
+// standing with its provider, gh account and binary overrides silently wiped.
 func (s *Service) DeleteProject(id string) error {
 	if id == globalScope {
 		return fmt.Errorf("delete project: empty id")
 	}
-	if _, err := s.db.Exec(`DELETE FROM settings WHERE project_id = ?`, id); err != nil {
-		return fmt.Errorf("delete project settings %q: %w", id, err)
-	}
-	if _, err := s.db.Exec(`DELETE FROM projects WHERE id = ?`, id); err != nil {
-		return fmt.Errorf("delete project %q: %w", id, err)
-	}
-	return nil
+	return s.tx(func(tx *sql.Tx) error {
+		if _, err := tx.Exec(`DELETE FROM settings WHERE project_id = ?`, id); err != nil {
+			return fmt.Errorf("delete project settings %q: %w", id, err)
+		}
+		if _, err := tx.Exec(`DELETE FROM projects WHERE id = ?`, id); err != nil {
+			return fmt.Errorf("delete project %q: %w", id, err)
+		}
+		return nil
+	})
 }
 
 // AddSession inserts a session, makes it the project's active one and records the

--- a/internal/terminal/search.go
+++ b/internal/terminal/search.go
@@ -19,9 +19,8 @@ const minSearchQuery = 3
 // the search is re-run as the user types; the bound is what keeps a keystroke
 // from turning into a full disk read per session.
 //
-// ponytail: the ceiling means a mention old enough to have fallen out of the
-// tail is not found. Indexing is the fix if that ever bites — not a bigger
-// number.
+// Ceiling: a mention old enough to have fallen out of the tail is not found.
+// Indexing is the fix if that ever bites — not a bigger number.
 const searchTailBytes = 4 << 20
 
 // snippetWidth is how many runes of the matched message the palette row shows.

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -471,10 +471,33 @@ func parseSessionStart(body []byte) (startRequest, error) {
 	if req.ProviderSessionID == "" {
 		return startRequest{}, errors.New("session-start missing provider_session_id")
 	}
+	if !opaqueID(req.ProviderSessionID) {
+		return startRequest{}, fmt.Errorf(
+			"session-start has an unusable provider_session_id %q", req.ProviderSessionID)
+	}
 	if !providers.Known(req.Provider) {
 		return startRequest{}, fmt.Errorf("session-start has unknown provider %q", req.Provider)
 	}
 	return req, nil
+}
+
+// opaqueID reports whether a provider's conversation id is the opaque token
+// every provider actually reports — a UUID, or something spelled like one.
+//
+// It is checked here, at the only door such an id comes through, because
+// downstream it is pasted into a filesystem glob: the transcript a conversation
+// is read from is located by joining the id onto the harness's directory and
+// globbing what lich cannot reconstruct (transcript.go). A path separator there
+// climbs out of that directory — "../../../../etc/passwd" resolves to a real
+// path — and a glob metacharacter widens the pattern until it matches somebody
+// else's conversation, whose text the palette search would then show and whose
+// tokens the cost readout would bill to this session.
+//
+// Spelled as the characters that make an id something other than a token,
+// rather than as one provider's id format: five providers report these and each
+// picks its own shape.
+func opaqueID(id string) bool {
+	return !strings.ContainsAny(id, `/\*?[]`) && !strings.Contains(id, "..")
 }
 
 // titleRequest is an ai-title POST body.

--- a/internal/terminal/transport_test.go
+++ b/internal/terminal/transport_test.go
@@ -411,6 +411,30 @@ func TestParseSessionStart(t *testing.T) {
 			`{"session_id":"s1","provider_session_id":"uuid-1","provider":"gemini"}`,
 			"", "", "", true},
 		{"bad json", `{`, "", "", "", true},
+		// A provider session id is pasted into a filesystem glob to find that
+		// conversation's transcript, so an id that is not an opaque token is
+		// refused here rather than reaching it: a separator climbs out of the
+		// harness directory, and a metacharacter widens the pattern onto
+		// somebody else's conversation.
+		{"traversing provider id",
+			`{"session_id":"s1","provider_session_id":"../../../../etc/passwd"}`,
+			"", "", "", true},
+		{"windows traversing provider id",
+			`{"session_id":"s1","provider_session_id":"..\\..\\secrets"}`,
+			"", "", "", true},
+		{"wildcard provider id", `{"session_id":"s1","provider_session_id":"*"}`, "", "", "", true},
+		{"character class provider id",
+			`{"session_id":"s1","provider_session_id":"uuid-[ab]"}`,
+			"", "", "", true},
+		{"question mark provider id",
+			`{"session_id":"s1","provider_session_id":"uuid-?"}`,
+			"", "", "", true},
+		{"legacy field is checked too",
+			`{"session_id":"s1","claude_session_id":"../../etc/passwd"}`,
+			"", "", "", true},
+		{"a dot inside an id is not a traversal",
+			`{"session_id":"s1","provider_session_id":"ses.2026-08-17.a1b2"}`,
+			"s1", "ses.2026-08-17.a1b2", "claude", false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/terminal/usage_claude.go
+++ b/internal/terminal/usage_claude.go
@@ -30,8 +30,10 @@ func windowForModel(model string, tokens int) int {
 // assistant message. One JSONL line (a single message, tool results and all) can
 // run to tens of KB, so this holds several — the read stays O(tail), not
 // O(file), yet still reaches the last assistant line past a couple of large user
-// turns. ponytail: a turn larger than this whole window makes the read miss and
-// the readout keep its prior number — widen it then, nothing breaks.
+// turns.
+//
+// Ceiling: a turn larger than this whole window makes the read miss and the
+// readout keep its prior number — widen it then, nothing breaks.
 const usageTailBytes = 512 * 1024
 
 // contextUsage is one provider conversation's context-window occupancy.


### PR DESCRIPTION
A read of the whole Go backend — 219 files, ~19k lines of source — against
correctness, test coverage, complexity, magic values and dead code. What it
found, in the order it matters.

## Fixed

**A provider session id reached a filesystem glob unchecked.** The transcript a
conversation is read from is located by joining that id onto the harness
directory and globbing what lich cannot reconstruct, and `/session-start` only
ever checked the id for being non-empty. A separator climbed out of that
directory (`../../../../etc/passwd` resolves to a real path) and a glob
metacharacter widened the pattern onto whichever conversation matched first —
whose text the palette search would show, and whose tokens the cost readout
would bill to this session. The id is now required to be the opaque token every
provider actually reports, checked beside the state and provider checks that are
there for the same reason.

**A session whose model could not be recorded never got its terminal.** The
model write sits between the card and the spawn so a failed write cannot hide
the session; it returned early, so the PTY never started and the card had
nothing behind it — invisible to `lich sessions`, unreachable by `lich send`.
The comment above it already claimed the failure cost the provider's default and
nothing else. Now it does.

**Deleting a project could wipe its settings and keep the row.** Two bare
statements in a file where every other multi-statement mutation is a
transaction; a failure between them left the project standing with its provider,
gh account and binary overrides gone.

**A wait past ~9.2e9 seconds wrapped negative.** Both clamps multiplied before
comparing, so an absurd `--timeout` produced a timer that had already fired and
an `http.Client` deadline in the past: the caller was told the send never
reached lich while the task was being typed at the target's prompt.

**oh-my-pi's plugin was written non-atomically.** The one install path still
calling `os.WriteFile` directly, for a module omp imports that carries lich's
version marker on its first line — a write cut short still loads and still
declares itself whole.

## Changed

`spawn.Open` was 107 lines with a nested branch deciding the checkout, the setup
flag and the card's label at once; that block is now `resolveCheckout`. Two
ceiling comments took the `Ceiling:` label the same note carries in `pr.go`,
`prthreads.go` and `system.go`. `parseRemote` converts `remoteEntry` to `Rate`
instead of restating its five fields.

## Not changed

No `CHANGELOG.md` entry. None of these is something a user of a published
version lived: each needs a failing SQLite write, an absurd flag value, or a
plugin reporting a malformed id. Say the word if you want one anyway.

Came back clean: no dead code anywhere in the backend (`unused`), no function
over the cognitive-complexity bar (`gocognit`), every unexplained literal
already a named constant with its reason written.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test ./...` — 1581 pass across 30 packages (was 1574; seven new cases
      pin the ids `/session-start` must refuse, including the traversal and the
      wildcard, and one that must still be accepted)
- [x] `go test -race` clean on the seven packages touched
- [x] `for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done`
- [x] Coverage held at 88.5%
- [x] Frontend untouched — no JSON tag moved, so `api-types.ts` still matches