### PR TITLE
Show the relay ticket, and answer without one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   either way: the provider's auto-title never overwrites it again. A name another
   session in that project already holds is refused, because two sessions under
   one label is the one thing `lich send` cannot resolve.
+- **A session's card now shows the ticket it is answering.** Hover a card with an
+  open request and the tooltip names the other end and the ticket number, and on
+  the side that owes the answer it spells the command that sends it home. Until
+  now the number was written down in exactly one place — the message typed at the
+  prompt — so a session whose context was compacted past it left nobody, agent or
+  person, able to close the errand.
 
 ### Changed
 
+- **`lich reply` no longer needs the ticket.** Called with the answer alone —
+  `lich reply "<your answer>"`, or `reply_to_session` with no ticket — it answers
+  the request open against the calling session, so an agent that has lost the
+  message naming the number can still get its answer home. With several requests
+  open the oldest delivered is the one closed, and naming the ticket is still the
+  way to pick a specific errand.
 - **Building lich from source now needs Go 1.27.0.** The pin stays exact so that
   every release binary carries the current toolchain's own security fixes, and
   the module is what CI reads its Go version from. `GOTOOLCHAIN=auto` — the

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -100,6 +100,13 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   `draftIdle` for nothing. The stale-draft release is what keeps that a delay instead of a wedged relay. Two gaps
   stay open: input arriving in the ~150ms between the paste and its Enter (`defaultSubmitDelay`) still rides along,
   and a provider that takes keystrokes through anything other than this PTY is invisible here.
+- **An answer that names no ticket is matched by delivery order** (`internal/relay/relay.go`,
+  `errandOfLocked`): `lich reply "<answer>"` and `reply_to_session` without a ticket close the oldest message
+  delivered to that session and still open, because nothing in an answer itself says which request it belongs to.
+  A session working two relayed tasks at once that answers the second one first sends it home as the answer to the
+  first, and both senders read a confident wrong report — nothing anywhere reports the mismatch. Naming the ticket
+  is still the only exact route, which is why every relayed message spells it and why the card's tooltip shows it.
+
 - **Installing the plugin writes into three harnesses' own directories** (`internal/agentplugin`): Claude Code and
   Codex are driven through their plugin CLI, but opencode, oh-my-pi and Crush have none, so lich writes the
   released files itself. None of them records what is installed, so the version lives in a marker line lich wrote —

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -221,12 +221,22 @@ the command the nudge at a sender's prompt names, and it needs a session of
 its own — run from a plain shell it is an error, because there is no inbox to
 drain.
 
-### `lich reply <ticket> <answer>`
+### `lich reply [<ticket>] <answer>`
 
 Hands `<answer>` to the session waiting on `<ticket>`; prints `Answer sent.`
 This is what a relayed message asks the receiving agent to run. An answer is
 capped at 64 KiB. Replying twice to one ticket is an error — the first answer
 already went home.
+
+Called with the answer alone it hands it to the request open against the
+calling session: the oldest message actually delivered there and still
+unanswered. The ticket is written down in one place only — the message typed at
+the target's prompt — so an agent whose context was compacted past that message
+would otherwise be holding an answer with no route home. With several requests
+open the oldest delivery is closed first, the order every provider hands queued
+tasks to its agent in; a task still queued for a prompt that has not received it
+is never picked. Outside a session, or with nothing open, it is an error rather
+than a guess, and the ticket is still the way to name a specific errand.
 
 ### `lich open [--project <name>] [--kind <provider>] [--worktree <branch>] [--base <branch>] [--model <model>] [--prompt <task>]`
 
@@ -405,7 +415,7 @@ at lich.
 | `list_sessions` | The live sessions that can be given work, as JSON — each with the state it last reported, `waiting` among them. |
 | `send_to_session` | `session`, `prompt`, optional `project` and `timeout_seconds`. |
 | `wait_for_answer` | optional `ticket` and `timeout_seconds` — with a ticket, `lich wait <ticket>`; without one, the collect: everything ready at once. |
