### PR TITLE
fix(frontend): say why this machine cannot confine, per platform

### DIFF
--- a/frontend/src/components/settings/SandboxSettings.tsx
+++ b/frontend/src/components/settings/SandboxSettings.tsx
@@ -10,12 +10,20 @@ import {
   type SandboxLevel,
 } from "@/lib/providers-store"
 import { GH_ACCOUNT_KEY } from "@/lib/project-settings"
+import { isMac, isWindows } from "@/lib/platform"
+import { cannotConfineCopy } from "@/lib/sandbox-copy"
 import { splitAccount } from "@/lib/gh-account"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { Switch } from "@/components/ui/switch"
 import { SettingBlock } from "./SettingBlock"
 
 const GLOBAL_SCOPE = ""
+
+// Why this machine cannot confine, decided once. sandbox.Backend() answers ""
+// for three different reasons — no bubblewrap, no working sandbox-exec, no
+// backend at all on Windows — and by the time the pane reads it, the platform is
+// the only thing left that tells them apart.
+const cannotConfine = cannotConfineCopy(isWindows ? "windows" : isMac ? "mac" : "linux")
 
 // The rungs, ordered by how much of the machine a session can reach. Labels
 // alone: they carry their own meaning, and the ladder is now read as a whole —
@@ -104,9 +112,7 @@ export function SandboxSettings({ projectId }: { projectId?: string }) {
     return (
       <section className="py-5">
         <StatusStrip backend="" />
-        <p className="mt-2 max-w-prose text-xs text-muted-foreground">
-          Install bubblewrap and reopen lich. Until then every session runs on the machine.
-        </p>
+        <p className="mt-2 max-w-prose text-xs text-muted-foreground">{cannotConfine.advice}</p>
       </section>
     )
   }
@@ -213,7 +219,7 @@ function StatusStrip({ backend }: { backend: string }) {
       <span className="font-medium text-foreground">
         This machine {backend ? "can" : "cannot"} confine sessions
       </span>
-      <span className="text-muted-foreground">— {backend || "bubblewrap is not installed"}</span>
+      <span className="text-muted-foreground">— {backend || cannotConfine.reason}</span>
     </div>
   )
 }

--- a/frontend/src/lib/sandbox-copy.test.ts
+++ b/frontend/src/lib/sandbox-copy.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+import { cannotConfineCopy, type SandboxPlatform } from "./sandbox-copy"
+
+describe("cannotConfineCopy", () => {
+  it("keeps the bubblewrap install line on Linux", () => {
+    expect(cannotConfineCopy("linux")).toEqual({
+      reason: "bubblewrap is not installed",
+      advice: "Install bubblewrap and reopen lich. Until then every session runs on the machine.",
+    })
+  })
+
+  it("names sandbox-exec on macOS", () => {
+    expect(cannotConfineCopy("mac")).toEqual({
+      reason: "sandbox-exec is not available",
+      advice:
+        "macOS ships /usr/bin/sandbox-exec, so a machine without a working one is broken in a way lich cannot repair. Every session runs on the machine.",
+    })
+  })
+
+  it("tells Windows there is no backend rather than offering an install", () => {
+    expect(cannotConfineCopy("windows")).toEqual({
+      reason: "lich has no sandbox backend on Windows",
+      advice: "There is nothing to install — every session runs on the machine.",
+    })
+  })
+
+  it("does not repeat the reason in the advice on Windows", () => {
+    const { reason, advice } = cannotConfineCopy("windows")
+    expect(advice).not.toContain(reason)
+  })
+
+  it("names bubblewrap on Linux only", () => {
+    for (const platform of ["mac", "windows"] satisfies SandboxPlatform[]) {
+      const { reason, advice } = cannotConfineCopy(platform)
+      expect(`${reason} ${advice}`.toLowerCase()).not.toContain("bubblewrap")
+    }
+  })
+
+  it("says every session runs on the machine on all three", () => {
+    for (const platform of ["linux", "mac", "windows"] satisfies SandboxPlatform[]) {
+      expect(cannotConfineCopy(platform).advice.toLowerCase()).toContain(
+        "every session runs on the machine",
+      )
+    }
+  })
+})

