### PR TITLE
Bind the session card's actions to shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Six more keyboard shortcuts, all aimed at the session sidebar.**
+  `Ctrl+Shift+B` opens the worktree dialog — the New session menu's **Worktree**
+  item, reached without the menu — and the active session's own card actions get
+  the rest: `Ctrl+Shift+E` renames it in place, `Ctrl+Shift+X` closes it,
+  `Ctrl+Shift+K` pins or unpins it, `Ctrl+Shift+L` opens a terminal in its
+  directory, and `Ctrl+Shift+H` opens the delegate picker. A collapsed sidebar
+  opens first, since none of that chrome lives in the rail, and a shortcut the
+  card does not offer — closing a pinned session, delegating from a terminal —
+  is declined rather than silently doing nothing. All are listed in the
+  shortcuts overlay (`Ctrl+/`) and rebindable in Settings › Hotkeys.
+- **The terminal search chord is documented.** `Ctrl+F` has always opened the
+  session's search bar; the shortcuts overlay and Settings › Hotkeys now say so,
+  under a **Terminal** heading beside the chords passed through to the agent.
+
 ### Changed
 
 - **The command palette leads with the sessions worth interrupting.** Its `All`

--- a/README.md
+++ b/README.md
@@ -119,9 +119,14 @@ window. Upgrading from the old formula needs `brew uninstall lich` first —
 - **Version control** — a project can name the GitHub account `gh` runs as
   (Settings › Version Control), for a repository only one of your accounts can
   see. It governs what lich reads from GitHub, not what git pushes.
