### PR TITLE
refactor: one rule for Cursor's config dir, one builder for an mcp.json

### DIFF
--- a/internal/agentplugin/agentplugin.go
+++ b/internal/agentplugin/agentplugin.go
@@ -67,9 +67,11 @@ const (
 //
 // Cursor CLI is the registry's seventh and the odd one: lich ships it no hooks,
 // because the CLI already executes every Claude Code hook on the machine. Its
-// install writes the MCP registration that route does not carry and installs
-// the plugin into Claude Code, and its version is the version installed there —
-// cursor.go says why.
+// install writes the MCP registration that route does not carry and nothing
+// else — it refuses while Claude Code has no plugin rather than installing one
+// there, since an install that silently changes another provider is not a thing
+// lich does — and its version is the version installed there. cursor.go says
+// why.
 var supported = []string{
 	providers.Claude, providers.Codex, providers.Antigravity,
 	providers.OpenCode, providers.OMP, providers.Crush, providers.Cursor,
@@ -185,7 +187,7 @@ func (s *Service) HasTools(provider string) bool {
 //
 // It is what stops HasTools promising tools the install could not register: all
 // three write the lich binary's own path, and all three leave the registration
-// out when it cannot be resolved (crushrcBlock, ompMCPDocument,
+// out when it cannot be resolved (crushrcBlock, mcpDocument,
 // antigravityRegisterMCP) — so a session there has the plugin's reports and no
 // tool list, and must be told the command line instead. opencode is absent
 // because its plugin defines the tools itself, with no binary to name.

--- a/internal/agentplugin/agentplugin_test.go
+++ b/internal/agentplugin/agentplugin_test.go
@@ -607,8 +607,8 @@ func TestHasToolsIsAlwaysTrueForTheHarnessesToldAtSpawn(t *testing.T) {
 
 // Which providers depend on a registration lich writes with its own path: the
 // ones whose installs leave that registration out — or refuse outright — when
-// the path cannot be resolved (crushrcBlock, ompMCPDocument,
-// antigravityRegisterMCP, cursorMCPDocument). Pinned as a list rather than
+// the path cannot be resolved (crushrcBlock, mcpDocument,
+// antigravityRegisterMCP). Pinned as a list rather than
 // derived, because a provider added to one side and not the other is exactly the
 // drift that promises tools nobody registered.
 func TestRegistersServerAtInstall(t *testing.T) {

--- a/internal/agentplugin/cursor.go
+++ b/internal/agentplugin/cursor.go
@@ -31,10 +31,6 @@ const (
 	// `~/.cursor` — resolved off the home with no variable in the way, unlike
 	// the config directory that holds the credentials and the chats.
 	cursorMCPFile = "mcp.json"
-
-	// cursorMCPServers is the key Cursor reads servers under: the Claude Desktop
-	// shape, which it adopted the way omp did.
-	cursorMCPServers = "mcpServers"
 )
 
 // cursorInstall registers lich's MCP server with Cursor. It refuses while the
@@ -53,17 +49,17 @@ func (s *Service) cursorInstall() error {
 	}
 	// Merged before anything is written, for the reason omp's install gives: the
 	// only way this step fails is a document lich must not replace.
-	registration, err := cursorMCPDocument(s.lichBin())
+	path, err := cursorMCPPath()
+	if err != nil {
+		return err
+	}
+	registration, err := mcpDocument(path, s.lichBin())
 	if err != nil {
 		return err
 	}
 	if registration == nil {
 		return fmt.Errorf("lich cannot resolve its own binary to register with %s",
 			providerName(providers.Cursor))
-	}
-	path, err := cursorMCPPath()
-	if err != nil {
-		return err
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create %s: %w", filepath.Dir(path), err)
@@ -103,53 +99,6 @@ func cursorRegistered() bool {
 	}
 	_, ok := config.Servers[relay.MCPServerName]
 	return ok
-}
-
-// cursorMCPDocument is Cursor's `mcpServers` document with lich's server
-// registered in it, leaving every other server and every other key as they were.
-// Nil when lich cannot name its own binary: a registration naming a command that
-// cannot run is worse than none, and the session still has the `lich` command
-// line.
-//
-// The path written is this binary's, resolved now — a document cannot expand a
-// variable per session. It is only the transport; which lich a session reaches
-// is decided by the coordinates in its PTY.
-func cursorMCPDocument(lichBin string) ([]byte, error) {
-	if lichBin == "" {
-		return nil, nil
-	}
-	path, err := cursorMCPPath()
-	if err != nil {
-		return nil, err
-	}
-	existing, err := os.ReadFile(path)
-	if err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("read %s: %w", path, err)
-	}
-	config := map[string]any{}
-	if len(existing) > 0 {
-		// Refused rather than replaced, as omp's is: the file belongs to the
-		// user, and overwriting one lich failed to understand would delete
-		// servers it cannot see.
-		if err := json.Unmarshal(existing, &config); err != nil {
-			return nil, fmt.Errorf("%s is not a JSON object lich can merge into: %w", path, err)
-		}
-	}
-	servers, ok := config[cursorMCPServers].(map[string]any)
-	if !ok {
-		servers = map[string]any{}
-	}
-	servers[relay.MCPServerName] = map[string]any{
-		"command": lichBin,
-		"args":    []string{relay.MCPSubcommand},
-	}
-	config[cursorMCPServers] = servers
-
-	body, err := json.MarshalIndent(config, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("encode %s: %w", path, err)
-	}
-	return append(body, '\n'), nil
 }
 
 // cursorMCPPath is `~/.cursor/mcp.json`. Cursor reads this one off the home

--- a/internal/agentplugin/files_test.go
+++ b/internal/agentplugin/files_test.go
@@ -394,9 +394,9 @@ func readOMPServers(t *testing.T, agent string) map[string]any {
 	if err := json.Unmarshal(data, &config); err != nil {
 		t.Fatalf("the mcp document is not JSON: %v\n%s", err, data)
 	}
-	servers, ok := config[ompMCPServers].(map[string]any)
+	servers, ok := config[mcpServersKey].(map[string]any)
 	if !ok {
-		t.Fatalf("no %s table in:\n%s", ompMCPServers, data)
+		t.Fatalf("no %s table in:\n%s", mcpServersKey, data)
 	}
 	return servers
 }
@@ -1123,7 +1123,7 @@ func readCursorServers(t *testing.T, home string) map[string]any {
 	if err := json.Unmarshal(data, &doc); err != nil {
 		t.Fatalf("cursor's MCP document is not JSON: %v", err)
 	}
-	servers, _ := doc[cursorMCPServers].(map[string]any)
+	servers, _ := doc[mcpServersKey].(map[string]any)
 	return servers
 }
 

--- a/internal/agentplugin/mcpdocument.go
+++ b/internal/agentplugin/mcpdocument.go
@@ -1,0 +1,63 @@
+package agentplugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/omartelo/lich/internal/relay"
+)
+
+// mcpServersKey is the key an `mcpServers` document holds its servers under —
+// the Claude Desktop shape, which oh-my-pi and Cursor CLI both adopted
+// wholesale. One constant, because it is one wire format and not two.
+const mcpServersKey = "mcpServers"
+
+// mcpDocument is the `mcpServers` document at path with lich's server
+// registered in it, leaving every other server and every other key exactly as
+// they were. Nil when lich cannot name its own binary: a registration pointing
+// at a command that cannot run is worse than none.
+//
+// Two harnesses read one of these — oh-my-pi's, beside its extensions, and
+// Cursor's under ~/.cursor — and neither takes a `--mcp-config` flag, so for
+// both the file is the whole registration. It is the same trade Crush's crushrc
+// block makes, one step worse: JSON has no comment to hide a marker in and no
+// way to append, so lich rewrites the document. Every key survives the round
+// trip; the user's formatting does not.
+//
+// The path written is this binary's, resolved now (lichBinary) — a document
+// cannot expand a variable per session. It is only the transport; which lich a
+// session reaches is decided by the coordinates in its PTY.
+func mcpDocument(path, lichBin string) ([]byte, error) {
+	if lichBin == "" {
+		return nil, nil
+	}
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	config := map[string]any{}
+	if len(existing) > 0 {
+		// Refused rather than replaced: the file belongs to the user, and
+		// overwriting one lich failed to understand would delete servers it
+		// cannot see.
+		if err := json.Unmarshal(existing, &config); err != nil {
+			return nil, fmt.Errorf("%s is not a JSON object lich can merge into: %w", path, err)
+		}
+	}
+	servers, ok := config[mcpServersKey].(map[string]any)
+	if !ok {
+		servers = map[string]any{}
+	}
+	servers[relay.MCPServerName] = map[string]any{
+		"command": lichBin,
+		"args":    []string{relay.MCPSubcommand},
+	}
+	config[mcpServersKey] = servers
+
+	body, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode %s: %w", path, err)
+	}
+	return append(body, '\n'), nil
+}

--- a/internal/agentplugin/omp.go
+++ b/internal/agentplugin/omp.go
@@ -1,12 +1,9 @@
 package agentplugin
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/omartelo/lich/internal/relay"
 )
 
 // The oh-my-pi side. omp has no plugin CLI either, and its extensions are
@@ -17,10 +14,8 @@ import (
 //
 // The MCP registration is the part that differs. omp takes no `--mcp-config`
 // flag, and the only place it reads a server from is an `mcpServers` document
-// beside the extensions — so lich writes one, merging into whatever is already
-// there. It is the same trade Crush's crushrc block makes, one step worse: JSON
-// has no comment to hide a marker in and no way to append, so lich rewrites the
-// document. Every key survives the round trip; the user's formatting does not.
+// beside the extensions — so lich writes one (mcpDocument, shared with Cursor
+// CLI, which reads the same shape).
 
 const (
 	// ompSource is the module's path inside the plugin repository, and ompFile
@@ -31,12 +26,9 @@ const (
 	ompExtensionsDir = "extensions"
 
 	// ompMCPFile is the document omp reads MCP servers from, in the same agent
-	// directory as the extensions.
+	// directory as the extensions. Its contents are mcpDocument's, which Cursor
+	// CLI reads the same shape of.
 	ompMCPFile = "mcp.json"
-
-	// ompMCPServers is the key omp reads servers under — the Claude Desktop
-	// shape, which omp adopted wholesale.
-	ompMCPServers = "mcpServers"
 )
 
 func (s *Service) ompInstall() error {
@@ -55,7 +47,7 @@ func (s *Service) ompInstall() error {
 	// Merged before anything is written, because the only way this step fails is
 	// a document lich must not replace — and an install that leaves an extension
 	// behind while refusing the registration is worse than one the user retries.
-	registration, err := ompMCPDocument(dir, s.lichBin())
+	registration, err := mcpDocument(filepath.Join(dir, ompMCPFile), s.lichBin())
 	if err != nil {
 		return err
 	}
@@ -86,51 +78,6 @@ func (s *Service) ompInstalledVersion() (string, bool) {
 		return "", false
 	}
 	return versionOf(data, jsComment)
-}
-
-// ompMCPDocument is omp's `mcpServers` document with lich's server registered in
-// it, leaving every other server and every other key exactly as they were. Nil
-// when there is nothing to write: a lich that cannot name its own binary
-// registers nothing rather than a command that cannot run — the reports are the
-// half omp needs to be useful, and they do not depend on it.
-//
-// The path written is this binary's, resolved now, for the reason Crush's block
-// gives: a registration in a file cannot expand a variable per session. It is
-// only the transport — which lich a session reaches is decided by the
-// coordinates in its PTY.
-func ompMCPDocument(dir, lichBin string) ([]byte, error) {
-	if lichBin == "" {
-		return nil, nil
-	}
-	path := filepath.Join(dir, ompMCPFile)
-	existing, err := os.ReadFile(path)
-	if err != nil && !os.IsNotExist(err) {
-		return nil, fmt.Errorf("read %s: %w", path, err)
-	}
-	config := map[string]any{}
-	if len(existing) > 0 {
-		// Refused rather than replaced: the file belongs to the user, and
-		// overwriting one lich failed to understand would delete servers it
-		// cannot see.
-		if err := json.Unmarshal(existing, &config); err != nil {
-			return nil, fmt.Errorf("%s is not a JSON object lich can merge into: %w", path, err)
-		}
-	}
-	servers, ok := config[ompMCPServers].(map[string]any)
-	if !ok {
-		servers = map[string]any{}
-	}
-	servers[relay.MCPServerName] = map[string]any{
-		"command": lichBin,
-		"args":    []string{relay.MCPSubcommand},
-	}
-	config[ompMCPServers] = servers
-
-	body, err := json.MarshalIndent(config, "", "  ")
-	if err != nil {
-		return nil, fmt.Errorf("encode %s: %w", path, err)
-	}
-	return append(body, '\n'), nil
 }
 
 // ompAgentDir resolves the directory omp keeps its state in — extensions, MCP

--- a/internal/providers/cursor.go
+++ b/internal/providers/cursor.go
@@ -1,0 +1,40 @@
+package providers
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// CursorConfigDir resolves Cursor CLI's config directory under home — where it
+// keeps the credentials (`auth.json`, `cli-config.json`) and the chats.
+//
+// It lives here because two packages need the same answer and got two: the
+// sandbox binds this directory into a confined session, and the terminal reads
+// the chats under it to decide whether a conversation can still be resumed. A
+// second copy of the rule had already drifted on whether a relative variable
+// counts.
+//
+// Cursor is not xdg-basedir, which is the trap: $CURSOR_CONFIG_DIR wins
+// outright, else $XDG_CONFIG_HOME with "cursor" under it — and with neither set
+// it lands on ~/.cursor, never ~/.config/cursor. Reading it the way opencode and
+// Crush are read would name a directory the CLI never writes on a machine with
+// no XDG_CONFIG_HOME, which is most of them. Measured on 2026.08.11.
+//
+// A relative variable is ignored rather than resolved, both because
+// XDG_CONFIG_HOME is specified that way and because there is nothing to resolve
+// it against: lich's working directory is not the CLI's, so a relative path here
+// names a directory nobody involved would agree on.
+//
+// It answers for the config dir alone. `~/.cursor` is a second directory the CLI
+// resolves off the home with no variable in the way at all — it holds mcp.json,
+// the per-project transcripts and the CLI state — and a caller that needs the
+// whole picture binds both (internal/sandbox).
+func CursorConfigDir(home string) string {
+	if dir := os.Getenv("CURSOR_CONFIG_DIR"); filepath.IsAbs(dir) {
+		return dir
+	}
+	if base := os.Getenv("XDG_CONFIG_HOME"); filepath.IsAbs(base) {
+		return filepath.Join(base, "cursor")
+	}
+	return filepath.Join(home, ".cursor")
+}

--- a/internal/providers/cursor_test.go
+++ b/internal/providers/cursor_test.go
@@ -1,0 +1,52 @@
+package providers
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// The precedence Cursor was measured to apply, and the one thing about it that
+// surprises: with neither variable set it lands on ~/.cursor, not on the
+// xdg-basedir ~/.config/cursor every other provider here follows.
+func TestCursorConfigDirPrecedence(t *testing.T) {
+	home := t.TempDir()
+	explicit := t.TempDir()
+	xdg := t.TempDir()
+
+	t.Setenv("CURSOR_CONFIG_DIR", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+	if got, want := CursorConfigDir(home), filepath.Join(home, ".cursor"); got != want {
+		t.Errorf("with nothing set = %q, want %q", got, want)
+	}
+
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	if got, want := CursorConfigDir(home), filepath.Join(xdg, "cursor"); got != want {
+		t.Errorf("with XDG_CONFIG_HOME = %q, want %q", got, want)
+	}
+
+	t.Setenv("CURSOR_CONFIG_DIR", explicit)
+	if got := CursorConfigDir(home); got != explicit {
+		t.Errorf("CURSOR_CONFIG_DIR loses to XDG_CONFIG_HOME: %q, want %q", got, explicit)
+	}
+}
+
+// A relative variable is ignored, not resolved. This is the rule the two copies
+// of this resolver disagreed on: one required an absolute path and the other
+// took whatever was set, so a relative CURSOR_CONFIG_DIR had the sandbox binding
+// ~/.cursor while the resume check looked somewhere else entirely.
+func TestCursorConfigDirIgnoresARelativeVariable(t *testing.T) {
+	home := t.TempDir()
+	want := filepath.Join(home, ".cursor")
+
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("CURSOR_CONFIG_DIR", filepath.Join("relative", "cursor"))
+	if got := CursorConfigDir(home); got != want {
+		t.Errorf("a relative CURSOR_CONFIG_DIR = %q, want %q", got, want)
+	}
+
+	t.Setenv("CURSOR_CONFIG_DIR", "")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join("relative", "config"))
+	if got := CursorConfigDir(home); got != want {
+		t.Errorf("a relative XDG_CONFIG_HOME = %q, want %q", got, want)
+	}
+}

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -102,10 +102,11 @@ func stateDirs(providerID, home string) []string {
 		// Two, because Cursor splits its state and reaches the second half
 		// through the home directly rather than through its config dir: the
 		// credentials (`auth.json`, `cli-config.json`) and the chats are under
-		// the config dir, while `~/.cursor` holds the `mcp.json` it reads, its
+		// the config dir (providers.CursorConfigDir, which is not xdg-basedir
+		// and says why), while `~/.cursor` holds the `mcp.json` it reads, its
 		// per-project transcripts and its CLI state. With no XDG_CONFIG_HOME
 		// the two are the same directory, which is the usual case.
-		dirs := []string{cursorConfigDir(home)}
+		dirs := []string{providers.CursorConfigDir(home)}
 		if underHome := filepath.Join(home, ".cursor"); underHome != dirs[0] {
 			dirs = append(dirs, underHome)
 		}
@@ -134,26 +135,6 @@ func envDir(name, fallback string) string {
 		return dir
 	}
 	return fallback
-}
-
-// cursorConfigDir resolves Cursor CLI's config directory. It reads the XDG
-// variable but not the XDG fallback: with neither variable set Cursor lands on
-// ~/.cursor, never ~/.config/cursor, so configHome below would confine a Cursor
-// session to a directory its CLI never writes — a session that opens at the
-// login prompt. Measured on 2026.08.11; the same rule lives in
-// internal/terminal/transcript.go, which reads the chats under it.
-//
-// It answers for the config dir alone. `~/.cursor` is a second directory the
-// CLI resolves off the home with no variable in the way at all, and stateDirs
-// binds both.
-func cursorConfigDir(home string) string {
-	if dir := os.Getenv("CURSOR_CONFIG_DIR"); filepath.IsAbs(dir) {
-		return dir
-	}
-	if base := os.Getenv("XDG_CONFIG_HOME"); filepath.IsAbs(base) {
-		return filepath.Join(base, "cursor")
-	}
-	return filepath.Join(home, ".cursor")
 }
 
 // configHome and dataHome are the XDG directories, which every provider here

--- a/internal/terminal/transcript.go
+++ b/internal/terminal/transcript.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/omartelo/lich/internal/providers"
 )
 
 // globTranscript completes a transcript path under base: the parts lich does not
@@ -129,26 +131,16 @@ func cursorWorkspaceKey(cwd string) string {
 	return fmt.Sprintf("%x", md5.Sum([]byte(abs)))
 }
 
-// cursorConfigDir resolves Cursor CLI's config directory, or false when there is
-// no home to hang it off. It does not go through harnessDir because Cursor
-// answers to two variables in a shape no other provider uses: $CURSOR_CONFIG_DIR
-// wins outright, else $XDG_CONFIG_HOME with "cursor" under it — and the fallback
-// when neither is set is ~/.cursor, not ~/.config/cursor. Reading it as
-// xdg-basedir the way opencode and Crush are read would point at a directory
-// Cursor never writes on a machine with no XDG_CONFIG_HOME, which is most of
-// them. Measured on 2026.08.11; the same rule lives in internal/sandbox.
+// cursorConfigDir is providers.CursorConfigDir against this machine's home, or
+// false when there is no home to hang it off. It does not go through harnessDir
+// because Cursor is not xdg-basedir — the resolver says why, and it is shared
+// with internal/sandbox, which binds the same directory into a confined session.
 func cursorConfigDir() (string, bool) {
-	if dir := os.Getenv("CURSOR_CONFIG_DIR"); dir != "" {
-		return dir, true
-	}
-	if base := os.Getenv("XDG_CONFIG_HOME"); base != "" {
-		return filepath.Join(base, "cursor"), true
-	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", false
 	}
-	return filepath.Join(home, ".cursor"), true
+	return providers.CursorConfigDir(home), true
 }
 
 // ompTranscriptPath locates an oh-my-pi conversation by its id under omp's agent


### PR DESCRIPTION
Two duplications found by the audit of `62cb5f4..113c98a`. One of them had already drifted.

### `cursorConfigDir`, twice, with different answers

`internal/sandbox/sandbox.go` required `filepath.IsAbs` on both variables; `internal/terminal/transcript.go` accepted any non-empty string. Each comment pointed at the other as "the same rule". With `CURSOR_CONFIG_DIR=relative/x` the sandbox bound `~/.cursor` into the session while the resume check looked under lich's own working directory — one of the two was wrong.

The rule moves to `providers.CursorConfigDir(home)`, keeping the strict reading: a relative variable is ignored rather than resolved, because `XDG_CONFIG_HOME` is specified that way and because lich's working directory is not the CLI's, so a relative path here names a directory nobody involved would agree on. `home` is the parameter, which is what actually differed between the callers — the sandbox passes a confined home, the terminal the real one.

### `ompMCPDocument` ≡ `cursorMCPDocument`

Thirty-three identical lines with a different path in front, down to the refusal to overwrite a document lich cannot parse. Both call `mcpDocument(path, lichBin)` now, which also owns the `mcpServers` key the two constants spelled separately.

### One comment that said the opposite of the code

The docblock over `supported` claimed Cursor's install "installs the plugin into Claude Code". `cursorInstall` refuses while Claude Code has none, and `cursor.go` explains why an install that silently changes another provider is not a thing lich does.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test ./...` (1962) green
- [x] New: `TestCursorConfigDirIgnoresARelativeVariable` pins the rule the two copies disagreed on
- [x] Cross-compile loop green for linux/darwin/windows (`go build` + `go vet`)