### PR TITLE
feat: open a session's checkout from its card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with nothing, and the keypress falls through to the session underneath. The
   shortcuts sheet reads it as unassigned rather than naming a default it no
   longer answers to, and reset still puts that default back.
+- **A card can open its own checkout.** Right-click a session and *Open in
+  editor* opens its folder in `$VISUAL`/`$EDITOR` — a terminal editor lands in a
+  new shell session at the checkout, the same as opening a single file from the
+  files panel — while *Open folder* shows it in the system file manager. Getting
+  to a worktree from outside lich meant reading the path off the card and typing
+  it somewhere else, and a worktree path is exactly the kind nobody types twice.
+  A card whose checkout was removed behind lich's back says so instead of
+  launching at nothing.
 
 ### Changed
 

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -6,6 +6,8 @@ import {
   ArrowRight,
   CircleQuestionMark,
   CornerDownLeft,
+  FolderCode,
+  FolderOpen,
   GitBranch,
   GitPullRequestArrow,
   Inbox,
@@ -19,7 +21,8 @@ import {
   X,
 } from "lucide-react"
 import { useSortable } from "@dnd-kit/sortable"
-import { cn } from "@/lib/utils"
+import { toast } from "sonner"
+import { cn, errorText } from "@/lib/utils"
 import { dragStyle } from "@/lib/use-sortable-list"
 import { displayPath } from "@/lib/paths"
 import type { Session } from "@/lib/session/sessions"
@@ -46,7 +49,8 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
-import { Terminal as TerminalService } from "@/lib/rpc"
+import { System, Terminal as TerminalService } from "@/lib/rpc"
+import { queuePaste } from "@/lib/terminal/paste-queue"
 import type { DelegateGroup } from "@/lib/session/delegate-targets"
 import { delegatePrompt, delegateWorktreePrompt } from "@/lib/session/delegate-prompt"
 import { bracketedPaste } from "@/lib/terminal/bracketed-paste"
@@ -68,10 +72,11 @@ interface SessionCardProps {
   // Pin the card to the head of the list, or unpin it. A pinned card offers no
   // close affordance at all — unpinning is the way back to closing it.
   onPin: (pinned: boolean) => void
-  // Open a shell session rooted at this card's shown directory. Wired only for
-  // agent sessions, so the user can drop into a terminal in the worktree the
-  // agent is working in without cd-ing there by hand.
-  onOpenTerminal: (cwd: string) => void
+  // Open a shell session rooted at this card's shown directory, and answer with
+  // its id. The menu item is wired for agent sessions alone — the user dropping
+  // into a terminal in the worktree the agent works in, without cd-ing there by
+  // hand — but the id is what lets a terminal editor be launched in it.
+  onOpenTerminal: (cwd: string) => string
   // Record the command this terminal opens into, "" to clear it back to a plain
   // shell. Offered on shell sessions alone: on a provider card the entrypoint is
   // the provider, and the store refuses one there anyway.
@@ -161,6 +166,28 @@ export function SessionCard({
   const delegateWorktree = () => {
     void TerminalService.Write(session.id, bracketedPaste(delegateWorktreePrompt(session.kind)))
     requestTerminalFocus(session.id)
+  }
+
+  // Open this card's checkout, the folder itself. The backend either launched a
+  // GUI editor detached (empty reply) or handed back the command line for a
+  // terminal editor: run that in a shell session at the checkout, the way the
+  // files panel does for a single file.
+  const openFolderInEditor = () => {
+    void System.OpenFolderInEditor(shownPath)
+      .then((command) => {
+        if (command) {
+          queuePaste(onOpenTerminal(shownPath), `${command}\n`)
+        }
+      })
+      .catch((error) => toast.error(`Could not open the checkout: ${errorText(error)}`))
+  }
+
+  // A worktree removed outside lich leaves its card behind, so both openers
+  // report a checkout that is gone rather than launching at nothing.
+  const openFolder = () => {
+    void System.OpenFolder(shownPath).catch((error) =>
+      toast.error(`Could not open the folder: ${errorText(error)}`),
+    )
   }
 
   // Every provider can delegate, and no live target is required: the picker's
@@ -511,6 +538,14 @@ export function SessionCard({
               Open Terminal
             </ContextMenuItem>
           )}
+          <ContextMenuItem onClick={openFolderInEditor}>
+            <FolderCode />
+            Open in editor
+          </ContextMenuItem>
+          <ContextMenuItem onClick={openFolder}>
+            <FolderOpen />
+            Open folder
+          </ContextMenuItem>
           <ContextMenuItem onClick={onPulls}>
             <GitPullRequestArrow />
             Pull request

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -412,6 +412,13 @@ export const System = {
    * Returns "" when it launched a GUI editor detached, or a shell command line
    * to run in a terminal session when the editor is a terminal editor. */
   OpenInEditor: (dir: string, rel: string) => call<string>("system.OpenInEditor", [dir, rel]),
+  /** Open a session's checkout — the folder itself — in $VISUAL/$EDITOR. Same
+   * two answers as OpenInEditor: "" for a detached GUI launch, or a shell
+   * command line to run in a terminal session. */
+  OpenFolderInEditor: (dir: string) => call<string>("system.OpenFolderInEditor", [dir]),
+  /** Show a session's checkout in the platform's file manager. Rejects a path
+   * that is no longer a folder, so a card outliving its worktree says so. */
+  OpenFolder: (dir: string) => call<null>("system.OpenFolder", [dir]),
   /** Version, platform and log path — the page cannot derive any of the three. */
   Diagnostics: () => call<DiagnosticsData>("system.Diagnostics", []),
   /** Open the log's folder in the platform's file manager, for attaching it. */

--- a/internal/sandbox/agent_unix_test.go
+++ b/internal/sandbox/agent_unix_test.go
@@ -14,11 +14,25 @@ import (
 
 // listenUnix puts a real socket on disk and returns its path: what the ssh
 // agent leaves behind, and the only thing AgentSocket is willing to mount.
-func listenUnix(t *testing.T, path string) string {
+//
+// The directory is its own, deliberately not the caller's t.TempDir(): a unix
+// address is capped at 104 bytes on macOS and 108 on Linux (sun_path), and
+// TempDir spends most of that before the file name — /var/folders/<32 chars>/T/
+// plus the test's own name is already over the line on macOS, where the bind
+// fails with a bare "invalid argument". Nothing reads the socket's directory:
+// AgentSocket takes the path from SSH_AUTH_SOCK, so the socket has no reason to
+// sit beside the home a test builds.
+func listenUnix(t *testing.T) string {
 	t.Helper()
+	dir, err := os.MkdirTemp("", "l")
+	if err != nil {
+		t.Fatalf("temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	path := filepath.Join(dir, "a.sock")
 	listener, err := net.Listen("unix", path)
 	if err != nil {
-		t.Fatalf("listen on %s: %v", path, err)
+		t.Fatalf("listen on %s (%d bytes): %v", path, len(path), err)
 	}
 	t.Cleanup(func() { _ = listener.Close() })
 	return path
@@ -48,7 +62,7 @@ func TestAgentSocketRefusesWhatIsNotASocket(t *testing.T) {
 		}
 	}
 
-	socket := listenUnix(t, filepath.Join(dir, "agent.sock"))
+	socket := listenUnix(t)
 	t.Setenv("SSH_AUTH_SOCK", socket)
 	if got := AgentSocket(); got != socket {
 		t.Errorf("AgentSocket = %q, want %q", got, socket)
@@ -63,7 +77,7 @@ func TestDescribeMountsTheAgentOnlyWhenAsked(t *testing.T) {
 	if err := os.MkdirAll(cwd, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
-	socket := listenUnix(t, filepath.Join(home, "agent.sock"))
+	socket := listenUnix(t)
 	t.Setenv("SSH_AUTH_SOCK", socket)
 	if err := os.MkdirAll(filepath.Join(home, ".ssh"), 0o700); err != nil {
 		t.Fatalf("mkdir .ssh: %v", err)
@@ -131,7 +145,7 @@ func TestDescribeNeverMountsAPrivateKey(t *testing.T) {
 	if err := os.WriteFile(key, []byte("private\n"), 0o600); err != nil {
 		t.Fatalf("write key: %v", err)
 	}
-	t.Setenv("SSH_AUTH_SOCK", listenUnix(t, filepath.Join(home, "agent.sock")))
+	t.Setenv("SSH_AUTH_SOCK", listenUnix(t))
 
 	spec := Describe(providers.Claude, home, cwd, "", nil, true)
 	for _, path := range append(append([]string{}, spec.Read...), spec.Write...) {

--- a/internal/system/open_darwin.go
+++ b/internal/system/open_darwin.go
@@ -20,3 +20,10 @@ func (s *Service) openURL(rawURL string) error {
 func (s *Service) quoteForShell(full string) (string, bool) {
 	return shquote.Quote(full), true
 }
+
+// openFolder shows a directory in Finder. Deliberately without the -t of
+// openDefault: that flag forces the default *text editor*, which is what a
+// source file wants and what a folder has no use for.
+func (s *Service) openFolder(dir string) error {
+	return s.run("open", dir)
+}

--- a/internal/system/open_linux.go
+++ b/internal/system/open_linux.go
@@ -19,3 +19,10 @@ func (s *Service) openURL(rawURL string) error {
 func (s *Service) quoteForShell(full string) (string, bool) {
 	return shquote.Quote(full), true
 }
+
+// openFolder shows a directory in the desktop's file manager. Same resolver as
+// openDefault: xdg-open already answers a directory with the file manager
+// rather than an editor.
+func (s *Service) openFolder(dir string) error {
+	return s.run("xdg-open", dir)
+}

--- a/internal/system/open_windows.go
+++ b/internal/system/open_windows.go
@@ -22,3 +22,10 @@ func (s *Service) quoteForShell(full string) (string, bool) {
 func (s *Service) openURL(rawURL string) error {
 	return s.run("rundll32", "url.dll,FileProtocolHandler", rawURL)
 }
+
+// openFolder shows a directory in File Explorer. Same launcher as openDefault,
+// and for the same reason: explorer takes the path as a plain argument, with no
+// shell in between to read & | < > out of it.
+func (s *Service) openFolder(dir string) error {
+	return s.run("explorer", dir)
+}

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -102,7 +103,7 @@ func (s *Service) RevealLog() error {
 	if s.logPath == "" {
 		return fmt.Errorf("no log file: lich is logging to stderr only")
 	}
-	return s.openDefault(filepath.Dir(s.logPath))
+	return s.openFolder(filepath.Dir(s.logPath))
 }
 
 // notifyTitle is the app name carried by every notification lich raises. macOS
@@ -170,7 +171,46 @@ func (s *Service) OpenInEditor(dir, rel string) (string, error) {
 	if err := relpath.Validate(rel); err != nil {
 		return "", err
 	}
-	full := filepath.Join(dir, rel)
+	return s.openInEditor(filepath.Join(dir, rel), s.openDefault)
+}
+
+// OpenFolderInEditor opens a session's checkout — the directory itself, not a
+// file under it — exactly the way OpenInEditor opens one of its files, terminal
+// editors included.
+func (s *Service) OpenFolderInEditor(dir string) (string, error) {
+	if err := requireDir(dir); err != nil {
+		return "", err
+	}
+	return s.openInEditor(dir, s.openFolder)
+}
+
+// OpenFolder shows a checkout in the platform's file manager. It never consults
+// $VISUAL/$EDITOR: this is the way out of lich to the OS's own view of the
+// folder, which is the one thing opening it in an editor does not give.
+func (s *Service) OpenFolder(dir string) error {
+	if err := requireDir(dir); err != nil {
+		return err
+	}
+	return s.openFolder(dir)
+}
+
+// requireDir refuses a path that is not a directory any more, naming it. lich
+// watches no checkout: a worktree removed from a terminal, or a project folder
+// moved, still has its card, and a launcher handed the dead path either does
+// nothing or fails somewhere nobody is looking.
+func requireDir(dir string) error {
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return fmt.Errorf("this folder is gone: %s", dir)
+	}
+	return nil
+}
+
+// openInEditor resolves the editor for one absolute target — a file or a
+// directory — and either launches it or hands back the command line to run.
+// fallback opens the target without an editor, and differs by what it is: a
+// file goes to its default handler, a folder to the file manager.
+func (s *Service) openInEditor(full string, fallback func(string) error) (string, error) {
 	editor := s.getenv("VISUAL")
 	if editor == "" {
 		editor = s.getenv("EDITOR")
@@ -184,23 +224,23 @@ func (s *Service) OpenInEditor(dir, rel string) (string, error) {
 		// worse than not using the editor.
 		quoted, ok := s.quoteForShell(full)
 		if !ok {
-			return "", s.openDefault(full)
+			return "", fallback(full)
 		}
 		return editor + " " + quoted, nil
 	}
 	if editor != "" {
-		return "", s.runEditor(editor, full)
+		return "", s.runEditor(editor, full, fallback)
 	}
-	return "", s.openDefault(full)
+	return "", fallback(full)
 }
 
 // runEditor launches a GUI $EDITOR value that may carry flags ("code --wait"),
-// appending the file as the final argument. An all-whitespace value degrades to
-// the default opener rather than launching an empty command.
-func (s *Service) runEditor(editor, full string) error {
+// appending the target as the final argument. An all-whitespace value degrades
+// to the fallback opener rather than launching an empty command.
+func (s *Service) runEditor(editor, full string, fallback func(string) error) error {
 	fields := strings.Fields(editor)
 	if len(fields) == 0 {
-		return s.openDefault(full)
+		return fallback(full)
 	}
 	args := append(fields[1:], full)
 	return s.run(fields[0], args...)

--- a/internal/system/system_test.go
+++ b/internal/system/system_test.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -385,5 +386,108 @@ func TestNotifyRejectsEmpty(t *testing.T) {
 	}
 	if raised {
 		t.Error("an empty notification reached the desktop")
+	}
+}
+
+// TestOpenFolderLaunchesTheFileManager proves the checkout itself reaches the
+// opener as a plain argument, with no shell in between.
+func TestOpenFolderLaunchesTheFileManager(t *testing.T) {
+	var name string
+	var args []string
+	dir := t.TempDir()
+	s := &Service{run: captureRun(&name, &args)}
+
+	if err := s.OpenFolder(dir); err != nil {
+		t.Fatalf("OpenFolder: %v", err)
+	}
+	if name == "cmd" || name == "sh" || name == "bash" {
+		t.Errorf("launcher is %q: the path must not route through a shell", name)
+	}
+	if len(args) == 0 || args[len(args)-1] != dir {
+		t.Errorf("args = %v, want the directory %q as the last argument", args, dir)
+	}
+}
+
+// TestOpenFolderRefusesAPathThatIsGone proves a card whose worktree was removed
+// outside lich says so rather than launching a file manager at nothing. A file
+// counts as gone too: it is not the checkout the card is offering.
+func TestOpenFolderRefusesAPathThatIsGone(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.txt")
+	if err := os.WriteFile(file, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{filepath.Join(dir, "gone"), file, ""} {
+		launched := false
+		s := &Service{run: func(string, ...string) error {
+			launched = true
+			return nil
+		}}
+		if err := s.OpenFolder(path); err == nil {
+			t.Errorf("want %q refused", path)
+		}
+		if launched {
+			t.Errorf("%q was opened anyway", path)
+		}
+		if _, err := s.OpenFolderInEditor(path); err == nil || launched {
+			t.Errorf("want %q refused by the editor path too", path)
+		}
+	}
+}
+
+// TestOpenFolderInEditorOpensTheCheckout proves the folder goes to $EDITOR the
+// same way a file does — and that a terminal editor still hands back a command
+// line instead of being launched with no controlling terminal.
+func TestOpenFolderInEditorOpensTheCheckout(t *testing.T) {
+	var name string
+	var args []string
+	dir := t.TempDir()
+	s := &Service{env: []string{"EDITOR=code --wait"}, run: captureRun(&name, &args)}
+
+	cmd, err := s.OpenFolderInEditor(dir)
+	if err != nil {
+		t.Fatalf("OpenFolderInEditor: %v", err)
+	}
+	if cmd != "" {
+		t.Errorf("cmd = %q, want a detached GUI launch", cmd)
+	}
+	if name != "code" || len(args) != 2 || args[0] != "--wait" || args[1] != dir {
+		t.Errorf("launched %q %v, want code --wait %q", name, args, dir)
+	}
+
+	terminal := &Service{env: []string{"EDITOR=nvim"}, run: func(string, ...string) error {
+		t.Error("a terminal editor must not be launched detached")
+		return nil
+	}}
+	cmd, err = terminal.OpenFolderInEditor(dir)
+	if err != nil {
+		t.Fatalf("OpenFolderInEditor: %v", err)
+	}
+	if !strings.HasPrefix(cmd, "nvim ") || !strings.Contains(cmd, dir) {
+		t.Errorf("cmd = %q, want nvim on %q", cmd, dir)
+	}
+}
+
+// TestOpenFolderInEditorWithoutAnEditorShowsTheFolder proves the no-$EDITOR
+// fallback is the file manager, not the default *file* handler: on macOS that
+// one forces the text editor, which has nothing to open a folder with.
+func TestOpenFolderInEditorWithoutAnEditorShowsTheFolder(t *testing.T) {
+	var name string
+	var args []string
+	dir := t.TempDir()
+	s := &Service{run: captureRun(&name, &args)}
+
+	cmd, err := s.OpenFolderInEditor(dir)
+	if err != nil {
+		t.Fatalf("OpenFolderInEditor: %v", err)
+	}
+	if cmd != "" {
+		t.Errorf("cmd = %q, want nothing to run in a terminal", cmd)
+	}
+	if runtime.GOOS == "darwin" && len(args) > 1 {
+		t.Errorf("args = %v, want the folder alone — -t is the text-editor flag", args)
+	}
+	if len(args) == 0 || args[len(args)-1] != dir {
+		t.Errorf("launched %q %v, want the folder %q", name, args, dir)
 	}
 }


### PR DESCRIPTION
Getting from a card to its worktree outside lich meant reading the path off the card and typing it somewhere else — and a worktree path is exactly the kind nobody types twice. The session context menu now carries two items for the checkout itself:

- **Open in editor** — the folder in `$VISUAL`/`$EDITOR`.
- **Open folder** — the folder in the system file manager.

## How it reuses what was there

`System.OpenInEditor` already resolved the editor for a *file* in the dock's files panel: GUI editors launch detached, terminal editors hand back a command line the panel runs in a fresh shell session (a detached launch would give them no controlling terminal). That tail is now `openInEditor(full, fallback)`, and the two new methods — `OpenFolderInEditor` and `OpenFolder` — reuse it whole. The card runs a returned command line the same way the panel does, which is why `onOpenTerminal` now answers with the session id it created; `SessionGroup`'s handler already returned it.

`fallback` is the parameter the split needed: with no `$EDITOR` set, a file goes to its default handler and a folder to the file manager, and those are not the same launcher.

## OS seam

`openFolder` is new beside `openDefault` in `open_linux.go` / `open_darwin.go` / `open_windows.go`. Linux and Windows reuse their existing launcher; macOS drops the `-t` of `openDefault`, which forces the default *text editor* — right for a source file, and with nothing to open a folder with. `RevealLog` routes through it too: it was already handing a directory to the file opener, so that was the same latent macOS bug in a sibling caller.

## A card that outlived its checkout

Both openers go through `requireDir` first. A worktree removed behind lich's back leaves its card, and a launcher fired at a dead path either does nothing or fails where nobody is looking — so it is refused by name (`this folder is gone: <path>`) and the card shows it in a toast.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` — 1780 tests
- [x] `for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done`
- [x] `pnpm check`, `vitest run` (1047), `pnpm build`
- [x] Four new tests in `internal/system/system_test.go`: the folder reaches the opener as a plain argument with no shell in between; a missing path, a file and `""` are refused by both openers with nothing launched; a GUI editor gets the folder and a terminal editor returns a command line; the no-`$EDITOR` fallback is the file manager, asserting no `-t` on darwin.
- [x] Both items exercised by hand in `task dev`.

## Also here: macOS CI was already red

`main` has been failing on the macOS runner since the ssh-agent grant landed (#347) — `f97688d` green, `f4cb379` and `971dcf9` red — so this branch inherited it. Three tests in `internal/sandbox/agent_unix_test.go` bind a real socket at `t.TempDir()/agent.sock`, and macOS caps a unix address at 104 bytes (`sun_path`): `/var/folders/<32 chars>/T/<test name><10 digits>/001/` spends most of that before the file name, and the bind comes back as a bare `invalid argument`.

`listenUnix` now makes its own short directory rather than taking a path from the caller. Nothing reads the socket's parent — `AgentSocket` takes the path from `SSH_AUTH_SOCK` — so it never had a reason to sit beside the home a test builds. The failure message carries the byte count now, because the length is the whole story and the OS error does not say it.

Reproduced on Linux (limit 108) by running the package with `TMPDIR` padded to the 49 bytes macOS uses: the same three tests fail with the same error before the change and pass after it. No `CHANGELOG` entry — nothing here reached a published version.

The sibling helper in `display_linux_test.go` has the same shape but is not affected: it is `//go:build linux`, so it never runs on macOS, and its socket has to live under the `XDG_RUNTIME_DIR` the test sets, which on Linux is a five-byte `/tmp`.

## Not in scope

No editor picker, no per-project editor setting, nothing in the dock. The rest of the context menu is untouched — the two items sit between *Open Terminal* and *Pull request*.