-- **Appearance & hotkeys** — themes, fonts and key combos in Settings; the theme
-  you pick persists in the workspace database, the rest of the UI preferences in
-  `localStorage` under `lich.*` keys (inside lich's Chromium profile at
+- **Hotkeys** — `Ctrl`/`Cmd`+`/` lists every shortcut lich binds, and Settings ›
+  Hotkeys is where you rebind one: press the combo you want and it is stored, or
+  reset the row to lich's default. Two actions may hold the same combo, and the
+  rows that do say so. Rebinds live in the page's `localStorage`, so wiping
+  lich's Chromium profile takes them with it.
+- **Appearance** — themes and fonts in Settings; the theme you pick persists in
+  the workspace database, the rest of the UI preferences in `localStorage` under
+  `lich.*` keys (inside lich's Chromium profile at
   `~/.config/lich/chromium-profile`), and imported themes as JSON under
   `<config-dir>/lich/themes`.
 - **Workspace** — projects and sessions persist in SQLite at

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -53,6 +53,13 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   gone relocates it instead, keeping the stored id its sessions and its worktree directory hang off. Only the 25
   most recent closes are offered back (`recentLimit`, `internal/store/store.go`) — the row survives, but past that
   a project is reachable only through the directory picker, and neither the menu nor the palette says so.
+- **A hotkey is taken from the agent, and its rebind lives only in the page** (`frontend/src/lib/use-hotkey.ts`,
+  `hotkeys.ts`): every bound combo is caught in the window capture phase and stopped there, so the chord never
+  reaches the PTY — the defaults spend chords no TUI can bind, but a rebind is checked against nothing, and
+  recording `Ctrl+R` silently costs the shell its history search with nothing on screen connecting the two. The
+  bindings are a `lich.hotkeys` entry in localStorage, which the theme left for the workspace database precisely
+  because a recreated Chromium profile drops it: the combos revert to the defaults, and both the overlay and
+  Settings then show those defaults as if nothing had ever been rebound.
 - **Hidden sessions are serialized and destroyed**: 2MB replay rings on both sides
   (`frontend/src/lib/terminal/replay-buffer.ts` page-side, `internal/terminal/replay.go` backend-side — the latter
   survives a full page reload). Scrollback past the ring is gone, not paged. The snapshot carries only the modes

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,15 @@
 import { useEffect, useRef, useState } from "react"
-import { HashRouter, Outlet, Route, Routes } from "react-router-dom"
+import { HashRouter, Outlet, Route, Routes, useMatch } from "react-router-dom"
 import { SettingsProvider, useSettings } from "@/providers/settings"
 import { useHotkey } from "@/lib/use-hotkey"
 import { parseBoolPref, readPref, writePref } from "@/lib/prefs"
-import { ProjectsProvider } from "@/providers/projects"
+import { ProjectsProvider, useProjects } from "@/providers/projects"
+import { activeSessionId, sessionsOf } from "@/lib/session/sessions"
+import {
+  requestSessionIntent,
+  requestWorktreeDialog,
+  type SessionIntent,
+} from "@/lib/use-sidebar-intent"
 import { ProjectTabs } from "@/components/tabs/ProjectTabs"
 import { SessionSidebar } from "@/components/sidebar/SessionSidebar"
 import { SidebarRail } from "@/components/sidebar/SidebarRail"
@@ -33,14 +39,47 @@ const SIDEBAR_KEY = "lich.sidebar.open"
 // top of the terminals.
 function Layout() {
   const { hotkeys } = useSettings()
+  const { sessions } = useProjects()
+  const match = useMatch("/projects/:projectId/*")
+  const projectId = match?.params.projectId ?? ""
   const [dock, setDock] = useState<DockTab | null>(null)
   const [sidebar, setSidebar] = useState(() => parseBoolPref(readPref(SIDEBAR_KEY), true))
-  const toggleSidebar = () => {
-    const open = !sidebar
+  const showSidebar = (open: boolean) => {
     setSidebar(open)
     writePref(SIDEBAR_KEY, open)
   }
+  const toggleSidebar = () => showSidebar(!sidebar)
   useHotkey(hotkeys.toggleSidebar, toggleSidebar)
+  // Both of these act on sidebar chrome — the worktree dialog, a card's rename
+  // field — and the rail carries neither, so a collapsed sidebar is opened
+  // first rather than letting the chord quietly do nothing. The request is a
+  // pending flag for exactly that reason: its consumer mounts a render later
+  // (use-sidebar-intent).
+  useHotkey(hotkeys.newWorktree, () => {
+    if (!projectId) return false
+    showSidebar(true)
+    requestWorktreeDialog(projectId)
+  })
+  // The card actions all aim at the same card — the active session's — so they
+  // share one route to it. A shortcut is declined wherever that card offers no
+  // such action, rather than being swallowed for nothing.
+  const active = sessionsOf(sessions, projectId).find(
+    (session) => session.id === activeSessionId(sessions, projectId),
+  )
+  const cardAction = (intent: SessionIntent) => {
+    if (!active) return false
+    showSidebar(true)
+    requestSessionIntent(active.id, intent)
+  }
+  useHotkey(hotkeys.renameSession, () => cardAction("rename"))
+  // A pinned card shows no × at all — closing is what the pin withholds — so
+  // the shortcut withholds it too.
+  useHotkey(hotkeys.closeSession, () => !active?.pinned && cardAction("close"))
+  useHotkey(hotkeys.togglePin, () => cardAction("pin"))
+  useHotkey(hotkeys.openTerminal, () => cardAction("terminal"))
+  // Delegating writes the request at the session's own prompt, and the thing
+  // reading a terminal's prompt is a shell: it would run the line as a command.
+  useHotkey(hotkeys.delegate, () => active?.kind !== "shell" && cardAction("delegate"))
   const toggleDock = (tab: DockTab) => setDock((cur) => (cur === tab ? null : tab))
   // The shortcut toggles the dock as a whole, so it reopens on the tab it was
   // last showing — the two tabs have their own footer buttons.

--- a/frontend/src/components/settings/HotkeysSettings.tsx
+++ b/frontend/src/components/settings/HotkeysSettings.tsx
@@ -13,14 +13,14 @@ import {
   type HotkeyAction,
   type HotkeyId,
 } from "@/lib/hotkeys"
-import { PASSTHROUGH_TITLE, passthroughRows } from "@/lib/shortcuts"
+import { PASSTHROUGH_TITLE, passthroughRows, TERMINAL_TITLE, terminalRows } from "@/lib/shortcuts"
 import { Button } from "@/components/ui/button"
 import { ShortcutLine } from "@/components/common/ShortcutLine"
 import { isMac, isWindows } from "@/lib/platform"
 import { cn } from "@/lib/utils"
 
-// A dense list rather than one setting block per action: eleven bindings read as
-// a table of rows, and a block each would be a column of near-empty cards.
+// A dense list rather than one setting block per action: the bindings read as a
+// table of rows, and a block each would be a column of near-empty cards.
 function Group({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <section className="pt-8 first:pt-0">
@@ -111,6 +111,15 @@ export function HotkeysSettings() {
           ))}
         </Group>
       ))}
