### PR TITLE
Switch a custom binary off without deleting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   install button. All three warn that the `PATH` is read at launch, so a tool
   installed with lich open needs a restart. `lich doctor` reports both as well,
   as warnings: lich starts and every session spawns without them.
+- **A custom binary can be switched off without being deleted.** Settings ›
+  Providers › Binary gives each layer — the project's own override and the
+  global one — a switch beside its path. Off, the layer resolves as if it were
+  unset and falls through to the layer below, while the path stays written: going
+  back to the default and back again is two clicks rather than deleting a path
+  and typing it in from memory. A switched-off layer is also no longer checked,
+  so a custom binary that has gone missing stops holding the block open and
+  colouring it red. Nothing was migrated: a layer with no switch stored is on,
+  which is every override configured before this release.
 
 ### Fixed
 

--- a/frontend/src/components/settings/ProviderBinary.tsx
+++ b/frontend/src/components/settings/ProviderBinary.tsx
@@ -2,17 +2,40 @@ import { useEffect, useState, type ReactNode } from "react"
 import { Check, ChevronDown, FolderOpen, TriangleAlert, X } from "lucide-react"
 import { toast } from "sonner"
 import type { BinaryCheck } from "@/lib/api-types"
-import { checkDetail, checkLabel, failed, winningScope } from "@/lib/binary-layers"
+import { checkDetail, checkLabel, failed, resolves, winningScope } from "@/lib/binary-layers"
 import { ProjectService, Store } from "@/lib/rpc"
 import { useBinaryCheck } from "@/lib/use-binary-check"
-import { binKey } from "@/lib/providers-store"
+import { binKey, binOffKey } from "@/lib/providers-store"
 import { useProjects } from "@/providers/projects"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { Switch } from "@/components/ui/switch"
 import { SettingBlock } from "./SettingBlock"
 
 const GLOBAL_SCOPE = ""
+
+// useStoredSetting is one settings value in one scope: read once, written
+// through on every change. An undefined scope is a layer this pane does not have
+// — the hub has no project — and reads as empty without touching the store.
+function useStoredSetting(key: string, scope: string | undefined) {
+  const [value, setValue] = useState("")
+
+  useEffect(() => {
+    if (scope === undefined) {
+      return
+    }
+    void Store.GetSetting(key, scope).then(setValue)
+  }, [key, scope])
+
+  const persist = (next: string) => {
+    setValue(next)
+    if (scope !== undefined) {
+      void Store.SetSetting(key, scope, next.trim())
+    }
+  }
+  return [value, persist] as const
+}
 
 // ProviderBinary is the "which executable runs" block. Closed it is a fact — the
 // binary a session here would spawn, and whether it is there — because almost
@@ -20,6 +43,12 @@ const GLOBAL_SCOPE = ""
 // the resolution as it is: the project's override, the global one and $PATH, in
 // the order the spawn reads them, with the winning layer marked. The precedence
 // stops being a sentence to trust and becomes the thing on screen.
+//
+// Each configurable layer carries a switch, because a path and whether it counts
+// are two facts: parking an override used to mean deleting it and typing it back
+// later. A parked layer resolves as if it were unset and is checked as if it
+// were absent — which is what lets a broken custom binary be silenced rather
+// than fixed.
 //
 // A layer that resolves to nothing runnable opens the block itself: an error
 // hidden behind a disclosure is an error nobody fixes.
