### PR TITLE
feat: filter the session sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   either way: the provider's auto-title never overwrites it again. A name another
   session in that project already holds is refused, because two sessions under
   one label is the one thing `lich send` cannot resolve.
+- **The session sidebar filters.** With a dozen cards open across three
+  checkouts, finding the two you are actually shepherding was a scan. A
+  magnifier beside New Session opens a field that narrows the list as you type,
+  matching a card's name or the checkout it runs in — so typing a worktree name
+  keeps that whole block. Unlike the command palette, which jumps once and
+  closes, this one is held while you work: the surviving cards stay live, with
+  their status rings, their close buttons and everything else. A group with
+  nothing left drops out entirely, the session you are looking at stays visible
+  whether it matches or not, and the filter is never narrowing the list out of
+  sight — it clears when you close it, when you collapse the sidebar and when
+  you switch project, and it is never restored on a restart.
 - **A session's card now shows the ticket it is answering.** Hover a card with an
   open request and the tooltip names the other end and the ticket number, and on
   the side that owes the answer it spells the command that sends it home. Until

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -88,6 +88,9 @@ interface SessionCardProps {
   onSetEntrypoint: (entrypoint: string) => void
   // Open the Pulls screen for this session's worktree, parking its PR card.
   onPulls: () => void
+  // Whether the card can be dragged. False while the sidebar holds a filter,
+  // where a drop would compute an order the store rejects wholesale.
+  sortable: boolean
   // Sessions this one can hand work to, grouped by project. Only the card
   // whose terminal is on screen offers them — the request is written at that
   // terminal's prompt, so any other card would be writing somewhere the user
@@ -108,6 +111,7 @@ export function SessionCard({
   onOpenTerminal,
   onSetEntrypoint,
   onPulls,
+  sortable,
   delegateGroups,
 }: SessionCardProps) {
   const pinned = !!session.pinned
@@ -166,7 +170,7 @@ export function SessionCard({
   // before the input could be clicked into or its text selected.
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: session.id,
-    disabled: editing,
+    disabled: editing || !sortable,
   })
 
   // Write the request at this session's own prompt and hand the cursor back.

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -34,6 +34,10 @@ interface SessionGroupProps {
   // header doubles as the group's drag handle, so a lone group is also the case
   // where reordering groups has nothing to reorder.
   showHeader: boolean
+  // Whether this block and its cards can be dragged at all. False while the
+  // sidebar holds a filter: the ids a filtered group renders are not the ids
+  // reorderSubset needs to splice an order back into the stored list.
+  sortable: boolean
   // Commits a new order for this group's sessions; a drag can only ever produce
   // one, since each group owns an isolated DndContext. Not derivable here: the
   // sidebar splices it back into the flat list its siblings share.
@@ -75,6 +79,7 @@ export function SessionGroup({
   projectPath,
   activeId,
   showHeader,
+  sortable,
   onReorder,
   onClose,
   pullsActive,
@@ -96,7 +101,7 @@ export function SessionGroup({
   const ids = sessions.map((session) => session.id)
   const { sensors, onDragEnd } = useSortableList(ids, onReorder)
   const name = pinned ? "Pinned" : checkoutLabel(path, projectPath, projectId)
-  const group = useSortable({ id: sortId, disabled: !showHeader || pinned })
+  const group = useSortable({ id: sortId, disabled: !sortable || !showHeader || pinned })
   // The PR card keys off the group's real checkout — the project root for the
   // root group (empty path), else the worktree — so a root project on a feature
   // branch parks its card too, not only worktrees.
@@ -173,6 +178,7 @@ export function SessionGroup({
                     onPin={(pinned) => pinSession(projectId, session.id, pinned)}
                     onOpenTerminal={(cwd) => newSession(projectId, "shell", cwd)}
                     onPulls={onPulls}
+                    sortable={sortable}
                     delegateGroups={delegateGroups}
                   />
                 ))}

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -1,8 +1,9 @@
-import { useMemo, useState, useSyncExternalStore } from "react"
+import { useEffect, useMemo, useState, useSyncExternalStore } from "react"
+import type { KeyboardEvent } from "react"
 import { useMatch, useNavigate } from "react-router-dom"
 import { DndContext, closestCenter } from "@dnd-kit/core"
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable"
-import { GitPullRequestArrow, PanelLeftClose, Plus } from "lucide-react"
+import { GitPullRequestArrow, PanelLeftClose, Plus, Search } from "lucide-react"
 import { ProjectService } from "@/lib/rpc"
 import { closeSettings, isSettingsOpen, subscribeSettingsCard } from "@/lib/settings-card-store"
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
@@ -13,7 +14,9 @@ import {
   subscribePullsListCard,
 } from "@/lib/pulls-list-card-store"
 import { enabledProviders, projectDefaultProviderKind, useProviders } from "@/lib/providers-store"
+import { Notice } from "@/components/common/Notice"
 import { ResizeHandle } from "@/components/common/ResizeHandle"
+import { SearchInput } from "@/components/common/SearchInput"
 import { SettingsCard } from "./SettingsCard"
 import { SidebarCard } from "@/components/common/SidebarCard"
 import { Button } from "@/components/ui/button"
@@ -24,6 +27,8 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { useProjects } from "@/providers/projects"
 import { queueSetup } from "@/lib/terminal/setup-queue"
+import { filterSessions } from "@/lib/session/session-filter"
+import { requestTerminalFocus } from "@/lib/terminal/focus-request"
 import {
   activeSessionId,
   orderGroups,
@@ -100,6 +105,18 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
     edge: "right",
   })
   const [worktreeOpen, setWorktreeOpen] = useState(false)
+  // The filter over this project's cards. Deliberately neither persisted nor a
+  // store: the sidebar's width and collapsed state survive a restart because
+  // they are layout, but a filter is a lens held while working — a lich that
+  // boots showing two of nine sessions is a bug report, not a restored setting.
+  // It drops on a project switch for the reason the dock's file filter does:
+  // the list underneath is a different set of sessions entirely.
+  const [filterOpen, setFilterOpen] = useState(false)
+  const [query, setQuery] = useState("")
+  useEffect(() => {
+    setFilterOpen(false)
+    setQuery("")
+  }, [projectId])
   // The shortcut's half of the New session menu's Worktree item. Ungated where
   // the menu item is disabled without a branch: git status may still be loading
   // on the render this mounts in, and the dialog reports git's own error in
@@ -108,7 +125,13 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   // Resolved ahead of the no-project bail below: hooks cannot sit behind it.
   const list = sessionsOf(sessions, projectId ?? "")
   const worktreeClose = useWorktreeClose(projectId ?? "", path, list)
-  const groups = sidebarGroups(list)
+  const realActiveId = activeSessionId(sessions, projectId ?? "")
+  // The query narrows the flat list before the groups are built from it, so
+  // grouping, the pinned block and the stored order all keep working on the
+  // survivors without knowing a filter exists.
+  const filtering = query.trim() !== ""
+  const { sessions: visible, matched } = filterSessions(list, query, path, realActiveId)
+  const groups = sidebarGroups(visible)
   // The pinned block is out of the drag list entirely: it is always first, and
   // the worktree blocks reorder among themselves. Dragging one moves its whole
   // block of ids inside the flat list the groups are read back from — there is
@@ -121,7 +144,6 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
       reorderSubset(list, orderGroups(groups, keys), (session) => !session.pinned),
     ),
   )
-  const realActiveId = activeSessionId(sessions, projectId ?? "")
   // Resolved once here, not per group: the list spans every open project, so
   // it is the same for every card in the sidebar. Memoised because the picker
   // downstream keys its own flatten and filter off this array's identity, and
@@ -130,6 +152,31 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
     () => delegateTargets(projects, sessions, realActiveId),
     [projects, sessions, realActiveId],
   )
+
+  // Closing clears the query: a filter outliving its own field would be hiding
+  // cards with nothing on screen to say why. Same reason the collapsed rail
+  // never filters — unmounting this sidebar drops the query with it.
+  const toggleFilter = () => {
+    setQuery("")
+    setFilterOpen((open) => !open)
+  }
+
+  // Esc with text clears the query and keeps the field; Esc on an empty field
+  // closes it and hands the keyboard back to the terminal. Two presses to leave,
+  // so a long query is never one keystroke from taking focus off the sidebar.
+  const onFilterKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Escape") {
+      return
+    }
+    if (query !== "") {
+      setQuery("")
+      return
+    }
+    setFilterOpen(false)
+    if (realActiveId) {
+      requestTerminalFocus(realActiveId)
+    }
+  }
 
   if (!projectId) {
     return null
@@ -203,6 +250,16 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
         </DropdownMenu>
         <Button
           variant="ghost"
+          title="Filter sessions"
+          aria-label="Filter sessions"
+          aria-pressed={filterOpen}
+          onClick={toggleFilter}
+          className="size-8 shrink-0 justify-center px-0 text-muted-foreground hover:bg-accent hover:text-foreground aria-pressed:bg-accent aria-pressed:text-foreground"
+        >
+          <Search className="size-4" />
+        </Button>
+        <Button
+          variant="ghost"
           title="Collapse sidebar"
           aria-label="Collapse sidebar"
           onClick={onCollapse}
@@ -211,6 +268,26 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
           <PanelLeftClose className="size-4" />
         </Button>
       </div>
+      {/* Revealed rather than resident: 36px is half a session card off a list
+          that already scrolls, and unlike the dock's file tree — a panel opened
+          to find something — the sidebar is watched all day and opened for
+          nothing. */}
+      {filterOpen && (
+        <div className="mb-2">
+          <SearchInput
+            // The field exists only once the magnifier is pressed, and that press
+            // is the request for it.
+            autoFocus
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            onKeyDown={onFilterKeyDown}
+            placeholder="Filter sessions"
+            aria-label="Filter sessions"
+            spellCheck={false}
+            className="h-7 text-xs"
+          />
+        </div>
+      )}
       {/* The scrollbar takes width, so it rides the aside's own padding (-mr-2)
           and the padding is re-applied inside — a gap between thumb and card
           when it shows, no shift in card width when it doesn't. */}
@@ -246,6 +323,14 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
             }}
           />
         )}