--- a/frontend/src/lib/sandbox-copy.ts
+++ b/frontend/src/lib/sandbox-copy.ts
@@ -1,0 +1,32 @@
+// The three reasons sandbox.Backend() answers "", and the only place the pane is
+// told them apart. Only Linux's is about bubblewrap: macOS confines with
+// sandbox-exec, and Windows has no backend at all — telling either of them to go
+// install a Linux program is an error message about somebody else's machine.
+export type SandboxPlatform = "linux" | "mac" | "windows"
+
+export interface CannotConfineCopy {
+  // What the status strip says after the em dash: why this machine cannot.
+  reason: string
+  // The line under it: what, if anything, the user can do about it.
+  advice: string
+}
+
+export function cannotConfineCopy(platform: SandboxPlatform): CannotConfineCopy {
+  if (platform === "windows") {
+    return {
+      reason: "lich has no sandbox backend on Windows",
+      advice: "There is nothing to install — every session runs on the machine.",
+    }
+  }
+  if (platform === "mac") {
+    return {
+      reason: "sandbox-exec is not available",
+      advice:
+        "macOS ships /usr/bin/sandbox-exec, so a machine without a working one is broken in a way lich cannot repair. Every session runs on the machine.",
+    }
+  }
+  return {
+    reason: "bubblewrap is not installed",
+    advice: "Install bubblewrap and reopen lich. Until then every session runs on the machine.",
+  }
+}


### PR DESCRIPTION
`sandbox.Backend()` answers `""` for three different reasons, and the Sandbox pane knew only one of
them. It rendered a single "cannot confine" state with no platform gate at all, telling every user to
install bubblewrap:

- **Linux** (`internal/sandbox/bwrap_linux.go`) — bubblewrap is genuinely not on `PATH`. The copy was
  right here, and is unchanged.
- **macOS** (`internal/sandbox/seatbelt_darwin.go`) — `/usr/bin/sandbox-exec` is missing or not
  executable. macOS ships it, so this is a broken machine rather than a missing package, and bubblewrap
  has nothing to do with it.
- **Windows** (`internal/sandbox/unsupported.go`) — there is no sandbox backend at all and never was.
  bubblewrap does not exist on Windows, so the pane was pointing the user at a Linux program they cannot
  install and would not want.

`CLAUDE.md` opens by saying lich is built for other developers to use, "docs, errors and defaults answer
to a stranger". An error message that sends a Windows user shopping for a Linux program is that rule
inverted. `docs/ceilings.md` has said "Windows has no sandbox backend, so neither switch exists" for as
long as the port has existed — the pane was the one place that did not know it.

`cannotConfineCopy(platform)` in `frontend/src/lib/sandbox-copy.ts` now picks both strings — the status
strip's reason and the line under it — from the platform. The pane derives the platform once from
`isMac`/`isWindows` in `frontend/src/lib/platform.ts`. The markup is unchanged; only the two strings moved.

| platform | strip reason | advice below it |
| --- | --- | --- |
| linux | `bubblewrap is not installed` | `Install bubblewrap and reopen lich. Until then every session runs on the machine.` |
| mac | `sandbox-exec is not available` | `macOS ships /usr/bin/sandbox-exec, so a machine without a working one is broken in a way lich cannot repair. Every session runs on the machine.` |
| windows | `lich has no sandbox backend on Windows` | `There is nothing to install — every session runs on the machine.` |

Only Linux is offered an install, because Linux is the only one of the three where something can be
installed. Windows is told the plain fact and nothing else; macOS is told what is broken rather than a
repair lich is in no position to advise on.

## Test plan

The sentence-picking is a pure helper so the gate can actually hold it. The frontend suite runs in the
node environment and `src/**/*.tsx` is excluded from coverage by design, so a test that rendered the pane
would prove nothing it does not already prove — `frontend/src/lib/sandbox-copy.test.ts` targets the
helper instead, asserting against literals:

- one `toEqual` per platform pinning both strings verbatim (three tests),
- bubblewrap is named on Linux and on no other platform,
- every platform's advice still says a session runs on the machine, since that is the consequence the
  user is actually reading the pane for,
- the Windows advice does not contain the Windows reason: the two render one under the other, and the
  first draft repeated the sentence word for word.

Gate, binaries run directly and `$?` read after each (from `frontend/`):

- `./node_modules/.bin/vitest run` — 93 files, 1106 tests, exit 0
- `./node_modules/.bin/biome check .` — exit 0 (14 pre-existing warnings, the standing a11y backlog)
- `./node_modules/.bin/tsc -b --noEmit` — exit 0

No `CHANGELOG.md` entry: the Sandbox pane has never shipped in a release, so there is no version whose
users lived with the wrong message.
