### PR TITLE
fix: hang up on a session's PTY once, not twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Removing a worktree no longer fails when the agent in it has just exited.** A
+  session's terminal is released twice — once by the close you asked for, once by
+  the reap of the process that ended — and whichever of the two arrived second
+  reported the handle as already closed. Closing a card ignored that, but removing
+  a checkout reads it as a failed close and stops before it touches git: the
+  worktree stayed on disk, its row stayed on screen, and the only account of why
+  was an error naming `/dev/ptmx`. The hang-up now happens once, and both callers
+  are told what it did. Windows already closed once, where a second one costs more
+  than a message.
 - **A turn you interrupt no longer spins forever.** Pressing Esc or Ctrl+C to stop
   an agent mid-turn left its card spinning until some later turn happened to
   finish — Claude Code, Codex and oh-my-pi all say nothing at all when a turn is

--- a/internal/terminal/pty.go
+++ b/internal/terminal/pty.go
@@ -28,6 +28,9 @@ const noExitStatus = -1
 // input, Resize changes the window size, Pid identifies the child (0 when
 // unknown), Wait reaps the exited child and reports its exit status
 // (noExitStatus when there is none), and Close hangs up and terminates it.
+// Close is called twice on every session that ends — once by Service.Close and
+// once by the stream goroutine reaping the child — so each implementation has
+// to make the second call a no-op that reports no failure.
 // Each OS provides startPTY(spec) plus an implementation of this interface
 // (build tags select the file, the Go idiom for OS-specific code) —
 // terminal.go never touches a platform PTY API directly.

