### PR TITLE
fix: give a confined session the files dropped on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   launcher and has no terminal to ask in. Load it with `ssh-add` and the
   checkout goes through.
 
+- **Dropping a file on a confined session's terminal works again.** A file
+  dragged onto a sandboxed terminal pasted the path it has on your machine —
+  and that session's home is an empty private one, so the agent opened nothing
+  and said the file did not exist. lich now attaches a copy instead for anything
+  outside the session's checkout, and mounts it read-only where the agent can
+  read it. The copy is the agent's to read, not to edit: changes land on the
+  copy, not on your file. It is deleted when the session closes, and a dropped
+  *folder* from outside the checkout is still refused — there is nothing to copy
+  a directory into.
+
 - **Removing a worktree takes every session in it off the sidebar.** With more
   than one session open in the same checkout — after merging its pull request,
   say — only one card went away and the others stayed behind on a directory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,15 +43,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   launcher and has no terminal to ask in. Load it with `ssh-add` and the
   checkout goes through.
 
-- **Dropping a file on a confined session's terminal works again.** A file
-  dragged onto a sandboxed terminal pasted the path it has on your machine —
-  and that session's home is an empty private one, so the agent opened nothing
-  and said the file did not exist. lich now attaches a copy instead for anything
-  outside the session's checkout, and mounts it read-only where the agent can
-  read it. The copy is the agent's to read, not to edit: changes land on the
-  copy, not on your file. It is deleted when the session closes, and a dropped
-  *folder* from outside the checkout is still refused — there is nothing to copy
-  a directory into.
+- **Handing a file to a confined session works again, dropped or attached.** A
+  file dragged onto a sandboxed terminal — or chosen through the footer's attach
+  button — pasted the path it has on your machine, and that session's home is an
+  empty private one, so the agent opened nothing and said the file did not
+  exist. lich now attaches a copy instead for anything outside the session's
+  checkout, and mounts it read-only where the agent can read it. The copy is the
+  agent's to read, not to edit: changes land on the copy, not on your file. It is
+  deleted when the session closes, and a *folder* from outside the checkout is
+  still refused — there is nothing to copy a directory into. An attached path is
+  now quoted too, so a file whose name has a space in it stops arriving at the
+  prompt as two.
 
 - **Removing a worktree takes every session in it off the sidebar.** With more
   than one session open in the same checkout — after merging its pull request,

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -119,6 +119,16 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   X11 socket and its cookie instead, the wider of the two — X clients are not isolated from one another —
   and macOS gets neither, its pasteboard being a mach service rather than a socket, so a confined session
   there has no clipboard at all. macOS has no hardware here — its profile is unit-tested and has never run.
