### PR TITLE
chore: cut v0.38.0, and bring the READMEs back level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.0] - 2026-08-19
+
 ### Added
 
 - **Six more keyboard shortcuts, all aimed at the session sidebar.**
@@ -2955,7 +2957,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.37.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.38.0...HEAD
+[0.38.0]: https://github.com/omartelo/lich/compare/v0.37.0...v0.38.0
 [0.37.0]: https://github.com/omartelo/lich/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/omartelo/lich/compare/v0.35.1...v0.36.0
 [0.35.1]: https://github.com/omartelo/lich/compare/v0.35.0...v0.35.1

--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ lich lets you:
   first-class. Point lich at each binary once, then pick the default or choose
   per session.
 - **Keep a real terminal.** PTY-backed shells, several per project, rendered on
-  the GPU — searchable scrollback that survives a full page reload. The footer
-  follows `cd` and names the branch — and, for a Claude session, the model, the
-  context window in use and, if you ask, what the session has spent.
+  the GPU — searchable scrollback that survives a full page reload. Give one an
+  entrypoint — `lazygit`, `k9s`, `pnpm dev` — and it opens straight into that
+  tool every time. The footer follows `cd` and names the branch — and, for a
+  Claude Code or Codex session, the model, the context window in use and how
+  much of your plan's rolling window is left; for Claude Code, if you ask, what
+  the session has spent.
 - **Put one session to work for another.** Hand a task to another card and its
   own agent writes the answer back, whatever runs in either end: the agent
   reaches the other sessions through tools handed at spawn — MCP for Claude
@@ -48,6 +51,13 @@ lich lets you:
   branch and lich seeds it with your gitignored `.env*` files, hands it a
   dev-server port no other checkout and no process on the machine is using, and
   runs your per-project setup script before the agent starts.
+- **Run a session confined.** An agent can open inside an OS sandbox: a fresh
+  empty home holding only that provider's own state, the rest of the machine
+  read-only, and write access to the checkout it was opened for. Your ssh keys,
+  your cloud credentials and every other repository on the disk are simply not
+  there — the counterweight to letting an agent skip permission prompts. Linux
+  runs bubblewrap and macOS `sandbox-exec`; it is not a boundary against hostile
+  code, and [`docs/ceilings.md`](docs/ceilings.md) says what it does not stop.
 - **Review the diff where you read it.** A CodeMirror dock shows the working
   changes beside a live file tree. Right-click a selection to comment against
   those lines; the batch is pasted into the session as a single prompt, unsent.
@@ -109,9 +119,17 @@ window. Upgrading from the old formula needs `brew uninstall lich` first —
 - **Providers** — set each provider's binary path and the global default in
   Global Settings › Providers. Project Settings › Providers can override that
   choice for one project; **Use default** removes the override, so later changes
