### PR TITLE
feat: say what a waiting session is waiting for

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A waiting card now says what it is waiting for.** A session blocked on you
+  wore the same amber bell and the same "Waiting on you" whether it wanted
+  permission to delete a directory or an answer about which file to touch — the
+  only way to tell was to open it. The card and the toast now carry the question
+  itself, in the words the agent used. Claude Code sessions say it in a sentence;
+  Codex and opencode name the tool or permission being asked about, which is
+  coarser and still enough to pick the card; oh-my-pi and Crush report no block at
+  all, so their cards keep the line they had.
 - **Sessions can be renamed from the command line and from an agent's own
   tools.** Renaming a card was a thing only the window could do; `lich rename
   "the login bug"` now renames the session the command runs in, `lich rename

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -148,6 +148,16 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   anywhere (the line truncates), but on those two the card spends its width on a server name nobody asked for.
   Splitting them needs the list of registered server names, which the card does not have. Crush is not on this
   list at all: it reports no tool.
+- **Only Claude Code says what a session is waiting for; the others say less or nothing**
+  (`frontend/src/components/sidebar/SessionCard.tsx`, table in `docs/hooks/session-state.md`): its
+  `Notification` carries a `message` written for a human, so the card reads "Claude needs your permission to
+  use Bash". Codex's `PermissionRequest` and opencode's `.asked` events carry only the thing being asked
+  about — `tool_name`, `permission`, `action` — so those cards read a bare `Bash` or `edit`, which says which
+  card to open and not what it will ask. **oh-my-pi and Crush send no reason at all** and keep the generic
+  "Waiting on you": neither reports `waiting` in the first place (omp declares an approval event no run was
+  ever seen emitting; Crush reports no state), so there is nothing to hang a reason on. The trap is reading a
+  bare card as "nothing to say" — on those two it means the harness never spoke, not that the block is
+  trivial.
 - **omp's state directory answers to two variables, and the profile wins** (`internal/agentplugin/omp.go`,
   `internal/terminal/transcript.go`, resolving it independently as the Claude Code pair do): `OMP_PROFILE` moves
   the whole directory and beats an explicit `PI_CODING_AGENT_DIR`. Get it backwards and the install lands where omp

--- a/docs/hooks/fixtures/session-state.jsonl
+++ b/docs/hooks/fixtures/session-state.jsonl
@@ -8,6 +8,10 @@
 {"name":"tool and detail are trimmed","body":{"session_id":"s1","state":"busy","tool":"  shell  ","detail":"  go test ./...  "},"accept":{"session_id":"s1","state":"busy","tool":"shell","detail":"go test ./..."}}
 {"name":"a detail with no tool names nothing","body":{"session_id":"s1","state":"busy","detail":"pnpm test"},"accept":{"session_id":"s1","state":"busy","tool":"","detail":""}}
 {"name":"whitespace is not a tool","body":{"session_id":"s1","state":"busy","tool":"   ","detail":"pnpm test"},"accept":{"session_id":"s1","state":"busy","tool":"","detail":""}}
+{"name":"waiting says what it is blocked on","body":{"session_id":"s1","state":"waiting","reason":"Claude needs your permission to use Bash"},"accept":{"session_id":"s1","state":"waiting","reason":"Claude needs your permission to use Bash"}}
+{"name":"a reason is trimmed","body":{"session_id":"s1","state":"waiting","reason":"  edit  "},"accept":{"session_id":"s1","state":"waiting","reason":"edit"}}
+{"name":"whitespace is not a reason","body":{"session_id":"s1","state":"waiting","reason":"   "},"accept":{"session_id":"s1","state":"waiting","reason":""}}
+{"name":"a reason outside waiting names nothing","body":{"session_id":"s1","state":"busy","reason":"Claude needs your permission to use Bash"},"accept":{"session_id":"s1","state":"busy","reason":""}}
 {"name":"missing session_id","body":{"state":"busy"},"reject":"session_id is required"}
 {"name":"empty session_id","body":{"session_id":"","state":"busy"},"reject":"session_id is required"}
 {"name":"unknown state","body":{"session_id":"s1","state":"cooking"},"reject":"state must be one of busy, done, waiting, idle"}

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -3,8 +3,8 @@
 Reports a session's processing state to lich so its card shows a spinner while
 the agent is working, a check when the turn ends, and a bell when it is blocked
 on the user — plus a toast that routes to the waiting card. A `busy` report may
-also name the tool the agent is about to run, which the card shows under the
-session's label.
+also name the tool the agent is about to run, and a `waiting` what it is blocked
+on; the card shows either one under the session's label.
 
 See [README.md](README.md) for the shared transport (`LICH_PORT` / `LICH_TOKEN`
 / `LICH_SESSION_ID`) and the client rules every hook follows.
@@ -16,7 +16,8 @@ POST http://127.0.0.1:${LICH_PORT}/hook?token=${LICH_TOKEN}
 Content-Type: application/json
 
 {"session_id": "<LICH_SESSION_ID>", "state": "<busy|done|waiting|idle>",
- "tool": "<tool name>", "detail": "<what it acts on>"}
+ "tool": "<tool name>", "detail": "<what it acts on>",
+ "reason": "<what the agent is blocked on>"}
 ```
 
 States: `busy`, `done`, `waiting`, `idle`. lich rejects anything else — the
