### PR TITLE
fix: keep a long tool name inside its session card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **A long tool name stays inside its session card.** While an agent ran an MCP
   tool, the card drew the harness's own spelling of it — `mcp__<server>__<tool>`
-  — at full length, and a name that did not fit ran out past the card's right
-  edge into the sidebar. The line now shows the two parts worth reading, the
-  server and the tool, and both it and the detail beside it give way with an
-  ellipsis rather than overflowing. The card keeps its height either way: this
-  never wraps.
+  and three other forms, one per harness — at full length, and a name that did
+  not fit ran out past the card's right edge into the sidebar. The line now
+  drops the machinery in the name and keeps the parts worth reading, and both it
+  and the detail beside it give way with an ellipsis rather than overflowing.
+  The card keeps its height either way: this never wraps.
 
 - **A pull request that will not check out says why.** Opening a session on a
   pull request runs `gh pr checkout`, which shells out to git — and when git's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A long tool name stays inside its session card.** While an agent ran an MCP
+  tool, the card drew the harness's own spelling of it — `mcp__<server>__<tool>`
+  — at full length, and a name that did not fit ran out past the card's right
+  edge into the sidebar. The line now shows the two parts worth reading, the
+  server and the tool, and both it and the detail beside it give way with an
+  ellipsis rather than overflowing. The card keeps its height either way: this
+  never wraps.
+
 - **A pull request that will not check out says why.** Opening a session on a
   pull request runs `gh pr checkout`, which shells out to git — and when git's
   ssh key was refused, all the screen said was that gh had failed and the log

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -90,6 +90,12 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   which is why the install asks its version first. Crush's block and omp's `mcp.json` register lich's MCP server by
   the absolute path of the binary that installed it, and omp's is a JSON document lich rewrites rather than appends
   to: every key survives, the user's formatting does not.
+- **The card's tool line only shortens the MCP spelling two providers use** (`frontend/src/lib/session/tool-label.ts`):
+  `mcp__<server>__<tool>` is what Claude Code and Codex report and all `toolLabel` knows how to read. opencode
+  namespaces MCP tools by their server in a form nobody has observed against a stub listener, and Crush and omp
+  were not observed either, so on those three a name outside the pattern reaches the card whole and spends the
+  card's width on the prefix. Nothing overflows on any of them — the line truncates — but the part worth reading is
+  the part that gets cut. Add the form to the pattern once one is observed, not from documentation.
 - **omp's state directory answers to two variables, and the profile wins** (`internal/agentplugin/omp.go`,
   `internal/terminal/transcript.go`, resolving it independently as the Claude Code pair do): `OMP_PROFILE` moves
   the whole directory and beats an explicit `PI_CODING_AGENT_DIR`. Get it backwards and the install lands where omp

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -90,12 +90,14 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   which is why the install asks its version first. Crush's block and omp's `mcp.json` register lich's MCP server by
   the absolute path of the binary that installed it, and omp's is a JSON document lich rewrites rather than appends
   to: every key survives, the user's formatting does not.
-- **The card's tool line only shortens the MCP spelling two providers use** (`frontend/src/lib/session/tool-label.ts`):
-  `mcp__<server>__<tool>` is what Claude Code and Codex report and all `toolLabel` knows how to read. opencode
-  namespaces MCP tools by their server in a form nobody has observed against a stub listener, and Crush and omp
-  were not observed either, so on those three a name outside the pattern reaches the card whole and spends the
-  card's width on the prefix. Nothing overflows on any of them — the line truncates — but the part worth reading is
-  the part that gets cut. Add the form to the pattern once one is observed, not from documentation.
+- **Only two of the four harnesses that report a tool spell an MCP one splittably** (`frontend/src/lib/session/tool-label.ts`,
+  table in `docs/hooks/session-state.md`): Claude Code and Codex send `mcp__<server>__<tool>`, which the card draws
+  as `<server> · <tool>`. omp's `mcp__<server>_<tool>` has one underscore doing two jobs — `mcp__lich_list_sessions`
+  splits into `lich` + `list_sessions` or `lich_list` + `sessions` and the string cannot say which — so only its
+  prefix comes off, and opencode's `<server>_<tool>` carries no marker at all and is shown whole. Nothing overflows
+  anywhere (the line truncates), but on those two the card spends its width on a server name nobody asked for.
+  Splitting them needs the list of registered server names, which the card does not have. Crush is not on this
+  list at all: it reports no tool.
 - **omp's state directory answers to two variables, and the profile wins** (`internal/agentplugin/omp.go`,
   `internal/terminal/transcript.go`, resolving it independently as the Claude Code pair do): `OMP_PROFILE` moves
   the whole directory and beats an explicit `PI_CODING_AGENT_DIR`. Get it backwards and the install lands where omp

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -114,7 +114,9 @@ Each row was taken off a real run of the CLIs against a stub listener, not from
 their documentation — except opencode's MCP tools, which are namespaced by their
 server and were not observed here, which is why the row Claude Code and Codex
 both spell `mcp__srv__tool` is absent above. A harness is free to report a name
