### PR TITLE
chore: build on Go 1.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Building lich from source now needs Go 1.27.0.** The pin stays exact so that
+  every release binary carries the current toolchain's own security fixes, and
+  the module is what CI reads its Go version from. `GOTOOLCHAIN=auto` — the
+  default — fetches 1.27.0 on its own; a build pinned to `local` on anything
+  older will refuse the module.
+
 ## [0.39.0] - 2026-08-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the per-line decode that prices a session went from ~90µs to ~27µs on a
   full assistant turn, allocating 2 objects where it used to allocate 13. A
   project whose sessions carry long transcripts feels it on every refresh.
+- **A `lich rage` bundle now names the goroutines that leaked.** `goroutines.txt`
+  carried every stack in the process, leaving whoever read it to work out which
+  of a few hundred was the one still waiting on something nobody will ever send.
+  The dump now ends with a second section holding only the goroutines blocked on
+  a channel, mutex or WaitGroup that no runnable goroutine can still reach —
+  which is the shape of a window that stopped updating while the process stayed
+  alive. An empty section is the answer too: the hang is somewhere else.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the module is what CI reads its Go version from. `GOTOOLCHAIN=auto` — the
   default — fetches 1.27.0 on its own; a build pinned to `local` on anything
   older will refuse the module.
+- **The cost readout scans a transcript about three times faster.** Nothing in
+  lich changed: Go 1.27 rebuilt `encoding/json` on top of its v2 implementation,
+  and the per-line decode that prices a session went from ~90µs to ~27µs on a
+  full assistant turn, allocating 2 objects where it used to allocate 13. A
+  project whose sessions carry long transcripts feels it on every refresh.
+
+### Removed
+
+- **macOS builds no longer run on Big Sur or Monterey.** Go 1.27 dropped every
+  macOS before 13 Ventura, so the cask now declares that floor and Homebrew
+  refuses the install on an older machine rather than handing it a binary that
+  cannot start. Nothing in lich itself needs 13 — the floor is the compiler's,
+  and it moves with the next Go bump.
 
 ## [0.39.0] - 2026-08-21
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ lives in the code, `docs/` and `CHANGELOG.md` — never restate any of it here.
 
 ## Rules of the codebase
 
-- Go 1.26, pure Go: `CGO_ENABLED=0` and a fully static binary are a constraint, not a default.
+- Go 1.27, pure Go: `CGO_ENABLED=0` and a fully static binary are a constraint, not a default.
 - OS-specific code is selected by build tags behind small seams, never by runtime checks — the PTY is the model
   (`internal/terminal`).
 - Service shapes are hand-owned in `frontend/src/lib/api-types.ts`: touch a Go struct's JSON tags and that mirror

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Bugs and ideas are welcome, and so are patches. This file is the short version;
 
 ## Getting it running
 
