### PR TITLE
test(frontend): pin how much of the tree repaints for one action

### DIFF
--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -22,6 +22,7 @@ src/
 │   ├── common/    shared across features (Notice, EmptyScreen, CloseButton, …)
 │   ├── ui/        shadcn primitives — CLI output, see below
 │   └── <feature>/ diff · dock · pulls · settings · sidebar · tabs
+├── test/          test utilities only — never imported by the app
 └── lib/           no React elements; a `.tsx` in here is misfiled
     ├── session/   sessions, their events, the four per-session stores + hooks
     ├── terminal/  xterm/PTY plumbing: term-*, replay, paste and setup queues
@@ -86,11 +87,27 @@ cross-project queue, and neither fits without widening the primitive for a singl
 
 ## Testing
 
-- vitest runs in the **node environment — there is no jsdom**. The gate covers pure logic (stores, parsers,
-  reducers, `lib/*`); it does **not** render components. A base-ui/DOM render crash passes the suite green.
+- vitest defaults to the **node environment**. The gate covers pure logic (stores, parsers, reducers,
+  `lib/*`); it does **not** render components, so a base-ui/DOM render crash passes the suite green.
 - So: verify any render-path change by hand in `task dev`, and check base-ui contracts (below). Assert the
   empty/default/error branch of a component's data, not just the happy path.
 - Coverage bar is 80% on the logic that *is* testable. Don't chase coverage by rendering in node.
+
+### Render budgets
+
+`src/components/render-budget.test.tsx` is the one suite that renders: it opts into jsdom with a
+`// @vitest-environment jsdom` docblock and pins **how much of the tree repaints for one action** — a status
+event, a usage report, a project switch. Every session's card and every session's terminal stay mounted at
+once, so one background session waking the whole window is a real regression, and one nobody feels for months.
+
+- The harness is `src/test/render-budget.ts`: React's own DevTools hook, the `PerformedWork` flag, and a
+  count per component. It is ~120 lines and stays that way — a test utility, not a profiler.
+- **Assert the whole map with `toEqual`, and exact counts.** `toBeLessThanOrEqual(1)` also passes when a
+  renamed component measures nothing at all, and half of each budget is the names that must be *absent*.
+- Keep anything jsdom cannot measure honestly out of it: it reports every element at zero height, so
+  virtualized lists and the canvas-backed terminal are stubbed rather than budgeted.
+- Numbers moving is not a failure to paper over. Read the diff: fewer is a win to keep, more is the
+  regression this suite exists to catch.
 
 ## Adapting a shadcn component to lich
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -51,6 +51,7 @@
     "@types/react-dom": "^18.2.17",
     "@vitejs/plugin-react": "^6.0.0",
     "@vitest/coverage-v8": "4.1.10",
+    "jsdom": "^30.0.1",
     "tailwindcss": "^4.3.2",
     "typescript": "^5.2.2",
     "vite": "^8.0.5",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.1.10
         version: 4.1.10(vitest@4.1.10)
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
       tailwindcss:
         specifier: ^4.3.2
         version: 4.3.2
@@ -125,9 +128,17 @@ importers:
         version: 8.1.3(@types/node@26.1.0)(jiti@2.7.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0))
+        version: 4.1.10(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0))
 
 packages:
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -350,6 +361,10 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@codemirror/autocomplete@6.20.3':
     resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
 
@@ -434,6 +449,42 @@ packages:
   '@codemirror/view@6.43.6':
     resolution: {integrity: sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==}
 