-| `reply_to_session` | `ticket`, `answer` — what a relayed message asks for. |
+| `reply_to_session` | `answer`, optional `ticket` — what a relayed message asks for; without a ticket, the request open against the calling session. |
 | `open_session` | optional `project`, `kind`, `worktree`, `base`, `model` — `lich open` — plus optional `prompt` — `lich open --prompt`, the same hand-off in the same call. |
 | `close_session` | `session`, optional `project`, `worktree` (`keep`/`remove`), `force`. |
 | `rename_session` | `label`, optional `session` (omitted renames the caller's own) and `project` — `lich rename`. |
@@ -621,8 +631,12 @@ receiving agent only because this text describes it.
   answer comes back on. Tickets live in memory: one exists for as long as its
   errand does, and a lich that restarted has no PTY left to answer into.
 - **UI push** — the relay emits the global app event `session-relay`
-  (`{id, peer, direction}`) for **both** ends when a message lands in a PTY, and
-  again with an empty direction for both when the errand closes. It is raised
+  (`{id, peer, direction, ticket}`) for **both** ends when a message lands in a
+  PTY, and again with an empty direction and ticket for both when the errand
+  closes. The ticket rides along because the window is the only other place it
+  can be read: the number is otherwise in the message typed at the target's
+  prompt and nowhere else, so a card's tooltip is what a person falls back to
+  when an agent no longer has it. It is raised
   after the write, never before: a mark that outlived a delivery which never
   happened would be a card claiming something untrue. A caller with no session
   of its own gets no mark — there is no card to put one on — and the target's

--- a/frontend/src/components/sidebar/SessionTooltip.tsx
+++ b/frontend/src/components/sidebar/SessionTooltip.tsx
@@ -1,6 +1,15 @@
-import { GitBranch, GitPullRequestArrow, Play, Shield, TriangleAlert } from "lucide-react"
+import {
+  ArrowLeft,
+  ArrowRight,
+  GitBranch,
+  GitPullRequestArrow,
+  Play,
+  Shield,
+  TriangleAlert,
+} from "lucide-react"
 import type { Session } from "@/lib/session/sessions"
 import { useSessionCwd } from "@/lib/session/use-session-cwd"
+import { useSessionRelay } from "@/lib/session/use-session-relay"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { baseReadout } from "@/lib/git/base-status"
 import { usePullRequest } from "@/lib/pulls/use-pull-request"
@@ -29,6 +38,7 @@ interface SessionTooltipProps {
 // the second reader costs a subscription, not a second poll.
 export function SessionTooltip({ session, path }: SessionTooltipProps) {
   const liveCwd = useSessionCwd(session.id)
+  const relay = useSessionRelay(session.id)
   const shownPath = liveCwd || session.path || path
   const git = useGitStatus(shownPath)
   const pr = usePullRequest(shownPath, git?.branch ?? "", git?.head ?? "")
@@ -38,6 +48,38 @@ export function SessionTooltip({ session, path }: SessionTooltipProps) {
       <div className="flex flex-col gap-1.5">
         <span className="font-medium">{session.label}</span>
         <span className="break-all font-mono text-muted-foreground">{shownPath}</span>
+        {/* The open request, and the ticket it runs on. The card already draws
+            the arrow and the peer; the number is the part that exists nowhere
+            else a person can read it — it is typed once, into the target's
+            prompt, and an agent whose context was compacted past that message
+            has no way back to it. The reply line is drawn only on the side that
+            owes the answer, because it is what you hand back to a session that
+            lost the instruction; the side that is waiting has nothing to run. */}
+        {relay && (
+          <span className="flex flex-col gap-0.5">
+            <span className="flex items-center gap-1.5 text-muted-foreground">
+              {relay.direction === "out" ? (
+                <ArrowRight className="size-3 shrink-0" />
+              ) : (
+                <ArrowLeft className="size-3 shrink-0" />
+              )}
+              <span>
+                {relay.direction === "out" ? "Waiting on " : "Answering "}
+                {relay.peer ? (
+                  <span className="font-medium text-foreground">{relay.peer}</span>
+                ) : (
+                  <span className="italic">the command line</span>
+                )}
+              </span>
+            </span>
+            {relay.ticket && <span className="font-mono tabular-nums">ticket {relay.ticket}</span>}
+            {relay.ticket && relay.direction === "in" && (
+              <span className="break-all font-mono text-muted-foreground">
+                {`lich reply ${relay.ticket} "…"`}
+              </span>
+            )}
+          </span>
+        )}
         {/* The command this terminal opens into. The card's label already says
             it while the label is still automatic — this is the only place it is
             named once the user has renamed the card. */}

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -59,10 +59,10 @@ export const SANDBOX_EVENT = "session-sandbox"
 export const USAGE_EVENT = "session-usage"
 
 // Global event the backend emits while one session has a request open with
-// another (see relay.RelayEventName). Payload: { id, peer, direction } — the
-// session whose card changes, the label at the other end, and which way the
-// request runs. An empty direction clears it: the request is over, answered or
-// expired.
+// another (see relay.RelayEventName). Payload: { id, peer, direction, ticket } —
+// the session whose card changes, the label at the other end, which way the
+// request runs, and the ticket the two ends share. An empty direction clears it:
+// the request is over, answered or expired.
 export const RELAY_EVENT = "session-relay"
 
 // Global event the backend emits when a session was opened outside the window —
@@ -110,6 +110,12 @@ export type RelayDirection = (typeof RELAY_DIRECTIONS)[number]
 export interface SessionRelay {
   peer: string
   direction: RelayDirection
+  // The ticket the request runs on. Written down nowhere else a person can
+  // read: the number lives in the message typed at the target's prompt, and an
+  // agent whose context no longer reaches that message has no way back to it.
+  // Empty from a backend older than the field, which the tooltip draws nothing
+  // for rather than an empty line.
+  ticket: string
 }
 
 // toSessionRelay narrows a relay payload to an open request, or null when there
@@ -117,14 +123,22 @@ export interface SessionRelay {
 // backend that this build cannot draw. Both mean "show nothing", which is
 // safer than stranding a mark no event will ever take down.
 export function toSessionRelay(data: unknown): SessionRelay | null {
-  const { peer, direction } = (data ?? {}) as { peer?: unknown; direction?: unknown }
+  const { peer, direction, ticket } = (data ?? {}) as {
+    peer?: unknown
+    direction?: unknown
+    ticket?: unknown
+  }
   if (typeof direction !== "string") {
     return null
   }
   if (!(RELAY_DIRECTIONS as readonly string[]).includes(direction)) {
     return null
   }
-  return { peer: typeof peer === "string" ? peer : "", direction: direction as RelayDirection }
+  return {
+    peer: typeof peer === "string" ? peer : "",
+    direction: direction as RelayDirection,
+    ticket: typeof ticket === "string" ? ticket : "",
+  }
 }
 
 // A session's context-window occupancy as the footer shows it, and what the

--- a/frontend/src/lib/session/session-relay-store.test.ts
+++ b/frontend/src/lib/session/session-relay-store.test.ts
@@ -50,11 +50,11 @@ describe("createSessionRelayStore", () => {
   it("marks both ends of one request independently", () => {
     const { relay, store } = build()
 
-    relay.emit({ id: "s1", peer: "docs", direction: "out" })
-    relay.emit({ id: "s2", peer: "auth", direction: "in" })
+    relay.emit({ id: "s1", peer: "docs", direction: "out", ticket: "fd94999a" })
+    relay.emit({ id: "s2", peer: "auth", direction: "in", ticket: "a1b2c3d4" })
 
-    expect(store.get("s1")).toEqual({ peer: "docs", direction: "out" })
-    expect(store.get("s2")).toEqual({ peer: "auth", direction: "in" })
+    expect(store.get("s1")).toEqual({ peer: "docs", direction: "out", ticket: "fd94999a" })
+    expect(store.get("s2")).toEqual({ peer: "auth", direction: "in", ticket: "a1b2c3d4" })
   })
 
   it("clears on the empty direction the backend sends when the errand closes", () => {
@@ -69,9 +69,9 @@ describe("createSessionRelayStore", () => {
   it("keeps a request with no peer label — the other end is the command line", () => {
     const { relay, store } = build()
 
-    relay.emit({ id: "s2", peer: "", direction: "in" })
+    relay.emit({ id: "s2", peer: "", direction: "in", ticket: "fd94999a" })
 
-    expect(store.get("s2")).toEqual({ peer: "", direction: "in" })
+    expect(store.get("s2")).toEqual({ peer: "", direction: "in", ticket: "fd94999a" })
   })
 
   it("shows nothing for a direction this build cannot draw", () => {
@@ -104,12 +104,34 @@ describe("createSessionRelayStore", () => {
   it("survives every other state: a busy session is still owed an answer", () => {
     const { relay, status, store } = build()
 
-    relay.emit({ id: "s2", peer: "auth", direction: "in" })
+    relay.emit({ id: "s2", peer: "auth", direction: "in", ticket: "fd94999a" })
     for (const state of ["busy", "done", "waiting"]) {
       status.emit({ id: "s2", state })
     }
 
-    expect(store.get("s2")).toEqual({ peer: "auth", direction: "in" })
+    expect(store.get("s2")).toEqual({ peer: "auth", direction: "in", ticket: "fd94999a" })
+  })
+
+  it("keeps a request from a backend that sends no ticket", () => {
+    const { relay, store } = build()
+
+    relay.emit({ id: "s2", peer: "auth", direction: "in" })
+
+    expect(store.get("s2")).toEqual({ peer: "auth", direction: "in", ticket: "" })
+  })
+
+  it("notifies when only the ticket changed — it is the errand, not a detail", () => {
+    const { relay, store } = build()
+    let notifications = 0
+    store.subscribe("s2", () => {
+      notifications += 1
+    })
+
+    relay.emit({ id: "s2", peer: "auth", direction: "in", ticket: "fd94999a" })
+    relay.emit({ id: "s2", peer: "auth", direction: "in", ticket: "a1b2c3d4" })
+
+    expect(notifications).toBe(2)
+    expect(store.get("s2")).toEqual({ peer: "auth", direction: "in", ticket: "a1b2c3d4" })
   })
 
   it("does not notify subscribers when a repeat report changes nothing", () => {
@@ -119,8 +141,8 @@ describe("createSessionRelayStore", () => {
       notifications += 1
     })
 
-    relay.emit({ id: "s1", peer: "docs", direction: "out" })
-    relay.emit({ id: "s1", peer: "docs", direction: "out" })
+    relay.emit({ id: "s1", peer: "docs", direction: "out", ticket: "fd94999a" })
+    relay.emit({ id: "s1", peer: "docs", direction: "out", ticket: "fd94999a" })
 
     expect(notifications).toBe(1)
   })

--- a/frontend/src/lib/session/session-relay-store.ts
+++ b/frontend/src/lib/session/session-relay-store.ts
@@ -14,7 +14,7 @@ function sameRelay(a: SessionRelay | null, b: SessionRelay | null): boolean {
   if (a === null || b === null) {
     return a === b
   }
-  return a.peer === b.peer && a.direction === b.direction
+  return a.peer === b.peer && a.direction === b.direction && a.ticket === b.ticket
 }
 
 // createSessionRelayStore keeps the request each session has open with another,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -304,10 +304,17 @@ func (c *client) reply(args []string) error {
 	if err := c.parse(flags, args); err != nil {
 		return err
 	}
-	if flags.NArg() != 2 {
+	if flags.NArg() < 1 || flags.NArg() > 2 {
 		return usageError("reply")
 	}
-	if err := c.call("relay.Reply", []any{flags.Arg(0), flags.Arg(1)}, shortCall, nil); err != nil {
+	// One argument is the answer alone: the ticket is the thing an agent whose
+	// context was compacted no longer has, and the session it is running in
+	// names the errand well enough for the usual case of one open request.
+	ticket, answer := "", flags.Arg(0)
+	if flags.NArg() == 2 {
+		ticket, answer = flags.Arg(0), flags.Arg(1)
+	}
+	if err := c.call("relay.Reply", []any{c.sessionID(), ticket, answer}, shortCall, nil); err != nil {
 		return err
 	}
 	fmt.Fprintln(c.stdout, "Answer sent.")

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -408,8 +408,28 @@ func TestReplySendsTheAnswerHome(t *testing.T) {
 	if call.method != "relay.Reply" {
 		t.Errorf("method = %q", call.method)
 	}
-	if call.args[0] != "a1b2c3d4" || call.args[1] != "3 failures in foo_test" {
+	if call.args[1] != "a1b2c3d4" || call.args[2] != "3 failures in foo_test" {
 		t.Errorf("args = %v", call.args)
+	}
+	if !strings.Contains(stdout, "Answer sent.") {
+		t.Errorf("stdout = %q", stdout)
+	}
+}
+
+// One argument is the answer alone: the ticket is exactly what an agent whose
+// context was compacted past the message no longer has, and the session it runs
+// in names the errand for it.
+func TestReplyWithoutATicketSendsTheSessionsOwnErrandHome(t *testing.T) {
+	f := newFakeLich(t, `null`)
+
+	code, stdout, stderr := run(t, f, "reply", "3 failures in foo_test")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+
+	call := f.only(t)
+	if call.args[1] != "" || call.args[2] != "3 failures in foo_test" {
+		t.Errorf("args = %v, want an empty ticket and the answer", call.args)
 	}
 	if !strings.Contains(stdout, "Answer sent.") {
 		t.Errorf("stdout = %q", stdout)
@@ -423,7 +443,8 @@ func TestWrongArgumentCountsFailWithUsage(t *testing.T) {
 		{"send", "docs"},
 		{"send", "docs", "a prompt", "extra"},
 		{"wait", "a1b2c3d4", "extra"},
-		{"reply", "a1b2c3d4"},
+		{"reply"},
+		{"reply", "a1b2c3d4", "an answer", "extra"},
 		// A positional argument these take no notice of is a caller who believes
 		// it asked for something else: `lich open feature-x` reads as a worktree
 		// on that branch, and silently opening a session beside the caller's own

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -43,9 +43,11 @@ var commands = []command{
 	},
 	{
 		name: "reply",
-		args: "<ticket> <answer>",
+		args: "[<ticket>] <answer>",
 		about: "Send <answer> back to whoever is waiting on <ticket>. This is what a\n" +
-			"relayed message asks you to run when you are done.",
+			"relayed message asks you to run when you are done. Without a ticket it\n" +
+			"answers the request open against this session, for when the message\n" +
+			"carrying the number is no longer in reach.",
 	},
 	{
 		name: "open",

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -513,11 +513,14 @@ var mcpTools = []mcpTool{
 			"It is the only route back — a peer message does not reach them, because they are " +
 			"waiting on the ticket and reading nothing else.",
 		Schema: schema(map[string]any{
-			"ticket": property("string", "The ticket from the message you were given."),
+			"ticket": property("string", "The ticket from the message you were given. "+
+				"Leave it out only if that message is no longer in your context — then the "+
+				"request open against this session is answered."),
 			"answer": property("string", "Your answer, in full — nothing else is sent back."),
-		}, "ticket", "answer"),
+		}, "answer"),
 		Run: func(c *client, args mcpArgs) (string, error) {
-			if err := c.call("relay.Reply", []any{args.text("ticket"), args.text("answer")}, shortCall, nil); err != nil {
+			call := []any{c.sessionID(), args.text("ticket"), args.text("answer")}
+			if err := c.call("relay.Reply", call, shortCall, nil); err != nil {
 				return "", err
 			}
 			return "Answer sent.", nil

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -225,7 +225,7 @@ func TestMCPListsEveryTool(t *testing.T) {
 		"list_worktrees":   {},
 		"send_to_session":  {"session", "prompt"},
 		"wait_for_answer":  {},
-		"reply_to_session": {"ticket", "answer"},
+		"reply_to_session": {"answer"},
 	}
 	// The read-only ones, which a client may auto-allow. wait_for_answer is
 	// not among them: collecting drains the inbox.
@@ -407,7 +407,7 @@ func TestMCPReplyToSession(t *testing.T) {
 		t.Fatalf("tool reported a failure: %s", text)
 	}
 	call := f.only(t)
-	if call.method != "relay.Reply" || call.args[0] != "a1b2c3d4" || call.args[1] != "done" {
+	if call.method != "relay.Reply" || call.args[1] != "a1b2c3d4" || call.args[2] != "done" {
 		t.Errorf("call = %+v", call)
 	}
 }

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -145,13 +145,20 @@ type StalledEvent struct {
 }
 
 // RelayEvent is the payload of RelayEventName: the session whose mark changed,
-// the label at the other end, and which way the request runs. Peer is empty
-// when the other end is not a session at all — the CLI run from a script or a
-// shell — which the card words its own way.
+// the label at the other end, which way the request runs, and the ticket the
+// two ends share. Peer is empty when the other end is not a session at all —
+// the CLI run from a script or a shell — which the card words its own way.
+//
+// The ticket rides along because it is otherwise written down in exactly one
+// place: the message typed at the target's prompt. An agent whose context was
+// compacted past that message has no way back to it, and neither had the person
+// watching — the window knew a request was open and could not say which one.
+// Empty when the mark is being cleared, along with the direction.
 type RelayEvent struct {
 	ID        string `json:"id"`
 	Peer      string `json:"peer"`
 	Direction string `json:"direction"`
+	Ticket    string `json:"ticket"`
 }
 
 // Sessions is the persistence the relay reads: every open session, so a label
@@ -479,8 +486,8 @@ func (s *Service) handOff(id string, t *ticket, kind, message string) error {
 	}
 	// Announced only once the message is actually in the PTY: a mark raised
 	// before the write would survive a delivery that never happened.
-	s.announce(t.targetID, t.sender, DirectionIn)
-	s.announce(t.fromID, t.target, DirectionOut)
+	s.announce(t.targetID, t.sender, DirectionIn, id)
+	s.announce(t.fromID, t.target, DirectionOut, id)
 	// A target that was already working is not checked: it will read this at the
 	// end of the turn it is in, whenever that is, and its provider is busy the
 	// whole time — there is nothing here to tell apart.
@@ -719,7 +726,14 @@ func (s *Service) Wait(ticketID string, waitSeconds int) (Result, error) {
 
 // Reply hands an answer back to whoever is waiting on ticketID. It is what the
 // message composed by Send asks the receiving agent to run.
-func (s *Service) Reply(ticketID, answer string) error {
+//
+// An empty ticketID answers the errand open against replierID instead, the way
+// an empty ticket collects everything waiting for a sender (see Collect). The
+// ticket is written down in one place only — the message typed at the target's
+// prompt — so an agent whose context no longer reaches that message would
+// otherwise be holding an answer with no route home, and the sender blocked on
+// a ticket nobody can name.
+func (s *Service) Reply(replierID, ticketID, answer string) error {
 	answer = sanitize(answer)
 	if len(answer) > answerLimit {
 		// The cut is in bytes and can land inside a rune; the tail is typed into
@@ -728,6 +742,14 @@ func (s *Service) Reply(ticketID, answer string) error {
 	}
 
 	s.mu.Lock()
+	if ticketID == "" {
+		id, err := s.errandOfLocked(replierID)
+		if err != nil {
+			s.mu.Unlock()
+			return err
+		}
+		ticketID = id
+	}
 	t, ok := s.tickets[ticketID]
 	if !ok {
 		s.mu.Unlock()
@@ -754,6 +776,38 @@ func (s *Service) Reply(ticketID, answer string) error {
 		s.stash(ticketID, t, StatusAnswered, answer)
 	}
 	return nil
+}
+
+// errandOfLocked is the errand an answer that named no ticket belongs to: the
+// oldest message actually delivered to this session that is still open. Called
+// under s.mu.
+//
+// Oldest-delivered is the same rule turnErrand closes a turn by, and for the
+// same reason: every provider queues typed input, so a session handed several
+// tasks works through them in the order they arrived. It is a guess all the
+// same — an agent that answers its second task first pays it back on the third
+// — which is why the ticket is still named everywhere it is known, and why the
+// window now shows it. A queued task nobody has read yet is never picked: it is
+// not at that prompt, so no answer at that prompt can be about it.
+func (s *Service) errandOfLocked(replierID string) (string, error) {
+	if replierID == "" {
+		return "", fmt.Errorf(
+			"answering without a ticket needs a session of your own — name it instead: lich reply <ticket> \"<answer>\"")
+	}
+	var oldestID string
+	var oldest *ticket
+	for id, t := range s.tickets {
+		if t.targetID != replierID || t.delivered.IsZero() {
+			continue
+		}
+		if oldest == nil || t.delivered.Before(oldest.delivered) {
+			oldestID, oldest = id, t
+		}
+	}
+	if oldest == nil {
+		return "", fmt.Errorf("no open request to answer — nobody is waiting on this session")
+	}
+	return oldestID, nil
 }
 
 // await blocks on one ticket until it is answered or the wait runs out. It only
@@ -1006,17 +1060,19 @@ func (s *Service) turnErrand(sessionID string) (string, *ticket) {
 // announce raises or clears one session's mark. Called outside s.mu on every
 // path: Emit blocks on a stalled /events client, and holding the relay's lock
 // across it would stall every other errand behind one unread window.
-func (s *Service) announce(sessionID, peer, direction string) {
+func (s *Service) announce(sessionID, peer, direction, ticketID string) {
 	if s.events == nil || sessionID == "" {
 		return
 	}
-	s.events.Emit(RelayEventName, RelayEvent{ID: sessionID, Peer: peer, Direction: direction})
+	s.events.Emit(RelayEventName, RelayEvent{
+		ID: sessionID, Peer: peer, Direction: direction, Ticket: ticketID,
+	})
 }
 
 // clear takes down both ends' marks for a ticket that is over.
 func (s *Service) clear(t *ticket) {
-	s.announce(t.targetID, "", "")
-	s.announce(t.fromID, "", "")
+	s.announce(t.targetID, "", "", "")
+	s.announce(t.fromID, "", "", "")
 }
 
 func (s *Service) clearAll(tickets []*ticket) {

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -371,7 +371,7 @@ func TestSendDeliversAndReplyAnswers(t *testing.T) {
 	})
 
 	ticketID := waitForTicket(svc)
-	if err := svc.Reply(ticketID, "3 failures in foo_test"); err != nil {
+	if err := svc.Reply("", ticketID, "3 failures in foo_test"); err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 	wg.Wait()
@@ -421,7 +421,7 @@ func TestAMessageFromOutsideLichIsAttributedToTheCommandLine(t *testing.T) {
 	term := newFakeTerminal("s2")
 	svc := newRelay(workspace(), term, nil)
 
-	go func() { _ = svc.Reply(waitForTicket(svc), "ok") }()
+	go func() { _ = svc.Reply("", waitForTicket(svc), "ok") }()
 	if _, err := svc.Send("", "docs", "", "hello", 30); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
@@ -483,7 +483,7 @@ func TestARosterNameReachesTheSameSession(t *testing.T) {
 	term := newFakeTerminal("s1", "s2")
 	svc := newRelay(workspace(), term, nil)
 
-	go func() { _ = svc.Reply(waitForTicket(svc), "ok") }()
+	go func() { _ = svc.Reply("", waitForTicket(svc), "ok") }()
 	got, err := svc.Send("s1", RosterName("/src/lich", "s2"), "", "hello", 30)
 	if err != nil {
 		t.Fatalf("Send by roster name: %v", err)
@@ -512,7 +512,7 @@ func TestTheLabelWinsARosterCollision(t *testing.T) {
 	term := newFakeTerminal("s1", "s2", "s3")
 	svc := newRelay(collide, term, nil)
 
-	go func() { _ = svc.Reply(waitForTicket(svc), "ok") }()
+	go func() { _ = svc.Reply("", waitForTicket(svc), "ok") }()
 	if _, err := svc.Send("s1", "lich-s3", "", "hello", 30); err != nil {
 		t.Fatalf("Send: %v", err)
 	}
@@ -580,15 +580,23 @@ func TestBothCardsAreMarkedAndCleared(t *testing.T) {
 	if sender, _ := events.markOf("s1"); sender.Peer != "docs" {
 		t.Errorf("sender mark names %q, want the target's label", sender.Peer)
 	}
+	// Both ends carry the ticket: it is written down nowhere else the window can
+	// read, and an agent that lost the message naming it leaves the person in
+	// front of the card as the only way back to the number.
+	for _, id := range []string{"s1", "s2"} {
+		if mark, _ := events.markOf(id); mark.Ticket != ticketID {
+			t.Errorf("session %q mark carries ticket %q, want %q", id, mark.Ticket, ticketID)
+		}
+	}
 
-	if err := svc.Reply(ticketID, "3 failures"); err != nil {
+	if err := svc.Reply("", ticketID, "3 failures"); err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 	<-done
 
 	for _, id := range []string{"s1", "s2"} {
 		mark, _ := events.markOf(id)
-		if mark.Direction != "" || mark.Peer != "" {
+		if mark.Direction != "" || mark.Peer != "" || mark.Ticket != "" {
 			t.Errorf("session %q kept the mark %+v after the answer", id, mark)
 		}
 	}
@@ -605,7 +613,7 @@ func TestAnExternalSenderMarksOnlyTheTarget(t *testing.T) {
 		if !events.awaitMark("s2", DirectionIn) {
 			return
 		}
-		_ = svc.Reply(waitForTicket(svc), "ok")
+		_ = svc.Reply("", waitForTicket(svc), "ok")
 	}()
 	if _, err := svc.Send("", "docs", "", "hello", 30); err != nil {
 		t.Fatalf("Send: %v", err)
@@ -796,7 +804,7 @@ func TestAQueuedRequestIgnoresTheTurnAlreadyRunning(t *testing.T) {
 	if got := <-done; got.Status != StatusUnanswered {
 		t.Fatalf("status = %q, want %q", got.Status, StatusUnanswered)
 	}
-	if err := svc.Reply(ticketID, "late"); err == nil {
+	if err := svc.Reply("", ticketID, "late"); err == nil {
 		t.Error("the ticket outlived the turn that closed it")
 	}
 }
@@ -950,7 +958,7 @@ func TestABusyReportInsideTheDeliveryWindowCountsForTheTicket(t *testing.T) {
 	if result.Status != StatusPending {
 		t.Fatalf("status = %q, want the errand still open", result.Status)
 	}
-	if err := svc.Reply(result.Ticket, "all green"); err != nil {
+	if err := svc.Reply("", result.Ticket, "all green"); err != nil {
 		t.Errorf("the target's own answer was refused: %v", err)
 	}
 }
@@ -1001,7 +1009,7 @@ func TestAnAnsweredTicketIsNotAlsoStalled(t *testing.T) {
 	ticketID := waitForTicket(svc)
 
 	svc.Observe("s2", "busy")
-	if err := svc.Reply(ticketID, "3 failures"); err != nil {
+	if err := svc.Reply("", ticketID, "3 failures"); err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 	svc.Observe("s2", "done")
@@ -1080,7 +1088,7 @@ func TestAnAnswerNobodyWaitedForIsStashedAndNudged(t *testing.T) {
 		t.Fatalf("the sender was typed at before any answer existed: %q", term.written("s1"))
 	}
 
-	if err := svc.Reply(got.Ticket, "3 failures in foo_test"); err != nil {
+	if err := svc.Reply("", got.Ticket, "3 failures in foo_test"); err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 
@@ -1131,7 +1139,7 @@ func TestAnAnswerSomeoneIsWaitingForIsNotAlsoTyped(t *testing.T) {
 		done <- got
 	}()
 	ticketID := waitForTicket(svc)
-	if err := svc.Reply(ticketID, "all green"); err != nil {
+	if err := svc.Reply("", ticketID, "all green"); err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 
@@ -1154,7 +1162,7 @@ func TestAnExternalSenderHasNoPromptToAnswerAt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Send: %v", err)
 	}
-	if err := svc.Reply(got.Ticket, "all green"); err != nil {
+	if err := svc.Reply("", got.Ticket, "all green"); err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 
@@ -1185,7 +1193,7 @@ func TestSendNarrowsAnAmbiguousLabelByProject(t *testing.T) {
 
 	go func() {
 		ticketID := waitForTicket(svc)
-		_ = svc.Reply(ticketID, "ok")
+		_ = svc.Reply("", ticketID, "ok")
 	}()
 	got, err := svc.Send("s1", "api", "revu", "hello", 30)
 	if err != nil {
@@ -1255,7 +1263,7 @@ func TestSendPendsWhenTheWaitRunsOutAndWaitPicksItUp(t *testing.T) {
 
 	go func() {
 		time.Sleep(10 * time.Millisecond)
-		_ = svc.Reply(got.Ticket, "late but here")
+		_ = svc.Reply("", got.Ticket, "late but here")
 	}()
 	again, err := svc.Wait(got.Ticket, 30)
 	if err != nil {
@@ -1270,7 +1278,7 @@ func TestReplyRefusesUnknownAndRepeatedTickets(t *testing.T) {
 	term := newFakeTerminal("s1", "s2")
 	svc := newRelay(workspace(), term, nil)
 
-	if err := svc.Reply("deadbeef", "hello"); err == nil {
+	if err := svc.Reply("", "deadbeef", "hello"); err == nil {
 		t.Error("want an error replying to a ticket that never existed")
 	}
 
@@ -1280,15 +1288,95 @@ func TestReplyRefusesUnknownAndRepeatedTickets(t *testing.T) {
 		done <- got
 	}()
 	ticketID := waitForTicket(svc)
-	if err := svc.Reply(ticketID, "first"); err != nil {
+	if err := svc.Reply("", ticketID, "first"); err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 	got := <-done
 	if got.Answer != "first" {
 		t.Fatalf("answer = %q", got.Answer)
 	}
-	if err := svc.Reply(ticketID, "second"); err == nil {
+	if err := svc.Reply("", ticketID, "second"); err == nil {
 		t.Error("want an error replying to an answered ticket")
+	}
+}
+
+// TestReplyWithoutATicketAnswersTheOldestErrandDelivered proves the route home
+// survives losing the message that named it: an agent whose context no longer
+// reaches the ticket answers its own session's open request, and with several
+// open the oldest delivery is closed first — the order every provider hands
+// queued tasks to its agent in.
+func TestReplyWithoutATicketAnswersTheOldestErrandDelivered(t *testing.T) {
+	events := &fakeEvents{}
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2", "s3"), events)
+
+	first := make(chan Result, 1)
+	go func() {
+		got, _ := svc.Send("s1", "docs", "", "run the tests", 30)
+		first <- got
+	}()
+	if !events.awaitMark("s1", DirectionOut) {
+		t.Fatal("the first message was never delivered")
+	}
+	second := make(chan Result, 1)
+	go func() {
+		got, _ := svc.Send("s3", "docs", "", "build the docs", 30)
+		second <- got
+	}()
+	if !events.awaitMark("s3", DirectionOut) {
+		t.Fatal("the second message was never delivered")
+	}
+
+	if err := svc.Reply("s2", "", "3 failures in foo_test"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	select {
+	case got := <-first:
+		if got.Answer != "3 failures in foo_test" {
+			t.Errorf("answer = %q", got.Answer)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the oldest errand was not the one answered")
+	}
+	select {
+	case got := <-second:
+		t.Fatalf("the second errand was closed by the same answer: %+v", got)
+	default:
+	}
+
+	// The next answer takes the next errand, which is what makes this usable
+	// twice over rather than only for a session with exactly one request open.
+	if err := svc.Reply("s2", "", "docs are built"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	if got := <-second; got.Answer != "docs are built" {
+		t.Errorf("second answer = %q", got.Answer)
+	}
+}
+
+// TestReplyWithoutATicketNeedsAnErrandItCanName proves the guess is refused
+// rather than made badly: a caller with no session of its own has nothing to
+// look the errand up by, a session nobody asked anything has none, and a task
+// still queued for a prompt that never received it is not an errand this
+// session can be answering.
+func TestReplyWithoutATicketNeedsAnErrandItCanName(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, nil)
+	svc.deliveryLimit = 50 * time.Millisecond
+
+	if err := svc.Reply("", "", "from a script"); err == nil {
+		t.Error("want an error answering with no ticket and no session")
+	}
+	if err := svc.Reply("s2", "", "nobody asked"); err == nil {
+		t.Error("want an error answering a session with no open request")
+	}
+
+	term.setUp("s2", true)
+	go func() { _, _ = svc.Send("s1", "docs", "", "run the tests", 1) }()
+	if waitForTicket(svc) == "" {
+		t.Fatal("the queued errand never registered")
+	}
+	if err := svc.Reply("s2", "", "answered before it was asked"); err == nil {
+		t.Error("a task still queued for its prompt was answered")
 	}
 }
 
@@ -1335,7 +1423,7 @@ func TestSendBoundsThePrompt(t *testing.T) {
 
 	go func() {
 		ticketID := waitForTicket(svc)
-		_ = svc.Reply(ticketID, "ok")
+		_ = svc.Reply("", ticketID, "ok")
 	}()
 	if _, err := svc.Send("s1", "docs", "", strings.Repeat("a", 8192), 30); err != nil {
 		t.Errorf("a prompt of 8192 characters was refused: %v", err)
@@ -1363,7 +1451,7 @@ func TestReplyTruncatesAnOversizedAnswer(t *testing.T) {
 				done <- got
 			}()
 			ticketID := waitForTicket(svc)
-			if err := svc.Reply(ticketID, tt.answer); err != nil {
+			if err := svc.Reply("", ticketID, tt.answer); err != nil {
 				t.Fatalf("Reply: %v", err)
 			}
 
@@ -1540,7 +1628,7 @@ func TestSendQueuesForASessionThatIsNotAtAPromptYet(t *testing.T) {
 
 	// The ticket the caller left with is the one that answers: an errand
 	// delivered late is not a different errand.
-	if err := svc.Reply(result.Ticket, "green"); err != nil {
+	if err := svc.Reply("", result.Ticket, "green"); err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 	answered, err := svc.Wait(result.Ticket, 1)
@@ -2004,10 +2092,10 @@ func TestABurstOfAnswersCoalescesIntoOneNudge(t *testing.T) {
 	plant(svc, "t1", "s1", "s2", "docs")
 	plant(svc, "t2", "s1", "s3", "api")
 
-	if err := svc.Reply("t1", "done here"); err != nil {
+	if err := svc.Reply("", "t1", "done here"); err != nil {
 		t.Fatalf("Reply t1: %v", err)
 	}
-	if err := svc.Reply("t2", "done there"); err != nil {
+	if err := svc.Reply("", "t2", "done there"); err != nil {
 		t.Fatalf("Reply t2: %v", err)
 	}
 
@@ -2036,7 +2124,7 @@ func TestABusySenderIsNudgedOnlyWhenItsTurnEnds(t *testing.T) {
 	svc.Observe("s1", stateBusy)
 	plant(svc, "t1", "s1", "s2", "docs")
 
-	if err := svc.Reply("t1", "all green"); err != nil {
+	if err := svc.Reply("", "t1", "all green"); err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 	time.Sleep(20 * time.Millisecond)
@@ -2057,7 +2145,7 @@ func TestANudgeIsNotRepeatedOnLaterTurnEnds(t *testing.T) {
 	term := newFakeTerminal("s1", "s2")
 	svc := newRelay(workspace(), term, nil)
 	plant(svc, "t1", "s1", "s2", "docs")
-	if err := svc.Reply("t1", "all green"); err != nil {
+	if err := svc.Reply("", "t1", "all green"); err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 	if !awaitWritten(term, "s1", "[lich]") {
@@ -2082,7 +2170,7 @@ func TestANudgeThatNeverLandedIsSentAgain(t *testing.T) {
 	term.failWrites(errors.New("pty closed"))
 	plant(svc, "t1", "s1", "s2", "docs")
 
-	if err := svc.Reply("t1", "all green"); err != nil {
+	if err := svc.Reply("", "t1", "all green"); err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 	deadline := time.Now().Add(2 * time.Second)
@@ -2111,7 +2199,7 @@ func TestNothingIsTypedIntoAPromptItsUserIsHolding(t *testing.T) {
 	term.typeAt("s1", true)
 	plant(svc, "t1", "s1", "s2", "docs")
 
-	if err := svc.Reply("t1", "all green"); err != nil {
+	if err := svc.Reply("", "t1", "all green"); err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 	// Long enough for the nudge's debounce to have fired and typed.
@@ -2133,7 +2221,7 @@ func TestCollectHoldsTheLineForTheNextResult(t *testing.T) {
 
 	go func() {
 		time.Sleep(20 * time.Millisecond)
-		_ = svc.Reply("t1", "all green")
+		_ = svc.Reply("", "t1", "all green")
 	}()
 	collected, err := svc.Collect("s1", 2)
 	if err != nil {
@@ -2155,7 +2243,7 @@ func TestCollectReportsWhoStillOwes(t *testing.T) {
 	svc := newRelay(workspace(), term, nil)
 	plant(svc, "t1", "s1", "s2", "docs")
 	plant(svc, "t2", "s1", "s3", "api")
-	if err := svc.Reply("t1", "all green"); err != nil {
+	if err := svc.Reply("", "t1", "all green"); err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 
@@ -2199,7 +2287,7 @@ func TestWaitPicksAStashedOutcomeUp(t *testing.T) {
 	term := newFakeTerminal("s1", "s2")
 	svc := newRelay(workspace(), term, nil)
 	plant(svc, "t1", "s1", "s2", "docs")
-	if err := svc.Reply("t1", "all green"); err != nil {
+	if err := svc.Reply("", "t1", "all green"); err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 
@@ -2243,10 +2331,10 @@ func TestTheInboxSizeIsAnnouncedAsItGrowsAndDrains(t *testing.T) {
 	plant(svc, "t1", "s1", "s2", "docs")
 	plant(svc, "t2", "s1", "s3", "api")
 
-	if err := svc.Reply("t1", "one"); err != nil {
+	if err := svc.Reply("", "t1", "one"); err != nil {
 		t.Fatalf("Reply t1: %v", err)
 	}
-	if err := svc.Reply("t2", "two"); err != nil {
+	if err := svc.Reply("", "t2", "two"); err != nil {
 		t.Fatalf("Reply t2: %v", err)
 	}
 	if got := events.inboxCounts("s1"); len(got) != 2 || got[0] != 1 || got[1] != 2 {
@@ -2266,7 +2354,7 @@ func TestASingleTicketPickupAnnouncesTheSmallerInbox(t *testing.T) {
 	events := &fakeEvents{}
 	svc := newRelay(workspace(), newFakeTerminal("s1", "s2"), events)
 	plant(svc, "t1", "s1", "s2", "docs")
-	if err := svc.Reply("t1", "one"); err != nil {
+	if err := svc.Reply("", "t1", "one"); err != nil {
 		t.Fatalf("Reply: %v", err)
 	}
 
@@ -2312,7 +2400,7 @@ func TestTheNudgeNamesTheToolOnlyWhereItExists(t *testing.T) {
 			svc := newRelay(workspace(), term, nil)
 			svc.SetPlugins(fakePlugins{installed: true, tools: tt.tools})
 			plant(svc, "t1", "s1", "s2", "docs")
-			if err := svc.Reply("t1", "all green"); err != nil {
+			if err := svc.Reply("", "t1", "all green"); err != nil {
 				t.Fatalf("Reply: %v", err)
 			}
 


### PR DESCRIPTION
## The problem

The ticket a relayed errand runs on was written down in exactly one place: the message typed at the target's prompt. A session whose context was compacted past that message had no route home — and neither had the person watching. The window knew a request was open (the card already drew the arrow and the peer) and could not say *which* request. Reported after a fan-out broke mid-flight and had to be patched by hand.

## What lands

**The number is on the card.** `session-relay` gained a `ticket` field, carried on both ends and cleared with the mark. The tooltip names the other end and the ticket, and on the side that owes the answer it spells the command that sends it home:

```
Session 62
/home/you/.local/share/lich/worktrees/…/amber-meadow
← Answering Session 61
  ticket 28b25be1
  lich reply 28b25be1 "…"
```

The sender's side gets the same block without the command — there is nothing there to run.

**The number stopped being mandatory.** `lich reply "<answer>"`, and `reply_to_session` with no `ticket`, answer the request open against the calling session: the oldest message actually delivered there and still unanswered. It is the symmetric half of `lich wait` with no ticket, which already collects everything a sender is owed. `Reply` now takes the caller's session first (`Reply(replierID, ticketID, answer)`), matching `Send` and `Collect`.

A task still queued for a prompt that never received it is never picked, and a caller with no session of its own — or with nothing open — is refused rather than guessed at.

## The ceiling, written down

Matching by delivery order is a guess. A session working two relayed tasks at once that answers the second one first sends it home as the answer to the first, and nothing reports the mismatch. That is a new bullet in `docs/ceilings.md`, and it is why naming the ticket stays the exact route — and why the window now shows it.

## Deliberately not built

No separate "open tickets" screen. The sidebar is already that list: every card in an errand carries the arrow and the peer, and a second list is a copy that can disagree with it.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean; `go test ./...` green (1741), `-race` on `internal/relay` and `internal/cli`, `-count=3` on the new cases.
- [x] Cross-compile loop for linux/darwin/windows (`go build` + `go vet`).
- [x] `biome check`, `tsc -b`, `vite build`, `vitest run` (1036) green.
- [x] New backend cases: the mark carries the ticket on both ends and clears it; a ticketless reply takes the oldest delivered errand and the next one after that; it is refused with no session, with nothing open, and for a task still queued.
- [x] **Render smoke** (headless Chromium over CDP, isolated config dir, two shell sessions with a live errand between them): both tooltips draw, no exceptions and no console errors. Target side reads `Answering Session 61 / ticket 28b25be1 / lich reply 28b25be1 "…"`, sender side reads `Waiting on Session 62 / ticket 28b25be1`.