### PR TITLE
fix: say why a pull request checkout was refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A pull request that will not check out says why.** Opening a session on a
+  pull request runs `gh pr checkout`, which shells out to git — and when git's
+  ssh key was refused, all the screen said was that gh had failed and the log
+  had the rest. The reason now reaches the screen the same way it already did
+  for lich's own git calls, including the case behind most of them: a key whose
+  passphrase nothing can be typed into, because lich runs from a desktop
+  launcher and has no terminal to ask in. Load it with `ssh-add` and the
+  checkout goes through.
+
 - **Removing a worktree takes every session in it off the sidebar.** With more
   than one session open in the same checkout — after merging its pull request,
   say — only one card went away and the others stayed behind on a directory

--- a/internal/project/gherror.go
+++ b/internal/project/gherror.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"strings"
 )
 
 // ghFailure turns one failed gh call into the message the screen shows. See
@@ -92,6 +93,17 @@ func ghMessage(stderr string, runErr, ctxErr error) string {
 	}
 	if message, ok := matchFailure(ghFailures, stderr); ok {
 		return message
+	}
+	// gh runs git itself for the checkout flow and hands git's stderr up whole
+	// under its own "failed to run git" line. That failure is git's, so it reads
+	// off git's table — an ssh key the remote refuses is the same cause whether
+	// lich ran git or gh did. Gated on the marker rather than tried on every
+	// stderr: gh has wordings of its own ("a pull request ... already exists")
+	// that git's table would answer for, wrongly.
+	if strings.Contains(strings.ToLower(stderr), "failed to run git") {
+		if message, ok := matchFailure(gitFailures, stderr); ok {
+			return message
+		}
 	}
 	return "gh could not complete the request. lich's log has what it reported."
 }

--- a/internal/project/gherror_test.go
+++ b/internal/project/gherror_test.go
@@ -78,6 +78,26 @@ func TestGHMessage(t *testing.T) {
 			errTest, nil,
 			"A ruleset on the base branch refused this merge — GitHub named the rules it broke; lich's log has them.",
 		},
+		// `gh pr checkout` shells out to git, so the failure a person meets is
+		// git's with a gh line wrapped round it. It has to read as the cause,
+		// not as "look in the log".
+		{
+			"an ssh key git refused under gh",
+			"ssh_askpass: exec(/usr/lib/ssh/ssh-askpass): No such file or directory\r\n" +
+				"git@github.com: Permission denied (publickey).\n" +
+				"fatal: Could not read from remote repository.\nfailed to run git: exit status 128",
+			errTest, nil,
+			"That remote's ssh key needs a passphrase, and lich has no terminal to ask for it. " +
+				"Load the key with `ssh-add` in a terminal, then try again.",
+		},
+		// gh's own wordings must never reach git's table: git reads "already
+		// exists" as a branch name collision, which this is not.
+		{
+			"a pull request that already exists stays gh's failure",
+			"a pull request for branch \"fix/poll\" into branch \"main\" already exists",
+			errTest, nil,
+			"gh could not complete the request. lich's log has what it reported.",
+		},
 		{
 			"gh missing, reported by exec",
 			"", &exec.Error{Name: "gh", Err: exec.ErrNotFound}, nil,

--- a/internal/project/giterror.go
+++ b/internal/project/giterror.go
@@ -24,6 +24,16 @@ var gitFailures = []toolFailure{
 	{"is locked", "git has that worktree locked."},
 	{"is not a working tree", "git no longer knows that worktree — it may already be gone."},
 	{"couldn't find remote ref", "That branch is no longer on the remote."},
+	// ssh reaches for an askpass helper when the key it picked wants a
+	// passphrase and there is no tty to type it into — which is every call lich
+	// makes, GUI-launched and never attached to a terminal. Matched ahead of the
+	// publickey line below because ssh prints both, and only this one names the
+	// thing the person can fix.
+	{
+		"ssh_askpass",
+		"That remote's ssh key needs a passphrase, and lich has no terminal to ask for it. " +
+			"Load the key with `ssh-add` in a terminal, then try again.",
+	},
 	{"could not read from remote repository", "The remote refused the connection — check its ssh key or credentials."},
 	{"authentication failed", "The remote refused the connection — check its ssh key or credentials."},
 	{"permission denied (publickey)", "The remote refused the connection — check its ssh key or credentials."},

--- a/internal/project/giterror_test.go
+++ b/internal/project/giterror_test.go
@@ -38,6 +38,14 @@ func TestGitMessage(t *testing.T) {
 			"That worktree has uncommitted changes. Remove it from the sidebar to discard them.",
 		},
 		{
+			"a key whose passphrase nothing can be typed into",
+			"ssh_askpass: exec(/usr/lib/ssh/ssh-askpass): No such file or directory\r\n" +
+				"git@github.com: Permission denied (publickey).\nfatal: Could not read from remote repository.",
+			errTest,
+			"That remote's ssh key needs a passphrase, and lich has no terminal to ask for it. " +
+				"Load the key with `ssh-add` in a terminal, then try again.",
+		},
+		{
 			"a remote that rejected the key",
 			"git@github.com: Permission denied (publickey).\nfatal: Could not read from remote repository.",
 			errTest,


### PR DESCRIPTION
Opening a session on a pull request runs `gh pr checkout`, which shells out to git. When git's ssh key was refused, the screen said `gh could not complete the request. lich's log has what it reported.` — the reader had to open the log to find `Permission denied (publickey)`.

`gitFailures` already translates that. `ghMessage` never consulted it.

## What changed

- `ghMessage` falls through to `gitFailures` when gh's stderr carries its own `failed to run git` marker. Gated on the marker rather than tried on every stderr: gh has wordings git's table would answer for, wrongly — `a pull request ... already exists` would come back as "A branch or worktree with that name already exists."
- New `gitFailures` entry ahead of the publickey lines: `ssh_askpass`. ssh reaches for an askpass helper when the key it picked wants a passphrase and there is no tty to type it into — which is every call lich makes, GUI-launched and never attached to a terminal. ssh prints both lines, and only this one names the thing the person can fix.

Found from a real log: a checkout of PR #41 on a repo whose remote key carries a passphrase, against a `/usr/lib/ssh/ssh-askpass` that Arch does not ship.

## Test plan

- [x] `TestGitMessage` gains the askpass case; `TestGHMessage` gains both the git-under-gh case and the gh-wording-stays-gh guard. Red before the change (4 failures), green after.
- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` clean.
- [x] Manual: `ssh-add` the key, open a session on a PR whose remote needs it.

No frontend, no OS seam.