### PR TITLE
fix: stop one stalled socket write from parking every session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **One session's output can no longer freeze every other session's.** Each session
+  already had its own queue, so a card producing faster than the window could draw
+  it backed up alone. One socket carries them all, though, and a session's turn to
+  write held a lock the others queued on — so whenever a write to the window
+  stalled, every card in the workspace stopped updating with it, for up to five
+  seconds at a time, however quiet those sessions were. The socket now belongs to a
+  writer of its own: a session hands over its output and goes back to work, and a
+  stalled window costs the connection rather than the workspace. Nothing is
+  dropped — output the socket refuses still crosses on the event bridge, in order.
 - **The plan gauge now reads the account the session in front of you actually
   spends.** A project pointed at a binary of your own — a wrapper exporting
   another `CLAUDE_CONFIG_DIR`, or an OAuth token for a second account — still had

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -107,6 +107,14 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   hand in `frontend/src/lib/terminal/term-modes.ts` — today the mouse encoding and cursor visibility. Cursor
   *shape* (DECSCUSR) is not among them: a TUI that chose a bar or underline cursor gets lich's block back after a
   card switch.
+- **One socket carries every session's output** (`internal/terminal/writequeue.go`): the per-session outbox
+  decouples the *producers*, never the wire. A window that stops reading stalls the connection's single writer,
+  so after `wsWriteTimeout` (5s) every session's output switches to the `/events` bridge at once. That is a
+  second socket, and the page reads the two independently: a frame that fell back can land ahead of one still
+  sitting in the stalled connection's buffer, so output is never dropped but its order across that switch is not
+  guaranteed. Until then the queue holds `writeQueueDepth` frames for the whole app, and two things still wait on
+  it across sessions: a push that finds it full, and the flush a session runs before its exit banner so the banner
+  cannot overtake its own last bytes.
 - **Single instance via the pinned port**: the bind is the lock (`internal/singleton`); a duplicate launch focuses
   the running window (best-effort, untested against a real window) and exits 0.
 - **lich appends to the agent's system prompt, for two providers only**

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -366,7 +366,19 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 		},
 	)
 	s.ws, s.wsErr = ws, err
+	if ws != nil {
+		// The transport is built before the service that owns the bridge, so the
+		// path output takes when the socket cannot carry it is wired here.
+		ws.setFallback(s.emitData)
+	}
 	return s
+}
+
+// emitData puts one session's output on the /events bridge — where terminal
+// output goes whenever the /ws transport cannot carry it, whether because no
+// client is connected or because the socket refused the frame.
+func (s *Service) emitData(id string, data []byte) {
+	s.hub.Emit(dataEventPrefix+id, base64.StdEncoding.EncodeToString(data))
 }
 
 // Mount exposes an extra handler (the RPC dispatcher, the events push socket)
@@ -599,8 +611,7 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 		if s.ws != nil && s.ws.send(id, data) {
 			return
 		}
