### PR TITLE
fix: quote the `lich send` line for the shell the user is actually in

### DIFF
--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -59,6 +59,7 @@ import { System, Terminal as TerminalService } from "@/lib/rpc"
 import { queuePaste } from "@/lib/terminal/paste-queue"
 import type { DelegateGroup } from "@/lib/session/delegate-targets"
 import { delegatePrompt, delegateWorktreePrompt } from "@/lib/session/delegate-prompt"
+import { isWindows } from "@/lib/platform"
 import { sendCommand } from "@/lib/session/send-command"
 import { bracketedPaste } from "@/lib/terminal/bracketed-paste"
 import { requestTerminalFocus } from "@/lib/terminal/focus-request"
@@ -207,10 +208,11 @@ export function SessionCard({
   }
 
   // The line another terminal — or another agent — hands this session work
-  // with. The label is quoted for a shell on the way out (sendCommand): getting
-  // that right from memory is exactly what goes wrong when the line is retyped.
+  // with. The label is quoted for a shell on the way out (sendCommand), in the
+  // spelling this machine's own shell reads: getting that right from memory is
+  // exactly what goes wrong when the line is retyped.
   const copySendCommand = () => {
-    const command = sendCommand(projects, sessions, session)
+    const command = sendCommand(projects, sessions, session, isWindows)
     void navigator.clipboard.writeText(command).then(
       () => toast(`Copied: ${command}`),
       (error) => toast.error(`Could not copy the command: ${errorText(error)}`),

--- a/frontend/src/lib/session/send-command.test.ts
+++ b/frontend/src/lib/session/send-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { sendCommand, shQuote } from "./send-command"
+import { pwshQuote, sendCommand, shQuote } from "./send-command"
 import type { Session, SessionState } from "./sessions"
 
 const PROJECTS = [
@@ -28,6 +28,19 @@ describe("shQuote", () => {
   })
 })
 
+// The same cases against the other rule, because lich opens its own Windows
+// sessions in PowerShell: single quotes expand nothing there either, and only
+// the escape differs. Mirrors internal/shquote's TestQuotePwsh.
+describe("pwshQuote", () => {
+  it("doubles the quote instead of closing the run", () => {
+    expect(pwshQuote("plain")).toBe("'plain'")
+    expect(pwshQuote("with space")).toBe("'with space'")
+    expect(pwshQuote("it's")).toBe("'it''s'")
+    expect(pwshQuote("")).toBe("''")
+    expect(pwshQuote("$HOME `id` ;rm")).toBe("'$HOME `id` ;rm'")
+  })
+})
+
 describe("sendCommand", () => {
   it("names the session alone while its label is unambiguous", () => {
     expect(sendCommand(PROJECTS, state([]), auth)).toBe(`lich send 'auth' "<prompt>"`)
@@ -49,6 +62,18 @@ describe("sendCommand", () => {
 
   // The label is the user's own text: a card renamed to something with a quote
   // or a metacharacter in it still has to paste as one argument.
+  // On Windows the line is pasted into PowerShell, where the POSIX escape is
+  // four literal characters and the argument ends at the first apostrophe.
+  it("spells the same label for PowerShell", () => {
+    const awkward: Session = { id: "dddd4444", label: `the $PATH 'bug'`, kind: "claude" }
+    expect(sendCommand(PROJECTS, state([awkward]), awkward, true)).toBe(
+      `lich send 'the $PATH ''bug''' "<prompt>"`,
+    )
+    expect(sendCommand(PROJECTS, state([otherAuth]), auth, true)).toBe(
+      `lich send --project 'lich' 'auth' "<prompt>"`,
+    )
+  })
+
   it("quotes a label the shell would otherwise read", () => {
     const awkward: Session = { id: "dddd4444", label: `the $PATH 'bug'`, kind: "claude" }
     expect(sendCommand(PROJECTS, state([awkward]), awkward)).toBe(

--- a/frontend/src/lib/session/send-command.ts
+++ b/frontend/src/lib/session/send-command.ts
@@ -17,6 +17,17 @@ export function shQuote(value: string): string {
   return `'${value.split("'").join(`'\\''`)}'`
 }
 
+/**
+ * The same word for PowerShell, which is the shell a Windows box drops the user
+ * into — and, since lich opens its own Windows sessions there, the shell this
+ * line is most often pasted back into. Single quotes expand nothing there
+ * either; only the escape differs, doubling the quote instead of closing and
+ * reopening the run. The page-side half of shquote.QuotePwsh.
+ */
+export function pwshQuote(value: string): string {
+  return `'${value.split("'").join("''")}'`
+}
+
 // Left for the user to fill in, spelled as `lich send --help` spells it. Double
 // quotes rather than the shQuote rule: what goes here is prose, and an
 // apostrophe in it must not end the argument.
@@ -24,6 +35,10 @@ const PROMPT = '"<prompt>"'
 
 /**
  * The command that hands this session a task from anywhere else.
+ *
+ * isWindows picks the quoting rule, the way composeDroppedPaths does: the line
+ * is pasted into a terminal on this machine, so the shell that matters is the
+ * user's own, not the session's.
  *
  * `--project` is written only when it decides something. `lich send` resolves a
  * label on its own and asks for the project exactly when the same label names
@@ -35,7 +50,9 @@ export function sendCommand(
   projects: readonly Project[],
   sessions: SessionState,
   session: Session,
+  isWindows = false,
 ): string {
+  const quote = isWindows ? pwshQuote : shQuote
   const all = projects.flatMap((project) =>
     sessionsOf(sessions, project.id).map((candidate) => ({ project, candidate })),
   )
@@ -45,6 +62,6 @@ export function sendCommand(
       entry.candidate.id !== session.id &&
       entry.candidate.label.toLowerCase() === session.label.toLowerCase(),
   )
-  const scope = shared && own ? ` --project ${shQuote(own.project.name)}` : ""
-  return `lich send${scope} ${shQuote(session.label)} ${PROMPT}`
+  const scope = shared && own ? ` --project ${quote(own.project.name)}` : ""
+  return `lich send${scope} ${quote(session.label)} ${PROMPT}`
 }

--- a/internal/shquote/shquote.go
+++ b/internal/shquote/shquote.go
@@ -7,8 +7,11 @@
 // metacharacter that survives one call site cannot survive the other.
 //
 // The window composes a fourth — the `lich send` line a session's card hands
-// out — and quotes it the same way in frontend/src/lib/session/send-command.ts,
-// the page-side half of this rule, tested against the same cases.
+// out — and carries both rules the same way in
+// frontend/src/lib/session/send-command.ts, the page-side half of this file,
+// tested against the same cases. It picks between them by the platform the
+// window itself runs on: that line is pasted into a terminal on this machine,
+// so the shell that decides is the user's own.
 package shquote
 
 import "strings"


### PR DESCRIPTION
Last finding from the audit of `62cb5f4..113c98a`.

`internal/shquote`'s docblock names four command lines built from one rule, the fourth being the copyable `lich send` line on a session card — "quotes it the same way in `frontend/src/lib/session/send-command.ts`". Since #383 a Windows session runs PowerShell, `QuotePwsh` was added for it, and `drop-files.ts` was taught the same rule. `send-command.ts` was not: it still spelled every label for POSIX alone, so a card renamed to something with an apostrophe pasted back as `'\''` — four literal characters in PowerShell, with the argument ending at the first quote.

`sendCommand` now takes `isWindows` and picks between `shQuote` and the new `pwshQuote`, mirroring `composeDroppedPaths(paths, isWindows)`. The platform that decides is the window's own: this line is pasted into a terminal on this machine, not into the session.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean, `go test ./...` green
- [x] `biome check` clean (14 pre-existing warnings, none in touched files)
- [x] `vitest run` 1121 green — `pwshQuote` runs the same cases as `shquote.TestQuotePwsh`, plus the label round trip through `sendCommand`
- [x] `vite build` succeeds