### PR TITLE
fix: report untracked paths relative to the project path again

### DIFF
--- a/internal/project/status.go
+++ b/internal/project/status.go
@@ -17,7 +17,7 @@ type workTreeStatus struct {
 	head      string   // "" in a repository with no commits
 	base      string   // what a diff runs against: "HEAD", or the empty tree
 	files     int      // dirty entries: changed, renamed, unmerged, untracked
-	untracked []string // untracked paths, relative to the work tree root
+	untracked []string // untracked paths, relative to the path that was read
 }
 
 // readWorkTree runs the single status call and parses it. A path git will not
@@ -35,7 +35,43 @@ func readWorkTree(path string) workTreeStatus {
 	if !ok {
 		return workTreeStatus{base: emptyTreeHash}
 	}
-	return parseWorkTree(out)
+	status := parseWorkTree(out)
+	// Asked for only when there is something to translate: on a clean tree the
+	// prefix would cost a second git child to be told nothing, on the read the
+	// frontend runs per second per checkout on screen.
+	if len(status.untracked) > 0 {
+		status.untracked = relativeToPath(path, status.untracked)
+	}
+	return status
+}
+
+// relativeToPath translates the untracked paths porcelain v2 reports — always
+// relative to the repository root, and covering the whole repository, which
+// --porcelain forces whatever status.relativePaths says — back to being
+// relative to path, the way the `ls-files --others` call this read replaced
+// reported them. Both callers join them onto path to reach the file.
+//
+// git answers where path sits with `rev-parse --show-prefix`: "sub/" from a
+// subdirectory, "" when path is the repository root itself. Entries outside the
+// prefix are dropped rather than kept: they live outside the directory the
+// caller asked about, and `ls-files --others`, scoped to it, never reported
+// them either.
+func relativeToPath(path string, untracked []string) []string {
+	out, ok := gitQuiet(path, "rev-parse", "--show-prefix")
+	// The overwhelmingly common case: path is the repository root, and every
+	// entry is already relative to it. A git that refused the question leaves
+	// them alone too — the same paths the read handed back before this call.
+	prefix := strings.TrimRight(out, "\r\n")
+	if !ok || prefix == "" {
+		return untracked
+	}
+	scoped := untracked[:0]
+	for _, rel := range untracked {
+		if under, found := strings.CutPrefix(rel, prefix); found {
+			scoped = append(scoped, under)
+		}
+	}
+	return scoped
 }
 
 // parseWorkTree reads porcelain v2's NUL-terminated records. Every record shape

