### PR TITLE
Close the gaps a sandbox audit turned up

### DIFF
--- a/frontend/src/components/sidebar/WorktreeDialog.tsx
+++ b/frontend/src/components/sidebar/WorktreeDialog.tsx
@@ -133,7 +133,7 @@ export function WorktreeDialog({
   const [submitting, setSubmitting] = useState(false)
   const listRef = useRef<HTMLDivElement>(null)
   // A worktree is always the linked checkout, so the rung is read on that side.
-  const sandbox = useSandboxChoice(providerId, projectId, true)
+  const sandbox = useSandboxChoice(providerId, projectId, true, open)
 
   const vis = filterBranches(branches, filter)
   const flat = flatValues(vis)

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -892,3 +892,15 @@ describe("setSessionSandboxed", () => {
     expect(setSessionSandboxed(current, "gone", true)).toBe(current)
   })
 })
+
+// The mark is dropped rather than set to undefined: the two hydration paths omit
+// the key entirely, and a session that reached the same state two ways must not
+// carry two different shapes.
+describe("setSessionSandboxed shape", () => {
+  it("leaves no sandboxed key on an unconfined session", () => {
+    const confined = setSessionSandboxed(buildState(1), "s1", true)
+    const cleared = setSessionSandboxed(confined, "s1", false)
+    const session = cleared[P]?.sessions[0]
+    expect(session && "sandboxed" in session).toBe(false)
+  })
+})

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -266,11 +266,15 @@ export function setSessionSandboxed(
     ...state,
     [projectId]: {
       ...current,
-      sessions: current.sessions.map((s) =>
-        s.id === sessionId
-          ? { ...s, ...(sandboxed ? { sandboxed: true } : { sandboxed: undefined }) }
-          : s,
-      ),
+      sessions: current.sessions.map((s) => {
+        if (s.id !== sessionId) {
+          return s
+        }
+        // Dropped rather than set to undefined, so an unconfined session carries
+        // no key at all — the shape the two hydration paths produce.
+        const { sandboxed: _was, ...rest } = s
+        return sandboxed ? { ...rest, sandboxed: true } : rest
+      }),
     },
   }
 }

--- a/frontend/src/lib/use-sandbox-choice.ts
+++ b/frontend/src/lib/use-sandbox-choice.ts
@@ -12,8 +12,6 @@ export interface SandboxChoice {
   /** Whether the session opens confined. */
   confined: boolean
   setConfined: (confined: boolean) => void
-  /** Whether the rung — rather than the user — is what set the box. */
-  fromRung: boolean
   /** What to record on the session row. */
   answer: SandboxAnswer
 }
@@ -24,18 +22,28 @@ export interface SandboxChoice {
 // exactly what it shows.
 //
 // worktree says which side of the rung this session lands on: a linked checkout,
-// or the project's own directory.
+// or the project's own directory. open is whether the dialog is on screen, and it
+// is what the rung is read on: the dialog lives inside the sidebar, which stays
+// mounted while Settings takes the screen (App.tsx), so a read done at mount
+// would show — and then record — the rung as it was before the user changed it.
 //
 // The answer is recorded either way, never left empty once the machine can
 // confine: an untouched box is still this session's answer, and freezing it on
 // the row is what keeps a later change to the rung from quietly confining — or
 // releasing — a session the user already opened.
-export function useSandboxChoice(providerId: string, projectId: string, worktree: boolean) {
+export function useSandboxChoice(
+  providerId: string,
+  projectId: string,
+  worktree: boolean,
+  open: boolean,
+) {
   const [available, setAvailable] = useState(false)
   const [confined, setChoice] = useState(false)
-  const [fromRung, setFromRung] = useState(true)
 
   useEffect(() => {
+    if (!open) {
+      return
+    }
     let stale = false
     const load = async () => {
       const canConfine = await System.SandboxAvailable()
@@ -50,7 +58,6 @@ export function useSandboxChoice(providerId: string, projectId: string, worktree
       }
       setAvailable(canConfine)
       setChoice(sandboxDefaultFor(sandboxLevel(scoped || global), worktree))
-      setFromRung(true)
     }
     // A settings read that fails leaves the row absent and the session
     // unconfined, which is what lich did before the sandbox existed.
@@ -58,13 +65,8 @@ export function useSandboxChoice(providerId: string, projectId: string, worktree
     return () => {
       stale = true
     }
-  }, [providerId, projectId, worktree])
-
-  const setConfined = (next: boolean) => {
-    setChoice(next)
-    setFromRung(false)
-  }
+  }, [providerId, projectId, worktree, open])
 
   const answer: SandboxAnswer = available ? (confined ? "on" : "off") : ""
-  return { available, confined, setConfined, fromRung, answer }
+  return { available, confined, setConfined: setChoice, answer }
 }

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -121,3 +121,57 @@ func TestSplitNULDropsTheTrailingTerminator(t *testing.T) {
 		t.Errorf("splitNUL(\"\") = %q, want nil", got)
 	}
 }
