### PR TITLE
feat: open a terminal session straight into a tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Crush run on your own API keys, where there is no plan to meter, so they are
   absent from the block rather than shown empty.
 
+- **A terminal can open straight into a tool.** Right-click a terminal card and
+  set its **Entrypoint** — `lazygit`, `lazydocker`, `k9s`, `pnpm dev` — and that
+  command runs every time the terminal starts: the card's first view, a reload,
+  a respawn, the resume of a parked worktree. Quit the tool and you are back at
+  the prompt in the same card, so a crashed dev server leaves its error on
+  screen with a shell under it. The card takes the command as its name until you
+  rename it yourself, and then says what it runs in its tooltip. Emptying the
+  field puts the terminal back on a plain shell.
+
+  It belongs to that one terminal card and nothing else: a session running an
+  agent has no entrypoint to set, and it is not the project-wide
+  `.lich/setup-worktree.sh`, which still runs once when a worktree is born.
+
 ### Changed
 
 - **The binary setting says which binary, and whether it is there.** *Custom
@@ -50,6 +63,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   appears with the rung that shows a cost. Nothing needs setting again: an
   install already showing both reads as the top rung, one showing neither as the
   bottom.
+
+### Fixed
+
+- **Resuming a parked worktree session no longer forgets how it was started.** A
+  session opened with `lich open --model` came back on the provider's default
+  model after the worktree was kept and reopened, with nothing on screen saying
+  the model had changed.
 
 ## [0.35.1] - 2026-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Terminals no longer offer to delegate.** *Delegate to session…* was on every
+  card, terminals included, where the thing reading the prompt it writes is a
+  shell — so the request landed as a command line rather than as a request. The
+  action now belongs to sessions running an agent, which are the ones that can
+  act on it.
+
 - **The binary setting says which binary, and whether it is there.** *Custom
   path* and *Override for <project>* were two fields and a sentence about
   inheritance, and neither said what a session would actually spawn — a typo sat

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -22,6 +22,11 @@ work when nobody knows it and that the call site never shows. The mechanism and 
 - **A dropped file has no path, so lich guesses it** (`internal/drop`): a file under neither the session directory
   nor home is *copied*, so an agent told to edit it edits the copy — and that copy is deleted 3 days on, so a path
   pasted into a prompt eventually stops resolving.
+- **A terminal entrypoint reaches shell sessions on Linux and macOS alone** (`internal/terminal/entrypoint.go`):
+  the menu item is absent on a provider card, and on Windows the setting saves and the terminal opens on a bare
+  shell anyway — the wrap is skipped there for `wrapSetup`'s reason, and nothing on screen says so. It also runs
+  through the shell's `-c`, which loads no interactive rc: an alias defined in `.zshrc` is not a command that can
+  be an entrypoint, though `$PATH` is intact (`internal/terminal/shellenv.go`).
 - **The worktree setup script answers to the main checkout, never the new branch** (`internal/project/setup.go`):
   improve `.lich/setup-worktree.sh` on a feature branch and fresh worktrees keep running the old one until the
   change reaches the checkout the project points at.