+        {/* Not `groups.length === 0`: the active card is kept whatever the
+            query says, so the list is rarely empty and the sentence has to
+            explain the one card that is still there. */}
+        {filtering && !matched && (
+          <Notice className="px-2 py-3">
+            No sessions match “{query.trim()}”. The active session stays.
+          </Notice>
+        )}
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
@@ -267,8 +352,16 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
                   activeId={activeId}
                   // The divider only earns its place once a worktree — or a pin
                   // — splits the list; a lone group keeps the old flat,
-                  // header-less look.
-                  showHeader={groups.length > 1}
+                  // header-less look. A filter is the exception: which checkout
+                  // a surviving card sits in is the thing the query was typed to
+                  // find out, so the title stays even for a lone group.
+                  showHeader={groups.length > 1 || filtering}
+                  // A drop computed from a filtered view hands reorderSubset an
+                  // id set that does not name the group's members, and
+                  // reorderSessions rejects the whole order — so the gesture
+                  // would be a silent no-op. Take it away instead of leaving a
+                  // dead one on screen.
+                  sortable={!filtering}
                   onReorder={(ids) => commitGroupOrder(group, ids)}
                   onClose={worktreeClose.requestClose}
                   pullsActive={onPullsRoute && groupActive}

--- a/frontend/src/lib/session/session-filter.test.ts
+++ b/frontend/src/lib/session/session-filter.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+import { filterSessions } from "./session-filter"
+import type { Session } from "./sessions"
+
+const PROJECT = "/home/u/code/lich"
+const WORKTREE = "/home/u/.local/share/lich/worktrees/lich/feat/auth-relay"
+
+const sessions: Session[] = [
+  { id: "s1", label: "Relay inbox nudge", kind: "claude", pinned: true },
+  { id: "s2", label: "Patch notes", kind: "codex", pinned: true },
+  { id: "s3", label: "Relay ticket lifecycle", kind: "claude" },
+  { id: "s4", label: "shell", kind: "shell" },
+  { id: "s5", label: "Wire the auth token", kind: "claude", path: WORKTREE },
+  { id: "s6", label: "Round-trip tests", kind: "codex", path: WORKTREE },
+]
+
+const ids = (list: Session[]) => list.map((session) => session.id)
+
+describe("filterSessions", () => {
+  it("hands the list straight back for a blank query", () => {
+    const filter = filterSessions(sessions, "   ", PROJECT, "s3")
+    expect(filter.sessions).toBe(sessions)
+    expect(filter.matched).toBe(true)
+  })
+
+  it("matches labels across groups and keeps the stored order", () => {
+    const filter = filterSessions(sessions, "relay", PROJECT, "s3")
+    // s5 and s6 ride in on their checkout path, which carries "auth-relay".
+    expect(ids(filter.sessions)).toEqual(["s1", "s3", "s5", "s6"])
+    expect(filter.matched).toBe(true)
+  })
+
+  it("narrows to a checkout when the query is a worktree name", () => {
+    const filter = filterSessions(sessions, "auth-relay", PROJECT, "s5")
+    expect(ids(filter.sessions)).toEqual(["s5", "s6"])
+  })
+
+  it("matches the project's own path for a session without one", () => {
+    const filter = filterSessions(sessions, "code/lich", PROJECT, "s3")
+    expect(ids(filter.sessions)).toEqual(["s1", "s2", "s3", "s4"])
+  })
+
+  it("keeps the active session when it does not match", () => {
+    const filter = filterSessions(sessions, "relay", PROJECT, "s4")
+    expect(ids(filter.sessions)).toEqual(["s1", "s3", "s4", "s5", "s6"])
+    expect(filter.matched).toBe(true)
+  })
+
+  it("reports no match even though the active session is still drawn", () => {
+    const filter = filterSessions(sessions, "webgl", PROJECT, "s4")
+    expect(ids(filter.sessions)).toEqual(["s4"])
+    expect(filter.matched).toBe(false)
+  })
+
+  it("draws nothing at all when nothing matches and no session is active", () => {
+    const filter = filterSessions(sessions, "webgl", PROJECT, "")
+    expect(filter.sessions).toEqual([])
+    expect(filter.matched).toBe(false)
+  })
+
+  it("is case-insensitive and splits the query into tokens", () => {
+    expect(ids(filterSessions(sessions, "TICKET relay", PROJECT, "").sessions)).toEqual(["s3"])
+  })
+})