+
+// GitCommonDir is what a confined session mounts so git works at all
+// (internal/sandbox): a linked worktree's `.git` is a file naming that
+// directory, so a sandbox that mounts the worktree and not the common directory
+// hands the agent a checkout git refuses to read.
+func TestGitCommonDirOfARepositoryAndItsWorktree(t *testing.T) {
+	repo := initBareRepo(t)
+	if err := os.WriteFile(filepath.Join(repo, "a.txt"), []byte("a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-c", "user.email=t@example.com", "-c", "user.name=t", "add", "a.txt"},
+		{"-c", "user.email=t@example.com", "-c", "user.name=t", "commit", "-m", "first"},
+	} {
+		cmd := exec.Command("git", append([]string{"-C", repo}, args...)...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Skipf("git %v unavailable: %v (%s)", args, err, out)
+		}
+	}
+
+	// The repository's own checkout answers with its own metadata directory.
+	own := GitCommonDir(repo)
+	if own == "" {
+		t.Fatalf("GitCommonDir(%q) = \"\", want its .git", repo)
+	}
+	if !filepath.IsAbs(own) {
+		t.Errorf("GitCommonDir = %q, want an absolute path — a mount source cannot be relative", own)
+	}
+	if filepath.Base(own) != ".git" {
+		t.Errorf("GitCommonDir = %q, want the repository's .git", own)
+	}
+
+	// A linked worktree answers with the *main* repository's directory, which is
+	// the whole reason this is asked of git rather than derived from the path.
+	linked := filepath.Join(t.TempDir(), "wt")
+	cmd := exec.Command("git", "-C", repo, "worktree", "add", "-b", "side", linked)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("git worktree unavailable: %v (%s)", err, out)
+	}
+	if got := GitCommonDir(linked); got != own {
+		t.Errorf("GitCommonDir(worktree) = %q, want the main repository's %q", got, own)
+	}
+}
+
+// A directory that is not in a repository is not an error: a session can be
+// opened anywhere, and the sandbox simply has no common directory to mount.
+func TestGitCommonDirOutsideARepository(t *testing.T) {
+	if got := GitCommonDir(t.TempDir()); got != "" {
+		t.Errorf("GitCommonDir outside a repository = %q, want \"\"", got)
+	}
+	if got := GitCommonDir(filepath.Join(t.TempDir(), "gone")); got != "" {
+		t.Errorf("GitCommonDir of a missing directory = %q, want \"\"", got)
+	}
+}

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -160,7 +160,9 @@ func TestGitCommonDirOfARepositoryAndItsWorktree(t *testing.T) {
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Skipf("git worktree unavailable: %v (%s)", err, out)
 	}
-	if got := GitCommonDir(linked); got != own {
+	// Cleaned before comparing: git answers with forward slashes on Windows, and
+	// the contract is the same directory, not the same string.
+	if got := GitCommonDir(linked); filepath.Clean(got) != filepath.Clean(own) {
 		t.Errorf("GitCommonDir(worktree) = %q, want the main repository's %q", got, own)
 	}
 }

