### PR TITLE
fix: park the session a plain `lich close` takes down

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -356,7 +356,9 @@ conversation back up.
   the second question the window asks. What it discards is in no commit and on no
   remote.
 - A session sharing its checkout with another, or living in the project's own
-  directory, has nothing at stake and closes on the spot.
+  directory, has nothing at stake and closes on the spot — parked like every
+  other close, so the palette's History tab still finds it and a resume still
+  picks its conversation back up.
 - **A session cannot close itself.** The answer would have nowhere to go.
 - Unlike `sessions`, this reaches a card whose terminal was never opened: it is
   still a session, and closing it is the one thing you can do with it.

--- a/internal/spawn/close.go
+++ b/internal/spawn/close.go
@@ -29,8 +29,13 @@ type Closed struct {
 	// Worktree is the checkout the session lived in, empty for a session in the
 	// project's own directory.
 	Worktree string `json:"worktree"`
-	// Kept is whether the checkout was left on disk (and the session parked for
-	// a later resume) rather than removed. Meaningless without a Worktree.
+	// Kept is the answer given to the worktree question: the checkout was left on
+	// disk rather than removed. Meaningless unless the close had that question to
+	// answer — a session sharing its checkout, or living in the project's own
+	// directory, reports false while leaving everything where it was.
+	//
+	// Nothing here reports the park, because every close but a removal parks and
+	// a field that is true on all of them tells a caller nothing.
 	Kept bool `json:"kept"`
 	// Removed is whether the checkout was deleted.
 	Removed bool `json:"removed"`
@@ -105,7 +110,12 @@ func (s *Service) Close(fromID, target, projectName, worktree string, force bool
 		return closed, nil
 	}
 
-	if err := s.sessions.DeleteSession(found.project.ID, found.session.ID, active); err != nil {
+	// Parked, not deleted: nothing about this close is a decision to destroy the
+	// session. The row carries the conversation, the cost ledgers and the name
+	// the user gave it, and it is what puts the session in the history a resume
+	// reads back — the same close the window performs (projects.tsx,
+	// closeSession). Only a checkout's removal takes a row with it.
+	if err := s.sessions.CloseSession(found.project.ID, found.session.ID, active); err != nil {
 		return Closed{}, err
 	}
 	s.finish(found, active)
@@ -150,10 +160,11 @@ func (s *Service) removeCheckout(found located, active string, force bool) error
 // session nobody can reach.
 func (s *Service) finish(found located, active string) {
 	if err := s.term.Close(found.session.ID); err != nil {
-		// The row is already gone, so there is nothing to undo and nothing the
-		// caller could do about it. The window's own close ignores this too — but
-		// the card still has to come down, or a failed PTY close leaves one on
-		// screen for a session that no longer exists anywhere else.
+		// The row is already written — parked, or deleted with its checkout — so
+		// there is nothing to undo and nothing the caller could do about it. The
+		// window's own close ignores this too, but the card still has to come
+		// down, or a failed PTY close leaves one on screen for a session the
+		// workspace no longer lists.
 		slog.Warn("spawn: close the session's terminal", "session", found.session.ID, "err", err)
 	}
 	if s.events != nil {

--- a/internal/spawn/close_test.go
+++ b/internal/spawn/close_test.go
@@ -51,8 +51,13 @@ func TestCloseTakesDownASessionWithNothingAtStake(t *testing.T) {
 	if closed.Kept || closed.Removed {
 		t.Errorf("closed = %+v, want the checkout untouched — another session is in it", closed)
 	}
-	if len(sessions.deleted) != 1 || sessions.deleted[0].sessionID != "s2" {
-		t.Errorf("deleted = %+v", sessions.deleted)
+	// Parked, not deleted: the close destroys nothing, so the row stays for the
+	// history and for a resume to pick the conversation back up.
+	if len(sessions.parked) != 1 || sessions.parked[0].sessionID != "s2" {
+		t.Errorf("parked = %+v, want the session kept for a resume", sessions.parked)
+	}
+	if len(sessions.deleted) != 0 {
+		t.Errorf("deleted = %+v, want nothing destroyed by a plain close", sessions.deleted)
 	}
 	if len(worktrees.removed) != 0 {
 		t.Errorf("removed a checkout another session is working in: %+v", worktrees.removed)
@@ -245,7 +250,7 @@ func TestCloseHandsTheProjectToTheNeighbour(t *testing.T) {
 	if _, err := svc.Close("s1", "shared-a", "", "", false); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	if got := sessions.deleted[0].activeID; got != "s3" {
+	if got := sessions.parked[0].activeID; got != "s3" {
 		t.Errorf("active session = %q, want the card that filled the closed slot", got)
 	}
 	closed, ok := events.events[0].data.(ClosedEvent)
@@ -266,7 +271,7 @@ func TestCloseAnInactiveSessionLeavesTheFocusAlone(t *testing.T) {
 	if _, err := svc.Close("s3", "shared-a", "", "", false); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	if got := sessions.deleted[0].activeID; got != "s1" {
+	if got := sessions.parked[0].activeID; got != "s1" {
 		t.Errorf("active session = %q, want the active card untouched", got)
 	}
 	closed, ok := events.events[0].data.(ClosedEvent)
@@ -278,9 +283,9 @@ func TestCloseAnInactiveSessionLeavesTheFocusAlone(t *testing.T) {
 	}
 }
 
-// The row is deleted before the PTY is asked to go, so a terminal that refuses
+// The row is written before the PTY is asked to go, so a terminal that refuses
 // to close leaves nothing to undo — and a card that stayed would point at a
-// session no other part of lich still knows about.
+// session the workspace no longer lists.
 func TestCloseTakesTheCardDownEvenWhenThePTYRefuses(t *testing.T) {
 	svc, sessions, _, term, events := closer(t)
 	term.closeErr = errors.New("process already gone")
@@ -288,8 +293,8 @@ func TestCloseTakesTheCardDownEvenWhenThePTYRefuses(t *testing.T) {
 	if _, err := svc.Close("s1", "shared-a", "", "", false); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	if len(sessions.deleted) != 1 {
-		t.Fatalf("deleted = %+v, want the row gone", sessions.deleted)
+	if len(sessions.parked) != 1 {
+		t.Fatalf("parked = %+v, want the row taken out of the workspace", sessions.parked)
 	}
 	if len(events.events) != 1 || events.events[0].name != ClosedEventName {
 		t.Errorf("events = %+v, want the card taken down anyway", events.events)
@@ -332,15 +337,15 @@ func TestCloseRefusesANameThatFitsTwoSessions(t *testing.T) {
 	if !strings.Contains(err.Error(), "narrow it with the project") {
 		t.Errorf("error = %q, want it to say how to pick one", err)
 	}
-	if len(sessions.deleted) != 0 {
-		t.Error("deleted a session picked by a name that named two")
+	if len(sessions.parked) != 0 {
+		t.Error("closed a session picked by a name that named two")
 	}
 	// Naming the project settles it.
 	if _, err := svc.Close("s9", "worker", "revu", "", false); err != nil {
 		t.Fatalf("Close with the project named: %v", err)
 	}
-	if len(sessions.deleted) != 1 || sessions.deleted[0].sessionID != "s2" {
-		t.Errorf("deleted = %+v, want the session in the named project", sessions.deleted)
+	if len(sessions.parked) != 1 || sessions.parked[0].sessionID != "s2" {
+		t.Errorf("parked = %+v, want the session in the named project", sessions.parked)
 	}
 }
 
@@ -385,7 +390,7 @@ func TestCloseTheLastSessionOfAProjectLeavesNoneActive(t *testing.T) {
 	if _, err := svc.Close("", "Session 1", "", "", false); err != nil {
 		t.Fatalf("Close: %v", err)
 	}
-	if got := sessions.deleted[0].activeID; got != "" {
+	if got := sessions.parked[0].activeID; got != "" {
 		t.Errorf("active session = %q, want none left", got)
 	}
 }

--- a/internal/spawn/park_test.go
+++ b/internal/spawn/park_test.go
@@ -1,0 +1,191 @@
+package spawn
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/store"
+)
+
+// parked runs the close against the real store rather than the fake, because
+// what these tests are about is not which method was called but what survives
+// the call: a row the workspace stops listing and the history starts to. Only
+// SQLite can answer that.
+//
+// The workspace it builds is the one a close has to tell apart: a session in the
+// project's own directory, two sharing one checkout, and one alone in another.
+func parked(t *testing.T) (*Service, *store.Service, *fakeWorktrees) {
+	t.Helper()
+	rows := realStore(t)
+	if err := rows.AddProject("p1", "lich", "/src/lich"); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+	for _, s := range []struct{ id, label, path string }{
+		{"s1", "Session 1", ""},
+		{"s2", "shared-a", "/wt/shared"},
+		{"s3", "shared-b", "/wt/shared"},
+		{"s4", "alone", "/wt/alone"},
+	} {
+		if err := rows.AddSession("p1", s.id, s.label, "claude", s.path, 9, ""); err != nil {
+			t.Fatalf("AddSession %q: %v", s.id, err)
+		}
+	}
+	worktrees := &fakeWorktrees{dirty: map[string]bool{}}
+	return New(rows, worktrees, &fakeTerminal{}, nil), rows, worktrees
+}
+
+// realStore opens a store on disk with the user's config directory redirected
+// into a temporary one.
+//
+// XDG_CONFIG_HOME alone is a Linux-only redirect: os.UserConfigDir reads
+// $HOME/Library/Application Support on macOS and %AppData% on Windows, so a test
+// setting only XDG would write its database into the real user's config
+// directory on the other two — agreeing with every assertion here and leaving a
+// file behind on a machine it was never supposed to touch. All three are set,
+// and the answer is read back from the standard library rather than rebuilt,
+// because the per-OS layout is its rule and not lich's.
+func realStore(t *testing.T) *store.Service {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", root)
+	t.Setenv("AppData", root)
+	t.Setenv("HOME", root)
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("resolve config directory: %v", err)
+	}
+	if !strings.HasPrefix(dir, root) {
+		t.Fatalf("config dir %q is outside the test's temp dir %q", dir, root)
+	}
+	rows, err := store.New()
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	t.Cleanup(func() { _ = rows.Close() })
+	return rows
+}
+
+// listed reports whether the workspace still shows the session, and whether the
+// history does. A parked row is in the second and not the first; a deleted one
+// is in neither.
+func listed(t *testing.T, rows *store.Service, id string) (open, history bool) {
+	t.Helper()
+	projects, err := rows.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	for _, p := range projects {
+		for _, sess := range p.Sessions {
+			if sess.ID == id {
+				open = true
+			}
+		}
+	}
+	closed, err := rows.ClosedSessions()
+	if err != nil {
+		t.Fatalf("ClosedSessions: %v", err)
+	}
+	for _, sess := range closed {
+		if sess.ID == id {
+			history = true
+		}
+	}
+	return open, history
+}
+
+// A session sharing its checkout closes without deciding anything about that
+// checkout — which is not a reason to destroy the row. `lich close` and the MCP
+// close_session tool go through here, and a deleted row takes the conversation,
+// the cost ledgers and the name the user chose with it.
+func TestClosingASharedCheckoutParksTheSession(t *testing.T) {
+	svc, rows, worktrees := parked(t)
+
+	if _, err := svc.Close("s1", "shared-a", "", "", false); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	open, history := listed(t, rows, "s2")
+	if open {
+		t.Error("the workspace still lists a session that was closed")
+	}
+	if !history {
+		t.Error("the closed session is in no history — its row was destroyed, not parked")
+	}
+	if len(worktrees.removed) != 0 {
+		t.Errorf("removed = %+v, want the checkout another session is in left alone", worktrees.removed)
+	}
+	// The session it shared the checkout with is untouched.
+	if open, _ := listed(t, rows, "s3"); !open {
+		t.Error("closing one session took its neighbour in the same checkout with it")
+	}
+}
+
+// A session in the project's own directory has no checkout at all, so there is
+// nothing to remove and nothing to decide — and still a conversation to keep.
+func TestClosingASessionInTheProjectDirectoryParksIt(t *testing.T) {
+	svc, rows, _ := parked(t)
+
+	if _, err := svc.Close("s2", "Session 1", "", "", false); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	open, history := listed(t, rows, "s1")
+	if open {
+		t.Error("the workspace still lists a session that was closed")
+	}
+	if !history {
+		t.Error("the closed session is in no history — its row was destroyed, not parked")
+	}
+}
+
+// The pin the other way: a row must not outlive the directory it points at, so
+// the one close that removes a checkout still deletes for good. It is the only
+// one that does.
+func TestClosingTheLastSessionAndRemovingItsWorktreeDeletesTheRow(t *testing.T) {
+	svc, rows, worktrees := parked(t)
+
+	if _, err := svc.Close("s1", "alone", "", "remove", false); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	open, history := listed(t, rows, "s4")
+	if open || history {
+		t.Errorf(
+			"session still listed (open %v, history %v) — a resume would open a directory that is gone",
+			open, history,
+		)
+	}
+	if len(worktrees.removed) != 1 || worktrees.removed[0].path != "/wt/alone" {
+		t.Errorf("removed = %+v, want the checkout deleted", worktrees.removed)
+	}
+}
+
+// Keeping the checkout parks too, and the history is where the two parked closes
+// meet: whichever way a session was closed, opening it again starts from a row
+// that is still there.
+func TestAParkedSessionIsFoundInTheHistoryWithItsName(t *testing.T) {
+	svc, rows, _ := parked(t)
+
+	if _, err := svc.Close("s1", "shared-a", "", "", false); err != nil {
+		t.Fatalf("Close shared-a: %v", err)
+	}
+	if _, err := svc.Close("s1", "alone", "", "keep", false); err != nil {
+		t.Fatalf("Close alone: %v", err)
+	}
+
+	closed, err := rows.ClosedSessions()
+	if err != nil {
+		t.Fatalf("ClosedSessions: %v", err)
+	}
+	found := map[string]store.ClosedSession{}
+	for _, sess := range closed {
+		found[sess.ID] = sess
+	}
+	if len(found) != 2 {
+		t.Fatalf("history = %+v, want both closed sessions", closed)
+	}
+	if got := found["s2"]; got.Label != "shared-a" || got.Path != "/wt/shared" || got.ProjectName != "lich" {
+		t.Errorf("history row = %+v, want the session identifiable by what the user called it", got)
+	}
+	if got := found["s4"]; got.Label != "alone" || got.Path != "/wt/alone" {
+		t.Errorf("history row = %+v, want the kept checkout's session findable too", got)
+	}
+}


### PR DESCRIPTION
## Every close parks a session — except the two `lich close` was deleting

This release made closing a session **park** it instead of deleting it: the row
survives with `is_open = 0`, so the palette's History tab can list it and opening
a session on that branch again picks the conversation back up. `CloseSession` in
`internal/store/mutations.go` says as much on its own doc — "Every close lands
here" — and the window keeps it: `closeSession` and `keepSession` both call
`Store.CloseSession`, and only `discardSession`, which removes the checkout,
calls `DeleteSession`.

`internal/spawn` did not keep it. Its plain-close path — a session that shares
its checkout with another, or lives in the project's own directory — called
`DeleteSession`. So `lich close <session>` and the MCP `close_session` tool
destroyed the row for good: the provider conversation id, the cost ledgers and
the name the user gave the card went with it, and the session reached no
history. That is the tool the lich MCP server's own instructions tell agents to
close their worker sessions with, so an orchestration that fanned work out and
tidied up after itself was throwing away every one of those conversations.

### What changed

- The plain-close path calls `CloseSession`. It is the only line of behaviour
  in the diff.
- `finish()` carried a comment saying "The row is already gone", which stops
  being true for that path. It now says the row is already written — parked, or
  deleted with its checkout.

### What was deliberately left alone

- **`removeCheckout` keeps `DeleteSession`, and must.** A row must not outlive
  the directory it points at, which is also why it calls
  `PurgeWorktreeSessions`: a parked row left behind would offer a resume into a
  checkout that no longer exists. The `last && KeepWorktree` path already called
  `CloseSession` and is untouched.
- **The `Closed` struct keeps its shape.** `Kept` answers the worktree
  question — did the checkout stay on disk — not what happened to the row. Now
  that every close but a removal parks, a field that is true on all of them
  tells a caller nothing, and setting `Kept` on the plain path would make
  `closedText` print "Its worktree  is still there" for a session that never had
  one. No new field was invented for the park; `Kept`'s doc now says which of
  the two questions it answers, and that nothing here reports the park.
- **`closedText` and the `close_session` description are unchanged.** Neither
  claimed the row was destroyed, so neither had anything false to correct.

### `docs/cli.md`

One bullet described the plain close as having "nothing at stake" and closing
"on the spot". Not false, but it sat directly under the `keep` bullet, which
spells the park out — the contrast read as "this one is gone". It now says the
plain close parks like every other close.

### No CHANGELOG entry

This is an unreleased regression: the parking contract and this hole in it both
landed after the last tag, so no published version ever behaved the broken way.
There is nothing for a user reading the release notes to have lived through.

## Test plan

New file `internal/spawn/park_test.go`, run against the **real** store rather
than the package's fake, because what is at stake here is not which method was
called but what survives the call — a row the workspace stops listing and the
history starts to. Only SQLite can answer that. It opens a store through
`store.New()` with `os.UserConfigDir` redirected into a temp directory, and
asserts the resolved path is inside it before anything is written.

- `TestClosingASharedCheckoutParksTheSession` — the row leaves `LoadState` and
  appears in `ClosedSessions`; the session sharing the checkout is untouched and
  no checkout is removed.
- `TestClosingASessionInTheProjectDirectoryParksIt` — the same for the session
  with no checkout at all.
- `TestClosingTheLastSessionAndRemovingItsWorktreeDeletesTheRow` — the pin the
  other way, so the fix cannot over-reach: `--worktree remove` still leaves the
  row in neither list.
- `TestAParkedSessionIsFoundInTheHistoryWithItsName` — both parked closes land
  in `ClosedSessions` carrying label, path and project name, which is what makes
  a closed session findable at all.

Every assertion is against literals — `"keep"`, `"remove"`, ids and labels —
never the constants the production code uses, so a rename of either constant
cannot make a test agree with a change it should have caught.

Six existing tests in `close_test.go` moved from asserting `deleted` to
asserting `parked`. Per CLAUDE.md Hard Invariant 2, a test may change for
exactly two reasons, and this is the first of them: **the contract changed**.
Those tests were not wrong about anything — they pinned the delete the plain
close used to do, and that delete is the bug. Nothing was weakened, skipped or
deleted to buy a green run.

Reverting the one-line fix and rerunning: three of the four new tests fail. The
fourth is the `--worktree remove` pin, which passes either way by design — that
is its job.

### Gate

| Check | Result |
| --- | --- |
| `gofmt -l .` | exit 0, no output |
| `LICH_LISTEN_PORT= go vet ./...` | exit 0 |
| `LICH_LISTEN_PORT= go test ./...` | exit 0, 31 packages |
| `LICH_LISTEN_PORT= go test -count=20 ./internal/spawn/` | exit 0, no flake |
| `for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done` | exit 0 each |
| `internal/spawn` coverage | 95.1% |

The cross-compile loop is run because `park_test.go` is a new `_test.go` with no
build tag, which passes on Linux and can break the cross-vet. Exit codes were
read directly rather than inferred from output.

No frontend file is touched, so the frontend gate does not apply.