+      <Group label={TERMINAL_TITLE}>
+        <p className="mb-2 max-w-prose text-xs text-muted-foreground">
+          lich's own, and fixed: this one shadows a browser accelerator, which answers to a chord
+          rather than to whatever it was rebound to.
+        </p>
+        {terminalRows.map((row) => (
+          <ShortcutLine key={row.label} label={row.label} keys={row.keys} />
+        ))}
+      </Group>
       <Group label={PASSTHROUGH_TITLE}>
         <p className="mb-2 max-w-prose text-xs text-muted-foreground">
           lich rewrites these on their way to the agent's terminal, so they are fixed rather than

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -50,6 +50,7 @@ import type { DelegateGroup } from "@/lib/session/delegate-targets"
 import { delegatePrompt, delegateWorktreePrompt } from "@/lib/session/delegate-prompt"
 import { bracketedPaste } from "@/lib/terminal/bracketed-paste"
 import { requestTerminalFocus } from "@/lib/terminal/focus-request"
+import { useSessionIntent } from "@/lib/use-sidebar-intent"
 import { SessionTargetPicker } from "./SessionTargetPicker"
 import { EntrypointDialog } from "./EntrypointDialog"
 
@@ -184,6 +185,31 @@ export function SessionCard({
       setDelegatePickerOpen(false)
     }
   }, [canDelegate])
+
+  // The shortcuts for this card's own actions. They aim at the active session,
+  // which is this card, and they call the same handlers its context menu items
+  // do — one behaviour, two ways in. Whether an action is offered at all is
+  // decided where the shortcut is raised (App), so a chord the card cannot
+  // honour never reaches here.
+  useSessionIntent(session.id, (intent) => {
+    switch (intent) {
+      case "rename":
+        setEditing(true)
+        break
+      case "close":
+        onClose()
+        break
+      case "pin":
+        onPin(!pinned)
+        break
+      case "terminal":
+        onOpenTerminal(shownPath)
+        break
+      case "delegate":
+        setDelegatePickerOpen(true)
+        break
+    }
+  })
 
   const commit = (value: string) => {
     setEditing(false)

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -40,6 +40,7 @@ import { WorktreeDialog } from "./WorktreeDialog"
 import { useWorktreeClose } from "./useWorktreeClose"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { usePanelWidth } from "@/lib/use-panel-width"
+import { useWorktreeDialogIntent } from "@/lib/use-sidebar-intent"
 import { SessionLaunchMenuItems } from "./SessionLaunchMenuItems"
 
 // Named here like every other `lich.*` pref rather than spelled at the call
@@ -99,6 +100,11 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
     edge: "right",
   })
   const [worktreeOpen, setWorktreeOpen] = useState(false)
+  // The shortcut's half of the New session menu's Worktree item. Ungated where
+  // the menu item is disabled without a branch: git status may still be loading
+  // on the render this mounts in, and the dialog reports git's own error in
+  // place anyway.
+  useWorktreeDialogIntent(projectId ?? "", () => setWorktreeOpen(true))
   // Resolved ahead of the no-project bail below: hooks cannot sit behind it.
   const list = sessionsOf(sessions, projectId ?? "")
   const worktreeClose = useWorktreeClose(projectId ?? "", path, list)

--- a/frontend/src/lib/hotkeys.ts
+++ b/frontend/src/lib/hotkeys.ts
@@ -11,6 +11,12 @@ import { readPref, writePref } from "@/lib/prefs"
 export type HotkeyId =
   | "commandPalette"
   | "newSession"
+  | "newWorktree"
+  | "renameSession"
+  | "closeSession"
+  | "togglePin"
+  | "openTerminal"
+  | "delegate"
   | "nextSession"
   | "prevSession"
   | "focusTerminal"
