### PR TITLE
fix: read the context percentage a /compact just reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A Claude Code session's context readout now follows a `/compact`.** The
+  percentage came from the newest assistant message in the transcript, and a
+  compaction writes none — so a card that had just been emptied from 236k to 13k
+  went on reporting 24% full until the next reply landed, which is exactly the
+  moment the number is read. The compaction boundary is now what the readout
+  takes its count from when it is the newer of the two, for an automatic
+  compaction as much as a manual one; the model, which that line does not record,
+  still comes from the last message that named one. The cost readout is unchanged
+  — it sums assistant messages and never saw the boundary.
+
 - **One session's output can no longer freeze every other session's.** Each session
   already had its own queue, so a card producing faster than the window could draw
   it backed up alone. One socket carries them all, though, and a session's turn to

--- a/internal/terminal/usage_claude.go
+++ b/internal/terminal/usage_claude.go
@@ -97,18 +97,30 @@ func readTail(path string, max int64) ([]byte, bool) {
 // are skipped: their context is the sub-agent's, not the window the user sees. A
 // leading partial line (the tail was cut mid-line) fails to parse and is skipped
 // like any malformed line.
+//
+// A compaction writes no assistant line, only a compact_boundary carrying the
+// post-compaction count. Meeting one first means it is newer than the last
+// assistant line, whose count is now stale, so the tokens come from the boundary
+// — while the scan keeps going for the model, which the boundary does not
+// record and only an assistant line can name. Both triggers, "manual" and
+// "auto", write the same shape.
 func parseContextUsage(tail []byte) (contextUsage, bool) {
 	lines := bytes.Split(tail, []byte("\n"))
+	compacted := -1
 	for _, line := range slices.Backward(lines) {
 		line := bytes.TrimSpace(line)
 		if len(line) == 0 {
 			continue
 		}
 		var entry struct {
-			Type        string `json:"type"`
-			IsSidechain bool   `json:"isSidechain"`
-			Effort      string `json:"effort"`
-			Message     struct {
+			Type            string `json:"type"`
+			Subtype         string `json:"subtype"`
+			IsSidechain     bool   `json:"isSidechain"`
+			Effort          string `json:"effort"`
+			CompactMetadata *struct {
+				PostTokens int `json:"postTokens"`
+			} `json:"compactMetadata"`
+			Message struct {
 				Model string `json:"model"`
 				Usage *struct {
 					Input       int `json:"input_tokens"`
@@ -120,20 +132,38 @@ func parseContextUsage(tail []byte) (contextUsage, bool) {
 		if err := json.Unmarshal(line, &entry); err != nil {
 			continue
 		}
+		if compacted < 0 && entry.Type == "system" && entry.Subtype == "compact_boundary" &&
+			!entry.IsSidechain && entry.CompactMetadata != nil {
+			compacted = entry.CompactMetadata.PostTokens
+			continue
+		}
 		if entry.Type != "assistant" || entry.IsSidechain || entry.Message.Usage == nil {
 			continue
 		}
 		u := entry.Message.Usage
 		tokens := u.Input + u.CacheRead + u.CacheCreate
-		window := windowForModel(entry.Message.Model, tokens)
-		percent := min(tokens*100/window, 100)
-		return contextUsage{
-			tokens:  tokens,
-			percent: percent,
-			window:  window,
-			model:   entry.Message.Model,
-			effort:  entry.Effort,
-		}, true
+		if compacted >= 0 {
+			tokens = compacted
+		}
+		return usageFor(tokens, entry.Message.Model, entry.Effort), true
+	}
+	if compacted >= 0 {
+		// A compaction with no assistant line left in the tail to name the
+		// model: the default window is the same guess windowForModel makes for
+		// a model it has never heard of.
+		return usageFor(compacted, "", ""), true
 	}
 	return contextUsage{}, false
+}
+
+// usageFor resolves the window and percent a token count reads as on a model.
+func usageFor(tokens int, model, effort string) contextUsage {
+	window := windowForModel(model, tokens)
+	return contextUsage{
+		tokens:  tokens,
+		percent: min(tokens*100/window, 100),
+		window:  window,
+		model:   model,
+		effort:  effort,
+	}
 }

--- a/internal/terminal/usage_claude_test.go
+++ b/internal/terminal/usage_claude_test.go
@@ -23,6 +23,16 @@ func assistantLine(model string, input, cacheRead, cacheCreate int) string {
 		`,"output_tokens":1975}}}`
 }
 
+// boundaryLine builds the system line a /compact writes: no assistant message,
+// only the post-compaction count. trigger is "manual" or "auto" — both shapes
+// are identical in a real transcript.
+func boundaryLine(trigger string, preTokens, postTokens int) string {
+	return `{"type":"system","subtype":"compact_boundary","isSidechain":false,` +
+		`"compactMetadata":{"trigger":"` + trigger +
+		`","preTokens":` + strconv.Itoa(preTokens) +
+		`,"postTokens":` + strconv.Itoa(postTokens) + `}}`
+}
+
 func TestParseContextUsage(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -93,6 +103,59 @@ func TestParseContextUsage(t *testing.T) {
 			wantOK:      true,
 			wantTokens:  5002,
 			wantPercent: 2,
+		},
+		{
+			// A /compact writes no assistant line, so the newest count on the
+			// thread is the boundary's, not the stale line before it.
+			name: "a manual compaction reads the post-compaction count",
+			tail: assistantLine(modelOpus, 2, 236_082, 0) + "\n" +
+				boundaryLine("manual", 236_084, 12_642) + "\n" +
+				`{"type":"user","isCompactSummary":true,"message":{"content":"summary"}}` + "\n",
+			wantOK:      true,
+			wantTokens:  12_642,
+			wantPercent: 1, // 12642 * 100 / 1_000_000
+		},
+		{
+			name: "an auto compaction reads the same way",
+			tail: assistantLine(modelOpus, 2, 937_040, 0) + "\n" +
+				boundaryLine("auto", 937_042, 25_402) + "\n",
+			wantOK:      true,
+			wantTokens:  25_402,
+			wantPercent: 2,
+		},
+		{
+			name: "the window still comes from the model of the line before the boundary",
+			tail: assistantLine(modelHaiku, 2, 180_000, 0) + "\n" +
+				boundaryLine("manual", 180_002, 40_000) + "\n",
+			wantOK:      true,
+			wantTokens:  40_000,
+			wantPercent: 20, // 40000 * 100 / 200_000, the Haiku window
+		},
+		{
+			name: "an assistant line after the boundary wins over it",
+			tail: boundaryLine("manual", 236_084, 12_642) + "\n" +
+				assistantLine(modelOpus, 2, 30_000, 0) + "\n",
+			wantOK:      true,
+			wantTokens:  30_002,
+			wantPercent: 3,
+		},
+		{
+			name:        "a boundary alone in the tail reads against the default window",
+			tail:        boundaryLine("manual", 236_084, 12_642) + "\n",
+			wantOK:      true,
+			wantTokens:  12_642,
+			wantPercent: 1,
+		},
+		{
+			// Same rule as an assistant line: a sub-agent's compaction is not
+			// the window the user sees.
+			name: "skips a sidechain boundary for the main thread",
+			tail: assistantLine(modelOpus, 2, 40_000, 0) + "\n" +
+				`{"type":"system","subtype":"compact_boundary","isSidechain":true,` +
+				`"compactMetadata":{"trigger":"manual","preTokens":9,"postTokens":1}}` + "\n",
+			wantOK:      true,
+			wantTokens:  40_002,
+			wantPercent: 4,
 		},
 		{
 			name:   "no assistant line yields not-ok",


### PR DESCRIPTION
## The bug

`parseContextUsage` (`internal/terminal/usage_claude.go`) scans a transcript tail
backwards for the newest main-thread `assistant` line and takes its token usage.
A Claude Code compaction writes no assistant line — only a
`{"type":"system","subtype":"compact_boundary","compactMetadata":{...}}` followed
by the `isCompactSummary` user line. So after a `/compact` the card kept showing
the pre-compact context (236k / 24% in the transcript this was found in) until
the next turn answered — the exact moment the number is worth reading.

## The fix

Meeting a boundary before any usable assistant line means the boundary is newer,
so the count comes from `compactMetadata.postTokens`. Two things the report asked
to settle:

- **Which window the percentage is taken against.** The boundary records no
  model, so the scan keeps walking backwards for one: the last assistant line
  before the boundary still names it, and a compaction does not change the model.
  If the tail holds no assistant line at all, the model resolves empty and
  `windowForModel` gives the 1M default it already gives a model it has never
  heard of.
- **Whether `trigger:"auto"` has the same shape.** A grep over every transcript
  under `~/.claude/projects` found 48 boundaries — 47 `manual`, 1 `auto` — with
  one metadata shape, `postTokens` present on all 48, and none on a sidechain.
  Sidechain boundaries are skipped regardless, for the same reason a sidechain
  assistant line is: that context belongs to a sub-agent.

**The cost ledger is unaffected.** `usage_cost.go` folds `type == "assistant"`
lines with usage; a `system` boundary is not one and never entered the sum. Cost
is cumulative spend, which a compaction does not reduce.

## Verification

Driven over the real transcript that surfaced this
(`f88f16cf-…jsonl`, boundary at line 777), feeding the tail as the poll would see
it:

| tail through | tokens | percent | model |
|---|---|---|---|
| line 776 (pre-boundary) | 233,585 | 23% | claude-opus-4-8 |
| line 777 (the boundary) | 12,642 | 1% | claude-opus-4-8 |
| line 781 (user lines after) | 12,642 | 1% | claude-opus-4-8 |

Six cases added to `usage_claude_test.go`, all four of the new behaviours failing
on `main` before the change: manual boundary, auto boundary, the window still
resolving from the model of the line before the boundary, an assistant line after
a boundary winning over it, a boundary alone in the tail, and a sidechain boundary
being skipped.

No `docs/ceilings.md` change: the existing tail-window ceiling still holds (the
boundary sits at the end of the file, so the tail always reaches it), and the
ceiling naming oh-my-pi / opencode / Crush as having no context readout at all is
unchanged by this.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` — 1885 passed
- [x] `pnpm check` clean, `vitest run` — 1096 passed, `vite build` succeeds
- [x] New tests verified red on `main`
- [x] Checked against a real post-`/compact` transcript