@@ -27,6 +28,12 @@ below). Both are trimmed and capped at 120 characters — they decorate a state
 that has to land either way, so an over-long value is truncated, never a reason
 to reject the report. A `detail` with no `tool` to qualify names nothing and is
 dropped.
+
+`reason` is the same kind of field for the other half of the contract: optional,
+trimmed, capped at 120, and belonging to the `waiting` report alone — it says
+what the agent is blocked on, and no other state is a question. A `reason` on
+any other state is dropped, and one that is absent, empty or over-long is never
+a reason to refuse the report: the bell has to land either way.
 
 Responses: `204` ok · `401` invalid token · `400` invalid body.
 
@@ -40,7 +47,7 @@ Both sides test against the payloads in
 | `UserPromptSubmit` | `UserPromptSubmit`  | `session.status` (`busy`) | `input`        | —          | `busy`    |
 | `PreToolUse`       | `PreToolUse`        | `tool.execute.before`    | `tool_call`    | —          | `busy` + `tool` |
 | `PostToolUse`      | `PostToolUse`       | `tool.execute.after`     | `turn_start`   | —          | `busy`    |
-| `Notification`     | `PermissionRequest` | any `*.asked`            | —              | —          | `waiting` |
+| `Notification`     | `PermissionRequest` | any `*.asked`            | —              | —          | `waiting` + `reason` |
 | `Stop`             | `Stop`              | `session.status` (`idle`) | `session_stop` | —          | `done`    |
 | `SessionEnd`       | —                   | —                        | —              | —          | `idle`    |
 
@@ -149,16 +156,55 @@ never on `idle` alone, which Codex has no event for.
 harnesses a hook exiting `2` there **blocks the tool call**. Until now the worst
 a broken script could do was lose a status report.
 
+## What a turn is waiting for
+
+A `waiting` may carry `reason`: one short line naming what the agent is blocked
+on, shown on the card in place of its "Waiting on you" and under the session's
+name in the toast. Free text, passed through as sent — the same rule the tool
+pair follows, and for the same reason: the word on the card should be the word
+in the terminal beside it.
+
+The card is where the user decides which of five sessions to open, and a bare
+bell makes every one of them look alike: a permission prompt for a destructive
+command and a question about which file to touch are the same badge until one is
+opened. What each harness can say about it differs, because none of these events
+was written to be read this way:
+
+| Harness     | Waiting event          | What the event carries                            | Reason to send            |
+|-------------|------------------------|---------------------------------------------------|---------------------------|
+| Claude Code | `Notification`         | `message`, `title`, `notification_type`            | `message` — its own sentence, already written for a human |
+| Codex       | `PermissionRequest`    | `tool_name`, `tool_input`, and no message of its own | `tool_name`, qualified from `tool_input` the way `detail` already is |
+| opencode    | `permission.asked`     | `permission`, `patterns`, `metadata`               | `permission`              |
+| opencode    | `permission.v2.asked`  | `action`, `resources`                              | `action`                  |
+| opencode    | `question(.v2).asked`  | `questions[]` of `question` / `header` / `options` | `questions[0].header` — the ≤30-char label the question already carries for narrow surfaces |
+| oh-my-pi    | —                      | —                                                  | — (reports no `waiting` at all) |
+| Crush       | —                      | —                                                  | — (reports no state at all) |
+
+Read off what each harness ships rather than off its documentation: Claude Code
+2.1.240's own hook-input builder, the `permission-request.command.input` schema
+embedded in Codex 0.147.0, and opencode 1.18.x's `/doc` — which is also where the
+four `.asked` types the client matches on are enumerated (`permission.asked`,
+`permission.v2.asked`, `question.asked`, `question.v2.asked`).
+
+Only Claude Code hands over a sentence. Codex and opencode name the thing being
+asked about and nothing else, so their cards read `Bash` or `edit` where a Claude
+card reads "Claude needs your permission to use Bash" — coarser, and still the
+difference between opening the right card and opening three. A harness with
+nothing to say sends no `reason`, and its card keeps the bare "Waiting on you": a
+missing reason never costs a bell.
+
 ## lich server side
 
 - **Env injection** — `internal/terminal/terminal.go`, `Service.sessionEnv`:
   adds the three `LICH_*` vars to each PTY's environment.
 - **Endpoint** — `internal/terminal/transport.go`, `transport.hook`: validates
   the token and body (`parseHookRequest`) on the same loopback listener as
