### PR TITLE
fix: ask $PATH for a provider's binary, not its id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Settings › Antigravity no longer reports the binary it runs as missing.**
+  The Binary block asked $PATH for the provider's id, which is the command for
+  every provider but this one — Antigravity ships as `agy` — so a working
+  install opened on `not on $PATH — Sessions will not start until this is
+  fixed`, beside sessions that were starting perfectly well. The block now asks
+  for the executable a session actually spawns.
+
 ## [0.40.0] - 2026-08-23
 
 ### Added

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -88,10 +88,12 @@ function useSkipPermissions(providerId: string, worktree: boolean) {
 export function ProviderBinSettings({
   providerId,
   providerName,
+  providerBin,
   projectId,
 }: {
   providerId: string
   providerName: string
+  providerBin: string
   projectId?: string
 }) {
   const { showContextUsage, setShowContextUsage, costBudget, setCostBudget } = useSettings()
@@ -144,7 +146,12 @@ export function ProviderBinSettings({
           provider that meters no subscription. */}
       <PlanUsageSetting providerId={providerId} />
 
-      <ProviderBinary providerId={providerId} providerName={providerName} projectId={projectId} />
+      <ProviderBinary
+        providerId={providerId}
+        providerName={providerName}
+        providerBin={providerBin}
+        projectId={projectId}
+      />
 
       {/* Only providers with a context-window transcript reader carry this
           control; the underlying preference stays global. */}

--- a/frontend/src/components/settings/ProviderBinary.tsx
+++ b/frontend/src/components/settings/ProviderBinary.tsx
@@ -77,10 +77,13 @@ function useStoredFlag(key: string, scope: string | undefined) {
 export function ProviderBinary({
   providerId,
   providerName,
+  providerBin,
   projectId,
 }: {
   providerId: string
   providerName: string
+  /** The executable $PATH is asked for — a provider's id is not its command. */
+  providerBin: string
   projectId?: string
 }) {
   const { projects } = useProjects()
@@ -106,7 +109,7 @@ export function ProviderBinary({
   // Both layers go through the same check, so the bottom row answers with the
   // resolution the spawn would make rather than a second opinion about $PATH.
   const typed = useBinaryCheck(configured)
-  const onPath = useBinaryCheck(providerId)
+  const onPath = useBinaryCheck(providerBin)
   const check = scope === "path" ? onPath : typed
   const broken = failed(check)
 
@@ -183,7 +186,7 @@ export function ProviderBinary({
                 <Input
                   value={layer.value}
                   onChange={(event) => layer.persist(event.target.value)}
-                  placeholder={providerId}
+                  placeholder={providerBin}
                   spellCheck={false}
                   aria-label={`${providerName} binary for ${layer.label}`}
                   className={cn(
@@ -202,9 +205,9 @@ export function ProviderBinary({
                 </Button>
               </Layer>
             ))}
-            <Layer label="$PATH" wins={scope === "path"} check={onPath} value={providerId}>
+            <Layer label="$PATH" wins={scope === "path"} check={onPath} value={providerBin}>
               <span className="min-w-0 flex-1 truncate font-mono text-xs text-muted-foreground">
-                {onPath?.path || providerId}
+                {onPath?.path || providerBin}
               </span>
             </Layer>
           </div>
@@ -212,9 +215,9 @@ export function ProviderBinary({
       ) : (
         <div className="flex items-center justify-between gap-4">
           <span className="flex min-w-0 items-center gap-2 text-xs">
-            <Verdict check={check} bin={configured || providerId} />
+            <Verdict check={check} bin={configured || providerBin} />
             <span className="truncate font-mono text-foreground">
-              {check?.path || configured || providerId}
+              {check?.path || configured || providerBin}
             </span>
             <span className="whitespace-nowrap text-muted-foreground">
               · {sourceLabel(scope, project?.name)}
@@ -231,7 +234,7 @@ export function ProviderBinary({
         <p className="mt-3 flex max-w-prose items-start gap-2 text-xs text-destructive">
           <TriangleAlert className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
           <span>
-            <span className="font-medium">{checkLabel(check, configured || providerId)}</span> —{" "}
+            <span className="font-medium">{checkLabel(check, configured || providerBin)}</span> —{" "}
             {checkDetail(check)}
           </span>
         </p>

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -104,7 +104,12 @@ export function Settings() {
     label: provider.name,
     group: "provider",
     render: (id) => (
-      <ProviderBinSettings providerId={provider.id} providerName={provider.name} projectId={id} />
+      <ProviderBinSettings
+        providerId={provider.id}
+        providerName={provider.name}
+        providerBin={provider.binary}
+        projectId={id}
+      />
     ),
   }))
   const sections = [...BASE_SECTIONS, ...providerSections, ...FOOTER_SECTIONS]

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -464,6 +464,8 @@ export interface Diagnostics {
 export interface DetectedProvider {
   id: string
   name: string
+  /** The executable a session spawns. Not the id: Antigravity's is `agy`. */
+  binary: string
   installed: boolean
   path: string
 }

--- a/frontend/src/lib/provider-setup.test.ts
+++ b/frontend/src/lib/provider-setup.test.ts
@@ -5,6 +5,7 @@ import type { ProviderState } from "./providers-store"
 const p = (id: string, installed: boolean): ProviderState => ({
   id: id as ProviderState["id"],
   name: id,
+  binary: id,
   installed,
   enabled: false,
 })

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -138,6 +138,7 @@ describe("enabledProviders", () => {
   const p = (id: string, enabled: boolean, installed: boolean): ProviderState => ({
     id: id as ProviderState["id"],
     name: id,
+    binary: id,
     installed,
     enabled,
   })
@@ -153,6 +154,7 @@ describe("resolveDefaultProvider", () => {
   const p = (id: string, enabled: boolean): ProviderState => ({
     id: id as ProviderState["id"],
     name: id,
+    binary: id,
     installed: true,
     enabled,
   })
@@ -177,6 +179,7 @@ describe("resolveProjectDefaultProvider", () => {
   const p = (id: string, enabled: boolean): ProviderState => ({
     id: id as ProviderState["id"],
     name: id,
+    binary: id,
     installed: true,
     enabled,
   })
@@ -199,9 +202,16 @@ describe("resolveProjectDefaultProvider", () => {
 
 describe("createProvidersStore", () => {
   const detected: DetectedProvider[] = [
-    { id: "claude", name: "Claude Code", installed: true, path: "/usr/bin/claude" },
-    { id: "codex", name: "Codex", installed: false, path: "" },
-    { id: "mystery", name: "Mystery", installed: true, path: "/x" }, // unknown id
+    {
+      id: "claude",
+      name: "Claude Code",
+      binary: "claude",
+      installed: true,
+      path: "/usr/bin/claude",
+    },
+    // A binary that is not the id, which is what antigravity ships as.
+    { id: "codex", name: "Codex", binary: "cdx", installed: false, path: "" },
+    { id: "mystery", name: "Mystery", binary: "mystery", installed: true, path: "/x" }, // unknown id
   ]
 
   function build(enabledValues: Record<string, string> = {}, defaultValue = "") {
@@ -228,6 +238,9 @@ describe("createProvidersStore", () => {
     expect(got.find((p) => p.id === "claude")?.enabled).toBe(true)
     expect(got.find((p) => p.id === "codex")?.enabled).toBe(false)
     expect(got.find((p) => p.id === "codex")?.installed).toBe(false)
+    // Carried through, because the settings screen asks $PATH for this and not
+    // for the id.
+    expect(got.find((p) => p.id === "codex")?.binary).toBe("cdx")
   })
 
   it("honors a stored enabled flag over the default", async () => {

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -163,6 +163,8 @@ export function readEnabled(id: string, value: string): boolean {
 export interface ProviderState {
   id: ProviderKind
   name: string
+  /** The executable a session spawns — a provider id is not its command. */
+  binary: string
   installed: boolean
   enabled: boolean
 }
@@ -318,6 +320,7 @@ class ProviderStoreImpl implements ProvidersStore {
         .map(async (provider) => ({
           id: provider.id as ProviderKind,
           name: provider.name,
+          binary: provider.binary,
           installed: provider.installed,
           enabled: readEnabled(provider.id, await this.deps.getEnabled(provider.id)),
         })),

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -79,9 +79,13 @@ func DefaultBinary(id string) string {
 }
 
 // Detected reports a provider and whether one of its binaries was found on PATH.
+// Binary is the executable name a session spawns (DefaultBinary), which the
+// settings screen needs even when nothing was found: a provider id is not its
+// command — Antigravity's is `agy`.
 type Detected struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`
+	Binary    string `json:"binary"`
 	Installed bool   `json:"installed"`
 	Path      string `json:"path"`
 }
@@ -102,7 +106,7 @@ func New() *Service {
 func (s *Service) Detect() ([]Detected, error) {
 	out := make([]Detected, 0, len(Registry))
 	for _, p := range Registry {
-		d := Detected{ID: p.ID, Name: p.Name}
+		d := Detected{ID: p.ID, Name: p.Name, Binary: DefaultBinary(p.ID)}
 		for _, name := range p.Binaries {
 			if path, err := s.lookPath(name); err == nil {
 				d.Installed = true

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -59,6 +59,25 @@ func TestDetect(t *testing.T) {
 	}
 }
 
+// TestDetectCarriesTheBinary pins the field the settings screen asks $PATH for.
+// Antigravity is the case that matters: its id is not its command, so a screen
+// falling back to the id verifies a binary nobody ships.
+func TestDetectCarriesTheBinary(t *testing.T) {
+	svc := &Service{lookPath: func(string) (string, error) { return "", exec.ErrNotFound }}
+	got, err := svc.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	for _, d := range got {
+		if d.Binary != DefaultBinary(d.ID) || d.Binary == "" {
+			t.Errorf("%s binary = %q, want %q", d.ID, d.Binary, DefaultBinary(d.ID))
+		}
+	}
+	if got[2].ID != Antigravity || got[2].Binary != "agy" {
+		t.Errorf("antigravity = %+v, want binary agy", got[2])
+	}
+}
+
 func TestDetectAllMissing(t *testing.T) {
 	svc := &Service{lookPath: func(string) (string, error) { return "", errors.New("nope") }}
 	got, err := svc.Detect()


### PR DESCRIPTION
Settings › Antigravity opened on `not on $PATH — Sessions will not start until this is fixed`, beside Antigravity sessions that were running and a Providers list that read `Installed`.

The Binary block verified the **provider id** against `$PATH`. For five of the six providers the id is the command; Antigravity's is not — it ships as `agy`. Nothing else shared that assumption: the spawn resolves `providers.DefaultBinary` (`internal/terminal/command.go`) and detection walks `Provider.Binaries`, so only the screen had its own opinion, and it was wrong about the one provider whose name differs.

## What changed

- `providers.Detected` carries `Binary` — the executable a session spawns — so the name is served rather than guessed. `Path` was no help here: it is empty exactly when the check has something to report.
- `DetectedProvider` / `ProviderState` mirror the field, and `ProviderBinary` takes `providerBin` instead of reaching for `providerId`: the `$PATH` check, the override placeholders, the `$PATH` row, the closed-state readout and the error sentence.

## Test plan

- [x] `TestDetectCarriesTheBinary` pins `Binary == DefaultBinary` for every provider, and `agy` for Antigravity by name.
- [x] The store test carries a binary that is not the id (`codex` → `cdx`), which is the shape that used to slip through.
- [x] Local gate: `gofmt -l .`, `go vet ./...`, `go test ./...` (1917), `vitest` (1108), `tsc --noEmit`, `vite build`, biome clean.
- [x] Settings › Antigravity now reads `executable · from $PATH` with the resolved `agy` path.