### PR TITLE
feat: hand a confined session the ssh agent and a GitHub token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A confined session can push and use `gh` again, if you let it.** The sandbox
+  gives a session an empty home, which takes the ssh agent and gh's keyring with
+  it: `git push` has nothing to sign with and `gh` opens on a login prompt. Two
+  switches hand each one back, separately and off by default — the ssh agent, so
+  a push authenticates without any key entering the sandbox, and a GitHub token,
+  so `gh` works as the account the project already answers as. They are separate
+  because they open different doors: wanting `gh` to work is not wanting to hand
+  over your ssh keys. The agent switch lists the identities loaded in your agent
+  right beside it, because a session holding that socket can sign with every one
+  of them, against any host — not only the key you had in mind.
+- **Settings has a Sandbox pane.** Everything about confining sessions now lives
+  in one place: whether this machine can confine at all and what it uses to do
+  it, the rung for each provider you have enabled, and the two grants above. The
+  rung used to be repeated inside every provider's own section, so a machine with
+  several enabled drew the same ladder several times — and on a machine with no
+  bubblewrap the control simply vanished, leaving the question unanswered instead
+  of answered.
+
 ### Changed
 
 - **Building lich from source now needs Go 1.27.0.** The pin stays exact so that

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -126,14 +126,14 @@ work when nobody knows it and that the call site never shows. The mechanism and 
 - **The sandbox confines a working agent, not hostile code** (`internal/sandbox`): namespaces and mounts on
   Linux, a path policy on macOS, and nothing else — no seccomp filter, no Landlock ruleset. The network is
   never cut (the agent needs its API and the plugin's hooks report over loopback), so anything readable
-  inside is exfiltrable, and `~/.config` *is* readable: a token stored there, `gh`'s among them, is in
-  reach. Every session also carries `LICH_TOKEN`, so a confined agent can call lich's own RPC over
+  inside is exfiltrable, and `~/.config` *is* readable: a token stored there is in reach. `gh`'s is not
+  one of them — it lives in the system keyring, which is why reaching it takes the flag below. Every session also carries `LICH_TOKEN`, so a confined agent can call lich's own RPC over
   loopback: a method that reads a host path it was *handed* would copy anything into reach of the sandbox,
   which is why the attach flow opens the picker inside the backend (`drop.Attach`) instead of taking a path. The private home is writable and vanishes with the session, so a dotfile an agent writes is gone
   next spawn with nothing saying so. On Ubuntu and Debian the kernel may refuse the user namespace outright
   (an AppArmor policy), which surfaces as bubblewrap's own error in the card and no session. `~/.ssh` is not
-  mounted at all: a push over ssh from inside a confined session fails, and lich's own PR flows run outside
-  it and are unaffected. The distribution's `/etc/ssh/ssh_config.d` drop-ins are replaced by an empty
+  mounted at all: a push over ssh from inside a confined session fails unless the project hands over the ssh
+  agent (below), and lich's own PR flows run outside the sandbox and are unaffected either way. The distribution's `/etc/ssh/ssh_config.d` drop-ins are replaced by an empty
   directory, because inside the namespace they belong to nobody and ssh refuses to read a config file it
   does not own — so a host whose ssh depends on one of them (a corporate `ProxyCommand`, say) does not have
   it inside the sandbox. The display server's socket *is* mounted, because the agent's own copy and its
@@ -142,6 +142,31 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   X11 socket and its cookie instead, the wider of the two — X clients are not isolated from one another —
   and macOS gets neither, its pasteboard being a mach service rather than a socket, so a confined session
   there has no clipboard at all. macOS has no hardware here — its profile is unit-tested and has never run.
+- **The two sandbox grants hand over more than what they are read as** (`internal/store/settings.go`,
+  `internal/sandbox`, `internal/terminal/sandbox.go`): a confined session reaches the network as the user only
+  where the project turned one of them on, and each is all-or-nothing. The ssh agent is handed over as a socket,
+  so nothing private enters the sandbox — but the session signs with **every** identity loaded in that agent,
+  against any host it can reach, for as long as it runs. OpenSSH can pin a key to one destination, and only when
+  the key is added on the host (`ssh-add -h`); lich is given a socket that is already populated and can only
+  pass it on whole. The socket does not travel alone: `~/.ssh/known_hosts` is mounted read-only beside it,
+  because without it ssh cannot verify github.com, has no tty to ask on, and fails with "Host key
+  verification failed" before the key is ever offered — the grant would hand over the credential and not the
+  push. That file is public host keys, never a secret; what a confined session learns from it is the list of
+  machines the user connects to. Read-only, so a host the user has never connected to *outside* the sandbox
+  still fails inside it and cannot be learned there — blind trust-on-first-use is not a thing to grant an
+  unattended agent. And a `known_hosts` symlinked out of a dotfiles repository is dropped like every other
+  link in the home (below), which takes the whole grant down with it and says nothing. That is why Settings lists what is in the agent — and the list is read when the pane opens,
+  so a key added afterwards is handed over by a switch that never named it. The GitHub token is one account's,
+  the project's own (`vcs.account`), and it rides in the session's environment: the agent can read it back out
+  of its own environment and spend it on anything that account's scopes allow, this repository or not. Neither
+  grant is keyed by provider — a grant describes what is inside the sandbox, not who runs in it — so turning
+  one on turns it on for every provider confined in that project. It is
+  resolved once per spawn, so a token gh rotates mid-session goes stale with nothing saying so, and a `gh auth
+  token` that fails leaves the session with no token rather than failing the spawn. Both are off by default,
+  and both are Linux in practice: the macOS profile denies reads *inside* the home while a launchd agent socket
+  and gh's keyring live outside it, so a confined macOS session never lost either and the switches change
+  nothing there — they are inert rather than hidden, and there is no macOS hardware here to prove it further.
+  Windows has no sandbox backend, so neither switch exists.
 - **A file handed to a confined session arrives as a copy** (`internal/drop`): the session's home is empty,
   so lich does not look there for a dropped file at all — anything outside its checkout is copied and the
   copy's path is what lands at the prompt, for a drag and for the footer's attach button alike. The agent may read it and not write back: an edit lands on the

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -1,16 +1,13 @@
 import { useEffect, useState } from "react"
-import { Store, System } from "@/lib/rpc"
+import { Store } from "@/lib/rpc"
 import {
   footerReadout,
   footerReadoutPair,
   skipLevel,
   skipLevelPair,
-  sandboxKey,
-  sandboxLevel,
   skipPermissionFlags,
   skipPermissionsKey,
   type FooterReadout,
-  type SandboxLevel,
   type SkipLevel,
 } from "@/lib/providers-store"
 import { useSettings } from "@/providers/settings"
@@ -46,33 +43,6 @@ const FOOTER_READOUTS: { level: FooterReadout; label: string; consequence: strin
   },
 ]
 
-// The same shape again for which sessions run confined, ordered by how much of
-// the machine a session can reach. "Ask each time" sits second because a session
-// nobody answered for runs unconfined, exactly like "Off".
-const SANDBOX_LEVELS: { level: SandboxLevel; label: string; consequence: string }[] = [
-  {
-    level: "off",
-    label: "Off",
-    consequence: "Sessions run straight on the machine, reaching everything you can reach.",
-  },
-  {
-    level: "ask",
-    label: "Ask each time",
-    consequence:
-      "Every new session asks before it opens. Nothing is remembered — a session opened any other way, by a delegation or an MCP tool, is not confined.",
-  },
-  {
-    level: "worktrees",
-    label: "Worktrees only",
-    consequence: "Sessions in the project directory run on the machine.",
-  },
-  {
-    level: "everywhere",
-    label: "Everywhere",
-    consequence: "Including the tree you work in. Every session opens confined.",
-  },
-]
-
 // The same shape for how far the provider runs without asking, ordered by risk.
 const SKIP_LEVELS: { level: SkipLevel; label: string; consequence: string }[] = [
   {
@@ -91,37 +61,6 @@ const SKIP_LEVELS: { level: SkipLevel; label: string; consequence: string }[] = 
     consequence: "Including the tree you work in. Nothing will ask.",
   },
 ]