--- a/internal/sandbox/bwrap_linux.go
+++ b/internal/sandbox/bwrap_linux.go
@@ -14,6 +14,13 @@ import (
 // below, and no setuid helper of lich's own.
 const bwrapBin = "bwrap"
 
+// sandboxHostname is what a confined session reports as its host name. It is the
+// cheapest proof from inside that the sandbox is on — `hostname` cannot answer
+// this anywhere else — so it is named here and pinned by a test rather than
+// spelled inline where a rename would cost nothing and silently invalidate the
+// check.
+const sandboxHostname = "lich-sandbox"
+
 // systemDirs are the top-level directories that make the sandbox an operating
 // system rather than an empty namespace, all read-only. /nix and /opt are here
 // for the machines that have them and cost nothing on the machines that do not:
@@ -146,7 +153,7 @@ func bwrapArgs(spec Spec, roots []root) []string {
 		"--unshare-pid",
 		"--unshare-uts",
 		"--unshare-ipc",
-		"--hostname", "lich-sandbox",
+		"--hostname", sandboxHostname,
 		// The sandbox dies with the PTY rather than outliving it as an orphan
 		// nothing on screen accounts for. No --new-session: it calls setsid,
 		// which would take the session's controlling terminal away from the PTY

--- a/internal/sandbox/confine_linux_test.go
+++ b/internal/sandbox/confine_linux_test.go
@@ -159,3 +159,17 @@ func TestAnAgentInstalledAsASymlinkRuns(t *testing.T) {
 		t.Errorf("the agent did not run: %q", out)
 	}
 }
+
+// The hostname is what somebody checks from inside a session to tell whether it
+// is confined at all, so it is pinned to a literal here rather than derived from
+// the constant: reading the constant would let a rename pass this test and break
+// every instruction that names it.
+func TestConfinedSessionReportsItsHostname(t *testing.T) {
+	if !Available() {
+		t.Skip("bubblewrap is not installed")
+	}
+	home, cwd := confinedHome(t)
+	if out := runConfined(t, home, cwd, "hostname"); strings.TrimSpace(out) != "lich-sandbox" {
+		t.Errorf("hostname inside the sandbox = %q, want %q", strings.TrimSpace(out), "lich-sandbox")
+	}
+}

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -31,41 +31,61 @@ func TestStateDirsCoversEveryRegisteredProvider(t *testing.T) {
 	}
 }
 
