### PR TITLE
Cut v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-08-18
+
 ### Added
 
 - **Sessions can run confined.** Settings › Providers gains a **Sandbox** ladder
@@ -2860,7 +2862,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.35.1...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.36.0...HEAD
+[0.36.0]: https://github.com/omartelo/lich/compare/v0.35.1...v0.36.0
 [0.35.1]: https://github.com/omartelo/lich/compare/v0.35.0...v0.35.1
 [0.35.0]: https://github.com/omartelo/lich/compare/v0.34.0...v0.35.0
 [0.34.0]: https://github.com/omartelo/lich/compare/v0.33.0...v0.34.0


### PR DESCRIPTION
Moves `[Unreleased]` under a `0.36.0` heading and refreshes the compare links. No code.

## What ships

**Added**
- Sessions can run confined — a **Sandbox** ladder per provider, a `Run confined` box in the New worktree dialog, and a shield on the card that says which side a session is on.
- How much of your plan is left, without leaving lich — the rolling windows Claude Code and Codex report, in the footer and in full in each provider's settings.
- A terminal can open straight into a tool — an entrypoint per card, run on every spawn.

**Changed**
- Terminals no longer offer to delegate.
- The binary setting says which binary, and whether it is there.
- The two footer switches are one ladder.

**Fixed**
- Resuming a parked worktree session no longer forgets how it was started.

## Why minor

The release adds behaviour and changes no contract read from outside lich. The sandbox is off until someone turns it on, and every session opens exactly as it did before until then.

## Release gate

- `gofmt` and `go vet` clean; backend suite green **with `-race`** (1675 tests).
- Frontend: 1007 tests, biome clean, `tsc` clean, `vite build` succeeds.
- Cross-compiled and vetted for linux, darwin and windows — and the Windows runner is green again on `main` as of #315, which is what a release tag needs.
- `build/linux/nfpm/nfpm.yaml` untouched: the version comes from the tag.