@@ -67,6 +73,49 @@ export const HOTKEY_ACTIONS: readonly HotkeyAction[] = [
     label: "New session",
     group: "sessions",
     combo: { mod: true, shift: true, alt: false, key: "t" },
+  },
+  // B for branch: the dialog's whole subject is which branch the checkout is
+  // cut from. Ctrl+Shift+W would have read better and is Chromium's close
+  // window, which a page cannot take back.
+  {
+    id: "newWorktree",
+    label: "New worktree session",
+    group: "sessions",
+    combo: { mod: true, shift: true, alt: false, key: "b" },
+  },
+  {
+    id: "renameSession",
+    label: "Rename the active session",
+    group: "sessions",
+    combo: { mod: true, shift: true, alt: false, key: "e" },
+  },
+  // The rest of the card's own actions. Only X carries a mnemonic anyone would
+  // guess; the letters that would (P for pin, T for terminal, D for delegate)
+  // are spent, and what was left had to avoid Chromium's own (N, W, Q, I, J, C,
+  // O, M, A, R) and Ctrl+Shift+U, which starts Unicode entry under IBus.
+  {
+    id: "closeSession",
+    label: "Close the active session",
+    group: "sessions",
+    combo: { mod: true, shift: true, alt: false, key: "x" },
+  },
+  {
+    id: "togglePin",
+    label: "Pin or unpin the active session",
+    group: "sessions",
+    combo: { mod: true, shift: true, alt: false, key: "k" },
+  },
+  {
+    id: "openTerminal",
+    label: "Open a terminal in the session's directory",
+    group: "sessions",
+    combo: { mod: true, shift: true, alt: false, key: "l" },
+  },
+  {
+    id: "delegate",
+    label: "Delegate to another session",
+    group: "sessions",
+    combo: { mod: true, shift: true, alt: false, key: "h" },
   },
   // Down/up because the sidebar list is vertical; the project pair below is the
   // same shape turned sideways, because the tab strip is horizontal.

--- a/frontend/src/lib/shortcuts.test.ts
+++ b/frontend/src/lib/shortcuts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { DEFAULT_HOTKEYS, HOTKEY_ACTIONS, HOTKEY_GROUPS } from "./hotkeys"
-import { PASSTHROUGH_TITLE, shortcutGroups } from "./shortcuts"
+import { PASSTHROUGH_TITLE, shortcutGroups, TERMINAL_TITLE } from "./shortcuts"
 
 const groupTitled = (
   groups: { title: string; rows: { label: string; keys: string }[] }[],
@@ -20,9 +20,10 @@ describe("shortcutGroups", () => {
     const groups = shortcutGroups(DEFAULT_HOTKEYS, false, false)
     expect(groups.map((g) => g.title)).toEqual([
       ...HOTKEY_GROUPS.map((g) => g.label),
+      TERMINAL_TITLE,
       PASSTHROUGH_TITLE,
     ])
-    const listed = groups.slice(0, -1).flatMap((g) => g.rows.map((row) => row.label))
+    const listed = groups.slice(0, -2).flatMap((g) => g.rows.map((row) => row.label))
     expect(listed).toEqual(HOTKEY_ACTIONS.map((a) => a.label))
     expect(groupTitled(groups, "Sessions").rows.map((r) => r.label)).toContain("New session")
   })
@@ -38,6 +39,12 @@ describe("shortcutGroups", () => {
       commandPalette: { mod: true, shift: false, alt: true, key: "p" },
     }
     expect(keysFor(shortcutGroups(rebound, false, false), "Command palette")).toBe("Ctrl+Alt+P")
+  })
+
+  it("lists the terminal search, which is bound but not rebindable", () => {
+    expect(
+      keysFor(shortcutGroups(DEFAULT_HOTKEYS, true, false), "Search the session's output"),
+    ).toBe("Ctrl+F")
   })
 
   it("splits the image-paste chord by platform", () => {

--- a/frontend/src/lib/shortcuts.ts
+++ b/frontend/src/lib/shortcuts.ts
@@ -14,7 +14,15 @@ export interface ShortcutGroup {
   rows: ShortcutRow[]
 }
 
+export const TERMINAL_TITLE = "Terminal"
 export const PASSTHROUGH_TITLE = "Passed through to the agent"
+
+// lich's own chord, and not a rebindable one: it shadows Chromium's Find in
+// --app mode, and an accelerator answers to a fixed chord (TerminalView). Ctrl
+// on macOS too, for the same reason as the rows below.
+export const terminalRows: ShortcutRow[] = [
+  { label: "Search the session's output", keys: "Ctrl+F" },
+]
 
 // These are spelled out rather than built from a Combo: they are matched on
 // event.ctrlKey (term-keys.ts), so the modifier is Control on macOS too and
@@ -41,5 +49,9 @@ export function shortcutGroups(
       keys: formatCombo(hotkeys[action.id], isMac),
     })),
   }))
