### PR TITLE
Fix Codex context window reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Codex context usage now follows the session's configured window.** A default
+  272k session no longer appears to use the model catalog's optional 872k
+  maximum; sessions configured for either size report their own effective
+  window from the rollout.
+
 ## [0.37.0] - 2026-08-18
 
 ### Added

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -22,11 +22,9 @@ work when nobody knows it and that the call site never shows. The mechanism and 
 - **The session readout understands Claude Code and Codex transcripts only**
   (`internal/terminal/usage_claude.go`, `internal/terminal/usage_codex.go`): oh-my-pi, opencode and Crush record
   token usage but not the model's context-window size, so lich cannot turn those counts into a trustworthy
-  percentage. Their footer therefore carries no model or context ring. Codex's rollout reports its current
-  context tranche rather than the maximum its own status line uses, so lich prefers the maximum effective window
-  in Codex's `models_cache.json`; without that cache it falls back to the rollout and may overstate usage. Codex
-  rollouts also carry no API-cost accounting, so its setting stops at model and context while Claude Code alone
-  offers the cost rung.
+  percentage. Their footer therefore carries no model or context ring. Codex rollouts carry the effective window
+  selected for that session — 95% of its default or configured `model_context_window` — but no API-cost
+  accounting, so its setting stops at model and context while Claude Code alone offers the cost rung.
 - **A dropped file has no path, so lich guesses it** (`internal/drop`): a file under neither the session directory
   nor home is *copied*, so an agent told to edit it edits the copy — and that copy is deleted 3 days on, so a path
   pasted into a prompt eventually stops resolving.

--- a/internal/terminal/usage_codex.go
+++ b/internal/terminal/usage_codex.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"io"
 	"os"
-	"path/filepath"
 )
 
 // A rollout line can be much larger than a normal event. Reading 64 KiB at a
@@ -28,62 +27,17 @@ type codexRolloutEntry struct {
 	} `json:"payload"`
 }
 
-type codexModelsCache struct {
-	Models []struct {
-		Slug                          string `json:"slug"`
-		ContextWindow                 int    `json:"context_window"`
-		MaxContextWindow              int    `json:"max_context_window"`
-		EffectiveContextWindowPercent int    `json:"effective_context_window_percent"`
-	} `json:"models"`
-}
-
 // codexContextUsage reads the latest active context size, model and effort from
-// a Codex rollout. Codex writes the current context tranche into the rollout,
-// while its own readout uses the model cache's maximum effective window; prefer
-// that maximum and keep the rollout value as the fallback. The reverse scan
-// stops at the current turn's turn_context, so an old conversation costs no
-// more to read than a new one.
+// a Codex rollout. The rollout carries the effective window selected for that
+// session, including a model_context_window override. The reverse scan stops at
+// the current turn's turn_context, so an old conversation costs no more to read
+// than a new one.
 func codexContextUsage(providerSessionID string) (contextUsage, bool) {
 	path, ok := codexTranscriptPath(providerSessionID)
 	if !ok {
 		return contextUsage{}, false
 	}
-	usage, ok := scanCodexContextUsage(path)
-	if !ok {
-		return contextUsage{}, false
-	}
-	if window, ok := codexMaxContextWindow(usage.model); ok {
-		usage.window = window
-		usage.percent = min(usage.tokens*100/window, 100)
-	}
-	return usage, true
-}
-
-func codexMaxContextWindow(model string) (int, bool) {
-	base, ok := harnessDir("CODEX_HOME", ".codex")
-	if !ok {
-		return 0, false
-	}
-	data, err := os.ReadFile(filepath.Join(base, "models_cache.json"))
-	if err != nil {
-		return 0, false
-	}
-	var cache codexModelsCache
-	if json.Unmarshal(data, &cache) != nil {
-		return 0, false
-	}
-	for _, candidate := range cache.Models {
-		if candidate.Slug != model {
-			continue
-		}
-		window := max(candidate.ContextWindow, candidate.MaxContextWindow)
-		percent := candidate.EffectiveContextWindowPercent
-		if window <= 0 || percent <= 0 || percent > 100 {
-			return 0, false
-		}
-		return window * percent / 100, true
-	}
-	return 0, false
+	return scanCodexContextUsage(path)
 }
 
 func scanCodexContextUsage(path string) (contextUsage, bool) {

--- a/internal/terminal/usage_codex_test.go
+++ b/internal/terminal/usage_codex_test.go
@@ -49,38 +49,3 @@ func TestCodexContextUsageMisses(t *testing.T) {
 		t.Error("a missing rollout should be not-ok")
 	}
 }
