### PR TITLE
perf: read a checkout's git status in one call, not four

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A card's git readout costs half of what it did.** Every second, each checkout
+  on screen spawned six `git` children to answer one status badge — and on a
+  normal repository most of that was process startup rather than work. One
+  `git status --porcelain=v2` reports the branch, the HEAD commit and every dirty
+  file in a single call, so a tick is three children now: measured here on git
+  2.55, a small worktree fell from 21.2 ms to 13.4 ms per read (20.1 ms to 12.6 ms
+  of CPU), and a 50,000-file checkout with 200 dirty files from 101.8 ms to
+  66.4 ms (202.7 ms to 168.2 ms of CPU). Nothing about the badge changes.
 - **`lich reply` no longer needs the ticket.** Called with the answer alone —
   `lich reply "<your answer>"`, or `reply_to_session` with no ticket — it answers
   the request open against the calling session, so an agent that has lost the

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -79,6 +79,10 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   repository itself keeps failing the old silent way.
 - **git status is polled** — one shared poller per repository path (`frontend/src/lib/git/git-status-store.ts`); the
   lich plugin's `session-touched` hook nudges an immediate refresh.
+- **The status badge has a single source** (`internal/project/status.go`): the branch, the HEAD commit and the
+  dirty count all come out of one `git status --porcelain=v2 --branch` parse. A git release that changes those
+  records breaks all three together rather than one at a time, and there is no second call left to disagree with
+  the first — `Branch` still asks `symbolic-ref`, but nothing on the polled path calls it.
 - **lich fetches on its own** (`internal/project/basestatus.go`) — the only git write lich makes outside the
   worktree flows: it moves remote refs in the user's own repository, unannounced, for as long as a card is on
   screen.

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -15,13 +15,17 @@ export interface Project {
  * only, hence the same shape as an opened one. */
 export type RecentProject = Project
 
-/** internal/project.DiffStats — uncommitted-changes summary of a work tree. */
+/** internal/project.DiffStats — uncommitted-changes summary of a work tree,
+ * plus the branch and commit they sit on: git answers all three in the one
+ * status call the counts come out of. */
 export interface DiffStats {
   files: number
   added: number
   deleted: number
   /** The HEAD commit the counts sit on; "" in a repository without commits. */
   head: string
+  /** The checked-out branch; "" for a detached HEAD, as ProjectService.Branch. */
+  branch: string
 }
 
 /** internal/project.BaseStatus — where a checkout stands against the branch it

--- a/frontend/src/lib/git/use-git-status.ts
+++ b/frontend/src/lib/git/use-git-status.ts
@@ -10,14 +10,15 @@ export type { GitStatus }
 // session-touched hook still nudges an immediate read on top of this.
 const GIT_POLL: PollCadence = { fastMs: 1_000, slowMs: 3_000, idleTicks: 5 }
 
+// Two calls, not three: Diff carries the branch, because the one git status it
+// runs already reports it alongside the head and the dirty entries.
 async function fetchGitStatus(path: string): Promise<GitStatus | null> {
   try {
-    const [branch, diff, base] = await Promise.all([
-      ProjectService.Branch(path),
+    const [diff, base] = await Promise.all([
       ProjectService.Diff(path),
       ProjectService.BaseStatus(path),
     ])
-    return { branch, ...diff, base }
+    return { ...diff, base }
   } catch {
     return null
   }

--- a/internal/project/difftext.go
+++ b/internal/project/difftext.go
@@ -8,40 +8,28 @@ import (
 	"strings"
 )
 
-// emptyTreeHash is git's well-known empty tree object, the diff base for a
-// repository whose HEAD does not exist yet (no commits).
-const emptyTreeHash = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
-
 // DiffText returns the full unified diff of uncommitted changes (staged +
 // unstaged + untracked) against HEAD. A repository without commits diffs
 // against git's empty tree. Untracked files are rendered as new-file hunks so
 // the review panel shows them alongside tracked changes.
 func (s *Service) DiffText(path string) (string, error) {
-	_, base := diffBase(path)
-	tracked, err := runGit(path, "diff", base)
+	status := readWorkTree(path)
+	tracked, err := runGit(path, "diff", status.base)
 	if err != nil {
 		return "", err
 	}
 
 	var out strings.Builder
 	out.WriteString(tracked)
-	for _, rel := range untrackedFiles(path) {
+	for _, rel := range status.untracked {
 		out.WriteString(untrackedDiff(path, rel))
 	}
 	return out.String(), nil
 }
 
-// untrackedFiles lists paths unknown to git, relative to the work tree root.
-// A failure yields an empty list — both callers (the polled Diff counts and the
-// review panel's full text) are worth returning without it.
-func untrackedFiles(path string) []string {
-	out, _ := gitQuiet(path, "ls-files", "--others", "--exclude-standard", "-z")
-	return splitNUL(out)
-}
-
 // untrackedDiff renders an untracked file as a new-file unified diff via
 // git diff --no-index, which exits 1 when the files differ — success here.
-// Any other failure (file vanished between ls-files and now) yields "".
+// Any other failure (file vanished since the status read) yields "".
 func untrackedDiff(dir, rel string) string {
 	if info, err := os.Stat(filepath.Join(dir, rel)); err != nil || !info.Mode().IsRegular() || info.Size() > maxTextFileBytes {
 		return ""

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -234,50 +234,38 @@ func (s *Service) PickSaveFile(title, defaultName string) (string, error) {
 	return path, nil
 }
 
-// DiffStats summarizes the uncommitted changes of a work tree. Head is the
-// commit those changes sit on — the frontend watches it to notice a commit the
-// way it watches Files/Added/Deleted to notice an edit.
+// DiffStats is what one status read says about a work tree: its uncommitted
+// changes, and the two things they sit on. Head is the commit — the frontend
+// watches it to notice a commit the way it watches Files/Added/Deleted to
+// notice an edit — and Branch is the branch, carried here because git answers
+// both in the same call the counts come out of.
 type DiffStats struct {
 	Files   int    `json:"files"`
 	Added   int    `json:"added"`
 	Deleted int    `json:"deleted"`
 	Head    string `json:"head"`
+	Branch  string `json:"branch"`
 }
 
 // Diff returns the dirty-file count (modified + untracked), the added/deleted
-// line totals against HEAD, and the HEAD commit itself. A non-repository path
-// yields the zero value, matching Branch's contract.
+// line totals against HEAD, the HEAD commit itself and the branch it is on. A
+// non-repository path yields the zero value, matching Branch's contract.
+//
+// Two git children, not four: one status read answers the branch, the head and
+// everything dirty (status.go), and only the line totals still need a diff of
+// their own.
 func (s *Service) Diff(path string) DiffStats {
-	var stats DiffStats
-	// --untracked-files=all, because the default collapses a new directory into
-	// one "?? dir/" line: an agent writing 25 files into fresh packages would
-	// count as one changed file.
-	if out, ok := gitQuiet(path, "status", "--porcelain", "--untracked-files=all"); ok {
-		stats.Files = len(splitLines(out))
-	}
-	head, base := diffBase(path)
-	stats.Head = head
-	if out, ok := gitQuiet(path, "diff", "--numstat", base); ok {
+	status := readWorkTree(path)
+	stats := DiffStats{Files: status.files, Head: status.head, Branch: status.branch}
+	if out, ok := gitQuiet(path, "diff", "--numstat", status.base); ok {
 		stats.Added, stats.Deleted = numstatTotals(out)
 	}
 	// Untracked files are invisible to `git diff`; count their lines as
 	// additions, the way Warp and forge diff views present a fresh file.
-	for _, rel := range untrackedFiles(path) {
+	for _, rel := range status.untracked {
 		stats.Added += countFileLines(filepath.Join(path, rel))
 	}
 	return stats
-}
-
-// diffBase resolves what uncommitted changes are diffed against: HEAD and its
-// commit, or git's empty tree with no commit at all when the repository has no
-// HEAD yet. A repository without commits is an ordinary state here, not a
-// failure — hence the quiet probe.
-func diffBase(path string) (head, base string) {
-	out, ok := gitQuiet(path, "rev-parse", "--verify", "HEAD")
-	if !ok {
-		return "", emptyTreeHash
-	}
-	return strings.TrimSpace(out), "HEAD"
 }
 
 // numstatTotals sums the added and deleted line counts of `git diff --numstat`.

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -307,6 +307,22 @@ func TestDiff(t *testing.T) {
 	}
 }
 
+// TestDiffCarriesTheBranch pins the field the status badge now reads its branch
+// from. It rides Diff rather than a call of its own — that is the subprocess
+// the collapse saves — so the detached case has to hold here too, not only in
+// Branch.
+func TestDiffCarriesTheBranch(t *testing.T) {
+	repo, git := initRepo(t)
+
+	if got := New(nil).Diff(repo); got.Branch != "main" {
+		t.Errorf("Diff(repo).Branch = %q, want main", got.Branch)
+	}
+	git("checkout", "--detach", "HEAD")
+	if got := New(nil).Diff(repo); got.Branch != "" {
+		t.Errorf("Diff(detached).Branch = %q, want empty", got.Branch)
+	}
+}
+
 // TestDiffNoCommits covers a freshly `git init`'d repo with no HEAD: numstat
 // against HEAD fails, and the untracked additions must still be counted rather
 // than the whole stat collapsing to +0 -0.

--- a/internal/project/status.go
+++ b/internal/project/status.go
@@ -1,0 +1,94 @@
+package project
+
+import "strings"
+
+// emptyTreeHash is git's well-known empty tree object, the diff base for a
+// repository whose HEAD does not exist yet (no commits).
+const emptyTreeHash = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+// workTreeStatus is everything one `git status --porcelain=v2 --branch` read
+// answers at once: the branch, the commit it sits on, and every dirty entry.
+// It replaces three separate git children — `symbolic-ref --short HEAD`,
+// `rev-parse --verify HEAD` and `ls-files --others` — on a read the frontend
+// runs per second per checkout on screen, where process startup, not work, is
+// what a tick costs on a normal repository.
+type workTreeStatus struct {
+	branch    string   // "" for a detached HEAD, as Branch answers
+	head      string   // "" in a repository with no commits
+	base      string   // what a diff runs against: "HEAD", or the empty tree
+	files     int      // dirty entries: changed, renamed, unmerged, untracked
+	untracked []string // untracked paths, relative to the work tree root
+}
+
+// readWorkTree runs the single status call and parses it. A path git will not
+// read as a work tree yields the zero readout, whose base is the empty tree —
+// the same pair diffBase handed back before, so the callers behind it fail the
+// way they always did rather than on a new code path.
+//
+// -z, because the counters index the untracked paths straight into the
+// filesystem and v2 C-quotes them otherwise. --untracked-files=all, because the
+// default collapses a new directory into one "? dir/" entry: an agent writing
+// 25 files into fresh packages would count as one changed file.
+func readWorkTree(path string) workTreeStatus {
+	out, ok := gitQuiet(path, "status", "--porcelain=v2", "--branch",
+		"--untracked-files=all", "-z")
+	if !ok {
+		return workTreeStatus{base: emptyTreeHash}
+	}
+	return parseWorkTree(out)
+}
+
+// parseWorkTree reads porcelain v2's NUL-terminated records. Every record shape
+// git does not promise here is skipped rather than guessed at: this one parse
+// feeds the branch, the head and the dirty count together, so a line it cannot
+// read must cost that line alone.
+func parseWorkTree(out string) workTreeStatus {
+	status := workTreeStatus{base: emptyTreeHash}
+	records := strings.Split(out, "\x00")
+	for i := 0; i < len(records); i++ {
+		record := records[i]
+		if record == "" {
+			continue
+		}
+		switch record[0] {
+		case '#':
+			status.readHeader(record)
+		case '2':
+			// A rename or copy spells its original path as a second record of
+			// its own, which v1 kept on the one "R orig -> new" line. Consumed
+			// here, or one renamed file would count as two dirty ones.
+			i++
+			status.files++
+		case '1', 'u':
+			status.files++
+		case '?':
+			status.files++
+			if _, path, ok := strings.Cut(record, " "); ok {
+				status.untracked = append(status.untracked, path)
+			}
+		}
+	}
+	return status
+}
+
+// readHeader takes the two `# branch.*` lines the readout needs, mapping v2's
+// sentinels back onto the contracts the separate calls held: a detached HEAD
+// names no branch, and a repository with no commits has no HEAD to diff
+// against — git's empty tree stands in for it. Left unmapped, the badge would
+// read a literal "(detached)" and a diff would run against "(initial)".
+func (s *workTreeStatus) readHeader(record string) {
+	key, value, ok := strings.Cut(strings.TrimPrefix(record, "# "), " ")
+	if !ok {
+		return
+	}
+	switch key {
+	case "branch.head":
+		if value != "(detached)" {
+			s.branch = value
+		}
+	case "branch.oid":
+		if value != "(initial)" {
+			s.head, s.base = value, "HEAD"
+		}
+	}
+}

--- a/internal/project/status_test.go
+++ b/internal/project/status_test.go
@@ -1,0 +1,236 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// v2 assembles a porcelain v2 -z payload the way git writes it: every record,
+// headers included, terminated by a NUL rather than separated by one.
+func v2(records ...string) string {
+	var out strings.Builder
+	for _, record := range records {
+		out.WriteString(record)
+		out.WriteString("\x00")
+	}
+	return out.String()
+}
+
+// TestParseWorkTreeBranchAndHead pins the two header lines against the
+// contracts the separate git calls held. The sentinels are the whole point: v2
+// spells a detached HEAD "(detached)" where Branch answers "", and a repository
+// with no commits "(initial)" where the diff base is git's empty tree — mapped
+// straight through, the badge would read a literal "(detached)".
+func TestParseWorkTreeBranchAndHead(t *testing.T) {
+	oid := "6d19bac07168c90c890aab654501e68498ac4d57"
+	tests := []struct {
+		name       string
+		out        string
+		wantBranch string
+		wantHead   string
+		wantBase   string
+	}{
+		{
+			name:       "on a branch",
+			out:        v2("# branch.oid "+oid, "# branch.head main"),
+			wantBranch: "main",
+			wantHead:   oid,
+			wantBase:   "HEAD",
+		},
+		{
+			name:       "detached HEAD names no branch",
+			out:        v2("# branch.oid "+oid, "# branch.head (detached)"),
+			wantBranch: "",
+			wantHead:   oid,
+			wantBase:   "HEAD",
+		},
+		{
+			name:       "unborn repository has no head to diff against",
+			out:        v2("# branch.oid (initial)", "# branch.head main"),
+			wantBranch: "main",
+			wantHead:   "",
+			wantBase:   emptyTreeHash,
+		},
+		{
+			name:       "upstream headers are ignored",
+			out:        v2("# branch.oid "+oid, "# branch.head main", "# branch.upstream origin/main", "# branch.ab +0 -2"),
+			wantBranch: "main",
+			wantHead:   oid,
+			wantBase:   "HEAD",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseWorkTree(tt.out)
+			if got.branch != tt.wantBranch {
+				t.Errorf("branch = %q, want %q", got.branch, tt.wantBranch)
+			}
+			if got.head != tt.wantHead {
+				t.Errorf("head = %q, want %q", got.head, tt.wantHead)
+			}
+			if got.base != tt.wantBase {
+				t.Errorf("base = %q, want %q", got.base, tt.wantBase)
+			}
+		})
+	}
+}
+
+// TestParseWorkTreeCountsEveryDirtyEntryOnce covers the shapes v2 spells
+// differently from the porcelain v1 line count it replaces. A rename is the one
+// that bites: v1 kept "R orig -> new" on a single line, while v2 writes the
+// original path as a second record of its own, so a naive split counts one
+// renamed file twice.
+func TestParseWorkTreeCountsEveryDirtyEntryOnce(t *testing.T) {
+	oid := "6d19bac07168c90c890aab654501e68498ac4d57"
+	blobs := "45b983be36b73c0788dc9cbcb76cbb80fc7bb057 45b983be36b73c0788dc9cbcb76cbb80fc7bb057"
+	tests := []struct {
+		name          string
+		records       []string
+		wantFiles     int
+		wantUntracked []string
+	}{
+		{
+			name:      "clean tree",
+			records:   []string{"# branch.oid " + oid, "# branch.head main"},
+			wantFiles: 0,
+		},
+		{
+			name:      "modified and staged files",
+			records:   []string{"1 .M N... 100644 100644 100644 " + blobs + " new.txt", "1 M. N... 100644 100644 100644 " + blobs + " staged.txt"},
+			wantFiles: 2,
+		},
+		{
+			name:      "a rename is one file, not two records",
+			records:   []string{"2 R. N... 100644 100644 100644 " + blobs + " R100 renamed.txt", "old.txt"},
+			wantFiles: 1,
+		},
+		{
+			name:      "a copy spells its source the same way",
+			records:   []string{"2 C. N... 100644 100644 100644 " + blobs + " C75 copy.txt", "source.txt", "? after.txt"},
+			wantFiles: 2,
+			// The source record must be consumed, or "source.txt" would be read
+			// as the next entry and "? after.txt" lost behind it.
+			wantUntracked: []string{"after.txt"},
+		},
+		{
+			name:      "an unmerged path counts once",
+			records:   []string{"u UU N... 100644 100644 100644 100644 " + blobs + " " + oid + " c.txt"},
+			wantFiles: 1,
+		},
+		{
+			name:          "untracked files are listed as well as counted",
+			records:       []string{"? a.txt", "? pkg/deep/b.txt"},
+			wantFiles:     2,
+			wantUntracked: []string{"a.txt", "pkg/deep/b.txt"},
+		},
+		{
+			name:      "ignored entries are neither counted nor listed",
+			records:   []string{"! node_modules/x.js", "? a.txt"},
+			wantFiles: 1,
+			// The status call never asks for them; a git that volunteers one
+			// must not inflate the badge.
+			wantUntracked: []string{"a.txt"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseWorkTree(v2(tt.records...))
+			if got.files != tt.wantFiles {
+				t.Errorf("files = %d, want %d", got.files, tt.wantFiles)
+			}
+			if strings.Join(got.untracked, "|") != strings.Join(tt.wantUntracked, "|") {
+				t.Errorf("untracked = %q, want %q", got.untracked, tt.wantUntracked)
+			}
+		})
+	}
+}
+
+// TestParseWorkTreeSurvivesMalformedOutput is the reason this parse is written
+// the way it is: branch, head and dirty count now come out of one call, so a
+// record it cannot read has to cost that record alone. Nothing here may panic,
+// and the headers must still land.
+func TestParseWorkTreeSurvivesMalformedOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+	}{
+		{name: "empty output", out: ""},
+		{name: "no trailing NUL", out: "# branch.head main"},
+		{name: "header with no value", out: v2("# branch.head", "# branch.oid")},
+		{name: "header with no key", out: v2("#", "# ")},
+		{name: "untracked entry with no path", out: v2("?")},
+		{name: "rename record with no source behind it", out: v2("# branch.head main", "2 R.")},
+		{name: "a shape no git version has emitted", out: v2("$ who knows", "1", "u", "2")},
+		{name: "nothing but separators", out: "\x00\x00\x00"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseWorkTree(tt.out) // must not panic
+			if got.base != emptyTreeHash && got.base != "HEAD" {
+				t.Errorf("base = %q, want one of the two the contract allows", got.base)
+			}
+		})
+	}
+	if got := parseWorkTree(v2("# branch.head main", "2 R.")); got.branch != "main" {
+		t.Errorf("branch = %q, want main — a bad entry must not cost the header", got.branch)
+	}
+}
+
+// TestReadWorkTreeOnANonRepository proves the failure path hands back the same
+// pair diffBase did, so DiffText's `git diff <base>` still fails as a git error
+// rather than on some new shape.
+func TestReadWorkTreeOnANonRepository(t *testing.T) {
+	got := readWorkTree(t.TempDir())
+	if got.branch != "" || got.head != "" || got.files != 0 || got.untracked != nil {
+		t.Errorf("readWorkTree(non-repo) = %+v, want the zero readout", got)
+	}
+	if got.base != emptyTreeHash {
+		t.Errorf("base = %q, want the empty tree", got.base)
+	}
+}
+
+// TestReadWorkTreeAgainstRealGit ties the parse to the git actually installed:
+// the table tests above pin shapes captured from git 2.55, and this is what
+// notices when a git in the wild stops writing them.
+func TestReadWorkTreeAgainstRealGit(t *testing.T) {
+	repo, git := initRepo(t)
+
+	clean := readWorkTree(repo)
+	if clean.branch != "main" || clean.files != 0 || len(clean.head) < 7 {
+		t.Errorf("readWorkTree(clean) = %+v, want main, no dirty entries, a head", clean)
+	}
+
+	// A staged rename, a modified tracked file and an untracked one in a fresh
+	// directory: three dirty files, but four v2 records — the rename writes its
+	// original path as a record of its own.
+	if err := os.WriteFile(filepath.Join(repo, "kept.txt"), []byte("one\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("add", "kept.txt")
+	git("commit", "-m", "second file")
+	git("mv", "a.txt", "b.txt")
+	if err := os.WriteFile(filepath.Join(repo, "kept.txt"), []byte("one\ntwo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "pkg", "new.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dirty := readWorkTree(repo)
+	if dirty.files != 3 {
+		t.Errorf("readWorkTree(renamed+modified+untracked).files = %d, want 3", dirty.files)
+	}
+	// git reports its paths with forward slashes on every platform.
+	if len(dirty.untracked) != 1 || dirty.untracked[0] != "pkg/new.txt" {
+		t.Errorf("untracked = %q, want [pkg/new.txt]", dirty.untracked)
+	}
+
+	git("checkout", "--detach", "HEAD")
+	if got := readWorkTree(repo); got.branch != "" {
+		t.Errorf("readWorkTree(detached).branch = %q, want empty", got.branch)
+	}
+}


### PR DESCRIPTION
Every second, each card on screen spawned **six `git` children** to answer one status badge. On a
normal repository most of that is process startup rather than work — roughly 1.9 ms per spawn, so
about 11 ms of an 18 ms tick was fork/exec/git-init.

`git status --porcelain=v2 --branch --untracked-files=all -z` already reports the branch, the HEAD
commit and every untracked path in a single call, so three of the six go away with no dependency, no
new failure mode and no platform asymmetry. A tick is three children now.

| # | before | after |
|---|--------|-------|
| 1 | `symbolic-ref --short HEAD` | *(subsumed)* |
| 2 | `status --porcelain -uall` | `status --porcelain=v2 --branch -uall -z` |
| 3 | `rev-parse --verify HEAD` | *(subsumed)* |
| 4 | `diff --numstat` | `diff --numstat` |
| 5 | `ls-files --others` | *(subsumed)* |
| 6 | `rev-parse --git-common-dir …` | unchanged (`BaseStatus`, out of scope) |

The commit subject scopes `Diff()`, which went from four children to two. `DiffText()` drops from
three to two on the same read.

## Measured

git 2.55, 20 cores, warm page cache, p50 over 30 iterations. Rig lives outside the checkout.

| repo | wall | child CPU |
|------|------|-----------|
| small worktree, 695 tracked, clean | 21.2 → **13.4 ms** | 20.1 → **12.6 ms** |
| large, 50k tracked, clean | 85.0 → **46.8 ms** | 190.1 → **154.4 ms** |
| large, 50k tracked, 200 dirty | 101.8 → **66.4 ms** | 202.7 → **168.2 ms** |

## Contracts held

v2 spells its edges as sentinel strings, and they must not reach the UI:

- `# branch.head (detached)` maps back to `""`, which is what `Branch()` answers. Passed through, the
  badge would render a literal `(detached)`.
- `# branch.oid (initial)` maps back to `("", emptyTreeHash)` — `diffBase`'s exact old pair — so
  `DiffText`'s `git diff <base>` still fails as an ordinary git error rather than on a new code path.

One shape that is *not* a sentinel and did bite: a rename or copy writes its original path as a
second, separate NUL record, where porcelain v1 kept `R orig -> new` on one line. Unconsumed, one
renamed file counts as two dirty files and the record behind it is misread. Caught by test, not by
inspection.

The parse skips every record shape git does not promise, one record at a time. That is deliberate:
branch, head and dirty count now come out of a single call, so a line it cannot read has to cost that
line alone rather than all three.

`Branch()` itself still asks `symbolic-ref`. It serves `BranchesOf`, which walks a long list of parked
sessions one path at a time, and a full status scan per row would be a regression on exactly the case
that batch exists for. Nothing on the polled path calls it — the badge takes its branch off `Diff`,
which is the subprocess the collapse saves.

`DiffStats` gains `Branch`, so `frontend/src/lib/api-types.ts` moves with the Go JSON tags.

## Ceiling

`docs/ceilings.md` gains the trap this sets: the status badge now has a single source, so a git
release that changes those records breaks branch, head and dirty count together rather than one at a
time, with no second call left to disagree.

## Out of scope, deliberately

`baseFetchInterval` and the network path untouched; no timeout added to the git helpers (another
change is doing that and would collide); no filesystem watcher; nothing written into a user's
repository config.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` — 1874 passed across 32 packages
- [x] `go test -race ./internal/project/` clean; package coverage 90.5%
- [x] `cd frontend && pnpm check` rc=0 (14 warnings, all pre-existing, none in touched files)
- [x] `vitest run` — 1096 passed in 91 files; `tsc --noEmit` and `vite build` clean
- [x] `GOOS=linux|darwin|windows go build ./... && go vet ./...` clean
- [x] `CHANGELOG.md` `[Unreleased]` entry in the same commit

New coverage in `internal/project/status_test.go`: header parsing (on a branch, detached, unborn,
upstream headers ignored); entry counting (clean, modified+staged, rename, copy, unmerged, untracked,
ignored); eight malformed inputs asserting no panic and that a bad entry does not cost the header;
non-repository; and one test tying the captured shapes to the git actually installed. Plus
`TestDiffCarriesTheBranch`. The existing `Branch`/`Diff`/`DiffNoCommits` contract tests are untouched.