### PR TITLE
fix: hang up on a session before killing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Closing a session hangs up on the agent instead of killing it outright.** A
+  card's close sent the process `SIGKILL`, which leaves an agent no chance to run
+  its own exit path. Claude Code reads that as a crash: a session killed within
+  ten seconds of its first frame counts as a fullscreen renderer that failed to
+  start, and two of those turn fullscreen off for every session on the machine —
+  the `tui` setting still says `fullscreen`, every session comes up on the classic
+  renderer anyway, and only `/tui fullscreen` clears it. A close now sends
+  `SIGTERM` and kills only a child that outstays a one-second grace, so exit
+  hooks, transcripts and renderer state are written the way they are in any
+  terminal. Windows keeps the abrupt close — a ConPTY has no signal to send.
 - **A deep file tree is readable again.** A pull request whose paths run
   `src/main/java/br/com/acme/...` spent the panel's whole width on indentation,
   and every file name arrived as an ellipsis with no way to reach the rest of

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -28,6 +28,10 @@ work when nobody knows it and that the call site never shows. The mechanism and 
 - **A dropped file has no path, so lich guesses it** (`internal/drop`): a file under neither the session directory
   nor home is *copied*, so an agent told to edit it edits the copy — and that copy is deleted 3 days on, so a path
   pasted into a prompt eventually stops resolving.
+- **A session close is a hang-up on Unix and a kill on Windows** (`internal/terminal/pty_unix.go`,
+  `pty_windows.go`): closing a card signals the agent and gives it `closeGrace` to leave, so its exit path runs —
+  hooks, transcripts, whatever it writes on the way out. A ConPTY has no signal to deliver, so the same close on
+  Windows is still abrupt: an agent that saves state on exit loses it there, and nothing on screen says so.
 - **A terminal entrypoint reaches shell sessions on Linux and macOS alone** (`internal/terminal/entrypoint.go`):
   the menu item is absent on a provider card, and on Windows the setting saves and the terminal opens on a bare
   shell anyway — the wrap is skipped there for `wrapSetup`'s reason, and nothing on screen says so. It also runs

--- a/internal/terminal/pty_unix.go
+++ b/internal/terminal/pty_unix.go
@@ -5,9 +5,18 @@ package terminal
 import (
 	"os"
 	"os/exec"
+	"syscall"
+	"time"
 
 	"github.com/creack/pty"
 )