-  terminal I/O, then forwards the whole report.
+  terminal I/O, then forwards the whole report. The free text is trimmed and
+  capped there, and each field is dropped on the states it does not belong to:
+  `detail` with no `tool`, `reason` on anything but `waiting`.
 - **UI push** — `internal/terminal/terminal.go`: emits the global app event
-  `session-status` (`{id, state, tool, detail}`). Global rather than per-session
-  because its consumers outlive any one card.
+  `session-status` (`{id, state, tool, detail, reason}`). Global rather than
+  per-session because its consumers outlive any one card.
 - **What `waiting` meant** — `internal/terminal/hookstate.go`, `turnLog`: the one
   report lich does not pass through as sent. A permission decision only ever
   happens inside a turn, so the report before it settles which `Notification`
@@ -199,19 +245,25 @@ a broken script could do was lose a status report.
   switching projects unmounts them, and a status reported meanwhile would be lost.
   `session-tool-store.ts` reads the same event for the tool pair, keeping its own
   keyed entry so a repeat `busy` — which the status store collapses into no
-  change at all — still moves the tool line. The status store also keeps whether
-  each session's state has been **read**: `markSeen` is called for the one
-  session whose terminal is on screen, while the window has focus, and a fresh
-  report clears the mark again. Only `done` reads it — the live states say what
-  they say whether or not anybody is watching.
+  change at all — still moves the tool line. The `waiting` reason is held by the
+  status store itself, beside the state it belongs to: it is the only field whose
+  own state is the thing that clears it, and a second prompt in one turn moves the
+  line because the store weighs the reason alongside the state. The status store
+  also keeps whether each session's state has been **read**: `markSeen` is called
+  for the one session whose terminal is on screen, while the window has focus, and
+  a fresh report clears the mark again. Only `done` reads it — the live states say
+  what they say whether or not anybody is watching.
 - **Render** — `frontend/src/components/sidebar/SessionCard.tsx`: reads the stores
-  (`useSessionStatus`, `useSessionTool`) and shows a spinner (`busy`), check
-  (`done`) or bell (`waiting`); any other value, including `idle` and
-  `interrupted`, clears the indicator. A `done` is drawn at two weights
+  (`useSessionStatus`, `useSessionTool`, `useSessionWaitingReason`) and shows a
+  spinner (`busy`), check (`done`) or bell (`waiting`); any other value, including
+  `idle` and `interrupted`, clears the indicator. A `done` is drawn at two weights
   (`SessionStatusIcon`, `useSessionUnread`): solid while the finished turn is
   still unread, faded once the user has watched that card. It is the same mark
   the tab badge and the notification queue read, so one session cannot be news
-  in one place and read in another. The tool line sits under the session's label and exists only while
+  in one place and read in another. A reported reason takes the waiting line's
+  whole width — the amber glyph beside it is what still says "waiting on you", so
+  spending the line on that phrase again would cost the card the only words on it
+  the user does not already know. The tool line sits under the session's label and exists only while
   one is reported, so a card outside a turn is exactly the card it was before.
 - **Tab badge** — `frontend/src/components/tabs/ProjectTab.tsx`: reduces a
   project's sessions to one indicator (`useProjectStatus`, ranking `waiting` over
@@ -221,8 +273,8 @@ a broken script could do was lose a status report.
   `busy` and `waiting` badge for as long as they hold, being live states rather
   than notifications.
 - **Toast + route** — `frontend/src/providers/projects.tsx`: raises an actionable toast
-  that navigates to the session's card when a report says `waiting`, skipped for
-  the session already focused. It reads the raw event rather than the store: the
+  that navigates to the session's card when a report says `waiting`, carrying the
+  reason under the session's name, skipped for the session already focused. It reads the raw event rather than the store: the
   store collapses a repeat state into no notification, which would swallow a
   toast.
 - **Desktop notification** — same handler, `system.Notify`
