### PR TITLE
Bring the settings screen back the way it was left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Settings comes back the way you left it.** Stepping out of Settings — into a
+  session, into another project — used to reset the whole screen: it reopened on
+  Providers with the search box emptied, however deep into a provider's
+  configuration you were, and every pane read the machine again from scratch
+  behind its own blank state. The Sandbox pane in particular drew nothing at all
+  until it had asked whether this machine can confine a session. Now the pane you
+  had open and what you typed to find it are remembered, and the answers each
+  pane is about — your gh accounts and this project's chosen one, the sandbox
+  backend and what your ssh agent holds, the installed fonts, every stored
+  setting behind a switch, path and rung — paint from the last one while a fresh
+  one is fetched underneath. Nothing is shown as newer than it is: every read
+  still runs on every visit, and a reload starts from nothing.
+
 - **The pull request screen comes back the way you left it.** A review
   interrupted — another project, the terminal next door, a branch to check —
   used to cost the whole screen: five gh round-trips behind a skeleton, the

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -422,3 +422,30 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   `useState`, which holds because every route into the screen carries its own project and leaving one unmounts
   it. A future route that reuses `Pulls` across two projects would keep the first one's box and its selection,
   and nothing in the component would say so.
+- **The settings screen remembers nothing per project, on purpose** (`frontend/src/lib/settings-prefs.ts`):
+  the pane that was open and the search box are stored under one key each, so opening Settings in project B
+  lands on the pane project A was reading. That is the rule pulls-prefs states, landing on the other side —
+  the nav is the same list of panes in every project, so neither is about a repository — and it is a decision
+  rather than an oversight: the *values* those panes read and write are project-scoped already, in the
+  workspace database under the project's own id. The trap is for whoever adds a pane that is genuinely about
+  one repository's content. Its remembered state belongs on the per-project side, which means a new key with
+  the project id in it, not another global one beside these two.
+- **A remembered section id is never validated, and a dead one is simply waited out** (`Settings.tsx`):
+  section ids include `provider-<id>` for every enabled provider, so the set is not knowable at build time and
+  the pref is stored raw rather than parsed against a list. `Settings` resolves an id it cannot place to its
+  first section, which is what makes a provider disabled for an afternoon come back to its own pane rather
+  than being forgotten — but it also means a pane removed from the app for good leaves a pref that resolves
+  silently, forever, and nothing rewrites it. Deleting a section means the users who were on it open on
+  Appearance with no explanation.
+- **`agentplugin.Status` is the one settings read that is not remembered** (`UpdatesSettings.tsx`): it costs
+  ~180 ms and its rows blank on every visit to Updates, while every other read on the screen paints from the
+  last answer. It is not an oversight — `PluginSetting` awaits that read for its *outcome*, telling "Checked."
+  from "Check failed — are you online?", and `useRemoteResource`'s `refresh` is fire-and-forget with the
+  failure folded into state, so there is nothing to await. Caching it means rewiring both of that pane's flows
+  around a resource's `loading` and `error`, and that is the price, not a line of config.
+- **`useBinaryCheck` is deliberately not a `useRemoteResource` caller** (`frontend/src/lib/use-binary-check.ts`):
+  it answers `null` until a verdict is in and debounces its input, because the value it checks arrives one
+  keystroke at a time — and `useRemoteResource` has no debounce seam to hang that on. So the path verdicts on
+  Settings › Version Control and every provider's binary block still blink through "unknown" on the way back
+  to the screen. Measured at 1–3 ms per check (`providers.Verify` is a `LookPath`), which is why closing it
+  was not worth widening a hook the whole app reads through.

--- a/frontend/src/components/settings/FontSetting.tsx
+++ b/frontend/src/components/settings/FontSetting.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from "react"
+import { useMemo } from "react"
 import { Fonts as FontService } from "@/lib/rpc"