+
+// closeGrace is how long a hang-up waits for the signalled child to leave on
+// its own before killing it. An agent killed outright never runs its own exit
+// path: Claude Code, for one, treats a session that dies within ten seconds of
+// its first frame as a fullscreen renderer that failed to start, and two of
+// those turn its fullscreen renderer off for every session on the machine.
+const closeGrace = time.Second
 
 // startPTY starts spec's child attached to a fresh PTY sized cols x rows.
 func startPTY(spec ptySpec) (ptyHandle, error) {
@@ -18,15 +27,24 @@ func startPTY(spec ptySpec) (ptyHandle, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &unixPTY{File: ptmx, cmd: cmd}, nil
+	p := &unixPTY{File: ptmx, cmd: cmd, exited: make(chan struct{})}
+	go p.reap()
+	return p, nil
 }
 
 // unixPTY pairs the PTY master file creack/pty returns (which carries
-// Read/Write) with the child it drives: Wait reaps it after the master hits
-// EOF, and Close also kills it so hanging up ends the session.
+// Read/Write) with the child it drives: a goroutine reaps that child the
+// moment it exits, so Close can tell a child that left from one that has to be
+// made to.
 type unixPTY struct {
 	*os.File
 	cmd *exec.Cmd
+
+	// exited is closed once the child is reaped; code and err are written
+	// before that close and read only after it.
+	exited chan struct{}
+	code   int
+	err    error
 }
 
 func (p *unixPTY) Resize(cols, rows int) error {
@@ -35,24 +53,38 @@ func (p *unixPTY) Resize(cols, rows int) error {
 
 func (p *unixPTY) Pid() int { return p.cmd.Process.Pid }
 
-// Wait reaps the child and reports its exit status. ProcessState carries it
+// reap waits for the child and records its exit status. ProcessState carries it
 // even when Wait errors, because a non-zero exit is itself an *exec.ExitError;
 // os.ProcessState.ExitCode already answers noExitStatus for a child killed by a
 // signal.
-func (p *unixPTY) Wait() (int, error) {
-	err := p.cmd.Wait()
-	if p.cmd.ProcessState == nil {
-		return noExitStatus, err
+func (p *unixPTY) reap() {
+	p.err = p.cmd.Wait()
+	p.code = noExitStatus
+	if p.cmd.ProcessState != nil {
+		p.code = p.cmd.ProcessState.ExitCode()
 	}
-	return p.cmd.ProcessState.ExitCode(), err
+	close(p.exited)
 }
 
+// Wait reports the child's exit status once it has been reaped.
+func (p *unixPTY) Wait() (int, error) {
+	<-p.exited
+	return p.code, p.err
+}
+
+// Close hangs up: the child is asked to leave with SIGTERM and killed only if
+// it outstays closeGrace. The master is closed last so the departing child's
+// final bytes — the escape sequences that put the terminal back the way it was
+// — still reach the reader.
 func (p *unixPTY) Close() error {
-	err := p.File.Close()
-	if p.cmd.Process != nil {
-		_ = p.cmd.Process.Kill()
+	if p.cmd.Process != nil && p.cmd.Process.Signal(syscall.SIGTERM) == nil {
+		select {
+		case <-p.exited:
+		case <-time.After(closeGrace):
+			_ = p.cmd.Process.Kill()
+		}
 	}
-	return err
+	return p.File.Close()
 }
 
 func winsize(cols, rows int) *pty.Winsize {

--- a/internal/terminal/pty_unix_test.go
+++ b/internal/terminal/pty_unix_test.go
@@ -1,0 +1,95 @@
+//go:build !windows
+
+package terminal
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+)
+
+// startTrapped starts a shell that installs trap for SIGTERM and then idles,
+// and returns once that shell says the trap is armed — a hang-up delivered
+// before it is armed would be answered by the default disposition, and the
+// test would be measuring the kernel instead of the shell.
+func startTrapped(t *testing.T, trap string) ptyHandle {
+	t.Helper()
+	p, err := startPTY(ptySpec{
+		bin:  "/bin/sh",
+		args: []string{"-c", "trap '" + trap + "' TERM; echo armed; while :; do sleep 0.05; done"},
+		cols: 80,
+		rows: 24,
+	})
+	if err != nil {
+		t.Fatalf("startPTY: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+
+	armed := make(chan struct{})
+	go func() {
+		var seen bytes.Buffer
+		buf := make([]byte, 64)
+		for {
+			n, err := p.Read(buf)
+			seen.Write(buf[:n])
+			if bytes.Contains(seen.Bytes(), []byte("armed")) {
+				close(armed)
+				_, _ = io.Copy(io.Discard, p)
+				return
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	select {
+	case <-armed:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the shell to arm its SIGTERM trap")
+	}
+	return p
+}
+
+// TestCloseHangsUpBeforeKilling proves a session close reaches the child as
+// SIGTERM: the shell exits through its own handler with a status of its own
+// choosing, which a kill could never produce. That signal is what lets an agent
+// run its exit path — Claude Code counts a session killed during its first ten
+// seconds as a failed fullscreen start (see closeGrace).
+func TestCloseHangsUpBeforeKilling(t *testing.T) {
+	p := startTrapped(t, "exit 7")
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	code, _ := p.Wait()
+	if code != 7 {
+		t.Errorf("exit status = %d, want the trap's 7 (a kill leaves %d)", code, noExitStatus)
+	}
+}
+
+// TestCloseKillsAChildThatIgnoresTheHangUp proves the grace period is a grace
+// period and not a promise: a child that ignores SIGTERM is still gone when
+// Close returns, the way it was before the signal was ever sent.
+func TestCloseKillsAChildThatIgnoresTheHangUp(t *testing.T) {
+	p := startTrapped(t, "")
+
+	start := time.Now()
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if waited := time.Since(start); waited < closeGrace {
+		t.Errorf("Close returned after %v, want it to wait out the %v grace", waited, closeGrace)
+	}
+
+	done := make(chan int, 1)
+	go func() { code, _ := p.Wait(); done <- code }()
+	select {
+	case code := <-done:
+		if code != noExitStatus {
+			t.Errorf("exit status = %d, want %d for a killed child", code, noExitStatus)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("child survived Close")
+	}
+}


### PR DESCRIPTION
Closing a card sent the child `SIGKILL` — `unixPTY.Close` closed the master and killed the process in the same breath — so an agent never reached its own exit path.

Claude Code reads that as a crash. Its fullscreen renderer arms a boot canary in `~/.claude.json` (`fullscreenBootPending[pid]`) and retires it only ten seconds after the first frame; a session that dies inside that window without running its exit hook is counted as a failed start, and **two of them** write `fullscreenAutoDisabled`, which is sticky per version and overrides `"tui": "fullscreen"` for every session on the machine. Closing two cards early was enough to take the setting away, with nothing on either side saying why — and since the strike count is scoped to the Claude Code version, every update rearms the trap.

## What changed

- `Close` signals the child `SIGTERM` and kills it only if it outstays `closeGrace` (1s).
- The master is hung up last, so the escape sequences a departing agent writes to put the terminal back still reach the reader.
- The PTY reaps its own child in a goroutine; `Wait` reports what the reaper recorded. That is what lets `Close` tell a child that left from one that has to be made to, without a second `cmd.Wait`.
- Windows is unchanged — a ConPTY has no signal to deliver — and the gap is now a bullet in `docs/ceilings.md`.

## Test plan

- [x] `go test ./...` — 1757 pass; `./internal/terminal` also green under `-race`.
- [x] New `TestCloseHangsUpBeforeKilling` (the trapped shell exits with its own status 7, which a kill could never produce) and `TestCloseKillsAChildThatIgnoresTheHangUp` (a child that ignores SIGTERM is still gone when `Close` returns), 30 runs each, no flake.
- [x] Measured against the real thing: a `claude` started on a PTY armed the canary (`fullscreenBootPending[pid]` present), and `SIGTERM` retired it clean — `pending: null, strikes: null` — with `SessionEnd` hooks and the atomic `~/.claude.json` write both showing up in its debug log. `SIGKILL` is what leaves the record behind.
- [x] `gofmt -l .`, `go vet ./...`, and the `GOOS=linux/darwin/windows` build+vet loop all clean.