### PR TITLE
fix: check gh before the Pulls screen looks anything up

### DIFF
--- a/frontend/src/components/GitMissingGate.tsx
+++ b/frontend/src/components/GitMissingGate.tsx
@@ -2,7 +2,7 @@ import { useState } from "react"
 import { ExternalLink } from "lucide-react"
 import { failed } from "@/lib/binary-layers"
 import { System } from "@/lib/rpc"
-import { useBinaryCheck } from "@/lib/use-binary-check"
+import { NO_SETTLE, useBinaryCheck } from "@/lib/use-binary-check"
 import { GIT, RESTART_HINT } from "@/lib/vcs-tools"
 import { Button } from "@/components/ui/button"
 import {
@@ -28,7 +28,7 @@ import {
 // the condition is not a preference to be honoured — it is a machine that
 // cannot do half of what lich offers, and it stops asking the moment git exists.
 export function GitMissingGate() {
-  const check = useBinaryCheck(GIT.bin)
+  const check = useBinaryCheck(GIT.bin, NO_SETTLE)
   const [dismissed, setDismissed] = useState(false)
 
   if (!failed(check) || dismissed) {

--- a/frontend/src/components/pulls/Pulls.tsx
+++ b/frontend/src/components/pulls/Pulls.tsx
@@ -8,7 +8,7 @@ import { baseName } from "@/lib/paths"
 import { Notice } from "@/components/common/Notice"
 import { ToolMissing } from "@/components/common/ToolMissing"
 import { failed } from "@/lib/binary-layers"
-import { useBinaryCheck } from "@/lib/use-binary-check"
+import { NO_SETTLE, useBinaryCheck } from "@/lib/use-binary-check"
 import { GH } from "@/lib/vcs-tools"
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
 import { sessionsOf } from "@/lib/session/sessions"
@@ -65,7 +65,14 @@ export function Pulls({ list = false }: PullsProps) {
   const projectPath = projects.find((p) => p.id === projectId)?.path ?? ""
   // Every read this screen makes is a gh call, so a machine without gh gets the
   // one screen that can say so instead of three lookups failing in a row.
-  const noGH = failed(useBinaryCheck(GH.bin))
+  const gh = useBinaryCheck(GH.bin, NO_SETTLE)
+  const noGH = failed(gh)
+  // A check still in flight is neither verdict, and treating it as "gh is fine"
+  // is what let the lookups run ahead of it: they fail first and paint their own
+  // error until the screen that explains it takes over. Nothing is looked up
+  // until gh has answered — one local check, so a machine that has gh loses a
+  // frame rather than sitting on a skeleton.
+  const hasGH = gh !== null && !noGH
   const { sessionId, path, checkout } = useActiveSession()
   const status = useGitStatus(path)
   const branch = status?.branch ?? ""
@@ -75,7 +82,7 @@ export function Pulls({ list = false }: PullsProps) {
   // addresses one directly, which only the list can produce.
   const selected = Number(number) || 0
   const { detail, loading, error, refresh } = usePullRequestDetail(
-    noGH ? "" : path,
+    hasGH ? path : "",
     branch,
     head,
     selected,
@@ -90,7 +97,7 @@ export function Pulls({ list = false }: PullsProps) {
   const parsedQuery = useMemo(() => parsePullsQuery(query), [query])
   // An empty path is the hook's own "nothing to look up", so the single pull
   // request screen never spends a gh call on a list it does not show.
-  const pulls = usePullRequests(list && !noGH ? projectPath || path : "", parsedQuery.state)
+  const pulls = usePullRequests(list && hasGH ? projectPath || path : "", parsedQuery.state)
   const { checkouts, refresh: refreshCheckouts } = useCheckouts(projectPath)
   // Where the pull request's own branch already lives, if anywhere. Every
   // "work on this PR" decision hangs off it: whether to create a checkout,
@@ -229,7 +236,12 @@ export function Pulls({ list = false }: PullsProps) {
   }
 
   let body: ReactNode
-  if (noGH) {
+  if (gh === null) {
+    // Held rather than drawn: every branch below needs gh to have answered, and
+    // the one that would win by default is an error about a lookup that only
+    // failed because it ran too early.
+    body = null
+  } else if (noGH) {
     body = <ToolMissing tool={GH} icon={GitPullRequestArrow} />
   } else if (!path) {
     body = <CentredNotice>No repository</CentredNotice>
@@ -258,7 +270,7 @@ export function Pulls({ list = false }: PullsProps) {
 
   return (
     <div className="absolute inset-0 z-10 flex bg-background">
-      {list && !noGH && (
+      {list && hasGH && (
         <PullsList
           list={pulls.list}
           loading={pulls.loading}

--- a/frontend/src/components/settings/VcsToolsSetting.tsx
+++ b/frontend/src/components/settings/VcsToolsSetting.tsx
@@ -3,7 +3,7 @@ import { ExternalLink, GitBranch, GitPullRequestArrow, Wrench } from "lucide-rea
 import type { BinaryCheck } from "@/lib/api-types"
 import { failed } from "@/lib/binary-layers"
 import { System } from "@/lib/rpc"
-import { useBinaryCheck } from "@/lib/use-binary-check"
+import { NO_SETTLE, useBinaryCheck } from "@/lib/use-binary-check"
 import { GH, GIT, RESTART_HINT, type VcsTool } from "@/lib/vcs-tools"
 import { Button } from "@/components/ui/button"
 import { SettingBlock } from "./SettingBlock"
@@ -17,8 +17,8 @@ import { SettingBlock } from "./SettingBlock"
 // rarely the real question: lich pins the login shell's $PATH at launch, so
 // *which* git it found is what a machine with two of them needs to see.
 export function VcsToolsSetting() {
-  const git = useBinaryCheck(GIT.bin)
-  const gh = useBinaryCheck(GH.bin)
+  const git = useBinaryCheck(GIT.bin, NO_SETTLE)
+  const gh = useBinaryCheck(GH.bin, NO_SETTLE)
   return (
     <SettingBlock
       icon={<Wrench className="size-4" />}

--- a/frontend/src/components/settings/VersionControlSettings.tsx
+++ b/frontend/src/components/settings/VersionControlSettings.tsx
@@ -6,7 +6,7 @@ import { accountLabel, accountSelectItems, upgradeAccount } from "@/lib/gh-accou
 import { GH_ACCOUNT_KEY } from "@/lib/project-settings"
 import { errorText } from "@/lib/utils"
 import { failed } from "@/lib/binary-layers"
-import { useBinaryCheck } from "@/lib/use-binary-check"
+import { NO_SETTLE, useBinaryCheck } from "@/lib/use-binary-check"
 import { GIT } from "@/lib/vcs-tools"
 import { invalidatePullRequests } from "@/lib/pulls/pull-request-lookup"
 import { useProjects } from "@/providers/projects"
@@ -38,7 +38,7 @@ export function VersionControlSettings({ projectId }: { projectId?: string }) {
   const [accounts, setAccounts] = useState<string[] | null>(null)
   const [account, setAccount] = useState("")
   const [identity, setIdentity] = useState<CommitIdentity | null>(null)
-  const noGit = failed(useBinaryCheck(GIT.bin))
+  const noGit = failed(useBinaryCheck(GIT.bin, NO_SETTLE))
   const [error, setError] = useState("")
 
   // Read once per project: git's config changes outside lich, but so rarely

--- a/frontend/src/lib/use-binary-check.ts
+++ b/frontend/src/lib/use-binary-check.ts
@@ -7,11 +7,16 @@ import { Providers } from "./rpc"
 // round trip per character to report a file nobody has finished naming yet.
 const SETTLE_MS = 400
 
+// The settle for a `bin` that is a constant: there is no next keystroke to wait
+// for, and every millisecond of it is one the caller spends not knowing whether
+// the tool it is about to shell out to exists.
+export const NO_SETTLE = 0
+
 // useBinaryCheck resolves a configured binary through the backend, re-checking
 // whenever the value settles. Null while the first answer for a value is in
 // flight — the callers draw nothing rather than flashing a failure between
 // keystrokes.
-export function useBinaryCheck(bin: string): BinaryCheck | null {
+export function useBinaryCheck(bin: string, settleMs: number = SETTLE_MS): BinaryCheck | null {
   const [check, setCheck] = useState<BinaryCheck | null>(null)
 
   useEffect(() => {
@@ -27,12 +32,12 @@ export function useBinaryCheck(bin: string): BinaryCheck | null {
         // A failed call is not a failed path: leaving the verdict absent says
         // "unknown", which is the truth when nothing answered.
         .catch(() => {})
-    }, SETTLE_MS)
+    }, settleMs)
     return () => {
       live = false
       clearTimeout(timer)
     }
-  }, [bin])
+  }, [bin, settleMs])
 
   return check
 }


### PR DESCRIPTION
`useBinaryCheck` waited `SETTLE_MS` (400 ms) before it verified anything. That debounce belongs to a path being typed into — every keystroke is a state the path has never been in — but four of its five callers pass a constant.

Pulls paid for it twice over: `usePullRequestDetail` and `usePullRequests` fire on mount with no delay, gh failed them, and `Couldn't load the pull request: …` painted for 400 ms before `ToolMissing` replaced it — the opposite of the one screen a machine without gh was meant to get.

## What changed

- The settle is an argument defaulting to `SETTLE_MS`, and `NO_SETTLE` is what the constant-bin callers pass: `Pulls`, `GitMissingGate`, `VcsToolsSetting`, `VersionControlSettings`. `ProviderBinary` is the one that genuinely types into it and keeps the debounce.
- That alone only shortens the flash — a check in flight is neither verdict, and `failed(null)` is false, so the first render and its RPC still ran as if gh were fine. `Pulls` now holds on the answer instead of guessing it: the detail and list lookups take an empty path until gh has verified, the list column stays out, and the body renders nothing rather than falling through to the error branch.

Holding was chosen over a skeleton or letting the lookups race: `Providers.Verify` is a local exec on the pinned `$PATH`, not a network call, so with `NO_SETTLE` the wait is one round trip. A machine that has gh loses a frame; a machine without it never sees an error about a lookup that only failed because it ran too early. A skeleton would advertise that frame as work in progress and then replace itself immediately — the same flash in another colour.

Found auditing the unreleased range; no user of a published release lived it, so there is no CHANGELOG entry.

## Test plan

- [x] `biome check .` · `vitest run` (88 files, 1028 tests) · `tsc` · `vite build --mode production`
- [x] `gofmt -l .` · `go vet ./...` · `go test ./...`
- [ ] By hand, the only way this render path can be checked: the frontend suite is node-only with no jsdom and `.tsx` is out of coverage by design. Open Pull Requests with gh off `PATH` and confirm no error paints before `ToolMissing`.
