### PR TITLE
fix: make a deep file tree readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cannot start. Nothing in lich itself needs 13 — the floor is the compiler's,
   and it moves with the next Go bump.
 
+### Fixed
+
+- **A deep file tree is readable again.** A pull request whose paths run
+  `src/main/java/br/com/acme/...` spent the panel's whole width on indentation,
+  and every file name arrived as an ellipsis with no way to reach the rest of
+  it. Directories with nothing in them but the next directory now collapse into
+  one row, the tree scrolls sideways when a name still overruns, and the Files
+  changed tree drags wider by its right edge like every other side panel — the
+  width is remembered. The dock's file browser gets the same three.
+
 ## [0.39.0] - 2026-08-21
 
 ### Added

--- a/frontend/src/components/FileTree.tsx
+++ b/frontend/src/components/FileTree.tsx
@@ -82,21 +82,26 @@ export function FileTree({
     })
 
   return (
-    <div role="tree" className={cn("py-1 font-mono text-xs", className)}>
-      {tree.map((node) => (
-        <TreeRow
-          key={node.path}
-          node={node}
-          depth={0}
-          active={active}
-          stats={stats}
-          isOpen={isOpen}
-          onToggle={toggle}
-          onSubtree={setSubtree}
-          onEditor={onEditor}
-          onSelect={onSelect}
-        />
-      ))}
+    // Names run past the panel's width on a deep tree; the rows size to their
+    // content and the tree scrolls sideways, because an ellipsis with no way to
+    // reach the rest of the name hides which file the row is.
+    <div className={cn("overflow-auto", className)}>
+      <div role="tree" className="w-max min-w-full py-1 font-mono text-xs">
+        {tree.map((node) => (
+          <TreeRow
+            key={node.path}
+            node={node}
+            depth={0}
+            active={active}
+            stats={stats}
+            isOpen={isOpen}
+            onToggle={toggle}
+            onSubtree={setSubtree}
+            onEditor={onEditor}
+            onSelect={onSelect}
+          />
+        ))}
+      </div>
     </div>
   )
 }
