### PR TITLE
Browse the files of a folder that is not a git repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Files tab browses a folder that is not a git repository.** The tree was
+  built from `git ls-files`, so a project opened on a plain directory — notes, a
+  scratch folder, a checkout of something that is not git — answered "Not a git
+  repository" and offered nothing to read, though every file beside it was
+  perfectly readable. Outside a repository lich now walks the directory itself:
+  `.git` is skipped, symlinks are left alone, and the listing stops at 20,000
+  files, since there is no `.gitignore` out there to keep a `node_modules` out.
+  Inside a repository nothing changes — git still answers, ignored files stay
+  invisible, and a broken repository still reports its error rather than
+  flooding the tree.
 - **A provider installed by Homebrew is found again when lich is opened from
   its icon.** lich already recovers the environment your shell's rc files
   export, but a bare command name is resolved against the process's own `PATH`,

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -41,6 +41,13 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   `frontend/src/lib/session/peer-name.ts`) for the relay to resolve against, and the derived string goes stale the
   moment anyone renames — it then addresses a session that no longer answers to it. Nothing reads the real name
   back, so `/list-agents` inside the session is the only place it is true.
+- **The file tree outside a repository is unfiltered and capped**
+  (`internal/project/tree.go`, `walkFiles`): a plain folder has no `.gitignore`
+  for lich to obey, so the Files tab lists dependency and build directories like
+  any other, and stops at `walkLimit` files with nothing on screen saying the
+  listing was cut. It also has no git status to poll, so the tree there refreshes
+  only when the panel is reopened — a file the agent just wrote shows up on the
+  next visit, not while you watch.
 - **git status is polled** — one shared poller per repository path (`frontend/src/lib/git/git-status-store.ts`); the
   lich plugin's `session-touched` hook nudges an immediate refresh.
 - **lich fetches on its own** (`internal/project/basestatus.go`) — the only git write lich makes outside the

--- a/frontend/src/components/dock/FilesPanel.tsx
+++ b/frontend/src/components/dock/FilesPanel.tsx
@@ -23,7 +23,8 @@ import { errorText } from "@/lib/utils"
 import { useFileEditor } from "./useFileEditor"
 
 // FilesPanel is the Files tab of the right dock: a read-only tree of the active
-// session's tracked files, master-detail with an in-dock preview. It follows the
+// session's files — tracked and untracked in a repository, whatever is on disk
+// in a plain folder — master-detail with an in-dock preview. It follows the
 // active session like the review panel — a worktree session browses its
 // checkout, not the project root — so clicking a file opens it beside the same
 // terminal it belongs to. It never edits; clicks only navigate, inject
