### PR TITLE
Run a session confined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Sessions can run confined.** Settings › Providers gains a **Sandbox** ladder
+  beside the permission one — Off, Ask each time, Worktrees only, Everywhere —
+  and a session on a confined rung opens inside an OS sandbox: a fresh empty
+  home holding only that provider's own state, the rest of the machine
+  read-only, and write access to the checkout it was opened for. Your ssh keys,
+  your cloud credentials and every other repository on the disk are simply not
+  there. The network stays on, so the agent still reaches its API and lich still
+  hears its hooks, and the plan gauge, the cost readout and resume all keep
+  working — the provider writes its transcript to the same place it always did.
+
+  It is the counterweight to skipping permission prompts: the two rungs are read
+  together, and an agent turned loose in a worktree can be turned loose inside a
+  sandbox. The rung is per provider and can be set for one project alone, and
+  the New worktree dialog carries a **Run confined** box that starts on whatever
+  the rung would do and overrides it for that session alone — including every
+  later spawn of it, so a reload or a resume opens the way you opened it.
+
+  A confined card wears a shield beside its status dot, and its tooltip says
+  what that means and that the answer was taken when the session opened.
+
+  Linux runs bubblewrap and macOS `sandbox-exec`; the control is absent on a
+  machine with neither, and on Windows. It is not a boundary against hostile
+  code — see `docs/ceilings.md` for what it does not stop.
+
 - **How much of your plan is left, without leaving lich.** Claude Code and Codex
   both report what a subscription has spent of its rolling windows, and lich now
   reads it: the footer carries the window closest to running out beside the

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -89,3 +89,33 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   those logins and never writes them: it does not refresh the token, so an expired one reads as signed out until
   the provider's own CLI rotates it. A reading is cached for five minutes because both endpoints rate-limit hard —
   the number on screen is up to that old, and nothing on it says so.
+- **The sandbox confines a working agent, not hostile code** (`internal/sandbox`): namespaces and mounts on
+  Linux, a path policy on macOS, and nothing else — no seccomp filter, no Landlock ruleset. The network is
+  never cut (the agent needs its API and the plugin's hooks report over loopback), so anything readable
+  inside is exfiltrable, and `~/.config` *is* readable: a token stored there, `gh`'s among them, is in
+  reach. The private home is writable and vanishes with the session, so a dotfile an agent writes is gone
+  next spawn with nothing saying so. On Ubuntu and Debian the kernel may refuse the user namespace outright
+  (an AppArmor policy), which surfaces as bubblewrap's own error in the card and no session. `~/.ssh` is not
+  mounted at all: a push over ssh from inside a confined session fails, and lich's own PR flows run outside
+  it and are unaffected. macOS has no hardware here — its profile is unit-tested and has never run.
+- **A symlink in the home is not mounted into the sandbox** (`internal/sandbox`): every path lich binds is
+  taken as it is on disk, and a link is skipped — following one would let a dotfile manager point the
+  private home at whatever it likes, and binding one fails the spawn outright when a parent directory is
+  already mounted (bubblewrap resolves a mount destination through symlinks). So a `~/.gitconfig` symlinked
+  out of a dotfiles repository is absent inside a confined session, with nothing on screen saying so. The
+  binaries are the exception: their symlink chains are walked and the *directory* of every hop is mounted
+  (`BinaryDirs`), which is what makes an agent installed the usual way — a link on `PATH` into a versioned
+  store — runnable at all.
+- **Only the New worktree dialog asks** (`frontend/src/lib/use-sandbox-choice.ts`): the `Ask each time` rung
+  has one place to put the question, so a session opened from the New Session menu, by a delegation, or
+  through the MCP tool is not confined on that rung — it takes the answer closing the dialog would give.
+  `Worktrees only` and `Everywhere` reach every caller; `Ask` reaches one.
+- **A confined session is frozen at the answer it opened with** (`internal/terminal/sandbox.go`): the row
+  wins over the rung in both directions, so moving the ladder afterwards changes nothing for the cards
+  already on screen — including a parked worktree session resumed months later. The card's shield is the only
+  thing that says so, and it says confined or not, never why: a card with no shield beside a rung set to
+  Everywhere is a session that opened before the rung moved, and reopening it is the only way to change it.
+- **A terminal session is never confined by a rung** (`internal/store/settings.go`): the rung is keyed by
+  provider, and `shell` is not one — the sandbox exists to confine an agent working unattended, not the
+  user's own prompt. A terminal opened in a project whose provider is on `Everywhere` still runs on the
+  machine, and nothing says so.

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useState } from "react"
-import { Store } from "@/lib/rpc"
+import { Store, System } from "@/lib/rpc"
 import {
   footerReadout,
   footerReadoutPair,
   skipLevel,
   skipLevelPair,
+  sandboxKey,
+  sandboxLevel,
   skipPermissionFlags,
   skipPermissionsKey,
   type FooterReadout,
+  type SandboxLevel,
   type SkipLevel,
 } from "@/lib/providers-store"
 import { useSettings } from "@/providers/settings"
@@ -43,6 +46,33 @@ const FOOTER_READOUTS: { level: FooterReadout; label: string; consequence: strin
   },
 ]
 
+// The same shape again for which sessions run confined, ordered by how much of
+// the machine a session can reach. "Ask each time" sits second because a session
+// nobody answered for runs unconfined, exactly like "Off".
+const SANDBOX_LEVELS: { level: SandboxLevel; label: string; consequence: string }[] = [
+  {
+    level: "off",
+    label: "Off",
+    consequence: "Sessions run straight on the machine, reaching everything you can reach.",
+  },
+  {
+    level: "ask",
+    label: "Ask each time",
+    consequence:
+      "Every new session asks before it opens. Nothing is remembered — a session opened any other way, by a delegation or an MCP tool, is not confined.",
+  },
+  {
+    level: "worktrees",
+    label: "Worktrees only",
+    consequence: "Sessions in the project directory run on the machine.",
+  },
+  {
+    level: "everywhere",
+    label: "Everywhere",
+    consequence: "Including the tree you work in. Every session opens confined.",
+  },
+]
+
 // The same shape for how far the provider runs without asking, ordered by risk.
 const SKIP_LEVELS: { level: SkipLevel; label: string; consequence: string }[] = [
   {
@@ -61,6 +91,37 @@ const SKIP_LEVELS: { level: SkipLevel; label: string; consequence: string }[] = 
     consequence: "Including the tree you work in. Nothing will ask.",
   },
 ]
+
+// useSandboxLevel is the stored sandbox rung for one provider in one scope, read
+// once and written through on every change. It reads "off" until the value
+// arrives, which is also what an unreadable value means: the unknown state is
+// drawn as the one lich has always behaved like, never as one that silently
+// starts confining sessions.
+function useSandboxLevel(providerId: string, projectId: string) {
+  const key = sandboxKey(providerId)
+  const [level, setLevel] = useState<SandboxLevel>("off")
+
+  useEffect(() => {
+    void Store.GetSetting(key, projectId).then((value) => setLevel(sandboxLevel(value)))
+  }, [key, projectId])
+
+  const choose = (next: SandboxLevel) => {
+    setLevel(next)
+    void Store.SetSetting(key, projectId, next)
+  }
+  return [level, choose] as const
+}
+
+// useSandboxAvailable answers whether this machine can confine anything at all —
+// bubblewrap on Linux, sandbox-exec on macOS. Undefined until it arrives, so the
+// control is absent rather than briefly drawn as unavailable on every mount.
+function useSandboxAvailable() {
+  const [available, setAvailable] = useState<boolean | undefined>(undefined)
+  useEffect(() => {
+    void System.SandboxAvailable().then(setAvailable)
+  }, [])
+  return available
+}
 
 // useSkipPermissions is the stored "run without permission prompts" flag for one
 // checkout scope: read once, written through on every toggle. It reads off until
@@ -101,6 +162,12 @@ export function ProviderBinSettings({
   const [budget, setBudget] = useState(() => (costBudget > 0 ? String(costBudget) : ""))
   const [skipHere, setSkipHere] = useSkipPermissions(providerId, false)
   const [skipInWorktrees, setSkipInWorktrees] = useSkipPermissions(providerId, true)
+  // The sandbox is scoped to whichever pane this is: the project's own rung when
+  // opened from a project, the global one from the hub.
+  const [sandbox, setSandbox] = useSandboxLevel(providerId, projectId ?? GLOBAL_SCOPE)
+  const sandboxAvailable = useSandboxAvailable()
+  const sandboxConsequence =
+    SANDBOX_LEVELS.find((rung) => rung.level === sandbox)?.consequence ?? ""
   const skipFlag = skipPermissionFlags[providerId]
   const level = skipLevel(skipHere, skipInWorktrees)
   const consequence = SKIP_LEVELS.find((rung) => rung.level === level)?.consequence ?? ""
@@ -183,6 +250,32 @@ export function ProviderBinSettings({
             </SettingBlock>
           )}
         </>
+      )}
+
+      {/* Directly above the permission ladder: the two answer the same worry
+          from opposite ends, and are read together. Absent on a machine with no
+          backend for it — a control that saves a setting nothing can act on is
+          worse than no control. */}
+      {sandboxAvailable && (
+        <SettingBlock
+          title="Sandbox"
+          description={`Run ${providerName} confined: an empty home holding only its own state, the machine read-only, and writes only inside the checkout. The network stays on — the agent still reaches its API, and lich still hears its hooks.`}
+        >
+          <ToggleGroup
+            value={[sandbox]}
+            onValueChange={(next) => next[0] && setSandbox(next[0] as SandboxLevel)}
+            spacing={1}
+            aria-label={`Which ${providerName} sessions run confined`}
+            className="border border-border p-[3px]"
+          >
+            {SANDBOX_LEVELS.map((rung) => (
+              <ToggleGroupItem key={rung.level} value={rung.level} size="sm">
+                {rung.label}
+              </ToggleGroupItem>
+            ))}
+          </ToggleGroup>
+          <p className="mt-2 max-w-prose text-xs text-muted-foreground">{sandboxConsequence}</p>
+        </SettingBlock>
       )}
 
       {/* Never unless the user says otherwise. A worktree is its own rung

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -13,6 +13,7 @@ import {
   Pin,
   PinOff,
   Play,
+  Shield,
   Terminal,
   TriangleAlert,
   X,
@@ -276,6 +277,16 @@ export function SessionCard({
                     <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
                       {age}
                     </span>
+                  )}
+                  {/* Permanent state, so it sits with the status and the age
+                      rather than on the line below, which is a ladder where one
+                      rung draws at a time and every rung is news. Muted and
+                      wordless: the tooltip carries what it means. */}
+                  {session.sandboxed && (
+                    <Shield
+                      aria-label="Sandboxed"
+                      className="size-3 shrink-0 text-muted-foreground"
+                    />
                   )}
                   <span className="truncate text-sm font-medium text-foreground">
                     {session.label}

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -12,7 +12,7 @@ import {
   isPullsListOpen,
   subscribePullsListCard,
 } from "@/lib/pulls-list-card-store"
-import { enabledProviders, useProviders } from "@/lib/providers-store"
+import { enabledProviders, projectDefaultProviderKind, useProviders } from "@/lib/providers-store"
 import { ResizeHandle } from "@/components/common/ResizeHandle"
 import { SettingsCard } from "./SettingsCard"
 import { SidebarCard } from "@/components/common/SidebarCard"
@@ -143,12 +143,17 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
     reorderSessions(projectId, reorderSubset(list, ids, member))
   }
 
-  const createWorktree = async (name: string, base: string, baseIsRemote: boolean) => {
+  const createWorktree = async (
+    name: string,
+    base: string,
+    baseIsRemote: boolean,
+    sandbox: string,
+  ) => {
     const wt = await ProjectService.CreateWorktree(path, projectId, name, base, baseIsRemote)
     if (wt) {
       // A fresh checkout is the one moment the project's setup script runs;
       // reopening an existing worktree never queues it.
-      queueSetup(newWorktreeSession(projectId, wt))
+      queueSetup(newWorktreeSession(projectId, wt, sandbox))
     }
     setWorktreeOpen(false)
   }
@@ -288,6 +293,8 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
         open={worktreeOpen}
         onOpenChange={setWorktreeOpen}
         projectPath={path}
+        projectId={projectId}
+        providerId={projectDefaultProviderKind(projectId)}
         currentBranch={git?.branch ?? ""}
         onCreate={createWorktree}
         onResume={resumeWorktree}

--- a/frontend/src/components/sidebar/SessionTooltip.tsx
+++ b/frontend/src/components/sidebar/SessionTooltip.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, GitPullRequestArrow, Play, TriangleAlert } from "lucide-react"
+import { GitBranch, GitPullRequestArrow, Play, Shield, TriangleAlert } from "lucide-react"
 import type { Session } from "@/lib/session/sessions"
 import { useSessionCwd } from "@/lib/session/use-session-cwd"
 import { useGitStatus } from "@/lib/git/use-git-status"