@@ -134,7 +139,7 @@ function TreeRow({
       <>
         <span className="size-3.5 shrink-0" aria-hidden />
         <FileIcon path={node.path} />
-        <span className="min-w-0 truncate">{node.name}</span>
+        <span className="whitespace-nowrap">{node.name}</span>
         {stat && (
           <span className="ml-auto flex shrink-0 items-center gap-1.5 pl-2 tabular-nums">
             <DiffStat added={stat.added} deleted={stat.deleted} />
@@ -199,7 +204,7 @@ function TreeRow({
         >
           <Chevron className="size-3.5 shrink-0 text-muted-foreground" />
           <FolderIcon className="size-3.5 shrink-0 text-muted-foreground" />
-          <span className="truncate">{node.name}</span>
+          <span className="whitespace-nowrap">{node.name}</span>
         </ContextMenuTrigger>
         <ContextMenuContent>
           <ContextMenuItem onClick={() => onSubtree(node, true)}>Expand all</ContextMenuItem>

--- a/frontend/src/components/dock/FilesPanel.tsx
+++ b/frontend/src/components/dock/FilesPanel.tsx
@@ -206,7 +206,7 @@ function TreeBody({ tree, query, active, stats, failed, onOpen, onEditor }: Tree
       expandAll={filtering}
       stats={stats}
       onEditor={onEditor}
-      className="h-full overflow-y-auto"
+      className="h-full"
       onSelect={onOpen}
     />
   )

--- a/frontend/src/components/pulls/PullsFiles.tsx
+++ b/frontend/src/components/pulls/PullsFiles.tsx
@@ -1,6 +1,7 @@
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react"
 import { useMemo, useRef, useState, useSyncExternalStore } from "react"
 import { IconAction } from "@/components/common/IconAction"
+import { ResizeHandle } from "@/components/common/ResizeHandle"
 import { Notice } from "@/components/common/Notice"
 import { CommentBatch } from "@/components/diff/CommentBatch"
 import { CollapseAllAction, useDiffBulk } from "@/components/diff/diff-bulk"
@@ -31,11 +32,20 @@ import {
 import { usePullRequestDiff } from "@/lib/pulls/use-pull-request-diff"
 import { addReviewComment } from "@/lib/review-comments"
 import { usePanelVisible } from "@/lib/use-panel-visible"
+import { usePanelWidth } from "@/lib/use-panel-width"
 
 // The file tree is a navigator, not the review itself: hiding it hands the
 // whole width to the diff. Remembered in localStorage like every other UI pref,
 // so the choice survives leaving the screen.
 const TREE_HIDDEN_KEY = "lich.pulls.tree.hidden"
+
+// A monorepo's paths are long enough that no fixed width fits them, so the tree
+// drags like every other side panel — narrow when the diff matters more, wide
+// when the navigating does.
+const WIDTH_KEY = "lich.pulls.tree.width"
+const MIN_REM = 12
+const MAX_REM = 40
+const DEFAULT_REM = 15
 
 // Ragged widths, so the placeholders read as file names and code rather than a
 // stack of identical bars.
@@ -45,11 +55,14 @@ const CODE_ROWS = ["w-3/5", "w-4/5", "w-2/5", "w-11/12", "w-1/2", "w-3/4", "w-1/
 // The diff is a gh round-trip, so this tab is empty for about a second. A bare
 // "Loading…" line reads as a broken tab on a screen that wide; the skeleton
 // stands in for the shape that arrives — tree, toolbar, then file cards.
-function FilesSkeleton({ tree }: { tree: boolean }) {
+function FilesSkeleton({ tree, width }: { tree: boolean; width: number }) {
   return (
     <div className="flex h-full" aria-busy>
       {tree && (
-        <div className="flex w-60 shrink-0 flex-col gap-3 border-r border-border p-3">
+        <div
+          className="flex shrink-0 flex-col gap-3 border-r border-border p-3"
+          style={{ width: `${width}rem` }}
+        >
           <SkeletonLines widths={TREE_ROWS} />
         </div>
       )}
@@ -122,6 +135,13 @@ export function PullsFiles({
   // all at once — same directive the Review dock hands its panel.
   const [bulk, toggleAll] = useDiffBulk()
   const [treeOpen, toggleTree] = usePanelVisible(TREE_HIDDEN_KEY)
+  const { width, handleProps } = usePanelWidth({
+    storageKey: WIDTH_KEY,
+    minRem: MIN_REM,
+    maxRem: MAX_REM,
+    defaultRem: DEFAULT_REM,
+    edge: "right",
+  })
   const viewed = useSyncExternalStore(subscribeViewed, () => viewedFiles(pullRequest))
   // A tick is against the file's content, so a new commit unticks exactly the
   // files it rewrote. Recomputed only when the diff itself changes.
@@ -165,7 +185,7 @@ export function PullsFiles({
     return <Notice className="px-4 py-6 text-sm">Couldn’t load the diff: {error}</Notice>
   }
   if (files === null) {
-    return <FilesSkeleton tree={treeOpen} />
+    return <FilesSkeleton tree={treeOpen} width={width} />
   }
   if (files.length === 0) {
     return <Notice className="px-4 py-6 text-sm">No file changes</Notice>
@@ -185,8 +205,9 @@ export function PullsFiles({
   return (
     <div className="flex h-full">
       {treeOpen && (
-        <div className="w-60 shrink-0 overflow-y-auto border-r border-border">
-          <FileTree tree={tree} active={active} defaultOpen onSelect={jumpTo} />
+        <div className="relative shrink-0 border-r border-border" style={{ width: `${width}rem` }}>
+          <FileTree tree={tree} active={active} defaultOpen className="h-full" onSelect={jumpTo} />
+          <ResizeHandle edge="right" label="Resize the file tree" handleProps={handleProps} />
         </div>
       )}
       <div className="flex flex-1 flex-col overflow-hidden">

--- a/frontend/src/lib/git/file-tree.test.ts
+++ b/frontend/src/lib/git/file-tree.test.ts
@@ -9,8 +9,38 @@ function names(nodes: TreeNode[]): string[] {
 
 describe("buildTree", () => {
   it("nests paths by their slash segments", () => {
-    const tree = buildTree(["internal/rpc/rpc.go"])
-    expect(names(tree)).toEqual(["dir:internal", "dir:internal/rpc", "file:internal/rpc/rpc.go"])
+    const tree = buildTree(["internal/rpc/rpc.go", "internal/x.go"])
+    expect(names(tree)).toEqual([
+      "dir:internal",
+      "dir:internal/rpc",
+      "file:internal/rpc/rpc.go",
+      "file:internal/x.go",
+    ])
+  })
+
+  it("collapses a chain of single-child directories into one row", () => {
+    const tree = buildTree(["src/main/java/br/One.java", "src/main/java/br/Two.java"])
+    expect(names(tree)).toEqual([
+      "dir:src/main/java/br",
+      "file:src/main/java/br/One.java",
+      "file:src/main/java/br/Two.java",
+    ])
+    expect(tree[0]?.name).toBe("src/main/java/br")
+  })
+
+  it("stops collapsing where the tree branches", () => {
+    const tree = buildTree(["a/b/c/one.go", "a/b/d/two.go"])
+    expect(names(tree)).toEqual([
+      "dir:a/b",
+      "dir:a/b/c",
+      "file:a/b/c/one.go",
+      "dir:a/b/d",
+      "file:a/b/d/two.go",
+    ])
+  })
+
+  it("keeps a directory holding a single file as its own row", () => {
+    expect(names(buildTree(["a/one.go"]))).toEqual(["dir:a", "file:a/one.go"])
   })
 
   it("merges siblings under a shared directory", () => {

--- a/frontend/src/lib/git/file-tree.ts
+++ b/frontend/src/lib/git/file-tree.ts
@@ -38,7 +38,24 @@ export function buildTree(paths: string[]): TreeNode[] {
     })
   }
   sortTree(root)
-  return root
+  return collapseChains(root)
+}
+
+// A changed-files tree is mostly corridor: src/main/java/br/com/acme holds
+// nothing but the next directory, and a row per segment spends the panel's
+// width on indentation until every file name is an ellipsis. A chain of
+// directories with no branch in it collapses into one row — what GitHub's file
+// tree and VS Code's compact folders show. The merged node keeps the deepest
+// path as its id, so expand state stays unique per row.
+function collapseChains(nodes: TreeNode[]): TreeNode[] {
+  return nodes.map((node) => {
+    let merged = node
+    while (merged.children.length === 1 && merged.children[0].type === "dir") {
+      const only = merged.children[0]
+      merged = { ...only, name: `${merged.name}/${only.name}` }
+    }
+    return { ...merged, children: collapseChains(merged.children) }
+  })
 }
 
 function sortTree(nodes: TreeNode[]): void {


### PR DESCRIPTION
A pull request whose paths run `src/main/java/br/com/acme/...` spent the file tree's whole width on indentation: every directory in the chain earned its own row, and the file names arrived as an ellipsis with no way to reach the rest of them. Neither escape hatch existed — the panel had a fixed 15rem width and no horizontal scroll.

Three changes, all on the `FileTree` the Pulls screen and the dock's Code tab share:

- **`buildTree` collapses corridors.** A chain of directories holding nothing but the next directory becomes one row — `src/main/java/br/com/acme` instead of six levels of indentation, the way GitHub's file tree and VS Code's compact folders show it. The merged node keeps the deepest path as its id, so expand state stays unique per row and branches still split where the tree actually branches.
- **The tree scrolls sideways.** Rows size to their content (`w-max min-w-full`) and the names stop truncating, so a name that still overruns the panel is reachable.
- **The Files changed tree resizes.** It drags by its right edge like the dock and the session sidebar, reusing `usePanelWidth` + `ResizeHandle`; the width persists under `lich.pulls.tree.width` (12–40rem, default 15rem, the old fixed width).

## Test plan

- [x] `vitest` — 88 files / 1037 tests green, including four new `buildTree` cases: chain collapse, stopping at a branch, a directory holding a single file, and the existing nesting case widened so it no longer collapses.
- [x] `biome check .`, `tsc -b`, `vite build`
- [x] `gofmt -l .`, `go vet ./...` (no Go changed)
- [x] Confirmed by hand on a deep Java monorepo PR — the tree that motivated the report.