### PR TITLE
perf: skip the numstat when the tree is already known clean

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -251,14 +251,21 @@ type DiffStats struct {
 // line totals against HEAD, the HEAD commit itself and the branch it is on. A
 // non-repository path yields the zero value, matching Branch's contract.
 //
-// Two git children, not four: one status read answers the branch, the head and
-// everything dirty (status.go), and only the line totals still need a diff of
-// their own.
+// One git child on a clean checkout, two on a dirty one: the status read
+// answers the branch, the head and everything dirty (status.go), and the line
+// totals are asked for only when there is something to total.
 func (s *Service) Diff(path string) DiffStats {
 	status := readWorkTree(path)
 	stats := DiffStats{Files: status.files, Head: status.head, Branch: status.branch}
-	if out, ok := gitQuiet(path, "diff", "--numstat", status.base); ok {
-		stats.Added, stats.Deleted = numstatTotals(out)
+	// A tree the status read found nothing dirty in has nothing to total, so the
+	// second child would spend a process to be told so — on a call the frontend
+	// runs per second per checkout on screen, most of which nobody is editing.
+	// The implication runs one way only: untracked files are dirty and produce
+	// no numstat lines, so this over-asks rather than under-counts.
+	if status.files > 0 {
+		if out, ok := gitQuiet(path, "diff", "--numstat", status.base); ok {
+			stats.Added, stats.Deleted = numstatTotals(out)
+		}
 	}
 	// Untracked files are invisible to `git diff`; count their lines as
 	// additions, the way Warp and forge diff views present a fresh file.

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -346,6 +346,65 @@ func TestDiffNoCommits(t *testing.T) {
 	}
 }
 
+// TestDiffSpendsNoNumstatOnACleanTree pins the call budget itself, not only the
+// numbers: a checkout with nothing dirty must answer from the status read
+// alone. The counts are asserted alongside, because a skipped call that also
+// dropped a number would be a regression wearing the optimisation's clothes.
+//
+// The children are counted through git's own GIT_TRACE, so nothing in the
+// package has to grow a seam to be observed. The dirty cases assert the *same*
+// trace line is present — without them a git that stopped writing the trace, or
+// a path it refused, would turn the clean assertion into one that can no longer
+// fail.
+func TestDiffSpendsNoNumstatOnACleanTree(t *testing.T) {
+	repo, git := initRepo(t)
+	trace := filepath.Join(t.TempDir(), "git-trace.log")
+	t.Setenv("GIT_TRACE", trace)
+
+	numstats := func() int {
+		t.Helper()
+		// Absent until the first git child runs, which is the zero the clean
+		// case expects to read.
+		out, err := os.ReadFile(trace)
+		if err != nil && !os.IsNotExist(err) {
+			t.Fatalf("read %s: %v", trace, err)
+		}
+		return strings.Count(string(out), "diff --numstat")
+	}
+
+	svc := New(nil)
+	if got := svc.Diff(repo); got.Added != 0 || got.Deleted != 0 {
+		t.Errorf("Diff(clean) = %+v, want no lines", got)
+	}
+	if spent := numstats(); spent != 0 {
+		t.Errorf("Diff(clean) spent %d numstat calls, want 0", spent)
+	}
+
+	if err := os.WriteFile(filepath.Join(repo, "a.txt"), []byte("one\ntwo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := svc.Diff(repo); got.Files != 1 || got.Added != 1 || got.Deleted != 0 {
+		t.Errorf("Diff(edited) = %+v, want {Files:1 Added:1 Deleted:0}", got)
+	}
+	if spent := numstats(); spent != 1 {
+		t.Errorf("Diff(edited) spent %d numstat calls, want 1", spent)
+	}
+
+	// Untracked-only is the case the skip must not swallow: the tree is dirty,
+	// so the call is spent, and git legitimately answers with no lines — the
+	// additions come from reading the file instead.
+	git("checkout", "--", "a.txt")
+	if err := os.WriteFile(filepath.Join(repo, "new.txt"), []byte("x\ny\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := svc.Diff(repo); got.Files != 1 || got.Added != 2 || got.Deleted != 0 {
+		t.Errorf("Diff(untracked only) = %+v, want {Files:1 Added:2 Deleted:0}", got)
+	}
+	if spent := numstats(); spent != 2 {
+		t.Errorf("Diff(untracked only) spent %d numstat calls in total, want 2", spent)
+	}
+}
+
 // sparseTextFile writes a text prefix and stretches the file to size with a
 // hole, so a file past the read cap costs neither disk nor a 10MiB write. The
 // prefix has to cover the whole binary sniff window: a shorter one leaves NULs


### PR DESCRIPTION
## What

`Service.Diff` ran `git diff --numstat` unconditionally. The `git status --porcelain=v2` read immediately before it has already walked the whole tree — when it finds no dirty entry, the numstat can only come back empty. So the call spends a process to be told nothing changed, on the read the frontend runs per second per checkout on screen (`git-status-store.ts`: `fastMs` 1000, `slowMs` 3000), most of which nobody is editing.

```go
if status.files > 0 {
    if out, ok := gitQuiet(path, "diff", "--numstat", status.base); ok {
        stats.Added, stats.Deleted = numstatTotals(out)
    }
}
```

## Why it is safe

The implication runs one way only: untracked files count as dirty and produce no numstat lines at all, so the guard **over-asks rather than under-counts**. Verified against every state that could break it — clean, unstaged modify, staged delete, untracked-only, `assume-unchanged` + edit, `skip-worktree` + edit, mode change, staged rename, symlink, detached HEAD. `files == 0` never coexisted with a non-empty numstat.

## Numbers

Child CPU via `getrusage(RUSAGE_CHILDREN)`, n=60, git 2.55, warm cache. One poll tick on a clean checkout = `Diff` + a `BaseStatus` memo hit, i.e. `rev-parse` + `status -uall` + `numstat`:

| run | before | after | |
|---|---|---|---|
| 1 | 12.06 ms | 7.65 ms | −37 % |
| 2 | 12.90 ms | 8.03 ms | −38 % |
| 3 | 13.08 ms | 7.88 ms | −40 % |

Aggregate, 20 clean checkouts on screen at `slowMs`: **8.0–8.7 % → 5.1–5.4 % of one core.**

A dirty checkout pays exactly what it paid before — the saving lands on idle checkouts, which is where the multi-card load lives.

## Test

`TestDiffSpendsNoNumstatOnACleanTree` counts the git children through git's own `GIT_TRACE` rather than growing a seam in the package. It asserts all three cases: clean spends 0, a tracked edit spends 1, untracked-only spends 1 and still reports its lines. The dirty assertions are what keep the absence assertion honest — without them a git that stopped writing the trace would turn it into an assertion that can no longer fail. Confirmed it fails on all three counts with the guard removed.

`internal/project` coverage 90.6 %, `Diff` at 100 %.

## Not in this PR

- **No `CHANGELOG.md` entry.** Nobody on a published version lives this: the readout is byte-identical, only the process count moves.
- **No `docs/ceilings.md` entry.** This closes no trap and sets none.
- **No filesystem watcher.** This came out of a study of whether lich can stop polling git for the ref half of a status. The verdict was no — 83 % of a tick is the working tree, which a `.git` watch cannot see, and a file watch on `HEAD`/`index`/`refs/heads/<branch>` dies on its own first event because git writes all three by rename-over. This change is what the study found instead, and it is worth more than the watcher would have been.

## Gate

`gofmt -l` · `go vet ./...` · `go test -race ./...` (1880) · `biome check` · `tsc` · `vite build` · `vitest run` (1096) — all green. Cross-compiled and vetted for linux/darwin/windows.