### PR TITLE
fix: make the Taskfile work on a plain Windows box

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,10 @@ task --list   # everything else
 `task dev` gets its own database, port and Chromium profile, so it never
 touches the workspace of a lich you have installed.
 
+**On Windows**, put `C:\Program Files\Git\usr\bin` on `PATH` first. Task runs
+every command through its own embedded shell, and `task dev` reaches for `sleep`
+and `kill` — Git for Windows ships both, but only that directory has them.
+
 The frontend is **pnpm**, not npm — `npm install` errors out.
 
 ## Before you open a pull request

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,8 +9,12 @@ vars:
   BIN_DIR: "bin"
   VITE_PORT: '{{.LICH_VITE_PORT | default 9245}}'
   # Package version follows the git tag (env VERSION overrides) — no manual bump.
-  VERSION:
-    sh: echo "${VERSION:-$(git describe --tags --always 2>/dev/null | sed 's/^v//')}"
+  # The tag is trimmed in the template, not with sed: Task's shell is mvdan/sh
+  # on every OS, and a plain Windows box has no sed on PATH — the pipeline would
+  # fail silently and stamp an empty version into the binary.
+  RAW_VERSION:
+    sh: echo "${VERSION:-$(git describe --tags --always 2>/dev/null)}"
+  VERSION: '{{trimPrefix "v" .RAW_VERSION}}'
   # -X main.version stamps the git tag into the binary so the in-app update
   # check knows what it is running (dev builds via `go run` stay "dev").
   LDFLAGS: '-s -w -X main.version={{.VERSION}}'
@@ -26,7 +30,10 @@ tasks:
     desc: Build the static binary into bin/
     deps: [build:frontend]
     cmds:
-      - cmd: CGO_ENABLED=0 go build {{.GO_BUILD_FLAGS}} -o {{.BIN_DIR}}/{{.APP_NAME}} .
+      # {{exeExt}}: `go build -o bin/lich` writes exactly that name — no .exe —
+      # and Windows then refuses to exec it (PATHEXT resolution needs the
+      # extension), so `task run` fails on the binary `task build` just made.
+      - cmd: CGO_ENABLED=0 go build {{.GO_BUILD_FLAGS}} -o {{.BIN_DIR}}/{{.APP_NAME}}{{exeExt}} .
 
   icons:windows:
     desc: Regenerate rsrc_windows_amd64.syso from build/windows/lich.ico
@@ -68,7 +75,7 @@ tasks:
     desc: Build and run
     deps: [build]
     cmds:
-      - cmd: ./{{.BIN_DIR}}/{{.APP_NAME}}
+      - cmd: ./{{.BIN_DIR}}/{{.APP_NAME}}{{exeExt}}
 
   dev:
     desc: Dev mode — Vite HMR, isolated DB, port and Chromium profile


### PR DESCRIPTION
Task interprets every command with its own embedded shell (mvdan/sh) on every OS — the parent shell is never used, so `PATH` alone decides what exists. A Windows box without Git's `usr/bin` has no `sed`, `sleep` or `kill`, and three of our tasks quietly depend on them.

## What broke

- **`task build` + `task run`** — `go build -o bin/lich` writes exactly that name (Go only appends `.exe` when `-o` names a *directory*). Windows resolves executables through `PATHEXT`, so it refuses to run the extensionless file, and `task run` failed on the binary `task build` had just produced.
- **The stamped version** — `git describe --tags | sed 's/^v//'`. With no `sed`, the pipeline fails but Task does *not* abort: the var resolves empty and the build ships `-ldflags "-X main.version="`. A Windows build had no version, and the in-app update check had nothing to compare against.
- **`task dev`** — `sleep 1.5` under `set -e` kills the task right after Vite starts, and the `trap 'kill $VITE_PID' EXIT` has nothing to run either.

## What this changes

- `{{exeExt}}` on the `build` and `run` paths — `bin/lich` on Unix, `bin/lich.exe` on Windows.
- The tag is trimmed by the template (`trimPrefix "v"`) instead of `sed`, so the version needs no external tool anywhere.
- `task dev` keeps `sleep`/`kill`: CONTRIBUTING now says to put `C:\Program Files\Git\usr\bin` on `PATH` on Windows, which is where both come from.

Rewriting `dev` to need neither (Task `deps` running in parallel, no sleep) is deliberately left out: it costs Vite outliving the backend and a race on the first load, for a command that works once that directory is on `PATH`.

## Why CI never caught it

The only Windows job that runs `task` is `release.yml`, and its steps default to git-bash — which already carries `sed`, `sleep` and `kill` on `PATH`. `ci.yml`'s Windows leg runs `go test` directly and never touches the Taskfile.

## Test plan

- [x] `task build --dry` / `task run --dry` on Linux — `-o bin/lich`, version `0.40.1`, unchanged.
- [x] Measured with `GOOS=windows go build`: `-o out/lich` → `lich`, `-o out/` → `x.exe`.
- [x] Measured under Task's shell with an emptied `PATH`: `sleep`, `kill` and `sed` all resolve as external commands, and a failing `sh:` var resolves empty without failing the task.
- [ ] `task build` + `task run` on a real Windows box (no hardware here).

No `CHANGELOG.md` entry: nothing here reaches a user of a published version — the shipped Windows binary already came from `build:windows`, which always named it `.exe`.