### PR TITLE
feat: copy a session's send command from its card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A session's card hands out the command that reaches it.** Naming a session
+  is what makes `lich send` usable from another terminal, but the name lived on a
+  card in the window and the line had to be retyped from memory, quoting
+  included. Copy send command puts the whole invocation on the clipboard, with
+  the label quoted for the shell — so a card called `the $PATH bug` pastes as one
+  argument rather than as three words and an empty variable. The project is named
+  in the line only when another session holds the same label, which is the one
+  case `lich send` cannot resolve without it.
 - **A waiting card now says what it is waiting for.** A session blocked on you
   wore the same amber bell and the same "Waiting on you" whether it wanted
   permission to delete a directory or an answer about which file to touch — the

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -5,6 +5,7 @@ import {
   ArrowLeft,
   ArrowRight,
   CircleQuestionMark,
+  Copy,
   CornerDownLeft,
   FolderCode,
   FolderOpen,
@@ -58,9 +59,11 @@ import { System, Terminal as TerminalService } from "@/lib/rpc"
 import { queuePaste } from "@/lib/terminal/paste-queue"
 import type { DelegateGroup } from "@/lib/session/delegate-targets"
 import { delegatePrompt, delegateWorktreePrompt } from "@/lib/session/delegate-prompt"
+import { sendCommand } from "@/lib/session/send-command"
 import { bracketedPaste } from "@/lib/terminal/bracketed-paste"
 import { requestTerminalFocus } from "@/lib/terminal/focus-request"
 import { useSessionIntent } from "@/lib/use-sidebar-intent"
+import { useProjects } from "@/providers/projects"
 import { SessionTargetPicker } from "./SessionTargetPicker"
 import { EntrypointDialog } from "./EntrypointDialog"
 
@@ -110,6 +113,10 @@ export function SessionCard({
   onPulls,
   delegateGroups,
 }: SessionCardProps) {
+  // Read here rather than threaded down as a prop: the `lich send` line names
+  // the project only when another session shares this card's label, and that is
+  // a question about every open project — not about the one this card sits in.
+  const { projects, sessions } = useProjects()
   const pinned = !!session.pinned
   const pathRef = useRef<HTMLSpanElement>(null)
   const [pathOverflow, setPathOverflow] = useState(false)
@@ -193,6 +200,17 @@ export function SessionCard({
         }
       })
       .catch((error) => toast.error(`Could not open the checkout: ${errorText(error)}`))
+  }
+
+  // The line another terminal — or another agent — hands this session work
+  // with. The label is quoted for a shell on the way out (sendCommand): getting
+  // that right from memory is exactly what goes wrong when the line is retyped.
+  const copySendCommand = () => {
+    const command = sendCommand(projects, sessions, session)
+    void navigator.clipboard.writeText(command).then(
+      () => toast(`Copied: ${command}`),
+      (error) => toast.error(`Could not copy the command: ${errorText(error)}`),
+    )
   }
 
   // A worktree removed outside lich leaves its card behind, so both openers
@@ -540,6 +558,10 @@ export function SessionCard({
               Delegate to session…
             </ContextMenuItem>
           )}
+          <ContextMenuItem onClick={copySendCommand}>
+            <Copy />
+            Copy send command
+          </ContextMenuItem>
           <ContextMenuItem onClick={() => setEditing(true)}>
             <Pencil />
             Rename

--- a/frontend/src/lib/session/send-command.test.ts
+++ b/frontend/src/lib/session/send-command.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+import { sendCommand, shQuote } from "./send-command"
+import type { Session, SessionState } from "./sessions"
+
+const PROJECTS = [
+  { id: "p1", name: "lich", path: "/home/me/code/lich" },
+  { id: "p2", name: "revu", path: "/home/me/code/revu" },
+]
+
+const auth: Session = { id: "aaaa1111", label: "auth", kind: "claude" }
+const docs: Session = { id: "bbbb2222", label: "docs", kind: "codex" }
+const otherAuth: Session = { id: "cccc3333", label: "Auth", kind: "crush" }
+
+const state = (p2: Session[]): SessionState => ({
+  p1: { activeId: auth.id, nextSeq: 3, sessions: [auth, docs] },
+  p2: { activeId: "", nextSeq: 2, sessions: p2 },
+})
+
+// The Go half is internal/shquote; these are its cases, so a divergence shows
+// up as a failure here rather than as a command that runs the wrong thing.
+describe("shQuote", () => {
+  it("survives the shell round trip's edge cases", () => {
+    expect(shQuote("plain")).toBe("'plain'")
+    expect(shQuote("with space")).toBe("'with space'")
+    expect(shQuote("it's")).toBe(`'it'\\''s'`)
+    expect(shQuote("")).toBe("''")
+    expect(shQuote("$HOME `id` ;rm")).toBe("'$HOME `id` ;rm'")
+  })
+})
+
+describe("sendCommand", () => {
+  it("names the session alone while its label is unambiguous", () => {
+    expect(sendCommand(PROJECTS, state([]), auth)).toBe(`lich send 'auth' "<prompt>"`)
+  })
+
+  // --project is what the CLI disambiguates with, and lich send matches a label
+  // case-insensitively — so a differently-cased twin is a twin.
+  it("narrows to the project once another session holds the label", () => {
+    const command = sendCommand(PROJECTS, state([otherAuth]), auth)
+    expect(command).toBe(`lich send --project 'lich' 'auth' "<prompt>"`)
+    expect(sendCommand(PROJECTS, state([otherAuth]), otherAuth)).toBe(
+      `lich send --project 'revu' 'Auth' "<prompt>"`,
+    )
+  })
+
+  it("leaves a sibling in the same project out of it", () => {
+    expect(sendCommand(PROJECTS, state([]), docs)).toBe(`lich send 'docs' "<prompt>"`)
+  })
+
+  // The label is the user's own text: a card renamed to something with a quote
+  // or a metacharacter in it still has to paste as one argument.
+  it("quotes a label the shell would otherwise read", () => {
+    const awkward: Session = { id: "dddd4444", label: `the $PATH 'bug'`, kind: "claude" }
+    expect(sendCommand(PROJECTS, state([awkward]), awkward)).toBe(
+      `lich send 'the $PATH '\\''bug'\\''' "<prompt>"`,
+    )
+  })
+
+  // A session whose project is not in the list has no project to name; the line
+  // still addresses it, because the label alone is what lich send resolves.
+  it("still writes a line for a session no listed project holds", () => {
+    const stray: Session = { id: "eeee5555", label: "stray", kind: "shell" }
+    expect(sendCommand(PROJECTS, state([]), stray)).toBe(`lich send 'stray' "<prompt>"`)
+  })
+})