--- a/frontend/src/components/sidebar/EntrypointDialog.tsx
+++ b/frontend/src/components/sidebar/EntrypointDialog.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+
+interface EntrypointDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  // The command already on this session, "" for a terminal on a plain shell.
+  entrypoint: string
+  // Where the command will run, shown so a card in a worktree says which
+  // checkout its lazygit is about to open.
+  cwd: string
+  onSave: (entrypoint: string) => void
+}
+
+// EntrypointDialog edits the one command a terminal session opens into. One
+// field and no options: emptying it is how a card goes back to a plain shell,
+// which is why there is no separate clear button to keep out of the footer.
+export function EntrypointDialog({
+  open,
+  onOpenChange,
+  entrypoint,
+  cwd,
+  onSave,
+}: EntrypointDialogProps) {
+  const [value, setValue] = useState(entrypoint)
+
+  // Reseed on every open: the dialog outlives one editing session, and a card
+  // reopened after a cancel would otherwise still hold the abandoned text.
+  useEffect(() => {
+    if (open) {
+      setValue(entrypoint)
+    }
+  }, [open, entrypoint])
+
+  const commit = () => {
+    onOpenChange(false)
+    const next = value.trim()
+    if (next !== entrypoint) {
+      onSave(next)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Entrypoint</DialogTitle>
+          <DialogDescription>
+            Runs each time this terminal starts. Quit it and you are back in the shell.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="session-entrypoint">Command</Label>
+          <Input
+            id="session-entrypoint"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            onKeyDown={(event) => event.key === "Enter" && commit()}
+            placeholder="lazygit"
+            autoFocus
+            className="font-mono"
+          />
+          <p className="text-xs text-muted-foreground">
+            Runs in <span className="font-mono">{cwd}</span>. Leave empty for a plain shell.
+          </p>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button onClick={commit}>Save</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -12,6 +12,7 @@ import {
   Pencil,
   Pin,
   PinOff,
+  Play,
   Terminal,
   TriangleAlert,
   X,
@@ -49,6 +50,7 @@ import { delegatePrompt, delegateWorktreePrompt } from "@/lib/session/delegate-p
 import { bracketedPaste } from "@/lib/terminal/bracketed-paste"
 import { requestTerminalFocus } from "@/lib/terminal/focus-request"
 import { SessionTargetPicker } from "./SessionTargetPicker"
+import { EntrypointDialog } from "./EntrypointDialog"
 
 interface SessionCardProps {
   session: Session
@@ -67,6 +69,10 @@ interface SessionCardProps {
   // agent sessions, so the user can drop into a terminal in the worktree the
   // agent is working in without cd-ing there by hand.
   onOpenTerminal: (cwd: string) => void
+  // Record the command this terminal opens into, "" to clear it back to a plain
+  // shell. Offered on shell sessions alone: on a provider card the entrypoint is
+  // the provider, and the store refuses one there anyway.
+  onSetEntrypoint: (entrypoint: string) => void
   // Open the Pulls screen for this session's worktree, parking its PR card.
   onPulls: () => void
   // Sessions this one can hand work to, grouped by project. Only the card
@@ -87,6 +93,7 @@ export function SessionCard({
   onRename,
   onPin,
   onOpenTerminal,
+  onSetEntrypoint,
   onPulls,
   delegateGroups,
 }: SessionCardProps) {
@@ -95,6 +102,7 @@ export function SessionCard({
   const [pathOverflow, setPathOverflow] = useState(false)
   const [editing, setEditing] = useState(false)
   const [delegatePickerOpen, setDelegatePickerOpen] = useState(false)
+  const [entrypointOpen, setEntrypointOpen] = useState(false)
   // Processing state reported by the lich Claude Code hook, drawn as a ring
   // around the provider icon: a spinning ring while Claude produces output,
   // solid emerald once its turn ends, amber when it is blocked on the user.
@@ -435,6 +443,12 @@ export function SessionCard({
             <Pencil />
             Rename
           </ContextMenuItem>
+          {session.kind === "shell" && (
+            <ContextMenuItem onClick={() => setEntrypointOpen(true)}>
+              <Play />
+              Entrypoint…
+            </ContextMenuItem>
+          )}
           <ContextMenuItem onClick={() => onPin(!pinned)}>
             {pinned ? <PinOff /> : <Pin />}
             {pinned ? "Unpin" : "Pin"}
@@ -467,6 +481,15 @@ export function SessionCard({
           groups={delegateGroups}
           onPick={(target) => delegate(target.label)}
           onPickWorktree={delegateWorktree}
+        />
+      )}
+      {session.kind === "shell" && (
+        <EntrypointDialog
+          open={entrypointOpen}
+          onOpenChange={setEntrypointOpen}
+          entrypoint={session.entrypoint ?? ""}
+          cwd={displayPath(shownPath)}
+          onSave={onSetEntrypoint}
         />
       )}
     </div>

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -163,7 +163,14 @@ export function SessionCard({
   // Every provider can delegate, and no live target is required: the picker's
   // pinned row delegates into a fresh worktree session, which is most useful
   // exactly when there is nobody else to hand work to yet.
-  const canDelegate = active
+  //
+  // A terminal cannot. Delegating writes the request at this card's own prompt
+  // and hands the cursor back, and the thing reading a terminal's prompt is a
+  // shell: it would run the line as a command, or fail on it. The declared kind
+  // decides, never the live agent readout — a menu that appears and disappears
+  // as an agent is started and quit by hand offers no action the user can rely
+  // on being there.
+  const canDelegate = active && session.kind !== "shell"
 
   // The picker is only rendered while the card can delegate, so losing that
   // unmounts it — and an open flag left behind would spring the dialog back up

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -87,6 +87,7 @@ export function SessionGroup({
     sessions: workspace,
     activateSession,
     renameSession,
+    setEntrypoint,
     pinSession,
     newSession,
   } = useProjects()
@@ -166,6 +167,9 @@ export function SessionGroup({
                     onSelect={() => select(session.id)}
                     onClose={() => onClose(session)}
                     onRename={(label) => renameSession(projectId, session.id, label)}
+                    onSetEntrypoint={(entrypoint) =>
+                      setEntrypoint(projectId, session.id, entrypoint)
+                    }
                     onPin={(pinned) => pinSession(projectId, session.id, pinned)}
                     onOpenTerminal={(cwd) => newSession(projectId, "shell", cwd)}
                     onPulls={onPulls}

--- a/frontend/src/components/sidebar/SessionTooltip.tsx
+++ b/frontend/src/components/sidebar/SessionTooltip.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, GitPullRequestArrow, TriangleAlert } from "lucide-react"
+import { GitBranch, GitPullRequestArrow, Play, TriangleAlert } from "lucide-react"
 import type { Session } from "@/lib/session/sessions"
 import { useSessionCwd } from "@/lib/session/use-session-cwd"
 import { useGitStatus } from "@/lib/git/use-git-status"
@@ -38,6 +38,15 @@ export function SessionTooltip({ session, path }: SessionTooltipProps) {
       <div className="flex flex-col gap-1.5">
         <span className="font-medium">{session.label}</span>
         <span className="break-all font-mono text-muted-foreground">{shownPath}</span>
+        {/* The command this terminal opens into. The card's label already says
+            it while the label is still automatic — this is the only place it is
+            named once the user has renamed the card. */}
+        {session.entrypoint && (
+          <span className="flex items-center gap-1.5 text-muted-foreground">
+            <Play className="size-3 shrink-0" />
+            <span className="break-all font-mono">{session.entrypoint}</span>
+          </span>
+        )}
         {git?.branch && (
           <span className="flex flex-wrap items-center gap-2 text-muted-foreground">
             <span className="flex items-center gap-1">

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -296,6 +296,8 @@ export interface StoredSession {
   kind: string
   path: string
   providerSessionId: string
+  /** The command a terminal session opens into; always "" for a provider one. */
+  entrypoint: string
   pinned: boolean
   /** The session that asked for this one, "" for a session nobody delegated. */
   originSessionId: string

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -334,6 +334,15 @@ export const Store = {
     call<null>("store.PurgeWorktreeSessions", [projectID, path]),
   RenameSession: (sessionID: string, label: string) =>
     call<null>("store.RenameSession", [sessionID, label]),
+  /** The command a terminal session opens into; "" clears it back to a plain
+   * shell. The store refuses it on anything but a shell session. */
+  SetSessionEntrypoint: (sessionID: string, entrypoint: string) =>
+    call<null>("store.SetSessionEntrypoint", [sessionID, entrypoint]),
+  /** Name a session from an automatic source — the provider's ai-title, or a
+   * terminal's own entrypoint. A no-op once the user has renamed the card;
+   * answers whether the label actually moved. */
+  SetSessionTitle: (sessionID: string, title: string) =>
+    call<boolean>("store.SetSessionTitle", [sessionID, title]),
   /** The provider conversation id recorded for a session, "" when none. */
   ProviderSession: (sessionID: string) => call<string>("store.ProviderSession", [sessionID]),
   /** Re-attach a provider conversation id to a session row. */

--- a/frontend/src/lib/session/delegate-prompt.ts
+++ b/frontend/src/lib/session/delegate-prompt.ts
@@ -15,9 +15,11 @@ import type { SessionKind } from "./sessions"
 // agent offered a tool it does not have answers the user with an error. The
 // command works in all four and costs nothing.
 //
-// The session's declared kind, never the live agent readout: a shell card
-// running `claude` by hand was spawned without the registration, so it has the
-// command and not the tools.
+// The session's declared kind, never the live agent readout. A terminal is not
+// offered the action at all (SessionCard's canDelegate) — the thing reading its
+// prompt is a shell — so the only kind that ever reaches here is the one the
+// session was spawned as, and that is also the one the registration was decided
+// by.
 const TOOL_KINDS: readonly string[] = ["claude", "codex"]
 
 /**

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -24,6 +24,7 @@ import {
   sessionOrigin,
   sessionsOf,
   setActiveSession,
+  setSessionEntrypoint,
   setSessionPinned,
   sidebarGroups,
   type Session,
@@ -208,6 +209,52 @@ describe("renameSession", () => {
     const state = buildState(2)
     expect(renameSession(state, "nope", "s1", "x")).toBe(state)
     expect(renameSession(state, P, "ghost", "x")).toBe(state)
+  })
+})
+
+describe("setSessionEntrypoint", () => {
+  // A terminal beside an agent session, which is the shape every assertion here
+  // is about: only the terminal can carry a command.
+  const withTerminal = () => addSession(buildState(1), P, "t1", "shell")
+
+  it("records the command and names the card after it while lich owns the name", () => {
+    const state = setSessionEntrypoint(withTerminal(), P, "t1", "lazygit", true)
+    const terminal = sessionsOf(state, P).find((s) => s.id === "t1")
+    expect(terminal?.entrypoint).toBe("lazygit")
+    expect(terminal?.label).toBe("lazygit")
+  })
+
+  it("leaves a name the user chose alone", () => {
+    const named = renameSession(withTerminal(), P, "t1", "Containers")
+    const state = setSessionEntrypoint(named, P, "t1", "lazydocker", false)
+    const terminal = sessionsOf(state, P).find((s) => s.id === "t1")
+    expect(terminal?.entrypoint).toBe("lazydocker")
+    expect(terminal?.label).toBe("Containers")
+  })
+
+  it("clears the command without blanking the card's name", () => {
+    const set = setSessionEntrypoint(withTerminal(), P, "t1", "lazygit", true)
+    const state = setSessionEntrypoint(set, P, "t1", "", true)
+    const terminal = sessionsOf(state, P).find((s) => s.id === "t1")
+    expect(terminal?.entrypoint).toBe("")
+    expect(terminal?.label).toBe("lazygit")
+  })
+
+  it("refuses a provider session, matching what the store will accept", () => {
+    const state = withTerminal()
+    expect(setSessionEntrypoint(state, P, "s1", "lazygit", true)).toBe(state)
+  })
+
+  it("does not mutate the input state", () => {
+    const before = withTerminal()
+    setSessionEntrypoint(before, P, "t1", "lazygit", true)
+    expect(sessionsOf(before, P).find((s) => s.id === "t1")?.entrypoint).toBeUndefined()
+  })
+
+  it("ignores unknown project or session ids", () => {
+    const state = withTerminal()
+    expect(setSessionEntrypoint(state, "nope", "t1", "x", true)).toBe(state)
+    expect(setSessionEntrypoint(state, P, "ghost", "x", true)).toBe(state)
   })
 })
 

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -36,6 +36,10 @@ export interface Session {
   // set by the store: a session created in this run has none, and the hook's
   // later report is not mirrored here — a running session has nothing to resume.
   providerSessionId?: string
+  // The command this terminal opens into, absent for a plain shell and for
+  // every provider session — the store refuses to record one against a card
+  // whose PTY runs an agent.
+  entrypoint?: string
   // Kept at the head of the project's list and refused a close until unpinned.
   pinned?: boolean
   // The session that asked for this one, when it was opened by delegation:
@@ -234,6 +238,42 @@ export function renameSession(
     [projectId]: {
       ...current,
       sessions: current.sessions.map((s) => (s.id === sessionId ? { ...s, label } : s)),
+    },
+  }
+}
+
+// setSessionEntrypoint records the command a terminal session opens into, and
+// takes the command as the card's label while that label is still whatever lich
+// named it — a card called "Terminal 2" that runs lazygit is a card the user has
+// to open to identify. `auto` is what the store answered about the rename it was
+// asked for in the same breath, so the decision is never guessed here: a card
+// the user named keeps its name, and the command shows in its tooltip instead.
+//
+// Unknown project or session ids are ignored, returning the input state
+// unchanged, and a session that is not a terminal is left alone — the store
+// refuses the write for it, so accepting it here would draw a card that does not
+// match the row behind it.
+export function setSessionEntrypoint(
+  state: SessionState,
+  projectId: string,
+  sessionId: string,
+  entrypoint: string,
+  auto: boolean,
+): SessionState {
+  const current = state[projectId]
+  const session = current?.sessions.find((s) => s.id === sessionId)
+  if (!current || !session || session.kind !== "shell") {
+    return state
+  }
+  return {
+    ...state,
+    [projectId]: {
+      ...current,
+      sessions: current.sessions.map((s) =>
+        s.id === sessionId
+          ? { ...s, entrypoint, ...(auto && entrypoint ? { label: entrypoint } : {}) }
+          : s,
+      ),
     },
   }
 }

--- a/frontend/src/providers/project-workspace.test.ts
+++ b/frontend/src/providers/project-workspace.test.ts
@@ -8,6 +8,7 @@ const storedSession = (overrides: Partial<StoredSession> = {}): StoredSession =>
   kind: "claude",
   path: "",
   providerSessionId: "",
+  entrypoint: "",
   pinned: false,
   originSessionId: "",
   originLabel: "",
@@ -43,6 +44,19 @@ describe("buildSessionState", () => {
   it("reads a null session list as a project with no sessions", () => {
     const state = buildSessionState([storedProject({ sessions: null })])
     expect(state.p1).toEqual({ sessions: [], activeId: "", nextSeq: 2 })
+  })
+
+  it("restores a terminal's entrypoint, and leaves the field off a plain shell", () => {
+    const state = buildSessionState([
+      storedProject({
+        sessions: [
+          storedSession({ id: "t1", kind: "shell", entrypoint: "lazygit" }),
+          storedSession({ id: "t2", kind: "shell" }),
+        ],
+      }),
+    ])
+    expect(state.p1.sessions[0].entrypoint).toBe("lazygit")
+    expect(state.p1.sessions[1]).not.toHaveProperty("entrypoint")
   })
 
   it("falls back to Claude for a kind this build does not know", () => {

--- a/frontend/src/providers/project-workspace.ts
+++ b/frontend/src/providers/project-workspace.ts
@@ -14,6 +14,7 @@ export function buildSessionState(loaded: StoredProject[]): SessionState {
       kind: isSessionKind(session.kind) ? session.kind : "claude",
       ...(session.path ? { path: session.path } : {}),
       ...(session.providerSessionId ? { providerSessionId: session.providerSessionId } : {}),
+      ...(session.entrypoint ? { entrypoint: session.entrypoint } : {}),
       ...(session.pinned ? { pinned: true } : {}),
       ...(session.originSessionId
         ? { originSessionId: session.originSessionId, originLabel: session.originLabel }

--- a/frontend/src/providers/projects-context.ts
+++ b/frontend/src/providers/projects-context.ts
@@ -37,6 +37,9 @@ export interface ProjectsValue {
   activateSession: (projectId: string, sessionId: string) => void
   /** Rename a session's display label. */
   renameSession: (projectId: string, sessionId: string, label: string) => void
+  // Record the command a terminal session opens into, "" to clear it. Refused
+  // by the store on anything but a shell session.
+  setEntrypoint: (projectId: string, sessionId: string, entrypoint: string) => void
   /** Pin a session to the head of its project's list, or unpin it. */
   pinSession: (projectId: string, sessionId: string, pinned: boolean) => void
   /** Rearrange the project tabs to the given id order. */

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -22,6 +22,7 @@ import {
   restoreSession,
   sessionsOf,
   setActiveSession,
+  setSessionEntrypoint as recordEntrypoint,
   setSessionPinned,
   type Session,
   type SessionKind,
@@ -347,6 +348,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
         kind: isSessionKind(restored.kind) ? restored.kind : "claude",
         path: restored.path,
         ...(restored.providerSessionId ? { providerSessionId: restored.providerSessionId } : {}),
+        ...(restored.entrypoint ? { entrypoint: restored.entrypoint } : {}),
         ...(restored.originSessionId
           ? { originSessionId: restored.originSessionId, originLabel: restored.originLabel }
           : {}),
@@ -733,6 +735,29 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     void Store.RenameSession(sessionId, label)
   }, [])
 
+  // setEntrypoint records the command a terminal opens into and reports back,
+  // because saving it changes nothing the user can see: the running PTY keeps
+  // whatever is in it, and the command only takes over on the next spawn. The
+  // card is left to say the rest — its name once lich still owns the name, its
+  // tooltip once the user has taken it over.
+  const setEntrypoint = useCallback((projectId: string, sessionId: string, entrypoint: string) => {
+    Store.SetSessionEntrypoint(sessionId, entrypoint)
+      // The store answers whether the label actually moved; it refuses a card
+      // the user has renamed, and that answer is what decides the card here.
+      .then(() => (entrypoint ? Store.SetSessionTitle(sessionId, entrypoint) : false))
+      .then((renamed) => {
+        setSessions(
+          recordEntrypoint(sessionsRef.current, projectId, sessionId, entrypoint, !!renamed),
+        )
+        toast.success(entrypoint ? "Entrypoint set" : "Entrypoint cleared", {
+          description: entrypoint
+            ? "Runs the next time this terminal starts."
+            : "This terminal starts a plain shell again.",
+        })
+      })
+      .catch((error: unknown) => toast.error(`Could not save the entrypoint: ${errorText(error)}`))
+  }, [])
+
   const pinSession = useCallback((projectId: string, sessionId: string, pinned: boolean) => {
     const next = setSessionPinned(sessionsRef.current, projectId, sessionId, pinned)
     if (next === sessionsRef.current) {
@@ -759,6 +784,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       keepSession,
       activateSession,
       renameSession,
+      setEntrypoint,
       pinSession,
       reorderProjects,
       reorderSessions,
@@ -779,6 +805,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       keepSession,
       activateSession,
       renameSession,
+      setEntrypoint,
       pinSession,
       reorderProjects,
       reorderSessions,

--- a/internal/store/entrypoint_test.go
+++ b/internal/store/entrypoint_test.go
@@ -1,0 +1,114 @@
+package store
+
+import "testing"
+
+// TestSetSessionEntrypointOnlyReachesShellSessions is the write-side half of the
+// separation: the entrypoint belongs to one terminal card, and no caller can
+// park one on a provider session — where the provider *is* the entrypoint and
+// nothing would ever read the value back.
+func TestSetSessionEntrypointOnlyReachesShellSessions(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "term", "Terminal 1", "shell", "", 2)
+	_ = svc.AddSession("p1", "agent", "Session 1", "claude", "", 3)
+
+	if err := svc.SetSessionEntrypoint("term", "lazygit"); err != nil {
+		t.Fatalf("SetSessionEntrypoint on a shell session: %v", err)
+	}
+	if err := svc.SetSessionEntrypoint("agent", "lazygit"); err != nil {
+		t.Fatalf("SetSessionEntrypoint on a provider session errored: %v", err)
+	}
+	if err := svc.SetSessionEntrypoint("gone", "lazygit"); err != nil {
+		t.Fatalf("SetSessionEntrypoint on a missing session errored: %v", err)
+	}
+
+	if got := svc.SessionEntrypoint("term"); got != "lazygit" {
+		t.Errorf("shell session entrypoint = %q, want lazygit", got)
+	}
+	if got := svc.SessionEntrypoint("agent"); got != "" {
+		t.Errorf("provider session entrypoint = %q, want it refused", got)
+	}
+	if got := svc.SessionEntrypoint("gone"); got != "" {
+		t.Errorf("missing session entrypoint = %q, want empty", got)
+	}
+}
+
+// TestSetSessionEntrypointTrimsAndClears pins the two ends of the dialog's one
+// field: a pasted command keeps no surrounding whitespace (it is spliced into a
+// shell script), and emptying the field is how a card goes back to a plain
+// shell — there is no separate clear.
+func TestSetSessionEntrypointTrimsAndClears(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "term", "Terminal 1", "shell", "", 2)
+
+	_ = svc.SetSessionEntrypoint("term", "  lazydocker\n")
+	if got := svc.SessionEntrypoint("term"); got != "lazydocker" {
+		t.Errorf("entrypoint = %q, want it trimmed", got)
+	}
+
+	_ = svc.SetSessionEntrypoint("term", "   ")
+	if got := svc.SessionEntrypoint("term"); got != "" {
+		t.Errorf("entrypoint = %q, want a blank field to clear it", got)
+	}
+}
+
+// TestSessionsCarryTheirEntrypoint proves the window is told which terminals run
+// something. The card reads it to prefill the dialog and to name what a renamed
+// terminal actually runs, so a workspace that restores without it loses the
+// answer for every card the user renamed.
+func TestSessionsCarryTheirEntrypoint(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "term", "Terminal 1", "shell", "", 2)
+	_ = svc.SetSessionEntrypoint("term", "k9s")
+
+	projects, err := svc.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if len(projects) != 1 || len(projects[0].Sessions) != 1 {
+		t.Fatalf("LoadState = %+v, want one project with one session", projects)
+	}
+	if got := projects[0].Sessions[0].Entrypoint; got != "k9s" {
+		t.Errorf("restored entrypoint = %q, want k9s", got)
+	}
+}
+
+// TestReopenWorktreeSessionCarriesSpawnOverrides pins the two overrides a resume
+// used to drop. Both are documented to survive every later spawn of a session,
+// and the park/resume cycle is the one path that keeps a card's identity while
+// changing its id — so a reinsert that forgot them put the provider back on its
+// default model and the terminal back on a bare shell, with nothing on screen
+// saying so.
+func TestReopenWorktreeSessionCarriesSpawnOverrides(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2)
+
+	_ = svc.AddSession("p1", "wt1", "worker", "claude", "/wt/foo", 3)
+	_ = svc.SetSessionModel("wt1", "opus")
+	_ = svc.CloseSession("p1", "wt1", "base")
+
+	_ = svc.AddSession("p1", "sh1", "Terminal 1", "shell", "/wt/bar", 4)
+	_ = svc.SetSessionEntrypoint("sh1", "lazygit")
+	_ = svc.CloseSession("p1", "sh1", "base")
+
+	if _, err := svc.ReopenWorktreeSession("p1", "/wt/foo", "wt2"); err != nil {
+		t.Fatalf("ReopenWorktreeSession (provider): %v", err)
+	}
+	if got := svc.SessionModel("wt2"); got != "opus" {
+		t.Errorf("resumed model = %q, want opus", got)
+	}
+
+	restored, err := svc.ReopenWorktreeSession("p1", "/wt/bar", "sh2")
+	if err != nil {
+		t.Fatalf("ReopenWorktreeSession (shell): %v", err)
+	}
+	if got := svc.SessionEntrypoint("sh2"); got != "lazygit" {
+		t.Errorf("resumed entrypoint = %q, want lazygit", got)
+	}
+	if restored == nil || restored.Entrypoint != "lazygit" {
+		t.Errorf("restored = %+v, want the entrypoint reported to the window", restored)
+	}
+}

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/omartelo/lich/internal/providers"
 )
@@ -166,7 +167,7 @@ func (s *Service) CloseSession(projectID, sessionID, activeID string) error {
 // ReopenWorktreeSession resumes a parked worktree session. It finds the parked
 // (is_open = 0) session for the worktree at path and re-adds it to the workspace
 // under a fresh id (newSessionID), carrying over the old label, kind, provider
-// session id, label_auto flag and origin. The fresh id is deliberate: it makes the frontend treat the card
+// session id, label_auto flag, model, entrypoint and origin. The fresh id is deliberate: it makes the frontend treat the card
 // as never-spawned, so its resume prompt fires and the provider conversation
 // continues instead of starting cold. Returns nil when nothing is parked at path
 // — the caller then opens a brand-new session.
@@ -177,16 +178,25 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 		// label_auto rides along so a user rename survives the park/resume
 		// cycle — reinserting without it would reset to 1 and let the ai-title
 		// stomp the chosen name, breaking SetSessionTitle's contract.
+		//
+		// model and entrypoint ride along for the same reason, one rung lower:
+		// both are spawn overrides their own doc comments promise survive every
+		// later spawn of the session, and a reinsert that dropped them would put
+		// the provider back on its default model and the terminal back on a bare
+		// shell — silently, on the one path where the card keeps its identity but
+		// not its id.
 		var labelAuto int
+		var model, entrypoint string
 		row := tx.QueryRow(
-			`SELECT id, label, kind, provider_session_id, label_auto, origin_session_id, origin_label
+			`SELECT id, label, kind, provider_session_id, label_auto, model, entrypoint,
+			        origin_session_id, origin_label
 			   FROM sessions
 			  WHERE project_id = ? AND path = ? AND is_open = 0
 			  ORDER BY rowid DESC LIMIT 1`,
 			projectID, path,
 		)
 		if err := row.Scan(
-			&old.ID, &old.Label, &old.Kind, &old.ProviderSessionID, &labelAuto,
+			&old.ID, &old.Label, &old.Kind, &old.ProviderSessionID, &labelAuto, &model, &entrypoint,
 			&old.OriginSessionID, &old.OriginLabel,
 		); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
@@ -207,10 +217,10 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 		if _, err := tx.Exec(
 			`INSERT INTO sessions
 			   (id, project_id, label, kind, path, provider_session_id, label_auto,
-			    origin_session_id, origin_label, position)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
+			    model, entrypoint, origin_session_id, origin_label, position)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
 			newSessionID, projectID, old.Label, old.Kind, path, old.ProviderSessionID, labelAuto,
-			old.OriginSessionID, old.OriginLabel, projectID,
+			model, entrypoint, old.OriginSessionID, old.OriginLabel, projectID,
 		); err != nil {
 			return fmt.Errorf("reinsert session %q: %w", newSessionID, err)
 		}
@@ -226,6 +236,7 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 			Kind:              old.Kind,
 			Path:              path,
 			ProviderSessionID: old.ProviderSessionID,
+			Entrypoint:        entrypoint,
 			OriginSessionID:   old.OriginSessionID,
 			OriginLabel:       old.OriginLabel,
 		}
@@ -330,6 +341,46 @@ func (s *Service) SessionModel(sessionID string) string {
 		return ""
 	}
 	return model.String
+}
+
+// SetSessionEntrypoint records the command a terminal session opens into, so
+// every later spawn of that session runs it again — a reload, a respawn, and the
+// resume of a parked worktree session all go through the same path. An empty
+// command clears it and leaves a plain shell.
+//
+// The kind clause is the guard that keeps this out of every other session: lich
+// has one project-wide way to put something in front of a PTY already
+// (.lich/setup-worktree.sh), and this is deliberately the opposite — one row,
+// one shell. Written in SQL rather than checked in Go because that is the only
+// spelling no future caller can skip: an RPC or an MCP tool that aims this at a
+// provider row changes nothing instead of parking a setting nothing reads.
+// 'shell' is terminal.KindShell, which SQL cannot interpolate — the same
+// coupling the schema's 'claude' default already carries.
+//
+// A session whose row is gone, or whose kind is not shell, matches nothing and
+// is not an error.
+func (s *Service) SetSessionEntrypoint(sessionID, entrypoint string) error {
+	if _, err := s.db.Exec(
+		`UPDATE sessions SET entrypoint = ? WHERE id = ? AND kind = 'shell'`,
+		strings.TrimSpace(entrypoint), sessionID,
+	); err != nil {
+		return fmt.Errorf("set entrypoint on %q: %w", sessionID, err)
+	}
+	return nil
+}
+
+// SessionEntrypoint returns the command recorded for a session, or "" for none —
+// which is what every provider session has, and what leaves a terminal on a
+// plain shell. A read failure answers "" for the same reason SessionModel does:
+// the entrypoint is an override, and the bare shell is the safe fallback.
+func (s *Service) SessionEntrypoint(sessionID string) string {
+	var entrypoint sql.NullString
+	if err := s.db.QueryRow(
+		`SELECT entrypoint FROM sessions WHERE id = ?`, sessionID,
+	).Scan(&entrypoint); err != nil {
+		return ""
+	}
+	return entrypoint.String
 }
 
 // SetProviderSession records the provider conversation id running inside a lich

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -49,6 +49,11 @@ CREATE TABLE IF NOT EXISTS sessions (
     position            INTEGER NOT NULL DEFAULT 0,
     pinned              INTEGER NOT NULL DEFAULT 0,
     model               TEXT NOT NULL DEFAULT '',
+    -- The command a terminal session opens into, empty for a plain shell. Only
+    -- a kind = 'shell' row ever holds one (SetSessionEntrypoint's WHERE clause):
+    -- on a provider row the entrypoint is the provider, and a value parked there
+    -- would be a setting nothing reads.
+    entrypoint          TEXT NOT NULL DEFAULT '',
     -- The session that asked for this one, when it was opened by delegation.
     -- Two columns rather than a foreign key: the id resolves to whatever the
     -- parent is called now, and the label is what it was called when the
@@ -107,9 +112,13 @@ type Session struct {
 	Kind              string `json:"kind"`
 	Path              string `json:"path"`
 	ProviderSessionID string `json:"providerSessionId"`
-	Pinned            bool   `json:"pinned"`
-	OriginSessionID   string `json:"originSessionId"`
-	OriginLabel       string `json:"originLabel"`
+	// Entrypoint is the command a terminal session opens into; always empty for
+	// a provider session. The window reads it to prefill its dialog and to say
+	// on the card what a renamed terminal actually runs.
+	Entrypoint      string `json:"entrypoint"`
+	Pinned          bool   `json:"pinned"`
+	OriginSessionID string `json:"originSessionId"`
+	OriginLabel     string `json:"originLabel"`
 }
 
 // Project is a persisted project together with its restorable session state.
@@ -174,6 +183,7 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN model TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN entrypoint TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN origin_session_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN origin_label TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
@@ -366,7 +376,8 @@ func (s *Service) ProjectAt(path string) (string, string) {
 // the frontend would have no order left to put an unpinned card back into.
 func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	rows, err := s.db.Query(
-		`SELECT id, label, kind, path, provider_session_id, pinned, origin_session_id, origin_label
+		`SELECT id, label, kind, path, provider_session_id, entrypoint, pinned,
+		        origin_session_id, origin_label
 		   FROM sessions WHERE project_id = ? AND is_open = 1 ORDER BY position, rowid`,
 		projectID,
 	)
@@ -379,8 +390,8 @@ func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	for rows.Next() {
 		var sess Session
 		if err := rows.Scan(
-			&sess.ID, &sess.Label, &sess.Kind, &sess.Path, &sess.ProviderSessionID, &sess.Pinned,
-			&sess.OriginSessionID, &sess.OriginLabel,
+			&sess.ID, &sess.Label, &sess.Kind, &sess.Path, &sess.ProviderSessionID,
+			&sess.Entrypoint, &sess.Pinned, &sess.OriginSessionID, &sess.OriginLabel,
 		); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}

--- a/internal/terminal/entrypoint.go
+++ b/internal/terminal/entrypoint.go
@@ -1,0 +1,44 @@
+package terminal
+
+import (
+	"strings"
+
+	"github.com/omartelo/lich/internal/shquote"
+)
+
+// wrapEntrypoint rewrites a terminal session's spawn so its PTY opens straight
+// into one command — lazygit, k9s, `pnpm dev` — instead of a bare prompt. The
+// command is stored on the session row, so it comes back on every later spawn:
+// the card's first view, a respawn after a reload, the resume of a parked
+// worktree session.
+//
+// It borrows wrapSetup's idiom, and shares nothing else with it. The setup
+// script belongs to the project, is written into the repository, runs once when
+// a worktree is born, and runs for whatever kind of session created it. This
+// belongs to one row, is typed into a dialog on one card, runs on every spawn of
+// that card, and reaches only a shell. The kind check lives in here rather than
+// at the call site for that reason: one place decides, so there is no second
+// caller to forget it. The write side is guarded independently, in SQL
+// (store.SetSessionEntrypoint) — neither guard depends on the other holding.
+//
+// The command exits into the shell rather than taking the PTY with it. A card
+// whose process is gone is a card the user has to notice and revive, which is
+// the wrong answer for both halves of what this is for: quitting lazygit means
+// wanting a prompt, and a dev server that crashed wants its error still on
+// screen with a shell under it.
+//
+// goos is runtime.GOOS, passed in so the decision stays pure and testable
+// off-Windows — wrapSetup's pattern, and Windows is skipped for wrapSetup's
+// reason: composing a cmd.exe chain is not worth it while the port stays
+// experimental. shell is the resolved user shell, which is also what the command
+// is run by: a value the user typed is their own shell's syntax, not sh's.
+func wrapEntrypoint(spec ptySpec, kind, entrypoint, goos string) ptySpec {
+	entrypoint = strings.TrimSpace(entrypoint)
+	if kind != KindShell || entrypoint == "" || goos == "windows" {
+		return spec
+	}
+	// The newline is load-bearing: a command ending in a comment or an unclosed
+	// `&&` would otherwise swallow the exec that follows it.
+	spec.args = []string{"-c", entrypoint + "\nexec " + shquote.Quote(spec.bin)}
+	return spec
+}

--- a/internal/terminal/entrypoint_test.go
+++ b/internal/terminal/entrypoint_test.go
@@ -1,0 +1,116 @@
+package terminal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// entrypointSpec is a shell session's spawn before the wrap: the user's shell,
+// no arguments, exactly what resolveCommand hands spawnSession.
+func entrypointSpec() ptySpec {
+	return ptySpec{
+		bin:  "/usr/bin/zsh",
+		dir:  "/home/user/dev/lich",
+		env:  []string{"HOME=/home/user"},
+		cols: 80,
+		rows: 24,
+	}
+}
+
+// TestWrapEntrypointLeavesOtherSessionsAlone is the separation this feature is
+// built around: an entrypoint reaches the one shell session it was typed on and
+// nothing else. The provider cases are the ones that matter — a value that
+// arrived on a provider row (a stale row, a caller that skipped the store's own
+// WHERE clause) must not rewrite that spawn, because a provider's argv is the
+// whole session.
+func TestWrapEntrypointLeavesOtherSessionsAlone(t *testing.T) {
+	base := entrypointSpec()
+	cases := []struct {
+		name, kind, entrypoint, goos string
+	}{
+		{"no entrypoint", KindShell, "", "linux"},
+		{"whitespace only", KindShell, "   \n\t ", "linux"},
+		{"claude session", providers.Claude, "lazygit", "linux"},
+		{"codex session", providers.Codex, "lazygit", "linux"},
+		{"opencode session", providers.OpenCode, "lazygit", "linux"},
+		{"omp session", providers.OMP, "lazygit", "linux"},
+		{"crush session", providers.Crush, "lazygit", "linux"},
+		{"windows", KindShell, "lazygit", "windows"},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wrapEntrypoint(base, tt.kind, tt.entrypoint, tt.goos)
+			if got.bin != base.bin || len(got.args) != 0 {
+				t.Errorf("spawn rewritten: bin=%q args=%v", got.bin, got.args)
+			}
+		})
+	}
+}
+
+// TestWrapEntrypointRunsThenExecsTheShell pins the two halves of the contract:
+// the command runs, and the shell replaces it afterwards rather than the PTY
+// dying with it. The exec argument is quoted, so a shell installed under a path
+// with a space is still the shell the user lands in.
+func TestWrapEntrypointRunsThenExecsTheShell(t *testing.T) {
+	spec := entrypointSpec()
+	spec.bin = "/opt/my shells/zsh"
+
+	got := wrapEntrypoint(spec, KindShell, "  lazydocker  ", "linux")
+
+	if got.bin != spec.bin {
+		t.Errorf("bin = %q, want the session's own shell %q", got.bin, spec.bin)
+	}
+	if len(got.args) != 2 || got.args[0] != "-c" {
+		t.Fatalf("args = %v, want the shell's own -c", got.args)
+	}
+	script := got.args[1]
+	run := strings.Index(script, "lazydocker")
+	exec := strings.Index(script, "exec '/opt/my shells/zsh'")
+	if run == -1 || exec == -1 {
+		t.Fatalf("script runs the command then execs the shell, got: %q", script)
+	}
+	if exec < run {
+		t.Errorf("the shell replaces the command before it runs: %q", script)
+	}
+	if got.dir != spec.dir || got.cols != spec.cols || got.rows != spec.rows {
+		t.Errorf("wrap changed dir/size: %+v", got)
+	}
+}
+
+// TestWrapEntrypointSurvivesATrailingComment is why the exec sits on a line of
+// its own. A command ending in a comment — or in a `\` continuation — would
+// otherwise swallow the exec, and the card would die with the tool instead of
+// falling back to a prompt.
+func TestWrapEntrypointSurvivesATrailingComment(t *testing.T) {
+	for _, entrypoint := range []string{"lazygit # the good one", "pnpm dev \\"} {
+		script := wrapEntrypoint(entrypointSpec(), KindShell, entrypoint, "linux").args[1]
+		if !strings.Contains(script, "\nexec ") {
+			t.Errorf("exec is not on its own line after %q: %q", entrypoint, script)
+		}
+	}
+}
+
+// TestWrapEntrypointComposesWithSetup proves the order a fresh worktree terminal
+// carrying both gets: the project's setup script, then the command, then the
+// shell — and that wrapSetup's end marker still lands between the script and
+// everything the user asked for, so a session is never handed work mid-install.
+func TestWrapEntrypointComposesWithSetup(t *testing.T) {
+	spec := wrapEntrypoint(entrypointSpec(), KindShell, "lazygit", "linux")
+	spec, wrapped := wrapSetup(spec, "pnpm install", "linux")
+	if !wrapped {
+		t.Fatal("setup wrap skipped")
+	}
+
+	script := spec.args[1]
+	install := strings.Index(script, "pnpm install")
+	marker := strings.Index(script, "lich-setup-done")
+	tool := strings.Index(script, "lazygit")
+	if install == -1 || marker == -1 || tool == -1 {
+		t.Fatalf("composed script lost a stage: %q", script)
+	}
+	if !(install < marker && marker < tool) {
+		t.Errorf("stages out of order (install=%d marker=%d tool=%d): %q", install, marker, tool, script)
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -156,6 +156,7 @@ type Store interface {
 	SetProviderSession(sessionID, providerSessionID string) error
 	ProviderSession(sessionID string) (string, error)
 	SessionModel(sessionID string) string
+	SessionEntrypoint(sessionID string) string
 	SetSessionTitle(sessionID, title string) (bool, error)
 	CostReadout() bool
 	CostLedger(sessionID, transcriptID string) (int64, string, float64, error)
@@ -499,6 +500,9 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 		cols: cols,
 		rows: rows,
 	}
+	// Before wrapSetup, so a fresh worktree terminal carrying both runs the
+	// project's setup script first, then the entrypoint, then the shell.
+	spec = wrapEntrypoint(spec, kind, s.store.SessionEntrypoint(id), runtime.GOOS)
 	settingUp := false
 	if setup {
 		spec, settingUp = wrapSetup(spec, project.SetupScript(s.store.ProjectPath(projectID)), runtime.GOOS)

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -39,6 +39,7 @@ type stubBins struct {
 	providerSession string
 	providerErr     error
 	model           string
+	entrypoint      string
 	skipPerms       bool
 	costOn          bool
 	ledgers         map[string]stubLedger
@@ -85,6 +86,7 @@ func (s stubBins) ProviderBin(_, _ string) string       { return s.bin }
 func (s stubBins) SkipPermissions(_, _, _ string) bool  { return s.skipPerms }
 func (s stubBins) ProjectPath(_ string) string          { return s.projectPath }
 func (s stubBins) SessionModel(_ string) string         { return s.model }
+func (s stubBins) SessionEntrypoint(_ string) string    { return s.entrypoint }
 func (s stubBins) SetProviderSession(_, _ string) error { return nil }
 
 func (s stubBins) WorktreePorts() map[string]int {


### PR DESCRIPTION
A terminal card can carry one command — `lazygit`, `lazydocker`, `k9s`, `pnpm dev` — set from its own context menu. The command runs on every spawn of that session: the card's first view, a reload, a respawn, the resume of a parked worktree. Quitting it execs the shell, so the card is never a dead process the user has to notice and revive — a crashed dev server leaves its error on screen with a prompt under it.

The card takes the command as its name while the label is still automatic, and names it in the tooltip once the user has renamed the card. Emptying the field puts the terminal back on a plain shell; there is no separate clear.

## Not the setup script

lich already has one way to put something in front of a PTY, and the two are separated on every axis so neither can stand in for the other:

|  | `.lich/setup-worktree.sh` | Entrypoint |
| --- | --- | --- |
| Scope | the project — a file in the repository | one session row |
| When | once, at the birth of a worktree | every spawn of that session |
| Applies to | whatever session created the worktree, any kind | shell sessions only |
| Job | make the checkout usable | make this one card *be* a tool |

A per-session command cannot live in `.lich/` at all: session ids are lich's, not the repository's, and a file there is shared with everyone who clones it. Same answer to "why not a settings key" — both are project-scoped storage, which is exactly the leak.

Both sides of the column are guarded independently, so neither depends on the other holding:

- **Write** — `UPDATE sessions SET entrypoint = ? WHERE id = ? AND kind = 'shell'`. In SQL rather than checked in Go because that is the spelling no future caller can skip: an RPC or an MCP tool aimed at a provider row changes nothing instead of parking a setting nothing reads.
- **Read** — the kind check lives inside `wrapEntrypoint`, not around it, so there is no second call site to forget it.

When a fresh worktree terminal carries both, the entrypoint is applied first and `wrapSetup` wraps the result: setup script, then the tool, then the shell — with the setup marker still landing before either, so a session is never handed relayed work mid-install.

## Fixed along the way

`ReopenWorktreeSession` reinserts a parked row under a fresh id, carrying label, kind, path, provider session id, `label_auto` and origin. `model` was **not** in that list, so a session opened with `lich open --model` silently came back on the provider's default after a keep-and-resume — which is exactly what `SetSessionModel`'s own comment promises it does not do. `entrypoint` would have landed in the same hole. Both now ride along, in the same statement.

## Ceilings

Two bullets in `docs/ceilings.md`:

- Shell sessions only — on a provider card the entrypoint *is* the provider, so the menu item is absent (Invariant 5).
- No Windows — the wrap is skipped there for `wrapSetup`'s reason, and the setting saves anyway with nothing on screen saying it will not run. The `-c` shell also loads no interactive rc, so an alias from `.zshrc` cannot be an entrypoint; `$PATH` is intact via `ResolveShellEnv`.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` — 1597 pass; `-race` on `internal/store` and `internal/terminal`
- [x] Cross-compile loop: `GOOS=linux|darwin|windows go build ./... && go vet ./...` clean
- [x] `pnpm check` clean (only the standing a11y warning backlog), `tsc --noEmit` clean, `vite build` succeeds
- [x] `vitest run` — 964 pass, including the new `setSessionEntrypoint` and hydration cases
- [x] New Go tests pin the separation directly: every provider kind, an empty command and Windows all leave the spawn untouched; the shell case runs then execs; a trailing comment does not swallow the exec; setup + entrypoint compose in order
- [x] New store tests pin the write guard (a provider row refuses the value), trim/clear, and the reopen carry-over for both `model` and `entrypoint`
- [x] **Not exercised:** the render path. The frontend gate is node-only, so a base-ui composition crash ships green — worth eyeballing the dialog and the menu item in `task dev`. The dialog mirrors `MergeMessageDialog` verbatim and the menu item is the same `ContextMenuItem` used five times in that file.
