### PR TITLE
fix: give a confined session its display socket back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that no longer existed. Closing such a leftover card asked again whether to
   keep or remove the worktree, and removing it failed.
 
+- **The clipboard works in a confined session again.** Copying out of an
+  agent's TUI and attaching an image to it are the agent's own work — Claude
+  Code shells out to `wl-copy`, `wl-paste`, `xclip` and `xsel` for both — and a
+  sandboxed session had no display socket left to reach, so every copy and every
+  paste of a screenshot failed with nothing on screen saying why. The sandbox
+  now hands the session the display server's socket: Wayland where the host has
+  it, X11 with its cookie otherwise. A confined session can read the clipboard
+  as well as write it, which is the trade the clipboard is.
+
 - **ssh no longer fails outright inside a confined session.** Every remote git
   command in a sandboxed session died on `Bad owner or permissions on
   /etc/ssh/ssh_config.d/...`: inside the sandbox's user namespace the

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -106,7 +106,12 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   it and are unaffected. The distribution's `/etc/ssh/ssh_config.d` drop-ins are replaced by an empty
   directory, because inside the namespace they belong to nobody and ssh refuses to read a config file it
   does not own — so a host whose ssh depends on one of them (a corporate `ProxyCommand`, say) does not have
-  it inside the sandbox. macOS has no hardware here — its profile is unit-tested and has never run.
+  it inside the sandbox. The display server's socket *is* mounted, because the agent's own copy and its
+  clipboard image paste shell out to `wl-copy` and `xclip` and both fail without it: a confined session can
+  therefore read whatever you copy, a password manager's paste included. A host without Wayland gets the
+  X11 socket and its cookie instead, the wider of the two — X clients are not isolated from one another —
+  and macOS gets neither, its pasteboard being a mach service rather than a socket, so a confined session
+  there has no clipboard at all. macOS has no hardware here — its profile is unit-tested and has never run.
 - **A symlink in the home is not mounted into the sandbox** (`internal/sandbox`): every path lich binds is
   taken as it is on disk, and a link is skipped — following one would let a dotfile manager point the
   private home at whatever it likes, and binding one fails the spawn outright when a parent directory is

--- a/internal/sandbox/display_linux.go
+++ b/internal/sandbox/display_linux.go
@@ -1,0 +1,101 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// x11SocketDir is where an X server puts the socket for each display it serves.
+const x11SocketDir = "/tmp/.X11-unix"
+
+// displaySockets returns the display server sockets a confined session is given
+// back, and they are there for one thing: the clipboard.
+//
+// Nothing else in this package needs a display. But copying out of an agent's
+// TUI and pasting a screenshot into it are the agent's own work, not the
+// terminal's — Claude Code shells out to wl-copy, wl-paste, xclip and xsel for
+// both — and a private home that empties XDG_RUNTIME_DIR takes the compositor's
+// socket with it, so every one of those tools fails to connect. Copy and image
+// attach are basic terminal behaviour; a session that loses them is not a
+// confined session, it is a broken one. ai-jail, which this sandbox is a port
+// of, hands over the Wayland socket the same way.
+//
+// The cost is the honest one: a session that can reach the clipboard can read
+// whatever the user copied into it, a password manager's paste included, and
+// write it back. That is the trade the clipboard is, and it is written down in
+// docs/ceilings.md.
+//
+// Wayland wins when the host has it, and X11 is the fallback rather than a
+// second mount, because the X socket is the wider hole of the two: X clients
+// are not isolated from one another, so a session given the X socket can watch
+// every other client's input. A host running both (Xwayland) has no need of it.
+func displaySockets(home string) []string {
+	if socket := waylandSocket(); socket != "" {
+		return []string{socket}
+	}
+	return x11Sockets(x11SocketDir, home)
+}
+
+// waylandSocket resolves the compositor's socket from the environment the way
+// the Wayland spec says a client does: an absolute WAYLAND_DISPLAY names the
+// socket outright, and a bare name is one path component under
+// XDG_RUNTIME_DIR. A name with a separator in it is not a name — it is a path
+// escaping the runtime directory — and is refused rather than joined.
+func waylandSocket() string {
+	display := os.Getenv("WAYLAND_DISPLAY")
+	if display == "" {
+		return ""
+	}
+	path := display
+	if !filepath.IsAbs(path) {
+		runtime := os.Getenv("XDG_RUNTIME_DIR")
+		if !filepath.IsAbs(runtime) || strings.ContainsRune(display, filepath.Separator) {
+			return ""
+		}
+		path = filepath.Join(runtime, display)
+	}
+	if !isSocket(path) {
+		return ""
+	}
+	return path
+}
+
+// x11Sockets resolves the X display's socket and the cookie file that
+// authorises a connection to it. Only a local display has a socket to mount:
+// DISPLAY is ":N" or ":N.screen" locally, and anything else names a server
+// reached over TCP, which the sandbox already has (the network is never cut).
+//
+// The cookie is XAUTHORITY when the display manager exported one, and
+// ~/.Xauthority otherwise — inside the home the sandbox is about to empty,
+// which is exactly why it has to be named here. A cookie that is a symlink is
+// dropped by existing() along with every other link, and an X11 session whose
+// cookie is symlinked connects to nothing.
+func x11Sockets(dir, home string) []string {
+	display := os.Getenv("DISPLAY")
+	if !strings.HasPrefix(display, ":") {
+		return nil
+	}
+	number, _, _ := strings.Cut(strings.TrimPrefix(display, ":"), ".")
+	if number == "" {
+		return nil
+	}
+	socket := filepath.Join(dir, "X"+number)
+	if !isSocket(socket) {
+		return nil
+	}
+	cookie := os.Getenv("XAUTHORITY")
+	if !filepath.IsAbs(cookie) {
+		cookie = filepath.Join(home, ".Xauthority")
+	}
+	return []string{socket, cookie}
+}
+
+// isSocket reports whether path is a unix socket on disk, without following a
+// link to get there — the answer decides what gets mounted into the sandbox.
+func isSocket(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode()&os.ModeSocket != 0
+}

