### PR TITLE
fix: keep a session-state report off the PTY spawn lock

### DIFF
--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -175,10 +175,6 @@ type session struct {
 	// confined records whether this PTY was spawned inside the sandbox, so Start
 	// can report it once the spawn is out of the lock.
 	confined bool
-	// kind is what this PTY was spawned to run: a provider id, or KindShell.
-	// Read by providerKind, which is what stops a session-start report from
-	// repainting a card lich itself chose the provider for.
-	kind string
 }
 
 // Store is the persistence the terminal service depends on: the binary to spawn
@@ -241,6 +237,18 @@ type Service struct {
 	// without answering (internal/relay). Guarded by mu: wired after the
 	// transport is already serving.
 	onState func(id, state string)
+	// kinds is what each live session's PTY was spawned to run — a provider id,
+	// or KindShell — keyed by session id. Read by providerKind, which is what
+	// stops a session-start report from repainting a card lich itself chose the
+	// provider for, and by the state report's own filter.
+	//
+	// Deliberately not under mu, and that is the whole reason it is not simply a
+	// field on session: spawnSession holds mu across the PTY spawn, so a report
+	// that had to ask mu what a session runs would queue behind another
+	// session's spawn — which is exactly what the note on turns below forbids.
+	// Written once per spawn and read on every report, which is what sync.Map
+	// is for.
+	kinds sync.Map
 	// turns is which sessions have a turn open right now, which is what tells a
 	// `waiting` report that a human is blocking from one that only says the
 	// session is sitting at its prompt (see turnLog). It carries its own lock:
@@ -683,9 +691,11 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 		// is quiet too.
 		lastOut:  time.Now(),
 		confined: inSandbox,
-		kind:     kind,
 	}
 	s.sessions[id] = sess
+	// Outside mu's protection by design (see Service.kinds), and stored with the
+	// registration so no report can arrive for a session whose kind is unknown.
+	s.kinds.Store(id, kind)
 	go s.stream(id, sess)
 	return sess, cwd, nil
 }
@@ -702,13 +712,15 @@ func (s *Service) providerKind(id, reported string) string {
 }
 
 // kindOf is what a live session's PTY was spawned to run, or "" once it is gone.
+// It never takes mu: a hook asks this on every report, and mu is held across a
+// PTY spawn (see Service.kinds).
 func (s *Service) kindOf(id string) string {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if sess, running := s.sessions[id]; running {
-		return sess.kind
+	kind, ok := s.kinds.Load(id)
+	if !ok {
+		return ""
 	}
-	return ""
+	spawned, _ := kind.(string)
+	return spawned
 }
 
 // closableState reports whether a state reported from inside a session of this
@@ -775,6 +787,12 @@ func (s *Service) stream(id string, sess *session) {
 		delete(s.sessions, id)
 		close(current.done)
 		reaped = true
+	}
+	// Inside the same guard the map delete is: a reap that lost the race to a
+	// respawn under this id must not drop the kind the live session was
+	// registered with.
+	if reaped {
+		s.kinds.Delete(id)
 	}
 	s.mu.Unlock()
 
@@ -975,6 +993,7 @@ func (s *Service) Close(id string) error {
 		close(sess.done)
 	}
 	s.mu.Unlock()
+	s.kinds.Delete(id)
 
 	// Before the bail below, because a card is closed far more often than it is
 	// running: its row is deleted either way, so nothing will ever ask what its

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -559,11 +559,14 @@ func TestResolveCommand(t *testing.T) {
 // `claude` from inside a Cursor session. What lich spawned wins; only a shell,
 // where lich genuinely does not know what is running inside, wears the report.
 func TestProviderKindOutranksTheReport(t *testing.T) {
-	svc := &Service{sessions: map[string]*session{
-		"cursor-card": {kind: providers.Cursor},
-		"shell-card":  {kind: KindShell},
-		"odd-card":    {kind: "something-else"},
-	}}
+	svc := &Service{}
+	for id, kind := range map[string]string{
+		"cursor-card": providers.Cursor,
+		"shell-card":  KindShell,
+		"odd-card":    "something-else",
+	} {
+		svc.kinds.Store(id, kind)
+	}
 	cases := []struct {
 		name, id, reported, want string
 	}{
@@ -578,6 +581,43 @@ func TestProviderKindOutranksTheReport(t *testing.T) {
 			t.Errorf("%s: providerKind(%q, %q) = %q, want %q",
 				tc.name, tc.id, tc.reported, got, tc.want)
 		}
+	}
+}
+
+// The invariant the note on Service.turns states: a hook must never queue behind
+// a PTY spawn. spawnSession holds mu across startPTY, so asking mu what a
+// session runs would hold the report — and with it the agent's next step — for
+// however long another session takes to spawn.
+func TestAReportNeverQueuesBehindASpawn(t *testing.T) {
+	svc := &Service{}
+	svc.kinds.Store("s1", providers.Cursor)
+
+	// Stands in for a spawn in flight: the same lock, held by another session.
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+
+	answered := make(chan string, 1)
+	go func() { answered <- svc.kindOf("s1") }()
+	select {
+	case got := <-answered:
+		if got != providers.Cursor {
+			t.Errorf("kindOf = %q, want %q", got, providers.Cursor)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a state report queued behind a PTY spawn")
+	}
+}
+
+// A kind that outlived its PTY would have providerKind answering for a session
+// that is gone, which is the one case the report is the better answer.
+func TestClosingASessionDropsItsKind(t *testing.T) {
+	svc := &Service{sessions: map[string]*session{}}
+	svc.kinds.Store("s1", providers.Cursor)
+	if err := svc.Close("s1"); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if got := svc.kindOf("s1"); got != "" {
+		t.Errorf("a closed session still runs %q", got)
 	}
 }
 


### PR DESCRIPTION
From the audit of `62cb5f4..113c98a`.

The note on `Service.turns` states the rule and the reason it carries its own lock:

> nothing else about a report needs mu, and a hook must never queue behind a PTY spawn.

The Cursor state filter broke it. `closableState(s.kindOf(req.SessionID), req.State)` runs on every state report, and `kindOf` read `sess.kind` under `s.mu` — the lock `spawnSession` holds across `startPTY`, the sandbox resolution and the store reads in front of it. So every report from every session waited on any other session's spawn, and a report that waits is an agent that waits.

The kind moves off the `session` struct into a `sync.Map` on the service: written once per spawn beside the registration, dropped by whichever of `Close` or the reap evicts the PTY — inside the reap's own `current.pty == p` guard, so a reap that lost the race to a respawn under the same id does not drop the live session's kind.

`TestAReportNeverQueuesBehindASpawn` holds `s.mu` the way a spawn does and asserts the report is still answered; it hangs to its timeout on the old code.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test ./...` (1966) green, `-race` on `internal/terminal` green
- [x] Cross-compile loop green for linux/darwin/windows