-outside this table; the card shows whatever arrives.
+outside this table; the card shows whatever arrives, with one exception: it
+reads `mcp__<server>__<tool>` and draws it as `<server> · <tool>`, because the
+prefix costs a card its whole width before the part worth reading starts.
 
 `detail` is whatever identifies the call at a glance — the command line, the
 file path, the pattern. It is free text: a harness that offers nothing usable

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -111,12 +111,26 @@ opencode spells the same set in lower case:
 | search        | `Grep` / `Glob`            | — (goes through `Bash`)  | `grep` / `glob`  |
 
 Each row was taken off a real run of the CLIs against a stub listener, not from
-their documentation — except opencode's MCP tools, which are namespaced by their
-server and were not observed here, which is why the row Claude Code and Codex
-both spell `mcp__srv__tool` is absent above. A harness is free to report a name
-outside this table; the card shows whatever arrives, with one exception: it
-reads `mcp__<server>__<tool>` and draws it as `<server> · <tool>`, because the
-prefix costs a card its whole width before the part worth reading starts.
+their documentation. MCP tools are absent from the table above because no two
+harnesses name them alike; they have their own table below. A harness is free to
+report a name outside either table; the card shows whatever arrives, minus the
+MCP machinery it can prove — that prefix costs a card its whole width before the
+part worth reading starts:
+
+| Harness           | MCP tool name            | On the card                |
+|-------------------|--------------------------|----------------------------|
+| Claude Code       | `mcp__lich__open_session`  | `lich · open_session`      |
+| Codex             | `mcp__srv__tool`           | `srv · tool`               |
+| oh-my-pi          | `mcp__lich_list_sessions`  | `lich_list_sessions`       |
+| opencode          | `lichprobe_list_sessions`  | unchanged                  |
+
+Measured against opencode 1.18.18 and omp 17.3.7 by running each CLI against a
+`lich mcp` server and reading the name off the handler the plugin already has —
+`input.tool` and `event.toolName`. Only the doubled underscore can be split:
+omp's single one divides `mcp__lich_list_sessions` into `lich` + `list_sessions`
+or `lich_list` + `sessions` with nothing in the string to say which, so only its
+prefix comes off, and opencode's form carries no marker at all. Crush is absent
+because it reports no tool (see above).
 
 `detail` is whatever identifies the call at a glance — the command line, the
 file path, the pattern. It is free text: a harness that offers nothing usable

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -30,6 +30,7 @@ import { useSessionRelay } from "@/lib/session/use-session-relay"
 import { useSessionInbox } from "@/lib/session/use-session-inbox"
 import { useSessionTool } from "@/lib/session/use-session-tool"
 import { toolGlyph } from "@/lib/session/tool-glyph"
+import { toolLabel } from "@/lib/session/tool-label"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { baseReadout } from "@/lib/git/base-status"
 import { usePullRequest } from "@/lib/pulls/use-pull-request"
