### PR TITLE
feat: narrow the Review panel to the last turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The Review panel can narrow to the last turn.** A session that reports its
+  state gains a switch above the file list: **Working tree** is the panel you
+  already had — everything uncommitted — and **Last turn** shows only what
+  changed on disk while that session's last finished turn ran, with the diff,
+  the comment batch and the file actions all working as before. It is a window
+  of time and not an attribution: a formatter, an editor open beside lich and
+  your own hands all land inside it, which is what the panel says. A turn that
+  changed nothing says so in as many words, and a turn nobody recorded says
+  something different — the two are never shown as each other. Sessions whose
+  provider reports no state at all (Crush today, Cursor CLI until its plugin
+  lands) have no turn to bracket, so the switch is simply absent there.
 - **Cursor CLI runs as a session.** Cursor's `cursor-agent` joins Claude Code,
   Codex, Antigravity, opencode, oh-my-pi and Crush in Settings › Providers: a
   session of its own, resumed after a restart, run without permission prompts if

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -42,6 +42,22 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   fires there. And an errand the relay delivered survives an interrupt on purpose: stopping a turn is not
   answering the request, so the sender keeps waiting for the target's next turn rather than being told the work
   is over.
+- **The Review panel's "Last turn" is a window of wall-clock time, and it lives in memory**
+  (`internal/terminal/turnsnap.go`, `internal/project/turnsnap.go`): the panel brackets a turn with two
+  `git write-tree` snapshots taken against an index of lich's own, so what it shows is everything that
+  touched the checkout between the `busy` and the `done` — a formatter, an editor open beside lich, the
+  user's own hands. Nothing in it can attribute a line, which is why the copy names the window and never
+  the agent. Four traps follow. The pair is held in Go memory alone: a lich restart empties it, so every
+  live session reads "No last turn recorded" until its next turn ends, and that wording is the same one a
+  session whose first turn is still running gets — the panel cannot say which. `add -A` obeys `.gitignore`
+  (deliberately, so this and `DiffText` never disagree about which files exist), so a turn that only
+  touched ignored files reports itself as having changed nothing. Every snapshot in the app runs on one
+  FIFO worker, because git refuses a second `add` against an index another holds — so one session's first
+  snapshot of a large checkout delays the next session's, and a queue past `snapQueueDepth` drops a job,
+  costing that turn its record with only the log saying so. And the boundary is the session-state contract,
+  so **Crush and Cursor CLI have no last turn at all**: neither reports a state (`docs/hooks/session-state.md`),
+  so nothing ever opens or closes a window there and the switch is never drawn — a rule read off the
+  session's own reports, not a list of providers, so it corrects itself the day either one starts reporting.
 - **A finished turn is unread until its own card is watched** (`frontend/src/lib/session/session-status-store.ts`,
   `frontend/src/providers/projects.tsx`): the solid emerald ring means "back from the agent, not read yet", and it
   fades only for the session whose terminal is on screen **while the window has focus**. Two things follow. A card

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -274,6 +274,16 @@ missing reason never costs a bell.
   same rule as `turnLog`: a `waiting` inside a turn is published, because it is
   the state that means "do not send work here", and one outside a turn is not,
   because a session idle at its prompt is the most available it will ever be.
+- **The turn's window** — `internal/terminal/turnsnap.go`: reads the same stream
+  for a third question, what the turn changed on disk. `busy` opens a window and
+  `done` closes it, each taking a `git write-tree` snapshot of the session's
+  checkout; the Review panel diffs the pair. Only the first `busy` of a run opens
+  anything — the repeat every provider sends between tools would otherwise walk
+  the opening snapshot forward through the turn it is meant to precede — and
+  `idle` abandons an open window rather than closing it, there being no closing
+  report coming. lich's own `interrupted` closes one: a stopped turn is a turn
+  that ended, and it changed files like any other. A provider that reports no
+  state has no window here at all, which today is Crush and Cursor CLI.
 - **Store** — `frontend/src/lib/session/session-status-store.ts`: one subscription taken
   at page load keeps the last state of every session, keyed by id. The card
   cannot hold it: the sidebar only renders cards for the active project, so

--- a/frontend/src/components/diff/ReviewPanel.tsx
+++ b/frontend/src/components/diff/ReviewPanel.tsx
@@ -1,10 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 import { Notice } from "@/components/common/Notice"
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import type { LastTurn } from "@/lib/api-types"
 import { discardTargets, parseDiff, type DiffFile } from "@/lib/git/diff"
 import { addReviewComment } from "@/lib/review-comments"
-import { ProjectService } from "@/lib/rpc"
+import { ProjectService, Terminal } from "@/lib/rpc"
 import { useActiveSession } from "@/lib/session/use-active-session"
+import { formatAge, subscribeAge } from "@/lib/session/session-age"
+import { useSessionEverReported, useSessionStatus } from "@/lib/session/use-session-status"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { useInject } from "@/lib/use-inject"
 import { errorText } from "@/lib/utils"
@@ -21,10 +25,23 @@ import { FileDiff } from "./FileDiff"
 // counts stood still — not one tick, but indefinitely.
 const DIFF_POLL_MS = 2_000
 
-// ReviewPanel is the Review tab's body: the active session's uncommitted diff,
-// one collapsible file at a time. Context-menu actions write file/line
-// references into the session's PTY, mirroring the footer's attach-file button,
-// or hold a comment on the selection for the batch at the panel's foot.
+// Which changes the panel is showing. "worktree" is everything uncommitted, the
+// panel's original and default answer; "turn" narrows it to the window the
+// session's last finished turn ran in (internal/terminal.LastTurnDiff).
+type DiffSource = "worktree" | "turn"
+
+// Said in full on the option itself, because the card cannot: the pair of
+// snapshots brackets wall-clock time, so every hand that touched the checkout
+// while the turn ran is inside it. Nothing here can attribute a line, and the
+// wording must not imply otherwise.
+const LAST_TURN_HINT =
+  "What changed on disk while the last turn ran — including edits from a formatter, your editor, or you."
+
+// ReviewPanel is the Review tab's body: the active session's diff, one
+// collapsible file at a time, read either from the working tree or from the
+// session's last finished turn. Context-menu actions write file/line references
+// into the session's PTY, mirroring the footer's attach-file button, or hold a
+// comment on the selection for the batch at the panel's foot.
 // It follows the active session — a worktree session reviews its checkout, not
 // the project root. The dock (RightDock) owns the surrounding chrome: width,
 // full screen, the tab bar and the close button.
@@ -32,8 +49,15 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
   const { sessionId, path } = useActiveSession()
   const inject = useInject(sessionId)
   const status = useGitStatus(path)
+  // The source switch is earned, not assumed: a provider that never reports its
+  // state has no turn to bracket, so it is offered the working tree alone.
+  const switchable = useSessionEverReported(sessionId)
+  const sessionStatus = useSessionStatus(sessionId)
+  const [source, setSource] = useState<DiffSource>("worktree")
   const [files, setFiles] = useState<DiffFile[] | null>(null)
   const [failed, setFailed] = useState(false)
+  const [turnState, setTurnState] = useState<string | null>(null)
+  const [endedAt, setEndedAt] = useState<number | null>(null)
   const [pendingDiscard, setPendingDiscard] = useState<DiffFile | null>(null)
 
   // The text behind what is on screen, and the id of the newest read — a reply
@@ -51,11 +75,20 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
     }
     const mine = ++seq.current
     try {
-      const text = await ProjectService.DiffText(path)
+      // The working tree wears the same shape rather than branching the whole
+      // read: it is always "ok", it has no window to date, and every line below
+      // then reads one source.
+      const turn: LastTurn =
+        source === "turn"
+          ? await Terminal.LastTurnDiff(sessionId)
+          : { state: "ok", diff: await ProjectService.DiffText(path) }
       if (mine !== seq.current) {
         return
       }
       setFailed(false)
+      setTurnState(turn.state)
+      setEndedAt(turn.endedAt ?? null)
+      const text = turn.diff ?? ""
       if (text === lastText.current) {
         return
       }
@@ -69,16 +102,44 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
       setFiles([])
       setFailed(true)
     }
