### PR TITLE
feat: browse and resume the sessions you have closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Codex and opencode name the tool or permission being asked about, which is
   coarser and still enough to pick the card; oh-my-pi and Crush report no block at
   all, so their cards keep the line they had.
+- **Closing a session no longer throws it away, and the palette has a History
+  tab to find it in.** A closed session used to be gone for good unless it lived
+  in a worktree you chose to keep; now every close parks it, and `Ctrl+K` →
+  History lists what you have closed, newest first, across every project — the
+  closed ones included. Each row names the session, the agent that ran it, the
+  project, the branch its checkout is on and when you closed it, and the search
+  narrows on all of those, so "the conpty thing, three weeks ago" is a query and
+  not an archaeology dig. Enter resumes: the card comes back where it was and
+  picks the conversation up rather than starting cold. A row whose checkout was
+  removed behind lich's back says so and offers to forget it instead.
 - **Sessions can be renamed from the command line and from an agent's own
   tools.** Renaming a card was a thing only the window could do; `lich rename
   "the login bug"` now renames the session the command runs in, `lich rename

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -251,3 +251,33 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   cask's `depends_on` and the bundle's `LSMinimumSystemVersion` say 13.0 because the compiler does —
   both move with the next Go bump, and a machine below the floor is refused by Homebrew rather than
   by a crash.
+- **A closed session's history reaches back a hundred rows, and the search never goes deeper**
+  (`internal/store/store.go`, `frontend/src/lib/session/command-palette.ts`): the History tab is handed the
+  hundred most recently closed sessions when it opens and filters those in the window, the bargain the closed
+  projects list already makes. So a session closed further back than that is in the database, counts against
+  nothing, and cannot be found — typing its name narrows a list it was never in. The fix when it bites is a
+  `LIKE` in the query, not a bigger number; nothing warns that the list was cut, because a cut that is always
+  in force is not news.
+- **The history's branch is read live, so a row whose checkout is gone has none** (`internal/project.BranchesOf`):
+  the branch is not stored — a worktree keeps the name it was created with while an agent moves the branch
+  inside it, so the directory cannot answer and only git can. The batch runs once per opening, which also means
+  a branch that moved while the palette is up is stale until it is reopened. A checkout removed behind lich's
+  back has no branch to read and no session to resume: that row says `checkout gone` and offers to forget
+  itself, which is the only way such a row is ever collected — `PurgeWorktreeSessions` never ran for it,
+  because the removal never went through the app.
+- **Parked rows are never swept, and their dropped-file copies expire on the clock instead of at the close**
+  (`internal/store/mutations.go`, `internal/drop`): every close now parks a row, so the sessions table grows
+  monotonically with the sessions a workspace has ever opened — a few hundred bytes each, which is a megabyte
+  or so a year and deliberately not worth a retention timer. Nothing deletes history on a schedule; a row goes
+  when its worktree is removed through lich, when the user forgets it, or when its project is deleted. The one
+  thing that changed underneath is `internal/drop`: `SetSessionGone` still does not fire on a park, so a plain
+  close no longer takes that session's dropped-file copies with it and they fall to the three-day prune. They
+  are unreachable either way — a resume comes back under a fresh id, so the old copies directory can never be
+  addressed again — but they now sit on disk for up to three days rather than going at the close.
+- **The History tab searches names, never what was said** (`internal/terminal/search.go`): the Messages tab
+  reads a 4 MB tail per session per keystroke, and it is pointed at the sessions the palette can route to —
+  the open ones. History is the long list, so widening the transcript search to it would put a hundred disk
+  reads behind every character typed. The parked row keeps its `provider_session_id`, so the transcript is
+  still there to be searched by whatever does it later; and that search is Claude-only today
+  (`claudeTranscriptPath`) while `canResume` locates all five providers, so widening it would inherit that gap
+  rather than close it.

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react"
 import { useNavigate } from "react-router-dom"
-import { Folder, FolderX, MessageSquareText } from "lucide-react"
+import { Folder, FolderX, GitBranch, MessageSquareText, TriangleAlert } from "lucide-react"
 import { useProjects } from "@/providers/projects"
 import { useSettings } from "@/providers/settings"
 import { useHotkey } from "@/lib/use-hotkey"
@@ -12,6 +12,8 @@ import {
 import { SessionStatusIcon } from "@/components/sidebar/SessionStatusIcon"
 import {
   filterPalette,
+  historyAction,
+  historyRows,
   nextTab,
   paletteGroups,
   paletteSessions,
@@ -19,16 +21,21 @@ import {
   PALETTE_TABS,
   rankSessions,
   rowKey,
+  type PaletteHistory,
   type PaletteMessage,
   type PaletteRow,
   type PaletteSession,
   type PaletteTab,
 } from "@/lib/session/command-palette"
 import { useTranscriptSearch } from "@/lib/session/use-transcript-search"
+import { toast } from "sonner"
 import { PickerDialog, PickerEmpty, PickerGroup, PickerRow } from "@/components/common/PickerDialog"
-import type { Project, RecentProject } from "@/lib/api-types"
+import { agoLabel } from "@/lib/ago"
+import { displayPath } from "@/lib/paths"
+import { isSessionKind } from "@/lib/session/sessions"
+import type { ClosedSession, Project, RecentProject } from "@/lib/api-types"
 import { ProjectService, Store } from "@/lib/rpc"
-import { cn } from "@/lib/utils"
+import { cn, errorText } from "@/lib/utils"
 
 // CommandPalette is the app-wide quick switcher: one shortcut (Ctrl/Cmd+K by
 // default, rebindable in Settings) to jump to any session across every project,
@@ -40,7 +47,7 @@ import { cn } from "@/lib/utils"
 // hotkeys) so it beats the shell binding it shadows; while open, focus is
 // trapped in the dialog and keys never reach the terminal.
 export function CommandPalette() {
-  const { projects, sessions, activateSession, openRecent } = useProjects()
+  const { projects, sessions, activateSession, openRecent, resumeClosedSession } = useProjects()
   const { hotkeys } = useSettings()
   const navigate = useNavigate()
   const [open, setOpen] = useState(false)
@@ -48,6 +55,8 @@ export function CommandPalette() {
   const [tab, setTab] = useState<PaletteTab>("All")
   const [selected, setSelected] = useState(0)
   const [closed, setClosed] = useState<RecentProject[]>([])
+  const [parked, setParked] = useState<ClosedSession[]>([])
+  const [branches, setBranches] = useState<Readonly<Record<string, string>>>({})
   const [running, setRunning] = useState<ReadonlySet<string>>(new Set())
   const [missing, setMissing] = useState<ReadonlySet<string>>(new Set())
 
@@ -58,33 +67,59 @@ export function CommandPalette() {
     setSelected(0)
   })
 
-  // The closed projects live in the store, not in the projects state, so they
-  // are fetched per opening — a project closed or reopened since the last one
-  // moves in or out of this list. Their directories are read with them: one
-  // whose folder moved is relocated rather than reopened, and the row says so.
+  // The closed projects and the parked sessions both live in the store, not in
+  // the workspace state, so they are fetched per opening — anything closed or
+  // reopened since the last one moves in or out of these lists. Their
+  // directories are read with them: a project whose folder moved is relocated
+  // rather than reopened, and a session whose checkout is gone says so.
+  //
+  // The branches are asked for in one batch rather than by subscribing each row
+  // to the git poller a live card uses: that poll is three calls per path per
+  // second, and this list is long and on screen for as long as it takes to type.
   useEffect(() => {
     if (!open) {
       return
     }
     let live = true
-    void Store.RecentProjects().then((rows) => {
-      const recents = rows ?? []
-      if (!live) {
-        return
-      }
-      setClosed(recents)
-      // Asked for after the rows are up: the mark is what a row says about
-      // itself, and a failed check must not cost the palette its entries.
-      void ProjectService.Missing(recents.map((row) => row.path)).then((gone) => {
-        if (live) {
-          setMissing(new Set(gone ?? []))
+    void Promise.all([Store.RecentProjects(), Store.ClosedSessions()]).then(
+      ([recentRows, parkedRows]) => {
+        const recents = recentRows ?? []
+        const history = parkedRows ?? []
+        if (!live) {
+          return
         }
-      })
-    })
+        setClosed(recents)
+        setParked(history)
+        // Asked for after the rows are up: what git and the filesystem say is
+        // what a row says about itself, and a failed check must not cost the
+        // palette its entries.
+        const paths = history.map((row) => row.path).filter(Boolean)
+        void ProjectService.Missing([...recents.map((row) => row.path), ...paths]).then((gone) => {
+          if (live) {
+            setMissing(new Set(gone ?? []))
+          }
+        })
+        void ProjectService.BranchesOf(paths).then((named) => {
+          if (live) {
+            setBranches(named ?? {})
+          }
+        })
+      },
+    )
     return () => {
       live = false
     }
   }, [open])
+
+  // Forgetting drops the row from the list in place rather than closing the
+  // palette: the whole point of the action is that there are usually several of
+  // them, left by worktrees removed outside lich.
+  const forget = (session: PaletteHistory) => {
+    setParked((rows) => rows.filter((row) => row.id !== session.id))
+    void Store.ForgetSession(session.id).catch((error: unknown) => {
+      toast.error(`Could not forget ${session.label}: ${errorText(error)}`)
+    })
+  }
 
   const flat = useMemo(() => paletteSessions(projects, sessions), [projects, sessions])
   // Which sessions hold a turn, sampled once per opening rather than
@@ -99,9 +134,10 @@ export function CommandPalette() {
     }
   }, [open])
   const all = useMemo(() => rankSessions(flat, running), [flat, running])
+  const history = useMemo(() => historyRows(parked, branches, missing), [parked, branches, missing])
   const results = useMemo(
-    () => filterPalette(query, all, projects, closed),
-    [query, all, projects, closed],
+    () => filterPalette(query, all, projects, closed, history),
+    [query, all, projects, closed, history],
   )
   // What was said inside the sessions, not just their names. It arrives after
   // the name-matched groups (it is a disk read behind a debounce), so it is
@@ -154,6 +190,17 @@ export function CommandPalette() {
         close()
         void openRecent(row.project)
         return
+      // A resume navigates on its own, so the palette closes with it. Forgetting
+      // does not: it drops one row and leaves the list up, because a workspace
+      // with one stale row usually has several.
+      case "history":
+        if (historyAction(row.session) === "forget") {
+          forget(row.session)
+          return
+        }
+        close()
+        void resumeClosedSession(row.session)
+        return
     }
   }
 
@@ -170,6 +217,14 @@ export function CommandPalette() {
     setTab("All")
     setSelected(0)
   }
+
+  // What Enter does with the row the cursor is on. Every row but one opens
+  // something; the exception is a history row whose checkout is gone, which can
+  // only be dropped — and the hint bar has to say so before it is pressed.
+  const actionHint = (() => {
+    const row = rows[active]
+    return row?.kind === "history" ? historyAction(row.session) : "open"
+  })()
 
   const onInputKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === "ArrowDown") {
@@ -203,14 +258,28 @@ export function CommandPalette() {
       query={query}
       onQueryChange={setQuery}
       onKeyDown={onInputKeyDown}
-      actionHint="open"
+      actionHint={actionHint}
       filters={<FilterTabs tab={tab} counts={counts} onPick={setTab} />}
     >
       {total === 0 ? (
-        <PickerEmpty>
-          No matches for <span className="font-mono text-foreground/80">{query.trim()}</span>
-          {tab !== "All" && <> in {tab.toLowerCase()}</>}
-        </PickerEmpty>
+        // Two different empties, deliberately not sharing a sentence: one says
+        // the query found nothing, the other says nothing has ever been closed.
+        // The second is the only place the retention rule is stated, which is
+        // where it belongs — the moment somebody wonders what this remembers.
+        tab === "History" && parked.length === 0 ? (
+          <PickerEmpty>
+            <span className="block text-foreground">Nothing closed yet</span>
+            <span className="mx-auto mt-2 block max-w-[44ch] leading-relaxed">
+              Close a session and it waits here — its branch, its agent and its conversation — until
+              its worktree is removed.
+            </span>
+          </PickerEmpty>
+        ) : (
+          <PickerEmpty>
+            No matches for <span className="font-mono text-foreground/80">{query.trim()}</span>
+            {tab !== "All" && <> in {tab.toLowerCase()}</>}
+          </PickerEmpty>
+        )
       ) : (
         sections.map(({ group, offset }) => (
           <PickerGroup
@@ -331,7 +400,77 @@ function ListRow({
           onRun={onRun}
         />
       )
+    case "history":
+      return (
+        <HistoryRow session={row.session} selected={selected} onSelect={onSelect} onRun={onRun} />
+      )
   }
+}
+
+// A closed session names itself the way its card did — the provider mark, the
+// label, the project and the checkout — plus the two facts a card never needed:
+// the branch, because a worktree keeps the name it was created with while the
+// branch moves on, and when it was closed, because that is what turns a list of
+// old work into one somebody can find something in.
+//
+// The provider mark carries no status ring: nothing is running in a closed
+// session, so the ring has nothing to report, and its absence is what tells a
+// history row from a live one at a glance. That is also why the unread flag is
+// a plain false — an unread turn is a turn somebody has not looked at yet, and
+// closing the session is looking at it.
+function HistoryRow({
+  session,
+  selected,
+  onSelect,
+  onRun,
+}: {
+  session: PaletteHistory
+  selected: boolean
+  onSelect: () => void
+  onRun: () => void
+}) {
+  const closedAt = agoLabel(session.closedAt)
+  return (
+    <PickerRow selected={selected} onSelect={onSelect} onRun={onRun}>
+      <SessionStatusIcon
+        kind={isSessionKind(session.kind) ? session.kind : "claude"}
+        status={null}
+        unread={false}
+      />
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate text-sm">{session.label}</span>
+        <span className="flex min-w-0 items-center gap-1.5 font-mono text-xs text-muted-foreground">
+          <span className="shrink-0 text-foreground/70">{session.projectName}</span>
+          <span className="shrink-0 opacity-45">·</span>
+          {/* The checkout being gone replaces the branch rather than sitting
+              beside it: there is no branch to read off a directory that is not
+              there, and it is the same absence that makes the row unresumable. */}
+          {session.gone ? (
+            <span className="flex shrink-0 items-center gap-1 text-amber-500">
+              <TriangleAlert className="size-3 shrink-0" />
+              checkout gone
+            </span>
+          ) : (
+            session.branch && (
+              <span className="flex shrink-0 items-center gap-1">
+                <GitBranch className="size-3 shrink-0" />
+                {session.branch}
+              </span>
+            )
+          )}
+          {(session.gone || session.branch) && <span className="shrink-0 opacity-45">·</span>}
+          <span className={cn("truncate", session.gone && "opacity-60")}>
+            {displayPath(session.path)}
+          </span>
+        </span>
+      </span>
+      {closedAt && (
+        <span className="shrink-0 font-mono text-[0.625rem] tabular-nums text-muted-foreground">
+          {closedAt}
+        </span>
+      )}
+    </PickerRow>
+  )
 }
 
 function SessionRow({

--- a/frontend/src/lib/ago.test.ts
+++ b/frontend/src/lib/ago.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { agoLabel, agoUnit } from "./ago"
+
+const MIN = 60_000
+const HOUR = 60 * MIN
+const DAY = 24 * HOUR
+
+describe("agoUnit", () => {
+  it("floors each unit rather than rounding, so it never claims time that has not passed", () => {
+    expect(agoUnit(59 * 1000)).toBe("now")
+    expect(agoUnit(MIN)).toBe("1m")
+    expect(agoUnit(59 * MIN + 59_000)).toBe("59m")
+    expect(agoUnit(HOUR)).toBe("1h")
+    expect(agoUnit(23 * HOUR + 59 * MIN)).toBe("23h")
+    expect(agoUnit(DAY)).toBe("1d")
+    expect(agoUnit(6 * DAY + 23 * HOUR)).toBe("6d")
+    expect(agoUnit(7 * DAY)).toBe("1w")
+    expect(agoUnit(21 * DAY)).toBe("3w")
+  })
+
+  it("reads a backwards clock jump as now, never as a negative age", () => {
+    expect(agoUnit(-5 * HOUR)).toBe("now")
+  })
+})
+
+describe("agoLabel", () => {
+  const now = 1_700_000_000_000
+
+  it("phrases the unit, so a history row cannot be read as a live card's age", () => {
+    expect(agoLabel(now / 1000 - 2 * 3600, now)).toBe("2h ago")
+    expect(agoLabel(now / 1000 - 3 * 86400, now)).toBe("3d ago")
+    expect(agoLabel(now / 1000 - 21 * 86400, now)).toBe("3w ago")
+  })
+
+  it("says just now rather than 'now ago'", () => {
+    expect(agoLabel(now / 1000 - 5, now)).toBe("just now")
+  })
+
+  it("has no date for a row parked before lich recorded one", () => {
+    expect(agoLabel(0, now)).toBe("")
+    expect(agoLabel(-1, now)).toBe("")
+  })
+})

--- a/frontend/src/lib/ago.ts
+++ b/frontend/src/lib/ago.ts
@@ -1,0 +1,46 @@
+// How long ago something happened, at the coarsest unit that still says
+// something. Two lists read it: the pull requests, where a row has space for
+// "3h" and not for a date and a time, and the closed sessions in the palette,
+// where the same is true and the scale runs further back.
+//
+// One vocabulary rather than two, so "3d" means the same thing wherever the
+// window shows it.
+
+const MINUTE_MS = 60_000
+
+// agoUnit renders elapsed milliseconds as a single unit: minutes, then hours,
+// then days, then weeks. Each is floored, so it never claims time that has not
+// passed, and anything under a minute is "now" — a readout that counted seconds
+// would change under the eye of somebody reading a list.
+//
+// A negative elapsed time (a clock the machine corrected backwards) reads as
+// "now" rather than as a negative age.
+export function agoUnit(ms: number): string {
+  const minutes = Math.floor(Math.max(0, ms) / MINUTE_MS)
+  if (minutes < 1) {
+    return "now"
+  }
+  if (minutes < 60) {
+    return `${minutes}m`
+  }
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) {
+    return `${hours}h`
+  }
+  const days = Math.floor(hours / 24)
+  return days < 7 ? `${days}d` : `${Math.floor(days / 7)}w`
+}
+
+// agoLabel is agoUnit as a phrase, for the places where the unit alone would be
+// ambiguous: a history row's "3d" sits where a live card shows how long its
+// current state has lasted, and the two must not read alike.
+//
+// at is unix seconds — what the store records — and 0 means the row predates
+// lich recording it, which is no date rather than 1970.
+export function agoLabel(at: number, now: number = Date.now()): string {
+  if (at <= 0) {
+    return ""
+  }
+  const unit = agoUnit(now - at * 1000)
+  return unit === "now" ? "just now" : `${unit} ago`
+}

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -308,6 +308,25 @@ export interface StoredSession {
   originLabel: string
 }
 
+/** internal/store.ClosedSession — one parked session offered for resuming. What
+ * identifies it in a list somebody is browsing: the project rides along because
+ * history spans every project at once, closed ones included. No branch — it
+ * lives in git and the window reads it off the checkout (ProjectService.Branches). */
+export interface ClosedSession {
+  id: string
+  projectId: string
+  projectName: string
+  /** The project's own directory, so resuming a session of a closed project can
+   * reopen that project first — and ask where it went if it has moved. */
+  projectPath: string
+  label: string
+  kind: string
+  path: string
+  /** Unix seconds; 0 for a row parked before lich recorded the close, which
+   * sorts last and is drawn as no date rather than as 1970. */
+  closedAt: number
+}
+
 /** internal/terminal.TranscriptMatch — a session whose conversation mentions a
  * search query, with its newest matching message. */
 export interface TranscriptMatch {

--- a/frontend/src/lib/pulls/pull-request-list.ts
+++ b/frontend/src/lib/pulls/pull-request-list.ts
@@ -1,4 +1,5 @@
 import type { PullRequestSummary } from "@/lib/api-types"
+import { agoUnit } from "@/lib/ago"
 import { parseEnumPref, readPref, writePref } from "@/lib/prefs"
 
 // The list column's own logic: which rows a quick filter and the search box
@@ -236,24 +237,12 @@ export function sortPullRequests(
 // updatedAgo renders how long ago a pull request last moved, at the coarsest
 // unit that still says something — a row has space for "3h", not for a date and
 // a time. now is injectable so a test does not depend on the clock.
+//
+// The scale itself is shared with the palette's closed sessions (lib/ago.ts):
+// what differs here is only the input, gh's ISO timestamp.
 export function updatedAgo(updatedAt: string, now: number = Date.now()): string {
   const at = Date.parse(updatedAt)
-  if (Number.isNaN(at)) {
-    return ""
-  }
-  const minutes = Math.floor((now - at) / 60_000)
-  if (minutes < 1) {
-    return "now"
-  }
-  if (minutes < 60) {
-    return `${minutes}m`
-  }
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) {
-    return `${hours}h`
-  }
-  const days = Math.floor(hours / 24)
-  return days < 7 ? `${days}d` : `${Math.floor(days / 7)}w`
+  return Number.isNaN(at) ? "" : agoUnit(now - at)
 }
 
 // Which order the column is in is a UI preference, so it lives in the page's

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -11,6 +11,7 @@ import type {
   BaseStatus,
   BinaryCheck,
   BranchRules,
+  ClosedSession,
   Branches,
   CommitIdentity,
   DetectedProvider,
@@ -177,6 +178,10 @@ export const ProjectService = {
   PickSaveFile: (title: string, defaultName: string) =>
     call<string>("project.PickSaveFile", [title, defaultName]),
   Branch: (path: string) => call<string>("project.Branch", [path]),
+  /** Branch for several checkouts at once, keyed by path; a checkout that names
+   * none is left out. For the lists that want each row's branch once as it is
+   * drawn, rather than the per-path poll a live card subscribes to. */
+  BranchesOf: (paths: string[]) => call<Record<string, string>>("project.BranchesOf", [paths]),
   Diff: (path: string) => call<DiffStats>("project.Diff", [path]),
   /** How far the checkout's base branch has moved and what a merge would
    * collide on. null when the repository has no origin to measure against. */
@@ -342,6 +347,16 @@ export const Store = {
   /** Resume a parked worktree session under a fresh id, or null when none. */
   ReopenWorktreeSession: (projectID: string, path: string, newSessionID: string) =>
     call<StoredSession | null>("store.ReopenWorktreeSession", [projectID, path, newSessionID]),
+  /** The parked sessions, last closed first — the history the palette browses.
+   * Capped store-side, so this is also how far back a search can reach. */
+  ClosedSessions: () => call<ClosedSession[] | null>("store.ClosedSessions", []),
+  /** Resume one parked session by its own id, or null when it is no longer
+   * parked — another window resumed it, or its worktree was removed. */
+  ReopenSession: (sessionID: string, newSessionID: string) =>
+    call<StoredSession | null>("store.ReopenSession", [sessionID, newSessionID]),
+  /** Delete one parked session for good. Refused on a session that is open: a
+   * card on screen is closed, never forgotten. */
+  ForgetSession: (sessionID: string) => call<null>("store.ForgetSession", [sessionID]),
   /** Drop every session row for a worktree path when the worktree is removed. */
   PurgeWorktreeSessions: (projectID: string, path: string) =>
     call<null>("store.PurgeWorktreeSessions", [projectID, path]),

--- a/frontend/src/lib/session/command-palette.test.ts
+++ b/frontend/src/lib/session/command-palette.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest"
 import {
   filterPalette,
+  historyAction,
+  historyRows,
   matchesQuery,
   nextTab,
+  type PaletteHistory,
   paletteGroups,
   paletteMessages,
   paletteSessions,
@@ -10,7 +13,7 @@ import {
   rankSessions,
   rowKey,
 } from "./command-palette"
-import type { Project } from "@/lib/api-types"
+import type { ClosedSession, Project } from "@/lib/api-types"
 import type { SessionState } from "./sessions"
 
 const projects: Project[] = [
@@ -210,8 +213,9 @@ describe("paletteTabCount", () => {
 describe("nextTab", () => {
   it("wraps at both ends", () => {
     expect(nextTab("All", 1)).toBe("Sessions")
-    expect(nextTab("Messages", 1)).toBe("All")
-    expect(nextTab("All", -1)).toBe("Messages")
+    expect(nextTab("Messages", 1)).toBe("History")
+    expect(nextTab("History", 1)).toBe("All")
+    expect(nextTab("All", -1)).toBe("History")
   })
 })
 
@@ -261,5 +265,127 @@ describe("paletteMessages", () => {
   it("is empty when the search found nothing or never ran", () => {
     expect(paletteMessages([], all)).toEqual([])
     expect(paletteMessages(null, all)).toEqual([])
+  })
+})
+
+const parked: ClosedSession[] = [
+  {
+    id: "h1",
+    projectId: "p1",
+    projectName: "lich",
+    projectPath: "/home/u/try/skipo",
+    label: "Wire the relay inbox",
+    kind: "claude",
+    path: "/home/u/wt/lich/relay-inbox",
+    closedAt: 1_700_000_200,
+  },
+  {
+    id: "h2",
+    projectId: "p1",
+    projectName: "lich",
+    projectPath: "/home/u/try/skipo",
+    label: "Conpty handle recycling",
+    kind: "claude",
+    path: "/home/u/wt/lich/conpty",
+    closedAt: 1_700_000_100,
+  },
+  {
+    id: "h3",
+    projectId: "p2",
+    projectName: "revu",
+    projectPath: "/home/u/try/revu",
+    label: "vitest --ui",
+    kind: "shell",
+    path: "/home/u/wt/revu/gone",
+    closedAt: 1_700_000_000,
+  },
+]
+
+const parkedBranches = {
+  "/home/u/wt/lich/relay-inbox": "feat/relay-inbox",
+  "/home/u/wt/lich/conpty": "fix/conpty-handle",
+}
+
+describe("historyRows", () => {
+  it("hangs the live branch off each parked row, and marks the checkouts that are gone", () => {
+    const rows = historyRows(parked, parkedBranches, new Set(["/home/u/wt/revu/gone"]))
+    expect(rows.map((r) => [r.id, r.branch, r.gone])).toEqual([
+      ["h1", "feat/relay-inbox", false],
+      ["h2", "fix/conpty-handle", false],
+      ["h3", "", true],
+    ])
+  })
+
+  it("leaves a checkout that is present but nameless unmarked — no branch is not gone", () => {
+    const rows = historyRows(parked.slice(0, 1), {}, new Set())
+    expect(rows[0]?.branch).toBe("")
+    expect(rows[0]?.gone).toBe(false)
+  })
+
+  it("survives a store that answered before git did", () => {
+    expect(historyRows([], {}, new Set())).toEqual([])
+    expect(historyRows(parked, {}, new Set())).toHaveLength(3)
+  })
+})
+
+describe("history search", () => {
+  const rows = historyRows(parked, parkedBranches, new Set())
+
+  it("narrows on the branch, which the path cannot stand in for", () => {
+    const hit = filterPalette("conpty-handle", [], [], [], rows).history
+    expect(hit.map((h) => h.id)).toEqual(["h2"])
+  })
+
+  it("narrows on the label, the project and the path too", () => {
+    expect(filterPalette("relay", [], [], [], rows).history.map((h) => h.id)).toEqual(["h1"])
+    expect(filterPalette("revu", [], [], [], rows).history.map((h) => h.id)).toEqual(["h3"])
+    expect(filterPalette("wt/lich", [], [], [], rows).history.map((h) => h.id)).toEqual([
+      "h1",
+      "h2",
+    ])
+  })
+
+  it("takes every token, so two words narrow further than one", () => {
+    expect(filterPalette("lich relay", [], [], [], rows).history.map((h) => h.id)).toEqual(["h1"])
+    expect(filterPalette("lich nothing", [], [], [], rows).history).toEqual([])
+  })
+
+  it("is empty rather than everything when no history was loaded", () => {
+    expect(filterPalette("relay", [], [], []).history).toEqual([])
+  })
+})
+
+describe("the History tab", () => {
+  const rows = historyRows(parked, parkedBranches, new Set())
+  const results = filterPalette("", [], projects, closed, rows)
+
+  it("lists the parked sessions whole, under their own heading", () => {
+    const groups = paletteGroups("History", results, [])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]?.label).toBe("Closed sessions")
+    expect(groups[0]?.rows.map((r) => rowKey(r))).toEqual(["h1", "h2", "h3"])
+  })
+
+  it("keeps history out of All, which is the mid-work posture", () => {
+    const kinds = paletteGroups("All", results, []).flatMap((g) => g.rows.map((r) => r.kind))
+    expect(kinds).not.toContain("history")
+  })
+
+  it("counts what it holds", () => {
+    expect(paletteTabCount("History", results, [])).toBe(3)
+  })
+
+  it("draws no group at all when nothing has ever been closed", () => {
+    const none = filterPalette("", [], projects, closed, [])
+    expect(paletteGroups("History", none, [])).toEqual([])
+  })
+})
+
+describe("historyAction", () => {
+  const rows = historyRows(parked, parkedBranches, new Set(["/home/u/wt/revu/gone"]))
+
+  it("resumes a row whose checkout is still there and forgets one whose is not", () => {
+    expect(historyAction(rows[0] as PaletteHistory)).toBe("resume")
+    expect(historyAction(rows[2] as PaletteHistory)).toBe("forget")
   })
 })

--- a/frontend/src/lib/session/command-palette.ts
+++ b/frontend/src/lib/session/command-palette.ts
@@ -2,7 +2,7 @@
 // flat, filterable list the palette lists and routes to. Kept pure (no React,
 // no stores) so the flatten and filter are testable without a render.
 
-import type { Project, TranscriptMatch } from "@/lib/api-types"
+import type { ClosedSession, Project, TranscriptMatch } from "@/lib/api-types"
 import type { SessionKind, SessionState } from "./sessions"
 
 // PaletteSession is one session flattened with the project it belongs to — what
@@ -56,12 +56,41 @@ export function matchesQuery(haystack: string, query: string): boolean {
   return q.split(/\s+/).every((token) => hay.includes(token))
 }
 
+// PaletteHistory is one parked session as the History tab lists it: the store's
+// row plus the branch its checkout is on, which lives in git and not in the row
+// (internal/store.ClosedSession). Both are "" for a checkout that is gone —
+// which is also the row that cannot be resumed, so one absence explains both.
+export interface PaletteHistory extends ClosedSession {
+  branch: string
+  /** The checkout is no longer on disk: this row forgets rather than resumes. */
+  gone: boolean
+}
+
+// historyRows joins the parked rows to what git says about their checkouts. A
+// path with no branch and a path in `missing` are different failures — not a
+// repository, versus not there at all — but the row only acts on the second,
+// so only that one marks it.
+export function historyRows(
+  closed: readonly ClosedSession[],
+  branches: Readonly<Record<string, string>>,
+  missing: ReadonlySet<string>,
+): PaletteHistory[] {
+  return closed.map((session) => ({
+    ...session,
+    branch: branches[session.path] ?? "",
+    gone: missing.has(session.path),
+  }))
+}
+
 export interface PaletteResults {
   sessions: PaletteSession[]
   projects: Project[]
   // The closed projects, which the reopen menu shows five of: past that the
   // palette is the only way back to one.
   closed: Project[]
+  // The parked sessions — what the History tab lists, and the only group whose
+  // rows are not in the workspace at all.
+  history: PaletteHistory[]
 }
 
 export function filterPalette(
@@ -69,6 +98,7 @@ export function filterPalette(
   allSessions: readonly PaletteSession[],
   projects: readonly Project[],
   closed: readonly Project[] = [],
+  history: readonly PaletteHistory[] = [],
 ): PaletteResults {
   return {
     sessions: allSessions.filter((s) =>
@@ -76,6 +106,13 @@ export function filterPalette(
     ),
     projects: projects.filter((p) => matchesQuery(`${p.name} ${p.path}`, query)),
     closed: closed.filter((p) => matchesQuery(`${p.name} ${p.path}`, query)),
+    // The branch is in the haystack because it is what a user remembers a piece
+    // of work by, and it is the one part of the row the path cannot stand in
+    // for: a worktree keeps the name it was created with while the branch moves
+    // on (lib/git/checkout-label.ts).
+    history: history.filter((h) =>
+      matchesQuery(`${h.label} ${h.projectName} ${h.branch} ${h.path}`, query),
+    ),
   }
 }
 
@@ -112,10 +149,15 @@ export function paletteMessages(
 }
 
 // PALETTE_TABS is the filter row, in the order Tab walks it. A query can hit
-// four kinds of thing at once, which is a page of rows nobody reads: All shows
+// five kinds of thing at once, which is a page of rows nobody reads: All shows
 // the first few of the three worth interrupting for, and a tab lists one kind
-// whole — including the closed projects, which only their tab carries.
-export const PALETTE_TABS = ["All", "Sessions", "Projects", "Messages"] as const
+// whole — including the closed projects and the closed sessions, which only
+// their own tabs carry.
+//
+// History is last because it is the one posture the palette is not opened in:
+// the other four are asked mid-work, and this one is asked when the work is
+// already over and somebody is looking for what they did.
+export const PALETTE_TABS = ["All", "Sessions", "Projects", "Messages", "History"] as const
 
 export type PaletteTab = (typeof PALETTE_TABS)[number]
 
@@ -152,6 +194,7 @@ export type PaletteRow =
   | { kind: "project"; project: Project }
   | { kind: "closed"; project: Project }
   | { kind: "message"; message: PaletteMessage }
+  | { kind: "history"; session: PaletteHistory }
 
 export interface PaletteGroup {
   label: string
@@ -164,11 +207,24 @@ export interface PaletteGroup {
 // rowKey identifies a row inside the list it is rendered in. A session and a
 // message about it share an id, and they never share a group.
 export function rowKey(row: PaletteRow): string {
-  return row.kind === "session"
-    ? row.session.sessionId
-    : row.kind === "message"
-      ? row.message.sessionId
-      : row.project.id
+  switch (row.kind) {
+    case "session":
+      return row.session.sessionId
+    case "message":
+      return row.message.sessionId
+    case "history":
+      return row.session.id
+    default:
+      return row.project.id
+  }
+}
+
+// historyAction is what Enter does with one history row, and what its hint bar
+// says. A checkout that is gone has nothing to resume into — the row is a
+// leftover PurgeWorktreeSessions never collected, because the removal never went
+// through lich — so the only honest action left is to drop it.
+export function historyAction(row: PaletteHistory): "resume" | "forget" {
+  return row.gone ? "forget" : "resume"
 }
 
 // cap of 0 means no cap — the tab that names one kind lists all of it.
@@ -185,6 +241,7 @@ export function paletteGroups(
   const open = results.projects.map((project): PaletteRow => ({ kind: "project", project }))
   const closed = results.closed.map((project): PaletteRow => ({ kind: "closed", project }))
   const said = messages.map((message): PaletteRow => ({ kind: "message", message }))
+  const history = results.history.map((session): PaletteRow => ({ kind: "history", session }))
 
   const groups = ((): PaletteGroup[] => {
     switch (tab) {
@@ -194,10 +251,12 @@ export function paletteGroups(
         return [group("Open", open, 0), group("Closed", closed, 0)]
       case "Messages":
         return [group("Messages", said, 0)]
-      // No closed projects here: reopening one is not what the palette is
-      // reached for mid-work, and the rows it costs are rows the sessions and
-      // the open projects are cut to make room for. The Projects tab lists
-      // them whole, which is where somebody looking for one already goes.
+      case "History":
+        return [group("Closed sessions", history, 0)]
+      // No closed projects or closed sessions here: bringing one back is not
+      // what the palette is reached for mid-work, and the rows it costs are
+      // rows the sessions and the open projects are cut to make room for. Their
+      // own tabs list them whole, which is where somebody looking already goes.
       default:
         return [
           group("Sessions", sessions, ALL_TAB_ROWS),
@@ -223,6 +282,8 @@ export function paletteTabCount(
       return results.projects.length + results.closed.length
     case "Messages":
       return messages.length
+    case "History":
+      return results.history.length
     default:
       return null
   }

--- a/frontend/src/providers/projects-context.ts
+++ b/frontend/src/providers/projects-context.ts
@@ -1,5 +1,5 @@
 import { createContext, useContext } from "react"
-import type { Project, RecentProject } from "@/lib/api-types"
+import type { ClosedSession, Project, RecentProject } from "@/lib/api-types"
 import type { SessionKind, SessionState } from "@/lib/session/sessions"
 
 export interface ProjectsValue {
@@ -11,8 +11,9 @@ export interface ProjectsValue {
   /** Show the OS directory picker, add the chosen project and navigate to it. */
   openProject: () => Promise<void>
   /** Reopen a closed project without the picker. A project whose directory is
-   * gone asks for the new one instead, keeping its id and its sessions. */
-  openRecent: (recent: RecentProject) => Promise<void>
+   * gone asks for the new one instead, keeping its id and its sessions. Answers
+   * whether the project is open afterwards — a cancelled relocate is a no. */
+  openRecent: (recent: RecentProject) => Promise<boolean>
   /** Ensure a project rooted at $HOME exists (no picker) and return its id — the
    * update flow's install terminal when no project is in view. */
   ensureHomeProject: () => Promise<string>
@@ -32,9 +33,14 @@ export interface ProjectsValue {
   /** Resume a worktree: reopen its parked session when one exists, else open a
    * fresh session on it. */
   reopenWorktreeSession: (projectId: string, wt: { name: string; path: string }) => Promise<void>
-  /** Permanently delete a session, offering an Undo toast for a stray click. */
+  /** Resume a session picked out of the history, reopening its project first
+   * when that project's tab is gone. */
+  resumeClosedSession: (closed: ClosedSession) => Promise<void>
+  /** Close a session, parking its row so the history can resume it. Offers an
+   * Undo toast for a stray click. */
   closeSession: (projectId: string, sessionId: string) => void
-  /** Delete a session with no undo offered. */
+  /** Delete a session for good, with no undo offered — the close that takes the
+   * checkout with it, where a parked row would outlive its directory. */
   discardSession: (projectId: string, sessionId: string) => void
   /** Close a worktree session but park its row so it can be resumed later. */
   keepSession: (projectId: string, sessionId: string) => void

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -3,8 +3,8 @@ import type { ReactNode } from "react"
 import { toast } from "sonner"
 import { Bell, Folder, MessageSquareDashed } from "lucide-react"
 import { useMatch, useNavigate } from "react-router-dom"
-import type { Project, RecentProject } from "@/lib/api-types"
-import type { StoredProject as StoreProject } from "@/lib/api-types"
+import type { ClosedSession, Project, RecentProject } from "@/lib/api-types"
+import type { StoredProject as StoreProject, StoredSession } from "@/lib/api-types"
 import { ProjectService, Store, System } from "@/lib/rpc"
 import { onAppEvent } from "@/lib/app-events"
 import {
@@ -72,6 +72,22 @@ import { ProjectsContext } from "./projects-context"
 export { useProjects } from "./projects-context"
 
 const newSessionId = (): string => crypto.randomUUID()
+
+// cardFromStored turns the row a resume hands back into the card the sidebar
+// draws. Shared by both doors into a resume — the worktree picker and the
+// history list — so a field one carried and the other dropped cannot happen.
+const cardFromStored = (restored: StoredSession): Session => ({
+  id: restored.id,
+  label: restored.label,
+  kind: isSessionKind(restored.kind) ? restored.kind : "claude",
+  path: restored.path,
+  ...(restored.providerSessionId ? { providerSessionId: restored.providerSessionId } : {}),
+  ...(restored.entrypoint ? { entrypoint: restored.entrypoint } : {}),
+  ...(restored.sandbox === "on" ? { sandboxed: true } : {}),
+  ...(restored.originSessionId
+    ? { originSessionId: restored.originSessionId, originLabel: restored.originLabel }
+    : {}),
+})
 
 // The first session of any project is always "Session 1"; the counter then
 // points at 2 for the next one.
@@ -280,21 +296,28 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
   // which is what its sessions and its worktree directory hang off. Cancelling
   // leaves the row exactly as it was, to relocate on the next attempt; a
   // directory another project already holds is refused backend-side.
+  //
+  // Answers whether the project is open afterwards, for the caller that has more
+  // to do once it is: resuming a session of a closed project reopens the project
+  // first, and a cancelled relocate has to stop that resume rather than land a
+  // card in a project the window is not holding.
   const openRecent = useCallback(
-    async (recent: RecentProject) => {
+    async (recent: RecentProject): Promise<boolean> => {
       if (await ProjectService.Exists(recent.path)) {
         await adopt(recent)
-        return
+        return true
       }
       try {
         const moved = await ProjectService.Relocate(recent.id)
         if (!moved) {
-          return
+          return false
         }
         await adopt(moved)
         toast.success(`${moved.name} now opens ${displayPath(moved.path)}`)
+        return true
       } catch (error) {
         toast.error(`Relocate failed: ${errorText(error)}`)
+        return false
       }
     },
     [adopt],
@@ -382,21 +405,40 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
         newWorktreeSession(projectId, wt)
         return
       }
-      const session: Session = {
-        id: restored.id,
-        label: restored.label,
-        kind: isSessionKind(restored.kind) ? restored.kind : "claude",
-        path: restored.path,
-        ...(restored.providerSessionId ? { providerSessionId: restored.providerSessionId } : {}),
-        ...(restored.entrypoint ? { entrypoint: restored.entrypoint } : {}),
-        ...(restored.sandbox === "on" ? { sandboxed: true } : {}),
-        ...(restored.originSessionId
-          ? { originSessionId: restored.originSessionId, originLabel: restored.originLabel }
-          : {}),
-      }
-      commit(restoreSession(sessionsRef.current, projectId, session))
+      commit(restoreSession(sessionsRef.current, projectId, cardFromStored(restored)))
     },
     [newWorktreeSession],
+  )
+
+  // Resume one session picked out of the history, wherever it was parked. The
+  // project comes back first when its tab is gone — a card cannot land in a
+  // project the window is not holding — and a cancelled relocate stops the
+  // resume rather than reopening the session into nowhere.
+  //
+  // A row the store no longer has is not an error: another window resumed it, or
+  // its worktree was removed since the list was drawn. The toast says which,
+  // because the row disappearing with no explanation reads as a failure.
+  const resumeClosedSession = useCallback(
+    async (closed: ClosedSession) => {
+      if (!sessionsRef.current[closed.projectId]) {
+        const opened = await openRecent({
+          id: closed.projectId,
+          name: closed.projectName,
+          path: closed.projectPath,
+        })
+        if (!opened) {
+          return
+        }
+      }
+      const restored = await Store.ReopenSession(closed.id, newSessionId())
+      if (!restored) {
+        toast(`${closed.label} is no longer available to resume`)
+        return
+      }
+      commit(restoreSession(sessionsRef.current, closed.projectId, cardFromStored(restored)))
+      navigate(`/projects/${closed.projectId}`)
+    },
+    [openRecent, navigate],
   )
 
   // dropSession removes a session's card and persists that removal via `persist`
@@ -420,49 +462,36 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     [],
   )
 
-  // Undo re-creates the row a close deleted, from what the page still holds,
-  // rather than parking it for the toast's lifetime: parking would need a
-  // reopen-by-id the store has no other reason to grow, and every app exit
-  // inside the toast window would strand a hidden parked row that a later
-  // worktree resume could resurrect. Re-creating owns no window — the close is
-  // final the moment it is made, and the undo is a plain new write. What the
-  // row does not carry back: label_auto (a restored card is auto-titleable
-  // again, even if its name was hand-picked) and the cost ledgers of any
-  // transcript it will not run through again.
+  // Undo puts the parked row back rather than re-creating one: every close parks
+  // now, so the reopen-by-id the history list needed is the same door an undo
+  // wants, and re-inserting a second row for a session the store still holds
+  // would leave the first one hidden in the history forever.
   //
-  // The PTY is not held open for the window either — a closed session's terminal
-  // is gone. The restored card comes back unspawned, so the resume prompt is
-  // what brings the conversation with it, exactly as for a parked worktree.
+  // What it therefore keeps that the old re-insert dropped: label_auto, the cost
+  // ledgers, and the position — the resume appends and the reorder below puts the
+  // card back in its slot.
+  //
+  // The PTY is not held open for the toast's lifetime — a closed session's
+  // terminal is gone. The restored card comes back unspawned under a fresh id, so
+  // the resume prompt is what brings the conversation with it, exactly as for a
+  // parked worktree.
   const restoreClosedSession = useCallback(
-    (projectId: string, session: Session, index: number, nextSeq: number) => {
-      const next = restoreSession(sessionsRef.current, projectId, session, index)
+    async (projectId: string, session: Session, index: number) => {
+      const restored = await Store.ReopenSession(session.id, newSessionId())
+      if (!restored) {
+        toast.error(`Could not bring ${session.label} back`)
+        return
+      }
+      const next = restoreSession(sessionsRef.current, projectId, cardFromStored(restored), index)
       if (next === sessionsRef.current) {
         return // the project was closed while the toast was up
       }
       commit(next)
-      const order = sessionsOf(next, projectId).map((s) => s.id)
-      const {
-        id,
-        label,
-        kind,
-        path = "",
-        providerSessionId,
-        originSessionId = "",
-        originLabel = "",
-      } = session
-      void Store.AddSessionFrom(
+      // The resume appends, so the slot the card went back to is a reorder.
+      void Store.ReorderSessions(
         projectId,
-        id,
-        label,
-        kind,
-        path,
-        nextSeq,
-        originSessionId,
-        originLabel,
+        sessionsOf(next, projectId).map((s) => s.id),
       )
-        .then(() => providerSessionId && Store.SetProviderSession(id, providerSessionId))
-        // AddSession appends: the slot the card went back to is a reorder.
-        .then(() => Store.ReorderSessions(projectId, order))
     },
     [],
   )
@@ -475,31 +504,20 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
         return
       }
       const session = project.sessions[index]
-      const { nextSeq } = project
-      // The conversation id lives on the row, not on the card — a session started
-      // in this run never mirrors it into the page — so it is read back before
-      // the delete takes it with it: an undo without it restores an empty card.
-      const conversation = session.providerSessionId
-        ? Promise.resolve(session.providerSessionId)
-        : Store.ProviderSession(sessionId).catch(() => "")
-      const deleted = dropSession(projectId, sessionId, (activeID) =>
-        conversation.then(() => Store.DeleteSession(projectId, sessionId, activeID)),
+      // Parked, not deleted: the row is what the history lists and what an undo
+      // resumes, and its conversation id, cost ledgers and chosen name all ride
+      // on it. Removing the checkout is the one close that still deletes
+      // (discardSession), because a row must not outlive its directory.
+      const parked = dropSession(projectId, sessionId, (activeID) =>
+        Store.CloseSession(projectId, sessionId, activeID),
       )
       toast(`Closed ${session.label}`, {
         duration: UNDO_TOAST_MS,
         action: {
           label: "Undo",
-          // Waits on the delete: the store can sit on a lock for seconds, and an
-          // insert that overtook it would be deleted right back out.
-          onClick: () =>
-            void Promise.all([conversation, deleted]).then(([providerSessionId]) =>
-              restoreClosedSession(
-                projectId,
-                { ...session, ...(providerSessionId ? { providerSessionId } : {}) },
-                index,
-                nextSeq,
-              ),
-            ),
+          // Waits on the park: the store can sit on a lock for seconds, and a
+          // resume that overtook it would find the row still open and do nothing.
+          onClick: () => void parked.then(() => restoreClosedSession(projectId, session, index)),
         },
       })
     },
@@ -515,6 +533,8 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     [dropSession],
   )
 
+  // closeSession without the toast: the keep-or-remove dialog already asked, so
+  // there is nothing left to offer an undo for.
   const keepSession = useCallback(
     (projectId: string, sessionId: string) => {
       void dropSession(projectId, sessionId, (activeID) =>
@@ -847,6 +867,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       newSession,
       newWorktreeSession,
       reopenWorktreeSession,
+      resumeClosedSession,
       closeSession,
       discardSession,
       keepSession,
@@ -868,6 +889,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       newSession,
       newWorktreeSession,
       reopenWorktreeSession,
+      resumeClosedSession,
       closeSession,
       discardSession,
       keepSession,

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -196,6 +196,24 @@ func (s *Service) Missing(paths []string) []string {
 	return gone
 }
 
+// BranchesOf answers Branch for several checkouts at once, keyed by path; a path
+// that names no branch — gone, not a repository, a detached HEAD — is left out
+// rather than mapped to "", so a caller reads "no branch" from the absence.
+//
+// The batch exists because the list that asks is a list of parked sessions: it
+// wants each row's branch once, when it is drawn, not the per-path poll a live
+// card subscribes to (frontend/src/lib/git/use-git-status.ts). Three RPCs per
+// row per second is what that poll costs, and a history list is long.
+func (s *Service) BranchesOf(paths []string) map[string]string {
+	branches := map[string]string{}
+	for _, path := range paths {
+		if branch := s.Branch(path); branch != "" {
+			branches[path] = branch
+		}
+	}
+	return branches
+}
+
 // PickFile shows the native file picker and returns the chosen file path, or ""
 // if the user cancels the dialog.
 func (s *Service) PickFile(title string) (string, error) {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -165,6 +165,33 @@ func TestBranch(t *testing.T) {
 	}
 }
 
+// TestBranchesOf proves the batch answers one entry per checkout that names a
+// branch and leaves the rest out entirely — the history rows read "no branch"
+// from a missing key, so a path mapped to "" would draw an empty badge instead
+// of none at all.
+func TestBranchesOf(t *testing.T) {
+	repo := t.TempDir()
+	if out, err := exec.Command("git", "init", "-b", "trunk", repo).CombinedOutput(); err != nil {
+		t.Skipf("git init unavailable: %v (%s)", err, out)
+	}
+	notARepo := t.TempDir()
+	gone := filepath.Join(t.TempDir(), "removed-behind-our-back")
+
+	got := New(nil).BranchesOf([]string{repo, notARepo, gone})
+	if len(got) != 1 || got[repo] != "trunk" {
+		t.Errorf("BranchesOf = %v, want only the real checkout, on trunk", got)
+	}
+}
+
+// TestBranchesOfNothing keeps the empty call cheap and non-nil: the window calls
+// it on every palette opening, including the one where no session has ever been
+// closed.
+func TestBranchesOfNothing(t *testing.T) {
+	if got := New(nil).BranchesOf(nil); got == nil || len(got) != 0 {
+		t.Errorf("BranchesOf(nil) = %v, want an empty map", got)
+	}
+}
+
 // TestParsePullRequest proves the gh output decoder: a real PR yields its number
 // and URL, while malformed JSON, an empty object, and a PR missing its number or
 // URL all collapse to nil so the badge hides instead of showing garbage.

--- a/internal/store/history_test.go
+++ b/internal/store/history_test.go
@@ -1,0 +1,285 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// atClock stamps every close during fn with the given wall clock, so a test can
+// order two closes without waiting out a real second.
+func atClock(t *testing.T, at time.Time, fn func()) {
+	t.Helper()
+	previous := now
+	now = func() time.Time { return at }
+	defer func() { now = previous }()
+	fn()
+}
+
+// TestClosedSessionsOrdersByCloseNotByInsert is the whole reason closed_at
+// exists: rowid dates the insert, so a session opened first and closed last
+// would sort to the bottom of a list that claims to be "most recently closed".
+func TestClosedSessionsOrdersByCloseNotByInsert(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 2, "")
+	_ = svc.AddSession("p1", "first", "opened first", "claude", "/wt/a", 3, "")
+	_ = svc.AddSession("p1", "second", "opened second", "claude", "/wt/b", 4, "")
+
+	// The one inserted first is closed last, so insert order and close order
+	// disagree on every row.
+	atClock(t, time.Unix(1_700_000_100, 0), func() { _ = svc.CloseSession("p1", "second", "keep") })
+	atClock(t, time.Unix(1_700_000_200, 0), func() { _ = svc.CloseSession("p1", "first", "keep") })
+
+	closed, err := svc.ClosedSessions()
+	if err != nil {
+		t.Fatalf("ClosedSessions: %v", err)
+	}
+	if len(closed) != 2 {
+		t.Fatalf("got %d closed sessions, want 2", len(closed))
+	}
+	if closed[0].ID != "first" || closed[1].ID != "second" {
+		t.Errorf("order = %q, %q; want the last one closed first", closed[0].ID, closed[1].ID)
+	}
+	if closed[0].ClosedAt != 1_700_000_200 {
+		t.Errorf("ClosedAt = %d, want the close's own stamp", closed[0].ClosedAt)
+	}
+}
+
+// TestClosedSessionsIdentifiesEachRow pins what a history row carries, since
+// that is what makes a closed session findable at all: nothing here is derivable
+// from the session id the row is keyed by.
+func TestClosedSessionsIdentifiesEachRow(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 2, "")
+	_ = svc.AddSession("p1", "gone", "Wire the relay inbox", "shell", "/wt/relay", 3, "")
+	atClock(t, time.Unix(1_700_000_000, 0), func() { _ = svc.CloseSession("p1", "gone", "keep") })
+
+	closed, _ := svc.ClosedSessions()
+	if len(closed) != 1 {
+		t.Fatalf("got %d closed sessions, want 1", len(closed))
+	}
+	got := closed[0]
+	want := ClosedSession{
+		ID: "gone", ProjectID: "p1", ProjectName: "alpha", ProjectPath: "/tmp/alpha",
+		Label: "Wire the relay inbox", Kind: "shell", Path: "/wt/relay",
+		ClosedAt: 1_700_000_000,
+	}
+	if got != want {
+		t.Errorf("closed session = %+v, want %+v", got, want)
+	}
+}
+
+// TestClosedSessionsSkipsOpenOnes guards the list against the sessions the user
+// is looking at: a history that offered to resume a live card would resume it
+// against a PTY already running.
+func TestClosedSessionsSkipsOpenOnes(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "live", "Session 1", "claude", "", 2, "")
+
+	closed, err := svc.ClosedSessions()
+	if err != nil {
+		t.Fatalf("ClosedSessions: %v", err)
+	}
+	if len(closed) != 0 {
+		t.Errorf("closed = %+v, want none while the only session is open", closed)
+	}
+}
+
+// TestClosedSessionsIncludesClosedProjects is the case the join must not drop:
+// the work a user goes looking for months later is usually in a project whose
+// tab is long gone, and resuming one of its sessions is what reopens it.
+func TestClosedSessionsIncludesClosedProjects(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 2, "")
+	_ = svc.AddSession("p1", "old", "old work", "claude", "/wt/old", 3, "")
+	_ = svc.CloseSession("p1", "old", "keep")
+	_ = svc.CloseProject("p1")
+
+	closed, _ := svc.ClosedSessions()
+	if len(closed) != 1 || closed[0].ProjectName != "alpha" {
+		t.Errorf("closed = %+v, want the session of the closed project, named", closed)
+	}
+}
+
+// TestClosedSessionsCapsTheList pins the bound rather than deriving it from the
+// constant: the cap is how far back a search can reach, so a change to it has to
+// be a deliberate edit here too.
+func TestClosedSessionsCapsTheList(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 2, "")
+	for i := range 101 {
+		id := "s" + string(rune('a'+i%26)) + string(rune('a'+i/26))
+		_ = svc.AddSession("p1", id, "work", "claude", "/wt/"+id, i+3, "")
+		atClock(t, time.Unix(int64(1_700_000_000+i), 0), func() {
+			_ = svc.CloseSession("p1", id, "keep")
+		})
+	}
+
+	closed, _ := svc.ClosedSessions()
+	if len(closed) != 100 {
+		t.Errorf("got %d closed sessions, want the list capped at 100", len(closed))
+	}
+	// The cap keeps the newest, not the first hundred it happened to read.
+	if closed[0].ClosedAt != 1_700_000_100 {
+		t.Errorf("newest = %d, want the last close of the run", closed[0].ClosedAt)
+	}
+}
+
+// TestReopenSessionRestoresByID covers the history list's own door: the row is
+// picked, not looked up by path, and a project-root session has no path to look
+// it up by in the first place.
+func TestReopenSessionRestoresByID(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 2, "")
+	_ = svc.AddSession("p1", "root", "root work", "claude", "", 3, "")
+	_ = svc.SetProviderSession("root", "conv-root")
+	_ = svc.RenameSession("root", "named by hand")
+	_ = svc.CloseSession("p1", "root", "keep")
+
+	restored, err := svc.ReopenSession("root", "fresh")
+	if err != nil {
+		t.Fatalf("ReopenSession: %v", err)
+	}
+	if restored == nil {
+		t.Fatal("ReopenSession = nil, want the parked session")
+	}
+	if restored.ID != "fresh" || restored.Label != "named by hand" {
+		t.Errorf("restored = %+v, want a fresh id keeping the chosen label", restored)
+	}
+	if restored.ProviderSessionID != "conv-root" {
+		t.Errorf("ProviderSessionID = %q, want the conversation carried over", restored.ProviderSessionID)
+	}
+
+	// It comes back open, in its project, and stops being history.
+	projects, _ := svc.LoadState()
+	if len(projects) != 1 || len(projects[0].Sessions) != 2 {
+		t.Fatalf("sessions after resume = %+v, want the kept one and the resumed one", projects)
+	}
+	closed, _ := svc.ClosedSessions()
+	if len(closed) != 0 {
+		t.Errorf("closed = %+v, want the resumed row out of the history", closed)
+	}
+}
+
+// TestReopenSessionClearsTheCloseStamp keeps a resumed row from dating its next
+// close before it happens — the stamp belongs to the close that made it, and
+// carrying it over would sort the row by a close it no longer had.
+func TestReopenSessionClearsTheCloseStamp(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 2, "")
+	_ = svc.AddSession("p1", "s1", "work", "claude", "/wt/a", 3, "")
+	atClock(t, time.Unix(1_700_000_000, 0), func() { _ = svc.CloseSession("p1", "s1", "keep") })
+
+	if _, err := svc.ReopenSession("s1", "s2"); err != nil {
+		t.Fatalf("ReopenSession: %v", err)
+	}
+	var stamp int64
+	if err := svc.db.QueryRow(`SELECT closed_at FROM sessions WHERE id = ?`, "s2").Scan(&stamp); err != nil {
+		t.Fatalf("read closed_at: %v", err)
+	}
+	if stamp != 0 {
+		t.Errorf("closed_at after resume = %d, want 0 on an open row", stamp)
+	}
+}
+
+// TestReopenSessionRefusesALiveOne stops the history's door from reaching a card
+// on screen: resuming one would delete and reinsert the row under a new id while
+// its PTY is still running against the old one.
+func TestReopenSessionRefusesALiveOne(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "live", "Session 1", "claude", "", 2, "")
+
+	restored, err := svc.ReopenSession("live", "fresh")
+	if err != nil {
+		t.Fatalf("ReopenSession: %v", err)
+	}
+	if restored != nil {
+		t.Errorf("ReopenSession on an open session = %+v, want nil", restored)
+	}
+}
+
+// TestReopenWorktreeSessionRefusesTheEmptyPath is PurgeWorktreeSessions' guard
+// on the read side. Now that every close parks, a project's own sessions sit in
+// the table with no path — and an unguarded lookup would hand one of those to a
+// worktree picker that asked for a checkout.
+func TestReopenWorktreeSessionRefusesTheEmptyPath(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 2, "")
+	_ = svc.AddSession("p1", "root", "root work", "claude", "", 3, "")
+	_ = svc.CloseSession("p1", "root", "keep")
+
+	restored, err := svc.ReopenWorktreeSession("p1", "", "fresh")
+	if err != nil {
+		t.Fatalf("ReopenWorktreeSession: %v", err)
+	}
+	if restored != nil {
+		t.Errorf("ReopenWorktreeSession(path: \"\") = %+v, want nil", restored)
+	}
+	// And the parked root session is still there for its own door.
+	closed, _ := svc.ClosedSessions()
+	if len(closed) != 1 || closed[0].ID != "root" {
+		t.Errorf("closed = %+v, want the root session still parked", closed)
+	}
+}
+
+// TestForgetSessionRemovesOneParkedRow covers the only way out for a row whose
+// checkout was removed behind lich's back — nothing else ever collects it.
+func TestForgetSessionRemovesOneParkedRow(t *testing.T) {
+	svc := newTestStore(t)
+	var gone []string
+	svc.SetSessionGone(func(id string) { gone = append(gone, id) })
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 2, "")
+	_ = svc.AddSession("p1", "dead", "work", "claude", "/wt/dead", 3, "")
+	_ = svc.CloseSession("p1", "dead", "keep")
+
+	if err := svc.ForgetSession("dead"); err != nil {
+		t.Fatalf("ForgetSession: %v", err)
+	}
+	closed, _ := svc.ClosedSessions()
+	if len(closed) != 0 {
+		t.Errorf("closed = %+v, want the forgotten row gone", closed)
+	}
+	if len(gone) != 1 || gone[0] != "dead" {
+		t.Errorf("reported gone = %v, want the forgotten session once", gone)
+	}
+}
+
+// TestForgetSessionRefusesALiveOne is the guard that keeps the verb apart from
+// closing: a card on screen is closed, never forgotten, and an id that reached
+// here by mistake must not take a running session's row with it.
+func TestForgetSessionRefusesALiveOne(t *testing.T) {
+	svc := newTestStore(t)
+	var gone []string
+	svc.SetSessionGone(func(id string) { gone = append(gone, id) })
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "live", "Session 1", "claude", "", 2, "")
+
+	if err := svc.ForgetSession("live"); err != nil {
+		t.Fatalf("ForgetSession: %v", err)
+	}
+	projects, _ := svc.LoadState()
+	if len(projects) != 1 || len(projects[0].Sessions) != 1 {
+		t.Errorf("sessions = %+v, want the live one untouched", projects)
+	}
+	if len(gone) != 0 {
+		t.Errorf("reported gone = %v, want nothing reported for a row that stayed", gone)
+	}
+}
+
+// TestForgetSessionOnAMissingRowIsNotAnError keeps the action idempotent: two
+// windows can forget the same row, and the second must not raise.
+func TestForgetSessionOnAMissingRowIsNotAnError(t *testing.T) {
+	svc := newTestStore(t)
+	if err := svc.ForgetSession("never-existed"); err != nil {
+		t.Errorf("ForgetSession on a missing row = %v, want nil", err)
+	}
+}

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -6,9 +6,14 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/omartelo/lich/internal/providers"
 )
+
+// now is time.Now, replaced in tests: a close stamps the row with it, and a
+// test about the order that stamp produces cannot wait out a real second.
+var now = time.Now
 
 // nextSessionPosition is the position a newly inserted session takes: after the
 // project's last one, so a new card appends to the list even once the user has
@@ -179,26 +184,87 @@ func (s *Service) DeleteSession(projectID, sessionID, activeID string) error {
 // CloseSession parks a session instead of deleting it: is_open flips to 0, which
 // hides it from LoadState while keeping its row — and its provider session id —
 // intact for a later resume. The project's active session moves to activeID (the
-// neighbor the frontend picked). The keep-the-worktree close uses this; a plain
-// close still calls DeleteSession, which removes it for good.
+// neighbor the frontend picked).
+//
+// Every close lands here. DeleteSession is what the checkout's own removal uses,
+// where the row must not outlive the directory it points at.
+//
+// closed_at is stamped in the same statement rather than after it: it is what
+// orders the history the parked row exists to appear in, and a row parked
+// without one sorts as if it had been closed before everything else.
 func (s *Service) CloseSession(projectID, sessionID, activeID string) error {
 	return s.tx(func(tx *sql.Tx) error {
-		if _, err := tx.Exec(`UPDATE sessions SET is_open = 0 WHERE id = ?`, sessionID); err != nil {
+		if _, err := tx.Exec(
+			`UPDATE sessions SET is_open = 0, closed_at = ? WHERE id = ?`,
+			now().Unix(), sessionID,
+		); err != nil {
 			return fmt.Errorf("close session %q: %w", sessionID, err)
 		}
 		return setActiveSession(tx, projectID, activeID)
 	})
 }
 
-// ReopenWorktreeSession resumes a parked worktree session. It finds the parked
-// (is_open = 0) session for the worktree at path and re-adds it to the workspace
-// under a fresh id (newSessionID), carrying over the old label, kind, provider
-// session id, label_auto flag, model, entrypoint and origin. The fresh id is
+// ForgetSession deletes one parked session for good. It is the way out for the
+// row whose checkout was removed behind lich's back: nothing can resume it, and
+// PurgeWorktreeSessions never ran for it because the removal never went through
+// the app.
+//
+// is_open = 0 is the whole guard: a session on screen is closed, never
+// forgotten, so an id belonging to a live card matches nothing here. A row that
+// was already gone is not an error, and only a delete that actually removed one
+// reports the session gone.
+func (s *Service) ForgetSession(sessionID string) error {
+	res, err := s.db.Exec(`DELETE FROM sessions WHERE id = ? AND is_open = 0`, sessionID)
+	if err != nil {
+		return fmt.Errorf("forget session %q: %w", sessionID, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("forget session %q rows: %w", sessionID, err)
+	}
+	if n > 0 {
+		s.sessionIsGone(sessionID)
+	}
+	return nil
+}
+
+// ReopenWorktreeSession resumes the session parked for the worktree at path,
+// the last one closed there. Returns nil when nothing is parked at path — the
+// caller then opens a brand-new session.
+//
+// The empty path is refused, and that guard is load-bearing for the same reason
+// PurgeWorktreeSessions carries one: a project's own sessions are stored with no
+// path, so an unguarded lookup would answer the worktree picker with a parked
+// session that never lived in a worktree at all.
+func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*Session, error) {
+	if path == "" {
+		return nil, nil
+	}
+	return s.reopen(newSessionID,
+		`WHERE project_id = ? AND path = ? AND is_open = 0 ORDER BY rowid DESC LIMIT 1`,
+		projectID, path)
+}
+
+// ReopenSession resumes one parked session by its own id — the history list's
+// door, where the row was picked rather than looked up. Returns nil when no
+// parked session has that id, which is what a row already resumed in another
+// window looks like.
+//
+// Deliberately not scoped to a project: the row names its own, and that is the
+// only answer that stays right for a session parked in a project the caller is
+// not looking at — which is most of the history.
+func (s *Service) ReopenSession(sessionID, newSessionID string) (*Session, error) {
+	return s.reopen(newSessionID, `WHERE id = ? AND is_open = 0`, sessionID)
+}
+
+// reopen is the resume behind both doors: it finds one parked session with the
+// given WHERE clause and re-adds it to the workspace under a fresh id
+// (newSessionID), carrying over the old label, kind, path, provider session id,
+// label_auto flag, model, entrypoint, sandbox and origin. The fresh id is
 // deliberate: it makes the frontend treat the card as never-spawned, so its
 // resume prompt fires and the provider conversation continues instead of
-// starting cold. Returns nil when nothing is parked at path — the caller then
-// opens a brand-new session.
-func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*Session, error) {
+// starting cold.
+func (s *Service) reopen(newSessionID, where string, args ...any) (*Session, error) {
 	var restored *Session
 	err := s.tx(func(tx *sql.Tx) error {
 		var old Session
@@ -212,24 +278,25 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 		// the provider back on its default model and the terminal back on a bare
 		// shell — silently, on the one path where the card keeps its identity but
 		// not its id.
+		//
+		// project_id is read rather than passed: reopening by id knows only the
+		// session, and the row is what says where it belongs.
 		var labelAuto int
-		var model, entrypoint, sandbox string
+		var projectID, model, entrypoint, sandbox string
 		row := tx.QueryRow(
-			`SELECT id, label, kind, provider_session_id, label_auto, model, entrypoint, sandbox,
-			        origin_session_id, origin_label
-			   FROM sessions
-			  WHERE project_id = ? AND path = ? AND is_open = 0
-			  ORDER BY rowid DESC LIMIT 1`,
-			projectID, path,
+			`SELECT id, project_id, label, kind, path, provider_session_id, label_auto,
+			        model, entrypoint, sandbox, origin_session_id, origin_label
+			   FROM sessions `+where,
+			args...,
 		)
 		if err := row.Scan(
-			&old.ID, &old.Label, &old.Kind, &old.ProviderSessionID, &labelAuto, &model, &entrypoint,
-			&sandbox, &old.OriginSessionID, &old.OriginLabel,
+			&old.ID, &projectID, &old.Label, &old.Kind, &old.Path, &old.ProviderSessionID,
+			&labelAuto, &model, &entrypoint, &sandbox, &old.OriginSessionID, &old.OriginLabel,
 		); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
-				return nil // nothing parked here; caller creates a new session
+				return nil // nothing parked; caller creates a new session
 			}
-			return fmt.Errorf("find parked session for %q: %w", path, err)
+			return fmt.Errorf("find parked session: %w", err)
 		}
 		// The cost ledgers are read out before the row goes, because deleting it
 		// cascades them away — and a resumed session that forgot what it spent
@@ -241,12 +308,15 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 		if _, err := tx.Exec(`DELETE FROM sessions WHERE id = ?`, old.ID); err != nil {
 			return fmt.Errorf("drop parked session %q: %w", old.ID, err)
 		}
+		// closed_at is left to its default: the reinserted row is open again, and
+		// a resume that carried the old stamp over would date the next close
+		// before it happened.
 		if _, err := tx.Exec(
 			`INSERT INTO sessions
 			   (id, project_id, label, kind, path, provider_session_id, label_auto,
 			    model, entrypoint, sandbox, origin_session_id, origin_label, position)
 			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