--- a/internal/terminal/pty_unix.go
+++ b/internal/terminal/pty_unix.go
@@ -5,6 +5,7 @@ package terminal
 import (
 	"os"
 	"os/exec"
+	"sync"
 	"syscall"
 	"time"
 
@@ -45,6 +46,11 @@ type unixPTY struct {
 	exited chan struct{}
 	code   int
 	err    error
+
+	// closeOnce keeps the hang-up single-shot; closeErr is what every caller
+	// of Close gets back, including the one that did not perform it.
+	closeOnce sync.Once
+	closeErr  error
 }
 
 func (p *unixPTY) Resize(cols, rows int) error {
@@ -76,15 +82,24 @@ func (p *unixPTY) Wait() (int, error) {
 // it outstays closeGrace. The master is closed last so the departing child's
 // final bytes — the escape sequences that put the terminal back the way it was
 // — still reach the reader.
+//
+// It happens once. os.File.Close is safe to repeat, but the second call reports
+// os.ErrClosed rather than nothing, and the two closes the seam promises race
+// whenever a session's child dies just as the user closes it. Handing that error
+// to the loser is what made removing a worktree fail with "file already closed"
+// and leave the checkout on disk (internal/spawn.removeCheckout).
 func (p *unixPTY) Close() error {
-	if p.cmd.Process != nil && p.cmd.Process.Signal(syscall.SIGTERM) == nil {
-		select {
-		case <-p.exited:
-		case <-time.After(closeGrace):
-			_ = p.cmd.Process.Kill()
+	p.closeOnce.Do(func() {
+		if p.cmd.Process != nil && p.cmd.Process.Signal(syscall.SIGTERM) == nil {
+			select {
+			case <-p.exited:
+			case <-time.After(closeGrace):
+				_ = p.cmd.Process.Kill()
+			}
 		}
-	}
-	return p.File.Close()
+		p.closeErr = p.File.Close()
+	})
+	return p.closeErr
 }
 
 func winsize(cols, rows int) *pty.Winsize {

--- a/internal/terminal/pty_unix_test.go
+++ b/internal/terminal/pty_unix_test.go
@@ -93,3 +93,22 @@ func TestCloseKillsAChildThatIgnoresTheHangUp(t *testing.T) {
 		t.Fatal("child survived Close")
 	}
 }
+
+// TestUnixPTYCloseIsSingleShot pins the same guard its Windows counterpart
+// pins, for the seam's other reason: os.File.Close reports os.ErrClosed the
+// second time, and both closes are expected — Service.Close releases the PTY
+// while stream reaps the same one the moment its child dies. Handing that error
+// to whichever lost failed the close its caller asked for.
+func TestUnixPTYCloseIsSingleShot(t *testing.T) {
+	p := startTrapped(t, "exit 7")
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := p.Close(); err != nil {
+		t.Fatalf("second Close: %v, want the first close's nil", err)
+	}
+	if code, _ := p.Wait(); code != 7 {
+		t.Errorf("exit status = %d, want the trap's 7", code)
+	}
+}

--- a/internal/terminal/pty_windows.go
+++ b/internal/terminal/pty_windows.go
@@ -54,9 +54,10 @@ func commandLine(bin string, args []string) (string, error) {
 // loopback listener's socket, the log file, another session's pipes — and the
 // app stops answering with nothing panicking and nothing logged. Every
 // user-driven close reaches that second call: Service.Close closes the PTY and
-// the read loop, freed by the same close, reaps it again (see stream). The
-// Unix seam is *os.File, whose repeat Close is the harmless no-op stream's
-// comment describes; this one has to be made into it.
+// the read loop, freed by the same close, reaps it again (see stream). The Unix
+// seam guards its own repeat Close for a milder reason — os.File.Close only
+// reports os.ErrClosed the second time; here the second call hands Windows
+// handles it has already reissued.
 type windowsPTY struct {
 	*conpty.ConPty
 	waitCtx    context.Context


### PR DESCRIPTION
Every session's PTY is closed twice by design: `Service.Close` releases it when
the user closes the session, and the `stream` goroutine releases it again when
it reaps the child that ended. `stream`'s own comment already declares that
contract — *"a no-op each seam has to make safe"* — and the Windows seam is
guarded for it. The Unix seam was not: `os.File.Close` reports `os.ErrClosed`
the second time, so whichever call lost the race handed that error to its
caller.

`stream` swallows its own error, so only the reverse ordering surfaces: the
child exits at the moment the user closes, `stream` closes first, and
`Service.Close` returns the error.

## Why it is not test-only

`spawn.removeCheckout` treats that error as a failed close and returns before it
touches git, ahead of `DeleteSession`, `PurgeWorktreeSessions` and
`RemoveWorktree`. Removing a worktree whose agent had just exited failed with
`close the session's terminal: close /dev/ptmx: file already closed`, and left
the checkout on disk with its row still on screen. `finish` only logs, so a
plain card close was cosmetic — which is why this surfaced as a flaky test long
before anyone read it as a bug.

## The fix

`unixPTY.Close` runs under a `sync.Once` and reports that one close's result to
every caller. It keeps the real error rather than returning nil on repeat, so a
genuine close failure still reaches `Service.Close`.

`ptyHandle` now states the contract instead of leaving it to a comment in
`stream`: Close is called twice on every session that ends, so each seam has to
make the second call a no-op that reports no failure.

The Windows seam is unchanged in behaviour — its guard already covered this, and
its harsher reason (a second `ClosePseudoConsole` plus `CloseHandle` on values
Windows has since reissued) stands. Only its comment moves: it justified itself
against the claim that the Unix repeat close was free, and that premise was
false.

## Measured

    LICH_LISTEN_PORT= go test -count=200 \
      -run TestRespawnedSessionIsNotToldItExited ./internal/terminal/

| | failures |
|---|---|
| before | 8 / 200 (4%), all at the explicit `svc.Close` |
| after | 0 / 200 |
| after, `-race`, with the new seam test | 0 / 500 each, no data race |

## Test

`TestUnixPTYCloseIsSingleShot` mirrors the existing
`TestWindowsPTYCloseIsSingleShot`: close twice, the second must return nil, and
the child still reports its trap's exit status. Deterministic — it pins the
contract rather than sampling the race. No existing test was weakened, skipped
or rewritten.

## Gate

`gofmt -l .` clean · `go vet ./...` clean · `go test -race ./...` 1831 passed
across 32 packages · cross-compile loop (`linux`, `darwin`, `windows`) build and
vet clean · frontend `biome check` clean, 1080 tests passed, `pnpm build` ok.

`CHANGELOG.md` gets an `[Unreleased] › Fixed` entry: the failed worktree removal
is something a user of a published version lived through.

No `docs/ceilings.md` change — this closes a trap rather than setting one, and
the mechanism lives in the seam's own comments.