-  }, [path])
+  }, [path, sessionId, source])
+
+  // Switching source — or checkout — invalidates the held text rather than
+  // trusting the identity check below it: two sources legitimately produce the
+  // same string, most often "", and the short-circuit would leave the previous
+  // source's files on screen under the new source's name.
+  useEffect(() => {
+    lastText.current = null
+    setFiles(null)
+    setTurnState(null)
+    setEndedAt(null)
+  }, [source, path, sessionId])
+
+  // A source the session cannot answer for must not stay selected: a resumed
+  // card, or one whose provider stopped reporting, would sit on an empty panel
+  // with no control on screen to leave it by.
+  useEffect(() => {
+    if (!switchable) {
+      setSource("worktree")
+    }
+  }, [switchable])
 
   // Two signals feeding one read: the status counts move the instant a file is
   // touched, so they invalidate immediately, and the interval covers the edits
   // they are blind to (see DIFF_POLL_MS).
+  //
+  // A finished turn has neither problem — it cannot change once it is over — so
+  // that source is not polled at all. The session's own state is what moves it:
+  // every transition is a turn starting or ending, and the panel answers for the
+  // last one that ended.
   useEffect(() => {
     void refresh()
+    if (source === "turn") {
+      return
+    }
     const timer = setInterval(() => void refresh(), DIFF_POLL_MS)
     return () => clearInterval(timer)
-  }, [refresh, status?.files, status?.added, status?.deleted])
+  }, [refresh, source, sessionStatus, status?.files, status?.added, status?.deleted])
 
   // Reverting a rename touches both paths (new removed, old restored); the
   // panel refreshes immediately instead of waiting for the next poll tick.
@@ -100,13 +161,19 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
 
   return (
     <div className="flex h-full flex-col">
+      {switchable && <SourceRow source={source} onSource={setSource} endedAt={endedAt} />}
       <div className="flex-1 overflow-y-auto">
         <PanelBody
+          source={source}
+          turnState={turnState}
           files={files}
           failed={failed}
           onInject={inject}
           onSessionComment={(file, lines, text) => addReviewComment(path, file, lines, text)}
-          onDiscard={setPendingDiscard}
+          // Discarding is an edit to the working tree, so it belongs to the
+          // working tree's own view. Offered on a finished turn it would read as
+          // an undo for that turn, which is not what it does.
+          onDiscard={source === "worktree" ? setPendingDiscard : undefined}
           bulk={bulk}
         />
       </div>
@@ -120,23 +187,116 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
   )
 }
 
+interface SourceRowProps {
+  source: DiffSource
+  onSource: (source: DiffSource) => void
+  /** When the shown turn's window closed (unix ms), or null when none is. */
+  endedAt: number | null
+}
+
+// SourceRow is the strip above the file list holding the source switch — the
+// same shape the Code tab gives its filter field, so the two tabs read as
+// siblings rather than as two different panels.
+function SourceRow({ source, onSource, endedAt }: SourceRowProps) {
+  const age = useAge(source === "turn" ? endedAt : null)
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-b border-border p-1.5">
+      <ToggleGroup
+        value={[source]}
+        onValueChange={(next) => next[0] && onSource(next[0] as DiffSource)}
+        spacing={1}
+        aria-label="Which changes to show"
+        className="border border-border p-[3px]"
+      >
+        <ToggleGroupItem value="worktree" size="sm" className="h-6 px-2.5 text-xs">
+          Working tree
+        </ToggleGroupItem>
+        <ToggleGroupItem
+          value="turn"
+          size="sm"
+          className="h-6 px-2.5 text-xs"
+          title={LAST_TURN_HINT}
+        >
+          Last turn
+        </ToggleGroupItem>
+      </ToggleGroup>
+      {/* The one thing the panel can state without claiming authorship: when
+          the window closed. Absent while there is no window to date, which is
+          also what tells an empty turn from an unrecorded one at a glance. */}
+      {age !== "" && (
+        <span className="ml-auto shrink-0 pr-1 text-[0.6875rem] text-muted-foreground">
+          ended {age} ago
+        </span>
+      )}
+    </div>
+  )
+}
+
+// useAge renders how long ago a moment was, on the sidebar's shared clock — one
+// timer for every readout on screen, and none at all while there is nothing to
+// count (see subscribeAge).
+function useAge(from: number | null): string {
+  const [now, setNow] = useState(() => Date.now())
+  useEffect(() => {
+    if (from === null) {
+      return
+    }
+    return subscribeAge(from, setNow)
+  }, [from])
+  return from === null ? "" : formatAge(now - from)
+}
+
 interface PanelBodyProps {
+  source: DiffSource
+  /** The last turn's own answer ("ok" | "empty" | "unavailable"), null while
+   * showing the working tree or before the first read lands. */
+  turnState: string | null
   files: DiffFile[] | null
   failed: boolean
   onInject: (text: string) => void
   onSessionComment: (path: string, lines: string, text: string) => void
-  onDiscard: (file: DiffFile) => void
+  /** Absent when discarding does not belong to this source. */
+  onDiscard?: (file: DiffFile) => void
   bulk: DiffBulk
 }
 
-function PanelBody({ files, failed, onInject, onSessionComment, onDiscard, bulk }: PanelBodyProps) {
+function PanelBody({
+  source,
+  turnState,
+  files,
+  failed,
+  onInject,
+  onSessionComment,
+  onDiscard,
+  bulk,
+}: PanelBodyProps) {
   if (failed) {
     return <Notice>Not a git repository</Notice>
   }
   if (files === null) {
     return <Notice>Loading…</Notice>
   }
-  if (files.length === 0) {
+  if (source === "turn") {
+    // A turn that changed nothing and a turn nobody recorded are different
+    // answers, and each says which one it is. Conflating them would have the
+    // panel report "nothing happened" for a snapshot it simply lost.
+    if (turnState === "empty") {
+      return (
+        <Notice>
+          <span className="block text-foreground">Nothing changed in this window.</span>
+          No file on disk moved between the last turn starting and ending.
+        </Notice>
+      )
+    }
+    if (turnState !== "ok" || files.length === 0) {
+      return (
+        <Notice>
+          <span className="block text-foreground">No last turn recorded.</span>
+          This fills in when a turn ends here.
+        </Notice>
+      )
+    }
+  } else if (files.length === 0) {
     return <Notice>No uncommitted changes</Notice>
   }
   return (
@@ -147,7 +307,7 @@ function PanelBody({ files, failed, onInject, onSessionComment, onDiscard, bulk 
           file={file}
           onInject={onInject}
           onSessionComment={onSessionComment}
-          onDiscard={() => onDiscard(file)}
+          onDiscard={onDiscard && (() => onDiscard(file))}
           bulk={bulk}
         />
       ))}

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -498,3 +498,18 @@ export interface QuotaPlan {
   windows?: QuotaWindow[]
   status: "ok" | "signed-out" | "error" | "unknown"
 }
+
+/** internal/terminal.LastTurn — what changed on disk in the window this
+ * session's last finished turn ran in. `diff` is unified-diff text (parseDiff
+ * reads it) and is present only for "ok"; `endedAt` is unix ms and present only
+ * when there is a window to date.
+ *
+ * The three states are kept apart on purpose: "empty" is a turn that ran and
+ * changed nothing, "unavailable" is no turn on record at all — no turn has
+ * finished here yet, or its snapshot was lost. The panel must never show one as
+ * the other. */
+export interface LastTurn {
+  state: "ok" | "empty" | "unavailable"
+  diff?: string
+  endedAt?: number
+}

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -12,6 +12,7 @@ import type {
   BinaryCheck,
   BranchRules,
   ClosedSession,
+  LastTurn,
   Branches,
   CommitIdentity,
   DetectedProvider,
@@ -142,6 +143,9 @@ export const Terminal = {
   SearchTranscripts: (ids: string[], query: string) =>
     call<TranscriptMatch[] | null>("terminal.SearchTranscripts", [ids, query]),
   Close: (id: string) => call<null>("terminal.Close", [id]),
+  /** What changed on disk while this session's last finished turn ran — a
+   * window of time, not an attribution (see internal/terminal.LastTurnDiff). */
+  LastTurnDiff: (id: string) => call<LastTurn>("terminal.LastTurnDiff", [id]),
 }
 
 export const DropService = {

--- a/frontend/src/lib/session/session-status-store.test.ts
+++ b/frontend/src/lib/session/session-status-store.test.ts
@@ -522,3 +522,57 @@ describe("pendingAll / subscribeAll", () => {
     expect(store.pendingAll()).toEqual([{ id: "s1", status: "waiting" }])
   })
 })
+
+// `reported` is what decides whether a turn-shaped control is drawn at all —
+// the Review panel's "Last turn" switch. It answers a different question from
+// `get`, and a control that appears and disappears is worse than one that was
+// never there, so the flag only ever goes one way.
+describe("has this session ever reported", () => {
+  it("is false until the first report", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    expect(store.reported("s1")).toBe(false)
+    emit(report("s1", "busy"))
+    expect(store.reported("s1")).toBe(true)
+  })
+
+  // The trap `get(id) !== null` falls into: both map to no indicator, and both
+  // are still proof the provider reports.
+  it.each(["idle", "interrupted"])("counts a %s, which maps to no status", (state) => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", state))
+    expect(store.get("s1")).toBeNull()
+    expect(store.reported("s1")).toBe(true)
+  })
+
+  it("stays true once a session goes quiet again", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "busy"))
+    emit(report("s1", "done"))
+    emit(report("s1", "idle"))
+    expect(store.reported("s1")).toBe(true)
+  })
+
+  it("is per session", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "busy"))
+    expect(store.reported("s2")).toBe(false)
+  })
+
+  // The first report is normally a state change and notifies anyway. It is the
+  // one that is not — a report repeating a status the store already holds, or
+  // one mapping to no status at all — that would otherwise leave a subscriber
+  // showing no switch for a session that has just proved it can have one.
+  it("notifies subscribers on a first report that changes no status", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    const notify = vi.fn()
+    store.subscribe("s1", notify)
+    emit(report("s1", "idle"))
+    expect(notify).toHaveBeenCalledTimes(1)
+    expect(store.reported("s1")).toBe(true)
+  })
+})

