### PR TITLE
feat: let a shortcut be left unassigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now the number was written down in exactly one place — the message typed at the
   prompt — so a session whose context was compacted past it left nobody, agent or
   person, able to close the errand.
-
-### Added
-
 - **A confined session can push and use `gh` again, if you let it.** The sandbox
   gives a session an empty home, which takes the ssh agent and gh's keyring with
   it: `git push` has nothing to sign with and `gh` opens on a login prompt. Two
@@ -44,6 +41,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   several enabled drew the same ladder several times — and on a machine with no
   bubblewrap the control simply vanished, leaving the question unanswered instead
   of answered.
+- **A keyboard shortcut can now be left unassigned.** Settings › Hotkeys gained a
+  clear button beside each binding's reset, because every chord the window claims
+  is a chord the agent's TUI in the terminal never sees, and rebinding lich's
+  action onto some key you will never press was the closest thing to giving one
+  back. Cleared, the action holds no chord at all: it fires on nothing, collides
+  with nothing, and the keypress falls through to the session underneath. The
+  shortcuts sheet reads it as unassigned rather than naming a default it no
+  longer answers to, and reset still puts that default back.
 
 ### Changed
 

--- a/frontend/src/components/common/ShortcutLine.tsx
+++ b/frontend/src/components/common/ShortcutLine.tsx
@@ -1,4 +1,5 @@
 import { Keys } from "@/components/common/Keys"
+import { UNASSIGNED_LABEL } from "@/lib/hotkeys"
 
 // One listed shortcut: what it does on the left, the chord on the right. Shared
 // by the shortcuts overlay and the read-only half of Settings › Hotkeys so the
@@ -7,7 +8,13 @@ export function ShortcutLine({ label, keys }: { label: string; keys: string }) {
   return (
     <div className="flex items-center gap-4 rounded-md px-3 py-1.5 hover:bg-accent/50">
       <span className="min-w-0 flex-1 truncate text-sm">{label}</span>
-      <Keys>{keys}</Keys>
+      {/* An unassigned action has no chord to print, and a key cap around the
+          word would read as a key the user could press. */}
+      {keys === UNASSIGNED_LABEL ? (
+        <span className="shrink-0 text-xs text-muted-foreground">{keys}</span>
+      ) : (
+        <Keys>{keys}</Keys>
+      )}
     </div>
   )
 }