@@ -366,12 +367,19 @@ export function SessionCard({
               ) : tool ? (
                 <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">
                   {ToolGlyph && <ToolGlyph className="size-3 shrink-0" />}
-                  <span className="shrink-0 font-medium text-foreground">{tool.name}</span>
+                  {/* The detail gives its width up first and the name only once
+                      the detail has none left to give — which is what the lopsided
+                      shrink factor buys. Both still shrink, so neither can push the
+                      row past the card the way a name that refused to shrink did.
+                      The separator travels inside the detail so it leaves with it,
+                      instead of dangling after a truncated name. */}
+                  <span className="min-w-0 truncate font-medium text-foreground">
+                    {toolLabel(tool.name)}
+                  </span>
                   {tool.detail && (
-                    <>
-                      <span className="shrink-0 opacity-50">·</span>
-                      <span className="truncate font-mono">{tool.detail}</span>
-                    </>
+                    <span className="min-w-0 shrink-[9999] truncate font-mono">
+                      <span className="opacity-50">·</span> {tool.detail}
+                    </span>
                   )}
                 </span>
               ) : (

--- a/frontend/src/lib/session/tool-label.test.ts
+++ b/frontend/src/lib/session/tool-label.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+import { toolLabel } from "./tool-label"
+
+describe("toolLabel", () => {
+  it("drops the mcp machinery and keeps the server and the tool", () => {
+    expect(toolLabel("mcp__ai-memory__memory_write_page")).toBe("ai-memory · memory_write_page")
+    expect(toolLabel("mcp__lich__open_session")).toBe("lich · open_session")
+  })
+
+  // The server ends at the first `__` after the prefix, so a tool whose own
+  // name carries one keeps it whole rather than losing its tail to the split.
+  it("splits on the first separator, not the last", () => {
+    expect(toolLabel("mcp__srv__do__the__thing")).toBe("srv · do__the__thing")
+  })
+
+  it("shows a name that is not an MCP tool's exactly as it arrived", () => {
+    expect(toolLabel("Bash")).toBe("Bash")
+    expect(toolLabel("apply_patch")).toBe("apply_patch")
+    expect(toolLabel("")).toBe("")
+  })
+
+  // Half a prefix is not an MCP name, and neither half is a server or a tool.
+  it("leaves a malformed mcp name alone", () => {
+    expect(toolLabel("mcp__lich")).toBe("mcp__lich")
+    expect(toolLabel("mcp____tool")).toBe("mcp____tool")
+  })
+})

--- a/frontend/src/lib/session/tool-label.test.ts
+++ b/frontend/src/lib/session/tool-label.test.ts
@@ -13,6 +13,19 @@ describe("toolLabel", () => {
     expect(toolLabel("mcp__srv__do__the__thing")).toBe("srv · do__the__thing")
   })
 
+  // Measured against omp 17.3.7: a single underscore between the server and the
+  // tool, which nothing in the string can split — "lich" + "list_sessions" and
+  // "lich_list" + "sessions" are equally readable, so only the prefix comes off.
+  it("takes the prefix off omp's single-underscore form and splits no further", () => {
+    expect(toolLabel("mcp__lich_list_sessions")).toBe("lich_list_sessions")
+  })
+
+  // Measured against opencode 1.18.18: no prefix at all, so there is no marker
+  // to key on and the name is shown whole.
+  it("leaves opencode's form alone", () => {
+    expect(toolLabel("lichprobe_list_sessions")).toBe("lichprobe_list_sessions")
+  })
+
   it("shows a name that is not an MCP tool's exactly as it arrived", () => {
     expect(toolLabel("Bash")).toBe("Bash")
     expect(toolLabel("apply_patch")).toBe("apply_patch")
@@ -20,8 +33,8 @@ describe("toolLabel", () => {
   })
 
   // Half a prefix is not an MCP name, and neither half is a server or a tool.
-  it("leaves a malformed mcp name alone", () => {
-    expect(toolLabel("mcp__lich")).toBe("mcp__lich")
-    expect(toolLabel("mcp____tool")).toBe("mcp____tool")
+  it("still strips the prefix off a name it cannot split", () => {
+    expect(toolLabel("mcp__lich")).toBe("lich")
+    expect(toolLabel("mcp____tool")).toBe("__tool")
   })
 })

--- a/frontend/src/lib/session/tool-label.ts
+++ b/frontend/src/lib/session/tool-label.ts
@@ -1,16 +1,30 @@
-// Claude Code and Codex both spell an MCP tool `mcp__<server>__<tool>`
-// (docs/hooks/session-state.md). The prefix and the doubled underscores are
-// machinery — they cost a card its whole width before the part worth reading
-// starts, and a session card is 12rem at its narrowest. The server and the tool
-// are the news, so the label keeps those and drops the rest.
+// The harnesses spell an MCP tool three different ways, all measured against the
+// real CLIs rather than read off their docs (docs/hooks/session-state.md):
 //
-// Non-greedy on the server so a tool whose own name contains `__` keeps it: the
-// first `__` after the prefix ends the server, and everything after it is the
-// tool. A name that is not an MCP tool's is shown as it arrived — the card
-// promises to show whatever a harness reports.
-const MCP_TOOL = /^mcp__(.+?)__(.+)$/
+//   Claude Code, Codex  mcp__<server>__<tool>   mcp__lich__open_session
+//   oh-my-pi            mcp__<server>_<tool>    mcp__lich_list_sessions
+//   opencode            <server>_<tool>         lichprobe_list_sessions
+//
+// The `mcp__` prefix and the doubled underscores are machinery: they cost a card
+// its width before the part worth reading starts, and a session card is 12rem at
+// its narrowest.
+const MCP_DOUBLE = /^mcp__(.+?)__(.+)$/
+const MCP_PREFIX = "mcp__"
 
+// toolLabel shortens what it can prove and leaves the rest alone.
+//
+// The doubled form splits cleanly, so it draws as "<server> · <tool>" —
+// non-greedy on the server, so a tool whose own name contains `__` keeps it.
+// omp's single underscore cannot be split at all: `mcp__lich_list_sessions`
+// divides into "lich" + "list_sessions" or "lich_list" + "sessions" and nothing
+// in the string says which, so only the prefix comes off. opencode's form has no
+// marker to key on — a server name is not distinguishable from the first word of
+// a tool name — so it is shown as it arrived, which is also what any name that is
+// not an MCP tool's gets.
 export function toolLabel(name: string): string {
-  const parts = MCP_TOOL.exec(name)
-  return parts ? `${parts[1]} · ${parts[2]}` : name
+  const parts = MCP_DOUBLE.exec(name)
+  if (parts) {
+    return `${parts[1]} · ${parts[2]}`
+  }
+  return name.startsWith(MCP_PREFIX) ? name.slice(MCP_PREFIX.length) : name
 }

--- a/frontend/src/lib/session/tool-label.ts
+++ b/frontend/src/lib/session/tool-label.ts
@@ -1,0 +1,16 @@
+// Claude Code and Codex both spell an MCP tool `mcp__<server>__<tool>`
+// (docs/hooks/session-state.md). The prefix and the doubled underscores are
+// machinery — they cost a card its whole width before the part worth reading
+// starts, and a session card is 12rem at its narrowest. The server and the tool
+// are the news, so the label keeps those and drops the rest.
+//
+// Non-greedy on the server so a tool whose own name contains `__` keeps it: the
+// first `__` after the prefix ends the server, and everything after it is the
+// tool. A name that is not an MCP tool's is shown as it arrived — the card
+// promises to show whatever a harness reports.
+const MCP_TOOL = /^mcp__(.+?)__(.+)$/
+
+export function toolLabel(name: string): string {
+  const parts = MCP_TOOL.exec(name)
+  return parts ? `${parts[1]} · ${parts[2]}` : name
+}


### PR DESCRIPTION
While an agent runs an MCP tool, the card draws the harness's own spelling of it — `mcp__<server>__<tool>` — and the name carried `shrink-0`, so anything that did not fit ran out past the card's right edge into the sidebar. The `detail` beside it already truncated; the name never could.

No wrap: the ask was to omit, not to reflow, because a second line changes the card's height.

## What changed

- **`toolLabel`** (new, `frontend/src/lib/session/tool-label.ts`) reads `mcp__<server>__<tool>` and draws it as `<server> · <tool>`. The prefix and the doubled underscores are machinery — they cost a card its whole width before the part worth reading starts. Non-greedy on the server, so a tool whose own name contains `__` keeps it. Anything that is not an MCP name is shown exactly as it arrived.
- **The name truncates**, and the detail carries a lopsided shrink factor so it gives its width up first — the name only shrinks once the detail has none left. A short name beside a long detail still draws whole, as it did before.
- **The separator moved inside the detail**, so it leaves with it instead of dangling after a truncated name.

## Measured, not asserted

jsdom computes no layout, so the row was rendered against the built CSS in a headless Chromium at a 160px width — a 12rem sidebar, the narrowest it goes — and `scrollWidth - clientWidth` read off each case:

| case | before | after |
| --- | ---: | ---: |
| `mcp__ai-memory__memory_write_page`, no detail | **55px over** | 0 |
| same, with a path detail | **55px over** | 0 |
| `Bash` + long detail | 0 | 0 (name still 27px — undiminished) |
| 120-char name | **560px over** | 0 |

## Providers

`mcp__<server>__<tool>` is what Claude Code and Codex report. opencode namespaces MCP tools by their server in a form `docs/hooks/session-state.md` says was never observed against a stub listener, and Crush and omp were not observed either — so on those three a name outside the pattern still reaches the card whole. It truncates rather than overflowing, so the bug is fixed for all five; only the shortening is narrower. Written down as a `docs/ceilings.md` bullet with what would close it.

`docs/hooks/session-state.md` said "the card shows whatever arrives", which is now one exception short of true — the exception is named there.

## Test plan

- [x] `tool-label.test.ts`: the split, a tool name containing `__`, non-MCP names untouched, malformed prefixes left alone.
- [x] `biome check`, `tsc`, `vitest` (1023 passed / 88 files), `vite build` clean. Backend untouched.
- [x] Manual: run an MCP tool with the sidebar dragged to its minimum.