-
-// useSandboxLevel is the stored sandbox rung for one provider in one scope, read
-// once and written through on every change. It reads "off" until the value
-// arrives, which is also what an unreadable value means: the unknown state is
-// drawn as the one lich has always behaved like, never as one that silently
-// starts confining sessions.
-function useSandboxLevel(providerId: string, projectId: string) {
-  const key = sandboxKey(providerId)
-  const [level, setLevel] = useState<SandboxLevel>("off")
-
-  useEffect(() => {
-    void Store.GetSetting(key, projectId).then((value) => setLevel(sandboxLevel(value)))
-  }, [key, projectId])
-
-  const choose = (next: SandboxLevel) => {
-    setLevel(next)
-    void Store.SetSetting(key, projectId, next)
-  }
-  return [level, choose] as const
-}
-
-// useSandboxAvailable answers whether this machine can confine anything at all —
-// bubblewrap on Linux, sandbox-exec on macOS. Undefined until it arrives, so the
-// control is absent rather than briefly drawn as unavailable on every mount.
-function useSandboxAvailable() {
-  const [available, setAvailable] = useState<boolean | undefined>(undefined)
-  useEffect(() => {
-    void System.SandboxAvailable().then(setAvailable)
-  }, [])
-  return available
-}
 
 // useSkipPermissions is the stored "run without permission prompts" flag for one
 // checkout scope: read once, written through on every toggle. It reads off until
@@ -162,12 +101,6 @@ export function ProviderBinSettings({
   const [budget, setBudget] = useState(() => (costBudget > 0 ? String(costBudget) : ""))
   const [skipHere, setSkipHere] = useSkipPermissions(providerId, false)
   const [skipInWorktrees, setSkipInWorktrees] = useSkipPermissions(providerId, true)
-  // The sandbox is scoped to whichever pane this is: the project's own rung when
-  // opened from a project, the global one from the hub.
-  const [sandbox, setSandbox] = useSandboxLevel(providerId, projectId ?? GLOBAL_SCOPE)
-  const sandboxAvailable = useSandboxAvailable()
-  const sandboxConsequence =
-    SANDBOX_LEVELS.find((rung) => rung.level === sandbox)?.consequence ?? ""
   const skipFlag = skipPermissionFlags[providerId]
   const level = skipLevel(skipHere, skipInWorktrees)
   const consequence = SKIP_LEVELS.find((rung) => rung.level === level)?.consequence ?? ""
@@ -257,32 +190,6 @@ export function ProviderBinSettings({
             </SettingBlock>
           )}
         </>
-      )}
-
-      {/* Directly above the permission ladder: the two answer the same worry
-          from opposite ends, and are read together. Absent on a machine with no
-          backend for it — a control that saves a setting nothing can act on is
-          worse than no control. */}
-      {sandboxAvailable && (
-        <SettingBlock
-          title="Sandbox"
-          description={`Run ${providerName} confined: an empty home holding only its own state, the machine read-only, and writes only inside the checkout. The network stays on — the agent still reaches its API, and lich still hears its hooks.`}
-        >
-          <ToggleGroup
-            value={[sandbox]}
-            onValueChange={(next) => next[0] && setSandbox(next[0] as SandboxLevel)}
-            spacing={1}
-            aria-label={`Which ${providerName} sessions run confined`}
-            className="border border-border p-[3px]"
-          >
-            {SANDBOX_LEVELS.map((rung) => (
-              <ToggleGroupItem key={rung.level} value={rung.level} size="sm">
-                {rung.label}
-              </ToggleGroupItem>
-            ))}
-          </ToggleGroup>
-          <p className="mt-2 max-w-prose text-xs text-muted-foreground">{sandboxConsequence}</p>
-        </SettingBlock>
       )}
 
       {/* Never unless the user says otherwise. A worktree is its own rung

--- a/frontend/src/components/settings/SandboxSettings.tsx
+++ b/frontend/src/components/settings/SandboxSettings.tsx
@@ -1,0 +1,248 @@
+import { useEffect, useState } from "react"
+import { Store, System } from "@/lib/rpc"
+import {
+  enabledProviders,
+  sandboxKey,
+  sandboxLevel,
+  useProviders,
+  GH_TOKEN_KEY,
+  SSH_AGENT_KEY,
+  type SandboxLevel,
+} from "@/lib/providers-store"
+import { GH_ACCOUNT_KEY } from "@/lib/project-settings"
+import { splitAccount } from "@/lib/gh-account"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { Switch } from "@/components/ui/switch"
+import { SettingBlock } from "./SettingBlock"
+
+const GLOBAL_SCOPE = ""
+
+// The rungs, ordered by how much of the machine a session can reach. Labels
+// alone: they carry their own meaning, and the ladder is now read as a whole —
+// several providers stacked and compared — rather than one consequence line at a
+// time. Only "Ask" keeps a caption below, its catch not being in its name.
+const RUNGS: { level: SandboxLevel; label: string }[] = [
+  { level: "off", label: "Off" },
+  { level: "ask", label: "Ask" },
+  { level: "worktrees", label: "Worktrees" },
+  { level: "everywhere", label: "Everywhere" },
+]
+
+// useSetting is one stored string in one scope, read once and written through on
+// every change. It reads as `fallback` until the value arrives, which is also
+// what an unreadable value means: the unknown state is drawn as the answer lich
+// has always behaved like, never as one that silently confines a session or
+// hands a credential to an agent.
+function useSetting(key: string, scope: string, fallback: string) {
+  const [value, setValue] = useState(fallback)
+
+  useEffect(() => {
+    void Store.GetSetting(key, scope).then((stored) => setValue(stored || fallback))
+  }, [key, scope, fallback])
+
+  const write = (next: string) => {
+    setValue(next)
+    void Store.SetSetting(key, scope, next)
+  }
+  return [value, write] as const
+}
+
+// useSandboxBackend names what confines a session here, "" for a machine that
+// cannot, and undefined until the answer arrives — so the pane does not flash its
+// "cannot confine" state on every mount.
+function useSandboxBackend() {
+  const [backend, setBackend] = useState<string | undefined>(undefined)
+  useEffect(() => {
+    void System.SandboxBackend().then(setBackend)
+  }, [])
+  return backend
+}
+
+// useAgentKeys lists what is loaded in the user's ssh agent, read when the pane
+// opens. It is the sentence the switch below it cannot say on its own: that
+// switch is read as "let it push with my GitHub key", and it hands over every
+// identity in this list. A key added after this read is handed over by a control
+// that never named it — reopening the pane is the cheap answer to that.
+function useAgentKeys() {
+  const [keys, setKeys] = useState<string[]>([])
+  useEffect(() => {
+    void System.SSHAgentKeys().then(setKeys)
+  }, [])
+  return keys
+}
+
+// SandboxSettings is the whole subject in one pane, asked in the order each
+// question depends on the one above it: whether this machine can confine at all,
+// which sessions are confined, and what a confined session may still carry in.
+//
+// The ladder used to sit inside every provider's own section, so a machine with
+// five providers enabled drew it five times — and the one fact governing all of
+// them, whether there is a backend at all, had nowhere to be said and took the
+// control with it when the answer was no.
+//
+// scope is the project's own id when the screen was opened from a project and the
+// global default from the hub, exactly the split the rung already had. Every
+// control on the pane writes to it, so a grant cannot drift from the rung it
+// qualifies.
+export function SandboxSettings({ projectId }: { projectId?: string }) {
+  const scope = projectId ?? GLOBAL_SCOPE
+  const providers = useProviders()
+  const backend = useSandboxBackend()
+  const agentKeys = useAgentKeys()
+  const [sshAgent, setSSHAgent] = useSetting(SSH_AGENT_KEY, scope, "")
+  const [ghToken, setGHToken] = useSetting(GH_TOKEN_KEY, scope, "")
+  // The account the token will be, read from the same setting the Pulls screen
+  // answers as. Naming it is the point: the switch hands over one account's
+  // credentials, and which one is a project's own choice made on another pane.
+  const [account] = useSetting(GH_ACCOUNT_KEY, scope, "")
+
+  if (backend === undefined) {
+    return null
+  }
+
+  if (backend === "") {
+    return (
+      <section className="py-5">
+        <StatusStrip backend="" />
+        <p className="mt-2 max-w-prose text-xs text-muted-foreground">
+          Install bubblewrap and reopen lich. Until then every session runs on the machine.
+        </p>
+      </section>
+    )
+  }
+
+  return (
+    <>
+      {/* No heading of its own: the screen is already titled Sandbox, and the
+          machine's answer is the state that title is about. */}
+      <section className="py-5">
+        <StatusStrip backend={backend} />
+        <p className="mt-2 max-w-prose text-xs text-muted-foreground">
+          An empty home, the machine read-only, writes only in the checkout. The network stays on.
+        </p>
+      </section>
+
+      <SettingBlock title="Which sessions run confined">
+        {enabledProviders(providers).map((provider) => (
+          <Rung
+            key={provider.id}
+            providerId={provider.id}
+            providerName={provider.name}
+            scope={scope}
+          />
+        ))}
+        <p className="mt-2 max-w-prose text-xs text-muted-foreground">
+          Ask reaches the New worktree dialog only.
+        </p>
+      </SettingBlock>
+
+      <SettingBlock title="What a confined session may carry in">
+        <Grant
+          title="SSH agent"
+          description="git push works inside. Signs with every identity in your agent, for any host."
+          detail={agentKeys.length > 0 ? `Loaded: ${agentKeys.join(" · ")}` : "Nothing loaded."}
+          checked={sshAgent === "true"}
+          onChange={(next) => setSSHAgent(String(next))}
+        />
+        <Grant
+          title="GitHub token"
+          description="gh works inside. The agent can read the token out of its environment."
+          detail={accountLine(account)}
+          checked={ghToken === "true"}
+          onChange={(next) => setGHToken(String(next))}
+        />
+      </SettingBlock>
+    </>
+  )
+}
+
+// accountLine names the account whose token a confined session would be handed.
+// An unset account is gh's own active one, which is what every lich gh call
+// already falls back to — and what the session would answer as, so it is said
+// rather than left blank.
+function accountLine(account: string): string {
+  const [, login] = splitAccount(account)
+  return login ? `As ${login}.` : "As gh's active account."
+}
+
+// Rung is one provider's row: its name, and the ladder for it. Compact, because
+// the pane holds one per enabled provider and they are read against each other.
+function Rung({
+  providerId,
+  providerName,
+  scope,
+}: {
+  providerId: string
+  providerName: string
+  scope: string
+}) {
+  const [stored, setStored] = useSetting(sandboxKey(providerId), scope, "off")
+
+  return (
+    <div className="flex items-center justify-between gap-4 border-t border-border py-2.5 first:border-t-0 first:pt-0">
+      <span className="text-sm font-medium text-foreground">{providerName}</span>
+      <ToggleGroup
+        value={[sandboxLevel(stored)]}
+        onValueChange={(next) => next[0] && setStored(next[0])}
+        spacing={1}
+        aria-label={`Which ${providerName} sessions run confined`}
+        className="shrink-0 border border-border p-[3px]"
+      >
+        {RUNGS.map((rung) => (
+          <ToggleGroupItem key={rung.level} value={rung.level} size="sm">
+            {rung.label}
+          </ToggleGroupItem>
+        ))}
+      </ToggleGroup>
+    </div>
+  )
+}
+
+// StatusStrip is the machine's own answer, drawn as state rather than prose. The
+// backend is named because the two have different holes, so a report about a
+// confined session that names the one in play starts a round ahead.
+function StatusStrip({ backend }: { backend: string }) {
+  return (
+    <div className="flex items-center gap-2.5 rounded-md border border-border px-3 py-2.5 text-xs">
+      <span
+        aria-hidden
+        className={`size-[7px] shrink-0 rounded-full ${
+          backend ? "bg-emerald-600 dark:bg-emerald-400" : "bg-muted-foreground"
+        }`}
+      />
+      <span className="font-medium text-foreground">
+        This machine {backend ? "can" : "cannot"} confine sessions
+      </span>
+      <span className="text-muted-foreground">— {backend || "bubblewrap is not installed"}</span>
+    </div>
+  )
+}
+
+// Grant is one credential handed back to a confined session. The description
+// carries the half nobody assumes — every identity, any host; a token the agent
+// can read straight out of its environment — because without it each switch reads
+// as a smaller promise than it makes.
+function Grant({
+  title,
+  description,
+  detail,
+  checked,
+  onChange,
+}: {
+  title: string
+  description: string
+  detail: string
+  checked: boolean
+  onChange: (next: boolean) => void
+}) {
+  return (
+    <div className="flex items-start gap-4 border-t border-border py-3.5 first:border-t-0 first:pt-0">
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-foreground">{title}</div>
+        <p className="mt-0.5 max-w-prose text-xs text-muted-foreground">{description}</p>
+        <p className="mt-1 font-mono text-[11px] leading-relaxed text-muted-foreground">{detail}</p>
+      </div>
+      <Switch checked={checked} onCheckedChange={onChange} aria-label={title} />
+    </div>
+  )
+}

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -5,6 +5,7 @@ import { AppearanceSettings } from "./AppearanceSettings"
 import { NotificationsSettings } from "./NotificationsSettings"
 import { HotkeysSettings } from "./HotkeysSettings"
 import { ProvidersSettings } from "./ProvidersSettings"
