### PR TITLE
feat: remember which session groups the sidebar had folded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   answer while a fresh one is fetched underneath. Nothing is shown as newer than
   it is: the screen still re-reads on focus, the Refresh button still asks
   again, and a reload starts from nothing.
+- **The sidebar remembers which session groups you folded.** Folding a worktree
+  block used to last only as long as the list it was drawn in: collapsing the
+  sidebar to its rail, or switching to another project and back, unfolded every
+  block again — so somebody working across several worktrees refolded the ones
+  they were not in on every trip. A fold is now remembered per project and per
+  checkout, and the two blocks every project has in common — its root sessions
+  and its pinned ones — no longer share a fold across projects.
 
 ### Fixed
 

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils"
 import { checkoutLabel } from "@/lib/git/checkout-label"
 import type { ProviderState } from "@/lib/providers-store"
 import type { DelegateGroup } from "@/lib/session/delegate-targets"
+import { readGroupCollapsed, writeGroupCollapsed } from "@/lib/session/group-prefs"
 import { type Session, sessionOrigin } from "@/lib/session/sessions"
 import { useProjects } from "@/providers/projects"
 import { SessionCard } from "./SessionCard"
@@ -97,7 +98,10 @@ export function SessionGroup({
     newSession,
   } = useProjects()
   const navigate = useNavigate()
-  const [collapsed, setCollapsed] = useState(false)
+  // Seeded once, which holds because the sidebar keys this component on the
+  // same (project, group) pair the pref is stored under: nothing can reuse this
+  // instance for another block without remounting it.
+  const [collapsed, setCollapsed] = useState(() => readGroupCollapsed(projectId, sortId))
   const ids = sessions.map((session) => session.id)
   const { sensors, onDragEnd } = useSortableList(ids, onReorder)
   const name = pinned ? "Pinned" : checkoutLabel(path, projectPath, projectId)
@@ -107,6 +111,15 @@ export function SessionGroup({
   // branch parks its card too, not only worktrees.
   const checkout = path || projectPath
   const pullsOpen = useSyncExternalStore(subscribePullsCard, () => isPullsOpen(checkout))
+
+  // Written from the handler rather than from the state updater: React may
+  // discard and replay an updater, and a pref written in one is a pref written
+  // for a fold that never happened.
+  const toggle = () => {
+    const next = !collapsed
+    setCollapsed(next)
+    writeGroupCollapsed(projectId, sortId, next)
+  }
 
   const select = (id: string) => {
     activateSession(projectId, id)
@@ -136,7 +149,7 @@ export function SessionGroup({
           // sortable with aria-disabled + aria-roledescription="draggable" —
           // which would announce a working collapse button as a dead handle.
           activatorProps={pinned ? {} : { ...group.attributes, ...group.listeners }}
-          onToggle={() => setCollapsed((current) => !current)}
+          onToggle={toggle}
           onNewSession={(kind) => newSession(projectId, kind, path)}
         />
       )}

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -342,7 +342,12 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
               const groupActive = group.sessions.some((s) => s.id === realActiveId)
               return (
                 <SessionGroup
-                  key={group.key}
+                  // The project is in the React key, not only in the props: two
+                  // projects both have a root block and a pinned one under the
+                  // same key, so without it React reuses one project's group
+                  // component for the other's — carrying its fold across with it,
+                  // and never re-reading the fold the switched-to project stored.
+                  key={`${projectId}:${group.key}`}
                   sortId={group.key}
                   pinned={group.pinned}
                   projectId={projectId}

--- a/frontend/src/lib/session/group-prefs.test.ts
+++ b/frontend/src/lib/session/group-prefs.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { PINNED_GROUP_KEY, ROOT_GROUP_KEY } from "./sessions"
+import { readGroupCollapsed, writeGroupCollapsed } from "./group-prefs"
+
+// The suite runs in node, which has no localStorage. A fold has to survive
+// leaving the project, so the storage is stubbed and the round trip is what is
+// checked.
+const stored = new Map<string, string>()
+
+vi.stubGlobal("localStorage", {
+  getItem: (key: string) => stored.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    stored.set(key, value)
+  },
+  removeItem: (key: string) => {
+    stored.delete(key)
+  },
+})
+
+beforeEach(() => {
+  stored.clear()
+})
+
+describe("a folded session group", () => {
+  it("reads unfolded with nothing stored", () => {
+    expect(readGroupCollapsed("proj-1", ROOT_GROUP_KEY)).toBe(false)
+  })
+
+  it("round-trips a fold", () => {
+    writeGroupCollapsed("proj-1", "/home/dev/wt/feature", true)
+
+    expect(readGroupCollapsed("proj-1", "/home/dev/wt/feature")).toBe(true)
+  })
+
+  it("round-trips an unfold", () => {
+    writeGroupCollapsed("proj-1", ROOT_GROUP_KEY, true)
+    writeGroupCollapsed("proj-1", ROOT_GROUP_KEY, false)
+
+    expect(readGroupCollapsed("proj-1", ROOT_GROUP_KEY)).toBe(false)
+  })
+
+  // Unfolded is the default, so it is stored by not being stored.
+  it("leaves nothing behind for an unfolded group", () => {
+    writeGroupCollapsed("proj-1", ROOT_GROUP_KEY, true)
+    writeGroupCollapsed("proj-1", ROOT_GROUP_KEY, false)
+
+    expect(stored.size).toBe(0)
+  })
+
+  // A pref must never be able to break a launch: a value from another build, or
+  // a hand-edited one, reads as unfolded rather than as a hidden block.
+  it.each(["yes", "1", ""])("reads %j as unfolded", (raw) => {
+    stored.set(`lich.sidebar.collapsed.proj-1:${ROOT_GROUP_KEY}`, raw)
+
+    expect(readGroupCollapsed("proj-1", ROOT_GROUP_KEY)).toBe(false)
+  })
+
+  // The whole reason the project id is in the key: these two stand-ins are not
+  // checkout paths, so every project has a block under each of them.
+  it.each([ROOT_GROUP_KEY, PINNED_GROUP_KEY])("keeps two projects' %s apart", (key) => {
+    writeGroupCollapsed("proj-1", key, true)
+
+    expect(readGroupCollapsed("proj-1", key)).toBe(true)
+    expect(readGroupCollapsed("proj-2", key)).toBe(false)
+  })
+
+  it("keeps two groups of one project apart", () => {
+    writeGroupCollapsed("proj-1", ROOT_GROUP_KEY, true)
+
+    expect(readGroupCollapsed("proj-1", PINNED_GROUP_KEY)).toBe(false)
+  })
+})

--- a/frontend/src/lib/session/group-prefs.ts
+++ b/frontend/src/lib/session/group-prefs.ts
@@ -1,0 +1,33 @@
+import { parseBoolPref, readPref, removePref, writePref } from "@/lib/prefs"
+
+// Which of the sidebar's session blocks are folded. A fold is not a view state:
+// somebody working across several worktrees folds the ones they are not in, and
+// a fold that unfolds itself on the next project switch — or on collapsing the
+// sidebar to its rail, which unmounts the whole list — is a fold typed again.
+//
+// UI preferences, so the page's localStorage rather than the workspace database
+// (see the root CLAUDE.md). Parsing is the pure half prefs.ts owns; reading and
+// writing the key stays the two-line wrapper it describes.
+//
+// Scoped by project *and* group key. The key alone would collide: a worktree
+// block is keyed by its absolute checkout path and no two projects can share
+// one, but ROOT_GROUP_KEY and PINNED_GROUP_KEY are stand-ins every project has,
+// so folding one project's pinned block would fold every project's. The project
+// id is hex (internal/project.projectID), so the separator is unambiguous.
+const COLLAPSED_PREFIX = "lich.sidebar.collapsed."
+
+export function readGroupCollapsed(projectId: string, groupKey: string): boolean {
+  return parseBoolPref(readPref(`${COLLAPSED_PREFIX}${projectId}:${groupKey}`), false)
+}
+
+export function writeGroupCollapsed(projectId: string, groupKey: string, collapsed: boolean): void {
+  const key = `${COLLAPSED_PREFIX}${projectId}:${groupKey}`
+  // Unfolded is the default, so it is stored by not being stored: what is left
+  // behind names exactly the blocks that are folded, and a worktree removed
+  // while unfolded leaves nothing behind at all.
+  if (collapsed) {
+    writePref(key, true)
+  } else {
+    removePref(key)
+  }
+}


### PR DESCRIPTION
Stacked on #389 (`feat/remember-the-pull-request-screen`).

## The bug

A folded session group unfolds itself. `SessionGroup` held `collapsed` in mount-local `useState`, and that mount is lost two ways: collapsing the sidebar to its rail unmounts `SessionSidebar` wholesale (`App.tsx`), and a project switch rebuilds the group list. Somebody working across several worktrees folds the ones they are not in, switches project, and finds them all open again.

## The fix

A pref, following the split `frontend/src/lib/prefs.ts` describes and `pulls/pulls-prefs.ts` is the worked example of: parsing stays the pure half `prefs.ts` already owns (`parseBoolPref`), and reading and writing the key is a two-line wrapper. Unfolded is the default and is stored by not being stored, so what is left behind names exactly the blocks that are folded — a worktree removed while unfolded leaves nothing behind at all.

## Which key, and why

`${projectId}:${group.key}`, where `group.key` is what `sidebarGroups` already computes.

The group key alone collides. A worktree block is keyed by its absolute checkout path and no two projects can share one — but `ROOT_GROUP_KEY` and `PINNED_GROUP_KEY` are stand-ins *every* project has, so folding one project's pinned block would fold every project's. The project id is hex (`internal/project.projectID`), so the separator is unambiguous.

That same collision turned out to be live in React's reconciler already: the sidebar keyed the component on `group.key`, so switching projects reused one project's `__root__` group component for the other's — carrying its live fold across and never re-reading the fold the switched-to project stored. The project id goes into the render key too, which is what makes seeding the state at mount honest: nothing can reuse the instance for another block without remounting it.

## Deliberately not done

The sidebar's filter box next door stays unpersisted — it argues for itself at `SessionSidebar.tsx` and this change leaves it alone. No `docs/ceilings.md` bullet: the mount-once read that `pulls-prefs` had to document as a ceiling is not one here, because the render key carries the identity the pref is stored under, and that reasoning lives in the comment at the key site.

## Test plan

- [x] `frontend/src/lib/session/group-prefs.test.ts` — 10 cases. Each guard was proved to bite by mutating the code it guards: dropping the project id from the key fails the two cross-project cases; storing `false` instead of removing fails the "leaves nothing behind" case; reading any stored value as folded fails the three foreign-value cases.
- [x] Verified in the running app (headless `task dev` rig, isolated `XDG_CONFIG_HOME`, driven over CDP): two projects seeded with a root block and a worktree block each. Folding alpha's worktree block survives a project switch to beta and back, and survives a rail collapse and expand; unfolding removes the key and that survives a rail trip too; folding alpha's *root* block leaves beta's root block unfolded. Reverting the render key to `group.key` alone reproduces the cross-project leak in the same rig (beta's root block comes up folded), which is the proof the key change bites.
- [x] Gate green, read by exit code: `gofmt -l .`, `go vet ./...`, `LICH_LISTEN_PORT= go test ./...`, and from `frontend/`: `biome check .`, `tsc --noEmit`, `vitest run` (1166 passed), `vite build`.