### PR TITLE
fix: read the plan quota of the account a session actually spends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The plan gauge now reads the account the session in front of you actually
+  spends.** A project pointed at a binary of your own — a wrapper exporting
+  another `CLAUDE_CONFIG_DIR`, or an OAuth token for a second account — still had
+  its footer showing what lich's own login had left, which is a number about
+  somebody else's plan and no way to tell. The reading is now taken against the
+  environment the session's own process runs with, so each card reports the
+  subscription it is spending, and two accounts on one machine no longer read as
+  one. A session whose login is a long-lived token (`claude setup-token`) is
+  measured through a one-token request, since the usage route refuses a token
+  that can only infer; a session pointed at another API host or running on an API
+  key shows no gauge, having no plan to report. On macOS and Windows, where the
+  environment of another process is out of reach, a session running a configured
+  binary shows nothing rather than the wrong account's numbers. Codex sessions
+  follow the same rule through `CODEX_HOME`.
 - **Removing a worktree no longer fails when the agent in it has just exited.** A
   session's terminal is released twice — once by the close you asked for, once by
   the reap of the process that ended — and whichever of the two arrived second

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -170,6 +170,21 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   those logins and never writes them: it does not refresh the token, so an expired one reads as signed out until
   the provider's own CLI rotates it. A reading is cached for five minutes because both endpoints rate-limit hard —
   the number on screen is up to that old, and nothing on it says so.
