### PR TITLE
fix: withhold the plan gauge when lich's own environment bills an API key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,10 +175,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one. A session whose login is a long-lived token (`claude setup-token`) is
   measured through a one-token request, since the usage route refuses a token
   that can only infer; a session pointed at another API host or running on an API
-  key shows no gauge, having no plan to report. On macOS and Windows, where the
-  environment of another process is out of reach, a session running a configured
-  binary shows nothing rather than the wrong account's numbers. Codex sessions
-  follow the same rule through `CODEX_HOME`.
+  key shows no gauge, having no plan to report — and that now counts a machine
+  whose *own* environment carries one, which used to be read as a subscription
+  and drawn as a full gauge for a plan nothing on that machine was spending. On
+  macOS and Windows, where the environment of another process is out of reach, a
+  session running a configured binary shows nothing rather than the wrong
+  account's numbers. Codex sessions follow the same rule through `CODEX_HOME`.
 - **A keystroke no longer waits on a batching window that has nothing to batch.**
   A session's output is collected into short windows so a burst — a full-screen
   redraw, a build log — reaches the window as a couple of frames instead of

--- a/internal/quota/account_test.go
+++ b/internal/quota/account_test.go
@@ -278,7 +278,47 @@ func TestPlansWithoutASessionReadsLichOwnEnvironment(t *testing.T) {
 		return Account{}
 	})
 
-	if got := s.Plans("")[0]; got.Status != StatusOK || *calls != 1 {
+	// The plan name is the pin: whatever withholds a reading from an account
+	// lich does not bill must not reach the machine that has nothing to hide.
+	if got := s.Plans("")[0]; got.Status != "ok" || got.Plan != "Max 5x" || *calls != 1 {
 		t.Errorf("plan = %+v after %d calls, want the default login read", got, *calls)
+	}
+}
+
+func TestAnApiKeyInLichOwnEnvironmentWithholdsTheReading(t *testing.T) {
+	for _, name := range []string{"ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"} {
+		t.Run(name, func(t *testing.T) {
+			writeCreds(t, claudeCredsJSON, "")
+			t.Setenv(name, "sk-ant-whatever")
+			url, calls := serve(t, http.StatusOK, claudeLimitsBody)
+
+			got := newService(url, "", time.Now()).Plans("")[0]
+
+			if got.Status != "unknown" {
+				t.Errorf("status = %q, want %q", got.Status, "unknown")
+			}
+			if got.Plan != "" {
+				t.Errorf("plan = %q, want none: the login on disk is not what this machine bills", got.Plan)
+			}
+			if *calls != 0 {
+				t.Errorf("calls = %d, want none: there is no subscription being spent", *calls)
+			}
+		})
+	}
+}
+
+func TestASessionWithNoEnvironmentOfItsOwnSharesTheMachineReading(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	url, calls := serve(t, http.StatusOK, claudeLimitsBody)
+	s := newService(url, "", time.Now())
+	// macOS and Windows read no session environment at all, so every session
+	// there arrives shaped like this one — and spends what Settings reads.
+	s.SetSessions(func(string) Account { return Account{Read: true} })
+
+	s.Plans("")
+	s.Plans("session-1")
+
+	if *calls != 1 {
+		t.Errorf("calls = %d, want 1: both readings are the same account", *calls)
 	}
 }