-  return [...bound, { title: PASSTHROUGH_TITLE, rows: passthroughRows(isWindows) }]
+  return [
+    ...bound,
+    { title: TERMINAL_TITLE, rows: terminalRows },
+    { title: PASSTHROUGH_TITLE, rows: passthroughRows(isWindows) },
+  ]
 }

--- a/frontend/src/lib/use-sidebar-intent.ts
+++ b/frontend/src/lib/use-sidebar-intent.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useSyncExternalStore } from "react"
+import { createKeyedStore } from "@/lib/keyed-store"
+
+// "Do this in the sidebar", raised by a global hotkey and honoured by the piece
+// of sidebar chrome that owns the action — the worktree dialog, a card's rename
+// field, its close and pin. Page-internal, like focus-request.
+//
+// A pending value rather than a tick: the chord expands a collapsed sidebar
+// first, so its consumer can mount a render *after* the press, and a
+// notification fired at press time would reach nobody. The value is cleared as
+// it is read, so a request fires once and never springs the dialog open again
+// the next time that consumer mounts.
+//
+// `empty` is both the idle value and what a consumed request resets to, so it
+// is the one value a request may not carry.
+function createIntent<T>(empty: T) {
+  const store = createKeyedStore<T>(empty)
+  return {
+    request: (key: string, value: T) => store.set(key, value),
+    // The action is written inline at the call site, so it is read through a
+    // ref: depending on its identity would re-run the effect every render.
+    useIntent(key: string, run: (value: T) => void): void {
+      const latest = useRef(run)
+      latest.current = run
+      const pending = useSyncExternalStore(
+        (onChange) => store.subscribe(key, onChange),
+        () => store.get(key),
+      )
+      useEffect(() => {
+        if (pending === empty) {
+          return
+        }
+        store.set(key, empty)
+        latest.current(pending)
+      }, [pending, key])
+    },
+  }
+}
+
+// Keyed by project id: the dialog belongs to the project's sidebar.
+const worktreeDialog = createIntent(false)
+export const requestWorktreeDialog = (projectId: string) => worktreeDialog.request(projectId, true)
+export const useWorktreeDialogIntent = worktreeDialog.useIntent
+
+/** What a shortcut asks one session's card to do — the card's own actions. */
+export type SessionIntent = "rename" | "close" | "pin" | "terminal" | "delegate"
+
+// One store for the card actions rather than one per action: they share a key
+// (the session id) and a consumer (the card), and a switch there reads better
+// than five subscriptions.
+const sessionAction = createIntent<SessionIntent | "">("")
+export const requestSessionIntent = (sessionId: string, intent: SessionIntent) =>
+  sessionAction.request(sessionId, intent)
+export const useSessionIntent = sessionAction.useIntent

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,12 +1,15 @@
 // Package store is lich's persistence layer: a single SQLite database holding
-// open projects, their terminal sessions and backend-read settings (currently
-// the provider binary paths, global or per-project). It never stores chat or
-// terminal content — only the metadata needed to restore the workspace after a
-// restart.
+// open projects, their terminal sessions and the settings scoped globally or to
+// one project — provider binaries and defaults, the permission and sandbox
+// rungs, the gh account. It never stores chat or terminal content — only the
+// metadata needed to restore the workspace after a restart.
 //
