### PR TITLE
chore: cut the 0.40.1 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.40.1] - 2026-08-24
+
 ### Fixed
 
 - **Settings › Antigravity no longer reports the binary it runs as missing.**
@@ -3269,7 +3271,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.40.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.40.1...HEAD
+[0.40.1]: https://github.com/omartelo/lich/compare/v0.40.0...v0.40.1
 [0.40.0]: https://github.com/omartelo/lich/compare/v0.39.0...v0.40.0
 [0.39.0]: https://github.com/omartelo/lich/compare/v0.38.0...v0.39.0
 [0.38.0]: https://github.com/omartelo/lich/compare/v0.37.0...v0.38.0


### PR DESCRIPTION
Moves the `[Unreleased]` entry under `## [0.40.1] - 2026-08-24` and refreshes the compare links, so `release.yml` finds notes when the `v0.40.1` tag lands.

A patch release: one user-facing fix (#376), no API or behaviour change beyond it.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test -race ./...` (1917) green.
- [x] `tsc --noEmit`, `vitest` (1108), `vite build`, biome clean.
- [x] `grep '^## \[0.40.1\]' CHANGELOG.md` matches the heading the release job greps for.