### PR TITLE
fix: let ssh run inside a confined session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **ssh no longer fails outright inside a confined session.** Every remote git
+  command in a sandboxed session died on `Bad owner or permissions on
+  /etc/ssh/ssh_config.d/...`: inside the sandbox's user namespace the
+  distribution's ssh drop-in configs belong to nobody, and ssh refuses to read
+  them. The sandbox now hands ssh an empty drop-in directory, so `git fetch`
+  works again. Pushing still needs the credentials a confined session
+  deliberately does not have.
+
 - **Codex context usage now follows the session's configured window.** A default
   272k session no longer appears to use the model catalog's optional 872k
   maximum; sessions configured for either size report their own effective

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -103,7 +103,10 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   next spawn with nothing saying so. On Ubuntu and Debian the kernel may refuse the user namespace outright
   (an AppArmor policy), which surfaces as bubblewrap's own error in the card and no session. `~/.ssh` is not
   mounted at all: a push over ssh from inside a confined session fails, and lich's own PR flows run outside
-  it and are unaffected. macOS has no hardware here — its profile is unit-tested and has never run.
+  it and are unaffected. The distribution's `/etc/ssh/ssh_config.d` drop-ins are replaced by an empty
+  directory, because inside the namespace they belong to nobody and ssh refuses to read a config file it
+  does not own — so a host whose ssh depends on one of them (a corporate `ProxyCommand`, say) does not have
+  it inside the sandbox. macOS has no hardware here — its profile is unit-tested and has never run.
 - **A symlink in the home is not mounted into the sandbox** (`internal/sandbox`): every path lich binds is
   taken as it is on disk, and a link is skipped — following one would let a dotfile manager point the
   private home at whatever it likes, and binding one fails the spawn outright when a parent directory is

--- a/internal/sandbox/bwrap_linux.go
+++ b/internal/sandbox/bwrap_linux.go
@@ -39,6 +39,19 @@ var systemDirs = []string{"/usr", "/etc", "/opt", "/nix"}
 // not have, and a --symlink where the host has a directory hides half of it.
 var mergedDirs = []string{"/bin", "/sbin", "/lib", "/lib32", "/lib64", "/libx32"}
 
+// sshDropInDir is the distribution's ssh_config include directory, blanked with
+// an empty tmpfs rather than handed over as it is. bubblewrap's user namespace
+// maps the user and nobody else, so every root-owned file under /etc arrives
+// owned by the overflow uid — and ssh refuses to read a config file owned by
+// neither root nor itself: "Bad owner or permissions on
+// /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf", which fails every ssh
+// remote, `git fetch` included, before it reaches the network.
+//
+// Ceiling: the drop-ins are dropped, not repaired. They are the distribution's
+// (systemd's VM proxy on this machine); a host whose ssh depends on one of them
+// wants those files copied into a user-owned tmpfs instead.
+const sshDropInDir = "/etc/ssh/ssh_config.d"
+
 // Available reports whether this machine can confine a session. Linux answers
 // for bubblewrap being installed and nothing else — whether the kernel will
 // actually grant the namespace is a question only a spawn can ask, and the
@@ -63,12 +76,15 @@ func Wrap(spec Spec, bin string, args []string) (string, []string) {
 	return path, append(argv, args...)
 }
 
-// root is one entry of the read-only base filesystem: either a bind of a host
-// directory or a symlink reproduced from the host.
+// root is one entry of the read-only base filesystem: a bind of a host
+// directory, a symlink reproduced from the host, or an empty tmpfs blanking a
+// host directory the sandbox may not use as it stands.
 type root struct {
 	// target is the symlink's destination, empty for a bind mount.
 	target string
-	path   string
+	// blank replaces the path with an empty tmpfs instead of binding it.
+	blank bool
+	path  string
 }
 
 // hostRoots reads the base filesystem this machine actually has. Split from
@@ -96,6 +112,9 @@ func hostRoots() []root {
 		}
 		roots = append(roots, root{target: target, path: dir})
 	}
+	if _, err := os.Stat(sshDropInDir); err == nil {
+		roots = append(roots, root{blank: true, path: sshDropInDir})
+	}
 	return roots
 }
 