-Prerequisites: **Go 1.26.6+**, **Node + pnpm**, and **[Task](https://taskfile.dev)**.
+Prerequisites: **Go 1.27.0+**, **Node + pnpm**, and **[Task](https://taskfile.dev)**.
 No C toolchain and no system dev libraries — the backend is pure Go
 (`CGO_ENABLED=0`). At runtime you need a Chromium-family browser on `PATH`,
 plus `zenity` on Linux for the folder picker.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <p><a href="https://omartelo.github.io/lich/"><strong>omartelo.github.io/lich</strong></a></p>
   <p>
     <a href="https://github.com/omartelo/lich/releases"><img alt="Release" src="https://img.shields.io/github/v/release/omartelo/lich?color=4285F4&label=release" /></a>
-    <img alt="Go" src="https://img.shields.io/badge/Go-1.26-00ADD8?logo=go&logoColor=white" />
+    <img alt="Go" src="https://img.shields.io/badge/Go-1.27-00ADD8?logo=go&logoColor=white" />
     <img alt="Shell" src="https://img.shields.io/badge/shell-Chromium%20--app-4285F4?logo=googlechrome&logoColor=white" />
     <img alt="Platform" src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-333" />
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-AGPL--3.0-blue" /></a>
@@ -165,12 +165,12 @@ your gh login, never a session token — before you attach it to a bug report, a
 
 ## Build from source
 
-Pure-Go backend (Go 1.26, `CGO_ENABLED=0`) serving an embedded React 18 /
+Pure-Go backend (Go 1.27, `CGO_ENABLED=0`) serving an embedded React 18 /
 TypeScript / Vite frontend over a token-authenticated loopback listener (HTTP RPC
 + WebSockets). Terminals are xterm.js with the WebGL addon; the code and diff
 surfaces are CodeMirror 6. The Chromium shell is a decision record:
 [`docs/chromium-shell.md`](docs/chromium-shell.md). Prerequisites are **Go
-1.26.6+**, **Node + pnpm** and **[Task](https://taskfile.dev)** — no C toolchain,
+1.27.0+**, **Node + pnpm** and **[Task](https://taskfile.dev)** — no C toolchain,
 no system dev libraries.
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,7 +15,7 @@
   </p>
   <p>
     <a href="https://github.com/omartelo/lich/releases"><img alt="Release" src="https://img.shields.io/github/v/release/omartelo/lich?color=4285F4&label=release" /></a>
-    <img alt="Go" src="https://img.shields.io/badge/Go-1.26-00ADD8?logo=go&logoColor=white" />
+    <img alt="Go" src="https://img.shields.io/badge/Go-1.27-00ADD8?logo=go&logoColor=white" />
     <img alt="Shell" src="https://img.shields.io/badge/shell-Chromium%20--app-4285F4?logo=googlechrome&logoColor=white" />
     <img alt="Platform" src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-333" />
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-AGPL--3.0-blue" /></a>
@@ -143,10 +143,10 @@ Releases 发一次版本查询。更新在 Windows/macOS 上就地应用，在 A
 
 ## 从源码构建
 
-纯 Go 后端（Go 1.26，`CGO_ENABLED=0`），通过带 token 鉴权的本地回环监听器（HTTP RPC +
+纯 Go 后端（Go 1.27，`CGO_ENABLED=0`），通过带 token 鉴权的本地回环监听器（HTTP RPC +
 WebSocket）伺服内嵌的 React 18 / TypeScript / Vite 前端。终端是 xterm.js 配 WebGL
 插件；代码和 diff 界面是 CodeMirror 6。Chromium 外壳有一份决策记录：
-[`docs/chromium-shell.md`](docs/chromium-shell.md)。前置条件是 **Go 1.26.6+**、
+[`docs/chromium-shell.md`](docs/chromium-shell.md)。前置条件是 **Go 1.27.0+**、
 **Node + pnpm** 和 **[Task](https://taskfile.dev)** —— 不需要 C 工具链，也不需要
 系统开发库。
 

--- a/build/darwin/Info.plist.tpl
+++ b/build/darwin/Info.plist.tpl
@@ -30,7 +30,7 @@
   <key>CFBundleVersion</key>
   <string>@VERSION@</string>
   <key>LSMinimumSystemVersion</key>
-  <string>11.0</string>
+  <string>13.0</string>
   <key>LSUIElement</key>
   <true/>
   <key>NSHighResolutionCapable</key>

--- a/build/darwin/homebrew/lich.rb.tpl
+++ b/build/darwin/homebrew/lich.rb.tpl
@@ -16,7 +16,7 @@ cask "lich" do
   desc "Personal harness for AI-assisted development"
   homepage "https://github.com/omartelo/lich"
 
-  depends_on macos: ">= :big_sur"
+  depends_on macos: ">= :ventura"
 
   app "Lich.app"
   binary "#{appdir}/Lich.app/Contents/MacOS/lich"

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -173,3 +173,9 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   provider, and `shell` is not one — the sandbox exists to confine an agent working unattended, not the
   user's own prompt. A terminal opened in a project whose provider is on `Everywhere` still runs on the
   machine, and nothing says so.
+- **The macOS floor is the toolchain's, not lich's** (`build/darwin/Info.plist.tpl`,
+  `build/darwin/homebrew/lich.rb.tpl`): nothing in lich needs macOS 13, but Go 1.27 dropped every
+  release before Ventura, so a binary built from this module cannot run on Big Sur or Monterey. The
+  cask's `depends_on` and the bundle's `LSMinimumSystemVersion` say 13.0 because the compiler does —
+  both move with the next Go bump, and a machine below the floor is refused by Homebrew rather than
+  by a crash.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/omartelo/lich
 
-go 1.26.6
+go 1.27.0
 
 require (
 	github.com/UserExistsError/conpty v0.1.4

--- a/internal/agentplugin/files_test.go
+++ b/internal/agentplugin/files_test.go
@@ -841,7 +841,7 @@ func TestTheMCPRegistrationIsInsideLichsBlock(t *testing.T) {
 
 // lineWith returns the block's first line containing needle.
 func lineWith(block, needle string) (string, bool) {
-	for _, line := range strings.Split(block, "\n") {
+	for line := range strings.SplitSeq(block, "\n") {
 		if strings.Contains(line, needle) {
 			return strings.TrimSpace(line), true
 		}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -115,7 +115,7 @@ func buildUsage() string {
 	b.WriteString(helpHeader)
 	for _, cmd := range commands {
 		b.WriteString("  " + cmd.spelling() + "\n")
-		for _, line := range strings.Split(cmd.about, "\n") {
+		for line := range strings.SplitSeq(cmd.about, "\n") {
 			b.WriteString("      " + line + "\n")
 		}
 		b.WriteString("\n")

--- a/internal/fonts/fonts.go
+++ b/internal/fonts/fonts.go
@@ -28,7 +28,7 @@ func (s *Service) List() ([]string, error) {
 // output.
 func parseFamilies(out string) []string {
 	seen := make(map[string]struct{})
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		// A line may hold comma-separated localized aliases; the first is the
 		// canonical family name.
 		name := strings.TrimSpace(strings.SplitN(line, ",", 2)[0])
@@ -47,7 +47,7 @@ func parseFamilies(out string) []string {
 func parseRegistryFamilies(names []string) []string {
 	seen := make(map[string]struct{})
 	for _, name := range names {
-		for _, part := range strings.Split(stripFontFormat(name), "&") {
+		for part := range strings.SplitSeq(stripFontFormat(name), "&") {
 			family := trimFontFaces(strings.TrimSpace(part))
 			if family == "" {
 				continue

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -221,9 +222,7 @@ func (t *Table) releaseRefresh() {
 func (t *Table) merge(rates map[string]Rate) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	for model, rate := range rates {
-		t.rates[model] = rate
-	}
+	maps.Copy(t.rates, rates)
 }
 
 // fetch downloads the remote table and reduces it to lich's shape — every entry

--- a/internal/rage/rage_test.go
+++ b/internal/rage/rage_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -309,12 +310,7 @@ func keys(m map[string]string) []string {
 }
 
 func contains(list []string, want string) bool {
-	for _, s := range list {
-		if s == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, want)
 }
 
 // TestBundleReportsAWriteFailure pins that a broken destination is an error the

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"errors"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -182,9 +183,9 @@ func (f *fakeEvents) snapshot() []RelayEvent {
 // would be showing.
 func (f *fakeEvents) markOf(id string) (RelayEvent, bool) {
 	events := f.snapshot()
-	for i := len(events) - 1; i >= 0; i-- {
-		if events[i].ID == id {
-			return events[i], true
+	for _, event := range slices.Backward(events) {
+		if event.ID == id {
+			return event, true
 		}
 	}
 	return RelayEvent{}, false
@@ -365,11 +366,9 @@ func TestSendDeliversAndReplyAnswers(t *testing.T) {
 		err error
 		wg  sync.WaitGroup
 	)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		got, err = svc.Send("s1", "docs", "", "run the tests", 30)
-	}()
+	})
 
 	ticketID := waitForTicket(svc)
 	if err := svc.Reply(ticketID, "3 failures in foo_test"); err != nil {

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -654,13 +654,11 @@ func TestConcurrentOpensDoNotShareALabel(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 2 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			if _, err := svc.Open("s1", "", "", "", "", ""); err != nil {
 				t.Errorf("Open: %v", err)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/internal/terminal/sandbox_test.go
+++ b/internal/terminal/sandbox_test.go
@@ -108,8 +108,8 @@ func TestWrapSandboxKeepsTheCommandAndItsArguments(t *testing.T) {
 
 // lastIndex is the position of the final element equal to value, or -1.
 func lastIndex(args []string, value string) int {
-	for i := len(args) - 1; i >= 0; i-- {
-		if args[i] == value {
+	for i, arg := range slices.Backward(args) {
+		if arg == value {
 			return i
 		}
 	}

--- a/internal/terminal/search.go
+++ b/internal/terminal/search.go
@@ -92,7 +92,7 @@ func (s *Service) SearchTranscripts(ids []string, query string) []TranscriptMatc
 func searchTranscript(tail []byte, q string) (TranscriptMatch, bool) {
 	needle := []byte(q)
 	var match TranscriptMatch
-	for _, line := range bytes.Split(tail, []byte("\n")) {
+	for line := range bytes.SplitSeq(tail, []byte("\n")) {
 		if !bytes.Contains(bytes.ToLower(line), needle) {
 			continue
 		}
@@ -172,10 +172,7 @@ func snippetAround(text, q string) (string, bool) {
 	if len(runes) <= snippetWidth {
 		return flat, true
 	}
-	start := at - snippetWidth/3
-	if start < 0 {
-		start = 0
-	}
+	start := max(at-snippetWidth/3, 0)
 	end := start + snippetWidth
 	if end > len(runes) {
 		end = len(runes)

--- a/internal/terminal/shellenv.go
+++ b/internal/terminal/shellenv.go
@@ -58,12 +58,12 @@ func ResolveShellEnv(base []string) []string {
 // is line-based, so a value spanning a newline loses its tail; switch the dump
 // to `env -0` and split on NUL if that ever bites.
 func parseShellEnvDump(sentinel, out string) []string {
-	idx := strings.LastIndex(out, sentinel)
-	if idx < 0 {
+	_, dump, ok := strings.CutLast(out, sentinel)
+	if !ok {
 		return nil
 	}
 	var kv []string
-	for line := range strings.SplitSeq(out[idx+len(sentinel):], "\n") {
+	for line := range strings.SplitSeq(dump, "\n") {
 		line = strings.TrimSuffix(line, "\r")
 		if key, _, ok := strings.Cut(line, "="); ok && validEnvKey(key) {
 			kv = append(kv, line)

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -269,13 +269,19 @@ func (t *transport) ping(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// goroutines dumps every goroutine's stack, blocked ones included. It answers
-// the failure a log cannot describe: the window stops updating while the
-// process is still alive, so nothing panicked, nothing exited, and nothing was
-// ever written. `lich rage` fetches this into the bug report; an instance that
-// holds its port and will not answer here is itself the finding. Token-gated
-// like every other endpoint, and deliberately not net/http/pprof: this is one
-// dump of one thing, not a profiling surface.
+// leakHeading separates the leak profile from the stacks above it in the dump,
+// so a reader scrolling the bundle finds the short answer without knowing the
+// endpoint writes two things.
+const leakHeading = "\n\n===== leaked goroutines =====\n\n"
+
+// goroutines dumps every goroutine's stack, blocked ones included, then the
+// leak profile over the same process. It answers the failure a log cannot
+// describe: the window stops updating while the process is still alive, so
+// nothing panicked, nothing exited, and nothing was ever written. `lich rage`
+// fetches this into the bug report; an instance that holds its port and will
+// not answer here is itself the finding. Token-gated like every other endpoint,
+// and deliberately not net/http/pprof: this is one dump of one question, not a
+// profiling surface.
 func (t *transport) goroutines(w http.ResponseWriter, r *http.Request) {
 	if !t.authorized(r) {
 		http.Error(w, "invalid token", http.StatusUnauthorized)
@@ -286,6 +292,23 @@ func (t *transport) goroutines(w http.ResponseWriter, r *http.Request) {
 	// hang and a crash are read side by side.
 	if err := pprof.Lookup("goroutine").WriteTo(w, 2); err != nil {
 		slog.Warn("goroutine dump", "err", err)
+	}
+	writeLeaks(w)
+}
+
+// writeLeaks appends the goroutineleak profile: the goroutines blocked on a
+// channel, mutex or WaitGroup that nothing runnable can still reach, which is
+// exactly the shape of a lich that went quiet. It is the narrow answer the full
+// dump above buries, and it costs a leak-detecting GC to collect — acceptable
+// on a debug endpoint reached by hand, not on a poll. debug level 1 is the
+// readable count-and-stack form; level 2 would fall back to every goroutine
+// again, which is the dump we just wrote.
+func writeLeaks(w io.Writer) {
+	if _, err := io.WriteString(w, leakHeading); err != nil {
+		return
+	}
+	if err := pprof.Lookup("goroutineleak").WriteTo(w, 1); err != nil {
+		slog.Warn("goroutine leak profile", "err", err)
 	}
 }
 

--- a/internal/terminal/transport_test.go
+++ b/internal/terminal/transport_test.go
@@ -319,6 +319,16 @@ func TestGoroutineDumpAnswersWithTheStacks(t *testing.T) {
 		!strings.Contains(string(body), "TestGoroutineDumpAnswersWithTheStacks") {
 		t.Errorf("dump carries no stacks: %q", string(body))
 	}
+	// The leak profile follows under its heading. A healthy process leaks
+	// nothing, so this pins that the section is written at all — the count it
+	// reports is the finding, and an empty one is the answer here.
+	_, leaks, found := strings.CutLast(string(body), leakHeading)
+	if !found {
+		t.Fatalf("dump carries no leak section: %q", string(body))
+	}
+	if !strings.HasPrefix(leaks, "goroutineleak profile: total ") {
+		t.Errorf("leak section = %q, want a goroutineleak profile", leaks)
+	}
 }
 
 func TestGoroutineDumpRejectsBadToken(t *testing.T) {

--- a/internal/terminal/usage_claude.go
+++ b/internal/terminal/usage_claude.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+	"slices"
 	"strings"
 )
 
@@ -98,8 +99,8 @@ func readTail(path string, max int64) ([]byte, bool) {
 // like any malformed line.
 func parseContextUsage(tail []byte) (contextUsage, bool) {
 	lines := bytes.Split(tail, []byte("\n"))
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := bytes.TrimSpace(lines[i])
+	for _, line := range slices.Backward(lines) {
+		line := bytes.TrimSpace(line)
 		if len(line) == 0 {
 			continue
 		}

--- a/internal/themes/git.go
+++ b/internal/themes/git.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -200,8 +201,8 @@ func clone(ctx context.Context, url, dir string) error {
 // naming the failure ("repository not found", "could not read Username").
 func gitError(out []byte, err error) string {
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-	for i := len(lines) - 1; i >= 0; i-- {
-		line := strings.TrimSpace(lines[i])
+	for _, line := range slices.Backward(lines) {
+		line := strings.TrimSpace(line)
 		if line != "" {
 			return line
 		}


### PR DESCRIPTION
Go 1.27.0 landed, so lich builds on it. The bump is the point; the rest of this
PR is what the release notes turned out to be worth once measured against the
code, plus the one promise the bump quietly broke.

## The bump

`go.mod` moves to `go 1.27.0` — exact, as before, so every release binary carries
the current toolchain's own security fixes. CI needed no edit: both workflows
read `go-version-file: go.mod`. Badges, `CONTRIBUTING.md`, both READMEs and
`CLAUDE.md` follow.

## The promise it broke: the macOS floor

Go 1.27 dropped every macOS before 13 Ventura. The cask still said
`depends_on macos: ">= :big_sur"` and the bundle still said
`LSMinimumSystemVersion 11.0`, so the next release would have handed a Big Sur or
Monterey machine a binary that cannot start — Homebrew happily installing it
first. Both now say 13, and `docs/ceilings.md` carries the bullet: the floor is
the compiler's, not lich's, and it moves with the next Go bump.

## Free performance, measured

Go 1.27 rebuilt `encoding/json` on top of its v2 implementation. That lands
directly on the hottest JSON path in lich: `parseCostLine`, the per-line decode
that prices a session from its transcript. It pulls five counters out of a full
assistant turn and skips everything else, which is exactly the shape v1 was slow
at.

Measured on one toolchain, `GOEXPERIMENT=nojsonv2` against the default, 5×2s,
on a realistic assistant line (24 text blocks plus a tool result):

| | ns/op | allocs/op | B/op |
| --- | --- | --- | --- |
| v1 (`nojsonv2`) | ~90,000 | 13 | 512 |
| v2 (default) | ~27,000 | 2 | 112 |

**≈3.3× faster, allocations 13 → 2**, no code changed. The cost scan runs per
session on every refresh, so a project whose sessions carry long transcripts
feels it. The benchmark was a throwaway — the repo keeps no benchmarks, and one
that exists only to prove a toolchain claim would go stale the moment it stopped
being asked.

Riding along, also free and not separately measured: size-specialized allocation
for objects under 80 bytes (~1% on allocation-heavy code, ~60 KB of binary),
HTTP/1 response bodies draining themselves on close for better connection reuse,
`stdversion` in `go test`'s default vet set, and pprof labels in tracebacks.

## Naming the goroutines that leaked

`goroutineleak` graduated to a general-availability profile. It answers precisely
the failure `/debug/goroutines` exists for: the window stops updating while the
process is still alive, so nothing panicked, nothing exited, nothing was logged.
Until now that endpoint handed whoever read the bug report every stack in the
process and left them to work out which of a few hundred goroutines was waiting
on something nobody will ever send.

The dump now ends with a second section holding only the goroutines blocked on a
channel, mutex or WaitGroup that no runnable goroutine can still reach. An empty
section is an answer too — it says the hang is somewhere else.

Deliberately small: it appends to the existing handler rather than adding an
endpoint, so `lich rage` picks the section up in `goroutines.txt` with no change
to `internal/rage`. It writes at debug level 1, because level 2 falls back to
printing every goroutine — which is the dump immediately above it. Collecting it
costs a leak-detecting GC, which is fine on a token-gated endpoint reached by
hand and would not be on a poll; the comment on `writeLeaks` says so.

## Idioms the toolchain now names

`go fix ./...` across 11 files — `strings`/`bytes.SplitSeq` (no intermediate
slice), `wg.Go`, `maps.Copy`, `slices.Contains`, `slices.Backward`, `max()`.
Mechanical, mostly 1.24/1.25 idioms that `go fix` only now surfaces.

Two of its suggestions were rejected: rewriting a `ptr()` test helper to
`new(v)` plus a `//go:fix inline` directive (noise for a three-word helper), and
squashing a `Spec` literal in `internal/sandbox` into one composite literal that
reads worse than the two statements it replaces.

One genuinely-1.27 change by hand: `strings.CutLast` in `parseShellEnvDump`,
which was the last-sentinel split that function was already doing by index
arithmetic. The other three `LastIndex` sites in the tree do not improve —
`internal/terminal/cwd.go` would get slower, since `LastIndexByte` beats a slice
separator.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` — 31 packages, green
- [x] Cross-compile loop for `linux`, `darwin`, `windows` — `go build` + `go vet` green on each
- [x] `TestGoroutineDumpAnswersWithTheStacks` extended to pin the leak section, and proven to fail with `writeLeaks` commented out
- [x] `go mod tidy` — no diff; `go.mod` was already in 1.27's two-block layout
- [ ] macOS floor is unverifiable here — there is no Apple hardware on this machine. The cask's `depends_on` and `LSMinimumSystemVersion` are the declaration; the darwin runners in CI prove the build, not the floor.

Frontend untouched, so its gate was not run.
