### PR TITLE
fix: file a turn's snapshot before the panel is told it ended

### DIFF
--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -54,7 +54,9 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   touched ignored files reports itself as having changed nothing. Every snapshot in the app runs on one
   FIFO worker, because git refuses a second `add` against an index another holds — so one session's first
   snapshot of a large checkout delays the next session's, and a queue past `snapQueueDepth` drops a job,
-  costing that turn its record with only the log saying so. And the boundary is the session-state contract,
+  costing that turn its record with only the log saying so. A checkout whose *first* snapshot fails is
+  dropped outright and never asked again — the ordinary reason is a session opened outside a repository,
+  but a transient failure at spawn reads the same and leaves that card with no last turn until it respawns. And the boundary is the session-state contract,
   so **Crush and Cursor CLI have no last turn at all**: neither reports a state (`docs/hooks/session-state.md`),
   so nothing ever opens or closes a window there and the switch is never drawn — a rule read off the
   session's own reports, not a list of providers, so it corrects itself the day either one starts reporting.
@@ -247,7 +249,7 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   use Bash". Codex's `PermissionRequest` and opencode's `.asked` events carry only the thing being asked
   about — `tool_name`, `permission`, `action` — so those cards read a bare `Bash` or `edit`, which says which
   card to open and not what it will ask. **Antigravity, oh-my-pi, Crush and Cursor CLI send no reason at all** and keep the
-  generic "Waiting on you": none of the three reports `waiting` in the first place (Antigravity's permission
+  generic "Waiting on you": none of the four reports `waiting` in the first place (Antigravity's permission
   prompt raises no lifecycle event that has been measured; omp declares an approval event no run was ever seen
   emitting; Crush reports no state), so there is nothing to hang a reason on. The trap is reading a bare card as
   "nothing to say" — on those three it means the harness never spoke, not that the block is trivial.

--- a/frontend/src/components/diff/ReviewPanel.tsx
+++ b/frontend/src/components/diff/ReviewPanel.tsx
@@ -3,12 +3,15 @@ import { toast } from "sonner"
 import { Notice } from "@/components/common/Notice"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import type { LastTurn } from "@/lib/api-types"
+import { onAppEvent } from "@/lib/app-events"
 import { discardTargets, parseDiff, type DiffFile } from "@/lib/git/diff"
+import { lastTurnNotice } from "@/lib/git/last-turn"
 import { addReviewComment } from "@/lib/review-comments"
 import { ProjectService, Terminal } from "@/lib/rpc"
 import { useActiveSession } from "@/lib/session/use-active-session"
 import { formatAge, subscribeAge } from "@/lib/session/session-age"
-import { useSessionEverReported, useSessionStatus } from "@/lib/session/use-session-status"
+import { isIdEvent, TURN_EVENT } from "@/lib/session/session-events"
+import { useSessionEverReported } from "@/lib/session/use-session-status"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { useInject } from "@/lib/use-inject"
 import { errorText } from "@/lib/utils"
@@ -52,11 +55,10 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
   // The source switch is earned, not assumed: a provider that never reports its
   // state has no turn to bracket, so it is offered the working tree alone.
   const switchable = useSessionEverReported(sessionId)
-  const sessionStatus = useSessionStatus(sessionId)
   const [source, setSource] = useState<DiffSource>("worktree")
   const [files, setFiles] = useState<DiffFile[] | null>(null)
   const [failed, setFailed] = useState(false)
-  const [turnState, setTurnState] = useState<string | null>(null)
+  const [turnState, setTurnState] = useState<LastTurn["state"] | null>(null)
   const [endedAt, setEndedAt] = useState<number | null>(null)
   const [pendingDiscard, setPendingDiscard] = useState<DiffFile | null>(null)
 
@@ -129,17 +131,22 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
   // they are blind to (see DIFF_POLL_MS).
   //
   // A finished turn has neither problem — it cannot change once it is over — so
-  // that source is not polled at all. The session's own state is what moves it:
-  // every transition is a turn starting or ending, and the panel answers for the
-  // last one that ended.
+  // that source is not polled at all. TURN_EVENT is what moves it, and it has to
+  // be that rather than the session's state: the record is filed on a snapshot
+  // worker well after the `done` that closed the turn, so a read taken on the
+  // state report answers with the turn before this one.
   useEffect(() => {
     void refresh()
     if (source === "turn") {
-      return
+      return onAppEvent(TURN_EVENT, (data) => {
+        if (isIdEvent(data) && data.id === sessionId) {
+          void refresh()
+        }
+      })
     }
     const timer = setInterval(() => void refresh(), DIFF_POLL_MS)
     return () => clearInterval(timer)
-  }, [refresh, source, sessionStatus, status?.files, status?.added, status?.deleted])
+  }, [refresh, source, sessionId, status?.files, status?.added, status?.deleted])
 
   // Reverting a rename touches both paths (new removed, old restored); the
   // panel refreshes immediately instead of waiting for the next poll tick.