--- a/frontend/src/lib/session/session-filter.ts
+++ b/frontend/src/lib/session/session-filter.ts
@@ -1,0 +1,56 @@
+// The session sidebar's own filter: which of a project's cards survive the
+// query typed into it. Kept here rather than in the component because the
+// frontend suite runs in node and cannot render one — and this is the half with
+// a rule in it.
+//
+// It is not the command palette. The palette spans every open project and
+// navigates once; this narrows one sidebar and is held while the work happens,
+// so the surviving cards stay live — status ring, tool rung, close, delegate.
+
+import { matchesQuery } from "./command-palette"
+import type { Session } from "./sessions"
+
+export interface SidebarFilter {
+  // The cards the sidebar draws, in the stored order: the matches, plus the
+  // active session whatever the query says.
+  sessions: Session[]
+  // Whether anything actually matched. Not derivable from `sessions` being
+  // empty — the kept active card means it rarely is — and it is what tells the
+  // empty state apart from a narrowed list.
+  matched: boolean
+}
+
+// filterSessions narrows a project's sessions to the ones whose label or
+// checkout matches the query. The stored order is preserved, so grouping, the
+// pinned block and the drag order downstream all keep working on the survivors
+// without knowing a filter exists.
+//
+// The active session survives whatever the query says: the lit card is the
+// identity of the terminal beside it, and a sidebar with nothing lit while a
+// session is on screen reads as broken. SidebarRail keeps its highlight on the
+// full-screen routes for the same reason.
+//
+// The haystack is the label and the checkout, which is what makes typing a
+// worktree name narrow to that checkout — the trick FilesPanel already relies
+// on for directory names. The branch is deliberately not in it: it is read per
+// card by useGitStatus, and hoisting that into the sidebar to filter on it buys
+// little the checkout path does not already give.
+//
+// A blank query hands the input array straight back, so the ordinary case costs
+// nothing.
+export function filterSessions(
+  sessions: Session[],
+  query: string,
+  projectPath: string,
+  activeId: string,
+): SidebarFilter {
+  if (query.trim() === "") {
+    return { sessions, matched: true }
+  }
+  const hit = (session: Session) =>
+    matchesQuery(`${session.label} ${session.path || projectPath}`, query)
+  return {
+    sessions: sessions.filter((session) => session.id === activeId || hit(session)),
+    matched: sessions.some(hit),
+  }
+}


