### PR TITLE
feat: say when git or the GitHub CLI is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **lich says when git or the GitHub CLI is missing, instead of going quiet.**
+  Every branch, diff and worktree on screen is read through `git`, and pull
+  requests, checks and PR checkouts through `gh` — but a machine without either
+  was told nothing: the readers swallow their failures by design, so the sidebar
+  simply showed no branch and the Pull Requests screen no pull requests, with
+  nothing anywhere saying why. A launch without `git` now opens with a dialog
+  that says what stays empty and offers the download page; the Pull Requests
+  screen without `gh` says the same in place of the list. Settings › Version
+  Control opens on both tools, each with the path it resolved to — which
+  answers the question a machine with two `git` installs actually has — or an
+  install button. All three warn that the `PATH` is read at launch, so a tool
+  installed with lich open needs a restart. `lich doctor` reports both as well,
+  as warnings: lich starts and every session spawns without them.
+
 ### Fixed
 
 - **The Files tab browses a folder that is not a git repository.** The tree was
@@ -19,6 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Inside a repository nothing changes — git still answers, ignored files stay
   invisible, and a broken repository still reports its error rather than
   flooding the tree.
+- **The Version Control screen no longer answers a missing `gh` with `gh auth
+  login`.** Every failure to list your GitHub accounts had that sentence
+  appended to it, including the one where `gh` is not installed at all — which
+  sent you to authenticate a command that does not exist. The advice gh's own
+  failure carries is now the only advice shown, and a `gh` that is installed but
+  signed in to nothing says so before it becomes an error.
 - **A provider installed by Homebrew is found again when lich is opened from
   its icon.** lich already recovers the environment your shell's rc files
   export, but a bare command name is resolved against the process's own `PATH`,

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,6 +23,14 @@ Chromium, Edge or Brave are looked up as `.app` bundles under `/Applications`
 Edge or Brave are found via their conventional install paths (Edge ships with
 Windows) and the folder picker is native.
 