-		encoded := base64.StdEncoding.EncodeToString(data)
-		s.hub.Emit(dataEventPrefix+id, encoded)
+		s.emitData(id, data)
 	}, outboxDepth)
 	out := newCoalescer(box.push, visibleFlushInterval, hiddenFlushInterval)
 	sess := &session{
@@ -648,9 +659,14 @@ func (s *Service) stream(id string, sess *session) {
 	_ = p.Close()
 	// Flush any batched output and wait for it to be delivered before the exit
 	// event, so the frontend always sees the final bytes ahead of the exit
-	// banner.
+	// banner. Delivery now ends at the transport's writer rather than at the
+	// socket, so the wait runs one step further: the outbox for this session's
+	// own frames, then the connection's queue for the wire.
 	sess.out.Close()
 	sess.outbox.close()
+	if s.ws != nil {
+		s.ws.flush()
+	}
 
 	s.mu.Lock()
 	reaped := false

--- a/internal/terminal/transport.go
+++ b/internal/terminal/transport.go
@@ -97,8 +97,12 @@ func decodeFrame(buf []byte) (string, []byte, error) {
 // transport is the local WebSocket endpoint. One client (the webview) is
 // expected; a new connection replaces the previous one.
 type transport struct {
-	mu          sync.Mutex
-	conn        *websocket.Conn
+	mu   sync.Mutex
+	conn *websocket.Conn
+	// out is the live connection's writer (writequeue.go). It is swapped with
+	// conn and under the same lock: the two are one client, and send finding a
+	// connection without its writer would have nowhere to put a frame.
+	out         *writeQueue
 	port        int
 	token       string
 	mux         *http.ServeMux
@@ -112,6 +116,11 @@ type transport struct {
 	// Guarded by mu: set via setRestart after the server goroutine is already
 	// running, and read by the request goroutine handling /restart.
 	restart func() error
+	// fallback is where output goes when the socket cannot carry it — the
+	// /events bridge. Guarded by mu and wired by setFallback, for the same
+	// reason restart is: the service owns the bridge and the transport is built
+	// before it.
+	fallback func(id string, data []byte)
 }
 
 // newTransport starts the listener on a random loopback port. input receives
@@ -265,6 +274,28 @@ func (t *transport) setRestart(fn func() error) {
 	t.mu.Lock()
 	t.restart = fn
 	t.mu.Unlock()
+}
+
+// setFallback records where a frame goes when the socket refuses it. Wired after
+// construction like setRestart, and read by each connection's writer when it
+// takes over the delivery the socket stopped doing.
+func (t *transport) setFallback(fn func(id string, data []byte)) {
+	t.mu.Lock()
+	t.fallback = fn
+	t.mu.Unlock()
+}
+
+// emitFallback hands one frame to the bridge. The lookup happens per frame
+// rather than once per connection: the listener answers before the service that
+// owns the bridge has wired it, so a writer that read the callback when its
+// client connected could hold on to nothing for the life of that connection.
+func (t *transport) emitFallback(id string, data []byte) {
+	t.mu.Lock()
+	fn := t.fallback
+	t.mu.Unlock()
+	if fn != nil {
+		fn(id, data)
+	}
 }
 
 // ping is the liveness probe a second lich launch uses to tell "a live lich
@@ -628,9 +659,10 @@ func (t *transport) handle(w http.ResponseWriter, r *http.Request) {
 	}
 	conn.SetReadLimit(wsReadLimit)
 
+	out := newWriteQueue()
 	t.mu.Lock()
-	previous := t.conn
-	t.conn = conn
+	previous, previousOut := t.conn, t.out
+	t.conn, t.out = conn, out
 	t.mu.Unlock()
 	if previous != nil {
 		// Not a graceful close: that waits for the replaced client's close
@@ -638,6 +670,12 @@ func (t *transport) handle(w http.ResponseWriter, r *http.Request) {
 		// Nothing reads the status anyway — the page reconnects on any close.
 		_ = previous.CloseNow()
 	}
+	if previousOut != nil {
+		// After the close above, so the retired writer's next write fails at
+		// once rather than sitting out the send timeout on a dead socket.
+		previousOut.close()
+	}
+	go out.run(conn, func() { t.forget(conn) }, t.emitFallback)
 	go t.readLoop(conn)
 }
 
@@ -661,38 +699,63 @@ func (t *transport) readLoop(conn *websocket.Conn) {
 	}
 }
 
-// drop forgets conn if it is still the active client.
-func (t *transport) drop(conn *websocket.Conn) {
+// forget clears conn as the transport's client and retires the writer that owned
+// its socket, so the frames still queued take the fallback instead of vanishing
+// with the connection. A no-op once some other connection has taken over.
+func (t *transport) forget(conn *websocket.Conn) {
 	t.mu.Lock()
-	if t.conn == conn {
-		t.conn = nil
+	out := t.out
+	if t.conn != conn {
+		out = nil
+	} else {
+		t.conn, t.out = nil, nil
 	}
 	t.mu.Unlock()
+	if out != nil {
+		out.close()
+	}
+}
+
+// drop forgets conn if it is still the active client.
+func (t *transport) drop(conn *websocket.Conn) {
+	t.forget(conn)
 	_ = conn.Close(websocket.StatusNormalClosure, "")
 }
 
-// send delivers one session's output frame to the connected client. It
-// returns false — and drops the client on write failure — when the caller
-// should fall back to the event bridge. One mutex serializes writes for every
-// session; per-session queues only if a local loopback write ever measurably
-// stalls.
+// send hands one session's output frame to the connected client's writer. It
+// returns false when the caller should fall back to the event bridge itself:
+// there is no client, or the frame cannot be addressed to one. A frame the
+// writer accepts and the socket then refuses is not the caller's problem — the
+// writer takes it to the same bridge, in order (see writequeue.go).
+//
+// It never waits on the socket. The write is the slow part, it is bounded only
+// by wsWriteTimeout, and every session's outbox goroutine comes through here;
+// holding a lock across it would recouple the sessions the outbox queues exist
+// to keep apart.
 func (t *transport) send(id string, data []byte) bool {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.conn == nil {
-		return false
-	}
 	frame, err := encodeFrame(id, data)
 	if err != nil {
 		return false
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), wsWriteTimeout)
-	defer cancel()
-	if err := t.conn.Write(ctx, websocket.MessageBinary, frame); err != nil {
-		t.conn = nil
+	t.mu.Lock()
+	out := t.out
+	t.mu.Unlock()
+	if out == nil {
 		return false
 	}
-	return true
+	return out.push(frame)
+}
+
+// flush waits for the queued output of every session to reach the socket. A
+// session calls it before its exit event so the banner cannot overtake the last
+// bytes the session wrote.
+func (t *transport) flush() {
+	t.mu.Lock()
+	out := t.out
+	t.mu.Unlock()
+	if out != nil {
+		out.flush()
+	}
 }
 
 // TransportInfo tells the frontend where the terminal I/O WebSocket lives. A

--- a/internal/terminal/transport_stall_test.go
+++ b/internal/terminal/transport_stall_test.go
@@ -1,0 +1,119 @@
+package terminal
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// stallBudget bounds how long a send for one session may take while another
+// session's output is stuck in the socket. The work send has to do is encode a
+// frame and hand it over, so the real number is microseconds; the budget only
+// has to sit far below wsWriteTimeout, which is what a write the senders queue
+// behind costs when one lock serializes them all.
+const stallBudget = time.Second
+
+// stallFrameBytes and stallFrames are the load that fills the client's socket:
+// a non-reading peer buffers a few megabytes between the two kernels before a
+// write blocks, so this overshoots that on purpose. Pinned rather than derived
+// from writeQueueDepth — the point is that the frames outlast the socket and
+// still leave the transport room to take one more.
+const (
+	stallFrameBytes = 1 << 20
+	stallFrames     = 24
+)
+
+// TestStalledSessionDoesNotBlockAnother is the regression for a freeze that
+// outbox.go alone could not prevent. Each session gets its own queue and its own
+// delivery goroutine so a window that stops reading backs up the session that is
+// producing and nobody else — but every one of those goroutines went through
+// transport.send, which held the transport's mutex across conn.Write. One
+// stalled write, bounded only by wsWriteTimeout, therefore parked every session
+// behind it: the per-session decoupling, undone one layer down.
+//
+// The client here connects and never reads, so the loud session's frames fill
+// the socket and stay there. A quiet session's send must still return promptly
+// — it is handing a frame to the connection's writer, not waiting on the wire.
+func TestStalledSessionDoesNotBlockAnother(t *testing.T) {
+	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+
+	// Never read from: a client that drains the socket is a client that never
+	// stalls the write, and there would be nothing to measure.
+	client, err := dial(t, tr, tr.token)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = client.CloseNow() }()
+	waitForClient(t, tr)
+
+	var accepted atomic.Int64
+	loud := make(chan struct{})
+	go func() {
+		defer close(loud)
+		payload := make([]byte, stallFrameBytes)
+		for i := 0; i < stallFrames; i++ {
+			tr.send("loud", payload)
+			accepted.Add(1)
+		}
+	}()
+
+	waitForStall(t, &accepted, loud)
+
+	start := time.Now()
+	tr.send("quiet", []byte("still here"))
+	blocked := time.Since(start)
+	t.Logf("a send for an idle session waited %v on a stalled one", blocked.Round(time.Millisecond))
+	if blocked > stallBudget {
+		t.Fatalf("a send for an idle session waited %v on a stalled one, want under %v",
+			blocked.Round(time.Millisecond), stallBudget)
+	}
+
+	// The loud session is still stuck in the socket; it comes back when the send
+	// timeout drops the connection. Waiting keeps the goroutine out of the tests
+	// that run after this one.
+	select {
+	case <-loud:
+	case <-time.After(2 * wsWriteTimeout):
+		t.Fatal("the stalled session never came back")
+	}
+}
+
+// waitForStall blocks until the loud session stops making progress and the
+// socket has had a moment to fill.
+//
+// Progress stops in one of two shapes, and the assertion after it is the same
+// either way. A transport that writes on the caller's goroutine stops because
+// the send that filled the socket never returns. A transport that queues stops
+// because every frame was accepted and the goroutine finished — the writer is
+// then alone against a peer that is not reading, which is the state the
+// assertion needs, so the settle below gives it time to hit that wall.
+func waitForStall(t *testing.T, accepted *atomic.Int64, done <-chan struct{}) {
+	t.Helper()
+	const (
+		quietFor = 250 * time.Millisecond
+		settle   = 250 * time.Millisecond
+	)
+	deadline := time.Now().Add(10 * time.Second)
+	last := int64(-1)
+	still := time.Now()
+	for time.Now().Before(deadline) {
+		if n := accepted.Load(); n != last {
+			last, still = n, time.Now()
+		}
+		if last > 0 && time.Since(still) > quietFor {
+			time.Sleep(settle)
+			return
+		}
+		select {
+		case <-done:
+			time.Sleep(settle)
+			return
+		default:
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("the loud session never filled the socket")
+}

--- a/internal/terminal/writequeue.go
+++ b/internal/terminal/writequeue.go
@@ -1,0 +1,161 @@
+package terminal
+
+import (
+	"context"
+	"sync"
+
+	"github.com/coder/websocket"
+)
+
+// writeQueueDepth is how many frames may wait on the connection's writer before
+// the session pushing one waits with it. A frame is one coalescer flush, capped
+// at maxPendingBytes, so this bounds what a stalled socket may hold in memory —
+// twice the depth one session's own outbox holds, because this queue is the one
+// every session shares.
+const writeQueueDepth = 64
+
+// writeQueue owns one client connection's socket: every session's output frame
+// crosses it on a single goroutine.
+//
+// A WebSocket admits one writer at a time, so something has to serialize the
+// sessions. Doing it on a mutex the senders take is what this replaces:
+// conn.Write is bounded only by wsWriteTimeout, and every session's outbox
+// goroutine (outbox.go) went through that mutex, so one stalled write froze
+// every session's delivery behind it — the per-session decoupling the outbox
+// exists to provide, undone one layer down. Here the socket belongs to the
+// writer alone: a session hands over a frame and returns, and the stall costs
+// the connection, never its neighbours.
+//
+// Frames leave in the order they arrived, so a session's output reaches the
+// client exactly as its outbox produced it. None is discarded: a frame the
+// socket refuses — and everything queued behind it — goes to the fallback the
+// transport hands over, which is the same /events bridge send already falls
+// back to when there is no client at all. A push that arrives once the queue is
+// closed waits for that drain before it reports failure, so the caller's own
+// fallback lands behind those frames rather than in front of them.
+type writeQueue struct {
+	mu   sync.Mutex
+	wake *sync.Cond
+	// frames holds encoded frames; the transport allocates each one, so the
+	// queue never copies. inflight is the frame the writer has taken but not
+	// finished with, which flush and a closed push both have to wait out.
+	frames   [][]byte
+	inflight int
+	closed   bool
+}
+
+func newWriteQueue() *writeQueue {
+	q := &writeQueue{}
+	q.wake = sync.NewCond(&q.mu)
+	return q
+}
+
+// push queues one encoded frame, blocking only while the queue is full — never
+// while the transport's own lock is held. It reports false once the queue is
+// closed, and only after everything already queued has been drained, so the
+// caller may fall back for this frame without overtaking the ones before it.
+func (q *writeQueue) push(frame []byte) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for len(q.frames) >= writeQueueDepth && !q.closed {
+		q.wake.Wait()
+	}
+	if q.closed {
+		q.waitDrained()
+		return false
+	}
+	q.frames = append(q.frames, frame)
+	q.wake.Broadcast()
+	return true
+}
+
+// pop hands the writer the next frame, waiting for one. ok is false once the
+// queue is closed and drained, which is the writer's signal to stop.
+func (q *writeQueue) pop() (frame []byte, ok bool) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	for len(q.frames) == 0 && !q.closed {
+		q.wake.Wait()
+	}
+	if len(q.frames) == 0 {
+		return nil, false
+	}
+	frame, q.frames = q.frames[0], q.frames[1:]
+	q.inflight++
+	return frame, true
+}
+
+// settle marks the frame the writer last popped as dealt with, whether the
+// socket carried it or the fallback did.
+func (q *writeQueue) settle() {
+	q.mu.Lock()
+	q.inflight--
+	q.wake.Broadcast()
+	q.mu.Unlock()
+}
+
+// flush waits until every frame pushed so far has left the queue and the writer
+// has finished with it. A session emits its exit event after this, so the banner
+// still cannot overtake the session's own last bytes.
+func (q *writeQueue) flush() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.waitDrained()
+}
+
+// waitDrained blocks until nothing is queued or in the writer's hands. Callers
+// hold q.mu. A closed queue still drains — the writer hands the rest to the
+// fallback — so this is bounded either way.
+func (q *writeQueue) waitDrained() {
+	for len(q.frames) > 0 || q.inflight > 0 {
+		q.wake.Wait()
+	}
+}
+
+// close retires the queue. The writer drains what is left to the fallback and
+// then stops; close itself does not wait, so a page reload never blocks the
+// incoming client on the outgoing one.
+func (q *writeQueue) close() {
+	q.mu.Lock()
+	q.closed = true
+	q.wake.Broadcast()
+	q.mu.Unlock()
+}
+
+// run is the writer goroutine: it puts frames on conn until one fails, calls
+// failed once when that happens, and hands that frame and every one after it to
+// fallback so nothing an outbox delivered is lost. A nil fallback discards,
+// which is the transport's own answer when no bridge has been wired yet.
+func (q *writeQueue) run(conn *websocket.Conn, failed func(), fallback func(id string, data []byte)) {
+	live := true
+	for {
+		frame, ok := q.pop()
+		if !ok {
+			return
+		}
+		if live && q.write(conn, frame) {
+			q.settle()
+			continue
+		}
+		if live {
+			live = false
+			failed()
+		}
+		if fallback != nil {
+			// The frame is its own record of which session it belongs to, so the
+			// queue carries one encoded slice rather than a slice and its parts.
+			if id, data, err := decodeFrame(frame); err == nil {
+				fallback(id, data)
+			}
+		}
+		q.settle()
+	}
+}
+
+// write puts one frame on the socket under the send timeout, reporting whether
+// the client took it.
+func (q *writeQueue) write(conn *websocket.Conn, frame []byte) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), wsWriteTimeout)
+	defer cancel()
+	return conn.Write(ctx, websocket.MessageBinary, frame) == nil
+}