+import { SandboxSettings } from "./SandboxSettings"
 import { ProjectProvidersSettings } from "./ProjectProvidersSettings"
 import { ProviderBinSettings } from "./ProviderBinSettings"
 import { VersionControlSettings } from "./VersionControlSettings"
@@ -48,6 +49,15 @@ const BASE_SECTIONS: Section[] = [
     accessibleLabel: "Global Providers",
     group: "global",
     render: () => <ProvidersSettings />,
+  },
+  {
+    // Global rather than project: most of what it says is about the machine —
+    // whether there is a backend at all, what is in your ssh agent — and the
+    // values are project-scoped the same way the provider sections' are.
+    id: "sandbox",
+    label: "Sandbox",
+    group: "global",
+    render: (id) => <SandboxSettings projectId={id} />,
   },
   {
     id: "project-providers",

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -90,6 +90,19 @@ export function sandboxKey(id: string): string {
   return `provider.${id}.sandbox`
 }
 
+// The sandbox grant keys, each handing a confined session one credential its
+// private home took away: the ssh agent a push authenticates through, and the
+// GitHub token gh works through (mirror store.sshAgentKey and store.ghTokenKey
+// in Go, which are what the spawn reads).
+//
+// Two keys rather than one because they open different doors — the agent signs
+// with every identity loaded into it, for any host; the token is one account's,
+// with that account's scopes. Neither carries a provider: a grant describes what
+// exists inside the sandbox, not which agent runs in it. Scoped like sandboxKey,
+// stored as "true" or nothing at all.
+export const SSH_AGENT_KEY = "sandbox.ssh-agent"
+export const GH_TOKEN_KEY = "sandbox.gh-token"
+
 // Which sessions of a provider run confined, as one ladder ordered by how much
 // of the machine a session can reach. "ask" sits second because a session
 // nobody answered for runs unconfined, exactly like "off" — it moves who

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -422,9 +422,17 @@ export const System = {
   /** Raise a desktop notification: a headline and an optional second line.
    * The caller decides it is warranted — the backend only delivers. */
   Notify: (summary: string, detail: string) => call<null>("system.Notify", [summary, detail]),
-  /** Whether this machine can run a session confined (bubblewrap on Linux,
-   * sandbox-exec on macOS). A fact about the machine, not about a provider. */
-  SandboxAvailable: () => call<boolean>("system.SandboxAvailable", []),
+  /** What confines a session on this machine — "bubblewrap", "sandbox-exec" —
+   * or "" when nothing can. A fact about the machine, not about a provider.
+   * The name rather than a yes: the two backends have different holes, and the
+   * Sandbox pane says which one is in play. */
+  SandboxBackend: () => call<string>("system.SandboxBackend", []),
+  /** The identities loaded in the user's ssh agent, one readable line each.
+   * Shown beside the setting that hands the agent to a confined session: that
+   * setting reads as "let it push with my GitHub key" and actually covers every
+   * key in the list. Empty for no agent, no ssh-add, or an agent holding
+   * nothing — all three mean the same thing to whoever is deciding. */
+  SSHAgentKeys: () => call<string[]>("system.SSHAgentKeys", []),
 }
 
 export const Providers = {

--- a/frontend/src/lib/use-sandbox-choice.ts
+++ b/frontend/src/lib/use-sandbox-choice.ts
@@ -46,7 +46,7 @@ export function useSandboxChoice(
     }
     let stale = false
     const load = async () => {
-      const canConfine = await System.SandboxAvailable()
+      const canConfine = (await System.SandboxBackend()) !== ""
       // The project's rung wins over the global one, which is the scope
       // store.SandboxLevel reads in the same order.
       const [scoped, global] = await Promise.all([

--- a/internal/project/ghaccount.go
+++ b/internal/project/ghaccount.go
@@ -82,6 +82,34 @@ func tokenArgs(account string) []string {
 	return append(args, "--user", login)
 }
 
+// GHToken returns the API token gh holds for one account ("<host>/<login>"), or
+// for gh's active account when account is empty. It is what a confined session
+// is handed in GH_TOKEN, and it is the whole reason gh can work inside one: gh
+// keeps its tokens in the system keyring, which a private home has no path to,
+// so a sandboxed gh without this is a login prompt.
+//
+// Every failure answers "" — gh not installed, gh not authenticated, an account
+// gh does not know — because the caller does the same thing with all three:
+// spawn the session without a token and let gh say so itself, rather than fail
+// a whole session over a credential it may never use.
+func GHToken(account string) string {
+	return ghToken(runGH, account)
+}
+
+// ghToken is GHToken against an injectable runner, so the token path is
+// exercised without a gh on the machine.
+func ghToken(run ghRunner, account string) string {
+	args := []string{"auth", "token"}
+	if account != "" {
+		args = tokenArgs(account)
+	}
+	out, err := run(ghAccountTimeout, "", "", args...)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
 // splitAccount reads "<host>/<login>", tolerating the host-less form written
 // before accounts carried one.
 func splitAccount(account string) (host, login string) {

--- a/internal/project/ghaccount_test.go
+++ b/internal/project/ghaccount_test.go
@@ -184,3 +184,38 @@ func TestTokenArgs(t *testing.T) {
 		})
 	}
 }
+
+// The token a confined session is handed is one account's, and which account is
+// the project's own choice — the same one the rest of lich asks gh as. A
+// session that answered as whichever account gh has active would push and
+// comment as the wrong person.
+func TestGHTokenNamesTheAccount(t *testing.T) {
+	gh := &fakeGH{out: []byte("gho_project_account\n")}
+	if got := ghToken(gh.run, "github.com/marcelo-filho_snk"); got != "gho_project_account" {
+		t.Errorf("ghToken = %q, want the account's token", got)
+	}
+	if want := "auth token --hostname github.com --user marcelo-filho_snk"; strings.Join(gh.args, " ") != want {
+		t.Errorf("ran %q, want %q", strings.Join(gh.args, " "), want)
+	}
+
+	// No account configured is gh's own active one, which is what lich did
+	// before projects could pick.
+	gh = &fakeGH{out: []byte("gho_active\n")}
+	if got := ghToken(gh.run, ""); got != "gho_active" {
+		t.Errorf("ghToken with no account = %q, want the active account's token", got)
+	}
+	if want := "auth token"; strings.Join(gh.args, " ") != want {
+		t.Errorf("ran %q, want %q", strings.Join(gh.args, " "), want)
+	}
+}
+
+// gh missing, gh logged out, an account it does not know: all three answer the
+// same way, because the caller does the same thing with all three — open the
+// session without a token rather than fail it over a credential it may never
+// use.
+func TestGHTokenSwallowsEveryFailure(t *testing.T) {
+	gh := &fakeGH{err: errTest}
+	if got := ghToken(gh.run, "github.com/nobody"); got != "" {
+		t.Errorf("ghToken on failure = %q, want \"\"", got)
+	}
+}

--- a/internal/sandbox/agent_unix_test.go
+++ b/internal/sandbox/agent_unix_test.go
@@ -1,0 +1,142 @@
+//go:build unix
+
+package sandbox
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// listenUnix puts a real socket on disk and returns its path: what the ssh
+// agent leaves behind, and the only thing AgentSocket is willing to mount.
+func listenUnix(t *testing.T, path string) string {
+	t.Helper()
+	listener, err := net.Listen("unix", path)
+	if err != nil {
+		t.Fatalf("listen on %s: %v", path, err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+	return path
+}
+
+// SSH_AUTH_SOCK is an environment variable, which means it can name anything at
+// all. Everything that is not a socket on disk is refused rather than mounted:
+// a bind of a missing source fails the whole spawn, and a relative path is one
+// this package would resolve against a working directory it does not own.
+func TestAgentSocketRefusesWhatIsNotASocket(t *testing.T) {
+	dir := t.TempDir()
+	regular := filepath.Join(dir, "regular")
+	if err := os.WriteFile(regular, nil, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	for name, value := range map[string]string{
+		"unset":    "",
+		"relative": "agent.sock",
+		"missing":  filepath.Join(dir, "gone.sock"),
+		"a file":   regular,
+		"a dir":    dir,
+	} {
+		t.Setenv("SSH_AUTH_SOCK", value)
+		if got := AgentSocket(); got != "" {
+			t.Errorf("%s SSH_AUTH_SOCK yielded %q, want no socket", name, got)
+		}
+	}
+
+	socket := listenUnix(t, filepath.Join(dir, "agent.sock"))
+	t.Setenv("SSH_AUTH_SOCK", socket)
+	if got := AgentSocket(); got != socket {
+		t.Errorf("AgentSocket = %q, want %q", got, socket)
+	}
+}
+
+// The agent is handed over only when asked for. This is the whole contract of
+// the setting: the default sandbox has no credentials in it.
+func TestDescribeMountsTheAgentOnlyWhenAsked(t *testing.T) {
+	home := t.TempDir()
+	cwd := filepath.Join(home, "repo")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	socket := listenUnix(t, filepath.Join(home, "agent.sock"))
+	t.Setenv("SSH_AUTH_SOCK", socket)
+	if err := os.MkdirAll(filepath.Join(home, ".ssh"), 0o700); err != nil {
+		t.Fatalf("mkdir .ssh: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".ssh", "known_hosts"), []byte("github.com ssh-ed25519 AAAA\n"), 0o600); err != nil {
+		t.Fatalf("write known_hosts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".ssh", "id_ed25519"), []byte("private\n"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	if spec := Describe(providers.Claude, home, cwd, "", nil, false); slices.Contains(spec.Read, socket) {
+		t.Errorf("the agent socket was mounted without being asked for: %v", spec.Read)
+	}
+	// Neither half of the grant travels without the grant.
+	if spec := Describe(providers.Claude, home, cwd, "", nil, false); slices.Contains(spec.Read, filepath.Join(home, ".ssh", "known_hosts")) {
+		t.Errorf("known_hosts was mounted without the grant: %v", spec.Read)
+	}
+	spec := Describe(providers.Claude, home, cwd, "", nil, true)
+	if !slices.Contains(spec.Read, socket) {
+		t.Errorf("the agent socket is missing from Read: %v", spec.Read)
+	}
+	// The socket without the host keys is a grant that cannot do the one thing
+	// it exists for: ssh fails to verify github.com before it offers the key.
+	if !slices.Contains(spec.Read, filepath.Join(home, ".ssh", "known_hosts")) {
+		t.Errorf("known_hosts is missing from Read: %v", spec.Read)
+	}
+	// The directory holding it is what the sandbox exists to keep out.
+	if slices.Contains(spec.Read, filepath.Join(home, ".ssh")) {
+		t.Errorf("~/.ssh itself was mounted: %v", spec.Read)
+	}
+	// Read-only, never writable: connecting to a socket is not a write to the
+	// mount, and a writable bind would hand over the directory holding it.
+	if slices.Contains(spec.Write, socket) {
+		t.Errorf("the agent socket is writable: %v", spec.Write)
+	}
+}
+
+// An agent that is not there is not an error: the session opens without it, and
+// git says so itself when a push needs a key.
+func TestDescribeSurvivesAMissingAgent(t *testing.T) {
+	home := t.TempDir()
+	cwd := filepath.Join(home, "repo")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	t.Setenv("SSH_AUTH_SOCK", "")
+	if spec := Describe(providers.Claude, home, cwd, "", nil, true); slices.Contains(spec.Read, "") {
+		t.Errorf("an absent agent left an empty mount behind: %v", spec.Read)
+	}
+}
+
+// The grant is the socket and the host keys, and nothing else under ~/.ssh. A
+// private key inside the sandbox is the thing the agent exists to avoid.
+func TestDescribeNeverMountsAPrivateKey(t *testing.T) {
+	home := t.TempDir()
+	cwd := filepath.Join(home, "repo")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(home, ".ssh"), 0o700); err != nil {
+		t.Fatalf("mkdir .ssh: %v", err)
+	}
+	key := filepath.Join(home, ".ssh", "id_ed25519")
+	if err := os.WriteFile(key, []byte("private\n"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	t.Setenv("SSH_AUTH_SOCK", listenUnix(t, filepath.Join(home, "agent.sock")))
+
+	spec := Describe(providers.Claude, home, cwd, "", nil, true)
+	for _, path := range append(append([]string{}, spec.Read...), spec.Write...) {
+		if path == key || path == filepath.Join(home, ".ssh") {
+			t.Fatalf("a confined session was given %q", path)
+		}
+	}
+}

--- a/internal/sandbox/binarydirs_unix_test.go
+++ b/internal/sandbox/binarydirs_unix_test.go
@@ -133,7 +133,7 @@ func TestDescribeRefusesSymlinkedDotfiles(t *testing.T) {
 		t.Fatalf("mkdir: %v", err)
 	}
 
-	spec := Describe("claude", home, filepath.Join(home, "repo"), "", nil)
+	spec := Describe("claude", home, filepath.Join(home, "repo"), "", nil, false)
 	if slices.Contains(spec.Read, link) {
 		t.Errorf("a symlinked dotfile was mounted: %v", spec.Read)
 	}

--- a/internal/sandbox/bwrap_linux.go
+++ b/internal/sandbox/bwrap_linux.go
@@ -203,3 +203,6 @@ func resolvedLink(path string) string {
 	}
 	return target
 }
+
+// backendName is what the window calls this backend.
+const backendName = "bubblewrap"

--- a/internal/sandbox/confine_linux_test.go
+++ b/internal/sandbox/confine_linux_test.go
@@ -33,7 +33,7 @@ func confinedHome(t *testing.T) (home, cwd string) {
 // output. The shell is /bin/sh, which the read-only base filesystem provides.
 func runConfined(t *testing.T, home, cwd, script string) string {
 	t.Helper()
-	spec := Describe(providers.Claude, home, cwd, "", nil)
+	spec := Describe(providers.Claude, home, cwd, "", nil, false)
 	bin, args := Wrap(spec, "/bin/sh", []string{"-c", script})
 	out, err := exec.Command(bin, args...).CombinedOutput()
 	if err != nil {
@@ -149,7 +149,7 @@ func TestAnAgentInstalledAsASymlinkRuns(t *testing.T) {
 	// to be on it — the same way the user's own installer puts it there.
 	t.Setenv("PATH", filepath.Join(home, ".local", "bin")+":"+os.Getenv("PATH"))
 
-	spec := Describe(providers.Claude, home, cwd, "", BinaryDirs("agent"))
+	spec := Describe(providers.Claude, home, cwd, "", BinaryDirs("agent"), false)
 	bin, args := Wrap(spec, link, nil)
 	out, err := exec.Command(bin, args...).CombinedOutput()
 	if err != nil {

--- a/internal/sandbox/display_linux.go
+++ b/internal/sandbox/display_linux.go
@@ -92,10 +92,3 @@ func x11Sockets(dir, home string) []string {
 	}
 	return []string{socket, cookie}
 }
-
-// isSocket reports whether path is a unix socket on disk, without following a
-// link to get there — the answer decides what gets mounted into the sandbox.
-func isSocket(path string) bool {
-	info, err := os.Lstat(path)
-	return err == nil && info.Mode()&os.ModeSocket != 0
-}

--- a/internal/sandbox/display_linux_test.go
+++ b/internal/sandbox/display_linux_test.go
@@ -159,7 +159,7 @@ func TestDescribeMountsTheDisplaySocket(t *testing.T) {
 	t.Setenv("XDG_RUNTIME_DIR", runtime)
 	t.Setenv("WAYLAND_DISPLAY", "wayland-1")
 
-	spec := Describe("claude", t.TempDir(), t.TempDir(), "", nil)
+	spec := Describe("claude", t.TempDir(), t.TempDir(), "", nil, false)
 	if !slices.Contains(spec.Read, socket) {
 		t.Errorf("the display socket %q is not in the spec's readable paths %v", socket, spec.Read)
 	}

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -192,12 +192,80 @@ var readableToolchain = []string{
 // Paths that do not exist are dropped: a bind mount of a missing source fails
 // the whole spawn, and every entry here is optional by nature — a machine
 // without Rust has no ~/.cargo, and that is not an error.
-func Describe(providerID, home, cwd, gitCommon string, extraRead []string) Spec {
+func Describe(providerID, home, cwd, gitCommon string, extraRead []string, sshAgent bool) Spec {
 	spec := Spec{Home: home, Cwd: cwd, GitCommon: gitCommon}
 	spec.Write = existing(append(stateDirs(providerID, home), under(home, writableCaches)...))
 	read := append(under(home, readableToolchain), displaySockets(home)...)
+	if sshAgent {
+		read = append(read, AgentSocket(), knownHosts(home))
+	}
 	spec.Read = existing(append(read, extraRead...))
 	return spec
+}
+
+// Backend names what confines a session on this machine, or "" when nothing can.
+// It is Available's answer with the name attached: a confined session behaves
+// differently on each backend, and the name is the first thing a report about
+// one needs.
+func Backend() string {
+	if !Available() {
+		return ""
+	}
+	return backendName
+}
+
+// AgentSocket is the ssh agent's socket, read from the environment lich itself
+// was launched in, or "" when there is no agent to hand over. Mounting it is
+// what makes `git push` work in a confined session: the private home takes
+// ~/.ssh with it, and the agent is the way to authenticate without ever putting
+// a private key inside the sandbox — the agent signs, and the key never moves.
+//
+// The cost is the honest one, and it is why this is behind a setting rather
+// than always on: an agent holds every identity loaded into it, and a session
+// handed the socket can sign with all of them, for any host it can reach, for
+// as long as it runs. OpenSSH can pin a key to one destination (`ssh-add -h`),
+// but only at the moment the key is added on the host — lich is given a socket
+// that is already populated and can only pass it on whole.
+//
+// Exported because the window shows what is in the agent beside the setting
+// that hands it over (internal/system): a choice made without that list is a
+// choice about "my GitHub key" that actually covers every key.
+func AgentSocket() string {
+	path := os.Getenv("SSH_AUTH_SOCK")
+	if !filepath.IsAbs(path) || !isSocket(path) {
+		return ""
+	}
+	return path
+}
+
+// knownHosts is the user's ssh host-key file, mounted read-only alongside the
+// agent socket because without it the agent is useless: the private home takes
+// ~/.ssh with it, so ssh has no record of github.com's host key, cannot verify
+// it, and — with no tty and no askpass — cannot ask. It fails with "Host key
+// verification failed" before the key it was just handed is ever offered.
+//
+// The file rather than the directory it sits in, which is the whole point:
+// ~/.ssh holds the private keys this sandbox exists to keep away from an
+// unattended agent, and known_hosts holds none of them. Its contents are public
+// host keys; what a confined session learns from it is the list of machines the
+// user connects to, not a credential.
+//
+// Read-only, so ssh may verify a host and may not record a new one. A host the
+// user has never connected to outside the sandbox therefore still fails inside
+// it — blind trust-on-first-use is not something to grant a session running
+// unattended, and the fix is to connect to it once on the machine.
+//
+// The system-wide file (/etc/ssh/ssh_known_hosts) needs nothing here: /etc is
+// already mounted read-only.
+func knownHosts(home string) string {
+	return filepath.Join(home, ".ssh", "known_hosts")
+}
+
+// isSocket reports whether path is a unix socket on disk, without following a
+// link to get there — the answer decides what gets mounted into the sandbox.
+func isSocket(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && info.Mode()&os.ModeSocket != 0
 }
 
 // symlinkHops caps the chain BinaryDirs walks, so a link that points at itself

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -131,7 +131,7 @@ func TestDescribeDropsMissingPathsAndDuplicates(t *testing.T) {
 	spec := Describe(providers.Claude, home, cwd, "", []string{
 		filepath.Join(home, ".config"),
 		filepath.Join(home, "nonexistent"),
-	})
+	}, false)
 
 	if !slices.Contains(spec.Write, filepath.Join(home, ".claude")) {
 		t.Errorf("provider state missing from Write: %v", spec.Write)
@@ -176,4 +176,18 @@ func count(haystack []string, needle string) int {
 		}
 	}
 	return n
+}
+
+// Backend is Available's answer with a name on it, and the two can never
+// disagree: a machine that can confine has something to call it, and one that
+// cannot must answer "" — which is what the window draws its "cannot confine"
+// state from.
+func TestBackendAgreesWithAvailable(t *testing.T) {
+	name := Backend()
+	if Available() && name == "" {
+		t.Error("a machine that can confine has no backend name")
+	}
+	if !Available() && name != "" {
+		t.Errorf("a machine that cannot confine named %q", name)
+	}
 }

--- a/internal/sandbox/seatbelt_darwin.go
+++ b/internal/sandbox/seatbelt_darwin.go
@@ -88,3 +88,6 @@ func subpath(path string) string {
 	escaped := strings.NewReplacer(`\`, `\\`, `"`, `\"`).Replace(path)
 	return `(subpath "` + escaped + `")`
 }
+
+// backendName is what the window calls this backend.
+const backendName = "sandbox-exec"

--- a/internal/sandbox/unsupported.go
+++ b/internal/sandbox/unsupported.go
@@ -15,3 +15,6 @@ func Available() bool { return false }
 func Wrap(_ Spec, bin string, args []string) (string, []string) {
 	return bin, args
 }
+
+// backendName is unused here: Backend answers "" before it is read.
+const backendName = ""

--- a/internal/store/sandbox_test.go
+++ b/internal/store/sandbox_test.go
@@ -164,3 +164,43 @@ func TestSessionSandboxOfAMissingRowIsNotAnError(t *testing.T) {
 		t.Errorf("SessionSandbox of a missing row = %q, want \"\"", got)
 	}
 }
+
+// The credential flags are the doors the sandbox opens back up, so anything
+// that is not the literal "true" has to leave them shut — an absent value, a
+// stale one, a value some other feature wrote.
+func TestSandboxCredentialsAreOnlyTheLiteralTrue(t *testing.T) {
+	svc := sandboxProject(t, "/work/alpha")
+	for _, value := range []string{"", "yes", "1", "TRUE", "on"} {
+		_ = svc.SetSetting(sshAgentKey, globalScope, value)
+		_ = svc.SetSetting(ghTokenKey, globalScope, value)
+		if svc.SandboxSSHAgent("p1") {
+			t.Errorf("ssh agent handed over for %q, want off", value)
+		}
+		if svc.SandboxGHToken("p1") {
+			t.Errorf("gh token handed over for %q, want off", value)
+		}
+	}
+	_ = svc.SetSetting(sshAgentKey, globalScope, "true")
+	if !svc.SandboxSSHAgent("p1") {
+		t.Error("ssh agent off for \"true\", want on")
+	}
+	// The two are separate doors: turning the agent on must not turn gh on.
+	if svc.SandboxGHToken("p1") {
+		t.Error("the ssh agent flag turned the gh token on, want them independent")
+	}
+}
+
+// Scoped like the rung above them: one repository may hand credentials over
+// while the rest of the machine's projects do not.
+func TestSandboxCredentialsPreferTheProjectOverTheGlobal(t *testing.T) {
+	svc := sandboxProject(t, "/work/alpha")
+	key := ghTokenKey
+	_ = svc.SetSetting(key, globalScope, "true")
+	if !svc.SandboxGHToken("p1") {
+		t.Error("the global flag does not reach the project, want it inherited")
+	}
+	_ = svc.SetSetting(key, "p1", "false")
+	if svc.SandboxGHToken("p1") {
+		t.Error("the project's own \"false\" lost to the global \"true\"")
+	}
+}

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -164,22 +164,64 @@ func sandboxKey(providerID string) string {
 // project's own value, then the global one, then SandboxOff. An unreadable or
 // unrecognised value is SandboxOff for the reason the constants give.
 func (s *Service) SandboxLevel(providerID, projectID string) string {
-	level := ""
-	if projectID != globalScope {
-		if value, err := s.GetSetting(sandboxKey(providerID), projectID); err == nil {
-			level = value
-		}
-	}
-	if level == "" {
-		if value, err := s.GetSetting(sandboxKey(providerID), globalScope); err == nil {
-			level = value
-		}
-	}
-	switch level {
+	switch level := s.projectSetting(sandboxKey(providerID), projectID); level {
 	case SandboxAsk, SandboxWorktrees, SandboxEverywhere:
 		return level
 	}
 	return SandboxOff
+}
+
+// projectSetting reads one setting the way every sandbox control is scoped: the
+// project's own value when it has one, the global value otherwise, and "" when
+// neither answers. An unreadable value is indistinguishable from an absent one,
+// which is what each caller here wants — every one of them treats the unknown
+// state as the restrictive answer.
+func (s *Service) projectSetting(key, projectID string) string {
+	if projectID != globalScope {
+		if value, err := s.GetSetting(key, projectID); err == nil && value != "" {
+			return value
+		}
+	}
+	value, err := s.GetSetting(key, globalScope)
+	if err != nil {
+		return ""
+	}
+	return value
+}
+
+// The sandbox grant keys each hand a confined session one of the two credentials
+// its private home took away, and they are two keys rather than one because they
+// open different doors. The agent signs with every identity loaded into it, for
+// any host it can reach; the token is one GitHub account's, limited to the scopes
+// that account was granted. Someone who wants gh to work does not necessarily
+// want to hand over their ssh keys, and the reverse is just as true.
+//
+// Unlike sandboxKey they carry no provider. A grant describes what exists inside
+// the sandbox, not which agent is running in it — and keying them by provider
+// would multiply every future grant by the provider list for a distinction
+// nobody makes. Which sessions are confined is the rung's question; what a
+// confined session may carry in is this one.
+//
+// Scoped like sandboxKey all the same — a project value wins over the global one
+// — because the repository is what the answer is about. On only for the literal
+// "true": each puts a credential in front of an agent running unattended, so
+// anything else has to mean no.
+const (
+	sshAgentKey = "sandbox.ssh-agent"
+	ghTokenKey  = "sandbox.gh-token"
+)
+
+// SandboxSSHAgent reports whether a confined session in this project is given the
+// user's ssh agent, which is what makes `git push` work inside one.
+func (s *Service) SandboxSSHAgent(projectID string) bool {
+	return s.projectSetting(sshAgentKey, projectID) == "true"
+}
+
+// SandboxGHToken reports whether a confined session in this project is given a
+// GitHub token in its environment, which is what makes gh work inside one: the
+// token lives in the system keyring, and a private home cannot reach it.
+func (s *Service) SandboxGHToken(projectID string) bool {
+	return s.projectSetting(ghTokenKey, projectID) == "true"
 }
 
 // SandboxDefault reports whether a session of this provider, starting in cwd,

--- a/internal/system/sshagent.go
+++ b/internal/system/sshagent.go
@@ -1,0 +1,74 @@
+package system
+
+import (
+	"context"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/omartelo/lich/internal/sandbox"
+)
+
+// agentListTimeout caps the call to ssh-add. Listing identities is a round trip
+// to a socket on the same machine; an agent that has not answered in a second is
+// one the setting can describe as empty rather than one worth blocking the
+// settings pane on.
+const agentListTimeout = time.Second
+
+// SSHAgentKeys lists the identities loaded in the user's ssh agent, one line
+// each ("me@example.com (ED25519 256)"), newest gh has none first.
+//
+// It exists for one sentence in the UI. The setting that hands a confined
+// session the ssh agent is read as "let it push with my GitHub key", and what it
+// actually hands over is every identity in the agent, usable against any host —
+// so the control shows the list instead of asking the user to remember it. A
+// choice made without seeing this is a choice about a different thing.
+//
+// Empty for everything that is not a list of keys: no agent in the environment,
+// no ssh-add on the machine, an agent holding nothing, output this cannot read.
+// The caller draws "nothing loaded", which is the truthful reading of all of
+// them — the flag hands over whatever is there, and nothing is a real answer.
+func (s *Service) SSHAgentKeys() []string {
+	if sandbox.AgentSocket() == "" {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), agentListTimeout)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "ssh-add", "-l").Output()
+	if err != nil {
+		return nil
+	}
+	return parseAgentKeys(string(out))
+}
+
+// parseAgentKeys reads `ssh-add -l` output: "<bits> <fingerprint> <comment>
+// (<TYPE>)", one identity per line. The fingerprint is dropped — it identifies a
+// key to a machine, and the comment is what identifies it to the person who
+// loaded it — and the bits move in beside the type.
+//
+// A line that does not have all four parts is kept whole rather than skipped: an
+// identity the parser cannot read is still an identity the setting hands over,
+// and a shorter list here would understate what the flag opens.
+func parseAgentKeys(out string) []string {
+	var keys []string
+	for line := range strings.SplitSeq(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "The agent has no identities") {
+			continue
+		}
+		keys = append(keys, formatAgentKey(line))
+	}
+	return keys
+}
+
+// formatAgentKey turns one ssh-add line into the phrase the control shows, or
+// returns it unchanged when it is not shaped like one.
+func formatAgentKey(line string) string {
+	fields := strings.Fields(line)
+	if len(fields) < 4 || !strings.HasPrefix(fields[len(fields)-1], "(") {
+		return line
+	}
+	kind := strings.Trim(fields[len(fields)-1], "()")
+	comment := strings.Join(fields[2:len(fields)-1], " ")
+	return comment + " (" + kind + " " + fields[0] + ")"
+}

--- a/internal/system/sshagent_test.go
+++ b/internal/system/sshagent_test.go
@@ -1,0 +1,43 @@
+package system
+
+import (
+	"slices"
+	"testing"
+)
+
+// The list is what the setting shows instead of asking the user to remember
+// what is in their agent, so it has to read like the person who loaded the key
+// would name it: the comment they gave it, not the fingerprint ssh identifies it
+// by.
+func TestParseAgentKeysReadsSSHAddOutput(t *testing.T) {
+	out := "4096 SHA256:abc+def/ghi me@example.com (RSA)\n" +
+		"256 SHA256:jkl work laptop key (ED25519)\n"
+	want := []string{
+		"me@example.com (RSA 4096)",
+		"work laptop key (ED25519 256)",
+	}
+	if got := parseAgentKeys(out); !slices.Equal(got, want) {
+		t.Errorf("parseAgentKeys = %v, want %v", got, want)
+	}
+}
+
+// An agent holding nothing is not a key called "The agent has no identities."
+func TestParseAgentKeysReadsAnEmptyAgent(t *testing.T) {
+	if got := parseAgentKeys("The agent has no identities.\n"); len(got) != 0 {
+		t.Errorf("an empty agent listed %v, want nothing", got)
+	}
+	if got := parseAgentKeys("\n  \n"); len(got) != 0 {
+		t.Errorf("blank output listed %v, want nothing", got)
+	}
+}
+
+// A line this cannot read is still an identity the flag hands over. Dropping it
+// would understate what the setting opens, which is the one thing this list
+// exists to state.
+func TestParseAgentKeysKeepsALineItCannotRead(t *testing.T) {
+	const odd = "something ssh-add printed"
+	got := parseAgentKeys(odd + "\n")
+	if !slices.Equal(got, []string{odd}) {
+		t.Errorf("parseAgentKeys = %v, want the line kept whole", got)
+	}
+}

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -81,15 +81,17 @@ func (s *Service) Diagnostics() Diagnostics {
 	}
 }
 
-// SandboxAvailable reports whether this machine can run a session confined
-// (internal/sandbox). It answers here rather than beside the provider list
-// because it is a fact about the machine — bubblewrap installed, or macOS —
+// SandboxBackend names what confines a session on this machine — "bubblewrap",
+// "sandbox-exec" — or "" when nothing can (internal/sandbox). It answers here
+// rather than beside the provider list because it is a fact about the machine,
 // and the same answer for every provider on it.
 //
-// The frontend hides the sandbox control when this is false rather than
-// offering one that saves a setting nothing can act on.
-func (s *Service) SandboxAvailable() bool {
-	return sandbox.Available()
+// The name rather than a yes: the two backends have different holes, and the
+// Sandbox pane says which one is in play so a report about a confined session
+// starts a round ahead. "" is what the pane draws its "cannot confine" state
+// from, and what the new-session dialog reads as "do not offer the choice".
+func (s *Service) SandboxBackend() string {
+	return sandbox.Backend()
 }
 
 // RevealLog opens the log's directory with the platform's file manager, not the

--- a/internal/terminal/sandbox.go
+++ b/internal/terminal/sandbox.go
@@ -27,14 +27,65 @@ import (
 // dropDir is where this session's dropped-file copies live (sessionDropDir),
 // bound read-only so a file dragged onto a confined terminal is a file the
 // agent can actually open. Empty leaves it out.
-func wrapSandbox(spec ptySpec, kind, home, dropDir string, confined bool) ptySpec {
+func wrapSandbox(spec ptySpec, kind, home, dropDir string, confined bool, creds sandboxCreds) ptySpec {
 	if !confined || home == "" || !sandbox.Available() {
 		return spec
 	}
 	read := append(executables(spec.bin), dropDir)
-	sb := sandbox.Describe(kind, home, spec.dir, project.GitCommonDir(spec.dir), read)
+	sb := sandbox.Describe(kind, home, spec.dir, project.GitCommonDir(spec.dir), read, creds.sshAgent)
 	spec.bin, spec.args = sandbox.Wrap(sb, spec.bin, spec.args)
+	// The token goes in the child's environment rather than through bubblewrap's
+	// --setenv, which would write it into an argument list any process on the
+	// machine can read out of /proc.
+	if creds.ghToken != "" {
+		spec.env = append(spec.env, "GH_TOKEN="+creds.ghToken)
+	}
 	return spec
+}
+
+// sandboxCreds is what a confined session is handed to act on the network as the
+// user: the ssh agent a push authenticates through, and the GitHub token gh
+// works through. The zero value is the sandbox as it first shipped — a session
+// that commits locally and hands the push back to whoever is watching.
+//
+// They are two answers rather than one because they open different doors. The
+// agent signs with every identity loaded into it, for any host; the token is one
+// account's, carrying the scopes that account was granted. Wanting gh to work is
+// not wanting to hand over your ssh keys.
+type sandboxCreds struct {
+	// sshAgent binds the host's ssh-agent socket into the session.
+	sshAgent bool
+	// ghToken is the GitHub token to put in the session's environment, or "" for
+	// none — which is also what a token lookup that failed leaves behind.
+	ghToken string
+}
+
+// sandboxCredentials reads what this session's project allows a confined spawn to
+// carry in. An unconfined session gets nothing: it already runs with the user's
+// whole environment, and asking gh for a token it does not need would put one in
+// an environment that never lacked it.
+//
+// The grants carry no provider — they describe what is inside the sandbox, not
+// who runs in it (internal/store/settings.go) — which is why the provider is not
+// a parameter here even though the rung above it is keyed by one.
+//
+// The account is the project's own gh account (the store's "vcs.account"), so a
+// confined session answers as the account the rest of lich answers as for this
+// repository rather than as whichever one gh has active.
+//
+// Ceiling: one `gh auth token` subprocess in front of every confined spawn that
+// asks for it, capped by the project package's own timeout. gh's tokens are
+// short-lived and gh owns their refresh, so caching one here would mean owning
+// the invalidation too — the same trade internal/project already priced.
+func (s *Service) sandboxCredentials(projectID, cwd string, confined bool) sandboxCreds {
+	if !confined {
+		return sandboxCreds{}
+	}
+	creds := sandboxCreds{sshAgent: s.store.SandboxSSHAgent(projectID)}
+	if s.store.SandboxGHToken(projectID) {
+		creds.ghToken = project.GHToken(s.store.GHAccountForPath(cwd))
+	}
+	return creds
 }
 
 // sessionDropDir is the directory holding the copies of the files dropped into

--- a/internal/terminal/sandbox_test.go
+++ b/internal/terminal/sandbox_test.go
@@ -72,7 +72,7 @@ func TestWrapSandboxLeavesAnUnconfinedSpawnAlone(t *testing.T) {
 		{"not confined", "/home/u", false},
 		{"no home to empty", "", true},
 	} {
-		got := wrapSandbox(baseSpec(), providers.Claude, tt.home, "", tt.confined)
+		got := wrapSandbox(baseSpec(), providers.Claude, tt.home, "", tt.confined, sandboxCreds{})
 		if got.bin != original.bin || !slices.Equal(got.args, original.args) {
 			t.Errorf("%s: spawn rewritten to %q %v", tt.name, got.bin, got.args)
 		}
@@ -84,7 +84,7 @@ func TestWrapSandboxKeepsTheCommandAndItsArguments(t *testing.T) {
 		t.Skip("no sandbox backend on this machine")
 	}
 	original := baseSpec()
-	got := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), "", true)
+	got := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), "", true, sandboxCreds{})
 	if got.bin == original.bin {
 		t.Fatalf("the spawn was not confined: still %q", got.bin)
 	}
@@ -201,7 +201,7 @@ func TestWrapSandboxMountsTheSessionsCopies(t *testing.T) {
 	}
 	copies := sessionDropDir(t.TempDir(), "s1", true)
 
-	got := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), copies, true)
+	got := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), copies, true, sandboxCreds{})
 
 	// Substring, not an argv element: the two backends spell a mounted path in
 	// their own vocabulary — bubblewrap takes it as its own argument
@@ -210,5 +210,35 @@ func TestWrapSandboxMountsTheSessionsCopies(t *testing.T) {
 	// carry is the path, not a shape only one of them uses.
 	if !slices.ContainsFunc(got.args, func(arg string) bool { return strings.Contains(arg, copies) }) {
 		t.Fatalf("the session's copies dir %q is not in the confined spawn: %v", copies, got.args)
+	}
+}
+
+// The token is a credential, and an argument list is public: /proc/<pid>/cmdline
+// is readable by every process on the machine, so a token passed through
+// bubblewrap's --setenv would be handed to more than the session it is for.
+func TestWrapSandboxKeepsTheTokenOutOfTheArguments(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bubblewrap is not installed")
+	}
+	const token = "gho_secret_probe_value"
+	got := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), "", true, sandboxCreds{ghToken: token})
+
+	if !slices.Contains(got.env, "GH_TOKEN="+token) {
+		t.Errorf("GH_TOKEN missing from the child environment: %v", got.env)
+	}
+	if slices.ContainsFunc(got.args, func(a string) bool { return strings.Contains(a, token) }) {
+		t.Error("the token reached the argument list, where any process can read it")
+	}
+}
+
+// No flag, no credential: the sandbox as it shipped puts nothing in the
+// environment, so a session that was never granted a token cannot find one.
+func TestWrapSandboxAddsNoTokenWithoutOne(t *testing.T) {
+	if _, err := exec.LookPath("bwrap"); err != nil {
+		t.Skip("bubblewrap is not installed")
+	}
+	got := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), "", true, sandboxCreds{})
+	if slices.ContainsFunc(got.env, func(kv string) bool { return strings.HasPrefix(kv, "GH_TOKEN=") }) {
+		t.Errorf("GH_TOKEN set without the flag: %v", got.env)
 	}
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -177,6 +177,9 @@ type Store interface {
 	SessionSandbox(sessionID string) string
 	SetSessionSandbox(sessionID, sandbox string) error
 	SandboxDefault(providerID, projectID, cwd string) bool
+	SandboxSSHAgent(projectID string) bool
+	SandboxGHToken(projectID string) bool
+	GHAccountForPath(path string) string
 	SetSessionTitle(sessionID, title string) (bool, error)
 	CostReadout() bool
 	CostLedger(sessionID, transcriptID string) (int64, string, float64, error)
@@ -546,7 +549,8 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 	// Outermost, so the setup script and the entrypoint are confined with the
 	// session they run in front of.
 	inSandbox := confined(s.store, id, kind, projectID, cwd)
-	spec = wrapSandbox(spec, kind, userHome(), sessionDropDir(s.dropDir, id, inSandbox), inSandbox)
+	creds := s.sandboxCredentials(projectID, cwd, inSandbox)
+	spec = wrapSandbox(spec, kind, userHome(), sessionDropDir(s.dropDir, id, inSandbox), inSandbox, creds)
 	p, err := startPTY(spec)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to start pty for %q: %w", id, err)

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -42,6 +42,9 @@ type stubBins struct {
 	entrypoint      string
 	sandbox         string
 	sandboxOn       bool
+	sshAgent        bool
+	ghToken         bool
+	ghAccount       string
 	skipPerms       bool
 	costOn          bool
 	ledgers         map[string]stubLedger
@@ -92,6 +95,9 @@ func (s stubBins) SessionEntrypoint(_ string) string    { return s.entrypoint }
 func (s stubBins) SessionSandbox(_ string) string       { return s.sandbox }
 func (s stubBins) SetSessionSandbox(_, _ string) error  { return nil }
 func (s stubBins) SandboxDefault(_, _, _ string) bool   { return s.sandboxOn }
+func (s stubBins) SandboxSSHAgent(_ string) bool        { return s.sshAgent }
+func (s stubBins) SandboxGHToken(_ string) bool         { return s.ghToken }
+func (s stubBins) GHAccountForPath(_ string) string     { return s.ghAccount }
 func (s stubBins) SetProviderSession(_, _ string) error { return nil }
 
 func (s stubBins) WorktreePorts() map[string]int {
@@ -1390,5 +1396,18 @@ func TestReadyIsFalseForASessionThatIsNotRunning(t *testing.T) {
 
 	if svc.Ready("ghost") {
 		t.Error("a session with no PTY was reported ready for work")
+	}
+}
+
+// An unconfined session already runs with the user's whole environment. Asking
+// gh for a token there would spend a subprocess to hand over something the
+// session never lacked.
+func TestSandboxCredentialsAreOnlyForConfinedSessions(t *testing.T) {
+	svc := New(stubBins{sshAgent: true, ghToken: true, ghAccount: "github.com/someone"}, nil, events.New())
+	if got := svc.sandboxCredentials("p1", "/repo", false); got != (sandboxCreds{}) {
+		t.Errorf("an unconfined session was handed %+v, want nothing", got)
+	}
+	if got := svc.sandboxCredentials("p1", "/repo", true); !got.sshAgent {
+		t.Error("a confined session was refused the agent its project turned on")
 	}
 }


### PR DESCRIPTION
A confined session gets an empty home, which takes the ssh agent and gh's keyring with it: `git push` has nothing to sign with, and `gh` opens on a login prompt. Two grants hand each one back, off by default, under a new **Settings › Sandbox** pane.

They are two switches rather than one because they open different doors. The agent signs with **every** identity loaded into it, against any host it can reach; the token is one GitHub account's — the project's own `vcs.account` — carrying that account's scopes. Wanting `gh` to work is not wanting to hand over your ssh keys.

## Measured, not assumed

Inside a real bwrap jail with a tmpfs home:

| probe | result |
|---|---|
| `gh` alone | dead — `please run: gh auth login` |
| `GH_TOKEN` in the environment | `gh api user` → `omartelo` ✅ |
| `~/.config/gh` + D-Bus socket | works — and hands over the entire Secret Service, every password in the keyring. **Refused** |
| D-Bus socket alone | dead (gh does not consult the keyring for a host absent from `hosts.yml`) |
| `git fetch` with the agent socket, no `known_hosts` | `Host key verification failed` |
| same, with `known_hosts` mounted | `exit=0` ✅ |

The socket alone does not make a push work: a tmpfs home has no host-key file, so ssh cannot verify github.com, has no tty or askpass to ask on, and dies **before** offering the key it was just handed. So `~/.ssh/known_hosts` travels with the socket — the file, never the directory that holds the private keys, and read-only so no blind trust-on-first-use happens inside.

End-to-end in the shipped sandbox with both grants on: `ssh -T git@github.com` greets, `git fetch --prune` lands, `gh pr list` works, rate limit 5000/h. Still out: no private key anywhere in the home, `/run/user/1000/bus` absent, and the second gh account does **not** come along.

## Notes

- The token rides in the child's environment, never through bubblewrap's `--setenv`, which would write it into an argument list any process on the machine can read out of `/proc`.
- The Sandbox pane shows what is loaded in your agent beside the switch that hands it over: that control reads as "let it push with my GitHub key", and it hands over every identity in the list.
- The rung moves into the pane. It used to sit inside every provider's section, so a machine with several enabled drew the same ladder several times — and with no backend the control vanished, leaving the question unanswered instead of answered.
- Grants carry no provider: a grant describes what is inside the sandbox, not who runs in it.
- `system.SandboxAvailable` → `system.SandboxBackend`, which names the backend, because the two have different holes.
- Corrects a claim in `docs/ceilings.md`: gh's token is not among the ones readable under `~/.config` — it lives in the system keyring, which is the whole reason this takes a grant.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean on linux, darwin and windows
- [x] `go test ./...` — 1752 pass
- [x] `pnpm check`, `tsc`, `vitest` (1034), `vite build` all clean
- [x] Sandbox pane driven by CDP in a headless lich: renders, no exceptions, both switches persist to the project scope, the agent list reads the real key
- [x] `git fetch` proven both ways in a hand-built bwrap jail
- [x] Someone on macOS: the grants are inert there by design (the seatbelt profile never removed either credential) — unverified on hardware