@@ -35,34 +64,17 @@ export function ProviderBinary({
   const { projects } = useProjects()
   const project = projects.find((p) => p.id === projectId)
   const key = binKey(providerId)
-  const [globalBin, setGlobalBin] = useState("")
-  const [projectBin, setProjectBin] = useState("")
+  const offKey = binOffKey(providerId)
+  const [globalBin, setGlobalBin] = useStoredSetting(key, GLOBAL_SCOPE)
+  const [projectBin, setProjectBin] = useStoredSetting(key, projectId)
+  const [globalOff, setGlobalOff] = useStoredSetting(offKey, GLOBAL_SCOPE)
+  const [projectOff, setProjectOff] = useStoredSetting(offKey, projectId)
   const [open, setOpen] = useState(false)
 
-  useEffect(() => {
-    void Store.GetSetting(key, GLOBAL_SCOPE).then(setGlobalBin)
-  }, [key])
-
-  useEffect(() => {
-    if (!projectId) {
-      return
-    }
-    void Store.GetSetting(key, projectId).then(setProjectBin)
-  }, [key, projectId])
-
-  const persistGlobal = (value: string) => {
-    setGlobalBin(value)
-    void Store.SetSetting(key, GLOBAL_SCOPE, value.trim())
-  }
-
-  const persistProject = (value: string) => {
-    setProjectBin(value)
-    if (projectId) {
-      void Store.SetSetting(key, projectId, value.trim())
-    }
-  }
-
-  const scope = winningScope(project ? projectBin : "", globalBin)
+  const scope = winningScope(
+    { bin: project ? projectBin : "", off: projectOff === "true" },
+    { bin: globalBin, off: globalOff === "true" },
+  )
   const configured = scope === "project" ? projectBin.trim() : globalBin.trim()
   // Both layers go through the same check, so the bottom row answers with the
   // resolution the spawn would make rather than a second opinion about $PATH.
@@ -87,13 +99,17 @@ export function ProviderBinary({
       scope: "project" as const,
       label: `${project.name} only`,
       value: projectBin,
-      persist: persistProject,
+      persist: setProjectBin,
+      off: projectOff === "true",
+      setOff: setProjectOff,
     },
     {
       scope: "global" as const,
       label: "All projects",
       value: globalBin,
-      persist: persistGlobal,
+      persist: setGlobalBin,
+      off: globalOff === "true",
+      setOff: setGlobalOff,
     },
   ].filter((layer) => layer !== undefined)
 
@@ -111,7 +127,7 @@ export function ProviderBinary({
           <div className="mb-3 flex items-center justify-between gap-4">
             <span className="flex items-center gap-1.5 text-xs text-foreground">
               <ChevronDown className="size-3.5" aria-hidden="true" />
-              Where it comes from — the first layer with a path wins
+              Where it comes from — the first layer switched on wins
             </span>
             {!broken && (
               <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
@@ -127,6 +143,15 @@ export function ProviderBinary({
                 wins={scope === layer.scope}
                 check={scope === layer.scope ? check : null}
                 value={layer.value}
+                control={
+                  <Switch
+                    size="sm"
+                    checked={resolves({ bin: layer.value, off: layer.off })}
+                    disabled={!layer.value.trim()}
+                    onCheckedChange={(on) => layer.setOff(on ? "false" : "true")}
+                    aria-label={`Use the ${providerName} binary set for ${layer.label}`}
+                  />
+                }
               >
                 <Input
                   value={layer.value}
@@ -134,7 +159,10 @@ export function ProviderBinary({
                   placeholder={providerId}
                   spellCheck={false}
                   aria-label={`${providerName} binary for ${layer.label}`}
-                  className="h-8 min-w-0 flex-1 font-mono text-xs"
+                  className={cn(
+                    "h-8 min-w-0 flex-1 font-mono text-xs",
+                    layer.off && "text-muted-foreground",
+                  )}
                 />
                 <Button
                   variant="ghost"
@@ -163,6 +191,7 @@ export function ProviderBinary({
             </span>
             <span className="whitespace-nowrap text-muted-foreground">
               · {sourceLabel(scope, project?.name)}
+              {parkedLabel(scope, projectOff === "true", globalOff === "true", project?.name)}
             </span>
           </span>
           <Button variant="ghost" size="sm" onClick={() => setOpen(true)}>
@@ -174,7 +203,10 @@ export function ProviderBinary({
       {broken && (
         <p className="mt-3 flex max-w-prose items-start gap-2 text-xs text-destructive">
           <TriangleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
-          {checkDetail(check)}
+          <span>
+            <span className="font-medium">{checkLabel(check, configured || providerId)}</span> —{" "}
+            {checkDetail(check)}
+          </span>
         </p>
       )}
     </SettingBlock>
@@ -190,21 +222,40 @@ function sourceLabel(scope: string, projectName: string | undefined): string {
   return scope === "global" ? "set for all projects" : "from $PATH"
 }
 
-// Layer is one row of the resolution stack: the marker, the scope it configures,
-// its control, and — on the winning row alone — what that path resolves to. The
-// losing rows say they are overridden instead, which is the question a second
-// path on screen raises.
+// parkedLabel names an override that is set but switched off — the one fact the
+// closed state would otherwise hide, since the switch saying it is not on
+// screen. Only layers the winner did not come from can be parked.
+function parkedLabel(
+  scope: string,
+  projectOff: boolean,
+  globalOff: boolean,
+  projectName: string | undefined,
+): string {
+  if (projectOff && scope !== "project") {
+    return ` · ${projectName ?? "project"} override off`
+  }
+  return globalOff && scope === "path" ? " · global override off" : ""
+}
+
+// Layer is one row of the resolution stack: the scope it configures, its
+// control, its switch, and — on the winning row alone — a glyph for what that
+// path resolves to. The verdict is a glyph and not a phrase because the phrase
+// arrives mid-typing: reserving its width leaves a hole on every other row, and
+// not reserving it shoves the field aside the moment a check comes back. The
+// words go under the block instead, where nothing has to move for them.
 function Layer({
   label,
   wins,
   check,
   value,
+  control,
   children,
 }: {
   label: string
   wins: boolean
   check: BinaryCheck | null
   value: string
+  control?: ReactNode
   children: ReactNode
 }) {
   return (
@@ -223,18 +274,12 @@ function Layer({
         {label}
       </span>
       {children}
-      {wins ? (
-        <span className="flex items-center gap-1 whitespace-nowrap text-xs">
-          <Verdict check={check} bin={value} />
-          <span className={cn(failed(check) ? "text-destructive" : "text-muted-foreground")}>
-            {checkLabel(check, value)}
-          </span>
-        </span>
-      ) : (
-        <span className="whitespace-nowrap text-xs text-muted-foreground opacity-70">
-          overridden
-        </span>
-      )}
+      <span className="flex size-3.5 shrink-0 items-center justify-center">
+        {wins && <Verdict check={check} bin={value} />}
+      </span>
+      {/* $PATH cannot be switched off, and holds the column so the switches
+          above it stay in line. */}
+      {control ?? <span className="w-6 shrink-0" aria-hidden="true" />}
     </div>
   )
 }

--- a/frontend/src/lib/binary-layers.test.ts
+++ b/frontend/src/lib/binary-layers.test.ts
@@ -1,22 +1,41 @@
 import { describe, expect, it } from "vitest"
 import type { BinaryCheck } from "./api-types"
-import { checkDetail, checkLabel, failed, winningScope } from "./binary-layers"
+import { checkDetail, checkLabel, failed, resolves, winningScope } from "./binary-layers"
 
 const check = (status: BinaryCheck["status"], path = ""): BinaryCheck => ({ path, status })
 
+const layer = (bin: string, off = false) => ({ bin, off })
+
 describe("winningScope", () => {
   it("prefers the project override, then the global one", () => {
-    expect(winningScope("/opt/next/claude", "/opt/claude")).toBe("project")
-    expect(winningScope("", "/opt/claude")).toBe("global")
-    expect(winningScope("", "")).toBe("path")
+    expect(winningScope(layer("/opt/next/claude"), layer("/opt/claude"))).toBe("project")
+    expect(winningScope(layer(""), layer("/opt/claude"))).toBe("global")
+    expect(winningScope(layer(""), layer(""))).toBe("path")
   })
 
   // A field holding spaces is a field nobody filled in — and the Go side trims
   // before storing, so a value that reached the store this way is whitespace
   // from an older build.
   it("treats a whitespace-only value as unset", () => {
-    expect(winningScope("   ", "")).toBe("path")
-    expect(winningScope(" \t ", "/opt/claude")).toBe("global")
+    expect(winningScope(layer("   "), layer(""))).toBe("path")
+    expect(winningScope(layer(" \t "), layer("/opt/claude"))).toBe("global")
+  })
+
+  // The switch is the whole feature: the path stays written and stops counting,
+  // so falling back a layer costs a click rather than the path.
+  it("skips a parked layer while it keeps its path", () => {
+    expect(winningScope(layer("/opt/next/claude", true), layer("/opt/claude"))).toBe("global")
+    expect(winningScope(layer("/opt/next/claude", true), layer("/opt/claude", true))).toBe("path")
+    expect(winningScope(layer("", true), layer("/opt/claude"))).toBe("global")
+  })
+})
+
+describe("resolves", () => {
+  it("is true only for a switched-on layer holding a path", () => {
+    expect(resolves(layer("/opt/claude"))).toBe(true)
+    expect(resolves(layer("/opt/claude", true))).toBe(false)
+    expect(resolves(layer(""))).toBe(false)
+    expect(resolves(layer("  ", false))).toBe(false)
   })
 })
 

--- a/frontend/src/lib/binary-layers.ts
+++ b/frontend/src/lib/binary-layers.ts
@@ -5,14 +5,26 @@ import type { BinaryCheck } from "./api-types"
 // store.ProviderBin (Go), which is what the spawn actually calls.
 export type BinaryScope = "project" | "global" | "path"
 
-// winningScope is the layer a session would spawn from — the first one with a
-// path. Values are compared trimmed, because a field holding only spaces is a
-// field nobody filled in.
-export function winningScope(projectBin: string, globalBin: string): BinaryScope {
-  if (projectBin.trim()) {
+// A configurable layer as the screen holds it: the path written into it, and
+// whether its switch is on. The two are separate so a path can be parked rather
+// than deleted — putting it back is a switch, not retyping it.
+export type BinaryLayer = { bin: string; off: boolean }
+
+// winningScope is the layer a session would spawn from — the first switched-on
+// one with a path. Values are compared trimmed, because a field holding only
+// spaces is a field nobody filled in.
+export function winningScope(project: BinaryLayer, global: BinaryLayer): BinaryScope {
+  if (resolves(project)) {
     return "project"
   }
-  return globalBin.trim() ? "global" : "path"
+  return resolves(global) ? "global" : "path"
+}
+
+// resolves reports a layer a session could spawn from. A parked layer never is,
+// whatever it holds — which is what keeps a broken path switched off from
+// failing a check nobody is being asked to fix.
+export function resolves(layer: BinaryLayer): boolean {
+  return !layer.off && layer.bin.trim() !== ""
 }
 
 // checkLabel is the verdict beside a path, in the width a row has. Empty when

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest"
 import type { DetectedProvider } from "./api-types"
 import {
   binKey,
+  binOffKey,
   createProvidersStore,
   enabledKey,
   enabledProviders,
@@ -30,6 +31,13 @@ describe("provider setting keys", () => {
     expect(binKey("claude")).toBe("claude.bin")
     expect(binKey("codex")).toBe("provider.codex.bin")
     expect(binKey("opencode")).toBe("provider.opencode.bin")
+  })
+
+  // The switch that parks a layer hangs off the path's own key, legacy one
+  // included — the Go spawn reads these exact strings.
+  it("suffixes the parked flag onto the path key", () => {
+    expect(binOffKey("claude")).toBe("claude.bin.off")
+    expect(binOffKey("codex")).toBe("provider.codex.bin.off")
   })
 
   // The two scopes are separate rows in the settings table, and the Go spawn

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -31,6 +31,13 @@ export function binKey(id: string): string {
   return id === "claude" ? "claude.bin" : `provider.${id}.bin`
 }
 
+// binOffKey parks a binary layer without erasing it: the path stays in the
+// store, the layer stops resolving. Mirrors store.binOffKey in Go, scoped
+// exactly like the path it parks.
+export function binOffKey(id: string): string {
+  return `${binKey(id)}.off`
+}
+
 // skipPermissionsKey holds the flag that spawns a provider without its
 // permission prompts, in one of two scopes (mirrors store.skipPermissionsKey in
 // Go, which is what the spawn reads). Two keys because a worktree is a throwaway

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -63,22 +63,41 @@ func binKey(providerID string) string {
 	return "provider." + providerID + ".bin"
 }
 
+// binOffKey is the settings key that parks a binary layer: the path stays
+// written, but the layer is skipped when resolving. Scoped exactly like the path
+// it parks, and on only for the literal "true" — an absent key is a layer nobody
+// switched off, which is every layer configured before this key existed.
+func binOffKey(providerID string) string {
+	return binKey(providerID) + ".off"
+}
+
 // ProviderBin resolves a provider's binary path for a project: the project
 // override wins, then the global value, then "" (letting the terminal fall back
-// to the provider's default). It is the single call the terminal service makes
-// when spawning a session's PTY.
+// to the provider's default). A parked layer is skipped as if it were unset. It
+// is the single call the terminal service makes when spawning a session's PTY.
 func (s *Service) ProviderBin(providerID, projectID string) string {
-	key := binKey(providerID)
-	if projectID != globalScope {
+	key, offKey := binKey(providerID), binOffKey(providerID)
+	if projectID != globalScope && !s.binParked(offKey, projectID) {
 		if bin, err := s.GetSetting(key, projectID); err == nil && bin != "" {
 			return bin
 		}
+	}
+	if s.binParked(offKey, globalScope) {
+		return ""
 	}
 	bin, err := s.GetSetting(key, globalScope)
 	if err != nil {
 		return ""
 	}
 	return bin
+}
+
+// binParked reports a layer switched off in one scope. An unreadable value is
+// not one: a layer the user configured keeps resolving rather than silently
+// falling through to a different binary.
+func (s *Service) binParked(offKey, projectID string) bool {
+	value, err := s.GetSetting(offKey, projectID)
+	return err == nil && value == "true"
 }
 
 // skipPermissionsKey is the settings key that spawns a provider with its

--- a/internal/store/settings_test.go
+++ b/internal/store/settings_test.go
@@ -127,6 +127,48 @@ func TestProviderBinResolution(t *testing.T) {
 	}
 }
 
+// TestProviderBinParkedLayer pins what a switched-off layer does: it resolves as
+// if it were unset, while the path it holds stays in the store — which is the
+// whole point of the switch, since deleting the path was the old way to do this.
+func TestProviderBinParkedLayer(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.SetSetting("provider.codex.bin", globalScope, "global-codex")
+	_ = svc.SetSetting("provider.codex.bin", "p1", "p1-codex")
+
+	_ = svc.SetSetting("provider.codex.bin.off", "p1", "true")
+	if got := svc.ProviderBin("codex", "p1"); got != "global-codex" {
+		t.Errorf("parked project layer = %q, want global-codex", got)
+	}
+	if got, _ := svc.GetSetting("provider.codex.bin", "p1"); got != "p1-codex" {
+		t.Errorf("parked path = %q, want it kept as p1-codex", got)
+	}
+
+	// Parking the global layer too leaves the provider's own default.
+	_ = svc.SetSetting("provider.codex.bin.off", globalScope, "true")
+	if got := svc.ProviderBin("codex", "p1"); got != "" {
+		t.Errorf("both layers parked = %q, want \"\"", got)
+	}
+	// A project scope parked while global runs still reads the global value.
+	_ = svc.SetSetting("provider.codex.bin.off", globalScope, "false")
+	if got := svc.ProviderBin("codex", "p2"); got != "global-codex" {
+		t.Errorf("unparked global = %q, want global-codex", got)
+	}
+
+	// Anything but the literal "true" is a layer nobody switched off — the key
+	// is absent for every override configured before it existed.
+	_ = svc.SetSetting("provider.codex.bin.off", "p1", "1")
+	if got := svc.ProviderBin("codex", "p1"); got != "p1-codex" {
+		t.Errorf("non-\"true\" off value = %q, want p1-codex", got)
+	}
+
+	// Claude parks through the legacy key's own suffix.
+	_ = svc.SetSetting(claudeBinKey, globalScope, "global-claude")
+	_ = svc.SetSetting(claudeBinKey+".off", globalScope, "true")
+	if got := svc.ProviderBin("claude", "p1"); got != "" {
+		t.Errorf("parked claude = %q, want \"\"", got)
+	}
+}
+
 // TestSkipPermissionsIsScopedByCheckout pins the two scopes apart: the flag a
 // session in the project's own directory reads is not the one a session in a
 // worktree reads, so turning it on for throwaway checkouts leaves the main


### PR DESCRIPTION
## The problem

Settings › Providers › Binary made one text field carry two facts: *which* path, and *whether* it counts. Going back to the default meant emptying the field; going back to the override meant typing the path in again from memory.

The sharper version: a custom binary that has gone missing fails its check, and a failed check sets `broken`, which forces the block open and pins a destructive line under it. The only way to silence a broken override was to erase it.

## What changed

Each configurable layer — the project's own override and the global one — now carries a switch on its row.

- **Off**: the layer resolves as if it were unset and falls through to the layer below, while the path stays in the store. Back and forth is two clicks.
- **Off is also unchecked**: a parked layer is skipped by `failed()`, so a broken binary switched off stops holding the block open.
- **Disabled until the field holds something**: there is nothing to park before that, and an empty layer reads as off rather than on.
- The closed state gains `· <project> override off`, because that is the one place the switch is not on screen to say it.

## Storage

`binOffKey(id)` is `binKey(id) + ".off"`, in the same scope as the path it parks, read only as the literal `"true"`. An absent key is a layer nobody switched off — which is every override configured before this PR, so nothing migrates.

`ProviderBin` keeps its shape: one call, project over global over `$PATH`. All five providers get this from the same code; nothing is provider-specific.

## Two layout notes

Both came out of trying it rather than drawing it:

- The verdict is a **glyph on the row** and a **phrase under the block**. The phrase arrives mid-typing, so on the row it shoved the field aside every time a check came back.
- Nothing reserves width it only uses on one row. Only the field stretches, which puts the switch hard against the right edge of every row with no hole in the middle.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test ./...` — 1732 passed, including `TestProviderBinParkedLayer`, which pins both halves: resolution drops a layer **and** the path it holds stays in the store
- [x] `pnpm check` clean on the touched files; `tsc` and `vite build` clean
- [x] `vitest run` — 1028 passed, covering `winningScope` skipping a parked layer, `resolves`, and the `.off` key spelling on both sides
- [x] By hand in `task dev`: parked override falls through to `$PATH`; broken parked override no longer forces the block open; the field keeps its width as checks come and go

The frontend gate runs in node and does not render, so the layout above is hand-verified, not covered.