### PR TITLE
chore: cut v0.35.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.1] - 2026-08-17
+
 ### Fixed
 
 - **A relayed message no longer sends the sentence you were typing with it.** A
@@ -2756,7 +2758,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.35.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.35.1...HEAD
+[0.35.1]: https://github.com/omartelo/lich/compare/v0.35.0...v0.35.1
 [0.35.0]: https://github.com/omartelo/lich/compare/v0.34.0...v0.35.0
 [0.34.0]: https://github.com/omartelo/lich/compare/v0.33.0...v0.34.0
 [0.33.0]: https://github.com/omartelo/lich/compare/v0.32.0...v0.33.0


### PR DESCRIPTION
Move the `[Unreleased]` entries under a `v0.35.1` heading and refresh the compare
links. No other file moves: the version is read from the git tag, so
`build/linux/nfpm/nfpm.yaml` is left alone, and nothing since v0.35.0 changed a
claim either README makes.

Both entries are fixes — a relayed message no longer taking the sentence you were
typing with it (#307), and a dragged session card staying visible and opaque
(#306) — so this is a patch release. The other three commits since v0.35.0 are
the two audit sweeps (#308, #309) and the CLAUDE.md/docs split (#305), none of
which a user of a published version lived through.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test -race ./...` — 1581 passed in 30 packages
- [x] `biome check` clean (same 15 diagnostics as `main`, none new)
- [x] `vitest run` — 957 passed in 84 files
- [x] `tsc -b` clean, `vite build` succeeds