+- **Which account a session spends is read from its process, and only Linux answers**
+  (`internal/quota`, `internal/terminal/account.go`): the reading follows `/proc/<pid>/environ` of the process in
+  the session's PTY, so a wrapper binary that exports a login of its own is seen only there. macOS could answer
+  the same question through `KERN_PROCARGS2` and does not yet; Windows cannot at all. On both, a session running
+  a user-configured binary reports `unknown` and its gauge disappears from the footer — the alternative was the
+  default account's numbers under a session spending another plan, and silence is the failure that does not lie.
+  A card with no live process is in the same position until its PTY is up.
+- **Measuring a token-only login costs a request against the very plan it measures** (`internal/quota/claude.go`):
+  a long-lived OAuth token (`claude setup-token`) carries `user:inference` alone, so the usage route answers it
+  403 and the account is read the way Claude Code reads it for itself — one `max_tokens: 1` message, for the
+  rate-limit headers on the response. Reading the gauge therefore spends quota (negligibly) and appears in the
+  account's own usage, once per cache window. That request carries Claude Code's system prompt verbatim because
+  the API rejects an OAuth token without it — the same coupling as the user agent, and it fails closed, as a
+  failed reading. Headers carry the two account-wide windows and no plan name, so such a session shows no
+  model-scoped weekly cap and no "Max 5x" badge.
 - **The sandbox confines a working agent, not hostile code** (`internal/sandbox`): namespaces and mounts on
   Linux, a path policy on macOS, and nothing else — no seccomp filter, no Landlock ruleset. The network is
   never cut (the agent needs its API and the plugin's hooks report over loopback), so anything readable

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -249,7 +249,7 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
 
       <span className="ml-auto flex items-center gap-4">
         {showContextUsage && <SessionModel sessionId={sessionId} kind={kind} />}
-        <PlanQuota kind={kind} />
+        <PlanQuota kind={kind} sessionId={sessionId} />
         {costReadout}
         {contextReadout}
         {(contextReadout || costReadout) && (status?.branch || path) && (

--- a/frontend/src/components/PlanQuota.tsx
+++ b/frontend/src/components/PlanQuota.tsx
@@ -11,6 +11,9 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 interface PlanQuotaProps {
   /** Which provider the active session runs; "" when none is active. */
   kind: SessionKind | ""
+  /** Whose plan to read: the active session, which may spend an account of its
+   * own when it runs a binary the user configured. */
+  sessionId: string
 }
 
 // PlanQuota is the footer's plan-usage slot: how much of the active session's
@@ -19,11 +22,13 @@ interface PlanQuotaProps {
 //
 // One window is shown, and it is the fullest one: a weekly cap about to run out
 // must not hide behind a session window that reset an hour ago. Nothing renders
-// at all for a provider that meters no subscription, or while the reading is
+// at all for a provider that meters no subscription, while the reading is
 // signed out or failed — the Settings screen is where a login is fixed, and a
-// status strip is the wrong place to be told to run a command.
-export function PlanQuota({ kind }: PlanQuotaProps) {
-  const plan = usePlanQuotaFor(kind || undefined)
+// status strip is the wrong place to be told to run a command — or for a
+// session whose account lich could not identify, where any number would be
+// somebody else's.
+export function PlanQuota({ kind, sessionId }: PlanQuotaProps) {
+  const plan = usePlanQuotaFor(kind || undefined, sessionId)
   const now = useNow()
   const hottest = plan && plan.status === "ok" ? hottestWindow(plan) : null
   if (!plan || !hottest) {

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -482,11 +482,13 @@ export interface QuotaWindow {
 }
 
 /** internal/quota.Plan — one provider's quota reading. Windows are empty for
- * every status other than "ok". */
+ * every status other than "ok"; "unknown" is a session lich cannot identify the
+ * account of — it runs a binary the user configured whose environment is out of
+ * reach — where the default account's numbers would be the wrong ones. */
 export interface QuotaPlan {
   provider: string
   name: string
   plan?: string
   windows?: QuotaWindow[]
-  status: "ok" | "signed-out" | "error"
+  status: "ok" | "signed-out" | "error" | "unknown"
 }

--- a/frontend/src/lib/quota/plan-quota-store.test.ts
+++ b/frontend/src/lib/quota/plan-quota-store.test.ts
@@ -20,13 +20,13 @@ describe("createPlanQuotaStore", () => {
     const fetch = vi.fn(async () => reading(2))
     const store = createPlanQuotaStore(fetch)
 
-    expect(store.getSnapshot()).toEqual([])
-    const a = store.subscribe(() => {})
-    const b = store.subscribe(() => {})
+    expect(store.getSnapshot("")).toEqual([])
+    const a = store.subscribe("", () => {})
+    const b = store.subscribe("", () => {})
     await vi.advanceTimersByTimeAsync(0)
 
     expect(fetch).toHaveBeenCalledTimes(1)
-    expect(store.getSnapshot()).toEqual(reading(2))
+    expect(store.getSnapshot("")).toEqual(reading(2))
     a()
     b()
   })
@@ -34,13 +34,13 @@ describe("createPlanQuotaStore", () => {
   it("keeps the same array while the numbers do not change", async () => {
     const store = createPlanQuotaStore(async () => reading(2), 1000)
     const notify = vi.fn()
-    const stop = store.subscribe(notify)
+    const stop = store.subscribe("", notify)
     await vi.advanceTimersByTimeAsync(0)
-    const first = store.getSnapshot()
+    const first = store.getSnapshot("")
 
     await vi.advanceTimersByTimeAsync(1000)
 
-    expect(store.getSnapshot()).toBe(first)
+    expect(store.getSnapshot("")).toBe(first)
     expect(notify).toHaveBeenCalledTimes(1)
     stop()
   })
@@ -49,13 +49,13 @@ describe("createPlanQuotaStore", () => {
     let percent = 2
     const store = createPlanQuotaStore(async () => reading(percent), 1000)
     const notify = vi.fn()
-    const stop = store.subscribe(notify)
+    const stop = store.subscribe("", notify)
     await vi.advanceTimersByTimeAsync(0)
 
     percent = 91
     await vi.advanceTimersByTimeAsync(1000)
 
-    expect(store.getSnapshot()[0].windows?.[0].percent).toBe(91)
+    expect(store.getSnapshot("")[0].windows?.[0].percent).toBe(91)
     expect(notify).toHaveBeenCalledTimes(2)
     stop()
   })
@@ -68,26 +68,26 @@ describe("createPlanQuotaStore", () => {
       }
       return reading(2)
     }, 1000)
-    const stop = store.subscribe(() => {})
+    const stop = store.subscribe("", () => {})
     await vi.advanceTimersByTimeAsync(0)
 
     fail = true
     await vi.advanceTimersByTimeAsync(1000)
 
-    expect(store.getSnapshot()).toEqual(reading(2))
+    expect(store.getSnapshot("")).toEqual(reading(2))
     stop()
   })
 
   it("keeps the last reading when a read returns nothing", async () => {
     let empty = false
     const store = createPlanQuotaStore(async () => (empty ? null : reading(2)), 1000)
-    const stop = store.subscribe(() => {})
+    const stop = store.subscribe("", () => {})
     await vi.advanceTimersByTimeAsync(0)
 
     empty = true
     await vi.advanceTimersByTimeAsync(1000)
 
-    expect(store.getSnapshot()).toEqual(reading(2))
+    expect(store.getSnapshot("")).toEqual(reading(2))
     stop()
   })
 
@@ -95,12 +95,43 @@ describe("createPlanQuotaStore", () => {
     const fetch = vi.fn(async () => reading(2))
     const store = createPlanQuotaStore(fetch, 1000)
 
-    const stop = store.subscribe(() => {})
+    const stop = store.subscribe("", () => {})
     await vi.advanceTimersByTimeAsync(0)
     stop()
     await vi.advanceTimersByTimeAsync(5000)
 
     expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it("reads each session's account on its own, and keeps the readings apart", async () => {
+    const fetch = vi.fn(async (sessionId: string) => reading(sessionId === "a" ? 4 : 91))
+    const store = createPlanQuotaStore(fetch)
+
+    const a = store.subscribe("a", () => {})
+    const b = store.subscribe("b", () => {})
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(fetch.mock.calls.map(([id]) => id)).toEqual(["a", "b"])
+    expect(store.getSnapshot("a")[0].windows?.[0].percent).toBe(4)
+    expect(store.getSnapshot("b")[0].windows?.[0].percent).toBe(91)
+    a()
+    b()
+  })
+
+  it("keeps polling one session after another stops watching", async () => {
+    const fetch = vi.fn(async () => reading(2))
+    const store = createPlanQuotaStore(fetch, 1000)
+
+    const a = store.subscribe("a", () => {})
+    const b = store.subscribe("b", () => {})
+    await vi.advanceTimersByTimeAsync(0)
+    a()
+    await vi.advanceTimersByTimeAsync(1000)
+
+    // Two first readings, then only the session still on screen.
+    expect(fetch).toHaveBeenCalledTimes(3)
+    expect(fetch).toHaveBeenLastCalledWith("b")
+    b()
   })
 
   it("notices a plan whose status changed but whose windows did not", async () => {
@@ -110,13 +141,13 @@ describe("createPlanQuotaStore", () => {
       1000,
     )
     const notify = vi.fn()
-    const stop = store.subscribe(notify)
+    const stop = store.subscribe("", notify)
     await vi.advanceTimersByTimeAsync(0)
 
     status = "signed-out"
     await vi.advanceTimersByTimeAsync(1000)
 
-    expect(store.getSnapshot()[0].status).toBe("signed-out")
+    expect(store.getSnapshot("")[0].status).toBe("signed-out")
     stop()
   })
 })

--- a/frontend/src/lib/quota/plan-quota-store.ts
+++ b/frontend/src/lib/quota/plan-quota-store.ts
@@ -1,12 +1,17 @@
 import type { QuotaPlan } from "@/lib/api-types"
 import { Quota } from "@/lib/rpc"
 
-export type PlanQuotaFetcher = () => Promise<QuotaPlan[] | null>
+export type PlanQuotaFetcher = (sessionId: string) => Promise<QuotaPlan[] | null>
 
 // How often the reading is re-read while anything is watching it. The backend
 // serves a five-minute cache, so this only decides how quickly a fresh reading
 // reaches the screen — the providers are not asked any more often than that.
 const REFRESH_MS = 60_000
+
+// The snapshot a key nothing has read yet answers with. One shared array, so
+// useSyncExternalStore sees the same reference on every render until a reading
+// actually lands.
+const NONE: QuotaPlan[] = []
 
 // Two readings are the same when every window of every plan is. Keeping the
 // previous array on an unchanged reading is what stops a footer and a settings
@@ -32,33 +37,50 @@ const unchanged = (a: QuotaPlan[], b: QuotaPlan[]): boolean =>
     )
   })
 
-// createPlanQuotaStore shares one poll loop across every subscriber. The fetcher
-// is injected so the store is testable without React or the network, mirroring
-// git-status-store.
-export function createPlanQuotaStore(fetch: PlanQuotaFetcher, refreshMs = REFRESH_MS) {
-  let plans: QuotaPlan[] = []
-  const listeners = new Set<() => void>()
-  let timer: ReturnType<typeof setTimeout> | undefined
+// One poll loop and one reading per key. The key is the session the reading was
+// taken for — "" is the machine-wide one the settings screen asks for — because
+// a session spawned from a binary the user configured can spend another account
+// entirely, and one card's numbers are not another's to show.
+interface Entry {
+  plans: QuotaPlan[]
+  listeners: Set<() => void>
+  timer?: ReturnType<typeof setTimeout>
   // Monotonic fetch id — a reading that started before the last subscriber left
   // must not publish after another one started.
-  let seq = 0
+  seq: number
+}
 
-  const publish = (next: QuotaPlan[]) => {
-    if (unchanged(plans, next)) {
+// createPlanQuotaStore shares one poll loop per key across every subscriber to
+// it. The fetcher is injected so the store is testable without React or the
+// network, mirroring git-status-store.
+export function createPlanQuotaStore(fetch: PlanQuotaFetcher, refreshMs = REFRESH_MS) {
+  const entries = new Map<string, Entry>()
+
+  const entryOf = (key: string): Entry => {
+    let entry = entries.get(key)
+    if (!entry) {
+      entry = { plans: NONE, listeners: new Set(), seq: 0 }
+      entries.set(key, entry)
+    }
+    return entry
+  }
+
+  const publish = (entry: Entry, next: QuotaPlan[]) => {
+    if (unchanged(entry.plans, next)) {
       return
     }
-    plans = next
-    for (const listener of listeners) {
+    entry.plans = next
+    for (const listener of entry.listeners) {
       listener()
     }
   }
 
-  const refresh = () => {
-    const id = ++seq
-    void fetch()
+  const refresh = (key: string, entry: Entry) => {
+    const id = ++entry.seq
+    void fetch(key)
       .then((next) => {
-        if (id === seq && next) {
-          publish(next)
+        if (id === entry.seq && next) {
+          publish(entry, next)
         }
       })
       // A failed read keeps the previous numbers on screen: a gauge that blanks
@@ -66,28 +88,28 @@ export function createPlanQuotaStore(fetch: PlanQuotaFetcher, refreshMs = REFRES
       .catch(() => {})
   }
 
-  const poll = () => {
-    refresh()
-    timer = setTimeout(poll, refreshMs)
+  const poll = (key: string, entry: Entry) => {
+    refresh(key, entry)
+    entry.timer = setTimeout(() => poll(key, entry), refreshMs)
   }
 
   return {
-    subscribe(listener: () => void): () => void {
-      listeners.add(listener)
-      if (listeners.size === 1) {
-        poll()
+    subscribe(key: string, listener: () => void): () => void {
+      const entry = entryOf(key)
+      entry.listeners.add(listener)
+      if (entry.listeners.size === 1) {
+        poll(key, entry)
       }
       return () => {
-        listeners.delete(listener)
-        if (listeners.size === 0) {
-          clearTimeout(timer)
-          timer = undefined
+        entry.listeners.delete(listener)
+        if (entry.listeners.size === 0) {
+          clearTimeout(entry.timer)
+          entry.timer = undefined
         }
       }
     },
-    getSnapshot: (): QuotaPlan[] => plans,
-    refresh,
+    getSnapshot: (key: string): QuotaPlan[] => entries.get(key)?.plans ?? NONE,
   }
 }
 
-export const planQuotaStore = createPlanQuotaStore(() => Quota.Plans())
+export const planQuotaStore = createPlanQuotaStore((sessionId) => Quota.Plans(sessionId))

--- a/frontend/src/lib/quota/use-plan-quota.ts
+++ b/frontend/src/lib/quota/use-plan-quota.ts
@@ -1,19 +1,26 @@
-import { useSyncExternalStore } from "react"
+import { useCallback, useSyncExternalStore } from "react"
 import type { QuotaPlan } from "@/lib/api-types"
 import { planQuotaStore } from "./plan-quota-store"
 
 // usePlanQuota reads the plan usage of every provider that meters a
-// subscription. Empty until the first reading lands, and empty forever for a
-// machine signed in to none of them.
-export function usePlanQuota(): QuotaPlan[] {
-  return useSyncExternalStore(planQuotaStore.subscribe, planQuotaStore.getSnapshot)
+// subscription, for the account sessionId spends — an empty sessionId reads the
+// machine's own login, which is the settings screen's question. Empty until the
+// first reading lands, and empty forever for a machine signed in to none of
+// them.
+export function usePlanQuota(sessionId: string): QuotaPlan[] {
+  const subscribe = useCallback(
+    (listener: () => void) => planQuotaStore.subscribe(sessionId, listener),
+    [sessionId],
+  )
+  const snapshot = useCallback(() => planQuotaStore.getSnapshot(sessionId), [sessionId])
+  return useSyncExternalStore(subscribe, snapshot)
 }
 
 // usePlanQuotaFor is one provider's reading, by its provider id — null for a
 // provider that meters nothing (opencode, oh-my-pi and Crush run on the user's
 // own API keys) and while the first reading is in flight.
-export function usePlanQuotaFor(provider: string | undefined): QuotaPlan | null {
-  const plans = usePlanQuota()
+export function usePlanQuotaFor(provider: string | undefined, sessionId = ""): QuotaPlan | null {
+  const plans = usePlanQuota(sessionId)
   if (!provider) {
     return null
   }

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -466,10 +466,11 @@ export const Providers = {
 }
 
 export const Quota = {
-  /** Plan usage for every provider that meters a subscription. Served from a
-   * five-minute cache, so calling it often is cheap and asks nothing extra of
-   * endpoints that rate-limit. */
-  Plans: () => call<QuotaPlan[]>("quota.Plans", []),
+  /** Plan usage for every provider that meters a subscription, for the account
+   * a session spends — an empty id reads lich's own login, the machine-wide
+   * question. Served from a five-minute cache per account, so calling it often
+   * is cheap and asks nothing extra of endpoints that rate-limit. */
+  Plans: (sessionId: string) => call<QuotaPlan[]>("quota.Plans", [sessionId]),
 }
 
 export const Themes = {

--- a/internal/quota/account_test.go
+++ b/internal/quota/account_test.go
@@ -1,0 +1,284 @@
+package quota
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// credsDir writes a Claude credentials file into a fresh directory and returns
+// the directory — the shape a session's own CLAUDE_CONFIG_DIR points at.
+func credsDir(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write creds: %v", err)
+	}
+	return dir
+}
+
+// probeHeaders is what a message response carries for an account 5% into its
+// session window and 1% into its weekly one.
+var probeHeaders = map[string]string{
+	"anthropic-ratelimit-unified-5h-utilization": "0.05",
+	"anthropic-ratelimit-unified-5h-reset":       "1789318316",
+	"anthropic-ratelimit-unified-7d-utilization": "0.01",
+	"anthropic-ratelimit-unified-7d-reset":       "1789318316",
+}
+
+// probeCall is the request the probe made, filled in by serveProbe's handler.
+type probeCall struct {
+	header http.Header
+	method string
+	body   string
+}
+
+// serveProbe answers with the given rate-limit headers and an empty message,
+// recording the request the probe made.
+func serveProbe(t *testing.T, headers map[string]string) (url string, call *probeCall) {
+	t.Helper()
+	made := &probeCall{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, _ := io.ReadAll(r.Body)
+		made.body, made.header, made.method = string(raw), r.Header.Clone(), r.Method
+		for k, v := range headers {
+			w.Header().Set(k, v)
+		}
+		_, _ = w.Write([]byte(`{"id":"msg_x"}`))
+	}))
+	t.Cleanup(server.Close)
+	return server.URL, made
+}
+
+func TestASessionConfigDirWinsOverLichOwn(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	session := credsDir(t, `{"claudeAiOauth":{"accessToken":"tok-session","subscriptionType":"pro"}}`)
+	var auth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(claudeLimitsBody))
+	}))
+	defer server.Close()
+
+	got := newService(server.URL, "", time.Now()).claudePlan(Account{
+		Env:  map[string]string{claudeDirVar: session},
+		Read: true,
+	})
+
+	if auth != "Bearer tok-session" {
+		t.Errorf("Authorization = %q, want the session's own login", auth)
+	}
+	if got.Plan != "Pro" {
+		t.Errorf("plan = %q, want the session account's plan", got.Plan)
+	}
+}
+
+func TestACodexHomeInTheSessionWinsOverLichOwn(t *testing.T) {
+	writeCreds(t, "", codexCredsJSON)
+	session := t.TempDir()
+	if err := os.WriteFile(filepath.Join(session, "auth.json"),
+		[]byte(`{"tokens":{"access_token":"tok-session"}}`), 0o600); err != nil {
+		t.Fatalf("write creds: %v", err)
+	}
+	var auth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth = r.Header.Get("Authorization")
+		_, _ = w.Write([]byte(`{"plan_type":"pro","rate_limit":{"primary_window":
+			{"used_percent":9,"limit_window_seconds":18000}}}`))
+	}))
+	defer server.Close()
+
+	newService("", server.URL, time.Now()).codexPlan(Account{
+		Env:  map[string]string{codexHomeVar: session},
+		Read: true,
+	})
+
+	if auth != "Bearer tok-session" {
+		t.Errorf("Authorization = %q, want the session's own login", auth)
+	}
+}
+
+func TestATokenOnlySessionIsMeasuredByTheProbe(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	url, call := serveProbe(t, probeHeaders)
+
+	got := newService(url, "", time.Now()).claudePlan(Account{
+		Env:  map[string]string{claudeTokenVar: "oat-token"},
+		Read: true,
+	})
+
+	if got.Status != StatusOK {
+		t.Fatalf("status = %q, want %q", got.Status, StatusOK)
+	}
+	want := []Window{
+		{Label: "Session", Seconds: 18000, Percent: 5, ResetsAt: "2026-09-13T16:51:56Z"},
+		{Label: "Weekly", Seconds: 604800, Percent: 1, ResetsAt: "2026-09-13T16:51:56Z"},
+	}
+	if len(got.Windows) != 2 || got.Windows[0] != want[0] || got.Windows[1] != want[1] {
+		t.Errorf("windows = %+v, want %+v", got.Windows, want)
+	}
+	// The credentials file on disk belongs to another account and must not be
+	// what was measured.
+	if auth := call.header.Get("Authorization"); auth != "Bearer oat-token" {
+		t.Errorf("Authorization = %q, want the session's own token", auth)
+	}
+	if call.method != http.MethodPost {
+		t.Errorf("method = %q, want POST", call.method)
+	}
+	// The API rejects an OAuth token that arrives without Claude Code's system
+	// prompt, so the probe is not a request anyone may trim.
+	if call.body != claudeProbeBody {
+		t.Errorf("body = %s, want the probe request verbatim", call.body)
+	}
+	for header, want := range map[string]string{
+		"anthropic-beta":    claudeBetaHeader,
+		"anthropic-version": claudeAPIVersion,
+		"content-type":      "application/json",
+	} {
+		if got := call.header.Get(header); got != want {
+			t.Errorf("%s = %q, want %q", header, got, want)
+		}
+	}
+}
+
+func TestTheProbeReadsWhicheverWindowsTheHeadersCarry(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	url, _ := serveProbe(t, map[string]string{
+		"anthropic-ratelimit-unified-5h-utilization": "0.4",
+	})
+
+	got := newService(url, "", time.Now()).claudePlan(Account{
+		Env:  map[string]string{claudeTokenVar: "oat-token"},
+		Read: true,
+	})
+
+	want := Window{Label: "Session", Seconds: 18000, Percent: 40}
+	if len(got.Windows) != 1 || got.Windows[0] != want {
+		t.Errorf("windows = %+v, want only %+v", got.Windows, want)
+	}
+}
+
+func TestAProbeWithoutRateLimitHeadersFails(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	url, _ := serveProbe(t, nil)
+
+	got := newService(url, "", time.Now()).claudePlan(Account{
+		Env:  map[string]string{claudeTokenVar: "oat-token"},
+		Read: true,
+	})
+
+	if got.Status != StatusError {
+		t.Errorf("status = %q, want %q", got.Status, StatusError)
+	}
+}
+
+func TestARejectedProbeTokenReadsAsSignedOut(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	url, _ := serve(t, http.StatusUnauthorized, `{}`)
+
+	got := newService(url, "", time.Now()).claudePlan(Account{
+		Env:  map[string]string{claudeTokenVar: "expired"},
+		Read: true,
+	})
+
+	if got.Status != StatusSignedOut {
+		t.Errorf("status = %q, want %q", got.Status, StatusSignedOut)
+	}
+}
+
+func TestACustomBinaryWithNoReadableEnvironmentIsUnknown(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, codexCredsJSON)
+	claudeURL, claudeCalls := serve(t, http.StatusOK, claudeLimitsBody)
+	codexURL, codexCalls := serve(t, http.StatusOK, `{"plan_type":"pro"}`)
+	s := newService(claudeURL, codexURL, time.Now())
+	s.SetSessions(func(string) Account { return Account{Custom: true} })
+
+	for _, got := range s.Plans("session-1") {
+		if got.Status != StatusUnknown {
+			t.Errorf("%s status = %q, want %q", got.Provider, got.Status, StatusUnknown)
+		}
+		if len(got.Windows) != 0 {
+			t.Errorf("%s windows = %+v, want none", got.Provider, got.Windows)
+		}
+	}
+	if *claudeCalls != 0 || *codexCalls != 0 {
+		t.Errorf("calls = %d/%d, want none: there is no account to ask about", *claudeCalls, *codexCalls)
+	}
+}
+
+func TestAReadableSessionWithoutOverridesReadsTheDefaultLogin(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	url, calls := serve(t, http.StatusOK, claudeLimitsBody)
+	s := newService(url, "", time.Now())
+	// A wrapper that changes nothing about the login — a PATH tweak, a
+	// profiler — leaves the session spending exactly what lich reads.
+	s.SetSessions(func(string) Account {
+		return Account{Env: map[string]string{"PATH": "/opt/bin"}, Custom: true, Read: true}
+	})
+
+	got := s.Plans("session-1")[0]
+
+	if got.Status != StatusOK || *calls != 1 {
+		t.Errorf("plan = %+v after %d calls, want the default login read", got, *calls)
+	}
+}
+
+func TestASessionPointedSomewhereElseIsUnknown(t *testing.T) {
+	for _, name := range []string{"ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"} {
+		t.Run(name, func(t *testing.T) {
+			writeCreds(t, claudeCredsJSON, "")
+			url, calls := serve(t, http.StatusOK, claudeLimitsBody)
+
+			got := newService(url, "", time.Now()).claudePlan(Account{
+				Env:  map[string]string{name: "somewhere-else"},
+				Read: true,
+			})
+
+			if got.Status != StatusUnknown {
+				t.Errorf("status = %q, want %q", got.Status, StatusUnknown)
+			}
+			if *calls != 0 {
+				t.Errorf("calls = %d, want none: that session spends no plan lich meters", *calls)
+			}
+		})
+	}
+}
+
+func TestEachAccountGetsItsOwnCachedReading(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	url, calls := serve(t, http.StatusOK, claudeLimitsBody)
+	s := newService(url, "", time.Now())
+	s.SetSessions(func(sessionID string) Account {
+		return Account{Env: map[string]string{claudeTokenVar: "token-" + sessionID}, Read: true}
+	})
+
+	s.Plans("a")
+	s.Plans("b")
+	if *calls != 2 {
+		t.Fatalf("calls = %d, want one per account: a cached reading is not another login's", *calls)
+	}
+
+	// The same account is served from the one reading, inside the TTL.
+	s.Plans("a")
+	if *calls != 2 {
+		t.Errorf("calls = %d, want the second session's reading reused", *calls)
+	}
+}
+
+func TestPlansWithoutASessionReadsLichOwnEnvironment(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	url, calls := serve(t, http.StatusOK, claudeLimitsBody)
+	s := newService(url, "", time.Now())
+	s.SetSessions(func(string) Account {
+		t.Error("the machine-wide reading must not ask about a session")
+		return Account{}
+	})
+
+	if got := s.Plans("")[0]; got.Status != StatusOK || *calls != 1 {
+		t.Errorf("plan = %+v after %d calls, want the default login read", got, *calls)
+	}
+}

--- a/internal/quota/claude.go
+++ b/internal/quota/claude.go
@@ -1,6 +1,9 @@
 package quota
 
 import (
+	"io"
+	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,6 +18,36 @@ const (
 	// token. Sent as anything else it rate-limits within a few requests; the
 	// patch version is not checked, so a recent one stays good.
 	claudeUserAgent = "claude-code/2.1.183"
+	// claudeAPIVersion is the dated API contract the probe request is written
+	// against; the usage route above needs none.
+	claudeAPIVersion = "2023-06-01"
+)
+
+// The environment variables a session's own process names its Claude login
+// with: a long-lived OAuth token, which wins over everything on disk, and the
+// config directory holding the credentials file when there is no token.
+const (
+	claudeTokenVar = "CLAUDE_CODE_OAUTH_TOKEN"
+	claudeDirVar   = "CLAUDE_CONFIG_DIR"
+)
+
+// The quota probe: what lich sends when a session's login is a long-lived
+// OAuth token rather than a credentials file. Such a token carries the
+// `user:inference` scope alone — the usage route above answers it 403, since
+// that one wants `user:profile` — so the account is measured the way Claude
+// Code measures it for itself: send the smallest possible message and read the
+// rate-limit headers off the response.
+const (
+	claudeProbeURL = "https://api.anthropic.com/v1/messages"
+	// claudeProbeBody is one token of output on the cheapest model. The system
+	// prompt is not decoration: the API rejects an OAuth token that arrives
+	// without Claude Code's own, which is the same coupling as the user agent
+	// above.
+	claudeProbeBody = `{"model":"claude-haiku-4-5-20251001","max_tokens":1,` +
+		`"messages":[{"role":"user","content":"quota"}],` +
+		`"system":[{"type":"text","text":"You are Claude Code, Anthropic's official CLI for Claude."}]}`
+	// claudeClaimPrefix is what every unified rate-limit header starts with.
+	claudeClaimPrefix = "anthropic-ratelimit-unified-"
 )
 
 // claudeCredentials is the part of ~/.claude/.credentials.json lich reads. The
@@ -68,10 +101,18 @@ type claudeLimit struct {
 	} `json:"scope"`
 }
 
-// claudePlan reads Claude Code's quota off the login its CLI wrote.
-func (s *Service) claudePlan() Plan {
+// claudePlan reads Claude Code's quota for the account a session spends: the
+// token its own environment names, else the login its CLI wrote under the
+// config directory that environment points at.
+func (s *Service) claudePlan(a Account) Plan {
 	p := plan(providers.Claude)
-	path, ok := harnessFile("CLAUDE_CONFIG_DIR", ".claude", ".credentials.json")
+	if a.hidden() || a.elsewhere() {
+		return unknown(p)
+	}
+	if token := a.Env[claudeTokenVar]; token != "" {
+		return s.claudeProbe(p, token)
+	}
+	path, ok := harnessFile(a.Env, claudeDirVar, ".claude", ".credentials.json")
 	if !ok {
 		return failed(p)
 	}
@@ -97,6 +138,62 @@ func (s *Service) claudePlan() Plan {
 		return failed(p)
 	}
 	return p
+}
+
+// claudeProbe measures a token that can only infer: it sends the probe request
+// and reads the windows off the response headers. The plan name stays empty —
+// the headers carry the spend, never the subscription it is spent against.
+func (s *Service) claudeProbe(p Plan, token string) Plan {
+	resp, authOK, err := s.send(http.MethodPost, s.probeURL, token, claudeProbeBody, map[string]string{
+		"anthropic-beta":    claudeBetaHeader,
+		"anthropic-version": claudeAPIVersion,
+		"content-type":      "application/json",
+		"User-Agent":        claudeUserAgent,
+	})
+	if !authOK {
+		return signedOut(p)
+	}
+	if err != nil {
+		return failed(p)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	// The answer is in the headers; draining the body is what lets the
+	// connection be reused for the next reading.
+	_, _ = io.Copy(io.Discard, resp.Body)
+	p.Windows = probeWindows(resp.Header)
+	if len(p.Windows) == 0 {
+		return failed(p)
+	}
+	return p
+}
+
+// probeWindows reads the unified rate-limit headers every message response
+// carries: the share of each window this account has spent (0–1), and the Unix
+// second it turns over. A claim the response does not report is skipped, which
+// is how an account metered on one window alone reads right.
+func probeWindows(h http.Header) []Window {
+	out := make([]Window, 0, 2)
+	for _, claim := range []struct {
+		abbrev  string
+		label   string
+		seconds int
+	}{
+		{"5h", "Session", sessionWindow},
+		{"7d", "Weekly", weeklyWindow},
+	} {
+		used, err := strconv.ParseFloat(h.Get(claudeClaimPrefix+claim.abbrev+"-utilization"), 64)
+		if err != nil {
+			continue
+		}
+		reset, _ := strconv.ParseInt(h.Get(claudeClaimPrefix+claim.abbrev+"-reset"), 10, 64)
+		out = append(out, Window{
+			Label:    claim.label,
+			Seconds:  claim.seconds,
+			Percent:  percent(used * 100),
+			ResetsAt: unixTimestamp(reset),
+		})
+	}
+	return out
 }
 
 // windows projects the response onto the neutral shape, preferring the limits

--- a/internal/quota/codex.go
+++ b/internal/quota/codex.go
@@ -11,6 +11,9 @@ const (
 	// codexUserAgent identifies the CLI this token belongs to, as the Anthropic
 	// route's does.
 	codexUserAgent = "codex_cli_rs/0.56.0"
+	// codexHomeVar is the environment variable a session's own process names
+	// its Codex state directory with.
+	codexHomeVar = "CODEX_HOME"
 )
 
 // codexCredentials is the part of ~/.codex/auth.json lich reads. As with
@@ -37,10 +40,14 @@ type codexWindow struct {
 	ResetAt int64 `json:"reset_at"`
 }
 
-// codexPlan reads Codex's quota off the login its CLI wrote.
-func (s *Service) codexPlan() Plan {
+// codexPlan reads Codex's quota off the login its CLI wrote, under the state
+// directory the session's own environment points at.
+func (s *Service) codexPlan(a Account) Plan {
 	p := plan(providers.Codex)
-	path, ok := harnessFile("CODEX_HOME", ".codex", "auth.json")
+	if a.hidden() {
+		return unknown(p)
+	}
+	path, ok := harnessFile(a.Env, codexHomeVar, ".codex", "auth.json")
 	if !ok {
 		return failed(p)
 	}

--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -8,6 +8,15 @@
 // OAuth access token that CLI already wrote to disk; opencode, oh-my-pi and
 // Crush run on the user's own API keys, where there is no plan to report.
 //
+// Which account is read is a question about one session, never about lich. A
+// session can be spawned from a binary the user configured — a wrapper that
+// exports its own CLAUDE_CONFIG_DIR, or an OAuth token of its own — and the
+// account it spends is then not the one lich's own environment names. So the
+// reading is taken against the environment of the process running in that
+// session's PTY (Account, wired to internal/terminal). A session lich cannot
+// read that from, yet knows runs a binary it did not choose, is reported as
+// StatusUnknown: a gauge drawn for the wrong account is worse than no gauge.
+//
 // lich reads those credentials and never writes them. Token rotation belongs to
 // the CLI that owns the login: a refresh whose write-back fails spends the
 // stored refresh token and logs the user out of their agent, which is a far
@@ -17,10 +26,12 @@ package quota
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"math"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -55,7 +66,25 @@ const (
 	// provider's own login, so they are one state, not two.
 	StatusSignedOut = "signed-out"
 	StatusError     = "error"
+	// StatusUnknown is "this session does not spend the account lich can read":
+	// it runs a binary the user configured, and lich cannot see the environment
+	// that binary set up (no live process, or a platform that exposes no other
+	// process's environment). The alternative would be the default account's
+	// numbers under a session spending someone else's plan.
+	StatusUnknown = "unknown"
 )
+
+// accountVars are the environment variables that decide which account a session
+// spends: Claude's own token and config dir, Codex's config dir, and the three
+// that point Claude somewhere other than the user's subscription.
+var accountVars = []string{
+	claudeTokenVar,
+	claudeDirVar,
+	codexHomeVar,
+	"ANTHROPIC_BASE_URL",
+	"ANTHROPIC_API_KEY",
+	"ANTHROPIC_AUTH_TOKEN",
+}
 
 // Window is one metered window of a plan: how much of it is spent, how long it
 // runs, and when it starts over.
@@ -81,23 +110,63 @@ type Plan struct {
 	Status   string   `json:"status"`
 }
 
-// Service reads plan quota, caching one reading for every caller.
+// Account is what a lich session's own process says about the account it
+// spends. Env is that process's environment — where a wrapper binary puts a
+// config dir or a token of its own — and Read is false when lich could not read
+// it at all. Custom reports a session spawned from a binary the user
+// configured, which is the only case where an unreadable environment is worth
+// withholding a reading over: every other session spends the login lich reads.
+type Account struct {
+	Env    map[string]string
+	Custom bool
+	Read   bool
+}
+
+// hidden reports an account lich cannot identify.
+func (a Account) hidden() bool { return a.Custom && !a.Read }
+
+// elsewhere reports a session pointed at something other than the user's own
+// subscription: another API host, or an API key, which is billed per token and
+// metered by no plan. Reading lich's own login for one of those would draw a
+// gauge for an account that session never touches.
+func (a Account) elsewhere() bool {
+	return a.Env["ANTHROPIC_BASE_URL"] != "" ||
+		a.Env["ANTHROPIC_API_KEY"] != "" ||
+		a.Env["ANTHROPIC_AUTH_TOKEN"] != ""
+}
+
+// Sessions answers what a session's process says about the account it spends.
+// main wires it to the terminal service; a Service without one reads only
+// lich's own environment, which is the machine-wide question Settings asks.
+type Sessions func(sessionID string) Account
+
+// Service reads plan quota, caching one reading per account.
 type Service struct {
 	http *http.Client
-	// claudeURL and codexURL are the usage endpoints, fields so tests drive the
-	// parsers against a local server.
+	// claudeURL, codexURL and probeURL are the endpoints, fields so tests drive
+	// the parsers against a local server.
 	claudeURL string
 	codexURL  string
+	probeURL  string
 
 	// now is time.Now, a field so a test can age the cache without sleeping.
 	now func() time.Time
 
-	// mu guards the cached reading and is held across the fetch itself, so a
-	// second caller arriving mid-request waits for that answer instead of
-	// firing its own at an endpoint that rate-limits.
-	mu     sync.Mutex
-	cached []Plan
-	at     time.Time
+	// sessions resolves a session id to the account it spends; nil until main
+	// wires it, and never called for the machine-wide reading.
+	sessions Sessions
+
+	// mu guards the cache and is held across the fetch itself, so a second
+	// caller arriving mid-request waits for that answer instead of firing its
+	// own at an endpoint that rate-limits.
+	mu    sync.Mutex
+	cache map[string]reading
+}
+
+// reading is one cached answer, and when it was taken.
+type reading struct {
+	plans []Plan
+	at    time.Time
 }
 
 // New returns a Service pointed at the live endpoints.
@@ -106,22 +175,52 @@ func New() *Service {
 		http:      &http.Client{Timeout: httpTimeout},
 		claudeURL: claudeUsageURL,
 		codexURL:  codexUsageURL,
+		probeURL:  claudeProbeURL,
 		now:       time.Now,
+		cache:     make(map[string]reading),
 	}
 }
 
-// Plans is every provider that meters a subscription, in Registry order. There
-// is always one entry per such provider — a failed reading is a Status, not an
-// omission, so the UI can say which provider it could not read.
-func (s *Service) Plans() []Plan {
+// SetSessions wires the answer to "which account does this session spend".
+// Startup wiring, called once before the service serves.
+func (s *Service) SetSessions(fn Sessions) { s.sessions = fn }
+
+// Plans is every provider that meters a subscription, in Registry order, read
+// for the account sessionID spends. There is always one entry per such provider
+// — a failed reading is a Status, not an omission, so the UI can say which
+// provider it could not read.
+//
+// An empty sessionID reads lich's own environment: the Settings screen asks
+// about the machine, not about a card.
+func (s *Service) Plans(sessionID string) []Plan {
+	account := Account{Read: true}
+	if sessionID != "" && s.sessions != nil {
+		account = s.sessions(sessionID)
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.cached != nil && s.now().Sub(s.at) < cacheTTL {
-		return s.cached
+	key := cacheKey(account)
+	if cached, ok := s.cache[key]; ok && s.now().Sub(cached.at) < cacheTTL {
+		return cached.plans
 	}
-	plans := []Plan{s.claudePlan(), s.codexPlan()}
-	s.cached, s.at = plans, s.now()
+	plans := []Plan{s.claudePlan(account), s.codexPlan(account)}
+	s.cache[key] = reading{plans: plans, at: s.now()}
 	return plans
+}
+
+// cacheKey identifies the account a reading belongs to, so two sessions on the
+// same login share one reading — and a session on another login gets its own
+// instead of being served someone else's numbers. Every account lich cannot
+// identify shares the one key whose reading needs no request at all.
+func cacheKey(a Account) string {
+	if a.hidden() {
+		return "?"
+	}
+	values := make([]string, 0, len(accountVars))
+	for _, name := range accountVars {
+		values = append(values, a.Env[name])
+	}
+	return strings.Join(values, "\x00")
 }
 
 // plan is the common shape of a reading, before its windows are known.
@@ -135,8 +234,9 @@ func plan(id string) Plan {
 	return Plan{Provider: id, Name: name, Status: StatusOK}
 }
 
-// signedOut and failed are the two ways a reading ends without windows. Keeping
-// them as constructors keeps every caller's error path one line.
+// signedOut, failed and unknown are the three ways a reading ends without
+// windows. Keeping them as constructors keeps every caller's error path one
+// line.
 func signedOut(p Plan) Plan {
 	p.Status = StatusSignedOut
 	return p
@@ -147,11 +247,21 @@ func failed(p Plan) Plan {
 	return p
 }
 
+func unknown(p Plan) Plan {
+	p.Status = StatusUnknown
+	return p
+}
+
 // harnessFile locates a file a provider CLI keeps in its own state directory:
-// under the directory its environment variable names, else under home. Mirrors
+// under the directory its environment variable names, else under home. The
+// session's own environment wins over lich's — a wrapper binary exporting
+// another config dir is the whole reason this is not a plain os.Getenv. Mirrors
 // terminal.harnessDir, which resolves the same two directories for transcripts.
-func harnessFile(homeVar, sub string, name ...string) (string, bool) {
-	base := os.Getenv(homeVar)
+func harnessFile(env map[string]string, homeVar, sub string, name ...string) (string, bool) {
+	base := env[homeVar]
+	if base == "" {
+		base = os.Getenv(homeVar)
+	}
 	if base == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -162,13 +272,19 @@ func harnessFile(homeVar, sub string, name ...string) (string, bool) {
 	return filepath.Join(append([]string{base}, name...)...), true
 }
 
-// readJSON GETs url with the given headers and decodes the body into out. The
-// bool is "the endpoint rejected our token": a 401 or 403 is a login the user
-// has to redo, which every caller reports differently from a network failure.
-func (s *Service) readJSON(url, token string, headers map[string]string, out any) (authOK bool, err error) {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+// send performs one request with the given bearer token and headers, and hands
+// back the response for the caller to read. The bool is "the endpoint rejected
+// our token": a 401 or 403 is a login the user has to redo, which every caller
+// reports differently from a network failure. The body is closed here on every
+// path that returns no response.
+func (s *Service) send(method, url, token, body string, headers map[string]string) (*http.Response, bool, error) {
+	var payload io.Reader
+	if body != "" {
+		payload = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, payload)
 	if err != nil {
-		return true, err
+		return nil, true, err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	for k, v := range headers {
@@ -176,15 +292,26 @@ func (s *Service) readJSON(url, token string, headers map[string]string, out any
 	}
 	resp, err := s.http.Do(req)
 	if err != nil {
-		return true, err
+		return nil, true, err
 	}
-	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		return false, fmt.Errorf("usage endpoint answered %d", resp.StatusCode)
+		_ = resp.Body.Close()
+		return nil, false, fmt.Errorf("usage endpoint answered %d", resp.StatusCode)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return true, fmt.Errorf("usage endpoint answered %d", resp.StatusCode)
+		_ = resp.Body.Close()
+		return nil, true, fmt.Errorf("usage endpoint answered %d", resp.StatusCode)
 	}
+	return resp, true, nil
+}
+
+// readJSON GETs url with the given headers and decodes the body into out.
+func (s *Service) readJSON(url, token string, headers map[string]string, out any) (authOK bool, err error) {
+	resp, authOK, err := s.send(http.MethodGet, url, token, "", headers)
+	if err != nil {
+		return authOK, err
+	}
+	defer func() { _ = resp.Body.Close() }()
 	if err := json.NewDecoder(resp.Body).Decode(out); err != nil {
 		return true, fmt.Errorf("decode usage response: %w", err)
 	}

--- a/internal/quota/quota_test.go
+++ b/internal/quota/quota_test.go
@@ -63,9 +63,15 @@ func newService(claudeURL, codexURL string, now time.Time) *Service {
 		http:      &http.Client{Timeout: httpTimeout},
 		claudeURL: claudeURL,
 		codexURL:  codexURL,
+		probeURL:  claudeURL,
 		now:       func() time.Time { return now },
+		cache:     make(map[string]reading),
 	}
 }
+
+// lichEnv is the account every reading was taken for before a session could
+// name one of its own: whatever lich's own environment points at.
+func lichEnv() Account { return Account{Read: true} }
 
 const claudeLimitsBody = `{
 	"five_hour": {"utilization": 2.0, "resets_at": "2026-08-17T23:20:00.153182+00:00"},
@@ -81,7 +87,7 @@ const claudeLimitsBody = `{
 func TestClaudePlanReadsLimits(t *testing.T) {
 	writeCreds(t, claudeCredsJSON, "")
 	url, calls := serve(t, http.StatusOK, claudeLimitsBody)
-	got := newService(url, "", time.Now()).claudePlan()
+	got := newService(url, "", time.Now()).claudePlan(lichEnv())
 
 	if got.Status != StatusOK {
 		t.Fatalf("status = %q, want %q", got.Status, StatusOK)
@@ -119,7 +125,7 @@ func TestClaudeRequestCarriesTheHeadersTheEndpointDemands(t *testing.T) {
 	}))
 	defer server.Close()
 
-	newService(server.URL, "", time.Now()).claudePlan()
+	newService(server.URL, "", time.Now()).claudePlan(lichEnv())
 
 	if auth := got.Get("Authorization"); auth != "Bearer tok-claude" {
 		t.Errorf("Authorization = %q, want %q", auth, "Bearer tok-claude")
@@ -139,7 +145,7 @@ func TestClaudeFallsBackToTheOriginalWindowPair(t *testing.T) {
 		"seven_day":{"utilization":7,"resets_at":"2026-08-24T15:00:00Z"},"limits":[]}`
 	url, _ := serve(t, http.StatusOK, body)
 
-	got := newService(url, "", time.Now()).claudePlan()
+	got := newService(url, "", time.Now()).claudePlan(lichEnv())
 
 	want := []Window{
 		{Label: "Session", Seconds: 18000, Percent: 63, ResetsAt: "2026-08-17T23:20:00Z"},
@@ -161,7 +167,7 @@ func TestClaudeSkipsEntriesItCannotDraw(t *testing.T) {
 	]}`
 	url, _ := serve(t, http.StatusOK, body)
 
-	got := newService(url, "", time.Now()).claudePlan()
+	got := newService(url, "", time.Now()).claudePlan(lichEnv())
 
 	if len(got.Windows) != 1 || got.Windows[0].Label != "Session" {
 		t.Fatalf("windows = %+v, want only the session window", got.Windows)
@@ -173,7 +179,7 @@ func TestClaudeDropsAnUnparseableResetTime(t *testing.T) {
 	body := `{"limits":[{"kind":"session","percent":5,"resets_at":"whenever"}]}`
 	url, _ := serve(t, http.StatusOK, body)
 
-	got := newService(url, "", time.Now()).claudePlan()
+	got := newService(url, "", time.Now()).claudePlan(lichEnv())
 
 	if len(got.Windows) != 1 || got.Windows[0].ResetsAt != "" {
 		t.Errorf("windows = %+v, want the window with no reset time", got.Windows)
@@ -196,7 +202,7 @@ func TestSignedOutStates(t *testing.T) {
 			writeCreds(t, tt.creds, "")
 			url, _ := serve(t, tt.status, `{}`)
 
-			got := newService(url, "", time.Now()).claudePlan()
+			got := newService(url, "", time.Now()).claudePlan(lichEnv())
 
 			if got.Status != StatusSignedOut {
 				t.Errorf("status = %q, want %q", got.Status, StatusSignedOut)
@@ -223,7 +229,7 @@ func TestFailedStates(t *testing.T) {
 			writeCreds(t, claudeCredsJSON, "")
 			url, _ := serve(t, tt.status, tt.body)
 
-			got := newService(url, "", time.Now()).claudePlan()
+			got := newService(url, "", time.Now()).claudePlan(lichEnv())
 
 			if got.Status != StatusError {
 				t.Errorf("status = %q, want %q", got.Status, StatusError)
@@ -240,7 +246,7 @@ func TestCodexPlanNamesWindowsByDuration(t *testing.T) {
 		"used_percent":26,"limit_window_seconds":2592000,"reset_at":1789318316}}}`
 	url, _ := serve(t, http.StatusOK, body)
 
-	got := newService("", url, time.Now()).codexPlan()
+	got := newService("", url, time.Now()).codexPlan(lichEnv())
 
 	if got.Status != StatusOK || got.Plan != "Free" {
 		t.Fatalf("plan = %+v, want an ok Free plan", got)
@@ -258,7 +264,7 @@ func TestCodexReadsBothWindows(t *testing.T) {
 		"secondary_window":{"used_percent":88.6,"limit_window_seconds":604800,"reset_at":1789318316}}}`
 	url, _ := serve(t, http.StatusOK, body)
 
-	got := newService("", url, time.Now()).codexPlan()
+	got := newService("", url, time.Now()).codexPlan(lichEnv())
 
 	want := []Window{
 		{Label: "Session", Seconds: 18000, Percent: 12},
@@ -273,7 +279,7 @@ func TestCodexWithoutRateLimitBlockFails(t *testing.T) {
 	writeCreds(t, "", codexCredsJSON)
 	url, _ := serve(t, http.StatusOK, `{"plan_type":"plus"}`)
 
-	if got := newService("", url, time.Now()).codexPlan(); got.Status != StatusError {
+	if got := newService("", url, time.Now()).codexPlan(lichEnv()); got.Status != StatusError {
 		t.Errorf("status = %q, want %q", got.Status, StatusError)
 	}
 }
@@ -347,7 +353,7 @@ func TestPlansServesEveryMeteredProviderFromOneReading(t *testing.T) {
 	now := time.Date(2026, 8, 17, 12, 0, 0, 0, time.UTC)
 	s := newService(claudeURL, codexURL, now)
 
-	plans := s.Plans()
+	plans := s.Plans("")
 	if len(plans) != 2 {
 		t.Fatalf("plans = %+v, want one per metered provider", plans)
 	}
@@ -357,14 +363,14 @@ func TestPlansServesEveryMeteredProviderFromOneReading(t *testing.T) {
 
 	// Inside the TTL the endpoints are not asked again.
 	s.now = func() time.Time { return now.Add(4*time.Minute + 59*time.Second) }
-	s.Plans()
+	s.Plans("")
 	if *claudeCalls != 1 || *codexCalls != 1 {
 		t.Fatalf("calls = %d/%d after a cached read, want 1/1", *claudeCalls, *codexCalls)
 	}
 
 	// Past it they are.
 	s.now = func() time.Time { return now.Add(5*time.Minute + time.Second) }
-	s.Plans()
+	s.Plans("")
 	if *claudeCalls != 2 || *codexCalls != 2 {
 		t.Errorf("calls = %d/%d after the TTL, want 2/2", *claudeCalls, *codexCalls)
 	}
@@ -377,6 +383,9 @@ func TestNewPointsAtTheLiveEndpoints(t *testing.T) {
 	}
 	if s.codexURL != "https://chatgpt.com/backend-api/wham/usage" {
 		t.Errorf("codexURL = %q", s.codexURL)
+	}
+	if s.probeURL != "https://api.anthropic.com/v1/messages" {
+		t.Errorf("probeURL = %q", s.probeURL)
 	}
 	if s.now == nil || s.http == nil {
 		t.Error("New must wire a clock and an HTTP client")

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -92,6 +92,21 @@ func (s *Service) ProviderBin(providerID, projectID string) string {
 	return bin
 }
 
+// SessionCustomBin reports whether a session runs a binary the user configured
+// rather than the provider's own — the question the quota reader asks before
+// trusting lich's own login to say what that session spends (internal/quota).
+// A session row that cannot be read is not one: the reading it gates is the one
+// every session got before this existed.
+func (s *Service) SessionCustomBin(sessionID string) bool {
+	var kind, projectID string
+	if err := s.db.QueryRow(
+		`SELECT kind, project_id FROM sessions WHERE id = ?`, sessionID,
+	).Scan(&kind, &projectID); err != nil {
+		return false
+	}
+	return s.ProviderBin(kind, projectID) != ""
+}
+
 // binParked reports a layer switched off in one scope. An unreadable value is
 // not one: a layer the user configured keeps resolving rather than silently
 // falling through to a different binary.

--- a/internal/store/settings_test.go
+++ b/internal/store/settings_test.go
@@ -212,3 +212,40 @@ func TestSkipPermissionsIsScopedByCheckout(t *testing.T) {
 		t.Error("value \"1\" skips permissions, want only \"true\" to")
 	}
 }
+
+func TestSessionCustomBin(t *testing.T) {
+	svc := newTestStore(t)
+	if err := svc.AddProject("p1", "one", "/tmp/one"); err != nil {
+		t.Fatalf("add project: %v", err)
+	}
+	if err := svc.AddSession("p1", "s1", "card", providers.Claude, "/tmp/one", 0, ""); err != nil {
+		t.Fatalf("add session: %v", err)
+	}
+
+	// Nothing configured: the session runs the provider's own binary.
+	if svc.SessionCustomBin("s1") {
+		t.Error("unconfigured session reads as custom")
+	}
+	// A session lich has no row for is not custom either — the reading it gates
+	// is the one every session got before this existed.
+	if svc.SessionCustomBin("gone") {
+		t.Error("unknown session reads as custom")
+	}
+
+	// The binary configured for another provider is not this session's.
+	_ = svc.SetSetting(binKey(providers.Codex), globalScope, "/opt/codex")
+	if svc.SessionCustomBin("s1") {
+		t.Error("another provider's binary reads as this session's")
+	}
+
+	_ = svc.SetSetting(claudeBinKey, "p1", "/home/me/claude-work.sh")
+	if !svc.SessionCustomBin("s1") {
+		t.Error("a project override must read as custom")
+	}
+
+	// A parked layer is skipped exactly as ProviderBin skips it.
+	_ = svc.SetSetting(binOffKey(providers.Claude), "p1", "true")
+	if svc.SessionCustomBin("s1") {
+		t.Error("a parked binary must read as the provider's own")
+	}
+}

--- a/internal/terminal/account.go
+++ b/internal/terminal/account.go
@@ -1,0 +1,28 @@
+package terminal
+
+// SessionAccount reports what a session says about the account its provider
+// spends: the environment of the process running in its PTY, whether that
+// environment could be read at all, and whether the session was spawned from a
+// binary the user configured rather than the provider's own.
+//
+// It exists for the quota reader (internal/quota), which asks it before deciding
+// which login to measure. read is false for a session with no live process as
+// well as for a platform that exposes no environment (env_other.go); custom is
+// answered from the settings either way, because the whole point of the pairing
+// is to tell "this session spends another account and I cannot see which" apart
+// from "this session spends the default one".
+//
+// Denied to the frontend (denyInternal in main.go): the environment it returns
+// carries that session's own credentials.
+func (s *Service) SessionAccount(id string) (env map[string]string, custom, read bool) {
+	custom = s.store.SessionCustomBin(id)
+	if !envReadable {
+		return nil, custom, false
+	}
+	p := s.ptyOf(id)
+	if p == nil {
+		return nil, custom, false
+	}
+	env = readEnv(p.Pid())
+	return env, custom, env != nil
+}

--- a/internal/terminal/account_linux_test.go
+++ b/internal/terminal/account_linux_test.go
@@ -1,0 +1,49 @@
+//go:build linux
+
+package terminal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/omartelo/lich/internal/events"
+)
+
+// TestSessionAccountReadsWhatTheWrapperExecsInto is the mechanism the whole
+// per-session quota reading rests on: a configured binary that exports a login
+// of its own and `exec`s the provider replaces its own image, and what lich
+// reads back is the environment the provider actually runs with — not the one
+// lich spawned the wrapper with.
+func TestSessionAccountReadsWhatTheWrapperExecsInto(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "claude-work.sh")
+	script := "#!/bin/sh\nexport CLAUDE_CONFIG_DIR=" + dir + "\nexec sleep 30\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write wrapper: %v", err)
+	}
+	svc := New(stubBins{bin: bin}, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1") })
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+
+	// The export lands when the wrapper execs, which is after the spawn returns.
+	var env map[string]string
+	var read bool
+	for range 200 {
+		env, _, read = svc.SessionAccount("s1")
+		if read && env["CLAUDE_CONFIG_DIR"] == dir {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	if !read {
+		t.Fatal("read = false, want the live process's environment")
+	}
+	if got := env["CLAUDE_CONFIG_DIR"]; got != dir {
+		t.Errorf("CLAUDE_CONFIG_DIR = %q, want %q — the wrapper's own login", got, dir)
+	}
+}

--- a/internal/terminal/account_test.go
+++ b/internal/terminal/account_test.go
@@ -1,0 +1,37 @@
+// stubBins, the Store every session test builds on, lives in the Unix-only
+// suite (terminal_test.go), so these ride the same tag. What Windows would
+// prove here it proves by construction instead: env_other.go's envReadable is
+// a false constant, and the platform CI run covers the spawn path around it.
+//go:build !windows
+
+package terminal
+
+import (
+	"testing"
+
+	"github.com/omartelo/lich/internal/events"
+)
+
+func TestSessionAccountWithoutALiveProcess(t *testing.T) {
+	svc := New(stubBins{bin: "/opt/claude-work.sh"}, nil, events.New())
+
+	env, custom, read := svc.SessionAccount("s1")
+
+	if read || env != nil {
+		t.Errorf("read = %v, env = %v, want nothing: the session has no process", read, env)
+	}
+	// Which binary a session runs is a settings question, answerable with no
+	// process at all — and it is what keeps a card whose PTY is not up from
+	// being served another account's quota.
+	if !custom {
+		t.Error("custom = false, want the configured binary reported")
+	}
+}
+
+func TestSessionAccountOfADefaultSession(t *testing.T) {
+	svc := New(stubBins{}, nil, events.New())
+
+	if _, custom, _ := svc.SessionAccount("s1"); custom {
+		t.Error("custom = true for a session running the provider's own binary")
+	}
+}

--- a/internal/terminal/env_linux.go
+++ b/internal/terminal/env_linux.go
@@ -1,0 +1,36 @@
+//go:build linux
+
+package terminal
+
+import (
+	"os"
+	"strconv"
+	"strings"
+)
+
+// envReadable reports whether this platform can read the environment of a
+// process lich started; declared per platform the way cwdTracked is, so the
+// callers on a platform without it answer "cannot tell" rather than guessing.
+const envReadable = true
+
+// readEnv returns the environment pid runs with, or nil when it cannot be read
+// (the process exited, or was never ours to inspect).
+//
+// /proc holds the environment of the process's current image, not of the one
+// lich spawned — and that difference is the whole point. A wrapper binary
+// exports a config dir or a token and then `exec`s the provider, replacing
+// itself; what shows up here is what the provider actually runs with, which is
+// where a session's credentials come from.
+func readEnv(pid int) map[string]string {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/environ")
+	if err != nil {
+		return nil
+	}
+	env := make(map[string]string)
+	for entry := range strings.SplitSeq(string(data), "\x00") {
+		if key, value, ok := strings.Cut(entry, "="); ok {
+			env[key] = value
+		}
+	}
+	return env
+}

--- a/internal/terminal/env_other.go
+++ b/internal/terminal/env_other.go
@@ -1,0 +1,16 @@
+//go:build !linux
+
+package terminal
+
+// envReadable: no other process's environment on this platform, so a session
+// running a binary lich did not choose cannot be told apart from one running
+// the default login — the quota reading is withheld rather than taken against
+// the wrong account (internal/quota, StatusUnknown).
+//
+// macOS could answer this through sysctl's KERN_PROCARGS2, the way
+// cwd_darwin.go answers the working directory; nobody has had the hardware to
+// write and prove it. Windows exposes nothing short of reading another
+// process's memory.
+const envReadable = false
+
+func readEnv(int) map[string]string { return nil }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -165,6 +165,7 @@ type session struct {
 
 // Store is the persistence the terminal service depends on: the binary to spawn
 // for a provider in a project (empty return spawns the provider's default),
+// whether a given session runs one of those rather than the provider's own,
 // whether that spawn drops the provider's permission prompts and whether it runs
 // confined, that project's own directory, the dev-server port reserved for each
 // checkout, where to record the provider session id a PTY reports through its
@@ -173,6 +174,7 @@ type session struct {
 // them all.
 type Store interface {
 	ProviderBin(providerID, projectID string) string
+	SessionCustomBin(sessionID string) bool
 	SkipPermissions(providerID, projectID, cwd string) bool
 	ProjectPath(projectID string) string
 	WorktreePorts() map[string]int

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -88,6 +88,7 @@ func newCostStore(providerSession string) stubBins {
 }
 
 func (s stubBins) ProviderBin(_, _ string) string       { return s.bin }
+func (s stubBins) SessionCustomBin(_ string) bool       { return s.bin != "" }
 func (s stubBins) SkipPermissions(_, _, _ string) bool  { return s.skipPerms }
 func (s stubBins) ProjectPath(_ string) string          { return s.projectPath }
 func (s stubBins) SessionModel(_ string) string         { return s.model }

--- a/main.go
+++ b/main.go
@@ -148,7 +148,15 @@ func main() {
 	uncleanExit := singleton.UncleanExit(configDir, os.Getenv(restart.WaitEnv))
 	dispatcher.Register("system", system.New(env, logPath, version, uncleanExit))
 	dispatcher.Register("providers", providers.New())
-	dispatcher.Register("quota", quota.New())
+	// The quota reading is per session, not per machine: a session spawned from
+	// a binary the user configured can spend another account entirely, and the
+	// terminal is what knows the environment that binary set up.
+	plans := quota.New()
+	plans.SetSessions(func(sessionID string) quota.Account {
+		env, custom, read := term.SessionAccount(sessionID)
+		return quota.Account{Env: env, Custom: custom, Read: read}
+	})
+	dispatcher.Register("quota", plans)
 	// The relay is the only service whose caller is not the window: the `lich`
 	// CLI running inside a session reaches it over the same listener. It watches
 	// the hooks' state reports too, to notice a target that ends a turn without
@@ -199,13 +207,16 @@ func main() {
 //     closes sessions through the store, which is what reports one gone.
 //   - drop.SetPicker is startup wiring like the ones below, and nilling it
 //     would leave the footer's attach button with no dialog to open.
+//   - terminal.SessionAccount hands back the environment of the process a
+//     session runs, credentials and all, so the quota reader can tell which
+//     account that session spends.
 //   - relay.SetPlugins, project.SetAccounts, project.SetProjects,
-//     store.SetSessionGone and terminal.SetDropDir are startup wiring. Called
-//     with [null] they silently nil what they wired (encoding/json leaves a
-//     func or pointer alone on null), and the write races the readers already
-//     serving — nilling SetProjects also disarms the guard that keeps two
-//     projects off the same directory, and SetDropDir points the sandbox's
-//     read-only bind wherever the caller likes.
+//     quota.SetSessions, store.SetSessionGone and terminal.SetDropDir are
+//     startup wiring. Called with [null] they silently nil what they wired
+//     (encoding/json leaves a func or pointer alone on null), and the write
+//     races the readers already serving — nilling SetProjects also disarms the
+//     guard that keeps two projects off the same directory, and SetDropDir
+//     points the sandbox's read-only bind wherever the caller likes.
 func denyInternal(d *rpc.Handler) {
 	for _, method := range []string{
 		"store.Close",
@@ -218,6 +229,8 @@ func denyInternal(d *rpc.Handler) {
 		"relay.SetPlugins",
 		"project.SetAccounts",
 		"project.SetProjects",
+		"quota.SetSessions",
+		"terminal.SessionAccount",
 		"terminal.SetDropDir",
 	} {
 		d.Deny(method)


### PR DESCRIPTION
## What

The footer's plan gauge was read from lich's own environment — whichever login `~/.claude/.credentials.json` held. A project pointed at a binary of the user's own (a wrapper exporting another `CLAUDE_CONFIG_DIR`, or an OAuth token for a second account) showed a number about somebody else's plan, with nothing on screen saying so.

The reading now follows the session:

- `quota.Plans(sessionID)` resolves the account from the environment of the process in that session's PTY — where a wrapper's `export` lands once it `exec`s the provider (`/proc/<pid>/environ`, via the new `terminal.SessionAccount`). Readings are cached per account instead of globally, so two logins on one machine stay apart. An empty id keeps reading the machine's own login, which is the question the Settings screen asks.
- A login that is a long-lived token (`claude setup-token`) carries `user:inference` alone, and `GET /api/oauth/usage` answers it **403 `scope requirement user:profile`** — measured, not assumed. Such an account is read the way Claude Code reads it for itself: one `max_tokens: 1` message, for its `anthropic-ratelimit-unified-*` response headers.
- A session pointed at another API host, or running on an API key, reports no plan — it spends none that lich meters.
- Codex follows the same rule through `CODEX_HOME`. opencode, oh-my-pi and Crush meter no subscription, as before.

Where the environment is out of reach — macOS, Windows, or a card whose PTY is not up — a session running a user-configured binary reports the new `unknown` status and the footer draws nothing, rather than the default account's numbers under a session spending another plan.

## Shape

| where | what |
|---|---|
| `internal/quota` | `Account`/`Sessions`, per-account cache, the header probe, `unknown` |
| `internal/terminal` | `env_linux.go` / `env_other.go` seam (`envReadable`, `readEnv`) and `SessionAccount` |
| `internal/store` | `SessionCustomBin`, reusing `ProviderBin`, answerable with no live process |
| `main.go` | wiring, plus `terminal.SessionAccount` and `quota.SetSessions` denied to the window — the first hands back credentials |
| frontend | `plan-quota-store` keyed by session, `Quota.Plans(sessionId)`, `"unknown"` in the type |

`docs/ceilings.md` gains two bullets: the environment read is Linux-only (macOS could do it through `KERN_PROCARGS2`; nobody has the hardware), and measuring a token-only login spends a request against the very plan it measures, carrying Claude Code's system prompt verbatim because the API rejects an OAuth token without it.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean; `go test ./...` green (1849)
- [x] `pnpm check`, `tsc`, `vite build`, `vitest run` green (1096)
- [x] Cross-compile loop for linux/darwin/windows — build and vet
- [x] New coverage: probe request and its headers, per-account cache isolation, an unreadable custom binary reading `unknown`, a session pointed elsewhere, `SessionCustomBin` including a parked layer, and a Linux end-to-end proving a wrapper's `exec` is what lich reads back
- [x] Live check against a real second account (a wrapper exporting `CLAUDE_CODE_OAUTH_TOKEN`): `status=ok · Session 10% · Weekly 1%` — that account's numbers, not the default login's