### PR TITLE
chore: cut the 0.40.0 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.40.0] - 2026-08-23
+
 ### Added
 
 - **Antigravity CLI runs as a session, like every other provider.** Google's
@@ -3258,7 +3260,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.39.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.40.0...HEAD
+[0.40.0]: https://github.com/omartelo/lich/compare/v0.39.0...v0.40.0
 [0.39.0]: https://github.com/omartelo/lich/compare/v0.38.0...v0.39.0
 [0.38.0]: https://github.com/omartelo/lich/compare/v0.37.0...v0.38.0
 [0.37.0]: https://github.com/omartelo/lich/compare/v0.36.0...v0.37.0


### PR DESCRIPTION
Release prep for **v0.40.0**. CHANGELOG only — no code.

`[Unreleased]` stays at the top and empties; its entries move under
`## [0.40.0] - 2026-08-23`, sections kept in the canonical order they were
already in (Added, Changed, Removed, Fixed). The compare links move with it:
`[Unreleased]` now runs from `v0.40.0`, and `[0.40.0]` spans
`v0.39.0..v0.40.0`.

The heading spelling is load-bearing. `.github/workflows/release.yml` extracts
the release body with an awk anchored on `^## \[0.40.0\]` and ships an empty
one if it misses, so it was simulated against this file before committing:

```
awk -v ver="0.40.0" '$0 ~ "^## \\[" ver "\\]" { grab = 1; next }
                     grab && /^## \[/ { exit }
                     grab { print }' CHANGELOG.md
→ 234 lines, 4 section headings
```

## Test plan

The release checklist in CLAUDE.md, run on the merge base:

- `LICH_LISTEN_PORT= go test -race ./...` — 1916 passed, 32 packages, no data race
- `gofmt -l .` — no output
- `LICH_LISTEN_PORT= go vet ./...` — clean
- cross-compile build + vet for linux, darwin, windows — clean on all three
- `./node_modules/.bin/vitest run` — 93 files, 1108 tests
- `./node_modules/.bin/biome check .` — 0 errors
- `./node_modules/.bin/tsc && ./node_modules/.bin/vite build` — clean

Dependabot is at zero open alerts as of #374.

The `v0.40.0` tag goes on this once it lands — the release job reads the notes
from the tag's own tree, so the section has to be in `main` first.