### PR TITLE
Open a Windows session in PowerShell, not cmd.exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   up. A Cursor card shows no spinner and no bell, and keeps the name you gave it:
   the CLI raises no start-of-turn or end-of-turn event, so lich would have had a
   spinner it could never turn off.
+- **A terminal entrypoint works on Windows.** Setting one on a shell card saved
+  the value and then opened a bare prompt anyway, with nothing on screen saying
+  the setting had not been used. The command now runs, and the prompt you land
+  in afterwards is the same shell process rather than a second one — so the
+  card's path line follows a `cd` the way it does everywhere else. On Windows
+  the command also sees your `$PROFILE`, which the Unix `-c` equivalent does not
+  load: an alias you defined there can be an entrypoint.
+
+### Changed
+
+- **A Windows session opens in PowerShell, not `cmd.exe`.** lich read `COMSPEC`
+  the way it reads `$SHELL` on Unix, and that variable is set on every Windows
+  box and always names `cmd.exe` — so the shell a Windows user got was never one
+  they chose, and there was no way to choose another. A shell session now opens
+  in PowerShell 7 (`pwsh.exe`) when it is installed and in the `powershell.exe`
+  that ships with Windows otherwise. `cmd.exe` is still what runs a provider
+  shipped as a `.cmd` or `.bat`, which is a limitation of `CreateProcess` rather
+  than a shell anyone is dropped into.
+- **A file dropped on a Windows session, and a terminal editor opened from one,
+  are quoted for the shell that reads them.** Both wrapped a path in double
+  quotes for `cmd.exe`. A path that `cmd` could not express at all — one holding
+  a `"` or a `%VAR%`, or ending in a backslash — was refused outright, and Open
+  in editor silently fell back to the file's default handler instead. PowerShell
+  can express all three, so the refusal is gone with the shell it was written
+  for.
 
 ## [0.40.1] - 2026-08-24
 

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -53,14 +53,18 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   `pty_windows.go`): closing a card signals the agent and gives it `closeGrace` to leave, so its exit path runs —
   hooks, transcripts, whatever it writes on the way out. A ConPTY has no signal to deliver, so the same close on
   Windows is still abrupt: an agent that saves state on exit loses it there, and nothing on screen says so.
-- **A terminal entrypoint reaches shell sessions on Linux and macOS alone** (`internal/terminal/entrypoint.go`):
-  the menu item is absent on a provider card, and on Windows the setting saves and the terminal opens on a bare
-  shell anyway — the wrap is skipped there for `wrapSetup`'s reason, and nothing on screen says so. It also runs
-  through the shell's `-c`, which loads no interactive rc: an alias defined in `.zshrc` is not a command that can
-  be an entrypoint, though `$PATH` is intact (`internal/terminal/shellenv.go`).
-- **The worktree setup script answers to the main checkout, never the new branch** (`internal/project/setup.go`):
-  improve `.lich/setup-worktree.sh` on a feature branch and fresh worktrees keep running the old one until the
-  change reaches the checkout the project points at.
+- **A terminal entrypoint reaches shell sessions only, and reads a different rc on each OS**
+  (`internal/terminal/entrypoint.go`): the menu item is absent on a provider card. On Linux and macOS the command
+  runs through the shell's `-c`, which loads no interactive rc: an alias defined in `.zshrc` is not a command that
+  can be an entrypoint, though `$PATH` is intact (`internal/terminal/shellenv.go`). On Windows it runs through
+  PowerShell's `-EncodedCommand`, which *does* load `$PROFILE` first — so the same alias works there, and an
+  entrypoint one user shares is not necessarily one the next can run.
+- **The worktree setup script answers to the main checkout, never the new branch, and never runs on Windows**
+  (`internal/project/setup.go`, `internal/terminal/setup.go`): improve `.lich/setup-worktree.sh` on a feature
+  branch and fresh worktrees keep running the old one until the change reaches the checkout the project points
+  at. And `.lich/setup-worktree.sh` is one file, versioned and shared by every checkout, holding sh — so a
+  Windows session skips it rather than feeding it to PowerShell, which would run the leading words of every line
+  as commands. A worktree opens there with its setup silently not done.
 - **A session is named at birth, never on resume** (`internal/terminal/command.go`, `nameArgs`): the trap is that
   lich still *derives* that name (`internal/relay/rostername.go`, its page-side half
   `frontend/src/lib/session/peer-name.ts`) for the relay to resolve against, and the derived string goes stale the