-// UI-only preferences (font, theme, zoom) intentionally stay in the frontend's
-// localStorage: they need synchronous access on first paint and the backend
-// never reads them.
+// A UI preference stays in the frontend's localStorage by default: it needs
+// synchronous access on first paint and the backend never reads it. It moves
+// here when losing it costs more than reading it a frame late — the theme
+// selections and the "what's new" mark did, because Chromium recreates a
+// damaged profile from scratch and takes every `lich.*` key with it (the why is
+// at the setting keys in frontend/src/providers/settings.tsx).
 package store
 
 import (


### PR DESCRIPTION
New session had a shortcut; nothing else in the sidebar did. Six chords now reach the chrome around it — one for the worktree dialog, the rest for the active session's own card actions.

| Action | Chord |
| --- | --- |
| New worktree session | `Ctrl+Shift+B` |
| Rename the active session | `Ctrl+Shift+E` |
| Close the active session | `Ctrl+Shift+X` |
| Pin or unpin the active session | `Ctrl+Shift+K` |
| Open a terminal in the session's directory | `Ctrl+Shift+L` |
| Delegate to another session | `Ctrl+Shift+H` |

Only `X` carries a mnemonic anyone would guess. The letters that would (`P` for pin, `T` for terminal, `D` for delegate) are already spent, and what was left had to avoid Chromium's own (`N`, `W`, `Q`, `I`, `J`, `C`, `O`, `M`, `A`, `R`) and `Ctrl+Shift+U`, which starts Unicode entry under IBus. All six are rebindable in Settings › Hotkeys.

## How the shortcut reaches the card

The card actions share one route. `App` resolves the active session, decides whether the action is offered at all, and raises an intent; the card consumes it and calls the same handlers its context menu items do, so the two ways in cannot drift.

A shortcut the card does not offer is declined — the chord falls through instead of being swallowed for nothing:

- closing a pinned session, because the pin is what withholds the close affordance;
- delegating from a shell, because the request is written at that session's own prompt and a shell would run the line as a command.

The request is a pending value rather than a notification (`use-sidebar-intent.ts`) because a collapsed sidebar is expanded first — the rail carries neither the dialog nor a rename field — so the consumer mounts a render *after* the press, and a notification fired at press time would reach nobody. The value is cleared as it is read, so an expand later in the day does not spring the dialog open again.

## Ctrl+F was bound and undocumented

The shortcuts overlay and Settings › Hotkeys now list it under a **Terminal** heading, beside the chords passed through to the agent. It stays out of `HOTKEY_ACTIONS`: it exists to shadow Chromium's Find in `--app` mode, and an accelerator answers to a fixed chord rather than to whatever it was rebound to. `shortcuts.test.ts` moves with that contract — the overlay now lists lich's fixed terminal chords — not against it.

## Docs

Neither the overlay nor the capture field says what a shortcut costs, so `docs/ceilings.md` does: a bound combo is stopped in the window capture phase and never reaches the PTY, a rebind is checked against nothing (recording `Ctrl+R` quietly costs the shell its history search), and the bindings are a `lich.hotkeys` entry in localStorage that a recreated Chromium profile drops — the theme left for the workspace database over exactly that.

README's `Appearance & hotkeys` bullet split in two; the hotkeys half names `Ctrl`/`Cmd`+`/` and Settings › Hotkeys and no other chord, so it does not age when the next binding lands.

The `internal/store` package comment still claimed the theme lived in localStorage and that the settings table held provider binary paths alone. Both stopped being true; it now states the rule (localStorage by default, for first-paint access) and the exception (what moves to the database, and why).

## Test plan

- [ ] Each of the six chords with the sidebar open, on a worktree session and on a plain one.
- [ ] Each of them with the sidebar collapsed to the rail: it expands, then the dialog opens / the rename field appears.
- [ ] `Ctrl+Shift+X` on a pinned card and `Ctrl+Shift+H` on a terminal session: nothing happens, and nothing lands in the PTY.
- [ ] `Ctrl+Shift+B` in a project that is not a git repository: the dialog opens and shows git's error in place.
- [ ] `Ctrl+/` and Settings › Hotkeys list all six plus the Terminal group; rebinding one and resetting it both take effect without a reload.
- [ ] Rename via the chord and via the context menu commit the same way (Enter saves, Escape cancels, blur commits).