### PR TITLE
fix: write the Antigravity manifest only once the registration lands

### DIFF
--- a/internal/agentplugin/antigravity.go
+++ b/internal/agentplugin/antigravity.go
@@ -97,10 +97,19 @@ func (s *Service) antigravityInstall() error {
 	if err != nil {
 		return err
 	}
-	if err := writeFile(filepath.Join(dir, antigravityManifest), manifest, 0o644); err != nil {
+	// The registration goes in before the manifest, and the order is the whole
+	// guarantee: the manifest is what every later question reads as "installed,
+	// at this version" — Installed, the update check, and HasTools, which
+	// promises the session lich's own tools on the strength of it. Written
+	// first, a refused `agy mcp add` would leave an install that reported
+	// itself complete while the tools it claims were never registered, and the
+	// agent would meet that as an error at the prompt. Written last, a failure
+	// here leaves a directory with no version in it, which reads as not
+	// installed and is what the next install overwrites.
+	if err := s.antigravityRegisterMCP(); err != nil {
 		return err
 	}
-	return s.antigravityRegisterMCP()
+	return writeFile(filepath.Join(dir, antigravityManifest), manifest, 0o644)
 }
 
 // antigravityManifestFile is the manifest lich writes, carrying the released

--- a/internal/agentplugin/files_test.go
+++ b/internal/agentplugin/files_test.go
@@ -1065,3 +1065,38 @@ func TestAntigravityInstallWritesNothingWhenTheFetchFails(t *testing.T) {
 		t.Errorf("a failed install left a manifest behind (stat err = %v)", err)
 	}
 }
+
+// A refused `agy mcp add` must not leave an install that claims to be finished.
+// The manifest is what Installed, the update check and HasTools all read, and
+// HasTools promising lich's own tools is what an agent meets as an error at its
+// prompt — so the registration has to succeed before the version is written
+// down.
+func TestAntigravityInstallClaimsNothingWhenTheRegistrationFails(t *testing.T) {
+	dir := antigravityHome(t)
+	s, _ := fileServer(t, antigravityFiles())
+	antigravityCLI(t, s)
+	t.Setenv(fakeCLIFail, "mcp add")
+	s.lichBin = func() string { return "/opt/lich/lich" }
+
+	if err := s.Install(providers.Antigravity); err == nil {
+		t.Fatal("Install: want an error when the registration is refused, got nil")
+	}
+	// The hooks stay: they are written and they work, and the next install
+	// overwrites them. It is the claim that must not survive.
+	if _, err := os.Stat(filepath.Join(dir, antigravityHooksFile)); err != nil {
+		t.Errorf("the registration's own scripts were rolled back: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, antigravityManifest)); !os.IsNotExist(err) {
+		t.Errorf("a refused registration left a manifest behind (stat err = %v)", err)
+	}
+	if got, ok := s.installedVersion(providers.Antigravity); ok {
+		t.Errorf("installedVersion = (%q,true) after the registration failed, want false", got)
+	}
+	if s.Installed(providers.Antigravity) {
+		t.Error("Installed = true after the registration failed")
+	}
+	// HasTools is not asserted here, and the omission is the point: it reads the
+	// same manifest, so the three checks above already decide it — and at this
+	// fixture's version (below toolsMinVersion) it answers false either way,
+	// which would be an assertion that cannot fail.
+}


### PR DESCRIPTION
Found auditing #370.

## What was wrong

`antigravityInstall` wrote the manifest and then ran `agy mcp add`. The
manifest is what every later question reads as "installed, at this version":
`Installed`, the update check, and `HasTools` — which promises the session
lich's own MCP tools on the strength of it.

So a refused registration left an install that reported itself finished while
the tools it claimed had never been registered. `Install` returned an error and
the card said installed at the same time, and an Antigravity agent reaching for
`open_session` would meet it as an error at its prompt — the harm
`frontend/src/lib/session/delegate-prompt.ts` already names in its own comment.

That is the case `registersServerAtInstall` exists to prevent, and it only
covered the other half of it: a lich that cannot name its own binary registers
nothing, and `HasTools` answers false. A registration that was *attempted and
refused* had no such guard.

Measured before the fix, with the fake CLI refusing `mcp add`:

```
Install err   = ... mcp add lich /opt/lich/lich mcp: exit status 1
hooks.json    = present
installedVersion = ("0.8.0", true)
Installed        = true
HasTools         = true      (with a released version on the manifest)
```

opencode, oh-my-pi and Crush never had this shape: their registration is part
of the same file write, so it cannot half-succeed.

## What changed

The registration now runs before the manifest, so the manifest is the last
write and means what it says. A failure leaves the hooks and their scripts on
disk — they work, and the next install overwrites them — with no version to
read, which is exactly what a directory installed some other way already looks
like (`TestAntigravityInstalledVersionIgnoresAnUnversionedManifest` pins that
reading).

## Test plan

New `TestAntigravityInstallClaimsNothingWhenTheRegistrationFails`: a refused
`agy mcp add` leaves no manifest, no installed version and no `Installed`,
while the scripts stay on disk. The harness already had `fakeCLIFail`; this is
the first Antigravity test to use it.

Against the old order three of those assertions go red — verified by checking
out the pre-fix `antigravity.go` and re-running.

`HasTools` is deliberately **not** asserted, and the omission is commented in
the test: it reads the same manifest the three checks above already decide, and
at the fixture's version (0.8.0, below `toolsMinVersion` 0.9.0) it answers
false either way — which would be an assertion that cannot fail.

Gate:

- `gofmt -l .` — no output
- `LICH_LISTEN_PORT= go vet ./...` — clean
- `LICH_LISTEN_PORT= go test ./...` — 1916 passed, 32 packages
- cross-compile build + vet for linux, darwin, windows — clean on all three

No CHANGELOG entry: #370 has not shipped, so this corrects code no released
version ever ran.