-
-func TestCodexMaxContextWindow(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("CODEX_HOME", dir)
-	path := filepath.Join(dir, "models_cache.json")
-	write := func(body string) {
-		t.Helper()
-		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	write(`{"models":[{"slug":"gpt-5.6-sol","context_window":272000,"max_context_window":872000,"effective_context_window_percent":95}]}`)
-	if got, ok := codexMaxContextWindow("gpt-5.6-sol"); !ok || got != 828400 {
-		t.Errorf("codexMaxContextWindow = %d, %v; want 828400, true", got, ok)
-	}
-	if _, ok := codexMaxContextWindow("unknown"); ok {
-		t.Error("unknown model should be not-ok")
-	}
-
-	write(`{"models":[{"slug":"gpt-5.6-sol","max_context_window":872000,"effective_context_window_percent":101}]}`)
-	if _, ok := codexMaxContextWindow("gpt-5.6-sol"); ok {
-		t.Error("invalid effective percent should be not-ok")
-	}
-	write(`not json`)
-	if _, ok := codexMaxContextWindow("gpt-5.6-sol"); ok {
-		t.Error("malformed cache should be not-ok")
-	}
-	if err := os.Remove(path); err != nil {
-		t.Fatal(err)
-	}
-	if _, ok := codexMaxContextWindow("gpt-5.6-sol"); ok {
-		t.Error("missing cache should be not-ok")
-	}
-}

--- a/internal/terminal/usage_test.go
+++ b/internal/terminal/usage_test.go
@@ -47,14 +47,6 @@ func writeCodexTranscript(t *testing.T, providerSessionID, body string) {
 	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 }
 
-func writeCodexModelsCache(t *testing.T, body string) {
-	t.Helper()
-	path := filepath.Join(os.Getenv("CODEX_HOME"), "models_cache.json")
-	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
-		t.Fatal(err)
-	}
-}
-
 // writeSubagentTranscript plants the transcript of one sub-agent beside the
 // conversation that spawned it. It writes into the directory writeTranscript
 // pointed CLAUDE_CONFIG_DIR at, so the parent is planted first.
@@ -92,7 +84,6 @@ func TestSessionUsageReportsCodexRollout(t *testing.T) {
 	body := `{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"xhigh"}}` + "\n" +
 		`{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":65111},"model_context_window":258400}}}` + "\n"
 	writeCodexTranscript(t, "uuid-codex", body)
-	writeCodexModelsCache(t, `{"models":[{"slug":"gpt-5.6-sol","context_window":272000,"max_context_window":872000,"effective_context_window_percent":95}]}`)
 	svc := New(stubBins{providerSession: "uuid-codex"}, nil, events.New())
 
 	got, ok := svc.sessionUsage("s1")
@@ -100,25 +91,25 @@ func TestSessionUsageReportsCodexRollout(t *testing.T) {
 		t.Fatal("sessionUsage: want ok, got false")
 	}
 	want := usageEvent{
-		ID: "s1", Percent: 7, Tokens: 65111, Window: 828400, Model: "gpt-5.6-sol", Effort: "xhigh",
+		ID: "s1", Percent: 25, Tokens: 65111, Window: 258400, Model: "gpt-5.6-sol", Effort: "xhigh",
 	}
 	if got != want {
 		t.Errorf("sessionUsage = %+v, want %+v", got, want)
 	}
 }
 
-func TestSessionUsageFallsBackToCodexRolloutWindow(t *testing.T) {
+func TestSessionUsageReportsConfiguredCodexWindow(t *testing.T) {
 	body := `{"type":"turn_context","payload":{"model":"gpt-5.6-sol","effort":"high"}}` + "\n" +
-		`{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":65111},"model_context_window":258400}}}` + "\n"
+		`{"type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"total_tokens":65111},"model_context_window":828400}}}` + "\n"
 	writeCodexTranscript(t, "uuid-codex", body)
 	svc := New(stubBins{providerSession: "uuid-codex"}, nil, events.New())
 
 	got, ok := svc.sessionUsage("s1")
 	if !ok {
-		t.Fatal("sessionUsage: want rollout fallback, got false")
+		t.Fatal("sessionUsage: want configured Codex window, got false")
 	}
-	if got.Window != 258400 || got.Percent != 25 {
-		t.Errorf("sessionUsage = %+v, want rollout window 258400 at 25%%", got)
+	if got.Window != 828400 || got.Percent != 7 {
+		t.Errorf("sessionUsage = %+v, want configured window 828400 at 7%%", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- trust the effective context window recorded in each Codex rollout
- report 258,400 tokens for default 272k sessions and 828,400 for sessions configured to 872k
- remove the incorrect model catalog maximum override and document the corrected behavior

## Tests

- gofmt -l .
- go vet ./...
- task test
- cd frontend && pnpm check
- cd frontend && pnpm build