### PR TITLE
fix: find a provider installed outside the system prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A provider installed by Homebrew is found again when lich is opened from
+  its icon.** lich already recovers the environment your shell's rc files
+  export, but a bare command name is resolved against the process's own `PATH`,
+  which a launch from Finder or a desktop entry inherits from the session
+  manager — without Homebrew's prefix, or any other directory an rc file adds.
+  Codex installed with `brew install` was reported missing, and a session
+  configured to run it could not start; the same launch from a terminal worked.
+  The recovered `PATH` is now pinned into lich itself, so detection, the spawn
+  and the Chromium search all read it.
+
 ## [0.38.0] - 2026-08-19
 
 ### Added

--- a/internal/terminal/shellenv.go
+++ b/internal/terminal/shellenv.go
@@ -113,3 +113,25 @@ func mergeEnv(base, extra []string) []string {
 	}
 	return merged
 }
+
+// PinPath copies env's PATH into lich's own process. ResolveShellEnv's merge
+// only reaches what lich hands a child as cmd.Env, and that is not what
+// resolves a bare binary name: exec.LookPath — and exec.Command, which calls it
+// — reads the process PATH, never cmd.Env. So a GUI launch that never sourced
+// the rc files fails to find anything the rc files put on PATH: provider
+// detection reports codex missing, the spawn cannot start it, and the Chromium
+// search misses a browser outside the system prefix. macOS is where this bites
+// hardest — a Finder-launched .app gets launchd's bare PATH, without Homebrew's
+// prefix — but a .desktop launch is the same shape.
+func PinPath(env []string) {
+	for _, kv := range env {
+		v, ok := strings.CutPrefix(kv, "PATH=")
+		if !ok {
+			continue
+		}
+		if err := os.Setenv("PATH", v); err != nil {
+			slog.Warn("terminal: pin resolved PATH", "err", err)
+		}
+		return
+	}
+}

--- a/internal/terminal/shellenv_test.go
+++ b/internal/terminal/shellenv_test.go
@@ -138,3 +138,19 @@ func TestResolveShellEnvBrokenShell(t *testing.T) {
 		t.Fatalf("ResolveShellEnv with broken shell = %v, want %v", got, base)
 	}
 }
+
+func TestPinPath(t *testing.T) {
+	t.Setenv("PATH", "/orig")
+	PinPath([]string{"A=1", "PATH=/shell/bin:/orig", "B=2"})
+	if got := os.Getenv("PATH"); got != "/shell/bin:/orig" {
+		t.Fatalf("PATH = %q, want %q", got, "/shell/bin:/orig")
+	}
+}
+
+func TestPinPathWithoutPATH(t *testing.T) {
+	t.Setenv("PATH", "/orig")
+	PinPath([]string{"A=1"})
+	if got := os.Getenv("PATH"); got != "/orig" {
+		t.Fatalf("PATH = %q, want it untouched", got)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -65,6 +65,9 @@ func main() {
 	// what the user launched lich with (see terminal.childEnv). ResolveShellEnv
 	// recovers the rc-exported vars a GUI launch misses (see its doc).
 	env := terminal.ResolveShellEnv(os.Environ())
+	// The slice above is what children inherit; exec.LookPath reads the process
+	// PATH instead, so the resolved one has to land there too (see PinPath).
+	terminal.PinPath(env)
 
 	configDir, err := os.UserConfigDir()
 	if err != nil {


### PR DESCRIPTION
Reported on macOS: `codex` installed with `brew install` is invisible to lich when the app is opened from its icon, and visible when the same binary is launched from a terminal.

## Cause

Not the shell-env recovery — `terminal.ResolveShellEnv` runs at boot and does merge the rc-exported `PATH`. The problem is what that merged slice reaches. It is passed to children as `cmd.Env`, and `cmd.Env` is not what resolves a bare binary name: `exec.LookPath`, and `exec.Command` which calls it, read the **process** `PATH`.

Two call sites miss it:

- `internal/providers/providers.go:93` — detection is `exec.LookPath`, so the provider list is built against launchd's `PATH` and reports codex missing.
- `internal/terminal/pty_unix.go:14` — `exec.Command(spec.bin, ...)` resolves the same way, so a session pinned to codex could not start either, `cmd.Env` notwithstanding.

A launch from a terminal works because there the process `PATH` is already the shell's. A Finder-launched `.app` gets launchd's, which has no `/opt/homebrew/bin`; a `.desktop` launch is the same shape.

## Change

`terminal.PinPath` copies the resolved `PATH` into lich's own process, called once in `main` right after `ResolveShellEnv`. One pin fixes every in-process lookup — detection, the spawn, the Chromium browser search — instead of threading an environment through each.

Best-effort like the resolution it follows: no `PATH` in the resolved env leaves the process untouched.

## Test plan

- [x] `go vet ./...`, `go test ./...` (1729 pass), `gofmt -l .` clean
- [x] Cross-compile loop for linux/darwin/windows
- [x] Unit tests for `PinPath`: PATH pinned, and env without PATH leaves the process value alone
- [x] macOS: open the installed `.app` from Finder with `codex` on a Homebrew prefix only, confirm it is detected and a codex session starts

Note for the reporter: if `SHELL` is absent from the `.app`'s environment, `ResolveShellEnv` returns the launch env unchanged and this pin has nothing better to pin — `grep "shell env resolution yielded nothing" ~/Library/Application\ Support/lich/*.log` tells which case it is.