--- a/frontend/src/lib/session/session-status-store.ts
+++ b/frontend/src/lib/session/session-status-store.ts
@@ -44,6 +44,14 @@ interface Entry {
   // at, and the sessions beside it in the sidebar are exactly the ones whose
   // results nobody has collected yet (see the provider's markSessionSeen).
   seen: boolean
+  // Whether this session has ever reported a state at all — which is not the
+  // same question as `status !== null`, since `idle` and `interrupted` both map
+  // to no indicator. It is what tells a session whose provider will never report
+  // apart from one that simply has not yet, and the surfaces that offer a
+  // turn-shaped feature (the Review panel's "Last turn") show it only once this
+  // is true. It never goes back to false: a control that appears and disappears
+  // is worse than one that was never there.
+  reported: boolean
   listeners: Set<() => void>
 }
 
@@ -69,7 +77,14 @@ export function createSessionStatusStore(source: SessionEventSource) {
   const entryOf = (id: string): Entry => {
     let entry = entries.get(id)
     if (!entry) {
-      entry = { status: null, reason: "", since: 0, seen: false, listeners: new Set() }
+      entry = {
+        status: null,
+        reason: "",
+        since: 0,
+        seen: false,
+        reported: false,
+        listeners: new Set(),
+      }
       entries.set(id, entry)
     }
     return entry
@@ -121,11 +136,21 @@ export function createSessionStatusStore(source: SessionEventSource) {
     const entry = entryOf(data.id)
     const next = toSessionStatus(data.state)
     const reason = next === "waiting" ? statusReason(data) : ""
+    // Recorded before the bail below, and for every report whatever it maps to:
+    // an `idle` or an `interrupted` is still proof this session's provider
+    // reports at all (see Entry.reported).
+    const first = !entry.reported
+    entry.reported = true
     // The snapshot is a string union, so identity is free: bail on a repeat
     // state and subscribers skip the re-render entirely. The reason is weighed
     // with it because a second permission prompt inside one turn repeats the
     // state and changes the question — the one repeat that is news.
     if (entry.status === next && entry.reason === reason) {
+      // Unless this was the first report: it changed nothing about the status
+      // and everything about whether a turn-shaped control is drawn.
+      if (first) {
+        notify(entry)
+      }
       return
     }
     // Stamped on the state's own transition alone: a session has been waiting
@@ -194,6 +219,10 @@ export function createSessionStatusStore(source: SessionEventSource) {
 
   const get = (id: string): SessionStatus | null => entries.get(id)?.status ?? null
 
+  // reported answers whether this session has ever reported a state — see
+  // Entry.reported for why it is not `get(id) !== null`.
+  const reported = (id: string): boolean => entries.get(id)?.reported ?? false
+
   // unread is the one question the card's ring asks beyond the status itself:
   // a turn that finished and has not been looked at since. Only "done" can be
   // unread — the live states say what they say whether or not anyone is
@@ -232,6 +261,7 @@ export function createSessionStatusStore(source: SessionEventSource) {
   return {
     subscribe,
     get,
+    reported,
     unread,
     reason,
     since,

--- a/frontend/src/lib/session/use-session-status.ts
+++ b/frontend/src/lib/session/use-session-status.ts
@@ -30,6 +30,22 @@ export function useSessionUnread(sessionId: string): boolean {
   return useSyncExternalStore(subscribe, () => store.unread(sessionId))
 }
 
+// useSessionEverReported is whether this session's provider reports its state
+// at all — true from its first report onwards, and never false again. It is
+// what a turn-shaped surface asks before drawing itself: a provider that never
+// reports has no turn boundary, so the Review panel's "Last turn" switch is
+// simply absent there rather than present and permanently empty.
+//
+// Dynamic rather than a list of providers: the day one of them starts
+// reporting, its sessions get the control with no code change here.
+export function useSessionEverReported(sessionId: string): boolean {
+  const subscribe = useCallback(
+    (onChange: () => void) => store.subscribe(sessionId, onChange),
+    [sessionId],
+  )
+  return useSyncExternalStore(subscribe, () => store.reported(sessionId))
+}
+
 // useSessionWaitingReason reads what a blocked session is waiting for, in the
 // provider's own words, or "" when the report said nothing — the card falls back
 // to its generic line then. Kept out of useSessionStatus so a card that only

--- a/internal/project/turnsnap.go
+++ b/internal/project/turnsnap.go
@@ -1,0 +1,73 @@
+package project
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// SnapshotTree records a checkout's whole working tree — tracked edits,
+// deletions and untracked files alike — as a git tree object, and returns its
+// oid. Two of these bracket a session's turn, and the pair is what TreeDiff
+// renders (see internal/terminal/turnsnap.go).
+//
+// It writes nothing but loose objects. index is an index file of lich's own, so
+// `.git/index`, HEAD, the refs and the working tree are all untouched: a
+// snapshot taken while the user is halfway through their own `git add` neither
+// sees nor disturbs it. It must be ABSOLUTE, because `-C dir` moves git before
+// it resolves the variable, and a relative path would silently name an index
+// inside the checkout.
+//
+// The same file has to be reused across a session's snapshots. git's stat cache
+// is what makes the second one cheap — measured on a 37k-file checkout, 2.9s
+// against an empty index and 170ms against a warm one — so a per-call temporary
+// would re-hash the whole worktree every turn.
+//
+// Ignored files are absent: `add -A` obeys .gitignore, which is the same rule
+// DiffText's untracked pass follows, so the two diff sources never disagree
+// about which files exist.
+func SnapshotTree(dir, index string) (string, error) {
+	if !filepath.IsAbs(index) {
+		return "", fmt.Errorf("snapshot index %q must be absolute", index)
+	}
+	if err := os.MkdirAll(filepath.Dir(index), 0o700); err != nil {
+		return "", fmt.Errorf("create snapshot directory: %w", err)
+	}
+	if _, err := snapGit(dir, index, "add", "-A"); err != nil {
+		return "", err
+	}
+	out, err := snapGit(dir, index, "write-tree")
+	if err != nil {
+		return "", err
+	}
+	oid := strings.TrimSpace(out)
+	if oid == "" {
+		return "", fmt.Errorf("git write-tree in %s said nothing", dir)
+	}
+	return oid, nil
+}
+
+// TreeDiff renders the change between two snapshots as a unified diff — the
+// same text `git diff` produces, which is what parseDiff and FileDiff already
+// consume. -M is what keeps it the same text: diff-tree is plumbing and detects
+// no rename without it, where the porcelain `git diff` behind DiffText does.
+func TreeDiff(dir, before, after string) (string, error) {
+	return runGit(dir, "diff-tree", "-p", "-M", before, after)
+}
+
+// snapGit runs one snapshot call against an index of lich's own. It reports
+// failures like runGit rather than swallowing them like gitQuiet: a snapshot
+// that fails costs the panel a whole turn, and the reason has to reach the log.
+func snapGit(dir, index string, args ...string) (string, error) {
+	cmd := command("git", append([]string{"-C", dir}, args...)...)
+	cmd.Env = append(os.Environ(), "GIT_INDEX_FILE="+index)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", gitFailure(args, stderr.String(), err)
+	}
+	return string(out), nil
+}

--- a/internal/project/turnsnap_test.go
+++ b/internal/project/turnsnap_test.go
@@ -1,0 +1,229 @@
+package project
+
+import (
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// snapIndex names a snapshot index under the test's own directory, absolute the
+// way SnapshotTree requires.
+func snapIndex(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "turn.idx")
+}
+
+// digest of a file, for proving one was left byte-identical.
+func digest(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(data)
+	return string(sum[:])
+}
+
+// The whole point of the pair: every kind of change a turn can make to the
+// working tree reaches the rendered diff, whether or not the user staged it.
+func TestSnapshotPairRendersEveryChange(t *testing.T) {
+	repo, git := initRepo(t)
+	write(t, repo, "sub/b.txt", "keep\n")
+	git("add", "-A")
+	git("commit", "-m", "second")
+	index := snapIndex(t)
+
+	before, err := SnapshotTree(repo, index)
+	if err != nil {
+		t.Fatalf("SnapshotTree (before): %v", err)
+	}
+
+	write(t, repo, "a.txt", "one\ntwo\n")
+	write(t, repo, "c.txt", "new\n")
+	if err := os.Remove(filepath.Join(repo, "sub", "b.txt")); err != nil {
+		t.Fatal(err)
+	}
+
+	after, err := SnapshotTree(repo, index)
+	if err != nil {
+		t.Fatalf("SnapshotTree (after): %v", err)
+	}
+	if before == after {
+		t.Fatal("a turn that edited, added and deleted files produced one tree oid")
+	}
+
+	diff, err := TreeDiff(repo, before, after)
+	if err != nil {
+		t.Fatalf("TreeDiff: %v", err)
+	}
+	for _, want := range []string{
+		"diff --git a/a.txt b/a.txt", "+two",
+		"+++ b/c.txt", "new file mode", "+new",
+		"--- a/sub/b.txt", "deleted file mode", "-keep",
+	} {
+		if !strings.Contains(diff, want) {
+			t.Errorf("diff missing %q:\n%s", want, diff)
+		}
+	}
+}
+
+// The one comparison the panel makes without running a diff: a turn that left
+// the checkout as it found it has to be recognisable by the oids alone.
+func TestSnapshotTreeIsStableWhenNothingChanged(t *testing.T) {
+	repo, _ := initRepo(t)
+	index := snapIndex(t)
+
+	first, err := SnapshotTree(repo, index)
+	if err != nil {
+		t.Fatalf("SnapshotTree: %v", err)
+	}
+	second, err := SnapshotTree(repo, index)
+	if err != nil {
+		t.Fatalf("SnapshotTree: %v", err)
+	}
+	if first != second {
+		t.Fatalf("an unchanged worktree snapshotted as %s then %s", first, second)
+	}
+}
+
+// A snapshot must be invisible to the user's own git: it runs while they are
+// halfway through staging, and moving HEAD or their index would be data loss
+// they never asked for.
+func TestSnapshotTreeLeavesTheRepositoryAlone(t *testing.T) {
+	repo, git := initRepo(t)
+	write(t, repo, "staged.txt", "s\n")
+	git("add", "staged.txt")
+	write(t, repo, "loose.txt", "l\n")
+
+	indexPath := filepath.Join(repo, ".git", "index")
+	beforeIndex := digest(t, indexPath)
+	beforeHead := git("rev-parse", "HEAD")
+	beforeStatus := git("status", "--porcelain")
+	beforeRefs := git("for-each-ref")
+
+	if _, err := SnapshotTree(repo, snapIndex(t)); err != nil {
+		t.Fatalf("SnapshotTree: %v", err)
+	}
+
+	if got := digest(t, indexPath); got != beforeIndex {
+		t.Error("the snapshot rewrote .git/index")
+	}
+	if got := git("rev-parse", "HEAD"); got != beforeHead {
+		t.Errorf("HEAD moved: %q → %q", beforeHead, got)
+	}
+	if got := git("status", "--porcelain"); got != beforeStatus {
+		t.Errorf("the working tree changed:\n%q\n%q", beforeStatus, got)
+	}
+	if got := git("for-each-ref"); got != beforeRefs {
+		t.Error("the snapshot moved a ref")
+	}
+}
+
+// Both diff sources have to agree about which files exist, or a file would be
+// in one view and missing from the other with nothing saying why. DiffText's
+// untracked pass obeys .gitignore; `add -A` does too, and this pins it.
+func TestSnapshotTreeSkipsIgnoredFiles(t *testing.T) {
+	repo, git := initRepo(t)
+	write(t, repo, ".gitignore", "build/\n")
+	git("add", "-A")
+	git("commit", "-m", "ignore")
+	index := snapIndex(t)
+
+	before, err := SnapshotTree(repo, index)
+	if err != nil {
+		t.Fatalf("SnapshotTree: %v", err)
+	}
+	write(t, repo, "build/out.js", "generated\n")
+	after, err := SnapshotTree(repo, index)
+	if err != nil {
+		t.Fatalf("SnapshotTree: %v", err)
+	}
+	if before != after {
+		diff, _ := TreeDiff(repo, before, after)
+		t.Fatalf("an ignored file changed the snapshot:\n%s", diff)
+	}
+}
+
+// `-C dir` moves git before it resolves GIT_INDEX_FILE, so a relative path
+// would name an index inside the user's checkout — a file lich writes into a
+// repository it promised not to touch. Refused rather than resolved, because
+// the caller that passed one is the bug.
+func TestSnapshotTreeRefusesARelativeIndex(t *testing.T) {
+	repo, _ := initRepo(t)
+	if _, err := SnapshotTree(repo, "turn.idx"); err == nil {
+		t.Fatal("a relative index path was accepted")
+	}
+}
+
+// The index lives under lich's own directory, which need not exist yet on a
+// fresh install — the first snapshot of the first session is what creates it.
+func TestSnapshotTreeCreatesItsOwnDirectory(t *testing.T) {
+	repo, _ := initRepo(t)
+	index := filepath.Join(t.TempDir(), "turns", "s1.idx")
+
+	if _, err := SnapshotTree(repo, index); err != nil {
+		t.Fatalf("SnapshotTree: %v", err)
+	}
+	if _, err := os.Stat(index); err != nil {
+		t.Fatalf("the index was not written: %v", err)
+	}
+}
+
+// Browsing files is not a git feature, but bracketing a turn is: a plain folder
+// has no trees to compare, and the panel has to hear that as an error rather
+// than as a turn that changed nothing.
+func TestSnapshotTreeOutsideARepository(t *testing.T) {
+	if _, err := SnapshotTree(t.TempDir(), snapIndex(t)); err == nil {
+		t.Fatal("SnapshotTree outside a repository: want an error, got nil")
+	}
+}
+
+// diff-tree is plumbing and detects no rename on its own, where the porcelain
+// `git diff` behind DiffText does. Without -M the two sources would describe the
+// same change differently — a rename in one, a delete plus an add in the other.
+func TestTreeDiffDetectsARename(t *testing.T) {
+	repo, git := initRepo(t)
+	write(t, repo, "long.txt", strings.Repeat("a stable line of content\n", 20))
+	git("add", "-A")
+	git("commit", "-m", "long")
+	index := snapIndex(t)
+
+	before, err := SnapshotTree(repo, index)
+	if err != nil {
+		t.Fatalf("SnapshotTree: %v", err)
+	}
+	if err := os.Rename(filepath.Join(repo, "long.txt"), filepath.Join(repo, "moved.txt")); err != nil {
+		t.Fatal(err)
+	}
+	after, err := SnapshotTree(repo, index)
+	if err != nil {
+		t.Fatalf("SnapshotTree: %v", err)
+	}
+
+	diff, err := TreeDiff(repo, before, after)
+	if err != nil {
+		t.Fatalf("TreeDiff: %v", err)
+	}
+	if !strings.Contains(diff, "rename from long.txt") || !strings.Contains(diff, "rename to moved.txt") {
+		t.Errorf("the rename was not detected:\n%s", diff)
+	}
+}
+
+// A snapshot whose index cannot be written is an error, never a silent success:
+// the pair would otherwise look taken and the panel would report a turn that
+// changed nothing when what actually happened is that nothing was recorded.
+func TestSnapshotTreeReportsAnUnusableIndexLocation(t *testing.T) {
+	repo, _ := initRepo(t)
+	// A file where the index's directory should be, which is the shape a
+	// misconfigured config directory takes on disk.
+	blocker := filepath.Join(t.TempDir(), "turns")
+	if err := os.WriteFile(blocker, []byte("not a directory\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := SnapshotTree(repo, filepath.Join(blocker, "s1.idx")); err == nil {
+		t.Fatal("an unwritable index location was accepted")
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -234,6 +234,11 @@ type Service struct {
 	// nothing else about a report needs mu, and a hook must never queue behind a
 	// PTY spawn.
 	turns turnLog
+	// snaps brackets each session's turn with a tree snapshot of its checkout,
+	// which is what the Review panel's "Last turn" mode diffs (see turnSnaps).
+	// It reads the same boundary turns does and carries its own lock for the
+	// same reason.
+	snaps turnSnaps
 	// lastCols/lastRows is the last terminal size the window reported, and the
 	// size a session spawned with none of its own is started at. See
 	// sizeFor. Guarded by mu.
@@ -342,6 +347,11 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 			if watch := s.stateWatcher(); watch != nil {
 				watch(req.SessionID, req.State)
 			}
+			// The same boundary brackets the Review panel's "Last turn": `busy`
+			// opens the window, `done` closes it. Queued, never taken here — a
+			// snapshot on this goroutine would hold the hook's own response, and
+			// with it the agent's next step (see turnSnaps).
+			s.snaps.note(req.SessionID, req.State)
 			// Every non-idle state is a point where a fresh assistant usage line
 			// may have landed — a tool call mid-turn (busy), a prompt (waiting),
 			// or the turn's end (done) — so refresh the context window then, and
@@ -434,6 +444,10 @@ func (s *Service) noteInterrupt(id string) {
 		return
 	}
 	s.hub.Emit(statusEventName, statusEvent{ID: id, State: statusInterrupted})
+	// An interrupted turn is still a turn that ended, and it changed files like
+	// any other. Closing the window here is what keeps the panel from holding
+	// an older turn open until the next one finishes.
+	s.snaps.closeTurn(id)
 	// The relay keeps its own turn accounting off the same stream, and a turn
 	// that ended has to read as ended there too — a queued delivery waits on the
 	// target's prompt being free.
@@ -562,6 +576,10 @@ func (s *Service) Start(id, projectID, cwd, kind, resume, name string, setup boo
 	s.hub.Emit(cwdEventName, cwdEvent{ID: id, Cwd: cwd})
 	s.hub.Emit(agentEventName, agentEvent{ID: id, Agent: ""})
 	s.hub.Emit(sandboxEventName, sandboxEvent{ID: id, Confined: sess.confined})
+	// Bound to the effective cwd rather than the requested one, and outside
+	// s.mu: track queues a warm-up of this checkout's snapshot index, and the
+	// first one on a large repository is measured in seconds.
+	s.snaps.track(id, cwd)
 	go watchCwd(id, sess.pty.Pid(), cwd, sess.done, s.hub)
 	return nil
 }
@@ -941,6 +959,9 @@ func (s *Service) Close(id string) error {
 	if !ok {
 		return nil
 	}
+	// A closed card's row is deleted, so nothing will ever ask what its last
+	// turn changed — and its snapshot index would otherwise outlive it on disk.
+	s.snaps.forget(id)
 	return sess.pty.Close()
 }
 

--- a/internal/terminal/turnsnap.go
+++ b/internal/terminal/turnsnap.go
@@ -1,0 +1,293 @@
+package terminal
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/omartelo/lich/internal/project"
+)
+
+// snapQueueDepth bounds the work waiting on the snapshot worker. A full queue
+// drops the job rather than blocking the hook that raised it: losing a turn's
+// diff is a panel that says so, where a stalled hook is an agent that stops.
+const snapQueueDepth = 32
+
+// The three answers LastTurnDiff can give, kept apart on the wire because the
+// panel must never dress one as another: a turn that changed nothing is a real
+// answer, and no turn on record is the absence of one.
+const (
+	turnDiffOK          = "ok"
+	turnDiffEmpty       = "empty"
+	turnDiffUnavailable = "unavailable"
+)
+
+// LastTurn is what the Review panel's "Last turn" mode reads. Diff is empty for
+// every state but "ok", and EndedAt (unix ms) is set only when there is a window
+// to date — its absence is the second signal that nothing is on record.
+type LastTurn struct {
+	State   string `json:"state"`
+	Diff    string `json:"diff,omitempty"`
+	EndedAt int64  `json:"endedAt,omitempty"`
+}
+
+// turnPair is one closed turn: the trees on either side of the window it ran in,
+// and when that window shut.
+type turnPair struct {
+	before  string
+	after   string
+	endedAt time.Time
+}
+
+// snapState is one session's snapshot accounting. seq numbers the turns so a
+// snapshot landing late is filed against the turn it was taken for and no other;
+// before is the opening tree of turn seq, still empty while its job is queued.
+type snapState struct {
+	dir    string
+	index  string
+	seq    uint64
+	open   bool
+	before string
+	last   *turnPair
+}
+
+// turnSnaps records what each session's last finished turn changed on disk, by
+// bracketing the turn with two tree snapshots of its checkout
+// (project.SnapshotTree). The turn boundary is the session-state contract's own
+// `busy` and `done` (docs/hooks/session-state.md), which is why a provider that
+// reports no state has no last turn here and never will.
+//
+// Every snapshot runs on ONE worker, for two reasons that happen to have the
+// same fix. git refuses a second `add` against an index another one holds
+// (`<index>.lock: File exists`), and a turn's two snapshots must be taken in the
+// order they were asked for. A single FIFO worker gives both, at the cost of one
+// session's cold snapshot delaying another's — acceptable while the cold case is
+// paid once per checkout, at spawn. Per-session workers are the way out if it
+// ever stops being.
+//
+// The zero value is ready to use.
+type turnSnaps struct {
+	mu       sync.Mutex
+	sessions map[string]*snapState
+	jobs     chan func()
+	// root holds the index files. Empty means "resolve it from the config
+	// directory on first use"; tests set it to a directory of their own.
+	root string
+}
+
+// track binds a session to the checkout its PTY was spawned at and warms the
+// index, so the first turn's opening snapshot is not the one paying for hashing
+// the whole worktree. Any previous accounting under this id belongs to the
+// provider that left: a respawn is a new session's turns, and the last one it
+// recorded is not this one's.
+func (t *turnSnaps) track(id, dir string) {
+	if id == "" || dir == "" {
+		return
+	}
+	index, err := t.indexPath(id)
+	if err != nil {
+		slog.Warn("turnsnap: no place to keep the index", "session", id, "err", err)
+		return
+	}
+	t.mu.Lock()
+	if t.sessions == nil {
+		t.sessions = make(map[string]*snapState)
+	}
+	t.sessions[id] = &snapState{dir: dir, index: index}
+	t.mu.Unlock()
+	// Warming discards the tree it computes: what is being bought is git's stat
+	// cache in the index file, not the oid.
+	t.submit(func() {
+		if _, err := project.SnapshotTree(dir, index); err != nil {
+			slog.Debug("turnsnap: warm-up failed", "session", id, "err", err)
+		}
+	})
+}
+
+// note reads one session-state report as a turn boundary. Repeat `busy` reports
+// are what every provider sends between tool calls, and Antigravity sends one
+// before each model call, so only the first of a run opens anything — otherwise
+// the "before" would creep forward through the turn it is supposed to precede.
+func (t *turnSnaps) note(id, state string) {
+	switch state {
+	case statusBusy:
+		t.openTurn(id)
+	case statusDone:
+		t.closeTurn(id)
+	case statusIdle:
+		t.dropTurn(id)
+	}
+}
+
+// openTurn takes the tree the turn starts from. The job is queued rather than
+// run here: this is the hook's own goroutine, and it holds the agent's next step.
+func (t *turnSnaps) openTurn(id string) {
+	t.mu.Lock()
+	state, ok := t.sessions[id]
+	if !ok || state.open {
+		t.mu.Unlock()
+		return
+	}
+	state.seq++
+	state.open = true
+	state.before = ""
+	seq, dir, index := state.seq, state.dir, state.index
+	t.mu.Unlock()
+
+	t.submit(func() {
+		oid, err := project.SnapshotTree(dir, index)
+		if err != nil {
+			slog.Warn("turnsnap: opening snapshot failed", "session", id, "err", err)
+			return
+		}
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		if state, ok := t.sessions[id]; ok && state.seq == seq {
+			state.before = oid
+		}
+	})
+}
+
+// closeTurn takes the tree the turn ends on and files the pair. A turn whose
+// opening snapshot never landed clears the record instead of keeping the one
+// before it: this answers for the LAST turn, and offering an older one in its
+// place would quietly answer a question nobody asked.
+func (t *turnSnaps) closeTurn(id string) {
+	t.mu.Lock()
+	state, ok := t.sessions[id]
+	if !ok || !state.open {
+		t.mu.Unlock()
+		return
+	}
+	state.open = false
+	seq, dir, index := state.seq, state.dir, state.index
+	t.mu.Unlock()
+
+	t.submit(func() {
+		oid, err := project.SnapshotTree(dir, index)
+		if err != nil {
+			slog.Warn("turnsnap: closing snapshot failed", "session", id, "err", err)
+		}
+		t.mu.Lock()
+		defer t.mu.Unlock()
+		state, ok := t.sessions[id]
+		if !ok || state.seq != seq {
+			return
+		}
+		if err != nil || state.before == "" {
+			state.last = nil
+			return
+		}
+		state.last = &turnPair{before: state.before, after: oid, endedAt: time.Now()}
+	})
+}
+
+// dropTurn abandons a turn nothing will close — the CLI left mid-run. The last
+// closed turn survives it: the session ending does not un-happen what its last
+// turn did.
+func (t *turnSnaps) dropTurn(id string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if state, ok := t.sessions[id]; ok {
+		state.open = false
+		state.before = ""
+	}
+}
+
+// forget drops a closed session's accounting and its index file. A queued job
+// for it finds no state and files nothing.
+func (t *turnSnaps) forget(id string) {
+	t.mu.Lock()
+	state, ok := t.sessions[id]
+	delete(t.sessions, id)
+	t.mu.Unlock()
+	if ok && state.index != "" {
+		_ = os.Remove(state.index)
+	}
+}
+
+// pair answers with the session's last closed turn and the checkout to render it
+// against. ok is false when there is nothing on record — no turn has finished
+// here, or the one that did lost a snapshot.
+func (t *turnSnaps) pair(id string) (turnPair, string, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	state, ok := t.sessions[id]
+	if !ok || state.last == nil {
+		return turnPair{}, "", false
+	}
+	return *state.last, state.dir, true
+}
+
+// submit hands one snapshot to the worker, starting it on first use. A full
+// queue drops the job: the turn it belonged to then reads as unavailable, which
+// is the honest answer and not the one that says nothing changed.
+func (t *turnSnaps) submit(job func()) {
+	t.mu.Lock()
+	if t.jobs == nil {
+		t.jobs = make(chan func(), snapQueueDepth)
+		go func(jobs <-chan func()) {
+			for job := range jobs {
+				job()
+			}
+		}(t.jobs)
+	}
+	jobs := t.jobs
+	t.mu.Unlock()
+
+	select {
+	case jobs <- job:
+	default:
+		slog.Warn("turnsnap: snapshot queue full, dropping a turn's snapshot")
+	}
+}
+
+// indexPath resolves where a session's index lives. LICH_DEV separates a
+// development rig's indexes from the installed lich's, the same split the
+// workspace database makes.
+func (t *turnSnaps) indexPath(id string) (string, error) {
+	t.mu.Lock()
+	root := t.root
+	t.mu.Unlock()
+
+	if root == "" {
+		dir, err := os.UserConfigDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve config directory: %w", err)
+		}
+		name := "turns"
+		if os.Getenv("LICH_DEV") != "" {
+			name = "turns-dev"
+		}
+		root = filepath.Join(dir, "lich", name)
+	}
+	return filepath.Join(root, id+".idx"), nil
+}
+
+// LastTurnDiff returns what changed on disk in the window this session's last
+// finished turn ran in, as a unified diff.
+//
+// It is a window and not an attribution: everything that touched the checkout
+// while the turn ran is in it — a formatter, an editor open beside lich, the
+// user's own hands — and nothing here can tell them apart. The panel says as
+// much, which is why it names the window rather than the agent.
+func (s *Service) LastTurnDiff(id string) (LastTurn, error) {
+	pair, dir, ok := s.snaps.pair(id)
+	if !ok {
+		return LastTurn{State: turnDiffUnavailable}, nil
+	}
+	ended := pair.endedAt.UnixMilli()
+	// Equal trees is the whole answer: the turn ran and left the checkout as it
+	// found it. No diff is computed, and none is needed.
+	if pair.before == pair.after {
+		return LastTurn{State: turnDiffEmpty, EndedAt: ended}, nil
+	}
+	text, err := project.TreeDiff(dir, pair.before, pair.after)
+	if err != nil {
+		return LastTurn{}, err
+	}
+	return LastTurn{State: turnDiffOK, Diff: text, EndedAt: ended}, nil
+}

--- a/internal/terminal/turnsnap_test.go
+++ b/internal/terminal/turnsnap_test.go
@@ -1,0 +1,328 @@
+package terminal
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// snapRepo creates a git repository with one commit and a Service wired to keep
+// its snapshot indexes under the test's own directory, never the user's config
+// directory. Skips when git is unavailable.
+func snapRepo(t *testing.T) (*Service, string) {
+	t.Helper()
+	repo := t.TempDir()
+	if out, err := exec.Command("git", "init", "-b", "main", repo).CombinedOutput(); err != nil {
+		t.Skipf("git init unavailable: %v (%s)", err, out)
+	}
+	for _, args := range [][]string{
+		{"config", "user.email", "t@example.com"},
+		{"config", "user.name", "t"},
+		{"config", "core.autocrlf", "false"},
+	} {
+		run(t, repo, args...)
+	}
+	writeIn(t, repo, "a.txt", "one\n")
+	run(t, repo, "add", "-A")
+	run(t, repo, "commit", "-m", "init")
+
+	svc := &Service{}
+	svc.snaps.root = t.TempDir()
+	return svc, repo
+}
+
+func run(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v (%s)", strings.Join(args, " "), err, out)
+	}
+}
+
+func writeIn(t *testing.T, dir, rel, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, rel), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// snapBefore reads the opening tree of the turn a session has open, which is
+// what a test has to wait for before editing: the snapshot runs on the worker,
+// and an edit racing it would land on the wrong side of the window.
+func snapBefore(s *turnSnaps, id string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if state, ok := s.sessions[id]; ok {
+		return state.before
+	}
+	return ""
+}
+
+// openAndWait opens a turn and blocks until its opening snapshot has landed.
+func openAndWait(t *testing.T, svc *Service, id string) {
+	t.Helper()
+	svc.snaps.note(id, statusBusy)
+	waitFor(t, func() bool { return snapBefore(&svc.snaps, id) != "" },
+		"the turn's opening snapshot")
+}
+
+// closeAndWait ends a turn and blocks until the panel can answer for it.
+func closeAndWait(t *testing.T, svc *Service, id, want string) LastTurn {
+	t.Helper()
+	svc.snaps.note(id, statusDone)
+	var got LastTurn
+	waitFor(t, func() bool {
+		turn, err := svc.LastTurnDiff(id)
+		if err != nil {
+			return false
+		}
+		got = turn
+		return turn.State == want
+	}, "the last turn to read as "+want)
+	return got
+}
+
+// The feature itself: what the checkout gained between a turn starting and
+// ending, rendered as the unified diff the panel already knows how to draw.
+func TestLastTurnDiffRendersTheWindow(t *testing.T) {
+	svc, repo := snapRepo(t)
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "a.txt", "one\ntwo\n")
+	writeIn(t, repo, "b.txt", "fresh\n")
+	turn := closeAndWait(t, svc, "s1", turnDiffOK)
+
+	for _, want := range []string{"a/a.txt", "+two", "+++ b/b.txt", "+fresh"} {
+		if !strings.Contains(turn.Diff, want) {
+			t.Errorf("the diff is missing %q:\n%s", want, turn.Diff)
+		}
+	}
+	if turn.EndedAt == 0 {
+		t.Error("a closed window carried no time")
+	}
+}
+
+// The distinction the whole contract exists for: a turn that ran and touched
+// nothing is an answer, and it must not wear the words for having no answer.
+func TestATurnThatChangedNothingIsEmpty(t *testing.T) {
+	svc, repo := snapRepo(t)
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	turn := closeAndWait(t, svc, "s1", turnDiffEmpty)
+
+	if turn.Diff != "" {
+		t.Errorf("an empty turn carried a diff: %q", turn.Diff)
+	}
+	if turn.EndedAt == 0 {
+		t.Error("an empty turn is still a window and should be dated")
+	}
+}
+
+// Every provider reports `busy` again between tool calls, and Antigravity
+// reports one before each model call. Treating those as new turns would walk the
+// opening snapshot forward through the turn it is supposed to precede, so the
+// panel would show only whatever happened after the last tool.
+func TestARepeatBusyDoesNotMoveTheWindow(t *testing.T) {
+	svc, repo := snapRepo(t)
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "early.txt", "before the tool\n")
+	// The pre-tool report, arriving mid-turn.
+	svc.snaps.note("s1", statusBusy)
+	writeIn(t, repo, "late.txt", "after the tool\n")
+	turn := closeAndWait(t, svc, "s1", turnDiffOK)
+
+	for _, want := range []string{"+++ b/early.txt", "+++ b/late.txt"} {
+		if !strings.Contains(turn.Diff, want) {
+			t.Errorf("the window closed over %q:\n%s", want, turn.Diff)
+		}
+	}
+}
+
+// "Last turn" is the last turn, full stop. A quiet turn after a busy one must
+// report itself as quiet — offering the earlier turn's diff instead would
+// answer a question nobody asked, and would do it convincingly.
+func TestAQuietTurnDoesNotFallBackToTheOneBefore(t *testing.T) {
+	svc, repo := snapRepo(t)
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "a.txt", "changed\n")
+	if turn := closeAndWait(t, svc, "s1", turnDiffOK); !strings.Contains(turn.Diff, "+changed") {
+		t.Fatalf("the first turn did not record its change:\n%s", turn.Diff)
+	}
+
+	openAndWait(t, svc, "s1")
+	closeAndWait(t, svc, "s1", turnDiffEmpty)
+}
+
+// The same rule against a lost snapshot rather than a quiet turn: a turn whose
+// opening tree never landed — a dropped job, a git that failed — clears the
+// record instead of leaving the previous turn standing as if it were this one.
+func TestATurnWithNoOpeningSnapshotClearsTheRecord(t *testing.T) {
+	svc, repo := snapRepo(t)
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "a.txt", "changed\n")
+	closeAndWait(t, svc, "s1", turnDiffOK)
+
+	// The state a dropped opening snapshot leaves behind: a turn is open and
+	// nothing recorded where it started.
+	svc.snaps.mu.Lock()
+	svc.snaps.sessions["s1"].open = true
+	svc.snaps.sessions["s1"].seq++
+	svc.snaps.sessions["s1"].before = ""
+	svc.snaps.mu.Unlock()
+
+	closeAndWait(t, svc, "s1", turnDiffUnavailable)
+}
+
+// A session whose first turn is still running has nothing to show, and a
+// session lich never tracked has nothing to show either. Both are the absence
+// of an answer, never a quiet turn.
+func TestNoClosedTurnIsUnavailable(t *testing.T) {
+	svc, repo := snapRepo(t)
+
+	turn, err := svc.LastTurnDiff("never-tracked")
+	if err != nil {
+		t.Fatalf("LastTurnDiff: %v", err)
+	}
+	if turn.State != turnDiffUnavailable {
+		t.Errorf("an untracked session reads as %q, want %q", turn.State, turnDiffUnavailable)
+	}
+
+	svc.snaps.track("s1", repo)
+	openAndWait(t, svc, "s1")
+	turn, err = svc.LastTurnDiff("s1")
+	if err != nil {
+		t.Fatalf("LastTurnDiff: %v", err)
+	}
+	if turn.State != turnDiffUnavailable {
+		t.Errorf("a turn still running reads as %q, want %q", turn.State, turnDiffUnavailable)
+	}
+	if turn.EndedAt != 0 {
+		t.Error("an unrecorded turn was dated")
+	}
+}
+
+// lich reads an interrupt off the PTY because no provider reports one, and a
+// stopped turn still changed files. Without this the panel would hold the turn
+// before it open until some later one finished.
+func TestAnInterruptClosesTheWindow(t *testing.T) {
+	svc, repo := snapRepo(t)
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "a.txt", "half done\n")
+	svc.snaps.closeTurn("s1")
+
+	waitFor(t, func() bool {
+		turn, err := svc.LastTurnDiff("s1")
+		return err == nil && turn.State == turnDiffOK && strings.Contains(turn.Diff, "+half done")
+	}, "the interrupted turn to be recorded")
+}
+
+// SessionEnd says the CLI left mid-turn: there is no closing snapshot coming,
+// so that turn is abandoned — but the last one that did close is still the last
+// one that closed, and the session ending does not un-happen it.
+func TestSessionEndAbandonsTheOpenTurnAndKeepsTheClosedOne(t *testing.T) {
+	svc, repo := snapRepo(t)
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "a.txt", "recorded\n")
+	closeAndWait(t, svc, "s1", turnDiffOK)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "b.txt", "never closed\n")
+	svc.snaps.note("s1", statusIdle)
+
+	turn, err := svc.LastTurnDiff("s1")
+	if err != nil {
+		t.Fatalf("LastTurnDiff: %v", err)
+	}
+	if !strings.Contains(turn.Diff, "+recorded") {
+		t.Errorf("the closed turn was lost with the session:\n%s", turn.Diff)
+	}
+	if strings.Contains(turn.Diff, "never closed") {
+		t.Error("a turn nothing closed was reported as finished")
+	}
+	// And the abandoned turn cannot be closed later by the next `done`.
+	svc.snaps.note("s1", statusDone)
+	svc.snaps.mu.Lock()
+	open := svc.snaps.sessions["s1"].open
+	svc.snaps.mu.Unlock()
+	if open {
+		t.Error("a session that ended still holds a turn open")
+	}
+}
+
+// A closed card's row is deleted, so its accounting is dead weight — and its
+// index file would outlive it under lich's config directory.
+func TestForgetDropsTheRecordAndTheIndex(t *testing.T) {
+	svc, repo := snapRepo(t)
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "a.txt", "changed\n")
+	closeAndWait(t, svc, "s1", turnDiffOK)
+
+	index := filepath.Join(svc.snaps.root, "s1.idx")
+	if _, err := os.Stat(index); err != nil {
+		t.Fatalf("the index was never written: %v", err)
+	}
+
+	svc.snaps.forget("s1")
+	if _, err := os.Stat(index); !os.IsNotExist(err) {
+		t.Errorf("the index survived the close: %v", err)
+	}
+	turn, err := svc.LastTurnDiff("s1")
+	if err != nil {
+		t.Fatalf("LastTurnDiff: %v", err)
+	}
+	if turn.State != turnDiffUnavailable {
+		t.Errorf("a forgotten session reads as %q, want %q", turn.State, turnDiffUnavailable)
+	}
+}
+
+// A respawn under the same id is a new session's turns. Whatever the provider
+// that left had recorded belongs to it, not to the one now typing.
+func TestRespawnDropsThePreviousProvidersTurn(t *testing.T) {
+	svc, repo := snapRepo(t)
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "a.txt", "the last provider's work\n")
+	closeAndWait(t, svc, "s1", turnDiffOK)
+
+	svc.snaps.track("s1", repo)
+	turn, err := svc.LastTurnDiff("s1")
+	if err != nil {
+		t.Fatalf("LastTurnDiff: %v", err)
+	}
+	if turn.State != turnDiffUnavailable {
+		t.Errorf("a respawned session inherited a turn: %q", turn.State)
+	}
+}
+
+// A `done` for a session with no turn open is what every idle prompt produces,
+// and it must not invent a window out of two unrelated snapshots.
+func TestADoneWithNoTurnOpenRecordsNothing(t *testing.T) {
+	svc, repo := snapRepo(t)
+	svc.snaps.track("s1", repo)
+
+	svc.snaps.note("s1", statusDone)
+	turn, err := svc.LastTurnDiff("s1")
+	if err != nil {
+		t.Fatalf("LastTurnDiff: %v", err)
+	}
+	if turn.State != turnDiffUnavailable {
+		t.Errorf("a stray done recorded %q", turn.State)
+	}
+}


