### PR TITLE
Bring the pull request screen back the way it was left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The pull request screen comes back the way you left it.** A review
+  interrupted — another project, the terminal next door, a branch to check —
+  used to cost the whole screen: five gh round-trips behind a skeleton, the
+  filter box emptied, the quick filter and the tab reset, and the pull request
+  you were reading swapped for whatever the checkout's own branch had open.
+  Now the filter text, the quick filter and the tab you were on are remembered,
+  each project reopens on the pull request it was showing, and the list, the
+  detail, the conversation, the diff and the checkouts paint from the last
+  answer while a fresh one is fetched underneath. Nothing is shown as newer than
+  it is: the screen still re-reads on focus, the Refresh button still asks
+  again, and a reload starts from nothing.
+
 ### Fixed
 
 - **Opening Settings › Sandbox no longer blanks the whole lich window on a

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -391,3 +391,23 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   still there to be searched by whatever does it later; and that search is Claude-only today
   (`claudeTranscriptPath`) while `canResume` locates all six providers, so widening it would inherit that gap
   rather than close it.
+- **A filed backend answer outlives the screen that asked, under a key its caller writes by hand**
+  (`frontend/src/lib/remote-cache.ts`): a `useRemoteResource` caller that passes `cache` has its answers kept
+  in module memory until the page reloads, under exactly the string it composed. Two callers that compose the
+  same string serve each other's answers, and a string that leaves out something identifying paints one
+  repository's answer onto another's screen — instantly, and then corrected one round-trip later, which reads
+  as a flicker rather than as a bug. It is deliberately not `key`: `key` carries what *dates* an answer (the
+  checkout's HEAD), which a fresh mount does not have until its git poll lands, so a cache keyed by it misses
+  on the one frame the cache exists for. The cap is 32 answers with no byte budget, so a review that walks
+  through more pull requests than that pays a skeleton on the way back to the first.
+- **Seeding that filed answer runs during render, so its bookkeeping may never live in a ref**
+  (`frontend/src/lib/use-remote-resource.ts`): React can discard a render that updates state during it and
+  replay it, and a ref written by the discarded pass makes the replay skip the very update it guarded. The
+  symptom is silent and looks nothing like the cause — the answer is seeded, the screen paints, and the next
+  frame is blank again with no setter anywhere having run. The suite does not reproduce it: the jsdom probe
+  passes against the ref version, and it took a real browser to see.
+- **The pull request screen's remembered state is read once, at mount** (`frontend/src/lib/pulls/pulls-prefs.ts`):
+  the filter box, the quick filter and the selected pull request are keyed per project but seeded from
+  `useState`, which holds because every route into the screen carries its own project and leaving one unmounts
+  it. A future route that reuses `Pulls` across two projects would keep the first one's box and its selection,
+  and nothing in the component would say so.

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -409,6 +409,14 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   (a remount initialises the marker and never exercises the replay), and it must record frames from a layout
   effect rather than from the render body (the body sees passes that were never committed, which reads a
   correct hook as an oscillation). A probe missing either one calls the ref version green.
+- **One filed answer drives an action rather than a readout** (`frontend/src/lib/git/use-checkouts.ts`): every
+  other `cache` on this screen decides what is *shown*, and a value one round-trip old is only ever a stale
+  label. This one decides what a button *does* — `Pulls.tsx` asks it whether the pull request's head branch is
+  already checked out, and the answer picks between reusing a session and creating a worktree. A checkout
+  removed from a terminal while the user was on another screen therefore offers "Go to session" for a
+  directory that is gone. The window is one round-trip (it re-reads on mount, on focus, and after this screen
+  creates a checkout itself) and git refuses the wrong move anyway, which is why it is filed rather than left
+  cold — but it is the one to think twice about before the next `cache` is added to something a button reads.
 - **The pull request screen's remembered state is read once, at mount** (`frontend/src/lib/pulls/pulls-prefs.ts`):
   the filter box, the quick filter and the selected pull request are keyed per project but seeded from
   `useState`, which holds because every route into the screen carries its own project and leaving one unmounts

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -401,11 +401,14 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   on the one frame the cache exists for. The cap is 32 answers with no byte budget, so a review that walks
   through more pull requests than that pays a skeleton on the way back to the first.
 - **Seeding that filed answer runs during render, so its bookkeeping may never live in a ref**
-  (`frontend/src/lib/use-remote-resource.ts`): React can discard a render that updates state during it and
-  replay it, and a ref written by the discarded pass makes the replay skip the very update it guarded. The
-  symptom is silent and looks nothing like the cause — the answer is seeded, the screen paints, and the next
-  frame is blank again with no setter anywhere having run. The suite does not reproduce it: the jsdom probe
-  passes against the ref version, and it took a real browser to see.
+  (`useMovedAnswer`, `frontend/src/lib/use-remote-resource.ts`): React can discard a render that updates state
+  during it and replay it, and a ref written by the discarded pass makes the replay skip the very update it
+  guarded. The symptom is silent and looks nothing like the cause — the answer is seeded, the screen paints,
+  and the next frame is blank again with no setter anywhere having run. `use-remote-resource.test.tsx` pins it,
+  but only under two conditions that are easy to drop: the probe must change the request on a *live* component
+  (a remount initialises the marker and never exercises the replay), and it must record frames from a layout
+  effect rather than from the render body (the body sees passes that were never committed, which reads a
+  correct hook as an oscillation). A probe missing either one calls the ref version green.
 - **The pull request screen's remembered state is read once, at mount** (`frontend/src/lib/pulls/pulls-prefs.ts`):
   the filter box, the quick filter and the selected pull request are keyed per project but seeded from
   `useState`, which holds because every route into the screen carries its own project and leaving one unmounts

--- a/frontend/src/components/pulls/PullRequestView.tsx
+++ b/frontend/src/components/pulls/PullRequestView.tsx
@@ -31,6 +31,7 @@ import {
   mergeBlockedReason,
   mergeRuleNote,
 } from "@/lib/pulls/merge-gate"
+import { readPullsTab, writePullsTab, type PullsTab } from "@/lib/pulls/pulls-prefs"
 import { useBranchRules } from "@/lib/pulls/use-branch-rules"
 import { cn, errorText } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -61,8 +62,6 @@ export interface SessionAction {
   busy: boolean
   run: () => void
 }
-
-type Tab = "overview" | "commits" | "files" | "conversation" | "checks"
 
 const MERGE_LABELS: Record<MergeMethod, string> = {
   squash: "Squash and merge",
@@ -121,7 +120,14 @@ export function PullRequestView({
   const [submitting, setSubmitting] = useState(false)
   const [verdict, setVerdict] = useState<ReviewEvent | null>(null)
   const [edit, setEdit] = useState<MergeEdit | null>(null)
-  const [tab, setTab] = useState<Tab>("overview")
+  // Which tab is a habit, not a fact about this pull request: a reviewer who
+  // lives in Files changed should land there on the next one too, and on the
+  // same one after a detour into another project.
+  const [tab, setTab] = useState<PullsTab>(readPullsTab)
+  const showTab = (next: PullsTab) => {
+    writePullsTab(next)
+    setTab(next)
+  }
   // Read here rather than threaded down from the screen: it is keyed by the
   // base branch, which only exists once the detail has resolved — and this is
   // the one place that is guaranteed.
@@ -373,7 +379,7 @@ export function PullRequestView({
           {detail.checks.total > 0 ? (
             <button
               type="button"
-              onClick={() => setTab("checks")}
+              onClick={() => showTab("checks")}
               className="rounded-sm transition-opacity hover:opacity-80"
             >
               <ChecksStat checks={detail.checks} />
@@ -390,27 +396,27 @@ export function PullRequestView({
         </div>
 
         <div role="tablist" className="mt-4 flex gap-1">
-          <TabButton active={tab === "overview"} onClick={() => setTab("overview")}>
+          <TabButton active={tab === "overview"} onClick={() => showTab("overview")}>
             Overview
           </TabButton>
-          <TabButton active={tab === "commits"} onClick={() => setTab("commits")}>
+          <TabButton active={tab === "commits"} onClick={() => showTab("commits")}>
             Commits
             {commitCount > 0 && (
               <span className="tabular-nums text-muted-foreground">{commitCount}</span>
             )}
           </TabButton>
-          <TabButton active={tab === "files"} onClick={() => setTab("files")}>
+          <TabButton active={tab === "files"} onClick={() => showTab("files")}>
             Files changed
             {detail.changedFiles > 0 && (
               <span className="tabular-nums text-muted-foreground">{detail.changedFiles}</span>
             )}
           </TabButton>
-          <TabButton active={tab === "conversation"} onClick={() => setTab("conversation")}>
+          <TabButton active={tab === "conversation"} onClick={() => showTab("conversation")}>
             Conversation
             {talk > 0 && <span className="tabular-nums text-muted-foreground">{talk}</span>}
           </TabButton>
           {detail.checks.total > 0 && (
-            <TabButton active={tab === "checks"} onClick={() => setTab("checks")}>
+            <TabButton active={tab === "checks"} onClick={() => showTab("checks")}>
               Checks
               <span className="tabular-nums text-muted-foreground">{detail.checks.total}</span>
             </TabButton>

--- a/frontend/src/components/pulls/Pulls.tsx
+++ b/frontend/src/components/pulls/Pulls.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type ReactNode } from "react"
+import { useEffect, useMemo, useState, type ReactNode } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { GitPullRequestArrow } from "lucide-react"
 import { toast } from "sonner"
@@ -17,7 +17,14 @@ import { queueSetup } from "@/lib/terminal/setup-queue"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { useCheckouts } from "@/lib/git/use-checkouts"
 import { invalidatePullRequests } from "@/lib/pulls/pull-request-lookup"
-import { parsePullsQuery, readPullsSort, type PullsSort } from "@/lib/pulls/pull-request-list"
+import { parsePullsQuery } from "@/lib/pulls/pull-request-list"
+import {
+  forgetLastPull,
+  readLastPull,
+  readPullsQuery,
+  writeLastPull,
+  writePullsQuery,
+} from "@/lib/pulls/pulls-prefs"
 import { usePullRequestConversation } from "@/lib/pulls/use-pull-request-conversation"
 import { usePullRequestDetail } from "@/lib/pulls/use-pull-request-detail"
 import { usePullRequests } from "@/lib/pulls/use-pull-requests"
@@ -80,7 +87,13 @@ export function Pulls({ list = false }: PullsProps) {
   // No number in the route means the PR of whatever branch this checkout is on
   // — the whole screen without the list, and the default row with it. A number
   // addresses one directly, which only the list can produce.
-  const selected = Number(number) || 0
+  //
+  // Every way back into the list route is the bare one, so a return would drop
+  // the pull request being read for the checkout's own. The remembered number
+  // stands in for the one the URL is missing — read once per project, never
+  // from the write below, so the selection cannot chase itself.
+  const remembered = useMemo(() => (list ? readLastPull(projectId ?? "") : 0), [list, projectId])
+  const selected = Number(number) || remembered
   const { detail, loading, error, refresh } = usePullRequestDetail(
     hasGH ? path : "",
     branch,
@@ -93,8 +106,14 @@ export function Pulls({ list = false }: PullsProps) {
   const conversation = usePullRequestConversation(path, detail?.number ?? 0, head)
   // The filter box lives here, not in the column: its `is:` state decides which
   // pull requests gh is asked for, and that is a fetch rather than a filter.
-  const [query, setQuery] = useState("")
+  // Remembered like the sort beside it: a review interrupted by another project
+  // is otherwise a query typed twice.
+  const [query, setQuery] = useState(() => readPullsQuery(projectId ?? ""))
   const parsedQuery = useMemo(() => parsePullsQuery(query), [query])
+  const changeQuery = (next: string) => {
+    writePullsQuery(projectId ?? "", next)
+    setQuery(next)
+  }
   // An empty path is the hook's own "nothing to look up", so the single pull
   // request screen never spends a gh call on a list it does not show.
   const pulls = usePullRequests(list && hasGH ? projectPath || path : "", parsedQuery.state)
@@ -106,8 +125,25 @@ export function Pulls({ list = false }: PullsProps) {
   // checkout of a branch just as hard when the project itself holds it.
   const checkedOut = checkouts.find((c) => c.name === detail?.headRefName)
   const inject = useInject(sessionId)
-  const [sort, setSort] = useState<PullsSort>(readPullsSort)
   const [opening, setOpening] = useState(false)
+
+  // Written from the selection rather than from the click, so a pull request
+  // reached by URL is remembered too.
+  useEffect(() => {
+    if (list && projectId && selected > 0) {
+      writeLastPull(projectId, selected)
+    }
+  }, [list, projectId, selected])
+
+  // A remembered pull request that no longer resolves — deleted, or belonging to
+  // a repository this project no longer points at — would greet every return
+  // with the same error. Forget it once; the next visit lands on the checkout's
+  // own pull request instead.
+  useEffect(() => {
+    if (error && !number && remembered > 0 && projectId) {
+      forgetLastPull(projectId)
+    }
+  }, [error, number, remembered, projectId])
 
   // This screen and the badges around it read the same pull request through two
   // separate lookups, so a change with HEAD standing still — a merge, a PR
@@ -277,10 +313,9 @@ export function Pulls({ list = false }: PullsProps) {
           error={pulls.error}
           selected={selected || (detail?.number ?? 0)}
           onSelect={(picked) => navigate(`/projects/${projectId}/pulls/all/${picked}`)}
-          sort={sort}
-          onSortChange={setSort}
+          projectId={projectId ?? ""}
           query={query}
-          onQueryChange={setQuery}
+          onQueryChange={changeQuery}
           parsed={parsedQuery}
           checkedOutBranches={new Set(checkouts.map((c) => c.name))}
         />

--- a/frontend/src/components/pulls/Pulls.tsx
+++ b/frontend/src/components/pulls/Pulls.tsx
@@ -19,7 +19,6 @@ import { useCheckouts } from "@/lib/git/use-checkouts"
 import { invalidatePullRequests } from "@/lib/pulls/pull-request-lookup"
 import { parsePullsQuery } from "@/lib/pulls/pull-request-list"
 import {
-  forgetLastPull,
   readLastPull,
   readPullsQuery,
   writeLastPull,
@@ -110,6 +109,10 @@ export function Pulls({ list = false }: PullsProps) {
   // is otherwise a query typed twice.
   const [query, setQuery] = useState(() => readPullsQuery(projectId ?? ""))
   const parsedQuery = useMemo(() => parsePullsQuery(query), [query])
+  // Stored on every keystroke rather than on some settle: a box half-typed when
+  // the user walks off is still what they were about to search for, and one
+  // short localStorage write per character is cheaper than the timer that would
+  // avoid it.
   const changeQuery = (next: string) => {
     writePullsQuery(projectId ?? "", next)
     setQuery(next)
@@ -134,16 +137,6 @@ export function Pulls({ list = false }: PullsProps) {
       writeLastPull(projectId, selected)
     }
   }, [list, projectId, selected])
-
-  // A remembered pull request that no longer resolves — deleted, or belonging to
-  // a repository this project no longer points at — would greet every return
-  // with the same error. Forget it once; the next visit lands on the checkout's
-  // own pull request instead.
-  useEffect(() => {
-    if (error && !number && remembered > 0 && projectId) {
-      forgetLastPull(projectId)
-    }
-  }, [error, number, remembered, projectId])
 
   // This screen and the badges around it read the same pull request through two
   // separate lookups, so a change with HEAD standing still — a merge, a PR

--- a/frontend/src/components/pulls/PullsList.tsx
+++ b/frontend/src/components/pulls/PullsList.tsx
@@ -23,12 +23,17 @@ import {
   filterPullRequests,
   sortPullRequests,
   updatedAgo,
-  writePullsSort,
   type CheckVerdict,
   type PullsFilter,
   type PullsQuery,
   type PullsSort,
 } from "@/lib/pulls/pull-request-list"
+import {
+  readPullsFilter,
+  readPullsSort,
+  writePullsFilter,
+  writePullsSort,
+} from "@/lib/pulls/pulls-prefs"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
@@ -72,8 +77,9 @@ interface PullsListProps {
   /** The pull request the detail pane is showing; 0 before one is chosen. */
   selected: number
   onSelect: (number: number) => void
-  sort: PullsSort
-  onSortChange: (sort: PullsSort) => void
+  /** Whose pull requests these are — the quick filter narrows one repository's
+   * list, so it is remembered against that repository and not across all. */
+  projectId: string
   /** The raw filter box, owned by the screen: its `is:` state decides which
    * pull requests gh is asked for, which is a fetch, not a filter. */
   query: string
@@ -91,15 +97,18 @@ export function PullsList({
   error,
   selected,
   onSelect,
-  sort,
-  onSortChange,
+  projectId,
   query,
   onQueryChange,
   parsed,
   checkedOutBranches,
 }: PullsListProps) {
   const [open, toggle] = usePanelVisible(LIST_HIDDEN_KEY)
-  const [filter, setFilter] = useState<PullsFilter>("all")
+  // Both are how this user reads a list of pull requests rather than facts about
+  // one, so they are remembered across leaving the screen — a review resumed
+  // after a detour must not start by re-narrowing the column.
+  const [filter, setFilter] = useState<PullsFilter>(() => readPullsFilter(projectId))
+  const [sort, setSort] = useState<PullsSort>(readPullsSort)
   const counts = useMemo(() => filterCounts(list, parsed), [list, parsed])
   const rows = useMemo(
     () => sortPullRequests(filterPullRequests(list, filter, parsed), sort),
@@ -108,7 +117,12 @@ export function PullsList({
 
   const chooseSort = (next: PullsSort) => {
     writePullsSort(next)
-    onSortChange(next)
+    setSort(next)
+  }
+
+  const chooseFilter = (next: PullsFilter) => {
+    writePullsFilter(projectId, next)
+    setFilter(next)
   }
 
   // Collapsed, the column keeps a rail: the toggle has to survive its own
@@ -158,7 +172,7 @@ export function PullsList({
                 type="button"
                 role="radio"
                 aria-checked={active}
-                onClick={() => setFilter(value)}
+                onClick={() => chooseFilter(value)}
                 className={cn(
                   "flex flex-1 items-center justify-center gap-1 rounded-[0.3125rem] px-1 py-1 text-xs transition-colors outline-none focus-visible:ring-2 focus-visible:ring-ring",
                   active

--- a/frontend/src/lib/git/use-checkouts.ts
+++ b/frontend/src/lib/git/use-checkouts.ts
@@ -23,7 +23,7 @@ export function useCheckouts(projectPath: string): {
   const { data, refresh } = useRemoteResource(
     projectPath,
     () => ProjectService.ListCheckouts(projectPath).then((list) => list ?? NO_CHECKOUTS),
-    { empty: NO_CHECKOUTS, refetchOnFocus: true },
+    { empty: NO_CHECKOUTS, refetchOnFocus: true, cache: `git.checkouts ${projectPath}` },
   )
   return { checkouts: data, refresh }
 }

--- a/frontend/src/lib/prefs.ts
+++ b/frontend/src/lib/prefs.ts
@@ -1,8 +1,8 @@
 // UI preferences live in the page's localStorage (see the root CLAUDE.md:
-// the workspace is SQLite, the prefs are not). What each stored string means
-// is the parsing half, kept pure so the suite owns it; reading and writing the
-// key itself is the boundary half, and stays a two-line wrapper — the same
-// split parsePullsSort/readPullsSort already uses.
+// the workspace is SQLite, the prefs are not). What each stored string means is
+// the parsing half, kept pure so the suite owns it — the parseXPref helpers
+// below; reading and writing the key itself is the boundary half, and stays a
+// two-line wrapper (pulls/pulls-prefs.ts is the worked example).
 //
 // Every reader answers with the fallback for a key that is absent, or that
 // holds something this build no longer understands. A pref is a convenience:

--- a/frontend/src/lib/pulls/pull-request-list.test.ts
+++ b/frontend/src/lib/pulls/pull-request-list.test.ts
@@ -1,31 +1,13 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { describe, expect, it } from "vitest"
 import type { PullRequestSummary } from "@/lib/api-types"
 import {
   checkVerdict,
   filterCounts,
   filterPullRequests,
   parsePullsQuery,
-  parsePullsSort,
-  readPullsSort,
   sortPullRequests,
   updatedAgo,
-  writePullsSort,
 } from "./pull-request-list"
-
-// The suite runs in node, which has no localStorage; the sort is a UI pref that
-// has to survive leaving the screen, so the storage is stubbed and the round-trip
-// through it is what is checked.
-const stored = new Map<string, string>()
-
-vi.stubGlobal("localStorage", {
-  getItem: (key: string) => stored.get(key) ?? null,
-  setItem: (key: string, value: string) => {
-    stored.set(key, value)
-  },
-  removeItem: (key: string) => {
-    stored.delete(key)
-  },
-})
 
 function pr(over: Partial<PullRequestSummary> = {}): PullRequestSummary {
   return {
@@ -212,16 +194,6 @@ describe("updatedAgo", () => {
   })
 })
 
-describe("parsePullsSort", () => {
-  it("keeps a stored sort this build knows", () => {
-    expect(parsePullsSort("failing")).toBe("failing")
-  })
-
-  it.each([null, "", "by-vibes"])("falls back to recently updated for %j", (raw) => {
-    expect(parsePullsSort(raw)).toBe("updated")
-  })
-})
-
 describe("parsePullsQuery", () => {
   it("defaults to the open pull requests and no other constraint", () => {
     expect(parsePullsQuery("")).toEqual({
@@ -325,29 +297,5 @@ describe("filtering by qualifier", () => {
   it("ands the qualifiers with the quick filter and the text", () => {
     expect(filterPullRequests(list, "drafts", q("is:ready"))).toEqual([])
     expect(filterPullRequests(list, "all", q("review:approved #2"))).toEqual([])
-  })
-})
-
-describe("the stored sort", () => {
-  beforeEach(() => {
-    stored.clear()
-  })
-
-  it("reads the default with nothing stored", () => {
-    expect(readPullsSort()).toBe("updated")
-  })
-
-  it("round-trips a chosen sort", () => {
-    writePullsSort("failing")
-
-    expect(readPullsSort()).toBe("failing")
-  })
-
-  // A pref must never be able to break a launch: a sort from another build, or a
-  // hand-edited one, reads as the default rather than as an unsortable column.
-  it("reads a value this build does not know as the default", () => {
-    stored.set("lich.pulls.sort", "by-vibes")
-
-    expect(readPullsSort()).toBe("updated")
   })
 })

--- a/frontend/src/lib/pulls/pull-request-list.ts
+++ b/frontend/src/lib/pulls/pull-request-list.ts
@@ -1,6 +1,5 @@
 import type { PullRequestSummary } from "@/lib/api-types"
 import { agoUnit } from "@/lib/ago"
-import { parseEnumPref, readPref, writePref } from "@/lib/prefs"
 
 // The list column's own logic: which rows a quick filter and the search box
 // leave standing, and in what order. Kept out of the component because this is
@@ -243,21 +242,4 @@ export function sortPullRequests(
 export function updatedAgo(updatedAt: string, now: number = Date.now()): string {
   const at = Date.parse(updatedAt)
   return Number.isNaN(at) ? "" : agoUnit(now - at)
-}
-
-// Which order the column is in is a UI preference, so it lives in the page's
-// localStorage beside the panel widths — not in the workspace database.
-const SORT_KEY = "lich.pulls.sort"
-
-/** Reads a stored sort, falling back for anything this build does not know. */
-export function parsePullsSort(raw: string | null): PullsSort {
-  return parseEnumPref(raw, PULLS_SORTS, "updated")
-}
-
-export function readPullsSort(): PullsSort {
-  return parsePullsSort(readPref(SORT_KEY))
-}
-
-export function writePullsSort(sort: PullsSort): void {
-  writePref(SORT_KEY, sort)
 }

--- a/frontend/src/lib/pulls/pulls-prefs.test.ts
+++ b/frontend/src/lib/pulls/pulls-prefs.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  forgetLastPull,
+  parsePullsSort,
+  readLastPull,
+  readPullsFilter,
+  readPullsQuery,
+  readPullsSort,
+  readPullsTab,
+  writeLastPull,
+  writePullsFilter,
+  writePullsQuery,
+  writePullsSort,
+  writePullsTab,
+} from "./pulls-prefs"
+
+// The suite runs in node, which has no localStorage. These are the prefs that
+// have to survive leaving the screen, so the storage is stubbed and the round
+// trip through it is what is checked.
+const stored = new Map<string, string>()
+
+vi.stubGlobal("localStorage", {
+  getItem: (key: string) => stored.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    stored.set(key, value)
+  },
+  removeItem: (key: string) => {
+    stored.delete(key)
+  },
+})
+
+beforeEach(() => {
+  stored.clear()
+})
+
+describe("parsePullsSort", () => {
+  it("keeps a stored sort this build knows", () => {
+    expect(parsePullsSort("failing")).toBe("failing")
+  })
+
+  it.each([null, "", "by-vibes"])("falls back to recently updated for %j", (raw) => {
+    expect(parsePullsSort(raw)).toBe("updated")
+  })
+})
+
+describe("the stored sort", () => {
+  it("reads the default with nothing stored", () => {
+    expect(readPullsSort()).toBe("updated")
+  })
+
+  it("round-trips a chosen sort", () => {
+    writePullsSort("failing")
+
+    expect(readPullsSort()).toBe("failing")
+  })
+
+  // A pref must never be able to break a launch: a sort from another build, or a
+  // hand-edited one, reads as the default rather than as an unsortable column.
+  it("reads a value this build does not know as the default", () => {
+    stored.set("lich.pulls.sort", "by-vibes")
+
+    expect(readPullsSort()).toBe("updated")
+  })
+})
+
+describe("the stored quick filter", () => {
+  it("reads every pull request with nothing stored", () => {
+    expect(readPullsFilter("proj-1")).toBe("all")
+  })
+
+  it("round-trips a chosen filter", () => {
+    writePullsFilter("proj-1", "failing")
+
+    expect(readPullsFilter("proj-1")).toBe("failing")
+  })
+
+  it("reads a value this build does not know as the default", () => {
+    stored.set("lich.pulls.filter.proj-1", "mine")
+
+    expect(readPullsFilter("proj-1")).toBe("all")
+  })
+
+  // It narrows one repository's list, so it is that repository's.
+  it("keeps two projects apart", () => {
+    writePullsFilter("proj-1", "failing")
+    writePullsFilter("proj-2", "drafts")
+
+    expect(readPullsFilter("proj-1")).toBe("failing")
+    expect(readPullsFilter("proj-2")).toBe("drafts")
+  })
+
+  it("reads and writes nothing without a project", () => {
+    writePullsFilter("", "failing")
+
+    expect(stored.size).toBe(0)
+    expect(readPullsFilter("")).toBe("all")
+  })
+})
+
+describe("the stored tab", () => {
+  it("reads the overview with nothing stored", () => {
+    expect(readPullsTab()).toBe("overview")
+  })
+
+  it("round-trips a chosen tab", () => {
+    writePullsTab("files")
+
+    expect(readPullsTab()).toBe("files")
+  })
+
+  it("reads a value this build does not know as the default", () => {
+    stored.set("lich.pulls.tab", "blame")
+
+    expect(readPullsTab()).toBe("overview")
+  })
+})
+
+describe("the stored filter box", () => {
+  it("reads empty with nothing stored", () => {
+    expect(readPullsQuery("proj-1")).toBe("")
+  })
+
+  // Free text: whatever was typed is what comes back, qualifiers and all.
+  it("round-trips what was typed", () => {
+    writePullsQuery("proj-1", "is:merged review:approved cache")
+
+    expect(readPullsQuery("proj-1")).toBe("is:merged review:approved cache")
+  })
+
+  it("round-trips an emptied box", () => {
+    writePullsQuery("proj-1", "is:merged")
+    writePullsQuery("proj-1", "")
+
+    expect(readPullsQuery("proj-1")).toBe("")
+  })
+
+  // The reason this is not one global box: a query left on `is:merged` would
+  // otherwise make the next project's list look empty of open pull requests.
+  it("keeps two projects apart", () => {
+    writePullsQuery("proj-1", "is:merged")
+
+    expect(readPullsQuery("proj-2")).toBe("")
+  })
+
+  it("reads and writes nothing without a project", () => {
+    writePullsQuery("", "is:merged")
+
+    expect(stored.size).toBe(0)
+    expect(readPullsQuery("")).toBe("")
+  })
+})
+
+describe("the remembered pull request", () => {
+  it("answers 0 for a project with none", () => {
+    expect(readLastPull("proj-1")).toBe(0)
+  })
+
+  it("round-trips a selection", () => {
+    writeLastPull("proj-1", 388)
+
+    expect(readLastPull("proj-1")).toBe(388)
+  })
+
+  // Two repositories are two reviews: one must never open on the other's number.
+  it("keeps two projects apart", () => {
+    writeLastPull("proj-1", 388)
+    writeLastPull("proj-2", 12)
+
+    expect(readLastPull("proj-1")).toBe(388)
+    expect(readLastPull("proj-2")).toBe(12)
+  })
+
+  it("forgets a selection that no longer resolves", () => {
+    writeLastPull("proj-1", 388)
+    forgetLastPull("proj-1")
+
+    expect(readLastPull("proj-1")).toBe(0)
+  })
+
+  // 0 is the screen's own "no pull request selected", so storing it would be
+  // storing nothing — and a hand-edited or foreign value reads the same way.
+  it.each([null, "", "0", "-3", "1.5", "latest"])("reads %j as no selection", (raw) => {
+    if (raw !== null) {
+      stored.set("lich.pulls.last.proj-1", raw)
+    }
+
+    expect(readLastPull("proj-1")).toBe(0)
+  })
+
+  it("never writes a number that is not a selection", () => {
+    writeLastPull("proj-1", 0)
+
+    expect(stored.has("lich.pulls.last.proj-1")).toBe(false)
+  })
+
+  // Every reader is handed a project id straight from the route, which is empty
+  // before one is open.
+  it("reads and writes nothing without a project", () => {
+    writeLastPull("", 388)
+
+    expect(stored.size).toBe(0)
+    expect(readLastPull("")).toBe(0)
+  })
+})

--- a/frontend/src/lib/pulls/pulls-prefs.test.ts
+++ b/frontend/src/lib/pulls/pulls-prefs.test.ts
@@ -1,7 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
-  forgetLastPull,
-  parsePullsSort,
   readLastPull,
   readPullsFilter,
   readPullsQuery,
@@ -31,16 +29,6 @@ vi.stubGlobal("localStorage", {
 
 beforeEach(() => {
   stored.clear()
-})
-
-describe("parsePullsSort", () => {
-  it("keeps a stored sort this build knows", () => {
-    expect(parsePullsSort("failing")).toBe("failing")
-  })
-
-  it.each([null, "", "by-vibes"])("falls back to recently updated for %j", (raw) => {
-    expect(parsePullsSort(raw)).toBe("updated")
-  })
 })
 
 describe("the stored sort", () => {
@@ -170,11 +158,13 @@ describe("the remembered pull request", () => {
     expect(readLastPull("proj-2")).toBe(12)
   })
 
-  it("forgets a selection that no longer resolves", () => {
+  // Nothing forgets a selection: a lookup that fails is transient far more often
+  // than it is a pull request that is gone, and the two look the same from here.
+  it("survives a selection being written again", () => {
     writeLastPull("proj-1", 388)
-    forgetLastPull("proj-1")
+    writeLastPull("proj-1", 12)
 
-    expect(readLastPull("proj-1")).toBe(0)
+    expect(readLastPull("proj-1")).toBe(12)
   })
 
   // 0 is the screen's own "no pull request selected", so storing it would be

--- a/frontend/src/lib/pulls/pulls-prefs.ts
+++ b/frontend/src/lib/pulls/pulls-prefs.ts
@@ -1,0 +1,103 @@
+import { parseEnumPref, readPref, removePref, writePref } from "@/lib/prefs"
+import { PULLS_FILTERS, PULLS_SORTS, type PullsFilter, type PullsSort } from "./pull-request-list"
+
+// Everything the pull request screen remembers about how it was left. A review
+// is not a page view: the user walks off to another project mid-diff and comes
+// back expecting the screen they had, and a filter box that has emptied itself
+// is a review typed twice.
+//
+// UI preferences, so the page's localStorage rather than the workspace database
+// (see the root CLAUDE.md). Parsing is the half kept pure and tested; reading
+// and writing the key stays a two-line wrapper, the split prefs.ts describes.
+//
+// One rule decides the scope of each of these: anything that *narrows the list*
+// is about a repository's content and is keyed per project — a box left on
+// `is:merged` would otherwise make the next project's list look empty of open
+// pull requests. How the column is read (the sort) and where a pull request
+// opens (the tab) are habits of this user, and are global.
+const SORT_KEY = "lich.pulls.sort"
+const TAB_KEY = "lich.pulls.tab"
+const FILTER_PREFIX = "lich.pulls.filter."
+const QUERY_PREFIX = "lich.pulls.query."
+const LAST_PULL_PREFIX = "lich.pulls.last."
+
+/** The tabs of one pull request, in the order the header shows them. */
+export const PULLS_TABS = ["overview", "commits", "files", "conversation", "checks"] as const
+export type PullsTab = (typeof PULLS_TABS)[number]
+
+/** Reads a stored sort, falling back for anything this build does not know. */
+export function parsePullsSort(raw: string | null): PullsSort {
+  return parseEnumPref(raw, PULLS_SORTS, "updated")
+}
+
+export function readPullsSort(): PullsSort {
+  return parsePullsSort(readPref(SORT_KEY))
+}
+
+export function writePullsSort(sort: PullsSort): void {
+  writePref(SORT_KEY, sort)
+}
+
+export function readPullsFilter(projectId: string): PullsFilter {
+  return parseEnumPref(scoped(FILTER_PREFIX, projectId), PULLS_FILTERS, "all")
+}
+
+export function writePullsFilter(projectId: string, filter: PullsFilter): void {
+  if (projectId) {
+    writePref(`${FILTER_PREFIX}${projectId}`, filter)
+  }
+}
+
+export function readPullsTab(): PullsTab {
+  return parseEnumPref(readPref(TAB_KEY), PULLS_TABS, "overview")
+}
+
+export function writePullsTab(tab: PullsTab): void {
+  writePref(TAB_KEY, tab)
+}
+
+/** The filter box, verbatim — it is free text, so anything stored is valid. */
+export function readPullsQuery(projectId: string): string {
+  return scoped(QUERY_PREFIX, projectId) ?? ""
+}
+
+export function writePullsQuery(projectId: string, query: string): void {
+  if (projectId) {
+    writePref(`${QUERY_PREFIX}${projectId}`, query)
+  }
+}
+
+// Every project-scoped read goes through here, so a screen with no project open
+// yet — the id comes straight from the route — reads the default rather than
+// whatever sits under a key ending in nothing.
+function scoped(prefix: string, projectId: string): string | null {
+  return projectId ? readPref(`${prefix}${projectId}`) : null
+}
+
+// Which pull request the list column had selected. Every way back into the
+// screen navigates to the bare list route, so without this a return lands on
+// the checkout's own pull request rather than the one being read.
+function lastPullKey(projectId: string): string {
+  return `${LAST_PULL_PREFIX}${projectId}`
+}
+
+/** The remembered pull request, or 0 for a project with none — which is also
+ * what a stored value this build cannot read as a positive number means. */
+export function readLastPull(projectId: string): number {
+  const number = Number(scoped(LAST_PULL_PREFIX, projectId))
+  return Number.isInteger(number) && number > 0 ? number : 0
+}
+
+export function writeLastPull(projectId: string, number: number): void {
+  if (projectId && number > 0) {
+    writePref(lastPullKey(projectId), number)
+  }
+}
+
+/** Forget the selection — for a remembered number that no longer resolves, so
+ * one dead pull request cannot greet every return with the same error. */
+export function forgetLastPull(projectId: string): void {
+  if (projectId) {
+    removePref(lastPullKey(projectId))
+  }
+}

--- a/frontend/src/lib/pulls/pulls-prefs.ts
+++ b/frontend/src/lib/pulls/pulls-prefs.ts
@@ -1,4 +1,4 @@
-import { parseEnumPref, readPref, removePref, writePref } from "@/lib/prefs"
+import { parseEnumPref, readPref, writePref } from "@/lib/prefs"
 import { PULLS_FILTERS, PULLS_SORTS, type PullsFilter, type PullsSort } from "./pull-request-list"
 
 // Everything the pull request screen remembers about how it was left. A review
@@ -25,13 +25,8 @@ const LAST_PULL_PREFIX = "lich.pulls.last."
 export const PULLS_TABS = ["overview", "commits", "files", "conversation", "checks"] as const
 export type PullsTab = (typeof PULLS_TABS)[number]
 
-/** Reads a stored sort, falling back for anything this build does not know. */
-export function parsePullsSort(raw: string | null): PullsSort {
-  return parseEnumPref(raw, PULLS_SORTS, "updated")
-}
-
 export function readPullsSort(): PullsSort {
-  return parsePullsSort(readPref(SORT_KEY))
+  return parseEnumPref(readPref(SORT_KEY), PULLS_SORTS, "updated")
 }
 
 export function writePullsSort(sort: PullsSort): void {
@@ -77,27 +72,21 @@ function scoped(prefix: string, projectId: string): string | null {
 // Which pull request the list column had selected. Every way back into the
 // screen navigates to the bare list route, so without this a return lands on
 // the checkout's own pull request rather than the one being read.
-function lastPullKey(projectId: string): string {
-  return `${LAST_PULL_PREFIX}${projectId}`
-}
-
-/** The remembered pull request, or 0 for a project with none — which is also
- * what a stored value this build cannot read as a positive number means. */
+//
+// Nothing forgets it on a failed lookup. A pull request that no longer resolves
+// is rare, and lich already says so in as many words ("GitHub has no pull
+// request with that number") with the list beside it to pick from — while every
+// *transient* failure looks the same from here, so forgetting on one would let
+// an offline launch quietly erase the selection of every project it touched.
 export function readLastPull(projectId: string): number {
+  // 0 for a project with none — which is also what a stored value this build
+  // cannot read as a positive number means.
   const number = Number(scoped(LAST_PULL_PREFIX, projectId))
   return Number.isInteger(number) && number > 0 ? number : 0
 }
 
 export function writeLastPull(projectId: string, number: number): void {
   if (projectId && number > 0) {
-    writePref(lastPullKey(projectId), number)
-  }
-}
-
-/** Forget the selection — for a remembered number that no longer resolves, so
- * one dead pull request cannot greet every return with the same error. */
-export function forgetLastPull(projectId: string): void {
-  if (projectId) {
-    removePref(lastPullKey(projectId))
+    writePref(`${LAST_PULL_PREFIX}${projectId}`, number)
   }
 }

--- a/frontend/src/lib/pulls/use-branch-rules.ts
+++ b/frontend/src/lib/pulls/use-branch-rules.ts
@@ -19,7 +19,7 @@ export function useBranchRules(path: string, branch: string): BranchRules | null
   const { data } = useRemoteResource(
     path && branch ? `${path} ${branch}` : "",
     () => ProjectService.BranchRules(path, branch),
-    { empty: NO_RULES },
+    { empty: NO_RULES, cache: `pulls.rules ${path} ${branch}` },
   )
   return data
 }

--- a/frontend/src/lib/pulls/use-pull-request-conversation.ts
+++ b/frontend/src/lib/pulls/use-pull-request-conversation.ts
@@ -31,7 +31,7 @@ export function usePullRequestConversation(
   const { data, loading, error, refresh } = useRemoteResource(
     path && number > 0 ? `${path} ${number} ${head}` : "",
     () => ProjectService.PullRequestConversation(path, number),
-    { empty: NO_CONVERSATION, refetchOnFocus: true },
+    { empty: NO_CONVERSATION, refetchOnFocus: true, cache: `pulls.conversation ${path} ${number}` },
   )
   return { conversation: data, loading, error, refresh }
 }

--- a/frontend/src/lib/pulls/use-pull-request-detail.ts
+++ b/frontend/src/lib/pulls/use-pull-request-detail.ts
@@ -38,7 +38,17 @@ export function usePullRequestDetail(
   const { data, loading, error, refresh } = useRemoteResource(
     path && `${path} ${number} ${branch} ${head}`,
     () => ProjectService.PullRequestDetail(path, number),
-    { empty: NO_DETAIL, refetchOnFocus: true },
+    {
+      empty: NO_DETAIL,
+      refetchOnFocus: true,
+      // Two different requests, and the cache key says which: a number
+      // addresses one pull request outright, and a zero asks for whichever the
+      // branch has open. Neither is dated by head — it makes the answer stale,
+      // it does not say what was asked for, and a cache key carrying it could
+      // not be read until a fresh mount's git poll had answered, which is the
+      // one frame this exists for.
+      cache: number > 0 ? `pulls.detail ${path} #${number}` : `pulls.detail ${path} @${branch}`,
+    },
   )
 
   // Depends on the count, not the detail object: while it stays at 3 the

--- a/frontend/src/lib/pulls/use-pull-request-diff.ts
+++ b/frontend/src/lib/pulls/use-pull-request-diff.ts
@@ -10,11 +10,18 @@ export interface PullRequestDiffState {
 }
 
 // usePullRequestDiff fetches and parses the PR's unified diff (gh pr diff) for
-// the Files changed tab. Fetched on demand — the diff is a gh round-trip and can
-// be large — and refetched when the checkout's HEAD moves. Unlike the PR detail
-// next door it does not refresh on window focus: re-rendering a wide diff is far
-// too expensive to spend on every alt-tab back into the app. files is null while
-// loading or on error; an empty array is a PR with no file changes.
+// the Files changed tab, and is refetched when the checkout's HEAD moves. Unlike
+// the PR detail next door it does not refresh on window focus: re-rendering a
+// wide diff is far too expensive to spend on every alt-tab back into the app.
+// files is null while loading or on error; an empty array is a PR with no file
+// changes.
+//
+// Fetched when the tab is open, which is no longer the same as on demand: the
+// tab is remembered (pulls-prefs), so a reviewer who lives in Files changed
+// opens every pull request straight into a diff round-trip. That is the trade
+// the remembered tab makes — landing where the work is, at the cost of a call
+// the Overview would not have made — and the answer is filed, so the second
+// visit to the same diff pays nothing.
 export function usePullRequestDiff(
   path: string,
   head: string,

--- a/frontend/src/lib/pulls/use-pull-request-diff.ts
+++ b/frontend/src/lib/pulls/use-pull-request-diff.ts
@@ -23,7 +23,9 @@ export function usePullRequestDiff(
   const { data, error } = useRemoteResource(
     path && `${path} ${number} ${head}`,
     () => ProjectService.PullRequestDiff(path, number).then(parseDiff),
-    { empty: NO_FILES },
+    // head is not in the cache key: `gh pr diff` is asked for a number and
+    // answers with GitHub's head, so the local HEAD only dates the answer.
+    { empty: NO_FILES, cache: `pulls.diff ${path} ${number}` },
   )
   return { files: data, error }
 }

--- a/frontend/src/lib/pulls/use-pull-requests.ts
+++ b/frontend/src/lib/pulls/use-pull-requests.ts
@@ -26,6 +26,9 @@ export function usePullRequests(path: string, state: PullsState): PullRequestLis
     {
       empty: NO_PULL_REQUESTS,
       refetchOnFocus: true,
+      // The state rides the cache key because it is what was asked for; the
+      // path, because two repositories are two lists.
+      cache: `pulls.list ${path} ${state}`,
       // Rows of the state being left have to go before the new ones arrive: the
       // column labels itself from the query, so keeping them would caption open
       // pull requests as merged for as long as gh takes to answer.

--- a/frontend/src/lib/remote-cache.test.ts
+++ b/frontend/src/lib/remote-cache.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { clearRemoteCache, readRemoteCache, writeRemoteCache } from "./remote-cache"
+
+// The cap is pinned here rather than imported: a test that derives its bounds
+// from the constant it is guarding moves with it and stops guarding anything.
+const MAX_ENTRIES = 32
+
+beforeEach(() => {
+  clearRemoteCache()
+})
+
+describe("the remote answer cache", () => {
+  it("reads back what was filed", () => {
+    writeRemoteCache("pulls.detail /repo #12", { number: 12 })
+
+    expect(readRemoteCache("pulls.detail /repo #12")).toEqual({ number: 12 })
+  })
+
+  it("answers undefined for a key never filed", () => {
+    expect(readRemoteCache("pulls.detail /repo #12")).toBeUndefined()
+  })
+
+  // Why every caller names itself in its key: a pull request's diff and its
+  // conversation are asked for in the very same words otherwise.
+  it("keeps two callers naming the same request apart", () => {
+    writeRemoteCache("pulls.diff /repo 12", "diff")
+    writeRemoteCache("pulls.conversation /repo 12", "conversation")
+
+    expect(readRemoteCache("pulls.diff /repo 12")).toBe("diff")
+    expect(readRemoteCache("pulls.conversation /repo 12")).toBe("conversation")
+  })
+
+  it("replaces the answer under a key that is filed again", () => {
+    writeRemoteCache("pulls.list /repo open", ["stale"])
+    writeRemoteCache("pulls.list /repo open", ["fresh"])
+
+    expect(readRemoteCache("pulls.list /repo open")).toEqual(["fresh"])
+  })
+
+  it("holds the cap without evicting", () => {
+    for (let i = 0; i < MAX_ENTRIES; i++) {
+      writeRemoteCache(`pulls.diff pr-${i}`, i)
+    }
+
+    expect(readRemoteCache("pulls.diff pr-0")).toBe(0)
+    expect(readRemoteCache(`pulls.diff pr-${MAX_ENTRIES - 1}`)).toBe(MAX_ENTRIES - 1)
+  })
+
+  it("evicts the oldest answer once past the cap", () => {
+    for (let i = 0; i <= MAX_ENTRIES; i++) {
+      writeRemoteCache(`pulls.diff pr-${i}`, i)
+    }
+
+    expect(readRemoteCache("pulls.diff pr-0")).toBeUndefined()
+    expect(readRemoteCache("pulls.diff pr-1")).toBe(1)
+    expect(readRemoteCache(`pulls.diff pr-${MAX_ENTRIES}`)).toBe(MAX_ENTRIES)
+  })
+
+  // Re-filing is what a refetch does on every focus, so the answer being read
+  // over and over must not be the one eviction takes.
+  it("counts a re-filed answer as the newest", () => {
+    for (let i = 0; i < MAX_ENTRIES; i++) {
+      writeRemoteCache(`pulls.diff pr-${i}`, i)
+    }
+    writeRemoteCache("pulls.diff pr-0", "revalidated")
+    writeRemoteCache("pulls.diff one-too-many", true)
+
+    expect(readRemoteCache("pulls.diff pr-0")).toBe("revalidated")
+    expect(readRemoteCache("pulls.diff pr-1")).toBeUndefined()
+  })
+})

--- a/frontend/src/lib/remote-cache.ts
+++ b/frontend/src/lib/remote-cache.ts
@@ -1,0 +1,45 @@
+// The last answer of every backend read that asked to be remembered, kept for
+// the next mount. The screens of this app are routes, so walking away from one
+// destroys it: the pull request screen alone is five gh round-trips, and coming
+// back to a review in progress used to cost all five, with a skeleton in their
+// place while they ran.
+//
+// A cache, not a store: nothing here is a source of truth. Whoever reads an
+// entry refetches behind it and replaces it with the answer
+// (use-remote-resource) — this only decides what is on screen while that runs.
+//
+// Module-level and never persisted. It survives navigation, which is the whole
+// problem; it does not survive a reload, where a fresh page and fresh answers
+// are what was asked for.
+
+// How many answers are held at once. Diffs are the large ones and there is no
+// byte budget here, only a count — a review that walks through more pull
+// requests than this loses the oldest, and paints a skeleton on returning to
+// it, which is exactly where the screen was before this file existed.
+const MAX_ENTRIES = 32
+
+const entries = new Map<string, unknown>()
+
+/** The last answer filed under this key, or undefined for one never answered. */
+export function readRemoteCache<T>(key: string): T | undefined {
+  return entries.get(key) as T | undefined
+}
+
+/** File an answer, evicting the least recently filed once the cache is full. */
+export function writeRemoteCache(key: string, value: unknown): void {
+  // A Map iterates in insertion order, so deleting before setting is what makes
+  // that order a recency order — and the first key the one eviction should take.
+  entries.delete(key)
+  entries.set(key, value)
+  if (entries.size > MAX_ENTRIES) {
+    const oldest = entries.keys().next()
+    if (!oldest.done) {
+      entries.delete(oldest.value)
+    }
+  }
+}
+
+/** Drop everything. For the suite, which must not read another test's answers. */
+export function clearRemoteCache(): void {
+  entries.clear()
+}

--- a/frontend/src/lib/use-remote-resource.test.tsx
+++ b/frontend/src/lib/use-remote-resource.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+//
+// The caching half of useRemoteResource, mounted for real. The rest of the
+// suite runs in node against pure modules, and remote-cache.test.ts covers the
+// store on its own — but what this feature is about happens between two mounts
+// of a component, and no pure test can see that: a screen the user walked away
+// from has to come back painted, and the refetch has to run anyway.
+//
+// The harness has to be imported before anything that reaches react-dom, which
+// is why it is first here (see @/test/render-budget).
+import { mountBudget } from "@/test/render-budget"
+import { StrictMode, createElement } from "react"
+import { beforeEach, describe, expect, it } from "vitest"
+import { clearRemoteCache } from "@/lib/remote-cache"
+import { useRemoteResource } from "@/lib/use-remote-resource"
+
+const KEY = "/repo 388 abc"
+const CACHE = "probe /repo 388"
+
+interface Frame {
+  data: string
+  loading: boolean
+  error: string | null
+}
+
+// Every frame the hook produced, so a mount can be read as a sequence rather
+// than as a final value: what the user saw on the way to the answer is the
+// whole question here.
+//
+// Mounted inside StrictMode, as the app runs (main.tsx). That is not
+// decoration — React discards and replays a render that updates state during
+// it, and the first version of this hook lost its seeded answer only under
+// that replay. A probe mounted bare called the bug green.
+function probe(frames: Frame[], load: () => Promise<string>, cache?: string, key = KEY) {
+  function Probe() {
+    const { data, loading, error } = useRemoteResource(key, load, { empty: "", cache })
+    frames.push({ data, loading, error })
+    return null
+  }
+  return createElement(StrictMode, null, createElement(Probe))
+}
+
+/** The distinct states a mount passed through, in order, as readable strings. */
+function states(frames: Frame[]): string[] {
+  const seen = frames.map((f) => `${JSON.stringify(f.data)} loading=${f.loading} error=${f.error}`)
+  return seen.filter((state, i) => state !== seen[i - 1])
+}
+
+const ANSWERED = '"answer" loading=false error=null'
+
+beforeEach(() => {
+  clearRemoteCache()
+})
+
+describe("a remembered lookup", () => {
+  it("paints the last answer on the next mount and refetches underneath", async () => {
+    const frames: Frame[] = []
+    let calls = 0
+    const load = () => {
+      calls++
+      return Promise.resolve("answer")
+    }
+
+    const first = await mountBudget(probe(frames, load, CACHE))
+    await first.act(() => {})
+    expect(states(frames)).toEqual(['"" loading=true error=null', ANSWERED])
+    await first.unmount()
+    const asked = calls
+
+    frames.length = 0
+    const second = await mountBudget(probe(frames, load, CACHE))
+    await second.act(() => {})
+
+    // One state for the whole mount: the answer was there from the first frame
+    // and never left it. A seed laid down and then dropped by a replayed render
+    // is the bug this pins, and it shows up here as an extra blank state.
+    expect(states(frames)).toEqual([ANSWERED])
+    // Stale-while-revalidate, not a hit that skips the call: what is on screen
+    // is the old answer exactly until the new one lands. How many calls that is
+    // is StrictMode's business — it double-invokes every effect — so what is
+    // asserted is that the request was made again at all.
+    expect(calls).toBeGreaterThan(asked)
+    await second.unmount()
+  })
+
+  // The reason the cache key is not `key`. `key` carries what dates an answer —
+  // on the pull request screen, the checkout's HEAD, which a fresh mount does
+  // not have until its git poll answers. A cache keyed by it would miss on
+  // exactly the frame it exists for.
+  it("paints an answer filed under a key that has since moved", async () => {
+    const frames: Frame[] = []
+    const load = () => Promise.resolve("answer")
+
+    const first = await mountBudget(probe(frames, load, CACHE, "/repo 388 abc"))
+    await first.act(() => {})
+    await first.unmount()
+
+    frames.length = 0
+    // The same request, with the marker not yet arrived — the shape of a remount.
+    const second = await mountBudget(probe(frames, load, CACHE, "/repo 388 "))
+    await second.act(() => {})
+
+    expect(states(frames)).toEqual([ANSWERED])
+    await second.unmount()
+  })
+
+  it("starts blank and loading when the caller keeps no answers", async () => {
+    const frames: Frame[] = []
+    const load = () => Promise.resolve("answer")
+
+    const first = await mountBudget(probe(frames, load))
+    await first.act(() => {})
+    await first.unmount()
+
+    frames.length = 0
+    const second = await mountBudget(probe(frames, load))
+    await second.act(() => {})
+
+    expect(states(frames)).toEqual(['"" loading=true error=null', ANSWERED])
+    await second.unmount()
+  })
+
+  // The answer is filed before the sequence guard drops it, so a lookup the user
+  // walked out on still pays for the return trip.
+  it("keeps an answer that arrived after the component was gone", async () => {
+    const frames: Frame[] = []
+    let land: (value: string) => void = () => {}
+    const load = () =>
+      new Promise<string>((resolve) => {
+        land = resolve
+      })
+
+    const first = await mountBudget(probe(frames, load, CACHE))
+    await first.unmount()
+    land("late")
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    frames.length = 0
+    const second = await mountBudget(probe(frames, load, CACHE))
+
+    expect(states(frames)).toEqual(['"late" loading=false error=null'])
+    await second.unmount()
+  })
+
+  // A lookup that failed says nothing about the last one that worked, so the
+  // answer stays filed and the mount after it is painted again.
+  it("leaves the filed answer standing when a refetch fails", async () => {
+    const frames: Frame[] = []
+    const answer = () => Promise.resolve("answer")
+    const fail = () => Promise.reject(new Error("gh: not found"))
+
+    const first = await mountBudget(probe(frames, answer, CACHE))
+    await first.act(() => {})
+    await first.unmount()
+
+    frames.length = 0
+    const second = await mountBudget(probe(frames, fail, CACHE))
+    await second.act(() => {})
+    expect(frames[frames.length - 1]?.error).toContain("not found")
+    await second.unmount()
+
+    frames.length = 0
+    const third = await mountBudget(probe(frames, answer, CACHE))
+    await third.act(() => {})
+
+    expect(states(frames)).toEqual([ANSWERED])
+    await third.unmount()
+  })
+})

--- a/frontend/src/lib/use-remote-resource.test.tsx
+++ b/frontend/src/lib/use-remote-resource.test.tsx
@@ -9,7 +9,7 @@
 // The harness has to be imported before anything that reaches react-dom, which
 // is why it is first here (see @/test/render-budget).
 import { mountBudget } from "@/test/render-budget"
-import { StrictMode, createElement } from "react"
+import { StrictMode, createElement, useLayoutEffect, useState } from "react"
 import { beforeEach, describe, expect, it } from "vitest"
 import { clearRemoteCache } from "@/lib/remote-cache"
 import { useRemoteResource } from "@/lib/use-remote-resource"
@@ -23,9 +23,14 @@ interface Frame {
   error: string | null
 }
 
-// Every frame the hook produced, so a mount can be read as a sequence rather
-// than as a final value: what the user saw on the way to the answer is the
-// whole question here.
+// Every frame the hook *committed*, so a mount can be read as a sequence rather
+// than as a final value: what the user saw on the way to the answer is the whole
+// question here.
+//
+// Recorded from a layout effect, never from the render body. A render that
+// updates state during it runs again from its base state, and StrictMode runs
+// every pass twice — so the body sees values that were never painted, and an
+// assertion written against them reads a correct hook as an oscillation.
 //
 // Mounted inside StrictMode, as the app runs (main.tsx). That is not
 // decoration — React discards and replays a render that updates state during
@@ -34,7 +39,9 @@ interface Frame {
 function probe(frames: Frame[], load: () => Promise<string>, cache?: string, key = KEY) {
   function Probe() {
     const { data, loading, error } = useRemoteResource(key, load, { empty: "", cache })
-    frames.push({ data, loading, error })
+    useLayoutEffect(() => {
+      frames.push({ data, loading, error })
+    })
     return null
   }
   return createElement(StrictMode, null, createElement(Probe))
@@ -102,6 +109,70 @@ describe("a remembered lookup", () => {
 
     expect(states(frames)).toEqual([ANSWERED])
     await second.unmount()
+  })
+
+  // resetOn only ever fires on a *live* component — the state it guards changes
+  // under the user, it does not arrive with a fresh mount — so these drive it
+  // from inside, through a probe that owns the value and hands back the setter.
+  function resettable(frames: Frame[], cached: boolean) {
+    let move: (next: string) => void = () => {}
+    function Probe() {
+      const [reset, setReset] = useState("open")
+      move = setReset
+      const r = useRemoteResource(`k ${reset}`, () => Promise.resolve(reset), {
+        empty: "",
+        resetOn: reset,
+        cache: cached ? `probe ${reset}` : undefined,
+      })
+      useLayoutEffect(() => {
+        frames.push({ data: r.data, loading: r.loading, error: r.error })
+      })
+      return null
+    }
+    return {
+      element: createElement(StrictMode, null, createElement(Probe)),
+      move: (next: string) => move(next),
+    }
+  }
+
+  // A readout that captions itself from the request — the pull request column
+  // labels its rows with the state it asked for — must drop the old rows before
+  // the new ones arrive, or they sit under the wrong label for a whole call.
+  it("blanks on a reset it has no filed answer for", async () => {
+    const frames: Frame[] = []
+    const { element, move } = resettable(frames, false)
+
+    const mounted = await mountBudget(element)
+    await mounted.act(() => {})
+    frames.length = 0
+    await mounted.act(() => move("merged"))
+
+    // Blank first, in the same render as the change, and only then the call —
+    // "open" never appears under the "merged" label.
+    expect(states(frames)).toEqual([
+      '"" loading=false error=null',
+      '"" loading=true error=null',
+      '"merged" loading=false error=null',
+    ])
+    await mounted.unmount()
+  })
+
+  // The exception, and the reason the two rules are written in one place: an
+  // answer already on file for the *new* request is captioned correctly, so it
+  // is shown rather than blanked.
+  it("paints the filed answer through a reset instead of blanking", async () => {
+    const frames: Frame[] = []
+    const { element, move } = resettable(frames, true)
+
+    const mounted = await mountBudget(element)
+    await mounted.act(() => {})
+    // Both states asked for once, so both have an answer on file.
+    await mounted.act(() => move("merged"))
+    frames.length = 0
+    await mounted.act(() => move("open"))
+
+    expect(states(frames)).toEqual(['"open" loading=false error=null'])
+    await mounted.unmount()
   })
 
   it("starts blank and loading when the caller keeps no answers", async () => {

--- a/frontend/src/lib/use-remote-resource.ts
+++ b/frontend/src/lib/use-remote-resource.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react"
+import { readRemoteCache, writeRemoteCache } from "@/lib/remote-cache"
 import { errorText } from "@/lib/utils"
 
 // The read side of a backend lookup: what came back, whether a call is in
@@ -24,8 +25,22 @@ export interface RemoteResourceOptions<T> {
    * request column labels its rows with the state it asked for — where holding
    * the old rows would mislabel them for as long as the call takes. Off by
    * default: a plain refetch keeps what it has, so a moved HEAD refreshes a
-   * screen in place instead of flashing it back to a skeleton. */
+   * screen in place instead of flashing it back to a skeleton. A filed answer
+   * for the new request wins over blanking: that one is captioned correctly. */
   resetOn?: string
+  /** File each answer under this key, so the next mount of the same request
+   * paints from it and revalidates underneath instead of showing a skeleton
+   * (remote-cache). Off by default, and pointless for anything that never
+   * unmounts.
+   *
+   * Deliberately not `key`. `key` is what makes an answer *stale*, and on the
+   * pull request screen that includes the checkout's HEAD — which a fresh mount
+   * does not have until its git poll has answered, so a cache keyed by it would
+   * miss on the one frame this exists for. This is what the answer is *about*:
+   * the caller's own name and the request, and nothing that merely dates it.
+   * Two callers sharing one of these serve each other's answers, so the name is
+   * not optional. */
+  cache?: string
 }
 
 // useRemoteResource is the one lookup skeleton behind the screens' backend
@@ -48,11 +63,16 @@ export function useRemoteResource<T>(
   load: () => Promise<T>,
   options: RemoteResourceOptions<T>,
 ): RemoteResource<T> {
-  const { empty, refetchOnFocus = false, resetOn } = options
-  const [data, setData] = useState<T>(empty)
+  const { empty, refetchOnFocus = false, resetOn, cache } = options
+  // The answer this request already has, if it was asked for before and the
+  // caller keeps them. Read every render: the first paint and every move to
+  // another request both have to see it.
+  const held = cache && key ? readRemoteCache<T>(cache) : undefined
+  const [data, setData] = useState<T>(held ?? empty)
   // Starts true so the first paint of a real request reads as loading rather
-  // than as an answered "there is nothing here".
-  const [loading, setLoading] = useState(key !== "")
+  // than as an answered "there is nothing here" — unless the answer is already
+  // in hand, which is the whole point of filing it.
+  const [loading, setLoading] = useState(key !== "" && held === undefined)
   const [error, setError] = useState<string | null>(null)
   // Sequence number of the newest request; a reply carrying an older one is
   // dropped. The cleanup bumps it, which is also how unmount invalidates.
@@ -71,31 +91,64 @@ export function useRemoteResource<T>(
       return
     }
     const mine = ++seq.current
-    setLoading(true)
+    // A request whose last answer is in hand revalidates underneath: the screen
+    // keeps what it is showing rather than flipping back to a skeleton, as true
+    // of a manual reload after a merge as of a return to the screen. `data` is
+    // moved during render, not here — by the time an effect ran, the frame this
+    // exists to prevent would already have been painted.
+    if (!cache || readRemoteCache(cache) === undefined) {
+      setLoading(true)
+    }
     loadRef
       .current()
       .then((result) => {
+        // Filed before the sequence check: the key is this closure's own, so a
+        // reply that arrived too late for the screen is still the right answer
+        // to the request it was made for, and the next mount should have it.
+        if (cache) {
+          writeRemoteCache(cache, result)
+        }
         if (mine !== seq.current) return
         setData(result)
         setError(null)
       })
       .catch((err: unknown) => {
         if (mine !== seq.current) return
+        // The filed answer is left standing: a lookup that failed says nothing
+        // about the last one that worked, and the next success replaces it.
         setData(emptyRef.current)
         setError(errorText(err))
       })
       .finally(() => {
         if (mine === seq.current) setLoading(false)
       })
-  }, [key])
+  }, [key, cache])
 
-  // Blanking during render, not in an effect: the old data must never reach
-  // the screen once the request behind it has been abandoned, and an effect
-  // would paint it one frame first.
-  const lastReset = useRef(resetOn)
-  if (resetOn !== undefined && resetOn !== lastReset.current) {
-    lastReset.current = resetOn
-    setData(emptyRef.current)
+  // Moving the data during render, not in an effect: whatever belongs to the
+  // abandoned request must never reach the screen, and an effect would paint it
+  // one frame first.
+  //
+  // What has already been accounted for is held in state, never in a ref. React
+  // may discard a render that updates state during it and replay it, and a ref
+  // written by the discarded pass makes the replay skip the very update it was
+  // guarding — the filed answer is seeded and then silently lost, which is how
+  // this screen came back blank instead of painted.
+  const [seenCache, setSeenCache] = useState(cache)
+  const [seenReset, setSeenReset] = useState(resetOn)
+  if (cache !== seenCache || resetOn !== seenReset) {
+    const resetting = resetOn !== seenReset
+    setSeenCache(cache)
+    setSeenReset(resetOn)
+    if (held !== undefined) {
+      // The filed answer is this request's own, so it is captioned correctly
+      // even where resetOn was about to blank the screen. Nothing is being
+      // waited for either: the refetch the effect is about to run replaces what
+      // is already there.
+      setData(held)
+      setLoading(false)
+    } else if (resetting) {
+      setData(empty)
+    }
   }
 
   useEffect(() => {

--- a/frontend/src/lib/use-remote-resource.ts
+++ b/frontend/src/lib/use-remote-resource.ts
@@ -124,30 +124,11 @@ export function useRemoteResource<T>(
       })
   }, [key, cache])
 
-  // Moving the data during render, not in an effect: whatever belongs to the
-  // abandoned request must never reach the screen, and an effect would paint it
-  // one frame first.
-  //
-  // What has already been accounted for is held in state, never in a ref. React
-  // may discard a render that updates state during it and replay it, and a ref
-  // written by the discarded pass makes the replay skip the very update it was
-  // guarding — the filed answer is seeded and then silently lost, which is how
-  // this screen came back blank instead of painted.
-  const [seenCache, setSeenCache] = useState(cache)
-  const [seenReset, setSeenReset] = useState(resetOn)
-  if (cache !== seenCache || resetOn !== seenReset) {
-    const resetting = resetOn !== seenReset
-    setSeenCache(cache)
-    setSeenReset(resetOn)
-    if (held !== undefined) {
-      // The filed answer is this request's own, so it is captioned correctly
-      // even where resetOn was about to blank the screen. Nothing is being
-      // waited for either: the refetch the effect is about to run replaces what
-      // is already there.
-      setData(held)
+  const moved = useMovedAnswer(key, cache, resetOn, held, empty)
+  if (moved) {
+    setData(moved.data)
+    if (moved.inHand) {
       setLoading(false)
-    } else if (resetting) {
-      setData(empty)
     }
   }
 
@@ -165,4 +146,44 @@ export function useRemoteResource<T>(
   }, [refresh, refetchOnFocus])
 
   return { data, loading, error, refresh }
+}
+
+// What the screen should move to now that the request has changed, or null to
+// leave it where it is. Done during render, not in an effect: whatever belongs
+// to the abandoned request must never reach the screen, and an effect would
+// paint it one frame first.
+//
+// Its own function because the rule it follows is easy to break by accident:
+// what has already been accounted for is held in state, never in a ref. React
+// may discard a render that updates state during it and replay it, and a ref
+// written by the discarded pass makes the replay skip the very update it was
+// guarding — the filed answer is seeded and then silently lost, which is how
+// this screen came back blank instead of painted.
+//
+// `idle` rides the marker beside the cache key because a request can fall away
+// and come back without that key moving — a caller whose `key` empties on a
+// value its `cache` does not spell would otherwise never be handed its answer.
+function useMovedAnswer<T>(
+  key: string,
+  cache: string | undefined,
+  resetOn: string | undefined,
+  held: T | undefined,
+  empty: T,
+): { data: T; inHand: boolean } | null {
+  const idle = key === ""
+  const [seen, setSeen] = useState({ cache, resetOn, idle })
+  if (seen.cache === cache && seen.resetOn === resetOn && seen.idle === idle) {
+    return null
+  }
+  const resetting = seen.resetOn !== resetOn
+  setSeen({ cache, resetOn, idle })
+  if (held !== undefined) {
+    // The filed answer is this request's own, so it is captioned correctly even
+    // where resetOn was about to blank the screen. Nothing is being waited for
+    // either: the refetch the effect is about to run replaces what is there.
+    return { data: held, inHand: true }
+  }
+  // Blanking is resetOn's alone. A plain move to another request keeps what it
+  // has, so a screen refreshes in place instead of flashing back to a skeleton.
+  return resetting ? { data: empty, inHand: false } : null
 }


### PR DESCRIPTION
Leaving the pull request screen mid-review and coming back cost the whole thing: the route unmounts, so every gh read started over behind a skeleton, the filter box emptied itself, the quick filter and the tab reset, and the pull request being read was swapped for whatever the checkout's own branch had open.

Three things now survive leaving the screen.

**The answers.** `useRemoteResource` gains a `cache` option: a caller that passes one has its answers filed in module memory (`remote-cache.ts`), so the next mount paints from the last one and revalidates underneath. Nothing is shown as newer than it is — the focus re-read, the Refresh button and the checks poll are untouched, and a page reload starts from nothing. Opted into by the list, the detail, the conversation, the diff, the branch rules and the checkouts.

**The screen's own state**, gathered into `pulls-prefs.ts` (which absorbs the sort that already lived in localStorage). One rule decides the scope of each: what *narrows the list* is about a repository and is keyed per project — a box left on `is:merged` would otherwise make the next project's list look empty of open pull requests — while how the column is read (the sort) and where a pull request opens (the tab) are habits of the user, and stay global.

**The selection.** Every way back into the list route is the bare one, so the pull request being read is remembered per project and stands in for the number the URL is missing. One that no longer resolves is forgotten once rather than greeting every return with the same error.

### Two things worth a reviewer's eye

**The cache key is deliberately not `key`.** `key` carries what makes an answer *stale* — on this screen, the checkout's HEAD, which a fresh mount does not have until its git poll lands. A cache keyed by it misses on the one frame the cache exists for, which is exactly what the first version of this did. So `cache` is what the answer is *about*, composed by its caller, and the trap that creates is written down in `docs/ceilings.md`.

**Seeding during render may never be guarded by a ref.** React can discard a render that updates state during it and replay it, and a ref written by the discarded pass makes the replay skip the very update it guarded. The symptom looks nothing like the cause: the answer is seeded, the screen paints, and the next frame is blank again with no setter anywhere having run. It is state now, the documented way. Also in `docs/ceilings.md` — including the part a reviewer should not have to rediscover, that **the suite does not reproduce it**: the jsdom probe inside `StrictMode` passes against the ref version, and it took a real browser to see.

### Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` (1968 pass) — backend untouched, run anyway.
- [x] Cross-compile loop over linux/darwin/windows: build + vet clean.
- [x] `pnpm check`, `tsc --noEmit`, `pnpm build`.
- [x] `pnpm test` — 1158 pass across 97 files. New: `remote-cache.test.ts` (the store, its cap and its eviction order), `pulls-prefs.test.ts` (every pref's default, round trip, unknown value and project scoping — the sort's own tests moved here whole), `use-remote-resource.test.tsx` (the first jsdom suite outside the render budgets: two mounts of one hook, asserting the answer is there from the first frame and never leaves it).
- [x] Both new suites mutation-checked: disabling the cache read fails 3 of 4, so they bite.
- [x] Driven for real in a headless lich against this repository, 50 pull requests: filter, chip, tab and the selected pull request all come back, and the screen is readable on the first frame instead of after 921ms of skeleton.

### Not in this PR

Persisting the "viewed" ticks. They already survive navigation (module-level store) and only die on an app restart, which is not the complaint this answers — and the code says the decision not to store them was deliberate. Left as it is rather than flipped in passing.