### PR DESCRIPTION
With a dozen cards open across three checkouts, finding the two you are shepherding was a scan. A magnifier joins the row `New Session` and `Collapse` already share and opens a field that narrows the list as you type.

It has to earn its place beside the command palette, and the one sentence is: **the filter narrows what stays on screen while you work, where the palette navigates once and closes.** The palette is modal — it dims the app, takes the keyboard, and is gone on Enter. This one is held while the work happens, so the surviving cards stay live: status ring, tool rung, close, delegate.

A mockup of every state, in both bundled themes, was reviewed before any of this was written.

## The rules it answers to

- **No permanent row.** The field is revealed, at the compact size the dock's file tree already uses, and costs nothing at rest. The dock's Files tab is opened *to find something*; the sidebar is watched all day and opened for nothing, so it pays for the field only while the field is in use.
- **The query narrows the flat list before `sidebarGroups` reads it**, so grouping, the pinned block and the stored order keep working on the survivors without knowing a filter exists.
- **The haystack is the label and the checkout**, which is what lets a worktree name narrow to that checkout — the trick `FilesPanel` already relies on for directory names. The branch stays out: it is read per card by `useGitStatus`, and hoisting that into the sidebar buys little the path does not already give.
- **A group with nothing left drops out whole**, header included, the same way `paletteGroups` drops an empty one. Headers draw even for a lone group while a query stands: which checkout a survivor sits in is what was typed to find out.
- **The active session survives whatever the query says.** The lit card is the identity of the terminal beside it, and a sidebar with nothing lit while a session is on screen reads as broken — `SidebarRail` keeps its highlight on the full-screen routes for the same reason.
- **The filter is never narrowing the list out of sight.** Closing it clears it, collapsing the sidebar clears it, a project switch clears it, and it is never persisted: width and collapsed state survive a restart because they are layout, but a filter is a lens held while working — booting to two of nine sessions is a bug report, not a restored setting.
- **Drag is off while a query stands.** A drop computed from a filtered view hands `reorderSubset` an id set that does not name the group's members, which `reorderSessions` rejects wholesale — so the gesture was a silent no-op. Taken away rather than left dead on screen.

