### PR TITLE
Add Codex session readout to the footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Codex sessions now carry their model and context usage in the footer.** The
-  same readout setting Claude Code offers is available for Codex, backed by the
-  active context count, model and reasoning effort in its rollout transcript.
+  model-and-context readout is available for Codex, backed by the active context
+  count, model and reasoning effort in its rollout transcript and the maximum
+  effective window advertised by its model cache.
 
 ## [0.36.0] - 2026-08-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Codex sessions now carry their model and context usage in the footer.** The
+  same readout setting Claude Code offers is available for Codex, backed by the
+  active context count, model and reasoning effort in its rollout transcript.
+
 ## [0.36.0] - 2026-08-18
 
 ### Added

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -22,7 +22,11 @@ work when nobody knows it and that the call site never shows. The mechanism and 
 - **The session readout understands Claude Code and Codex transcripts only**
   (`internal/terminal/usage_claude.go`, `internal/terminal/usage_codex.go`): oh-my-pi, opencode and Crush record
   token usage but not the model's context-window size, so lich cannot turn those counts into a trustworthy
-  percentage. Their footer therefore carries no model or context ring.
+  percentage. Their footer therefore carries no model or context ring. Codex's rollout reports its current
+  context tranche rather than the maximum its own status line uses, so lich prefers the maximum effective window
+  in Codex's `models_cache.json`; without that cache it falls back to the rollout and may overstate usage. Codex
+  rollouts also carry no API-cost accounting, so its setting stops at model and context while Claude Code alone
+  offers the cost rung.
 - **A dropped file has no path, so lich guesses it** (`internal/drop`): a file under neither the session directory
   nor home is *copied*, so an agent told to edit it edits the copy — and that copy is deleted 3 days on, so a path
   pasted into a prompt eventually stops resolving.

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -19,6 +19,10 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   conversation forked inside the PTY bills its copied history twice — lich's own resume continues the same
   transcript and is unaffected — and each sub-agent's own transcript is counted in, so one unreadable or
   unpriceable sub-agent withholds the whole session's number.
+- **The session readout understands Claude Code and Codex transcripts only**
+  (`internal/terminal/usage_claude.go`, `internal/terminal/usage_codex.go`): oh-my-pi, opencode and Crush record
+  token usage but not the model's context-window size, so lich cannot turn those counts into a trustworthy
+  percentage. Their footer therefore carries no model or context ring.
 - **A dropped file has no path, so lich guesses it** (`internal/drop`): a file under neither the session directory
   nor home is *copied*, so an agent told to edit it edits the copy — and that copy is deleted 3 days on, so a path
   pasted into a prompt eventually stops resolving.

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -86,7 +86,7 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
   const navigate = useNavigate()
   const { projectId, sessionId, path, checkout, kind } = useActiveSession()
   // Context-window occupancy of the active session, read off its transcript at
-  // each turn's end (null until the first turn of a Claude session lands).
+  // each turn's end (null until the first turn of a supported session lands).
   const usage = useSessionUsage(sessionId)
   // The footer context readout is opt-out (Settings › Providers); the cost
   // beside it is opt-in, and off for everyone not billed per token.
@@ -227,7 +227,7 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
       )}
 
       <span className="ml-auto flex items-center gap-4">
-        {showContextUsage && <SessionModel sessionId={sessionId} />}
+        {showContextUsage && <SessionModel sessionId={sessionId} kind={kind} />}
         <PlanQuota kind={kind} />
         {costReadout}
         {contextReadout}

--- a/frontend/src/components/SessionModel.tsx
+++ b/frontend/src/components/SessionModel.tsx
@@ -1,25 +1,29 @@
 import { ProviderIcon } from "./ProviderIcon"
 import { formatModel } from "@/lib/model-name"
+import { useSessionAgent } from "@/lib/session/use-session-agent"
 import { useSessionUsage } from "@/lib/session/use-session-usage"
+import type { SessionKind } from "@/lib/session/sessions"
 
 interface SessionModelProps {
   sessionId: string
+  kind: SessionKind | ""
 }
 
 // SessionModel is the footer's AI-session slot: which model the active session
 // runs, read from the same usage report as the context ring (so it appears once