@@ -108,11 +127,14 @@ func hostRoots() []root {
 func bwrapArgs(spec Spec, roots []root) []string {
 	var args []string
 	for _, r := range roots {
-		if r.target != "" {
+		switch {
+		case r.target != "":
 			args = append(args, "--symlink", r.target, r.path)
-			continue
+		case r.blank:
+			args = append(args, "--tmpfs", r.path)
+		default:
+			args = append(args, "--ro-bind", r.path, r.path)
 		}
-		args = append(args, "--ro-bind", r.path, r.path)
 	}
 	// /etc/resolv.conf is a symlink into /run on a systemd-resolved machine, and
 	// /run is not mounted: without its target the sandbox has no DNS, which

--- a/internal/sandbox/bwrap_linux_test.go
+++ b/internal/sandbox/bwrap_linux_test.go
@@ -207,3 +207,38 @@ func TestResolvedLinkMountsOnlyWhatTheBaseDoesNotCover(t *testing.T) {
 		t.Errorf("resolvedLink(missing) = %q, want \"\"", got)
 	}
 }
+
+// A blank root is an empty tmpfs over a directory that came in with the base
+// filesystem, and it has to land after the bind that brought it in. It is what
+// keeps ssh working inside the sandbox: the drop-in configs arrive owned by the
+// overflow uid and ssh refuses to read them, taking `git fetch` and `git push`
+// down with them.
+func TestBwrapArgsBlankRootIsAnEmptyTmpfsOverTheBind(t *testing.T) {
+	roots := append(slices.Clone(fakeRoots), root{blank: true, path: sshDropInDir})
+	args := bwrapArgs(testSpec(), roots)
+
+	blank := pairIndex(args, "--tmpfs", sshDropInDir)
+	if blank < 0 {
+		t.Fatalf("%s is not blanked: %v", sshDropInDir, args)
+	}
+	if etc := pairIndex(args, "--ro-bind", "/etc"); etc > blank {
+		t.Errorf("/etc is bound at %d, after the tmpfs blanking %s at %d", etc, sshDropInDir, blank)
+	}
+	if at := pairIndex(args, "--ro-bind", sshDropInDir); at >= 0 {
+		t.Errorf("%s is also bound read-only at %d, which defeats the tmpfs", sshDropInDir, at)
+	}
+}
+
+// The blank entry is read off the host like every other root: a machine that
+// has the directory gets it emptied, one that does not gets no mount at all
+// (bubblewrap fails a spawn whose mount point it cannot create under a
+// read-only /etc).
+func TestHostRootsBlanksTheSSHDropInsWhenThePlatformHasThem(t *testing.T) {
+	_, err := os.Stat(sshDropInDir)
+	blanked := slices.ContainsFunc(hostRoots(), func(r root) bool {
+		return r.blank && r.path == sshDropInDir
+	})
+	if want := err == nil; blanked != want {
+		t.Errorf("hostRoots blanks %s = %v, want %v", sshDropInDir, blanked, want)
+	}
+}


### PR DESCRIPTION
A session on a confined sandbox rung could not reach a remote at all. Every
remote git command died before the network:

```
$ git fetch origin
Bad owner or permissions on /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf
fatal: Could not read from remote repository.
```

## Why

bubblewrap's user namespace maps the user and nobody else, so every root-owned
file under `/etc` arrives owned by the overflow uid (65534). ssh refuses to read
a config file owned by neither root nor itself, and the distribution ships its
drop-ins there — so ssh fails on the include, before any key or host is
considered. `git fetch` in a confined session was collateral, and nobody chose
that.

## What changes

`/etc/ssh/ssh_config.d` is replaced with an empty tmpfs, laid down after the
`/etc` bind that brings it in. `hostRoots` reads whether the machine has the
directory (bubblewrap fails a spawn whose mount point it cannot create under a
read-only `/etc`), and `bwrapArgs` stays the pure translation it was, with the
new root shape covered by its own order assertion.

Credentials stay out of the sandbox as designed — `~/.ssh` is still not mounted
and a push from inside a confined session still fails on the missing key. This
only takes ssh's own refusal off the path, which is what was making read-only
remote work impossible too. The ceiling it opens (a host whose ssh depends on a
drop-in does not get it inside the sandbox) is written down in `docs/ceilings.md`.

## Test plan

- [x] `go test ./...` — 1681 passed, including two new assertions: a blank root
      becomes a tmpfs mounted after the bind it covers, and `hostRoots` blanks
      the drop-in directory exactly when the machine has one.
- [x] `gofmt -l .`, `go vet ./...` clean; cross-compile loop green for linux,
      darwin and windows (OS seam touched).
- [x] Measured by hand in a bubblewrap namespace reproducing the spawn: before,
      `git fetch origin` fails as above; after, ssh reads its config and reaches
      github.com, failing only on the absent key (`Permission denied
      (publickey)`) — and authenticating when an ssh-agent socket is bound,
      which confirms nothing but the config check was in the way.