### PR TITLE
fix: end a turn the user interrupts, and mark a finished one unread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a channel, mutex or WaitGroup that no runnable goroutine can still reach —
   which is the shape of a window that stopped updating while the process stayed
   alive. An empty section is the answer too: the hang is somewhere else.
+- **A finished turn now says whether you have read it.** A session that came back
+  while you were away wears the same solid green ring as one you dealt with
+  twenty minutes ago, which is the one question that ring exists to answer. It
+  now fades once you have actually watched that session's card — and only that
+  card, so a sidebar of finished agents shows at a glance which results nobody
+  has collected. The project tab badge and the notifications list read the same
+  mark, so a session cannot be news in one place and read in another.
 
 ### Removed
 
@@ -94,6 +101,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A turn you interrupt no longer spins forever.** Pressing Esc or Ctrl+C to stop
+  an agent mid-turn left its card spinning until some later turn happened to
+  finish — Claude Code, Codex and oh-my-pi all say nothing at all when a turn is
+  stopped, so the last thing lich ever heard was "working". lich now reads the
+  interrupt from the keystroke itself: a lone Esc or Ctrl+C at a session that is
+  mid-turn ends that turn and the card goes quiet. It never reads as a *finished*
+  turn — stopping is not finishing, so no check, no notification, no tab badge —
+  and it never fires for a key pressed at an idle prompt, arriving inside a paste,
+  or belonging to an arrow key or a mouse report. Whatever the agent reports next
+  still wins.
 - **Closing a session hangs up on the agent instead of killing it outright.** A
   card's close sent the process `SIGKILL`, which leaves an agent no chance to run
   its own exit path. Claude Code reads that as a crash: a session killed within

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -28,6 +28,25 @@ work when nobody knows it and that the call site never shows. The mechanism and 
 - **A dropped file has no path, so lich guesses it** (`internal/drop`): a file under neither the session directory
   nor home is *copied*, so an agent told to edit it edits the copy — and that copy is deleted 3 days on, so a path
   pasted into a prompt eventually stops resolving.