+  '@csstools/color-helpers@6.1.1':
+    resolution: {integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.2.0':
+    resolution: {integrity: sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.8':
+    resolution: {integrity: sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
+
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
     peerDependencies:
@@ -471,6 +522,15 @@ packages:
 
   '@emnapi/wasi-threads@1.2.2':
     resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@floating-ui/core@1.7.5':
     resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
@@ -986,6 +1046,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
@@ -1129,6 +1192,10 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
@@ -1136,6 +1203,10 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   debounce-fn@4.0.0:
     resolution: {integrity: sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==}
@@ -1149,6 +1220,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1237,6 +1311,10 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
@@ -1441,6 +1519,10 @@ packages:
     resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -1547,6 +1629,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -1613,6 +1698,15 @@ packages:
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1739,6 +1833,10 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1808,6 +1906,9 @@ packages:
 
   mdast-util-to-string@4.0.0:
     resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -2033,6 +2134,9 @@ packages:
     resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
     engines: {node: '>=18'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -2103,6 +2207,10 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
@@ -2204,6 +2312,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -2348,6 +2460,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   systeminformation@5.31.13:
     resolution: {integrity: sha512-iUJXJoKzm4vtLSeT3nwe2s9QjoJAxHg7wYJ0KaQ54Xy2u9jsTq0ULWQQ0+T72FXjX2XnGqubazNx9lUfng7ELw==}
     engines: {node: '>=8.0.0'}
@@ -2382,6 +2497,13 @@ packages:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
+  tldts@7.4.10:
+    resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -2389,6 +2511,14 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -2424,6 +2554,10 @@ packages:
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -2570,6 +2704,26 @@ packages:
   w3c-keyname@2.2.8:
     resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2591,6 +2745,13 @@ packages:
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2615,6 +2776,21 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -2864,6 +3040,10 @@ snapshots:
   '@biomejs/cli-win32-x64@2.5.5':
     optional: true
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@codemirror/autocomplete@6.20.3':
     dependencies:
       '@codemirror/language': 6.12.4
@@ -3102,6 +3282,30 @@ snapshots:
       style-mod: 4.1.3
       w3c-keyname: 2.2.8
 
+  '@csstools/color-helpers@6.1.1': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.1
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.8(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
+
   '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -3163,6 +3367,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@exodus/bytes@1.15.1': {}
 
   '@floating-ui/core@1.7.5':
     dependencies:
@@ -3547,7 +3753,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0))
+      vitest: 4.1.10(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -3647,6 +3853,10 @@ snapshots:
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.42: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   body-parser@2.3.0:
     dependencies:
@@ -3781,9 +3991,21 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   debounce-fn@4.0.0:
     dependencies:
@@ -3792,6 +4014,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -3857,6 +4081,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@8.0.0: {}
 
   env-paths@2.2.1: {}
 
@@ -4098,6 +4324,12 @@ snapshots:
 
   hono@4.12.28: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   html-url-attributes@3.0.1: {}
@@ -4172,6 +4404,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-regexp@3.1.0: {}
@@ -4220,6 +4454,32 @@ snapshots:
   js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@30.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.8(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -4309,6 +4569,8 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
+
+  lru-cache@11.5.2: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -4488,6 +4750,8 @@ snapshots:
   mdast-util-to-string@4.0.0:
     dependencies:
       '@types/mdast': 4.0.4
+
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 
@@ -4812,6 +5076,10 @@ snapshots:
 
   parse-ms@4.0.0: {}
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
@@ -4866,6 +5134,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  punycode@2.3.1: {}
 
   qs@6.15.3:
     dependencies:
@@ -5018,6 +5288,10 @@ snapshots:
       queue-microtask: 1.2.3
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -5202,6 +5476,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   systeminformation@5.31.13: {}
 
   tailwind-merge@3.6.0: {}
@@ -5223,11 +5499,25 @@ snapshots:
 
   tinyrainbow@3.1.0: {}
 
+  tldts-core@7.4.10: {}
+
+  tldts@7.4.10:
+    dependencies:
+      tldts-core: 7.4.10
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.10
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -5259,6 +5549,8 @@ snapshots:
   undici-types@8.3.0: {}
 
   undici@7.28.0: {}
+
+  undici@8.10.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -5337,7 +5629,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
 
-  vitest@4.1.10(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0)):
+  vitest@4.1.10(@types/node@26.1.0)(@vitest/coverage-v8@4.1.10)(jsdom@30.0.1)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0))
@@ -5362,10 +5654,35 @@ snapshots:
     optionalDependencies:
       '@types/node': 26.1.0
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      jsdom: 30.0.1
     transitivePeerDependencies:
       - msw
 
   w3c-keyname@2.2.8: {}
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   which@2.0.2:
     dependencies:
@@ -5386,6 +5703,10 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/frontend/src/components/render-budget.test.tsx
+++ b/frontend/src/components/render-budget.test.tsx
@@ -1,0 +1,330 @@
+// @vitest-environment jsdom
+//
+// Render budgets: how much of the tree repaints for one thing happening.
+//
+// lich keeps every session's card in the sidebar and every session's terminal
+// mounted at once, so the cost of a background session reporting itself is paid
+// by the whole window. These pin that cost. Each budget is asserted whole, with
+// toEqual and an exact count per component: an upper bound would also pass when
+// a renamed component measures nothing at all, and the invariant here is as much
+// about the names that must be absent — the other cards, the sidebar — as about
+// the ones present.
+//
+// The tree measured starts below the providers: ProjectsProvider is replaced by
+// its context value, because standing the real one up means faking its whole
+// boot sequence of RPC calls. So a regression that made *the provider* re-render
+// on every status event would repaint everything and pass here — read a green
+// run as "the sidebar and the terminals are isolated", not as "nothing above
+// them can repaint the window".
+//
+// The harness has to be imported before anything that reaches react-dom, which
+// is why it is first here (see @/test/render-budget).
+import { mountBudget } from "@/test/render-budget"
+import { createElement, useEffect } from "react"
+import { HashRouter } from "react-router-dom"
+import { afterEach, beforeEach, expect, test, vi } from "vitest"
+import { ProjectsContext, type ProjectsValue } from "@/providers/projects-context"
+import { STATUS_EVENT, USAGE_EVENT } from "@/lib/session/session-events"
+
+// The /events channel, as the app sees it: the stores subscribe at import, and a
+// test publishes to the same registry the backend socket would. Mocked rather
+// than driven through app-events itself because the real module opens a
+// WebSocket and reconnects forever when it cannot.
+const bus = vi.hoisted(() => {
+  const handlers = new Map<string, Set<(data: unknown) => void>>()
+  return {
+    on(name: string, callback: (data: unknown) => void) {
+      let set = handlers.get(name)
+      if (!set) {
+        set = new Set()
+        handlers.set(name, set)
+      }
+      set.add(callback)
+      return () => {
+        handlers.get(name)?.delete(callback)
+      }
+    },
+    emit(name: string, data: unknown) {
+      for (const callback of handlers.get(name) ?? []) {
+        callback(data)
+      }
+    },
+  }
+})
+
+vi.mock("@/lib/app-events", () => ({ onAppEvent: bus.on, dispatchEnvelope: () => {} }))
+
+// Every backend call hangs, which is what a component should render for: the git
+// status, the pull request and the provider roster all stay at their loading
+// branch, and none of them lands mid-budget as a repaint nobody asked for. The
+// two spawn checks are the exception — a terminal that never clears them never
+// mounts, and the mounted terminals are the point of the last test.
+const never = () => new Promise<never>(() => {})
+vi.mock("@/lib/rpc", () => {
+  const hangs = new Proxy({}, { get: () => never })
+  return {
+    endpoint: () => ({ base: "http://localhost", token: "token" }),
+    Terminal: new Proxy(
+      {},
+      {
+        get: (_target, name) =>
+          name === "WorkdirMissing" || name === "ResumeAvailable" ? async () => false : never,
+      },
+    ),
+    DropService: hangs,
+    ProjectService: hangs,
+    Store: hangs,
+    Fonts: hangs,
+    AgentPlugin: hangs,
+    AppUpdate: hangs,
+    PatchNotes: hangs,
+    System: hangs,
+    Providers: hangs,
+    Quota: hangs,
+    Themes: hangs,
+  }
+})
+
+// The terminal is canvas and WebGL, which jsdom cannot measure honestly, so it
+// stands in as a component that records its own mounts. That counter answers the
+// question a render budget cannot: a re-render and a remount look alike from
+// outside, and only one of them throws away a running PTY.
+const terminalMounts = vi.hoisted(() => ({ counts: {} as Record<string, number> }))
+vi.mock("@/components/TerminalView", () => ({
+  TerminalView: ({ sessionId }: { sessionId: string }) => {
+    useEffect(() => {
+      terminalMounts.counts[sessionId] = (terminalMounts.counts[sessionId] ?? 0) + 1
+    }, [sessionId])
+    return null
+  },
+}))
+
+// HashRouter follows history, not the hash property, so a test moves the route
+// the way the browser's back button does.
+const navigate = (to: string) => {
+  window.location.hash = `#${to}`
+  window.dispatchEvent(new PopStateEvent("popstate", { state: null }))
+}
+
+const noop = () => {}
+
+// Two projects, so the last test has somewhere to switch to, and three sessions
+// in the first, so "this card and nothing else" has two cards to be wrong about.
+const workspace: ProjectsValue = {
+  projects: [
+    { id: "p1", name: "repo", path: "/repo" },
+    { id: "p2", name: "other", path: "/other" },
+  ],
+  sessions: {
+    p1: {
+      sessions: [
+        { id: "s1", label: "one", kind: "claude" },
+        { id: "s2", label: "two", kind: "claude" },
+        { id: "s3", label: "three", kind: "claude" },
+      ],
+      activeId: "s1",
+      nextSeq: 4,
+    },
+    p2: { sessions: [{ id: "s4", label: "four", kind: "claude" }], activeId: "s4", nextSeq: 2 },
+  },
+  homeId: null,
+  openProject: async () => {},
+  openRecent: async () => true,
+  ensureHomeProject: async () => "p1",
+  closeProject: noop,
+  newSession: () => "",
+  newWorktreeSession: () => "",
+  reopenWorktreeSession: async () => {},
+  resumeClosedSession: async () => {},
+  closeSession: noop,
+  discardSession: noop,
+  keepSession: noop,
+  activateSession: noop,
+  renameSession: noop,
+  setEntrypoint: noop,
+  pinSession: noop,
+  reorderProjects: noop,
+  reorderSessions: noop,
+}
+
+const usageEvent = (id: string) => ({
+  id,
+  percent: 10,
+  tokens: 100,
+  window: 1_000,
+  model: "model",
+  effort: "",
+})
+
+// A busy card counts how long it has been busy, on a shared 1s clock (see
+// session-age). Left running it lands a repaint of its own in the middle of a
+// budget, so the clock is frozen. Only the timers: faking the microtask queue
+// along with them stops React committing at all.
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"] })
+})
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+async function mountSidebar() {
+  window.location.hash = "#/projects/p1"
+  const { SessionSidebar } = await import("./sidebar/SessionSidebar")
+  const { FooterBar } = await import("./FooterBar")
+  const { SettingsProvider } = await import("@/providers/settings")
+  const budget = await mountBudget(
+    createElement(
+      HashRouter,
+      null,
+      createElement(
+        SettingsProvider,
+        null,
+        createElement(
+          ProjectsContext.Provider,
+          { value: workspace },
+          createElement(SessionSidebar, { onCollapse: noop }),
+          createElement(FooterBar, { dock: null, onDock: noop }),
+        ),
+      ),
+    ),
+  )
+  // The mount is not a budget; what one card costs after it is.
+  budget.take()
+  return budget
+}
+
+// What one card drags along when it repaints: its own chrome, and the base-ui
+// context-menu and tooltip parts wrapped around it. The unnamed pair are
+// base-ui's own anonymous render functions.
+const CARD_CHROME = {
+  ContextMenu: 1,
+  ContextMenuRoot: 1,
+  ContextMenuTrigger: 2,
+  ContextMenuContent: 1,
+  MenuRoot: 1,
+  MenuPortal: 1,
+  FloatingTree: 1,
+  Tooltip: 1,
+  TooltipRoot: 1,
+  TooltipTrigger: 2,
+  TooltipContent: 1,
+  TooltipPortal: 1,
+  SessionTooltip: 1,
+  SessionStatusIcon: 1,
+  ProviderIcon: 1,
+  BrandIcon: 1,
+  CloseButton: 1,
+  Pin: 1,
+  X: 1,
+  Anonymous: 2,
+}
+
+test("a status event repaints that session's card and nothing else", async () => {
+  const budget = await mountSidebar()
+  await budget.act(() => bus.emit(STATUS_EVENT, { id: "s2", state: "busy" }))
+  // s2 is a background card: the sidebar, the two cards beside it and the footer
+  // are all absent, which is the invariant.
+  expect(budget.take()).toEqual({ "SessionCard#s2": 1, ...CARD_CHROME })
+  await budget.unmount()
+})
+
+test("a usage event for a background session repaints nothing", async () => {
+  const budget = await mountSidebar()
+  await budget.act(() => bus.emit(USAGE_EVENT, usageEvent("s3")))
+  // No card reads usage — only the footer does, and it follows the active
+  // session. A background session's token count is free.
+  expect(budget.take()).toEqual({})
+  await budget.unmount()
+})
+
+test("a usage event for the active session repaints the footer, not the sidebar", async () => {
+  const budget = await mountSidebar()
+  await budget.act(() => bus.emit(USAGE_EVENT, usageEvent("s1")))
+  // The whole footer re-renders for a token count, segments that know nothing
+  // about usage included — that is the measured cost, not an endorsement of it.
+  // No SessionCard appears, which is what this pins.
+  expect(budget.take()).toEqual({
+    FooterBar: 1,
+    FooterButton: 2,
+    ContextRing: 1,
+    SessionModel: 1,
+    PlanQuota: 1,
+    ProviderIcon: 1,
+    BrandIcon: 1,
+    Separator: 4,
+    Tooltip: 4,
+    TooltipRoot: 4,
+    TooltipTrigger: 8,
+    TooltipContent: 4,
+    TooltipPortal: 4,
+    Paperclip: 1,
+    Folder: 1,
+    Code: 1,
+    Anonymous: 3,
+  })
+  await budget.unmount()
+})
+
+test("switching project re-renders the mounted terminals but never remounts one", async () => {
+  window.location.hash = "#/projects/p1"
+  const { TerminalHost } = await import("./TerminalHost")
+  const budget = await mountBudget(
+    createElement(
+      HashRouter,
+      null,
+      createElement(
+        ProjectsContext.Provider,
+        { value: workspace },
+        createElement(TerminalHost, null),
+      ),
+    ),
+  )
+  budget.take()
+  expect(terminalMounts.counts).toEqual({ s1: 1 })
+
+  // Two commits: the route moves, then p2's session clears its spawn gate and
+  // mounts. Three TerminalView renders across them — s1 in both, s4 in the
+  // second — because nothing under TerminalHost is memoized.
+  await budget.act(() => navigate("/projects/p2"))
+  expect(budget.take()).toEqual({
+    HashRouter: 1,
+    Router: 1,
+    TerminalHost: 2,
+    TerminalView: 3,
+    ResumeSessionDialog: 2,
+    WorktreeCloseDialogs: 2,
+    RunningSessionDialog: 2,
+    CloseWorktreeDialog: 2,
+    ForceRemoveWorktreeDialog: 2,
+    ConfirmDialog: 8,
+    Dialog: 8,
+    DialogRoot: 8,
+    DialogContent: 8,
+    DialogPortal: 16,
+  })
+  expect(terminalMounts.counts).toEqual({ s1: 1, s4: 1 })
+
+  // Coming back is one commit, both terminals already spawned — and both of them
+  // re-render for it.
+  await budget.act(() => navigate("/projects/p1"))
+  expect(budget.take()).toEqual({
+    HashRouter: 1,
+    Router: 1,
+    TerminalHost: 1,
+    TerminalView: 2,
+    ResumeSessionDialog: 1,
+    WorktreeCloseDialogs: 1,
+    RunningSessionDialog: 1,
+    CloseWorktreeDialog: 1,
+    ForceRemoveWorktreeDialog: 1,
+    ConfirmDialog: 4,
+    Dialog: 4,
+    DialogRoot: 4,
+    DialogContent: 4,
+    DialogPortal: 8,
+  })
+  // The point of the whole test: two round trips, one mount each. A terminal
+  // that remounted would have thrown away its PTY and its scrollback.
+  expect(terminalMounts.counts).toEqual({ s1: 1, s4: 1 })
+  await budget.unmount()
+})