## What this reuses

The matcher is the palette's `matchesQuery` and the field is `SearchInput`, both unchanged; the empty line is `Notice`. `sidebarGroups` is untouched, and `SidebarRail` takes no diff at all — it never learns a query exists, which is why collapsing clears the filter for free. The filter itself is pure and lives beside the sessions it narrows, so the node-only suite can hold it.

New code is two `useState`, one `.filter()`, the keep-the-active-session clause and a button.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` — 1830 passed across 32 packages
- [x] `cd frontend && biome check .` — 0 errors (14 warnings, all the standing a11y backlog)
- [x] `vitest run` — 1088 passed across 90 files, including 8 new cases for `filterSessions`
- [x] `tsc && vite build` succeeds
- [x] `CHANGELOG.md` entry under `[Unreleased]`
- [x] Exercised by hand in the window: open, type, clear, close, project switch, collapse
- [ ] Not applicable: no OS seam and no `_test.go` build tag touched, so the cross-compile loop is untouched territory here

## Known ceilings

- The branch is not matched — see above. Raise it if it is asked for twice.
- No hotkey. `Ctrl+Shift+F` is free, but it costs a row in the settings list and the shortcuts overlay for an action one click away. Worth adding once the filter earns daily use.
- No count of what is hidden. The visible field is the evidence; a counter restates it and buys a second thing to keep correct.