@@ -248,9 +255,9 @@ function useAge(from: number | null): string {
 
 interface PanelBodyProps {
   source: DiffSource
-  /** The last turn's own answer ("ok" | "empty" | "unavailable"), null while
-   * showing the working tree or before the first read lands. */
-  turnState: string | null
+  /** The last turn's own answer, null while showing the working tree or before
+   * the first read lands. */
+  turnState: LastTurn["state"] | null
   files: DiffFile[] | null
   failed: boolean
   onInject: (text: string) => void
@@ -271,7 +278,12 @@ function PanelBody({
   bulk,
 }: PanelBodyProps) {
   if (failed) {
-    return <Notice>Not a git repository</Notice>
+    // The two sources fail for different reasons, and the working tree's answer
+    // — read for a path that is not a checkout — says nothing true about a turn
+    // lich could not render.
+    return (
+      <Notice>{source === "turn" ? "Could not read the last turn" : "Not a git repository"}</Notice>
+    )
   }
   if (files === null) {
     return <Notice>Loading…</Notice>
@@ -279,8 +291,10 @@ function PanelBody({
   if (source === "turn") {
     // A turn that changed nothing and a turn nobody recorded are different
     // answers, and each says which one it is. Conflating them would have the
-    // panel report "nothing happened" for a snapshot it simply lost.
-    if (turnState === "empty") {
+    // panel report "nothing happened" for a snapshot it simply lost, which is
+    // why the weighing is pure and tested (lastTurnNotice).
+    const notice = lastTurnNotice(turnState, files.length)
+    if (notice === "empty") {
       return (
         <Notice>
           <span className="block text-foreground">Nothing changed in this window.</span>
@@ -288,7 +302,7 @@ function PanelBody({
         </Notice>
       )
     }
-    if (turnState !== "ok" || files.length === 0) {
+    if (notice === "unrecorded") {
       return (
         <Notice>
           <span className="block text-foreground">No last turn recorded.</span>

--- a/frontend/src/lib/git/last-turn.test.ts
+++ b/frontend/src/lib/git/last-turn.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest"
+import { lastTurnNotice } from "./last-turn"
+
+describe("lastTurnNotice", () => {
+  it("draws the diff only when there is one to draw", () => {
+    expect(lastTurnNotice("ok", 3)).toBe("diff")
+  })
+
+  // The distinction the whole feature turns on: a turn that changed nothing
+  // must never be reported as a turn nobody recorded, or the other way round.
+  it("keeps a turn that changed nothing apart from one nobody recorded", () => {
+    expect(lastTurnNotice("empty", 0)).toBe("empty")
+    expect(lastTurnNotice("unavailable", 0)).toBe("unrecorded")
+  })
+
+  // Before the first read lands, and for a session whose provider never
+  // reported: neither is an empty turn.
+  it("reads no answer at all as unrecorded", () => {
+    expect(lastTurnNotice(null, 0)).toBe("unrecorded")
+  })
+
+  // An "ok" whose text yielded no files — a mode-only change, a binary the
+  // parser skips — has nothing to show, and "nothing changed" would be a claim
+  // the backend never made.
+  it("does not promote an unrenderable diff to an empty turn", () => {
+    expect(lastTurnNotice("ok", 0)).toBe("unrecorded")
+  })
+})

--- a/frontend/src/lib/git/last-turn.ts
+++ b/frontend/src/lib/git/last-turn.ts
@@ -1,0 +1,22 @@
+import type { LastTurn } from "@/lib/api-types"
+
+// What the Review panel draws for the session's last finished turn. The three
+// answers are kept apart because conflating them is the one mistake this
+// feature can make: a turn that ran and changed nothing is a real answer, and
+// "nobody recorded a turn here" is the absence of one — reported as the first,
+// it reads as "the agent did nothing".
+export type LastTurnNotice = "diff" | "empty" | "unrecorded"
+
+// lastTurnNotice weighs the backend's own state against what parseDiff could
+// make of the text. An "ok" carrying nothing a file list can be built from is
+// unrecorded rather than empty: "empty" is the backend's word for two identical
+// trees, and it says so itself.
+export function lastTurnNotice(state: LastTurn["state"] | null, fileCount: number): LastTurnNotice {
+  if (state === "empty") {
+    return "empty"
+  }
+  if (state === "ok" && fileCount > 0) {
+    return "diff"
+  }
+  return "unrecorded"
+}

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -31,6 +31,12 @@ export const TITLE_EVENT = "session-title"
 // (see terminal.touchedEventName). Payload: { id }.
 export const TOUCHED_EVENT = "session-touched"
 
+// Global event the backend emits once a session's last-turn record has changed
+// (see terminal.turnEventName). Payload: { id }. Not the same moment as the
+// turn's `done`: the record is filed on a snapshot worker, so a panel that
+// refreshed off the status report would read the answer before it exists.
+export const TURN_EVENT = "session-turn"
+
 // Global event the backend emits with a session's live working directory (see
 // terminal.cwdEventName): once with the directory the PTY starts in, then on
 // every change the cwd watcher observes. Payload: { id, cwd }.

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -65,6 +65,12 @@ const (
 	// asked to work it out again. Persisted with the row too (store.Session's
 	// Sandbox), which is what a page reload hydrates from.
 	sandboxEventName = "session-sandbox"
+	// turnEventName carries the id of a session whose last finished turn has
+	// just been filed ({id}) — emitted when the closing snapshot lands, not when
+	// the turn's `done` is reported. The two are not the same moment: the
+	// snapshot runs on a worker, so a panel refreshed off the state report reads
+	// the record before it exists (see turnSnaps).
+	turnEventName = "session-turn"
 )
 
 // statusEvent is the payload of statusEventName: the session whose processing
@@ -123,6 +129,13 @@ type agentEvent struct {
 type sandboxEvent struct {
 	ID       string `json:"id"`
 	Confined bool   `json:"confined"`
+}
+
+// turnEvent is the payload of turnEventName: the session whose last-turn record
+// just changed. It carries no diff — the panel asks for one only while it is on
+// screen, and a turn's diff is far larger than an event ought to be.
+type turnEvent struct {
+	ID string `json:"id"`
 }
 
 // session is a single running PTY-backed shell. done closes when the session
@@ -314,6 +327,13 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 		// TERM into the array main still holds.
 		env:    append(slices.Clip(childEnv(env)), "TERM=xterm-256color"),
 		prices: pricing.New(),
+	}
+	// Wired here rather than emitted from the hook's own goroutine: the record
+	// is filed on the snapshot worker, minutes-of-CPU later on a cold checkout,
+	// and the panel has no other way to learn that the answer it already asked
+	// for has changed.
+	s.snaps.filed = func(id string) {
+		hub.Emit(turnEventName, turnEvent{ID: id})
 	}
 	ws, err := newTransport(
 		func(id string, data []byte) {
@@ -956,12 +976,14 @@ func (s *Service) Close(id string) error {
 	}
 	s.mu.Unlock()
 
+	// Before the bail below, because a card is closed far more often than it is
+	// running: its row is deleted either way, so nothing will ever ask what its
+	// last turn changed — and its snapshot index would otherwise outlive it on
+	// disk for the rest of the machine's life.
+	s.snaps.forget(id)
 	if !ok {
 		return nil
 	}
-	// A closed card's row is deleted, so nothing will ever ask what its last
-	// turn changed — and its snapshot index would otherwise outlive it on disk.
-	s.snaps.forget(id)
 	return sess.pty.Close()
 }
 

--- a/internal/terminal/turnsnap.go
+++ b/internal/terminal/turnsnap.go
@@ -76,6 +76,10 @@ type turnSnaps struct {
 	// root holds the index files. Empty means "resolve it from the config
 	// directory on first use"; tests set it to a directory of their own.
 	root string
+	// filed is called once a session's last-turn record has changed, which is
+	// the only moment the panel can act on: a turn is filed on the worker, well
+	// after the `done` that closed it. Nil in a test that does not care.
+	filed func(id string)
 }
 
 // track binds a session to the checkout its PTY was spawned at and warms the
@@ -102,7 +106,13 @@ func (t *turnSnaps) track(id, dir string) {
 	// cache in the index file, not the oid.
 	t.submit(func() {
 		if _, err := project.SnapshotTree(dir, index); err != nil {
-			slog.Debug("turnsnap: warm-up failed", "session", id, "err", err)
+			// A checkout git cannot snapshot has no turns to bracket, and the
+			// ordinary reason is a session opened outside a repository at all.
+			// Dropped once here rather than warned about twice per turn for the
+			// rest of the session; the panel then reads "unavailable", which is
+			// the true answer either way.
+			slog.Debug("turnsnap: no snapshots for this checkout", "session", id, "err", err)
+			t.forget(id)
 		}
 	})
 }
@@ -163,6 +173,11 @@ func (t *turnSnaps) closeTurn(id string) {
 		return
 	}
 	state.open = false
+	// Cleared here, not in the job: a job the queue drops never runs, and the
+	// turn before it would otherwise stay on screen wearing this turn's name.
+	// Between here and the snapshot landing the panel reads "unavailable",
+	// which is what "the last turn is not recorded yet" honestly looks like.
+	state.last = nil
 	seq, dir, index := state.seq, state.dir, state.index
 	t.mu.Unlock()
 
@@ -172,16 +187,17 @@ func (t *turnSnaps) closeTurn(id string) {
 			slog.Warn("turnsnap: closing snapshot failed", "session", id, "err", err)
 		}
 		t.mu.Lock()
-		defer t.mu.Unlock()
 		state, ok := t.sessions[id]
-		if !ok || state.seq != seq {
-			return
+		if ok && state.seq == seq && err == nil && state.before != "" {
+			state.last = &turnPair{before: state.before, after: oid, endedAt: time.Now()}
 		}
-		if err != nil || state.before == "" {
-			state.last = nil
-			return
+		filed := t.filed
+		t.mu.Unlock()
+		// Outside the lock, and whatever the outcome: a turn that lost its
+		// snapshot changed the answer too, from "the turn before" to "none".
+		if filed != nil {
+			filed(id)
 		}
-		state.last = &turnPair{before: state.before, after: oid, endedAt: time.Now()}
 	})
 }
 

--- a/internal/terminal/turnsnap_test.go
+++ b/internal/terminal/turnsnap_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // snapRepo creates a git repository with one commit and a Service wired to keep
@@ -30,7 +31,25 @@ func snapRepo(t *testing.T) (*Service, string) {
 
 	svc := &Service{}
 	svc.snaps.root = t.TempDir()
+	// Registered after both TempDirs, so it runs before either is removed:
+	// track queues a warm-up snapshot nothing waits for, and a `git add -A`
+	// still writing into a directory RemoveAll is walking fails the test with a
+	// cleanup error that has nothing to do with what it asserted.
+	t.Cleanup(func() { drainSnaps(t, svc) })
 	return svc, repo
+}
+
+// drainSnaps blocks until the snapshot worker has run everything queued before
+// it. FIFO is what makes this work: a job submitted last finishes last.
+func drainSnaps(t *testing.T, svc *Service) {
+	t.Helper()
+	drained := make(chan struct{})
+	svc.snaps.submit(func() { close(drained) })
+	select {
+	case <-drained:
+	case <-time.After(30 * time.Second):
+		t.Error("the snapshot worker never drained")
+	}
 }
 
 func run(t *testing.T, dir string, args ...string) {
@@ -324,5 +343,125 @@ func TestADoneWithNoTurnOpenRecordsNothing(t *testing.T) {
 	}
 	if turn.State != turnDiffUnavailable {
 		t.Errorf("a stray done recorded %q", turn.State)
+	}
+}
+
+// A card is closed far more often than it is running: its agent exits, the
+// terminal says so, and the user closes the dead card some time later. The
+// accounting and the index file have to go with it either way.
+func TestCloseForgetsASessionWhosePTYAlreadyExited(t *testing.T) {
+	svc, repo := snapRepo(t)
+	svc.sessions = map[string]*session{}
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "a.txt", "changed\n")
+	closeAndWait(t, svc, "s1", turnDiffOK)
+
+	index := filepath.Join(svc.snaps.root, "s1.idx")
+	if _, err := os.Stat(index); err != nil {
+		t.Fatalf("the index was never written: %v", err)
+	}
+	// No entry in s.sessions: the PTY was reaped by stream, which is the state
+	// every session that ended on its own leaves behind.
+	if err := svc.Close("s1"); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if _, err := os.Stat(index); !os.IsNotExist(err) {
+		t.Errorf("the index outlived the card: %v", err)
+	}
+	svc.snaps.mu.Lock()
+	_, held := svc.snaps.sessions["s1"]
+	svc.snaps.mu.Unlock()
+	if held {
+		t.Error("the accounting outlived the card")
+	}
+}
+
+// The panel is told when the record lands, not when the turn ends: the two are
+// different moments, and only the first one has an answer to give.
+func TestFilingATurnNotifiesOnce(t *testing.T) {
+	svc, repo := snapRepo(t)
+	filed := make(chan string, 4)
+	svc.snaps.filed = func(id string) { filed <- id }
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	select {
+	case id := <-filed:
+		t.Fatalf("an opening snapshot filed nothing, yet notified for %q", id)
+	default:
+	}
+
+	writeIn(t, repo, "a.txt", "changed\n")
+	svc.snaps.note("s1", statusDone)
+	select {
+	case id := <-filed:
+		if id != "s1" {
+			t.Errorf("notified for %q, want s1", id)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("the closing snapshot landed without telling the panel")
+	}
+}
+
+// A close still on the worker must not leave the turn before it on screen
+// wearing this turn's name: until the snapshot lands there is no last turn.
+func TestACloseInFlightNeverShowsTheTurnBefore(t *testing.T) {
+	svc, repo := snapRepo(t)
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "a.txt", "one turn\n")
+	closeAndWait(t, svc, "s1", turnDiffOK)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "a.txt", "another turn\n")
+
+	// Occupies the single worker, so the closing snapshot below is queued and
+	// cannot land — the same window a dropped job leaves open forever.
+	held := make(chan struct{})
+	svc.snaps.submit(func() { <-held })
+	svc.snaps.note("s1", statusDone)
+
+	turn, err := svc.LastTurnDiff("s1")
+	if err != nil {
+		t.Fatalf("LastTurnDiff: %v", err)
+	}
+	if turn.State != turnDiffUnavailable {
+		t.Errorf("a close in flight reads as %q (%q), want %q",
+			turn.State, turn.Diff, turnDiffUnavailable)
+	}
+	close(held)
+	waitFor(t, func() bool {
+		turn, err := svc.LastTurnDiff("s1")
+		return err == nil && turn.State == turnDiffOK
+	}, "the closing snapshot to land")
+}
+
+// A session opened outside a repository has nothing to snapshot. It is dropped
+// on the warm-up rather than warned about twice a turn for the rest of its life.
+func TestACheckoutGitCannotSnapshotIsDropped(t *testing.T) {
+	svc, _ := snapRepo(t)
+	plain := t.TempDir()
+	svc.snaps.track("s1", plain)
+
+	waitFor(t, func() bool {
+		svc.snaps.mu.Lock()
+		defer svc.snaps.mu.Unlock()
+		_, held := svc.snaps.sessions["s1"]
+		return !held
+	}, "the untrackable checkout to be dropped")
+
+	svc.snaps.note("s1", statusBusy)
+	svc.snaps.note("s1", statusDone)
+	turn, err := svc.LastTurnDiff("s1")
+	if err != nil {
+		t.Fatalf("LastTurnDiff: %v", err)
+	}
+	if turn.State != turnDiffUnavailable {
+		t.Errorf("a directory outside a repository reads as %q, want %q",
+			turn.State, turnDiffUnavailable)
 	}
 }


### PR DESCRIPTION
Found by a code-quality audit of `62cb5f4..113c98a`. Four defects around the Review panel's "Last turn", all in the same feature.

### The panel showed the previous turn

`hub.Emit(statusEventName, …)` runs on the hook's goroutine; `s.snaps.note` only *queues* the snapshot that closes the turn. The panel refreshed off that state report, so it read `pair()` before the record existed — and then had no trigger left until the next turn started. The backend's own test works around this with `waitFor`; the panel had nothing.

The record now announces itself: `turnSnaps.filed` fires once the closing snapshot lands **or fails**, the service emits `session-turn`, and `ReviewPanel` listens to that instead of to `useSessionStatus`.

### `Close` leaked the index and the accounting

`Close` returned at `if !ok` before reaching `snaps.forget` — so closing a card whose PTY had already exited (how most cards are closed) left `~/.config/lich/turns/<id>.idx` and its map entry behind forever. `TestCloseForgetsASessionWhosePTYAlreadyExited` fails on `main`.

### A close in flight showed the turn before it

A closing snapshot the queue drops never ran, and `state.last` still held the previous turn — the panel then drew it under this turn's name with an old "ended N ago". `closeTurn` clears the record under the lock and the job refills it, so the gap reads as unrecorded, which is what `docs/ceilings.md` already claimed happened.

### A session outside a repository warned twice a turn, forever

Its first snapshot failing now drops it once. New ceiling documented: a transient failure at spawn reads the same and costs that card its last turn until it respawns.

Also: the panel no longer says "Not a git repository" when it was a turn it could not read, and the empty/unrecorded weighing moved into `lastTurnNotice` where it is tested — reporting a lost snapshot as "nothing changed" is the one mistake this feature can make.

### Flake fixed at its root (test-only)

`snapRepo` now drains the snapshot worker before its `TempDir`s are removed. A warm-up `git add -A` racing `RemoveAll` failed `TestADoneWithNoTurnOpenRecordsNothing` on `main` at `-count=200`; green at `-count=200` after.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test ./...` (1964) and `-race` on `internal/terminal` green
- [x] `go test -run TestADoneWithNoTurnOpenRecordsNothing -count=200` green (red on `main`)
- [x] `biome check` clean (14 pre-existing warnings, none in touched files), `vitest run` 1119 green, `vite build` succeeds
- [ ] Manual: end a turn with the "Last turn" tab open — the diff appears without touching anything else