### PR TITLE
fix: name every parked binary override the closed block hides

### DIFF
--- a/frontend/src/components/settings/ProviderBinary.tsx
+++ b/frontend/src/components/settings/ProviderBinary.tsx
@@ -1,10 +1,18 @@
-import { useEffect, useState, type ReactNode } from "react"
+import { useState, type ReactNode } from "react"
 import { Check, ChevronDown, FolderOpen, TriangleAlert, X } from "lucide-react"
 import { toast } from "sonner"
 import type { BinaryCheck } from "@/lib/api-types"
-import { checkDetail, checkLabel, failed, resolves, winningScope } from "@/lib/binary-layers"
+import {
+  checkDetail,
+  checkLabel,
+  failed,
+  parkedLabel,
+  resolves,
+  winningScope,
+} from "@/lib/binary-layers"
 import { ProjectService, Store } from "@/lib/rpc"
 import { useBinaryCheck } from "@/lib/use-binary-check"
+import { useRemoteResource } from "@/lib/use-remote-resource"
 import { binKey, binOffKey } from "@/lib/providers-store"
 import { useProjects } from "@/providers/projects"
 import { cn } from "@/lib/utils"
@@ -18,23 +26,37 @@ const GLOBAL_SCOPE = ""
 // useStoredSetting is one settings value in one scope: read once, written
 // through on every change. An undefined scope is a layer this pane does not have
 // — the hub has no project — and reads as empty without touching the store.
+//
+// Settings renders every provider's section at the same position, so React keeps
+// one instance and the key changes underneath it. The read therefore has to be
+// the sequence-guarded one: two lookups in flight can answer out of order, and a
+// stale answer here is not a stale readout but the previous provider's path
+// written into this provider's key by the next keystroke. The scope is part of
+// the request for the same reason.
 function useStoredSetting(key: string, scope: string | undefined) {
-  const [value, setValue] = useState("")
-
-  useEffect(() => {
-    if (scope === undefined) {
-      return
-    }
-    void Store.GetSetting(key, scope).then(setValue)
-  }, [key, scope])
+  const request = scope === undefined ? "" : `${key}\n${scope}`
+  const { data } = useRemoteResource(request, () => Store.GetSetting(key, scope ?? ""), {
+    empty: "",
+    resetOn: request,
+  })
+  // What was typed, tagged with the request it was typed against, so it is
+  // dropped by the same change that blanks the value it was overriding.
+  const [draft, setDraft] = useState<{ request: string; value: string } | null>(null)
 
   const persist = (next: string) => {
-    setValue(next)
+    setDraft({ request, value: next })
     if (scope !== undefined) {
       void Store.SetSetting(key, scope, next.trim())
     }
   }
-  return [value, persist] as const
+  return [draft?.request === request ? draft.value : data, persist] as const
+}
+
+// The store holds strings, so one place knows that "true" is the only value that
+// means on — and the switches read as the booleans they are everywhere else.
+function useStoredFlag(key: string, scope: string | undefined) {
+  const [value, persist] = useStoredSetting(key, scope)
+  return [value === "true", (on: boolean) => persist(on ? "true" : "false")] as const
 }
 
 // ProviderBinary is the "which executable runs" block. Closed it is a fact — the