--- a/internal/quota/claude.go
+++ b/internal/quota/claude.go
@@ -112,7 +112,7 @@ func (s *Service) claudePlan(a Account) Plan {
 	if token := a.Env[claudeTokenVar]; token != "" {
 		return s.claudeProbe(p, token)
 	}
-	path, ok := harnessFile(a.Env, claudeDirVar, ".claude", ".credentials.json")
+	path, ok := harnessFile(a, claudeDirVar, ".claude", ".credentials.json")
 	if !ok {
 		return failed(p)
 	}

--- a/internal/quota/codex.go
+++ b/internal/quota/codex.go
@@ -47,7 +47,7 @@ func (s *Service) codexPlan(a Account) Plan {
 	if a.hidden() {
 		return unknown(p)
 	}
-	path, ok := harnessFile(a.Env, codexHomeVar, ".codex", "auth.json")
+	path, ok := harnessFile(a, codexHomeVar, ".codex", "auth.json")
 	if !ok {
 		return failed(p)
 	}

--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -74,17 +74,22 @@ const (
 	StatusUnknown = "unknown"
 )
 
-// accountVars are the environment variables that decide which account a session
-// spends: Claude's own token and config dir, Codex's config dir, and the three
-// that point Claude somewhere other than the user's subscription.
-var accountVars = []string{
-	claudeTokenVar,
-	claudeDirVar,
-	codexHomeVar,
+// redirectVars point Claude at something other than the user's subscription:
+// another API host, or a key billed per token and metered by no plan.
+var redirectVars = []string{
 	"ANTHROPIC_BASE_URL",
 	"ANTHROPIC_API_KEY",
 	"ANTHROPIC_AUTH_TOKEN",
 }
+
+// accountVars are the environment variables that decide which account a session
+// spends: Claude's own token and config dir, Codex's config dir, and the three
+// that redirect Claude away from the subscription.
+var accountVars = append([]string{
+	claudeTokenVar,
+	claudeDirVar,
+	codexHomeVar,
+}, redirectVars...)
 
 // Window is one metered window of a plan: how much of it is spent, how long it
 // runs, and when it starts over.
@@ -125,14 +130,32 @@ type Account struct {
 // hidden reports an account lich cannot identify.
 func (a Account) hidden() bool { return a.Custom && !a.Read }
 
-// elsewhere reports a session pointed at something other than the user's own
-// subscription: another API host, or an API key, which is billed per token and
-// metered by no plan. Reading lich's own login for one of those would draw a
-// gauge for an account that session never touches.
+// lookup resolves one account-deciding variable: the session's own process
+// wins, else lich's own environment. Every helper that decides which account a
+// reading belongs to has to resolve through this one, because a helper reading
+// only Env is blind on the two paths that matter most — the machine-wide
+// reading Settings asks for carries no session environment, and on macOS and
+// Windows no session's environment is readable at all (internal/terminal's
+// envReadable). Let two of them disagree and the gauge comes back wrong rather
+// than absent: harnessFile finds lich's own credentials file while elsewhere
+// cannot see the API key saying that login is never billed.
+func (a Account) lookup(name string) string {
+	if v := a.Env[name]; v != "" {
+		return v
+	}
+	return os.Getenv(name)
+}
+
+// elsewhere reports an account pointed at something other than the user's own
+// subscription. Reading lich's own login for one of those would draw a gauge
+// for an account nobody is spending.
 func (a Account) elsewhere() bool {
-	return a.Env["ANTHROPIC_BASE_URL"] != "" ||
-		a.Env["ANTHROPIC_API_KEY"] != "" ||
-		a.Env["ANTHROPIC_AUTH_TOKEN"] != ""
+	for _, name := range redirectVars {
+		if a.lookup(name) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // Sessions answers what a session's process says about the account it spends.
@@ -212,6 +235,13 @@ func (s *Service) Plans(sessionID string) []Plan {
 // same login share one reading — and a session on another login gets its own
 // instead of being served someone else's numbers. Every account lich cannot
 // identify shares the one key whose reading needs no request at all.
+//
+// It keys on the session's own values alone, not on lookup: the fallback half
+// of lookup is lich's own environment, one constant for every account in the
+// process, so folding it in would lengthen every key without telling one more
+// pair of accounts apart. The account naming none of these — the machine-wide
+// reading, and every session on a platform whose environment lich cannot read
+// — keys empty, which is what puts it and Settings on one reading.
 func cacheKey(a Account) string {
 	if a.hidden() {
 		return "?"
@@ -257,11 +287,8 @@ func unknown(p Plan) Plan {
 // session's own environment wins over lich's — a wrapper binary exporting
 // another config dir is the whole reason this is not a plain os.Getenv. Mirrors
 // terminal.harnessDir, which resolves the same two directories for transcripts.
-func harnessFile(env map[string]string, homeVar, sub string, name ...string) (string, bool) {
-	base := env[homeVar]
-	if base == "" {
-		base = os.Getenv(homeVar)
-	}
+func harnessFile(a Account, homeVar, sub string, name ...string) (string, bool) {
+	base := a.lookup(homeVar)
 	if base == "" {
 		home, err := os.UserHomeDir()
 		if err != nil {

--- a/internal/quota/quota_test.go
+++ b/internal/quota/quota_test.go
@@ -42,6 +42,12 @@ func writeCreds(t *testing.T, claude, codex string) {
 	}
 	t.Setenv("CLAUDE_CONFIG_DIR", claudeDir)
 	t.Setenv("CODEX_HOME", codexDir)
+	// A developer machine that exports one of these bills an API key, and every
+	// reading below would correctly come back unknown. Clear them so the suite
+	// answers to the credentials written here and not to whoever runs it.
+	for _, name := range []string{"ANTHROPIC_BASE_URL", "ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"} {
+		t.Setenv(name, "")
+	}
 }
 
 // serve answers every request with status and body, and counts the calls.


### PR DESCRIPTION
Two helpers in `internal/quota` disagreed about whose environment decides which account a reading belongs to. `harnessFile` resolved a provider's state directory from the session's own environment and fell back to lich's, while `Account.elsewhere()` — the check that withholds a gauge from a session billing an API key rather than a subscription — looked at the session's environment alone and never at lich's.

So a machine that exports `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL` or `ANTHROPIC_AUTH_TOKEN` globally, spending no subscription at all, still had its credentials file read and a full subscription gauge drawn from it. Measured: with `ANTHROPIC_API_KEY` exported and a readable credentials file naming `subscriptionType: "max"` present, `Plans("")` came back with status `"ok"` and plan `"Max 5x"` — the reading was taken, and the number on screen belonged to a plan nothing on that machine was spending.

It reached users two ways:

- **The Settings screen, on every platform.** `Plans("")` is the machine-wide reading, and the machine-wide reading has no session environment by definition — so it fell into the gap every time.
- **The footer gauge of every session on macOS and Windows.** There, no other process's environment is readable (`internal/terminal`'s `envReadable` is false), so `Account.Env` is always nil and `elsewhere()` could never see anything at all.

Both are the failure the feature exists to prevent: a gauge drawn for the wrong account is worse than no gauge.

## What changed

`Account.lookup(name)` is now the one way an account-deciding variable is resolved — the session's own value when it has one, else `os.Getenv` — and both `elsewhere()` and `harnessFile` go through it. The comment on `lookup` says why they must agree rather than what it does: a helper reading only `Env` is blind on exactly the two paths above, and when the two disagree the result is a wrong gauge rather than an absent one.

The three redirect variables were extracted into `redirectVars`, with `accountVars` built from it, so the trio has a single definition. `hidden()` is untouched — a session lich cannot identify stays `unknown` for its own reason — and no new `Status` was added: `StatusUnknown` is already the right answer and the frontend already draws it.

**`cacheKey` is deliberately unchanged.** The fallback half of `lookup` is `os.Getenv`, one constant for every account inside a lich process. After the fix, two accounts can differ in `elsewhere()` or `harnessFile` only where their session environments differ, which `cacheKey` already keys on — folding lookup in would lengthen every key without telling one further pair of accounts apart. It would also open a collision that does not exist today: the machine-wide reading and a session re-exporting lich's own `CLAUDE_CODE_OAUTH_TOKEN` would collapse onto one key while `claudePlan` still routes them differently (credentials file vs. probe). The sharing that matters already holds — an account naming none of the six variables keys empty, so `Plans("")` and every session with no environment of its own (which is every session on macOS and Windows) share one entry. That is now pinned by a test rather than left to be rediscovered.

The `CHANGELOG.md` change amends the existing plan-gauge entry rather than adding a bullet, because this is not a new feature note: a user on a published version lived exactly what that entry describes backwards. The entry promised that a session on an API key shows no gauge; it now also covers a machine whose *own* environment carries one, which used to be read as a subscription.

## Test plan

Added in `internal/quota/account_test.go`, asserting against literals rather than the constants the production code uses:

- `TestAnApiKeyInLichOwnEnvironmentWithholdsTheReading` — a table over all three redirect variables. With one exported in lich's own environment and a readable credentials file present, `Plans("")` reports status `"unknown"`, an empty plan name, and makes zero HTTP calls.
- `TestASessionWithNoEnvironmentOfItsOwnSharesTheMachineReading` — `Plans("")` followed by `Plans("session-1")` with `Account{Read: true}` costs exactly one request. This is the `cacheKey` conclusion above, pinned.

**RED verified.** With `elsewhere()` reverted to reading `a.Env` alone, the first test fails with status `"ok"`, plan `"Max 5x"` and one call — the reported failure reproduced exactly, on all three variables. It passes with the fix.

Two over-reach pins, so the fix cannot answer the bug by blanking every gauge:

- `TestPlansWithoutASessionReadsLichOwnEnvironment` was strengthened to also assert `Plan == "Max 5x"`; it previously checked only the status and the call count, which a fix that returned `unknown` for everything would still have satisfied.
- `TestASessionPointedSomewhereElseIsUnknown` already covers a session whose *own* environment carries one of the three, over the same table, and was left as it stands rather than duplicated.

`writeCreds` now clears the three redirect variables. This is isolation from the ambient environment, not a weakened assertion (CLAUDE.md invariant 2): without it, every reading in the package comes back `unknown` — correctly, and for a reason that has nothing to do with the credentials the test wrote — on any developer machine that exports an API key. The helper already pins `CLAUDE_CONFIG_DIR` and `CODEX_HOME` for the same reason; these three were the gap.

Gate, exit codes read, `LICH_LISTEN_PORT` empty:

- `gofmt -l .` — nothing.
- `go vet ./...` — clean.
- `go test ./...` — green, no failures.
- `internal/quota` coverage: **94.6%** of statements.
- Cross-compile loop, `linux` / `darwin` / `windows` — `go build ./...` and `go vet ./...` clean on all three.

The frontend gate was not run: no frontend file is touched, and `api-types.ts` already carries `"unknown"` in `QuotaPlan.status`.

`docs/ceilings.md` is unmoved — this sets no new trap and closes no documented one. The existing bullet on which account a session spends already states that an account lich cannot identify shows nothing rather than the wrong numbers; this change is what makes that true on the two paths where it was not.