--- a/frontend/src/lib/terminal/drop-files.test.ts
+++ b/frontend/src/lib/terminal/drop-files.test.ts
@@ -70,11 +70,15 @@ describe("composeDroppedPaths", () => {
     )
   })
 
-  // cmd.exe has no single quotes: quoting a Windows path with them hands the
-  // prompt a path that does not exist, quotes and all.
-  it("quotes a Windows path with a space the way cmd.exe reads it", () => {
+  // PowerShell is the shell a Windows session runs, and it doubles an embedded
+  // single quote rather than escaping it the POSIX way — a path under
+  // C:\\Users\\O'Brien has to come out as one argument on both hosts.
+  it("quotes a Windows path the way PowerShell reads it", () => {
     expect(composeDroppedPaths(["C:\\Program Files\\a.ts"], true)).toBe(
-      `${PASTE_START}"C:\\Program Files\\a.ts" ${PASTE_END}`,
+      `${PASTE_START}'C:\\Program Files\\a.ts' ${PASTE_END}`,
+    )
+    expect(composeDroppedPaths(["C:\\Users\\O'Brien\\a b.ts"], true)).toBe(
+      `${PASTE_START}'C:\\Users\\O''Brien\\a b.ts' ${PASTE_END}`,
     )
   })
 })

--- a/frontend/src/lib/terminal/drop-files.ts
+++ b/frontend/src/lib/terminal/drop-files.ts
@@ -170,15 +170,16 @@ export function composeDroppedPaths(paths: readonly string[], isWindows = false)
 // quotePath keeps a path with spaces — or anything else a shell would act on —
 // a single argument, because the prompt underneath may well be a shell. The
 // safe set covers both separators, so an ordinary path of either OS is written
-// bare. Beyond it the quote is the host's: cmd.exe knows only double quotes
-// (and a Windows path cannot contain one), POSIX gets single quotes, where a
-// path holding one closes, escapes it and reopens.
+// bare. Beyond it both hosts single-quote and differ only in the escape: POSIX
+// closes the quoting, escapes the quote and reopens; PowerShell — what a Windows
+// session runs (internal/terminal, windowsShells) — doubles it. Mirrors
+// internal/shquote, the backend half of the same rule.
 function quotePath(path: string, isWindows: boolean): string {
   if (/^[\w@%+=:,./\\-]+$/.test(path)) {
     return path
   }
   if (isWindows) {
-    return `"${path}"`
+    return `'${path.split("'").join("''")}'`
   }
   return `'${path.split("'").join(`'\\''`)}'`
 }

--- a/internal/shquote/shquote.go
+++ b/internal/shquote/shquote.go
@@ -1,20 +1,30 @@
-// Package shquote quotes a string for a POSIX shell command line. lich composes
-// two of those — the worktree setup wrapper that execs a provider
+// Package shquote quotes a string for a shell command line. lich composes
+// three of those — the worktree setup wrapper that execs a provider
 // (internal/terminal) and the terminal-editor invocation handed to a session
-// (internal/system) — and both interpolate a path or a binary name the user or
-// an agent chose. One copy of the rule, so a metacharacter that survives one
-// call site cannot survive the other.
+// (internal/system), on a POSIX shell; and the same editor invocation on
+// Windows, where the session's shell is PowerShell. All of them interpolate a
+// path or a binary name the user or an agent chose. One copy of each rule, so a
+// metacharacter that survives one call site cannot survive the other.
 //
-// The window composes a third — the `lich send` line a session's card hands out
-// — and quotes it the same way in frontend/src/lib/session/send-command.ts, the
-// page-side half of this rule, tested against the same cases.
+// The window composes a fourth — the `lich send` line a session's card hands
+// out — and quotes it the same way in frontend/src/lib/session/send-command.ts,
+// the page-side half of this rule, tested against the same cases.
 package shquote
 
 import "strings"
 
 // Quote returns s single-quoted, safe against embedded single quotes. It
-// assumes an sh/bash/zsh-style shell; cmd.exe (experimental Windows) quotes
-// differently, which is why the setup wrapper skips Windows entirely.
+// assumes an sh/bash/zsh-style shell; PowerShell, which a Windows session runs,
+// spells the escape differently — see QuotePwsh.
 func Quote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// QuotePwsh returns s single-quoted for PowerShell, safe against embedded
+// single quotes. PowerShell expands nothing inside a single-quoted string — no
+// $variable, no `backtick escape, no subexpression — so doubling the quote is
+// the whole rule, and unlike cmd.exe (which lich no longer opens a session in)
+// there is no character it cannot express.
+func QuotePwsh(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
 }

--- a/internal/shquote/shquote_test.go
+++ b/internal/shquote/shquote_test.go
@@ -20,3 +20,26 @@ func TestQuote(t *testing.T) {
 		}
 	}
 }