+- **A file dropped on a confined session arrives as a copy** (`internal/drop`): the session's home is empty,
+  so lich does not look there for a dropped file at all — anything outside its checkout is copied and the
+  copy's path is what lands at the prompt. The agent may read it and not write back: an edit lands on the
+  copy, the user's own file is untouched, and nothing on screen distinguishes the two paths afterwards. A
+  dropped *folder* from outside the checkout yields nothing, there being no copy to make of a tree. The
+  copies live one directory per session and only that session's directory is mounted, so one confined
+  session cannot read what was dropped into the one beside it; the directory goes when the session's row is
+  deleted (parking a worktree session keeps it, as a resume still wants those paths). A lich that dies
+  without deleting a row leaves copies behind, and the three-day age rule is what clears them — which also
+  means a copy is the one part of a confined session that outlives the sandbox.
 - **A symlink in the home is not mounted into the sandbox** (`internal/sandbox`): every path lich binds is
   taken as it is on disk, and a link is skipped — following one would let a dotfile manager point the
   private home at whatever it likes, and binding one fails the spawn outright when a parent directory is

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -106,7 +106,9 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   Linux, a path policy on macOS, and nothing else — no seccomp filter, no Landlock ruleset. The network is
   never cut (the agent needs its API and the plugin's hooks report over loopback), so anything readable
   inside is exfiltrable, and `~/.config` *is* readable: a token stored there, `gh`'s among them, is in
-  reach. The private home is writable and vanishes with the session, so a dotfile an agent writes is gone
+  reach. Every session also carries `LICH_TOKEN`, so a confined agent can call lich's own RPC over
+  loopback: a method that reads a host path it was *handed* would copy anything into reach of the sandbox,
+  which is why the attach flow opens the picker inside the backend (`drop.Attach`) instead of taking a path. The private home is writable and vanishes with the session, so a dotfile an agent writes is gone
   next spawn with nothing saying so. On Ubuntu and Debian the kernel may refuse the user namespace outright
   (an AppArmor policy), which surfaces as bubblewrap's own error in the card and no session. `~/.ssh` is not
   mounted at all: a push over ssh from inside a confined session fails, and lich's own PR flows run outside
@@ -119,9 +121,9 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   X11 socket and its cookie instead, the wider of the two — X clients are not isolated from one another —
   and macOS gets neither, its pasteboard being a mach service rather than a socket, so a confined session
   there has no clipboard at all. macOS has no hardware here — its profile is unit-tested and has never run.
-- **A file dropped on a confined session arrives as a copy** (`internal/drop`): the session's home is empty,
+- **A file handed to a confined session arrives as a copy** (`internal/drop`): the session's home is empty,
   so lich does not look there for a dropped file at all — anything outside its checkout is copied and the
-  copy's path is what lands at the prompt. The agent may read it and not write back: an edit lands on the
+  copy's path is what lands at the prompt, for a drag and for the footer's attach button alike. The agent may read it and not write back: an edit lands on the
   copy, the user's own file is untouched, and nothing on screen distinguishes the two paths afterwards. A
   dropped *folder* from outside the checkout yields nothing, there being no copy to make of a tree. The
   copies live one directory per session and only that session's directory is mounted, so one confined

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -11,13 +11,15 @@ import {
   Diff,
   GitPullRequestArrow,
 } from "lucide-react"
-import { ProjectService, Terminal as TerminalService } from "@/lib/rpc"
+import { DropService, Terminal as TerminalService } from "@/lib/rpc"
 import type { DockTab } from "@/components/dock/RightDock"
 import { useActiveSession } from "@/lib/session/use-active-session"
 import { useSessionUsage } from "@/lib/session/use-session-usage"
 import { useCostReadout } from "@/lib/use-cost-readout"
 import { budgetShare, formatCost } from "@/lib/session/session-cost"
-import { displayPath } from "@/lib/paths"
+import { baseName, displayPath } from "@/lib/paths"
+import { isWindows } from "@/lib/platform"
+import { composeDroppedPaths } from "@/lib/terminal/drop-files"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { usePullRequest } from "@/lib/pulls/use-pull-request"
 import { useSettings } from "@/providers/settings"
@@ -84,7 +86,7 @@ interface FooterBarProps {
 // shows its checkout's path, branch and diff.
 export function FooterBar({ dock, onDock }: FooterBarProps) {
   const navigate = useNavigate()
-  const { projectId, sessionId, path, checkout, kind } = useActiveSession()
+  const { projectId, sessionId, path, checkout, kind, sandboxed } = useActiveSession()
   // Context-window occupancy of the active session, read off its transcript at
   // each turn's end (null until the first turn of a supported session lands).
   const usage = useSessionUsage(sessionId)
@@ -96,14 +98,33 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
   const pr = usePullRequest(path, status?.branch ?? "", status?.head ?? "")
   const now = useNow()
 
+  // The picker runs on the backend (DropService.Attach), not through
+  // ProjectService: a confined session cannot open a file outside its checkout,
+  // so the same call that chooses the file also copies it where that session can
+  // read it. `checkout` and not `path`: the sandbox is built around the
+  // session's spawn directory, which a `cd` does not move.
   const attachFile = async () => {
+    if (!sessionId) {
+      return
+    }
     try {
-      const file = await ProjectService.PickFile("Attach File")
-      if (file && sessionId) {
-        void TerminalService.Write(sessionId, `${file} `)
+      const { path: file, copied } = await DropService.Attach(sessionId, checkout, sandboxed)
+      if (!file) {
+        return
       }
-    } catch {
-      toast.error("Could not open the file picker")
+      // Composed the way a drop is: quoted, so a path with a space stays one
+      // argument, and bracketed, so the prompt takes it unsent.
+      void TerminalService.Write(sessionId, composeDroppedPaths([file], isWindows))
+      if (copied) {
+        toast.info(`Attached as a copy: ${baseName(file)}`, {
+          description:
+            "This session is sandboxed, so a file outside its checkout is attached as a copy: edits land on the copy, not on your file, and the copy is deleted when the session closes.",
+        })
+      }
+    } catch (err) {
+      // The backend's own sentence when it has one — it names the ceiling a
+      // file was refused for, which nothing here could reconstruct.
+      toast.error(err instanceof Error ? err.message : "Could not attach the file")
     }
   }
 

--- a/frontend/src/components/TerminalHost.tsx
+++ b/frontend/src/components/TerminalHost.tsx
@@ -167,6 +167,7 @@ export function TerminalHost() {
                 resume={resuming[session.id] ?? ""}
                 roster={roster}
                 visible={visible}
+                sandboxed={session.sandboxed ?? false}
                 onClose={() => worktreeClose.requestClose(session)}
                 stillInWorkspace={() => hasSession(sessionsRef.current, session.id)}
               />

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -93,6 +93,12 @@ export interface TerminalViewProps {
   roster: readonly PaletteSession[]
   visible: boolean
   /**
+   * Whether this session's PTY runs confined (internal/sandbox). Only the drop
+   * reads it here: a confined session's home is an empty private one, so a file
+   * dragged in from outside its checkout has to arrive as a copy.
+   */
+  sandboxed: boolean
+  /**
    * Close this session's card, through the same flow the sidebar's × runs —
    * raised by the exit banner, which is the only affordance here that ends a
    * session rather than talking to one.
@@ -124,6 +130,7 @@ export function TerminalView({
   resume,
   roster,
   visible,
+  sandboxed,
   onClose,
   stillInWorkspace,
 }: TerminalViewProps) {
@@ -466,7 +473,7 @@ export function TerminalView({
 
   // Files dropped on the terminal land at the prompt as paths (useTerminalDrop).
   const { dropping, onDrop, onDragEnter, onDragOver, onDragLeave } = useTerminalDrop(
-    cwd,
+    { cwd, sessionId, confined: sandboxed },
     writeInput,
     () => liveRef.current?.term.focus(),
   )

--- a/frontend/src/components/useTerminalDrop.ts
+++ b/frontend/src/components/useTerminalDrop.ts
@@ -4,10 +4,22 @@ import { toast } from "sonner"
 import { isWindows } from "@/lib/platform"
 import {
   composeDroppedPaths,
+  type DropTarget,
   KEEP_DROPPED_DAYS,
   readDroppedFiles,
   resolveDroppedFiles,
 } from "@/lib/terminal/drop-files"
+
+// copyNotice is what a pasted copy costs. A confined session cannot see the
+// user's file at all (internal/sandbox), so the copy is the normal outcome
+// there rather than a fallback, and it dies with the session instead of ageing
+// out.
+function copyNotice(confined: boolean): string {
+  if (confined) {
+    return "This session is sandboxed, so a file outside its checkout is attached as a copy: edits land on the copy, not on your file, and the copy is deleted when the session closes."
+  }
+  return `Not found under this session or your home, so edits land on the copy, not on your file — and the copy is deleted after ${KEEP_DROPPED_DAYS} days.`
+}
 
 // carriesFiles tells a file drag from text dragged out of the app's own UI —
 // a selection, a link — which the terminal leaves alone.
@@ -28,11 +40,11 @@ export interface TerminalDrop {
 }
 
 // useTerminalDrop lands files dropped on a terminal at its prompt as paths, the
-// way a native emulator pastes a drop (lib/terminal/drop-files.ts). `cwd` is the
-// session's directory — the tree the backend looks the files up in — and `write`
-// is how the paths reach the PTY.
+// way a native emulator pastes a drop (lib/terminal/drop-files.ts). `target` is
+// the session the terminal belongs to — the tree the backend looks the files up
+// in, and whether it is confined — and `write` is how the paths reach the PTY.
 export function useTerminalDrop(
-  cwd: string,
+  target: DropTarget,
   write: (data: string) => void,
   focus: () => void,
 ): TerminalDrop {
@@ -50,7 +62,7 @@ export function useTerminalDrop(
       return
     }
     void (async () => {
-      const { paths, skipped, copied } = await resolveDroppedFiles(cwd, dropped)
+      const { paths, skipped, copied } = await resolveDroppedFiles(target, dropped)
       const paste = composeDroppedPaths(paths, isWindows)
       if (paste !== "") {
         write(paste)
@@ -63,7 +75,7 @@ export function useTerminalDrop(
       // read alike at the prompt.
       if (copied.length > 0) {
         toast.info(`Pasted as a copy: ${copied.join(", ")}`, {
-          description: `Not found under this session or your home, so edits land on the copy, not on your file — and the copy is deleted after ${KEEP_DROPPED_DAYS} days.`,
+          description: copyNotice(target.confined),
         })
       }
     })()

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -367,6 +367,14 @@ export interface DropItem {
   dir: boolean
 }
 
+/** internal/drop.Attachment — the path the picker produced, and whether it is a
+ * copy's (a confined session cannot open a file outside its checkout). Both
+ * empty for a cancelled dialog. */
+export interface Attachment {
+  path: string
+  copied: boolean
+}
+
 /** internal/themes.Theme — a color theme for the UI tokens and xterm. */
 export interface ThemeDefinition {
   id: string

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -145,9 +145,12 @@ export const Terminal = {
 export const DropService = {
   /** Absolute paths for the dropped items found under root, in order; "" where
    * the tree holds no single match and the caller must upload a copy instead.
-   * The upload is not here — its body is the file, so it has its own endpoint
-   * (see lib/terminal/drop-files.ts). */
-  Resolve: (root: string, items: DropItem[]) => call<string[]>("drop.Resolve", [root, items]),
+   * `confined` is whether the session runs in the sandbox: its home is an empty
+   * private one, so the home is not searched for it and anything outside the
+   * checkout falls through to the copy. The upload is not here — its body is
+   * the file, so it has its own endpoint (see lib/terminal/drop-files.ts). */
+  Resolve: (root: string, items: DropItem[], confined: boolean) =>
+    call<string[]>("drop.Resolve", [root, items, confined]),
 }
 
 export const ProjectService = {

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -17,6 +17,7 @@ import type {
   Diagnostics as DiagnosticsData,
   DiffStats,
   DraftReviewComment,
+  Attachment,
   DropItem,
   MergeMethod,
   PatchNotes as PatchNotesData,
@@ -151,6 +152,11 @@ export const DropService = {
    * the file, so it has its own endpoint (see lib/terminal/drop-files.ts). */
   Resolve: (root: string, items: DropItem[], confined: boolean) =>
     call<string[]>("drop.Resolve", [root, items, confined]),
+  /** Open the native file picker and answer with a path the session can open —
+   * the file's own, or a copy's when a confined session cannot reach it. The
+   * picker runs on the backend rather than here: see internal/drop.Attach. */
+  Attach: (sessionId: string, root: string, confined: boolean) =>
+    call<Attachment>("drop.Attach", [sessionId, root, confined]),
 }
 
 export const ProjectService = {

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -628,6 +628,7 @@ describe("activeTarget", () => {
       sessionId: "s2",
       path: root,
       kind: "claude",
+      sandboxed: false,
     })
   })
 
@@ -642,15 +643,40 @@ describe("activeTarget", () => {
       sessionId: "wt1",
       path: "/repo/.worktrees/swift-rabbit",
       kind: "shell",
+      sandboxed: false,
     })
   })
 
+  // The footer's attach button reads this: a confined session is handed a copy
+  // of anything outside its checkout, and it has to know which sessions those
+  // are before the picker opens.
+  it("reports a confined session as sandboxed", () => {
+    const state = restoreSession(buildState(1), P, {
+      id: "wt1",
+      label: "swift-rabbit",
+      kind: "claude",
+      path: "/repo/.worktrees/swift-rabbit",
+      sandboxed: true,
+    })
+    expect(activeTarget(state, P, root).sandboxed).toBe(true)
+  })
+
   it("keeps the project root when there is no session at all", () => {
-    expect(activeTarget({}, P, root)).toEqual({ sessionId: "", path: root, kind: "" })
+    expect(activeTarget({}, P, root)).toEqual({
+      sessionId: "",
+      path: root,
+      kind: "",
+      sandboxed: false,
+    })
   })
 
   it("is empty off a project route", () => {
-    expect(activeTarget(buildState(2), null, "")).toEqual({ sessionId: "", path: "", kind: "" })
+    expect(activeTarget(buildState(2), null, "")).toEqual({
+      sessionId: "",
+      path: "",
+      kind: "",
+      sandboxed: false,
+    })
   })
 })
 

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -479,7 +479,9 @@ export function sessionsOf(state: SessionState, projectId: string): Session[] {
 
 // activeTarget resolves what a project screen acts on: the active session's id,
 // the path it lives in — a worktree session resolves to its checkout, everything
-// else to the project root — and which provider it runs. Pure, and the whole of
+// else to the project root — which provider it runs, and whether it is confined
+// (the footer's attach button hands a confined session a copy instead of a path
+// it cannot open). Pure, and the whole of
 // useActiveSession's answer: every screen inside a project — the terminal, its
 // settings, its pull requests — reads this same triple, and so does the chrome
 // beside them. kind is "" when no session is active, which is not a SessionKind:
@@ -488,13 +490,18 @@ export function activeTarget(
   state: SessionState,
   projectId: string | null,
   projectPath: string,
-): { sessionId: string; path: string; kind: SessionKind | "" } {
+): { sessionId: string; path: string; kind: SessionKind | ""; sandboxed: boolean } {
   if (!projectId) {
-    return { sessionId: "", path: projectPath, kind: "" }
+    return { sessionId: "", path: projectPath, kind: "", sandboxed: false }
   }
   const sessionId = activeSessionId(state, projectId)
   const session = sessionsOf(state, projectId).find((s) => s.id === sessionId)
-  return { sessionId, path: session?.path || projectPath, kind: session?.kind ?? "" }
+  return {
+    sessionId,
+    path: session?.path || projectPath,
+    kind: session?.kind ?? "",
+    sandboxed: session?.sandboxed ?? false,
+  }
 }
 
 // A worktree's sessions under one roof. `path` is the checkout root ("" for the

--- a/frontend/src/lib/session/use-active-session.ts
+++ b/frontend/src/lib/session/use-active-session.ts
@@ -28,6 +28,8 @@ export function useActiveSession(): {
   checkout: string
   /** Which provider the active session runs, "" when none is active. */
   kind: SessionKind | ""
+  /** Whether the active session's PTY runs confined (internal/sandbox). */
+  sandboxed: boolean
 } {
   const { projects, sessions } = useProjects()
   const match = useMatch({ path: "/projects/:projectId", end: false })
@@ -41,5 +43,6 @@ export function useActiveSession(): {
     path: cwd || target.path,
     checkout: target.path,
     kind: target.kind,
+    sandboxed: target.sandboxed,
   }
 }

--- a/frontend/src/lib/terminal/drop-files.test.ts
+++ b/frontend/src/lib/terminal/drop-files.test.ts
@@ -12,10 +12,14 @@ import {
 const resolve = vi.fn()
 vi.mock("@/lib/rpc", () => ({
   DropService: {
-    Resolve: (root: string, items: unknown[]) => resolve(root, items),
+    Resolve: (root: string, items: unknown[], confined: boolean) => resolve(root, items, confined),
   },
   endpoint: () => ({ base: "http://127.0.0.1:47821", token: "t" }),
 }))
+
+// The session a drop landed on. Confined is the interesting half — the backend
+// searches one tree fewer for it, and the copy is what reaches the agent.
+const target = (confined = false) => ({ cwd: "/home/u", sessionId: "s1", confined })
 
 const file = (name: string): DroppedFile => ({
   name,
@@ -95,7 +99,7 @@ describe("resolveDroppedFiles", () => {
   it("reports no copy for a file the tree holds", async () => {
     resolve.mockResolvedValue(["/home/u/a.ts"])
 
-    const result = await resolveDroppedFiles("/home/u", [file("a.ts")])
+    const result = await resolveDroppedFiles(target(), [file("a.ts")])
 
     expect(result).toEqual({ paths: ["/home/u/a.ts"], skipped: [], copied: [] })
     expect(upload).not.toHaveBeenCalled()
@@ -105,7 +109,7 @@ describe("resolveDroppedFiles", () => {
   it("names the entries pasted as a copy", async () => {
     resolve.mockResolvedValue(["/home/u/a.ts", ""])
 
-    const result = await resolveDroppedFiles("/home/u", [file("a.ts"), file("b.png")])
+    const result = await resolveDroppedFiles(target(), [file("a.ts"), file("b.png")])
 
     expect(result).toEqual({
       paths: ["/home/u/a.ts", "/cfg/lich/dropped/b.png"],
@@ -119,7 +123,7 @@ describe("resolveDroppedFiles", () => {
     resolve.mockResolvedValue([""])
     upload.mockResolvedValue({ ok: false, status: 500 })
 
-    const result = await resolveDroppedFiles("/home/u", [file("b.png")])
+    const result = await resolveDroppedFiles(target(), [file("b.png")])
 
     expect(result).toEqual({ paths: [], skipped: ["b.png"], copied: [] })
   })
@@ -129,7 +133,7 @@ describe("resolveDroppedFiles", () => {
     resolve.mockResolvedValue([""])
     const folder: DroppedFile = { name: "docs", size: 0, mtime: 1, dir: true, blob: null }
 
-    const result = await resolveDroppedFiles("/home/u", [folder])
+    const result = await resolveDroppedFiles(target(), [folder])
 
     expect(result.copied).toEqual([])
     expect(result.skipped).toHaveLength(1)
@@ -148,7 +152,7 @@ describe("resolveDroppedFiles", () => {
       blob: { size: 33 * 1024 * 1024 } as Blob,
     }
 
-    const result = await resolveDroppedFiles("/home/u", [huge])
+    const result = await resolveDroppedFiles(target(), [huge])
 
     expect(result.paths).toEqual([])
     expect(result.copied).toEqual([])
@@ -156,8 +160,42 @@ describe("resolveDroppedFiles", () => {
     expect(upload).not.toHaveBeenCalled()
   })
 
+  // The upload is keyed by session: that is the directory a confined session
+  // reads the copy through, and the one its close deletes.
+  it("uploads a copy under the session it was dropped on", async () => {
+    resolve.mockResolvedValue([""])
+
+    await resolveDroppedFiles(target(), [file("b.png")])
+
+    const url = String(upload.mock.calls[0][0])
+    expect(url).toContain("session=s1")
+    expect(url).toContain("name=b.png")
+  })
+
+  // A confined session's home holds nothing it can open, so the backend is told
+  // not to search it — the copy is the only path that reaches the agent.
+  it("tells the backend a confined session searches one tree fewer", async () => {
+    resolve.mockResolvedValue([""])
+
+    const result = await resolveDroppedFiles(target(true), [file("b.png")])
+
+    expect(resolve).toHaveBeenCalledWith("/home/u", expect.anything(), true)
+    expect(result.copied).toEqual(["b.png"])
+  })
+
+  // The reason a folder yielded no path names the search that ran: a confined
+  // session's home was never looked at.
+  it("does not blame a home a confined session never searched", async () => {
+    resolve.mockResolvedValue([""])
+    const folder: DroppedFile = { name: "docs", size: 0, mtime: 1, dir: true, blob: null }
+
+    const result = await resolveDroppedFiles(target(true), [folder])
+
+    expect(result.skipped).toEqual(["docs (folder outside this sandboxed session's checkout)"])
+  })
+
   it("answers an empty drop without touching the backend", async () => {
-    expect(await resolveDroppedFiles("/home/u", [])).toEqual({
+    expect(await resolveDroppedFiles(target(), [])).toEqual({
       paths: [],
       skipped: [],
       copied: [],

--- a/frontend/src/lib/terminal/drop-files.ts
+++ b/frontend/src/lib/terminal/drop-files.ts
@@ -7,6 +7,11 @@
 // mtime — under the session's directory, then under home (internal/drop) — and
 // only what it cannot find is uploaded and pasted as a copy.
 //
+// A confined session (internal/sandbox) takes the copy far more often, and has
+// to: its home is an empty private one, so the backend does not look there for
+// it at all, and everything outside its checkout arrives as a copy — which is
+// the one thing lich writes where such a session can still read it.
+//
 // The provider on the other end does the rest — a pasted image path is
 // attached as an image, any other path is read as a path.
 
@@ -56,6 +61,17 @@ export function readDroppedFiles(transfer: DataTransfer): DroppedFile[] {
   return dropped
 }
 
+/**
+ * The session a drop landed on: the tree the backend searches, the id the
+ * copies are kept under (they are deleted with the session), and whether it
+ * runs in the sandbox.
+ */
+export interface DropTarget {
+  cwd: string
+  sessionId: string
+  confined: boolean
+}
+
 export interface DropResult {
   /** Absolute paths, in the order they were dropped. */
   paths: string[]
@@ -71,10 +87,10 @@ export interface DropResult {
 
 /**
  * Paths for a drop: the real one where the session's tree holds the file, a
- * copy's otherwise. `cwd` is the session's directory — the tree searched.
+ * copy's otherwise.
  */
 export async function resolveDroppedFiles(
-  cwd: string,
+  target: DropTarget,
   dropped: readonly DroppedFile[],
 ): Promise<DropResult> {
   const paths: string[] = []
@@ -84,7 +100,7 @@ export async function resolveDroppedFiles(
     return { paths, skipped, copied }
   }
   const items = dropped.map(({ name, size, mtime, dir }) => ({ name, size, mtime, dir }))
-  const found = await DropService.Resolve(cwd, items)
+  const found = await DropService.Resolve(target.cwd, items, target.confined)
   for (const [index, entry] of dropped.entries()) {
     const path = found[index] ?? ""
     if (path !== "") {
@@ -94,7 +110,7 @@ export async function resolveDroppedFiles(
     // Nothing to fall back to: a directory cannot be uploaded, and copying one
     // to paste the copy's path is not the drop the user made.
     if (entry.dir || !entry.blob) {
-      skipped.push(`${entry.name} (folder not found under this session or your home)`)
+      skipped.push(`${entry.name} (${missingFolder(target.confined)})`)
       continue
     }
     if (entry.blob.size > MAX_UPLOAD_BYTES) {
@@ -102,7 +118,7 @@ export async function resolveDroppedFiles(
       continue
     }
     try {
-      paths.push(await uploadDroppedFile(entry.name, entry.blob))
+      paths.push(await uploadDroppedFile(target.sessionId, entry.name, entry.blob))
       copied.push(entry.name)
     } catch {
       skipped.push(entry.name)
@@ -111,11 +127,22 @@ export async function resolveDroppedFiles(
   return { paths, skipped, copied }
 }
 
+// missingFolder is why a dropped folder yielded no path, which is a different
+// sentence for a confined session: its home was never searched, so "not found
+// under your home" would name a search that did not happen.
+function missingFolder(confined: boolean): string {
+  return confined
+    ? "folder outside this sandboxed session's checkout"
+    : "folder not found under this session or your home"
+}
+
 // uploadDroppedFile stores one file's bytes on the backend and answers with the
-// path of the copy. Its own endpoint, not the RPC: the body is the file.
-async function uploadDroppedFile(name: string, blob: Blob): Promise<string> {
+// path of the copy. Its own endpoint, not the RPC: the body is the file. The
+// session id rides along because the copy is kept under it and deleted with it.
+async function uploadDroppedFile(sessionId: string, name: string, blob: Blob): Promise<string> {
   const { base, token } = endpoint()
-  const url = `${base}/drop?token=${token}&name=${encodeURIComponent(name)}`
+  const query = `token=${token}&session=${encodeURIComponent(sessionId)}`
+  const url = `${base}/drop?${query}&name=${encodeURIComponent(name)}`
   const response = await fetch(url, { method: "POST", body: blob })
   if (!response.ok) {
     throw new Error(`drop upload: HTTP ${response.status}`)

--- a/internal/drop/drop.go
+++ b/internal/drop/drop.go
@@ -28,6 +28,11 @@
 //
 // A dropped directory only ever takes the first path: the page can walk one,
 // but copying a tree to paste a path to the copy is not what the drop meant.
+//
+// The footer's attach button lands here too (Attach): a file chosen from the
+// native picker already has its path, so there is nothing to look up — but a
+// confined session cannot open one outside its checkout either, and the same
+// copy is the answer.
 package drop
 
 import (
@@ -101,6 +106,15 @@ type Item struct {
 
 type Service struct {
 	dir string
+	// pick opens the host's file chooser. See SetPicker.
+	pick func(title string) (string, error)
+}
+
+// SetPicker wires the host's file picker (internal/project), which is what the
+// footer's attach button reaches through Attach. Startup wiring, called before
+// anything serves.
+func (s *Service) SetPicker(pick func(title string) (string, error)) {
+	s.pick = pick
 }
 
 // Dir is where a lich with this config directory keeps the copies. It is the
@@ -323,6 +337,101 @@ func (s *Service) Upload(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(map[string]string{"path": path}); err != nil {
 		slog.Warn("drop: encode response", "path", path, "err", err)
 	}
+}
+
+// attachTitle is the file chooser's own title, which is all the dialog says
+// about why it opened.
+const attachTitle = "Attach File"
+
+// Attachment is what the picker produced: the path to write at the prompt, and
+// whether that path is a copy's — the caller says so, because nothing about the
+// path itself does. Both empty for a cancelled dialog.
+type Attachment struct {
+	Path   string `json:"path"`
+	Copied bool   `json:"copied"`
+}
+
+// Attach opens the file chooser and answers with a path the session can
+// actually open: the file's own where the session reaches it, a copy's inside
+// the session's dropped-files directory otherwise. It is the footer's attach
+// button, and the counterpart of a drop — the same problem arrives through a
+// dialog instead of a drag.
+//
+// The picker runs here rather than in the caller, and that is the security
+// property of this method: every session carries LICH_TOKEN (see
+// internal/terminal), so a confined agent can call any RPC on the loopback
+// listener. A method that copied a *path it was handed* would let that agent
+// name ~/.ssh/id_rsa and read the copy from inside the sandbox — the sandbox
+// undone by its own harness. Here the path can only come from a dialog a human
+// answers on screen.
+//
+// root is the session's checkout, the one tree a confined session sees; a file
+// under it keeps its own path. Anything else is copied, including files under
+// directories the sandbox happens to bind (a toolchain, ~/.config): copying one
+// of those costs a few bytes, and deciding it does not need copying means
+// reproducing the mount list here, where it would go stale in silence.
+func (s *Service) Attach(sessionID, root string, confined bool) (Attachment, error) {
+	if s.pick == nil {
+		return Attachment{}, errors.New("no file picker wired")
+	}
+	path, err := s.pick(attachTitle)
+	if err != nil {
+		return Attachment{}, fmt.Errorf("open dialog failed: %w", err)
+	}
+	// A cancelled dialog is not a failure, and neither is a session that reaches
+	// the file where it is.
+	if path == "" || !confined || !sandboxAvailable() || under(root, path) {
+		return Attachment{Path: path}, nil
+	}
+	copied, err := s.copyIn(sessionID, path)
+	if err != nil {
+		return Attachment{}, err
+	}
+	return Attachment{Path: copied, Copied: true}, nil
+}
+
+// under reports whether path is inside root. Both are cleaned but neither is
+// resolved through symlinks: a link answering "outside" costs a copy, and a
+// wrong "inside" costs the session the file altogether.
+func under(root, path string) bool {
+	if root == "" {
+		return false
+	}
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// copyIn puts one of the user's own files in a session's copies directory, so a
+// confined session can read it. The ceiling is the upload's, for the same
+// reason: past it the copy is a mistake rather than an attachment.
+func (s *Service) copyIn(sessionID, path string) (string, error) {
+	// Without a session there is no directory the sandbox binds, so a copy would
+	// land where the session it was made for cannot read it.
+	session, name := element(sessionID), element(filepath.Base(path))
+	if session == "" || name == "" {
+		return "", fmt.Errorf("cannot attach %q to session %q", path, sessionID)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("%s is a folder — a sandboxed session takes files, not trees", path)
+	}
+	if info.Size() > maxUpload {
+		return "", fmt.Errorf(
+			"%s is over the %dMB a sandboxed session can be handed", filepath.Base(path), maxUpload>>20,
+		)
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open %s: %w", path, err)
+	}
+	defer file.Close()
+	return s.Save(session, name, file)
 }
 
 // element is one path element taken from untrusted input — a dropped file's

--- a/internal/drop/drop.go
+++ b/internal/drop/drop.go
@@ -14,6 +14,18 @@
 //     and paste the copy's path. Reading it works; editing it edits the copy —
 //     which is why Resolve is tried first. The copies expire (see Prune).
 //
+// A confined session takes the second way far more often, and has to: its home
+// is an empty private one (internal/sandbox), so a path found under the real
+// home is a path only lich can open. Resolve is told which sessions those are
+// and does not search home for them at all — the copy is what reaches the
+// session, because the sandbox binds the copies directory and nothing else of
+// the home.
+//
+// The copies are kept one directory per session, and that is the unit they are
+// deleted in: a confined session sees its own directory mounted and not the one
+// beside it, and every copy a session was dropped goes when its row does
+// (Purge).
+//
 // A dropped directory only ever takes the first path: the page can walk one,
 // but copying a tree to paste a path to the copy is not what the drop meant.
 package drop
@@ -30,6 +42,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/omartelo/lich/internal/sandbox"
 )
 
 // maxUpload bounds one dropped file. Screenshots and logs are the payload; a
@@ -44,6 +58,11 @@ const maxEntries = 50_000
 // homeDir is os.UserHomeDir, replaced in tests: the search must never reach
 // the machine's real home, on any OS.
 var homeDir = os.UserHomeDir
+
+// sandboxAvailable is sandbox.Available, replaced in tests: whether a machine
+// can confine anything is the host's answer — bubblewrap installed, macOS —
+// and a test about the search must not take it.
+var sandboxAvailable = sandbox.Available
 
 // mtimeSlackMs absorbs the rounding between the browser's millisecond
 // File.lastModified and the filesystem's timestamp.
@@ -84,9 +103,26 @@ type Service struct {
 	dir string
 }
 
-// New keeps uploaded copies under <configDir>/lich/dropped.
+// Dir is where a lich with this config directory keeps the copies. It is the
+// directory the sandbox binds into a confined session, so it is named here
+// rather than spelled out at the two callers (main.go wires it through to
+// internal/terminal).
+func Dir(configDir string) string {
+	return filepath.Join(configDir, "lich", "dropped")
+}
+
+// New keeps uploaded copies under Dir(configDir), and creates that directory
+// now rather than on the first drop. A confined session binds its own copies
+// directory when its PTY spawns (internal/terminal/sandbox.go), and a bind
+// whose source is not there yet is skipped: the first file dropped into a
+// session that opened before the directory existed would land where that
+// session cannot read it.
 func New(configDir string) *Service {
-	return &Service{dir: filepath.Join(configDir, "lich", "dropped")}
+	dir := Dir(configDir)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		slog.Warn("drop: could not create the copies dir", "dir", dir, "err", err)
+	}
+	return &Service{dir: dir}
 }
 
 // Resolve maps each item to its absolute path, or "" when neither the
@@ -95,16 +131,22 @@ func New(configDir string) *Service {
 // The session's directory is searched first, then home — a drop is most often
 // the session's own file, but it is just as often a screenshot or a directory
 // from somewhere else entirely, and a directory has no copy to fall back to.
-func (s *Service) Resolve(root string, items []Item) []string {
+//
+// confined is the verdict recorded for the calling session (internal/sandbox):
+// its home is an empty private one, so a match under the real home is a path
+// the session cannot open, and answering with it hands the prompt a file that
+// is not there. Those sessions search their checkout and nothing else, and
+// everything outside it falls through to the copy — which the sandbox does
+// bind. A machine with no sandbox backend confines nothing, so the flag alone
+// is not enough to stop searching: Windows, which has no backend at all, keeps
+// the unconfined behaviour whatever the row says.
+func (s *Service) Resolve(root string, items []Item, confined bool) []string {
 	paths := make([]string, len(items))
 	pending := make(map[int]bool, len(items))
 	for i := range items {
 		pending[i] = true
 	}
-	home, err := homeDir()
-	if err != nil {
-		slog.Warn("drop: no home directory to search", "err", err)
-	}
+	home := searchableHome(confined)
 	for _, search := range []struct {
 		root string
 		// Hidden directories are the session tree's own (.github, .config of a
@@ -119,6 +161,20 @@ func (s *Service) Resolve(root string, items []Item) []string {
 		find(search.root, search.skipHidden, items, pending, paths)
 	}
 	return paths
+}
+
+// searchableHome is the home directory Resolve falls back to, or "" when the
+// caller is a confined session on a machine that can actually confine one — see
+// Resolve for why that home is worse than no home at all.
+func searchableHome(confined bool) string {
+	if confined && sandboxAvailable() {
+		return ""
+	}
+	home, err := homeDir()
+	if err != nil {
+		slog.Warn("drop: no home directory to search", "err", err)
+	}
+	return home
 }
 
 // find walks root a level at a time, resolving each pending item to the
@@ -225,7 +281,8 @@ func matches(item Item, entry fs.DirEntry) bool {
 }
 
 // Upload stores one dropped file's bytes and answers with the path it landed
-// at. The name rides the query because the body is the file itself.
+// at. The name and the session ride the query because the body is the file
+// itself.
 func (s *Service) Upload(w http.ResponseWriter, r *http.Request) {
 	// CORS like the RPC's (internal/rpc): in dev the page's origin is the Vite
 	// server, not this listener, and the token is the actual auth. The preflight
@@ -242,12 +299,21 @@ func (s *Service) Upload(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "POST only", http.StatusMethodNotAllowed)
 		return
 	}
-	name := filepath.Base(filepath.FromSlash(r.URL.Query().Get("name")))
-	if name == "" || name == "." || name == string(filepath.Separator) || name == ".." {
+	name := element(r.URL.Query().Get("name"))
+	if name == "" {
 		http.Error(w, "missing name", http.StatusBadRequest)
 		return
 	}
-	path, err := s.Save(name, http.MaxBytesReader(w, r.Body, maxUpload))
+	// No session, no copy: the id is what decides which directory the file
+	// lands in, which is both what a confined session can read and what its
+	// close deletes. A copy dropped outside either would live on with nothing
+	// to end it.
+	session := element(r.URL.Query().Get("session"))
+	if session == "" {
+		http.Error(w, "missing session", http.StatusBadRequest)
+		return
+	}
+	path, err := s.Save(session, name, http.MaxBytesReader(w, r.Body, maxUpload))
 	if err != nil {
 		slog.Warn("drop: upload failed", "name", name, "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -259,13 +325,27 @@ func (s *Service) Upload(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Save writes one dropped file under the copies directory, without ever
-// overwriting an earlier drop — its path may still be sitting in a prompt.
-func (s *Service) Save(name string, body io.Reader) (string, error) {
-	if err := os.MkdirAll(s.dir, 0o755); err != nil {
+// element is one path element taken from untrusted input — a dropped file's
+// name, a session id off the query — reduced to its last element so it can only
+// ever name something inside the copies directory. Empty when nothing usable is
+// left, which the callers refuse.
+func element(raw string) string {
+	name := filepath.Base(filepath.FromSlash(raw))
+	if name == "." || name == ".." || name == string(filepath.Separator) {
+		return ""
+	}
+	return name
+}
+
+// Save writes one dropped file under the session's own copies directory,
+// without ever overwriting an earlier drop — its path may still be sitting in
+// a prompt. sessionID must already be one path element (element).
+func (s *Service) Save(sessionID, name string, body io.Reader) (string, error) {
+	dir := filepath.Join(s.dir, sessionID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", fmt.Errorf("dropped-files dir: %w", err)
 	}
-	path, err := uniquePath(s.dir, name)
+	path, err := uniquePath(dir, name)
 	if err != nil {
 		return "", err
 	}
@@ -290,15 +370,49 @@ func (s *Service) Save(name string, body io.Reader) (string, error) {
 	return path, nil
 }
 
-// Prune deletes copies older than keepDropped. Called after each new copy —
-// which is the only thing that grows the directory — and once at startup, so
-// the last of them is cleared even by a lich that is never dropped on again.
+// Purge deletes every copy dropped into one session. It is what makes a copy
+// die with the session it was dropped into rather than with the clock: the
+// paths pasted from it only ever meant anything inside that conversation, and
+// the session's own row is gone by the time this runs (store.SetSessionGone).
 //
-// Age is the rule because a copy's whole purpose is the prompt it was pasted
-// into: once that conversation is days behind, the path in it is scrollback.
+// Best effort, like Prune: a failure leaves copies that the age rule still
+// clears.
+func (s *Service) Purge(sessionID string) {
+	name := element(sessionID)
+	if name == "" {
+		return
+	}
+	dir := filepath.Join(s.dir, name)
+	if err := os.RemoveAll(dir); err != nil {
+		slog.Warn("drop: purge failed", "dir", dir, "err", err)
+	}
+}
+
+// Prune deletes copies older than keepDropped. Called after each new copy —
+// which is the only thing that grows the directory — so a lich left running
+// for weeks still clears what earlier drops left behind.
+//
+// Age is the backstop, not the rule: a session that ends takes its copies with
+// it (Purge), and what this catches is the session lich never saw end — a
+// crash, a kill, a machine that went down.
+//
 // A failure here is never the caller's problem — the copy it just wrote is
 // good, and the stale ones get another chance on the next drop.
 func (s *Service) Prune() {
+	s.prune(false)
+}
+
+// PruneStale is Prune plus the session directories left with nothing in them.
+// Startup only, and that is the whole reason it is a second method: a confined
+// session binds its own copies directory when it spawns, and removing that
+// directory under a live mount leaves every later copy of that session
+// invisible inside it — the mount would still point at the deleted one. At
+// startup no session has spawned yet, so there is no mount to strand.
+func (s *Service) PruneStale() {
+	s.prune(true)
+}
+
+func (s *Service) prune(empty bool) {
 	entries, err := os.ReadDir(s.dir)
 	if err != nil {
 		// Nothing dropped yet is the common case, not a fault.
@@ -309,18 +423,49 @@ func (s *Service) Prune() {
 	}
 	deadline := time.Now().Add(-keepDropped)
 	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		info, err := entry.Info()
-		if err != nil || info.ModTime().After(deadline) {
-			continue
-		}
 		path := filepath.Join(s.dir, entry.Name())
-		if err := os.Remove(path); err != nil {
-			slog.Warn("drop: prune failed", "path", path, "err", err)
+		if !entry.IsDir() {
+			pruneExpired(path, entry, deadline)
+			continue
+		}
+		s.pruneSession(path, deadline, empty)
+	}
+}
+
+// pruneSession clears the expired copies of one session, and the directory
+// itself when the caller allows it and nothing is left in it.
+func (s *Service) pruneSession(dir string, deadline time.Time, empty bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		slog.Warn("drop: prune could not read a session's copies", "dir", dir, "err", err)
+		return
+	}
+	left := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !pruneExpired(filepath.Join(dir, entry.Name()), entry, deadline) {
+			left++
 		}
 	}
+	if !empty || left > 0 {
+		return
+	}
+	if err := os.Remove(dir); err != nil {
+		slog.Warn("drop: prune failed", "path", dir, "err", err)
+	}
+}
+
+// pruneExpired deletes one copy when it is past the deadline, and reports
+// whether it is gone.
+func pruneExpired(path string, entry fs.DirEntry, deadline time.Time) bool {
+	info, err := entry.Info()
+	if err != nil || info.ModTime().After(deadline) {
+		return false
+	}
+	if err := os.Remove(path); err != nil {
+		slog.Warn("drop: prune failed", "path", path, "err", err)
+		return false
+	}
+	return true
 }
 
 // uniquePath is name, or name-2, name-3… up to maxCopies of them. Past that the

--- a/internal/drop/drop_test.go
+++ b/internal/drop/drop_test.go
@@ -57,7 +57,7 @@ func TestResolveFindsFileByMetadata(t *testing.T) {
 	want := filepath.Join(root, "src", "app.ts")
 	item := writeFile(t, want, 41, mtime)
 
-	got := newService(t).Resolve(root, []Item{item})
+	got := newService(t).Resolve(root, []Item{item}, false)
 
 	if len(got) != 1 || got[0] != want {
 		t.Fatalf("Resolve = %v, want [%s]", got, want)
@@ -80,7 +80,7 @@ func TestResolveRejectsNearMiss(t *testing.T) {
 	}
 	for name, dropped := range cases {
 		t.Run(name, func(t *testing.T) {
-			if got := newService(t).Resolve(root, []Item{dropped}); got[0] != "" {
+			if got := newService(t).Resolve(root, []Item{dropped}, false); got[0] != "" {
 				t.Fatalf("Resolve = %q, want no match", got[0])
 			}
 		})
@@ -95,7 +95,7 @@ func TestResolveAcceptsMtimeWithinSlack(t *testing.T) {
 	item := writeFile(t, filepath.Join(root, "app.ts"), 41, mtime)
 	item.Mtime += mtimeSlackMs - 1
 
-	if got := newService(t).Resolve(root, []Item{item}); got[0] == "" {
+	if got := newService(t).Resolve(root, []Item{item}, false); got[0] == "" {
 		t.Fatal("Resolve found nothing, want the file within the mtime slack")
 	}
 }
@@ -109,7 +109,7 @@ func TestResolveRefusesTwins(t *testing.T) {
 	item := writeFile(t, filepath.Join(root, "a", "app.ts"), 41, mtime)
 	writeFile(t, filepath.Join(root, "b", "app.ts"), 41, mtime)
 
-	if got := newService(t).Resolve(root, []Item{item}); got[0] != "" {
+	if got := newService(t).Resolve(root, []Item{item}, false); got[0] != "" {
 		t.Fatalf("Resolve = %q, want no match for twins", got[0])
 	}
 }
@@ -134,7 +134,7 @@ func TestResolveRefusesTwinsSplitByTheBudget(t *testing.T) {
 		}
 	}
 
-	if got := newService(t).Resolve(root, []Item{item}); got[0] != "" {
+	if got := newService(t).Resolve(root, []Item{item}, false); got[0] != "" {
 		t.Fatalf("Resolve = %q, want no match for twins the budget split", got[0])
 	}
 }
@@ -160,7 +160,7 @@ func TestResolveSurvivesAnUnreadableDir(t *testing.T) {
 	want := filepath.Join(root, "b-src", "app.ts")
 	item := writeFile(t, want, 41, mtime)
 
-	if got := newService(t).Resolve(root, []Item{item}); got[0] != want {
+	if got := newService(t).Resolve(root, []Item{item}, false); got[0] != want {
 		t.Fatalf("Resolve = %q, want %q", got[0], want)
 	}
 }
@@ -176,7 +176,7 @@ func TestResolveSkipsNoiseDirs(t *testing.T) {
 	writeFile(t, filepath.Join(root, ".git", "app.ts"), 41, mtime)
 	writeFile(t, filepath.Join(root, "node_modules", "pkg", "app.ts"), 41, mtime)
 
-	if got := newService(t).Resolve(root, []Item{item}); got[0] != want {
+	if got := newService(t).Resolve(root, []Item{item}, false); got[0] != want {
 		t.Fatalf("Resolve = %q, want %q", got[0], want)
 	}
 }
@@ -191,7 +191,7 @@ func TestResolveMatchesDirectoryByName(t *testing.T) {
 	}
 	item := Item{Name: "components", Size: 4096, Mtime: 0, Dir: true}
 
-	if got := newService(t).Resolve(root, []Item{item}); got[0] != want {
+	if got := newService(t).Resolve(root, []Item{item}, false); got[0] != want {
 		t.Fatalf("Resolve = %q, want %q", got[0], want)
 	}
 }
@@ -205,7 +205,7 @@ func TestResolveMapsEveryItem(t *testing.T) {
 	third := writeFile(t, filepath.Join(root, "c.ts"), 30, mtime)
 	elsewhere := Item{Name: "b.ts", Size: 20, Mtime: mtime.UnixMilli()}
 
-	got := newService(t).Resolve(root, []Item{first, elsewhere, third})
+	got := newService(t).Resolve(root, []Item{first, elsewhere, third}, false)
 
 	if len(got) != 3 || got[0] == "" || got[1] != "" || got[2] == "" {
 		t.Fatalf("Resolve = %v, want the outer two found and the middle empty", got)
@@ -234,7 +234,7 @@ func TestResolveFindsShallowSiblingBeforeNoise(t *testing.T) {
 	}
 	item := Item{Name: "project", Dir: true}
 
-	if got := newService(t).Resolve(root, []Item{item}); got[0] != want {
+	if got := newService(t).Resolve(root, []Item{item}, false); got[0] != want {
 		t.Fatalf("Resolve = %q, want %q", got[0], want)
 	}
 }
@@ -249,7 +249,7 @@ func TestResolveFallsBackToHome(t *testing.T) {
 	}
 	service := homeAt(t, home)
 
-	got := service.Resolve(t.TempDir(), []Item{{Name: "notes", Dir: true}})
+	got := service.Resolve(t.TempDir(), []Item{{Name: "notes", Dir: true}}, false)
 
 	if got[0] != want {
 		t.Fatalf("Resolve = %q, want %q", got[0], want)
@@ -266,7 +266,7 @@ func TestResolveSearchesHiddenDirsOfTheSessionOnly(t *testing.T) {
 	home := t.TempDir()
 	inHome := writeFile(t, filepath.Join(home, ".cache", "blob.bin"), 13, mtime)
 
-	got := homeAt(t, home).Resolve(root, []Item{inSession, inHome})
+	got := homeAt(t, home).Resolve(root, []Item{inSession, inHome}, false)
 
 	if want := filepath.Join(root, ".github", "ci.yml"); got[0] != want {
 		t.Fatalf("session hidden dir = %q, want %q", got[0], want)
@@ -277,8 +277,69 @@ func TestResolveSearchesHiddenDirsOfTheSessionOnly(t *testing.T) {
 }
 
 func TestResolveEmptyRoot(t *testing.T) {
-	if got := newService(t).Resolve("", []Item{{Name: "app.ts"}}); len(got) != 1 || got[0] != "" {
+	if got := newService(t).Resolve("", []Item{{Name: "app.ts"}}, false); len(got) != 1 || got[0] != "" {
 		t.Fatalf("Resolve = %v, want one empty path", got)
+	}
+}
+
+// canConfine fixes what the host would answer about the sandbox, so the tests
+// below describe a confined session on any machine — with or without
+// bubblewrap installed, on any OS.
+func canConfine(t *testing.T, available bool) {
+	t.Helper()
+	previous := sandboxAvailable
+	sandboxAvailable = func() bool { return available }
+	t.Cleanup(func() { sandboxAvailable = previous })
+}
+
+// TestResolveSkipsHomeForAConfinedSession is the whole point of the flag: the
+// file is there, under the user's real home, and its path names nothing inside
+// a sandbox whose home is empty. Answering with it would paste a path the agent
+// cannot open, so the item is left for the copy instead.
+func TestResolveSkipsHomeForAConfinedSession(t *testing.T) {
+	canConfine(t, true)
+	mtime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	home := t.TempDir()
+	item := writeFile(t, filepath.Join(home, "Downloads", "spec.pdf"), 20, mtime)
+
+	got := homeAt(t, home).Resolve(t.TempDir(), []Item{item}, true)
+
+	if got[0] != "" {
+		t.Fatalf("Resolve = %q, want no path — the sandbox has no such file", got[0])
+	}
+}
+
+// TestResolveSearchesTheCheckoutOfAConfinedSession: the checkout is the one
+// tree a confined session does see, so the real path is still the answer there.
+func TestResolveSearchesTheCheckoutOfAConfinedSession(t *testing.T) {
+	canConfine(t, true)
+	mtime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	root := t.TempDir()
+	want := filepath.Join(root, "src", "app.ts")
+	item := writeFile(t, want, 41, mtime)
+
+	got := newService(t).Resolve(root, []Item{item}, true)
+
+	if got[0] != want {
+		t.Fatalf("Resolve = %q, want %q", got[0], want)
+	}
+}
+
+// TestResolveSearchesHomeWhereNothingConfines pins the other half of the
+// answer, and with it the Windows behaviour: the row can say a session is
+// confined on a machine that has no backend to confine it, and there the home
+// is the session's own — searching it is what a drop there has always done.
+func TestResolveSearchesHomeWhereNothingConfines(t *testing.T) {
+	canConfine(t, false)
+	mtime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	home := t.TempDir()
+	want := filepath.Join(home, "Downloads", "spec.pdf")
+	item := writeFile(t, want, 20, mtime)
+
+	got := homeAt(t, home).Resolve(t.TempDir(), []Item{item}, true)
+
+	if got[0] != want {
+		t.Fatalf("Resolve = %q, want %q", got[0], want)
 	}
 }
 
@@ -305,7 +366,8 @@ func TestUploadRefusesOtherMethods(t *testing.T) {
 		t.Run(method, func(t *testing.T) {
 			recorder := httptest.NewRecorder()
 
-			New(t.TempDir()).Upload(recorder, httptest.NewRequest(method, "/drop?name=shot.png", nil))
+			target := "/drop?name=shot.png&session=s1"
+			New(t.TempDir()).Upload(recorder, httptest.NewRequest(method, target, nil))
 
 			if recorder.Code != http.StatusMethodNotAllowed {
 				t.Fatalf("%s = %d, want %d", method, recorder.Code, http.StatusMethodNotAllowed)
@@ -321,7 +383,8 @@ func TestUploadRefusesOtherMethods(t *testing.T) {
 func TestUploadStoresBytes(t *testing.T) {
 	dir := t.TempDir()
 	recorder := httptest.NewRecorder()
-	request := httptest.NewRequest(http.MethodPost, "/drop?name=shot.png", strings.NewReader("bytes"))
+	target := "/drop?name=shot.png&session=s1"
+	request := httptest.NewRequest(http.MethodPost, target, strings.NewReader("bytes"))
 
 	New(dir).Upload(recorder, request)
 
@@ -337,7 +400,7 @@ func TestUploadStoresBytes(t *testing.T) {
 	if err := json.Unmarshal(recorder.Body.Bytes(), &answer); err != nil {
 		t.Fatalf("decode %s: %v", recorder.Body, err)
 	}
-	if want := filepath.Join(dir, "lich", "dropped", "shot.png"); answer.Path != want {
+	if want := filepath.Join(dir, "lich", "dropped", "s1", "shot.png"); answer.Path != want {
 		t.Fatalf("path = %q, want %q", answer.Path, want)
 	}
 	if got, err := os.ReadFile(answer.Path); err != nil || string(got) != "bytes" {
@@ -353,7 +416,7 @@ func TestUploadRejectsBadName(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			dir := t.TempDir()
 			recorder := httptest.NewRecorder()
-			target := "/drop?name=" + url.QueryEscape(name)
+			target := "/drop?session=s1&name=" + url.QueryEscape(name)
 			request := httptest.NewRequest(http.MethodPost, target, strings.NewReader("x"))
 
 			New(dir).Upload(recorder, request)
@@ -370,7 +433,7 @@ func TestUploadRejectsBadName(t *testing.T) {
 				if err := json.Unmarshal(recorder.Body.Bytes(), &answer); err != nil {
 					t.Fatalf("decode: %v", err)
 				}
-				if want := filepath.Join(dir, "lich", "dropped", "passwd"); answer.Path != want {
+				if want := filepath.Join(dir, "lich", "dropped", "s1", "passwd"); answer.Path != want {
 					t.Fatalf("path = %q, want %q", answer.Path, want)
 				}
 				return
@@ -382,14 +445,15 @@ func TestUploadRejectsBadName(t *testing.T) {
 	}
 }
 
-// agedCopy puts a file in the copies directory with a chosen age, standing in
-// for a copy an earlier drop left behind.
-func agedCopy(t *testing.T, service *Service, name string, age time.Duration) string {
+// agedCopy puts a file in one session's copies directory with a chosen age,
+// standing in for a copy an earlier drop left behind.
+func agedCopy(t *testing.T, service *Service, session, name string, age time.Duration) string {
 	t.Helper()
-	if err := os.MkdirAll(service.dir, 0o755); err != nil {
+	dir := filepath.Join(service.dir, session)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	path := filepath.Join(service.dir, name)
+	path := filepath.Join(dir, name)
 	if err := os.WriteFile(path, []byte("x"), 0o644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
@@ -406,8 +470,8 @@ func agedCopy(t *testing.T, service *Service, name string, age time.Duration) st
 // week or a month.
 func TestPruneDeletesOnlyExpiredCopies(t *testing.T) {
 	service := New(t.TempDir())
-	expired := agedCopy(t, service, "old.png", 4*24*time.Hour)
-	kept := agedCopy(t, service, "recent.png", 2*24*time.Hour)
+	expired := agedCopy(t, service, "s1", "old.png", 4*24*time.Hour)
+	kept := agedCopy(t, service, "s1", "recent.png", 2*24*time.Hour)
 
 	service.Prune()
 
@@ -424,9 +488,9 @@ func TestPruneDeletesOnlyExpiredCopies(t *testing.T) {
 // clear the ones before it.
 func TestSavePrunes(t *testing.T) {
 	service := New(t.TempDir())
-	expired := agedCopy(t, service, "old.png", 4*24*time.Hour)
+	expired := agedCopy(t, service, "s1", "old.png", 4*24*time.Hour)
 
-	fresh, err := service.Save("new.png", strings.NewReader("bytes"))
+	fresh, err := service.Save("s1", "new.png", strings.NewReader("bytes"))
 	if err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -457,11 +521,11 @@ func (r *failingReader) Read(p []byte) (int, error) {
 func TestSaveLeavesNothingBehindOnFailure(t *testing.T) {
 	service := New(t.TempDir())
 
-	if _, err := service.Save("shot.png", &failingReader{}); err == nil {
+	if _, err := service.Save("s1", "shot.png", &failingReader{}); err == nil {
 		t.Fatal("Save reported success on a body that failed")
 	}
 
-	entries, err := os.ReadDir(service.dir)
+	entries, err := os.ReadDir(filepath.Join(service.dir, "s1"))
 	if err != nil {
 		t.Fatalf("read copies dir: %v", err)
 	}
@@ -470,10 +534,17 @@ func TestSaveLeavesNothingBehindOnFailure(t *testing.T) {
 	}
 }
 
-// TestPruneWithoutCopiesDir covers the first launch: nothing has been dropped,
-// so the directory does not exist, and that is not a fault.
+// TestPruneWithoutCopiesDir covers a copies directory that is not there — the
+// user cleared it, or the config directory is on a volume that went away. Not
+// a fault, and not something a prune may report as one.
 func TestPruneWithoutCopiesDir(t *testing.T) {
-	New(t.TempDir()).Prune()
+	service := New(t.TempDir())
+	if err := os.RemoveAll(service.dir); err != nil {
+		t.Fatalf("remove copies dir: %v", err)
+	}
+
+	service.Prune()
+	service.PruneStale()
 }
 
 // TestSaveKeepsEarlierDrops pins the no-overwrite rule: the first copy's path
@@ -481,11 +552,11 @@ func TestPruneWithoutCopiesDir(t *testing.T) {
 func TestSaveKeepsEarlierDrops(t *testing.T) {
 	service := New(t.TempDir())
 
-	first, err := service.Save("shot.png", strings.NewReader("one"))
+	first, err := service.Save("s1", "shot.png", strings.NewReader("one"))
 	if err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	second, err := service.Save("shot.png", strings.NewReader("two"))
+	second, err := service.Save("s1", "shot.png", strings.NewReader("two"))
 	if err != nil {
 		t.Fatalf("Save: %v", err)
 	}
@@ -511,25 +582,160 @@ func TestSaveKeepsEarlierDrops(t *testing.T) {
 // wherever it moved and never fail.
 func TestSaveRefusesAnExhaustedName(t *testing.T) {
 	service := New(t.TempDir())
-	if err := os.MkdirAll(service.dir, 0o755); err != nil {
+	dir := filepath.Join(service.dir, "s1")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	last := filepath.Join(service.dir, "shot-999.png")
+	last := filepath.Join(dir, "shot-999.png")
 	for i := 1; i <= 999; i++ {
 		name := "shot.png"
 		if i > 1 {
 			name = fmt.Sprintf("shot-%d.png", i)
 		}
-		if err := os.WriteFile(filepath.Join(service.dir, name), []byte("taken"), 0o644); err != nil {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("taken"), 0o644); err != nil {
 			t.Fatalf("write %s: %v", name, err)
 		}
 	}
 
-	if _, err := service.Save("shot.png", strings.NewReader("new bytes")); err == nil {
+	if _, err := service.Save("s1", "shot.png", strings.NewReader("new bytes")); err == nil {
 		t.Fatal("Save reported success with every name taken")
 	}
 
 	if got, err := os.ReadFile(last); err != nil || string(got) != "taken" {
 		t.Fatalf("last copy = %q (%v), want it untouched", got, err)
+	}
+}
+
+// TestNewCreatesTheCopiesDir: a confined session binds this directory when it
+// spawns, and a bind of a source that is not there is silently dropped — so the
+// directory has to exist before any session opens, not after the first drop.
+func TestNewCreatesTheCopiesDir(t *testing.T) {
+	config := t.TempDir()
+
+	service := New(config)
+
+	info, err := os.Stat(service.dir)
+	if err != nil || !info.IsDir() {
+		t.Fatalf("copies dir = %v (%v), want a directory at %s", info, err, service.dir)
+	}
+}
+
+// TestUploadRejectsAMissingSession: without an id there is no directory that a
+// confined session can read and no session whose close deletes the copy, so
+// the drop is refused rather than written somewhere nothing ends.
+func TestUploadRejectsAMissingSession(t *testing.T) {
+	for _, session := range []string{"", "..", "."} {
+		t.Run(session, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			target := "/drop?name=shot.png&session=" + url.QueryEscape(session)
+			request := httptest.NewRequest(http.MethodPost, target, strings.NewReader("x"))
+
+			New(t.TempDir()).Upload(recorder, request)
+
+			if recorder.Code != http.StatusBadRequest {
+				t.Fatalf("upload = %d, want %d", recorder.Code, http.StatusBadRequest)
+			}
+		})
+	}
+}
+
+// TestUploadKeepsATraversingSessionInside: the id reaches the backend off a
+// query string, so it is shaped by whatever sent it — and it may only ever name
+// a directory inside the copies tree.
+func TestUploadKeepsATraversingSessionInside(t *testing.T) {
+	config := t.TempDir()
+	recorder := httptest.NewRecorder()
+	target := "/drop?name=shot.png&session=" + url.QueryEscape("../../evil")
+	request := httptest.NewRequest(http.MethodPost, target, strings.NewReader("x"))
+
+	New(config).Upload(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("upload = %d (%s), want %d", recorder.Code, recorder.Body, http.StatusOK)
+	}
+	var answer struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &answer); err != nil {
+		t.Fatalf("decode %s: %v", recorder.Body, err)
+	}
+	if want := filepath.Join(config, "lich", "dropped", "evil", "shot.png"); answer.Path != want {
+		t.Fatalf("path = %q, want %q", answer.Path, want)
+	}
+}
+
+// TestPurgeDeletesOneSessionsCopies is the lifetime the feature promises: the
+// copies exist for the conversation they were dropped into, and the session
+// closing is what ends them — with the copies of every other session untouched.
+func TestPurgeDeletesOneSessionsCopies(t *testing.T) {
+	service := New(t.TempDir())
+	gone := agedCopy(t, service, "s1", "shot.png", time.Minute)
+	kept := agedCopy(t, service, "s2", "shot.png", time.Minute)
+
+	service.Purge("s1")
+
+	if _, err := os.Stat(gone); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("purged session's copy still there (%v)", err)
+	}
+	if _, err := os.Stat(kept); err != nil {
+		t.Fatalf("another session's copy was deleted: %v", err)
+	}
+}
+
+// TestPurgeRefusesToLeaveTheCopiesDir: Purge is handed a session id, and the
+// one thing it may never do is take a path out of the tree it owns.
+func TestPurgeRefusesToLeaveTheCopiesDir(t *testing.T) {
+	service := New(t.TempDir())
+	kept := agedCopy(t, service, "s1", "shot.png", time.Minute)
+
+	for _, session := range []string{"", ".", "..", "../"} {
+		service.Purge(session)
+	}
+
+	if _, err := os.Stat(kept); err != nil {
+		t.Fatalf("copies dir emptied by a bad session id: %v", err)
+	}
+	if _, err := os.Stat(service.dir); err != nil {
+		t.Fatalf("copies dir removed by a bad session id: %v", err)
+	}
+}
+
+// TestPruneKeepsAnEmptySessionDir is the trap the second method exists for: a
+// confined session binds its own copies directory at spawn, so removing it from
+// under a live session would leave every later copy of that session invisible
+// inside the sandbox. A drop by another session must not do that.
+func TestPruneKeepsAnEmptySessionDir(t *testing.T) {
+	service := New(t.TempDir())
+	expired := agedCopy(t, service, "s1", "old.png", 4*24*time.Hour)
+	dir := filepath.Dir(expired)
+
+	service.Prune()
+
+	if _, err := os.Stat(expired); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("expired copy still there (%v)", err)
+	}
+	if _, err := os.Stat(dir); err != nil {
+		t.Fatalf("session dir removed by a plain prune: %v", err)
+	}
+}
+
+// TestPruneStaleRemovesEmptySessionDirs is the startup sweep: nothing has
+// spawned yet, so a directory with nothing left in it belongs to a session that
+// is over — the crash that never reported one gone.
+func TestPruneStaleRemovesEmptySessionDirs(t *testing.T) {
+	service := New(t.TempDir())
+	expired := agedCopy(t, service, "s1", "old.png", 4*24*time.Hour)
+	kept := agedCopy(t, service, "s2", "recent.png", time.Minute)
+
+	service.PruneStale()
+
+	if _, err := os.Stat(filepath.Dir(expired)); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("emptied session dir still there (%v)", err)
+	}
+	if _, err := os.Stat(kept); err != nil {
+		t.Fatalf("copy inside the window was deleted: %v", err)
+	}
+	if _, err := os.Stat(filepath.Dir(kept)); err != nil {
+		t.Fatalf("session dir with copies left in it was removed: %v", err)
 	}
 }

--- a/internal/drop/drop_test.go
+++ b/internal/drop/drop_test.go
@@ -739,3 +739,163 @@ func TestPruneStaleRemovesEmptySessionDirs(t *testing.T) {
 		t.Fatalf("session dir with copies left in it was removed: %v", err)
 	}
 }
+
+// pickerAt stands in for the host's file chooser: it answers with path, and
+// records that it was asked.
+func pickerAt(path string, err error) (func(string) (string, error), *int) {
+	calls := 0
+	return func(string) (string, error) {
+		calls++
+		return path, err
+	}, &calls
+}
+
+// TestAttachKeepsAPathTheSessionCanOpen: a file inside the checkout is a file a
+// confined session reaches, and copying it would hand the agent a second
+// version of a file it can already edit in place.
+func TestAttachKeepsAPathTheSessionCanOpen(t *testing.T) {
+	canConfine(t, true)
+	root := t.TempDir()
+	want := filepath.Join(root, "src", "app.ts")
+	writeFile(t, want, 12, time.Now())
+	service := New(t.TempDir())
+	pick, _ := pickerAt(want, nil)
+	service.SetPicker(pick)
+
+	got, err := service.Attach("s1", root, true)
+
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	if got.Path != want || got.Copied {
+		t.Fatalf("Attach = %+v, want the file's own path", got)
+	}
+}
+
+// TestAttachCopiesForAConfinedSession is the whole point: the file is outside
+// the checkout, so its path names nothing inside the sandbox — the session gets
+// a copy it can read, holding the same bytes.
+func TestAttachCopiesForAConfinedSession(t *testing.T) {
+	canConfine(t, true)
+	elsewhere := filepath.Join(t.TempDir(), "spec.pdf")
+	if err := os.WriteFile(elsewhere, []byte("bytes"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	service := New(t.TempDir())
+	pick, _ := pickerAt(elsewhere, nil)
+	service.SetPicker(pick)
+
+	got, err := service.Attach("s1", t.TempDir(), true)
+
+	if err != nil {
+		t.Fatalf("Attach: %v", err)
+	}
+	if want := filepath.Join(service.dir, "s1", "spec.pdf"); got.Path != want || !got.Copied {
+		t.Fatalf("Attach = %+v, want a copy at %s", got, want)
+	}
+	if bytes, err := os.ReadFile(got.Path); err != nil || string(bytes) != "bytes" {
+		t.Fatalf("copy = %q (%v), want %q", bytes, err, "bytes")
+	}
+}
+
+// TestAttachLeavesAnUnconfinedSessionAlone, and with it Windows, which has no
+// backend to confine anything: the path the picker gave is the path the prompt
+// gets, copies and their expiry included in what it does not have.
+func TestAttachLeavesAnUnconfinedSessionAlone(t *testing.T) {
+	elsewhere := filepath.Join(t.TempDir(), "spec.pdf")
+	if err := os.WriteFile(elsewhere, []byte("bytes"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	for _, tt := range []struct {
+		name              string
+		confined, backend bool
+	}{
+		{"session not confined", false, true},
+		{"machine cannot confine", true, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			canConfine(t, tt.backend)
+			service := New(t.TempDir())
+			pick, _ := pickerAt(elsewhere, nil)
+			service.SetPicker(pick)
+
+			got, err := service.Attach("s1", t.TempDir(), tt.confined)
+
+			if err != nil {
+				t.Fatalf("Attach: %v", err)
+			}
+			if got.Path != elsewhere || got.Copied {
+				t.Fatalf("Attach = %+v, want %q uncopied", got, elsewhere)
+			}
+		})
+	}
+}
+
+// A cancelled dialog is the user changing their mind, not a failure to report.
+func TestAttachAnswersACancelledDialog(t *testing.T) {
+	canConfine(t, true)
+	service := New(t.TempDir())
+	pick, _ := pickerAt("", nil)
+	service.SetPicker(pick)
+
+	got, err := service.Attach("s1", t.TempDir(), true)
+
+	if err != nil || got.Path != "" || got.Copied {
+		t.Fatalf("Attach = %+v (%v), want an empty answer", got, err)
+	}
+}
+
+// TestAttachRefusesWhatItCannotCopy covers the two the copy has no answer for,
+// and the session with nowhere to keep one. Each has to fail loudly: a path
+// written at the prompt that the agent cannot open is worse than an error.
+func TestAttachRefusesWhatItCannotCopy(t *testing.T) {
+	canConfine(t, true)
+	dir := t.TempDir()
+	huge := filepath.Join(dir, "core.dump")
+	if err := os.WriteFile(huge, make([]byte, maxUpload+1), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	folder := filepath.Join(dir, "docs")
+	if err := os.Mkdir(folder, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, tt := range []struct{ name, path, session string }{
+		{"over the ceiling", huge, "s1"},
+		{"a folder", folder, "s1"},
+		{"gone from disk", filepath.Join(dir, "nothing.txt"), "s1"},
+		{"no session to keep it under", huge, ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			service := New(t.TempDir())
+			pick, _ := pickerAt(tt.path, nil)
+			service.SetPicker(pick)
+
+			if got, err := service.Attach(tt.session, t.TempDir(), true); err == nil {
+				t.Fatalf("Attach = %+v, want an error", got)
+			}
+		})
+	}
+}
+
+// TestAttachWithoutAPicker: the wiring is startup's, and a service without it
+// has no dialog to open — which must not read as a cancelled one.
+func TestAttachWithoutAPicker(t *testing.T) {
+	if _, err := New(t.TempDir()).Attach("s1", t.TempDir(), true); err == nil {
+		t.Fatal("Attach reported success with no picker wired")
+	}
+}
+
+// TestAttachReportsAFailedDialog keeps the picker's own failure from arriving as
+// a path nobody chose.
+func TestAttachReportsAFailedDialog(t *testing.T) {
+	service := New(t.TempDir())
+	pick, calls := pickerAt("/some/file", errors.New("no display"))
+	service.SetPicker(pick)
+
+	if _, err := service.Attach("s1", t.TempDir(), true); err == nil {
+		t.Fatal("Attach reported success on a dialog that failed")
+	}
+	if *calls != 1 {
+		t.Fatalf("picker called %d times, want 1", *calls)
+	}
+}

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/omartelo/lich/internal/providers"
@@ -163,12 +164,16 @@ func (s *Service) addSession(
 // DeleteSession removes a session for good and sets the project's active session
 // to activeID (the neighbor the frontend picked, or "" when none remain).
 func (s *Service) DeleteSession(projectID, sessionID, activeID string) error {
-	return s.tx(func(tx *sql.Tx) error {
+	if err := s.tx(func(tx *sql.Tx) error {
 		if _, err := tx.Exec(`DELETE FROM sessions WHERE id = ?`, sessionID); err != nil {
 			return fmt.Errorf("delete session %q: %w", sessionID, err)
 		}
 		return setActiveSession(tx, projectID, activeID)
-	})
+	}); err != nil {
+		return err
+	}
+	s.sessionIsGone(sessionID)
+	return nil
 }
 
 // CloseSession parks a session instead of deleting it: is_open flips to 0, which
@@ -281,12 +286,44 @@ func (s *Service) PurgeWorktreeSessions(projectID, path string) error {
 	if path == "" {
 		return nil
 	}
+	// Read before the delete, because what hangs off a session outside the
+	// database is keyed by id and the rows are about to be gone.
+	gone := s.sessionIDsAt(projectID, path)
 	if _, err := s.db.Exec(
 		`DELETE FROM sessions WHERE project_id = ? AND path = ?`, projectID, path,
 	); err != nil {
 		return fmt.Errorf("purge worktree sessions for %q: %w", path, err)
 	}
+	s.sessionIsGone(gone...)
 	return nil
+}
+
+// sessionIDsAt lists the sessions of a project living at path — the live one
+// and any parked leftovers alike. Only asked when something is listening for
+// deleted sessions, so a store without that wiring runs the query it always
+// ran. A failed read costs the cleanup, never the delete.
+func (s *Service) sessionIDsAt(projectID, path string) []string {
+	if s.sessionGone == nil {
+		return nil
+	}
+	rows, err := s.db.Query(
+		`SELECT id FROM sessions WHERE project_id = ? AND path = ?`, projectID, path,
+	)
+	if err != nil {
+		slog.Warn("list worktree sessions", "path", path, "err", err)
+		return nil
+	}
+	defer rows.Close()
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			slog.Warn("scan worktree session id", "path", path, "err", err)
+			return ids
+		}
+		ids = append(ids, id)
+	}
+	return ids
 }
 
 // RenameSession updates a session's display label from an explicit user rename.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -100,6 +100,32 @@ const busyTimeoutMS = 5000
 // Service owns the SQLite connection and exposes persistence to the frontend.
 type Service struct {
 	db *sql.DB
+	// sessionGone, when set, is told the id of every session whose row is
+	// deleted for good. See SetSessionGone.
+	sessionGone func(sessionID string)
+}
+
+// SetSessionGone registers what to run when a session's row is deleted for
+// good — DeleteSession and PurgeWorktreeSessions, never CloseSession, which
+// parks the row for a later resume and leaves everything hanging off it alone.
+//
+// It is startup wiring, called before anything serves: lich hangs the cleanup
+// of that session's dropped-file copies on it (internal/drop), which is what
+// makes a copy outlive its drop and not its session.
+func (s *Service) SetSessionGone(fn func(sessionID string)) {
+	s.sessionGone = fn
+}
+
+// sessionIsGone reports one deleted session to whatever SetSessionGone wired,
+// and nothing at all when the store runs without it — every test, and a lich
+// whose wiring has not run yet.
+func (s *Service) sessionIsGone(sessionIDs ...string) {
+	if s.sessionGone == nil {
+		return
+	}
+	for _, id := range sessionIDs {
+		s.sessionGone(id)
+	}
 }
 
 // Session is a persisted terminal session (metadata only). Kind selects what

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1314,3 +1314,55 @@ func TestDeleteProjectRemovesItsSessions(t *testing.T) {
 		t.Errorf("sessions after delete = %d, want 0 (cascade)", sessions)
 	}
 }
+
+// TestSessionGoneReportsDeletedSessions covers the wiring the dropped-file
+// copies hang off (internal/drop): the ids reported here are the ones whose
+// copies are deleted, and a parked session must not be among them — its row is
+// still there, waiting for a resume that would find its copies gone.
+func TestSessionGoneReportsDeletedSessions(t *testing.T) {
+	svc := newTestStore(t)
+	var gone []string
+	svc.SetSessionGone(func(id string) { gone = append(gone, id) })
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2, "")
+	_ = svc.AddSession("p1", "parked", "Session 2", "claude", "", 3, "")
+
+	if err := svc.CloseSession("p1", "parked", "base"); err != nil {
+		t.Fatalf("CloseSession: %v", err)
+	}
+	if len(gone) != 0 {
+		t.Fatalf("parking a session reported it gone: %v", gone)
+	}
+
+	if err := svc.DeleteSession("p1", "base", ""); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	if want := []string{"base"}; !slices.Equal(gone, want) {
+		t.Fatalf("reported %v, want %v", gone, want)
+	}
+}
+
+// TestSessionGoneReportsEveryRowOfARemovedWorktree: removing a worktree takes
+// the live session and every parked leftover at that path with it, and each one
+// leaves copies behind that nothing else would ever delete.
+func TestSessionGoneReportsEveryRowOfARemovedWorktree(t *testing.T) {
+	svc := newTestStore(t)
+	var gone []string
+	svc.SetSessionGone(func(id string) { gone = append(gone, id) })
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2, "")
+	_ = svc.AddSession("p1", "wtA", "foo", "claude", "/wt/foo", 3, "")
+	if err := svc.CloseSession("p1", "wtA", "base"); err != nil {
+		t.Fatalf("CloseSession: %v", err)
+	}
+	_ = svc.AddSession("p1", "wtA2", "foo", "claude", "/wt/foo", 4, "")
+
+	if err := svc.PurgeWorktreeSessions("p1", "/wt/foo"); err != nil {
+		t.Fatalf("PurgeWorktreeSessions: %v", err)
+	}
+
+	slices.Sort(gone)
+	if want := []string{"wtA", "wtA2"}; !slices.Equal(gone, want) {
+		t.Fatalf("reported %v, want %v", gone, want)
+	}
+}

--- a/internal/terminal/sandbox.go
+++ b/internal/terminal/sandbox.go
@@ -3,6 +3,7 @@ package terminal
 import (
 	"log/slog"
 	"os"
+	"path/filepath"
 
 	"github.com/omartelo/lich/internal/project"
 	"github.com/omartelo/lich/internal/sandbox"
@@ -22,13 +23,41 @@ import (
 // decision stays testable; an empty one returns the spawn untouched, because a
 // sandbox whose private home has no path is one that would confine a session to
 // nothing it can name.
-func wrapSandbox(spec ptySpec, kind, home string, confined bool) ptySpec {
+//
+// dropDir is where this session's dropped-file copies live (sessionDropDir),
+// bound read-only so a file dragged onto a confined terminal is a file the
+// agent can actually open. Empty leaves it out.
+func wrapSandbox(spec ptySpec, kind, home, dropDir string, confined bool) ptySpec {
 	if !confined || home == "" || !sandbox.Available() {
 		return spec
 	}
-	sb := sandbox.Describe(kind, home, spec.dir, project.GitCommonDir(spec.dir), executables(spec.bin))
+	read := append(executables(spec.bin), dropDir)
+	sb := sandbox.Describe(kind, home, spec.dir, project.GitCommonDir(spec.dir), read)
 	spec.bin, spec.args = sandbox.Wrap(sb, spec.bin, spec.args)
 	return spec
+}
+
+// sessionDropDir is the directory holding the copies of the files dropped into
+// one session (internal/drop), created here because a bind mount of a source
+// that does not exist yet is dropped from the spec — and the first drop of the
+// session comes long after the spawn.
+//
+// One session's directory rather than the whole copies tree, so a confined
+// session reads what was dropped into it and not what was dropped into the
+// session beside it. Empty when there is nothing to mount, which costs the
+// session its drops and never its spawn — and for an unconfined session, which
+// reads the copy at its real path like any other file and would otherwise leave
+// an empty directory behind for every spawn.
+func sessionDropDir(dropDir, sessionID string, confined bool) string {
+	if !confined || dropDir == "" || sessionID == "" {
+		return ""
+	}
+	dir := filepath.Join(dropDir, sessionID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		slog.Warn("session drop dir", "dir", dir, "err", err)
+		return ""
+	}
+	return dir
 }
 
 // executables are the directories holding the binaries a confined spawn has to

--- a/internal/terminal/sandbox_test.go
+++ b/internal/terminal/sandbox_test.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/omartelo/lich/internal/providers"
@@ -71,7 +72,7 @@ func TestWrapSandboxLeavesAnUnconfinedSpawnAlone(t *testing.T) {
 		{"not confined", "/home/u", false},
 		{"no home to empty", "", true},
 	} {
-		got := wrapSandbox(baseSpec(), providers.Claude, tt.home, tt.confined)
+		got := wrapSandbox(baseSpec(), providers.Claude, tt.home, "", tt.confined)
 		if got.bin != original.bin || !slices.Equal(got.args, original.args) {
 			t.Errorf("%s: spawn rewritten to %q %v", tt.name, got.bin, got.args)
 		}
@@ -83,7 +84,7 @@ func TestWrapSandboxKeepsTheCommandAndItsArguments(t *testing.T) {
 		t.Skip("no sandbox backend on this machine")
 	}
 	original := baseSpec()
-	got := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), true)
+	got := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), "", true)
 	if got.bin == original.bin {
 		t.Fatalf("the spawn was not confined: still %q", got.bin)
 	}
@@ -148,5 +149,66 @@ func TestExecutablesAreDirectoriesOnDisk(t *testing.T) {
 		if !slices.Contains(dirs, filepath.Dir(lich)) {
 			t.Errorf("the lich binary's directory is missing from %v", dirs)
 		}
+	}
+}
+
+// TestSessionDropDirCreatesTheDirectory: the bind is built when the PTY spawns
+// and the first file is dropped long after, so the directory has to be there
+// already — a bind of a source that does not exist is dropped from the spec,
+// and the copy would then land where the session cannot read it.
+func TestSessionDropDirCreatesTheDirectory(t *testing.T) {
+	copies := t.TempDir()
+
+	got := sessionDropDir(copies, "s1", true)
+
+	if want := filepath.Join(copies, "s1"); got != want {
+		t.Fatalf("sessionDropDir = %q, want %q", got, want)
+	}
+	if info, err := os.Stat(got); err != nil || !info.IsDir() {
+		t.Fatalf("sessionDropDir did not create %s (%v)", got, err)
+	}
+}
+
+// A session with nowhere to keep copies still spawns: it loses its drops, never
+// its card. An unconfined one wants no directory at all — it opens the copy at
+// the path it was written to, like any other file.
+func TestSessionDropDirWithoutABase(t *testing.T) {
+	for _, tt := range []struct {
+		base, session string
+		confined      bool
+	}{
+		{"", "s1", true},
+		{t.TempDir(), "", true},
+		{t.TempDir(), "s1", false},
+	} {
+		if got := sessionDropDir(tt.base, tt.session, tt.confined); got != "" {
+			t.Errorf("sessionDropDir(%q, %q, %v) = %q, want none", tt.base, tt.session, tt.confined, got)
+		}
+	}
+	base := t.TempDir()
+	if _, err := os.Stat(filepath.Join(base, "s1")); err == nil {
+		t.Error("an unconfined session left a copies directory behind")
+	}
+}
+
+// TestWrapSandboxMountsTheSessionsCopies is the drop's half of the sandbox: a
+// file dragged onto a confined terminal is copied by lich outside it, so the
+// path pasted at the prompt only names something the agent can open if the
+// directory holding it is bound in.
+func TestWrapSandboxMountsTheSessionsCopies(t *testing.T) {
+	if !sandbox.Available() {
+		t.Skip("no sandbox backend on this machine")
+	}
+	copies := sessionDropDir(t.TempDir(), "s1", true)
+
+	got := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), copies, true)
+
+	// Substring, not an argv element: the two backends spell a mounted path in
+	// their own vocabulary — bubblewrap takes it as its own argument
+	// (`--ro-bind dir dir`), seatbelt writes it into the profile it is handed as
+	// one string (`(allow file-read* (subpath "dir"))`). What the spawn has to
+	// carry is the path, not a shape only one of them uses.
+	if !slices.ContainsFunc(got.args, func(arg string) bool { return strings.Contains(arg, copies) }) {
+		t.Fatalf("the session's copies dir %q is not in the confined spawn: %v", copies, got.args)
 	}
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -221,6 +221,20 @@ type Service struct {
 	// size a session spawned with none of its own is started at. See
 	// sizeFor. Guarded by mu.
 	lastCols, lastRows int
+	// dropDir is where copies of dropped files live (internal/drop). Wired at
+	// startup; empty leaves a confined session without the copies dropped into
+	// it, never without a spawn. See SetDropDir.
+	dropDir string
+}
+
+// SetDropDir names the directory holding the copies of dropped files
+// (internal/drop). A confined session binds its own subdirectory of it at spawn
+// — the copy is written by lich, outside the sandbox, so without the bind the
+// path pasted at the prompt names a file the session cannot open.
+//
+// Startup wiring, called before anything spawns.
+func (s *Service) SetDropDir(dir string) {
+	s.dropDir = dir
 }
 
 // readySettle is how long a session's PTY must stay quiet before lich hands it
@@ -532,7 +546,7 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 	// Outermost, so the setup script and the entrypoint are confined with the
 	// session they run in front of.
 	inSandbox := confined(s.store, id, kind, projectID, cwd)
-	spec = wrapSandbox(spec, kind, userHome(), inSandbox)
+	spec = wrapSandbox(spec, kind, userHome(), sessionDropDir(s.dropDir, id, inSandbox), inSandbox)
 	p, err := startPTY(spec)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to start pty for %q: %w", id, err)

--- a/main.go
+++ b/main.go
@@ -117,8 +117,15 @@ func main() {
 	dispatcher := rpc.New()
 	drops := drop.New(configDir)
 	// The other prune runs after each new copy; this one is what clears the
-	// last of them for a lich that is never dropped on again.
-	drops.Prune()
+	// last of them for a lich that is never dropped on again — and the only one
+	// that may remove a session's directory outright, no session having spawned
+	// around it yet.
+	drops.PruneStale()
+	// A copy belongs to the session it was dropped into: that session reads it
+	// through a bind mount when it is confined, and deleting the session's row
+	// takes the copies with it.
+	term.SetDropDir(drop.Dir(configDir))
+	db.SetSessionGone(drops.Purge)
 	dispatcher.Register("terminal", term)
 	dispatcher.Register("drop", drops)
 	dispatcher.Register("fonts", fonts.New())
@@ -181,20 +188,27 @@ func main() {
 //     argument array with a 1MB bound.
 //   - relay.Observe is the hooks' session-state stream, which arrives over
 //     /hook: forging a SessionEnd here closes another session's errands.
-//   - relay.SetPlugins, project.SetAccounts and project.SetProjects are startup
-//     wiring. Called with [null] they silently nil what they wired
-//     (encoding/json leaves a func or pointer alone on null), and the write
-//     races the readers already serving — nilling SetProjects also disarms the
-//     guard that keeps two projects off the same directory.
+//   - drop.Purge deletes every copy dropped into a session, by id: the page
+//     closes sessions through the store, which is what reports one gone.
+//   - relay.SetPlugins, project.SetAccounts, project.SetProjects,
+//     store.SetSessionGone and terminal.SetDropDir are startup wiring. Called
+//     with [null] they silently nil what they wired (encoding/json leaves a
+//     func or pointer alone on null), and the write races the readers already
+//     serving — nilling SetProjects also disarms the guard that keeps two
+//     projects off the same directory, and SetDropDir points the sandbox's
+//     read-only bind wherever the caller likes.
 func denyInternal(d *rpc.Handler) {
 	for _, method := range []string{
 		"store.Close",
+		"store.SetSessionGone",
 		"drop.Upload",
 		"drop.Save",
+		"drop.Purge",
 		"relay.Observe",
 		"relay.SetPlugins",
 		"project.SetAccounts",
 		"project.SetProjects",
+		"terminal.SetDropDir",
 	} {
 		d.Deny(method)
 	}

--- a/main.go
+++ b/main.go
@@ -126,6 +126,10 @@ func main() {
 	// takes the copies with it.
 	term.SetDropDir(drop.Dir(configDir))
 	db.SetSessionGone(drops.Purge)
+	// The footer's attach button opens the picker through the drop service, so
+	// the file it copies for a confined session is one a human chose in a dialog
+	// (drop.Attach says why that matters).
+	drops.SetPicker(proj.PickFile)
 	dispatcher.Register("terminal", term)
 	dispatcher.Register("drop", drops)
 	dispatcher.Register("fonts", fonts.New())
@@ -190,6 +194,8 @@ func main() {
 //     /hook: forging a SessionEnd here closes another session's errands.
 //   - drop.Purge deletes every copy dropped into a session, by id: the page
 //     closes sessions through the store, which is what reports one gone.
+//   - drop.SetPicker is startup wiring like the ones below, and nilling it
+//     would leave the footer's attach button with no dialog to open.
 //   - relay.SetPlugins, project.SetAccounts, project.SetProjects,
 //     store.SetSessionGone and terminal.SetDropDir are startup wiring. Called
 //     with [null] they silently nil what they wired (encoding/json leaves a
@@ -204,6 +210,7 @@ func denyInternal(d *rpc.Handler) {
 		"drop.Upload",
 		"drop.Save",
 		"drop.Purge",
+		"drop.SetPicker",
 		"relay.Observe",
 		"relay.SetPlugins",
 		"project.SetAccounts",

--- a/main_test.go
+++ b/main_test.go
@@ -26,6 +26,7 @@ var denied = map[string]reflect.Type{
 	"drop.Upload":          reflect.TypeFor[*drop.Service](),
 	"drop.Save":            reflect.TypeFor[*drop.Service](),
 	"drop.Purge":           reflect.TypeFor[*drop.Service](),
+	"drop.SetPicker":       reflect.TypeFor[*drop.Service](),
 	"relay.Observe":        reflect.TypeFor[*relay.Service](),
 	"relay.SetPlugins":     reflect.TypeFor[*relay.Service](),
 	"project.SetAccounts":  reflect.TypeFor[*project.Service](),
@@ -43,6 +44,7 @@ func (stubService) SetSessionGone() error { return nil }
 func (stubService) Upload() error         { return nil }
 func (stubService) Save() error           { return nil }
 func (stubService) Purge() error          { return nil }
+func (stubService) SetPicker() error      { return nil }
 func (stubService) Observe() error        { return nil }
 func (stubService) SetPlugins() error     { return nil }
 func (stubService) SetAccounts() error    { return nil }

--- a/main_test.go
+++ b/main_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/omartelo/lich/internal/relay"
 	"github.com/omartelo/lich/internal/rpc"
 	"github.com/omartelo/lich/internal/store"
+	"github.com/omartelo/lich/internal/terminal"
 )
 
 // denied spells out denyInternal's list a second time, and names the type each
@@ -20,32 +21,38 @@ import (
 // fails TestDeniedMethodsAreUnreachable and an entry that names nothing —
 // Deny takes any string — fails TestDeniedMethodsExist.
 var denied = map[string]reflect.Type{
-	"store.Close":         reflect.TypeFor[*store.Service](),
-	"drop.Upload":         reflect.TypeFor[*drop.Service](),
-	"drop.Save":           reflect.TypeFor[*drop.Service](),
-	"relay.Observe":       reflect.TypeFor[*relay.Service](),
-	"relay.SetPlugins":    reflect.TypeFor[*relay.Service](),
-	"project.SetAccounts": reflect.TypeFor[*project.Service](),
-	"project.SetProjects": reflect.TypeFor[*project.Service](),
+	"store.Close":          reflect.TypeFor[*store.Service](),
+	"store.SetSessionGone": reflect.TypeFor[*store.Service](),
+	"drop.Upload":          reflect.TypeFor[*drop.Service](),
+	"drop.Save":            reflect.TypeFor[*drop.Service](),
+	"drop.Purge":           reflect.TypeFor[*drop.Service](),
+	"relay.Observe":        reflect.TypeFor[*relay.Service](),
+	"relay.SetPlugins":     reflect.TypeFor[*relay.Service](),
+	"project.SetAccounts":  reflect.TypeFor[*project.Service](),
+	"project.SetProjects":  reflect.TypeFor[*project.Service](),
+	"terminal.SetDropDir":  reflect.TypeFor[*terminal.Service](),
 }
 
-// stubService stands in for the four registered services: dispatch resolves a
+// stubService stands in for the registered services: dispatch resolves a
 // method by name alone, and the real ones want a database, a config directory
 // and a running terminal.
 type stubService struct{}
 
-func (stubService) Close() error       { return nil }
-func (stubService) Upload() error      { return nil }
-func (stubService) Save() error        { return nil }
-func (stubService) Observe() error     { return nil }
-func (stubService) SetPlugins() error  { return nil }
-func (stubService) SetAccounts() error { return nil }
-func (stubService) SetProjects() error { return nil }
-func (stubService) Allowed() error     { return nil }
+func (stubService) Close() error          { return nil }
+func (stubService) SetSessionGone() error { return nil }
+func (stubService) Upload() error         { return nil }
+func (stubService) Save() error           { return nil }
+func (stubService) Purge() error          { return nil }
+func (stubService) Observe() error        { return nil }
+func (stubService) SetPlugins() error     { return nil }
+func (stubService) SetAccounts() error    { return nil }
+func (stubService) SetProjects() error    { return nil }
+func (stubService) SetDropDir() error     { return nil }
+func (stubService) Allowed() error        { return nil }
 
 func denyingDispatcher() *rpc.Handler {
 	d := rpc.New()
-	for _, service := range []string{"store", "drop", "relay", "project"} {
+	for _, service := range []string{"store", "drop", "relay", "project", "terminal"} {
 		d.Register(service, stubService{})
 	}
 	denyInternal(d)


### PR DESCRIPTION
## The bug

Dragging a file onto a **sandboxed** session's terminal pasted the path the file has on the machine. That session's home is an empty private one (`internal/sandbox`), so the agent opened nothing and answered that the file does not exist.

The existing copy fallback never ran either: from `Resolve`'s side the lookup had *succeeded* — it found the file under the real home and handed back a path only lich can open.

## The fix

- `drop.Resolve` takes the session's confinement and stops searching home for a confined one. Everything outside the checkout falls through to the copy, which is the one thing lich writes where such a session can still read it.
- Copies move under one directory per session (`dropped/<sessionID>/`), and a confined spawn binds **its own** directory read-only. So the pasted path resolves inside the sandbox, and one confined session cannot read what was dropped into the one beside it.
- A copy now dies with the session it was dropped into: deleting the row — closing a session, removing its worktree — purges its directory through a new `store.SetSessionGone` hook. Parking a worktree session does **not** purge: it resumes, and its scrollback still holds those paths.
- The three-day age rule stays as the backstop for a lich that dies without reporting a session gone. Only the startup sweep (`PruneStale`) may remove a session directory outright — doing it under a live mount would leave every later copy of that session invisible inside its sandbox, the mount still pointing at the deleted directory.

Toast and skip messages stopped blaming a home that was never searched.

## Windows

Unchanged, deliberately. The flag alone does not stop the home search — the machine must have a sandbox backend — and Windows has none (`sandbox.Available()` is `false` there). The same guard covers a Linux host without bubblewrap.

## Providers

Provider-agnostic: a drop is a path written at the prompt, identical for all five in `providers.Registry`. Nothing here is per-provider.

## Measured, not assumed

`bwrap --tmpfs $HOME --ro-bind <dropped>/<session>`: the home is empty except the mount point, and a file written **after** the spawn is readable inside — the bind is live, not a snapshot. That is what makes a copy written at drop time reach a session that opened before it.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test ./...` — 31 packages green
- [x] Cross-compile loop: `GOOS=linux|darwin|windows go build ./... && go vet ./...`
- [x] `biome check` clean (14 pre-existing warnings, none in touched files); `vitest` 1018/1018; `vite build` ok
- [x] Coverage: `drop` 88.2%, `store` 85.7%, `terminal` 92.9%
- [x] `CHANGELOG.md` and `docs/ceilings.md` updated in the same commit
- [x] Manual: drop a screenshot from `~/Downloads` onto a confined session's terminal, confirm the agent reads it; close the session and confirm the copies directory is gone