-// a Claude session has taken a turn, null before). Self-contained on purpose —
+// a supported session has taken a turn, null before). Self-contained on purpose —
 // it reads its own data by id, so the slot can grow with more per-session detail
-// without touching FooterBar. Usage is Claude-only today, so the mark is
-// Claude's; a second provider that reports usage makes the kind dynamic here.
-export function SessionModel({ sessionId }: SessionModelProps) {
+// without touching FooterBar. A provider started inside a shell wins over the
+// card's persisted kind, matching the session card itself.
+export function SessionModel({ sessionId, kind }: SessionModelProps) {
   const usage = useSessionUsage(sessionId)
-  if (!usage) {
+  const provider = useSessionAgent(sessionId) ?? kind
+  if (!usage || !provider) {
     return null
   }
   return (
     <span className="flex items-center gap-1.5">
-      <ProviderIcon kind="claude" size={14} />
+      <ProviderIcon kind={provider} size={14} />
       {formatModel(usage.model)}
       {usage.effort ? ` · ${usage.effort}` : ""}
     </span>

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -144,8 +144,8 @@ function useSkipPermissions(providerId: string, worktree: boolean) {
 
 // ProviderBinSettings is the config section a provider gets when enabled: what
 // its plan has left, which binary its sessions spawn, and how far it runs
-// without asking. Claude Code adds the footer readout, which is the only
-// provider reporting one.
+// without asking. Claude Code and Codex add the footer readout because their
+// transcripts report the model and context-window usage.
 export function ProviderBinSettings({
   providerId,
   providerName,
@@ -206,9 +206,9 @@ export function ProviderBinSettings({
 
       <ProviderBinary providerId={providerId} providerName={providerName} projectId={projectId} />
 
-      {/* Only Claude Code reports context-window usage (via the lich plugin), so
-          the footer readout control lives in its section, not the generic hub. */}
-      {providerId === "claude" && (
+      {/* Only providers with a context-window transcript reader carry this
+          control; the underlying preference stays global. */}
+      {(providerId === "claude" || providerId === "codex") && (
         <>
           <SettingBlock
             title="Session readout in the footer"

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -172,8 +172,15 @@ export function ProviderBinSettings({
   const level = skipLevel(skipHere, skipInWorktrees)
   const consequence = SKIP_LEVELS.find((rung) => rung.level === level)?.consequence ?? ""
   const readout = footerReadout(showContextUsage, showCost)
+  const availableReadouts =
+    providerId === "codex"
+      ? FOOTER_READOUTS.filter((rung) => rung.level !== "cost")
+      : FOOTER_READOUTS
+  // Cost is a global preference but Codex has no transcript cost reader. If
+  // Claude enabled it, the Codex pane still truthfully shows its highest rung.
+  const visibleReadout = providerId === "codex" && readout === "cost" ? "context" : readout
   const readoutConsequence =
-    FOOTER_READOUTS.find((rung) => rung.level === readout)?.consequence ?? ""
+    availableReadouts.find((rung) => rung.level === visibleReadout)?.consequence ?? ""
 
   // One rung writes both settings, for the same reason the permission ladder
   // does: the pair is the storage, the rung is the choice.
@@ -215,13 +222,13 @@ export function ProviderBinSettings({
             description="How much of what a session is spending the footer carries, read from its transcript."
           >
             <ToggleGroup
-              value={[readout]}
+              value={[visibleReadout]}
               onValueChange={(next) => next[0] && setReadout(next[0] as FooterReadout)}
               spacing={1}
               aria-label="What the footer says about the session"
               className="border border-border p-[3px]"
             >
-              {FOOTER_READOUTS.map((rung) => (
+              {availableReadouts.map((rung) => (
                 <ToggleGroupItem key={rung.level} value={rung.level} size="sm">
                   {rung.label}
                 </ToggleGroupItem>
@@ -232,7 +239,7 @@ export function ProviderBinSettings({
 
           {/* A ceiling is only ever seen through the readout, so it is offered
               beside it and hidden with it. */}
-          {readout === "cost" && (
+          {providerId === "claude" && readout === "cost" && (
             <SettingBlock
               title="Spend ceiling"
               description="Colour the cost in the footer as a session approaches this many dollars — amber at 80%, red at 95%. It is a warning, not a limit: nothing is stopped, and the figure it watches is API pricing from a table. Leave empty for none."

--- a/frontend/src/lib/model-name.test.ts
+++ b/frontend/src/lib/model-name.test.ts
@@ -15,4 +15,8 @@ describe("formatModel", () => {
   it("leaves an id without a version split stripped but intact", () => {
     expect(formatModel("claude-experimental")).toBe("experimental")
   })
+
+  it("leaves another provider's model id intact", () => {
+    expect(formatModel("gpt-5.6-sol")).toBe("gpt-5.6-sol")
+  })
 })

--- a/frontend/src/lib/model-name.ts
+++ b/frontend/src/lib/model-name.ts
@@ -5,6 +5,9 @@
 // "claude-fable-5" → "fable 5". An id that doesn't fit the shape (no family +
 // version split) is shown stripped but otherwise untouched.
 export function formatModel(id: string): string {
+  if (!id.startsWith("claude-")) {
+    return id
+  }
   const stripped = id.replace(/^claude-/, "").replace(/-\d{8}$/, "")
   const [family, ...version] = stripped.split("-")
   return version.length > 0 ? `${family} ${version.join(".")}` : stripped

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -48,10 +48,11 @@ export const SANDBOX_EVENT = "session-sandbox"
 // Global event the backend emits after a turn ends with the session's
 // context-window usage (see terminal.usageEventName). Payload: { id, percent,
 // tokens, window, model, effort } — percent is 0–100 of the window, tokens the
-// raw input-side count, window the model's context size, model its id, effort
-// the reasoning level ("" when the turn records none) — plus an optional
-// costUsd, which is present only when the cost readout is on and every model in
-// the session has a known price. Its absence is the answer, not a zero.
+// provider's active context count, window the model's effective context size,
+// model its id, effort the reasoning level ("" when the turn records none) —
+// plus an optional costUsd, which is present only when the cost readout is on
+// and every model in the session has a known price. Its absence is the answer,
+// not a zero.
 export const USAGE_EVENT = "session-usage"
 
 // Global event the backend emits while one session has a request open with

--- a/frontend/src/lib/session/session-usage-store.test.ts
+++ b/frontend/src/lib/session/session-usage-store.test.ts
@@ -1,14 +1,31 @@
 import { describe, expect, it } from "vitest"
 import { createSessionUsageStore } from "./session-usage-store"
 
-// harness wires a store to a hand-driven event source, returning the emitter.
+// harness wires a store to hand-driven event sources, returning their emitters.
 function harness() {
-  let handler: (data: unknown) => void = () => {}
-  const store = createSessionUsageStore((h) => {
-    handler = h
-    return () => {}
-  })
-  return { store, emit: (data: unknown) => handler(data) }
+  let onUsage: (data: unknown) => void = () => {}
+  let onAgent: (data: unknown) => void = () => {}
+  let onStatus: (data: unknown) => void = () => {}
+  const store = createSessionUsageStore(
+    (h) => {
+      onUsage = h
+      return () => {}
+    },
+    (h) => {
+      onAgent = h
+      return () => {}
+    },
+    (h) => {
+      onStatus = h
+      return () => {}
+    },
+  )
+  return {
+    store,
+    emit: (data: unknown) => onUsage(data),
+    agent: (data: unknown) => onAgent(data),
+    status: (data: unknown) => onStatus(data),
+  }
 }
 
 describe("createSessionUsageStore", () => {
@@ -94,6 +111,30 @@ describe("createSessionUsageStore", () => {
       effort: eff,
       costUsd: null,
     })
+  })
+
+  it("clears stale usage when a provider starts, the PTY respawns, or the provider exits", () => {
+    const { store, emit, agent, status } = harness()
+    const report = {
+      id: "s1",
+      percent: 30,
+      tokens: 60000,
+      window: 200000,
+      model: opus,
+      effort: eff,
+    }
+
+    emit(report)
+    agent({ id: "s1", agent: "codex" })
+    expect(store.get("s1")).toBeNull()
+
+    emit(report)
+    agent({ id: "s1", agent: "" })
+    expect(store.get("s1")).toBeNull()
+
+    emit(report)
+    status({ id: "s1", state: "idle" })
+    expect(store.get("s1")).toBeNull()
   })
 
   it("carries the session cost when the backend sent one", () => {

--- a/frontend/src/lib/session/session-usage-store.ts
+++ b/frontend/src/lib/session/session-usage-store.ts
@@ -1,5 +1,7 @@
 import { createKeyedStore, type ReadableKeyedStore } from "@/lib/keyed-store"
 import {
+  isAgentEvent,
+  isIdleEvent,
   isUsageEvent,
   usageCost,
   type SessionEventSource,
@@ -21,14 +23,17 @@ const sameUsage = (a: SessionUsage | null, b: SessionUsage | null): boolean =>
     a.costUsd === b.costUsd)
 
 // createSessionUsageStore keeps the last reported context-window usage of every
-// session, keyed by session id, fed by one subscription taken at creation —
-// before any card mounts. get() answers null until the backend reports one, and
-// the footer shows no context badge at all.
+// session, keyed by session id, fed by subscriptions taken at creation — before
+// any card mounts. A provider start, PTY respawn or SessionEnd clears the prior
+// provider's report; get() otherwise answers null until the backend reports one,
+// and the footer shows no context badge at all.
 export function createSessionUsageStore(
-  source: SessionEventSource,
+  usageSource: SessionEventSource,
+  agentSource: SessionEventSource,
+  statusSource: SessionEventSource,
 ): ReadableKeyedStore<SessionUsage | null> {
   const store = createKeyedStore<SessionUsage | null>(null, sameUsage)
-  source((data) => {
+  usageSource((data) => {
     if (!isUsageEvent(data)) {
       return
     }
@@ -40,6 +45,16 @@ export function createSessionUsageStore(
       effort: data.effort,
       costUsd: usageCost(data),
     })
+  })
+  agentSource((data) => {
+    if (isAgentEvent(data)) {
+      store.set(data.id, null)
+    }
+  })
+  statusSource((data) => {
+    if (isIdleEvent(data)) {
+      store.set(data.id, null)
+    }
   })
   return store
 }

--- a/frontend/src/lib/session/use-session-usage.ts
+++ b/frontend/src/lib/session/use-session-usage.ts
@@ -1,16 +1,20 @@
 import { onAppEvent } from "@/lib/app-events"
-import { USAGE_EVENT, type SessionUsage } from "./session-events"
+import { AGENT_EVENT, STATUS_EVENT, USAGE_EVENT, type SessionUsage } from "./session-events"
 import { createSessionUsageStore } from "./session-usage-store"
 import { useKeyedStore } from "@/lib/use-keyed-store"
 
 // Subscribed at import rather than on first use: that opens the /events socket
 // at page load, so a usage report before any card mounts still lands.
-const store = createSessionUsageStore((handler) => onAppEvent(USAGE_EVENT, handler))
+const store = createSessionUsageStore(
+  (handler) => onAppEvent(USAGE_EVENT, handler),
+  (handler) => onAppEvent(AGENT_EVENT, handler),
+  (handler) => onAppEvent(STATUS_EVENT, handler),
+)
 
 // useSessionUsage reads a session's last reported context-window usage from the
 // shared store (see session-usage-store), which retains it across the card's
-// unmount. Returns null until the backend reports one — after the first turn
-// ends, for a Claude session.
+// unmount but clears it when that provider exits or the PTY respawns. Returns
+// null until the backend reports one.
 export function useSessionUsage(sessionId: string): SessionUsage | null {
   return useKeyedStore(store, sessionId)
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -106,7 +106,7 @@ type Service struct {
 // provider CLI assigns the conversation running in the PTY, reported by that
 // provider's session-start hook; empty until a hook fires (or for shell
 // sessions), it is the key for features that need to reach a session's
-// transcript or resume it. Only Claude Code reports one today. Pinned keeps a
+// transcript or resume it. Pinned keeps a
 // session at the head of its project's list and withholds its close affordances
 // until it is unpinned. OriginSessionID and OriginLabel record the session that
 // asked for this one, empty for a session nobody delegated: the id names the

--- a/internal/terminal/usage.go
+++ b/internal/terminal/usage.go
@@ -36,11 +36,6 @@ type usageEvent struct {
 // turn, not only at the end. Silent on any miss — no provider id yet, no
 // transcript, an unreadable or half-written file — so the readout keeps its last
 // value instead of flickering.
-//
-// Only Claude reports a provider session id today (resume and the session-start
-// hook are Claude-only), so the reader is Claude's. A second provider that grows
-// one selects its own reader here by the session's kind — not an interface until
-// there are two to hide behind it.
 func (s *Service) emitUsage(id string) {
 	if event, ok := s.sessionUsage(id); ok {
 		s.hub.Emit(usageEventName, event)
@@ -59,7 +54,7 @@ func (s *Service) sessionUsage(id string) (usageEvent, bool) {
 	if providerSessionID == "" {
 		return usageEvent{}, false
 	}
-	u, ok := claudeContextUsage(providerSessionID)
+	u, ok := contextUsageFor(providerSessionID)
 	if !ok {
 		return usageEvent{}, false
 	}
@@ -75,6 +70,13 @@ func (s *Service) sessionUsage(id string) (usageEvent, bool) {
 		event.CostUSD = &cost
 	}
 	return event, true
+}
+
+func contextUsageFor(providerSessionID string) (contextUsage, bool) {
+	if usage, ok := claudeContextUsage(providerSessionID); ok {
+		return usage, true
+	}
+	return codexContextUsage(providerSessionID)
 }
 
 // sessionCost is what session id has cost across every conversation it has run,

--- a/internal/terminal/usage.go
+++ b/internal/terminal/usage.go
@@ -12,9 +12,10 @@ import (
 const usageEventName = "session-usage"
 
 // usageEvent is the payload of usageEventName. Percent is the share of the
-// context window the turn left occupied (0–100); Tokens is the raw input-side
-// count behind it, Window the model's context window, Model the model id, and
-// Effort the reasoning effort level ("" when the line records none).
+// context window the turn left occupied (0–100); Tokens is the provider's active
+// context count behind it, Window the model's effective context window, Model
+// the model id, and Effort the reasoning effort level ("" when the line records
+// none).
 //
 // CostUSD is what the session has cost so far, and is omitted — not zeroed —
 // whenever there is no number worth showing: the setting is off, or a model in

--- a/internal/terminal/usage_codex.go
+++ b/internal/terminal/usage_codex.go
@@ -1,0 +1,96 @@
+package terminal
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+)
+
+const codexScanBlockBytes int64 = 64 * 1024
+
+type codexRolloutEntry struct {
+	Type    string `json:"type"`
+	Payload struct {
+		Type   string `json:"type"`
+		Model  string `json:"model"`
+		Effort string `json:"effort"`
+		Info   *struct {
+			Last *struct {
+				Total int `json:"total_tokens"`
+			} `json:"last_token_usage"`
+			Window int `json:"model_context_window"`
+		} `json:"info"`
+	} `json:"payload"`
+}
+
+// codexContextUsage reads the latest active context size, model and effort from
+// a Codex rollout. The reverse scan stops at the current turn's turn_context,
+// so an old conversation costs no more to read than a new one.
+func codexContextUsage(providerSessionID string) (contextUsage, bool) {
+	path, ok := codexTranscriptPath(providerSessionID)
+	if !ok {
+		return contextUsage{}, false
+	}
+	return scanCodexContextUsage(path)
+}
+
+func scanCodexContextUsage(path string) (contextUsage, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return contextUsage{}, false
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return contextUsage{}, false
+	}
+	var usage contextUsage
+	var suffix []byte
+	haveTokens := false
+	for end := info.Size(); end > 0; {
+		start := max(int64(0), end-codexScanBlockBytes)
+		chunk := make([]byte, end-start)
+		if _, err := f.ReadAt(chunk, start); err != nil && err != io.EOF {
+			return contextUsage{}, false
+		}
+		lines := bytes.Split(append(chunk, suffix...), []byte("\n"))
+		first := 0
+		if start > 0 {
+			first = 1
+		}
+		for i := len(lines) - 1; i >= first; i-- {
+			if consumeCodexUsageLine(lines[i], &usage, &haveTokens) {
+				return usage, true
+			}
+		}
+		suffix = append(suffix[:0], lines[0]...)
+		end = start
+	}
+	return contextUsage{}, false
+}
+
+func consumeCodexUsageLine(line []byte, usage *contextUsage, haveTokens *bool) bool {
+	var entry codexRolloutEntry
+	if json.Unmarshal(line, &entry) != nil {
+		return false
+	}
+	if !*haveTokens {
+		if entry.Type != "event_msg" || entry.Payload.Type != "token_count" ||
+			entry.Payload.Info == nil || entry.Payload.Info.Last == nil ||
+			entry.Payload.Info.Last.Total < 0 || entry.Payload.Info.Window <= 0 {
+			return false
+		}
+		usage.tokens = entry.Payload.Info.Last.Total
+		usage.window = entry.Payload.Info.Window
+		usage.percent = min(usage.tokens*100/usage.window, 100)
+		*haveTokens = true
+		return false
+	}
+	if entry.Type != "turn_context" || entry.Payload.Model == "" {
+		return false
+	}
+	usage.model = entry.Payload.Model
+	usage.effort = entry.Payload.Effort
+	return true
+}

--- a/internal/terminal/usage_codex.go
+++ b/internal/terminal/usage_codex.go
@@ -5,8 +5,12 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"path/filepath"
 )
 
+// A rollout line can be much larger than a normal event. Reading 64 KiB at a
+// time keeps allocations bounded without turning a long transcript into many
+// tiny reads; lines spanning blocks are carried into the next iteration.
 const codexScanBlockBytes int64 = 64 * 1024
 
 type codexRolloutEntry struct {
@@ -24,15 +28,62 @@ type codexRolloutEntry struct {
 	} `json:"payload"`
 }
 
+type codexModelsCache struct {
+	Models []struct {
+		Slug                          string `json:"slug"`
+		ContextWindow                 int    `json:"context_window"`
+		MaxContextWindow              int    `json:"max_context_window"`
+		EffectiveContextWindowPercent int    `json:"effective_context_window_percent"`
+	} `json:"models"`
+}
+
 // codexContextUsage reads the latest active context size, model and effort from
-// a Codex rollout. The reverse scan stops at the current turn's turn_context,
-// so an old conversation costs no more to read than a new one.
+// a Codex rollout. Codex writes the current context tranche into the rollout,
+// while its own readout uses the model cache's maximum effective window; prefer
+// that maximum and keep the rollout value as the fallback. The reverse scan
+// stops at the current turn's turn_context, so an old conversation costs no
+// more to read than a new one.
 func codexContextUsage(providerSessionID string) (contextUsage, bool) {
 	path, ok := codexTranscriptPath(providerSessionID)
 	if !ok {
 		return contextUsage{}, false
 	}
-	return scanCodexContextUsage(path)
+	usage, ok := scanCodexContextUsage(path)
+	if !ok {
+		return contextUsage{}, false
+	}
+	if window, ok := codexMaxContextWindow(usage.model); ok {
+		usage.window = window
+		usage.percent = min(usage.tokens*100/window, 100)
+	}
+	return usage, true
+}
+
+func codexMaxContextWindow(model string) (int, bool) {
+	base, ok := harnessDir("CODEX_HOME", ".codex")
+	if !ok {
+		return 0, false
+	}
+	data, err := os.ReadFile(filepath.Join(base, "models_cache.json"))
+	if err != nil {
+		return 0, false
+	}
+	var cache codexModelsCache
+	if json.Unmarshal(data, &cache) != nil {
+		return 0, false
+	}
+	for _, candidate := range cache.Models {
+		if candidate.Slug != model {
+			continue
+		}
+		window := max(candidate.ContextWindow, candidate.MaxContextWindow)
+		percent := candidate.EffectiveContextWindowPercent
+		if window <= 0 || percent <= 0 || percent > 100 {
+			return 0, false
+		}
+		return window * percent / 100, true
+	}
+	return 0, false
 }
 
 func scanCodexContextUsage(path string) (contextUsage, bool) {

--- a/internal/terminal/usage_codex_test.go
+++ b/internal/terminal/usage_codex_test.go
@@ -1,0 +1,44 @@
+package terminal
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestScanCodexContextUsage(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout.jsonl")
+	body := `{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"high"}}` + "\n" +
+		`{"type":"response_item","payload":{"text":"` + strings.Repeat("x", 2*int(codexScanBlockBytes)) + `"}}` + "\n" +
+		`not json` + "\n" +
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":300000},"model_context_window":258400}}}` + "\n" +
+		`{"type":"event_msg","payload":{"type":"token_count","info":null}}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, ok := scanCodexContextUsage(path)
+	if !ok {
+		t.Fatal("scanCodexContextUsage: want ok, got false")
+	}
+	want := contextUsage{
+		tokens: 300000, percent: 100, window: 258400, model: "gpt-5.6-sol", effort: "high",
+	}
+	if got != want {
+		t.Errorf("usage = %+v, want %+v", got, want)
+	}
+}
+
+func TestCodexContextUsageMisses(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "rollout.jsonl")
+	if err := os.WriteFile(path, []byte(`{"type":"event_msg","payload":{"type":"token_count","info":null}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := scanCodexContextUsage(path); ok {
+		t.Error("a rollout without token usage should be not-ok")
+	}
+	if _, ok := scanCodexContextUsage(filepath.Join(t.TempDir(), "missing.jsonl")); ok {
+		t.Error("a missing rollout should be not-ok")
+	}
+}

--- a/internal/terminal/usage_codex_test.go
+++ b/internal/terminal/usage_codex_test.go
@@ -31,14 +31,56 @@ func TestScanCodexContextUsage(t *testing.T) {
 }
 
 func TestCodexContextUsageMisses(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "rollout.jsonl")
-	if err := os.WriteFile(path, []byte(`{"type":"event_msg","payload":{"type":"token_count","info":null}}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if _, ok := scanCodexContextUsage(path); ok {
-		t.Error("a rollout without token usage should be not-ok")
+	for _, body := range []string{
+		`{"type":"event_msg","payload":{"type":"token_count","info":null}}`,
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"model_context_window":258400}}}`,
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":-1},"model_context_window":258400}}}`,
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":1},"model_context_window":0}}}`,
+	} {
+		path := filepath.Join(t.TempDir(), "rollout.jsonl")
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := scanCodexContextUsage(path); ok {
+			t.Errorf("scanCodexContextUsage(%s): want not-ok", body)
+		}
 	}
 	if _, ok := scanCodexContextUsage(filepath.Join(t.TempDir(), "missing.jsonl")); ok {
 		t.Error("a missing rollout should be not-ok")
+	}
+}
+
+func TestCodexMaxContextWindow(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("CODEX_HOME", dir)
+	path := filepath.Join(dir, "models_cache.json")
+	write := func(body string) {
+		t.Helper()
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	write(`{"models":[{"slug":"gpt-5.6-sol","context_window":272000,"max_context_window":872000,"effective_context_window_percent":95}]}`)
+	if got, ok := codexMaxContextWindow("gpt-5.6-sol"); !ok || got != 828400 {
+		t.Errorf("codexMaxContextWindow = %d, %v; want 828400, true", got, ok)
+	}
+	if _, ok := codexMaxContextWindow("unknown"); ok {
+		t.Error("unknown model should be not-ok")
+	}
+
+	write(`{"models":[{"slug":"gpt-5.6-sol","max_context_window":872000,"effective_context_window_percent":101}]}`)
+	if _, ok := codexMaxContextWindow("gpt-5.6-sol"); ok {
+		t.Error("invalid effective percent should be not-ok")
+	}
+	write(`not json`)
+	if _, ok := codexMaxContextWindow("gpt-5.6-sol"); ok {
+		t.Error("malformed cache should be not-ok")
+	}
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := codexMaxContextWindow("gpt-5.6-sol"); ok {
+		t.Error("missing cache should be not-ok")
 	}
 }

--- a/internal/terminal/usage_test.go
+++ b/internal/terminal/usage_test.go
@@ -30,6 +30,23 @@ func writeTranscript(t *testing.T, providerSessionID, body string) {
 	t.Setenv("CLAUDE_CONFIG_DIR", dir)
 }
 
+// writeCodexTranscript plants a rollout under CODEX_HOME and keeps the Claude
+// lookup empty, proving sessionUsage falls through to the Codex reader.
+func writeCodexTranscript(t *testing.T, providerSessionID, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, "sessions", "2026", "08", "18")
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sessions, "rollout-now-"+providerSessionID+".jsonl")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODEX_HOME", dir)
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+}
+
 // writeSubagentTranscript plants the transcript of one sub-agent beside the
 // conversation that spawned it. It writes into the directory writeTranscript
 // pointed CLAUDE_CONFIG_DIR at, so the parent is planted first.
@@ -58,6 +75,24 @@ func TestSessionUsageReportsTheTranscriptTail(t *testing.T) {
 		t.Fatal("sessionUsage: want ok, got false")
 	}
 	want := usageEvent{ID: "s1", Percent: 6, Tokens: 64800, Window: 1_000_000, Model: modelOpus}
+	if got != want {
+		t.Errorf("sessionUsage = %+v, want %+v", got, want)
+	}
+}
+
+func TestSessionUsageReportsCodexRollout(t *testing.T) {
+	body := `{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"xhigh"}}` + "\n" +
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":65111},"model_context_window":258400}}}` + "\n"
+	writeCodexTranscript(t, "uuid-codex", body)
+	svc := New(stubBins{providerSession: "uuid-codex"}, nil, events.New())
+
+	got, ok := svc.sessionUsage("s1")
+	if !ok {
+		t.Fatal("sessionUsage: want ok, got false")
+	}
+	want := usageEvent{
+		ID: "s1", Percent: 25, Tokens: 65111, Window: 258400, Model: "gpt-5.6-sol", Effort: "xhigh",
+	}
 	if got != want {
 		t.Errorf("sessionUsage = %+v, want %+v", got, want)
 	}

--- a/internal/terminal/usage_test.go
+++ b/internal/terminal/usage_test.go
@@ -47,6 +47,14 @@ func writeCodexTranscript(t *testing.T, providerSessionID, body string) {
 	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 }
 
+func writeCodexModelsCache(t *testing.T, body string) {
+	t.Helper()
+	path := filepath.Join(os.Getenv("CODEX_HOME"), "models_cache.json")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // writeSubagentTranscript plants the transcript of one sub-agent beside the
 // conversation that spawned it. It writes into the directory writeTranscript
 // pointed CLAUDE_CONFIG_DIR at, so the parent is planted first.
@@ -84,6 +92,7 @@ func TestSessionUsageReportsCodexRollout(t *testing.T) {
 	body := `{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"xhigh"}}` + "\n" +
 		`{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":65111},"model_context_window":258400}}}` + "\n"
 	writeCodexTranscript(t, "uuid-codex", body)
+	writeCodexModelsCache(t, `{"models":[{"slug":"gpt-5.6-sol","context_window":272000,"max_context_window":872000,"effective_context_window_percent":95}]}`)
 	svc := New(stubBins{providerSession: "uuid-codex"}, nil, events.New())
 
 	got, ok := svc.sessionUsage("s1")
@@ -91,10 +100,25 @@ func TestSessionUsageReportsCodexRollout(t *testing.T) {
 		t.Fatal("sessionUsage: want ok, got false")
 	}
 	want := usageEvent{
-		ID: "s1", Percent: 25, Tokens: 65111, Window: 258400, Model: "gpt-5.6-sol", Effort: "xhigh",
+		ID: "s1", Percent: 7, Tokens: 65111, Window: 828400, Model: "gpt-5.6-sol", Effort: "xhigh",
 	}
 	if got != want {
 		t.Errorf("sessionUsage = %+v, want %+v", got, want)
+	}
+}
+
+func TestSessionUsageFallsBackToCodexRolloutWindow(t *testing.T) {
+	body := `{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"high"}}` + "\n" +
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":65111},"model_context_window":258400}}}` + "\n"
+	writeCodexTranscript(t, "uuid-codex", body)
+	svc := New(stubBins{providerSession: "uuid-codex"}, nil, events.New())
+
+	got, ok := svc.sessionUsage("s1")
+	if !ok {
+		t.Fatal("sessionUsage: want rollout fallback, got false")
+	}
+	if got.Window != 258400 || got.Percent != 25 {
+		t.Errorf("sessionUsage = %+v, want rollout window 258400 at 25%%", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- read Codex active context, model, and reasoning effort from rollout transcripts
- expose the existing footer readout setting in Codex provider settings
- render the correct provider icon and preserve Codex model identifiers
- document unsupported provider ceilings and add the changelog entry

## Testing

- gofmt -l .
- go vet ./...
- go test ./... (1,678 passed, 1 skipped; 88.8% coverage)
- cd frontend && pnpm check
- cd frontend && pnpm test (1,008 passed; 95.71% line coverage)
- cd frontend && pnpm build
- task dev smoke test