-			newSessionID, projectID, old.Label, old.Kind, path, old.ProviderSessionID, labelAuto,
+			newSessionID, projectID, old.Label, old.Kind, old.Path, old.ProviderSessionID, labelAuto,
 			model, entrypoint, sandbox, old.OriginSessionID, old.OriginLabel, projectID,
 		); err != nil {
 			return fmt.Errorf("reinsert session %q: %w", newSessionID, err)
@@ -261,7 +331,7 @@ func (s *Service) ReopenWorktreeSession(projectID, path, newSessionID string) (*
 			ID:                newSessionID,
 			Label:             old.Label,
 			Kind:              old.Kind,
-			Path:              path,
+			Path:              old.Path,
 			ProviderSessionID: old.ProviderSessionID,
 			Entrypoint:        entrypoint,
 			Sandbox:           sandbox,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -68,7 +68,14 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- setting. Three states rather than a boolean because the row has to be able
     -- to say "nobody decided this one" — a session opened before the user picked
     -- a rung, or by a caller with nowhere to ask.
-    sandbox             TEXT NOT NULL DEFAULT ''
+    sandbox             TEXT NOT NULL DEFAULT '',
+    -- When this session was parked, in unix seconds; 0 while it is open, and on
+    -- a row parked before the column existed. rowid cannot stand in for it: it
+    -- dates the insert, not the close, and a resume reinserts the row under a
+    -- fresh id — so the history the palette lists would reorder itself every
+    -- time a session came back. Seconds, not a counter like projects.closed_seq:
+    -- that list only had to order, and this one has to say when.
+    closed_at           INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
 
@@ -106,8 +113,9 @@ type Service struct {
 }
 
 // SetSessionGone registers what to run when a session's row is deleted for
-// good — DeleteSession and PurgeWorktreeSessions, never CloseSession, which
-// parks the row for a later resume and leaves everything hanging off it alone.
+// good — DeleteSession, PurgeWorktreeSessions and ForgetSession, never
+// CloseSession, which parks the row for a later resume and leaves everything
+// hanging off it alone.
 //
 // It is startup wiring, called before anything serves: lich hangs the cleanup
 // of that session's dropped-file copies on it (internal/drop), which is what
@@ -227,6 +235,7 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN origin_session_id TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN origin_label TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN sandbox TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN closed_at INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN closed_seq INTEGER NOT NULL DEFAULT 0`,
 	}
@@ -380,6 +389,80 @@ func (s *Service) RecentProjects() ([]Recent, error) {
 		return nil, fmt.Errorf("iterate recent projects: %w", err)
 	}
 	return recents, nil
+}
+
+// ClosedSession is one parked session offered for resuming — what identifies it
+// in a list somebody is browsing rather than one they are already looking at.
+// The project rides along because history spans every project at once, closed
+// ones included, and the project name is what tells two sessions of the same
+// name apart.
+//
+// No branch: it lives in git, and a worktree's directory stops agreeing with it
+// the moment an agent branches inside the checkout, which is the ordinary way
+// to work in one (frontend/src/lib/git/checkout-label.ts). The window reads it
+// off the checkout instead, and a row whose checkout is gone has none to show —
+// which is the same row that cannot be resumed anyway.
+type ClosedSession struct {
+	ID          string `json:"id"`
+	ProjectID   string `json:"projectId"`
+	ProjectName string `json:"projectName"`
+	// The project's own directory, so resuming a session of a closed project can
+	// reopen that project first without a second lookup — and can ask where it
+	// went when the directory has moved.
+	ProjectPath string `json:"projectPath"`
+	Label       string `json:"label"`
+	Kind        string `json:"kind"`
+	Path        string `json:"path"`
+	// Unix seconds, 0 for a row parked before closed_at existed — which sorts
+	// last and is drawn as no date rather than as 1970.
+	ClosedAt int64 `json:"closedAt"`
+}
+
+// closedSessionLimit caps the history handed to the window. The palette filters
+// what it was given rather than asking again per keystroke (the same bargain
+// RecentProjects makes), so this number is how far back a search can reach:
+// deep enough to cover the sessions a workspace churns through in months, and
+// still a bound — the alternative is reading every session ever closed to draw
+// a list nobody scrolls to the end of.
+const closedSessionLimit = 100
+
+// ClosedSessions returns the parked sessions (is_open = 0), the last one closed
+// first, up to closedSessionLimit of them. Sessions of closed projects answer
+// too: a project hidden from the tab strip still owns the work done in it, and
+// resuming one of its sessions is what reopens it.
+//
+// rowid is the tiebreak, not the order, for RecentProjects' reason twice over:
+// it dates the insert, and a resumed session is reinserted — so rows parked
+// before closed_at existed all carry 0 and fall back to it together.
+func (s *Service) ClosedSessions() ([]ClosedSession, error) {
+	rows, err := s.db.Query(
+		`SELECT s.id, s.project_id, p.name, p.path, s.label, s.kind, s.path, s.closed_at
+		   FROM sessions s JOIN projects p ON p.id = s.project_id
+		  WHERE s.is_open = 0
+		  ORDER BY s.closed_at DESC, s.rowid DESC
+		  LIMIT ?`,
+		closedSessionLimit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("query closed sessions: %w", err)
+	}
+	defer rows.Close()
+
+	closed := []ClosedSession{}
+	for rows.Next() {
+		var c ClosedSession
+		if err := rows.Scan(
+			&c.ID, &c.ProjectID, &c.ProjectName, &c.ProjectPath,
+			&c.Label, &c.Kind, &c.Path, &c.ClosedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan closed session: %w", err)
+		}
+		closed = append(closed, c)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate closed sessions: %w", err)
+	}
+	return closed, nil
 }
 
 // ProjectPath returns the directory of the project with this id, or "" when


### PR DESCRIPTION
## Why

A closed session was already in SQLite and out of reach. `CloseSession` parked its row, but only the keep-the-worktree close ever called it — a plain close deleted — and nothing in the window could list what was parked. A session came back only by accident, when somebody happened to reopen its worktree.

## What

Every close now parks, and the command palette grows a **History** tab to find the parked rows in.

It is a tab rather than a screen because the palette already splits the two postures this needs: `All` is the mid-work posture, cut to five rows a group, and a named tab is the browse posture — one kind of thing, uncapped. Browsing history is the second exactly, and it inherits the query, the groups, the arrow keys and the Enter contract for free. Closed *projects* stay on the Projects tab: a project is reopened, a session is resumed, and two verbs under one `↵` is what that split avoids.

A row names the session, the agent that ran it, the project, the branch its checkout is on and when it was closed; the search narrows on all of those. `↵` resumes — the card comes back under a fresh id, so the resume prompt fires and the conversation continues instead of starting cold — reopening the project first when that project's tab is gone. A row whose checkout was removed behind lich's back says `checkout gone` and `↵` forgets it instead.

## Store

- **`closed_at` on `sessions`**, in unix seconds. `rowid` cannot stand in for it: it dates the insert, not the close, and a resume reinserts the row. Seconds rather than a counter like `projects.closed_seq`, because that list only had to *order* and this one has to *say when*.
- **`ClosedSessions()`** joins the parked rows to their projects, newest close first, capped at 100 — the same bargain `RecentProjects` makes, and therefore also how far back a search can reach.
- **`ReopenSession(id)`** is the history's door. It shares one body with `ReopenWorktreeSession`, which keeps a field one carried and the other dropped from being possible — and that reopen-by-id lets the undo toast stop re-creating a row by hand (net deletion in `projects.tsx`).
- **`ForgetSession(id)`**, scoped to `is_open = 0`: a card on screen is closed, never forgotten.
- **`ReopenWorktreeSession` refuses the empty path** — `PurgeWorktreeSessions`' guard on the read side. Now that every close parks, a project's own sessions sit in the table with no path.

The branch is deliberately **not** stored: a worktree keeps the name it was created with while an agent moves the branch inside it, so only git can answer. `project.BranchesOf` asks once per palette opening rather than subscribing every row to the poll a live card uses, which is three calls per path per second.

## Ceilings

Four bullets added to `docs/ceilings.md`: the hundred-row reach, the live branch and the row whose checkout is gone, no retention sweep on any clock (plus the dropped-file copies that now expire on their three-day prune rather than at the close), and History searching names while Messages searches transcripts.

## Test plan

- [x] `gofmt -l .` / `go vet ./...` clean; `go test ./...` green (12 new store tests, 2 new project tests)
- [x] Cross-compile loop green for linux / darwin / windows
- [x] `pnpm check`, `tsc`, `vitest` (1080 passed), `vite build`
- [x] Render driven headlessly over CDP, since the node gate cannot render: palette opens, five tabs with counts, History lists the rows with live branch and `checkout gone`, the query narrows, `↵` resumes end-to-end (verified against SQLite), `↵` forgets the dead row in place without closing the palette, both empty states read correctly, zero console errors
- [x] Worth a human pass in `task dev` on a real workspace with months of parked rows
