### PR TITLE
docs: correct three comments the audit found saying the wrong thing

### DIFF
--- a/frontend/src/lib/quota/plan-quota-store.ts
+++ b/frontend/src/lib/quota/plan-quota-store.ts
@@ -41,6 +41,13 @@ const unchanged = (a: QuotaPlan[], b: QuotaPlan[]): boolean =>
 // taken for — "" is the machine-wide one the settings screen asks for — because
 // a session spawned from a binary the user configured can spend another account
 // entirely, and one card's numbers are not another's to show.
+//
+// An entry outlives its listeners: the poll stops when the last one leaves, the
+// reading it took does not. Switching back to a card therefore draws the numbers
+// it had while the fresh fetch is in flight, which is the same bargain the
+// unchanged-reading check above makes — a gauge that blanks is worse than one a
+// minute old. The cost is one small entry per session ever looked at, for the
+// life of the window, and that is the cheaper half of the trade.
 interface Entry {
   plans: QuotaPlan[]
   listeners: Set<() => void>

--- a/internal/system/sshagent.go
+++ b/internal/system/sshagent.go
@@ -16,7 +16,7 @@ import (
 const agentListTimeout = time.Second
 
 // SSHAgentKeys lists the identities loaded in the user's ssh agent, one line
-// each ("me@example.com (ED25519 256)"), newest gh has none first.
+// each ("me@example.com (ED25519 256)"), in the order the agent holds them.
 //
 // It exists for one sentence in the UI. The setting that hands a confined
 // session the ssh agent is read as "let it push with my GitHub key", and what it

--- a/internal/terminal/writequeue.go
+++ b/internal/terminal/writequeue.go
@@ -33,6 +33,13 @@ const writeQueueDepth = 64
 // back to when there is no client at all. A push that arrives once the queue is
 // closed waits for that drain before it reports failure, so the caller's own
 // fallback lands behind those frames rather than in front of them.
+//
+// That last guarantee is this queue's alone, and it does not survive the layer
+// above: transport.send answers a caller directly once forget has cleared the
+// writer, without coming through push at all, so a frame handed to the bridge
+// that way can overtake one this queue is still draining to it. Order across
+// the switch to the bridge is therefore not guaranteed — see the ceiling in
+// docs/ceilings.md, which is the honest account of it.
 type writeQueue struct {
 	mu   sync.Mutex
 	wake *sync.Cond


### PR DESCRIPTION
Three comments that describe the code wrongly. No behaviour changes here — the
diff is comments only — but each of these is the kind of line that costs the
next reader an hour, and two of them contradict something the repo already
states correctly elsewhere.

**`internal/terminal/writequeue.go`** — `push`'s doc promised that "a push that
arrives once the queue is closed waits for that drain before it reports failure,
so the caller's own fallback lands behind those frames rather than in front of
them." That holds for `push`, and not for the path above it: `transport.send`
answers a caller directly once `forget` has cleared the writer, without coming
through `push` at all, so a frame handed to the `/events` bridge that way can
overtake one this queue is still draining to it. `docs/ceilings.md` already says
exactly this — "output is never dropped but its order across that switch is not
guaranteed" — so the comment was the half that was wrong. It now points at the
ceiling instead of contradicting it.

**`internal/system/sshagent.go`** — `SSHAgentKeys`'s doc ended in a fragment,
"newest gh has none first", which describes nothing the function does and names
a command it never runs. It lists what the agent holds, in the agent's order.

**`frontend/src/lib/quota/plan-quota-store.ts`** — entries outlive their
listeners on purpose: the poll stops when the last subscriber leaves, the
reading it took does not, so switching back to a card draws the numbers it had
while the fresh fetch is in flight. That is the same bargain the
unchanged-reading check makes a few lines above — a gauge that blanks is worse
than one a minute old. Nothing said so, which left a map that only reads as
something nobody swept.

## Test plan

Comments only, so there is nothing new to assert and no test was added or
changed. The gate was run to prove the diff is inert:

- `gofmt -l .` — no output
- `LICH_LISTEN_PORT= go vet ./...` — clean
- `LICH_LISTEN_PORT= go test ./internal/terminal/ ./internal/system/` — 545 passed
- `./node_modules/.bin/biome check .` — exit 0
- `./node_modules/.bin/tsc -b --noEmit` — exit 0
- `./node_modules/.bin/vitest run src/lib/quota` — exit 0

No CHANGELOG entry: nothing here is visible to anyone running a published
version.