--- a/frontend/src/lib/session/send-command.ts
+++ b/frontend/src/lib/session/send-command.ts
@@ -1,0 +1,50 @@
+// The `lich send` line that reaches one session, written out so it can be
+// pasted into another terminal instead of retyped from memory. The card knows
+// the two things the line needs — the label the session answers to and the
+// project it belongs to — and neither is anywhere else once the window is out
+// of sight.
+
+import type { Project } from "@/lib/api-types"
+import { sessionsOf, type Session, type SessionState } from "./sessions"
+
+/**
+ * Quote a word for a POSIX shell: the page-side half of internal/shquote, which
+ * quotes the command lines the backend composes the same way. One rule in two
+ * languages, because a label with a space, a quote or a `$` in it has to paste
+ * back as the single argument the user named the card.
+ */
+export function shQuote(value: string): string {
+  return `'${value.split("'").join(`'\\''`)}'`
+}
+
+// Left for the user to fill in, spelled as `lich send --help` spells it. Double
+// quotes rather than the shQuote rule: what goes here is prose, and an
+// apostrophe in it must not end the argument.
+const PROMPT = '"<prompt>"'
+
+/**
+ * The command that hands this session a task from anywhere else.
+ *
+ * `--project` is written only when it decides something. `lich send` resolves a
+ * label on its own and asks for the project exactly when the same label names
+ * more than one live session (internal/relay/roster.go, resolve) — and a label
+ * is unique inside a project, so a second holder is always in another one.
+ * Unconditionally naming the project would be noise on every card but that one.
+ */
+export function sendCommand(
+  projects: readonly Project[],
+  sessions: SessionState,
+  session: Session,
+): string {
+  const all = projects.flatMap((project) =>
+    sessionsOf(sessions, project.id).map((candidate) => ({ project, candidate })),
+  )
+  const own = all.find((entry) => entry.candidate.id === session.id)
+  const shared = all.some(
+    (entry) =>
+      entry.candidate.id !== session.id &&
+      entry.candidate.label.toLowerCase() === session.label.toLowerCase(),
+  )
+  const scope = shared && own ? ` --project ${shQuote(own.project.name)}` : ""
+  return `lich send${scope} ${shQuote(session.label)} ${PROMPT}`
+}

--- a/internal/shquote/shquote.go
+++ b/internal/shquote/shquote.go
@@ -4,6 +4,10 @@
 // (internal/system) — and both interpolate a path or a binary name the user or
 // an agent chose. One copy of the rule, so a metacharacter that survives one
 // call site cannot survive the other.
+//
+// The window composes a third — the `lich send` line a session's card hands out
+// — and quotes it the same way in frontend/src/lib/session/send-command.ts, the
+// page-side half of this rule, tested against the same cases.
 package shquote
 
 import "strings"


### PR DESCRIPTION
A session can be named, and `lich send <label> "<prompt>"` is how another terminal — or another agent — hands it work. But the label lived on a card in the window: the line had to be retyped from memory somewhere else, quoting included. The card knows its own label and its own project, so it can hand you the line.

One item in the session card's context menu, **Copy send command**, puts the whole invocation on the clipboard and confirms with a toast the way the rest of the app does. Neighbours are untouched and unreordered.

## Quoting

The label is quoted for a POSIX shell by `frontend/src/lib/session/send-command.ts`, the page-side half of `internal/shquote` — the same idiom this repo already uses for `internal/relay/rostername.go` and its page-side twin. A card called `the $PATH bug` has to paste back as the single argument the user named it, not as three words and an empty variable.

Calling the backend for the quoted line was the alternative; a one-line rule mirrored in TypeScript is smaller than an RPC round trip and its error path. Both halves are tested against the same cases, and each file's comment names the other, so a divergence fails a suite rather than silently running the wrong thing.

## `--project`

Written only where it decides something. `lich send` resolves a label on its own and asks for the project exactly when the same label names more than one live session (`internal/relay/roster.go`, `resolve`). A label is unique inside a project — rename enforces it — so a second holder is always in another project. An unconditional `--project` would be noise on every card but that one.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `LICH_LISTEN_PORT= go test ./...` green
- [x] `pnpm check` (biome) — errors clean; only the standing a11y warning backlog
- [x] `vitest run` green (1086 tests), cache cleared first
- [x] `tsc -b --noEmit` and `vite build` clean
- [x] Cross-compile loop `linux`/`darwin`/`windows`: build + vet green
- [x] New unit tests cover the quoting edge cases (space, `'`, `$`, empty) and both `--project` branches
- [ ] Hand-check in the window: the gate is node-only and cannot render, so the menu item itself is unverified by machine. It mirrors eight identical siblings; the one novel bit is the `useProjects()` call in `SessionCard`, which is safe because the card only ever renders under `SessionSidebar`, which already calls it.