### PR TITLE
Correct the backend comments that outlived what they describe

### DIFF
--- a/docs/hooks/session-touched.md
+++ b/docs/hooks/session-touched.md
@@ -61,7 +61,7 @@ refresh reads a tree the tool has not touched yet (see the ceilings).
 ## Known ceilings
 
 - **Poll stays the baseline.** This never replaces the ~3s poll (see the git
-  status ceiling in the repo `CLAUDE.md`); it only front-runs it. Changes from
+  status ceiling in `docs/ceilings.md`); it only front-runs it. Changes from
   outside Claude (a shell session, an external editor) are still caught by the
   poll, not this hook.
 - **No debounce.** A burst of edits fires one POST per tool, each an immediate

--- a/internal/agentplugin/agentplugin_test.go
+++ b/internal/agentplugin/agentplugin_test.go
@@ -707,3 +707,36 @@ func TestHasToolsFollowsThePluginVersionElsewhere(t *testing.T) {
 		})
 	}
 }
+
+// Installed is the question the relay asks before reading a session's silence as
+// an answer (relay.reportsState), so each way of answering "no" has to be its
+// own: a provider with no plugin at all, a CLI this machine does not have, and
+// an installed harness whose plugin was never written.
+func TestInstalledAnswersForEachWayThereIsNoPlugin(t *testing.T) {
+	agent := ompHome(t)
+	s := New(stubBins{})
+	s.lookPath = func(string) (string, error) { return "/usr/bin/omp", nil }
+
+	if s.Installed(providers.OMP) {
+		t.Error("Installed(omp) = true with nothing in its extensions directory")
+	}
+
+	writeMarkedModule(t, filepath.Join(agent, ompExtensionsDir, ompFile), "0.1.0")
+	if !s.Installed(providers.OMP) {
+		t.Error("Installed(omp) = false with the plugin's module in place")
+	}
+	// Written older than toolsMinVersion on purpose: reporting state and carrying
+	// lich's operations are two questions, and only the second weighs a version.
+	if s.HasTools(providers.OMP) {
+		t.Error("HasTools(omp) = true for a plugin older than the release that carries the tools")
+	}
+
+	s.lookPath = func(string) (string, error) { return "", errors.New("not found") }
+	if s.Installed(providers.OMP) {
+		t.Error("Installed(omp) = true on a machine with no omp CLI to run it")
+	}
+
+	if s.Installed("shell") {
+		t.Error(`Installed("shell") = true, but a session kind that is no provider has no plugin`)
+	}
+}

--- a/internal/chromium/chromium.go
+++ b/internal/chromium/chromium.go
@@ -1,7 +1,6 @@
 // Package chromium launches the app window as a system Chromium in --app
 // mode, pointed at the loopback listener that serves the frontend and the
-// RPC/terminal transports — option 1 of docs/chromium-shell.md. Promoted from
-// the cmd/spike skeleton that validated the approach.
+// RPC/terminal transports — option 1 of docs/chromium-shell.md.
 package chromium
 
 import (

--- a/internal/project/gherror_test.go
+++ b/internal/project/gherror_test.go
@@ -137,3 +137,33 @@ func TestErrUnreadableAnswer(t *testing.T) {
 		t.Errorf("errUnreadableAnswer() = %q, want %q", err, want)
 	}
 }
+
+// TestGHFailureCarriesTheMessageAndNotTheStderr walks the wrapper the pull
+// request flows actually call: the error that reaches the screen is ghMessage's
+// sentence, and gh's own words stay behind in the log.
+func TestGHFailureCarriesTheMessageAndNotTheStderr(t *testing.T) {
+	stderr := "GraphQL: Could not resolve to a Repository with the name 'acme/private'. (repository)"
+	err := ghFailure([]string{"pr", "view"}, stderr, errTest, nil)
+	if err == nil {
+		t.Fatal("ghFailure() = nil, want the screen's message")
+	}
+	if want := ghMessage(stderr, errTest, nil); err.Error() != want {
+		t.Errorf("ghFailure() = %q, want %q", err, want)
+	}
+	if strings.Contains(err.Error(), "GraphQL") {
+		t.Errorf("ghFailure() = %q, which carries gh's own words onto the screen", err)
+	}
+}
+
+// A cancelled call is the one failure with nothing on stderr to recognise, and
+// it still has to come back as a sentence rather than as "context deadline
+// exceeded".
+func TestGHFailureAnswersATimeout(t *testing.T) {
+	err := ghFailure([]string{"pr", "merge"}, "", errTest, context.DeadlineExceeded)
+	if err == nil {
+		t.Fatal("ghFailure() = nil, want the screen's message")
+	}
+	if strings.Contains(strings.ToLower(err.Error()), "context") {
+		t.Errorf("ghFailure() = %q, which names Go's own error instead of what happened", err)
+	}
+}

