### PR TITLE
perf: emit a session's first write after a silent window at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   environment of another process is out of reach, a session running a configured
   binary shows nothing rather than the wrong account's numbers. Codex sessions
   follow the same rule through `CODEX_HOME`.
+- **A keystroke no longer waits on a batching window that has nothing to batch.**
+  A session's output is collected into short windows so a burst — a full-screen
+  redraw, a build log — reaches the window as a couple of frames instead of
+  dozens. That window was charged to every write, the echo of a single keypress
+  on an otherwise silent terminal included, where there is no burst to collapse:
+  the character sat for the full 8 ms before it appeared. The first write after a
+  quiet window now goes out at once, and the window still batches everything the
+  burst piles up behind it — a lone write's echo went from 8034 µs to under 2 µs.
+  A hidden session is deliberately unchanged: it does not paint, so it has no
+  latency to protect and batches as hard as before.
 - **Removing a worktree no longer fails when the agent in it has just exited.** A
   session's terminal is released twice — once by the close you asked for, once by
   the reap of the process that ended — and whichever of the two arrived second

--- a/internal/terminal/coalescer.go
+++ b/internal/terminal/coalescer.go
@@ -23,9 +23,11 @@ const (
 )
 
 // coalescer batches PTY output before it is emitted to the frontend, on a
-// short cadence while visible and a long one while hidden. emit is called with
-// the mutex held, so emissions are strictly ordered; emit must not retain the
-// slice.
+// short cadence while visible and a long one while hidden. It is leading +
+// trailing while visible: the first write after a silent window goes out at
+// once, and the timer then batches whatever the burst adds behind it. emit is
+// called with the mutex held, so emissions are strictly ordered; emit must not
+// retain the slice.
 type coalescer struct {
 	mu           sync.Mutex
 	emit         func(data []byte)
@@ -35,8 +37,12 @@ type coalescer struct {
 	pending      []byte
 	// timer is armed (one-shot) only while data is pending, so an idle
 	// session costs nothing.
-	timer  *time.Timer
-	closed bool
+	timer *time.Timer
+	// lastEmit dates the previous emission, so a write can tell an idle
+	// terminal (nothing to batch, take the leading edge) from one still
+	// inside a burst's window. Its zero value makes the first write leading.
+	lastEmit time.Time
+	closed   bool
 }
 
 // newCoalescer returns a coalescer that starts visible — sessions spawn lazily
@@ -45,17 +51,22 @@ func newCoalescer(emit func(data []byte), visibleEvery, hiddenEvery time.Duratio
 	return &coalescer{emit: emit, visibleEvery: visibleEvery, hiddenEvery: hiddenEvery, visible: true}
 }
 
-// Write ingests one PTY read. Output buffers until the flush timer fires — at
-// the current visibility's cadence — visibility flips to visible, or the
-// buffer overflows. data may be reused by the caller after Write returns.
+// Write ingests one PTY read. A visible write that lands on an idle terminal
+// is emitted synchronously — there is no burst to collapse, so the window
+// would be latency bought for nothing. Otherwise output buffers until the
+// flush timer fires — at the current visibility's cadence — visibility flips
+// to visible, or the buffer overflows. A hidden terminal never takes the
+// leading edge: it does not paint, so it has no latency to protect. data may
+// be reused by the caller after Write returns.
 func (c *coalescer) Write(data []byte) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.closed || len(data) == 0 {
 		return
 	}
+	leading := c.visible && len(c.pending) == 0 && time.Since(c.lastEmit) >= c.visibleEvery
 	c.pending = append(c.pending, data...)
-	if len(c.pending) >= maxPendingBytes {
+	if leading || len(c.pending) >= maxPendingBytes {
 		c.flushLocked()
 		return
 	}
@@ -107,6 +118,7 @@ func (c *coalescer) flushLocked() {
 	}
 	c.emit(c.pending)
 	c.pending = nil
+	c.lastEmit = time.Now()
 }
 
 // onTimer flushes hidden output when the batch window elapses. A callback that

--- a/internal/terminal/coalescer_test.go
+++ b/internal/terminal/coalescer_test.go
@@ -15,29 +15,112 @@ func captureEmit(buf int) (func([]byte), chan []byte) {
 	}, emits
 }
 
