### PR TITLE
Keep what is being typed on a pull request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **What you were typing on a pull request stays typed.** A description being
+  rewritten, a comment being composed and a reply to a review thread all used to
+  be destroyed by a click on another tab — go and check a line in Files changed,
+  come back, and the box was empty with nothing said about it. The same went for
+  folding the file a thread was on, and for a new commit landing while you wrote:
+  the diff redraws, and the reply went with it. All three now survive every one
+  of those, and leaving the screen entirely. They are still held in the page, so
+  a reload starts fresh — what is gone is losing them to a tab you clicked on
+  purpose.
+
 ### Changed
 
 - **The pull request screen comes back the way you left it.** A review

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -417,6 +417,12 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   directory that is gone. The window is one round-trip (it re-reads on mount, on focus, and after this screen
   creates a checkout itself) and git refuses the wrong move anyway, which is why it is filed rather than left
   cold — but it is the one to think twice about before the next `cache` is added to something a button reads.
+- **Unsent prose on the pull request screen lives in memory, and nothing collects it**
+  (`frontend/src/lib/pulls/draft-store.ts`): a description, a comment and every thread reply survive each
+  unmount the screen can produce, and none of them survives a reload — unlike the pending review beside them,
+  which is mirrored to localStorage. Persisting these is the same argument that one already won, and the reason
+  it has not been taken is the other half: a filed review clears itself on submit, while an abandoned reply on
+  a thread nobody returns to would sit in storage forever with no one to collect it.
 - **The pull request screen's remembered state is read once, at mount** (`frontend/src/lib/pulls/pulls-prefs.ts`):
   the filter box, the quick filter and the selected pull request are keyed per project but seeded from
   `useState`, which holds because every route into the screen carries its own project and leaving one unmounts