@@ -310,6 +362,18 @@ a broken script could do was lose a status report.
   notification; macOS needs lich shipped as a signed `.app` bundle with
   `UNUserNotificationCenter`; Windows needs a registered AppUserModelID with a
   COM activation handler.
+- **Only Claude Code says what it is waiting for in words.** Codex's
+  `PermissionRequest` and opencode's `.asked` events carry the thing being asked
+  about (`tool_name`, `permission`, `action`) and no sentence, so those cards read
+  a bare `Bash` or `edit` where a Claude card reads why. oh-my-pi and Crush send
+  no `reason` at all, because neither reports `waiting` in the first place (see
+  the two bullets above), so their cards keep today's "Waiting on you".
+- **A reason is only as fresh as the report that carried it.** It lives beside the
+  state in the page's status store, so it clears when the state leaves `waiting`
+  and is gone after a reload like the state itself — a session already blocked
+  when the page loads shows nothing until its next report. Two prompts in one turn
+  do move the line: the store weighs the reason alongside the state, so a repeat
+  `waiting` with different words is a change rather than a no-op.
 - **The tool line names the call, not its progress.** It appears when the tool
   starts and holds that name for however long the tool runs — a 3-minute build
   and a 30ms read look identical. Nothing reports a tool finishing on its own:

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -80,9 +80,14 @@ tracks the request, not the event), the column fills in from the existing script
 
 `Notification` fires when Claude needs a permission decision **or** when the
 session has simply been sitting at its prompt with nothing to do. Only the first
-of those blocks a human, and the client cannot tell them apart — the event
-carries the same shape either way — so it reports `waiting` for both and **lich
-decides which one arrived** (see `turnLog` below). Codex has no `Notification`:
+of those blocks a human, and lich reads the difference off the report before it
+rather than off the event, so the client reports `waiting` for both and **lich
+decides which one arrived** (see `turnLog` below). Claude Code does now label the
+two — `notification_type` is one of 14 values, `permission_prompt` and
+`idle_prompt` among them (2.1.240) — but that is one harness of five: Codex's
+`PermissionRequest` and opencode's `.asked` events carry no such label, and a
+plugin older than the field sends nothing. The rule has to hold for all of them,
+so the label is not what decides. Codex has no `Notification`:
 the permission half arrives as `PermissionRequest`, where a hook exiting `2`
 would *deny* the request — which is why the contract's client rules (silent,
 always exit 0) are load-bearing there and not merely polite.

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -30,6 +30,7 @@ import {
   useSessionStatus,
   useSessionStatusAge,
   useSessionUnread,
+  useSessionWaitingReason,
 } from "@/lib/session/use-session-status"
 import { useSessionCwd } from "@/lib/session/use-session-cwd"
 import { useSessionAgent } from "@/lib/session/use-session-agent"
