### PR TITLE
Plan usage, one footer ladder, and a binary setting that answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **How much of your plan is left, without leaving lich.** Claude Code and Codex
+  both report what a subscription has spent of its rolling windows, and lich now
+  reads it: the footer carries the window closest to running out beside the
+  context ring — `5h 2%`, `wk 84%` — with every window, its share and its reset
+  time behind the tooltip. Each provider's own settings section opens with the
+  same reading in full, including the weekly caps Anthropic scopes to a single
+  model. Windows are named by the length the provider reports, so a Codex free
+  plan's 30-day window is labelled as one rather than mistaken for the five-hour
+  one a paid plan reports in its place.
+
+  lich reads the login its provider's CLI already wrote and never refreshes or
+  rewrites it — token rotation stays with the CLI that owns it. A rejected token
+  reads as signed out, with the command that fixes it. opencode, oh-my-pi and
+  Crush run on your own API keys, where there is no plan to meter, so they are
+  absent from the block rather than shown empty.
+
+### Changed
+
+- **The binary setting says which binary, and whether it is there.** *Custom
+  path* and *Override for <project>* were two fields and a sentence about
+  inheritance, and neither said what a session would actually spawn — a typo sat
+  there until a terminal refused to start. A provider's section now opens with
+  the answer: the executable a session here would run, where it came from, and a
+  tick that it exists and can be executed. **Use a different binary** unfolds the
+  whole resolution — this project, all projects, `$PATH` — in the order lich
+  reads it, with the layer that wins marked and the others shown as overridden.
+  Paths can be picked from a file dialog rather than typed.
+
+  It also names the two mistakes a shell would have hidden, because lich spawns
+  the binary directly: a leading `~` is never expanded, and a relative path means
+  a different binary in every session. A layer that resolves to nothing runnable
+  unfolds the block by itself.
+
+- **The two footer switches are one ladder.** *Model & context in the footer* and
+  *Session cost in the footer* asked the same question twice and left you to
+  assemble the answer; Claude Code's settings now offer **Nothing · Model &
+  context · And cost**, in the same shape as the permission ladder above it, with
+  a line under it saying what each rung puts on screen. The spend ceiling still
+  appears with the rung that shows a cost. Nothing needs setting again: an
+  install already showing both reads as the top rung, one showing neither as the
+  bottom.
+
 ## [0.35.1] - 2026-08-17
 
 ### Fixed

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -72,3 +72,11 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   `internal/terminal/transcript.go`, resolving it independently as the Claude Code pair do): `OMP_PROFILE` moves
   the whole directory and beats an explicit `PI_CODING_AGENT_DIR`. Get it backwards and the install lands where omp
   is not reading and every restored card silently starts fresh.
+- **The plan gauge answers to two undocumented endpoints, and only two providers have one**
+  (`internal/quota`): Claude Code's and Codex's usage routes are what their own CLIs poll, not published API. A
+  field renamed upstream drops the window it fed rather than raising anything — an entry lich has no name for is
+  skipped in silence, so a new kind of limit is invisible instead of wrong. The other three providers run on the
+  user's own API keys and can never report a plan, so the readout is provider-asymmetric by design. lich reads
+  those logins and never writes them: it does not refresh the token, so an expired one reads as signed out until
+  the provider's own CLI rotates it. A reading is cached for five minutes because both endpoints rate-limit hard —
+  the number on screen is up to that old, and nothing on it says so.

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react"
+import type { ReactNode } from "react"
 import { useNavigate } from "react-router-dom"
 import { openPulls } from "@/lib/pulls-card-store"
 import { toast } from "sonner"
@@ -21,32 +21,14 @@ import { displayPath } from "@/lib/paths"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { usePullRequest } from "@/lib/pulls/use-pull-request"
 import { useSettings } from "@/providers/settings"
+import { useNow } from "@/lib/use-now"
 import { cn } from "@/lib/utils"
 import { DiffStat } from "./DiffStat"
 import { ContextRing, usageColor } from "./ContextRing"
+import { PlanQuota } from "./PlanQuota"
 import { SessionModel } from "./SessionModel"
 import { Separator } from "@/components/ui/separator"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
-
-const MINUTE_MS = 60_000
-
-// The readout is HH:MM, so it is scheduled on the minute rather than on a fixed
-// interval: a 10s tick spent five of every six renders redrawing the same
-// string, and still showed a minute that could be ten seconds stale.
-function useNow(): Date {
-  const [now, setNow] = useState(() => new Date())
-  useEffect(() => {
-    let timer = 0
-    const tick = () => {
-      const at = new Date()
-      setNow(at)
-      timer = window.setTimeout(tick, MINUTE_MS - (at.getTime() % MINUTE_MS))
-    }
-    timer = window.setTimeout(tick, MINUTE_MS - (Date.now() % MINUTE_MS))
-    return () => window.clearTimeout(timer)
-  }, [])
-  return now
-}
 
 const two = (n: number): string => String(n).padStart(2, "0")
 
