### PR TITLE
chore: cut v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.39.0] - 2026-08-21
+
 ### Added
 
 - **lich says when git or the GitHub CLI is missing, instead of going quiet.**
@@ -3023,7 +3025,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.38.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.39.0...HEAD
+[0.39.0]: https://github.com/omartelo/lich/compare/v0.38.0...v0.39.0
 [0.38.0]: https://github.com/omartelo/lich/compare/v0.37.0...v0.38.0
 [0.37.0]: https://github.com/omartelo/lich/compare/v0.36.0...v0.37.0
 [0.36.0]: https://github.com/omartelo/lich/compare/v0.35.1...v0.36.0


### PR DESCRIPTION
`[Unreleased]` empties and its entries move under `## [0.39.0] - 2026-08-21`, sections kept in Keep a Changelog order (Added, then Fixed). The compare links follow: `[Unreleased]` starts at `v0.39.0` now, and `[0.39.0]` spans `v0.38.0..v0.39.0`.

Minor rather than patch: the release adds the missing-tool surfaces and the switch that parks a custom binary, neither of which existed in v0.38.0.

Nothing else carries a version by hand — `git describe` feeds the Taskfile and `nfpm.yaml`, and no README or workflow pins one.

## Test plan

- [x] `release.yml`'s notes extractor dry-run against the new heading: 67 lines, 6 entries (2 Added, 4 Fixed), stops at `## [0.38.0]`
- [x] `gofmt -l .` · `go vet ./...` · `go test -race ./...` (1739 tests, 32 packages)
- [x] `biome check .` · `vitest run` (88 files, 1034 tests) · `tsc` · `vite build --mode production`