@@ -129,6 +130,10 @@ export function SessionCard({
   // the bells all look alike and the one blocked longest is the one to answer
   // first. "" for the states that have no clock (see useSessionStatusAge).
   const age = useSessionStatusAge(session.id)
+  // What the session is blocked on, when its provider's event had words for it:
+  // the line the user reads to decide whether this is the card to open. "" from
+  // a provider that reports the block and nothing about it.
+  const waitingReason = useSessionWaitingReason(session.id)
   // The provider CLI live inside the PTY right now — a hand-run `claude` or
   // `codex` in a shell session puts that provider's mark on the card while it
   // runs; null falls back to the session's own kind.
@@ -390,7 +395,16 @@ export function SessionCard({
               ) : status === "waiting" ? (
                 <span className="flex w-full min-w-0 items-center gap-1 text-xs">
                   <CircleQuestionMark className="size-3 shrink-0 text-amber-500" />
-                  <span className="truncate font-medium text-amber-500">Waiting on you</span>
+                  {/* The question takes the whole line when there is one: the
+                      amber glyph and the ring around the icon already say the
+                      session is waiting, so spending the width on saying it
+                      again would cost the card the only words on it the user
+                      cannot already see. Not every provider has them (see
+                      docs/hooks/session-state.md), and the generic line is what
+                      those fall back to. */}
+                  <span className="truncate font-medium text-amber-500">
+                    {waitingReason || "Waiting on you"}
+                  </span>
                 </span>
               ) : status !== "busy" && inbox > 0 ? (
                 <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">

--- a/frontend/src/lib/session/session-events.test.ts
+++ b/frontend/src/lib/session/session-events.test.ts
@@ -10,6 +10,7 @@ import {
   isTitleEvent,
   isUsageEvent,
   shouldToastAttention,
+  statusReason,
   toClosedSession,
   toOpenedSession,
   toSessionStatus,
@@ -81,6 +82,27 @@ describe("toSessionStatus", () => {
     expect(toSessionStatus(null)).toBeNull()
     expect(toSessionStatus(42)).toBeNull()
     expect(toSessionStatus({ state: "busy" })).toBeNull()
+  })
+})
+
+describe("statusReason", () => {
+  it("reads what a report says the session is blocked on", () => {
+    expect(statusReason({ id: "s1", state: "waiting", reason: "permission to use Bash" })).toBe(
+      "permission to use Bash",
+    )
+  })
+
+  // A report from a provider whose event carries nothing usable, or from a
+  // backend older than the field: the card falls back to its generic line.
+  it("answers empty when the report names none", () => {
+    expect(statusReason({ id: "s1", state: "waiting" })).toBe("")
+    expect(statusReason({ id: "s1", state: "waiting", reason: "" })).toBe("")
+  })
+
+  it("answers empty for a payload that is not an object or not a string", () => {
+    expect(statusReason(undefined)).toBe("")
+    expect(statusReason(null)).toBe("")
+    expect(statusReason({ reason: 42 })).toBe("")
   })
 })
 

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -231,6 +231,14 @@ export function statusTool(data: unknown): SessionTool | null {
   return { name: tool, detail: typeof detail === "string" ? detail : "" }
 }
 
+// statusReason reads what a report says the session is blocked on, or "" when it
+// says nothing. Only a "waiting" carries one — the backend drops it on every
+// other state — so a caller does not have to check the state before asking.
+export function statusReason(data: unknown): string {
+  const { reason } = (data ?? {}) as { reason?: unknown }
+  return typeof reason === "string" ? reason : ""
+}
+
 // A session opened outside the window, as the workspace needs it: the card to
 // draw and the project's label counter after that card took its number.
 export interface OpenedSession {

--- a/frontend/src/lib/session/session-status-store.test.ts
+++ b/frontend/src/lib/session/session-status-store.test.ts
@@ -360,6 +360,83 @@ describe("since", () => {
   })
 })
 
+describe("reason", () => {
+  const waiting = (id: string, reason: string) => ({ id, state: "waiting", reason })
+
+  it("keeps what a waiting report is blocked on", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(waiting("s1", "Claude needs your permission to use Bash"))
+    expect(store.reason("s1")).toBe("Claude needs your permission to use Bash")
+  })
+
+  it("has nothing for a session that reported none", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    expect(store.reason("ghost")).toBe("")
+    emit(report("s1", "waiting"))
+    expect(store.reason("s1")).toBe("")
+  })
+
+  // A reason riding a state that is not a question describes nothing the card
+  // draws, and holding it would outlive the block it came with.
+  it("ignores one carried by any other state", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit({ id: "s1", state: "busy", reason: "permission to use Bash" })
+    expect(store.reason("s1")).toBe("")
+  })
+
+  it("clears when the session stops waiting", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(waiting("s1", "edit"))
+    emit(report("s1", "busy"))
+    expect(store.reason("s1")).toBe("")
+  })
+
+  // The one repeat that is news: the state is unchanged, so the store would
+  // normally bail, but a second prompt in the same turn asks something else.
+  it("moves on a repeat waiting that asks something else", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    const notify = vi.fn()
+    store.subscribe("s1", notify)
+    emit(waiting("s1", "permission to use Bash"))
+    emit(waiting("s1", "permission to use Write"))
+    expect(store.reason("s1")).toBe("permission to use Write")
+    expect(notify).toHaveBeenCalledTimes(2)
+  })
+
+  it("re-renders nobody for a repeat that asks the same thing", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    const notify = vi.fn()
+    store.subscribe("s1", notify)
+    emit(waiting("s1", "permission to use Bash"))
+    emit(waiting("s1", "permission to use Bash"))
+    expect(notify).toHaveBeenCalledTimes(1)
+  })
+
+  // The clock belongs to the block, not to the question: a second prompt in one
+  // turn is the same wait going on, and restarting it would hide how long the
+  // session has been stuck.
+  it("does not restart the clock when only the question changes", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const { source, emit } = fakeSource()
+      const store = createSessionStatusStore(source)
+      emit(waiting("s1", "permission to use Bash"))
+      vi.setSystemTime(30_000)
+      emit(waiting("s1", "permission to use Write"))
+      expect(store.since("s1")).toBe(1_000)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
 describe("pendingAll / subscribeAll", () => {
   it("starts empty", () => {
     const { source } = fakeSource()

--- a/frontend/src/lib/session/session-status-store.ts
+++ b/frontend/src/lib/session/session-status-store.ts
@@ -1,5 +1,6 @@
 import {
   isStatusEvent,
+  statusReason,
   toSessionStatus,
   type SessionEventSource,
   type SessionStatus,
@@ -22,6 +23,12 @@ function samePending(a: readonly PendingStatus[], b: readonly PendingStatus[]): 
 
 interface Entry {
   status: SessionStatus | null
+  // What the session is blocked on, in the provider's own words, and "" for
+  // every state that is not a question. It rides here rather than in a store of
+  // its own because "waiting" is the only thing that clears it: the reason and
+  // the state it belongs to leave together, and holding them apart would be two
+  // entries that must never disagree.
+  reason: string
   // When the current status started, as wall-clock ms — what the card's elapsed
   // readout counts from. Stamped on the transition alone: the hook reports the
   // same state repeatedly while a turn runs, and a session has been waiting
@@ -62,7 +69,7 @@ export function createSessionStatusStore(source: SessionEventSource) {
   const entryOf = (id: string): Entry => {
     let entry = entries.get(id)
     if (!entry) {
-      entry = { status: null, since: 0, seen: false, listeners: new Set() }
+      entry = { status: null, reason: "", since: 0, seen: false, listeners: new Set() }
       entries.set(id, entry)
     }
     return entry
@@ -113,13 +120,21 @@ export function createSessionStatusStore(source: SessionEventSource) {
     }
     const entry = entryOf(data.id)
     const next = toSessionStatus(data.state)
+    const reason = next === "waiting" ? statusReason(data) : ""
     // The snapshot is a string union, so identity is free: bail on a repeat
-    // state and subscribers skip the re-render entirely.
-    if (entry.status === next) {
+    // state and subscribers skip the re-render entirely. The reason is weighed
+    // with it because a second permission prompt inside one turn repeats the
+    // state and changes the question — the one repeat that is news.
+    if (entry.status === next && entry.reason === reason) {
       return
     }
+    // Stamped on the state's own transition alone: a session has been waiting
+    // since it started waiting, not since the question it is waiting on changed.
+    if (entry.status !== next) {
+      entry.since = Date.now()
+    }
     entry.status = next
-    entry.since = Date.now()
+    entry.reason = reason
     // A fresh report is by definition unseen, whether or not the last one was.
     entry.seen = false
     notify(entry)
@@ -188,6 +203,11 @@ export function createSessionStatusStore(source: SessionEventSource) {
     return entry?.status === "done" && !entry.seen
   }
 
+  // reason answers what a waiting session is blocked on, "" when nothing was
+  // reported — a provider whose event carries no words for it, or any state that
+  // is not a question (docs/hooks/session-state.md).
+  const reason = (id: string): string => entries.get(id)?.reason ?? ""
+
   // since answers when the current status started, or null when there is no
   // status to time — including for an entry a subscriber opened before the
   // first report landed.
@@ -213,6 +233,7 @@ export function createSessionStatusStore(source: SessionEventSource) {
     subscribe,
     get,
     unread,
+    reason,
     since,
     markSeen,
     pendingOf,

--- a/frontend/src/lib/session/use-session-status.ts
+++ b/frontend/src/lib/session/use-session-status.ts
@@ -30,6 +30,18 @@ export function useSessionUnread(sessionId: string): boolean {
   return useSyncExternalStore(subscribe, () => store.unread(sessionId))
 }
 
+// useSessionWaitingReason reads what a blocked session is waiting for, in the
+// provider's own words, or "" when the report said nothing — the card falls back
+// to its generic line then. Kept out of useSessionStatus so a card that only
+// draws the indicator does not re-render when the words change.
+export function useSessionWaitingReason(sessionId: string): string {
+  const subscribe = useCallback(
+    (onChange: () => void) => store.subscribe(sessionId, onChange),
+    [sessionId],
+  )
+  return useSyncExternalStore(subscribe, () => store.reason(sessionId))
+}
+
 // useSessionStatusAge returns how long the session has been in its current
 // status, short and relative ("40s", "12m", "3h"), or "" for a status with no
 // clock worth reading.

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -53,6 +53,7 @@ import {
   isStatusEvent,
   isTitleEvent,
   shouldToastAttention,
+  statusReason,
   toClosedSession,
   toOpenedSession,
   toSessionStatus,
@@ -650,6 +651,10 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       }
       const label = project.sessions.find((s) => s.id === id)?.label ?? UNLABELED_SESSION
       const projectName = projectsRef.current.find((p) => p.id === projectId)?.name
+      // Read off the raw event like the status above, and for the same reason:
+      // the store collapses a repeat "waiting", and a second prompt in one turn
+      // is a second question to show.
+      const reason = statusReason(data)
 
       // The desktop channel answers to window focus and to its own per-status
       // preference, both decided by decideStatusNotice; the toast below keeps
@@ -677,6 +682,12 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       toast(
         <div className="flex min-w-0 flex-col">
           <span>{label} needs your input</span>
+          {/* What it is blocked on, when the provider's event had words for it
+              (docs/hooks/session-state.md). The toast is read from across the
+              screen and its whole job is to say which card is worth the trip. */}
+          {reason && (
+            <span className="mt-0.5 truncate text-xs text-muted-foreground">{reason}</span>
+          )}
           {projectName && (
             <span className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
               <Folder className="size-3 shrink-0" />

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -38,10 +38,11 @@ const (
 	// carrying the status it exited with (see exitEvent).
 	exitEventPrefix = "terminal:exit:"
 	// statusEventName carries a session's processing state ({id, state, tool,
-	// detail} — "busy"/"done"/"waiting"/"idle", plus the tool a pre-tool report
-	// names), reported by the lich hooks running inside the PTY (see
-	// transport.hook and docs/hooks/session-state.md). "interrupted" is the one
-	// value lich raises itself, for a turn the user stopped at the PTY. The frontend keeps it in
+	// detail, reason} — "busy"/"done"/"waiting"/"idle", plus the tool a pre-tool
+	// report names and what a waiting one is blocked on), reported by the lich
+	// hooks running inside the PTY (see transport.hook and
+	// docs/hooks/session-state.md). "interrupted" is the one value lich raises
+	// itself, for a turn the user stopped at the PTY. The frontend keeps it in
 	// stores keyed by id (session-status-store.ts, session-tool-store.ts) rather
 	// than in the card, which is only mounted while its project is active.
 	statusEventName = "session-status"
@@ -67,13 +68,15 @@ const (
 
 // statusEvent is the payload of statusEventName: the session whose processing
 // state changed, the new state, and — on a pre-tool report alone — the tool it
-// is about to run and what that tool acts on. Both are the provider's own
-// words, never translated here (docs/hooks/session-state.md tables them).
+// is about to run and what that tool acts on, or — on a waiting one alone — what
+// it is blocked on. All three are the provider's own words, never translated
+// here (docs/hooks/session-state.md tables them).
 type statusEvent struct {
 	ID     string `json:"id"`
 	State  string `json:"state"`
 	Tool   string `json:"tool,omitempty"`
 	Detail string `json:"detail,omitempty"`
+	Reason string `json:"reason,omitempty"`
 }
 
 // titleEvent is the payload of titleEventName: the session whose label changed
@@ -319,6 +322,7 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 					State:  req.State,
 					Tool:   req.Tool,
 					Detail: req.Detail,
+					Reason: req.Reason,
 				})
 			}
 			// The relay reads the stream raw: it keeps its own turn accounting,

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -397,15 +397,18 @@ func servePost[T any](
 // hookRequest is a status POST body. Tool and Detail are the optional pair a
 // pre-tool report carries — the provider's own name for the tool it is about to
 // run, and its own words for what that tool acts on. Both are absent from every
-// other report.
+// other report. Reason is the same kind of field for the other end of the
+// contract: what a `waiting` report is blocked on, absent from every state that
+// is not a question.
 type hookRequest struct {
 	SessionID string `json:"session_id"`
 	State     string `json:"state"`
 	Tool      string `json:"tool"`
 	Detail    string `json:"detail"`
+	Reason    string `json:"reason"`
 }
 
-// hookTextLimit bounds the tool name and detail a report may carry, in runes.
+// hookTextLimit bounds the free text a report may carry, in runes.
 // Over-long values are truncated rather than rejected: they are decoration on a
 // state that has to land either way, and losing the spinner because a command
 // line grew is the worse failure.
@@ -423,7 +426,8 @@ func (t *transport) hook(w http.ResponseWriter, r *http.Request) {
 }
 
 // parseHookRequest validates a status POST body: a session id, one of the known
-// states, and the optional tool pair. It never trusts the payload — an unknown
+// states, the optional tool pair and the optional waiting reason. It never
+// trusts the payload — an unknown
 // state is rejected so a stray or hostile POST can't drive the UI into an
 // undefined status, and the free text is trimmed and capped (see hookTextLimit).
 func parseHookRequest(body []byte) (hookRequest, error) {
@@ -444,6 +448,13 @@ func parseHookRequest(body []byte) (hookRequest, error) {
 	// than shown on its own.
 	if req.Tool == "" {
 		req.Detail = ""
+	}
+	req.Reason = clampRunes(strings.TrimSpace(req.Reason), hookTextLimit)
+	// Only a `waiting` is a question, so only a `waiting` has something to be
+	// waiting for. A reason riding any other state names nothing the card could
+	// draw, and holding it would outlive the block it described.
+	if req.State != statusWaiting {
+		req.Reason = ""
 	}
 	return req, nil
 }


### PR DESCRIPTION
A session blocked on the user wore the same amber bell whether it wanted permission to delete a directory or an answer about which file to touch. The card is the surface that decides where to click, and neither it nor the toast said anything the bell had not already said.

## The contract, first

`docs/hooks/session-state.md` gains `reason`: one short line belonging to the `waiting` report the way `tool`/`detail` belong to the pre-tool one — optional, trimmed, capped at 120 runes, dropped on every other state, and never a reason to refuse the report. The bell has to land either way.

Four new lines in `docs/hooks/fixtures/session-state.jsonl` (reason sent, trimmed, whitespace-only, dropped on a non-waiting state). The existing lines were left untouched so the plugin's assertions do not move.

## Server side

`transport.go` carries `hookRequest.Reason` through the same clamp `tool`/`detail` use and zeroes it unless the state is `waiting`; `terminal.go` puts it on the `session-status` event. `hookstate.go` is untouched — `turnLog` still decides whether a `waiting` is published at all, and the reason rides the report it already passes.

## The two surfaces

- **Card** — the reason takes the waiting line whole and falls back to "Waiting on you" when there is none. The amber glyph and the ring already say the session is waiting; re-spending the width on that phrase costs the card the only words the user cannot already see.
- **Toast** — the reason as a muted line under the session's name, above the folder row. Read off the raw event like the status, so a second prompt in one turn is a second question shown.

The reason is held in the status store beside the state rather than in a store of its own: `waiting` leaving is the only thing that clears it. The store weighs the reason alongside the state, so a repeat `waiting` with different words moves the line instead of collapsing into a no-op — while `since` still stamps on the state transition alone, so the clock times the block, not the question.

## Traced across the registry

Measured off what each harness ships, not off its documentation:

| Harness | Waiting event | Reason |
|---|---|---|
| Claude Code 2.1.240 | `Notification` | `message` — the only sentence any harness offers |
| Codex 0.147.0 | `PermissionRequest` | `tool_name`; the embedded `permission-request.command.input` schema has no message field at all |
| opencode 1.18.x | four `.asked` types | `permission` / `action` / `questions[0].header`, by field |
| oh-my-pi | — | reports no `waiting` |
| Crush | — | reports no state |

The last two degrade to today's bare line, named by name in `docs/ceilings.md`. Two more ceilings bullets in the contract cover the coarse Codex/opencode wording and the reason's lifetime.

## Also here

A second commit corrects a stale claim in the same contract: it said the client cannot tell a permission prompt from an idle nudge "because the event carries the same shape either way". Claude Code 2.1.240 labels them — `notification_type` is one of 14 values, `permission_prompt` and `idle_prompt` among them. `turnLog` stays, because Codex and opencode carry no such label and a plugin older than the field sends nothing; the doc now says that instead of a reason that no longer holds.

## Order

The client side is written and committed in `omartelo/lich-plugin` (branch `feat/waiting-reason`), unpushed and unreleased. lich merges first — that repo's fixtures-drift job diffs against `lich@main` and stays red until this lands. The change is additive both ways (an older lich ignores an unknown field, a newer one accepts a payload without it), so no version gate was added.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` — 1816 pass
- [x] `biome check .` clean
- [x] `vitest run` — 1063 pass across 88 files
- [x] `tsc` + `vite build`
- [x] CHANGELOG `[Unreleased]` entry in the same change
- [ ] Manual: block a Claude session on a permission prompt and read the card and the toast