### PR DESCRIPTION
Was stacked on #378; rebased onto `main` now that it has landed.

## The gap

The Review panel showed one thing: everything uncommitted in the session's checkout. After a few turns that is the accumulation of all of them, and "what did this turn just do" had no answer on screen.

A session that reports its state now gets a switch above the file list. **Working tree** is the panel as it was; **Last turn** shows what changed on disk while that session's last finished turn ran.

## Mechanism

No shadow repository. Every lich session is a git worktree, so the window is bracketed by two `git write-tree` snapshots taken against an index of lich's own:

```
GIT_INDEX_FILE=<lich's index> git add -A && git write-tree
```

Nothing in the user's repository moves — not `.git/index`, not HEAD, not a ref, not the working tree — and a snapshot taken while they are halfway through their own `git add` neither sees nor disturbs it. The pair of tree oids renders through `git diff-tree -p -M`, which is the same unified diff `parseDiff`/`FileDiff` already consume, so the whole render pipeline is reused rather than rebuilt.

The boundary is the session-state contract's own `busy`/`done` (`docs/hooks/session-state.md`), which is also what decides whether the switch exists at all.

### Measured

The index is kept per session rather than made per snapshot: git's stat cache is what makes the second one cheap.

| checkout | tracked files | cold (empty index) | warm | index size |
|---|---|---|---|---|
| lich (linked worktree) | 713 | 99 ms | 9–10 ms | 76 KB |
| vial-qmk-firmware | 37,259 / 471 MB | 2877 ms | 163–209 ms | 4.5 MB |