+**git and the GitHub CLI** — every version control surface shells out to
+`git`, and lich does not bundle it: without `git` on your `PATH`, branches,
+diffs and worktrees stay empty, though sessions still run. Pull requests,
+checks and PR checkouts go through [`gh`](https://cli.github.com) as well,
+which is optional — install it only if you use them. lich resolves both when it
+launches, so one installed while lich is open is picked up on the next start,
+and `lich doctor` reports which it found.
+
 **Agent versions** — lich names each Claude Code session with `--name` at spawn,
 a flag added in Claude Code 2.1.76. An older build exits with
 `error: unknown option '--name'` before the session exists, which reads as lich

--- a/build/linux/nfpm/nfpm.yaml
+++ b/build/linux/nfpm/nfpm.yaml
@@ -24,15 +24,21 @@ contents:
   - src: "./build/linux/lich.desktop"
     dst: "/usr/share/applications/lich.desktop"
 
+# gh is deliberately absent: it is optional (pull requests only) and packaged
+# under a different name on each distribution, so a recommends here would name
+# the wrong package as often as the right one. INSTALL.md and the app both
+# point at cli.github.com instead.
 recommends:
   - chromium
   - zenity
+  - git
 
 overrides:
   deb:
     recommends:
       - chromium | chromium-browser | google-chrome-stable
       - zenity
+      - git
 
 scripts:
   postinstall: "./build/linux/nfpm/scripts/postinstall.sh"

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -48,6 +48,12 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   listing was cut. It also has no git status to poll, so the tree there refreshes
   only when the panel is reopened — a file the agent just wrote shows up on the
   next visit, not while you watch.
+- **A missing tool is answered from the launch's `PATH`** (`frontend/src/lib/vcs-tools.ts`): the git and gh
+  checks resolve through the `PATH` lich pinned at startup (`terminal.PinPath`), so installing either one
+  while lich is open leaves every surface still calling it missing until a restart. Each of them says so; a
+  live re-resolve would mean re-running the login shell under the running process. The check is
+  `exec.LookPath` — it proves the binary exists and runs, never that it works, so a git that fails on the
+  repository itself keeps failing the old silent way.
 - **git status is polled** — one shared poller per repository path (`frontend/src/lib/git/git-status-store.ts`); the
   lich plugin's `session-touched` hook nudges an immediate refresh.
 - **lich fetches on its own** (`internal/project/basestatus.go`) — the only git write lich makes outside the

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { Toaster } from "@/components/ui/sonner"
 import { AgentPluginGate } from "@/components/AgentPluginGate"
 import { AppUpdateGate } from "@/components/AppUpdateGate"
 import { PatchNotesGate } from "@/components/PatchNotesGate"
+import { GitMissingGate } from "@/components/GitMissingGate"
 import { ProviderSetupGate } from "@/components/ProviderSetupGate"
 import { UncleanExitGate } from "@/components/UncleanExitGate"
 import { CommandPalette } from "@/components/CommandPalette"
@@ -176,6 +177,10 @@ function App() {
       {/* A toast, so it shares no surface with the gates around it: the launch
           after a crash can be the launch that also has a release to announce. */}
       <UncleanExitGate />
+      {/* Ahead of the provider gate so that on a machine missing both, choosing
+          a harness is still the dialog on top: a session with no agent is a
+          worse first launch than one with no branch. */}
+      <GitMissingGate />
       {/* Last, so that on the one launch where it can coincide with another gate
           it is the dialog on top: choosing a provider comes before reading about
           a release. */}

--- a/frontend/src/components/GitMissingGate.tsx
+++ b/frontend/src/components/GitMissingGate.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react"
+import { ExternalLink } from "lucide-react"
+import { failed } from "@/lib/binary-layers"
+import { System } from "@/lib/rpc"
+import { useBinaryCheck } from "@/lib/use-binary-check"
+import { GIT, RESTART_HINT } from "@/lib/vcs-tools"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+
+// GitMissingGate says the one thing a machine without git is never told: git is
+// what every branch, diff and worktree is read through, and none of them will
+// ever fill in. The pollers swallow their failures by design — a status read
+// that logged would file a warning a second — so without this the app is simply
+// blank in the places git answers, with nothing on screen that says why.
+//
+// git is the only tool that earns a dialog. gh has a screen of its own to be
+// missing on (Pulls), while git has none: it is behind the sidebar, the footer
+// and the dock at once.
+//
+// Nothing is remembered across launches. The dismissal is this run's, because
+// the condition is not a preference to be honoured — it is a machine that
+// cannot do half of what lich offers, and it stops asking the moment git exists.
+export function GitMissingGate() {
+  const check = useBinaryCheck(GIT.bin)
+  const [dismissed, setDismissed] = useState(false)
+
+  if (!failed(check) || dismissed) {
+    return null
+  }
+
+  return (
+    <Dialog open onOpenChange={() => setDismissed(true)}>
+      <DialogContent showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle>git is not installed</DialogTitle>
+          <DialogDescription>
+            lich reads every branch, diff and worktree through git. Sessions still run without it —
+            the version control surfaces stay empty.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogDescription>{RESTART_HINT}</DialogDescription>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => setDismissed(true)}>
+            Not now
+          </Button>
+          <Button
+            onClick={() => {
+              void System.OpenExternal(GIT.url)
+              setDismissed(true)
+            }}
+          >
+            Install git
+            <ExternalLink />
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/common/ToolMissing.tsx
+++ b/frontend/src/components/common/ToolMissing.tsx
@@ -1,0 +1,34 @@
+import type { LucideIcon } from "lucide-react"
+import { ExternalLink } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { System } from "@/lib/rpc"
+import { RESTART_HINT, type VcsTool } from "@/lib/vcs-tools"
+
+interface ToolMissingProps {
+  tool: VcsTool
+  icon: LucideIcon
+}
+
+// ToolMissing is what a screen shows in place of itself when the command-line
+// tool it runs on is not installed: the fact, what it costs, and the page that
+// fixes it. Not a dialog — a screen that cannot do anything without the tool is
+// its own notice, and a box over it would only cover the explanation.
+//
+// It fills the area it is handed rather than overlaying one (see EmptyScreen),
+// so a panel and a whole screen can both show it.
+export function ToolMissing({ tool, icon: Icon }: ToolMissingProps) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+      <Icon className="size-8 text-muted-foreground" />
+      <div className="flex flex-col gap-1">
+        <p className="text-sm text-foreground">{tool.label} is not installed</p>
+        <p className="max-w-sm text-sm text-muted-foreground">{tool.without}</p>
+      </div>
+      <Button size="sm" onClick={() => void System.OpenExternal(tool.url)}>
+        Install {tool.bin}
+        <ExternalLink />
+      </Button>
+      <p className="text-xs text-muted-foreground">{RESTART_HINT}</p>
+    </div>
+  )
+}

--- a/frontend/src/components/pulls/Pulls.tsx
+++ b/frontend/src/components/pulls/Pulls.tsx
@@ -1,10 +1,15 @@
 import { useMemo, useState, type ReactNode } from "react"
 import { useNavigate, useParams } from "react-router-dom"
+import { GitPullRequestArrow } from "lucide-react"
 import { toast } from "sonner"
 import { ProjectService, Store } from "@/lib/rpc"
 import { useProjects } from "@/providers/projects"
 import { baseName } from "@/lib/paths"
 import { Notice } from "@/components/common/Notice"
+import { ToolMissing } from "@/components/common/ToolMissing"
+import { failed } from "@/lib/binary-layers"
+import { useBinaryCheck } from "@/lib/use-binary-check"
+import { GH } from "@/lib/vcs-tools"
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
 import { sessionsOf } from "@/lib/session/sessions"
 import { useActiveSession } from "@/lib/session/use-active-session"
@@ -58,6 +63,9 @@ export function Pulls({ list = false }: PullsProps) {
     activateSession,
   } = useProjects()
   const projectPath = projects.find((p) => p.id === projectId)?.path ?? ""
+  // Every read this screen makes is a gh call, so a machine without gh gets the
+  // one screen that can say so instead of three lookups failing in a row.
+  const noGH = failed(useBinaryCheck(GH.bin))
   const { sessionId, path, checkout } = useActiveSession()
   const status = useGitStatus(path)
   const branch = status?.branch ?? ""
@@ -66,7 +74,12 @@ export function Pulls({ list = false }: PullsProps) {
   // — the whole screen without the list, and the default row with it. A number
   // addresses one directly, which only the list can produce.
   const selected = Number(number) || 0
-  const { detail, loading, error, refresh } = usePullRequestDetail(path, branch, head, selected)
+  const { detail, loading, error, refresh } = usePullRequestDetail(
+    noGH ? "" : path,
+    branch,
+    head,
+    selected,
+  )
   // The conversation hangs off the pull request the detail resolved, not off the
   // route: the screen reaches one by number or by branch, and only the answer
   // says which pull request that was.
@@ -77,7 +90,7 @@ export function Pulls({ list = false }: PullsProps) {
   const parsedQuery = useMemo(() => parsePullsQuery(query), [query])
   // An empty path is the hook's own "nothing to look up", so the single pull
   // request screen never spends a gh call on a list it does not show.
-  const pulls = usePullRequests(list ? projectPath || path : "", parsedQuery.state)
+  const pulls = usePullRequests(list && !noGH ? projectPath || path : "", parsedQuery.state)
   const { checkouts, refresh: refreshCheckouts } = useCheckouts(projectPath)
   // Where the pull request's own branch already lives, if anywhere. Every
   // "work on this PR" decision hangs off it: whether to create a checkout,
@@ -216,7 +229,9 @@ export function Pulls({ list = false }: PullsProps) {
   }
 
   let body: ReactNode
-  if (!path) {
+  if (noGH) {
+    body = <ToolMissing tool={GH} icon={GitPullRequestArrow} />
+  } else if (!path) {
     body = <CentredNotice>No repository</CentredNotice>
   } else if (error) {
     body = <CentredNotice>Couldn’t load the pull request: {error}</CentredNotice>
@@ -243,7 +258,7 @@ export function Pulls({ list = false }: PullsProps) {
 
   return (
     <div className="absolute inset-0 z-10 flex bg-background">
-      {list && (
+      {list && !noGH && (
         <PullsList
           list={pulls.list}
           loading={pulls.loading}

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -8,6 +8,7 @@ import { ProvidersSettings } from "./ProvidersSettings"
 import { ProjectProvidersSettings } from "./ProjectProvidersSettings"
 import { ProviderBinSettings } from "./ProviderBinSettings"
 import { VersionControlSettings } from "./VersionControlSettings"
+import { VcsToolsSetting } from "./VcsToolsSetting"
 import { UpdatesSettings } from "./UpdatesSettings"
 import { HelpSettings } from "./HelpSettings"
 import { SearchInput } from "@/components/common/SearchInput"
@@ -59,7 +60,15 @@ const BASE_SECTIONS: Section[] = [
     id: "version-control",
     label: "Version Control",
     group: "project",
-    render: (id) => <VersionControlSettings projectId={id} />,
+    // The tools are the machine's, not the project's, so they render above the
+    // project block and outlive its "open a project first" state — a machine
+    // with no git has to be able to read that with nothing open.
+    render: (id) => (
+      <>
+        <VcsToolsSetting />
+        <VersionControlSettings projectId={id} />
+      </>
+    ),
   },
 ]
 

--- a/frontend/src/components/settings/VcsToolsSetting.tsx
+++ b/frontend/src/components/settings/VcsToolsSetting.tsx
@@ -1,0 +1,70 @@
+import type { LucideIcon } from "lucide-react"
+import { ExternalLink, GitBranch, GitPullRequestArrow, Wrench } from "lucide-react"
+import type { BinaryCheck } from "@/lib/api-types"
+import { failed } from "@/lib/binary-layers"
+import { System } from "@/lib/rpc"
+import { useBinaryCheck } from "@/lib/use-binary-check"
+import { GH, GIT, RESTART_HINT, type VcsTool } from "@/lib/vcs-tools"
+import { Button } from "@/components/ui/button"
+import { SettingBlock } from "./SettingBlock"
+
+// VcsToolsSetting is the first thing the Version Control screen answers: whether
+// the machine has the two tools every surface below it shells out to, and where
+// to get the one it does not. Without it, git or gh missing is silent — the
+// pollers swallow the failure and the screens simply stay empty.
+//
+// It reports the resolved path rather than a tick, because "is git installed" is
+// rarely the real question: lich pins the login shell's $PATH at launch, so
+// *which* git it found is what a machine with two of them needs to see.
+export function VcsToolsSetting() {
+  const git = useBinaryCheck(GIT.bin)
+  const gh = useBinaryCheck(GH.bin)
+  return (
+    <SettingBlock
+      icon={<Wrench className="size-4" />}
+      title="Command-line tools"
+      description="lich drives git and the GitHub CLI. Everything on this screen runs through them."
+    >
+      <div className="flex w-full flex-col gap-1">
+        <ToolRow tool={GIT} icon={GitBranch} check={git} />
+        <ToolRow tool={GH} icon={GitPullRequestArrow} check={gh} />
+        {(failed(git) || failed(gh)) && (
+          <p className="pt-1 text-xs text-muted-foreground">{RESTART_HINT}</p>
+        )}
+      </div>
+    </SettingBlock>
+  )
+}
+
+interface ToolRowProps {
+  tool: VcsTool
+  icon: LucideIcon
+  /** Null until the check answers — the row shows neither verdict until it does. */
+  check: BinaryCheck | null
+}
+
+function ToolRow({ tool, icon: Icon, check }: ToolRowProps) {
+  const gone = failed(check)
+  return (
+    <div>
+      <div className="flex items-center gap-2.5 py-1 text-sm">
+        <Icon className="size-4 text-muted-foreground" />
+        <span>{tool.label}</span>
+        <span className="ml-auto text-xs text-muted-foreground">
+          {gone ? (
+            <span className="text-destructive">Not on $PATH</span>
+          ) : (
+            <span className="font-mono">{check?.path}</span>
+          )}
+        </span>
+        {gone && (
+          <Button size="sm" onClick={() => void System.OpenExternal(tool.url)}>
+            Install
+            <ExternalLink />
+          </Button>
+        )}
+      </div>
+      {gone && <p className="ml-6.5 text-xs text-muted-foreground">{tool.without}</p>}
+    </div>
+  )
+}

--- a/frontend/src/components/settings/VersionControlSettings.tsx
+++ b/frontend/src/components/settings/VersionControlSettings.tsx
@@ -5,6 +5,9 @@ import { commitIdentityRow } from "@/lib/commit-identity"
 import { accountLabel, accountSelectItems, upgradeAccount } from "@/lib/gh-account"
 import { GH_ACCOUNT_KEY } from "@/lib/project-settings"
 import { errorText } from "@/lib/utils"
+import { failed } from "@/lib/binary-layers"
+import { useBinaryCheck } from "@/lib/use-binary-check"
+import { GIT } from "@/lib/vcs-tools"
 import { invalidatePullRequests } from "@/lib/pulls/pull-request-lookup"
 import { useProjects } from "@/providers/projects"
 import {
@@ -30,9 +33,12 @@ const ACTIVE_ACCOUNT_LABEL = "gh's active account"
 export function VersionControlSettings({ projectId }: { projectId?: string }) {
   const { projects } = useProjects()
   const project = projects.find((p) => p.id === projectId)
-  const [accounts, setAccounts] = useState<string[]>([])
+  // Null until gh answers: an empty list is "gh is signed in to nothing", which
+  // is a thing to say — and saying it before the first read would be a lie.
+  const [accounts, setAccounts] = useState<string[] | null>(null)
   const [account, setAccount] = useState("")
   const [identity, setIdentity] = useState<CommitIdentity | null>(null)
+  const noGit = failed(useBinaryCheck(GIT.bin))
   const [error, setError] = useState("")
 
   // Read once per project: git's config changes outside lich, but so rarely
@@ -76,7 +82,7 @@ export function VersionControlSettings({ projectId }: { projectId?: string }) {
     if (!projectId) {
       return
     }
-    const upgraded = upgradeAccount(account, accounts)
+    const upgraded = upgradeAccount(account, accounts ?? [])
     if (upgraded) {
       setAccount(upgraded)
       void Store.SetSetting(GH_ACCOUNT_KEY, projectId, upgraded)
@@ -93,10 +99,12 @@ export function VersionControlSettings({ projectId }: { projectId?: string }) {
 
   // The configured account survives a gh that no longer lists it, so a stale
   // value is visible (and changeable) instead of silently reading as default.
-  const options = Array.from(new Set([...accounts, ...(account ? [account] : [])]))
+  const options = Array.from(new Set([...(accounts ?? []), ...(account ? [account] : [])]))
   // The account governs what lich asks gh; this says who the commits are
-  // authored as. Both facts, no comparison — see commitIdentityRow.
-  const row = identity && commitIdentityRow(identity)
+  // authored as. Both facts, no comparison — see commitIdentityRow. Withheld
+  // without git: the empty answer git could not give reads as "this checkout
+  // has no identity", which is a claim about the checkout nobody measured.
+  const row = !noGit && identity && commitIdentityRow(identity)
 
   return (
     <SettingBlock
@@ -127,9 +135,15 @@ export function VersionControlSettings({ projectId }: { projectId?: string }) {
           </SelectGroup>
         </SelectContent>
       </Select>
+      {/* gh's own failure already names its cause and its fix — not signed in,
+          not installed, a host that would not answer — so the sentence that used
+          to be appended here told half of them to run the wrong command. */}
       {error && (
-        <p className="mt-2 text-xs text-destructive">
-          Could not list GitHub accounts: {error}. Run `gh auth login` to authenticate.
+        <p className="mt-2 text-xs text-destructive">Could not list GitHub accounts: {error}</p>
+      )}
+      {!error && accounts?.length === 0 && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          gh is signed in to no account. Run `gh auth login` in a terminal.
         </p>
       )}
       {row && (

--- a/frontend/src/lib/vcs-tools.ts
+++ b/frontend/src/lib/vcs-tools.ts
@@ -1,0 +1,36 @@
+// The two command-line tools every version control surface runs through, and
+// the page a machine without one installs it from. Both are resolved on $PATH
+// exactly as the backend spawns them (internal/providers.Verify), so what this
+// reports is what lich would actually run — not what a terminal would.
+//
+// The download pages are the vendors' own and detect the operating system
+// themselves, which is why there is no per-platform URL table here to go stale.
+
+export interface VcsTool {
+  /** The binary as lich spawns it, and what Verify is asked about. */
+  bin: string
+  label: string
+  url: string
+  /** What stops working without it — the reason the row is a fact, not a nag. */
+  without: string
+}
+
+export const GIT: VcsTool = {
+  bin: "git",
+  label: "git",
+  url: "https://git-scm.com/downloads",
+  without: "Branches, diffs and worktrees stay empty without it.",
+}
+
+export const GH: VcsTool = {
+  bin: "gh",
+  label: "GitHub CLI (gh)",
+  url: "https://cli.github.com",
+  without: "Pull requests, checks and PR checkouts need it.",
+}
+
+// lich resolves the login shell's $PATH once, at launch, and pins it into its
+// own process (terminal.PinPath). A tool installed while lich is open is
+// therefore still missing to the running one — which reads as the install
+// having failed unless every surface offering it says otherwise.
+export const RESTART_HINT = "Installed it already? Restart lich — the $PATH is read at launch."

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -69,6 +70,7 @@ type Doctor struct {
 	browser  func() (string, error)
 	detect   func() []providers.Detected
 	store    func() (io.Closer, error)
+	lookPath func(string) (string, error)
 }
 
 // New returns a Doctor for this machine. configDir is the OS config dir, and
@@ -82,6 +84,7 @@ func New(configDir string, getenv func(string) string) *Doctor {
 		browser:   Browser,
 		detect:    Providers,
 		store:     func() (io.Closer, error) { return store.New() },
+		lookPath:  exec.LookPath,
 	}
 }
 
@@ -102,6 +105,8 @@ func (d *Doctor) Run() []Check {
 		{"store", func() (Status, string) { return d.checkStore(info, running) }},
 		{"browser", d.checkBrowser},
 		{"providers", d.checkProviders},
+		{"git", func() (Status, string) { return d.checkTool("git", gitWithout) }},
+		{"gh", func() (Status, string) { return d.checkTool("gh", ghWithout) }},
 	}
 
 	checks := make([]Check, 0, len(steps))
@@ -204,6 +209,25 @@ func (d *Doctor) checkProviders() (Status, string) {
 	}
 	return OK, fmt.Sprintf("%d of %d on PATH: %s",
 		len(installed), len(found), strings.Join(installed, ", "))
+}
+
+// What a machine loses with each version control tool missing. The same two
+// sentences answer on screen (frontend/src/lib/vcs-tools.ts) — a diagnosis that
+// disagrees with the app about what is broken is worse than no diagnosis.
+const (
+	gitWithout = "branches, diffs and worktrees stay empty"
+	ghWithout  = "pull requests, checks and PR checkouts are unavailable"
+)
+
+// checkTool resolves one of the command-line tools lich shells out to. Never a
+// Fail: lich opens and every session spawns without either of them — what goes
+// missing is a surface, and `without` is the one that goes.
+func (d *Doctor) checkTool(name, without string) (Status, string) {
+	path, err := d.lookPath(name)
+	if err != nil {
+		return Warn, fmt.Sprintf("not on PATH — %s", without)
+	}
+	return OK, path
 }
 
 // Failed reports whether any check would stop a launch, which is what the exit

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -30,6 +31,7 @@ func healthy(t *testing.T) *Doctor {
 		}
 	}
 	d.store = func() (io.Closer, error) { return io.NopCloser(nil), nil }
+	d.lookPath = func(name string) (string, error) { return "/usr/bin/" + name, nil }
 	return d
 }
 
@@ -48,7 +50,7 @@ func TestAHealthyMachineWalksTheWholeBoot(t *testing.T) {
 	for _, c := range checks {
 		names = append(names, c.Name)
 	}
-	want := []string{"home", "log", "listener", "store", "browser", "providers"}
+	want := []string{"home", "log", "listener", "store", "browser", "providers", "git", "gh"}
 	if strings.Join(names, ",") != strings.Join(want, ",") {
 		t.Errorf("checks ran as %v, want the boot order %v", names, want)
 	}
@@ -59,6 +61,51 @@ func TestAHealthyMachineWalksTheWholeBoot(t *testing.T) {
 	}
 	if Failed(checks) {
 		t.Error("a healthy machine reports a launch-stopping failure")
+	}
+}
+
+func TestAMissingVersionControlToolWarnsWithoutStoppingTheLaunch(t *testing.T) {
+	for _, tc := range []struct{ name, without string }{
+		{"git", "worktrees"},
+		{"gh", "pull requests"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := healthy(t)
+			d.lookPath = func(name string) (string, error) {
+				if name == tc.name {
+					return "", exec.ErrNotFound
+				}
+				return "/usr/bin/" + name, nil
+			}
+
+			checks := d.Run()
+			got := statuses(checks)[tc.name]
+
+			if got.Status != Warn {
+				t.Errorf("%s = %s (%s), want warn — lich opens without it", tc.name, got.Status, got.Detail)
+			}
+			if !strings.Contains(got.Detail, tc.without) {
+				t.Errorf("detail does not say what stops working: %q", got.Detail)
+			}
+			if Failed(checks) {
+				t.Errorf("a missing %s is reported as launch-stopping", tc.name)
+			}
+		})
+	}
+}
+
+func TestAnInstalledToolReportsThePathItResolvedTo(t *testing.T) {
+	d := healthy(t)
+	d.lookPath = func(string) (string, error) { return "/opt/homebrew/bin/git", nil }
+
+	got := statuses(d.Run())["git"]
+
+	if got.Status != OK {
+		t.Errorf("git = %s (%s), want ok", got.Status, got.Detail)
+	}
+	// Which git, not whether: two of them on PATH is the whole reason to look.
+	if got.Detail != "/opt/homebrew/bin/git" {
+		t.Errorf("detail = %q, want the resolved path", got.Detail)
 	}
 }
 


### PR DESCRIPTION
Everything the version control surfaces show is read through `git`, and the pull request ones through `gh`. A machine without either was told nothing: the readers swallow their failures by design — a status poll that logged would file a warning a second — so the sidebar showed no branch and the Pull Requests screen no pull requests, with nothing anywhere saying why.

Detection needed no new backend. `providers.Verify` is already a `LookPath` over the RPC, resolving the same `PATH` the spawn reads, and `system.OpenExternal` already opens a URL in the default browser.

## What lands

- **A launch without `git` opens on a dialog** naming what stays empty, with the download page behind one button. `git` is the only tool that earns a dialog: `gh` has a screen of its own to be missing on, `git` is behind the sidebar, the footer and the dock at once. Dismissal is this run's — the condition is a machine that cannot do half of what lich offers, not a preference, and it stops asking the moment `git` exists.
- **The Pull Requests screen without `gh`** says so in place of the list and the detail, and spends no `gh` call on either.
- **Settings › Version Control opens on both tools**, each with the path it resolved to — the question a machine with two `git` installs actually has — or an install button.
- All three warn that the `PATH` is read at launch (`terminal.PinPath`), so a tool installed with lich open needs a restart.
- **`lich doctor` reports both**, as warnings: lich starts and every session spawns without them.

Two failures of the same shape go with it — an answer git or gh never gave, read as a fact:

- the screen appended ``run `gh auth login` `` to *every* account-listing failure, including the one where `gh` is not installed at all;
- the commit identity row read git's empty answer as "this checkout has no identity", a claim about the checkout nobody measured.

`git` joins the package `recommends`. `gh` deliberately does not: it is packaged as `gh` on Debian and Fedora and `github-cli` on Arch, and a recommends naming the wrong package is worse than none — `INSTALL.md` and the app's own button point at cli.github.com instead.

## Test plan

Backend suite covers the doctor checks (missing → `Warn`, never `Fail`; installed → the resolved path). The frontend gate is node-only, so the render paths were measured in a headless instance with an isolated `XDG_CONFIG_HOME`, driven over CDP, twice: once with `PATH` holding neither tool, once with both.

| | neither installed | both installed |
| --- | --- | --- |
| launch | dialog *git is not installed* | no dialog |
| Pull Requests | gate in place of list + detail | list renders |
| Settings › Version Control | `Not on $PATH` + Install on both | `/usr/bin/git`, `/usr/bin/gh` |
| Install click | reaches `xdg-open https://cli.github.com` | — |
| console | 0 exceptions, 0 errors | 0 |

`lich doctor` with neither: `warn git — not on PATH — branches, diffs and worktrees stay empty`, `warn gh — … are unavailable`, verdict `lich starts. 3 warnings above limit something it offers.`

- [x] `gofmt -l .` / `go vet ./...` clean
- [x] `go test ./...` — 1735 pass
- [x] `pnpm check` clean, `pnpm test` — 1025 pass, `pnpm build` succeeds
- [x] `GOOS=linux|darwin|windows` build + vet clean
- [x] `CHANGELOG.md` `[Unreleased]`, `INSTALL.md`, `docs/ceilings.md` moved in this PR

## Deliberate limits

`docs/ceilings.md` gains one bullet: the checks answer from the `PATH` pinned at startup, so installing either tool with lich open leaves every surface calling it missing until a restart — each of them says so. And `exec.LookPath` proves the binary exists and runs, never that it works, so a git that fails on the repository itself keeps failing the old silent way.

Refused on purpose: a `--version` per tool (lich has no minimum for either, and the resolved path answers the question that exists), a per-platform download URL table (both vendor pages detect the OS), and a **Sign in** button spawning `gh auth login` — worth its own PR, not this one.