--- a/internal/terminal/writequeue_test.go
+++ b/internal/terminal/writequeue_test.go
@@ -1,0 +1,195 @@
+package terminal
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// frameFor encodes one session frame the way send does.
+func frameFor(t *testing.T, id, payload string) []byte {
+	t.Helper()
+	frame, err := encodeFrame(id, []byte(payload))
+	if err != nil {
+		t.Fatalf("encodeFrame: %v", err)
+	}
+	return frame
+}
+
+// TestWriteQueueBlocksOnlyOnceFull pins the backpressure: pushes return while
+// the queue has room, so the outbox goroutine behind them is free to carry on,
+// and only a full queue makes a session wait — for the socket it is filling,
+// never for another session's.
+func TestWriteQueueBlocksOnlyOnceFull(t *testing.T) {
+	q := newWriteQueue()
+
+	filled := make(chan struct{})
+	go func() {
+		defer close(filled)
+		for i := 0; i < writeQueueDepth; i++ {
+			q.push(frameFor(t, "sess", "x"))
+		}
+	}()
+	select {
+	case <-filled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a push blocked while the queue still had room")
+	}
+
+	blocked := make(chan struct{})
+	go func() {
+		q.push(frameFor(t, "sess", "over"))
+		close(blocked)
+	}()
+	select {
+	case <-blocked:
+		t.Fatal("a push past the queue depth did not block")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Taking one frame off leaves room for the frame that was waiting.
+	if _, ok := q.pop(); !ok {
+		t.Fatal("pop found nothing in a full queue")
+	}
+	q.settle()
+	select {
+	case <-blocked:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a push stayed blocked after the queue made room")
+	}
+}
+
+// TestWriteQueueDrainsBeforeRejectingAPush is the ordering guarantee across the
+// switch to the fallback: once the queue is closed its caller delivers frames
+// itself, so a push may only report failure after the frames queued ahead of it
+// are out — otherwise the newest frame would reach the client first.
+func TestWriteQueueDrainsBeforeRejectingAPush(t *testing.T) {
+	q := newWriteQueue()
+	q.push(frameFor(t, "sess", "a"))
+	q.push(frameFor(t, "sess", "b"))
+	q.close()
+
+	rejected := make(chan struct{})
+	go func() {
+		defer close(rejected)
+		if q.push(frameFor(t, "sess", "c")) {
+			t.Error("a closed queue accepted a frame")
+		}
+	}()
+	select {
+	case <-rejected:
+		t.Fatal("a push reported failure before the frames ahead of it were drained")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// What the writer does with the rest of a closed queue.
+	var got []string
+	for {
+		frame, ok := q.pop()
+		if !ok {
+			break
+		}
+		_, data, err := decodeFrame(frame)
+		if err != nil {
+			t.Fatalf("decodeFrame: %v", err)
+		}
+		got = append(got, string(data))
+		q.settle()
+	}
+	if want := "ab"; join(got) != want {
+		t.Errorf("drained %q, want %q", join(got), want)
+	}
+
+	select {
+	case <-rejected:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a push never came back after the queue drained")
+	}
+}
+
+// TestWriteQueueFlushWaitsForTheFrameInTheWritersHands proves flush covers the
+// write itself and not just the wait for one: a session emits its exit event
+// after flush returns, and a frame the writer has taken but not yet put on the
+// socket would otherwise be overtaken by the banner.
+func TestWriteQueueFlushWaitsForTheFrameInTheWritersHands(t *testing.T) {
+	q := newWriteQueue()
+	q.push(frameFor(t, "sess", "last"))
+
+	if _, ok := q.pop(); !ok {
+		t.Fatal("pop found nothing")
+	}
+
+	flushed := make(chan struct{})
+	go func() {
+		q.flush()
+		close(flushed)
+	}()
+	select {
+	case <-flushed:
+		t.Fatal("flush returned while the writer still held a frame")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	q.settle()
+	select {
+	case <-flushed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("flush never returned after the writer finished")
+	}
+}
+
+// TestWriteQueueTakesRefusedFramesToTheFallback pins the outbox contract one
+// layer down: output is never lost. A socket that refuses a frame costs the
+// connection, not the bytes — that frame and every one queued behind it go to
+// the /events bridge instead, in the order the sessions produced them, and the
+// transport is told once that the client is gone.
+func TestWriteQueueTakesRefusedFramesToTheFallback(t *testing.T) {
+	tr, err := newTransport(func(string, []byte) {}, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("newTransport: %v", err)
+	}
+	client, err := dial(t, tr, tr.token)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = client.CloseNow() }()
+
+	// A connection that is already gone refuses the first write, which is the
+	// failure without the wait for one.
+	conn := waitForClient(t, tr)
+	_ = conn.CloseNow()
+
+	q := newWriteQueue()
+	for _, payload := range []string{"a", "b", "c"} {
+		q.push(frameFor(t, "sess", payload))
+	}
+	q.close()
+
+	var mu sync.Mutex
+	var got []string
+	var failures atomic.Int64
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		q.run(conn, func() { failures.Add(1) }, func(id string, data []byte) {
+			mu.Lock()
+			got = append(got, id+":"+string(data))
+			mu.Unlock()
+		})
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * wsWriteTimeout):
+		t.Fatal("the writer never finished with a dead socket")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if want := "sess:asess:bsess:c"; join(got) != want {
+		t.Errorf("the fallback got %q, want %q", join(got), want)
+	}
+	if n := failures.Load(); n != 1 {
+		t.Errorf("the transport was told the client was gone %d times, want 1", n)
+	}
+}


### PR DESCRIPTION
`internal/terminal/outbox.go` exists to make backpressure honest: each session gets its own queue and its own
delivery goroutine, so a window that stops reading backs up the session that is producing and nobody else.

`transport.send` undid that one layer down. It held `t.mu` across `conn.Write`, which is bounded only by
`wsWriteTimeout` (5s), and every session's outbox goroutine came through it. One stalled write therefore
serialized all of them — the per-session decoupling the outbox exists to provide, recoupled on a shared mutex,
and the failure `outbox.go` was written to prevent back in a different shape.

## The measurement

`TestStalledSessionDoesNotBlockAnother`: a client connects and never reads, one session fills the socket, and a
send for a *second, idle* session is timed.

| | idle session blocked |
|---|---|
| before | **4.50s** (4.496 / 4.497 / 4.500 over 3 runs) |
| after | **0s** (3/3 runs) |

Before, the wait ends only when `wsWriteTimeout` fires. The test is black-box over `send` — it uses nothing but
`newTransport`/`dial`/`waitForClient`/`send` — so it compiles and runs on `main` too, where it fails.

## The fix

The lock cannot simply go: a WebSocket admits one writer at a time, and `coder/websocket` blocks the second
until the first is done. So the socket gets an owner instead.

`internal/terminal/writequeue.go` (new) is one goroutine per connection draining a bounded queue
(`writeQueueDepth = 64`) of encoded frames. `send` encodes, takes `t.mu` only long enough to read the queue,
releases it, and pushes. A stall now costs the connection rather than the workspace.

It is a `sync.Cond` over a slice rather than a channel, because the close path has to be atomic with the
enqueue — a channel leaves a window where a frame is either lost or reordered as the queue is retired. That
also makes `close()` idempotent by construction.

### The two contracts `outbox.go` states, kept

- **Order.** One queue, one consumer, so a session's frames leave exactly as its outbox produced them. The sharp
  edge was a push arriving *after* the queue closed: it would have jumped ahead of frames still being drained.
  `push` therefore waits out the drain before it reports failure, so the caller's own fallback lands behind
  those frames rather than in front of them.
- **Nothing lost.** A frame the socket refuses — and every frame queued behind it — goes to the `/events`
  bridge, the same fallback `send` already used when no client was connected. The transport is told exactly once
  that the client is gone.

### Close semantics untouched

`handle` still replaces a client with `CloseNow`, `drop` still closes gracefully. `handle` retires the old
writer *after* the `CloseNow` so its next write fails immediately instead of sitting out the 5s timeout.

### One thing worth flagging

`stream()` documents that a session's exit banner must never overtake its own last bytes. Since `send` now
returns at the writer rather than at the socket, that guarantee would have quietly widened into a race, so
`stream()` also calls `ws.flush()` — which waits for the queue *and* the frame in the writer's hands. Same 5s
bound as before.

## Ceilings

`docs/ceilings.md` gains **"One socket carries every session's output"**: the outbox decouples the producers,
never the wire. After `wsWriteTimeout` everything switches to `/events` at once, and that is a second socket the
page reads independently — so a fallen-back frame can land ahead of one still buffered in the stalled
connection. Never dropped, but order *across that switch* is not guaranteed. The bullet also names the two
remaining cross-session waits: a push that finds the queue full, and the exit-banner flush.

## Test plan

- [x] `TestStalledSessionDoesNotBlockAnother` fails on `main` (4.50s) and passes here (0s), 3 runs each.
      Verified against `main` by extracting `origin/main` with `git archive` into a scratch tree.
- [x] `writequeue_test.go` — 4 tests: depth/backpressure, the close-ordering rule, `flush`, the fallback drain.
- [x] `gofmt -l .` clean, `go vet ./...` clean.
- [x] `LICH_LISTEN_PORT= go test ./...` — 31 packages ok, 0 failures.
- [x] `go test -race -count=50 ./internal/terminal/` — exit 0, 766s, zero `DATA RACE`/`FAIL`/`panic`.
- [x] Cross-compile loop `build` + `vet` green for linux, darwin, windows.
- [x] Frontend untouched but verified on the merged tree: biome clean, `tsc -b` clean, vitest 1096/1096,
      `vite build` ok.
- [x] `internal/terminal` coverage 94.3%; `writequeue.go` 100%.

## Left deliberately

- `writeQueueDepth = 64` (≤16 MiB, twice one session's own outbox depth) is a number chosen, not measured. A
  full queue is the one place a session still waits on another's output.
- The reorder across the `/ws` → `/events` switch is pre-existing and is documented rather than fixed; closing
  it needs the page to sequence the two channels.
- `transport.go` is now 782 lines against the 800 ceiling. The next change that lands there should split it.