--- a/internal/sandbox/display_linux_test.go
+++ b/internal/sandbox/display_linux_test.go
@@ -1,0 +1,166 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// listenSocket puts a real unix socket on disk and returns its path: what
+// displaySockets is asked to recognise, and the one thing a temp file cannot
+// stand in for.
+func listenSocket(t *testing.T, path string) string {
+	t.Helper()
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen on %s: %v", path, err)
+	}
+	t.Cleanup(func() { listener.Close() })
+	return path
+}
+
+// clearDisplayEnv blanks the display variables, so a test answers for what it
+// sets rather than for the desktop session running it.
+func clearDisplayEnv(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{"WAYLAND_DISPLAY", "XDG_RUNTIME_DIR", "DISPLAY", "XAUTHORITY"} {
+		t.Setenv(name, "")
+	}
+}
+
+func TestWaylandSocketUnderTheRuntimeDir(t *testing.T) {
+	clearDisplayEnv(t)
+	runtime := t.TempDir()
+	want := listenSocket(t, filepath.Join(runtime, "wayland-1"))
+	t.Setenv("XDG_RUNTIME_DIR", runtime)
+	t.Setenv("WAYLAND_DISPLAY", "wayland-1")
+
+	if got := waylandSocket(); got != want {
+		t.Errorf("waylandSocket() = %q, want %q", got, want)
+	}
+}
+
+// An absolute WAYLAND_DISPLAY names the socket outright, and the runtime
+// directory is not consulted at all — the Wayland spec allows it and a
+// compositor started by hand uses it.
+func TestWaylandSocketAbsoluteDisplayNeedsNoRuntimeDir(t *testing.T) {
+	clearDisplayEnv(t)
+	want := listenSocket(t, filepath.Join(t.TempDir(), "wl"))
+	t.Setenv("WAYLAND_DISPLAY", want)
+
+	if got := waylandSocket(); got != want {
+		t.Errorf("waylandSocket() = %q, want %q", got, want)
+	}
+}
+
+// A bare display name is one path component. Anything with a separator in it is
+// a path out of the runtime directory, and mounting whatever it reaches is how
+// a display variable turns into a hole.
+func TestWaylandSocketRefusesADisplayNameWithAPath(t *testing.T) {
+	clearDisplayEnv(t)
+	runtime := t.TempDir()
+	escape := filepath.Join(runtime, "elsewhere")
+	if err := os.Mkdir(escape, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	listenSocket(t, filepath.Join(escape, "wayland-1"))
+	t.Setenv("XDG_RUNTIME_DIR", runtime)
+	t.Setenv("WAYLAND_DISPLAY", filepath.Join("elsewhere", "wayland-1"))
+
+	if got := waylandSocket(); got != "" {
+		t.Errorf("waylandSocket() = %q, want nothing: the display name walks out of the runtime directory", got)
+	}
+}
+
+func TestWaylandSocketRefusesWhatIsNotASocket(t *testing.T) {
+	clearDisplayEnv(t)
+	runtime := t.TempDir()
+	if err := os.WriteFile(filepath.Join(runtime, "wayland-1"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_RUNTIME_DIR", runtime)
+	t.Setenv("WAYLAND_DISPLAY", "wayland-1")
+
+	if got := waylandSocket(); got != "" {
+		t.Errorf("waylandSocket() = %q, want nothing: the path is a regular file", got)
+	}
+}
+
+// X11 is the fallback, and it carries the cookie that authorises the
+// connection: without it the socket is mounted and every client is refused.
+func TestX11SocketsCarryTheCookie(t *testing.T) {
+	clearDisplayEnv(t)
+	dir := t.TempDir()
+	socket := listenSocket(t, filepath.Join(dir, "X7"))
+	t.Setenv("DISPLAY", ":7.0")
+	cookie := filepath.Join(t.TempDir(), "Xauthority")
+	t.Setenv("XAUTHORITY", cookie)
+
+	want := []string{socket, cookie}
+	if got := x11Sockets(dir, "/home/u"); !slices.Equal(got, want) {
+		t.Errorf("x11Sockets() = %v, want %v", got, want)
+	}
+}
+
+// Without XAUTHORITY the cookie is the one in the home — which is the home the
+// sandbox empties, so it has to be mounted back by name.
+func TestX11SocketsFallBackToTheCookieInTheHome(t *testing.T) {
+	clearDisplayEnv(t)
+	dir := t.TempDir()
+	socket := listenSocket(t, filepath.Join(dir, "X0"))
+	t.Setenv("DISPLAY", ":0")
+
+	want := []string{socket, filepath.Join("/home/u", ".Xauthority")}
+	if got := x11Sockets(dir, "/home/u"); !slices.Equal(got, want) {
+		t.Errorf("x11Sockets() = %v, want %v", got, want)
+	}
+}
+
+// A DISPLAY naming a host is a server reached over TCP: there is no socket to
+// mount, and the network is not cut, so the session reaches it either way.
+func TestX11SocketsSkipARemoteDisplay(t *testing.T) {
+	clearDisplayEnv(t)
+	dir := t.TempDir()
+	listenSocket(t, filepath.Join(dir, "X0"))
+	t.Setenv("DISPLAY", "somehost:0")
+
+	if got := x11Sockets(dir, "/home/u"); got != nil {
+		t.Errorf("x11Sockets() = %v, want nothing for a remote display", got)
+	}
+}
+
+// Wayland wins on a host running both. The X socket is the wider hole — X
+// clients are not isolated from one another — and Xwayland means the host has
+// one whether it needs it or not.
+func TestDisplaySocketsPreferWayland(t *testing.T) {
+	clearDisplayEnv(t)
+	runtime := t.TempDir()
+	want := listenSocket(t, filepath.Join(runtime, "wayland-1"))
+	t.Setenv("XDG_RUNTIME_DIR", runtime)
+	t.Setenv("WAYLAND_DISPLAY", "wayland-1")
+	t.Setenv("DISPLAY", ":0")
+
+	if got := displaySockets("/home/u"); !slices.Equal(got, []string{want}) {
+		t.Errorf("displaySockets() = %v, want just the Wayland socket %q", got, want)
+	}
+}
+
+// The clipboard is why any of this is mounted, so Describe has to carry it into
+// the spec the backends read — not merely resolve it.
+func TestDescribeMountsTheDisplaySocket(t *testing.T) {
+	clearHarnessEnv(t)
+	clearDisplayEnv(t)
+	runtime := t.TempDir()
+	socket := listenSocket(t, filepath.Join(runtime, "wayland-1"))
+	t.Setenv("XDG_RUNTIME_DIR", runtime)
+	t.Setenv("WAYLAND_DISPLAY", "wayland-1")
+
+	spec := Describe("claude", t.TempDir(), t.TempDir(), "", nil)
+	if !slices.Contains(spec.Read, socket) {
+		t.Errorf("the display socket %q is not in the spec's readable paths %v", socket, spec.Read)
+	}
+}

--- a/internal/sandbox/display_other.go
+++ b/internal/sandbox/display_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package sandbox
+
+// displaySockets answers for the platforms with no X11 or Wayland socket to
+// hand over. macOS reaches its pasteboard through a mach service rather than a
+// socket, so a confined session there has no clipboard at all — see
+// docs/ceilings.md, along with the rest of that profile having never run.
+func displaySockets(string) []string {
+	return nil
+}

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -178,6 +178,11 @@ var readableToolchain = []string{
 // the build caches writable, the toolchain and configuration readable, the
 // checkout writable, and nothing else in the home there at all.
 //
+// The display server's socket is in there too, which is the one thing mounted
+// back that is not about running the project: without it the agent's own copy
+// and its clipboard image paste fail, because both shell out to a tool that has
+// to reach the compositor (displaySockets).
+//
 // extraRead is what the caller knows and this package does not — where the
 // binaries the spawn actually runs live. The provider's own executable and the
 // lich binary (which the session calls back through, and which serves its MCP
@@ -190,7 +195,8 @@ var readableToolchain = []string{
 func Describe(providerID, home, cwd, gitCommon string, extraRead []string) Spec {
 	spec := Spec{Home: home, Cwd: cwd, GitCommon: gitCommon}
 	spec.Write = existing(append(stateDirs(providerID, home), under(home, writableCaches)...))
-	spec.Read = existing(append(under(home, readableToolchain), extraRead...))
+	read := append(under(home, readableToolchain), displaySockets(home)...)
+	spec.Read = existing(append(read, extraRead...))
 	return spec
 }
 


### PR DESCRIPTION
A session on a confined rung had no clipboard. Selecting text in Claude Code and
copying it went nowhere, and pasting a screenshot into any provider attached
nothing — with no error on screen either way.

## Why

Copy and image paste are the *agent's* work, not the terminal's: lich's own
copy-on-select writes the browser clipboard, but a TUI holding the mouse does its
own copying, and Claude Code shells out for it (`wl-copy`, `wl-paste`, `xclip`
and `xsel` all appear in its binary; OSC 52 is not the Linux path). The private
home replaces `XDG_RUNTIME_DIR` with an empty tmpfs, which takes the
compositor's socket with it:

```
$ echo hi | wl-copy          # inside a confined session
Failed to connect to a Wayland server: No such file or directory
$ echo hi | xclip -selection clipboard
Error: Can't open display: :0
```

`ai-jail`, which `internal/sandbox` is a port of, does not take the clipboard
away — it binds the Wayland socket by default, no flag, and gates only X11 behind
one. This is that behaviour, ported.

## What changes

`displaySockets` (Linux; a stub elsewhere) resolves the display server socket and
`Describe` mounts it with the rest of the read-only paths, after the tmpfs that
empties the runtime directory:

- **Wayland** — `WAYLAND_DISPLAY` resolved the way a client resolves it: absolute
  path used outright, bare name joined to `XDG_RUNTIME_DIR`, a name containing a
  separator refused rather than joined, and the result mounted only if it really
  is a socket.
- **X11** — the fallback, not a second mount: `/tmp/.X11-unix/X<N>` from `DISPLAY`
  plus the cookie (`XAUTHORITY`, or `~/.Xauthority`, which lives in the home the
  sandbox empties). A `DISPLAY` naming a host is TCP and mounts nothing.

Wayland wins on a host running both, because the X socket is the wider hole — X
clients are not isolated from one another, and Xwayland means the host has one
whether it needs it or not.

The trade is real and now written down in `docs/ceilings.md`: a session that can
reach the clipboard can read what you copy, a password manager's paste included.

## Test plan

- [x] `go test ./...` — 1690 passed, 9 new: Wayland resolution (runtime dir,
      absolute display, a display name with a path in it, a non-socket), the X11
      fallback and its cookie, a remote `DISPLAY`, Wayland winning over X11, and
      `Describe` actually carrying the socket into the spec.
- [x] `gofmt -l .`, `go vet ./...` clean; cross-compile loop green for linux,
      darwin and windows (OS seam touched).
- [x] End to end through the real `Describe`/`Wrap`, not a hand-rolled bwrap:
      `wl-paste --list-types` inside the confined spawn answered `text/plain`,
      and an `image/png` put on the clipboard read back byte-for-byte from
      inside — which is the image attach path.