@@ -45,6 +45,24 @@ export function SessionTooltip({ session, path }: SessionTooltipProps) {
           <span className="flex items-center gap-1.5 text-muted-foreground">
             <Play className="size-3 shrink-0" />
             <span className="break-all font-mono">{session.entrypoint}</span>
+          </span>
+        )}
+        {/* What the shield on the card means. Directly under the path, because
+            what it says is about that path: the sandbox is the difference
+            between a session that can write anywhere and one that can write
+            here. The last line is the part nothing else says — the answer was
+            taken when the session opened, and moving the rung in Settings will
+            not move this card. */}
+        {session.sandboxed && (
+          <span className="flex flex-col gap-0.5">
+            <span className="flex items-center gap-1.5">
+              <Shield className="size-3 shrink-0" />
+              Sandboxed
+            </span>
+            <span className="text-muted-foreground">
+              Empty home, machine read-only, writes only in this checkout. Set when the session
+              opened; reopen it to change.
+            </span>
           </span>
         )}
         {git?.branch && (

--- a/frontend/src/components/sidebar/WorktreeDialog.tsx
+++ b/frontend/src/components/sidebar/WorktreeDialog.tsx
@@ -3,6 +3,7 @@ import type { KeyboardEvent } from "react"
 import { ProjectService } from "@/lib/rpc"
 import type { Branches, Worktree } from "@/lib/api-types"
 import { SearchInput } from "@/components/common/SearchInput"
+import { WorktreeSandboxRow } from "@/components/sidebar/WorktreeSandboxRow"
 import { WorktreeSetupRow } from "@/components/sidebar/WorktreeSetupRow"
 import { Button } from "@/components/ui/button"
 import {
@@ -17,16 +18,28 @@ import {
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { isValidBranchName } from "@/lib/git/branch-name"
+import { useSandboxChoice, type SandboxAnswer } from "@/lib/use-sandbox-choice"
 import { cn, errorText } from "@/lib/utils"
 
 interface WorktreeDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   projectPath: string
+  /** The project the worktree belongs to, and the provider its session will
+   * run: together they scope the sandbox rung the confinement row starts on. */
+  projectId: string
+  providerId: string
   /** The repo's checked-out branch, preselected as the base. */
   currentBranch: string
-  /** Create the worktree and open its session; rejections show in the dialog. */
-  onCreate: (name: string, base: string, baseIsRemote: boolean) => Promise<void>
+  /** Create the worktree and open its session; rejections show in the dialog.
+   * sandbox is the confinement answer for that session ("on"/"off", "" when the
+   * machine cannot confine and nothing was asked). */
+  onCreate: (
+    name: string,
+    base: string,
+    baseIsRemote: boolean,
+    sandbox: SandboxAnswer,
+  ) => Promise<void>
   /** Reopen a session on an already-existing worktree. */
   onResume: (wt: { name: string; path: string }) => void
 }
@@ -105,6 +118,8 @@ export function WorktreeDialog({
   open,
   onOpenChange,
   projectPath,
+  projectId,
+  providerId,
   currentBranch,
   onCreate,
   onResume,
@@ -117,6 +132,8 @@ export function WorktreeDialog({
   const [submitError, setSubmitError] = useState("")
   const [submitting, setSubmitting] = useState(false)
   const listRef = useRef<HTMLDivElement>(null)
+  // A worktree is always the linked checkout, so the rung is read on that side.
+  const sandbox = useSandboxChoice(providerId, projectId, true)
 
   const vis = filterBranches(branches, filter)
   const flat = flatValues(vis)
@@ -211,7 +228,7 @@ export function WorktreeDialog({
     setSubmitting(true)
     setSubmitError("")
     try {
-      await onCreate(trimmed, id, group === "remote")
+      await onCreate(trimmed, id, group === "remote", sandbox.answer)
     } catch (err) {
       setSubmitError(errorText(err))
       setSubmitting(false)
@@ -320,6 +337,8 @@ export function WorktreeDialog({
         </div>
 
         <WorktreeSetupRow projectPath={projectPath} />
+
+        <WorktreeSandboxRow choice={sandbox} />
 
         {(loadError || submitError) && (
           <span className="text-xs break-words text-destructive">{loadError || submitError}</span>

--- a/frontend/src/components/sidebar/WorktreeSandboxRow.tsx
+++ b/frontend/src/components/sidebar/WorktreeSandboxRow.tsx
@@ -1,0 +1,36 @@
+import { Checkbox } from "@/components/ui/checkbox"
+import { Label } from "@/components/ui/label"
+import type { SandboxChoice } from "@/lib/use-sandbox-choice"
+
+// WorktreeSandboxRow is the New-worktree dialog's confinement line: whether the
+// session about to open runs inside the sandbox (internal/sandbox). It arrives
+// showing what the provider's rung would do on its own, and whatever it shows
+// when Create is pressed is recorded on that session alone — a later change to
+// the rung never moves a session already open.
+//
+// Absent on a machine with no backend for it, WorktreeSetupRow's rule: a control
+// that cannot change anything is worse than no control.
+export function WorktreeSandboxRow({ choice }: { choice: SandboxChoice }) {
+  if (!choice.available) {
+    return null
+  }
+  return (
+    <div className="flex items-start gap-2.5">
+      <Checkbox
+        id="worktree-sandbox"
+        checked={choice.confined}
+        onCheckedChange={choice.setConfined}
+        className="mt-0.5"
+      />
+      <div className="flex flex-col gap-0.5">
+        <Label htmlFor="worktree-sandbox" className="text-sm font-medium">
+          Run confined
+        </Label>
+        <span className="text-xs text-muted-foreground">
+          An empty home holding only the agent's own state, the machine read-only, and writes only
+          inside this worktree. The network stays on.
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -298,6 +298,9 @@ export interface StoredSession {
   providerSessionId: string
   /** The command a terminal session opens into; always "" for a provider one. */
   entrypoint: string
+  /** Whether this session runs confined: "on", "off", or "" for a row nothing
+   * has spawned yet. Written by the spawn, which is what resolves the rung. */
+  sandbox: string
   pinned: boolean
   /** The session that asked for this one, "" for a session nobody delegated. */
   originSessionId: string

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -10,11 +10,15 @@ import {
   readEnabled,
   resolveDefaultProvider,
   resolveProjectDefaultProvider,
+  sandboxDefaultFor,
+  sandboxKey,
+  sandboxLevel,
   skipLevel,
   skipLevelPair,
   skipPermissionFlags,
   skipPermissionsKey,
   type ProviderState,
+  type SandboxLevel,
 } from "./providers-store"
 
 describe("provider setting keys", () => {
@@ -365,5 +369,44 @@ describe("createProvidersStore", () => {
     await store.load()
 
     expect(store.getProjectProviderKind("p1")).toBe("claude")
+  })
+})
+
+describe("sandbox rung", () => {
+  it("keys the setting per provider, mirroring the Go spelling", () => {
+    expect(sandboxKey("claude")).toBe("provider.claude.sandbox")
+    expect(sandboxKey("crush")).toBe("provider.crush.sandbox")
+  })
+
+  it("reads every rung the ladder names", () => {
+    for (const level of ["off", "ask", "worktrees", "everywhere"] as const) {
+      expect(sandboxLevel(level)).toBe(level)
+    }
+  })
+
+  // An unknown value must never confine a session nobody asked to confine, and
+  // "off" is the only answer that surprises no one — it is what lich did before.
+  it("reads anything else as off", () => {
+    for (const value of ["", "true", "on", "Everywhere", " worktrees", "always"]) {
+      expect(sandboxLevel(value)).toBe("off")
+    }
+  })
+
+  // The dialog has to arrive showing the answer the spawn would reach on its
+  // own, or the box the user leaves untouched means something else.
+  it("matches store.SandboxDefault on both sides of the checkout", () => {
+    const cases: [SandboxLevel, boolean, boolean][] = [
+      ["off", false, false],
+      ["off", true, false],
+      ["ask", false, false],
+      ["ask", true, false],
+      ["worktrees", false, false],
+      ["worktrees", true, true],
+      ["everywhere", false, true],
+      ["everywhere", true, true],
+    ]
+    for (const [level, worktree, want] of cases) {
+      expect(sandboxDefaultFor(level, worktree)).toBe(want)
+    }
   })
 })

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -75,6 +75,40 @@ export function skipLevelPair(level: SkipLevel): { here: boolean; worktrees: boo
   return { here: level === "everywhere", worktrees: level !== "never" }
 }
 
+// sandboxKey holds which sessions of a provider run confined (mirrors
+// store.sandboxKey in Go, which is what the spawn reads). Scoped like binKey —
+// a project value wins over the global one — because the checkout full of
+// somebody else's code is the one to confine, and a scratch project is not.
+export function sandboxKey(id: string): string {
+  return `provider.${id}.sandbox`
+}
+
+// Which sessions of a provider run confined, as one ladder ordered by how much
+// of the machine a session can reach. "ask" sits second because a session
+// nobody answered for runs unconfined, exactly like "off" — it moves who
+// decides, not what the sandbox is. Mirrors the Sandbox* constants in Go.
+export type SandboxLevel = "off" | "ask" | "worktrees" | "everywhere"
+
+const SANDBOX_LEVELS: readonly SandboxLevel[] = ["off", "ask", "worktrees", "everywhere"]
+
+// sandboxLevel reads the stored value. Anything the ladder does not name is
+// "off": an unknown value must never confine a session nobody asked to confine,
+// nor leave one unconfined that the user meant to protect — and "off" is the
+// only answer that surprises no one, because it is what lich did before.
+export function sandboxLevel(value: string): SandboxLevel {
+  return SANDBOX_LEVELS.find((level) => level === value) ?? "off"
+}
+
+// sandboxDefaultFor is what the new-session dialog arrives showing: the rung
+// applied to the checkout the session will start in. It is the frontend's copy
+// of store.SandboxDefault in Go — the dialog has to show the same answer the
+// spawn would reach on its own, or the box the user leaves untouched means
+// something other than what it shows.
+export function sandboxDefaultFor(level: SandboxLevel, worktree: boolean): boolean {
+  if (level === "everywhere") return true
+  return level === "worktrees" && worktree
+}
+
 // How much of a session's own accounting the footer carries, as one ladder
 // ordered by how much it says. The two settings keys stay exactly as they are —
 // this is the shape the user chooses in, not the shape lich stores.

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -287,6 +287,9 @@ export const Store = {
   CloseProject: (id: string) => call<null>("store.CloseProject", [id]),
   /** The closed projects offered for reopening, newest first (capped backend-side). */
   RecentProjects: () => call<RecentProject[] | null>("store.RecentProjects", []),
+  /** sandbox is whether this session runs confined ("on"/"off", "" to follow the
+   * provider's rung). It rides the insert because the PTY reads it on the first
+   * spawn — a second call would race the card this one puts on screen. */
   AddSession: (
     projectID: string,
     sessionID: string,
@@ -294,7 +297,8 @@ export const Store = {
     kind: string,
     path: string,
     nextSeq: number,
-  ) => call<null>("store.AddSession", [projectID, sessionID, label, kind, path, nextSeq]),
+    sandbox = "",
+  ) => call<null>("store.AddSession", [projectID, sessionID, label, kind, path, nextSeq, sandbox]),
   /**
    * AddSession for a session that was opened by delegation: originID is the
    * session that asked for it and originLabel what that one was called then.
@@ -338,6 +342,11 @@ export const Store = {
    * shell. The store refuses it on anything but a shell session. */
   SetSessionEntrypoint: (sessionID: string, entrypoint: string) =>
     call<null>("store.SetSessionEntrypoint", [sessionID, entrypoint]),
+  /** Whether this one session runs confined, overriding the provider's rung for
+   * it alone: "on", "off", or "" to follow the setting. Read on every later
+   * spawn, so a reload and a resume keep the answer the session opened with. */
+  SetSessionSandbox: (sessionID: string, sandbox: string) =>
+    call<null>("store.SetSessionSandbox", [sessionID, sandbox]),
   /** Name a session from an automatic source — the provider's ai-title, or a
    * terminal's own entrypoint. A no-op once the user has renamed the card;
    * answers whether the label actually moved. */
@@ -404,6 +413,9 @@ export const System = {
   /** Raise a desktop notification: a headline and an optional second line.
    * The caller decides it is warranted — the backend only delivers. */
   Notify: (summary: string, detail: string) => call<null>("system.Notify", [summary, detail]),
+  /** Whether this machine can run a session confined (bubblewrap on Linux,
+   * sandbox-exec on macOS). A fact about the machine, not about a provider. */
+  SandboxAvailable: () => call<boolean>("system.SandboxAvailable", []),
 }
 
 export const Providers = {

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -38,6 +38,13 @@ export const CWD_EVENT = "session-cwd"
 // Payload: { id, agent }; an empty agent (every PTY spawn) clears the mark.
 export const AGENT_EVENT = "session-agent"
 
+// Global event the backend emits on every spawn with whether that PTY runs
+// inside the sandbox (see terminal.sandboxEventName). Payload: { id, confined }.
+// The verdict is the spawn's — it resolves the provider's rung, the checkout and
+// any per-session override — and it is persisted with the row too, which is what
+// a page reload hydrates from.
+export const SANDBOX_EVENT = "session-sandbox"
+
 // Global event the backend emits after a turn ends with the session's
 // context-window usage (see terminal.usageEventName). Payload: { id, percent,
 // tokens, window, model, effort } — percent is 0–100 of the window, tokens the
@@ -167,6 +174,10 @@ export function isIdEvent(data: unknown): data is { id: string } {
   return (
     typeof data === "object" && data !== null && typeof (data as { id?: unknown }).id === "string"
   )
+}
+
+export function isSandboxEvent(data: unknown): data is { id: string; confined: boolean } {
+  return isIdEvent(data) && typeof (data as { confined?: unknown }).confined === "boolean"
 }
 
 export function isStatusEvent(data: unknown): data is { id: string; state: string } {

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -26,6 +26,7 @@ import {
   setActiveSession,
   setSessionEntrypoint,
   setSessionPinned,
+  setSessionSandboxed,
   sidebarGroups,
   type Session,
   type SessionKind,
@@ -859,5 +860,35 @@ describe("dropClosedSession", () => {
     const before = buildState(2)
     expect(dropClosedSession(before, P, "ghost", "s1")).toBe(before)
     expect(dropClosedSession(before, "other", "s1", "")).toBe(before)
+  })
+})
+
+describe("setSessionSandboxed", () => {
+  const state = () => buildState(2)
+
+  it("marks the session the spawn reported", () => {
+    const next = setSessionSandboxed(state(), "s1", true)
+    expect(next[P]?.sessions[0]?.sandboxed).toBe(true)
+    expect(next[P]?.sessions[1]?.sandboxed).toBeUndefined()
+  })
+
+  it("clears the mark when a respawn reports it unconfined", () => {
+    const confined = setSessionSandboxed(state(), "s1", true)
+    const next = setSessionSandboxed(confined, "s1", false)
+    expect(next[P]?.sessions[0]?.sandboxed).toBeUndefined()
+  })
+
+  // The event fires on every spawn, so an unchanged answer has to return the
+  // same object: a new one re-renders every card in the project for nothing.
+  it("returns the same state when nothing changed", () => {
+    const current = state()
+    expect(setSessionSandboxed(current, "s1", false)).toBe(current)
+    const confined = setSessionSandboxed(current, "s1", true)
+    expect(setSessionSandboxed(confined, "s1", true)).toBe(confined)
+  })
+
+  it("ignores a session it does not know", () => {
+    const current = state()
+    expect(setSessionSandboxed(current, "gone", true)).toBe(current)
   })
 })

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -40,6 +40,11 @@ export interface Session {
   // every provider session — the store refuses to record one against a card
   // whose PTY runs an agent.
   entrypoint?: string
+  // Whether this session's PTY runs inside the sandbox (internal/sandbox).
+  // Absent means it does not — the spawn decides it, from the provider's rung,
+  // the checkout and any per-session override, and reports the verdict back;
+  // the card never re-derives it.
+  sandboxed?: boolean
   // Kept at the head of the project's list and refused a close until unpinned.
   pinned?: boolean
   // The session that asked for this one, when it was opened by delegation:
@@ -238,6 +243,34 @@ export function renameSession(
     [projectId]: {
       ...current,
       sessions: current.sessions.map((s) => (s.id === sessionId ? { ...s, label } : s)),
+    },
+  }
+}
+
+// setSessionSandboxed records whether a session's PTY runs confined, as the
+// spawn reported it. Unknown ids leave the state untouched, and a value that
+// already matches returns the same object — the event fires on every spawn, and
+// a re-render per respawn of an unchanged card is a card that flickers.
+export function setSessionSandboxed(
+  state: SessionState,
+  sessionId: string,
+  sandboxed: boolean,
+): SessionState {
+  const projectId = projectOfSession(state, sessionId)
+  const current = projectId ? state[projectId] : undefined
+  const session = current?.sessions.find((s) => s.id === sessionId)
+  if (!projectId || !current || !session || (session.sandboxed ?? false) === sandboxed) {
+    return state
+  }
+  return {
+    ...state,
+    [projectId]: {
+      ...current,
+      sessions: current.sessions.map((s) =>
+        s.id === sessionId
+          ? { ...s, ...(sandboxed ? { sandboxed: true } : { sandboxed: undefined }) }
+          : s,
+      ),
     },
   }
 }

--- a/frontend/src/lib/use-sandbox-choice.ts
+++ b/frontend/src/lib/use-sandbox-choice.ts
@@ -1,0 +1,70 @@
+import { useEffect, useState } from "react"
+import { sandboxDefaultFor, sandboxKey, sandboxLevel } from "@/lib/providers-store"
+import { Store, System } from "@/lib/rpc"
+
+// The answer a session about to open carries: "on", "off", or "" when nothing
+// was asked. The stored spelling, so it can go straight into the insert.
+export type SandboxAnswer = "on" | "off" | ""
+
+export interface SandboxChoice {
+  /** Whether this machine can confine anything at all. */
+  available: boolean
+  /** Whether the session opens confined. */
+  confined: boolean
+  setConfined: (confined: boolean) => void
+  /** Whether the rung — rather than the user — is what set the box. */
+  fromRung: boolean
+  /** What to record on the session row. */
+  answer: SandboxAnswer
+}
+
+// useSandboxChoice is the confinement decision for one session about to open. It
+// starts on the rung the spawn would reach by itself (store.SandboxDefault in
+// Go, mirrored by sandboxDefaultFor), so a box the user never touches means
+// exactly what it shows.
+//
+// worktree says which side of the rung this session lands on: a linked checkout,
+// or the project's own directory.
+//
+// The answer is recorded either way, never left empty once the machine can
+// confine: an untouched box is still this session's answer, and freezing it on
+// the row is what keeps a later change to the rung from quietly confining — or
+// releasing — a session the user already opened.
+export function useSandboxChoice(providerId: string, projectId: string, worktree: boolean) {
+  const [available, setAvailable] = useState(false)
+  const [confined, setChoice] = useState(false)
+  const [fromRung, setFromRung] = useState(true)
+
+  useEffect(() => {
+    let stale = false
+    const load = async () => {
+      const canConfine = await System.SandboxAvailable()
+      // The project's rung wins over the global one, which is the scope
+      // store.SandboxLevel reads in the same order.
+      const [scoped, global] = await Promise.all([
+        projectId ? Store.GetSetting(sandboxKey(providerId), projectId) : Promise.resolve(""),
+        Store.GetSetting(sandboxKey(providerId), ""),
+      ])
+      if (stale) {
+        return
+      }
+      setAvailable(canConfine)
+      setChoice(sandboxDefaultFor(sandboxLevel(scoped || global), worktree))
+      setFromRung(true)
+    }
+    // A settings read that fails leaves the row absent and the session
+    // unconfined, which is what lich did before the sandbox existed.
+    void load().catch(() => undefined)
+    return () => {
+      stale = true
+    }
+  }, [providerId, projectId, worktree])
+
+  const setConfined = (next: boolean) => {
+    setChoice(next)
+    setFromRung(false)
+  }
+
+  const answer: SandboxAnswer = available ? (confined ? "on" : "off") : ""
+  return { available, confined, setConfined, fromRung, answer }
+}

--- a/frontend/src/providers/project-workspace.test.ts
+++ b/frontend/src/providers/project-workspace.test.ts
@@ -9,6 +9,7 @@ const storedSession = (overrides: Partial<StoredSession> = {}): StoredSession =>
   path: "",
   providerSessionId: "",
   entrypoint: "",
+  sandbox: "",
   pinned: false,
   originSessionId: "",
   originLabel: "",
@@ -124,5 +125,25 @@ describe("buildSessionState", () => {
     ])
     expect(Object.keys(state)).toEqual(["p1", "p2"])
     expect(state.p2).toMatchObject({ activeId: "s9", nextSeq: 5 })
+  })
+})
+
+describe("confined sessions", () => {
+  it("marks a session the spawn recorded as confined", () => {
+    const state = buildSessionState([
+      storedProject({ sessions: [storedSession({ id: "s1", sandbox: "on" })] }),
+    ])
+    expect(state.p1?.sessions[0]?.sandboxed).toBe(true)
+  })
+
+  // "off" and "" are both "not confined" — the card carries no mark either way,
+  // and the difference (nobody decided yet) belongs to the spawn, not here.
+  it("leaves every other value unmarked", () => {
+    for (const sandbox of ["", "off", "maybe"]) {
+      const state = buildSessionState([
+        storedProject({ sessions: [storedSession({ id: "s1", sandbox })] }),
+      ])
+      expect(state.p1?.sessions[0]?.sandboxed).toBeUndefined()
+    }
   })
 })

--- a/frontend/src/providers/project-workspace.ts
+++ b/frontend/src/providers/project-workspace.ts
@@ -15,6 +15,7 @@ export function buildSessionState(loaded: StoredProject[]): SessionState {
       ...(session.path ? { path: session.path } : {}),
       ...(session.providerSessionId ? { providerSessionId: session.providerSessionId } : {}),
       ...(session.entrypoint ? { entrypoint: session.entrypoint } : {}),
+      ...(session.sandbox === "on" ? { sandboxed: true } : {}),
       ...(session.pinned ? { pinned: true } : {}),
       ...(session.originSessionId
         ? { originSessionId: session.originSessionId, originLabel: session.originLabel }

--- a/frontend/src/providers/projects-context.ts
+++ b/frontend/src/providers/projects-context.ts
@@ -22,8 +22,13 @@ export interface ProjectsValue {
    * defaults to the project's provider choice; path to its own directory. */
   newSession: (projectId: string, kind?: SessionKind, path?: string) => string
   /** Open a project-default session rooted at a git worktree, labeled after it,
-   * returning its id. */
-  newWorktreeSession: (projectId: string, wt: { name: string; path: string }) => string
+   * returning its id. sandbox is the dialog's confinement answer ("on"/"off"),
+   * "" to follow the provider's rung. */
+  newWorktreeSession: (
+    projectId: string,
+    wt: { name: string; path: string },
+    sandbox?: string,
+  ) => string
   /** Resume a worktree: reopen its parked session when one exists, else open a
    * fresh session on it. */
   reopenWorktreeSession: (projectId: string, wt: { name: string; path: string }) => Promise<void>

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -24,6 +24,7 @@ import {
   setActiveSession,
   setSessionEntrypoint as recordEntrypoint,
   setSessionPinned,
+  setSessionSandboxed,
   type Session,
   type SessionKind,
   type SessionState,
@@ -41,12 +42,14 @@ import {
   CLOSED_EVENT,
   OPENED_EVENT,
   RELAY_STALLED_EVENT,
+  SANDBOX_EVENT,
   STATUS_EVENT,
   TITLE_EVENT,
   TOUCHED_EVENT,
   decideStatusNotice,
   isIdEvent,
   isRelayStalledEvent,
+  isSandboxEvent,
   isStatusEvent,
   isTitleEvent,
   shouldToastAttention,
@@ -170,6 +173,22 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
         return
       }
       const next = relabelSession(sessionsRef.current, projectId, id, label)
+      if (next !== sessionsRef.current) {
+        setSessions(next)
+      }
+    })
+    return () => off()
+  }, [])
+
+  // Every spawn reports whether its PTY runs confined. Mirrored into local
+  // state so the card wears its mark the moment the session opens, rather than
+  // at the next reload — the row is already written, so this never writes back.
+  useEffect(() => {
+    const off = onAppEvent(SANDBOX_EVENT, (data) => {
+      if (!isSandboxEvent(data)) {
+        return
+      }
+      const next = setSessionSandboxed(sessionsRef.current, data.id, data.confined)
       if (next !== sessionsRef.current) {
         setSessions(next)
       }
@@ -318,15 +337,25 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     return sessionId
   }, [])
 
+  // sandbox is the answer the new-worktree dialog collected: "on", "off", or ""
+  // when the machine cannot confine anything and nothing was asked.
   const newWorktreeSession = useCallback(
-    (projectId: string, wt: { name: string; path: string }) => {
+    (projectId: string, wt: { name: string; path: string }, sandbox = "") => {
       const sessionId = newSessionId()
       const kind = projectDefaultProviderKind(projectId)
       const next = addSession(sessionsRef.current, projectId, sessionId, kind, wt.path, wt.name)
       const project = next[projectId]
       const created = project.sessions[project.sessions.length - 1]
       setSessions(next)
-      void Store.AddSession(projectId, sessionId, created.label, kind, wt.path, project.nextSeq)
+      void Store.AddSession(
+        projectId,
+        sessionId,
+        created.label,
+        kind,
+        wt.path,
+        project.nextSeq,
+        sandbox,
+      )
       return sessionId
     },
     [],
@@ -349,6 +378,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
         path: restored.path,
         ...(restored.providerSessionId ? { providerSessionId: restored.providerSessionId } : {}),
         ...(restored.entrypoint ? { entrypoint: restored.entrypoint } : {}),
+        ...(restored.sandbox === "on" ? { sandboxed: true } : {}),
         ...(restored.originSessionId
           ? { originSessionId: restored.originSessionId, originLabel: restored.originLabel }
           : {}),

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -60,6 +60,23 @@ func gitQuiet(dir string, args ...string) (string, bool) {
 	return string(out), true
 }
 
+// GitCommonDir returns the repository metadata directory shared by a checkout
+// and every worktree linked to it, or "" when dir is not in a repository. It is
+// the same question basestatus.go asks, in the same spelling, and absolute
+// because the caller needs a path rather than something to resolve against dir.
+//
+// A linked worktree's `.git` is a file naming that directory, so a process that
+// can see the worktree and not the common directory has a checkout git refuses
+// to read at all. It is asked of git rather than parsed out of the `.git` file
+// because git is the one thing that cannot be wrong about its own layout.
+func GitCommonDir(dir string) string {
+	out, ok := gitQuiet(dir, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(out)
+}
+
 // splitNUL splits the -z output of a git list command into its entries. git
 // terminates each with a NUL, so the trailing empty element is dropped along
 // with any other.

--- a/internal/sandbox/binarydirs_unix_test.go
+++ b/internal/sandbox/binarydirs_unix_test.go
@@ -1,0 +1,143 @@
+//go:build !windows
+
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// shim writes an executable at path, creating its directory.
+func shim(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// The shape every agent installer uses: a name on PATH that is a symlink into a
+// versioned store somewhere else. Both directories have to be mounted, and the
+// symlink itself must never be — binding it is what fails the spawn.
+func TestBinaryDirsFollowsAnInstallerSymlink(t *testing.T) {
+	home := t.TempDir()
+	store := filepath.Join(home, ".local", "share", "agent", "versions")
+	bin := filepath.Join(home, ".local", "bin")
+	shim(t, filepath.Join(store, "1.2.3"))
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(store, "1.2.3"), filepath.Join(bin, "agent")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	t.Setenv("PATH", bin)
+
+	want := []string{bin, store}
+	if got := BinaryDirs("agent"); !slices.Equal(got, want) {
+		t.Errorf("BinaryDirs = %v, want %v", got, want)
+	}
+	// Never the executable itself: bubblewrap resolves a mount destination
+	// through symlinks and fails on a target that is not in the sandbox yet.
+	for _, dir := range BinaryDirs("agent") {
+		if filepath.Base(dir) == "agent" || filepath.Base(dir) == "1.2.3" {
+			t.Errorf("an executable reached the mount list: %v", dir)
+		}
+	}
+}
+
+// A relative link target resolves against the directory holding the link, not
+// against the process's working directory.
+func TestBinaryDirsResolvesRelativeLinks(t *testing.T) {
+	home := t.TempDir()
+	shim(t, filepath.Join(home, "store", "tool-1.0"))
+	bin := filepath.Join(home, "bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink("../store/tool-1.0", filepath.Join(bin, "tool")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	t.Setenv("PATH", bin)
+
+	want := []string{bin, filepath.Join(home, "store")}
+	if got := BinaryDirs("tool"); !slices.Equal(got, want) {
+		t.Errorf("BinaryDirs = %v, want %v", got, want)
+	}
+}
+
+func TestBinaryDirsOfAPlainBinary(t *testing.T) {
+	home := t.TempDir()
+	bin := filepath.Join(home, "bin")
+	shim(t, filepath.Join(bin, "plain"))
+	t.Setenv("PATH", bin)
+
+	if got := BinaryDirs("plain"); !slices.Equal(got, []string{bin}) {
+		t.Errorf("BinaryDirs = %v, want %v", got, []string{bin})
+	}
+}
+
+// Nothing on PATH answers to it: a spawn that would have failed outside the
+// sandbox too, and not a reason to fail building one.
+func TestBinaryDirsOfAMissingBinary(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	if got := BinaryDirs("no-such-binary-anywhere"); got != nil {
+		t.Errorf("BinaryDirs = %v, want nil", got)
+	}
+}
+
+// A link that points at itself must not spin the spawn.
+func TestBinaryDirsSurvivesASymlinkLoop(t *testing.T) {
+	bin := t.TempDir()
+	if err := os.Symlink(filepath.Join(bin, "b"), filepath.Join(bin, "a")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(bin, "a"), filepath.Join(bin, "b")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	t.Setenv("PATH", bin)
+
+	got := BinaryDirs(filepath.Join(bin, "a"))
+	if len(got) > symlinkHops {
+		t.Errorf("the walk did not stop: %d entries", len(got))
+	}
+	for _, dir := range got {
+		if dir != bin {
+			t.Errorf("BinaryDirs left the loop's directory: %v", got)
+		}
+	}
+}
+
+// A dotfile symlinked out of a dotfiles repository is refused, not followed: it
+// is a mount destination bubblewrap resolves through (which fails the spawn when
+// a parent directory is already mounted), and an instruction to reach outside
+// the private home.
+func TestDescribeRefusesSymlinkedDotfiles(t *testing.T) {
+	home := t.TempDir()
+	dotfiles := filepath.Join(home, "dotfiles")
+	if err := os.MkdirAll(dotfiles, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dotfiles, "gitconfig"), []byte("[user]\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	link := filepath.Join(home, ".gitconfig")
+	if err := os.Symlink(filepath.Join(dotfiles, "gitconfig"), link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	// A real directory beside it, to prove the filter drops the link alone.
+	if err := os.MkdirAll(filepath.Join(home, ".config"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	spec := Describe("claude", home, filepath.Join(home, "repo"), "", nil)
+	if slices.Contains(spec.Read, link) {
+		t.Errorf("a symlinked dotfile was mounted: %v", spec.Read)
+	}
+	if !slices.Contains(spec.Read, filepath.Join(home, ".config")) {
+		t.Errorf("the filter dropped a real directory: %v", spec.Read)
+	}
+}

--- a/internal/sandbox/bwrap_linux.go
+++ b/internal/sandbox/bwrap_linux.go
@@ -1,0 +1,176 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// bwrapBin is bubblewrap's executable. It is what confines a session on Linux:
+// an unprivileged user namespace, a mount namespace built from the arguments
+// below, and no setuid helper of lich's own.
+const bwrapBin = "bwrap"
+
+// systemDirs are the top-level directories that make the sandbox an operating
+// system rather than an empty namespace, all read-only. /nix and /opt are here
+// for the machines that have them and cost nothing on the machines that do not:
+// a missing one is dropped before it reaches bwrap.
+//
+// /var is deliberately absent. Binding it brought in whatever was mounted
+// underneath — a running container's overlay, measured read-write inside a
+// confined session, because bubblewrap's read-only remount does not always
+// reach a submount it inherited. What it bought was the package database, which
+// a coding agent reads at most to answer a question it can ask another way.
+var systemDirs = []string{"/usr", "/etc", "/opt", "/nix"}
+
+// mergedDirs are the paths a modern distribution turns into symlinks into /usr
+// and an older one keeps as real directories. Reproduced as whatever the host
+// has: a --ro-bind over a host symlink would resolve to a path the sandbox does
+// not have, and a --symlink where the host has a directory hides half of it.
+var mergedDirs = []string{"/bin", "/sbin", "/lib", "/lib32", "/lib64", "/libx32"}
+
+// Available reports whether this machine can confine a session. Linux answers
+// for bubblewrap being installed and nothing else — whether the kernel will
+// actually grant the namespace is a question only a spawn can ask, and the
+// distributions that refuse (Ubuntu and Debian ship an AppArmor policy denying
+// unprivileged user namespaces) say so in bwrap's own error, which is the one
+// the user can act on.
+func Available() bool {
+	_, err := exec.LookPath(bwrapBin)
+	return err == nil
+}
+
+// Wrap returns the binary and arguments that run bin confined. It falls back to
+// the unconfined spawn when bubblewrap is not installed, which is the same
+// answer Available gives — a session must open either way, and a card that
+// never appears is worse than one that is not confined.
+func Wrap(spec Spec, bin string, args []string) (string, []string) {
+	path, err := exec.LookPath(bwrapBin)
+	if err != nil {
+		return bin, args
+	}
+	argv := append(bwrapArgs(spec, hostRoots()), "--", bin)
+	return path, append(argv, args...)
+}
+
+// root is one entry of the read-only base filesystem: either a bind of a host
+// directory or a symlink reproduced from the host.
+type root struct {
+	// target is the symlink's destination, empty for a bind mount.
+	target string
+	path   string
+}
+
+// hostRoots reads the base filesystem this machine actually has. Split from
+// bwrapArgs so the argument order — the part that decides whether a sandbox is
+// a sandbox — is a pure function with a test, on a machine with any layout.
+func hostRoots() []root {
+	roots := make([]root, 0, len(systemDirs)+len(mergedDirs))
+	for _, dir := range systemDirs {
+		if _, err := os.Stat(dir); err == nil {
+			roots = append(roots, root{path: dir})
+		}
+	}
+	for _, dir := range mergedDirs {
+		info, err := os.Lstat(dir)
+		if err != nil {
+			continue
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			roots = append(roots, root{path: dir})
+			continue
+		}
+		target, err := os.Readlink(dir)
+		if err != nil {
+			continue
+		}
+		roots = append(roots, root{target: target, path: dir})
+	}
+	return roots
+}
+
+// bwrapArgs is the sandbox itself: the arguments that build it, in the order
+// bubblewrap applies them. Order is the whole contract — every mount lands on
+// top of what came before it, so the base filesystem is laid down first, the
+// private home empties whatever the base left under it, and the paths the
+// session is allowed to keep are mounted back on top of that emptiness. Moving
+// the home above the paths mounted into it silently unmounts every one of them.
+func bwrapArgs(spec Spec, roots []root) []string {
+	var args []string
+	for _, r := range roots {
+		if r.target != "" {
+			args = append(args, "--symlink", r.target, r.path)
+			continue
+		}
+		args = append(args, "--ro-bind", r.path, r.path)
+	}
+	// /etc/resolv.conf is a symlink into /run on a systemd-resolved machine, and
+	// /run is not mounted: without its target the sandbox has no DNS, which
+	// looks like the agent's API being down.
+	if target := resolvedLink("/etc/resolv.conf"); target != "" {
+		args = append(args, "--ro-bind", target, target)
+	}
+	args = append(args,
+		"--proc", "/proc",
+		"--dev", "/dev",
+		"--tmpfs", "/tmp",
+		"--tmpfs", spec.Home,
+	)
+	// The host's runtime directory holds the session bus, the keyring and the
+	// display sockets. An empty one of its own answers the programs that expect
+	// the variable to name a real directory, and hands over none of that.
+	if dir := os.Getenv("XDG_RUNTIME_DIR"); filepath.IsAbs(dir) {
+		args = append(args, "--tmpfs", dir)
+	}
+	for _, path := range spec.Read {
+		args = append(args, "--ro-bind", path, path)
+	}
+	for _, path := range spec.Write {
+		args = append(args, "--bind", path, path)
+	}
+	if spec.GitCommon != "" {
+		args = append(args, "--bind", spec.GitCommon, spec.GitCommon)
+	}
+	// Last of the mounts: the checkout is the one place the session is here to
+	// change, and nothing may land on top of it.
+	args = append(args, "--bind", spec.Cwd, spec.Cwd)
+	return append(args,
+		"--setenv", "HOME", spec.Home,
+		"--chdir", spec.Cwd,
+		// No --unshare-net: the agent needs its own API, and the lich plugin's
+		// hooks report this session's status back over loopback. A sandbox that
+		// cuts the network is a card that opens and cannot work.
+		"--unshare-pid",
+		"--unshare-uts",
+		"--unshare-ipc",
+		"--hostname", "lich-sandbox",
+		// The sandbox dies with the PTY rather than outliving it as an orphan
+		// nothing on screen accounts for. No --new-session: it calls setsid,
+		// which would take the session's controlling terminal away from the PTY
+		// lich is reading.
+		"--die-with-parent",
+	)
+}
+
+// resolvedLink returns the destination of path when it is a symlink pointing
+// outside the directories already mounted, and "" otherwise — including for a
+// destination that no longer exists, which would fail the spawn rather than
+// leave one file missing.
+func resolvedLink(path string) string {
+	target, err := filepath.EvalSymlinks(path)
+	if err != nil || target == path {
+		return ""
+	}
+	for _, dir := range systemDirs {
+		if target == dir || strings.HasPrefix(target, dir+string(filepath.Separator)) {
+			return ""
+		}
+	}
+	if _, err := os.Stat(target); err != nil {
+		return ""
+	}
+	return target
+}

--- a/internal/sandbox/bwrap_linux_test.go
+++ b/internal/sandbox/bwrap_linux_test.go
@@ -1,0 +1,209 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// fakeRoots is a base filesystem with one of each shape: a plain directory and
+// a merged-usr symlink.
+var fakeRoots = []root{
+	{path: "/usr"},
+	{path: "/etc"},
+	{target: "usr/bin", path: "/bin"},
+}
+
+func testSpec() Spec {
+	return Spec{
+		Home:      "/home/u",
+		Cwd:       "/home/u/work/repo",
+		GitCommon: "/home/u/work/main/.git",
+		Write:     []string{"/home/u/.claude", "/home/u/.cache"},
+		Read:      []string{"/home/u/.config", "/home/u/.local/bin"},
+	}
+}
+
+// indexOf is the position of the first argument equal to value, or -1.
+func indexOf(args []string, value string) int {
+	return slices.Index(args, value)
+}
+
+// pairIndex is the position of a two-argument mount ("--bind", path) whose
+// source is path, or -1. It is how the order assertions below name a mount
+// without depending on what surrounds it.
+func pairIndex(args []string, flag, path string) int {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == flag && args[i+1] == path {
+			return i
+		}
+	}
+	return -1
+}
+
+// The private home unmounts everything already under it, so it has to be laid
+// down before the paths that are mounted back in. This is the assertion that
+// fails if somebody reorders the builder and quietly ships a sandbox where the
+// provider has no credentials.
+func TestBwrapArgsMountHomeBeforeWhatGoesIntoIt(t *testing.T) {
+	args := bwrapArgs(testSpec(), fakeRoots)
+
+	home := pairIndex(args, "--tmpfs", "/home/u")
+	if home < 0 {
+		t.Fatalf("no private home in %v", args)
+	}
+	for _, path := range []string{"/home/u/.claude", "/home/u/.cache"} {
+		if at := pairIndex(args, "--bind", path); at < home {
+			t.Errorf("%s is mounted at %d, before the private home at %d", path, at, home)
+		}
+	}
+	for _, path := range []string{"/home/u/.config", "/home/u/.local/bin"} {
+		if at := pairIndex(args, "--ro-bind", path); at < home {
+			t.Errorf("%s is mounted at %d, before the private home at %d", path, at, home)
+		}
+	}
+	if base := pairIndex(args, "--ro-bind", "/usr"); base > home {
+		t.Errorf("the base filesystem at %d lands after the private home at %d", base, home)
+	}
+}
+
+// The checkout is the one place the session exists to change: nothing may be
+// mounted over it.
+func TestBwrapArgsMountCheckoutLast(t *testing.T) {
+	args := bwrapArgs(testSpec(), fakeRoots)
+	cwd := pairIndex(args, "--bind", "/home/u/work/repo")
+	if cwd < 0 {
+		t.Fatalf("the checkout is not mounted: %v", args)
+	}
+	for i := cwd + 2; i+1 < len(args); i++ {
+		switch args[i] {
+		case "--bind", "--ro-bind", "--tmpfs", "--symlink":
+			t.Errorf("%s %s is mounted over the checkout", args[i], args[i+1])
+		}
+	}
+}
+
+// A worktree's .git is a file pointing at the main repository's metadata. Without
+// that directory every git command in the session fails.
+func TestBwrapArgsBindGitCommonDirWritable(t *testing.T) {
+	args := bwrapArgs(testSpec(), fakeRoots)
+	if pairIndex(args, "--bind", "/home/u/work/main/.git") < 0 {
+		t.Errorf("the git common directory is not writable: %v", args)
+	}
+
+	own := testSpec()
+	own.GitCommon = ""
+	if got := bwrapArgs(own, fakeRoots); indexOf(got, "/home/u/work/main/.git") >= 0 {
+		t.Errorf("a checkout that is its own repository got a common-dir mount: %v", got)
+	}
+}
+
+// The network is the one capability a coding session cannot lose: the agent
+// calls its own API, and the lich plugin's hooks report back over loopback.
+func TestBwrapArgsKeepTheNetwork(t *testing.T) {
+	args := bwrapArgs(testSpec(), fakeRoots)
+	if indexOf(args, "--unshare-net") >= 0 {
+		t.Errorf("the sandbox cuts the network: %v", args)
+	}
+	for _, want := range []string{"--unshare-pid", "--unshare-uts", "--unshare-ipc", "--die-with-parent"} {
+		if indexOf(args, want) < 0 {
+			t.Errorf("%s missing from %v", want, args)
+		}
+	}
+}
+
+// --new-session calls setsid, which would take the controlling terminal away
+// from the PTY lich reads.
+func TestBwrapArgsKeepTheControllingTerminal(t *testing.T) {
+	if args := bwrapArgs(testSpec(), fakeRoots); indexOf(args, "--new-session") >= 0 {
+		t.Errorf("the sandbox detaches the session's terminal: %v", args)
+	}
+}
+
+func TestBwrapArgsReproduceMergedUsrSymlinks(t *testing.T) {
+	args := bwrapArgs(testSpec(), fakeRoots)
+	at := pairIndex(args, "--symlink", "usr/bin")
+	if at < 0 || args[at+2] != "/bin" {
+		t.Errorf("merged-usr symlink not reproduced: %v", args)
+	}
+	if pairIndex(args, "--ro-bind", "/bin") >= 0 {
+		t.Errorf("a host symlink was bound as a directory: %v", args)
+	}
+}
+
+func TestBwrapArgsSetHomeAndStartDirectory(t *testing.T) {
+	args := bwrapArgs(testSpec(), fakeRoots)
+	at := indexOf(args, "--setenv")
+	if at < 0 || args[at+1] != "HOME" || args[at+2] != "/home/u" {
+		t.Errorf("HOME is not set to the private home: %v", args)
+	}
+	chdir := indexOf(args, "--chdir")
+	if chdir < 0 || args[chdir+1] != "/home/u/work/repo" {
+		t.Errorf("the sandbox does not start in the checkout: %v", args)
+	}
+}
+
+// Wrap has to keep the provider's own arguments after the separator, in order:
+// a flag that lands before "--" is read by bubblewrap instead of the agent.
+func TestWrapSeparatesBubblewrapFromTheCommand(t *testing.T) {
+	if !Available() {
+		t.Skip("bubblewrap is not installed")
+	}
+	bin, args := Wrap(testSpec(), "claude", []string{"--resume", "abc", "--model", "opus"})
+	if !strings.HasSuffix(bin, "bwrap") {
+		t.Fatalf("Wrap ran %q, want bubblewrap", bin)
+	}
+	at := indexOf(args, "--")
+	if at < 0 {
+		t.Fatalf("no separator in %v", args)
+	}
+	want := []string{"claude", "--resume", "abc", "--model", "opus"}
+	if got := args[at+1:]; !slices.Equal(got, want) {
+		t.Errorf("command after the separator = %v, want %v", got, want)
+	}
+}
+
+// /etc/resolv.conf is a symlink into /run on a systemd-resolved machine, and
+// /run is not mounted. Missing its target, the sandbox has no DNS — which looks
+// like the agent's API being down rather than like a mount that was skipped.
+func TestResolvedLinkMountsOnlyWhatTheBaseDoesNotCover(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.conf")
+	if err := os.WriteFile(target, []byte("nameserver 127.0.0.53\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	link := filepath.Join(dir, "link.conf")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if got := resolvedLink(link); got != target {
+		t.Errorf("resolvedLink(symlink) = %q, want %q", got, target)
+	}
+	// A plain file is already covered by the mount of the directory it sits in.
+	if got := resolvedLink(target); got != "" {
+		t.Errorf("resolvedLink(plain file) = %q, want \"\"", got)
+	}
+	// A destination inside the read-only base is mounted twice for nothing.
+	inside := filepath.Join(dir, "usr.conf")
+	if err := os.Symlink("/usr/lib", inside); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if got := resolvedLink(inside); got != "" {
+		t.Errorf("resolvedLink(into /usr) = %q, want \"\"", got)
+	}
+	// A dangling link would fail the whole spawn rather than leave one file out.
+	dangling := filepath.Join(dir, "gone.conf")
+	if err := os.Symlink(filepath.Join(dir, "nothing"), dangling); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if got := resolvedLink(dangling); got != "" {
+		t.Errorf("resolvedLink(dangling) = %q, want \"\"", got)
+	}
+	if got := resolvedLink(filepath.Join(dir, "absent")); got != "" {
+		t.Errorf("resolvedLink(missing) = %q, want \"\"", got)
+	}
+}

--- a/internal/sandbox/confine_linux_test.go
+++ b/internal/sandbox/confine_linux_test.go
@@ -1,0 +1,161 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// confinedHome is a home directory with the shapes the sandbox has to tell
+// apart: the provider's state, a build cache, a secret, and two checkouts of
+// which only one is the session's.
+func confinedHome(t *testing.T) (home, cwd string) {
+	t.Helper()
+	home = t.TempDir()
+	for _, dir := range []string{".claude", ".cache", ".ssh", "work/repo", "work/other-repo"} {
+		if err := os.MkdirAll(filepath.Join(home, dir), 0o700); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(home, ".ssh", "id_ed25519"), []byte("secret"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return home, filepath.Join(home, "work", "repo")
+}
+
+// runConfined runs one shell line inside the sandbox and returns its combined
+// output. The shell is /bin/sh, which the read-only base filesystem provides.
+func runConfined(t *testing.T, home, cwd, script string) string {
+	t.Helper()
+	spec := Describe(providers.Claude, home, cwd, "", nil)
+	bin, args := Wrap(spec, "/bin/sh", []string{"-c", script})
+	out, err := exec.Command(bin, args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("confined run failed: %v\n%s", err, out)
+	}
+	return string(out)
+}
+
+// This is the whole promise of the feature, checked against a real bubblewrap:
+// the provider's state is there, the secret and the sibling checkout are not.
+func TestConfinedSessionSeesOnlyItsOwnWork(t *testing.T) {
+	if !Available() {
+		t.Skip("bubblewrap is not installed")
+	}
+	home, cwd := confinedHome(t)
+	out := runConfined(t, home, cwd, `ls -A "$HOME"; echo ---; ls -A "$HOME/work"`)
+
+	for _, want := range []string{".claude", ".cache", "work"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("%s is missing from the confined home:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, ".ssh") {
+		t.Errorf("the ssh key directory is reachable inside the sandbox:\n%s", out)
+	}
+	if strings.Contains(out, "other-repo") {
+		t.Errorf("a sibling checkout is reachable inside the sandbox:\n%s", out)
+	}
+	if !strings.Contains(out, "repo") {
+		t.Errorf("the session's own checkout is missing:\n%s", out)
+	}
+}
+
+func TestConfinedSessionWritesOnlyWhereItWorks(t *testing.T) {
+	if !Available() {
+		t.Skip("bubblewrap is not installed")
+	}
+	home, cwd := confinedHome(t)
+	// Every touch is guarded, so the script itself always exits 0 and the
+	// verdicts arrive as output rather than as a failed run.
+	out := runConfined(t, home, cwd, strings.Join([]string{
+		`echo "checkout: $(touch ./probe 2>/dev/null && echo ok || echo denied)"`,
+		`echo "state: $(touch "$HOME/.claude/probe" 2>/dev/null && echo ok || echo denied)"`,
+		`echo "cache: $(touch "$HOME/.cache/probe" 2>/dev/null && echo ok || echo denied)"`,
+		`echo "system: $(touch /etc/probe 2>/dev/null && echo ok || echo denied)"`,
+	}, "; "))
+
+	for _, want := range []string{"checkout: ok", "state: ok", "cache: ok", "system: denied"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in:\n%s", want, out)
+		}
+	}
+	// The writes that succeeded are the ones the host must actually have.
+	for _, path := range []string{
+		filepath.Join(cwd, "probe"),
+		filepath.Join(home, ".claude", "probe"),
+	} {
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("a write the sandbox allowed never reached the host: %s", path)
+		}
+	}
+}
+
+// The private home is writable and thrown away with the session: a dotfile an
+// agent writes outside its state is gone next spawn, and never touches the host.
+func TestConfinedHomeIsEphemeral(t *testing.T) {
+	if !Available() {
+		t.Skip("bubblewrap is not installed")
+	}
+	home, cwd := confinedHome(t)
+	runConfined(t, home, cwd, `touch "$HOME/.bashrc"`)
+	if _, err := os.Stat(filepath.Join(home, ".bashrc")); err == nil {
+		t.Error("a write to the private home reached the host home")
+	}
+	out := runConfined(t, home, cwd, `test -e "$HOME/.bashrc" && echo kept || echo gone`)
+	if !strings.Contains(out, "gone") {
+		t.Errorf("the private home survived the session:\n%s", out)
+	}
+}
+
+// installedLikeAnAgent lays out the shape every agent installer uses: a symlink
+// on PATH pointing into a versioned store elsewhere in the home. It is the shape
+// that broke the first confined spawn — bubblewrap resolves a mount destination
+// through symlinks, so binding the link itself fails with "Can't create file".
+func installedLikeAnAgent(t *testing.T, home string) string {
+	t.Helper()
+	store := filepath.Join(home, ".local", "share", "agent", "versions")
+	bin := filepath.Join(home, ".local", "bin")
+	for _, dir := range []string{store, bin} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	real := filepath.Join(store, "9.9.9")
+	if err := os.WriteFile(real, []byte("#!/bin/sh\necho agent-ran\n"), 0o755); err != nil {
+		t.Fatalf("write agent: %v", err)
+	}
+	link := filepath.Join(bin, "agent")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	return link
+}
+
+func TestAnAgentInstalledAsASymlinkRuns(t *testing.T) {
+	if !Available() {
+		t.Skip("bubblewrap is not installed")
+	}
+	home, cwd := confinedHome(t)
+	link := installedLikeAnAgent(t, home)
+
+	// PATH is what BinaryDirs resolves a bare name through, so the fixture has
+	// to be on it — the same way the user's own installer puts it there.
+	t.Setenv("PATH", filepath.Join(home, ".local", "bin")+":"+os.Getenv("PATH"))
+
+	spec := Describe(providers.Claude, home, cwd, "", BinaryDirs("agent"))
+	bin, args := Wrap(spec, link, nil)
+	out, err := exec.Command(bin, args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("a confined spawn of a symlinked agent failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "agent-ran") {
+		t.Errorf("the agent did not run: %q", out)
+	}
+}

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -1,0 +1,279 @@
+// Package sandbox confines a session's process tree to the work it was opened
+// for: a private empty home, the rest of the machine read-only, and write
+// access only inside the checkout and the provider's own state directory.
+//
+// It is the counterweight to skipping permission prompts. An agent running
+// unattended edits files and runs commands with the user's whole account behind
+// it — every other repository on the disk, every credential in the home
+// directory, every dotfile. Confining it costs the session nothing it needs and
+// takes the rest of the machine off the table.
+//
+// It is not a boundary against hostile code. The backends here use namespaces
+// and mounts (Linux) or a path policy (macOS) and nothing else: no seccomp
+// filter, no Landlock ruleset, no kernel-bug mitigation. It protects a machine
+// from an agent working unsupervised, not from something written to break out.
+// Running genuinely hostile code still wants a disposable VM.
+//
+// The backend is selected by build tag behind Available and Wrap, the seam the
+// PTY uses (internal/terminal): Linux runs bubblewrap, macOS runs sandbox-exec,
+// and every other platform answers that it cannot confine anything.
+package sandbox
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// Spec is one confined spawn: what stays writable, what is merely readable, and
+// what is not there at all. Everything is an absolute host path, and the paths
+// are what the backends translate into their own vocabulary.
+//
+// Home is the user's real home directory. Inside the sandbox that path exists
+// and is empty — the point of the whole exercise — with Write and Read entries
+// under it mounted back in one by one.
+type Spec struct {
+	// Home is the user's home directory, replaced by an empty private one.
+	Home string
+	// Cwd is the checkout the session works in, writable.
+	Cwd string
+	// GitCommon is the repository's common git directory when Cwd is a linked
+	// worktree, writable, and empty when Cwd is a repository of its own. Without
+	// it every git command in a worktree session fails: the worktree's `.git` is
+	// a file pointing at a directory that would not be there.
+	GitCommon string
+	// Write is every other path bound read-write: the provider's state, and the
+	// build caches a toolchain cannot work without.
+	Write []string
+	// Read is every path bound read-only: configuration, installed toolchains,
+	// and the binaries the session runs.
+	Read []string
+}
+
+// stateDirs is where each provider keeps the state a confined session still
+// needs: its credentials, so it can authenticate at all, and its transcript, so
+// lich goes on reading the cost and context readouts off it. Bound read-write —
+// the session writes its own conversation there.
+//
+// Each entry is the directory that provider's own docs and CLI name, in the
+// same spelling internal/agentplugin and internal/terminal/transcript.go use.
+// Each of the three resolves its own harness paths rather than sharing one
+// table: they are read at different times, and a package that cannot see a
+// provider's env var would answer for it anyway.
+//
+// A provider missing from here confines to a home with no credentials in it,
+// which is a session that opens and cannot log in. The registry is the
+// checklist, so all five are listed.
+func stateDirs(providerID, home string) []string {
+	switch providerID {
+	case providers.Claude:
+		// The JSON file beside the directory holds the account, so a session
+		// without it starts at the login prompt.
+		return []string{
+			envDir("CLAUDE_CONFIG_DIR", filepath.Join(home, ".claude")),
+			filepath.Join(home, ".claude.json"),
+		}
+	case providers.Codex:
+		return []string{envDir("CODEX_HOME", filepath.Join(home, ".codex"))}
+	case providers.OMP:
+		return []string{ompAgentDir(home)}
+	case providers.OpenCode:
+		// opencode is xdg-basedir on every platform, and splits config from the
+		// session store it writes conversations into.
+		return []string{
+			filepath.Join(configHome(home), "opencode"),
+			filepath.Join(dataHome(home), "opencode"),
+		}
+	case providers.Crush:
+		return []string{
+			filepath.Join(configHome(home), "crush"),
+			filepath.Join(dataHome(home), "crush"),
+		}
+	}
+	return nil
+}
+
+// ompAgentDir resolves oh-my-pi's agent directory. A named profile wins outright
+// over the explicit override — the order `omp config path` was measured to
+// apply, and the same rule lives in internal/agentplugin/omp.go and
+// internal/terminal/transcript.go.
+func ompAgentDir(home string) string {
+	if profile := os.Getenv("OMP_PROFILE"); profile != "" {
+		return filepath.Join(home, ".omp", "profiles", profile, "agent")
+	}
+	return envDir("PI_CODING_AGENT_DIR", filepath.Join(home, ".omp", "agent"))
+}
+
+// envDir returns the directory named by an environment variable, or fallback
+// when it is unset. A relative value is ignored: a bind mount needs an absolute
+// path, and a provider pointed at a relative one resolves it against a working
+// directory this package does not own.
+func envDir(name, fallback string) string {
+	if dir := os.Getenv(name); filepath.IsAbs(dir) {
+		return dir
+	}
+	return fallback
+}
+
+// configHome and dataHome are the XDG directories, which every provider here
+// resolves the same way on Linux and macOS alike.
+func configHome(home string) string {
+	return envDir("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+}
+
+func dataHome(home string) string {
+	return envDir("XDG_DATA_HOME", filepath.Join(home, ".local", "share"))
+}
+
+// writableCaches are the directories a toolchain writes into on an ordinary
+// build, listed by what breaks without them rather than by which tool owns
+// them. They hold downloaded dependencies and compiler output — no credentials,
+// nothing the user typed — which is why they are the one part of the home a
+// confined session may still write outside its own state.
+//
+// A missing entry is not a warning, it is `go build` failing to write its cache
+// in a session that worked yesterday, so the list errs towards including a
+// cache rather than towards a smaller sandbox.
+var writableCaches = []string{
+	".cache",             // XDG, and where go-build, pnpm and pip land
+	"go/pkg",             // module downloads; ~/go/bin is read-only below
+	".cargo/registry",    // crate downloads
+	".npm",               // npm's own cache, which is not XDG
+	".bun/install/cache", // bun's package cache
+}
+
+// readableToolchain are the directories a session reads to find the language
+// versions and tools the project runs on, plus the configuration that makes git
+// and the shell behave the way they do outside the sandbox. Read-only: a
+// session may use the toolchain it was given and may not install into it.
+//
+// ~/.config is here as one entry rather than a list of the tools under it,
+// because a project uses whichever ones it uses. That is the deliberate hole in
+// this profile: a token stored under ~/.config (gh's, for one) is readable
+// inside the sandbox. What is not there at all is the material that hole would
+// be worth closing for — ~/.ssh, ~/.aws, ~/.gnupg, ~/.kube and every other
+// repository on the machine — and none of them is in this list.
+var readableToolchain = []string{
+	".config",
+	".local/bin",
+	".local/share",
+	".local/state",
+	".gitconfig",
+	".gitignore_global",
+	".asdf",
+	".nvm",
+	".rustup",
+	".cargo/bin",
+	".bun/bin",
+	".deno",
+	"go/bin",
+	".pyenv",
+	".rbenv",
+	".sdkman",
+}
+
+// Describe builds the Spec for one confined session: the provider's state and
+// the build caches writable, the toolchain and configuration readable, the
+// checkout writable, and nothing else in the home there at all.
+//
+// extraRead is what the caller knows and this package does not — where the
+// binaries the spawn actually runs live. The provider's own executable and the
+// lich binary (which the session calls back through, and which serves its MCP
+// server) are installed wherever the user put them, which is regularly inside
+// the home this call is about to empty. Pass directories, from BinaryDirs.
+//
+// Paths that do not exist are dropped: a bind mount of a missing source fails
+// the whole spawn, and every entry here is optional by nature — a machine
+// without Rust has no ~/.cargo, and that is not an error.
+func Describe(providerID, home, cwd, gitCommon string, extraRead []string) Spec {
+	spec := Spec{Home: home, Cwd: cwd, GitCommon: gitCommon}
+	spec.Write = existing(append(stateDirs(providerID, home), under(home, writableCaches)...))
+	spec.Read = existing(append(under(home, readableToolchain), extraRead...))
+	return spec
+}
+
+// symlinkHops caps the chain BinaryDirs walks, so a link that points at itself
+// cannot spin the spawn.
+const symlinkHops = 16
+
+// BinaryDirs returns the directories a confined session needs mounted to run
+// the executable named by name — a bare name resolved on PATH, or a path. Empty
+// when nothing on PATH answers to it, which is a spawn that would have failed
+// outside the sandbox too.
+//
+// It returns *directories*, never the executable itself, and that is the whole
+// point. Agents are installed as a symlink into a versioned store
+// (`~/.local/bin/claude` → `~/.local/share/claude/versions/2.1.234`), and
+// binding the symlink is what breaks: bubblewrap resolves a mount destination
+// through symlinks, so it tries to create the mount point at a target that is
+// not in the sandbox yet and fails the whole spawn with "Can't create file at
+// …: No such file or directory". Binding the directories that hold each hop
+// leaves the link intact and puts its target where the link already points.
+//
+// The chain is walked hop by hop rather than resolved in one step because it
+// can leave the home and come back — a version manager's shim into a store
+// elsewhere — and every directory it passes through has to be there.
+func BinaryDirs(name string) []string {
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return nil
+	}
+	var dirs []string
+	for range symlinkHops {
+		dirs = append(dirs, filepath.Dir(path))
+		target, err := os.Readlink(path)
+		if err != nil {
+			break
+		}
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(filepath.Dir(path), target)
+		}
+		path = target
+	}
+	return dirs
+}
+
+// under joins each relative name to base, so the tables above read as the
+// dotfiles they are.
+func under(base string, names []string) []string {
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		out = append(out, filepath.Join(base, name))
+	}
+	return out
+}
+
+// existing drops duplicates, paths that are not on disk, and symlinks. Order is
+// kept: a backend that mounts in order needs the parent before the child.
+//
+// Symlinks are refused rather than followed, for two reasons that point the same
+// way. A link under a directory this list already mounts is a mount destination
+// bubblewrap resolves *through* — it then tries to create the mount point at a
+// target that is not in the sandbox yet, and fails the whole spawn with "Can't
+// create file at …: No such file or directory". And a link is an instruction
+// written inside the home to reach somewhere outside it, which is the one thing
+// a private home exists to stop; following it would widen the sandbox by
+// whatever the user's dotfile manager happens to point at.
+//
+// The cost is real and deliberate: a `~/.gitconfig` symlinked out of a dotfiles
+// repository is not in a confined session, and nothing on screen says so. The
+// binaries the session runs are the exception, and they are handled by mounting
+// directories instead (BinaryDirs).
+func existing(paths []string) []string {
+	seen := make(map[string]bool, len(paths))
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		if path == "" || seen[path] {
+			continue
+		}
+		seen[path] = true
+		info, err := os.Lstat(path)
+		if err != nil || info.Mode()&os.ModeSymlink != 0 {
+			continue
+		}
+		out = append(out, path)
+	}
+	return out
+}

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -1,0 +1,156 @@
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// clearHarnessEnv blanks every variable a provider uses to move its state
+// directory, so a test answers for the fallback paths rather than for whatever
+// the machine running it has exported.
+func clearHarnessEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"CLAUDE_CONFIG_DIR", "CODEX_HOME", "OMP_PROFILE", "PI_CODING_AGENT_DIR",
+		"XDG_CONFIG_HOME", "XDG_DATA_HOME",
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+func TestStateDirsCoversEveryRegisteredProvider(t *testing.T) {
+	clearHarnessEnv(t)
+	for _, p := range providers.Registry {
+		if got := stateDirs(p.ID, "/home/u"); len(got) == 0 {
+			t.Errorf("provider %q has no state directory: a confined session of it cannot authenticate", p.ID)
+		}
+	}
+}
+
+func TestStateDirsPerProvider(t *testing.T) {
+	clearHarnessEnv(t)
+	tests := []struct {
+		provider string
+		want     []string
+	}{
+		{providers.Claude, []string{"/home/u/.claude", "/home/u/.claude.json"}},
+		{providers.Codex, []string{"/home/u/.codex"}},
+		{providers.OMP, []string{"/home/u/.omp/agent"}},
+		{providers.OpenCode, []string{"/home/u/.config/opencode", "/home/u/.local/share/opencode"}},
+		{providers.Crush, []string{"/home/u/.config/crush", "/home/u/.local/share/crush"}},
+	}
+	for _, tt := range tests {
+		if got := stateDirs(tt.provider, "/home/u"); !slices.Equal(got, tt.want) {
+			t.Errorf("stateDirs(%q) = %v, want %v", tt.provider, got, tt.want)
+		}
+	}
+	if got := stateDirs("shell", "/home/u"); got != nil {
+		t.Errorf("stateDirs for a shell session = %v, want none", got)
+	}
+}
+
+func TestStateDirsFollowsHarnessEnvironment(t *testing.T) {
+	clearHarnessEnv(t)
+	t.Setenv("CLAUDE_CONFIG_DIR", "/srv/claude")
+	t.Setenv("CODEX_HOME", "/srv/codex")
+	t.Setenv("XDG_CONFIG_HOME", "/srv/cfg")
+
+	if got := stateDirs(providers.Claude, "/home/u"); got[0] != "/srv/claude" {
+		t.Errorf("CLAUDE_CONFIG_DIR ignored: got %v", got)
+	}
+	if got := stateDirs(providers.Codex, "/home/u"); got[0] != "/srv/codex" {
+		t.Errorf("CODEX_HOME ignored: got %v", got)
+	}
+	if got := stateDirs(providers.Crush, "/home/u"); got[0] != "/srv/cfg/crush" {
+		t.Errorf("XDG_CONFIG_HOME ignored: got %v", got)
+	}
+}
+
+// A named omp profile wins over the explicit directory override, which is the
+// order `omp config path` applies.
+func TestOMPProfileBeatsDirectoryOverride(t *testing.T) {
+	clearHarnessEnv(t)
+	t.Setenv("PI_CODING_AGENT_DIR", "/srv/omp")
+	if got := ompAgentDir("/home/u"); got != "/srv/omp" {
+		t.Errorf("PI_CODING_AGENT_DIR ignored: got %q", got)
+	}
+	t.Setenv("OMP_PROFILE", "work")
+	want := "/home/u/.omp/profiles/work/agent"
+	if got := ompAgentDir("/home/u"); got != want {
+		t.Errorf("ompAgentDir with a profile = %q, want %q", got, want)
+	}
+}
+
+// A relative override is not a bind mount source: it resolves against a working
+// directory this package does not own, so the fallback stands.
+func TestEnvDirRejectsRelativeOverride(t *testing.T) {
+	t.Setenv("CODEX_HOME", "codex")
+	if got := envDir("CODEX_HOME", "/home/u/.codex"); got != "/home/u/.codex" {
+		t.Errorf("relative override honoured: got %q", got)
+	}
+}
+
+func TestDescribeDropsMissingPathsAndDuplicates(t *testing.T) {
+	clearHarnessEnv(t)
+	home := t.TempDir()
+	cwd := filepath.Join(home, "checkout")
+	for _, dir := range []string{".claude", ".config", ".cache", "checkout"} {
+		if err := os.MkdirAll(filepath.Join(home, dir), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+	// Listed twice on purpose: a caller naming the provider's own state
+	// directory as an extra read must not turn it into two mounts.
+	spec := Describe(providers.Claude, home, cwd, "", []string{
+		filepath.Join(home, ".config"),
+		filepath.Join(home, "nonexistent"),
+	})
+
+	if !slices.Contains(spec.Write, filepath.Join(home, ".claude")) {
+		t.Errorf("provider state missing from Write: %v", spec.Write)
+	}
+	if slices.Contains(spec.Write, filepath.Join(home, ".claude.json")) {
+		t.Errorf("a state path that is not on disk was kept: %v", spec.Write)
+	}
+	if !slices.Contains(spec.Write, filepath.Join(home, ".cache")) {
+		t.Errorf("build cache missing from Write: %v", spec.Write)
+	}
+	for _, path := range spec.Read {
+		if path == filepath.Join(home, "nonexistent") {
+			t.Errorf("a path that is not on disk was kept: %v", spec.Read)
+		}
+	}
+	if n := count(spec.Read, filepath.Join(home, ".config")); n != 1 {
+		t.Errorf("~/.config mounted %d times, want 1: %v", n, spec.Read)
+	}
+	if spec.Home != home || spec.Cwd != cwd {
+		t.Errorf("Describe = home %q cwd %q, want %q and %q", spec.Home, spec.Cwd, home, cwd)
+	}
+}
+
+// The material the sandbox exists to keep away from an unattended agent is
+// named nowhere in the tables: not writable, not readable, not there.
+func TestSecretsAreInNoTable(t *testing.T) {
+	for _, secret := range []string{".ssh", ".aws", ".gnupg", ".kube", ".netrc", ".docker"} {
+		if slices.Contains(writableCaches, secret) {
+			t.Errorf("%q is writable inside the sandbox", secret)
+		}
+		if slices.Contains(readableToolchain, secret) {
+			t.Errorf("%q is readable inside the sandbox", secret)
+		}
+	}
+}
+
+func count(haystack []string, needle string) int {
+	n := 0
+	for _, item := range haystack {
+		if item == needle {
+			n++
+		}
+	}
+	return n
+}

--- a/internal/sandbox/seatbelt_darwin.go
+++ b/internal/sandbox/seatbelt_darwin.go
@@ -1,0 +1,90 @@
+//go:build darwin
+
+package sandbox
+
+import (
+	"os"
+	"strings"
+)
+
+// seatbeltBin is Apple's sandbox interface. It is deprecated and has been for
+// years, and it is still the only path-level confinement a macOS process can
+// apply to a child without shipping a signed helper.
+const seatbeltBin = "/usr/bin/sandbox-exec"
+
+// Available reports whether this machine can confine a session. macOS answers
+// for sandbox-exec being present, which on a stock system it is.
+func Available() bool {
+	info, err := os.Stat(seatbeltBin)
+	return err == nil && !info.IsDir() && info.Mode()&0o111 != 0
+}
+
+// Wrap returns the binary and arguments that run bin confined, falling back to
+// the unconfined spawn when sandbox-exec is missing: a session must open either
+// way (bwrap_linux.go's reason).
+//
+// The profile goes in on the command line rather than through a file, so
+// nothing has to be written to disk for a spawn and nothing has to be cleaned
+// up after one.
+func Wrap(spec Spec, bin string, args []string) (string, []string) {
+	if !Available() {
+		return bin, args
+	}
+	argv := []string{"-p", seatbeltProfile(spec), bin}
+	return seatbeltBin, append(argv, args...)
+}
+
+// seatbeltProfile is the sandbox itself, in Apple's own policy language. Order
+// is the contract, and it is the opposite of bubblewrap's: the last rule that
+// matches an operation wins, so the profile opens permissive, closes the two
+// doors that matter, and then reopens exactly the paths the session works in.
+//
+// What this cannot reproduce is the private home Linux gets. A tmpfs over the
+// home directory needs privileges a user process does not have, so the home is
+// denied for reading instead: the paths are still there, and a session that
+// asks about one is refused rather than told it does not exist. The material
+// this exists to keep away from an unattended agent — ssh keys, cloud
+// credentials, every other repository — is unreachable either way, and the
+// difference shows up only in the error a program gets when it looks.
+func seatbeltProfile(spec Spec) string {
+	var b strings.Builder
+	b.WriteString("(version 1)\n(allow default)\n")
+	// The two denials, widest first: nothing outside the checkout is writable,
+	// and nothing in the home is even readable.
+	b.WriteString("(deny file-write*)\n")
+	if spec.Home != "" {
+		b.WriteString("(deny file-read* " + subpath(spec.Home) + ")\n")
+	}
+	// Then the exceptions, narrowest last. Readable before writable, so a path
+	// listed in both ends up writable.
+	writeRule(&b, "(allow file-read*", spec.Read)
+	writable := append([]string{spec.Cwd}, spec.Write...)
+	if spec.GitCommon != "" {
+		writable = append(writable, spec.GitCommon)
+	}
+	writeRule(&b, "(allow file-read* file-write*", writable)
+	return b.String()
+}
+
+// writeRule appends one rule covering every path, or nothing at all when there
+// are none — an operation list with no subpaths is a syntax error, and a
+// profile that fails to parse takes the session with it.
+func writeRule(b *strings.Builder, head string, paths []string) {
+	if len(paths) == 0 {
+		return
+	}
+	b.WriteString(head)
+	for _, path := range paths {
+		b.WriteString(" " + subpath(path))
+	}
+	b.WriteString(")\n")
+}
+
+// subpath renders one path as an SBPL subpath term. The quoting is the security
+// boundary of this file: a path holding a quote or a backslash would otherwise
+// close the string and continue the policy as code, and a directory name is
+// something the user types.
+func subpath(path string) string {
+	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(path)
+	return `(subpath "` + escaped + `")`
+}

--- a/internal/sandbox/seatbelt_darwin_test.go
+++ b/internal/sandbox/seatbelt_darwin_test.go
@@ -1,0 +1,110 @@
+//go:build darwin
+
+package sandbox
+
+import (
+	"slices"
+	"strings"
+	"testing"
+)
+
+func testSpec() Spec {
+	return Spec{
+		Home:      "/Users/u",
+		Cwd:       "/Users/u/work/repo",
+		GitCommon: "/Users/u/work/main/.git",
+		Write:     []string{"/Users/u/.claude"},
+		Read:      []string{"/Users/u/.config"},
+	}
+}
+
+// lineOf is the index of the first profile line containing needle, or -1.
+func lineOf(profile, needle string) int {
+	return slices.IndexFunc(strings.Split(profile, "\n"), func(line string) bool {
+		return strings.Contains(line, needle)
+	})
+}
+
+// The last matching rule wins in SBPL, so the two denials have to come before
+// the paths they carve exceptions out of. Reversed, the profile parses, runs,
+// and confines nothing.
+func TestProfileDeniesBeforeItAllows(t *testing.T) {
+	profile := seatbeltProfile(testSpec())
+
+	denyWrite := lineOf(profile, "(deny file-write*)")
+	denyRead := lineOf(profile, `(deny file-read* (subpath "/Users/u")`)
+	if denyWrite < 0 || denyRead < 0 {
+		t.Fatalf("a denial is missing:\n%s", profile)
+	}
+	for _, allowed := range []string{"/Users/u/.config", "/Users/u/.claude", "/Users/u/work/repo"} {
+		at := lineOf(profile, allowed)
+		if at < 0 {
+			t.Errorf("%s is in no rule:\n%s", allowed, profile)
+			continue
+		}
+		if at < denyWrite || at < denyRead {
+			t.Errorf("%s is allowed at line %d, before a denial (%d, %d)", allowed, at, denyWrite, denyRead)
+		}
+	}
+}
+
+// Readable is written before writable, so a path in both ends up writable.
+func TestProfileGivesTheCheckoutWriteAccess(t *testing.T) {
+	profile := seatbeltProfile(testSpec())
+	read := lineOf(profile, "(allow file-read* (subpath")
+	write := lineOf(profile, "(allow file-read* file-write* (subpath")
+	if read < 0 || write < 0 {
+		t.Fatalf("an allowance is missing:\n%s", profile)
+	}
+	if write < read {
+		t.Errorf("the writable rule at %d is overridden by the read-only rule at %d", write, read)
+	}
+	if !strings.Contains(profile, `file-write* (subpath "/Users/u/work/repo")`) {
+		t.Errorf("the checkout is not writable:\n%s", profile)
+	}
+	if !strings.Contains(profile, `(subpath "/Users/u/work/main/.git")`) {
+		t.Errorf("the git common directory is not writable:\n%s", profile)
+	}
+}
+
+// A directory name is something the user typed. A quote in one would close the
+// string and continue the policy as code.
+func TestProfileEscapesPaths(t *testing.T) {
+	spec := testSpec()
+	spec.Cwd = `/Users/u/we"ird\path`
+	profile := seatbeltProfile(spec)
+	if !strings.Contains(profile, `(subpath "/Users/u/we\"ird\\path")`) {
+		t.Errorf("a quote or backslash reached the policy unescaped:\n%s", profile)
+	}
+}
+
+// An operation list with no subpaths is a syntax error, and a profile that
+// fails to parse takes the session with it.
+func TestProfileOmitsEmptyRules(t *testing.T) {
+	profile := seatbeltProfile(Spec{Home: "/Users/u", Cwd: "/Users/u/work/repo"})
+	if strings.Contains(profile, "(allow file-read*)") {
+		t.Errorf("an empty rule reached the policy:\n%s", profile)
+	}
+	for _, line := range strings.Split(profile, "\n") {
+		if strings.HasSuffix(line, "*") {
+			t.Errorf("rule %q names no path:\n%s", line, profile)
+		}
+	}
+}
+
+func TestWrapPassesTheProfileAndTheCommand(t *testing.T) {
+	if !Available() {
+		t.Skip("sandbox-exec is not installed")
+	}
+	bin, args := Wrap(testSpec(), "claude", []string{"--model", "opus"})
+	if bin != seatbeltBin {
+		t.Fatalf("Wrap ran %q, want %q", bin, seatbeltBin)
+	}
+	if len(args) < 4 || args[0] != "-p" {
+		t.Fatalf("no inline profile in %v", args)
+	}
+	want := []string{"claude", "--model", "opus"}
+	if got := args[2:]; !slices.Equal(got, want) {
+		t.Errorf("command = %v, want %v", got, want)
+	}
+}

--- a/internal/sandbox/unsupported.go
+++ b/internal/sandbox/unsupported.go
@@ -1,0 +1,17 @@
+//go:build !linux && !darwin
+
+package sandbox
+
+// Available reports whether this machine can confine a session. Windows has no
+// backend here: its isolation primitives (AppContainer, a Job object with a
+// restricted token) confine an application built for them rather than an
+// arbitrary child process tree, and the port is experimental with no hardware
+// to prove one on. The control is absent rather than present and inert, so the
+// answer is one word instead of a setting that saves and does nothing.
+func Available() bool { return false }
+
+// Wrap returns the spawn unchanged. It exists so the caller has one seam on
+// every platform rather than a build tag of its own.
+func Wrap(_ Spec, bin string, args []string) (string, []string) {
+	return bin, args
+}

--- a/internal/store/cost_test.go
+++ b/internal/store/cost_test.go
@@ -9,7 +9,7 @@ func newCostSession(t *testing.T) *Service {
 	if err := svc.AddProject("p1", "alpha", "/tmp/alpha"); err != nil {
 		t.Fatalf("AddProject: %v", err)
 	}
-	if err := svc.AddSession("p1", "s1", "Session 1", "", "", 2); err != nil {
+	if err := svc.AddSession("p1", "s1", "Session 1", "", "", 2, ""); err != nil {
 		t.Fatalf("AddSession: %v", err)
 	}
 	return svc
@@ -139,7 +139,7 @@ func TestAResumedSessionKeepsWhatItSpent(t *testing.T) {
 	if err := svc.AddProject("p1", "alpha", "/tmp/alpha"); err != nil {
 		t.Fatalf("AddProject: %v", err)
 	}
-	if err := svc.AddSession("p1", "s1", "Session 1", "claude", "/tmp/alpha-wt", 2); err != nil {
+	if err := svc.AddSession("p1", "s1", "Session 1", "claude", "/tmp/alpha-wt", 2, ""); err != nil {
 		t.Fatalf("AddSession: %v", err)
 	}
 	if err := svc.SaveCostLedger("s1", "uuid-a", 100, "m1", 0.4); err != nil {

--- a/internal/store/entrypoint_test.go
+++ b/internal/store/entrypoint_test.go
@@ -9,8 +9,8 @@ import "testing"
 func TestSetSessionEntrypointOnlyReachesShellSessions(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "term", "Terminal 1", "shell", "", 2)
-	_ = svc.AddSession("p1", "agent", "Session 1", "claude", "", 3)
+	_ = svc.AddSession("p1", "term", "Terminal 1", "shell", "", 2, "")
+	_ = svc.AddSession("p1", "agent", "Session 1", "claude", "", 3, "")
 
 	if err := svc.SetSessionEntrypoint("term", "lazygit"); err != nil {
 		t.Fatalf("SetSessionEntrypoint on a shell session: %v", err)
@@ -40,7 +40,7 @@ func TestSetSessionEntrypointOnlyReachesShellSessions(t *testing.T) {
 func TestSetSessionEntrypointTrimsAndClears(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "term", "Terminal 1", "shell", "", 2)
+	_ = svc.AddSession("p1", "term", "Terminal 1", "shell", "", 2, "")
 
 	_ = svc.SetSessionEntrypoint("term", "  lazydocker\n")
 	if got := svc.SessionEntrypoint("term"); got != "lazydocker" {
@@ -60,7 +60,7 @@ func TestSetSessionEntrypointTrimsAndClears(t *testing.T) {
 func TestSessionsCarryTheirEntrypoint(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "term", "Terminal 1", "shell", "", 2)
+	_ = svc.AddSession("p1", "term", "Terminal 1", "shell", "", 2, "")
 	_ = svc.SetSessionEntrypoint("term", "k9s")
 
 	projects, err := svc.LoadState()
@@ -84,13 +84,13 @@ func TestSessionsCarryTheirEntrypoint(t *testing.T) {
 func TestReopenWorktreeSessionCarriesSpawnOverrides(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2)
+	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2, "")
 
-	_ = svc.AddSession("p1", "wt1", "worker", "claude", "/wt/foo", 3)
+	_ = svc.AddSession("p1", "wt1", "worker", "claude", "/wt/foo", 3, "")
 	_ = svc.SetSessionModel("wt1", "opus")
 	_ = svc.CloseSession("p1", "wt1", "base")
 
-	_ = svc.AddSession("p1", "sh1", "Terminal 1", "shell", "/wt/bar", 4)
+	_ = svc.AddSession("p1", "sh1", "Terminal 1", "shell", "/wt/bar", 4, "")
 	_ = svc.SetSessionEntrypoint("sh1", "lazygit")
 	_ = svc.CloseSession("p1", "sh1", "base")
 

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -101,8 +101,15 @@ func (s *Service) DeleteProject(id string) error {
 // working directory when it lives in a git worktree; empty means the project's.
 // The session takes the position after the project's last one, so it appends to
 // the card list even once the user has dragged the others around.
-func (s *Service) AddSession(projectID, sessionID, label, kind, path string, nextSeq int) error {
-	return s.AddSessionFrom(projectID, sessionID, label, kind, path, nextSeq, "", "")
+// sandbox is whether this session runs confined ("on"/"off", empty to follow the
+// provider's rung). It is written with the row rather than after it because the
+// PTY reads it on the very first spawn: a second call would race the card the
+// insert is about to put on screen, and lose that race silently — the session
+// would open unconfined and stay that way until something respawned it.
+func (s *Service) AddSession(
+	projectID, sessionID, label, kind, path string, nextSeq int, sandbox string,
+) error {
+	return s.addSession(projectID, sessionID, label, kind, path, nextSeq, "", "", sandbox)
 }
 
 // AddSessionFrom is AddSession for a session opened by delegation: originID is
@@ -116,14 +123,27 @@ func (s *Service) AddSession(projectID, sessionID, label, kind, path string, nex
 func (s *Service) AddSessionFrom(
 	projectID, sessionID, label, kind, path string, nextSeq int, originID, originLabel string,
 ) error {
+	// No sandbox answer: a delegated session is opened by another session, which
+	// has nobody to ask, so it follows the provider's rung like every other
+	// caller that cannot put the question on screen.
+	return s.addSession(projectID, sessionID, label, kind, path, nextSeq, originID, originLabel, "")
+}
+
+// addSession is the one insert behind both entry points.
+func (s *Service) addSession(
+	projectID, sessionID, label, kind, path string, nextSeq int, originID, originLabel, sandbox string,
+) error {
 	if kind == "" {
 		kind = providers.Claude
 	}
+	if sandbox != SessionConfined && sandbox != SessionUnconfined {
+		sandbox = ""
+	}
 	return s.tx(func(tx *sql.Tx) error {
 		if _, err := tx.Exec(
-			`INSERT INTO sessions (id, project_id, label, kind, path, origin_session_id, origin_label, position)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
-			sessionID, projectID, label, kind, path, originID, originLabel, projectID,
+			`INSERT INTO sessions (id, project_id, label, kind, path, origin_session_id, origin_label, sandbox, position)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
+			sessionID, projectID, label, kind, path, originID, originLabel, sandbox, projectID,
 		); err != nil {
 			return fmt.Errorf("insert session %q: %w", sessionID, err)
 		}
@@ -186,9 +206,9 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 		// shell — silently, on the one path where the card keeps its identity but
 		// not its id.
 		var labelAuto int
-		var model, entrypoint string
+		var model, entrypoint, sandbox string
 		row := tx.QueryRow(
-			`SELECT id, label, kind, provider_session_id, label_auto, model, entrypoint,
+			`SELECT id, label, kind, provider_session_id, label_auto, model, entrypoint, sandbox,
 			        origin_session_id, origin_label
 			   FROM sessions
 			  WHERE project_id = ? AND path = ? AND is_open = 0
@@ -197,7 +217,7 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 		)
 		if err := row.Scan(
 			&old.ID, &old.Label, &old.Kind, &old.ProviderSessionID, &labelAuto, &model, &entrypoint,
-			&old.OriginSessionID, &old.OriginLabel,
+			&sandbox, &old.OriginSessionID, &old.OriginLabel,
 		); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return nil // nothing parked here; caller creates a new session
@@ -217,10 +237,10 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 		if _, err := tx.Exec(
 			`INSERT INTO sessions
 			   (id, project_id, label, kind, path, provider_session_id, label_auto,
-			    model, entrypoint, origin_session_id, origin_label, position)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
+			    model, entrypoint, sandbox, origin_session_id, origin_label, position)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
 			newSessionID, projectID, old.Label, old.Kind, path, old.ProviderSessionID, labelAuto,
-			model, entrypoint, old.OriginSessionID, old.OriginLabel, projectID,
+			model, entrypoint, sandbox, old.OriginSessionID, old.OriginLabel, projectID,
 		); err != nil {
 			return fmt.Errorf("reinsert session %q: %w", newSessionID, err)
 		}
@@ -237,6 +257,7 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 			Path:              path,
 			ProviderSessionID: old.ProviderSessionID,
 			Entrypoint:        entrypoint,
+			Sandbox:           sandbox,
 			OriginSessionID:   old.OriginSessionID,
 			OriginLabel:       old.OriginLabel,
 		}
@@ -381,6 +402,50 @@ func (s *Service) SessionEntrypoint(sessionID string) string {
 		return ""
 	}
 	return entrypoint.String
+}
+
+// Session sandbox answers, the row's own spelling. Empty is not one of them: it
+// is the absence of an answer, and it means the provider's rung decides.
+const (
+	// SessionConfined runs this session in the sandbox whatever the rung says.
+	SessionConfined = "on"
+	// SessionUnconfined runs it on the machine whatever the rung says.
+	SessionUnconfined = "off"
+)
+
+// SetSessionSandbox records whether one session runs confined, overriding the
+// provider's rung for that session alone. It is written when a session is
+// opened — the dialog's answer — and read on every later spawn, so a respawn
+// after a reload and the resume of a parked worktree session are confined the
+// same way the user opened them.
+//
+// Anything that is not one of the two answers clears the override rather than
+// parking an unreadable value: a row that says neither is a row that follows
+// the setting, which is the state every session starts in.
+func (s *Service) SetSessionSandbox(sessionID, sandbox string) error {
+	if sandbox != SessionConfined && sandbox != SessionUnconfined {
+		sandbox = ""
+	}
+	if _, err := s.db.Exec(
+		`UPDATE sessions SET sandbox = ? WHERE id = ?`, sandbox, sessionID,
+	); err != nil {
+		return fmt.Errorf("set sandbox on %q: %w", sessionID, err)
+	}
+	return nil
+}
+
+// SessionSandbox returns the answer recorded for a session, or "" when nobody
+// decided for this one and the provider's rung stands. A read failure answers
+// "" for SessionEntrypoint's reason: the row is an override, and deferring to
+// the setting is the honest fallback.
+func (s *Service) SessionSandbox(sessionID string) string {
+	var sandbox sql.NullString
+	if err := s.db.QueryRow(
+		`SELECT sandbox FROM sessions WHERE id = ?`, sessionID,
+	).Scan(&sandbox); err != nil {
+		return ""
+	}
+	return sandbox.String
 }
 
 // SetProviderSession records the provider conversation id running inside a lich

--- a/internal/store/origin_test.go
+++ b/internal/store/origin_test.go
@@ -11,7 +11,7 @@ func TestSessionOriginPersistsAndDefaults(t *testing.T) {
 	if err := svc.AddProject("p1", "alpha", "/tmp/alpha"); err != nil {
 		t.Fatalf("AddProject: %v", err)
 	}
-	if err := svc.AddSession("p1", "parent", "planner", "claude", "", 2); err != nil {
+	if err := svc.AddSession("p1", "parent", "planner", "claude", "", 2, ""); err != nil {
 		t.Fatalf("AddSession: %v", err)
 	}
 	if err := svc.AddSessionFrom("p1", "child", "worker", "claude", "/wt/a", 3, "parent", "planner"); err != nil {
@@ -42,7 +42,7 @@ func TestSessionOriginPersistsAndDefaults(t *testing.T) {
 func TestSessionOriginSurvivesARenameOfTheParent(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "parent", "planner", "claude", "", 2)
+	_ = svc.AddSession("p1", "parent", "planner", "claude", "", 2, "")
 	_ = svc.AddSessionFrom("p1", "child", "worker", "claude", "", 3, "parent", "planner")
 
 	if err := svc.RenameSession("parent", "the boss"); err != nil {
@@ -68,7 +68,7 @@ func TestSessionOriginSurvivesARenameOfTheParent(t *testing.T) {
 func TestReopenWorktreeSessionCarriesTheOrigin(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "parent", "planner", "claude", "", 2)
+	_ = svc.AddSession("p1", "parent", "planner", "claude", "", 2, "")
 	_ = svc.AddSessionFrom("p1", "child", "worker", "claude", "/wt/a", 3, "parent", "planner")
 	_ = svc.CloseSession("p1", "child", "parent")
 

--- a/internal/store/reopen_test.go
+++ b/internal/store/reopen_test.go
@@ -10,12 +10,12 @@ import "testing"
 func TestReopenWorktreeSessionTakesTheNewestParkedRow(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2)
+	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2, "")
 
-	_ = svc.AddSession("p1", "wt1", "older", "claude", "/wt/foo", 3)
+	_ = svc.AddSession("p1", "wt1", "older", "claude", "/wt/foo", 3, "")
 	_ = svc.SetProviderSession("wt1", "conv-older")
 	_ = svc.CloseSession("p1", "wt1", "base")
-	_ = svc.AddSession("p1", "wt2", "newer", "claude", "/wt/foo", 4)
+	_ = svc.AddSession("p1", "wt2", "newer", "claude", "/wt/foo", 4, "")
 	_ = svc.SetProviderSession("wt2", "conv-newer")
 	_ = svc.CloseSession("p1", "wt2", "base")
 

--- a/internal/store/sandbox_test.go
+++ b/internal/store/sandbox_test.go
@@ -1,0 +1,166 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// sandboxProject is a store holding one project rooted at path, which is what
+// the worktree scope is measured against.
+func sandboxProject(t *testing.T, path string) *Service {
+	t.Helper()
+	svc := newTestStore(t)
+	if err := svc.AddProject("p1", "alpha", path); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+	return svc
+}
+
+func TestSandboxLevelPrefersTheProjectOverTheGlobal(t *testing.T) {
+	svc := sandboxProject(t, "/work/alpha")
+	key := sandboxKey(providers.Claude)
+
+	if got := svc.SandboxLevel(providers.Claude, "p1"); got != SandboxOff {
+		t.Errorf("unset level = %q, want %q", got, SandboxOff)
+	}
+	if err := svc.SetSetting(key, "", SandboxEverywhere); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	if got := svc.SandboxLevel(providers.Claude, "p1"); got != SandboxEverywhere {
+		t.Errorf("global level = %q, want %q", got, SandboxEverywhere)
+	}
+	if err := svc.SetSetting(key, "p1", SandboxWorktrees); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	if got := svc.SandboxLevel(providers.Claude, "p1"); got != SandboxWorktrees {
+		t.Errorf("project level = %q, want %q", got, SandboxWorktrees)
+	}
+	// Another project still reads the global value.
+	if got := svc.SandboxLevel(providers.Claude, "p2"); got != SandboxEverywhere {
+		t.Errorf("sibling project level = %q, want %q", got, SandboxEverywhere)
+	}
+}
+
+// A value from some other feature, a typo, or a rung that used to exist must
+// read as off — never as a rung that confines a session nobody asked to confine.
+func TestSandboxLevelRejectsUnknownValues(t *testing.T) {
+	svc := sandboxProject(t, "/work/alpha")
+	for _, value := range []string{"true", "on", "ON", "Everywhere", "always", " worktrees"} {
+		if err := svc.SetSetting(sandboxKey(providers.Codex), "", value); err != nil {
+			t.Fatalf("SetSetting: %v", err)
+		}
+		if got := svc.SandboxLevel(providers.Codex, "p1"); got != SandboxOff {
+			t.Errorf("level %q read as %q, want %q", value, got, SandboxOff)
+		}
+	}
+}
+
+func TestSandboxDefaultPerRungAndCheckout(t *testing.T) {
+	const root = "/work/alpha"
+	tests := []struct {
+		level    string
+		cwd      string
+		confined bool
+	}{
+		{SandboxOff, root, false},
+		{SandboxOff, "/work/wt", false},
+		{SandboxAsk, root, false},
+		// Ask hands the decision to whoever opens the session. A caller with
+		// nowhere to ask gets the answer closing the dialog would give.
+		{SandboxAsk, "/work/wt", false},
+		{SandboxWorktrees, root, false},
+		{SandboxWorktrees, root + "/", false},
+		{SandboxWorktrees, "/work/wt", true},
+		{SandboxEverywhere, root, true},
+		{SandboxEverywhere, "/work/wt", true},
+	}
+	for _, tt := range tests {
+		svc := sandboxProject(t, root)
+		if err := svc.SetSetting(sandboxKey(providers.Claude), "", tt.level); err != nil {
+			t.Fatalf("SetSetting: %v", err)
+		}
+		if got := svc.SandboxDefault(providers.Claude, "p1", tt.cwd); got != tt.confined {
+			t.Errorf("rung %q in %q = %v, want %v", tt.level, tt.cwd, got, tt.confined)
+		}
+	}
+}
+
+// A project whose path cannot be read cannot be told apart from its worktrees,
+// and the worktree rung is the one that would confine on that guess.
+func TestSandboxDefaultWithoutAProjectPath(t *testing.T) {
+	svc := newTestStore(t)
+	if err := svc.SetSetting(sandboxKey(providers.Claude), "", SandboxWorktrees); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	if svc.SandboxDefault(providers.Claude, "missing", "/work/wt") {
+		t.Error("a session whose project lich cannot place was confined on a guess")
+	}
+}
+
+func TestSessionSandboxRoundTrip(t *testing.T) {
+	svc := sandboxProject(t, "/work/alpha")
+	if err := svc.AddSession("p1", "s1", "one", providers.Claude, "", 0, ""); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+	if got := svc.SessionSandbox("s1"); got != "" {
+		t.Errorf("a new session = %q, want no override", got)
+	}
+	for _, want := range []string{SessionConfined, SessionUnconfined} {
+		if err := svc.SetSessionSandbox("s1", want); err != nil {
+			t.Fatalf("SetSessionSandbox(%q): %v", want, err)
+		}
+		if got := svc.SessionSandbox("s1"); got != want {
+			t.Errorf("SessionSandbox = %q, want %q", got, want)
+		}
+	}
+	// Anything else clears the override rather than parking a value no reader
+	// understands.
+	if err := svc.SetSessionSandbox("s1", "maybe"); err != nil {
+		t.Fatalf("SetSessionSandbox: %v", err)
+	}
+	if got := svc.SessionSandbox("s1"); got != "" {
+		t.Errorf("an unknown answer stored as %q, want cleared", got)
+	}
+}
+
+// The answer arrives with the insert because the PTY reads it on the first
+// spawn: written afterwards it would race the card the insert puts on screen.
+func TestAddSessionCarriesTheSandboxAnswer(t *testing.T) {
+	svc := sandboxProject(t, "/work/alpha")
+	if err := svc.AddSession("p1", "s1", "one", providers.Claude, "", 0, SessionConfined); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+	if got := svc.SessionSandbox("s1"); got != SessionConfined {
+		t.Errorf("SessionSandbox = %q, want %q", got, SessionConfined)
+	}
+	// An unusable answer is stored as no answer, so the rung decides rather than
+	// a value no reader understands.
+	if err := svc.AddSession("p1", "s2", "two", providers.Claude, "", 1, "yes please"); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+	if got := svc.SessionSandbox("s2"); got != "" {
+		t.Errorf("SessionSandbox = %q, want cleared", got)
+	}
+}
+
+// A delegated session is opened by another session, which has nobody to ask.
+func TestAddSessionFromLeavesTheAnswerToTheRung(t *testing.T) {
+	svc := sandboxProject(t, "/work/alpha")
+	if err := svc.AddSessionFrom("p1", "s1", "one", providers.Claude, "", 0, "parent", "Parent"); err != nil {
+		t.Fatalf("AddSessionFrom: %v", err)
+	}
+	if got := svc.SessionSandbox("s1"); got != "" {
+		t.Errorf("a delegated session recorded %q, want no override", got)
+	}
+}
+
+func TestSessionSandboxOfAMissingRowIsNotAnError(t *testing.T) {
+	svc := sandboxProject(t, "/work/alpha")
+	if err := svc.SetSessionSandbox("gone", SessionConfined); err != nil {
+		t.Errorf("SetSessionSandbox on a missing row: %v", err)
+	}
+	if got := svc.SessionSandbox("gone"); got != "" {
+		t.Errorf("SessionSandbox of a missing row = %q, want \"\"", got)
+	}
+}

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -113,6 +113,76 @@ func (s *Service) SkipPermissions(providerID, projectID, cwd string) bool {
 	return value == "true"
 }
 
+// Sandbox rungs, ordered by how much of the machine a session can reach. They
+// are the stored spelling of the control in Settings › Providers, and anything
+// this list does not name reads as SandboxOff — an unknown value must never be
+// the answer that leaves a session unconfined by accident, but it must also
+// never confine one the user never asked to confine.
+const (
+	// SandboxOff runs sessions straight on the machine. The default.
+	SandboxOff = "off"
+	// SandboxAsk leaves the answer to the session about to open: the dialog
+	// carries the choice, and a session opened any other way is not confined.
+	SandboxAsk = "ask"
+	// SandboxWorktrees confines sessions in a worktree and leaves the project's
+	// own checkout alone — a worktree is the throwaway one, which is the split
+	// skipPermissionsKey already makes for the opposite reason.
+	SandboxWorktrees = "worktrees"
+	// SandboxEverywhere confines every session of the provider.
+	SandboxEverywhere = "everywhere"
+)
+
+// sandboxKey is the settings key holding a provider's sandbox rung. Scoped like
+// ProviderBin — a project value wins over the global one — because confining is
+// a decision about a repository as much as about a provider: the checkout full
+// of other people's code is the one to confine, and the user's own scratch
+// project is not.
+func sandboxKey(providerID string) string {
+	return "provider." + providerID + ".sandbox"
+}
+
+// SandboxLevel returns the rung configured for a provider in a project: the
+// project's own value, then the global one, then SandboxOff. An unreadable or
+// unrecognised value is SandboxOff for the reason the constants give.
+func (s *Service) SandboxLevel(providerID, projectID string) string {
+	level := ""
+	if projectID != globalScope {
+		if value, err := s.GetSetting(sandboxKey(providerID), projectID); err == nil {
+			level = value
+		}
+	}
+	if level == "" {
+		if value, err := s.GetSetting(sandboxKey(providerID), globalScope); err == nil {
+			level = value
+		}
+	}
+	switch level {
+	case SandboxAsk, SandboxWorktrees, SandboxEverywhere:
+		return level
+	}
+	return SandboxOff
+}
+
+// SandboxDefault reports whether a session of this provider, starting in cwd,
+// is confined unless something says otherwise. cwd picks the scope the same way
+// SkipPermissions does: anything but the project's own directory is a worktree,
+// and a project whose path cannot be read falls back to the main checkout.
+//
+// SandboxAsk answers false here on purpose. It is the rung that hands the
+// decision to whoever opens the session, and every caller that cannot ask —
+// a respawn, an MCP tool, a delegation — has to be left with the answer the
+// user would get by closing the dialog rather than with one nobody chose.
+func (s *Service) SandboxDefault(providerID, projectID, cwd string) bool {
+	switch s.SandboxLevel(providerID, projectID) {
+	case SandboxEverywhere:
+		return true
+	case SandboxWorktrees:
+		root := s.ProjectPath(projectID)
+		return root != "" && filepath.Clean(cwd) != filepath.Clean(root)
+	}
+	return false
+}
+
 // ghAccountKey is the settings key holding the gh account a project's GitHub
 // calls run as. Project-scoped only, no global fallback: gh already has a
 // global answer (its active account), and this exists precisely to override it

--- a/internal/store/settings_test.go
+++ b/internal/store/settings_test.go
@@ -68,7 +68,7 @@ func TestGHAccountForPath(t *testing.T) {
 	}
 	// A worktree lives outside the project directory; only its session row ties
 	// the path back to the project.
-	if err := svc.AddSession("p1", "s1", "fix", "claude", "/data/worktrees/p1/fix", 2); err != nil {
+	if err := svc.AddSession("p1", "s1", "fix", "claude", "/data/worktrees/p1/fix", 2, ""); err != nil {
 		t.Fatalf("AddSession: %v", err)
 	}
 	if err := svc.SetSetting(ghAccountKey, "p1", "octocat"); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -59,7 +59,13 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- parent is called now, and the label is what it was called when the
     -- delegation happened — which is all that survives the parent being closed.
     origin_session_id   TEXT NOT NULL DEFAULT '',
-    origin_label        TEXT NOT NULL DEFAULT ''
+    origin_label        TEXT NOT NULL DEFAULT '',
+    -- Whether this session runs confined, when the answer belongs to the session
+    -- rather than to the provider's rung: 'on', 'off', or empty to follow the
+    -- setting. Three states rather than a boolean because the row has to be able
+    -- to say "nobody decided this one" — a session opened before the user picked
+    -- a rung, or by a caller with nowhere to ask.
+    sandbox             TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
 
@@ -115,7 +121,12 @@ type Session struct {
 	// Entrypoint is the command a terminal session opens into; always empty for
 	// a provider session. The window reads it to prefill its dialog and to say
 	// on the card what a renamed terminal actually runs.
-	Entrypoint      string `json:"entrypoint"`
+	Entrypoint string `json:"entrypoint"`
+	// Sandbox is whether this session runs confined: "on", "off", or empty for a
+	// row nothing has spawned yet. The spawn writes its own verdict here, so the
+	// window can mark a confined card without re-deriving a decision that took
+	// the provider's rung, the checkout and a per-session override to reach.
+	Sandbox         string `json:"sandbox"`
 	Pinned          bool   `json:"pinned"`
 	OriginSessionID string `json:"originSessionId"`
 	OriginLabel     string `json:"originLabel"`
@@ -186,6 +197,7 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN entrypoint TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN origin_session_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN origin_label TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN sandbox TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN closed_seq INTEGER NOT NULL DEFAULT 0`,
 	}
@@ -376,7 +388,7 @@ func (s *Service) ProjectAt(path string) (string, string) {
 // the frontend would have no order left to put an unpinned card back into.
 func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	rows, err := s.db.Query(
-		`SELECT id, label, kind, path, provider_session_id, entrypoint, pinned,
+		`SELECT id, label, kind, path, provider_session_id, entrypoint, sandbox, pinned,
 		        origin_session_id, origin_label
 		   FROM sessions WHERE project_id = ? AND is_open = 1 ORDER BY position, rowid`,
 		projectID,
@@ -391,7 +403,7 @@ func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 		var sess Session
 		if err := rows.Scan(
 			&sess.ID, &sess.Label, &sess.Kind, &sess.Path, &sess.ProviderSessionID,
-			&sess.Entrypoint, &sess.Pinned, &sess.OriginSessionID, &sess.OriginLabel,
+			&sess.Entrypoint, &sess.Sandbox, &sess.Pinned, &sess.OriginSessionID, &sess.OriginLabel,
 		); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -29,10 +29,10 @@ func TestLoadStateRestoresOpenProjectsAndSessions(t *testing.T) {
 	if err := svc.AddProject("p1", "alpha", "/tmp/alpha"); err != nil {
 		t.Fatalf("AddProject: %v", err)
 	}
-	if err := svc.AddSession("p1", "s1", "Session 1", "", "", 2); err != nil {
+	if err := svc.AddSession("p1", "s1", "Session 1", "", "", 2, ""); err != nil {
 		t.Fatalf("AddSession: %v", err)
 	}
-	if err := svc.AddSession("p1", "s2", "Session 2", "", "", 3); err != nil {
+	if err := svc.AddSession("p1", "s2", "Session 2", "", "", 3, ""); err != nil {
 		t.Fatalf("AddSession: %v", err)
 	}
 
@@ -110,7 +110,7 @@ func TestLoadStateIgnoresProjectProviderDefaultReadFailure(t *testing.T) {
 func TestSessionPathPersistsAndDefaults(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	if err := svc.AddSession("p1", "s1", "mellow-otter", "claude", "/data/wt/mellow-otter", 2); err != nil {
+	if err := svc.AddSession("p1", "s1", "mellow-otter", "claude", "/data/wt/mellow-otter", 2, ""); err != nil {
 		t.Fatalf("AddSession: %v", err)
 	}
 	// Row without the path column, as written before the migration.
@@ -135,10 +135,10 @@ func TestSessionPathPersistsAndDefaults(t *testing.T) {
 func TestSessionKindPersistsAndDefaults(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	if err := svc.AddSession("p1", "s1", "Session 1", "shell", "", 2); err != nil {
+	if err := svc.AddSession("p1", "s1", "Session 1", "shell", "", 2, ""); err != nil {
 		t.Fatalf("AddSession: %v", err)
 	}
-	if err := svc.AddSession("p1", "s2", "Session 2", "", "", 3); err != nil {
+	if err := svc.AddSession("p1", "s2", "Session 2", "", "", 3, ""); err != nil {
 		t.Fatalf("AddSession: %v", err)
 	}
 
@@ -158,8 +158,8 @@ func TestSessionKindPersistsAndDefaults(t *testing.T) {
 func TestSetProviderSessionPersistsAndDefaults(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
-	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3)
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2, "")
+	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3, "")
 
 	if err := svc.SetProviderSession("s1", "uuid-abc"); err != nil {
 		t.Fatalf("SetProviderSession: %v", err)
@@ -186,8 +186,8 @@ func TestSetProviderSessionPersistsAndDefaults(t *testing.T) {
 func TestSessionModelRoundTrips(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "s1", "Session 1", "claude", "", 2)
-	_ = svc.AddSession("p1", "s2", "Session 2", "claude", "", 3)
+	_ = svc.AddSession("p1", "s1", "Session 1", "claude", "", 2, "")
+	_ = svc.AddSession("p1", "s2", "Session 2", "claude", "", 3, "")
 
 	if err := svc.SetSessionModel("s1", "opus"); err != nil {
 		t.Fatalf("SetSessionModel: %v", err)
@@ -229,8 +229,8 @@ func TestSetProviderSessionUnknownSessionNoop(t *testing.T) {
 func TestProviderSessionReadsBackWhatWasReported(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
-	_ = svc.AddSession("p1", "shell", "Shell", "shell", "", 3)
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2, "")
+	_ = svc.AddSession("p1", "shell", "Shell", "shell", "", 3, "")
 
 	_ = svc.SetProviderSession("s1", "uuid-abc")
 	_ = svc.SetProviderSession("s1", "uuid-def")
@@ -266,7 +266,7 @@ func mustLoadSessions(t *testing.T, svc *Service) []Session {
 func TestCloseProjectHidesButKeepsSessions(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2, "")
 
 	if err := svc.CloseProject("p1"); err != nil {
 		t.Fatalf("CloseProject: %v", err)
@@ -291,8 +291,8 @@ func TestCloseProjectHidesButKeepsSessions(t *testing.T) {
 func TestDeleteSessionRemovesRowAndUpdatesActive(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
-	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3)
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2, "")
+	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3, "")
 
 	if err := svc.DeleteSession("p1", "s2", "s1"); err != nil {
 		t.Fatalf("DeleteSession: %v", err)
@@ -311,8 +311,8 @@ func TestDeleteSessionRemovesRowAndUpdatesActive(t *testing.T) {
 func TestRenameAndActivateSession(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
-	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3)
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2, "")
+	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3, "")
 
 	if err := svc.RenameSession("s1", "build"); err != nil {
 		t.Fatalf("RenameSession: %v", err)
@@ -337,7 +337,7 @@ func TestRenameAndActivateSession(t *testing.T) {
 func TestSetSessionTitleRespectsManualRename(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2, "")
 
 	applied, err := svc.SetSessionTitle("s1", "Fixing the auth bug")
 	if err != nil {
@@ -438,11 +438,11 @@ func TestOpenFailsWhenParentIsAFile(t *testing.T) {
 func TestAddSessionRollsBackOnDuplicate(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	if err := svc.AddSession("p1", "s1", "Session 1", "", "", 2); err != nil {
+	if err := svc.AddSession("p1", "s1", "Session 1", "", "", 2, ""); err != nil {
 		t.Fatalf("AddSession: %v", err)
 	}
 
-	if err := svc.AddSession("p1", "s1", "dup", "", "", 9); err == nil {
+	if err := svc.AddSession("p1", "s1", "dup", "", "", 9, ""); err == nil {
 		t.Fatal("duplicate session id = nil error, want error")
 	}
 	projects, _ := svc.LoadState()
@@ -472,7 +472,7 @@ func TestOperationsOnClosedStoreReturnErrors(t *testing.T) {
 	}
 	assertErr("AddProject", svc.AddProject("p2", "b", "/b"))
 	assertErr("CloseProject", svc.CloseProject("p1"))
-	assertErr("AddSession", svc.AddSession("p1", "s1", "Session 1", "", "", 2))
+	assertErr("AddSession", svc.AddSession("p1", "s1", "Session 1", "", "", 2, ""))
 	assertErr("DeleteSession", svc.DeleteSession("p1", "s1", ""))
 	assertErr("RenameSession", svc.RenameSession("s1", "x"))
 	assertErr("SetProviderSession", svc.SetProviderSession("s1", "uuid"))
@@ -506,7 +506,7 @@ func TestOperationsOnClosedStoreReturnErrors(t *testing.T) {
 func TestDeleteProjectCascadesSessions(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2, "")
 
 	// Direct row delete exercises the ON DELETE CASCADE foreign key (the
 	// future "forget project" path); close does not delete, so it is not used
@@ -611,9 +611,9 @@ func equalIDs(got, want []string) bool {
 func TestReorderSessionsPersistsOrder(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
-	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3)
-	_ = svc.AddSession("p1", "s3", "Session 3", "", "", 4)
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2, "")
+	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3, "")
+	_ = svc.AddSession("p1", "s3", "Session 3", "", "", 4, "")
 
 	if err := svc.ReorderSessions("p1", []string{"s3", "s1", "s2"}); err != nil {
 		t.Fatalf("ReorderSessions: %v", err)
@@ -628,11 +628,11 @@ func TestReorderSessionsPersistsOrder(t *testing.T) {
 func TestAddSessionAppendsAfterReorder(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
-	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3)
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2, "")
+	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3, "")
 	_ = svc.ReorderSessions("p1", []string{"s2", "s1"})
 
-	_ = svc.AddSession("p1", "s3", "Session 3", "", "", 4)
+	_ = svc.AddSession("p1", "s3", "Session 3", "", "", 4, "")
 
 	if got := sessionIDs(t, svc, "p1"); !equalIDs(got, []string{"s2", "s1", "s3"}) {
 		t.Errorf("session order = %v, want [s2 s1 s3]", got)
@@ -644,9 +644,9 @@ func TestReorderSessionsIgnoresForeignSession(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
 	_ = svc.AddProject("p2", "beta", "/tmp/beta")
-	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
-	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3)
-	_ = svc.AddSession("p2", "other", "Session 1", "", "", 2)
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2, "")
+	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3, "")
+	_ = svc.AddSession("p2", "other", "Session 1", "", "", 2, "")
 
 	if err := svc.ReorderSessions("p1", []string{"other", "s2", "s1"}); err != nil {
 		t.Fatalf("ReorderSessions: %v", err)
@@ -665,9 +665,9 @@ func TestReorderSessionsIgnoresForeignSession(t *testing.T) {
 func TestSetSessionPinnedPersistsWithoutMovingTheRow(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
-	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3)
-	_ = svc.AddSession("p1", "s3", "Session 3", "", "", 4)
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2, "")
+	_ = svc.AddSession("p1", "s2", "Session 2", "", "", 3, "")
+	_ = svc.AddSession("p1", "s3", "Session 3", "", "", 4, "")
 	_ = svc.ReorderSessions("p1", []string{"s2", "s3", "s1"})
 
 	if err := svc.SetSessionPinned("s1", true); err != nil {
@@ -791,7 +791,7 @@ CREATE TABLE sessions (
 	if err := svc.AddProject("p1", "alpha", "/tmp/alpha"); err != nil {
 		t.Fatalf("AddProject: %v", err)
 	}
-	if err := svc.AddSession("p1", "s1", "mellow-otter", "shell", "/data/wt", 2); err != nil {
+	if err := svc.AddSession("p1", "s1", "mellow-otter", "shell", "/data/wt", 2, ""); err != nil {
 		t.Fatalf("AddSession: %v", err)
 	}
 	got, err := svc.LoadState()
@@ -895,10 +895,10 @@ INSERT INTO sessions (id, project_id, label, claude_session_id)
 func TestCloseSessionParksAndReopenRestores(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	if err := svc.AddSession("p1", "base", "Session 1", "claude", "", 2); err != nil {
+	if err := svc.AddSession("p1", "base", "Session 1", "claude", "", 2, ""); err != nil {
 		t.Fatalf("AddSession base: %v", err)
 	}
-	if err := svc.AddSession("p1", "wt", "swift-rabbit", "claude", "/data/wt/swift-rabbit", 3); err != nil {
+	if err := svc.AddSession("p1", "wt", "swift-rabbit", "claude", "/data/wt/swift-rabbit", 3, ""); err != nil {
 		t.Fatalf("AddSession worktree: %v", err)
 	}
 	if err := svc.SetProviderSession("wt", "claude-uuid-1"); err != nil {
@@ -957,8 +957,8 @@ func TestCloseSessionParksAndReopenRestores(t *testing.T) {
 func TestReopenWorktreeSessionKeepsManualRename(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2)
-	_ = svc.AddSession("p1", "wt1", "auto name", "claude", "/wt/foo", 3)
+	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2, "")
+	_ = svc.AddSession("p1", "wt1", "auto name", "claude", "/wt/foo", 3, "")
 	if err := svc.RenameSession("wt1", "my name"); err != nil {
 		t.Fatalf("RenameSession: %v", err)
 	}
@@ -988,7 +988,7 @@ func TestReopenWorktreeSessionKeepsManualRename(t *testing.T) {
 func TestReopenWorktreeSessionNoParked(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2)
+	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2, "")
 
 	restored, err := svc.ReopenWorktreeSession("p1", "/data/wt/never-parked", "wt2")
 	if err != nil {
@@ -1018,13 +1018,13 @@ func countSessions(t *testing.T, svc *Service, projectID, path string) int {
 func TestPurgeWorktreeSessions(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2) // project's own, no path
-	_ = svc.AddSession("p1", "wtA", "foo", "claude", "/wt/foo", 3) // worktree foo
-	_ = svc.AddSession("p1", "wtB", "bar", "claude", "/wt/bar", 4) // worktree bar
-	if err := svc.CloseSession("p1", "wtA", "base"); err != nil {  // park foo (stale leftover)
+	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2, "") // project's own, no path
+	_ = svc.AddSession("p1", "wtA", "foo", "claude", "/wt/foo", 3, "") // worktree foo
+	_ = svc.AddSession("p1", "wtB", "bar", "claude", "/wt/bar", 4, "") // worktree bar
+	if err := svc.CloseSession("p1", "wtA", "base"); err != nil {      // park foo (stale leftover)
 		t.Fatalf("CloseSession: %v", err)
 	}
-	_ = svc.AddSession("p1", "wtA2", "foo", "claude", "/wt/foo", 5) // live foo again, same path
+	_ = svc.AddSession("p1", "wtA2", "foo", "claude", "/wt/foo", 5, "") // live foo again, same path
 
 	if err := svc.PurgeWorktreeSessions("p1", "/wt/foo"); err != nil {
 		t.Fatalf("PurgeWorktreeSessions: %v", err)
@@ -1265,7 +1265,7 @@ INSERT INTO projects (id, name, path, is_open) VALUES ('open', 'open', '/tmp/ope
 func TestReopeningARecentProjectRestoresItsSessions(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2, "")
 	_ = svc.CloseProject("p1")
 
 	if err := svc.AddProject("p1", "alpha", "/tmp/alpha"); err != nil {
@@ -1292,7 +1292,7 @@ func TestReopeningARecentProjectRestoresItsSessions(t *testing.T) {
 func TestDeleteProjectRemovesItsSessions(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
-	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2)
+	_ = svc.AddSession("p1", "s1", "Session 1", "", "", 2, "")
 	_ = svc.CloseProject("p1")
 
 	if err := svc.DeleteProject("p1"); err != nil {

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/ncruces/zenity"
 	"github.com/omartelo/lich/internal/relpath"
+	"github.com/omartelo/lich/internal/sandbox"
 )
 
 type Service struct {
@@ -78,6 +79,17 @@ func (s *Service) Diagnostics() Diagnostics {
 		Platform: runtime.GOOS + "/" + runtime.GOARCH,
 		LogPath:  s.logPath,
 	}
+}
+
+// SandboxAvailable reports whether this machine can run a session confined
+// (internal/sandbox). It answers here rather than beside the provider list
+// because it is a fact about the machine — bubblewrap installed, or macOS —
+// and the same answer for every provider on it.
+//
+// The frontend hides the sandbox control when this is false rather than
+// offering one that saves a setting nothing can act on.
+func (s *Service) SandboxAvailable() bool {
+	return sandbox.Available()
 }
 
 // RevealLog opens the log's directory with the platform's file manager, not the

--- a/internal/terminal/sandbox.go
+++ b/internal/terminal/sandbox.go
@@ -1,0 +1,105 @@
+package terminal
+
+import (
+	"log/slog"
+	"os"
+
+	"github.com/omartelo/lich/internal/project"
+	"github.com/omartelo/lich/internal/sandbox"
+	"github.com/omartelo/lich/internal/store"
+)
+
+// wrapSandbox rewrites a session's spawn so its whole process tree runs
+// confined: a private empty home holding only the provider's own state, the
+// machine read-only, and write access to the checkout alone (internal/sandbox).
+//
+// It is the outermost wrapper, applied after wrapEntrypoint and wrapSetup, so
+// everything those two put in front of the provider — the worktree setup script
+// above all — is confined too. A setup script is the first thing to run in a
+// new checkout and the last thing anyone reads before it does.
+//
+// home is the user's home directory, passed in rather than resolved here so the
+// decision stays testable; an empty one returns the spawn untouched, because a
+// sandbox whose private home has no path is one that would confine a session to
+// nothing it can name.
+func wrapSandbox(spec ptySpec, kind, home string, confined bool) ptySpec {
+	if !confined || home == "" || !sandbox.Available() {
+		return spec
+	}
+	sb := sandbox.Describe(kind, home, spec.dir, project.GitCommonDir(spec.dir), executables(spec.bin))
+	spec.bin, spec.args = sandbox.Wrap(sb, spec.bin, spec.args)
+	return spec
+}
+
+// executables are the directories holding the binaries a confined spawn has to
+// reach: the one it runs, and the lich binary a session calls back through
+// (LICH_BIN — the `lich` CLI and the MCP server the provider is handed both run
+// it). Both are regularly installed inside the home the sandbox is about to
+// empty, and a `task dev` build is under /tmp, which the sandbox replaces too.
+//
+// Directories rather than the executables themselves, and every hop of their
+// symlink chains: see sandbox.BinaryDirs, which is where that decision and the
+// spawn failure behind it are written down.
+func executables(bin string) []string {
+	var dirs []string
+	for _, name := range []string{bin, lichBin()} {
+		if name == "" {
+			continue
+		}
+		dirs = append(dirs, sandbox.BinaryDirs(name)...)
+	}
+	return dirs
+}
+
+// confined answers whether one session runs in the sandbox, and records the
+// answer on its own row: the row's own value when it has one, otherwise the
+// provider's rung for this project and checkout.
+//
+// The row wins outright, in both directions. A session the user opened confined
+// stays confined through every later spawn — a reload, a respawn, the resume of
+// a parked worktree session — and one they deliberately opened on the machine is
+// not quietly confined later because the rung moved under it.
+//
+// Writing the verdict back is what makes that true for a session nobody was
+// asked about, and it is also what the window reads to mark a confined card: the
+// decision takes a rung, a checkout and an override to reach, and the card is
+// not the place to reach it a second time. A failed write costs the mark on the
+// card, never the confinement — the spawn already has its answer.
+func confined(s sandboxStore, sessionID, kind, projectID, cwd string) bool {
+	answer := false
+	switch s.SessionSandbox(sessionID) {
+	case store.SessionConfined:
+		answer = true
+	case store.SessionUnconfined:
+		answer = false
+	default:
+		answer = s.SandboxDefault(kind, projectID, cwd)
+	}
+	record := store.SessionUnconfined
+	if answer {
+		record = store.SessionConfined
+	}
+	if err := s.SetSessionSandbox(sessionID, record); err != nil {
+		slog.Warn("record sandbox verdict", "session", sessionID, "err", err)
+	}
+	return answer
+}
+
+// sandboxStore is the store as this file uses it, named separately so the
+// decision above can be tested against a stub rather than a database.
+type sandboxStore interface {
+	SessionSandbox(sessionID string) string
+	SandboxDefault(providerID, projectID, cwd string) bool
+	SetSessionSandbox(sessionID, sandbox string) error
+}
+
+// userHome is the home directory the sandbox replaces, or "" when it cannot be
+// resolved — which wrapSandbox reads as "do not confine", because a sandbox
+// built around the wrong home is one that hides the checkout from the session.
+func userHome() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return home
+}

--- a/internal/terminal/sandbox_spawn_linux_test.go
+++ b/internal/terminal/sandbox_spawn_linux_test.go
@@ -1,0 +1,75 @@
+//go:build linux
+
+package terminal
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/events"
+	"github.com/omartelo/lich/internal/sandbox"
+)
+
+// A confined session is still a PTY session: bubblewrap sits between lich and
+// the shell, and everything the terminal does — reading output, writing at the
+// prompt, reaping the exit — has to keep working through it. The rest of the
+// suite proves the sandbox confines; this proves a card still opens.
+func TestAConfinedSessionRunsInItsPTY(t *testing.T) {
+	if !sandbox.Available() {
+		t.Skip("no sandbox backend on this machine")
+	}
+	t.Setenv("SHELL", "sh")
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cwd := filepath.Join(home, "checkout")
+	// A sibling of the checkout, inside the same home: what the private home has
+	// to leave behind while still carrying the directory the session works in.
+	for _, dir := range []string{"checkout", "other-work"} {
+		if err := os.MkdirAll(filepath.Join(home, dir), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+
+	svc := New(stubBins{sandboxOn: true}, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1") })
+
+	if err := svc.Start("s1", "p1", cwd, KindShell, "", "", false, 80, 24); err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+	// Both markers are assembled from two shell variables, so the PTY's echo of
+	// the command carries `$A$B` and only the shell's own output carries "HOME:"
+	// and "END". Matching the echo would pass this test on a sandbox that never
+	// ran, and the trailing marker is what says the answer is complete — the
+	// listing has no newline of its own.
+	if err := svc.Write("s1", `A=HO; B=ME; ls -A "$HOME" | tr '\n' ' ' | sed "s/^/$A$B: /;s/$/$B$A/"`+"\n"); err != nil {
+		t.Fatalf("Write = %v, want nil", err)
+	}
+
+	var answer string
+	waitFor(t, func() bool {
+		encoded, err := svc.Replay("s1")
+		if err != nil {
+			return false
+		}
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			return false
+		}
+		at := strings.LastIndex(string(decoded), "HOME: ")
+		if at < 0 {
+			return false
+		}
+		answer = string(decoded)[at:]
+		return strings.Contains(answer, "MEHO")
+	}, "a confined session to answer at its prompt")
+
+	if !strings.Contains(answer, "checkout") {
+		t.Errorf("the session's own checkout is missing from its home: %q", answer)
+	}
+	if strings.Contains(answer, "other-work") {
+		t.Errorf("the host home reached into the sandbox: %q", answer)
+	}
+}

--- a/internal/terminal/sandbox_test.go
+++ b/internal/terminal/sandbox_test.go
@@ -1,0 +1,158 @@
+package terminal
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/sandbox"
+	"github.com/omartelo/lich/internal/store"
+)
+
+// stubSandboxStore answers what confined asks, and records what it writes back.
+type stubSandboxStore struct {
+	row        string
+	rungAnswer bool
+	recorded   *string
+}
+
+func (s stubSandboxStore) SessionSandbox(string) string       { return s.row }
+func (s stubSandboxStore) SandboxDefault(_, _, _ string) bool { return s.rungAnswer }
+
+func (s stubSandboxStore) SetSessionSandbox(_, sandbox string) error {
+	if s.recorded != nil {
+		*s.recorded = sandbox
+	}
+	return nil
+}
+
+// The row wins in both directions: a session opened confined stays confined
+// when the rung is turned off under it, and one opened on the machine is not
+// confined later because the rung moved.
+func TestConfinedPrefersTheSessionRow(t *testing.T) {
+	tests := []struct {
+		row  string
+		rung bool
+		want bool
+	}{
+		{"", false, false},
+		{"", true, true},
+		{store.SessionConfined, false, true},
+		{store.SessionUnconfined, true, false},
+		// A value no reader understands is not an answer, so the rung decides.
+		{"maybe", true, true},
+	}
+	for _, tt := range tests {
+		got := confined(stubSandboxStore{row: tt.row, rungAnswer: tt.rung}, "s1", providers.Claude, "p1", "/work/wt")
+		if got != tt.want {
+			t.Errorf("confined(row %q, rung %v) = %v, want %v", tt.row, tt.rung, got, tt.want)
+		}
+	}
+}
+
+func baseSpec() ptySpec {
+	return ptySpec{bin: "/bin/sh", args: []string{"-c", "exec claude"}, dir: t0dir}
+}
+
+// t0dir is a directory every platform has, so the spec under test names
+// something real without a fixture.
+const t0dir = "/tmp"
+
+func TestWrapSandboxLeavesAnUnconfinedSpawnAlone(t *testing.T) {
+	original := baseSpec()
+	for _, tt := range []struct {
+		name     string
+		home     string
+		confined bool
+	}{
+		{"not confined", "/home/u", false},
+		{"no home to empty", "", true},
+	} {
+		got := wrapSandbox(baseSpec(), providers.Claude, tt.home, tt.confined)
+		if got.bin != original.bin || !slices.Equal(got.args, original.args) {
+			t.Errorf("%s: spawn rewritten to %q %v", tt.name, got.bin, got.args)
+		}
+	}
+}
+
+func TestWrapSandboxKeepsTheCommandAndItsArguments(t *testing.T) {
+	if !sandbox.Available() {
+		t.Skip("no sandbox backend on this machine")
+	}
+	original := baseSpec()
+	got := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), true)
+	if got.bin == original.bin {
+		t.Fatalf("the spawn was not confined: still %q", got.bin)
+	}
+	// The provider's own argv has to survive intact and in order, at the end —
+	// an argument absorbed by the sandbox binary is a session that never starts.
+	// The last occurrence, not the first: the binary is also mounted into the
+	// sandbox, so its path appears in the mount list before it appears as the
+	// command.
+	at := lastIndex(got.args, original.bin)
+	if at < 0 {
+		t.Fatalf("%q is not in the confined argv: %v", original.bin, got.args)
+	}
+	if want := append([]string{original.bin}, original.args...); !slices.Equal(got.args[at:], want) {
+		t.Errorf("confined argv tail = %v, want %v", got.args[at:], want)
+	}
+	// Everything else about the spawn belongs to the PTY, not to the sandbox.
+	if got.dir != original.dir {
+		t.Errorf("start directory moved to %q", got.dir)
+	}
+}
+
+// lastIndex is the position of the final element equal to value, or -1.
+func lastIndex(args []string, value string) int {
+	for i := len(args) - 1; i >= 0; i-- {
+		if args[i] == value {
+			return i
+		}
+	}
+	return -1
+}
+
+// The binaries a confined session has to reach are the one it runs and the lich
+// binary it calls back through, both resolved to a real path.
+func TestExecutablesResolveTheSpawnAndLich(t *testing.T) {
+	paths := executables("sh")
+	if len(paths) == 0 {
+		t.Fatal("sh resolved to nothing")
+	}
+	for _, path := range paths {
+		if path == "sh" {
+			t.Errorf("an unresolved name reached the mount list: %v", paths)
+		}
+	}
+	if got := executables("lich-no-such-binary-anywhere"); len(got) != 0 && got[0] != "" {
+		for _, path := range got {
+			if path == "lich-no-such-binary-anywhere" {
+				t.Errorf("a binary that is not on PATH reached the mount list: %v", got)
+			}
+		}
+	}
+}
+
+// The verdict is written back on every spawn, including for a session nobody
+// was asked about — it is what the card reads to draw its mark, and what keeps a
+// session running the way it opened once the rung moves under it.
+func TestConfinedRecordsItsVerdict(t *testing.T) {
+	tests := []struct {
+		row  string
+		rung bool
+		want string
+	}{
+		{"", true, store.SessionConfined},
+		{"", false, store.SessionUnconfined},
+		{store.SessionConfined, false, store.SessionConfined},
+		{store.SessionUnconfined, true, store.SessionUnconfined},
+	}
+	for _, tt := range tests {
+		recorded := ""
+		s := stubSandboxStore{row: tt.row, rungAnswer: tt.rung, recorded: &recorded}
+		confined(s, "s1", providers.Claude, "p1", "/work/wt")
+		if recorded != tt.want {
+			t.Errorf("row %q rung %v recorded %q, want %q", tt.row, tt.rung, recorded, tt.want)
+		}
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -55,6 +55,13 @@ const (
 	// CLI runs in it. An empty agent clears the mark; every PTY spawn emits that
 	// clear so a respawned session never wears a dead agent's icon.
 	agentEventName = "session-agent"
+	// sandboxEventName carries whether a session's PTY runs confined ({id,
+	// confined}), emitted by every spawn. The card marks a confined session, and
+	// the answer is the spawn's own — it takes the provider's rung, the checkout
+	// and a per-session override to reach, so the window is told rather than
+	// asked to work it out again. Persisted with the row too (store.Session's
+	// Sandbox), which is what a page reload hydrates from.
+	sandboxEventName = "session-sandbox"
 )
 
 // statusEvent is the payload of statusEventName: the session whose processing
@@ -106,6 +113,13 @@ type agentEvent struct {
 	Agent string `json:"agent"`
 }
 
+// sandboxEvent is the payload of sandboxEventName: the session and whether its
+// PTY is confined.
+type sandboxEvent struct {
+	ID       string `json:"id"`
+	Confined bool   `json:"confined"`
+}
+
 // session is a single running PTY-backed shell. done closes when the session
 // is reaped (by stream or Close — whichever removes it from the map), stopping
 // its cwd watcher. replay holds a capped tail of the PTY's output so a
@@ -137,11 +151,15 @@ type session struct {
 	// draft.go.
 	draftAt    time.Time
 	escPending []byte
+	// confined records whether this PTY was spawned inside the sandbox, so Start
+	// can report it once the spawn is out of the lock.
+	confined bool
 }
 
 // Store is the persistence the terminal service depends on: the binary to spawn
-// for a provider in a project (empty return spawns the provider's default) and
-// whether that spawn drops the provider's permission prompts,
+// for a provider in a project (empty return spawns the provider's default),
+// whether that spawn drops the provider's permission prompts and whether it runs
+// confined,
 // that project's own directory, the dev-server port reserved for each checkout,
 // where to record the provider session id a PTY reports through its
 // session-start hook, and the running cost
@@ -157,6 +175,9 @@ type Store interface {
 	ProviderSession(sessionID string) (string, error)
 	SessionModel(sessionID string) string
 	SessionEntrypoint(sessionID string) string
+	SessionSandbox(sessionID string) string
+	SetSessionSandbox(sessionID, sandbox string) error
+	SandboxDefault(providerID, projectID, cwd string) bool
 	SetSessionTitle(sessionID, title string) (bool, error)
 	CostReadout() bool
 	CostLedger(sessionID, transcriptID string) (int64, string, float64, error)
@@ -453,6 +474,7 @@ func (s *Service) Start(id, projectID, cwd, kind, resume, name string, setup boo
 	// overwrites whatever the previous PTY left in the frontend's stores.
 	s.hub.Emit(cwdEventName, cwdEvent{ID: id, Cwd: cwd})
 	s.hub.Emit(agentEventName, agentEvent{ID: id, Agent: ""})
+	s.hub.Emit(sandboxEventName, sandboxEvent{ID: id, Confined: sess.confined})
 	go watchCwd(id, sess.pty.Pid(), cwd, sess.done, s.hub)
 	return nil
 }
@@ -507,6 +529,10 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 	if setup {
 		spec, settingUp = wrapSetup(spec, project.SetupScript(s.store.ProjectPath(projectID)), runtime.GOOS)
 	}
+	// Outermost, so the setup script and the entrypoint are confined with the
+	// session they run in front of.
+	inSandbox := confined(s.store, id, kind, projectID, cwd)
+	spec = wrapSandbox(spec, kind, userHome(), inSandbox)
 	p, err := startPTY(spec)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to start pty for %q: %w", id, err)
@@ -530,7 +556,8 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 		// Timed from the spawn, so a program that never writes anything still
 		// becomes ready once: quiet is the signal, and silence from the start
 		// is quiet too.
-		lastOut: time.Now(),
+		lastOut:  time.Now(),
+		confined: inSandbox,
 	}
 	s.sessions[id] = sess
 	go s.stream(id, sess)

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -40,6 +40,8 @@ type stubBins struct {
 	providerErr     error
 	model           string
 	entrypoint      string
+	sandbox         string
+	sandboxOn       bool
 	skipPerms       bool
 	costOn          bool
 	ledgers         map[string]stubLedger
@@ -87,6 +89,9 @@ func (s stubBins) SkipPermissions(_, _, _ string) bool  { return s.skipPerms }
 func (s stubBins) ProjectPath(_ string) string          { return s.projectPath }
 func (s stubBins) SessionModel(_ string) string         { return s.model }
 func (s stubBins) SessionEntrypoint(_ string) string    { return s.entrypoint }
+func (s stubBins) SessionSandbox(_ string) string       { return s.sandbox }
+func (s stubBins) SetSessionSandbox(_, _ string) error  { return nil }
+func (s stubBins) SandboxDefault(_, _, _ string) bool   { return s.sandboxOn }
 func (s stubBins) SetProviderSession(_, _ string) error { return nil }
 
 func (s stubBins) WorktreePorts() map[string]int {


### PR DESCRIPTION
A session can open inside an OS sandbox: a private empty home holding only that provider's own state, the rest of the machine read-only, and write access to the checkout it was opened for. Your ssh keys, your cloud credentials and every other repository on the disk are simply not there.

It is the counterweight to skipping permission prompts — the two rungs sit together in Settings › Providers, and an agent turned loose in a worktree can be turned loose inside a sandbox.

## What it looks like

`Settings › Providers` gains a **Sandbox** ladder, per provider and settable for one project alone:

| Rung | What it does |
|---|---|
| Off | Sessions run straight on the machine. The default. |
| Ask each time | The New worktree dialog asks, and remembers nothing. |
| Worktrees only | Sessions in the project directory run on the machine. |
| Everywhere | Every session opens confined. |

The New worktree dialog carries a **Run confined** box that starts on whatever the rung would do and overrides it for that session. A confined card wears a shield beside its status dot; its tooltip says what that means and that the answer was taken when the session opened.

## How the decision travels

The spawn resolves the rung, the checkout and any per-session override, then writes its verdict onto the session row. That does three things at once: it freezes a session at the answer it opened with (a reload, a respawn and the resume of a parked worktree session all keep it), it gives the card one field to read instead of re-deriving the decision, and it means moving the ladder never moves a card already on screen.

## What stays working

The network is never cut — the agent needs its own API and the plugin's hooks report this session's status back over loopback. The provider's state directory is mounted read-write, so authentication, the plan gauge, the cost readout and `--resume` all keep working, and a worktree session gets its repository's common git directory so `git` works at all.

## Platforms

`internal/sandbox` is a seam behind `Available` and `Wrap`: Linux runs bubblewrap, macOS builds a `sandbox-exec` profile, every other platform answers that it cannot confine anything. The control is absent where there is no backend rather than saving a setting nothing can act on.

**macOS has never run.** There is no hardware for it here — the profile is generated by a pure function with unit tests, and that is all that has been proven. Its private home is also weaker by nature: a tmpfs over the home needs privileges a user process does not have, so the home is denied for reading instead.

## Two decisions learned from a spawn that failed

The first confined spawn died with `bwrap: Can't create file at ~/.local/bin/claude: No such file or directory`. Agents install as a symlink on `PATH` into a versioned store, and bubblewrap resolves a mount *destination* through symlinks — so binding the link itself tries to create a mount point at a target that is not in the sandbox yet. Binaries are now reached by mounting the **directory** of every hop of the chain (`BinaryDirs`), which also covers `LICH_BIN` — the binary the MCP server and the `lich` CLI both run.

The same shape decides the tables: a symlink is **refused, not followed**. Beyond the mount failure, a link is an instruction written inside the home to reach outside it, which is what a private home exists to stop.

`/var` is deliberately not mounted. Binding it brought in whatever was mounted underneath — a running container's overlay, measured read-write inside a confined session, because bubblewrap's read-only remount does not always reach an inherited submount.

## Verification

Measured against real bubblewrap, not derived:

```
mnt/pid/uts/ipc/user  isolated      net  shared, on purpose
HOME  tmpfs                          cwd  the worktree
rw    provider state, build caches, the checkout, the git common dir
ro    toolchain and config, the binaries' directories
gone  ~/.ssh, ~/.aws, ~/.gnupg, every other checkout on the disk
```

- `internal/sandbox` runs bubblewrap for real: what the session sees, what it may write, that the private home is ephemeral, and that an agent installed as a symlink runs (the regression for the failure above).
- `internal/terminal` spawns a confined PTY and reads the answer back off it, so the sandbox is proven not to cost the terminal.
- Backend and frontend suites green, cross-compiled and vetted for linux/darwin/windows, `-race` clean on the touched packages, `internal/sandbox` at 93.9% coverage.

## Ceilings

Recorded in `docs/ceilings.md`: namespaces and mounts only — no seccomp, no Landlock, so this confines an agent working unattended and not code written to break out; `~/.config` is readable, so a token stored there is in reach; only the New worktree dialog can ask, so the `Ask` rung does not reach a session opened from the menu, a delegation or the MCP tool; a symlinked dotfile is absent inside; and a terminal session is never confined by a rung.