### PR TITLE
Fold a null ssh agent answer into a list before reading it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Opening Settings › Sandbox no longer blanks the whole lich window on a
+  machine with no ssh agent.** That pane lists what your agent holds beside the
+  switch that hands it to a confined session. Asked on a machine with no agent
+  running, lich answered with nothing at all rather than an empty list, and the
+  pane threw reading a length off it — which takes the entire window with it,
+  not just the pane: the sidebar, your open terminals and the screen you were
+  on all vanish, and navigating does not bring them back. Only reloading the
+  window does. It hit any machine that *can* confine a session but has no
+  `SSH_AUTH_SOCK` — a plain Linux desktop without an agent started for the
+  login — and it was reachable from v0.41.0. The list now reads "Nothing
+  loaded.", which is what it always said for an agent holding no keys.
+
 ## [0.41.0] - 2026-08-25
 
 ### Added

--- a/frontend/src/components/settings/SandboxSettings.tsx
+++ b/frontend/src/components/settings/SandboxSettings.tsx
@@ -74,7 +74,9 @@ function useSandboxBackend() {
 function useAgentKeys() {
   const [keys, setKeys] = useState<string[]>([])
   useEffect(() => {
-    void System.SSHAgentKeys().then(setKeys)
+    // Folded here rather than trusted: an agent that holds nothing and a machine
+    // with no agent at all both answer null, and this list is read for a length.
+    void System.SSHAgentKeys().then((loaded) => setKeys(loaded ?? []))
   }, [])
   return keys
 }

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -457,8 +457,11 @@ export const System = {
    * Shown beside the setting that hands the agent to a confined session: that
    * setting reads as "let it push with my GitHub key" and actually covers every
    * key in the list. Empty for no agent, no ssh-add, or an agent holding
-   * nothing — all three mean the same thing to whoever is deciding. */
-  SSHAgentKeys: () => call<string[]>("system.SSHAgentKeys", []),
+   * nothing — all three mean the same thing to whoever is deciding, and all
+   * three answer null rather than []: Go marshals a nil slice that way, so the
+   * type says so and the caller folds it into a list before reading a length
+   * off it. */
+  SSHAgentKeys: () => call<string[] | null>("system.SSHAgentKeys", []),
 }
 
 export const Providers = {


### PR DESCRIPTION
`system.SSHAgentKeys` returns a Go `[]string`, and returns it **nil** for every machine it has nothing to say about — no agent in the environment, no `ssh-add`, an agent holding nothing, output it cannot parse. A nil slice marshals as `null`, not `[]`, so that is what reaches the window; the rpc facade claimed a bare `string[]` and `SandboxSettings` read a length off it.

## The symptom is not the empty pane it sounds like

There is **no ErrorBoundary anywhere in the frontend** — `ErrorBoundary`, `componentDidCatch` and `getDerivedStateFromError` all return zero hits, and `main.tsx` renders `<App/>` bare inside `StrictMode`. A throw during render therefore unmounts the whole React root.

Reproduced on a rig isolated from every other one on this machine — its own `LICH_LISTEN_PORT`, Vite port and `--remote-debugging-port`, a private `XDG_CONFIG_HOME` (own SQLite, own Chromium profile and SingletonLock) with `GH_CONFIG_DIR=$HOME/.config/gh` beside it so `gh` stays signed in. The driver refuses to evaluate anything until `location.href` names this rig's own Vite and backend ports, and it selects its CDP target by Vite port rather than taking the first page — a shared debugging port answers for whichever browser holds it. Backend confirmed as this rig's own PID on its own port, not a focused singleton.

With `SSH_AUTH_SOCK` unset for that backend process only (`internal/sandbox/sandbox.go:253` returns `""` unless it is an absolute path *and* a real socket, which is enough to make `SSHAgentKeys` answer nil):

```
system.SSHAgentKeys returns: null
system.SandboxBackend returns: "bubblewrap"     <- the pane renders its controls

root children before   : 2
root children after    : 0
body text length       : 0
window error events    : ["Uncaught TypeError: Cannot read properties of null (reading 'length')", ...]
```

The sidebar, the open terminals and the screen behind them all go with it. And it does not come back:

```
after navigating away   -> root children: 0 | text length: 0
after opening a project -> root children: 0 | text length: 0
after a reload          -> root children: 2 | text length: 446
```

Only a reload recovers it — in a Chromium `--app` window that offers no obvious way to ask for one.

**Who it hits:** a machine that *can* confine a session (the pane returns early otherwise) with no `SSH_AUTH_SOCK` — a plain Linux desktop with no agent started for the login. Reachable since v0.41.0.

## The fix, and the order it goes in

The honest facade type plus a fold at the one caller. The order matters: with `strict` on, **the honest type is what makes `tsc` find the unguarded caller at all**. Reverting the fold against the corrected type fails the typecheck on exactly that line:

```
src/components/settings/SandboxSettings.tsx(79,37): error TS2345:
  Argument of type 'Dispatch<SetStateAction<string[]>>' is not assignable to
  parameter of type '(value: string[] | null) => void | PromiseLike<void>'.
      Type 'null' is not assignable to type 'SetStateAction<string[]>'.
```

That is the guard this leaves behind — the boundary is typed, so the compiler owns it from here. The same probe against the *original* type passes clean, which is exactly why nothing caught this.

Verified after the fix in the same rig, same unset `SSH_AUTH_SOCK`: `SSHAgentKeys` still answers `null`, `#root` keeps its 2 children, zero error events, and the pane renders with **"Nothing loaded."** — what it always said for an agent holding no keys.

## Sweep of the rest of the mirror

`api-types.ts`/`rpc.ts` are hand-owned with no codegen, so the same question applies to every `call<T[]>`. Nothing else to fix:

| facade | Go return | verdict |
|---|---|---|
| `drop.Resolve` | `[]string` | `[]` — measured |
| `project.Missing` | `[]string` | `[]` — measured |
| `project.BranchesOf` | `map[string]string` | `{}` — measured |
| `agentplugin.Status` | `make([]Status, 0, n)` | never nil |
| `providers.Detect` | `make([]Detected, 0, n)` | never nil |
| `quota.Plans` | `[]Plan{…}` literal | never nil |

Eleven facades already say `| null`. In `api-types.ts`, seventeen array *fields* admit null against two that do not, and both of those hold: `QuotaWindow[]` is optional and its one reader already coalesces (`plan.windows ?? []`), and `PatchNotesGroup.items` is only nil for a group `patchnotes.go:113-118` filters out before returning — an upstream invariant rather than a type, but a real one.

The bug class is invisible until someone has an empty list, and `tsc` only helps once the facade type is honest. Worth remembering the next time a Go service returns a slice.

## Gate

`gofmt -l .`, `go vet ./...`, `go test ./...`, `biome check`, `tsc --noEmit`, `vitest run` (1121 passed), `vite build` — all clean.
