### PR TITLE
docs: say the prompt cap where the agent reads it

### DIFF
--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -329,7 +329,10 @@ var mcpTools = []mcpTool{
 		Schema: schema(map[string]any{
 			"session": property("string",
 				"Label of the target session, exactly as list_sessions returns it. Not a peer-roster name."),
-			"prompt":  property("string", "What to ask that session's agent to do."),
+			"prompt": property("string",
+				"What to ask that session's agent to do. Capped at 8 KB: it is typed at a "+
+					"terminal prompt, so name the paths, branches and commits to read rather "+
+					"than pasting a diff or a file — the target has the repository."),
 			"project": property("string", "Project name, needed only when two live sessions share a label."),
 			"timeout_seconds": property("number",
 				"Seconds to hold the line for a quick answer, at most 90 — longer is capped, "+
@@ -405,7 +408,8 @@ var mcpTools = []mcpTool{
 					"given one."),
 			"prompt": property("string",
 				"Task to hand the new session as soon as its agent is up. Omit to open it idle "+
-					"and send later."),
+					"and send later. Capped at 8 KB, like send_to_session: name what to read, "+
+					"do not paste it."),
 		}),
 		Run: func(c *client, args mcpArgs) (string, error) {
 			var opened spawn.Session

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -398,7 +398,8 @@ func (s *Service) Send(fromID, target, project, prompt string, waitSeconds int) 
 		return Result{}, fmt.Errorf("nothing to send: the prompt is empty")
 	}
 	if len(prompt) > promptLimit {
-		return Result{}, fmt.Errorf("prompt is %d bytes, over the %d limit", len(prompt), promptLimit)
+		return Result{}, fmt.Errorf("prompt is %d bytes, over the %d limit: "+
+			"name the paths to read instead of pasting their contents", len(prompt), promptLimit)
 	}
 
 	dest, err := s.resolve(fromID, target, project)


### PR DESCRIPTION
The 8 KB prompt cap was only enforced, never announced. An agent calling
`send_to_session` or `open_session` reads the tool schema, sees nothing about a
limit, pastes a diff, and finds out from `relay.Send` after the fact.

Both sides now say the same thing:

- `send_to_session` / `open_session` prompt descriptions state the cap and why
  it exists — the prompt is typed at a terminal, and the target session has the
  repository, so naming paths, branches and commits beats pasting contents.
- The over-limit error tells the caller what to do instead of only how far over
  it went.

Text only: no behaviour, no schema shape, no new field.

## Test plan

- [x] `gofmt -l` clean on both changed files
