### PR TITLE
fix: run `task dev` without sleep or kill on PATH

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,11 +31,9 @@ task --list   # everything else
 ```
 
 `task dev` gets its own database, port and Chromium profile, so it never
-touches the workspace of a lich you have installed.
-
-**On Windows**, put `C:\Program Files\Git\usr\bin` on `PATH` first. Task runs
-every command through its own embedded shell, and `task dev` reaches for `sleep`
-and `kill` — Git for Windows ships both, but only that directory has them.
+touches the workspace of a lich you have installed. Stop it with Ctrl+C — that
+takes the Vite server with it; closing the window leaves Vite running, and the
+next `task dev` refuses to start on the port it still holds.
 
 The frontend is **pnpm**, not npm — `npm install` errors out.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -88,12 +88,15 @@ tasks:
       - cmd: |
           set -e
           (cd frontend && pnpm install --frozen-lockfile && pnpm run build)
+          # Ctrl+C reaches the whole process group and takes Vite with it;
+          # closing the window instead leaves it running (Task's shell has no
+          # kill and its `$!` is not a pid) — vite's strictPort then says so.
           (cd frontend && pnpm run dev) &
-          VITE_PID=$!
-          # Task's embedded shell (mvdan/sh) only knows the EXIT trap; Ctrl+C
-          # reaches the whole process group (Vite included) on its own.
-          trap 'kill $VITE_PID 2>/dev/null || true' EXIT
-          sleep 1.5
+          # node, not `sleep`: Task interprets every command with its own shell
+          # (mvdan/sh) on every OS, where sleep is no builtin — a plain Windows
+          # box has no such binary on PATH and `task dev` dies right here. node
+          # is already required by the pnpm line above.
+          node -e "setTimeout(() => {}, 1500)"
           LICH_DEV=1 LICH_DEV_URL="http://127.0.0.1:{{.VITE_PORT}}" LICH_LISTEN_PORT=47822 go run .
 
   test:


### PR DESCRIPTION
`task dev` died on a plain Windows box at the line that gives Vite its head start.

Task interprets every command with its own embedded shell (mvdan/sh) on every OS, so `PATH` alone decides what exists — and `sleep` is no builtin there. Without Git's `usr/bin` on `PATH` the command fails, `set -e` sees it, and the task ends right before `go run .`. node already has to be on `PATH` for the pnpm line two rows up, and `setTimeout` waits the same 1.5s everywhere.

The EXIT trap goes with it. `kill` is no builtin either, and mvdan/sh's `$!` hands back a job id (`g1`), not a pid — so `kill $VITE_PID` has never reaped anything, on any OS; `2>/dev/null || true` only hid the error. Measured, not assumed:

```
$ task t   # PATH=/nonexistent sleep 0.2
"sleep": executable file not found in $PATH
$ task t   # PATH=/nonexistent kill -0 $$
kill: unimplemented builtin
$ task t   # echo $! for a background job
g1
```

What is left is the truth, now written down: Ctrl+C reaches the whole process group and takes Vite with it; closing the window leaves Vite running, and `strictPort: true` (already in `vite.config.ts`) makes the next `task dev` refuse the port instead of quietly serving the stale server. A real reaper would have to kill a process *tree* — pnpm spawns vite as a grandchild, and no portable one-liner does that on Windows.

CONTRIBUTING loses the "put `C:\Program Files\Git\usr\bin` on PATH first" paragraph, which is no longer true, and gains the sentence about how to stop the dev rig.

No `CHANGELOG.md` entry: contributor tooling, nothing a user of a published version can see.

## Test plan

- [x] `task --dry dev` renders the block
- [x] `sleep`/`kill` absence and `$!` reproduced under Task 3.48.0 (output above)
- [x] `node -e "setTimeout(() => {}, 1500)"` waits under Task's shell
- [ ] `task dev` on a Windows box without Git's `usr/bin` on `PATH`