-  to the global default flow through automatically. Claude Code's section also
-  holds the footer's context ring and its cost readout — the cost one off by
-  default, since the figure only means something when you are billed per token.
+  to the global default flow through automatically. The Claude Code and Codex
+  sections open with how much of your plan is left and carry the ladder for what
+  the footer says about a session — the context ring, plus the cost readout for
+  Claude Code, that last rung off by default since the figure only means
+  something when you are billed per token.
+- **Sandbox** — a **Sandbox** ladder sits beside the permission one in each
+  provider's section: Off, Ask each time, Worktrees only, Everywhere. It is per
+  provider, a project can set its own, and the New worktree dialog's **Run
+  confined** box overrides the rung for that session alone — every later spawn
+  of it included. Linux needs bubblewrap and macOS `sandbox-exec`; the control
+  is absent on a machine with neither, and on Windows.
 - **Worktrees** — `.lich/setup-worktree.sh` in the project checkout runs in a
   new worktree's terminal ahead of the agent; the New worktree dialog shows it
   and offers a detected suggestion when the repo ships none. A

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -36,8 +36,10 @@
   oh-my-pi 和 [Crush](https://github.com/charmbracelet/crush) 都是一等公民。把 lich
   指向各自的二进制文件，这只需一次，之后选一个默认的，或者逐个会话单独指定。
 - **留住一个真正的终端。** 由 PTY 支撑的 shell，每个项目可以开好几个，在 GPU 上渲染
-  —— 滚动缓冲区可以搜索，还能挺过整页刷新。底栏跟随 `cd` 并标明分支 —— 对于 Claude
-  会话，还有模型、已占用的上下文窗口，以及 —— 如果你要求的话 —— 这个会话花了多少钱。
+  —— 滚动缓冲区可以搜索，还能挺过整页刷新。给其中一个设一个入口命令 —— `lazygit`、
+  `k9s`、`pnpm dev` —— 它每次启动都会直接进到那个工具里。底栏跟随 `cd` 并标明分支
+  —— 对于 Claude Code 或 Codex 会话，还有模型、已占用的上下文窗口，以及你的套餐额度
+  还剩多少；Claude Code 会话还能 —— 如果你要求的话 —— 显示它花了多少钱。
 - **让一个会话为另一个干活。** 把任务交给另一张卡片，答案由它自己的智能体写回来，两端
   各跑着什么都不影响：智能体通过启动时交予的工具够到其他会话 —— Claude Code 和 Codex
   走 MCP —— 其余的随插件获得。这整套能力同时也是任何 shell 里的 `lich` 命令，`--json`
@@ -46,6 +48,11 @@
 - **免去配置地分出一个 worktree。** 从任意基础分支开一个，lich 会把你被 gitignore 掉的
   `.env*` 文件播种进去，派给它一个既不与其他检出目录重合、也没被机器上任何进程占用的
   开发服务器端口，并在智能体启动前跑一遍按项目配置的初始化脚本。
+- **让会话在沙箱里运行。** 一个智能体可以开在操作系统的沙箱里：一个只装着该 provider
+  自身状态的空白 home，机器的其余部分只读，只有它被打开时所在的那个检出目录可写。你的
+  ssh 密钥、你的云凭据以及磁盘上其他所有仓库，在里面根本不存在 —— 这正是放手让智能体
+  跳过权限确认的那一头的配重。Linux 用 bubblewrap，macOS 用 `sandbox-exec`；它不是
+  针对恶意代码的边界，[`docs/ceilings.md`](docs/ceilings.md) 写明了它挡不住什么。
 - **在读 diff 的地方审查它。** 一个 CodeMirror 面板在实时文件树旁展示工作区改动。右键
   选中的内容就能针对这些行写评论；整批评论会作为一条 prompt 粘贴进会话，但不发送。
 - **在这里把 Pull Request 送到终点。** 列出仓库开启的 Pull Request，把其中一个检出到
@@ -99,15 +106,25 @@ Homebrew 安装可以绕开 Gatekeeper 的提示；从 Releases 页面下载的�
 - **智能体** —— 在全局设置 › Providers 里为每个 provider 设定二进制文件路径，并选定
   全局默认。项目设置 › Providers 可以为单个项目覆盖这个选择；**Use default** 会移除
   这层覆盖，之后全局默认的变化便会自动流过来。
-  Claude Code 那一节还管着底栏的上下文圆环和费用读数 —— 费用默认关闭，因为只有当你按
+  Claude Code 和 Codex 两节的开头是你的套餐还剩多少，往下是底栏会说些什么的那一档梯子
+  —— 上下文圆环，以及 Claude Code 才有的费用读数；费用那一档默认关闭，因为只有当你按
   token 计费时这个数字才有意义。
+- **沙箱** —— 每个 provider 那一节里，权限梯子旁边还有一条 **Sandbox** 梯子：Off、
+  Ask each time、Worktrees only、Everywhere。它按 provider 生效，项目可以设自己的一
+  档，而 New worktree 对话框里的 **Run confined** 复选框只为那一个会话覆盖这一档 ——
+  连同它此后每一次重新启动。Linux 需要 bubblewrap，macOS 需要 `sandbox-exec`；两者都
+  没有的机器上，以及 Windows 上，这个控件不会出现。
 - **Worktree** —— 项目仓库里的 `.lich/setup-worktree.sh` 会在新 worktree 的终端里
   先于智能体运行；New worktree 对话框会展示这个脚本，若仓库没有则给出检测到的建议。
   `.worktreeinclude` 文件用来调整哪些被 gitignore 的文件会被复制过去。
 - **版本控制** —— 一个项目可以指定 `gh` 以哪个 GitHub 账号运行（设置 › Version
   Control），用于只有你其中一个账号看得见的仓库。它管的是 lich 从 GitHub 读到什么，
   而不是 git 推送时用谁的身份。
-- **外观与快捷键** —— 主题、字体和组合键都在设置里；你选定的主题持久化在工作区数据库里，
+- **快捷键** —— `Ctrl`/`Cmd`+`/` 列出 lich 绑定的每一个快捷键，重新绑定则在设置 ›
+  Hotkeys 里：按下你想要的组合键就会存下来，也可以把某一行重置回 lich 的默认值。两个动
+  作可以持有同一个组合键，撞上的行会自己说明。重绑存在页面的 `localStorage` 里，所以清
+  掉 lich 的 Chromium 配置目录会把它们一并带走。
+- **外观** —— 主题和字体都在设置里；你选定的主题持久化在工作区数据库里，
   其余 UI 偏好以 `lich.*` 为键持久化在 `localStorage`（位于 lich 的 Chromium 配置目录
   `~/.config/lich/chromium-profile`），导入的主题则以 JSON 存在 `<config-dir>/lich/themes` 下。
 - **工作区** —— 项目和会话持久化在 SQLite 里，路径为 `<config-dir>/lich/lich.db`。


### PR DESCRIPTION
Two commits: the READMEs catch up with three releases they missed, then v0.38.0 is cut.

## The READMEs were two versions behind

Nothing here is a new claim — each one is checked against the code it describes.

- **The sandbox was missing entirely.** v0.36.0's flagship — a session that opens inside an OS sandbox — had no line in either README, neither in "Why lich" nor under Configuration, while three of its own fixes ship in this very release. Both files carry it now, including what it is *not*: `docs/ceilings.md` is linked rather than restated.
- **The footer readout said "for a Claude session".** v0.37.0 gave Codex its model and context and v0.36.0 put plan usage beside them, so the line named one provider where there are two and omitted the reading most worth having. The Providers bullet had the same split wrong: the readout ladder belongs to Claude Code *and* Codex, and only the cost rung is Claude Code's alone (`ProviderBinSettings.tsx` renders the ladder for both and filters `cost` for Codex).
- **A terminal's entrypoint** (v0.36.0) went unmentioned, in the bullet that promises a real terminal.
- **`README.zh-CN.md` never got the Hotkeys/Appearance split from #323**, so the two files had drifted apart on top of both being stale. They are level again, bullet for bullet.

## v0.38.0

Ten commits since v0.37.0, nine user-facing, all already in `[Unreleased]` — the cut moves them under a `0.38.0` heading and refreshes the compare links. Minor rather than patch: two of them add behaviour.

- Added: the session card's actions bound to shortcuts (#323), and `Ctrl+F` documented
- Changed: the command palette led by the sessions holding a turn (#321)
- Fixed: worktree removal taking every session in it off the sidebar (#322); a tool name that overflowed its card (#329); the clipboard (#324), ssh (#320) and a dropped or attached file (#328) inside a confined session; a refused pull request checkout saying why (#327); Codex context following the session's configured window (#319)

The tenth (#325) is comment-only and correctly carries no entry.

Rebased on `main` twice as #327, #328 and #329 merged, so all three land in this cut rather than in the next one. None of them touches a claim either README makes.

Verified the release workflow's own `awk` extracts the section: 85 lines, 10 entries, non-empty, and `docs/media/og.png` is where the banner check expects it.

## Gate

`gofmt -l .` clean · `go vet ./...` clean · `pnpm check` clean · `go test -race ./...` green · `pnpm test` 1025 passed / 88 files · `pnpm build` succeeds. Re-run on the rebased branch, not carried over from before it.

No `CHANGELOG.md` entry for the README commit: it documents what already shipped, matching how #325 was handled.

The `v0.38.0` tag is deliberately **not** pushed — every prior tag sits on a `chore: cut` commit already on `main`, so it goes up after this merges.