@@ -188,13 +189,13 @@ interface TreeBodyProps {
 function TreeBody({ tree, query, active, stats, failed, onOpen, onEditor }: TreeBodyProps) {
   const filtering = query.trim() !== ""
   if (failed) {
-    return <Notice>Not a git repository</Notice>
+    return <Notice>Could not read this folder</Notice>
   }
   if (tree === null) {
     return <Notice>Loading…</Notice>
   }
   if (tree.length === 0) {
-    return <Notice>{filtering ? "No file matches" : "No tracked files"}</Notice>
+    return <Notice>{filtering ? "No file matches" : "No files here"}</Notice>
   }
   return (
     <FileTree

--- a/internal/project/git_test.go
+++ b/internal/project/git_test.go
@@ -93,13 +93,15 @@ func TestDiscardNewFileStaysSilent(t *testing.T) {
 // TestRunGitStillReportsRealFailures is the counterweight: the quiet runner
 // exists for polls and probes, and must not have swallowed the failures a
 // person is waiting on. A read of a directory that is not a repository still
-// yields the screen's sentence and still reaches the log.
+// yields the screen's sentence and still reaches the log. It reads through
+// DiffText because Tree's contract moved: a non-repository is browsable now, so
+// it is no longer a caller with a failure to report.
 func TestRunGitStillReportsRealFailures(t *testing.T) {
 	logged := captureLog(t)
 
-	_, err := New(nil).Tree(t.TempDir())
+	_, err := New(nil).DiffText(t.TempDir())
 	if err == nil {
-		t.Fatal("Tree outside a repository: want an error, got nil")
+		t.Fatal("DiffText outside a repository: want an error, got nil")
 	}
 	if want := "not a git repository"; !strings.Contains(err.Error(), "not a git repository") {
 		t.Errorf("error %q does not name %q", err, want)

--- a/internal/project/tree.go
+++ b/internal/project/tree.go
@@ -3,6 +3,7 @@ package project
 import (
 	"bytes"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -31,14 +32,24 @@ func isBinary(data []byte) bool {
 	return bytes.IndexByte(data[:min(len(data), binarySniffBytes)], 0) >= 0
 }
 
-// Tree lists the work tree's files as repo-relative, slash-separated paths,
-// sorted. It merges tracked files with untracked-but-not-ignored ones
-// (`ls-files --cached --others --exclude-standard`) and drops any tracked file
-// deleted from disk (`--deleted`), so a file created or removed since the
-// session began shows without a commit. .gitignore is honored for free, so no
-// node_modules and no build output leak in. A non-repository path yields an
-// error, matching DiffText's contract.
+// Tree lists a directory's files as root-relative, slash-separated paths,
+// sorted. Inside a repository it merges tracked files with
+// untracked-but-not-ignored ones (`ls-files --cached --others
+// --exclude-standard`) and drops any tracked file deleted from disk
+// (`--deleted`), so a file created or removed since the session began shows
+// without a commit; .gitignore is honored for free, so no node_modules and no
+// build output leak in. Anywhere else — a plain folder, a machine without git —
+// it falls back to walking the directory: browsing a project's files is not a
+// git feature, and only the diff panel beside it is.
 func (s *Service) Tree(path string) ([]string, error) {
+	// Asked before anything is listed, and quietly: a plain directory is not a
+	// failure to report, and routing its refreshes through runGit would file a
+	// warning per poll for a folder that is behaving exactly as it should. A
+	// work tree still goes through git, so a repository that *is* broken keeps
+	// reporting its error instead of being walked as if it were a plain folder.
+	if _, ok := gitQuiet(path, "rev-parse", "--is-inside-work-tree"); !ok {
+		return walkFiles(path, walkLimit)
+	}
 	present, err := lsFiles(path, "--cached", "--others", "--exclude-standard")
 	if err != nil {
 		return nil, err
@@ -58,6 +69,55 @@ func (s *Service) Tree(path string) ([]string, error) {
 		}
 	}
 	// The --cached/--others merge is not globally sorted; the tree wants one order.
+	slices.Sort(files)
+	return files, nil
+}
+
+// walkLimit caps a non-repository walk. Without git there is no .gitignore to
+// obey, so the walk has no way to leave a dependency or build directory out;
+// the cap is what keeps a home directory or a node_modules from arriving as one
+// RPC answer the tree then has to render.
+const walkLimit = 20000
+
+// walkFiles lists a plain directory's regular files, root-relative and
+// slash-separated, stopping at limit files (walkLimit; a parameter so the cap
+// is testable without laying down 20k files). Symlinks are skipped (nothing here resolves one, and a link
+// to a directory is a walk that may not terminate), .git is skipped whole, and
+// an unreadable subdirectory costs its own subtree rather than the answer.
+func walkFiles(root string, limit int) ([]string, error) {
+	var files []string
+	err := filepath.WalkDir(root, func(full string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			if full == root {
+				return err
+			}
+			if entry != nil && !entry.IsDir() {
+				return nil
+			}
+			return fs.SkipDir
+		}
+		if entry.IsDir() {
+			if full != root && entry.Name() == ".git" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, full)
+		if err != nil {
+			return nil
+		}
+		files = append(files, filepath.ToSlash(rel))
+		if len(files) >= limit {
+			return fs.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("list %s: %w", root, err)
+	}
 	slices.Sort(files)
 	return files, nil
 }

--- a/internal/project/tree_test.go
+++ b/internal/project/tree_test.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -54,10 +55,50 @@ func TestTreeDropsDeleted(t *testing.T) {
 	}
 }
 
-// TestTreeNotRepo proves a non-repository path is an error, matching DiffText.
-func TestTreeNotRepo(t *testing.T) {
-	if _, err := New(nil).Tree(t.TempDir()); err == nil {
-		t.Error("Tree on non-repo: want error, got nil")
+// TestTreeWalksNonRepo proves a plain directory is still browsable: the files
+// come back root-relative, slash-separated and sorted, nested folders included
+// and .git skipped whole. The contract changed here — a non-repository path used
+// to be an error, matching DiffText; browsing files is not a git feature.
+func TestTreeWalksNonRepo(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "b.txt", "b\n")
+	write(t, dir, "src/main.go", "package main\n")
+	write(t, dir, ".git/config", "[core]\n")
+	files, err := New(nil).Tree(dir)
+	if err != nil {
+		t.Fatalf("Tree: %v", err)
+	}
+	if got, want := strings.Join(files, ","), "b.txt,src/main.go"; got != want {
+		t.Errorf("Tree = %q, want %q", got, want)
+	}
+}
+
+// TestTreeMissingDir proves an absent directory is still an error, so the panel
+// says so instead of drawing an empty tree over a folder that is gone.
+func TestTreeMissingDir(t *testing.T) {
+	if _, err := New(nil).Tree(filepath.Join(t.TempDir(), "nope")); err == nil {
+		t.Error("Tree on missing dir: want error, got nil")
+	}
+}
+
+// TestWalkFilesStopsAtLimit proves the walk is bounded: without .gitignore
+// nothing else keeps a dependency directory out of one RPC answer. walkLimit's
+// own value is pinned as a literal — deriving it would make the test follow the
+// constant instead of pinning it.
+func TestWalkFilesStopsAtLimit(t *testing.T) {
+	if walkLimit != 20000 {
+		t.Errorf("walkLimit = %d, want 20000", walkLimit)
+	}
+	dir := t.TempDir()
+	for i := range 12 {
+		write(t, dir, fmt.Sprintf("f%02d.txt", i), "x")
+	}
+	files, err := walkFiles(dir, 10)
+	if err != nil {
+		t.Fatalf("walkFiles: %v", err)
+	}
+	if len(files) != 10 {
+		t.Errorf("walkFiles = %d files, want 10", len(files))
 	}
 }
 


### PR DESCRIPTION
The Files tab built its tree from `git ls-files`, so a project opened on a plain
directory — notes, a scratch folder, a checkout of something that is not git —
answered *Not a git repository* and offered nothing to read, though every file
in it was perfectly readable. Browsing a checkout's files is not a git feature;
only the diff panel beside it is.

## What changed

- `project.Tree` asks `rev-parse --is-inside-work-tree` first, and quietly: a
  plain folder is not a failure to report, and routing its refreshes through
  `runGit` would file a warning per poll for a directory behaving exactly as it
  should.
- A work tree still goes through git, unchanged — `.gitignore` honored, deleted
  files dropped, and a repository that really is broken still reports its error
  instead of being walked as if it were a plain folder.
- Anywhere else, `walkFiles` lists the directory: `.git` skipped whole,
  symlinks left alone (nothing here resolves one, and a link to a directory is a
  walk that may not terminate), unreadable subdirectories costing their own
  subtree rather than the answer, and a 20,000-file cap — without `.gitignore`
  nothing else keeps a `node_modules` out of one RPC answer.
- The panel's two dead-end notices follow: *Could not read this folder* for a
  real failure, *No files here* for an empty one.

## Known ceiling

`docs/ceilings.md` gains the bullet: outside a repository the tree is unfiltered
and capped with nothing on screen saying the listing was cut, and there is no
git status to poll — the tree refreshes when the panel is reopened, not while
you watch.

## Test plan

- [x] `go test ./...` — 1731 passed, including a new `TestTreeWalksNonRepo`
      (nested folders, `.git` skipped), `TestTreeMissingDir` (an absent folder is
      still an error) and `TestWalkFilesStopsAtLimit`.
- [x] `TestRunGitStillReportsRealFailures` now reads through `DiffText`: it
      proved `runGit` reports what it fails at by way of `Tree`, and `Tree` is no
      longer a caller with a failure to report outside a repository.
- [x] `gofmt -l .`, `go vet ./...`, `pnpm check`, `vitest run` (1025 passed),
      `tsc -b` + `vite build`.