@@ -67,18 +89,23 @@ export function ProviderBinary({
   const offKey = binOffKey(providerId)
   const [globalBin, setGlobalBin] = useStoredSetting(key, GLOBAL_SCOPE)
   const [projectBin, setProjectBin] = useStoredSetting(key, projectId)
-  const [globalOff, setGlobalOff] = useStoredSetting(offKey, GLOBAL_SCOPE)
-  const [projectOff, setProjectOff] = useStoredSetting(offKey, projectId)
+  const [globalOff, setGlobalOff] = useStoredFlag(offKey, GLOBAL_SCOPE)
+  const [projectOff, setProjectOff] = useStoredFlag(offKey, projectId)
   const [open, setOpen] = useState(false)
 
-  const scope = winningScope(
-    { bin: project ? projectBin : "", off: projectOff === "true" },
-    { bin: globalBin, off: globalOff === "true" },
-  )
-  const configured = scope === "project" ? projectBin.trim() : globalBin.trim()
+  // The project layer is empty until its project is on hand: the pane can be
+  // pointed at a project id whose record has not arrived yet.
+  const projectLayer = { bin: project ? projectBin : "", off: projectOff }
+  const globalLayer = { bin: globalBin, off: globalOff }
+  const scope = winningScope(projectLayer, globalLayer)
+  // Nothing is configured when $PATH wins, whatever a parked layer still holds —
+  // otherwise the closed row would caption the $PATH binary with a path that is
+  // switched off.
+  const configured =
+    scope === "project" ? projectBin.trim() : scope === "global" ? globalBin.trim() : ""
   // Both layers go through the same check, so the bottom row answers with the
   // resolution the spawn would make rather than a second opinion about $PATH.
-  const typed = useBinaryCheck(scope === "path" ? "" : configured)
+  const typed = useBinaryCheck(configured)
   const onPath = useBinaryCheck(providerId)
   const check = scope === "path" ? onPath : typed
   const broken = failed(check)
@@ -100,7 +127,7 @@ export function ProviderBinary({
       label: `${project.name} only`,
       value: projectBin,
       persist: setProjectBin,
-      off: projectOff === "true",
+      off: projectOff,
       setOff: setProjectOff,
     },
     {
@@ -108,7 +135,7 @@ export function ProviderBinary({
       label: "All projects",
       value: globalBin,
       persist: setGlobalBin,
-      off: globalOff === "true",
+      off: globalOff,
       setOff: setGlobalOff,
     },
   ].filter((layer) => layer !== undefined)
@@ -148,7 +175,7 @@ export function ProviderBinary({
                     size="sm"
                     checked={resolves({ bin: layer.value, off: layer.off })}
                     disabled={!layer.value.trim()}
-                    onCheckedChange={(on) => layer.setOff(on ? "false" : "true")}
+                    onCheckedChange={(on) => layer.setOff(!on)}
                     aria-label={`Use the ${providerName} binary set for ${layer.label}`}
                   />
                 }
@@ -191,7 +218,7 @@ export function ProviderBinary({
             </span>
             <span className="whitespace-nowrap text-muted-foreground">
               · {sourceLabel(scope, project?.name)}
-              {parkedLabel(scope, projectOff === "true", globalOff === "true", project?.name)}
+              {parkedLabel(scope, projectLayer, globalLayer, project?.name)}
             </span>
           </span>
           <Button variant="ghost" size="sm" onClick={() => setOpen(true)}>
@@ -220,21 +247,6 @@ function sourceLabel(scope: string, projectName: string | undefined): string {
     return projectName ? `set for ${projectName}` : "set for this project"
   }
   return scope === "global" ? "set for all projects" : "from $PATH"
-}
-
-// parkedLabel names an override that is set but switched off — the one fact the
-// closed state would otherwise hide, since the switch saying it is not on
-// screen. Only layers the winner did not come from can be parked.
-function parkedLabel(
-  scope: string,
-  projectOff: boolean,
-  globalOff: boolean,
-  projectName: string | undefined,
-): string {
-  if (projectOff && scope !== "project") {
-    return ` · ${projectName ?? "project"} override off`
-  }
-  return globalOff && scope === "path" ? " · global override off" : ""
 }
 
 // Layer is one row of the resolution stack: the scope it configures, its

--- a/frontend/src/lib/binary-layers.test.ts
+++ b/frontend/src/lib/binary-layers.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it } from "vitest"
 import type { BinaryCheck } from "./api-types"
-import { checkDetail, checkLabel, failed, resolves, winningScope } from "./binary-layers"
+import {
+  checkDetail,
+  checkLabel,
+  failed,
+  parkedLabel,
+  resolves,
+  winningScope,
+} from "./binary-layers"
 
 const check = (status: BinaryCheck["status"], path = ""): BinaryCheck => ({ path, status })
 
@@ -36,6 +43,59 @@ describe("resolves", () => {
     expect(resolves(layer("/opt/claude", true))).toBe(false)
     expect(resolves(layer(""))).toBe(false)
     expect(resolves(layer("  ", false))).toBe(false)
+  })
+})
+
+describe("parkedLabel", () => {
+  const off = (bin: string) => layer(bin, true)
+  const unset = layer("")
+
+  it("says nothing when nothing is parked", () => {
+    expect(parkedLabel("path", unset, unset, "myproject")).toBe("")
+    expect(parkedLabel("project", layer("/opt/next/claude"), unset, "myproject")).toBe("")
+  })
+
+  // The repro this guard exists for: switching the override off writes the flag,
+  // then clearing the field writes an empty path over it. The flag outlives the
+  // path, and the closed state used to keep announcing an override nobody set.
+  it("does not claim an override for a flag with no path behind it", () => {
+    expect(parkedLabel("path", off(""), off(""), "myproject")).toBe("")
+    expect(parkedLabel("path", off("   "), off(" \t "), "myproject")).toBe("")
+  })
+
+  it("names a parked override the winner did not shadow", () => {
+    expect(parkedLabel("path", off("/opt/next/claude"), unset, "myproject")).toBe(
+      " · myproject override off",
+    )
+    expect(parkedLabel("global", off("/opt/next/claude"), layer("/opt/claude"), "myproject")).toBe(
+      " · myproject override off",
+    )
+    expect(parkedLabel("path", unset, off("/opt/claude"), "myproject")).toBe(
+      " · global override off",
+    )
+  })
+
+  // Both parked is why $PATH won, and either switch flipped back on would change
+  // what spawns — so the closed line owns up to both rather than the nearer one.
+  it("names both when both are parked", () => {
+    expect(parkedLabel("path", off("/opt/next/claude"), off("/opt/claude"), "myproject")).toBe(
+      " · myproject override off · global override off",
+    )
+  })
+
+  // A parked layer under a winning override is not news: its switch changes
+  // nothing while the layer above it resolves.
+  it("stays quiet about a layer the winner shadows", () => {
+    expect(parkedLabel("project", layer("/opt/next/claude"), off("/opt/claude"), "myproject")).toBe(
+      "",
+    )
+  })
+
+  // The pane can hold a project override before the project itself has loaded.
+  it("falls back to a generic name when the project has none yet", () => {
+    expect(parkedLabel("path", off("/opt/next/claude"), unset, undefined)).toBe(
+      " · project override off",
+    )
   })
 })
 

--- a/frontend/src/lib/binary-layers.ts
+++ b/frontend/src/lib/binary-layers.ts
@@ -27,6 +27,35 @@ export function resolves(layer: BinaryLayer): boolean {
   return !layer.off && layer.bin.trim() !== ""
 }
 
+// parked is the mirror of `resolves`: a layer holding a path with its switch
+// off, so it would spawn if it were switched back on. A layer that is off and
+// empty is not parked — there is nothing there to put back.
+function parked(layer: BinaryLayer): boolean {
+  return layer.off && layer.bin.trim() !== ""
+}
+
+// parkedLabel names the overrides that are set but switched off — the fact the
+// closed state would otherwise hide, since the switches themselves are not on
+// screen. A layer is named only when switching it back on would change what
+// spawns: an override the winner already shadows is not news, so a parked global
+// under a winning project override stays quiet while both parked under $PATH are
+// both named.
+export function parkedLabel(
+  scope: BinaryScope,
+  project: BinaryLayer,
+  global: BinaryLayer,
+  projectName: string | undefined,
+): string {
+  const names: string[] = []
+  if (scope !== "project" && parked(project)) {
+    names.push(`${projectName ?? "project"} override off`)
+  }
+  if (scope === "path" && parked(global)) {
+    names.push("global override off")
+  }
+  return names.map((name) => ` · ${name}`).join("")
+}
+
 // checkLabel is the verdict beside a path, in the width a row has. Empty when
 // there is nothing to say — an unset layer is not a failure.
 //
@@ -59,7 +88,7 @@ export function checkDetail(check: BinaryCheck | null): string {
       return "A relative path is resolved against each session's own working directory, so it names a different binary per session. Use a full path."
     case "not-found":
     case "not-executable":
-      return "Sessions will not start until this is fixed or cleared. Clearing it falls back to the layer below."
+      return "Sessions will not start until this is fixed. An override can also be switched off or cleared, falling back to the layer below."
     default:
       return ""
   }


### PR DESCRIPTION
Five defects in the provider Binary block, all found auditing the unreleased range. No user of a published release lived any of them, so there is no CHANGELOG entry.

## Findings

- **`parkedLabel` ignored the path.** It read only a layer's `.off` flag, so switching an override off and then clearing its path left the closed block announcing an override nobody has set. A layer is parked only when it is off *and* still holds a path — `parked()` is now the mirror of `resolves()`.
- **`parkedLabel` had four branches and no test.** It lived in a `.tsx`, and the frontend suite is node-only, so nothing could reach it. It moves to `binary-layers.ts` beside the rest of the resolution, with six new cases.
- **`useStoredSetting` had no sequence guard and never reset.** Settings renders every provider's section at the same position, so React keeps one instance while the key changes underneath it: two `Store.GetSetting` calls could answer out of order and strand one provider's path in another's field, where the next keystroke wrote it into the wrong key. It reads through `useRemoteResource` now — this codebase's existing answer to exactly that.
- **`configured` captioned `$PATH` with a switched-off path.** It was `globalBin.trim()` whenever the project layer did not win, `scope === "path"` included, so a parked global path plus a binary missing from `$PATH` labelled the `$PATH` verdict with the path that is switched off. It is empty when `$PATH` wins now.
- **Stale copy, and five `=== "true"`.** The not-found detail offered clearing as the only way out; switching a layer off is the other, and it is the feature this release ships. `useStoredFlag` keeps the `"true"` string in one place.

## Behaviour change worth a look

With **both** overrides parked and `$PATH` winning, both are now named — `· myproject override off · global override off`. The old code named only the nearer one, leaving the closed state hiding a fact it exists to show. The rule pinned behind every branch: a layer is named when switching it back on would change what spawns, which is why a parked global under a winning project override stays quiet.

## Test plan

- [x] `biome check .` · `vitest run` (88 files, 1034 tests) · `tsc` · `vite build --mode production`
- [x] `gofmt -l .` · `go vet ./...` · `go test ./...`
- [ ] By hand: park an override, clear its path, confirm the closed block stops claiming it
- [ ] By hand: switch provider sections quickly in Settings, confirm no path crosses providers