--- a/internal/project/worktree.go
+++ b/internal/project/worktree.go
@@ -228,8 +228,8 @@ func (s *Service) CreateWorktree(projectPath, projectID, name, base string, base
 		return nil, err
 	}
 
-	// The session spawns claude at wtPath immediately after; make sure the
-	// checkout actually works before handing it over.
+	// The session spawns its provider at wtPath immediately after; make sure
+	// the checkout actually works before handing it over.
 	if _, err := runGit(wtPath, "rev-parse", "--is-inside-work-tree"); err != nil {
 		return nil, errors.New("The worktree was created but git does not read it as a checkout.")
 	}

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -1,14 +1,14 @@
 // Package providers is the registry of AI coding CLI harnesses lich can run in
-// a session (Claude Code, Codex, opencode, Crush). A provider id doubles as the
-// session kind that spawns it; the terminal resolves the id to a binary, and the
-// settings store keys per-provider overrides on it. Detection is a PATH scan,
-// mirroring internal/chromium's browser detection.
+// a session (Claude Code, Codex, opencode, oh-my-pi, Crush). A provider id
+// doubles as the session kind that spawns it; the terminal resolves the id to a
+// binary, and the settings store keys per-provider overrides on it. Detection is
+// a PATH scan, mirroring internal/chromium's browser detection.
 package providers
 
 import "os/exec"
 
 // Provider ids. Each id is also the session kind (store column + terminal.Start)