@@ -102,7 +84,7 @@ interface FooterBarProps {
 // shows its checkout's path, branch and diff.
 export function FooterBar({ dock, onDock }: FooterBarProps) {
   const navigate = useNavigate()
-  const { projectId, sessionId, path, checkout } = useActiveSession()
+  const { projectId, sessionId, path, checkout, kind } = useActiveSession()
   // Context-window occupancy of the active session, read off its transcript at
   // each turn's end (null until the first turn of a Claude session lands).
   const usage = useSessionUsage(sessionId)
@@ -246,6 +228,7 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
 
       <span className="ml-auto flex items-center gap-4">
         {showContextUsage && <SessionModel sessionId={sessionId} />}
+        <PlanQuota kind={kind} />
         {costReadout}
         {contextReadout}
         {(contextReadout || costReadout) && (status?.branch || path) && (

--- a/frontend/src/components/PlanQuota.tsx
+++ b/frontend/src/components/PlanQuota.tsx
@@ -1,0 +1,58 @@
+import { Gauge } from "lucide-react"
+import { hottestWindow, shortWindow } from "@/lib/quota/quota-format"
+import { usePlanQuotaFor } from "@/lib/quota/use-plan-quota"
+import type { SessionKind } from "@/lib/session/sessions"
+import { useNow } from "@/lib/use-now"
+import { cn } from "@/lib/utils"
+import { usageColor } from "./ContextRing"
+import { QuotaGauge } from "./QuotaGauge"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+
+interface PlanQuotaProps {
+  /** Which provider the active session runs; "" when none is active. */
+  kind: SessionKind | ""
+}
+
+// PlanQuota is the footer's plan-usage slot: how much of the active session's
+// subscription is spent, with every window behind a tooltip. Self-contained like
+// SessionModel — it resolves its own reading from the provider id.
+//
+// One window is shown, and it is the fullest one: a weekly cap about to run out
+// must not hide behind a session window that reset an hour ago. Nothing renders
+// at all for a provider that meters no subscription, or while the reading is
+// signed out or failed — the Settings screen is where a login is fixed, and a
+// status strip is the wrong place to be told to run a command.
+export function PlanQuota({ kind }: PlanQuotaProps) {
+  const plan = usePlanQuotaFor(kind || undefined)
+  const now = useNow()
+  const hottest = plan && plan.status === "ok" ? hottestWindow(plan) : null
+  if (!plan || !hottest) {
+    return null
+  }
+  const length = shortWindow(hottest.seconds)
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <span
+            className={cn("flex items-center gap-1.5 tabular-nums", usageColor(hottest.percent))}
+          />
+        }
+      >
+        <Gauge className="size-3.5 shrink-0" aria-hidden="true" />
+        {length && <span className="opacity-70">{length}</span>}
+        {hottest.percent}%
+      </TooltipTrigger>
+      <TooltipContent side="top" className="border border-border bg-card text-foreground">
+        <div className="flex min-w-52 flex-col gap-2.5">
+          <span className="font-medium">
+            {plan.plan ? `${plan.name} · ${plan.plan}` : plan.name}
+          </span>
+          {(plan.windows ?? []).map((w) => (
+            <QuotaGauge key={w.label} window={w} now={now} stacked />
+          ))}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/frontend/src/components/QuotaGauge.tsx
+++ b/frontend/src/components/QuotaGauge.tsx
@@ -1,0 +1,64 @@
+import type { QuotaWindow } from "@/lib/api-types"
+import { formatWindow, timeLeft } from "@/lib/quota/quota-format"
+import { cn } from "@/lib/utils"
+import { usageColor } from "./ContextRing"
+
+// Every column is fixed but the bar's. Sized to its own text, the readout gave a
+// window with no reset time the width the rows beside it spent on "6d 18h", and
+// three gauges of the same thing ended at three different places. The bar is the
+// only thing here whose length means something, so it is the only one that
+// varies — and the header row shares this grid so the columns line up with it.
+export const gaugeGrid = "grid grid-cols-[7rem_minmax(0,1fr)_2.5rem_4rem] items-center gap-x-3"
+
+interface QuotaGaugeProps {
+  window: QuotaWindow
+  /** Wall clock, so the time to reset re-reads on the minute with everything
+   * else on screen rather than on a timer of its own. */
+  now: Date
+  /** Stack the label over the bar, for the narrow column a tooltip has. The
+   * settings screen has the width to put them on one line. */
+  stacked?: boolean
+}
+
+// QuotaGauge is one metered window: how full it is, and how long until it starts
+// over. It takes the colour ramp the context ring and the cost readout use, so a
+// window three-quarters spent reads the same everywhere.
+//
+// The prop is renamed on the way in: `window` is the global every browser
+// module already has, and shadowing it inside a component is a trap for the
+// next edit that reaches for a timer.
+export function QuotaGauge({ window: quota, now, stacked }: QuotaGaugeProps) {
+  const length = formatWindow(quota.seconds)
+  const left = timeLeft(quota.resetsAt, now)
+  const label = length ? `${quota.label} · ${length}` : quota.label
+  const bar = (
+    <span className="h-1.5 overflow-hidden rounded-full bg-muted">
+      <span
+        className="block h-full rounded-full bg-current"
+        style={{ width: `${quota.percent}%` }}
+      />
+    </span>
+  )
+
+  if (stacked) {
+    return (
+      <div className={cn("flex flex-col gap-1 text-xs", usageColor(quota.percent))}>
+        <div className="flex items-baseline justify-between gap-3">
+          <span className="text-muted-foreground">{label}</span>
+          <span className="tabular-nums">
+            {quota.percent}%{left && ` · ${left}`}
+          </span>
+        </div>
+        {bar}
+      </div>
+    )
+  }
+  return (
+    <div className={cn(gaugeGrid, "text-xs", usageColor(quota.percent))}>
+      <span className="truncate text-muted-foreground">{label}</span>
+      {bar}
+      <span className="text-right tabular-nums">{quota.percent}%</span>
+      <span className="text-right tabular-nums text-muted-foreground">{left}</span>
+    </div>
+  )
+}

--- a/frontend/src/components/settings/PlanUsageSetting.tsx
+++ b/frontend/src/components/settings/PlanUsageSetting.tsx
@@ -1,0 +1,81 @@
+import type { QuotaPlan } from "@/lib/api-types"
+import { usePlanQuotaFor } from "@/lib/quota/use-plan-quota"
+import { useNow } from "@/lib/use-now"
+import { QuotaGauge, gaugeGrid } from "@/components/QuotaGauge"
+import { cn } from "@/lib/utils"
+import { SettingBlock } from "./SettingBlock"
+
+// How each provider's login is redone, for the reading that has none. Both are
+// the provider's own command: lich reads the credentials those write and never
+// refreshes them itself, so a signed-out reading is only fixed there.
+const loginCommand: Record<string, string> = {
+  claude: "claude",
+  codex: "codex login",
+}
+
+// PlanUsageSetting shows what is left of one provider's subscription, inside
+// that provider's own settings section. Absent for a provider that meters
+// nothing — opencode, oh-my-pi and Crush run on the user's own API keys, where
+// there is no plan to report — and until the first reading lands.
+export function PlanUsageSetting({ providerId }: { providerId: string }) {
+  const plan = usePlanQuotaFor(providerId)
+  const now = useNow()
+  if (!plan) {
+    return null
+  }
+  return (
+    <SettingBlock
+      title="Plan usage"
+      description="How much of each window your subscription has spent, read from your account and refreshed every 5 minutes while lich is open."
+    >
+      <PlanBody plan={plan} now={now} />
+    </SettingBlock>
+  )
+}
+
+function PlanBody({ plan, now }: { plan: QuotaPlan; now: Date }) {
+  if (plan.status === "signed-out") {
+    const command = loginCommand[plan.provider]
+    return (
+      <p className="text-xs text-muted-foreground">
+        Signed out.
+        {command && (
+          <>
+            {" Run "}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono text-foreground">
+              {command}
+            </code>
+            {" to read plan usage."}
+          </>
+        )}
+      </p>
+    )
+  }
+  if (plan.status === "error") {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Could not read plan usage. The provider's usage endpoint is undocumented and may have
+        changed.
+      </p>
+    )
+  }
+  return (
+    <div className="flex max-w-prose flex-col gap-2">
+      {/* The plan doubles as the table's left header, which is what keeps it from
+          floating above the rows as a line of its own. */}
+      <div
+        className={cn(gaugeGrid, "text-[11px] uppercase tracking-wide text-muted-foreground/80")}
+      >
+        <span className="truncate normal-case tracking-normal text-muted-foreground">
+          {plan.plan}
+        </span>
+        <span />
+        <span className="text-right">used</span>
+        <span className="text-right">resets</span>
+      </div>
+      {(plan.windows ?? []).map((window) => (
+        <QuotaGauge key={window.label} window={window} now={now} />
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -1,27 +1,49 @@
 import { useEffect, useState } from "react"
 import { Store } from "@/lib/rpc"
-import { useProjects } from "@/providers/projects"
 import {
-  binKey,
+  footerReadout,
+  footerReadoutPair,
   skipLevel,
   skipLevelPair,
   skipPermissionFlags,
   skipPermissionsKey,
+  type FooterReadout,
   type SkipLevel,
 } from "@/lib/providers-store"
 import { useSettings } from "@/providers/settings"
 import { setCostReadout } from "@/lib/cost-readout-store"
 import { useCostReadout } from "@/lib/use-cost-readout"
 import { Input } from "@/components/ui/input"
-import { Switch } from "@/components/ui/switch"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { PlanUsageSetting } from "./PlanUsageSetting"
+import { ProviderBinary } from "./ProviderBinary"
 import { SettingBlock } from "./SettingBlock"
 
 const GLOBAL_SCOPE = ""
 
-// The ladder as the user reads it: the rung's label, and what the rung leaves
-// asking. The second line is the half of the answer the two switches made
-// people assemble in their heads.
+// Each rung says what lands in the footer, and the line under it says what that
+// means — the half of the answer the two switches made people assemble in their
+// heads.
+const FOOTER_READOUTS: { level: FooterReadout; label: string; consequence: string }[] = [
+  {
+    level: "off",
+    label: "Nothing",
+    consequence: "The footer keeps only the branch, the path and the clock.",
+  },
+  {
+    level: "context",
+    label: "Model & context",
+    consequence: "The model a session runs, and a ring showing how full its context window is.",
+  },
+  {
+    level: "cost",
+    label: "And cost",
+    consequence:
+      "Plus what the session has cost at API prices, summed from its transcript. That figure only means something when you are billed per token, not on a subscription.",
+  },
+]
+
+// The same shape for how far the provider runs without asking, ordered by risk.
 const SKIP_LEVELS: { level: SkipLevel; label: string; consequence: string }[] = [
   {
     level: "never",
@@ -59,10 +81,10 @@ function useSkipPermissions(providerId: string, worktree: boolean) {
   return [on, toggle] as const
 }
 
-// ProviderBinSettings is the config section a provider gets when enabled: the
-// custom path to its binary or launcher script, as a global default plus an
-// optional per-project override. Empty inherits: project → global → the
-// provider's own name on $PATH. Same keys the Go store resolves (see binKey).
+// ProviderBinSettings is the config section a provider gets when enabled: what
+// its plan has left, which binary its sessions spawn, and how far it runs
+// without asking. Claude Code adds the footer readout, which is the only
+// provider reporting one.
 export function ProviderBinSettings({
   providerId,
   providerName,
@@ -72,13 +94,8 @@ export function ProviderBinSettings({
   providerName: string
   projectId?: string
 }) {
-  const { projects } = useProjects()
   const { showContextUsage, setShowContextUsage, costBudget, setCostBudget } = useSettings()
   const showCost = useCostReadout()
-  const project = projects.find((p) => p.id === projectId)
-  const key = binKey(providerId)
-  const [globalBin, setGlobalBin] = useState("")
-  const [projectBin, setProjectBin] = useState("")
   // The field keeps the raw string so a half-typed "1." survives the keystroke;
   // the stored budget is the parsed value, and an emptied field is no budget.
   const [budget, setBudget] = useState(() => (costBudget > 0 ? String(costBudget) : ""))
@@ -87,6 +104,17 @@ export function ProviderBinSettings({
   const skipFlag = skipPermissionFlags[providerId]
   const level = skipLevel(skipHere, skipInWorktrees)
   const consequence = SKIP_LEVELS.find((rung) => rung.level === level)?.consequence ?? ""
+  const readout = footerReadout(showContextUsage, showCost)
+  const readoutConsequence =
+    FOOTER_READOUTS.find((rung) => rung.level === readout)?.consequence ?? ""
+
+  // One rung writes both settings, for the same reason the permission ladder
+  // does: the pair is the storage, the rung is the choice.
+  const setReadout = (next: FooterReadout) => {
+    const pair = footerReadoutPair(next)
+    setShowContextUsage(pair.context)
+    setCostReadout(pair.cost)
+  }
 
   // One rung writes both keys, always: the pair is the storage, the rung is the
   // choice. Writing only the one that changed would leave the other holding an
@@ -97,96 +125,47 @@ export function ProviderBinSettings({
     setSkipInWorktrees(pair.worktrees)
   }
 
-  useEffect(() => {
-    void Store.GetSetting(key, GLOBAL_SCOPE).then(setGlobalBin)
-  }, [key])
-
-  useEffect(() => {
-    if (!projectId) {
-      return
-    }
-    void Store.GetSetting(key, projectId).then(setProjectBin)
-  }, [key, projectId])
-
-  const persistGlobal = (value: string) => {
-    setGlobalBin(value)
-    void Store.SetSetting(key, GLOBAL_SCOPE, value.trim())
-  }
-
   const persistBudget = (value: string) => {
     setBudget(value)
     setCostBudget(Number(value))
   }
 
-  const persistProject = (value: string) => {
-    setProjectBin(value)
-    if (projectId) {
-      void Store.SetSetting(key, projectId, value.trim())
-    }
-  }
-
   return (
     <>
-      <SettingBlock
-        title="Custom path"
-        description="Path to the binary or a launcher script spawned in each terminal. Leave empty to run it from your $PATH."
-      >
-        <Input
-          value={globalBin}
-          onChange={(event) => persistGlobal(event.target.value)}
-          placeholder={providerId}
-          spellCheck={false}
-          aria-label={`${providerId} custom path`}
-          className="w-96 max-w-full font-mono"
-        />
-      </SettingBlock>
+      {/* What the plan has left comes first: it is the state of this provider,
+          and everything under it is configuration. Renders itself away for a
+          provider that meters no subscription. */}
+      <PlanUsageSetting providerId={providerId} />
 
-      {project && (
-        <SettingBlock
-          title={`Override for ${project.name}`}
-          description="A path used only in this project's terminals. Leave empty to inherit the global custom path."
-        >
-          <p className="mb-2 text-xs text-muted-foreground">{project.path}</p>
-          <Input
-            value={projectBin}
-            onChange={(event) => persistProject(event.target.value)}
-            placeholder={globalBin || providerId}
-            spellCheck={false}
-            aria-label={`${providerId} path for ${project.name}`}
-            className="w-96 max-w-full font-mono"
-          />
-        </SettingBlock>
-      )}
+      <ProviderBinary providerId={providerId} providerName={providerName} projectId={projectId} />
 
       {/* Only Claude Code reports context-window usage (via the lich plugin), so
-          the footer readout toggles live in its section, not the generic hub. */}
+          the footer readout control lives in its section, not the generic hub. */}
       {providerId === "claude" && (
         <>
           <SettingBlock
-            title="Model & context in the footer"
-            description="Show this session's model and context-window usage in the footer — the model name plus a ring with the percent, read from the transcript."
+            title="Session readout in the footer"
+            description="How much of what a session is spending the footer carries, read from its transcript."
           >
-            <Switch
-              checked={showContextUsage}
-              onCheckedChange={setShowContextUsage}
-              aria-label="Show model and context usage in the footer"
-            />
-          </SettingBlock>
-
-          <SettingBlock
-            title="Session cost in the footer"
-            description="Show what each session has cost at API prices, summed from its transcript. Leave this off on a subscription plan — the figure only means something when you are billed per token."
-          >
-            <Switch
-              checked={showCost}
-              onCheckedChange={setCostReadout}
-              aria-label="Show session cost in the footer"
-            />
+            <ToggleGroup
+              value={[readout]}
+              onValueChange={(next) => next[0] && setReadout(next[0] as FooterReadout)}
+              spacing={1}
+              aria-label="What the footer says about the session"
+              className="border border-border p-[3px]"
+            >
+              {FOOTER_READOUTS.map((rung) => (
+                <ToggleGroupItem key={rung.level} value={rung.level} size="sm">
+                  {rung.label}
+                </ToggleGroupItem>
+              ))}
+            </ToggleGroup>
+            <p className="mt-2 max-w-prose text-xs text-muted-foreground">{readoutConsequence}</p>
           </SettingBlock>
 
           {/* A ceiling is only ever seen through the readout, so it is offered
               beside it and hidden with it. */}
-          {showCost && (
+          {readout === "cost" && (
             <SettingBlock
               title="Spend ceiling"
               description="Colour the cost in the footer as a session approaches this many dollars — amber at 80%, red at 95%. It is a warning, not a limit: nothing is stopped, and the figure it watches is API pricing from a table. Leave empty for none."

--- a/frontend/src/components/settings/ProviderBinary.tsx
+++ b/frontend/src/components/settings/ProviderBinary.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useState, type ReactNode } from "react"
+import { Check, ChevronDown, FolderOpen, TriangleAlert, X } from "lucide-react"
+import { toast } from "sonner"
+import type { BinaryCheck } from "@/lib/api-types"
+import { checkDetail, checkLabel, failed, winningScope } from "@/lib/binary-layers"
+import { ProjectService, Store } from "@/lib/rpc"
+import { useBinaryCheck } from "@/lib/use-binary-check"
+import { binKey } from "@/lib/providers-store"
+import { useProjects } from "@/providers/projects"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { SettingBlock } from "./SettingBlock"
+
+const GLOBAL_SCOPE = ""
+
+// ProviderBinary is the "which executable runs" block. Closed it is a fact — the
+// binary a session here would spawn, and whether it is there — because almost
+// nobody sets this and the question they do have is that one. Opening it shows
+// the resolution as it is: the project's override, the global one and $PATH, in
+// the order the spawn reads them, with the winning layer marked. The precedence
+// stops being a sentence to trust and becomes the thing on screen.
+//
+// A layer that resolves to nothing runnable opens the block itself: an error
+// hidden behind a disclosure is an error nobody fixes.
+export function ProviderBinary({
+  providerId,
+  providerName,
+  projectId,
+}: {
+  providerId: string
+  providerName: string
+  projectId?: string
+}) {
+  const { projects } = useProjects()
+  const project = projects.find((p) => p.id === projectId)
+  const key = binKey(providerId)
+  const [globalBin, setGlobalBin] = useState("")
+  const [projectBin, setProjectBin] = useState("")
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    void Store.GetSetting(key, GLOBAL_SCOPE).then(setGlobalBin)
+  }, [key])
+
+  useEffect(() => {
+    if (!projectId) {
+      return
+    }
+    void Store.GetSetting(key, projectId).then(setProjectBin)
+  }, [key, projectId])
+
+  const persistGlobal = (value: string) => {
+    setGlobalBin(value)
+    void Store.SetSetting(key, GLOBAL_SCOPE, value.trim())
+  }
+
+  const persistProject = (value: string) => {
+    setProjectBin(value)
+    if (projectId) {
+      void Store.SetSetting(key, projectId, value.trim())
+    }
+  }
+
+  const scope = winningScope(project ? projectBin : "", globalBin)
+  const configured = scope === "project" ? projectBin.trim() : globalBin.trim()
+  // Both layers go through the same check, so the bottom row answers with the
+  // resolution the spawn would make rather than a second opinion about $PATH.
+  const typed = useBinaryCheck(scope === "path" ? "" : configured)
+  const onPath = useBinaryCheck(providerId)
+  const check = scope === "path" ? onPath : typed
+  const broken = failed(check)
+
+  const browse = async (persist: (value: string) => void) => {
+    try {
+      const file = await ProjectService.PickFile(`Choose the ${providerName} binary`)
+      if (file) {
+        persist(file)
+      }
+    } catch {
+      toast.error("Could not open the file picker")
+    }
+  }
+
+  const layers = [
+    project && {
+      scope: "project" as const,
+      label: `${project.name} only`,
+      value: projectBin,
+      persist: persistProject,
+    },
+    {
+      scope: "global" as const,
+      label: "All projects",
+      value: globalBin,
+      persist: persistGlobal,
+    },
+  ].filter((layer) => layer !== undefined)
+
+  return (
+    <SettingBlock
+      title="Binary"
+      description={
+        project
+          ? `Which executable a session in ${project.name} spawns.`
+          : "Which executable a session spawns."
+      }
+    >
+      {broken || open ? (
+        <>
+          <div className="mb-3 flex items-center justify-between gap-4">
+            <span className="flex items-center gap-1.5 text-xs text-foreground">
+              <ChevronDown className="size-3.5" aria-hidden="true" />
+              Where it comes from — the first layer with a path wins
+            </span>
+            {!broken && (
+              <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
+                Done
+              </Button>
+            )}
+          </div>
+          <div className="flex flex-col divide-y divide-border">
+            {layers.map((layer) => (
+              <Layer
+                key={layer.scope}
+                label={layer.label}
+                wins={scope === layer.scope}
+                check={scope === layer.scope ? check : null}
+                value={layer.value}
+              >
+                <Input
+                  value={layer.value}
+                  onChange={(event) => layer.persist(event.target.value)}
+                  placeholder={providerId}
+                  spellCheck={false}
+                  aria-label={`${providerName} binary for ${layer.label}`}
+                  className="h-8 min-w-0 flex-1 font-mono text-xs"
+                />
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => void browse(layer.persist)}
+                  aria-label={`Pick the ${providerName} binary for ${layer.label}`}
+                >
+                  <FolderOpen className="size-3.5" aria-hidden="true" />
+                  Browse
+                </Button>
+              </Layer>
+            ))}
+            <Layer label="$PATH" wins={scope === "path"} check={onPath} value={providerId}>
+              <span className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">
+                {onPath?.path || providerId}
+              </span>
+            </Layer>
+          </div>
+        </>
+      ) : (
+        <div className="flex items-center justify-between gap-4">
+          <span className="flex min-w-0 items-center gap-2 text-xs">
+            <Verdict check={check} bin={configured || providerId} />
+            <span className="truncate font-mono text-foreground">
+              {check?.path || configured || providerId}
+            </span>
+            <span className="whitespace-nowrap text-muted-foreground">
+              · {sourceLabel(scope, project?.name)}
+            </span>
+          </span>
+          <Button variant="ghost" size="sm" onClick={() => setOpen(true)}>
+            Use a different binary
+          </Button>
+        </div>
+      )}
+
+      {broken && (
+        <p className="mt-3 flex max-w-prose items-start gap-2 text-xs text-destructive">
+          <TriangleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+          {checkDetail(check)}
+        </p>
+      )}
+    </SettingBlock>
+  )
+}
+
+// sourceLabel names where the winning path came from, in the closed state where
+// the layers themselves are not on screen.
+function sourceLabel(scope: string, projectName: string | undefined): string {
+  if (scope === "project") {
+    return projectName ? `set for ${projectName}` : "set for this project"
+  }
+  return scope === "global" ? "set for all projects" : "from $PATH"
+}
+
+// Layer is one row of the resolution stack: the marker, the scope it configures,
+// its control, and — on the winning row alone — what that path resolves to. The
+// losing rows say they are overridden instead, which is the question a second
+// path on screen raises.
+function Layer({
+  label,
+  wins,
+  check,
+  value,
+  children,
+}: {
+  label: string
+  wins: boolean
+  check: BinaryCheck | null
+  value: string
+  children: ReactNode
+}) {
+  return (
+    <div className="flex items-center gap-2.5 py-2">
+      <span
+        className={cn(
+          "size-1.5 shrink-0 rounded-full bg-muted-foreground opacity-30",
+          wins && "opacity-100 bg-foreground",
+          wins && failed(check) && "bg-destructive",
+        )}
+        aria-hidden="true"
+      />
+      <span
+        className={cn("w-28 shrink-0 text-xs text-muted-foreground", wins && "text-foreground")}
+      >
+        {label}
+      </span>
+      {children}
+      {wins ? (
+        <span className="flex items-center gap-1 whitespace-nowrap text-xs">
+          <Verdict check={check} bin={value} />
+          <span className={cn(failed(check) ? "text-destructive" : "text-muted-foreground")}>
+            {checkLabel(check, value)}
+          </span>
+        </span>
+      ) : (
+        <span className="whitespace-nowrap text-xs text-muted-foreground opacity-70">
+          overridden
+        </span>
+      )}
+    </div>
+  )
+}
+
+// Verdict is the glyph beside a path. Nothing is drawn while a check is in
+// flight, so a field being typed into does not blink between states.
+function Verdict({ check, bin }: { check: BinaryCheck | null; bin: string }) {
+  if (!check) {
+    return null
+  }
+  const label = checkLabel(check, bin)
+  if (failed(check)) {
+    return <X className="size-3.5 shrink-0 text-destructive" aria-label={label} />
+  }
+  if (check.status === "ok") {
+    return <Check className="size-3.5 shrink-0 text-emerald-500" aria-label={label} />
+  }
+  return null
+}

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -431,3 +431,30 @@ export interface DetectedProvider {
   installed: boolean
   path: string
 }
+
+/** internal/providers.Check — what a configured binary resolves to. `path` is
+ * the executable a session would spawn, empty for every status but "ok". */
+export interface BinaryCheck {
+  path: string
+  status: "ok" | "empty" | "not-found" | "not-executable" | "home-shortcut" | "relative"
+}
+
+/** internal/quota.Window — one metered window of a subscription: how much of it
+ * is spent, how long it runs (0 when the provider does not say), and when it
+ * starts over (RFC 3339, empty when unreported). */
+export interface QuotaWindow {
+  label: string
+  seconds: number
+  percent: number
+  resetsAt?: string
+}
+
+/** internal/quota.Plan — one provider's quota reading. Windows are empty for
+ * every status other than "ok". */
+export interface QuotaPlan {
+  provider: string
+  name: string
+  plan?: string
+  windows?: QuotaWindow[]
+  status: "ok" | "signed-out" | "error"
+}

--- a/frontend/src/lib/binary-layers.test.ts
+++ b/frontend/src/lib/binary-layers.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+import type { BinaryCheck } from "./api-types"
+import { checkDetail, checkLabel, failed, winningScope } from "./binary-layers"
+
+const check = (status: BinaryCheck["status"], path = ""): BinaryCheck => ({ path, status })
+
+describe("winningScope", () => {
+  it("prefers the project override, then the global one", () => {
+    expect(winningScope("/opt/next/claude", "/opt/claude")).toBe("project")
+    expect(winningScope("", "/opt/claude")).toBe("global")
+    expect(winningScope("", "")).toBe("path")
+  })
+
+  // A field holding spaces is a field nobody filled in — and the Go side trims
+  // before storing, so a value that reached the store this way is whitespace
+  // from an older build.
+  it("treats a whitespace-only value as unset", () => {
+    expect(winningScope("   ", "")).toBe("path")
+    expect(winningScope(" \t ", "/opt/claude")).toBe("global")
+  })
+})
+
+describe("checkLabel", () => {
+  it("says how a missing binary was looked for", () => {
+    expect(checkLabel(check("not-found"), "claude")).toBe("not on $PATH")
+    expect(checkLabel(check("not-found"), "/opt/gone/claude")).toBe("no such file")
+    expect(checkLabel(check("not-found"), "C:\\tools\\claude.exe")).toBe("no such file")
+  })
+
+  it("names the two mistakes a shell would have hidden", () => {
+    expect(checkLabel(check("home-shortcut"), "~/dev/claude")).toBe("~ is not expanded")
+    expect(checkLabel(check("relative"), "bin/claude")).toBe("relative path")
+  })
+
+  it("says nothing for a check that has not arrived or has nothing to report", () => {
+    expect(checkLabel(null, "claude")).toBe("")
+    expect(checkLabel(check("empty"), "")).toBe("")
+  })
+
+  it("confirms a binary that resolves", () => {
+    expect(checkLabel(check("ok", "/usr/bin/claude"), "claude")).toBe("executable")
+  })
+})
+
+describe("checkDetail", () => {
+  it("explains only the states that need fixing", () => {
+    expect(checkDetail(check("home-shortcut"))).toContain("taken literally")
+    expect(checkDetail(check("relative"))).toContain("per session")
+    expect(checkDetail(check("not-found"))).toContain("will not start")
+    expect(checkDetail(check("not-executable"))).toContain("will not start")
+    expect(checkDetail(check("ok"))).toBe("")
+    expect(checkDetail(null)).toBe("")
+  })
+})
+
+describe("failed", () => {
+  // A check in flight is not a failure: drawn as one, a field being typed into
+  // would flash red between keystrokes.
+  it("is false while a check is in flight, and for an unset layer", () => {
+    expect(failed(null)).toBe(false)
+    expect(failed(check("empty"))).toBe(false)
+  })
+
+  it("is true for every state a session cannot spawn from", () => {
+    for (const status of ["not-found", "not-executable", "home-shortcut", "relative"] as const) {
+      expect(failed(check(status))).toBe(true)
+    }
+    expect(failed(check("ok"))).toBe(false)
+  })
+})

--- a/frontend/src/lib/binary-layers.ts
+++ b/frontend/src/lib/binary-layers.ts
@@ -1,0 +1,60 @@
+import type { BinaryCheck } from "./api-types"
+
+// Where a provider's binary can be set, in the order lich resolves it: the
+// project's own override, the global one, then whatever $PATH answers. Mirrors
+// store.ProviderBin (Go), which is what the spawn actually calls.
+export type BinaryScope = "project" | "global" | "path"
+
+// winningScope is the layer a session would spawn from — the first one with a
+// path. Values are compared trimmed, because a field holding only spaces is a
+// field nobody filled in.
+export function winningScope(projectBin: string, globalBin: string): BinaryScope {
+  if (projectBin.trim()) {
+    return "project"
+  }
+  return globalBin.trim() ? "global" : "path"
+}
+
+// checkLabel is the verdict beside a path, in the width a row has. Empty when
+// there is nothing to say — an unset layer is not a failure.
+//
+// A missing binary reads differently depending on what was asked for: a bare
+// name was looked up on $PATH and a path was looked for where it was written.
+export function checkLabel(check: BinaryCheck | null, bin: string): string {
+  switch (check?.status) {
+    case "ok":
+      return "executable"
+    case "not-found":
+      return bin.includes("/") || bin.includes("\\") ? "no such file" : "not on $PATH"
+    case "not-executable":
+      return "not executable"
+    case "home-shortcut":
+      return "~ is not expanded"
+    case "relative":
+      return "relative path"
+    default:
+      return ""
+  }
+}
+
+// checkDetail is the sentence under a failing binary: what will happen, and what
+// to do about it. Empty for a check that passed or has not arrived.
+export function checkDetail(check: BinaryCheck | null): string {
+  switch (check?.status) {
+    case "home-shortcut":
+      return "lich spawns the binary directly, so ~ is taken literally rather than expanded. Use the full path."
+    case "relative":
+      return "A relative path is resolved against each session's own working directory, so it names a different binary per session. Use a full path."
+    case "not-found":
+    case "not-executable":
+      return "Sessions will not start until this is fixed or cleared. Clearing it falls back to the layer below."
+    default:
+      return ""
+  }
+}
+
+// failed reports a check that must be shown as a problem. A check still in
+// flight is not one: the row would flash a failure between keystrokes.
+export function failed(check: BinaryCheck | null): boolean {
+  return check !== null && check.status !== "ok" && check.status !== "empty"
+}

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -5,6 +5,8 @@ import {
   createProvidersStore,
   enabledKey,
   enabledProviders,
+  footerReadout,
+  footerReadoutPair,
   readEnabled,
   resolveDefaultProvider,
   resolveProjectDefaultProvider,
@@ -74,6 +76,34 @@ describe("the skip-permissions ladder", () => {
     for (const level of ["never", "worktrees", "everywhere"] as const) {
       const pair = skipLevelPair(level)
       expect(skipLevel(pair.here, pair.worktrees)).toBe(level)
+    }
+  })
+})
+
+describe("the footer readout ladder", () => {
+  it("folds the stored pair into a rung", () => {
+    expect(footerReadout(false, false)).toBe("off")
+    expect(footerReadout(true, false)).toBe("context")
+    expect(footerReadout(true, true)).toBe("cost")
+  })
+
+  // The pair nothing offers any more: the cost on its own, with no model and no
+  // ring beside it. The cost was always the addition, so it reads as the rung
+  // that carries it.
+  it("reads the pair no rung writes as the cost rung", () => {
+    expect(footerReadout(false, true)).toBe("cost")
+  })
+
+  it("writes both settings for the chosen rung", () => {
+    expect(footerReadoutPair("off")).toEqual({ context: false, cost: false })
+    expect(footerReadoutPair("context")).toEqual({ context: true, cost: false })
+    expect(footerReadoutPair("cost")).toEqual({ context: true, cost: true })
+  })
+
+  it("round-trips every rung", () => {
+    for (const level of ["off", "context", "cost"] as const) {
+      const pair = footerReadoutPair(level)
+      expect(footerReadout(pair.context, pair.cost)).toBe(level)
     }
   })
 })

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -75,6 +75,27 @@ export function skipLevelPair(level: SkipLevel): { here: boolean; worktrees: boo
   return { here: level === "everywhere", worktrees: level !== "never" }
 }
 
+// How much of a session's own accounting the footer carries, as one ladder
+// ordered by how much it says. The two settings keys stay exactly as they are —
+// this is the shape the user chooses in, not the shape lich stores.
+export type FooterReadout = "off" | "context" | "cost"
+
+// footerReadout folds the stored pair into a rung. The fourth combination — the
+// cost without the model and the ring — is a readout nobody chose: the cost
+// setting was always the extra one, offered beside a readout that was already
+// there. It reads as the top rung, and choosing that rung back turns both on.
+export function footerReadout(context: boolean, cost: boolean): FooterReadout {
+  if (cost) {
+    return "cost"
+  }
+  return context ? "context" : "off"
+}
+
+// footerReadoutPair is the inverse: the pair a chosen rung writes back.
+export function footerReadoutPair(level: FooterReadout): { context: boolean; cost: boolean } {
+  return { context: level !== "off", cost: level === "cost" }
+}
+
 // readEnabled interprets the stored flag: Claude is enabled by default (it was
 // always offered before the providers feature), every other provider is opt-in.
 // An explicit "1"/"0" overrides the default.

--- a/frontend/src/lib/quota/plan-quota-store.test.ts
+++ b/frontend/src/lib/quota/plan-quota-store.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { QuotaPlan } from "@/lib/api-types"
+import { createPlanQuotaStore } from "./plan-quota-store"
+
+const reading = (percent: number): QuotaPlan[] => [
+  {
+    provider: "claude",
+    name: "Claude Code",
+    plan: "Max 5x",
+    status: "ok",
+    windows: [{ label: "Session", seconds: 18000, percent }],
+  },
+]
+
+describe("createPlanQuotaStore", () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it("reads once the first subscriber arrives, and shares that reading", async () => {
+    const fetch = vi.fn(async () => reading(2))
+    const store = createPlanQuotaStore(fetch)
+
+    expect(store.getSnapshot()).toEqual([])
+    const a = store.subscribe(() => {})
+    const b = store.subscribe(() => {})
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    expect(store.getSnapshot()).toEqual(reading(2))
+    a()
+    b()
+  })
+
+  it("keeps the same array while the numbers do not change", async () => {
+    const store = createPlanQuotaStore(async () => reading(2), 1000)
+    const notify = vi.fn()
+    const stop = store.subscribe(notify)
+    await vi.advanceTimersByTimeAsync(0)
+    const first = store.getSnapshot()
+
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(store.getSnapshot()).toBe(first)
+    expect(notify).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it("publishes a changed reading to every subscriber", async () => {
+    let percent = 2
+    const store = createPlanQuotaStore(async () => reading(percent), 1000)
+    const notify = vi.fn()
+    const stop = store.subscribe(notify)
+    await vi.advanceTimersByTimeAsync(0)
+
+    percent = 91
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(store.getSnapshot()[0].windows?.[0].percent).toBe(91)
+    expect(notify).toHaveBeenCalledTimes(2)
+    stop()
+  })
+
+  it("keeps the last reading when a read fails", async () => {
+    let fail = false
+    const store = createPlanQuotaStore(async () => {
+      if (fail) {
+        throw new Error("offline")
+      }
+      return reading(2)
+    }, 1000)
+    const stop = store.subscribe(() => {})
+    await vi.advanceTimersByTimeAsync(0)
+
+    fail = true
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(store.getSnapshot()).toEqual(reading(2))
+    stop()
+  })
+
+  it("keeps the last reading when a read returns nothing", async () => {
+    let empty = false
+    const store = createPlanQuotaStore(async () => (empty ? null : reading(2)), 1000)
+    const stop = store.subscribe(() => {})
+    await vi.advanceTimersByTimeAsync(0)
+
+    empty = true
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(store.getSnapshot()).toEqual(reading(2))
+    stop()
+  })
+
+  it("stops polling once the last subscriber leaves", async () => {
+    const fetch = vi.fn(async () => reading(2))
+    const store = createPlanQuotaStore(fetch, 1000)
+
+    const stop = store.subscribe(() => {})
+    await vi.advanceTimersByTimeAsync(0)
+    stop()
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("notices a plan whose status changed but whose windows did not", async () => {
+    let status: QuotaPlan["status"] = "ok"
+    const store = createPlanQuotaStore(
+      async () => [{ provider: "codex", name: "Codex", status }],
+      1000,
+    )
+    const notify = vi.fn()
+    const stop = store.subscribe(notify)
+    await vi.advanceTimersByTimeAsync(0)
+
+    status = "signed-out"
+    await vi.advanceTimersByTimeAsync(1000)
+
+    expect(store.getSnapshot()[0].status).toBe("signed-out")
+    stop()
+  })
+})

--- a/frontend/src/lib/quota/plan-quota-store.ts
+++ b/frontend/src/lib/quota/plan-quota-store.ts
@@ -1,0 +1,93 @@
+import type { QuotaPlan } from "@/lib/api-types"
+import { Quota } from "@/lib/rpc"
+
+export type PlanQuotaFetcher = () => Promise<QuotaPlan[] | null>
+
+// How often the reading is re-read while anything is watching it. The backend
+// serves a five-minute cache, so this only decides how quickly a fresh reading
+// reaches the screen — the providers are not asked any more often than that.
+const REFRESH_MS = 60_000
+
+// Two readings are the same when every window of every plan is. Keeping the
+// previous array on an unchanged reading is what stops a footer and a settings
+// screen from re-rendering once a minute at a quota nobody is spending.
+const unchanged = (a: QuotaPlan[], b: QuotaPlan[]): boolean =>
+  a.length === b.length &&
+  a.every((plan, i) => {
+    const other = b[i]
+    const windows = plan.windows ?? []
+    const otherWindows = other.windows ?? []
+    return (
+      plan.provider === other.provider &&
+      plan.status === other.status &&
+      plan.plan === other.plan &&
+      windows.length === otherWindows.length &&
+      windows.every(
+        (w, j) =>
+          w.label === otherWindows[j].label &&
+          w.percent === otherWindows[j].percent &&
+          w.seconds === otherWindows[j].seconds &&
+          w.resetsAt === otherWindows[j].resetsAt,
+      )
+    )
+  })
+
+// createPlanQuotaStore shares one poll loop across every subscriber. The fetcher
+// is injected so the store is testable without React or the network, mirroring
+// git-status-store.
+export function createPlanQuotaStore(fetch: PlanQuotaFetcher, refreshMs = REFRESH_MS) {
+  let plans: QuotaPlan[] = []
+  const listeners = new Set<() => void>()
+  let timer: ReturnType<typeof setTimeout> | undefined
+  // Monotonic fetch id — a reading that started before the last subscriber left
+  // must not publish after another one started.
+  let seq = 0
+
+  const publish = (next: QuotaPlan[]) => {
+    if (unchanged(plans, next)) {
+      return
+    }
+    plans = next
+    for (const listener of listeners) {
+      listener()
+    }
+  }
+
+  const refresh = () => {
+    const id = ++seq
+    void fetch()
+      .then((next) => {
+        if (id === seq && next) {
+          publish(next)
+        }
+      })
+      // A failed read keeps the previous numbers on screen: a gauge that blanks
+      // on one dropped request is worse than one a minute out of date.
+      .catch(() => {})
+  }
+
+  const poll = () => {
+    refresh()
+    timer = setTimeout(poll, refreshMs)
+  }
+
+  return {
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener)
+      if (listeners.size === 1) {
+        poll()
+      }
+      return () => {
+        listeners.delete(listener)
+        if (listeners.size === 0) {
+          clearTimeout(timer)
+          timer = undefined
+        }
+      }
+    },
+    getSnapshot: (): QuotaPlan[] => plans,
+    refresh,
+  }
+}
+
+export const planQuotaStore = createPlanQuotaStore(() => Quota.Plans())

--- a/frontend/src/lib/quota/quota-format.test.ts
+++ b/frontend/src/lib/quota/quota-format.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest"
+import type { QuotaPlan } from "@/lib/api-types"
+import { formatWindow, hottestWindow, shortWindow, timeLeft } from "./quota-format"
+
+const plan = (...windows: Array<{ label: string; percent: number }>): QuotaPlan => ({
+  provider: "claude",
+  name: "Claude Code",
+  status: "ok",
+  windows: windows.map((w) => ({ ...w, seconds: 18000 })),
+})
+
+describe("hottestWindow", () => {
+  it("picks the window closest to spent, whatever its position", () => {
+    const got = hottestWindow(
+      plan({ label: "Session", percent: 4 }, { label: "Weekly", percent: 84 }),
+    )
+    expect(got?.label).toBe("Weekly")
+  })
+
+  it("keeps the provider's order on a tie", () => {
+    const got = hottestWindow(
+      plan({ label: "Session", percent: 50 }, { label: "Weekly", percent: 50 }),
+    )
+    expect(got?.label).toBe("Session")
+  })
+
+  it("is null for a plan with no windows", () => {
+    expect(hottestWindow(plan())).toBeNull()
+    expect(hottestWindow({ provider: "codex", name: "Codex", status: "signed-out" })).toBeNull()
+  })
+})
+
+describe("shortWindow", () => {
+  it("names a length in the width a status bar has", () => {
+    expect(shortWindow(18000)).toBe("5h")
+    expect(shortWindow(604800)).toBe("wk")
+    expect(shortWindow(2592000)).toBe("30d")
+  })
+
+  it("is empty when the provider reports no length", () => {
+    expect(shortWindow(0)).toBe("")
+    expect(shortWindow(-1)).toBe("")
+  })
+})
+
+describe("formatWindow", () => {
+  it("spells a week as days, where the bar has room", () => {
+    expect(formatWindow(18000)).toBe("5h")
+    expect(formatWindow(604800)).toBe("7d")
+    expect(formatWindow(2592000)).toBe("30d")
+    expect(formatWindow(0)).toBe("")
+  })
+})
+
+describe("timeLeft", () => {
+  const now = new Date("2026-08-17T12:00:00Z")
+
+  it("uses the two coarsest units that apply", () => {
+    expect(timeLeft("2026-08-24T08:00:00Z", now)).toBe("6d 20h")
+    expect(timeLeft("2026-08-17T16:12:00Z", now)).toBe("4h 12m")
+    expect(timeLeft("2026-08-17T12:41:00Z", now)).toBe("41m")
+  })
+
+  it("never counts down to a moment that has passed", () => {
+    expect(timeLeft("2026-08-17T11:59:00Z", now)).toBe("")
+    expect(timeLeft("2026-08-17T12:00:00Z", now)).toBe("")
+  })
+
+  it("rounds the last minute up rather than showing 0m", () => {
+    expect(timeLeft("2026-08-17T12:00:30Z", now)).toBe("1m")
+  })
+
+  it("is empty without a reset time it can read", () => {
+    expect(timeLeft(undefined, now)).toBe("")
+    expect(timeLeft("", now)).toBe("")
+    expect(timeLeft("whenever", now)).toBe("")
+  })
+})

--- a/frontend/src/lib/quota/quota-format.ts
+++ b/frontend/src/lib/quota/quota-format.ts
@@ -1,0 +1,70 @@
+import type { QuotaPlan, QuotaWindow } from "@/lib/api-types"
+
+const HOUR_S = 60 * 60
+const DAY_S = 24 * HOUR_S
+
+// hottestWindow is the window a plan is closest to spending — the one a single
+// readout has to show, because a weekly cap about to run out must not hide
+// behind a session window that just reset. Ties keep the first, which is the
+// order the provider reported. Null for a plan with no windows.
+export function hottestWindow(plan: QuotaPlan): QuotaWindow | null {
+  let hottest: QuotaWindow | null = null
+  for (const window of plan.windows ?? []) {
+    if (!hottest || window.percent > hottest.percent) {
+      hottest = window
+    }
+  }
+  return hottest
+}
+
+// shortWindow names a window's length in the width a status bar has: "5h",
+// "wk", "30d". Empty when the provider did not report a length.
+export function shortWindow(seconds: number): string {
+  if (seconds <= 0) {
+    return ""
+  }
+  if (seconds < DAY_S) {
+    return `${Math.round(seconds / HOUR_S)}h`
+  }
+  const days = Math.round(seconds / DAY_S)
+  return days === 7 ? "wk" : `${days}d`
+}
+
+// formatWindow names a window's length in full — "5h", "7d", "30d" — for the
+// places that print it beside the window's own name.
+export function formatWindow(seconds: number): string {
+  if (seconds <= 0) {
+    return ""
+  }
+  if (seconds < DAY_S) {
+    return `${Math.round(seconds / HOUR_S)}h`
+  }
+  return `${Math.round(seconds / DAY_S)}d`
+}
+
+// timeLeft is how long until a window starts over, in the two coarsest units
+// that apply ("6d 20h", "4h 12m", "41m"). Empty when there is no reset time, it
+// is unparseable, or it has already passed — a countdown to a moment in the
+// past is worse than no countdown.
+export function timeLeft(resetsAt: string | undefined, now: Date): string {
+  if (!resetsAt) {
+    return ""
+  }
+  const reset = new Date(resetsAt).getTime()
+  if (Number.isNaN(reset)) {
+    return ""
+  }
+  const seconds = Math.floor((reset - now.getTime()) / 1000)
+  if (seconds <= 0) {
+    return ""
+  }
+  if (seconds >= DAY_S) {
+    const days = Math.floor(seconds / DAY_S)
+    return `${days}d ${Math.floor((seconds % DAY_S) / HOUR_S)}h`
+  }
+  if (seconds >= HOUR_S) {
+    const hours = Math.floor(seconds / HOUR_S)
+    return `${hours}h ${Math.floor((seconds % HOUR_S) / 60)}m`
+  }
+  return `${Math.max(1, Math.floor(seconds / 60))}m`
+}

--- a/frontend/src/lib/quota/use-plan-quota.ts
+++ b/frontend/src/lib/quota/use-plan-quota.ts
@@ -1,0 +1,21 @@
+import { useSyncExternalStore } from "react"
+import type { QuotaPlan } from "@/lib/api-types"
+import { planQuotaStore } from "./plan-quota-store"
+
+// usePlanQuota reads the plan usage of every provider that meters a
+// subscription. Empty until the first reading lands, and empty forever for a
+// machine signed in to none of them.
+export function usePlanQuota(): QuotaPlan[] {
+  return useSyncExternalStore(planQuotaStore.subscribe, planQuotaStore.getSnapshot)
+}
+
+// usePlanQuotaFor is one provider's reading, by its provider id — null for a
+// provider that meters nothing (opencode, oh-my-pi and Crush run on the user's
+// own API keys) and while the first reading is in flight.
+export function usePlanQuotaFor(provider: string | undefined): QuotaPlan | null {
+  const plans = usePlanQuota()
+  if (!provider) {
+    return null
+  }
+  return plans.find((plan) => plan.provider === provider) ?? null
+}

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -9,6 +9,7 @@
 import type {
   AppUpdateStatus,
   BaseStatus,
+  BinaryCheck,
   BranchRules,
   Branches,
   CommitIdentity,
@@ -25,6 +26,7 @@ import type {
   PullRequestConversation,
   PullRequestDetail,
   PullRequestSummary,
+  QuotaPlan,
   RecentProject,
   ReviewCandidate,
   ReviewEvent,
@@ -398,6 +400,16 @@ export const System = {
 export const Providers = {
   /** Every known provider with its install state (binary found on PATH). */
   Detect: () => call<DetectedProvider[]>("providers.Detect", []),
+  /** Resolve a configured binary the way the spawn does, and report whether it
+   * can be run. "" answers `empty` — the layer below is what will be used. */
+  Verify: (bin: string) => call<BinaryCheck>("providers.Verify", [bin]),
+}
+
+export const Quota = {
+  /** Plan usage for every provider that meters a subscription. Served from a
+   * five-minute cache, so calling it often is cheap and asks nothing extra of
+   * endpoints that rate-limit. */
+  Plans: () => call<QuotaPlan[]>("quota.Plans", []),
 }
 
 export const Themes = {

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -576,10 +576,14 @@ describe("activeTarget", () => {
   const root = "/repo"
 
   it("falls back to the project root when the active session has no checkout", () => {
-    expect(activeTarget(buildState(2), P, root)).toEqual({ sessionId: "s2", path: root })
+    expect(activeTarget(buildState(2), P, root)).toEqual({
+      sessionId: "s2",
+      path: root,
+      kind: "claude",
+    })
   })
 
-  it("resolves a worktree session to its checkout", () => {
+  it("resolves a worktree session to its checkout, and reports what it runs", () => {
     const state = restoreSession(buildState(1), P, {
       id: "wt1",
       label: "swift-rabbit",
@@ -589,15 +593,16 @@ describe("activeTarget", () => {
     expect(activeTarget(state, P, root)).toEqual({
       sessionId: "wt1",
       path: "/repo/.worktrees/swift-rabbit",
+      kind: "shell",
     })
   })
 
   it("keeps the project root when there is no session at all", () => {
-    expect(activeTarget({}, P, root)).toEqual({ sessionId: "", path: root })
+    expect(activeTarget({}, P, root)).toEqual({ sessionId: "", path: root, kind: "" })
   })
 
   it("is empty off a project route", () => {
-    expect(activeTarget(buildState(2), null, "")).toEqual({ sessionId: "", path: "" })
+    expect(activeTarget(buildState(2), null, "")).toEqual({ sessionId: "", path: "", kind: "" })
   })
 })
 

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -400,22 +400,24 @@ export function sessionsOf(state: SessionState, projectId: string): Session[] {
   return state[projectId]?.sessions ?? []
 }
 
-// activeTarget resolves what a project screen acts on: the active session's id
-// and the path it lives in — a worktree session resolves to its checkout,
-// everything else to the project root. Pure, and the whole of useActiveSession's
-// answer: every screen inside a project — the terminal, its settings, its pull
-// requests — reads this same triple, and so does the chrome beside them.
+// activeTarget resolves what a project screen acts on: the active session's id,
+// the path it lives in — a worktree session resolves to its checkout, everything
+// else to the project root — and which provider it runs. Pure, and the whole of
+// useActiveSession's answer: every screen inside a project — the terminal, its
+// settings, its pull requests — reads this same triple, and so does the chrome
+// beside them. kind is "" when no session is active, which is not a SessionKind:
+// a screen with nothing running has no provider, and "shell" would be a claim.
 export function activeTarget(
   state: SessionState,
   projectId: string | null,
   projectPath: string,
-): { sessionId: string; path: string } {
+): { sessionId: string; path: string; kind: SessionKind | "" } {
   if (!projectId) {
-    return { sessionId: "", path: projectPath }
+    return { sessionId: "", path: projectPath, kind: "" }
   }
   const sessionId = activeSessionId(state, projectId)
   const session = sessionsOf(state, projectId).find((s) => s.id === sessionId)
-  return { sessionId, path: session?.path || projectPath }
+  return { sessionId, path: session?.path || projectPath, kind: session?.kind ?? "" }
 }
 
 // A worktree's sessions under one roof. `path` is the checkout root ("" for the

--- a/frontend/src/lib/session/use-active-session.ts
+++ b/frontend/src/lib/session/use-active-session.ts
@@ -1,6 +1,6 @@
 import { useMatch } from "react-router-dom"
 import { useProjects } from "@/providers/projects"
-import { activeTarget } from "./sessions"
+import { activeTarget, type SessionKind } from "./sessions"
 import { useSessionCwd } from "./use-session-cwd"
 
 // useActiveSession resolves what is currently in focus: the routed project, its
@@ -26,6 +26,8 @@ export function useActiveSession(): {
   /** The session's static checkout — what the sidebar keys a worktree's pull
    * request card on, so a `cd` cannot open a card no group can show. */
   checkout: string
+  /** Which provider the active session runs, "" when none is active. */
+  kind: SessionKind | ""
 } {
   const { projects, sessions } = useProjects()
   const match = useMatch({ path: "/projects/:projectId", end: false })
@@ -38,5 +40,6 @@ export function useActiveSession(): {
     sessionId: target.sessionId,
     path: cwd || target.path,
     checkout: target.path,
+    kind: target.kind,
   }
 }

--- a/frontend/src/lib/use-binary-check.ts
+++ b/frontend/src/lib/use-binary-check.ts
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react"
+import type { BinaryCheck } from "./api-types"
+import { Providers } from "./rpc"
+
+// How long a field rests before its value is verified. Every keystroke of a path
+// is a state the path has never been in, so checking on each one would spend a
+// round trip per character to report a file nobody has finished naming yet.
+const SETTLE_MS = 400
+
+// useBinaryCheck resolves a configured binary through the backend, re-checking
+// whenever the value settles. Null while the first answer for a value is in
+// flight — the callers draw nothing rather than flashing a failure between
+// keystrokes.
+export function useBinaryCheck(bin: string): BinaryCheck | null {
+  const [check, setCheck] = useState<BinaryCheck | null>(null)
+
+  useEffect(() => {
+    let live = true
+    setCheck(null)
+    const timer = setTimeout(() => {
+      Providers.Verify(bin)
+        .then((next) => {
+          if (live) {
+            setCheck(next)
+          }
+        })
+        // A failed call is not a failed path: leaving the verdict absent says
+        // "unknown", which is the truth when nothing answered.
+        .catch(() => {})
+    }, SETTLE_MS)
+    return () => {
+      live = false
+      clearTimeout(timer)
+    }
+  }, [bin])
+
+  return check
+}

--- a/frontend/src/lib/use-now.ts
+++ b/frontend/src/lib/use-now.ts
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react"
+
+const MINUTE_MS = 60_000
+
+// useNow is the wall clock, re-read on the minute rather than on a fixed
+// interval: every readout built on it is minute-resolution (the footer's HH:MM,
+// a quota window's time to reset), so a 10s tick spent five of every six renders
+// redrawing the same string, and still showed a minute that could be ten seconds
+// stale.
+export function useNow(): Date {
+  const [now, setNow] = useState(() => new Date())
+  useEffect(() => {
+    let timer = 0
+    const tick = () => {
+      const at = new Date()
+      setNow(at)
+      timer = window.setTimeout(tick, MINUTE_MS - (at.getTime() % MINUTE_MS))
+    }
+    timer = window.setTimeout(tick, MINUTE_MS - (Date.now() % MINUTE_MS))
+    return () => window.clearTimeout(timer)
+  }, [])
+  return now
+}

--- a/internal/providers/verify.go
+++ b/internal/providers/verify.go
@@ -1,0 +1,73 @@
+package providers
+
+import (
+	"errors"
+	"io/fs"
+	"path/filepath"
+	"strings"
+)
+
+// A Check's Status. Each failing value names a distinct mistake, because each
+// one is silent today: the session simply refuses to start, and the settings
+// screen that accepted the value says nothing.
+const (
+	// CheckOK: the binary resolves and can be executed.
+	CheckOK = "ok"
+	// CheckEmpty: nothing is configured at this layer, so the next one answers.
+	CheckEmpty    = "empty"
+	CheckNotFound = "not-found"
+	// CheckNotExecutable covers a file without the execute bit and a directory
+	// — both are "found, cannot be run".
+	CheckNotExecutable = "not-executable"
+	// CheckHomeShortcut: a leading ~ is a shell convenience. lich spawns the
+	// binary directly (internal/terminal/pty_unix.go), so nothing expands it and
+	// the path is taken literally.
+	CheckHomeShortcut = "home-shortcut"
+	// CheckRelative: a relative path is resolved against each session's own
+	// working directory, so the same setting means a different binary — or none
+	// — per session. Reported rather than resolved: there is no one directory
+	// this check could answer for.
+	CheckRelative = "relative"
+)
+
+// Check is what a configured binary resolves to. Path is the absolute
+// executable a session would spawn, empty for every status but CheckOK.
+type Check struct {
+	Path   string `json:"path"`
+	Status string `json:"status"`
+}
+
+// Verify resolves bin exactly as the spawn does — a bare name through $PATH, a
+// path taken as written — and reports whether it can be run. It is what turns
+// the binary setting from a field that accepts anything into one that answers.
+func (s *Service) Verify(bin string) Check {
+	bin = strings.TrimSpace(bin)
+	switch {
+	case bin == "":
+		return Check{Status: CheckEmpty}
+	case strings.HasPrefix(bin, "~"):
+		return Check{Status: CheckHomeShortcut}
+	case isRelativePath(bin):
+		return Check{Status: CheckRelative}
+	}
+	path, err := s.lookPath(bin)
+	if err == nil {
+		return Check{Path: path, Status: CheckOK}
+	}
+	// A directory and a file without the execute bit both surface as a
+	// permission error from LookPath's own executability test.
+	if errors.Is(err, fs.ErrPermission) {
+		return Check{Status: CheckNotExecutable}
+	}
+	return Check{Status: CheckNotFound}
+}
+
+// isRelativePath reports a value that names a location rather than a command,
+// without naming it from the root. A bare "claude" is not one of these: it is a
+// $PATH lookup, which resolves the same for every session.
+func isRelativePath(bin string) bool {
+	if filepath.IsAbs(bin) {
+		return false
+	}
+	return strings.ContainsRune(bin, '/') || strings.ContainsRune(bin, filepath.Separator)
+}

--- a/internal/providers/verify_test.go
+++ b/internal/providers/verify_test.go
@@ -1,0 +1,109 @@
+package providers
+
+import (
+	"io/fs"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// verifier resolves the given names and fails every other lookup the way
+// exec.LookPath does, so Verify is driven without touching the machine.
+func verifier(found map[string]string, denied map[string]bool) *Service {
+	return &Service{
+		lookPath: func(name string) (string, error) {
+			if denied[name] {
+				return "", &exec.Error{Name: name, Err: fs.ErrPermission}
+			}
+			if path, ok := found[name]; ok {
+				return path, nil
+			}
+			return "", &exec.Error{Name: name, Err: exec.ErrNotFound}
+		},
+	}
+}
+
+func TestVerifyResolvesLikeTheSpawn(t *testing.T) {
+	svc := verifier(map[string]string{
+		"claude":             "/home/dev/.local/bin/claude",
+		"/opt/claude/claude": "/opt/claude/claude",
+	}, nil)
+
+	// A bare name is a $PATH lookup, and the answer is the resolved path.
+	if got := svc.Verify("claude"); got.Status != CheckOK || got.Path != "/home/dev/.local/bin/claude" {
+		t.Errorf("Verify(bare name) = %+v, want ok at the resolved path", got)
+	}
+	// An absolute path is taken as written.
+	if got := svc.Verify("/opt/claude/claude"); got.Status != CheckOK || got.Path != "/opt/claude/claude" {
+		t.Errorf("Verify(absolute) = %+v, want ok", got)
+	}
+	// Surrounding whitespace is a paste artefact, not part of the path.
+	if got := svc.Verify("  claude \n"); got.Status != CheckOK {
+		t.Errorf("Verify(padded) = %+v, want ok", got)
+	}
+}
+
+func TestVerifyNamesEachSilentMistake(t *testing.T) {
+	svc := verifier(
+		map[string]string{"claude": "/usr/bin/claude"},
+		map[string]bool{"/etc": true, "/tmp/claude.sh": true},
+	)
+	tests := []struct {
+		name string
+		bin  string
+		want string
+	}{
+		{name: "nothing configured", bin: "", want: CheckEmpty},
+		{name: "only whitespace", bin: "   ", want: CheckEmpty},
+		{name: "not installed", bin: "codex", want: CheckNotFound},
+		{name: "absolute path that is not there", bin: "/opt/gone/claude", want: CheckNotFound},
+		{name: "a file without the execute bit", bin: "/tmp/claude.sh", want: CheckNotExecutable},
+		{name: "a directory", bin: "/etc", want: CheckNotExecutable},
+		// The spawn is exec, not a shell: nothing expands these two, and both
+		// fail long after this screen accepted them.
+		{name: "a home shortcut", bin: "~/dev/claude", want: CheckHomeShortcut},
+		{name: "bare tilde", bin: "~", want: CheckHomeShortcut},
+		{name: "a relative path", bin: "bin/claude", want: CheckRelative},
+		{name: "an explicitly relative path", bin: "./claude", want: CheckRelative},
+		{name: "a parent-relative path", bin: "../claude", want: CheckRelative},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := svc.Verify(tt.bin)
+			if got.Status != tt.want {
+				t.Errorf("Verify(%q) = %q, want %q", tt.bin, got.Status, tt.want)
+			}
+			if got.Path != "" {
+				t.Errorf("Verify(%q) reported path %q for a failing check", tt.bin, got.Path)
+			}
+		})
+	}
+}
+
+// The relative check must not swallow a bare command name: that is a $PATH
+// lookup, which resolves the same for every session and has to be verified.
+func TestIsRelativePath(t *testing.T) {
+	tests := map[string]bool{
+		"claude":          false,
+		"claude-2.1":      false,
+		"/usr/bin/claude": false,
+		"bin/claude":      true,
+		"./claude":        true,
+		"../claude":       true,
+	}
+	for bin, want := range tests {
+		if got := isRelativePath(bin); got != want {
+			t.Errorf("isRelativePath(%q) = %v, want %v", bin, got, want)
+		}
+	}
+	// A Windows path is absolute only with its volume; the rooted form depends
+	// on the current drive, which is the same ambiguity a relative path has.
+	if filepath.Separator == '\\' {
+		if !isRelativePath(`\tools\claude.exe`) {
+			t.Error(`isRelativePath("\tools\claude.exe") = false, want true on Windows`)
+		}
+		if isRelativePath(`C:\tools\claude.exe`) {
+			t.Error(`isRelativePath("C:\tools\claude.exe") = true, want false`)
+		}
+	}
+}

--- a/internal/providers/verify_test.go
+++ b/internal/providers/verify_test.go
@@ -3,9 +3,22 @@ package providers
 import (
 	"io/fs"
 	"os/exec"
-	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
+
+// absolute builds a path the running OS agrees is absolute. A POSIX literal is
+// not one on Windows: "/opt/claude" there names a location on whatever drive the
+// process sits on, which is the same per-session ambiguity a relative path has —
+// and which Verify reports as CheckRelative. So the two forms are spelled out
+// rather than assumed to be one.
+func absolute(parts ...string) string {
+	if runtime.GOOS == "windows" {
+		return `C:\` + strings.Join(parts, `\`)
+	}
+	return "/" + strings.Join(parts, "/")
+}
 
 // verifier resolves the given names and fails every other lookup the way
 // exec.LookPath does, so Verify is driven without touching the machine.
@@ -24,17 +37,19 @@ func verifier(found map[string]string, denied map[string]bool) *Service {
 }
 
 func TestVerifyResolvesLikeTheSpawn(t *testing.T) {
+	onPath := absolute("home", "dev", ".local", "bin", "claude")
+	installed := absolute("opt", "claude", "claude")
 	svc := verifier(map[string]string{
-		"claude":             "/home/dev/.local/bin/claude",
-		"/opt/claude/claude": "/opt/claude/claude",
+		"claude":  onPath,
+		installed: installed,
 	}, nil)
 
 	// A bare name is a $PATH lookup, and the answer is the resolved path.
-	if got := svc.Verify("claude"); got.Status != CheckOK || got.Path != "/home/dev/.local/bin/claude" {
-		t.Errorf("Verify(bare name) = %+v, want ok at the resolved path", got)
+	if got := svc.Verify("claude"); got.Status != CheckOK || got.Path != onPath {
+		t.Errorf("Verify(bare name) = %+v, want ok at %s", got, onPath)
 	}
 	// An absolute path is taken as written.
-	if got := svc.Verify("/opt/claude/claude"); got.Status != CheckOK || got.Path != "/opt/claude/claude" {
+	if got := svc.Verify(installed); got.Status != CheckOK || got.Path != installed {
 		t.Errorf("Verify(absolute) = %+v, want ok", got)
 	}
 	// Surrounding whitespace is a paste artefact, not part of the path.
@@ -44,9 +59,12 @@ func TestVerifyResolvesLikeTheSpawn(t *testing.T) {
 }
 
 func TestVerifyNamesEachSilentMistake(t *testing.T) {
+	gone := absolute("opt", "gone", "claude")
+	notExecutable := absolute("tmp", "claude.sh")
+	directory := absolute("etc")
 	svc := verifier(
-		map[string]string{"claude": "/usr/bin/claude"},
-		map[string]bool{"/etc": true, "/tmp/claude.sh": true},
+		map[string]string{"claude": absolute("usr", "bin", "claude")},
+		map[string]bool{directory: true, notExecutable: true},
 	)
 	tests := []struct {
 		name string
@@ -56,9 +74,9 @@ func TestVerifyNamesEachSilentMistake(t *testing.T) {
 		{name: "nothing configured", bin: "", want: CheckEmpty},
 		{name: "only whitespace", bin: "   ", want: CheckEmpty},
 		{name: "not installed", bin: "codex", want: CheckNotFound},
-		{name: "absolute path that is not there", bin: "/opt/gone/claude", want: CheckNotFound},
-		{name: "a file without the execute bit", bin: "/tmp/claude.sh", want: CheckNotExecutable},
-		{name: "a directory", bin: "/etc", want: CheckNotExecutable},
+		{name: "absolute path that is not there", bin: gone, want: CheckNotFound},
+		{name: "a file without the execute bit", bin: notExecutable, want: CheckNotExecutable},
+		{name: "a directory", bin: directory, want: CheckNotExecutable},
 		// The spawn is exec, not a shell: nothing expands these two, and both
 		// fail long after this screen accepted them.
 		{name: "a home shortcut", bin: "~/dev/claude", want: CheckHomeShortcut},
@@ -83,27 +101,37 @@ func TestVerifyNamesEachSilentMistake(t *testing.T) {
 // The relative check must not swallow a bare command name: that is a $PATH
 // lookup, which resolves the same for every session and has to be verified.
 func TestIsRelativePath(t *testing.T) {
+	// True everywhere: a bare command name is a $PATH lookup, and the three
+	// relative forms name a location without rooting it.
 	tests := map[string]bool{
-		"claude":          false,
-		"claude-2.1":      false,
-		"/usr/bin/claude": false,
-		"bin/claude":      true,
-		"./claude":        true,
-		"../claude":       true,
+		"claude":     false,
+		"claude-2.1": false,
+		"bin/claude": true,
+		"./claude":   true,
+		"../claude":  true,
 	}
 	for bin, want := range tests {
 		if got := isRelativePath(bin); got != want {
 			t.Errorf("isRelativePath(%q) = %v, want %v", bin, got, want)
 		}
 	}
-	// A Windows path is absolute only with its volume; the rooted form depends
-	// on the current drive, which is the same ambiguity a relative path has.
-	if filepath.Separator == '\\' {
-		if !isRelativePath(`\tools\claude.exe`) {
-			t.Error(`isRelativePath("\tools\claude.exe") = false, want true on Windows`)
-		}
+
+	// What counts as rooted is the one thing that is not portable. On Windows a
+	// path is absolute only with its volume: the leading-slash form resolves
+	// against whatever drive the process is on, which is the same per-session
+	// ambiguity a relative path has, so it is reported as one.
+	if runtime.GOOS == "windows" {
 		if isRelativePath(`C:\tools\claude.exe`) {
 			t.Error(`isRelativePath("C:\tools\claude.exe") = true, want false`)
 		}
+		for _, bin := range []string{`\tools\claude.exe`, "/usr/bin/claude"} {
+			if !isRelativePath(bin) {
+				t.Errorf("isRelativePath(%q) = false, want true on Windows", bin)
+			}
+		}
+		return
+	}
+	if isRelativePath("/usr/bin/claude") {
+		t.Error(`isRelativePath("/usr/bin/claude") = true, want false`)
 	}
 }

--- a/internal/quota/claude.go
+++ b/internal/quota/claude.go
@@ -1,0 +1,179 @@
+package quota
+
+import (
+	"strings"
+	"time"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+const (
+	claudeUsageURL = "https://api.anthropic.com/api/oauth/usage"
+	// claudeBetaHeader opts the OAuth token into the usage route.
+	claudeBetaHeader = "oauth-2025-04-20"
+	// claudeUserAgent is what the endpoint expects from the client holding this
+	// token. Sent as anything else it rate-limits within a few requests; the
+	// patch version is not checked, so a recent one stays good.
+	claudeUserAgent = "claude-code/2.1.183"
+)
+
+// claudeCredentials is the part of ~/.claude/.credentials.json lich reads. The
+// refresh token in the same file is deliberately not among these fields: lich
+// has no business spending it (see the package doc).
+type claudeCredentials struct {
+	OAuth struct {
+		AccessToken      string `json:"accessToken"`
+		SubscriptionType string `json:"subscriptionType"`
+		RateLimitTier    string `json:"rateLimitTier"`
+	} `json:"claudeAiOauth"`
+}
+
+// planLabel is the subscription as a person names it: the tier from the
+// credentials, plus the multiplier the rate-limit tier spells out ("Max 5x").
+func (c claudeCredentials) planLabel() string {
+	name := title(c.OAuth.SubscriptionType)
+	if name == "" {
+		return ""
+	}
+	for _, multiplier := range []string{"20x", "5x"} {
+		if strings.Contains(c.OAuth.RateLimitTier, multiplier) {
+			return name + " " + multiplier
+		}
+	}
+	return name
+}
+
+// claudeUsage is the response of the OAuth usage route. Every field is optional:
+// the route is undocumented, its shape varies by plan, and it has already grown
+// one representation of the same windows (limits) beside the original pair.
+type claudeUsage struct {
+	FiveHour *claudeWindow `json:"five_hour"`
+	SevenDay *claudeWindow `json:"seven_day"`
+	Limits   []claudeLimit `json:"limits"`
+}
+
+type claudeWindow struct {
+	Utilization float64 `json:"utilization"`
+	ResetsAt    string  `json:"resets_at"`
+}
+
+type claudeLimit struct {
+	Kind     string   `json:"kind"`
+	Percent  *float64 `json:"percent"`
+	ResetsAt string   `json:"resets_at"`
+	Scope    *struct {
+		Model *struct {
+			DisplayName string `json:"display_name"`
+		} `json:"model"`
+	} `json:"scope"`
+}
+
+// claudePlan reads Claude Code's quota off the login its CLI wrote.
+func (s *Service) claudePlan() Plan {
+	p := plan(providers.Claude)
+	path, ok := harnessFile("CLAUDE_CONFIG_DIR", ".claude", ".credentials.json")
+	if !ok {
+		return failed(p)
+	}
+	var creds claudeCredentials
+	if !readCredentials(path, &creds) || creds.OAuth.AccessToken == "" {
+		return signedOut(p)
+	}
+	p.Plan = creds.planLabel()
+
+	var usage claudeUsage
+	authOK, err := s.readJSON(s.claudeURL, creds.OAuth.AccessToken, map[string]string{
+		"anthropic-beta": claudeBetaHeader,
+		"User-Agent":     claudeUserAgent,
+	}, &usage)
+	if !authOK {
+		return signedOut(p)
+	}
+	if err != nil {
+		return failed(p)
+	}
+	p.Windows = usage.windows()
+	if len(p.Windows) == 0 {
+		return failed(p)
+	}
+	return p
+}
+
+// windows projects the response onto the neutral shape, preferring the limits
+// array: it is the representation that carries model-scoped weekly caps, which
+// have no field of their own. A payload without it — an older account, or the
+// array dropped again — falls back to the original pair so the two windows
+// everyone has keep reporting.
+func (u claudeUsage) windows() []Window {
+	out := make([]Window, 0, len(u.Limits))
+	for _, limit := range u.Limits {
+		if limit.Percent == nil {
+			continue
+		}
+		label, seconds := limit.window()
+		if label == "" {
+			continue
+		}
+		out = append(out, Window{
+			Label:    label,
+			Seconds:  seconds,
+			Percent:  percent(*limit.Percent),
+			ResetsAt: timestamp(limit.ResetsAt),
+		})
+	}
+	if len(out) > 0 {
+		return out
+	}
+	for _, w := range []struct {
+		window  *claudeWindow
+		label   string
+		seconds int
+	}{
+		{u.FiveHour, "Session", sessionWindow},
+		{u.SevenDay, "Weekly", weeklyWindow},
+	} {
+		if w.window == nil {
+			continue
+		}
+		out = append(out, Window{
+			Label:    w.label,
+			Seconds:  w.seconds,
+			Percent:  percent(w.window.Utilization),
+			ResetsAt: timestamp(w.window.ResetsAt),
+		})
+	}
+	return out
+}
+
+// window names one limit entry and gives its length. An empty label is an entry
+// lich does not draw: a kind it has no name for, or a model-scoped cap the API
+// did not name. A new kind is therefore silently skipped rather than rendered
+// as its wire spelling.
+func (l claudeLimit) window() (string, int) {
+	switch l.Kind {
+	case "session":
+		return "Session", sessionWindow
+	case "weekly_all":
+		return "Weekly", weeklyWindow
+	case "weekly_scoped":
+		if l.Scope == nil || l.Scope.Model == nil {
+			return "", 0
+		}
+		return l.Scope.Model.DisplayName, weeklyWindow
+	default:
+		return "", 0
+	}
+}
+
+// timestamp passes through a reset time the frontend can parse, and drops
+// anything else: a gauge with no reset reads better than one counting down to
+// an unparseable date.
+func timestamp(s string) string {
+	if s == "" {
+		return ""
+	}
+	if _, err := time.Parse(time.RFC3339, s); err != nil {
+		return ""
+	}
+	return s
+}

--- a/internal/quota/codex.go
+++ b/internal/quota/codex.go
@@ -1,0 +1,113 @@
+package quota
+
+import (
+	"time"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+const (
+	codexUsageURL = "https://chatgpt.com/backend-api/wham/usage"
+	// codexUserAgent identifies the CLI this token belongs to, as the Anthropic
+	// route's does.
+	codexUserAgent = "codex_cli_rs/0.56.0"
+)
+
+// codexCredentials is the part of ~/.codex/auth.json lich reads. As with
+// Claude, the refresh token beside it is left alone.
+type codexCredentials struct {
+	Tokens struct {
+		AccessToken string `json:"access_token"`
+	} `json:"tokens"`
+}
+
+// codexUsage is the response of the wham usage route.
+type codexUsage struct {
+	PlanType  string `json:"plan_type"`
+	RateLimit *struct {
+		Primary   *codexWindow `json:"primary_window"`
+		Secondary *codexWindow `json:"secondary_window"`
+	} `json:"rate_limit"`
+}
+
+type codexWindow struct {
+	UsedPercent float64 `json:"used_percent"`
+	Seconds     int     `json:"limit_window_seconds"`
+	// ResetAt is Unix seconds, absent on older CLIs.
+	ResetAt int64 `json:"reset_at"`
+}
+
+// codexPlan reads Codex's quota off the login its CLI wrote.
+func (s *Service) codexPlan() Plan {
+	p := plan(providers.Codex)
+	path, ok := harnessFile("CODEX_HOME", ".codex", "auth.json")
+	if !ok {
+		return failed(p)
+	}
+	var creds codexCredentials
+	if !readCredentials(path, &creds) || creds.Tokens.AccessToken == "" {
+		return signedOut(p)
+	}
+
+	var usage codexUsage
+	authOK, err := s.readJSON(s.codexURL, creds.Tokens.AccessToken, map[string]string{
+		"User-Agent": codexUserAgent,
+	}, &usage)
+	if !authOK {
+		return signedOut(p)
+	}
+	if err != nil {
+		return failed(p)
+	}
+	p.Plan = title(usage.PlanType)
+	p.Windows = usage.windows()
+	if len(p.Windows) == 0 {
+		return failed(p)
+	}
+	return p
+}
+
+// windows projects both reported windows onto the neutral shape.
+func (u codexUsage) windows() []Window {
+	if u.RateLimit == nil {
+		return nil
+	}
+	out := make([]Window, 0, 2)
+	for _, w := range []*codexWindow{u.RateLimit.Primary, u.RateLimit.Secondary} {
+		if w == nil {
+			continue
+		}
+		out = append(out, Window{
+			Label:    codexLabel(w.Seconds),
+			Seconds:  w.Seconds,
+			Percent:  percent(w.UsedPercent),
+			ResetsAt: unixTimestamp(w.ResetAt),
+		})
+	}
+	return out
+}
+
+// codexLabel names a window by how long it runs, never by where it sat in the
+// payload: the first window is the five-hour one on a paid plan and a monthly
+// one on the free tier, and a plan change must not silently relabel a gauge.
+func codexLabel(seconds int) string {
+	switch {
+	case seconds <= 0:
+		return "Usage"
+	case seconds < 24*60*60:
+		return "Session"
+	case seconds <= weeklyWindow:
+		return "Weekly"
+	default:
+		return "Monthly"
+	}
+}
+
+// unixTimestamp renders a Unix-seconds reset as the RFC 3339 the frontend
+// parses. Empty for the absent value, which older CLIs write as 0.
+func unixTimestamp(sec int64) string {
+	if sec <= 0 {
+		return ""
+	}
+	return time.Unix(sec, 0).UTC().Format(time.RFC3339)
+}

--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -1,0 +1,228 @@
+// Package quota reads the subscription quota a provider's own account API
+// reports: the rolling windows a plan is metered in, and how much of each one is
+// spent. It is not what a session cost — that is internal/pricing — and not how
+// full a context window is — that is internal/terminal's usage readout.
+//
+// Two of the five providers meter a subscription at all. Claude Code and Codex
+// each poll an undocumented endpoint from their own CLI, authenticated with the
+// OAuth access token that CLI already wrote to disk; opencode, oh-my-pi and
+// Crush run on the user's own API keys, where there is no plan to report.
+//
+// lich reads those credentials and never writes them. Token rotation belongs to
+// the CLI that owns the login: a refresh whose write-back fails spends the
+// stored refresh token and logs the user out of their agent, which is a far
+// worse outcome than a stale gauge. An expired token is reported as signed out.
+package quota
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+const (
+	// httpTimeout bounds one usage request. Both endpoints answer in well under
+	// a second; this is a hang stop.
+	httpTimeout = 10 * time.Second
+	// cacheTTL is how long a reading is served before the endpoints are asked
+	// again. Both rate-limit aggressively — the Waybar widgets that pioneered
+	// these routes recommend polling no tighter than five minutes — and a quota
+	// gauge is not a number anyone needs to the second.
+	cacheTTL = 5 * time.Minute
+)
+
+// Window lifetimes. Anthropic names its windows by kind and never reports how
+// long they run, so the two account-wide ones are named here; Codex reports the
+// duration itself and is read from the payload.
+const (
+	sessionWindow = 5 * 60 * 60
+	weeklyWindow  = 7 * 24 * 60 * 60
+)
+
+// A plan's Status. Anything other than StatusOK carries no windows: the reading
+// failed, and the frontend says so rather than drawing an empty gauge.
+const (
+	StatusOK = "ok"
+	// StatusSignedOut is "there is no usable login here" — no credentials file,
+	// or the provider rejected the token in it. Both are answered by running the
+	// provider's own login, so they are one state, not two.
+	StatusSignedOut = "signed-out"
+	StatusError     = "error"
+)
+
+// Window is one metered window of a plan: how much of it is spent, how long it
+// runs, and when it starts over.
+//
+// Label is the window's name as the provider frames it ("Session", "Weekly"), or
+// the display name of the model a scoped window belongs to. Seconds is its
+// length, so the frontend can print the window it is looking at; 0 when the
+// provider does not report one. ResetsAt is RFC 3339, empty when unreported.
+type Window struct {
+	Label    string `json:"label"`
+	Seconds  int    `json:"seconds"`
+	Percent  int    `json:"percent"`
+	ResetsAt string `json:"resetsAt,omitempty"`
+}
+
+// Plan is one provider's quota reading. Provider is a providers.Registry id, so
+// the frontend resolves the icon and the login command it already knows.
+type Plan struct {
+	Provider string   `json:"provider"`
+	Name     string   `json:"name"`
+	Plan     string   `json:"plan,omitempty"`
+	Windows  []Window `json:"windows,omitempty"`
+	Status   string   `json:"status"`
+}
+
+// Service reads plan quota, caching one reading for every caller.
+type Service struct {
+	http *http.Client
+	// claudeURL and codexURL are the usage endpoints, fields so tests drive the
+	// parsers against a local server.
+	claudeURL string
+	codexURL  string
+
+	// now is time.Now, a field so a test can age the cache without sleeping.
+	now func() time.Time
+
+	// mu guards the cached reading and is held across the fetch itself, so a
+	// second caller arriving mid-request waits for that answer instead of
+	// firing its own at an endpoint that rate-limits.
+	mu     sync.Mutex
+	cached []Plan
+	at     time.Time
+}
+
+// New returns a Service pointed at the live endpoints.
+func New() *Service {
+	return &Service{
+		http:      &http.Client{Timeout: httpTimeout},
+		claudeURL: claudeUsageURL,
+		codexURL:  codexUsageURL,
+		now:       time.Now,
+	}
+}
+
+// Plans is every provider that meters a subscription, in Registry order. There
+// is always one entry per such provider — a failed reading is a Status, not an
+// omission, so the UI can say which provider it could not read.
+func (s *Service) Plans() []Plan {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.cached != nil && s.now().Sub(s.at) < cacheTTL {
+		return s.cached
+	}
+	plans := []Plan{s.claudePlan(), s.codexPlan()}
+	s.cached, s.at = plans, s.now()
+	return plans
+}
+
+// plan is the common shape of a reading, before its windows are known.
+func plan(id string) Plan {
+	name := id
+	for _, p := range providers.Registry {
+		if p.ID == id {
+			name = p.Name
+		}
+	}
+	return Plan{Provider: id, Name: name, Status: StatusOK}
+}
+
+// signedOut and failed are the two ways a reading ends without windows. Keeping
+// them as constructors keeps every caller's error path one line.
+func signedOut(p Plan) Plan {
+	p.Status = StatusSignedOut
+	return p
+}
+
+func failed(p Plan) Plan {
+	p.Status = StatusError
+	return p
+}
+
+// harnessFile locates a file a provider CLI keeps in its own state directory:
+// under the directory its environment variable names, else under home. Mirrors
+// terminal.harnessDir, which resolves the same two directories for transcripts.
+func harnessFile(homeVar, sub string, name ...string) (string, bool) {
+	base := os.Getenv(homeVar)
+	if base == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", false
+		}
+		base = filepath.Join(home, sub)
+	}
+	return filepath.Join(append([]string{base}, name...)...), true
+}
+
+// readJSON GETs url with the given headers and decodes the body into out. The
+// bool is "the endpoint rejected our token": a 401 or 403 is a login the user
+// has to redo, which every caller reports differently from a network failure.
+func (s *Service) readJSON(url, token string, headers map[string]string, out any) (authOK bool, err error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return true, err
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return true, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return false, fmt.Errorf("usage endpoint answered %d", resp.StatusCode)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return true, fmt.Errorf("usage endpoint answered %d", resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
+		return true, fmt.Errorf("decode usage response: %w", err)
+	}
+	return true, nil
+}
+
+// readCredentials decodes the JSON credentials file at path into out. The bool
+// is false for every reason there is no login to read with — the file is
+// absent, unreadable, or not the JSON it should be.
+func readCredentials(path string, out any) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return json.Unmarshal(data, out) == nil
+}
+
+// percent clamps a reported share to the 0–100 the gauges are drawn on. A
+// provider that reports 103% of a soft limit is at the top of the bar, not off
+// the end of it.
+func percent(v float64) int {
+	if math.IsNaN(v) || v <= 0 {
+		return 0
+	}
+	if v >= 100 {
+		return 100
+	}
+	return int(math.Round(v))
+}
+
+// title upper-cases a plan name the wire spells in lower case ("max" → "Max").
+func title(s string) string {
+	if s == "" {
+		return ""
+	}
+	b := []byte(s)
+	if b[0] >= 'a' && b[0] <= 'z' {
+		b[0] -= 'a' - 'A'
+	}
+	return string(b)
+}

--- a/internal/quota/quota_test.go
+++ b/internal/quota/quota_test.go
@@ -1,0 +1,384 @@
+package quota
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// claudeCredsJSON is the shape Claude Code writes, trimmed to what lich reads.
+const claudeCredsJSON = `{"claudeAiOauth":{
+	"accessToken":"tok-claude",
+	"refreshToken":"never-read",
+	"subscriptionType":"max",
+	"rateLimitTier":"default_claude_max_5x"
+}}`
+
+const codexCredsJSON = `{"tokens":{"access_token":"tok-codex","refresh_token":"never-read"}}`
+
+// writeCreds points both providers' state directories at t.TempDir and writes
+// the given credential files there. An empty body means "no file at all".
+func writeCreds(t *testing.T, claude, codex string) {
+	t.Helper()
+	claudeDir := filepath.Join(t.TempDir(), "claude")
+	codexDir := filepath.Join(t.TempDir(), "codex")
+	for dir, body := range map[string]string{claudeDir: claude, codexDir: codex} {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if body == "" {
+			continue
+		}
+		name := ".credentials.json"
+		if dir == codexDir {
+			name = "auth.json"
+		}
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatalf("write creds: %v", err)
+		}
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
+	t.Setenv("CODEX_HOME", codexDir)
+}
+
+// serve answers every request with status and body, and counts the calls.
+func serve(t *testing.T, status int, body string) (url string, calls *int) {
+	t.Helper()
+	n := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n++
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	return server.URL, &n
+}
+
+// newService builds a Service pointed at the given endpoints with a fixed clock.
+func newService(claudeURL, codexURL string, now time.Time) *Service {
+	return &Service{
+		http:      &http.Client{Timeout: httpTimeout},
+		claudeURL: claudeURL,
+		codexURL:  codexURL,
+		now:       func() time.Time { return now },
+	}
+}
+
+const claudeLimitsBody = `{
+	"five_hour": {"utilization": 2.0, "resets_at": "2026-08-17T23:20:00.153182+00:00"},
+	"seven_day": {"utilization": 0.0, "resets_at": "2026-08-24T15:00:00+00:00"},
+	"limits": [
+		{"kind":"session","percent":2,"resets_at":"2026-08-17T23:20:00.153182+00:00"},
+		{"kind":"weekly_all","percent":41,"resets_at":"2026-08-24T15:00:00+00:00"},
+		{"kind":"weekly_scoped","percent":11,"resets_at":null,
+		 "scope":{"model":{"display_name":"Fable"}}}
+	]
+}`
+
+func TestClaudePlanReadsLimits(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	url, calls := serve(t, http.StatusOK, claudeLimitsBody)
+	got := newService(url, "", time.Now()).claudePlan()
+
+	if got.Status != StatusOK {
+		t.Fatalf("status = %q, want %q", got.Status, StatusOK)
+	}
+	if got.Provider != "claude" || got.Name != "Claude Code" {
+		t.Errorf("identity = %q/%q, want claude/Claude Code", got.Provider, got.Name)
+	}
+	if got.Plan != "Max 5x" {
+		t.Errorf("plan = %q, want %q", got.Plan, "Max 5x")
+	}
+	want := []Window{
+		{Label: "Session", Seconds: 18000, Percent: 2, ResetsAt: "2026-08-17T23:20:00.153182+00:00"},
+		{Label: "Weekly", Seconds: 604800, Percent: 41, ResetsAt: "2026-08-24T15:00:00+00:00"},
+		{Label: "Fable", Seconds: 604800, Percent: 11},
+	}
+	if len(got.Windows) != len(want) {
+		t.Fatalf("windows = %+v, want %d", got.Windows, len(want))
+	}
+	for i, w := range want {
+		if got.Windows[i] != w {
+			t.Errorf("window %d = %+v, want %+v", i, got.Windows[i], w)
+		}
+	}
+	if *calls != 1 {
+		t.Errorf("calls = %d, want 1", *calls)
+	}
+}
+
+func TestClaudeRequestCarriesTheHeadersTheEndpointDemands(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	var got http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.Header.Clone()
+		_, _ = w.Write([]byte(claudeLimitsBody))
+	}))
+	defer server.Close()
+
+	newService(server.URL, "", time.Now()).claudePlan()
+
+	if auth := got.Get("Authorization"); auth != "Bearer tok-claude" {
+		t.Errorf("Authorization = %q, want %q", auth, "Bearer tok-claude")
+	}
+	if beta := got.Get("anthropic-beta"); beta != "oauth-2025-04-20" {
+		t.Errorf("anthropic-beta = %q, want %q", beta, "oauth-2025-04-20")
+	}
+	// Sent as anything else the endpoint rate-limits within a few requests.
+	if agent := got.Get("User-Agent"); agent[:len("claude-code/")] != "claude-code/" {
+		t.Errorf("User-Agent = %q, want a claude-code/… build", agent)
+	}
+}
+
+func TestClaudeFallsBackToTheOriginalWindowPair(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	body := `{"five_hour":{"utilization":63,"resets_at":"2026-08-17T23:20:00Z"},
+		"seven_day":{"utilization":7,"resets_at":"2026-08-24T15:00:00Z"},"limits":[]}`
+	url, _ := serve(t, http.StatusOK, body)
+
+	got := newService(url, "", time.Now()).claudePlan()
+
+	want := []Window{
+		{Label: "Session", Seconds: 18000, Percent: 63, ResetsAt: "2026-08-17T23:20:00Z"},
+		{Label: "Weekly", Seconds: 604800, Percent: 7, ResetsAt: "2026-08-24T15:00:00Z"},
+	}
+	if len(got.Windows) != 2 || got.Windows[0] != want[0] || got.Windows[1] != want[1] {
+		t.Errorf("windows = %+v, want %+v", got.Windows, want)
+	}
+}
+
+func TestClaudeSkipsEntriesItCannotDraw(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	body := `{"limits":[
+		{"kind":"session","percent":5,"resets_at":"2026-08-17T23:20:00Z"},
+		{"kind":"opus_promotional","percent":80},
+		{"kind":"weekly_all","percent":null},
+		{"kind":"weekly_scoped","percent":3,"scope":{"model":{"display_name":""}}},
+		{"kind":"weekly_scoped","percent":4,"scope":null}
+	]}`
+	url, _ := serve(t, http.StatusOK, body)
+
+	got := newService(url, "", time.Now()).claudePlan()
+
+	if len(got.Windows) != 1 || got.Windows[0].Label != "Session" {
+		t.Fatalf("windows = %+v, want only the session window", got.Windows)
+	}
+}
+
+func TestClaudeDropsAnUnparseableResetTime(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	body := `{"limits":[{"kind":"session","percent":5,"resets_at":"whenever"}]}`
+	url, _ := serve(t, http.StatusOK, body)
+
+	got := newService(url, "", time.Now()).claudePlan()
+
+	if len(got.Windows) != 1 || got.Windows[0].ResetsAt != "" {
+		t.Errorf("windows = %+v, want the window with no reset time", got.Windows)
+	}
+}
+
+func TestSignedOutStates(t *testing.T) {
+	tests := []struct {
+		name   string
+		creds  string
+		status int
+	}{
+		{name: "no credentials file", creds: "", status: http.StatusOK},
+		{name: "no token in the file", creds: `{"claudeAiOauth":{"accessToken":""}}`, status: http.StatusOK},
+		{name: "token rejected", creds: claudeCredsJSON, status: http.StatusUnauthorized},
+		{name: "token forbidden", creds: claudeCredsJSON, status: http.StatusForbidden},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writeCreds(t, tt.creds, "")
+			url, _ := serve(t, tt.status, `{}`)
+
+			got := newService(url, "", time.Now()).claudePlan()
+
+			if got.Status != StatusSignedOut {
+				t.Errorf("status = %q, want %q", got.Status, StatusSignedOut)
+			}
+			if len(got.Windows) != 0 {
+				t.Errorf("windows = %+v, want none", got.Windows)
+			}
+		})
+	}
+}
+
+func TestFailedStates(t *testing.T) {
+	tests := []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "server error", status: http.StatusInternalServerError, body: `{}`},
+		{name: "unparseable body", status: http.StatusOK, body: `not json`},
+		{name: "no window in the payload", status: http.StatusOK, body: `{"limits":[]}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writeCreds(t, claudeCredsJSON, "")
+			url, _ := serve(t, tt.status, tt.body)
+
+			got := newService(url, "", time.Now()).claudePlan()
+
+			if got.Status != StatusError {
+				t.Errorf("status = %q, want %q", got.Status, StatusError)
+			}
+		})
+	}
+}
+
+func TestCodexPlanNamesWindowsByDuration(t *testing.T) {
+	writeCreds(t, "", codexCredsJSON)
+	// The free tier reports a single 30-day window where a paid plan reports
+	// five-hour and weekly ones — in the same primary_window slot.
+	body := `{"plan_type":"free","rate_limit":{"primary_window":{
+		"used_percent":26,"limit_window_seconds":2592000,"reset_at":1789318316}}}`
+	url, _ := serve(t, http.StatusOK, body)
+
+	got := newService("", url, time.Now()).codexPlan()
+
+	if got.Status != StatusOK || got.Plan != "Free" {
+		t.Fatalf("plan = %+v, want an ok Free plan", got)
+	}
+	want := Window{Label: "Monthly", Seconds: 2592000, Percent: 26, ResetsAt: "2026-09-13T16:51:56Z"}
+	if len(got.Windows) != 1 || got.Windows[0] != want {
+		t.Errorf("windows = %+v, want %+v", got.Windows, want)
+	}
+}
+
+func TestCodexReadsBothWindows(t *testing.T) {
+	writeCreds(t, "", codexCredsJSON)
+	body := `{"plan_type":"pro","rate_limit":{
+		"primary_window":{"used_percent":12.4,"limit_window_seconds":18000,"reset_at":0},
+		"secondary_window":{"used_percent":88.6,"limit_window_seconds":604800,"reset_at":1789318316}}}`
+	url, _ := serve(t, http.StatusOK, body)
+
+	got := newService("", url, time.Now()).codexPlan()
+
+	want := []Window{
+		{Label: "Session", Seconds: 18000, Percent: 12},
+		{Label: "Weekly", Seconds: 604800, Percent: 89, ResetsAt: "2026-09-13T16:51:56Z"},
+	}
+	if len(got.Windows) != 2 || got.Windows[0] != want[0] || got.Windows[1] != want[1] {
+		t.Errorf("windows = %+v, want %+v", got.Windows, want)
+	}
+}
+
+func TestCodexWithoutRateLimitBlockFails(t *testing.T) {
+	writeCreds(t, "", codexCredsJSON)
+	url, _ := serve(t, http.StatusOK, `{"plan_type":"plus"}`)
+
+	if got := newService("", url, time.Now()).codexPlan(); got.Status != StatusError {
+		t.Errorf("status = %q, want %q", got.Status, StatusError)
+	}
+}
+
+func TestCodexLabel(t *testing.T) {
+	tests := []struct {
+		seconds int
+		want    string
+	}{
+		{seconds: 0, want: "Usage"},
+		{seconds: -1, want: "Usage"},
+		{seconds: 18000, want: "Session"},
+		{seconds: 86399, want: "Session"},
+		{seconds: 86400, want: "Weekly"},
+		{seconds: 604800, want: "Weekly"},
+		{seconds: 604801, want: "Monthly"},
+		{seconds: 2592000, want: "Monthly"},
+	}
+	for _, tt := range tests {
+		if got := codexLabel(tt.seconds); got != tt.want {
+			t.Errorf("codexLabel(%d) = %q, want %q", tt.seconds, got, tt.want)
+		}
+	}
+}
+
+func TestPercentClampsToTheGauge(t *testing.T) {
+	tests := []struct {
+		in   float64
+		want int
+	}{
+		{in: -4, want: 0},
+		{in: 0, want: 0},
+		{in: 12.4, want: 12},
+		{in: 12.5, want: 13},
+		{in: 99.9, want: 100},
+		{in: 103, want: 100},
+	}
+	for _, tt := range tests {
+		if got := percent(tt.in); got != tt.want {
+			t.Errorf("percent(%v) = %d, want %d", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestPlanLabel(t *testing.T) {
+	tests := []struct {
+		subscription string
+		tier         string
+		want         string
+	}{
+		{subscription: "max", tier: "default_claude_max_5x", want: "Max 5x"},
+		{subscription: "max", tier: "default_claude_max_20x", want: "Max 20x"},
+		{subscription: "pro", tier: "default_claude_pro", want: "Pro"},
+		{subscription: "", tier: "default_claude_max_5x", want: ""},
+	}
+	for _, tt := range tests {
+		var creds claudeCredentials
+		creds.OAuth.SubscriptionType = tt.subscription
+		creds.OAuth.RateLimitTier = tt.tier
+		if got := creds.planLabel(); got != tt.want {
+			t.Errorf("planLabel(%q, %q) = %q, want %q", tt.subscription, tt.tier, got, tt.want)
+		}
+	}
+}
+
+func TestPlansServesEveryMeteredProviderFromOneReading(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, codexCredsJSON)
+	claudeURL, claudeCalls := serve(t, http.StatusOK, claudeLimitsBody)
+	codexURL, codexCalls := serve(t, http.StatusOK,
+		`{"plan_type":"plus","rate_limit":{"primary_window":{"used_percent":9,"limit_window_seconds":18000}}}`)
+	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
+	s := newService(claudeURL, codexURL, now)
+
+	plans := s.Plans()
+	if len(plans) != 2 {
+		t.Fatalf("plans = %+v, want one per metered provider", plans)
+	}
+	if plans[0].Provider != "claude" || plans[1].Provider != "codex" {
+		t.Errorf("order = %q/%q, want claude/codex", plans[0].Provider, plans[1].Provider)
+	}
+
+	// Inside the TTL the endpoints are not asked again.
+	s.now = func() time.Time { return now.Add(4*time.Minute + 59*time.Second) }
+	s.Plans()
+	if *claudeCalls != 1 || *codexCalls != 1 {
+		t.Fatalf("calls = %d/%d after a cached read, want 1/1", *claudeCalls, *codexCalls)
+	}
+
+	// Past it they are.
+	s.now = func() time.Time { return now.Add(5*time.Minute + time.Second) }
+	s.Plans()
+	if *claudeCalls != 2 || *codexCalls != 2 {
+		t.Errorf("calls = %d/%d after the TTL, want 2/2", *claudeCalls, *codexCalls)
+	}
+}
+
+func TestNewPointsAtTheLiveEndpoints(t *testing.T) {
+	s := New()
+	if s.claudeURL != "https://api.anthropic.com/api/oauth/usage" {
+		t.Errorf("claudeURL = %q", s.claudeURL)
+	}
+	if s.codexURL != "https://chatgpt.com/backend-api/wham/usage" {
+		t.Errorf("codexURL = %q", s.codexURL)
+	}
+	if s.now == nil || s.http == nil {
+		t.Error("New must wire a clock and an HTTP client")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/omartelo/lich/internal/patchnotes"
 	"github.com/omartelo/lich/internal/project"
 	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/quota"
 	"github.com/omartelo/lich/internal/relay"
 	"github.com/omartelo/lich/internal/restart"
 	"github.com/omartelo/lich/internal/rpc"
@@ -133,6 +134,7 @@ func main() {
 	uncleanExit := singleton.UncleanExit(configDir, os.Getenv(restart.WaitEnv))
 	dispatcher.Register("system", system.New(env, logPath, version, uncleanExit))
 	dispatcher.Register("providers", providers.New())
+	dispatcher.Register("quota", quota.New())
 	// The relay is the only service whose caller is not the window: the `lich`
 	// CLI running inside a session reaches it over the same listener. It watches
 	// the hooks' state reports too, to notice a target that ends a turn without


### PR DESCRIPTION
Three changes that share a screen: a provider's settings section, and the footer beside it.

## Plan usage

Claude Code and Codex each report what a subscription has spent of its rolling windows, through the undocumented endpoint their own CLI polls. `internal/quota` reads both.

- **Credentials are read, never written.** Token rotation belongs to the CLI that owns the login — a refresh whose write-back fails spends the stored refresh token and logs the user out of their agent, which is far worse than a stale gauge. A rejected token reads as signed out, with the command that fixes it.
- **Cached five minutes.** Both endpoints rate-limit hard. The mutex is held across the fetch, so a second caller waits for that answer instead of firing its own.
- **Each provider carries its own status**, so one failing does not blank the other.
- **Windows are named by the length the provider reports**, never by their position in the payload: a Codex free plan answers with a 30-day window in the slot a paid plan uses for five hours.

The footer carries the fullest window beside the context ring — `5h 2%`, `wk 84%` — with every window behind its tooltip. The provider's own section opens with the same reading in full, including the weekly caps Anthropic scopes to a single model.

opencode, oh-my-pi and Crush meter nothing — they run on the user's own API keys — so they show nothing rather than an empty gauge. That asymmetry is a `docs/ceilings.md` bullet in this PR, along with the rest of the trap: undocumented endpoints, a limit kind lich has no name for being skipped in silence, and a number that can be five minutes old without saying so.

## One ladder for the footer readout

*Model & context in the footer* and *Session cost in the footer* asked one question twice and left the reader to assemble the answer. They are now one segmented control — **Nothing · Model & context · And cost** — over the same two settings keys, the way the permission ladder above it already works. Nothing needs setting again. The pair no rung writes (a cost with no readout beside it) reads as the top rung.

## A binary setting that answers

The two path fields never said which binary would run, and nothing checked it was there: a typo waited until a terminal refused to start.

`providers.Verify` resolves a configured value exactly as the spawn does — a bare name through `$PATH`, a path as written — and reports whether it can be executed. It names the two mistakes a shell would have hidden, because lich execs directly:

- a leading `~`, which nothing expands;
- a relative path, which resolves against each session's own working directory and so names a different binary per session.

The section opens with the resolved binary and its verdict; **Use a different binary** unfolds the whole chain — this project, all projects, `$PATH` — in resolution order, with the winning layer marked and the others shown as overridden. Paths can be picked from the file dialog lich already ships. A layer that resolves to nothing runnable unfolds the block itself: an error behind a disclosure is an error nobody fixes.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test -race ./...` (1617)
- [x] `pnpm check`, `tsc`, `vitest` (987), `vite build`
- [x] Cross-compile loop for linux, darwin and windows
- [x] `internal/quota` at 92.3% statements; `providers.Verify` covered for every status
- [x] `quota.Plans` exercised end to end against the live endpoints with this machine's real credentials