The cold cost is paid once per checkout, off-thread, at spawn — `track` warms the index there so the first turn's opening snapshot is already warm. Two concurrent `add`s against one index die on `<index>.lock: File exists`, which is why every snapshot in the app runs on one FIFO worker; that also guarantees a turn's two snapshots are taken in the order they were asked for. Nothing runs on the hook's own goroutine: `servePost` responds after the apply, so a snapshot there would hold the agent's next step.

## Semantics

This is where the value is; the mechanism is the easy half.

- **A window of wall-clock time, not an attribution.** A formatter, an editor open beside lich and the user's own hands all land inside it. The copy names the window and never the agent, and the option's tooltip says so outright.
- **"Last turn" is the last turn.** A quiet turn reports itself as quiet rather than falling back to the busy one before it, and a turn whose opening snapshot was lost clears the record instead of leaving the previous turn standing in its place.
- **Empty and unavailable are different states on the wire** (`"empty"` / `"unavailable"`), and neither is ever drawn as the other. "Nothing changed in this window." against "No last turn recorded."
- **Repeat `busy` does not move the window.** Every provider reports one between tool calls and Antigravity reports one before each model call; only the first of a run opens anything.
- **An interrupt closes the window.** A stopped turn is a turn that ended, and it changed files like any other.
- **Discard is not offered on a finished turn.** `FileDiff` already omits it when `onDiscard` is absent — the shape a pull request's diff uses. It edits the working tree, and beside a turn's diff it would read as an undo for that turn.