--- a/frontend/src/test/render-budget.ts
+++ b/frontend/src/test/render-budget.ts
@@ -1,0 +1,192 @@
+import type { ReactElement } from "react"
+
+// A render budget: how many times each component's body ran for one action.
+//
+// React DOM only reports commits to a tree it believes is being profiled, and
+// it decides that once, when it is first imported, by looking for the DevTools
+// global hook. So the shim below is installed at module scope and react-dom is
+// pulled in lazily inside mountBudget — which means this module has to be
+// imported before anything else that reaches react-dom. `hook.renderers` is the
+// proof that it was: react-dom calls inject() on the way in, and mountBudget
+// refuses to measure a tree that never did.
+//
+// Counting is React's own answer, not an approximation: a fiber whose component
+// body ran in a commit carries the PerformedWork flag. Fibers React skipped
+// wholesale keep their flags from an earlier commit, so they are excluded by
+// identity — a fiber object reused from the previous committed tree was not
+// visited at all.
+
+const PERFORMED_WORK = 0b1
+
+interface Fiber {
+  key: string | null
+  type: unknown
+  elementType: unknown
+  flags: number
+  child: Fiber | null
+  sibling: Fiber | null
+}
+
+interface DevToolsHook {
+  renderers: Map<number, unknown>
+  supportsFiber: true
+  inject(renderer: unknown): number
+  onCommitFiberRoot(id: number, root: { current: Fiber }): void
+  onCommitFiberUnmount(): void
+  onPostCommitFiberRoot(): void
+}
+
+const commits: Fiber[] = []
+
+const hook: DevToolsHook = {
+  renderers: new Map(),
+  supportsFiber: true,
+  inject(renderer) {
+    const id = hook.renderers.size + 1
+    hook.renderers.set(id, renderer)
+    return id
+  },
+  onCommitFiberRoot(_id, root) {
+    commits.push(root.current)
+  },
+  onCommitFiberUnmount() {},
+  onPostCommitFiberRoot() {},
+}
+
+const globals = globalThis as Record<string, unknown>
+globals.__REACT_DEVTOOLS_GLOBAL_HOOK__ = hook
+// React's own flag for "act() is legal here"; without it every act call warns.
+globals.IS_REACT_ACT_ENVIRONMENT = true
+// jsdom ships no ResizeObserver and measures every element at zero, so the
+// components that watch their own width (a card's path ellipsis, the terminal's
+// fit) have nothing to observe here anyway. A stub that never fires is the
+// honest stand-in: it keeps the mount from throwing without inventing a size.
+if (!globals.ResizeObserver) {
+  globals.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+}
+// Same story for matchMedia, which the settings provider asks about the OS
+// colour scheme: jsdom has no answer, and a budget does not depend on one.
+if (!window.matchMedia) {
+  window.matchMedia = (media: string) =>
+    ({
+      media,
+      matches: false,
+      onchange: null,
+      addEventListener() {},
+      removeEventListener() {},
+      addListener() {},
+      removeListener() {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList
+}
+
+// componentName is what a budget is written against, so it answers with the
+// name in the source: the wrapped function for memo and forwardRef, never the
+// wrapper. An anonymous component would be indistinguishable from the next one,
+// so it is named after nothing and shows up as such.
+function componentName(type: unknown): string {
+  if (typeof type === "function") {
+    const fn = type as { displayName?: string; name?: string }
+    return fn.displayName || fn.name || "Anonymous"
+  }
+  if (type && typeof type === "object") {
+    const wrapper = type as { displayName?: string; render?: unknown; type?: unknown }
+    if (wrapper.displayName) {
+      return wrapper.displayName
+    }
+    if (wrapper.render) {
+      return componentName(wrapper.render)
+    }
+    if (wrapper.type) {
+      return componentName(wrapper.type)
+    }
+  }
+  return "Anonymous"
+}
+
+// A keyed element is one of several siblings of the same type, which is exactly
+// the case a per-session budget has to tell apart — so the key rides in the
+// name rather than collapsing three cards into "SessionCard: 3".
+function fiberLabel(fiber: Fiber): string {
+  const name = componentName(fiber.type ?? fiber.elementType)
+  return fiber.key === null ? name : `${name}#${fiber.key}`
+}
+
+export interface RenderBudget {
+  /** Renders since the last take(), by component. Empty means nothing repainted. */
+  take(): Record<string, number>
+  /** Run something that updates the tree and settle every render it causes. */
+  act(run: () => void | Promise<void>): Promise<void>
+  unmount(): Promise<void>
+}
+
+export async function mountBudget(element: ReactElement): Promise<RenderBudget> {
+  const { act } = await import("react")
+  const { createRoot } = await import("react-dom/client")
+  if (hook.renderers.size === 0) {
+    throw new Error(
+      "react-dom was imported before render-budget; move its import to the top of the test file",
+    )
+  }
+
+  const container = document.createElement("div")
+  document.body.appendChild(container)
+  const root = createRoot(container)
+
+  // The fibers of the last committed tree. A fiber still in this set was reused
+  // untouched by the next commit, so whatever its flags say happened earlier.
+  let previous = new Set<Fiber>()
+  // Commits are collected globally, so a budget starts reading where the tree
+  // it owns begins — never at another root's history.
+  let read = commits.length
+
+  const take = (): Record<string, number> => {
+    const counts: Record<string, number> = {}
+    // Every commit since the last read, so an action that settles in two passes
+    // is billed for both.
+    for (; read < commits.length; read++) {
+      const current = new Set<Fiber>()
+      const walk = (start: Fiber | null): void => {
+        for (let fiber = start; fiber !== null; fiber = fiber.sibling) {
+          current.add(fiber)
+          if (!previous.has(fiber) && (fiber.flags & PERFORMED_WORK) !== 0) {
+            const label = fiberLabel(fiber)
+            counts[label] = (counts[label] ?? 0) + 1
+          }
+          walk(fiber.child)
+        }
+      }
+      walk(commits[read])
+      previous = current
+    }
+    return counts
+  }
+
+  // An update can be raised from a promise the action only started — a spawn
+  // gate answering, a fetch landing — so every act is followed by an empty one:
+  // it drains the microtasks the first act left pending and commits whatever
+  // they scheduled, inside act, rather than after the budget was read.
+  const settle = async (run: () => void | Promise<void>): Promise<void> => {
+    await act(async () => await run())
+    await act(async () => {})
+  }
+
+  await settle(() => {
+    root.render(element)
+  })
+
+  return {
+    take,
+    act: settle,
+    unmount: async () => {
+      await act(async () => {
+        root.unmount()
+      })
+      container.remove()
+    },
+  }
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -3,7 +3,9 @@ import { defineConfig } from "vitest/config"
 
 // Standalone from vite.config.ts: the tested logic is pure, so a plain node
 // environment is enough — no need to drag the app's Vite plugins into the
-// test runner.
+// test runner. The render budgets are the exception and ask for jsdom in their
+// own docblock, which is why the default stays node: one suite of four files
+// paying for a DOM should not slow the ninety that do not need one.
 export default defineConfig({
   resolve: {
     alias: {
@@ -12,7 +14,7 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
     coverage: {
       provider: "v8",
       reporter: ["text-summary", "json-summary"],
@@ -32,13 +34,17 @@ export default defineConfig({
       exclude: [
         "src/**/*.test.ts",
         "src/**/*.d.ts",
+        // Test utilities. Measuring the harness that measures the app says
+        // nothing about the app.
+        "src/test/**",
         // Components: the DOM/xterm boundary invariant #1 exempts. Pulled in
         // transitively by the tests that import their pure helpers.
         "src/**/*.tsx",
-        // React hooks. Rendering one needs a renderer, and there is no jsdom
-        // here by design — the store behind each hook is what carries the
-        // tests. `useDiffEditor`/`useFileEditor` are hooks too, misfiled under
-        // components because they own a CodeMirror view.
+        // React hooks. The store behind each hook is what carries the tests;
+        // the render budgets run a few of them for real but measure repaints,
+        // not branches, so counting the hooks as covered would be a number
+        // nobody earned. `useDiffEditor`/`useFileEditor` are hooks too, misfiled
+        // under components because they own a CodeMirror view.
         "src/**/use-*.ts",
         "src/components/**/use*.ts",
         // OS/framework boundaries: fetch, EventSource, WebSocket, CodeMirror


### PR DESCRIPTION
## What

Adds render budgets to the frontend suite: a test that pins **how much of the React tree repaints for one action**, so a regression where one session's activity repaints every card fails in CI instead of being felt months later.

`frontend/src/test/render-budget.ts` (~120 lines) is the harness. It installs a shim for `__REACT_DEVTOOLS_GLOBAL_HOOK__`, reads the committed fiber tree, and counts a render per component using React's own `PerformedWork` flag — the flag React sets when a component body actually ran. Fibers React skipped wholesale keep stale flags, so they are excluded by identity against the previous committed tree. Instances are labelled by key (`SessionCard#s2`), which is what makes "this card and nothing else" expressible.

Counts are **exact and asserted as a whole map**. An upper bound (`toBeLessThanOrEqual`) also passes when a renamed component measures nothing at all, and half of each budget is the names that must be *absent* — the other cards, the sidebar.

## Invariants pinned — all measured first, all holding today

| Invariant | Result |
| --- | --- |
| A status event for session A repaints A's card and nothing else | Holds. Only `SessionCard#s2` and its base-ui chrome; the sidebar, the two neighbouring cards and the footer stay put. |
| A usage/cost event for A repaints neither the sidebar nor the other cards | Holds, and more strongly than asked: a usage report for a **background** session repaints *nothing at all*. For the **active** session it reaches `FooterBar` and no `SessionCard`. |
| Switching the active project does not remount already-mounted terminals | Holds. Two round trips, one mount per terminal. |

## What the measurement also showed

Neither is a regression, and neither is fixed here — both are pinned as they stand:

- **A token count repaints the whole footer.** `FooterBar` is not split, so a usage report re-renders `PlanQuota`, both `FooterButton`s, four `Separator`s and every tooltip alongside `ContextRing`.
- **A project switch re-renders every mounted terminal.** Nothing under `TerminalHost` is memoized, so all mounted `TerminalView`s re-render on a switch, plus all four worktree-close dialogs. No remount, so no PTY or scrollback is lost — but the cost scales with the number of live sessions.

## Fit

- vitest keeps **node** as its default environment; this one file opts into jsdom with a `// @vitest-environment jsdom` docblock, so the other 91 files pay nothing for a DOM.
- jsdom reports every element at zero height, so nothing virtualized or canvas-backed is budgeted: `TerminalView` stands in as a stub that records its own mounts — the one question a repaint count cannot answer, since a re-render and a remount look alike from outside.
- Only the OS/framework boundaries are mocked (`@/lib/rpc`, `@/lib/app-events`) — the same ones `vitest.config.ts` already exempts from coverage. Everything below `SessionSidebar` / `FooterBar` / `TerminalHost` is the real component tree.
- New dev dependency: `jsdom`. `src/test/**` is excluded from the coverage denominator.

## Known ceiling

The measured tree starts **below the providers**: `ProjectsProvider` is replaced by its context value, because standing the real one up means faking its whole boot sequence of RPC calls. A regression that made *the provider* re-render on every status event would repaint everything and still pass here. That is written at the top of the test file rather than in `docs/ceilings.md` — the trap is visible at the call site, and that file is about session, git and persistence traps, not frontend test scope.

## No CHANGELOG entry

Deliberate: nobody running a published version lives this. It is test infrastructure only, with no user-visible behaviour attached.

## Test plan

- [x] `biome check .` — 0 errors (14 pre-existing a11y warnings, none in new files)
- [x] `tsc` typecheck + `vite build --mode production`
- [x] Frontend suite: 92 files / 1100 tests green (was 91 / 1096)
- [x] Coverage 96.7% statements
- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` — 1879 passed
- [x] Ran the render-budget file 10× in separate processes: no flake
- [x] **Mutation-checked**: adding a group-wide `useProjectStatus(ids)` to `SessionGroup` makes the first budget fail with exactly `SessionCard#s1`, `SessionCard#s3` and `SessionGroup#__root__` appearing — the regression the suite exists to catch
- [x] Verified the harness's import-order guard throws rather than silently measuring nothing