### PR TITLE
docs: name the pkill trap that kills a running lich

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,9 @@ lives in the code, `docs/` and `CHANGELOG.md` — never restate any of it here.
   live in the companion repo `omartelo/lich-plugin`, so an endpoint or payload change breaks a repo this one
   cannot see — move the contract first, then both sides.
 - **Every task**: `task --list`. `task dev` gets its own DB, port and Chromium profile; it never touches an
-  installed lich's workspace.
+  installed lich's workspace. That isolation is one `pkill` wide: a pattern like `chromium-profile` matches the
+  running lich's own window, and killing it exits that backend and every session under it. Kill a rig's browser
+  by the PID it was launched with.
 - **User-facing feature history**: `CHANGELOG.md`.
 
 ## Rules of the codebase


### PR DESCRIPTION
A rig cleanup in one session ran `pkill -9 -f "chromium-profile"`. The pattern matched the installed lich's `--user-data-dir=~/.config/lich/chromium-profile` as much as the rig's own headless — and `chromium-profile-dev` on top of it. Both windows died in the same millisecond, both backends took `main.go`'s `os.Exit(1)`, and the sessions under them went with them.

Timeline, three independent sources:

| time | event |
| --- | --- |
| 21:01:44.725 | the session runs `pkill -9 -f "chromium-profile"` |
| 21:01:45.712 | `lich.log` (installed, :47821): `chromium shell err="signal: killed"` |
| 21:01:45.712 | `lich-dev.log` (`task dev`, :9245): same millisecond, same error |
| 21:01:45 | systemd closes three Chromium scopes, one of them 1d 1h53m old |

Not OOM: `systemd-oomd`, `earlyoom` and `nohang` are all inactive, the journal has no kill, and the peaks were 118M and 183M against 31Gi of RAM.

Nothing to fix in the code — lich cannot defend against an external SIGKILL, and exiting with its window is the Chromium shell's contract. What was missing was the warning, and the `task dev` bullet is where it belongs: that bullet already promises isolation, and the promise holds for files and ports but not for a kill by pattern.

## Test plan

- [x] Documentation only — no Go or frontend file touched, so the gate's build and test steps have nothing to run.