+import { useRemoteResource } from "@/lib/use-remote-resource"
 import { DEFAULT_FONT, useSettings } from "@/providers/settings"
 import {
   Select,
@@ -11,15 +12,20 @@ import {
 } from "@/components/ui/select"
 import { SettingBlock } from "./SettingBlock"
 
+// A module-level constant, as every array `empty` has to be: a fresh one per
+// render would notify subscribers on every failed read.
+const NO_FAMILIES: string[] = []
+
 export function FontSetting() {
   const { font, setFont } = useSettings()
-  const [families, setFamilies] = useState<string[]>([])
-
-  useEffect(() => {
-    void FontService.List()
-      .then((list) => setFamilies(list ?? []))
-      .catch(() => setFamilies([]))
-  }, [])
+  // Kept for the next visit: this is fontconfig's whole roster, and it is the
+  // same answer every time — a picker that empties itself back to two entries
+  // on the way in has nothing to gain by re-asking first.
+  const { data: families } = useRemoteResource(
+    "font-families",
+    () => FontService.List().then((list) => list ?? NO_FAMILIES),
+    { empty: NO_FAMILIES, cache: "settings.fontFamilies" },
+  )
 
   // Always offer the bundled default and the current selection, even if
   // fontconfig does not list them (the bundled font is not OS-installed).

--- a/frontend/src/components/settings/HelpSettings.tsx
+++ b/frontend/src/components/settings/HelpSettings.tsx
@@ -1,22 +1,20 @@
-import { useEffect, useState } from "react"
 import { Bug, Info, ScrollText } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { SettingBlock } from "./SettingBlock"
 import { System } from "@/lib/rpc"
 import { REPO_URL, bugReportUrl } from "@/lib/support-url"
 import { runWithToast } from "@/lib/toast-async"
+import { useRemoteResource } from "@/lib/use-remote-resource"
 import type { Diagnostics } from "@/lib/api-types"
 
 // The section a bug report starts from: the two things a reporter otherwise has
 // to be walked through — where the log file lives, and what to put in the issue.
 export function HelpSettings() {
-  const [diagnostics, setDiagnostics] = useState<Diagnostics | null>(null)
-
-  useEffect(() => {
-    void System.Diagnostics()
-      .then(setDiagnostics)
-      .catch(() => {})
-  }, [])
+  const { data: diagnostics } = useRemoteResource<Diagnostics | null>(
+    "diagnostics",
+    () => System.Diagnostics(),
+    { empty: null, cache: "settings.diagnostics" },
+  )
 
   return (
     <>

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react"
-import { Store } from "@/lib/rpc"
+import { useState } from "react"
 import {
   footerReadout,
   footerReadoutPair,
@@ -13,6 +12,7 @@ import {
 import { useSettings } from "@/providers/settings"
 import { setCostReadout } from "@/lib/cost-readout-store"
 import { useCostReadout } from "@/lib/use-cost-readout"
+import { useStoredFlag } from "@/lib/use-stored-setting"
 import { Input } from "@/components/ui/input"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { PlanUsageSetting } from "./PlanUsageSetting"
@@ -62,25 +62,6 @@ const SKIP_LEVELS: { level: SkipLevel; label: string; consequence: string }[] = 
   },
 ]
 
-// useSkipPermissions is the stored "run without permission prompts" flag for one
-// checkout scope: read once, written through on every toggle. It reads off until
-// the value arrives — this is the switch that hands an agent the machine, so the
-// unknown state must never be drawn as the permissive one.
-function useSkipPermissions(providerId: string, worktree: boolean) {
-  const key = skipPermissionsKey(providerId, worktree)
-  const [on, setOn] = useState(false)
-
-  useEffect(() => {
-    void Store.GetSetting(key, GLOBAL_SCOPE).then((value) => setOn(value === "true"))
-  }, [key])
-
-  const toggle = (next: boolean) => {
-    setOn(next)
-    void Store.SetSetting(key, GLOBAL_SCOPE, String(next))
-  }
-  return [on, toggle] as const
-}
-
 // ProviderBinSettings is the config section a provider gets when enabled: what
 // its plan has left, which binary its sessions spawn, and how far it runs
 // without asking. Claude Code and Codex add the footer readout because their
@@ -101,8 +82,14 @@ export function ProviderBinSettings({
   // The field keeps the raw string so a half-typed "1." survives the keystroke;
   // the stored budget is the parsed value, and an emptied field is no budget.
   const [budget, setBudget] = useState(() => (costBudget > 0 ? String(costBudget) : ""))
-  const [skipHere, setSkipHere] = useSkipPermissions(providerId, false)
-  const [skipInWorktrees, setSkipInWorktrees] = useSkipPermissions(providerId, true)
+  // Off until the store answers, and that direction is not a detail: this is
+  // the switch that hands an agent the machine, so the unknown state can never
+  // be drawn as the permissive one.
+  const [skipHere, setSkipHere] = useStoredFlag(skipPermissionsKey(providerId, false), GLOBAL_SCOPE)
+  const [skipInWorktrees, setSkipInWorktrees] = useStoredFlag(
+    skipPermissionsKey(providerId, true),
+    GLOBAL_SCOPE,
+  )
   const skipFlag = skipPermissionFlags[providerId]
   const level = skipLevel(skipHere, skipInWorktrees)
   const consequence = SKIP_LEVELS.find((rung) => rung.level === level)?.consequence ?? ""

--- a/frontend/src/components/settings/ProviderBinary.tsx
+++ b/frontend/src/components/settings/ProviderBinary.tsx
@@ -10,9 +10,9 @@ import {
   resolves,
   winningScope,
 } from "@/lib/binary-layers"
-import { ProjectService, Store } from "@/lib/rpc"
+import { ProjectService } from "@/lib/rpc"
 import { useBinaryCheck } from "@/lib/use-binary-check"
-import { useRemoteResource } from "@/lib/use-remote-resource"
+import { useStoredFlag, useStoredSetting } from "@/lib/use-stored-setting"
 import { binKey, binOffKey } from "@/lib/providers-store"
 import { useProjects } from "@/providers/projects"
 import { cn } from "@/lib/utils"
@@ -22,42 +22,6 @@ import { Switch } from "@/components/ui/switch"
 import { SettingBlock } from "./SettingBlock"
 
 const GLOBAL_SCOPE = ""
-
-// useStoredSetting is one settings value in one scope: read once, written
-// through on every change. An undefined scope is a layer this pane does not have
-// — the hub has no project — and reads as empty without touching the store.
-//
-// Settings renders every provider's section at the same position, so React keeps
-// one instance and the key changes underneath it. The read therefore has to be
-// the sequence-guarded one: two lookups in flight can answer out of order, and a
-// stale answer here is not a stale readout but the previous provider's path
-// written into this provider's key by the next keystroke. The scope is part of
-// the request for the same reason.
-function useStoredSetting(key: string, scope: string | undefined) {
-  const request = scope === undefined ? "" : `${key}\n${scope}`
-  const { data } = useRemoteResource(request, () => Store.GetSetting(key, scope ?? ""), {
-    empty: "",
-    resetOn: request,
-  })
-  // What was typed, tagged with the request it was typed against, so it is
-  // dropped by the same change that blanks the value it was overriding.
-  const [draft, setDraft] = useState<{ request: string; value: string } | null>(null)
-
-  const persist = (next: string) => {
-    setDraft({ request, value: next })
-    if (scope !== undefined) {
-      void Store.SetSetting(key, scope, next.trim())
-    }
-  }
-  return [draft?.request === request ? draft.value : data, persist] as const
-}
-
-// The store holds strings, so one place knows that "true" is the only value that
-// means on — and the switches read as the booleans they are everywhere else.
-function useStoredFlag(key: string, scope: string | undefined) {
-  const [value, persist] = useStoredSetting(key, scope)
-  return [value === "true", (on: boolean) => persist(on ? "true" : "false")] as const
-}
 
 // ProviderBinary is the "which executable runs" block. Closed it is a fact — the
 // binary a session here would spawn, and whether it is there — because almost

--- a/frontend/src/components/settings/SandboxSettings.tsx
+++ b/frontend/src/components/settings/SandboxSettings.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react"
-import { Store, System } from "@/lib/rpc"
+import { System } from "@/lib/rpc"
 import {
   enabledProviders,
   sandboxKey,
@@ -13,6 +12,8 @@ import { GH_ACCOUNT_KEY } from "@/lib/project-settings"
 import { isMac, isWindows } from "@/lib/platform"
 import { cannotConfineCopy } from "@/lib/sandbox-copy"
 import { splitAccount } from "@/lib/gh-account"
+import { useRemoteResource } from "@/lib/use-remote-resource"
+import { useStoredSetting } from "@/lib/use-stored-setting"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { Switch } from "@/components/ui/switch"
 import { SettingBlock } from "./SettingBlock"
@@ -36,49 +37,36 @@ const RUNGS: { level: SandboxLevel; label: string }[] = [
   { level: "everywhere", label: "Everywhere" },
 ]
 
-// useSetting is one stored string in one scope, read once and written through on
-// every change. It reads as `fallback` until the value arrives, which is also
-// what an unreadable value means: the unknown state is drawn as the answer lich
-// has always behaved like, never as one that silently confines a session or
-// hands a credential to an agent.
-function useSetting(key: string, scope: string, fallback: string) {
-  const [value, setValue] = useState(fallback)
-
-  useEffect(() => {
-    void Store.GetSetting(key, scope).then((stored) => setValue(stored || fallback))
-  }, [key, scope, fallback])
-
-  const write = (next: string) => {
-    setValue(next)
-    void Store.SetSetting(key, scope, next)
-  }
-  return [value, write] as const
-}
+// A module-level constant, as every array `empty` has to be: a fresh one per
+// render would notify subscribers on every failed read.
+const NO_KEYS: string[] = []
 
 // useSandboxBackend names what confines a session here, "" for a machine that
-// cannot, and undefined until the answer arrives — so the pane does not flash its
-// "cannot confine" state on every mount.
+// cannot. `loading` rather than a third value in `data`: the pane draws nothing
+// until the answer is in, so it never flashes its "cannot confine" state, and a
+// second visit has the answer already filed and paints on the first frame.
 function useSandboxBackend() {
-  const [backend, setBackend] = useState<string | undefined>(undefined)
-  useEffect(() => {
-    void System.SandboxBackend().then(setBackend)
-  }, [])
-  return backend
+  return useRemoteResource("sandbox-backend", () => System.SandboxBackend(), {
+    empty: "",
+    cache: "settings.sandboxBackend",
+  })
 }
 
 // useAgentKeys lists what is loaded in the user's ssh agent, read when the pane
 // opens. It is the sentence the switch below it cannot say on its own: that
 // switch is read as "let it push with my GitHub key", and it hands over every
 // identity in this list. A key added after this read is handed over by a control
-// that never named it — reopening the pane is the cheap answer to that.
-function useAgentKeys() {
-  const [keys, setKeys] = useState<string[]>([])
-  useEffect(() => {
-    // Folded here rather than trusted: an agent that holds nothing and a machine
-    // with no agent at all both answer null, and this list is read for a length.
-    void System.SSHAgentKeys().then((loaded) => setKeys(loaded ?? []))
-  }, [])
-  return keys
+// that never named it — reopening the pane refetches, which is the cheap answer
+// to that, and the filed list is only what stands on screen while it does.
+function useAgentKeys(): string[] {
+  const { data } = useRemoteResource(
+    "ssh-agent-keys",
+    // Folded rather than trusted: a machine with no agent answers null, not [],
+    // and this list is read for a length.
+    () => System.SSHAgentKeys().then((keys) => keys ?? NO_KEYS),
+    { empty: NO_KEYS, cache: "settings.sshAgentKeys" },
+  )
+  return data
 }
 
 // SandboxSettings is the whole subject in one pane, asked in the order each
@@ -97,16 +85,19 @@ function useAgentKeys() {
 export function SandboxSettings({ projectId }: { projectId?: string }) {
   const scope = projectId ?? GLOBAL_SCOPE
   const providers = useProviders()
-  const backend = useSandboxBackend()
+  const { data: backend, loading, error } = useSandboxBackend()
   const agentKeys = useAgentKeys()
-  const [sshAgent, setSSHAgent] = useSetting(SSH_AGENT_KEY, scope, "")
-  const [ghToken, setGHToken] = useSetting(GH_TOKEN_KEY, scope, "")
+  const [sshAgent, setSSHAgent] = useStoredSetting(SSH_AGENT_KEY, scope)
+  const [ghToken, setGHToken] = useStoredSetting(GH_TOKEN_KEY, scope)
   // The account the token will be, read from the same setting the Pulls screen
   // answers as. Naming it is the point: the switch hands over one account's
   // credentials, and which one is a project's own choice made on another pane.
-  const [account] = useSetting(GH_ACCOUNT_KEY, scope, "")
+  const [account] = useStoredSetting(GH_ACCOUNT_KEY, scope)
 
-  if (backend === undefined) {
+  // Nothing drawn until the machine has answered, and nothing drawn if it could
+  // not: "this machine cannot confine sessions" is a claim, and a lookup that
+  // failed measured nothing to back it.
+  if (loading || error) {
     return null
   }
 
@@ -184,7 +175,7 @@ function Rung({
   providerName: string
   scope: string
 }) {
-  const [stored, setStored] = useSetting(sandboxKey(providerId), scope, "off")
+  const [stored, setStored] = useStoredSetting(sandboxKey(providerId), scope, "off")
 
   return (
     <div className="flex items-center justify-between gap-4 border-t border-border py-2.5 first:border-t-0 first:pt-0">

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -14,6 +14,12 @@ import { UpdatesSettings } from "./UpdatesSettings"
 import { HelpSettings } from "./HelpSettings"
 import { SearchInput } from "@/components/common/SearchInput"
 import { enabledProviders, useProviders } from "@/lib/providers-store"
+import {
+  readSettingsQuery,
+  readSettingsSection,
+  writeSettingsQuery,
+  writeSettingsSection,
+} from "@/lib/settings-prefs"
 import { cn } from "@/lib/utils"
 
 // A settings category: a nav entry plus the pane it renders. Global and project
@@ -96,8 +102,21 @@ const FOOTER_SECTIONS: Section[] = [
 export function Settings() {
   const { projectId } = useParams()
   const providers = useProviders()
-  const [active, setActive] = useState("providers")
-  const [query, setQuery] = useState("")
+  // Seeded from the store and written through, so leaving the screen — a
+  // session next door, another project — brings back the pane that was open
+  // rather than the default one (settings-prefs).
+  const [active, setActive] = useState(readSettingsSection)
+  const [query, setQuery] = useState(readSettingsQuery)
+
+  const openSection = (id: string) => {
+    setActive(id)
+    writeSettingsSection(id)
+  }
+
+  const search = (next: string) => {
+    setQuery(next)
+    writeSettingsQuery(next)
+  }
 
   const providerSections: Section[] = enabledProviders(providers).map((provider) => ({
     id: `provider-${provider.id}`,
@@ -133,7 +152,7 @@ export function Settings() {
       key={section.id}
       type="button"
       aria-label={section.accessibleLabel}
-      onClick={() => setActive(section.id)}
+      onClick={() => openSection(section.id)}
       className={cn(
         "rounded-md px-3 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground",
         current.id === section.id && "bg-accent text-accent-foreground",
@@ -149,7 +168,7 @@ export function Settings() {
         <div className="p-3">
           <SearchInput
             value={query}
-            onChange={(event) => setQuery(event.target.value)}
+            onChange={(event) => search(event.target.value)}
             placeholder="Search"
             aria-label="Search settings"
           />

--- a/frontend/src/components/settings/UpdatesSettings.tsx
+++ b/frontend/src/components/settings/UpdatesSettings.tsx
@@ -6,25 +6,33 @@ import { PatchNotesDialog } from "@/components/PatchNotesDialog"
 import { PluginSetting } from "./PluginSetting"
 import { AgentPlugin, PatchNotes } from "@/lib/rpc"
 import { runUpdateCheck } from "@/lib/update/update-check"
+import { useRemoteResource } from "@/lib/use-remote-resource"
 import type { PatchNotes as PatchNotesData, PluginStatus } from "@/lib/api-types"
 
 export function UpdatesSettings() {
-  const [notes, setNotes] = useState<PatchNotesData | null>(null)
   const [notesOpen, setNotesOpen] = useState(false)
   const [checking, setChecking] = useState(false)
   const [checkResult, setCheckResult] = useState("")
+  const { data: notes } = useRemoteResource<PatchNotesData | null>(
+    "patch-notes",
+    () => PatchNotes.Current(),
+    { empty: null, cache: "settings.patchNotes" },
+  )
+  // Deliberately not a remembered lookup, unlike the patch notes above it.
+  // PluginSetting awaits this for its *outcome* — "Checked." against "Check
+  // failed — are you online?" — and useRemoteResource's refresh is
+  // fire-and-forget with the failure folded into state, so there is nothing to
+  // await. The rows blank for one read on the way back in; the alternative was
+  // rewiring both of that pane's flows around a resource's loading and error.
   const [plugin, setPlugin] = useState<PluginStatus[] | null>(null)
-
-  useEffect(() => {
-    void PatchNotes.Current()
-      .then(setNotes)
-      .catch(() => {})
-    void refreshPlugin()
-  }, [])
 
   const refreshPlugin = async () => {
     setPlugin(await AgentPlugin.Status())
   }
+
+  useEffect(() => {
+    void refreshPlugin()
+  }, [])
 
   const checkApp = async () => {
     setChecking(true)

--- a/frontend/src/components/settings/VersionControlSettings.tsx
+++ b/frontend/src/components/settings/VersionControlSettings.tsx
@@ -1,12 +1,13 @@
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 import type { CommitIdentity } from "@/lib/api-types"
-import { ProjectService, Store } from "@/lib/rpc"
+import { ProjectService } from "@/lib/rpc"
 import { commitIdentityRow } from "@/lib/commit-identity"
 import { accountLabel, accountSelectItems, upgradeAccount } from "@/lib/gh-account"
 import { GH_ACCOUNT_KEY } from "@/lib/project-settings"
-import { errorText } from "@/lib/utils"
 import { failed } from "@/lib/binary-layers"
 import { NO_SETTLE, useBinaryCheck } from "@/lib/use-binary-check"
+import { useRemoteResource } from "@/lib/use-remote-resource"
+import { useStoredSetting } from "@/lib/use-stored-setting"
 import { GIT } from "@/lib/vcs-tools"
 import { invalidatePullRequests } from "@/lib/pulls/pull-request-lookup"
 import { useProjects } from "@/providers/projects"
@@ -25,6 +26,13 @@ import { SettingBlock } from "./SettingBlock"
 const ACTIVE_ACCOUNT = "__active__"
 const ACTIVE_ACCOUNT_LABEL = "gh's active account"
 
+// Module-level, as every non-primitive `empty` has to be. The two are different
+// answers: null is "gh has not been asked yet", and an empty list is "gh is
+// signed in to nothing", which the pane says out loud.
+const NO_ACCOUNTS: string[] = []
+const NO_ACCOUNTS_YET = null
+const NO_IDENTITY = null
+
 // VersionControlSettings picks which authenticated GitHub account lich's gh
 // calls run as for this project. gh keeps one active account per host, so a
 // repository only one of your accounts can see reads as "not found" until the
@@ -35,59 +43,41 @@ export function VersionControlSettings({ projectId }: { projectId?: string }) {
   const project = projects.find((p) => p.id === projectId)
   // Null until gh answers: an empty list is "gh is signed in to nothing", which
   // is a thing to say — and saying it before the first read would be a lie.
-  const [accounts, setAccounts] = useState<string[] | null>(null)
-  const [account, setAccount] = useState("")
-  const [identity, setIdentity] = useState<CommitIdentity | null>(null)
-  const noGit = failed(useBinaryCheck(GIT.bin, NO_SETTLE))
-  const [error, setError] = useState("")
-
+  //
+  // `gh auth status` is a round trip to GitHub and the slowest read on this
+  // screen, so its answer is kept for the next visit: the picker comes back
+  // populated and revalidates underneath instead of emptying itself first.
+  const { data: accounts, error } = useRemoteResource<string[] | null>(
+    "github-accounts",
+    () => ProjectService.GitHubAccounts().then((list) => list ?? NO_ACCOUNTS),
+    { empty: NO_ACCOUNTS_YET, cache: "settings.githubAccounts" },
+  )
   // Read once per project: git's config changes outside lich, but so rarely
   // that polling the settings page for it would buy nothing.
-  useEffect(() => {
-    const path = project?.path
-    if (!path) {
-      return
-    }
-    void ProjectService.CommitIdentity(path).then(setIdentity)
-  }, [project?.path])
+  const { data: identity } = useRemoteResource<CommitIdentity | null>(
+    project?.path ?? "",
+    () => ProjectService.CommitIdentity(project?.path ?? ""),
+    { empty: NO_IDENTITY, cache: `settings.commitIdentity ${project?.path ?? ""}` },
+  )
+  const [account, setAccount] = useStoredSetting(GH_ACCOUNT_KEY, projectId)
+  const noGit = failed(useBinaryCheck(GIT.bin, NO_SETTLE))
 
-  useEffect(() => {
-    void ProjectService.GitHubAccounts()
-      .then((list) => {
-        setAccounts(list ?? [])
-        setError("")
-      })
-      .catch((err: unknown) => setError(errorText(err)))
-  }, [])
-
-  useEffect(() => {
-    if (!projectId) {
-      return
-    }
-    void Store.GetSetting(GH_ACCOUNT_KEY, projectId).then(setAccount)
-  }, [projectId])
-
+  // The invalidation waits for the write: it makes every pull request badge
+  // look up again, and a re-read that overtook the write would replay the old
+  // account's answer into the map it just cleared.
   const persist = (value: string) => {
-    const chosen = value === ACTIVE_ACCOUNT ? "" : value
-    setAccount(chosen)
-    if (projectId) {
-      void Store.SetSetting(GH_ACCOUNT_KEY, projectId, chosen).then(invalidatePullRequests)
-    }
+    void setAccount(value === ACTIVE_ACCOUNT ? "" : value).then(invalidatePullRequests)
   }
 
   // An account stored before hosts travelled with them is rewritten the moment
   // gh says which host it lives on. It resolves either way, but leaving it
   // half-formed would show the same account twice in the picker.
   useEffect(() => {
-    if (!projectId) {
-      return
-    }
-    const upgraded = upgradeAccount(account, accounts ?? [])
+    const upgraded = upgradeAccount(account, accounts ?? NO_ACCOUNTS)
     if (upgraded) {
       setAccount(upgraded)
-      void Store.SetSetting(GH_ACCOUNT_KEY, projectId, upgraded)
     }
-  }, [account, accounts, projectId])
+  }, [account, accounts, setAccount])
 
   if (!project) {
     return (
@@ -99,7 +89,7 @@ export function VersionControlSettings({ projectId }: { projectId?: string }) {
 
   // The configured account survives a gh that no longer lists it, so a stale
   // value is visible (and changeable) instead of silently reading as default.
-  const options = Array.from(new Set([...(accounts ?? []), ...(account ? [account] : [])]))
+  const options = Array.from(new Set([...(accounts ?? NO_ACCOUNTS), ...(account ? [account] : [])]))
   // The account governs what lich asks gh; this says who the commits are
   // authored as. Both facts, no comparison — see commitIdentityRow. Withheld
   // without git: the empty answer git could not give reads as "this checkout

--- a/frontend/src/lib/settings-prefs.test.ts
+++ b/frontend/src/lib/settings-prefs.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  readSettingsQuery,
+  readSettingsSection,
+  writeSettingsQuery,
+  writeSettingsSection,
+} from "./settings-prefs"
+
+// The suite runs in node, which has no localStorage. These are the prefs that
+// have to survive leaving the screen, so the storage is stubbed and the round
+// trip through it is what is checked.
+const stored = new Map<string, string>()
+
+vi.stubGlobal("localStorage", {
+  getItem: (key: string) => stored.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    stored.set(key, value)
+  },
+  removeItem: (key: string) => {
+    stored.delete(key)
+  },
+})
+
+beforeEach(() => {
+  stored.clear()
+})
+
+describe("the stored section", () => {
+  it("opens on the providers pane with nothing stored", () => {
+    expect(readSettingsSection()).toBe("providers")
+  })
+
+  it("round-trips the pane that was open", () => {
+    writeSettingsSection("sandbox")
+
+    expect(readSettingsSection()).toBe("sandbox")
+  })
+
+  // The opposite of the sort pref, and the reason this one is not parsed
+  // against a known set: a provider's section id only exists while that
+  // provider is enabled, so an id this build cannot place has to come back
+  // whole. The screen resolves it to its first section for as long as the
+  // provider is off, and the pane is there again when it is turned back on.
+  it("keeps a section id it cannot place, for the screen to resolve", () => {
+    writeSettingsSection("provider-crush")
+
+    expect(readSettingsSection()).toBe("provider-crush")
+  })
+})
+
+describe("the stored search box", () => {
+  it("reads empty with nothing stored", () => {
+    expect(readSettingsQuery()).toBe("")
+  })
+
+  it("round-trips what was typed", () => {
+    writeSettingsQuery("sand")
+
+    expect(readSettingsQuery()).toBe("sand")
+  })
+
+  // Clearing the box is a state to remember like any other: a screen left with
+  // the full nav must not come back filtered by the last search.
+  it("round-trips an emptied box", () => {
+    writeSettingsQuery("sand")
+    writeSettingsQuery("")
+
+    expect(readSettingsQuery()).toBe("")
+  })
+})
+
+// Both are global on purpose (see the file's docblock): the nav is the same
+// list of panes in every project, so nothing on this screen is keyed by one.
+describe("the scope of these prefs", () => {
+  it("answers with the same section and box whichever project asks", () => {
+    writeSettingsSection("hotkeys")
+    writeSettingsQuery("hot")
+
+    expect([...stored.keys()].sort()).toEqual(["lich.settings.query", "lich.settings.section"])
+  })
+})

--- a/frontend/src/lib/settings-prefs.ts
+++ b/frontend/src/lib/settings-prefs.ts
@@ -1,0 +1,52 @@
+import { readPref, writePref } from "@/lib/prefs"
+
+// Everything the settings screen remembers about how it was left. Like the pull
+// request screen it is an `<Outlet>` route, so stepping into a session or
+// another project unmounts it: however deep into a provider's configuration you
+// were, coming back landed on the Providers pane with an empty search box.
+//
+// UI preferences, so the page's localStorage rather than the workspace database
+// (see the root CLAUDE.md). pulls/pulls-prefs.ts is the worked example, and the
+// split prefs.ts describes applies here too — the parsing is the half worth
+// testing, reading and writing the key stays a two-line wrapper.
+//
+// Both of these are global, and the pull request screen's own rule is what puts
+// them there: what narrows a list of a *repository's* content is keyed per
+// project, and nothing here does. This route carries a project id, but the nav
+// it draws is the same list of panes in every project — the global sections, the
+// enabled providers, the footer — so which pane was open and what was typed to
+// find it are habits of this user. The project-scoped half of this screen is the
+// values the panes read and write, and those already live in the workspace
+// database under the project's own id.
+const SECTION_KEY = "lich.settings.section"
+const QUERY_KEY = "lich.settings.query"
+
+// The pane a screen with nothing remembered opens on: the one almost every
+// visit is for.
+const DEFAULT_SECTION = "providers"
+
+/** The pane the nav had open.
+ *
+ * Not checked against a known set the way a sort is. A provider's section id
+ * only exists while that provider is enabled, so the set is not knowable here —
+ * and the screen already resolves an id it cannot find to its first section,
+ * which means a pane belonging to a provider turned off for now is waited out
+ * rather than forgotten. */
+export function readSettingsSection(): string {
+  return readPref(SECTION_KEY) ?? DEFAULT_SECTION
+}
+
+export function writeSettingsSection(section: string): void {
+  writePref(SECTION_KEY, section)
+}
+
+/** The search box, verbatim — it is free text, so anything stored is valid.
+ * Stored per keystroke on purpose, as the pull request screen's filter box is:
+ * a screen left mid-search is a screen that comes back mid-search. */
+export function readSettingsQuery(): string {
+  return readPref(QUERY_KEY) ?? ""
+}
+
+export function writeSettingsQuery(query: string): void {
+  writePref(QUERY_KEY, query)
+}

--- a/frontend/src/lib/use-stored-setting.test.tsx
+++ b/frontend/src/lib/use-stored-setting.test.tsx
@@ -1,0 +1,229 @@
+// @vitest-environment jsdom
+//
+// The one thing useStoredSetting adds over the lookup underneath it: the pairing
+// of the request with the answer filed for it. Settings draws every provider's
+// section at the same position, so React keeps one instance and the key changes
+// underneath it — and a hook that lets one provider's answer stand under
+// another's request does not show a stale readout, it writes the wrong path into
+// the wrong key on the next keystroke.
+//
+// The harness has to be imported before anything that reaches react-dom, which
+// is why it is first here (see @/test/render-budget).
+import { mountBudget } from "@/test/render-budget"
+import { StrictMode, createElement, useLayoutEffect, useState } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { clearRemoteCache } from "@/lib/remote-cache"
+import { useStoredSetting } from "@/lib/use-stored-setting"
+
+const reads: string[] = []
+const writes: string[] = []
+
+vi.mock("@/lib/rpc", () => ({
+  Store: {
+    GetSetting: (key: string, scope: string) => {
+      reads.push(`${key}@${scope}`)
+      // "" is what the store answers for a key nobody has set, which is the
+      // case the fallback exists for — not only the frame before it answers.
+      if (key === "unset") {
+        return Promise.resolve("")
+      }
+      // The same key answers differently per scope, which is the whole point of
+      // a layered override.
+      return Promise.resolve(scope ? `/${scope}/${key}` : `/usr/bin/${key}`)
+    },
+    SetSetting: (key: string, scope: string, value: string) => {
+      writes.push(`${key}@${scope}=${value}`)
+      return Promise.resolve(null)
+    },
+  },
+}))
+
+// Every frame the hook *committed*, so a mount reads as a sequence rather than
+// as a final value: what stood on screen on the way to the answer is the whole
+// question here.
+//
+// Recorded from a layout effect, never from the render body. A render that
+// updates state during it runs again from its base state, and StrictMode runs
+// every pass twice — so the body sees values that were never painted, and an
+// assertion written against them reads a correct hook as an oscillation.
+//
+// Mounted inside StrictMode, as the app runs (main.tsx): React discards and
+// replays a render that updates state during it, and the seeding this hook
+// leans on is done during render.
+function probe(frames: string[], fallback = "") {
+  let move: (next: string) => void = () => {}
+  let type: (next: string) => void = () => {}
+  function Probe() {
+    // The key changes on a *live* component, which is the only way this hazard
+    // ever happens: a remount would start the lookup from scratch and never
+    // exercise the move at all.
+    const [provider, setProvider] = useState("claude")
+    move = setProvider
+    const [value, persist] = useStoredSetting(provider, "", fallback)
+    type = persist
+    useLayoutEffect(() => {
+      frames.push(`${provider}:${value}`)
+    })
+    return null
+  }
+  return {
+    element: createElement(StrictMode, null, createElement(Probe)),
+    move: (next: string) => move(next),
+    type: (next: string) => type(next),
+  }
+}
+
+/** The distinct states a mount passed through, in order. */
+function states(frames: string[]): string[] {
+  return frames.filter((state, i) => state !== frames[i - 1])
+}
+
+beforeEach(() => {
+  clearRemoteCache()
+  reads.length = 0
+  writes.length = 0
+})
+
+describe("a stored settings value", () => {
+  it("never lets one key's answer stand under another's", async () => {
+    const frames: string[] = []
+    const { element, move } = probe(frames)
+
+    const mounted = await mountBudget(element)
+    await mounted.act(() => {})
+    expect(states(frames)).toEqual(["claude:", "claude:/usr/bin/claude"])
+
+    frames.length = 0
+    await mounted.act(() => move("codex"))
+
+    // Blank in the same render as the change, and only then the new answer:
+    // "/usr/bin/claude" never appears beside "codex".
+    expect(states(frames)).toEqual(["codex:", "codex:/usr/bin/codex"])
+    await mounted.unmount()
+  })
+
+  it("paints a key it has already answered on the first frame back", async () => {
+    const frames: string[] = []
+    const { element, move } = probe(frames)
+
+    const mounted = await mountBudget(element)
+    await mounted.act(() => {})
+    await mounted.act(() => move("codex"))
+    frames.length = 0
+    await mounted.act(() => move("claude"))
+
+    // One state for the whole move: no blank between the two, because the
+    // answer for this key was still on file.
+    expect(states(frames)).toEqual(["claude:/usr/bin/claude"])
+    await mounted.unmount()
+  })
+
+  it("brings the answer back to the next mount of the screen", async () => {
+    const frames: string[] = []
+    const first = await mountBudget(probe(frames).element)
+    await first.act(() => {})
+    await first.unmount()
+    const asked = reads.length
+
+    frames.length = 0
+    const second = await mountBudget(probe(frames).element)
+    await second.act(() => {})
+
+    expect(states(frames)).toEqual(["claude:/usr/bin/claude"])
+    // Stale-while-revalidate, not a hit that skips the read: what is on screen
+    // is the old answer exactly until the new one lands.
+    expect(reads.length).toBeGreaterThan(asked)
+    await second.unmount()
+  })
+
+  // The half that makes the field usable while it is being typed in, and the
+  // half that makes it safe: what was typed is tagged with the request it was
+  // typed against, so moving to another provider drops it rather than showing
+  // it — and rather than writing it into that provider's key.
+  it("drops what was typed when the key moves under it", async () => {
+    const frames: string[] = []
+    const { element, move, type } = probe(frames)
+
+    const mounted = await mountBudget(element)
+    await mounted.act(() => {})
+    await mounted.act(() => type("  /opt/claude  "))
+    expect(frames[frames.length - 1]).toBe("claude:  /opt/claude  ")
+    // Stored trimmed, under the key it was typed against.
+    expect(writes).toEqual(["claude@=/opt/claude"])
+
+    frames.length = 0
+    await mounted.act(() => move("codex"))
+
+    expect(states(frames)).toEqual(["codex:", "codex:/usr/bin/codex"])
+    expect(writes).toEqual(["claude@=/opt/claude"])
+    await mounted.unmount()
+  })
+
+  // ProviderBinary reads one key at two scopes at once — the project's override
+  // and the global one — and draws them as two rows of the same block. They are
+  // two questions, so the scope has to be part of both the request and the key
+  // the answer is filed under.
+  //
+  // It takes two mounts to see a shared key go wrong, which is why this is not
+  // the obvious one-mount assertion: each hook still runs its own load closure
+  // with its own scope, so the first visit is right whatever the key says. The
+  // damage is on the way back, where both layers seed from the one filed answer
+  // and the block paints an override nobody typed — corrected a round-trip
+  // later, which reads as a flicker rather than as a bug.
+  it("keeps the layers of one key apart across a remount", async () => {
+    const frames: string[] = []
+    function Layers() {
+      const [global] = useStoredSetting("claude", "")
+      const [project] = useStoredSetting("claude", "proj-1")
+      useLayoutEffect(() => {
+        frames.push(`${global}|${project}`)
+      })
+      return null
+    }
+    const element = () => createElement(StrictMode, null, createElement(Layers))
+
+    const first = await mountBudget(element())
+    await first.act(() => {})
+    expect(frames[frames.length - 1]).toBe("/usr/bin/claude|/proj-1/claude")
+    expect(new Set(reads)).toEqual(new Set(["claude@", "claude@proj-1"]))
+    await first.unmount()
+
+    frames.length = 0
+    const second = await mountBudget(element())
+    await second.act(() => {})
+
+    // Painted from the first visit's answers, each layer from its own.
+    expect(states(frames)).toEqual(["/usr/bin/claude|/proj-1/claude"])
+    await second.unmount()
+  })
+
+  // The fallback is what the value reads as before the store answers and after
+  // it answers with nothing. These are the switches that confine a session and
+  // hand an agent a credential: the unknown state is drawn as the answer lich
+  // has always behaved like, never as the permissive one.
+  it("reads as the fallback until the store answers", async () => {
+    const frames: string[] = []
+    const { element } = probe(frames, "off")
+
+    const mounted = await mountBudget(element)
+    await mounted.act(() => {})
+
+    expect(states(frames)).toEqual(["claude:off", "claude:/usr/bin/claude"])
+    await mounted.unmount()
+  })
+
+  it("keeps reading as the fallback once the store answers with nothing", async () => {
+    const frames: string[] = []
+    const { element, move } = probe(frames, "off")
+
+    const mounted = await mountBudget(element)
+    await mounted.act(() => {})
+    frames.length = 0
+    await mounted.act(() => move("unset"))
+
+    // Never a frame of "", which the rung above this would have drawn as no
+    // rung selected at all.
+    expect(states(frames)).toEqual(["unset:off"])
+    await mounted.unmount()
+  })
+})

--- a/frontend/src/lib/use-stored-setting.ts
+++ b/frontend/src/lib/use-stored-setting.ts
@@ -1,0 +1,63 @@
+import { useCallback, useState } from "react"
+import { Store } from "@/lib/rpc"
+import { useRemoteResource } from "@/lib/use-remote-resource"
+
+// useStoredSetting is one stored settings string in one scope: read when the
+// pane opens, written through on every change, and remembered across the
+// screen's own unmount so the second visit paints the value instead of the
+// fallback.
+//
+// The read is the sequence-guarded one rather than a bare effect, and that is
+// not a preference. Settings renders every provider's section at the same
+// position, so React keeps one instance and the key changes underneath it — two
+// lookups in flight can answer out of order, and a stale answer here is not a
+// stale readout but the previous provider's path written into this provider's
+// key by the next keystroke. The scope is part of the request for the same
+// reason.
+//
+// `fallback` is what the value reads as until the store answers, and what it
+// keeps reading as for a key nobody has set. It is always the answer lich has
+// behaved like all along: this hook backs the switches that confine a session
+// and hand an agent a credential, and the unknown state must never be drawn as
+// the permissive one.
+//
+// An undefined scope is a layer this pane does not have — the hub has no
+// project — and reads as the fallback without touching the store.
+export function useStoredSetting(key: string, scope: string | undefined, fallback = "") {
+  const request = scope === undefined ? "" : `${key}\n${scope}`
+  const { data } = useRemoteResource(request, () => Store.GetSetting(key, scope ?? ""), {
+    empty: fallback,
+    resetOn: request,
+    // The request itself, which is the whole of what this answer is about: one
+    // key in one scope, and nothing that merely dates it. Two panes reading the
+    // same key in the same scope *are* asking the same question.
+    cache: `settings.value ${request}`,
+  })
+  // What was typed, tagged with the request it was typed against, so it is
+  // dropped by the same change that blanks the value it was overriding.
+  const [draft, setDraft] = useState<{ request: string; value: string } | null>(null)
+
+  // Stable across renders, so a caller can depend on it from an effect without
+  // that effect re-running on every render. It answers with the write, for the
+  // one caller that has to act only once the value has landed — naming a GitHub
+  // account makes every pull request badge look up again, and a re-read that
+  // overtakes the write replays the old account's answer.
+  const persist = useCallback(
+    (next: string): Promise<unknown> => {
+      setDraft({ request, value: next })
+      if (scope === undefined) {
+        return Promise.resolve()
+      }
+      return Store.SetSetting(key, scope, next.trim())
+    },
+    [key, scope, request],
+  )
+  return [draft?.request === request ? draft.value : data || fallback, persist] as const
+}
+
+/** The same value as the boolean it reads as everywhere else: the store holds
+ * strings, so one place knows that "true" is the only one that means on. */
+export function useStoredFlag(key: string, scope: string | undefined) {
+  const [value, persist] = useStoredSetting(key, scope)
+  return [value === "true", (on: boolean) => void persist(on ? "true" : "false")] as const
+}


### PR DESCRIPTION
Stacked on #389 — base is `feat/remember-the-pull-request-screen`, so review that one first. The diff here is only this commit.

`Settings` is an `<Outlet>` route like `Pulls`, so stepping into a session or another project destroyed it: it reopened on Providers with the search box emptied, however deep into a provider's configuration you were, and every pane read the machine again from scratch behind its own blank state. The Sandbox pane drew literally nothing until it had asked whether this machine can confine a session.

## What survives leaving the screen

**The screen's own state** — `frontend/src/lib/settings-prefs.ts`. The pane that was open and the search box, both **global**, and that is pulls-prefs' rule landing on its other side: what narrows a list of a *repository's* content is keyed per project, and neither of these does — the nav is the same list of panes in every project. The project-scoped half of this screen is the values the panes read and write, and those already live in the workspace database under the project's id.

The pane id is stored raw rather than parsed against a known set, because `provider-<id>` is only a section while that provider is enabled and the set is not knowable at build time. `Settings` already resolves an id it cannot place to its first section, so a provider turned off for an afternoon comes back to its own pane instead of being forgotten.

**The answers** — `useRemoteResource`'s `cache`, from #389. Three panels were hand-rolling the same "one stored setting in one scope" hook; one of them already knew the read has to be sequence-guarded, because Settings draws every provider's section at the same position and a stale answer there is not a stale readout but the previous provider's path written into this provider's key by the next keystroke. That one becomes `frontend/src/lib/use-stored-setting.ts`, which the other two call and which files its answers. The scope is part of both the request and the cache key, since `ProviderBinary` reads one key at two scopes at once. The standalone reads — sandbox backend, ssh agent, gh accounts, commit identity, fonts, diagnostics, patch notes — each lose a `useState`/`useEffect` pair to the same hook.

## Deliberately left alone (both in `docs/ceilings.md`)

- **`agentplugin.Status`** (~180ms, blanks on every visit to Updates). `PluginSetting` awaits it for its *outcome* — "Checked." against "Check failed — are you online?" — and `useRemoteResource`'s `refresh` is fire-and-forget with the failure folded into state, so there is nothing to await. Caching it means rewiring both of that pane's flows around a resource's `loading`/`error`.
- **`useBinaryCheck`.** It answers `null` until a verdict is in and debounces its input, because the path arrives one keystroke at a time — `useRemoteResource` has no debounce seam. Measured at 1–3ms a check (`providers.Verify` is a `LookPath`), so widening a hook the whole app reads through was not worth it.

## Not in this PR

The `system.SSHAgentKeys` null crash this refactor uncovered ships on its own in **#391**, off `main` — it is a live bug for anyone on v0.41.0 and should not wait behind a stacked refactor. What stays here is the four-word `?? NO_KEYS` fold inside a hook this PR rewrites anyway; the facade type that makes that fold checkable lives in #391, and the two reconcile with no conflict once it lands. This PR touches no `rpc.ts`.

## Tests

`use-stored-setting.test.tsx` pins the pairing whose failure corrupts data, under the two conditions #389 learned the hard way: the request changes on a **live** component, and frames come from a `useLayoutEffect`. The layers test needs a second mount on top of those — each hook runs its own load closure with its own scope, so a shared cache key is still *right* on the first visit and only wrong on the way back.

Every new assertion was checked by mutating the code it guards and watching it fail:

| mutation | tests that bit |
|---|---|
| drop `resetOn` | 3 |
| drop `cache` | 2 |
| untag the draft | 1 |
| drop the fallback coalesce | 1 |
| stop trimming the write | 1 |
| drop scope from the request | 1 |
| cache key ignores the scope | 1 |
| wrong default section | 1 |
| project-scope the query key | 1 |

## Measured

Headless (`LICH_DEV=1` + a `chromium` shim + CDP), against this workspace. Time from the route mounting to the pane's answered content standing on screen:

| pane | cold | on return |
|---|---|---|
| Sandbox — machine verdict | 80–159ms | 29–34ms |
| Version Control | 104–126ms | 25–29ms |
| Appearance — font resolved | 89ms | 31–73ms |
| Help — diagnostics | 28–34ms | 25–26ms |

25–34ms is the route transition itself: the Help pane, whose read costs 2ms, pays the same. At the RPC: `project.GitHubAccounts` 548–669ms, `agentplugin.Status` 163–198ms, `fonts.List` 26–27ms, everything else ≤8ms.

Also driven by hand in the same rig: picking Sandbox and typing `sand` survives leaving the screen *and* a full reload; every pane renders; typing `  /opt/claude-test  ` into Claude Code's global binary field stores it trimmed under `claude.bin`, and switching to Codex shows empty fields and writes nothing to `provider.codex.bin`.

## Gate

`gofmt -l .`, `go vet ./...`, `go test ./...` (1968 passed), `biome check`, `tsc --noEmit`, `vitest run` (1170 passed / 96.79% statements), `vite build` — all clean.