+// testHome is a home directory spelled the way the running OS spells one, so the
+// assertions below answer for what filepath.Join produces rather than for POSIX
+// separators. The paths need not exist: stateDirs only composes them.
+func testHome() string {
+	return filepath.Join(string(filepath.Separator), "home", "u")
+}
+
 func TestStateDirsPerProvider(t *testing.T) {
 	clearHarnessEnv(t)
+	home := testHome()
 	tests := []struct {
 		provider string
 		want     []string
 	}{
-		{providers.Claude, []string{"/home/u/.claude", "/home/u/.claude.json"}},
-		{providers.Codex, []string{"/home/u/.codex"}},
-		{providers.OMP, []string{"/home/u/.omp/agent"}},
-		{providers.OpenCode, []string{"/home/u/.config/opencode", "/home/u/.local/share/opencode"}},
-		{providers.Crush, []string{"/home/u/.config/crush", "/home/u/.local/share/crush"}},
+		{providers.Claude, []string{filepath.Join(home, ".claude"), filepath.Join(home, ".claude.json")}},
+		{providers.Codex, []string{filepath.Join(home, ".codex")}},
+		{providers.OMP, []string{filepath.Join(home, ".omp", "agent")}},
+		{providers.OpenCode, []string{
+			filepath.Join(home, ".config", "opencode"),
+			filepath.Join(home, ".local", "share", "opencode"),
+		}},
+		{providers.Crush, []string{
+			filepath.Join(home, ".config", "crush"),
+			filepath.Join(home, ".local", "share", "crush"),
+		}},
 	}
 	for _, tt := range tests {
-		if got := stateDirs(tt.provider, "/home/u"); !slices.Equal(got, tt.want) {
+		if got := stateDirs(tt.provider, home); !slices.Equal(got, tt.want) {
 			t.Errorf("stateDirs(%q) = %v, want %v", tt.provider, got, tt.want)
 		}
 	}
-	if got := stateDirs("shell", "/home/u"); got != nil {
+	if got := stateDirs("shell", home); got != nil {
 		t.Errorf("stateDirs for a shell session = %v, want none", got)
 	}
 }
 
+// The overrides come from t.TempDir rather than from a literal: envDir only
+// honours an absolute path, and what counts as absolute is the OS's own answer —
+// "/srv/claude" is not one on Windows, where a path needs its volume.
 func TestStateDirsFollowsHarnessEnvironment(t *testing.T) {
 	clearHarnessEnv(t)
-	t.Setenv("CLAUDE_CONFIG_DIR", "/srv/claude")
-	t.Setenv("CODEX_HOME", "/srv/codex")
-	t.Setenv("XDG_CONFIG_HOME", "/srv/cfg")
+	home := testHome()
+	root := t.TempDir()
+	claude, codex, config := filepath.Join(root, "claude"), filepath.Join(root, "codex"), filepath.Join(root, "cfg")
+	t.Setenv("CLAUDE_CONFIG_DIR", claude)
+	t.Setenv("CODEX_HOME", codex)
+	t.Setenv("XDG_CONFIG_HOME", config)
 
-	if got := stateDirs(providers.Claude, "/home/u"); got[0] != "/srv/claude" {
+	if got := stateDirs(providers.Claude, home); got[0] != claude {
 		t.Errorf("CLAUDE_CONFIG_DIR ignored: got %v", got)
 	}
-	if got := stateDirs(providers.Codex, "/home/u"); got[0] != "/srv/codex" {
+	if got := stateDirs(providers.Codex, home); got[0] != codex {
 		t.Errorf("CODEX_HOME ignored: got %v", got)
 	}
-	if got := stateDirs(providers.Crush, "/home/u"); got[0] != "/srv/cfg/crush" {
+	if got := stateDirs(providers.Crush, home); got[0] != filepath.Join(config, "crush") {
 		t.Errorf("XDG_CONFIG_HOME ignored: got %v", got)
 	}
 }
@@ -74,13 +94,15 @@ func TestStateDirsFollowsHarnessEnvironment(t *testing.T) {
 // order `omp config path` applies.
 func TestOMPProfileBeatsDirectoryOverride(t *testing.T) {
 	clearHarnessEnv(t)
-	t.Setenv("PI_CODING_AGENT_DIR", "/srv/omp")
-	if got := ompAgentDir("/home/u"); got != "/srv/omp" {
+	home := testHome()
+	override := t.TempDir()
+	t.Setenv("PI_CODING_AGENT_DIR", override)
+	if got := ompAgentDir(home); got != override {
 		t.Errorf("PI_CODING_AGENT_DIR ignored: got %q", got)
 	}
 	t.Setenv("OMP_PROFILE", "work")
-	want := "/home/u/.omp/profiles/work/agent"
-	if got := ompAgentDir("/home/u"); got != want {
+	want := filepath.Join(home, ".omp", "profiles", "work", "agent")
+	if got := ompAgentDir(home); got != want {
 		t.Errorf("ompAgentDir with a profile = %q, want %q", got, want)
 	}
 }
@@ -88,8 +110,9 @@ func TestOMPProfileBeatsDirectoryOverride(t *testing.T) {
 // A relative override is not a bind mount source: it resolves against a working
 // directory this package does not own, so the fallback stands.
 func TestEnvDirRejectsRelativeOverride(t *testing.T) {
+	fallback := filepath.Join(testHome(), ".codex")
 	t.Setenv("CODEX_HOME", "codex")
-	if got := envDir("CODEX_HOME", "/home/u/.codex"); got != "/home/u/.codex" {
+	if got := envDir("CODEX_HOME", fallback); got != fallback {
 		t.Errorf("relative override honoured: got %q", got)
 	}
 }

--- a/internal/terminal/sandbox_test.go
+++ b/internal/terminal/sandbox_test.go
@@ -1,6 +1,9 @@
 package terminal
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"slices"
 	"testing"
 
@@ -112,47 +115,38 @@ func lastIndex(args []string, value string) int {
 	return -1
 }
 
-// The binaries a confined session has to reach are the one it runs and the lich
-// binary it calls back through, both resolved to a real path.
-func TestExecutablesResolveTheSpawnAndLich(t *testing.T) {
-	paths := executables("sh")
-	if len(paths) == 0 {
+// What a confined spawn needs mounted is the directory holding each binary, not
+// the binary — binding the executable itself is what fails the spawn when it is
+// a symlink under a directory already mounted (sandbox.BinaryDirs). The missing
+// binary case is BinaryDirs' own (TestBinaryDirsOfAMissingBinary); what is here
+// is that this caller asks for both binaries and passes the answer through.
+func TestExecutablesAreDirectoriesOnDisk(t *testing.T) {
+	dirs := executables("sh")
+	if len(dirs) == 0 {
 		t.Fatal("sh resolved to nothing")
 	}
-	for _, path := range paths {
-		if path == "sh" {
-			t.Errorf("an unresolved name reached the mount list: %v", paths)
+	for _, dir := range dirs {
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Errorf("%q is not on disk: %v", dir, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("%q is a file; a mount of it would fail the spawn", dir)
 		}
 	}
-	if got := executables("lich-no-such-binary-anywhere"); len(got) != 0 && got[0] != "" {
-		for _, path := range got {
-			if path == "lich-no-such-binary-anywhere" {
-				t.Errorf("a binary that is not on PATH reached the mount list: %v", got)
-			}
-		}
+	// The shell's own directory, and the lich binary's — the session calls back
+	// through it, and its MCP server runs it.
+	shell, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("no sh on PATH")
 	}
-}
-
-// The verdict is written back on every spawn, including for a session nobody
-// was asked about — it is what the card reads to draw its mark, and what keeps a
-// session running the way it opened once the rung moves under it.
-func TestConfinedRecordsItsVerdict(t *testing.T) {
-	tests := []struct {
-		row  string
-		rung bool
-		want string
-	}{
-		{"", true, store.SessionConfined},
-		{"", false, store.SessionUnconfined},
-		{store.SessionConfined, false, store.SessionConfined},
-		{store.SessionUnconfined, true, store.SessionUnconfined},
+	if !slices.Contains(dirs, filepath.Dir(shell)) {
+		t.Errorf("the spawned binary's directory is missing from %v", dirs)
 	}
-	for _, tt := range tests {
-		recorded := ""
-		s := stubSandboxStore{row: tt.row, rungAnswer: tt.rung, recorded: &recorded}
-		confined(s, "s1", providers.Claude, "p1", "/work/wt")
-		if recorded != tt.want {
-			t.Errorf("row %q rung %v recorded %q, want %q", tt.row, tt.rung, recorded, tt.want)
+	if lich := lichBin(); lich != "" {
+		if !slices.Contains(dirs, filepath.Dir(lich)) {
+			t.Errorf("the lich binary's directory is missing from %v", dirs)
 		}
 	}
 }


### PR DESCRIPTION
A quality audit of #314. One finding reaches a user; the rest are tests that proved nothing and shapes that disagreed with each other.

## The one that matters

`useSandboxChoice` read the provider's rung once, on the sidebar's mount, and its effect deps never changed again. The sidebar stays mounted while the Outlet swaps in Settings (`App.tsx:31`), so:

1. Set the ladder to **Everywhere** in Settings › Providers.
2. Open **New worktree**.
3. The **Run confined** box is unticked — it is showing the rung as it was before step 1.
4. Create. The dialog records its answer either way, so the row is written `off` and that session is *frozen* unconfined, against the rung just set.

The rung is now read when the dialog opens. Same fix stops three settings requests firing per project at launch for a dialog nobody opened.

## The rest

| Finding | What was wrong |
|---|---|
| `fromRung` | State nothing read — declared on the interface, held, set in two places, returned, zero consumers. |
| `GitCommonDir` | No test at all, though a confined worktree session is unusable without what it returns. Now covered for a repository, a linked worktree (where the answer is the **main** repository's directory — the reason it is asked of git rather than derived) and a directory outside a repository. |
| `executables` test | Both assertions were unfalsifiable: the function returns directories, so neither a bare name nor a missing binary could ever appear, and the missing case was not isolated because `lichBin()` always resolves. Now asserts what the mount needs — every entry a directory on disk, both binaries present — and leaves the missing case on `BinaryDirs`, where it is real. |
| `"lich-sandbox"` | The hostname is the cheapest proof of confinement from inside a session, and it was an inline literal with no test: a rename cost nothing and silently invalidated the check. Named, and pinned to the literal by a test that runs real bubblewrap. |
| `setSessionSandboxed` | Left `sandboxed: undefined` on the row while both hydration paths omit the key — the same state in two shapes. |

## Verification

Backend and frontend suites green, `-race` clean on the three touched packages, vetted for linux/darwin/windows.

**What I could not check:** the dialog fix is typed and read, not clicked. The headless rig could not open the New worktree dialog — the menu item stays disabled until a git status lands for the project, and it never did in the isolated workspace. Worth a manual pass: set the ladder, open the dialog, confirm the box arrives ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