## Provider coverage (invariant 5)

Claude Code, Codex, Antigravity, opencode and oh-my-pi all report `busy` and `done`, so all five work. **Crush reports no state at all, and Cursor CLI has no plugin yet** — neither has a turn to bracket, so the switch is never drawn there. That is a `docs/ceilings.md` bullet in this PR.

The rule is read off the session's own reports, never a list of providers: the control appears the first time a session reports *any* state and never leaves after that. Once shown, shown for good — a newborn session and a Crush session look alike for one second, and a control that blinks in and out is worse than one that was never there. Either provider gets the feature the day it starts reporting, with no code change here.

## Not in scope

Rollback or restore of a file, a history of N turns, non-git directories, anything checkpoint-shaped.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` green, and again with `-race`
- [x] Cross-compile loop green for linux / darwin / windows (build + vet)
- [x] `biome check .` clean, `tsc` clean, `vite build` succeeds
- [x] `vitest run` — 93 files, 1115 tests
- [x] New Go coverage: `internal/project/turnsnap.go` 85–100% per function, `internal/terminal/turnsnap.go` 82–100%
- [x] Snapshot proven non-invasive by test: `.git/index` byte-identical, HEAD, refs and `git status` unchanged
- [x] base-ui composition of the segmented control smoke-rendered in jsdom (both options present, `aria-pressed` toggles, tooltip lands) — the frontend gate is node-only and would ship a render crash green

