### PR TITLE
docs: pin where a session title is cut, and by what

### DIFF
--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -104,7 +104,9 @@ two of the four reports and not four.
 [`docs/hooks/fixtures/`](hooks/fixtures/) is every contract as bytes, and the
 plugin's suite asserts against the same lines. A provider id lich has not
 registered is rejected by `/session-start` — so until the line below lands here,
-the plugin cannot carry a fixture for it and its own tests have to name the gap:
+the plugin cannot carry a fixture for it, and its own tests name the gap in a
+`PENDING_UPSTREAM` set that fails once the fixture lands — which is the signal
+to empty it:
 
 ```json
 {"name":"antigravity conversation id","body":{"session_id":"s1","provider_session_id":"…","provider":"antigravity"}, "accept":{…}}

--- a/docs/hooks/session-title.md
+++ b/docs/hooks/session-title.md
@@ -43,10 +43,23 @@ title=$(tac "$transcript_path" | grep -m1 '"type":"ai-title"' | jq -r '.aiTitle'
 
 A provider that generates no title sends whatever it names its own thread after
 — Codex uses the first user message verbatim, which the plugin reads from the
-rollout and trims to a card-sized label, and Antigravity is read the same way:
-its `Stop` payload carries a `transcriptPath` whose first `USER_INPUT` entry is
-that message. The contract only asks for a non-empty
-string; where it comes from is the client's business.
+rollout and trims to 80 characters, and Antigravity is read the same way: its
+`Stop` payload carries a `transcriptPath` whose first `USER_INPUT` entry is that
+message. The contract only asks for a non-empty string; where it comes from, and
+where it is cut, is the client's business.
+
+**A client that trims does it by codepoint, never by byte.** lich takes the
+string as sent and the card truncates what will not fit, so a title cut through
+the middle of a character is not rejected anywhere — it reaches the card as a
+trailing `U+FFFD`, and only for a title whose 80th character is not ASCII.
+`cut -c` is the way to get there: it counts characters only where the locale
+says UTF-8, and bytes under `LC_ALL=C`. lich passes the environment it was
+launched with straight into the PTY (`internal/terminal/childenv.go` drops
+AppImage internals and nothing else, and the sandbox sets only `HOME`), so a
+session started from a desktop carries that desktop's locale and never sees
+this. One started where the locale is not set does, and the report is the same
+shape either way — which is what makes it a thing to write down rather than to
+catch.
 
 Send it on `Stop`. Re-sending on every `Stop` is fine — lich only applies it
 while the label is still automatic (see below), so a stable title is idempotent.


### PR DESCRIPTION
Two notes the Antigravity work left owed. Docs only — no code changes.

## The title contract had no number

`docs/hooks/session-title.md` said the client trims to "a card-sized label", which nothing can be implemented against. The plugin cuts at **80 characters**, and does so in every harness whose title is read out of a transcript — Codex and Antigravity share the line.

Written down with the rule that makes 80 mean the same thing everywhere: **a trim counts codepoints, never bytes.** `cut -c` is the easy way to get that wrong — it counts characters only where the locale says UTF-8, and bytes under `LC_ALL=C`:

```
$ python3 -c "print('→'*40)" | cut -c 1-80 | tail -c 6 | xxd
00000000: 8692 e286 920a          ← whole character at the end

$ python3 -c "print('→'*40)" | LC_ALL=C cut -c 1-80 | tail -c 6 | xxd
00000000: e286 92e2 860a          ← cut through the last one
```

Checked lich's own side before writing it: `internal/terminal/childenv.go` drops AppImage internals and nothing else, and the sandbox sets only `HOME` (`internal/sandbox/bwrap_linux.go`), so the PTY carries whatever locale lich was launched with. A session started from a desktop never sees this; one started where the locale is not set does, and the report is the same shape either way — which is what makes it a thing to write down rather than something to catch.

Nothing here is a change lich can make. The string arrives as sent, the card truncates what will not fit, and a title cut through a character reaches it as a trailing `U+FFFD` — accepted everywhere, wrong only on screen. The fix belongs to the client, and `omartelo/lich-plugin` has it queued.

## The provider map now names the mechanism

`docs/adding-a-provider.md` described the fixture handshake without naming `PENDING_UPSTREAM` — the set on the plugin side that carries a provider id lich has not registered yet, and fails once the fixture lands, which is the signal to empty it. It is kept there deliberately, empty, for exactly this reason; the seventh provider should be able to find it by name.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean — no code touched
- [x] `go test ./internal/terminal/ -run Fixture` green (the contract docs' own suite)
- [x] Both `cut -c` behaviours reproduced on this machine, in a UTF-8 locale and under `LC_ALL=C`