--- a/internal/project/status_test.go
+++ b/internal/project/status_test.go
@@ -3,6 +3,7 @@ package project
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -232,5 +233,150 @@ func TestReadWorkTreeAgainstRealGit(t *testing.T) {
 	git("checkout", "--detach", "HEAD")
 	if got := readWorkTree(repo); got.branch != "" {
 		t.Errorf("readWorkTree(detached).branch = %q, want empty", got.branch)
+	}
+}
+
+// subRepo seeds the shape the whole subdirectory story is told against: a
+// repository whose project path is "sub", holding two untracked files worth 4
+// lines, plus one untracked file at the root worth 7 lines that must never be
+// seen from inside sub.
+func subRepo(t *testing.T) (repo, sub string) {
+	t.Helper()
+	repo, _ = initRepo(t)
+	sub = filepath.Join(repo, "sub")
+	if err := os.MkdirAll(filepath.Join(sub, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	files := map[string][]byte{
+		filepath.Join(sub, "new.txt"):            []byte("x\ny\nz\n"),
+		filepath.Join(sub, "nested", "deep.txt"): []byte("d\n"),
+		filepath.Join(repo, "outside.txt"):       []byte("1\n2\n3\n4\n5\n6\n7\n"),
+	}
+	for name, data := range files {
+		if err := os.WriteFile(name, data, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return repo, sub
+}
+
+// TestReadWorkTreeFromASubdirectory covers the case every other test in this
+// package misses: a project opened on a subdirectory of a repository, which
+// nothing normalises to the repository root.
+//
+// porcelain v2 spells its untracked paths from the repository root and covers
+// the whole repository, whatever the directory git ran in — `--porcelain`
+// forces that, and status.relativePaths does not lift it. The `ls-files
+// --others` call this read replaced answered relative to the directory and
+// scoped to it, and both callers still join these paths onto the project path,
+// so the readout has to answer the way ls-files did.
+func TestReadWorkTreeFromASubdirectory(t *testing.T) {
+	_, sub := subRepo(t)
+
+	got := readWorkTree(sub)
+	want := []string{"nested/deep.txt", "new.txt"}
+	slices.Sort(got.untracked)
+	if !slices.Equal(got.untracked, want) {
+		t.Errorf("untracked = %q, want %q", got.untracked, want)
+	}
+	// The dirty count is the whole repository's and always was: the porcelain
+	// v1 call this replaced ran without a pathspec too. Only the paths moved.
+	if got.files != 3 {
+		t.Errorf("files = %d, want 3", got.files)
+	}
+}
+
+// TestReadWorkTreeAtTheRepositoryRootIsUntouched is the pin behind the
+// translation: an empty prefix means the path *is* the repository root, the
+// overwhelmingly common case, and every entry must come back byte for byte as
+// git wrote it.
+func TestReadWorkTreeAtTheRepositoryRootIsUntouched(t *testing.T) {
+	repo, _ := subRepo(t)
+
+	got := readWorkTree(repo)
+	want := []string{"outside.txt", "sub/nested/deep.txt", "sub/new.txt"}
+	slices.Sort(got.untracked)
+	if !slices.Equal(got.untracked, want) {
+		t.Errorf("untracked = %q, want %q", got.untracked, want)
+	}
+	if got.files != 3 {
+		t.Errorf("files = %d, want 3", got.files)
+	}
+}
+
+// TestReadWorkTreeSpendsNoPrefixCallOnACleanTree pins the call budget the
+// translation is allowed: the prefix answers where the read ran, so it is worth
+// a git child only when there are untracked paths to move. A clean checkout —
+// what the frontend polls per second per checkout on screen — must still cost
+// the one status call.
+//
+// Counted through git's own GIT_TRACE, the way the numstat budget is, so
+// nothing in the package grows a seam to be observed. The dirty case asserts
+// the same trace line *is* written, without which a git that stopped tracing
+// would turn the clean assertion into one that can no longer fail.
+func TestReadWorkTreeSpendsNoPrefixCallOnACleanTree(t *testing.T) {
+	repo, _ := initRepo(t)
+	trace := filepath.Join(t.TempDir(), "git-trace.log")
+	t.Setenv("GIT_TRACE", trace)
+
+	prefixCalls := func() int {
+		t.Helper()
+		// Absent until the first git child runs, which is the zero the clean
+		// case expects to read.
+		out, err := os.ReadFile(trace)
+		if err != nil && !os.IsNotExist(err) {
+			t.Fatalf("read %s: %v", trace, err)
+		}
+		return strings.Count(string(out), "--show-prefix")
+	}
+
+	readWorkTree(repo)
+	if spent := prefixCalls(); spent != 0 {
+		t.Errorf("readWorkTree(clean) spent %d prefix calls, want 0", spent)
+	}
+
+	if err := os.WriteFile(filepath.Join(repo, "new.txt"), []byte("x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	readWorkTree(repo)
+	if spent := prefixCalls(); spent != 1 {
+		t.Errorf("readWorkTree(untracked) spent %d prefix calls, want 1", spent)
+	}
+}
+
+// TestDiffFromASubdirectory proves the line totals a subdirectory project shows
+// on its card: the untracked lines under it are counted, and the untracked file
+// beside it — outside the directory the caller asked about — is not.
+func TestDiffFromASubdirectory(t *testing.T) {
+	_, sub := subRepo(t)
+
+	got := New(nil).Diff(sub)
+	// 3 lines in sub/new.txt and 1 in sub/nested/deep.txt. Counting the root's
+	// outside.txt as well would read 11.
+	if got.Added != 4 {
+		t.Errorf("Diff(sub).Added = %d, want 4", got.Added)
+	}
+	if got.Deleted != 0 {
+		t.Errorf("Diff(sub).Deleted = %d, want 0", got.Deleted)
+	}
+}
+
+// TestDiffTextFromASubdirectory proves the review panel of a subdirectory
+// project renders its untracked files as new-file hunks, and shows nothing from
+// outside the directory.
+func TestDiffTextFromASubdirectory(t *testing.T) {
+	_, sub := subRepo(t)
+
+	out, err := New(nil).DiffText(sub)
+	if err != nil {
+		t.Fatalf("DiffText: %v", err)
+	}
+	for _, want := range []string{"+++ b/new.txt", "new file mode", "+x", "+y", "+z", "+++ b/nested/deep.txt", "+d"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("diff missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "outside.txt") {
+		t.Errorf("diff names a file outside the project path:\n%s", out)
 	}
 }


### PR DESCRIPTION
A card's git readout was collapsed onto one `git status --porcelain=v2` call, replacing the `git ls-files --others --exclude-standard` child that used to list untracked files. The two answer with different paths, and nothing said so out loud:

- `ls-files --others`, run as `git -C <path>`, reported paths **relative to `<path>`** and **scoped to `<path>`**.
- `status --porcelain=v2` reports paths **relative to the repository root**, covering the **whole repository**, whatever directory git ran in. The porcelain formats force this; `status.relativePaths=true` does not change it (measured on git 2.55).

Nothing normalises a lich project path to the repository root, so a project opened on a **subdirectory** of a repository got paths that `filepath.Join(path, rel)` (`internal/project/project.go`, `internal/project/difftext.go`) turns into files that are not there. The failure is silent: the joined path simply does not exist, so the count comes back zero and the diff comes back empty.

It was invisible because every existing `Diff`/`DiffText` test in `internal/project` runs at the repository root, where the prefix is empty and the two spellings agree.

## The measurement

A repository with `seed.txt` committed at the root and `sub/new.txt` untracked and 3 lines long, with the project opened on `sub`:

| | `Diff(sub).Added` | `DiffText(sub)` |
|---|---|---|
| v0.39.0 | 3 | 128 bytes |
| HEAD before this PR | 0 | 0 bytes |

So a subdirectory project silently stopped counting untracked line additions on its card, and stopped rendering untracked files in the review panel.

## What changed

`readWorkTree` (`internal/project/status.go`) now translates the untracked paths back to being relative to the path it was asked about, using `git rev-parse --show-prefix` — which answers where the read ran relative to the repository root: `"sub/"` from a subdirectory, `""` from the root.

- An **empty prefix** means the path *is* the repository root. Every entry is handed back byte for byte as git wrote it — the overwhelmingly common case, unchanged. A git that refuses the question takes the same path.
- A **non-empty prefix** is stripped from each entry, and entries that do not start with it are **dropped**: they live outside the directory the caller asked about, and `ls-files --others`, scoped to it, never reported them either.

The prefix call is **guarded behind `len(status.untracked) > 0`**, and that guard is the point. The collapse this fixes is a performance change whose claim is that a card's readout costs one git child on a clean tree — which is what the frontend polls, per second, per checkout on screen, and most checkouts are clean. A clean tree has no untracked entries to translate, so asking for the prefix there would spend a whole process to be told it has nothing to do, and quietly undo the number the change was made for.

The fix lives in `readWorkTree` rather than at the two call sites, so both `Diff` and `DiffText` are covered by one guard and neither can be fixed while the other stays broken.

`status.files` is deliberately left alone. The `git status --porcelain` call that preceded this ran without a pathspec too, so `Files` already counted the whole repository from a subdirectory. That is not a regression, and changing it is out of scope for this PR.

**This is an unreleased regression** — the code being fixed has never shipped in a tagged release, so it carries no `CHANGELOG.md` entry. There is nothing here a user of a published version lived through.

## Test plan

New tests in `internal/project/status_test.go`, all built on one `subRepo` helper: a repository holding `sub/new.txt` (3 lines) and `sub/nested/deep.txt` (1 line), plus `outside.txt` (7 lines) at the root that must never be visible from inside `sub`. Every assertion is against a literal, not against the constants the production code uses.

- `TestReadWorkTreeFromASubdirectory` — untracked comes back as `["nested/deep.txt", "new.txt"]`, and `files` stays 3 (the whole repository, as before).
- `TestReadWorkTreeAtTheRepositoryRootIsUntouched` — the pin, so the translation cannot drift: at the root the entries are `["outside.txt", "sub/nested/deep.txt", "sub/new.txt"]`, exactly what git wrote.
- `TestReadWorkTreeSpendsNoPrefixCallOnACleanTree` — pins the call budget through git's own `GIT_TRACE`, so nothing in the package grows a seam to be observed: 0 `--show-prefix` children on a clean tree, 1 on a dirty one. The dirty half is there so that a git which stopped writing the trace cannot turn the clean assertion into one that can no longer fail.
- `TestDiffFromASubdirectory` — `Added == 4` (the two files under `sub`), `Deleted == 0`. Reading 11 would mean the root's `outside.txt` leaked in.
- `TestDiffTextFromASubdirectory` — both files under `sub` render as new-file hunks, and the string `outside.txt` appears nowhere in the output.

**Revert check.** With `internal/project/status.go` reverted to its pre-fix state and the new tests left in place, 4 of the 5 fail and the root pin passes — `Diff(sub).Added = 0, want 4`, which reproduces the measurement above exactly. The tests fail for the reason they were written.

**Gate**, run with `LICH_LISTEN_PORT=` (inherited, the test binary collides with the running lich's pinned port) and with exit codes read directly:

- `gofmt -l .` — no output, exit 0
- `LICH_LISTEN_PORT= go vet ./...` — exit 0, no findings
- `LICH_LISTEN_PORT= go test ./...` — exit 0, 31 packages ok, 0 FAIL (`internal/project` 1.675s)

The frontend gate was not run: no frontend file is touched by this change.