-// that runs the provider. Kept in sync with frontend/src/lib/sessions.ts.
+// that runs the provider. Kept in sync with frontend/src/lib/session/sessions.ts.
 const (
 	Claude   = "claude"
 	Codex    = "codex"
@@ -26,9 +26,10 @@ type Provider struct {
 }
 
 // Registry is every provider lich knows about, in display order. Claude Code is
-// first: it is the default, and the plugin's home. It and Codex are the two
-// wired for resume and for the plugin's reports — the rest just spawn their TUI
-// in a PTY.
+// first: it is the default, and the plugin's home. Every one of them resumes a
+// conversation by id (terminal.resumeArgs) and runs the companion plugin
+// (agentplugin.supported); what still differs per provider is spelled at each
+// of those tables, and AcceptsMCPServer below is the one split this file owns.
 var Registry = []Provider{
 	{ID: Claude, Name: "Claude Code", Binaries: []string{"claude"}},
 	{ID: Codex, Name: "Codex", Binaries: []string{"codex"}},

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -1,7 +1,7 @@
 // Package relay lets one lich session hand a prompt to another and get an
 // answer back, for the providers whose own CLI has no cross-session channel of
-// its own. Claude Code has one; Codex, OpenCode and Crush do not, and this
-// works the same for all four.
+// its own. Claude Code has one; Codex, opencode, oh-my-pi and Crush do not, and
+// this works the same for all five.
 //
 // The delivery is deliberately dumb: lich types the message at the target's
 // prompt and submits it, exactly as the user would. What it never does is read

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -97,8 +97,9 @@ func (s *Service) DeleteProject(id string) error {
 // AddSession inserts a session, makes it the project's active one and records the
 // project's next label counter — all atomically, mirroring the frontend reducer.
 // Kind selects what the session's PTY runs (a provider id or "shell"); empty
-// defaults to "claude" so older callers keep the original behavior. Path is the session's
-// working directory when it lives in a git worktree; empty means the project's.
+// defaults to "claude", which is the schema's own default and the answer for a
+// caller that reached this over RPC without one. Path is the session's working
+// directory when it lives in a git worktree; empty means the project's.
 // The session takes the position after the project's last one, so it appends to
 // the card list even once the user has dragged the others around.
 // sandbox is whether this session runs confined ("on"/"off", empty to follow the
@@ -174,7 +175,7 @@ func (s *Service) DeleteSession(projectID, sessionID, activeID string) error {
 // hides it from LoadState while keeping its row — and its provider session id —
 // intact for a later resume. The project's active session moves to activeID (the
 // neighbor the frontend picked). The keep-the-worktree close uses this; a plain
-// close still DeleteSessions for good.
+// close still calls DeleteSession, which removes it for good.
 func (s *Service) CloseSession(projectID, sessionID, activeID string) error {
 	return s.tx(func(tx *sql.Tx) error {
 		if _, err := tx.Exec(`UPDATE sessions SET is_open = 0 WHERE id = ?`, sessionID); err != nil {
@@ -187,10 +188,11 @@ func (s *Service) CloseSession(projectID, sessionID, activeID string) error {
 // ReopenWorktreeSession resumes a parked worktree session. It finds the parked
 // (is_open = 0) session for the worktree at path and re-adds it to the workspace
 // under a fresh id (newSessionID), carrying over the old label, kind, provider
-// session id, label_auto flag, model, entrypoint and origin. The fresh id is deliberate: it makes the frontend treat the card
-// as never-spawned, so its resume prompt fires and the provider conversation
-// continues instead of starting cold. Returns nil when nothing is parked at path
-// — the caller then opens a brand-new session.
+// session id, label_auto flag, model, entrypoint and origin. The fresh id is
+// deliberate: it makes the frontend treat the card as never-spawned, so its
+// resume prompt fires and the provider conversation continues instead of
+// starting cold. Returns nil when nothing is parked at path — the caller then
+// opens a brand-new session.
 func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*Session, error) {
 	var restored *Session
 	err := s.tx(func(tx *sql.Tx) error {

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -159,12 +159,11 @@ type session struct {
 // Store is the persistence the terminal service depends on: the binary to spawn
 // for a provider in a project (empty return spawns the provider's default),
 // whether that spawn drops the provider's permission prompts and whether it runs
-// confined,
-// that project's own directory, the dev-server port reserved for each checkout,
-// where to record the provider session id a PTY reports through its
-// session-start hook, and the running cost
-// accounting behind the footer readout (CostReadout gates it — off, none of the
-// rest is called). The store implements them all.
+// confined, that project's own directory, the dev-server port reserved for each
+// checkout, where to record the provider session id a PTY reports through its
+// session-start hook, and the running cost accounting behind the footer readout
+// (CostReadout gates it — off, none of the rest is called). The store implements
+// them all.
 type Store interface {
 	ProviderBin(providerID, projectID string) string
 	SkipPermissions(providerID, projectID, cwd string) bool
@@ -389,7 +388,7 @@ func (s *Service) SetRestart(fn func() error) {
 
 // sessionEnv is the environment for one PTY: the shared base, the project this
 // session belongs to, the dev-server port its checkout owns, and the loopback
-// coordinates a Claude Code hook needs to report this session's status back to
+// coordinates a provider's hook needs to report this session's status back to
 // lich. All of it is per-session, so this returns a fresh slice rather than
 // aliasing (and appending to) the shared s.env.
 //
@@ -444,8 +443,8 @@ const readBufSize = 32 * 1024
 // shell when kind is "shell", otherwise the provider binary for that kind
 // resolved from the project's settings (falling back to the provider's default
 // on $PATH) — attached to a new PTY sized to cols x rows and rooted at cwd, then
-// streams its output to the frontend. An empty cwd defaults to the user's home directory. Starting a
-// session that is already running is a no-op.
+// streams its output to the frontend. An empty cwd defaults to the user's home
+// directory. Starting a session that is already running is a no-op.
 //
 // A non-empty resume is a provider conversation id to reopen, spelled for the
 // session's kind by resumeArgs, which the frontend passes after the user
@@ -460,10 +459,11 @@ const readBufSize = 32 * 1024
 // the user sees. Only Claude Code has a roster; every other kind ignores it.
 //
 // setup is passed once, by the flow that just created this session's worktree:
-// it runs the project's worktree setup script (Settings › Project) in the PTY
-// before the provider, so a fresh checkout installs its dependencies in view.
-// A respawn or resume never sets it. The script runs in the session's own
-// environment, so it reads the same LICH_WORKTREE_PORT the provider will.
+// it runs the project's worktree setup script (.lich/setup-worktree.sh, see
+// project.SetupScript) in the PTY before the provider, so a fresh checkout
+// installs its dependencies in view. A respawn or resume never sets it. The
+// script runs in the session's own environment, so it reads the same
+// LICH_WORKTREE_PORT the provider will.
 func (s *Service) Start(id, projectID, cwd, kind, resume, name string, setup bool, cols, rows int) error {
 	sess, cwd, err := s.spawnSession(id, projectID, cwd, kind, resume, name, setup, cols, rows)
 	if err != nil || sess == nil {

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -41,13 +41,14 @@ const (
 	wsReadLimit = 1 << 20
 	// tokenBytes is the size of the random connect token.
 	tokenBytes = 16
-	// hookBodyLimit bounds a status POST from the Claude Code hook; the payload
-	// is a tiny JSON object, so anything larger is malformed or hostile.
+	// hookBodyLimit bounds a status POST from a provider's hook; the payload is
+	// a tiny JSON object, so anything larger is malformed or hostile.
 	hookBodyLimit = 4 << 10
-	// These are the only session states the hook may report: busy while Claude
-	// is producing output, done when its turn finishes, waiting when Claude is
-	// blocked on the user (permission prompt or idle input, from Notification),
-	// and idle when the session ends (from SessionEnd) — idle clears the card's
+	// These are the only session states a hook may report, in every provider's
+	// spelling (docs/hooks/session-state.md maps each one's own events onto
+	// them): busy while the agent is producing output, done when its turn
+	// finishes, waiting when it is blocked on the user (a permission prompt, or
+	// an idle prompt), and idle when the session ends — idle clears the card's
 	// indicator so a stale spinner/check does not linger past a session or a
 	// /clear.
 	statusBusy    = "busy"
@@ -506,9 +507,9 @@ type titleRequest struct {
 	Title     string `json:"title"`
 }
 
-// sessionTitle receives the ai-title POST from the Claude Code hook and applies
-// it as the session's label via the setTitle callback, which no-ops when the
-// user has renamed the session.
+// sessionTitle receives the title POST from a provider's hook and applies it as
+// the session's label via the setTitle callback, which no-ops when the user has
+// renamed the session.
 func (t *transport) sessionTitle(w http.ResponseWriter, r *http.Request) {
 	servePost(t, w, r, parseSessionTitle, func(req titleRequest) error {
 		if t.setTitle == nil {
@@ -543,7 +544,7 @@ type touchedRequest struct {
 	SessionID string `json:"session_id"`
 }
 
-// sessionTouched receives a POST from the Claude Code hook when a session likely
+// sessionTouched receives a POST from a provider's hook when a session likely
 // changed files on disk (a file-mutating tool ran) and forwards the session id
 // via the touched callback, which nudges an immediate git-status refresh. It is
 // a best-effort latency optimization over the frontend's steady poll, so a

--- a/internal/terminal/usage_claude.go
+++ b/internal/terminal/usage_claude.go
@@ -89,8 +89,9 @@ func readTail(path string, max int64) ([]byte, bool) {
 // parseContextUsage pulls context-window occupancy from a transcript tail: the
 // newest main-thread assistant line's token usage. The context side is input +
 // cache-read + cache-creation (output is the reply, not context loaded); percent
-// is that against the line's model window (see windowForModel), capped at 100. false when the tail holds
-// no such line — a fresh conversation, or a tail of only user turns. Sidechain
+// is that against the line's model window (see windowForModel), capped at 100.
+// false when the tail holds no such line — a fresh conversation, or a tail of
+// only user turns. Sidechain
 // lines (a Task sub-agent's own conversation, written into the same transcript)
 // are skipped: their context is the sub-agent's, not the window the user sees. A
 // leading partial line (the tail was cut mid-line) fails to parse and is skipped


### PR DESCRIPTION
A sweep of every comment in the Go backend — 5 864 comment lines across 132 non-test files — checked against the code each one sits on: cited paths, cited symbols, provider counts, ceiling numbers. Most held. These did not.

## What was stale

| Comment | Said | Says now |
|---|---|---|
| `internal/providers/providers.go:2` | "(Claude Code, Codex, opencode, Crush)" | oh-my-pi is in the `Registry` right below it |
| `internal/providers/providers.go:28` | Claude Code and Codex are "the two wired for resume and for the plugin's reports — the rest just spawn their TUI in a PTY" | all five resume by id (`terminal.resumeArgs`) and all five run the plugin (`agentplugin.supported`); the comment points at those tables rather than restating a split that moved |
| `internal/providers/providers.go:11` | in sync with `frontend/src/lib/sessions.ts` | the file is `frontend/src/lib/session/sessions.ts` |
| `internal/relay/relay.go:3` | "works the same for all four" | five |
| `internal/terminal/terminal.go:463` | setup script lives in "Settings › Project" | `.lich/setup-worktree.sh` (`project.SetupScript`) — that pane is gone |
| `internal/terminal/transport.go:44,47,509,546` + `terminal.go:392` | the hook endpoints belong to "the Claude Code hook", "busy while Claude is producing output" | a provider's hook; the state table names `docs/hooks/session-state.md`, which maps each harness's own events onto these four |
| `internal/chromium/chromium.go:3` | "Promoted from the cmd/spike skeleton" | `cmd/` is empty and untracked |
| `internal/project/worktree.go:231` | "The session spawns claude at wtPath" | its provider |
| `internal/store/mutations.go:177` | "a plain close still DeleteSessions" | `DeleteSession` — the plural is not a symbol anywhere |
| `internal/store/mutations.go:100` | the empty-kind default is there "so older callers keep the original behavior" | no caller passes an empty kind; it is the schema's default and the RPC boundary |
| `docs/hooks/session-touched.md:64` | git-status ceiling is "in the repo `CLAUDE.md`" | `docs/ceilings.md:44` |

Three doc comments were also re-wrapped where successive edits left a 126-column line mid-sentence (`terminal.go` `Store` and `Start`, `mutations.go` `ReopenWorktreeSession`, `usage_claude.go` `parseContextUsage`).

## Two coverage gaps in the same pass

Both on functions whose failure is silent, both measured at 0% with `-coverpkg=./...`:

- **`agentplugin.Installed`** had no test at all. It is what `relay.reportsState` asks before reading a session's silence as an answer, so a wrong `true` turns "nothing read this task" into an errand that expires an hour later saying nothing. Each way of answering no is pinned now — no plugin written, no CLI on the machine, a kind that is no provider — plus the positive, plus the fact that reporting state and carrying lich's tools are two questions (a 0.1.0 plugin reports and has no tools).
- **`project.ghFailure`** had none either: `ghMessage` was covered by a table, the wrapper that logs gh's own words and returns only the sentence was not.

Mutation-checked: `return installed || true` fails the new test on its first assertion.

## What was deliberately not touched

- `spawn.Open` (86 code lines), `main` (70), `relay.Observe` (65) are over the repo's own 50-line rule and are essential complexity — linear sequences, nesting ≤3, guard clauses. Reported, not refactored.
- Three copies of `ompAgentDir` (`terminal/transcript.go`, `agentplugin/omp.go`, `sandbox/sandbox.go`): the comments say each package resolving its own harness paths is the point.
- `transport.startRequest.LegacyClaudeSessionID`: its comment says to drop it "once the install gate can no longer meet an older plugin", and no such gate exists — a call for the owner, not for a comment sweep.

Every ceiling comment in the backend was checked against the code it bounds (`searchTailBytes`, `usageTailBytes`, the unpaged `last:50/50/100/50` conversation query, `first:100` assignable users, `tokenFor`'s uncached `gh auth token`, the fixed terminal-editor list, the bwrap ssh drop-ins). All still true — none removed.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` — 1693 passing across 32 packages
- [x] `for os in linux darwin windows` build + vet loop clean
- [x] `agentplugin.Installed` and `project.ghFailure` both 0% → 100%