--- a/frontend/src/components/pulls/PullRequestView.tsx
+++ b/frontend/src/components/pulls/PullRequestView.tsx
@@ -441,6 +441,7 @@ export function PullRequestView({
             {tab === "commits" && <PullsCommits commits={detail.commits} />}
             {tab === "conversation" && (
               <PullsConversation
+                pullRequest={detail.url}
                 conversation={conversation}
                 loading={conversationLoading}
                 actions={actions}

--- a/frontend/src/components/pulls/PullsConversation.tsx
+++ b/frontend/src/components/pulls/PullsConversation.tsx
@@ -5,12 +5,16 @@ import { Markdown } from "@/components/Markdown"
 import { Notice } from "@/components/common/Notice"
 import type { PullRequestConversation, PullRequestReview } from "@/lib/api-types"
 import { conversationTimeline } from "@/lib/pulls/conversation-timeline"
+import { useDraft } from "@/lib/pulls/use-draft"
 import { errorText } from "@/lib/utils"
 import { Byline } from "./Byline"
 import { CommentBox } from "./CommentBox"
 import { ReviewThread, type ThreadActions } from "./ReviewThread"
 
 interface PullsConversationProps {
+  /** The pull request this is about, by URL — what its unsent comment is filed
+   * under, so the box survives the tab strip above it (draft-store). */
+  pullRequest: string
   conversation: PullRequestConversation | null
   loading: boolean
   actions: ThreadActions
@@ -26,10 +30,11 @@ interface PullsConversationProps {
 export function PullsConversation({
   conversation,
   loading,
+  pullRequest,
   actions,
   onComment,
 }: PullsConversationProps) {
-  const [draft, setDraft] = useState("")
+  const [draft, setDraft] = useDraft("comment", pullRequest)
   const [sending, setSending] = useState(false)
   const [showResolved, setShowResolved] = useState(false)
   const timeline = conversationTimeline(conversation)
@@ -37,8 +42,8 @@ export function PullsConversation({
   const send = async () => {
     setSending(true)
     try {
-      await onComment(draft)
-      setDraft("")
+      await onComment(draft ?? "")
+      setDraft(null)
     } catch (err: unknown) {
       toast.error(`Comment failed: ${errorText(err)}`)
     } finally {
@@ -109,7 +114,7 @@ export function PullsConversation({
       <div className="flex flex-col gap-1.5 border-t border-border pt-4">
         <span className="text-xs text-muted-foreground">Comment on the pull request</span>
         <CommentBox
-          value={draft}
+          value={draft ?? ""}
           onChange={setDraft}
           onSubmit={() => void send()}
           submitLabel="Comment"

--- a/frontend/src/components/pulls/PullsOverview.tsx
+++ b/frontend/src/components/pulls/PullsOverview.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { useDraft } from "@/lib/pulls/use-draft"
 import { toast } from "sonner"
 import {
   Check,
@@ -40,8 +41,9 @@ interface PullsOverviewProps {
 // the reader out to github.com.
 export function PullsOverview({ path, detail, onRefresh }: PullsOverviewProps) {
   // null is "not editing"; an empty string is a description being cleared, which
-  // is a legitimate edit and must not read as the same thing.
-  const [draft, setDraft] = useState<string | null>(null)
+  // is a legitimate edit and must not read as the same thing. Owned outside the
+  // tree, because the tab above this one unmounts it (draft-store).
+  const [draft, setDraft] = useDraft("body", detail.url)
   const [saving, setSaving] = useState(false)
 
   const save = async () => {

--- a/frontend/src/components/pulls/ReviewThread.tsx
+++ b/frontend/src/components/pulls/ReviewThread.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react"
+import { useDraft } from "@/lib/pulls/use-draft"
 import {
   CheckCheck,
   ChevronDown,
@@ -58,8 +59,13 @@ export function ReviewThread({
   defaultOpen,
   className,
 }: ReviewThreadProps) {
-  const [replying, setReplying] = useState(false)
-  const [draft, setDraft] = useState("")
+  // One value, not a flag beside a string: a reply box that is open but empty is
+  // still open, which is exactly what null-versus-"" already means everywhere a
+  // draft is filed. Owned outside the tree because three separate things destroy
+  // this component — the tab strip, folding the file, and a diff refetch
+  // rebuilding the CodeMirror widget this lives in (draft-store).
+  const [draft, setDraft] = useDraft("reply", thread.id)
+  const replying = draft !== null
   const [busy, setBusy] = useState(false)
   // Any thread folds, because any of them can be one you have already read and
   // want out of the way of the code. Where they differ is only where they
@@ -76,9 +82,8 @@ export function ReviewThread({
     }
     setBusy(true)
     try {
-      await actions.reply(last.id, draft)
-      setDraft("")
-      setReplying(false)
+      await actions.reply(last.id, draft ?? "")
+      setDraft(null)
     } catch (err: unknown) {
       toast.error(`Reply failed: ${errorText(err)}`)
     } finally {
@@ -172,13 +177,10 @@ export function ReviewThread({
       {open &&
         (replying ? (
           <CommentBox
-            value={draft}
+            value={draft ?? ""}
             onChange={setDraft}
             onSubmit={() => void send()}
-            onCancel={() => {
-              setDraft("")
-              setReplying(false)
-            }}
+            onCancel={() => setDraft(null)}
             submitLabel="Reply"
             busy={busy}
             placeholder="Reply to this thread"
@@ -187,7 +189,7 @@ export function ReviewThread({
         ) : (
           <button
             type="button"
-            onClick={() => setReplying(true)}
+            onClick={() => setDraft("")}
             disabled={!last}
             className="flex items-center gap-1.5 self-start rounded-md px-1.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-accent/50 hover:text-foreground"
           >

--- a/frontend/src/lib/pulls/draft-store.test.ts
+++ b/frontend/src/lib/pulls/draft-store.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { draftKey, draftStore } from "./draft-store"
+
+const PR = "https://github.com/omartelo/lich/pull/389"
+const OTHER = "https://github.com/omartelo/lich/pull/12"
+
+const KEYS = [
+  draftKey("body", PR),
+  draftKey("comment", PR),
+  draftKey("reply", PR),
+  draftKey("body", OTHER),
+  draftKey("comment", OTHER),
+  draftKey("reply", "PRRT_kwDOabc"),
+]
+
+beforeEach(() => {
+  for (const key of KEYS) {
+    draftStore.set(key, null)
+  }
+})
+
+describe("a draft's key", () => {
+  // The whole reason the kind is in the key: the description and the
+  // conversation box are both about the same pull request, and typing in one
+  // must not appear in the other.
+  it("keeps two kinds about the same pull request apart", () => {
+    draftStore.set(draftKey("body", PR), "a rewritten description")
+    draftStore.set(draftKey("comment", PR), "a comment")
+
+    expect(draftStore.get(draftKey("body", PR))).toBe("a rewritten description")
+    expect(draftStore.get(draftKey("comment", PR))).toBe("a comment")
+  })
+
+  it("keeps one kind on two pull requests apart", () => {
+    draftStore.set(draftKey("comment", PR), "about 389")
+    draftStore.set(draftKey("comment", OTHER), "about 12")
+
+    expect(draftStore.get(draftKey("comment", PR))).toBe("about 389")
+    expect(draftStore.get(draftKey("comment", OTHER))).toBe("about 12")
+  })
+
+  // A separator that could appear inside an id would let one id be written that
+  // lands on another kind's key. A newline appears in neither a URL nor a
+  // GitHub node id, and this is what says so out loud.
+  it("cannot be forged out of an id", () => {
+    expect(draftKey("body", PR)).not.toBe(draftKey("comment", PR))
+    expect(draftKey("reply", `${PR}\ncomment`)).not.toBe(draftKey("comment", PR))
+  })
+})
+
+describe("a draft that has not been written", () => {
+  it("reads as no draft, not as an empty one", () => {
+    expect(draftStore.get(draftKey("reply", "PRRT_kwDOabc"))).toBeNull()
+  })
+
+  // The distinction the reply box and the description both hang on: a box that
+  // is open and empty is still open, and a description being cleared is a
+  // legitimate edit. Collapsing the two would close a box under the user.
+  it("is not the same as a draft that was emptied", () => {
+    draftStore.set(draftKey("body", PR), "")
+
+    expect(draftStore.get(draftKey("body", PR))).toBe("")
+    expect(draftStore.get(draftKey("body", PR))).not.toBeNull()
+  })
+})
+
+describe("subscribers", () => {
+  it("hear their own key and no other", () => {
+    let body = 0
+    let comment = 0
+    const offBody = draftStore.subscribe(draftKey("body", PR), () => {
+      body++
+    })
+    const offComment = draftStore.subscribe(draftKey("comment", PR), () => {
+      comment++
+    })
+
+    draftStore.set(draftKey("body", PR), "typing")
+
+    expect(body).toBe(1)
+    expect(comment).toBe(0)
+    offBody()
+    offComment()
+  })
+
+  // Every keystroke re-renders the box it was typed into; a keystroke that
+  // changed nothing must not re-render anything, since the reply box lives
+  // inside a CodeMirror widget that redraws with it.
+  it("are not woken by a write that changes nothing", () => {
+    draftStore.set(draftKey("body", PR), "same")
+    let woken = 0
+    const off = draftStore.subscribe(draftKey("body", PR), () => {
+      woken++
+    })
+
+    draftStore.set(draftKey("body", PR), "same")
+
+    expect(woken).toBe(0)
+    off()
+  })
+})

--- a/frontend/src/lib/pulls/draft-store.ts
+++ b/frontend/src/lib/pulls/draft-store.ts
@@ -1,0 +1,43 @@
+import { createKeyedStore } from "@/lib/keyed-store"
+
+// Prose typed into the pull request screen and not yet sent: a description
+// being rewritten, a comment being composed, a reply to a review thread.
+//
+// CommentBox already refuses to own its text, and says why — the CodeMirror
+// editor under a thread widget is rebuilt whenever the diff refetches, so a box
+// holding its own state loses it there. That pushed ownership up to the caller,
+// which was not far enough: the callers held it in `useState`, and the tab strip
+// above them is a ternary between component types (PullRequestView), so every
+// trip to Files changed and back destroyed the caller too. Ownership has to
+// leave the tree, which is this file.
+//
+// Keyed rather than one bag, because a screen holds several of these open at
+// once — the description, the conversation box, a reply in every thread on the
+// diff — and one keystroke must re-render one of them.
+//
+// null is "no draft", and it is not the same as "": a description being cleared
+// is a legitimate edit, and a reply box that is open but empty is still open.
+// That distinction was already PullsOverview's, and it now carries the reply
+// box's `replying` flag too, which is one state fewer to keep in step.
+//
+// In memory only. It survives every unmount this screen can produce, which is
+// what was being lost; it does not survive a reload. Persisting is the same
+// argument pending-review-store already won — GitHub has no record of an unsent
+// comment either — and the reason to hold off is that nothing here would ever
+// collect an abandoned reply, where a filed review clears itself on submit. Add
+// it when a draft lost to a reload survives to be reported, not before.
+export const draftStore = createKeyedStore<string | null>(null)
+
+/** What a draft belongs to. The kind rides the key so two boxes about the same
+ * pull request — its description and its conversation — never share one. */
+export type DraftKind = "body" | "comment" | "reply"
+
+/** `id` identifies what is being written about: the pull request's URL for a
+ * description or a comment (unique across projects, like the viewed ticks and
+ * the pending review beside them), and the thread's own id for a reply, which
+ * GitHub already makes unique on its own. */
+export function draftKey(kind: DraftKind, id: string): string {
+  // A newline appears in neither a URL nor a GitHub node id, so no id can be
+  // written that lands on another kind's key.
+  return `${kind}\n${id}`
+}

--- a/frontend/src/lib/pulls/use-draft.test.tsx
+++ b/frontend/src/lib/pulls/use-draft.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+//
+// The one thing draft-store exists for, and the one thing a node test cannot
+// see: prose typed into a box survives the box being destroyed. Every way the
+// pull request screen destroys one is an unmount — the tab strip is a ternary
+// between component types, folding a file drops the diff body, and a refetched
+// diff rebuilds every CodeMirror widget — so a remount is the whole test.
+//
+// The harness has to be imported before anything that reaches react-dom, which
+// is why it is first here (see @/test/render-budget).
+import { mountBudget } from "@/test/render-budget"
+import { StrictMode, createElement, useLayoutEffect } from "react"
+import { beforeEach, describe, expect, it } from "vitest"
+import { draftKey, draftStore } from "./draft-store"
+import { useDraft } from "./use-draft"
+
+const PR = "https://github.com/omartelo/lich/pull/389"
+
+// Records what each commit saw, from a layout effect rather than the render
+// body: the body sees passes React never committed (use-remote-resource.test).
+function box(seen: (string | null)[], id = PR, kind: "body" | "comment" | "reply" = "comment") {
+  let type: (next: string | null) => void = () => {}
+  function Box() {
+    const [draft, setDraft] = useDraft(kind, id)
+    type = setDraft
+    useLayoutEffect(() => {
+      seen.push(draft)
+    })
+    return null
+  }
+  return {
+    element: createElement(StrictMode, null, createElement(Box)),
+    type: (next: string | null) => type(next),
+  }
+}
+
+beforeEach(() => {
+  for (const kind of ["body", "comment", "reply"] as const) {
+    draftStore.set(draftKey(kind, PR), null)
+  }
+})
+
+describe("a draft being typed", () => {
+  it("is still there when the box is built again", async () => {
+    const seen: (string | null)[] = []
+    const first = box(seen)
+    const mounted = await mountBudget(first.element)
+    await mounted.act(() => first.type("half a comment"))
+    await mounted.unmount()
+
+    seen.length = 0
+    const second = box(seen)
+    const again = await mountBudget(second.element)
+
+    // The first frame of the new box, before any effect could fetch anything.
+    expect(seen[0]).toBe("half a comment")
+    await again.unmount()
+  })
+
+  it("comes back empty once it has been sent", async () => {
+    const seen: (string | null)[] = []
+    const first = box(seen)
+    const mounted = await mountBudget(first.element)
+    await mounted.act(() => first.type("a comment"))
+    // What every send path does: null, not "", so the box closes rather than
+    // reopening empty.
+    await mounted.act(() => first.type(null))
+    await mounted.unmount()
+
+    seen.length = 0
+    const second = box(seen)
+    const again = await mountBudget(second.element)
+
+    expect(seen[0]).toBeNull()
+    await again.unmount()
+  })
+
+  // Two threads on one diff, two boxes open at once: the store is keyed, and a
+  // box must read its own key rather than the last one written.
+  it("does not reach a box with another id", async () => {
+    const mine: (string | null)[] = []
+    const theirs: (string | null)[] = []
+    const first = box(mine, "PRRT_one", "reply")
+    const other = box(theirs, "PRRT_two", "reply")
+
+    const a = await mountBudget(first.element)
+    const b = await mountBudget(other.element)
+    await a.act(() => first.type("about this line"))
+
+    expect(mine[mine.length - 1]).toBe("about this line")
+    expect(theirs[theirs.length - 1]).toBeNull()
+    await a.unmount()
+    await b.unmount()
+    draftStore.set(draftKey("reply", "PRRT_one"), null)
+  })
+})

--- a/frontend/src/lib/pulls/use-draft.ts
+++ b/frontend/src/lib/pulls/use-draft.ts
@@ -1,0 +1,24 @@
+import { useCallback } from "react"
+import { useKeyedStore } from "@/lib/use-keyed-store"
+import { draftStore, type DraftKind, draftKey } from "./draft-store"
+
+/** One box of unsent prose, read and written like `useState` but owned outside
+ * the tree (draft-store), so a tab switch, a collapsed file or a refetched diff
+ * cannot take what was typed. null is "no draft": for the description and the
+ * reply box, that is also what closes them. */
+export function useDraft(
+  kind: DraftKind,
+  id: string,
+): [string | null, (next: string | null) => void] {
+  const key = id ? draftKey(kind, id) : ""
+  const draft = useKeyedStore(draftStore, key)
+  const set = useCallback(
+    (next: string | null) => {
+      if (key) {
+        draftStore.set(key, next)
+      }
+    },
+    [key],
+  )
+  return [draft, set]
+}


### PR DESCRIPTION
A survey of the frontend for state lost on an unmount turned this problem around. The worst losses on the pull request screen are not leaving it — they are the tab strip *inside* it. `PullRequestView` renders its tabs as a ternary between component types, so every click on **Files changed** destroys whatever tab was open, and what those tabs were holding was prose nobody had sent.

Three boxes, three ways to lose them:

| | Lost on |
|---|---|
| The description being rewritten | a tab click |
| The comment being composed | a tab click |
| A reply to a review thread | a tab click, folding the file it hangs off, **and a diff refetch** — `useDiffEditor` memoises on the document, so a new commit rebuilds every CodeMirror widget and the reply with it |

### Why it lived in the wrong place

`CommentBox` had already met the third of those and says so in its own docblock: it deliberately holds no text, *"because the editor under this box is rebuilt by CodeMirror whenever the diff refetches and a box that kept its own state would lose it there."* Ownership moved up to the caller — which was not far enough, because the callers used `useState` and the tab strip above them takes those too. It has to leave the tree, which is what `draft-store.ts` is: `createKeyedStore` (the primitive the per-session readouts already use), keyed so that several open boxes re-render one at a time.

`null` is "no draft" and is not `""`. A description being cleared is a legitimate edit, and a reply box that is open but empty is still open — which lets `ReviewThread` drop its separate `replying` flag, since one value now says both.

In memory only, and `docs/ceilings.md` says where that line sits: persisting is the same argument `pending-review-store` already won, and the half that has not been answered is that a filed review clears itself on submit while an abandoned reply would sit in storage with nothing to collect it.

### Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` (1968 pass) — backend untouched, run anyway.
- [x] `biome check`, `tsc --noEmit`, `vite build`, `vitest run` — 1166 pass across 99 files.
- [x] New: `draft-store.test.ts` (node — key separation across kinds and pull requests, that a key cannot be forged out of an id, the null-versus-`""` distinction, per-key notification) and `use-draft.test.tsx` (jsdom — a draft outliving the box that held it, clearing on send, and two boxes not reaching each other).
- [x] Both suites mutation-checked: reverting `useDraft` to component-local state fails the survival test, and dropping the kind from the key fails three.
- [x] Driven in a headless lich against this repository: type into the comment box on #389, open Files changed, return — the text is there, and still there after leaving for the project screen and coming back.

### A note on the measurement

The first run of that check reported the fix as broken. It was not: several sessions were running the headless rig at once on the ports I had handed out, lich is a singleton on its pinned port so my backend exited 0 without starting, and CDP fell through to another rig's browser — so the driver was typing into someone else's build. Worth knowing for anyone using that recipe: give each rig its own listen port, Vite port, debugging port and `XDG_CONFIG_HOME` (with `GH_CONFIG_DIR` beside it, or `gh` comes up signed out), and check `location.href` before trusting a number.

Stacked on #389.