+- **An interrupted turn is read off the keystrokes, not from the provider** (`internal/terminal/draft.go`,
+  `hookstate.go`, `Service.noteInterrupt`): Claude Code, Codex and oh-my-pi all skip the hook that ends a turn
+  when the user stops one, so lich publishes `interrupted` itself when a lone Ctrl+C or Escape reaches a session
+  it knows is mid-turn. It is a guess made from bytes, and it has three edges. A provider session running a tool
+  that owns the terminal — an editor opened through a shell command — takes Escape as the interrupt and clears
+  the ring while the turn is still running; the next report from the provider puts it back. opencode does report
+  its own abort, and reports it as the turn *finishing* (`session.status idle`), so an interrupted opencode card
+  wears the same solid ring a completed turn does — nothing in the event says which happened, and the provider's
+  own word outranks the keystroke. Crush reports no state at all, so it has no turn to end and the fallback never
+  fires there. And an errand the relay delivered survives an interrupt on purpose: stopping a turn is not
+  answering the request, so the sender keeps waiting for the target's next turn rather than being told the work
+  is over.
+- **A finished turn is unread until its own card is watched** (`frontend/src/lib/session/session-status-store.ts`,
+  `frontend/src/providers/projects.tsx`): the solid emerald ring means "back from the agent, not read yet", and it
+  fades only for the session whose terminal is on screen **while the window has focus**. Two things follow. A card
+  left focused in a background window keeps its ring solid until the window is touched again, which is the point
+  — but it also means a browser that reports focus oddly never fades one. And the mark lives in the page like the
+  rest of the session state, so a reload starts every session unread again: a turn read twenty minutes ago comes
+  back looking like news, and nothing on screen says the page forgot.
 - **A session close is a hang-up on Unix and a kill on Windows** (`internal/terminal/pty_unix.go`,
   `pty_windows.go`): closing a card signals the agent and gives it `closeGrace` to leave, so its exit path runs —
   hooks, transcripts, whatever it writes on the way out. A ConPTY has no signal to deliver, so the same close on

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -19,7 +19,8 @@ Content-Type: application/json
  "tool": "<tool name>", "detail": "<what it acts on>"}
 ```
 
-States: `busy`, `done`, `waiting`, `idle`. lich rejects anything else.
+States: `busy`, `done`, `waiting`, `idle`. lich rejects anything else — the
+`interrupted` state it publishes to its own window included (see below).
 
 `tool` and `detail` are optional and belong to the pre-tool report alone (see
 below). Both are trimmed and capped at 120 characters — they decorate a state
@@ -168,6 +169,22 @@ a broken script could do was lose a status report.
   finished turn, an inbox count, nothing), which is what an unchanged session
   should show. `waiting` itself is not recorded: it interrupts a turn rather than
   replacing it, so two permission prompts in one turn are two blocks.
+- **The interrupt lich reads itself** — `internal/terminal/draft.go` and
+  `Service.noteInterrupt`: no harness event says "the user stopped this turn"
+  (see the ceiling above), so lich takes it from the keystrokes going into the
+  PTY, which is the one place every provider is alike. A lone `Ctrl+C` or
+  `Escape` — never a byte inside an escape sequence, never one carried in by a
+  bracketed paste — ends a turn `turnLog` already has open, and lich emits
+  `session-status` with the state **`interrupted`**. That state is outbound
+  only: the hook endpoint rejects it like any other unknown word, because it
+  says something only lich is in a position to know. It is deliberately not
+  `done` — stopping a turn is not finishing one, so an interrupted card must
+  not wear the check a completed turn earns. Consumers that know only the four
+  contract states read it as "no state" and clear the indicator, which is the
+  right reading for a session sitting at its prompt with nothing to show. And
+  it is a fallback, never a source of truth: it only ever ends a turn lich
+  heard start, so a `Ctrl+C` clearing a line at an idle prompt says nothing, and
+  the provider's next report overwrites whatever it concluded.
 - **The peer roster** — `internal/relay`, `Observe` and `roster.go`: reads the
   same stream raw, for two questions of its own. Which turn an errand belongs to
   is one (`s.state`, where a mid-turn `waiting` has to keep reading as `busy`).
@@ -182,17 +199,27 @@ a broken script could do was lose a status report.
   switching projects unmounts them, and a status reported meanwhile would be lost.
   `session-tool-store.ts` reads the same event for the tool pair, keeping its own
   keyed entry so a repeat `busy` — which the status store collapses into no
-  change at all — still moves the tool line.
+  change at all — still moves the tool line. The status store also keeps whether
+  each session's state has been **read**: `markSeen` is called for the one
+  session whose terminal is on screen, while the window has focus, and a fresh
+  report clears the mark again. Only `done` reads it — the live states say what
+  they say whether or not anybody is watching.
 - **Render** — `frontend/src/components/sidebar/SessionCard.tsx`: reads the stores
   (`useSessionStatus`, `useSessionTool`) and shows a spinner (`busy`), check
-  (`done`) or bell (`waiting`); any other value, including `idle`, clears the
-  indicator. The tool line sits under the session's label and exists only while
+  (`done`) or bell (`waiting`); any other value, including `idle` and
+  `interrupted`, clears the indicator. A `done` is drawn at two weights
+  (`SessionStatusIcon`, `useSessionUnread`): solid while the finished turn is
+  still unread, faded once the user has watched that card. It is the same mark
+  the tab badge and the notification queue read, so one session cannot be news
+  in one place and read in another. The tool line sits under the session's label and exists only while
   one is reported, so a card outside a turn is exactly the card it was before.
 - **Tab badge** — `frontend/src/components/tabs/ProjectTab.tsx`: reduces a
   project's sessions to one indicator (`useProjectStatus`, ranking `waiting` over
   `busy` over `done`), shown only while the project is not the active one. A
-  `done` stops badging once the project has been on screen; `busy` and `waiting`
-  badge for as long as they hold, being live states rather than notifications.
+  `done` stops badging once *that session's* card has been watched, so a project
+  left with three finished agents in it still badges for the two nobody opened;
+  `busy` and `waiting` badge for as long as they hold, being live states rather
+  than notifications.
 - **Toast + route** — `frontend/src/providers/projects.tsx`: raises an actionable toast
   that navigates to the session's card when a report says `waiting`, skipped for
   the session already focused. It reads the raw event rather than the store: the
@@ -210,8 +237,16 @@ a broken script could do was lose a status report.
 
 ## Known ceilings
 
-- `UserPromptSubmit` → busy, `Stop` → done. An interrupt (Esc) that skips `Stop`
-  can leave a spinner until the next turn resets it.
+- **An interrupted turn is lich's own reading, not a report.** Three harnesses
+  raise nothing when the user stops a turn — measured by driving each CLI at a
+  real PTY against a stub listener and pressing the key mid-turn: Claude Code
+  and Codex both go quiet after their last `busy` (Codex's rollout keeps the
+  `task_started` with no completion beside it), and omp cancels the running
+  tool and reports `busy` again without ever raising `session_stop`. opencode is
+  the exception: an abort raises `session.status idle` within the same second,
+  so its card closes the turn on its own — as a *finished* one, which is the
+  only word its event has. lich therefore reads the interrupt off the PTY
+  instead (below), and the state it publishes is not `done`.
 - Status is retained in the page, not in Go: a reload starts the store empty, so
   a session Claude is already working on shows no indicator until its next
   report. The PTY is backend-owned and survives the reload, so it does keep

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -63,7 +63,8 @@ The only chromatic color in the app. It encodes state, never decorates, and is n
 | language badge hues | file language | diff file header only (`lang-badge.ts`) |
 
 A busy/done/waiting ring wraps the provider glyph (`SessionStatusIcon`); the same three states badge an
-inactive project tab (`ProjectTab`).
+inactive project tab (`ProjectTab`). The done ring carries one opacity step of its own: solid while the
+finished turn is still unread, `emerald-500/30` once the user has watched that card.
 
 ### Typography
 

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -4,7 +4,11 @@ import { Folder, FolderX, MessageSquareText } from "lucide-react"
 import { useProjects } from "@/providers/projects"
 import { useSettings } from "@/providers/settings"
 import { useHotkey } from "@/lib/use-hotkey"
-import { runningSessions, useSessionStatus } from "@/lib/session/use-session-status"
+import {
+  runningSessions,
+  useSessionStatus,
+  useSessionUnread,
+} from "@/lib/session/use-session-status"
 import { SessionStatusIcon } from "@/components/sidebar/SessionStatusIcon"
 import {
   filterPalette,
@@ -342,9 +346,10 @@ function SessionRow({
   onRun: () => void
 }) {
   const status = useSessionStatus(session.sessionId)
+  const unread = useSessionUnread(session.sessionId)
   return (
     <PickerRow selected={selected} onSelect={onSelect} onRun={onRun}>
-      <SessionStatusIcon kind={session.kind} status={status} />
+      <SessionStatusIcon kind={session.kind} status={status} unread={unread} />
       <span className="flex min-w-0 flex-1 flex-col">
         <span className="truncate text-sm">{session.label}</span>
         <span className="truncate font-mono text-xs text-muted-foreground">

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -26,7 +26,11 @@ import { cn, errorText } from "@/lib/utils"
 import { dragStyle } from "@/lib/use-sortable-list"
 import { displayPath } from "@/lib/paths"
 import type { Session } from "@/lib/session/sessions"
-import { useSessionStatus, useSessionStatusAge } from "@/lib/session/use-session-status"
+import {
+  useSessionStatus,
+  useSessionStatusAge,
+  useSessionUnread,
+} from "@/lib/session/use-session-status"
 import { useSessionCwd } from "@/lib/session/use-session-cwd"
 import { useSessionAgent } from "@/lib/session/use-session-agent"
 import { useSessionRelay } from "@/lib/session/use-session-relay"
@@ -117,6 +121,10 @@ export function SessionCard({
   // null before the first report, and whenever the hook reports a state with
   // no indicator (see toSessionStatus) — then the icon shows ringless.
   const status = useSessionStatus(session.id)
+  // Whether that state is news: a turn that finished while the user was
+  // elsewhere, still unread. It fades out of the ring the moment this card is
+  // the one being looked at.
+  const unread = useSessionUnread(session.id)
   // How long that state has lasted, beside the ring: with five agents running,
   // the bells all look alike and the one blocked longest is the one to answer
   // first. "" for the states that have no clock (see useSessionStatusAge).
@@ -326,7 +334,7 @@ export function SessionCard({
                     pinned ? "pr-6" : "pr-11",
                   )}
                 >
-                  <SessionStatusIcon kind={agent ?? session.kind} status={status} />
+                  <SessionStatusIcon kind={agent ?? session.kind} status={status} unread={unread} />
                   {age && (
                     <span className="shrink-0 text-xs tabular-nums text-muted-foreground">
                       {age}

--- a/frontend/src/components/sidebar/SessionStatusIcon.tsx
+++ b/frontend/src/components/sidebar/SessionStatusIcon.tsx
@@ -12,18 +12,34 @@ const RING: Record<SessionStatus, string> = {
   waiting: "border-amber-500",
 }
 
+// A finished turn nobody has read yet keeps the ring at full strength; one that
+// has been read fades to the same weight the busy ring's track carries. Same
+// color, same shape — the only thing the step says is whether this is news,
+// which is the question the ring is there to answer when you come back to a
+// sidebar of finished agents. It is an opacity step on a semantic color, the
+// way every other weight in the app is (frontend/DESIGN.md).
+const READ_RING = "border-emerald-500/30"
+
 interface SessionStatusIconProps {
   kind: SessionKind
   // Last reported state from the lich hook; null renders the bare icon.
   status: SessionStatus | null
+  // Whether that state is a finished turn still waiting to be read. Only "done"
+  // is ever unread (see useSessionUnread).
+  unread: boolean
 }
 
 // The slot is a fixed size so the icon never shifts as the state changes.
-export function SessionStatusIcon({ kind, status }: SessionStatusIconProps) {
+export function SessionStatusIcon({ kind, status, unread }: SessionStatusIconProps) {
   return (
     <span className="relative flex size-[1.375rem] shrink-0 items-center justify-center text-muted-foreground">
       {status && (
-        <span className={cn("absolute inset-0 rounded-full border-[0.09375rem]", RING[status])} />
+        <span
+          className={cn(
+            "absolute inset-0 rounded-full border-[0.09375rem]",
+            status === "done" && !unread ? READ_RING : RING[status],
+          )}
+        />
       )}
       <ProviderIcon kind={kind} size={14} />
     </span>

--- a/frontend/src/components/sidebar/SessionTargetPicker.tsx
+++ b/frontend/src/components/sidebar/SessionTargetPicker.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react"
 import type { KeyboardEvent } from "react"
 import { GitBranchPlus } from "lucide-react"
-import { useSessionStatus } from "@/lib/session/use-session-status"
+import { useSessionStatus, useSessionUnread } from "@/lib/session/use-session-status"
 import { filterTargetRows, flattenTargetGroups, groupTargetRows } from "@/lib/session/target-picker"
 import type { DelegateGroup, DelegateTarget } from "@/lib/session/delegate-targets"
 import { PickerDialog, PickerEmpty, PickerGroup, PickerRow } from "@/components/common/PickerDialog"
@@ -146,9 +146,10 @@ function TargetRowView({
   onPick: () => void
 }) {
   const status = useSessionStatus(target.id)
+  const unread = useSessionUnread(target.id)
   return (
     <PickerRow selected={selected} onSelect={onSelect} onRun={onPick}>
-      <SessionStatusIcon kind={target.kind} status={status} />
+      <SessionStatusIcon kind={target.kind} status={status} unread={unread} />
       <span className="truncate text-sm">{target.label}</span>
     </PickerRow>
   )

--- a/frontend/src/components/sidebar/SidebarRail.tsx
+++ b/frontend/src/components/sidebar/SidebarRail.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/lib/utils"
 import { useProjects } from "@/providers/projects"
 import { activeSessionId, sessionsOf, sidebarGroups, type Session } from "@/lib/session/sessions"
 import { useSessionAgent } from "@/lib/session/use-session-agent"
-import { useSessionStatus } from "@/lib/session/use-session-status"
+import { useSessionStatus, useSessionUnread } from "@/lib/session/use-session-status"
 import { SessionStatusIcon } from "./SessionStatusIcon"
 import { SessionTooltip } from "./SessionTooltip"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
@@ -26,6 +26,7 @@ interface RailSessionProps {
 // go, so it is the card's own tooltip, not a shortened one.
 function RailSession({ session, projectPath, active, onSelect }: RailSessionProps) {
   const status = useSessionStatus(session.id)
+  const unread = useSessionUnread(session.id)
   const agent = useSessionAgent(session.id)
   return (
     <Tooltip>
@@ -42,7 +43,7 @@ function RailSession({ session, projectPath, active, onSelect }: RailSessionProp
           />
         }
       >
-        <SessionStatusIcon kind={agent ?? session.kind} status={status} />
+        <SessionStatusIcon kind={agent ?? session.kind} status={status} unread={unread} />
       </TooltipTrigger>
       <SessionTooltip session={session} path={projectPath} />
     </Tooltip>

--- a/frontend/src/lib/session/session-inbox-store.test.ts
+++ b/frontend/src/lib/session/session-inbox-store.test.ts
@@ -70,4 +70,15 @@ describe("createSessionInboxStore", () => {
 
     expect(store.get("s1")).toBe(0)
   })
+
+  // Stopping a turn is not the session leaving: the results are still there and
+  // the session is still the one able to collect them.
+  it("keeps the count when a turn is interrupted", () => {
+    const { inbox, status, store } = build()
+
+    inbox.emit({ id: "s1", count: 3 })
+    status.emit({ id: "s1", state: "interrupted" })
+
+    expect(store.get("s1")).toBe(3)
+  })
 })

--- a/frontend/src/lib/session/session-status-store.test.ts
+++ b/frontend/src/lib/session/session-status-store.test.ts
@@ -137,8 +137,8 @@ describe("pendingOf", () => {
     expect(store.pendingOf(["mine"])).toBe("busy")
   })
 
-  // Leaving a project marks its sessions seen, so the turn that finished while
-  // the user was in there does not badge the tab they just left.
+  // Leaving a card marks it seen, so the turn that finished while it was on
+  // screen does not badge the tab the user just walked away from.
   it("drops a done once seen, and keeps live states regardless", () => {
     const { source, emit } = fakeSource()
     const store = createSessionStatusStore(source)
@@ -194,6 +194,52 @@ describe("pendingOf", () => {
     const { source } = fakeSource()
     const store = createSessionStatusStore(source)
     expect(() => store.markSeen("ghost")).not.toThrow()
+  })
+})
+
+// The question the card's ring asks: is this finished turn news, or something
+// already read? Nothing else on the card could answer it — "done" looks the
+// same an hour later as it does the second it lands.
+describe("unread", () => {
+  it("is a finished turn nobody has looked at", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "done"))
+    expect(store.unread("s1")).toBe(true)
+    store.markSeen("s1")
+    expect(store.unread("s1")).toBe(false)
+  })
+
+  it("comes back for the next turn that finishes", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "done"))
+    store.markSeen("s1")
+    emit(report("s1", "busy"))
+    emit(report("s1", "done"))
+    expect(store.unread("s1")).toBe(true)
+  })
+
+  it("is never claimed by a live state or by a session nobody reported", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "busy"))
+    emit(report("s2", "waiting"))
+    expect(store.unread("s1")).toBe(false)
+    expect(store.unread("s2")).toBe(false)
+    expect(store.unread("ghost")).toBe(false)
+  })
+
+  // Stopping a turn is not finishing one: there is nothing to come back and
+  // read, so the ring goes out rather than turning solid.
+  it("is not claimed by an interrupted turn", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "busy"))
+    emit(report("s1", "interrupted"))
+    expect(store.get("s1")).toBeNull()
+    expect(store.unread("s1")).toBe(false)
+    expect(store.pendingOf(["s1"])).toBeNull()
   })
 })
 

--- a/frontend/src/lib/session/session-status-store.ts
+++ b/frontend/src/lib/session/session-status-store.ts
@@ -27,11 +27,15 @@ interface Entry {
   // same state repeatedly while a turn runs, and a session has been waiting
   // since it started waiting, not since the last report said so again.
   since: number
-  // Whether the user has had a chance to see the current status, which only
-  // "done" cares about: it is the one state that persists with nothing running,
-  // so a finished turn would badge its project tab forever. "busy" and
-  // "waiting" are live — a tab left mid-run should keep saying so, and a
-  // permission prompt left unanswered is still blocking.
+  // Whether the user has read the current status, which only "done" cares
+  // about: it is the one state that persists with nothing running, so a
+  // finished turn would badge its project tab forever and its ring would say
+  // "back from the agent" long after it was read. "busy" and "waiting" are
+  // live — a tab left mid-run should keep saying so, and a permission prompt
+  // left unanswered is still blocking. Reading is per session and not per
+  // project: the card whose terminal is on screen is the one that was looked
+  // at, and the sessions beside it in the sidebar are exactly the ones whose
+  // results nobody has collected yet (see the provider's markSessionSeen).
   seen: boolean
   listeners: Set<() => void>
 }
@@ -122,9 +126,9 @@ export function createSessionStatusStore(source: SessionEventSource) {
     refreshPending()
   })
 
-  // markSeen records that a session's status has been on screen — its project
-  // was opened, or was open when the status arrived. Only a "done" changes
-  // appearance from it (see Entry.seen), so only that notifies.
+  // markSeen records that a session's status has been read — its card was
+  // focused, or was on screen and being watched when the status arrived. Only a
+  // "done" changes appearance from it (see Entry.seen), so only that notifies.
   const markSeen = (id: string): void => {
     const entry = entries.get(id)
     if (!entry || entry.seen) {
@@ -138,7 +142,7 @@ export function createSessionStatusStore(source: SessionEventSource) {
   }
 
   // pendingOf reduces a project's sessions to the one status its tab should
-  // badge, or null when there is nothing to say. A seen "done" says nothing.
+  // badge, or null when there is nothing to say. A read "done" says nothing.
   const pendingOf = (ids: readonly string[]): SessionStatus | null => {
     const live = new Set<SessionStatus>()
     for (const id of ids) {
@@ -175,6 +179,15 @@ export function createSessionStatusStore(source: SessionEventSource) {
 
   const get = (id: string): SessionStatus | null => entries.get(id)?.status ?? null
 
+  // unread is the one question the card's ring asks beyond the status itself:
+  // a turn that finished and has not been looked at since. Only "done" can be
+  // unread — the live states say what they say whether or not anyone is
+  // watching — so everything else answers false.
+  const unread = (id: string): boolean => {
+    const entry = entries.get(id)
+    return entry?.status === "done" && !entry.seen
+  }
+
   // since answers when the current status started, or null when there is no
   // status to time — including for an entry a subscriber opened before the
   // first report landed.
@@ -196,5 +209,15 @@ export function createSessionStatusStore(source: SessionEventSource) {
   // changes, so it is safe to hand straight to useSyncExternalStore.
   const pendingAll = (): PendingStatus[] => pending
 
-  return { subscribe, get, since, markSeen, pendingOf, runningOf, subscribeAll, pendingAll }
+  return {
+    subscribe,
+    get,
+    unread,
+    since,
+    markSeen,
+    pendingOf,
+    runningOf,
+    subscribeAll,
+    pendingAll,
+  }
 }

--- a/frontend/src/lib/session/session-tool-store.test.ts
+++ b/frontend/src/lib/session/session-tool-store.test.ts
@@ -110,6 +110,15 @@ describe("createSessionToolStore", () => {
     expect(listener).toHaveBeenCalledTimes(1)
   })
 
+  // Leaving "busy" is what clears the line, whatever ended the turn — the tool
+  // the user stopped is no more still running than one that finished.
+  it("clears the tool when the turn is interrupted", () => {
+    const { store, status } = harness()
+    status({ id: "s1", state: "busy", tool: "Bash", detail: "pnpm test" })
+    status({ id: "s1", state: "interrupted" })
+    expect(store.get("s1")).toBeNull()
+  })
+
   it("notifies when only the detail moves", () => {
     const { store, status } = harness()
     const listener = vi.fn()

--- a/frontend/src/lib/session/use-session-status.ts
+++ b/frontend/src/lib/session/use-session-status.ts
@@ -17,6 +17,19 @@ export function useSessionStatus(sessionId: string): SessionStatus | null {
   return useKeyedStore(store, sessionId)
 }
 
+// useSessionUnread is whether this session's finished turn is still waiting to
+// be read — the news the ring exists to carry. False for every other status,
+// and false again the moment the card is focused (see markSessionSeen). It
+// subscribes to the same per-session entry the status does, which is what
+// markSeen notifies on a "done".
+export function useSessionUnread(sessionId: string): boolean {
+  const subscribe = useCallback(
+    (onChange: () => void) => store.subscribe(sessionId, onChange),
+    [sessionId],
+  )
+  return useSyncExternalStore(subscribe, () => store.unread(sessionId))
+}
+
 // useSessionStatusAge returns how long the session has been in its current
 // status, short and relative ("40s", "12m", "3h"), or "" for a status with no
 // clock worth reading.
@@ -46,9 +59,10 @@ export function useSessionStatusAge(sessionId: string): string {
   return started === null ? "" : formatAge(now - started)
 }
 
-// markSessionSeen records that a session's status has been on screen, so a
-// finished turn stops badging its project's tab. Called from the provider,
-// outside React's render.
+// markSessionSeen records that a session's status has been read — its card is
+// the one on screen and the window is being looked at — so a finished turn
+// stops badging its project's tab, drops out of the notification queue, and
+// lets its ring fade. Called from the provider, outside React's render.
 export function markSessionSeen(sessionId: string): void {
   store.markSeen(sessionId)
 }

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -700,23 +700,42 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     return () => off()
   }, [navigate, activateSession])
 
-  // Opening a project puts its cards on screen, so its sessions' statuses count
-  // as seen — and the cleanup marks them again on the way out, with the project
-  // being left. Without that second pass, a turn that finished while you sat in
-  // the project would badge the tab you just walked away from. A turn still
-  // running keeps its tab badged either way: only "done" reads this.
+  // The one session whose terminal is on screen, which is the only one the user
+  // can be said to have read. Everything that answers "what came back while I
+  // was away" hangs off it: the card's own ring, its project's tab badge and
+  // the notification queue all ask the same question of the same mark.
+  //
+  // Three moments count as reading it: arriving at the card, a report landing
+  // while it is on screen, and coming back to a window that was in the
+  // background. The window's focus is what separates the last two from a card
+  // left open in an app nobody is looking at — the same fact the desktop
+  // notification answers to, and one only the page holds. The cleanup marks the
+  // card being left, so a turn that finished while it was on screen does not
+  // badge the tab on the way out.
+  const focusedSessionId = activeProjectId ? activeSessionId(sessions, activeProjectId) : ""
   useEffect(() => {
-    if (!activeProjectId) {
+    if (!focusedSessionId) {
       return
     }
-    const markSeen = () => {
-      for (const session of sessionsOf(sessionsRef.current, activeProjectId)) {
-        markSessionSeen(session.id)
+    const markSeen = () => markSessionSeen(focusedSessionId)
+    const markSeenIfWatched = () => {
+      if (document.hasFocus()) {
+        markSeen()
       }
     }
-    markSeen()
-    return markSeen
-  }, [activeProjectId])
+    markSeenIfWatched()
+    const off = onAppEvent(STATUS_EVENT, (data) => {
+      if (isIdEvent(data) && data.id === focusedSessionId) {
+        markSeenIfWatched()
+      }
+    })
+    window.addEventListener("focus", markSeen)
+    return () => {
+      off()
+      window.removeEventListener("focus", markSeen)
+      markSeen()
+    }
+  }, [focusedSessionId])
 
   // A session that likely changed files on disk nudges an immediate git-status
   // refresh for the path its card watches (its worktree, else the project's),

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -2448,3 +2448,52 @@ func TestSpawnBriefingNamesTheRouteThisSpawnGave(t *testing.T) {
 		}
 	}
 }
+
+// Stopping a turn is not answering the errand it was running. lich raises
+// "interrupted" for a turn the user ended at the PTY (internal/terminal,
+// Service.noteInterrupt), and the errand has to survive it: the target is still
+// the one holding the request, and reporting it unanswered here would tell the
+// sender the work is over while the target sits at a prompt able to carry on.
+func TestAnInterruptedTurnDoesNotEndTheErrand(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, nil)
+
+	got, err := svc.Send("s1", "docs", "", "run the tests", 1)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if got.Status != StatusPending {
+		t.Fatalf("status = %q, want the sender to have taken a ticket", got.Status)
+	}
+
+	svc.Observe("s2", "busy")
+	svc.Observe("s2", "interrupted")
+
+	if awaitWritten(term, "s1", "[lich]") {
+		t.Fatalf("the sender was told its errand was over by an interrupt: %q", term.written("s1"))
+	}
+
+	// The turn that does end it is the target's next one.
+	svc.Observe("s2", "busy")
+	svc.Observe("s2", "done")
+	if !awaitWritten(term, "s1", "[lich]") {
+		t.Fatalf("the errand outlived the turn that ended it: %q", term.written("s1"))
+	}
+}
+
+// An interrupted session is at its prompt with nothing running, which is
+// exactly when a delivery held back for a busy target may go in.
+func TestAnInterruptedTargetIsNotBusy(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, nil)
+
+	svc.Observe("s2", "busy")
+	svc.Observe("s2", "interrupted")
+
+	svc.mu.Lock()
+	state := svc.state["s2"]
+	svc.mu.Unlock()
+	if state == stateBusy {
+		t.Fatal("a session whose turn was interrupted still read as working")
+	}
+}

--- a/internal/terminal/draft.go
+++ b/internal/terminal/draft.go
@@ -1,6 +1,9 @@
 package terminal
 
-import "time"
+import (
+	"bytes"
+	"time"
+)
 
 // What the user has typed at a prompt and not sent yet, and why lich has to
 // know: a relayed message is pasted straight into that prompt and an Enter is
@@ -33,39 +36,81 @@ const (
 	maxEscape = 32
 )
 
+// The brackets a terminal wraps pasted text in (DECSET 2004). What arrives
+// between them was pasted rather than typed, which is the one place a 0x03 or a
+// lone 0x1b in the stream is text instead of the user reaching for the
+// interrupt (see noteInput).
+var (
+	pasteStart = []byte("\x1b[200~")
+	pasteEnd   = []byte("\x1b[201~")
+)
+
 // noteInput records whether the user is composing something at this session's
 // prompt right now, so a relayed message is not pasted into the middle of it
-// (see Ready). Unknown sessions are a no-op.
-func (s *Service) noteInput(id string, data []byte) {
+// (see Ready), and answers whether this write was the user interrupting the
+// turn: a lone Ctrl+C or Escape, typed rather than pasted and never a byte
+// inside an escape sequence. Unknown sessions are a no-op.
+//
+// Reading the interrupt off the PTY is a fallback, not a source of truth — it
+// only ever ends a turn lich already knows is open, and the next report from
+// the provider overwrites whatever it concluded (see Service.noteInterrupt).
+func (s *Service) noteInput(id string, data []byte) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	sess, ok := s.sessions[id]
 	if !ok {
-		return
+		return false
 	}
 	if len(sess.escPending) > 0 {
 		data = append(sess.escPending, data...)
 		sess.escPending = nil
 	}
+	interrupted := false
 	for i := 0; i < len(data); i++ {
 		switch b := data[i]; {
 		case b == esc:
 			n, done := escapeSpan(data[i:])
 			if !done {
-				// The rest of it is in the next write. Held rather than counted:
-				// its parameters are digits, and digits read as typing.
-				if n <= maxEscape {
-					sess.escPending = append([]byte(nil), data[i:]...)
-				}
-				return
+				return interrupted || sess.splitEscape(data[i:], n)
 			}
+			sess.noteBracket(data[i : i+n])
 			i += n - 1
 		case b == '\r' || b == '\n' || b == ctrlC:
 			// Sent, or thrown away. Either way the line is the user's no longer.
 			sess.draftAt = time.Time{}
+			interrupted = interrupted || (b == ctrlC && !sess.pasting)
 		case b >= 0x20:
 			sess.draftAt = time.Now()
 		}
+	}
+	return interrupted
+}
+
+// splitEscape decides what an escape that did not end inside this write was,
+// and reports whether it was the Escape key. A lone ESC at the end of a write
+// is that key — nothing follows it to be the rest of a sequence. Anything
+// longer is a sequence the write split, held for the bytes still to come rather
+// than counted: its parameters are digits, and digits read as typing. Called
+// under the service's mu.
+func (sess *session) splitEscape(rest []byte, n int) bool {
+	if n > 1 {
+		if n <= maxEscape {
+			sess.escPending = append([]byte(nil), rest...)
+		}
+		return false
+	}
+	return !sess.pasting
+}
+
+// noteBracket records the bracketed-paste state a DECSET 2004 marker sets, so
+// the bytes between the two brackets are read as pasted rather than typed.
+// Called under the service's mu.
+func (sess *session) noteBracket(span []byte) {
+	switch {
+	case bytes.Equal(span, pasteStart):
+		sess.pasting = true
+	case bytes.Equal(span, pasteEnd):
+		sess.pasting = false
 	}
 }
 

--- a/internal/terminal/draft_test.go
+++ b/internal/terminal/draft_test.go
@@ -131,3 +131,50 @@ func TestAnEscapeThatNeverEndsDoesNotSwallowTyping(t *testing.T) {
 		t.Error("typing after an unterminated escape was discarded")
 	}
 }
+
+// Reading the interrupt off the keystrokes is the fallback for the providers
+// that report nothing when a turn is stopped. What counts is a key the user
+// pressed: a lone Ctrl+C or Escape, never a byte carried in by a paste and
+// never one inside an escape sequence.
+func TestInterruptIsReadFromALoneKey(t *testing.T) {
+	tests := []struct {
+		name   string
+		writes []string
+		want   bool
+	}{
+		{"ctrl+c", []string{"\x03"}, true},
+		{"escape", []string{"\x1b"}, true},
+		{"escape after a half-typed line", []string{"never mind", "\x1b"}, true},
+		{"plain typing", []string{"hello"}, false},
+		{"enter", []string{"\r"}, false},
+		{"an arrow key", []string{"\x1b[A"}, false},
+		{"a function key", []string{"\x1bOP"}, false},
+		{"alt and a letter", []string{"\x1bv"}, false},
+		{"a mouse report", []string{"\x1b[<35;42;7M"}, false},
+		{"a mouse report split across two writes", []string{"\x1b[<35;10", ";5M"}, false},
+		{"ctrl+c inside a pasted block", []string{"\x1b[200~kill \x03 the job\x1b[201~"}, false},
+		{"escape inside a pasted block", []string{"\x1b[200~press \x1b to stop\x1b[201~"}, false},
+		{"a paste split so a write ends on its escape", []string{"\x1b[200~press \x1b", "[A to stop\x1b[201~"}, false},
+		{"ctrl+c typed after the paste ended", []string{"\x1b[200~pasted\x1b[201~", "\x03"}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc, _ := settled(t)
+			got := false
+			for _, w := range tc.writes {
+				got = svc.noteInput("s1", []byte(w)) || got
+			}
+			if got != tc.want {
+				t.Fatalf("noteInput(%q) read an interrupt = %v, want %v", tc.writes, got, tc.want)
+			}
+		})
+	}
+}
+
+// A session lich is not running has no turn to end and no prompt to hold.
+func TestInterruptForAnUnknownSessionIsANoOp(t *testing.T) {
+	svc, _ := settled(t)
+	if svc.noteInput("nobody", []byte{ctrlC}) {
+		t.Fatal("a keystroke for a session lich does not run read as an interrupt")
+	}
+}

--- a/internal/terminal/hookstate.go
+++ b/internal/terminal/hookstate.go
@@ -58,3 +58,18 @@ func (l *turnLog) forget(id string) {
 	defer l.mu.Unlock()
 	delete(l.open, id)
 }
+
+// interrupt closes an open turn the user ended themselves at the PTY, and
+// reports whether there was one. Nothing is opened here: an interrupt is only
+// ever the end of a turn lich already heard start, so a Ctrl+C clearing the
+// line at an idle prompt — the common use of that key — says nothing and
+// changes nothing.
+func (l *turnLog) interrupt(id string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.open[id] {
+		return false
+	}
+	delete(l.open, id)
+	return true
+}

--- a/internal/terminal/hookstate_test.go
+++ b/internal/terminal/hookstate_test.go
@@ -1,11 +1,16 @@
 package terminal
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"slices"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+	"github.com/omartelo/lich/internal/events"
 )
 
 // The two readings of one `waiting` report, which is the whole point of
@@ -130,4 +135,131 @@ func postHook(t *testing.T, svc *Service, id, state string) {
 	if resp.StatusCode != http.StatusNoContent {
 		t.Fatalf("hook %q: status = %d, want 204", state, resp.StatusCode)
 	}
+}
+
+// The turn an interrupt ends is one lich heard start. Ctrl+C at a prompt with
+// nothing running is how a line is thrown away, and it must say nothing at all.
+func TestTurnLogInterruptOnlyEndsAnOpenTurn(t *testing.T) {
+	tests := []struct {
+		name   string
+		before []string
+		want   bool
+	}{
+		{"a turn is running", []string{statusBusy}, true},
+		{"blocked on a permission inside a turn", []string{statusBusy, statusWaiting}, true},
+		{"nothing was ever reported", nil, false},
+		{"the turn already finished", []string{statusBusy, statusDone}, false},
+		{"the session ended", []string{statusBusy, statusIdle}, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var log turnLog
+			for _, state := range tc.before {
+				log.report("s1", state)
+			}
+			if got := log.interrupt("s1"); got != tc.want {
+				t.Fatalf("interrupt after %v ended a turn = %v, want %v", tc.before, got, tc.want)
+			}
+		})
+	}
+}
+
+// An interrupt ends the turn for good: the report after it is read against a
+// session at its prompt, so a `waiting` that follows is the provider's "your
+// turn" nudge rather than a human being blocked.
+func TestTurnLogInterruptClosesTheTurn(t *testing.T) {
+	var log turnLog
+	log.report("s1", statusBusy)
+	if !log.interrupt("s1") {
+		t.Fatal("the open turn was not ended by the interrupt")
+	}
+	if log.interrupt("s1") {
+		t.Fatal("a second interrupt ended a turn that was already over")
+	}
+	if log.report("s1", statusWaiting) {
+		t.Fatal("an idle prompt after an interrupt was published as a block")
+	}
+}
+
+// One session's interrupt is not another's: the key was pressed at one prompt.
+func TestTurnLogInterruptKeepsSessionsApart(t *testing.T) {
+	var log turnLog
+	log.report("one", statusBusy)
+	log.report("two", statusBusy)
+	log.interrupt("one")
+	if !log.report("two", statusWaiting) {
+		t.Fatal("interrupting one session ended another session's turn")
+	}
+}
+
+// The end of the wire for the fallback: a key pressed in a busy session's
+// terminal reaches the window as the turn ending, and the provider's own report
+// still outranks it when one finally arrives.
+func TestInterruptedTurnReachesTheWindow(t *testing.T) {
+	hub, rec := newProbeHub(t)
+	svc := New(hookStore{}, nil, hub)
+	if svc.wsErr != nil {
+		t.Fatalf("transport: %v", svc.wsErr)
+	}
+	svc.mu.Lock()
+	svc.sessions["s1"] = &session{}
+	svc.mu.Unlock()
+
+	postHook(t, svc, "s1", statusBusy)
+	sendInput(t, svc, "s1", []byte{esc})
+	postHook(t, svc, "s1", statusDone)
+
+	hub.Emit(probeReadyEvent, nil)
+	waitFor(t, func() bool { return slices.Contains(rec.snapshot(), probeReadyEvent) },
+		"the window to be told about the interrupted turn")
+
+	want := []string{statusBusy, statusInterrupted, statusDone}
+	if got := rec.statesOf("s1"); strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("the window was told %v, want %v", got, want)
+	}
+}
+
+// The state lich raises itself is not one a hook may claim: it says something
+// only lich is in a position to know, and the endpoint stays closed to it.
+func TestHookRejectsTheInterruptedState(t *testing.T) {
+	svc := New(hookStore{}, nil, events.New())
+	if svc.wsErr != nil {
+		t.Fatalf("transport: %v", svc.wsErr)
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/hook?token=%s", svc.ws.port, svc.ws.token)
+	body := fmt.Sprintf(`{"session_id":"s1","state":%q}`, statusInterrupted)
+	resp, err := http.Post(url, "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("hook %q: status = %d, want 400", statusInterrupted, resp.StatusCode)
+	}
+}
+
+// sendInput writes one terminal input frame the way the window's xterm does —
+// through the socket, so the whole path the keystroke takes is under test and
+// not just the two halves of it.
+func sendInput(t *testing.T, svc *Service, id string, data []byte) {
+	t.Helper()
+	conn, err := dial(t, svc.ws, svc.ws.token)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = conn.CloseNow() }()
+	frame, err := encodeFrame(id, data)
+	if err != nil {
+		t.Fatalf("encodeFrame: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := conn.Write(ctx, websocket.MessageBinary, frame); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// The socket carries no acknowledgement, so the wait is on the turn the
+	// keystroke ends. Asked with the log's own question — a `waiting` is
+	// recorded neither way, so this reads the turn without moving it.
+	waitFor(t, func() bool { return !svc.turns.report(id, statusWaiting) },
+		"the keystroke to end the turn")
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -40,7 +40,8 @@ const (
 	// statusEventName carries a session's processing state ({id, state, tool,
 	// detail} — "busy"/"done"/"waiting"/"idle", plus the tool a pre-tool report
 	// names), reported by the lich hooks running inside the PTY (see
-	// transport.hook and docs/hooks/session-state.md). The frontend keeps it in
+	// transport.hook and docs/hooks/session-state.md). "interrupted" is the one
+	// value lich raises itself, for a turn the user stopped at the PTY. The frontend keeps it in
 	// stores keyed by id (session-status-store.ts, session-tool-store.ts) rather
 	// than in the card, which is only mounted while its project is active.
 	statusEventName = "session-status"
@@ -147,10 +148,13 @@ type session struct {
 	// draftAt is when the user last typed something at this prompt without
 	// sending it, and zero when there is nothing of theirs on the line.
 	// escPending is the beginning of an escape sequence a PTY write split, held
-	// until the rest of it arrives. Both guarded by the service's mu. See
-	// draft.go.
+	// until the rest of it arrives. pasting is whether the bytes arriving now
+	// are inside a bracketed paste, which is what keeps a pasted Ctrl+C or
+	// Escape from reading as the user interrupting the turn. All three guarded
+	// by the service's mu. See draft.go.
 	draftAt    time.Time
 	escPending []byte
+	pasting    bool
 	// confined records whether this PTY was spawned inside the sandbox, so Start
 	// can report it once the spawn is out of the lock.
 	confined bool
@@ -298,7 +302,9 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 	}
 	ws, err := newTransport(
 		func(id string, data []byte) {
-			s.noteInput(id, data)
+			if s.noteInput(id, data) {
+				s.noteInterrupt(id)
+			}
 			if err := s.writeBytes(id, data); err != nil {
 				slog.Warn("terminal: input write failed", "session", id, "err", err)
 			}
@@ -374,6 +380,33 @@ func (s *Service) MountPublic(pattern string, handler http.Handler) {
 		return
 	}
 	s.ws.mountPublic(pattern, handler)
+}
+
+// noteInterrupt publishes the end of a turn the user stopped at the PTY: a lone
+// Ctrl+C or Escape while lich has a turn open for that session (see noteInput
+// and turnLog.interrupt). It is the fallback for the three providers that raise
+// no event of their own when a turn is interrupted — Claude Code, Codex and
+// oh-my-pi all skip the hook that would end it, so without this the card spins
+// until some later turn finishes. It publishes "interrupted" rather than "done"
+// because stopping a turn is not finishing one, and it never opens a turn, so
+// nothing is invented for a session lich never heard start. Whatever the
+// provider reports next overwrites it: an event from inside the session always
+// outranks a guess made from its keystrokes.
+func (s *Service) noteInterrupt(id string) {
+	if !s.turns.interrupt(id) {
+		return
+	}
+	s.hub.Emit(statusEventName, statusEvent{ID: id, State: statusInterrupted})
+	// The relay keeps its own turn accounting off the same stream, and a turn
+	// that ended has to read as ended there too — a queued delivery waits on the
+	// target's prompt being free.
+	if watch := s.stateWatcher(); watch != nil {
+		watch(id, statusInterrupted)
+	}
+	// An interrupted turn spent tokens like any other, and it may be the last
+	// one for a while: refresh the context readout off the transcript, off the
+	// caller's thread the way the hook path does.
+	go s.emitUsage(id)
 }
 
 // SetSessionState wires fn to every session-state report the hooks deliver.

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -55,6 +55,17 @@ const (
 	statusDone    = "done"
 	statusWaiting = "waiting"
 	statusIdle    = "idle"
+
+	// statusInterrupted is lich's own: the only state it ever publishes that no
+	// provider reports and no hook may send — parseHookRequest rejects it like
+	// any other unknown word. It says a turn ended because the user stopped it
+	// at the PTY, which is neither a finished turn nor a session that has left,
+	// and lich has to say it itself because three of the five providers raise
+	// nothing at all when a turn is interrupted (see Service.noteInterrupt and
+	// docs/hooks/session-state.md). Consumers that only know the four above read
+	// it as "no state", which clears the card's indicator — the right reading:
+	// an interrupted session is sitting at its prompt with nothing to show.
+	statusInterrupted = "interrupted"
 )
 
 // encodeFrame prefixes payload with the session id. The id must fit one byte


### PR DESCRIPTION
A turn stopped with Esc or Ctrl+C left its card spinning until some later turn happened to finish, and a finished turn nobody had read looked exactly like one read twenty minutes ago. Both are the same surface — what a session card says about its own turn — so they land together.

## (a) The interrupted turn

**Root cause.** lich's turn state is derived entirely from provider hook reports: `busy` opens a turn in `turnLog`, `done` closes it, and nothing else can end one. When the user interrupts, most providers raise no event at all, so the last thing lich ever hears is `busy`.

Measured against all five providers in `internal/providers.Registry`, by driving each CLI at a real pty with the companion plugin pointed at a stub listener, typing a prompt, waiting for `busy`, sending the key and watching for 12–35s more:

| Provider | On interrupt | Turn closed? |
| --- | --- | --- |
| Claude Code | TUI prints "Interrupted", nothing else | **no** |
| Codex | rollout keeps `task_started` with no completion beside it | **no** |
| opencode | `session.status idle` within the same second | yes — as a *finished* turn |
| oh-my-pi | cancels the tool, reports `busy` again, never `session_stop` | **no** |
| Crush | reports no state at all | n/a — never spins |

**The fallback.** Three of five need one, and the only place every provider is alike is the bytes going into the PTY. `noteInput` already frames escape sequences for the draft heuristic, so it now also answers whether the write was the user interrupting: a lone `Ctrl+C` or `Escape`, never one inside a sequence and never one carried in by a bracketed paste (new `pasting` flag, DECSET 2004 brackets). A lone trailing ESC is now decided as the Escape key instead of being held pending forever.

That ends a turn `turnLog` already has open — a `Ctrl+C` clearing a line at an idle prompt says nothing — and lich publishes `interrupted`. It is deliberately **not** `done`: stopping a turn is not finishing one, so no check, no tab badge, no notification, no desktop notice. The state is outbound only; the hook endpoint still rejects it like any other unknown word. Whatever the provider reports next overwrites it, which is how opencode's own `done` keeps winning.

No frontend mapping was needed: an unknown state already narrows to `null` (indicator cleared), clears the tool line, and leaves the inbox count and the agent mark alone. Tests pin all three.

## (b) The unread ring

The store already knew whether a status had been seen — the tab badge read it. That mark now drives the card's ring too, and it is set for the one session whose terminal is on screen **while the window has focus**, rather than for every session of the project being opened. Without the focus half, a card left open in a background window fades itself and the feature lies in its commonest case.

An unread `done` keeps `border-emerald-500`; a read one fades to `border-emerald-500/30` — an opacity step on the same semantic token, which is the idiom `frontend/DESIGN.md` already uses, so no new vocabulary. Wired at all four call sites (card, rail, palette, delegate picker) so one session cannot read as news in one place and read in another.

One contract change falls out: opening a project no longer marks every session in it read, so a project left with three finished agents keeps badging for the two nobody opened.

## Docs

- `docs/hooks/session-state.md` — the old "Esc can leave a spinner" ceiling replaced by the measured per-provider result; `interrupted` documented as outbound-only; render, store and tab-badge bullets updated.
- `docs/ceilings.md` — two new bullets. The fallback's edges: an editor opened through a tool swallows Escape and clears the ring mid-turn (the next report puts it back), opencode's abort is indistinguishable from a finished turn, Crush is out by name, and a relayed errand deliberately survives an interrupt. The unread mark's edges: it depends on window focus, and it lives in the page, so a reload makes every session look like news again.
- `frontend/DESIGN.md` — the done ring's second weight.
- `CHANGELOG.md` — one Fixed entry and one Changed entry under `[Unreleased]`.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` — 1808 passed
- [x] `cd frontend && pnpm check` clean
- [x] `vitest run` — 1053 passed
- [x] `cd frontend && pnpm build`
- [x] cross-compile build + vet for linux, darwin, windows
- [x] Manual in `task dev`: Esc mid-turn clears the ring with no check; `Ctrl+C` at an idle prompt changes nothing; arrow keys, mouse reports and a paste mid-turn keep the spinner; a turn that finishes while another card is focused shows the solid ring and fades when its own card is opened.

## Known, not fixed here

`TestRespawnedSessionIsNotToldItExited` fails under `-race` — `close /dev/ptmx: file already closed`. Pre-existing, from #345: measured on an unmodified `origin/main` worktree at 21/50 with `-race` and 0/50 without. Root cause is that `unixPTY.Close` is not idempotent, so when the child exits on its own the reader loop's reaper closes the master first and the later explicit `Service.Close` returns `os.ErrClosed` to its caller — the comment at that reaper already claims the second close is "a no-op each seam has to make safe", and the Unix seam does not make it safe. Left for its own PR.