+
+// TestQuotePwsh proves the PowerShell rule against the same edge cases, plus
+// the three cmd.exe could not express at all: a double quote, a percent-wrapped
+// variable name and a trailing backslash all survive as literals here, which is
+// why the Windows caller no longer needs a refusal path.
+func TestQuotePwsh(t *testing.T) {
+	tests := []struct{ in, want string }{
+		{"plain", "'plain'"},
+		{"with space", "'with space'"},
+		{"it's", "'it''s'"},
+		{`C:\Users\O'Brien\a.txt`, `'C:\Users\O''Brien\a.txt'`},
+		{"", "''"},
+		{"$HOME `id` ;rm", "'$HOME `id` ;rm'"},
+		{`C:\repo\a"b.txt`, `'C:\repo\a"b.txt'`},
+		{`C:\repo\a%PATH%.txt`, `'C:\repo\a%PATH%.txt'`},
+		{`C:\repo\dir\`, `'C:\repo\dir\'`},
+	}
+	for _, tt := range tests {
+		if got := QuotePwsh(tt.in); got != tt.want {
+			t.Errorf("QuotePwsh(%q) = %s, want %s", tt.in, got, tt.want)
+		}
+	}
+}

--- a/internal/system/open_darwin.go
+++ b/internal/system/open_darwin.go
@@ -15,10 +15,9 @@ func (s *Service) openURL(rawURL string) error {
 	return s.run("open", rawURL)
 }
 
-// quoteForShell quotes a path for the POSIX shell a macOS session runs. Every
-// path can be expressed, so this never refuses.
-func (s *Service) quoteForShell(full string) (string, bool) {
-	return shquote.Quote(full), true
+// quoteForShell quotes a path for the POSIX shell a macOS session runs.
+func (s *Service) quoteForShell(full string) string {
+	return shquote.Quote(full)
 }
 
 // openFolder shows a directory in Finder. Deliberately without the -t of

--- a/internal/system/open_linux.go
+++ b/internal/system/open_linux.go
@@ -14,10 +14,9 @@ func (s *Service) openURL(rawURL string) error {
 	return s.run("xdg-open", rawURL)
 }
 
-// quoteForShell quotes a path for the POSIX shell a Linux session runs. Every
-// path can be expressed, so this never refuses.
-func (s *Service) quoteForShell(full string) (string, bool) {
-	return shquote.Quote(full), true
+// quoteForShell quotes a path for the POSIX shell a Linux session runs.
+func (s *Service) quoteForShell(full string) string {
+	return shquote.Quote(full)
 }
 
 // openFolder shows a directory in the desktop's file manager. Same resolver as

--- a/internal/system/open_windows.go
+++ b/internal/system/open_windows.go
@@ -1,5 +1,7 @@
 package system
 
+import "github.com/omartelo/lich/internal/shquote"
+
 // openDefault hands the file to its shell association when no $VISUAL/$EDITOR
 // is set. explorer takes the path as a plain argument, which is the point: the
 // `cmd /c start` this replaced handed it to a shell that reads & | < > as
@@ -10,9 +12,13 @@ func (s *Service) openDefault(full string) error {
 	return s.run("explorer", full)
 }
 
-// quoteForShell quotes a path for cmd.exe, the shell a Windows session runs.
-func (s *Service) quoteForShell(full string) (string, bool) {
-	return quoteCmdPath(full)
+// quoteForShell quotes a path for PowerShell, the shell a Windows session runs
+// (internal/terminal, windowsShells). Every path can be expressed, so this never
+// refuses — cmd.exe, which lich no longer opens a session in, could not express
+// a path holding a double quote or a %VAR% and had to hand those to the default
+// handler instead.
+func (s *Service) quoteForShell(full string) string {
+	return shquote.QuotePwsh(full)
 }
 
 // openURL hands an external URL to the default browser. Deliberately not the

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -219,14 +219,8 @@ func (s *Service) openInEditor(full string, fallback func(string) error) (string
 		// The command runs in the session's shell, so the file path — the
 		// caller-influenced part — must survive spaces and metacharacters. The
 		// quoting rule is the shell's, and the session's shell is per-OS (see
-		// the open_* files). A path that shell cannot express at all opens with
-		// the default handler instead: a line that would run something else is
-		// worse than not using the editor.
-		quoted, ok := s.quoteForShell(full)
-		if !ok {
-			return "", fallback(full)
-		}
-		return editor + " " + quoted, nil
+		// the open_* files).
+		return editor + " " + s.quoteForShell(full), nil
 	}
 	if editor != "" {
 		return "", s.runEditor(editor, full, fallback)
@@ -264,26 +258,6 @@ func isTerminalEditor(editor string) bool {
 		return false
 	}
 	return terminalEditors[filepath.Base(fields[0])]
-}
-
-// quoteCmdPath renders full as one argument of a cmd.exe command line, and
-// reports false when cmd cannot express it at all. Double quotes cover the
-// command separators (& | < >), the grouping parentheses, ^ and spaces — but
-// cmd has no escape for three cases, so they are refused rather than mangled:
-//
-//   - a literal " ends the quoted run and nothing puts one back;
-//   - % is expanded inside quotes too, so a defined variable's name between
-//     percents silently becomes a different path;
-//   - a trailing backslash escapes the closing quote for the target's own argv
-//     parser. filepath.Join cleans that away before we get here, so this is the
-//     belt to the caller's braces.
-//
-// Kept out of the build-tagged file so the rule is tested on any OS.
-func quoteCmdPath(full string) (string, bool) {
-	if strings.ContainsAny(full, `"%`) || strings.HasSuffix(full, `\`) {
-		return "", false
-	}
-	return `"` + full + `"`, true
 }
 
 // getenv reads a key from the resolved shell env, "" when absent.

--- a/internal/system/system_test.go
+++ b/internal/system/system_test.go
@@ -157,71 +157,16 @@ func TestOpenInEditorTerminalReturnsCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("OpenInEditor: %v", err)
 	}
-	// The quoting belongs to the session's shell: sh everywhere, cmd.exe on
-	// Windows, and the two spell a quoted argument differently.
+	// The quoting belongs to the session's shell — sh on Unix, PowerShell on
+	// Windows — and both spell a quoted argument with single quotes, differing
+	// only in how an embedded one is escaped (see internal/shquote).
 	full := filepath.Join("/repo", "src/main.go")
 	want := "nvim '" + full + "'"
-	if runtime.GOOS == "windows" {
-		want = `nvim "` + full + `"`
-	}
 	if cmd != want {
 		t.Errorf("cmd = %q, want %q", cmd, want)
 	}
 	if launched {
 		t.Error("a terminal editor was launched detached instead of returned")
-	}
-}
-
-// TestQuoteCmdPath proves the cmd.exe rule: the separators a shell would act on
-// are covered by the quotes, and the three characters cmd cannot express are
-// refused outright rather than handed over half-escaped.
-func TestQuoteCmdPath(t *testing.T) {
-	quoted := []string{
-		`C:\repo\a.txt`,
-		`C:\Users\First Last\repo\a.txt`,
-		`C:\repo\a&calc.txt`,
-		`C:\repo\a|b>c.txt`,
-		`C:\repo\a^b(c).txt`,
-	}
-	for _, full := range quoted {
-		got, ok := quoteCmdPath(full)
-		if !ok || got != `"`+full+`"` {
-			t.Errorf("quoteCmdPath(%q) = (%q, %v), want the path in quotes", full, got, ok)
-		}
-	}
-
-	refused := []string{
-		`C:\repo\a"b.txt`,     // no way to put a quote back inside a quoted run
-		`C:\repo\a%PATH%.txt`, // expanded even inside quotes
-		`C:\repo\dir\`,        // would escape the closing quote
-	}
-	for _, full := range refused {
-		if got, ok := quoteCmdPath(full); ok {
-			t.Errorf("quoteCmdPath(%q) = (%q, true), want refused", full, got)
-		}
-	}
-}
-
-// TestOpenInEditorFallsBackWhenTheShellCannotQuote proves an unquotable path
-// opens with the default handler instead of being pasted into a shell. Only
-// cmd.exe refuses anything, so only Windows has the branch to exercise.
-func TestOpenInEditorFallsBackWhenTheShellCannotQuote(t *testing.T) {
-	if runtime.GOOS != "windows" {
-		t.Skip("every path is expressible in a POSIX shell")
-	}
-	var name string
-	var args []string
-	s := &Service{env: []string{"EDITOR=nvim"}, run: captureRun(&name, &args)}
-
-	cmd, err := s.OpenInEditor(`C:\repo`, `a"b.txt`)
-	if err != nil {
-		t.Fatalf("OpenInEditor: %v", err)
-	}
-	if cmd != "" {
-		t.Errorf("cmd = %q, want empty: an unquotable path must not reach a shell", cmd)
-	}
-	if want := filepath.Join(`C:\repo`, `a"b.txt`); len(args) == 0 || args[len(args)-1] != want {
-		t.Errorf("args = %v, want the file %s handed to the default opener", args, want)
 	}
 }
 

--- a/internal/terminal/entrypoint.go
+++ b/internal/terminal/entrypoint.go
@@ -1,7 +1,10 @@
 package terminal
 
 import (
+	"encoding/base64"
+	"encoding/binary"
 	"strings"
+	"unicode/utf16"
 
 	"github.com/omartelo/lich/internal/shquote"
 )
@@ -28,17 +31,49 @@ import (
 // screen with a shell under it.
 //
 // goos is runtime.GOOS, passed in so the decision stays pure and testable
-// off-Windows — wrapSetup's pattern, and Windows is skipped for wrapSetup's
-// reason: composing a cmd.exe chain is not worth it while the port stays
-// experimental. shell is the resolved user shell, which is also what the command
-// is run by: a value the user typed is their own shell's syntax, not sh's.
+// off-Windows — wrapSetup's pattern. shell is the resolved user shell, which is
+// also what the command is run by: a value the user typed is their own shell's
+// syntax, not sh's. Which is why the two branches share no composition. A POSIX
+// shell reaches the prompt by exec'ing itself over the command, and PowerShell —
+// what a Windows session runs (windowsShells) — has -NoExit for exactly this,
+// which is the better half of the trade: the shell the user lands in is the same
+// process lich spawned, so the pid it polls for the working directory is still
+// the shell's (cwd.go) and no second process hangs off the PTY.
 func wrapEntrypoint(spec ptySpec, kind, entrypoint, goos string) ptySpec {
 	entrypoint = strings.TrimSpace(entrypoint)
-	if kind != KindShell || entrypoint == "" || goos == "windows" {
+	if kind != KindShell || entrypoint == "" {
+		return spec
+	}
+	if goos == "windows" {
+		// No -NoProfile: the profile is the user's own rc, this is their own
+		// shell, and PowerShell loads it before running the command — so an
+		// alias defined in $PROFILE can be an entrypoint, the one thing the
+		// POSIX branch cannot offer.
+		spec.args = []string{"-NoExit", "-EncodedCommand", encodePwshCommand(entrypoint)}
 		return spec
 	}
 	// The newline is load-bearing: a command ending in a comment or an unclosed
 	// `&&` would otherwise swallow the exec that follows it.
 	spec.args = []string{"-c", entrypoint + "\nexec " + shquote.Quote(spec.bin)}
 	return spec
+}
+
+// encodePwshCommand renders a script as the base64 of its UTF-16LE bytes, which
+// is what PowerShell's -EncodedCommand takes.
+//
+// The encoding is here to sidestep quoting, not to hide anything. A Windows
+// command line is one string: the argv lich builds is composed by
+// windows.ComposeCommandLine (pty_windows.go), which escapes an embedded double
+// quote as \" for CommandLineToArgvW — and PowerShell does not read \" as an
+// escape. An entrypoint is text a user typed into a dialog, so a double quote in
+// it (`pnpm run "dev server"`) is ordinary rather than hostile, and it would
+// arrive mangled or split. Base64 has no character either parser acts on, so
+// there is no rule left to get wrong.
+func encodePwshCommand(script string) string {
+	units := utf16.Encode([]rune(script))
+	buf := make([]byte, 2*len(units))
+	for i, unit := range units {
+		binary.LittleEndian.PutUint16(buf[2*i:], unit)
+	}
+	return base64.StdEncoding.EncodeToString(buf)
 }

--- a/internal/terminal/entrypoint_test.go
+++ b/internal/terminal/entrypoint_test.go
@@ -1,8 +1,10 @@
 package terminal
 
 import (
+	"encoding/base64"
 	"strings"
 	"testing"
+	"unicode/utf16"
 
 	"github.com/omartelo/lich/internal/providers"
 )
@@ -37,7 +39,7 @@ func TestWrapEntrypointLeavesOtherSessionsAlone(t *testing.T) {
 		{"opencode session", providers.OpenCode, "lazygit", "linux"},
 		{"omp session", providers.OMP, "lazygit", "linux"},
 		{"crush session", providers.Crush, "lazygit", "linux"},
-		{"windows", KindShell, "lazygit", "windows"},
+		{"windows provider session", providers.Claude, "lazygit", "windows"},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -113,4 +115,69 @@ func TestWrapEntrypointComposesWithSetup(t *testing.T) {
 	if !(install < marker && marker < tool) {
 		t.Errorf("stages out of order (install=%d marker=%d tool=%d): %q", install, marker, tool, script)
 	}
+}
+
+// TestWrapEntrypointOnWindowsKeepsOneProcess pins the Windows contract, which is
+// not the POSIX one: PowerShell's own -NoExit drops the user at a prompt after
+// the command, so the shell they land in is the process lich spawned rather than
+// a second one exec'd over it. A regression that composed a chain instead would
+// leave the working-directory poll (cwd.go) watching a parent that never moves.
+func TestWrapEntrypointOnWindowsKeepsOneProcess(t *testing.T) {
+	spec := entrypointSpec()
+	spec.bin = `C:\Program Files\PowerShell\7\pwsh.exe`
+
+	got := wrapEntrypoint(spec, KindShell, "  lazygit  ", "windows")
+
+	if got.bin != spec.bin {
+		t.Errorf("bin = %q, want the session's own shell %q", got.bin, spec.bin)
+	}
+	if len(got.args) != 3 || got.args[0] != "-NoExit" || got.args[1] != "-EncodedCommand" {
+		t.Fatalf("args = %v, want -NoExit -EncodedCommand <script>", got.args)
+	}
+	if command := decodePwshCommand(t, got.args[2]); command != "lazygit" {
+		t.Errorf("encoded command = %q, want the trimmed entrypoint", command)
+	}
+	if got.dir != spec.dir || got.cols != spec.cols || got.rows != spec.rows {
+		t.Errorf("wrap changed dir/size: %+v", got)
+	}
+}
+
+// TestEncodePwshCommandSurvivesQuotesAndUnicode is why the command is encoded at
+// all: a double quote in a value the user typed would not survive the escaping
+// windows.ComposeCommandLine applies for CommandLineToArgvW, which PowerShell
+// does not undo. Non-ASCII proves the UTF-16 half — PowerShell reads the bytes
+// as little-endian UTF-16, so a wrong width or order turns the command to noise.
+func TestEncodePwshCommandSurvivesQuotesAndUnicode(t *testing.T) {
+	for _, script := range []string{
+		`pnpm run "dev server"`,
+		"echo 'it''s'",
+		"cargo run -- --path C:\\Users\\Ana\\prova\u00e7\u00e3o",
+		"",
+	} {
+		encoded := encodePwshCommand(script)
+		if got := decodePwshCommand(t, encoded); got != script {
+			t.Errorf("round trip of %q gave %q", script, got)
+		}
+		if strings.ContainsAny(encoded, ` "'\`) {
+			t.Errorf("encoding of %q left a character a command line acts on: %q", script, encoded)
+		}
+	}
+}
+
+// decodePwshCommand reads an -EncodedCommand argument back, the way PowerShell
+// does: base64 of UTF-16LE.
+func decodePwshCommand(t *testing.T, encoded string) string {
+	t.Helper()
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatalf("decode %q: %v", encoded, err)
+	}
+	if len(raw)%2 != 0 {
+		t.Fatalf("encoded command is not whole UTF-16 units: %d bytes", len(raw))
+	}
+	units := make([]uint16, len(raw)/2)
+	for i := range units {
+		units[i] = uint16(raw[2*i]) | uint16(raw[2*i+1])<<8
+	}
+	return string(utf16.Decode(units))
 }

--- a/internal/terminal/setup.go
+++ b/internal/terminal/setup.go
@@ -12,9 +12,13 @@ import (
 // move the provider's start directory) and the provider starts even when the
 // script fails: a broken setup must not cost the session, so the failure is
 // echoed and the provider execs anyway. goos is runtime.GOOS, passed in so the
-// decision stays pure and testable off-Windows (wrapArgv's pattern): Windows
-// is skipped — composing a cmd.exe chain around wrapArgv's own cmd.exe
-// handling is not worth it while the port stays experimental.
+// decision stays pure and testable off-Windows (wrapArgv's pattern): Windows is
+// skipped, and not for the shell's sake — a Windows session runs PowerShell now
+// (windowsShells), which wrapEntrypoint composes for. What is skipped is the
+// script: setupScriptPath is `.lich/setup-worktree.sh`, one file, versioned in
+// the repository and shared by everyone who checks it out, and its contents are
+// sh. Running that through PowerShell would not fail cleanly — it would run the
+// leading words of every line as commands.
 //
 // The bool reports whether the wrap happened, and it is the only honest answer
 // to "will this PTY print the end marker". Re-deriving it from the returned

--- a/internal/terminal/shell.go
+++ b/internal/terminal/shell.go
@@ -1,0 +1,16 @@
+package terminal
+
+// windowsShells are the shells a Windows "shell" session is opened in, best
+// first: PowerShell 7 when the user installed it, else the 5.1 that has shipped
+// with Windows since 7. The first one on $PATH wins (userShell).
+//
+// cmd.exe is deliberately absent, and COMSPEC — which names it — is deliberately
+// not read. COMSPEC is set on every Windows box and always points at cmd.exe, so
+// honouring it the way $SHELL is honoured on Unix would mean never opening
+// anything else: it is not a shell the user chose, it is the one Windows ships.
+// cmd.exe is still what runs a .cmd or .bat provider shim (wrapArgv) — that is
+// CreateProcess' limitation, not a shell the user is ever dropped into.
+//
+// Kept out of the build-tagged file so the order is tested on any OS, the
+// pattern wrapArgv and dosPathRunes follow.
+var windowsShells = []string{"pwsh.exe", "powershell.exe"}

--- a/internal/terminal/shell_test.go
+++ b/internal/terminal/shell_test.go
@@ -1,0 +1,22 @@
+package terminal
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestWindowsShellsPreferPowerShell7 pins the order a Windows session resolves
+// its shell in, and the absence that is the whole point of the list: cmd.exe is
+// not a shell lich opens a session in, so a regression that puts it back — or
+// that reads COMSPEC, which names it on every box — fails here rather than on a
+// user's machine.
+func TestWindowsShellsPreferPowerShell7(t *testing.T) {
+	if len(windowsShells) != 2 || windowsShells[0] != "pwsh.exe" || windowsShells[1] != "powershell.exe" {
+		t.Errorf("windowsShells = %v, want pwsh.exe before powershell.exe", windowsShells)
+	}
+	for _, shell := range windowsShells {
+		if strings.Contains(strings.ToLower(shell), "cmd") {
+			t.Errorf("cmd.exe is back in the shell list: %v", windowsShells)
+		}
+	}
+}

--- a/internal/terminal/shell_windows.go
+++ b/internal/terminal/shell_windows.go
@@ -2,11 +2,23 @@
 
 package terminal
 
-import "os"
+import "os/exec"
 
-// defaultShell is spawned for "shell" sessions when the environment names none.
-const defaultShell = "cmd.exe"
+// defaultShell is spawned for "shell" sessions when nothing else resolves. It
+// is the shell every Windows install carries; a box without it fails the spawn
+// with the path it looked for, which is the honest answer.
+const defaultShell = "powershell.exe"
 
-// userShell reads the user's shell from the environment, "" when unset.
-// Windows has no $SHELL; COMSPEC is the closest equivalent.
-func userShell() string { return os.Getenv("COMSPEC") }
+// userShell returns the best shell on $PATH, "" when none of them resolves.
+// Windows has no $SHELL, and the variable that comes closest is not one — see
+// windowsShells. The resolved path is returned rather than the name: it is what
+// startPTY has to look up anyway, and asking $PATH once keeps the answer stable
+// for the life of the session.
+func userShell() string {
+	for _, shell := range windowsShells {
+		if path, err := exec.LookPath(shell); err == nil {
+			return path
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Three Windows users asked for PowerShell. The shell was never one they chose: `userShell()` read `COMSPEC`, the way it reads `$SHELL` on Unix — and `COMSPEC` is set on every Windows box and always names `cmd.exe`, which also made `defaultShell` unreachable. A shell session now asks `$PATH` for `pwsh.exe`, then `powershell.exe`.

`cmd.exe` stays where it is not a shell anyone is dropped into: `wrapArgv` still runs a provider shipped as `.cmd` or `.bat` through it, which is `CreateProcess`' limitation rather than a choice.

### What the shell change drags with it

**Path quoting** for the terminal editor and for a dropped file is PowerShell's now — single quotes, the embedded one doubled (`shquote.QuotePwsh`, mirrored page-side in `drop-files.ts`). PowerShell can express a path holding a `"` or a `%VAR%` or ending in a backslash, all three of which `cmd` refused outright, so `quoteCmdPath`, `quoteForShell`'s `ok` bool and `openInEditor`'s fallback are deleted with the shell they were written for. Net −60 lines there.

### Ceilings this closes, and the one it does not

- **Closed: a terminal entrypoint on Windows** (`docs/ceilings.md`). The setting saved and then opened a bare prompt anyway. PowerShell's own `-NoExit` reaches the prompt without composing a chain — and it is the better half of the trade, because the shell the user lands in is the same process lich spawned: the pid the cwd poll watches is still the shell's, and no second process hangs off the PTY. The command travels as `-EncodedCommand`, base64 of UTF-16LE: an entrypoint is text a user typed into a dialog, and a double quote in it (`pnpm run "dev server"`) would not survive the `\"` escaping `windows.ComposeCommandLine` applies for `CommandLineToArgvW`, which PowerShell does not undo.
- **Left open, with the reason corrected: `wrapSetup`.** It skipped Windows because composing a `cmd.exe` chain was not worth it. That is no longer the obstacle — the file is: `.lich/setup-worktree.sh` is one file, versioned and shared by every checkout, and it holds sh. Feeding it to PowerShell would not fail cleanly; it would run the leading words of every line as commands. Closing this needs a second file and a decision about which one a worktree runs, which is a separate PR.
- **Left open: `ResolveShellEnv`.** It is a no-op on Windows (no `$SHELL`). PowerShell has `$PROFILE`, so it *could* run — but that buys a 5s timeout on every Windows launch to recover variables nobody has reported missing, and `Restricted` execution policy blocks the profile on a default client install anyway. Not in this PR.

The entrypoint asymmetry is now itself a ceiling bullet: on Windows the command runs after `$PROFILE` loads, so an alias defined there **is** a valid entrypoint — which it is not under the POSIX `-c`.

### Verification

Local gate green: `gofmt`, `go vet ./...`, `go test ./...`, `biome check`, `vitest run` (1108 tests), `tsc && vite build`. The cross-compile loop passes for linux/darwin/windows. Coverage on the touched packages: shquote 100%, terminal 93.0%, system 88.1%.

**What no gate here can answer:** there is no Windows hardware on this machine. The quoting and the encoding are pure functions tested on any OS, and the OS suite runs on the Windows runner — but PowerShell actually starting under ConPTY, and `-NoExit -EncodedCommand` landing at a usable prompt, is what the branch needs a real box for. One user is lined up to homologate.