--- a/frontend/src/components/settings/HotkeysSettings.tsx
+++ b/frontend/src/components/settings/HotkeysSettings.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { RotateCcw, TriangleAlert } from "lucide-react"
+import { Ban, RotateCcw, TriangleAlert } from "lucide-react"
 import { useSettings } from "@/providers/settings"
 import {
   comboFromEvent,
@@ -10,6 +10,7 @@ import {
   HOTKEY_ACTIONS,
   HOTKEY_GROUPS,
   sameCombo,
+  UNASSIGNED,
   type HotkeyAction,
   type HotkeyId,
 } from "@/lib/hotkeys"
@@ -35,11 +36,16 @@ function Group({ label, children }: { label: string; children: React.ReactNode }
 // HotkeyRow shows the current combo as a capture button: click to record, press
 // the new combo to save, Escape to cancel. Key events are swallowed while
 // recording so they do not also trigger the very shortcut being rebound.
+//
+// The two trailing buttons are opposite moves and must not read as one: clearing
+// leaves the action with no chord at all, which is how the chord is handed back
+// to the agent's TUI; resetting puts lich's default back.
 function HotkeyRow({ action, conflicts }: { action: HotkeyAction; conflicts?: HotkeyId[] }) {
   const { hotkeys, setHotkey, resetHotkey } = useSettings()
   const [recording, setRecording] = useState(false)
   const combo = hotkeys[action.id]
   const isDefault = sameCombo(combo, DEFAULT_HOTKEYS[action.id])
+  const isUnassigned = !combo.key
 
   const onKeyDown = (event: React.KeyboardEvent) => {
     if (!recording) return
@@ -77,9 +83,8 @@ function HotkeyRow({ action, conflicts }: { action: HotkeyAction; conflicts?: Ho
         onBlur={() => setRecording(false)}
         className={cn(
           "min-w-36 shrink-0 rounded-md border px-3 py-1 text-left text-sm tabular-nums outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring",
-          recording
-            ? "border-ring text-muted-foreground"
-            : "border-border text-foreground hover:bg-accent",
+          recording ? "border-ring text-muted-foreground" : "border-border hover:bg-accent",
+          !recording && (isUnassigned ? "text-muted-foreground" : "text-foreground"),
           conflicts && !recording && "border-amber-500/60",
         )}
       >
@@ -88,7 +93,18 @@ function HotkeyRow({ action, conflicts }: { action: HotkeyAction; conflicts?: Ho
       <Button
         variant="ghost"
         size="icon"
+        aria-label={`Unassign ${action.label} shortcut`}
+        title="Leave this action unbound"
+        disabled={isUnassigned}
+        onClick={() => setHotkey(action.id, UNASSIGNED)}
+      >
+        <Ban />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
         aria-label={`Reset ${action.label} shortcut`}
+        title="Restore the default shortcut"
         disabled={isDefault}
         onClick={() => resetHotkey(action.id)}
       >

--- a/frontend/src/lib/hotkeys.test.ts
+++ b/frontend/src/lib/hotkeys.test.ts
@@ -10,6 +10,8 @@ import {
   mergeHotkeys,
   sameCombo,
   saveHotkeys,
+  UNASSIGNED,
+  UNASSIGNED_LABEL,
   type Combo,
   type KeyState,
 } from "./hotkeys"
@@ -66,6 +68,14 @@ describe("matchesCombo", () => {
   it("rejects a different key", () => {
     expect(matchesCombo(key({ ctrlKey: true, shiftKey: true, key: "N" }), newSession)).toBe(false)
   })
+
+  // The point of an unassigned action: nothing fires it, so the chord the user
+  // freed reaches the PTY the way it would if lich had never bound it.
+  it("never matches an unassigned combo", () => {
+    expect(matchesCombo(key({ ctrlKey: true, shiftKey: true, key: "T" }), UNASSIGNED)).toBe(false)
+    expect(matchesCombo(key({}), UNASSIGNED)).toBe(false)
+    expect(matchesCombo(key({ ctrlKey: true, key: "" }), UNASSIGNED)).toBe(false)
+  })
 })
 
 describe("comboFromEvent", () => {
@@ -107,6 +117,14 @@ describe("formatCombo", () => {
   it("uses symbols with no separator on macOS", () => {
     expect(formatCombo(combo, true)).toBe("⌘⇧T")
   })
+
+  it("names an unassigned combo instead of printing modifiers alone", () => {
+    expect(formatCombo(UNASSIGNED, false)).toBe(UNASSIGNED_LABEL)
+    expect(formatCombo(UNASSIGNED, true)).toBe(UNASSIGNED_LABEL)
+    expect(formatCombo({ mod: true, shift: true, alt: false, key: "" }, false)).toBe(
+      UNASSIGNED_LABEL,
+    )
+  })
 })
 
 describe("mergeHotkeys", () => {
@@ -140,6 +158,18 @@ describe("mergeHotkeys", () => {
     )
   })
 
+  it("keeps an unassigned action unassigned", () => {
+    expect(mergeHotkeys({ newSession: UNASSIGNED }).newSession).toEqual(UNASSIGNED)
+  })
+
+  it("folds modifiers with no key into the one unassigned shape", () => {
+    // What a hand-edited store can hold: nothing to press, but flags set. Two
+    // shapes for one nothing would read as a conflict and as a live binding.
+    expect(
+      mergeHotkeys({ newSession: { mod: true, shift: true, alt: true, key: "" } }).newSession,
+    ).toEqual(UNASSIGNED)
+  })
+
   it("drops malformed entries and non-objects", () => {
     expect(mergeHotkeys({ newSession: { mod: 1, key: "" } })).toEqual(DEFAULT_HOTKEYS)
     expect(mergeHotkeys(null)).toEqual(DEFAULT_HOTKEYS)
@@ -171,6 +201,17 @@ describe("hotkeyConflicts", () => {
     expect(conflicts.nextSession).toEqual(["newSession", "prevSession"])
   })
 
+  // Nothing is not a chord two actions can both hold: an unassigned action is
+  // bound to no key, so it collides with nothing, including another one.
+  it("never reports an unassigned action as a conflict", () => {
+    const conflicts = hotkeyConflicts({
+      ...DEFAULT_HOTKEYS,
+      newSession: UNASSIGNED,
+      nextSession: UNASSIGNED,
+    })
+    expect(conflicts).toEqual({})
+  })
+
   it("treats combos differing only in a modifier as distinct", () => {
     const conflicts = hotkeyConflicts({
       ...DEFAULT_HOTKEYS,
@@ -184,6 +225,12 @@ describe("sameCombo", () => {
   it("compares every field", () => {
     expect(sameCombo(DEFAULT_HOTKEYS.newSession, DEFAULT_HOTKEYS.newSession)).toBe(true)
     expect(sameCombo(DEFAULT_HOTKEYS.newSession, DEFAULT_HOTKEYS.commandPalette)).toBe(false)
+  })
+
+  // What the settings row reads to decide whether Reset and Unassign are live.
+  it("separates unassigned from a real binding", () => {
+    expect(sameCombo(UNASSIGNED, UNASSIGNED)).toBe(true)
+    expect(sameCombo(UNASSIGNED, DEFAULT_HOTKEYS.newSession)).toBe(false)
   })
 })
 
@@ -201,6 +248,19 @@ describe("loadHotkeys", () => {
     saveHotkeys({ ...DEFAULT_HOTKEYS, newSession: mine })
 
     expect(loadHotkeys().newSession).toEqual(mine)
+  })
+
+  it("round-trips an unassigned action, and takes its default back on reset", () => {
+    saveHotkeys({ ...DEFAULT_HOTKEYS, newSession: UNASSIGNED })
+    const cleared = loadHotkeys()
+    expect(cleared.newSession).toEqual(UNASSIGNED)
+    expect(matchesCombo(key({ ctrlKey: true, shiftKey: true, key: "T" }), cleared.newSession)).toBe(
+      false,
+    )
+
+    // What resetHotkey writes back (settings.tsx): the default for that id.
+    saveHotkeys({ ...cleared, newSession: DEFAULT_HOTKEYS.newSession })
+    expect(loadHotkeys()).toEqual(DEFAULT_HOTKEYS)
   })
 
   // A pref must never be able to break a launch: the value is a string somebody

--- a/frontend/src/lib/hotkeys.ts
+++ b/frontend/src/lib/hotkeys.ts
@@ -44,6 +44,14 @@ export interface Combo {
   key: string
 }
 
+// The stored value of an action bound to nothing: the empty key is what makes
+// it unassigned, and no keypress can produce one, so it never matches. It is
+// how a user gives a chord back to the TUI in the terminal, which never sees a
+// chord the window claims for itself.
+export const UNASSIGNED: Combo = { mod: false, shift: false, alt: false, key: "" }
+
+export const UNASSIGNED_LABEL = "Unassigned"
+
 export interface HotkeyAction {
   id: HotkeyId
   label: string
@@ -222,6 +230,7 @@ export function matchesCombo(event: KeyState, combo: Combo): boolean {
   // A held chord auto-repeats; every action here is a discrete command (spawn
   // a session, toggle the palette), so only the initial press may fire.
   if (event.repeat) return false
+  if (!combo.key) return false
   const mod = event.ctrlKey || event.metaKey
   return (
     mod === combo.mod &&
@@ -277,7 +286,9 @@ export function hotkeyLabel(id: HotkeyId): string {
 export function hotkeyConflicts(hotkeys: Hotkeys): Partial<Record<HotkeyId, HotkeyId[]>> {
   const byCombo = new Map<string, HotkeyId[]>()
   for (const action of HOTKEY_ACTIONS) {
-    const key = comboKey(hotkeys[action.id])
+    const combo = hotkeys[action.id]
+    if (!combo.key) continue
+    const key = comboKey(combo)
     const held = byCombo.get(key)
     if (held) {
       held.push(action.id)
@@ -302,6 +313,7 @@ function formatKey(key: string): string {
 }
 
 export function formatCombo(combo: Combo, isMac: boolean): string {
+  if (!combo.key) return UNASSIGNED_LABEL
   const parts: string[] = []
   if (combo.mod) parts.push(isMac ? "⌘" : "Ctrl")
   if (combo.shift) parts.push(isMac ? "⇧" : "Shift")
@@ -317,8 +329,7 @@ function isCombo(value: unknown): value is Combo {
     typeof c.mod === "boolean" &&
     typeof c.shift === "boolean" &&
     typeof c.alt === "boolean" &&
-    typeof c.key === "string" &&
-    c.key.length > 0
+    typeof c.key === "string"
   )
 }
 
@@ -335,7 +346,11 @@ export function mergeHotkeys(overrides: unknown): Hotkeys {
   if (overrides && typeof overrides === "object") {
     for (const id of Object.keys(DEFAULT_HOTKEYS) as HotkeyId[]) {
       const value = (overrides as Record<string, unknown>)[id]
-      if (isCombo(value)) result[id] = { ...value, key: normalizeKey(value.key) }
+      if (!isCombo(value)) continue
+      // Modifiers with no key are the same nothing as no key at all; folding
+      // them into UNASSIGNED keeps a single stored shape for "bound to nothing",
+      // which is what sameCombo and the conflict buckets compare against.
+      result[id] = value.key ? { ...value, key: normalizeKey(value.key) } : UNASSIGNED
     }
   }
   return result

--- a/frontend/src/lib/shortcuts.test.ts
+++ b/frontend/src/lib/shortcuts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { DEFAULT_HOTKEYS, HOTKEY_ACTIONS, HOTKEY_GROUPS } from "./hotkeys"
+import { DEFAULT_HOTKEYS, HOTKEY_ACTIONS, HOTKEY_GROUPS, UNASSIGNED } from "./hotkeys"
 import { PASSTHROUGH_TITLE, shortcutGroups, TERMINAL_TITLE } from "./shortcuts"
 
 const groupTitled = (
@@ -39,6 +39,13 @@ describe("shortcutGroups", () => {
       commandPalette: { mod: true, shift: false, alt: true, key: "p" },
     }
     expect(keysFor(shortcutGroups(rebound, false, false), "Command palette")).toBe("Ctrl+Alt+P")
+  })
+
+  // The sheet answers "what fires this right now"; listing the default an
+  // action no longer holds would name a chord that does nothing.
+  it("reads an unassigned action as unassigned rather than as its default", () => {
+    const cleared = { ...DEFAULT_HOTKEYS, commandPalette: UNASSIGNED }
+    expect(keysFor(shortcutGroups(cleared, false, false), "Command palette")).toBe("Unassigned")
   })
 
   it("lists the terminal search, which is bound but not rebindable", () => {


### PR DESCRIPTION
Settings › Hotkeys could rebind a shortcut or reset it to lich's default, but not leave an action with no chord at all. Every chord the window claims is a chord the agent's TUI never sees, and the closest a user could get to handing one back was rebinding the action onto a key they would then never press.

## What changed

An empty key is now a valid stored combo:

- **It never matches.** `matchesCombo` bails on an empty key, so the keypress falls through to the PTY exactly as if lich had never bound it.
- **It is not a conflict.** `hotkeyConflicts` skips unassigned actions — nothing is not a chord two actions can both hold, so two cleared actions do not collide either.
- **It reads as "Unassigned".** `formatCombo` returns the label before printing modifiers, which is what the shortcuts sheet renders; an unassigned action no longer lists a default it stopped answering to.
- **It round-trips.** `isCombo` accepts an empty key, and `mergeHotkeys` folds modifiers-with-no-key into the single `UNASSIGNED` shape, so a hand-edited store cannot hold two spellings of nothing — which would otherwise read as a conflict and as a live binding at once.

`HotkeyRow` gained a clear button beside its reset. They are opposite moves and read that way: one leaves the action unbound, the other puts lich's default back, each disabled at its own end. In the shortcuts sheet an unassigned row renders as muted text rather than a key cap, because a `<kbd>` around the word would read as a key you could press.

`lib/shortcuts.ts` needed no change — it already goes through `formatCombo`.

The module is otherwise untouched: the diff is guards and one constant, not a restructure.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test ./...` green
- [x] `pnpm check` clean (biome exit 0)
- [x] `vitest run` green — 1047 tests, 7 new in `hotkeys.test.ts` and 1 in `shortcuts.test.ts`: empty never matches, is never a conflict, formats as Unassigned, round-trips through settings, resets back to its default, and the help sheet reads it as unassigned
- [x] `pnpm build` (tsc + vite) succeeds
- [x] By hand in `task dev`: clear a binding in Settings › Hotkeys, confirm the chord reaches the agent's TUI, and check both the row and the shortcuts sheet — the vitest gate is node-only, so neither render path is covered by the suite