### PR TITLE
fix: say the same thing about a missing gh on both sides

### DIFF
--- a/frontend/src/lib/vcs-tools.ts
+++ b/frontend/src/lib/vcs-tools.ts
@@ -26,7 +26,7 @@ export const GH: VcsTool = {
   bin: "gh",
   label: "GitHub CLI (gh)",
   url: "https://cli.github.com",
-  without: "Pull requests, checks and PR checkouts need it.",
+  without: "Pull requests, checks and PR checkouts are unavailable without it.",
 }
 
 // lich resolves the login shell's $PATH once, at launch, and pins it into its

--- a/internal/project/tree_test.go
+++ b/internal/project/tree_test.go
@@ -73,6 +73,19 @@ func TestTreeWalksNonRepo(t *testing.T) {
 	}
 }
 
+// TestTreeReportsBrokenRepo proves the gate only routes a path away from git
+// when git itself disowns it: a repository whose index is corrupt still passes
+// rev-parse, so its ls-files failure is the answer. Walking it instead would
+// draw a plausible tree over a repository nobody can list.
+func TestTreeReportsBrokenRepo(t *testing.T) {
+	repo, _ := initRepo(t)
+	write(t, repo, ".git/index", "not an index")
+	files, err := New(nil).Tree(repo)
+	if err == nil {
+		t.Fatalf("Tree on a corrupt index = %v, want an error", files)
+	}
+}
+
 // TestTreeMissingDir proves an absent directory is still an error, so the panel
 // says so instead of drawing an empty tree over a folder that is gone.
 func TestTreeMissingDir(t *testing.T) {


### PR DESCRIPTION
Two small findings from an audit of the unreleased range. Neither reached a published release, so there is no CHANGELOG entry.

## The doctor and the app disagreed about a missing gh

`doctor.go` claims "the same two sentences answer on screen (`frontend/src/lib/vcs-tools.ts`) — a diagnosis that disagrees with the app about what is broken is worse than no diagnosis." git's pair matched; gh's did not: `"pull requests, checks and PR checkouts are unavailable"` against `"Pull requests, checks and PR checkouts need it."`

The app is aligned to the diagnosis rather than the reverse, in the shape git's pair already had — the Go clause capitalised, plus "without it". Both frames still read: the doctor prints `gh: not on PATH — pull requests, checks and PR checkouts are unavailable`, and `ToolRow`/`ToolMissing` show the standalone sentence. `doctor.go` and `doctor_test.go` are untouched, so the existing substring assertion passes unchanged.

## "A broken repository still reports its error" had no test

`Tree` gates on `rev-parse --is-inside-work-tree`: a path that fails it is walked as a plain folder, and a path that passes goes through `ls-files`, whose error is the answer. Both the comment on `Tree` and the CHANGELOG entry promise that, but the test that covered it moved to `DiffText` when the contract changed — so the walk fallback could start swallowing a broken repository's error and the whole suite would stay green.

`TestTreeReportsBrokenRepo` pins it. The split was reproduced by hand first (git 2.55.0, `.git/index` overwritten: `rev-parse --is-inside-work-tree` exits 0, `ls-files` exits 128), and the test was mutation-checked — forcing the walk fallback in `tree.go` makes it fail with `Tree on a corrupt index = [a.txt]`.

## Test plan

- [x] `gofmt -l .` · `go vet ./...` · `go test ./...` (31 packages)
- [x] `biome check .` · `vitest run` (88 files, 1028 tests) · `tsc` · `vite build --mode production`
- [x] Mutation-checked: the new test fails when `tree.go` routes a broken repository to the walk
