### PR TITLE
feat: lead the command palette with the sessions holding a turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The command palette leads with the sessions worth interrupting.** Its `All`
+  view now lists the sessions holding a turn first and the plain shells last,
+  so a project of parked terminals no longer fills the list ahead of the agent
+  that is actually running. It shows five rows per group instead of three, and
+  closed projects moved out of `All` into the `Projects` tab, which lists them
+  whole.
+
 ### Fixed
 
 - **Codex context usage now follows the session's configured window.** A default

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -4,7 +4,7 @@ import { Folder, FolderX, MessageSquareText } from "lucide-react"
 import { useProjects } from "@/providers/projects"
 import { useSettings } from "@/providers/settings"
 import { useHotkey } from "@/lib/use-hotkey"
-import { useSessionStatus } from "@/lib/session/use-session-status"
+import { runningSessions, useSessionStatus } from "@/lib/session/use-session-status"
 import { SessionStatusIcon } from "@/components/sidebar/SessionStatusIcon"
 import {
   filterPalette,
@@ -13,6 +13,7 @@ import {
   paletteSessions,
   paletteTabCount,
   PALETTE_TABS,
+  rankSessions,
   rowKey,
   type PaletteMessage,
   type PaletteRow,
@@ -43,6 +44,7 @@ export function CommandPalette() {
   const [tab, setTab] = useState<PaletteTab>("All")
   const [selected, setSelected] = useState(0)
   const [closed, setClosed] = useState<RecentProject[]>([])
+  const [running, setRunning] = useState<ReadonlySet<string>>(new Set())
   const [missing, setMissing] = useState<ReadonlySet<string>>(new Set())
 
   useHotkey(hotkeys.commandPalette, () => {
@@ -80,7 +82,19 @@ export function CommandPalette() {
     }
   }, [open])
 
-  const all = useMemo(() => paletteSessions(projects, sessions), [projects, sessions])
+  const flat = useMemo(() => paletteSessions(projects, sessions), [projects, sessions])
+  // Which sessions hold a turn, sampled once per opening rather than
+  // subscribed to. The palette is mounted for the whole app's life, so a
+  // subscription would re-render it for every status report with nothing on
+  // screen; and an order that moved under the cursor while a row is being
+  // aimed at costs more than the freshness is worth — the same reason the
+  // transcript hits are listed last.
+  useEffect(() => {
+    if (open) {
+      setRunning(new Set(runningSessions(flat.map((session) => session.sessionId))))
+    }
+  }, [open])
+  const all = useMemo(() => rankSessions(flat, running), [flat, running])
   const results = useMemo(
     () => filterPalette(query, all, projects, closed),
     [query, all, projects, closed],

--- a/frontend/src/lib/session/command-palette.test.ts
+++ b/frontend/src/lib/session/command-palette.test.ts
@@ -7,6 +7,7 @@ import {
   paletteMessages,
   paletteSessions,
   paletteTabCount,
+  rankSessions,
   rowKey,
 } from "./command-palette"
 import type { Project } from "@/lib/api-types"
@@ -121,21 +122,21 @@ describe("paletteGroups", () => {
   const results = filterPalette("", all, projects, closed)
   const messages = paletteMessages([{ id: "s1", snippet: "flaky again", count: 1 }], all)
 
-  it("shows every kind on All, three rows each, and says what it left out", () => {
+  it("shows the kinds worth interrupting for, and leaves the closed projects to their tab", () => {
     const groups = paletteGroups("All", results, messages)
-    expect(groups.map((g) => g.label)).toEqual([
-      "Sessions",
-      "Projects",
-      "Closed projects",
-      "Messages",
-    ])
-    const closedGroup = groups.find((g) => g.label === "Closed projects")
-    expect(closedGroup?.rows).toHaveLength(3)
-    expect(closedGroup?.total).toBe(4)
+    expect(groups.map((g) => g.label)).toEqual(["Sessions", "Projects", "Messages"])
     // Nothing was cut here, so the header has nothing to report.
     const projectGroup = groups.find((g) => g.label === "Projects")
     expect(projectGroup?.rows).toHaveLength(2)
     expect(projectGroup?.total).toBe(2)
+  })
+
+  it("cuts a group to five rows and says what it left out", () => {
+    const many = Array.from({ length: 7 }, (_, i) => ({ ...all[0], sessionId: `x${i}` }))
+    const groups = paletteGroups("All", { ...results, sessions: many }, [])
+    const sessionGroup = groups.find((g) => g.label === "Sessions")
+    expect(sessionGroup?.rows).toHaveLength(5)
+    expect(sessionGroup?.total).toBe(7)
   })
 
   it("lists one kind whole under its own tab", () => {
@@ -154,7 +155,31 @@ describe("paletteGroups", () => {
   it("carries what a row needs to be run", () => {
     const rows = paletteGroups("All", results, messages).flatMap((g) => g.rows)
     expect(rows[0]).toEqual({ kind: "session", session: all[0] })
-    expect(rows.find((r) => r.kind === "closed")).toEqual({ kind: "closed", project: closed[0] })
+    const reopen = paletteGroups("Projects", results, messages).flatMap((g) => g.rows)
+    expect(reopen.find((r) => r.kind === "closed")).toEqual({ kind: "closed", project: closed[0] })
+  })
+})
+
+describe("rankSessions", () => {
+  const all = paletteSessions(projects, sessions)
+
+  it("puts the sessions holding a turn first and the shells last", () => {
+    const ranked = rankSessions(all, new Set(["s3"]))
+    expect(ranked.map((r) => r.sessionId)).toEqual(["s3", "s1", "s2"])
+  })
+
+  it("keeps the tab order between sessions of equal rank", () => {
+    expect(rankSessions(all, new Set()).map((r) => r.sessionId)).toEqual(["s1", "s3", "s2"])
+  })
+
+  it("ranks a running shell with the running sessions", () => {
+    expect(rankSessions(all, new Set(["s2"])).map((r) => r.sessionId)).toEqual(["s2", "s1", "s3"])
+  })
+
+  it("leaves the list it was given alone", () => {
+    const before = all.map((r) => r.sessionId)
+    rankSessions(all, new Set(["s3"]))
+    expect(all.map((r) => r.sessionId)).toEqual(before)
   })
 })
 
@@ -166,7 +191,7 @@ describe("rowKey", () => {
     const results = filterPalette("", all, projects, closed)
     const messages = paletteMessages([{ id: "s1", snippet: "x", count: 1 }], all)
     const rows = paletteGroups("All", results, messages).flatMap((g) => g.rows)
-    expect(rows.map(rowKey)).toEqual(["s1", "s2", "s3", "p1", "p2", "c1", "c2", "c3", "s1"])
+    expect(rows.map(rowKey)).toEqual(["s1", "s2", "s3", "p1", "p2", "s1"])
   })
 })
 

--- a/frontend/src/lib/session/command-palette.ts
+++ b/frontend/src/lib/session/command-palette.ts
@@ -112,16 +112,37 @@ export function paletteMessages(
 }
 
 // PALETTE_TABS is the filter row, in the order Tab walks it. A query can hit
-// four kinds of thing at once, which is a page of rows nobody reads: All keeps
-// every kind but shows the first few of each, and a tab lists one kind whole.
+// four kinds of thing at once, which is a page of rows nobody reads: All shows
+// the first few of the three worth interrupting for, and a tab lists one kind
+// whole — including the closed projects, which only their tab carries.
 export const PALETTE_TABS = ["All", "Sessions", "Projects", "Messages"] as const
 
 export type PaletteTab = (typeof PALETTE_TABS)[number]
 
-// ALL_TAB_ROWS is how much of a group the All tab shows. Three is enough for the
-// hit that is obviously the one and short enough that four groups still fit
-// without scrolling.
-const ALL_TAB_ROWS = 3
+// ALL_TAB_ROWS is how much of a group the All tab shows. Enough that a project
+// with a handful of sessions is not represented by its first two, and short
+// enough that the three groups still fit without scrolling.
+const ALL_TAB_ROWS = 5
+
+// rankSessions puts the sessions worth jumping to at the top of the list the
+// All tab then cuts to ALL_TAB_ROWS. Order alone is what decides which sessions
+// survive that cut, and the natural one — the tab strip's, Home pinned first —
+// hands the whole group to whatever sits in the first project: a shell parked
+// on a TUI is what somebody keeps in Home, and never what Ctrl+K is opened for.
+//
+// running is a snapshot of the sessions holding a turn (busy or blocked on a
+// prompt), taken when the palette opens; a shell is last because it has no turn
+// to hold and no agent to come back to.
+export function rankSessions(
+  sessions: readonly PaletteSession[],
+  running: ReadonlySet<string>,
+): PaletteSession[] {
+  const rank = (session: PaletteSession): number =>
+    running.has(session.sessionId) ? 0 : session.kind === "shell" ? 2 : 1
+  // Sort is stable, so sessions of equal rank keep the order the tabs put them
+  // in — the ranking reorders what the user wants first, never everything.
+  return [...sessions].sort((a, b) => rank(a) - rank(b))
+}
 
 // PaletteRow is one option in the list, carrying what running it needs. The
 // groups are rendered in order and the rows flattened back out for the arrow
@@ -173,11 +194,14 @@ export function paletteGroups(
         return [group("Open", open, 0), group("Closed", closed, 0)]
       case "Messages":
         return [group("Messages", said, 0)]
+      // No closed projects here: reopening one is not what the palette is
+      // reached for mid-work, and the rows it costs are rows the sessions and
+      // the open projects are cut to make room for. The Projects tab lists
+      // them whole, which is where somebody looking for one already goes.
       default:
         return [
           group("Sessions", sessions, ALL_TAB_ROWS),
           group("Projects", open, ALL_TAB_ROWS),
-          group("Closed projects", closed, ALL_TAB_ROWS),
           group("Messages", said, ALL_TAB_ROWS),
         ]
     }


### PR DESCRIPTION
## What

The command palette's `All` view listed sessions in tab-strip order and cut every group to three rows, so the first project decided the whole group — and Home is pinned first, which is where parked shells running a TUI live. The agent actually working sat below the cut.

- Sessions are ranked before that cut: the ones **holding a turn** (busy, or blocked on a prompt) first, plain shells last, tab order kept between equals (`rankSessions`).
- The running set is **sampled when the palette opens**, not subscribed to: the palette is mounted for the app's life, so a subscription would re-render it for every status report with nothing on screen — and an order that moves under the cursor mid-aim costs more than the freshness is worth. Same reason the transcript hits are listed last.
- Groups show **five** rows instead of three.
- **Closed projects leave `All`** for the `Projects` tab, which already lists them whole. Reopening a project is not what the palette is reached for mid-work, and the rows it cost were rows the sessions and open projects are cut to make room for.

## Test plan

- [x] `command-palette.test.ts`: new `rankSessions` cases (running first, shells last, stable between equals, input left alone), the five-row cut and its `N of M` header, and `All` no longer carrying closed projects.
- [x] `pnpm test` — 1014 tests, 87 files, green.
- [x] `pnpm check` clean (14 pre-existing warnings, none in the touched files); `tsc` + `vite build` green.
- [x] Backend untouched: `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` 1679 passing.
- [x] `CHANGELOG.md` `[Unreleased] › Changed`.

Two tests changed because the contract did: they pinned `Closed projects` inside `All` and the cap of three.