-// TestCoalescerVisibleBatchesBurstOnShortTimer pairs a short visible interval
-// with an hour-long hidden one, so a flush also proves the timer picked the
-// visible cadence.
+// TestCoalescerVisibleBatchesBurstOnShortTimer is the trailing half of the
+// contract: everything written inside the window behind the leading write
+// batches into a single emission. It pairs a short visible interval with an
+// hour-long hidden one, so the flush also proves the timer picked the visible
+// cadence.
 func TestCoalescerVisibleBatchesBurstOnShortTimer(t *testing.T) {
-	emit, emits := captureEmit(1)
-	c := newCoalescer(emit, 10*time.Millisecond, time.Hour)
+	emit, emits := captureEmit(3)
+	c := newCoalescer(emit, 20*time.Millisecond, time.Hour)
 
-	c.Write([]byte("hel"))
-	c.Write([]byte("lo"))
+	c.Write([]byte("h"))
+	if got := <-emits; string(got) != "h" {
+		t.Fatalf("leading flush = %q, want %q", got, "h")
+	}
 
-	select {
-	case got := <-emits:
-		t.Fatalf("visible write emitted %q before the flush interval", got)
-	default:
+	for _, chunk := range []string{"e", "l", "lo"} {
+		c.Write([]byte(chunk))
+		select {
+		case got := <-emits:
+			t.Fatalf("burst write emitted %q before the flush interval", got)
+		default:
+		}
 	}
 
 	select {
 	case got := <-emits:
-		if string(got) != "hello" {
-			t.Fatalf("flushed %q, want %q", got, "hello")
+		if string(got) != "ello" {
+			t.Fatalf("flushed %q, want %q", got, "ello")
 		}
 	case <-time.After(time.Second):
 		t.Fatal("visible timer flush never happened")
+	}
+	select {
+	case got := <-emits:
+		t.Fatalf("burst emitted twice, second was %q", got)
+	default:
+	}
+}
+
+// TestCoalescerVisibleLeadingEdgeEmitsIdleWriteAtOnce pins the leading edge: a
+// lone write on an idle visible terminal — a keystroke echo — has no burst to
+// collapse, so it must not pay the window.
+func TestCoalescerVisibleLeadingEdgeEmitsIdleWriteAtOnce(t *testing.T) {
+	emit, emits := captureEmit(1)
+	c := newCoalescer(emit, time.Hour, time.Hour)
+
+	c.Write([]byte("k"))
+
+	select {
+	case got := <-emits:
+		if string(got) != "k" {
+			t.Fatalf("leading flush = %q, want %q", got, "k")
+		}
+	default:
+		t.Fatal("idle write waited for the flush interval instead of emitting at once")
+	}
+}
+
+// TestCoalescerLeadingEdgeWindowBoundary pins both sides of the idle check: a
+// write a whole window after the last emission is leading, one still inside
+// the window is not.
+func TestCoalescerLeadingEdgeWindowBoundary(t *testing.T) {
+	const window = 20 * time.Millisecond
+
+	atEdge, atEdgeEmits := captureEmit(1)
+	edge := newCoalescer(atEdge, window, time.Hour)
+	edge.lastEmit = time.Now().Add(-window)
+
+	edge.Write([]byte("edge"))
+
+	select {
+	case got := <-atEdgeEmits:
+		if string(got) != "edge" {
+			t.Fatalf("edge flush = %q, want %q", got, "edge")
+		}
+	default:
+		t.Fatal("a write exactly one window after the last emission did not take the leading edge")
+	}
+
+	// An hour-long window keeps the inside-the-window side immune to
+	// scheduling jitter: this write is a whole hour short of the edge.
+	inWindow, inWindowEmits := captureEmit(1)
+	inside := newCoalescer(inWindow, time.Hour, time.Hour)
+	inside.lastEmit = time.Now()
+
+	inside.Write([]byte("early"))
+
+	select {
+	case got := <-inWindowEmits:
+		t.Fatalf("a write inside the window took the leading edge and emitted %q", got)
+	default:
+	}
+}
+
+// TestCoalescerHiddenNeverTakesLeadingEdge: a hidden terminal does not paint,
+// so it has no echo latency to protect and batches hard instead.
+func TestCoalescerHiddenNeverTakesLeadingEdge(t *testing.T) {
+	emit, emits := captureEmit(1)
+	c := newCoalescer(emit, time.Hour, time.Hour)
+	c.SetVisible(false)
+
+	c.Write([]byte("bg"))
+
+	select {
+	case got := <-emits:
+		t.Fatalf("hidden write took the leading edge and emitted %q", got)
+	default:
 	}
 }
 
@@ -192,4 +275,24 @@ func TestCoalescerConcurrentWritesAndFlips(t *testing.T) {
 	if got, want := emitted.Len(), writers*writes; got != want {
 		t.Fatalf("emitted %d bytes, want %d", got, want)
 	}
+}
+
+// BenchmarkEchoLatency measures what a keystroke echo pays: the wall time from
+// a lone write on an idle visible coalescer to its emission, at the cadence
+// production runs.
+func BenchmarkEchoLatency(b *testing.B) {
+	emitted := make(chan time.Time, 1)
+	c := newCoalescer(func([]byte) { emitted <- time.Now() }, visibleFlushInterval, hiddenFlushInterval)
+	defer c.Close()
+
+	var total time.Duration
+	samples := 0
+	for b.Loop() {
+		time.Sleep(visibleFlushInterval) // lapse the window: the next write is a fresh echo
+		start := time.Now()
+		c.Write([]byte("x"))
+		total += (<-emitted).Sub(start)
+		samples++
+	}
+	b.ReportMetric(float64(total.Microseconds())/float64(samples), "us/echo")
 }


### PR DESCRIPTION
`internal/terminal/coalescer.go` batches a session's PTY output so a burst — an editor redraw, a build log —
reaches the window as a couple of frames instead of dozens, each paying the event-bridge overhead. That is worth
8 ms of latency when there is a burst to collapse.

It was trailing-only. Every `Write` that found no timer running armed one, the first write after an idle period
included, and nothing left the buffer until the window elapsed. So the window was charged to writes with no
burst behind them: the echo of a keystroke landing on a silent terminal waited the full 8 ms to collapse a batch
of one. Coalescing should cost latency only when it is saving work.

## The measurement

`BenchmarkEchoLatency` (new) times exactly that: the wall clock from a lone `Write` on an idle visible coalescer
to its emission, at the interval production runs (`visibleFlushInterval`, `hiddenFlushInterval`), sleeping a
window between samples so every write is a fresh echo.

| | echo latency, lone write |
|---|---|
| before | **8034 µs** (200x) |
| after | **1.1 – 1.8 µs** (200x, `-count=3`: 1.145 / 1.340 / 1.820) |

Roughly 4400x on the character you just typed. The `ns/op` column stays at ~8 ms in both, because the benchmark
deliberately sleeps a window between samples to go idle — the reported metric is the latency, not the loop.

## The change

`Write` decides, before it appends, whether this write can go out on its own:

```go
leading := c.visible && len(c.pending) == 0 && time.Since(c.lastEmit) >= c.visibleEvery
```

If it can, the bytes are appended and flushed synchronously. If it cannot, nothing about the old path changes:
the write buffers and the timer batches whatever the burst piles up behind that first emission. The timer keeps
its job — it was never the thing emitting the *first* byte, it is the silence window that closes a burst.

`lastEmit` is a new field, stamped inside `flushLocked` on a real emission only, so an empty flush does not
count as one. Its zero value makes the very first write leading, which is correct: a session that has emitted
nothing is as idle as a terminal gets.

### The invariant, kept

**Order.** Emissions are strictly ordered under the mutex and stay that way. The leading edge fires only when
`pending` is empty, so an immediate flush has nothing to overtake, and the data is appended *before* the flush
rather than emitted around the buffer.

**`maxPendingBytes`.** Untouched, and still short-circuits: the overflow branch is now `leading || len(pending)
>= maxPendingBytes`, either of which flushes and returns.

**No timer armed with nothing to send.** `pending` empty implies `timer == nil` — `flushLocked` always stops the
timer before it returns on an empty buffer, and the timer is only armed after an append. A leading flush
therefore cannot leave one behind, and `flushLocked` stops any stale one regardless.

**`SetVisible` does not double-emit.** Its flush now stamps `lastEmit` like any other, so the first write after
a flip is trailing rather than a second copy of what the flip already sent.

### Hidden is deliberately unchanged

A hidden terminal does not paint, so it has no echo latency to protect and batching hard is the whole point.
`c.visible` in the predicate is what keeps it out, and `hiddenFlushInterval` and `maxPendingBytes` are not
touched.

### On the new write queue

This lands on top of #360, which put the socket behind a queue. `push` can block while that queue is full, and
the coalescer's `emit` runs under its mutex by documented contract — but a full queue means a burst is in
flight, and a burst is exactly when the leading edge does not fire. It only fires after a window of silence,
with the queue drained.

## Tests

`internal/terminal/coalescer_test.go` gains the four cases the contract now needs:

- **`TestCoalescerVisibleLeadingEdgeEmitsIdleWriteAtOnce`** — idle → immediate, with an hour-long window so no
  timer flush can be mistaken for the leading edge.
- **`TestCoalescerLeadingEdgeWindowBoundary`** — both sides of the `>=`. `lastEmit` set to exactly one window
  ago must be leading (scheduling jitter only pushes it further past the edge, so it cannot flake); a write
  inside the window must not be, and that half uses an hour-long window so it is immune to jitter by an hour.
- **`TestCoalescerHiddenNeverTakesLeadingEdge`** — a hidden write emits nothing.
- **`TestCoalescerVisibleBatchesBurstOnShortTimer`** — **changed, because the contract changed**, not to buy a
  green run: its first write is now the leading edge. It consumes that emission, then writes three chunks inside
  one window and asserts exactly one emission carrying all three, and no second one. It still pairs a short
  visible interval with an hour-long hidden one, so it keeps proving the timer picks the visible cadence.

Negative control, to prove they are not vacuous: with the leading edge forced off, the two leading-edge tests
fail and everything else passes.

## Ceilings

`docs/ceilings.md` is unchanged on purpose. This closes a latency trap rather than setting a new one, and the
coalescer had no bullet to move. Nothing here is provider-visible either — it is PTY plumbing under all five.

## Gate

`gofmt -l .` and `go vet ./...` clean; `go test ./...` green; `go test -race -count=50 ./internal/terminal/`
green with 0 data races; the `linux`/`darwin`/`windows` build+vet loop clean; frontend untouched, `biome check`
clean and `vite build` green. `CHANGELOG.md` `[Unreleased] › Fixed` lands in the same commit.
