### PR TITLE
docs: count the fifth harness, and reflow two paragraphs that were not

### DIFF
--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -171,14 +171,15 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   Claude Code card draws `lich · open_session`. The trap is reaching for `tool-label.ts` when that line looks
   wrong: the tool's identity arrives in a different field on this provider, and a plugin older than the release
   that added it sends `call_mcp_tool` with no detail at all.
-- **Only two of the four harnesses that report a tool spell an MCP one splittably** (`frontend/src/lib/session/tool-label.ts`,
+- **Only two of the five harnesses that report a tool spell an MCP one splittably** (`frontend/src/lib/session/tool-label.ts`,
   table in `docs/hooks/session-state.md`): Claude Code and Codex send `mcp__<server>__<tool>`, which the card draws
   as `<server> · <tool>`. omp's `mcp__<server>_<tool>` has one underscore doing two jobs — `mcp__lich_list_sessions`
   splits into `lich` + `list_sessions` or `lich_list` + `sessions` and the string cannot say which — so only its
   prefix comes off, and opencode's `<server>_<tool>` carries no marker at all and is shown whole. Nothing overflows
   anywhere (the line truncates), but on those two the card spends its width on a server name nobody asked for.
-  Splitting them needs the list of registered server names, which the card does not have. Crush is not on this
-  list at all: it reports no tool.
+  Splitting them needs the list of registered server names, which the card does not have. Antigravity is the fifth
+  and nothing here reaches it: its name is not a tool name at all, so the split never applies and the bullet above
+  is where that one is answered. Crush is on no version of this list: it reports no tool.
 - **Only Claude Code says what a session is waiting for; the others say less or nothing**
   (`frontend/src/components/sidebar/SessionCard.tsx`, table in `docs/hooks/session-state.md`): its
   `Notification` carries a `message` written for a human, so the card reads "Claude needs your permission to

--- a/internal/terminal/resume.go
+++ b/internal/terminal/resume.go
@@ -10,8 +10,9 @@ import "github.com/omartelo/lich/internal/providers"
 // one then dies inside the PTY with the provider's error in place of a session —
 // the shortcut Start's doc names. Antigravity is worse than that and the same
 // question answers it: a `--conversation` it cannot find is dropped with a log
-// line, so the session opens as a brand new conversation rather than failing. What the provider left on disk is what answers
-// the question; this asks it for existence alone.
+// line, so the session opens as a brand new conversation rather than failing.
+// What the provider left on disk is what answers the question; this asks it for
+// existence alone.
 //
 // cwd is the session's working directory, needed only by Crush: it keeps one
 // database per checkout rather than one per machine.

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -554,8 +554,8 @@ func TestResolveCommand(t *testing.T) {
 
 // TestResumeArgs proves each provider resumes in its own spelling — a flag of
 // its own for Claude Code, Antigravity and oh-my-pi, a subcommand for Codex, one
-// they happen to share for opencode and Crush — and that a kind with none wired never grows one: a shell
-// must not be handed a stray id.
+// they happen to share for opencode and Crush — and that a kind with none wired
+// never grows one: a shell must not be handed a stray id.
 func TestResumeArgs(t *testing.T) {
 	cases := []struct {
 		name, kind, resume string


### PR DESCRIPTION
Text only, all three found auditing #370. No behaviour changes.

**`docs/ceilings.md`** — the MCP-tool-name ceiling still opened with "Only two
of the **four** harnesses that report a tool spell an MCP one splittably", and
its enumeration (Claude Code, Codex, omp, opencode, with Crush called out as
reporting none) skipped Antigravity entirely. The table it cites in
`docs/hooks/session-state.md` now lists five.

Nothing about the trap was missing — the bullet #370 added right beside it
answers Antigravity in full, including why `tool-label.ts` is the wrong place
to look. What was wrong is that a reader counting the list finds a harness it
cannot place. It is counted now and pointed at its own bullet, rather than
described twice in two places that would then have to agree.

**`internal/terminal/resume.go`** and **`internal/terminal/terminal_test.go`**
— both had text inserted mid-paragraph without the paragraph being reflowed,
leaving a 125-column line and a 105 where the files wrap near 100. `gofmt` does
not read prose.

Only those two lines are touched. The other long lines in `terminal_test.go`
are pre-existing code, not comments, and are left alone.

## Test plan

Nothing to assert — the diff is comments and one markdown bullet. Run to prove
it is inert:

- `gofmt -l .` — no output
- `LICH_LISTEN_PORT= go vet ./...` — clean
- `LICH_LISTEN_PORT= go test ./internal/terminal/` — 526 passed
- re-scanned both files for lines over 100 columns: the two this fixes are gone

No CHANGELOG entry: nothing here is visible to anyone running a published
version.