### PR TITLE
Keep the file the changed-files tree had marked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   they were not in on every trip. A fold is now remembered per project and per
   checkout, and the two blocks every project has in common — its root sessions
   and its pinned ones — no longer share a fold across projects.
+- **The Files changed tab keeps the file you jumped to.** Every other tab of a
+  pull request replaces that one outright, so a walk to Conversation and back
+  used to clear the changed-files tree's mark and leave a long review with
+  nothing saying which file it had reached. The mark is now remembered per pull
+  request, and comes back with the tab. Where the diff was scrolled to is not
+  remembered — the tab reopens at the top, as it always has.
 
 ### Fixed
 

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -455,3 +455,20 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   Settings › Version Control and every provider's binary block still blink through "unknown" on the way back
   to the screen. Measured at 1–3 ms per check (`providers.Verify` is a `LookPath`), which is why closing it
   was not worth widening a hook the whole app reads through.
+- **The Files changed tab remembers which file, never where in it**
+  (`frontend/src/lib/pulls/use-active-file.ts`): the changed-files tree's mark comes back with the tab, but
+  the diff pane reopens at the top. Nothing in this codebase restores a scroll offset, and the one that would
+  have to be restored here is not measurable at the time it is needed: `LazyDiffBody` builds each file's
+  editor only as its card nears the viewport (`FileDiff.tsx`), so on the way back every card is a placeholder
+  sized from a line count and the page's real height arrives over the following frames. Re-jumping to the
+  marked file would land on that estimate and drift as the editors mount. The mark already meant "the file
+  last selected" rather than "the file on screen" — a click followed by a hand scroll leaves it behind on a
+  live tab too — so restoring it alone says nothing untrue. That relanding is also why returning to the tab
+  costs the lazy mount again: the editors are destroyed with the tab and rebuilt on the way back, which is
+  the work `LazyDiffBody` exists to spread out rather than avoid.
+- **This screen's per-pull-request state is re-read during render, not at mount alone**
+  (`useActiveFile`): the bullet above about `pulls-prefs.ts` does not extend to it. The Files tab is *not*
+  remounted when the list column moves to another pull request, so a `useState` seed would mark the previous
+  pull request's file on the next one's tree. The re-read is held in state and never in a ref, for the replay
+  reason `use-remote-resource.ts` documents, and `use-active-file.test.tsx` pins it by moving the pull
+  request on a live component — a probe that remounted instead would call the ref version green.

--- a/frontend/src/components/pulls/PullsFiles.tsx
+++ b/frontend/src/components/pulls/PullsFiles.tsx
@@ -1,5 +1,5 @@
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react"
-import { useMemo, useRef, useState, useSyncExternalStore } from "react"
+import { useMemo, useRef, useSyncExternalStore } from "react"
 import { IconAction } from "@/components/common/IconAction"
 import { ResizeHandle } from "@/components/common/ResizeHandle"
 import { Notice } from "@/components/common/Notice"
@@ -29,6 +29,7 @@ import {
   subscribeViewed,
   viewedFiles,
 } from "@/lib/pulls/pull-request-viewed"
+import { useActiveFile } from "@/lib/pulls/use-active-file"
 import { usePullRequestDiff } from "@/lib/pulls/use-pull-request-diff"
 import { addReviewComment } from "@/lib/review-comments"
 import { usePanelVisible } from "@/lib/use-panel-visible"
@@ -129,7 +130,7 @@ export function PullsFiles({
 }: PullsFilesProps) {
   const { files, error } = usePullRequestDiff(path, head, number)
   const rows = useRef<Map<string, HTMLElement>>(new Map())
-  const [active, setActive] = useState<string | null>(null)
+  const [active, selectFile] = useActiveFile(pullRequest)
   const review = useSyncExternalStore(subscribePendingReview, () => pendingReview(pullRequest))
   // Every file mounts its own CodeMirror, so a wide PR earns a way to fold them
   // all at once — same directive the Review dock hands its panel.
@@ -198,7 +199,7 @@ export function PullsFiles({
   ).length
 
   const jumpTo = (target: string) => {
-    setActive(target)
+    selectFile(target)
     rows.current.get(target)?.scrollIntoView({ block: "start", behavior: "smooth" })
   }
 

--- a/frontend/src/lib/pulls/pulls-prefs.test.ts
+++ b/frontend/src/lib/pulls/pulls-prefs.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
+  readActiveFile,
   readLastPull,
   readPullsFilter,
   readPullsQuery,
   readPullsSort,
   readPullsTab,
+  writeActiveFile,
   writeLastPull,
   writePullsFilter,
   writePullsQuery,
@@ -190,5 +192,46 @@ describe("the remembered pull request", () => {
 
     expect(stored.size).toBe(0)
     expect(readLastPull("")).toBe(0)
+  })
+})
+
+describe("the marked changed file", () => {
+  const A = "https://github.com/o/r/pull/1"
+  const B = "https://github.com/o/r/pull/2"
+
+  it("marks nothing with nothing stored", () => {
+    expect(readActiveFile(A)).toBe("")
+  })
+
+  it("round-trips a path", () => {
+    writeActiveFile(A, "internal/terminal/pty_linux.go")
+
+    expect(readActiveFile(A)).toBe("internal/terminal/pty_linux.go")
+  })
+
+  // Keyed by the pull request and not by the project: the same reviewer is a
+  // different number of files into each of them.
+  it("keeps two pull requests apart", () => {
+    writeActiveFile(A, "internal/terminal/pty_linux.go")
+    writeActiveFile(B, "frontend/src/main.tsx")
+
+    expect(readActiveFile(A)).toBe("internal/terminal/pty_linux.go")
+    expect(readActiveFile(B)).toBe("frontend/src/main.tsx")
+  })
+
+  it("reads and writes nothing without a pull request", () => {
+    writeActiveFile("", "frontend/src/main.tsx")
+
+    expect(stored.size).toBe(0)
+    expect(readActiveFile("")).toBe("")
+  })
+
+  // "" is the screen's own "no file marked", so storing it would be storing
+  // nothing — and would drop a mark the tree never asked to clear.
+  it("keeps the last mark when handed no path", () => {
+    writeActiveFile(A, "internal/terminal/pty_linux.go")
+    writeActiveFile(A, "")
+
+    expect(readActiveFile(A)).toBe("internal/terminal/pty_linux.go")
   })
 })

--- a/frontend/src/lib/pulls/pulls-prefs.ts
+++ b/frontend/src/lib/pulls/pulls-prefs.ts
@@ -20,6 +20,7 @@ const TAB_KEY = "lich.pulls.tab"
 const FILTER_PREFIX = "lich.pulls.filter."
 const QUERY_PREFIX = "lich.pulls.query."
 const LAST_PULL_PREFIX = "lich.pulls.last."
+const ACTIVE_FILE_PREFIX = "lich.pulls.file."
 
 /** The tabs of one pull request, in the order the header shows them. */
 export const PULLS_TABS = ["overview", "commits", "files", "conversation", "checks"] as const
@@ -62,11 +63,12 @@ export function writePullsQuery(projectId: string, query: string): void {
   }
 }
 
-// Every project-scoped read goes through here, so a screen with no project open
-// yet — the id comes straight from the route — reads the default rather than
-// whatever sits under a key ending in nothing.
-function scoped(prefix: string, projectId: string): string | null {
-  return projectId ? readPref(`${prefix}${projectId}`) : null
+// Every scoped read goes through here, so a screen whose id is not resolved
+// yet — a project comes straight from the route, a pull request from a lookup
+// still in flight — reads the default rather than whatever sits under a key
+// ending in nothing.
+function scoped(prefix: string, id: string): string | null {
+  return id ? readPref(`${prefix}${id}`) : null
 }
 
 // Which pull request the list column had selected. Every way back into the
@@ -88,5 +90,23 @@ export function readLastPull(projectId: string): number {
 export function writeLastPull(projectId: string, number: number): void {
   if (projectId && number > 0) {
     writePref(`${LAST_PULL_PREFIX}${projectId}`, number)
+  }
+}
+
+// Which file of a pull request's diff the changed-files tree has marked: the
+// one the reviewer jumped to. Keyed by the pull request rather than the project
+// — it addresses that pull request's content, and the same reviewer is reading
+// a different file in each of them.
+//
+// Free text, like the filter box: a path is whatever the diff called it, so
+// anything stored is readable. A path the diff no longer carries marks no row,
+// which is what a file dropped by a force-push should look like.
+export function readActiveFile(pullRequest: string): string {
+  return scoped(ACTIVE_FILE_PREFIX, pullRequest) ?? ""
+}
+
+export function writeActiveFile(pullRequest: string, path: string): void {
+  if (pullRequest && path) {
+    writePref(`${ACTIVE_FILE_PREFIX}${pullRequest}`, path)
   }
 }

--- a/frontend/src/lib/pulls/use-active-file.test.tsx
+++ b/frontend/src/lib/pulls/use-active-file.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+//
+// The remembered selection of the changed-files tree, mounted for real. What
+// this feature is about happens between two mounts of a component — the Files
+// tab is destroyed by every tab switch — and no pure test can see that; the
+// prefs module underneath is covered by pulls-prefs.test.ts.
+//
+// The harness has to be imported before anything that reaches react-dom, which
+// is why it is first here (see @/test/render-budget).
+import { mountBudget } from "@/test/render-budget"
+import { StrictMode, createElement, useLayoutEffect, useState } from "react"
+import { beforeEach, describe, expect, it } from "vitest"
+import { useActiveFile } from "@/lib/pulls/use-active-file"
+
+const A = "https://github.com/o/r/pull/1"
+const B = "https://github.com/o/r/pull/2"
+
+// Every frame the hook *committed*, so a mount reads as a sequence rather than
+// as a final value: a selection laid down and then dropped shows up here as an
+// extra null, and only a committed frame proves the user saw it.
+//
+// Recorded from a layout effect, never from the render body. A render that
+// updates state during it runs again from its base state, and StrictMode runs
+// every pass twice — so the body sees values that were never painted, and an
+// assertion written against them reads a correct hook as an oscillation.
+//
+// Mounted inside StrictMode, as the app runs (main.tsx): React discards and
+// replays a render that updates state during it, and holding this hook's
+// bookkeeping in a ref would let the replay skip the re-read it guards.
+function probe(frames: (string | null)[], initial: string) {
+  let move: (next: string) => void = () => {}
+  let select: (path: string) => void = () => {}
+  function Probe() {
+    const [pullRequest, setPullRequest] = useState(initial)
+    move = setPullRequest
+    const [active, choose] = useActiveFile(pullRequest)
+    select = choose
+    useLayoutEffect(() => {
+      frames.push(active)
+    })
+    return null
+  }
+  return {
+    element: createElement(StrictMode, null, createElement(Probe)),
+    move: (next: string) => move(next),
+    select: (path: string) => select(path),
+  }
+}
+
+/** The distinct selections a mount passed through, in order. */
+function states(frames: (string | null)[]): (string | null)[] {
+  return frames.filter((state, i) => state !== frames[i - 1])
+}
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe("the changed-files selection", () => {
+  it("comes back marked on the next mount of the tab", async () => {
+    const frames: (string | null)[] = []
+    const first = probe(frames, A)
+    const mounted = await mountBudget(first.element)
+    await mounted.act(() => first.select("internal/pty/pty.go"))
+    await mounted.unmount()
+
+    frames.length = 0
+    const second = probe(frames, A)
+    const back = await mountBudget(second.element)
+
+    // One state for the whole mount: the file was marked from the first frame
+    // and never left it. A tab that paints unmarked first is the bug this pins.
+    expect(states(frames)).toEqual(["internal/pty/pty.go"])
+    await back.unmount()
+  })
+
+  // The Files tab is not remounted when the list column moves to another pull
+  // request, so this is driven on a *live* component: a remount would seed the
+  // marker from scratch and never exercise the re-read at all.
+  it("re-reads when the pull request moves under it", async () => {
+    const seed = probe([], B)
+    const seeded = await mountBudget(seed.element)
+    await seeded.act(() => seed.select("frontend/src/main.tsx"))
+    await seeded.unmount()
+
+    const frames: (string | null)[] = []
+    const live = probe(frames, A)
+    const mounted = await mountBudget(live.element)
+    await mounted.act(() => live.select("internal/pty/pty.go"))
+    frames.length = 0
+    await mounted.act(() => live.move(B))
+
+    // The other pull request's own file, and never A's under B's tree.
+    expect(states(frames)).toEqual(["frontend/src/main.tsx"])
+    await mounted.unmount()
+  })
+
+  it("marks nothing for a pull request never read before", async () => {
+    const frames: (string | null)[] = []
+    const fresh = probe(frames, A)
+    const mounted = await mountBudget(fresh.element)
+
+    expect(states(frames)).toEqual([null])
+    await mounted.unmount()
+  })
+})

--- a/frontend/src/lib/pulls/use-active-file.ts
+++ b/frontend/src/lib/pulls/use-active-file.ts
@@ -1,0 +1,29 @@
+import { useState } from "react"
+import { readActiveFile, writeActiveFile } from "./pulls-prefs"
+
+// The changed-files tree's selection, remembered across the tab switch that
+// destroys it. Every other tab of the pull request screen replaces the Files
+// tab outright, so walking to Conversation and back used to forget which file
+// the review had reached, on a screen whose whole job is to be walked away from.
+//
+// The pull request is a prop, not a constant: the Files tab is not remounted
+// when the list column moves to another pull request, so the seed has to be
+// re-read when it does. That is done during render and held in state — a ref
+// would be written by a render React discarded and replayed, and the replay
+// would skip the re-read (the trap `use-remote-resource.ts` documents).
+export function useActiveFile(pullRequest: string): [string | null, (path: string) => void] {
+  const [active, setActive] = useState(() => readActiveFile(pullRequest))
+  const [seen, setSeen] = useState(pullRequest)
+  if (seen !== pullRequest) {
+    setSeen(pullRequest)
+    setActive(readActiveFile(pullRequest))
+  }
+  // The write sits beside the setter rather than inside it: React treats an
+  // updater as pure and calls it twice under StrictMode.
+  const select = (path: string) => {
+    writeActiveFile(pullRequest, path)
+    setActive(path)
+  }
+  // "" is how the store spells "nothing marked"; the tree spells it null.
+  return [active || null, select]
+}


### PR DESCRIPTION
Stacked on #389. The Files changed tab of a pull request loses where you were reading: `PullRequestView.tsx` picks the tab body with a ternary between component types, so every switch to Overview, Commits, Conversation or Checks unmounts the whole tab. What went with it is `active` — the row the changed-files tree had marked, i.e. the file you jumped to.

## What this remembers

`active`, and only that. Keyed by the pull request's URL — the key `pull-request-viewed.ts` and `pending-review-store.ts` already use, unique across projects — in `pulls-prefs.ts`, following the rule its header states: a path addresses one repository's content, so it is scoped rather than global.

The seed is re-read **during render**, not at mount alone. The Files tab is *not* remounted when the list column moves to another pull request, so a plain `useState` seed would mark the previous pull request's file on the next one's tree. The bookkeeping is held in state and never in a ref, for the replay reason `use-remote-resource.ts` documents.

## The judgement call: `bulk` and `expanded` are not worth remembering

Asked for a verdict, and the read that they are not worth it holds. Reasons, in order of weight:

1. **`expanded` deliberately re-syncs on a content change** (`FileDiff.tsx:84-98`): a file whose diff text moves is reopened to its own large-file default, so an unread file is never left folded with nothing saying why. Persisting the hand-folded state fights that on exactly the case the re-sync exists for — you come back after a new commit, and the file it rewrote is the one you are least entitled to have closed.
2. **The Viewed ticks already fold a file away and already survive the tab switch** (`pull-request-viewed.ts`, module-level). That is the fold that carries meaning — "I have read this" — and it is content-fingerprinted, so it unticks exactly the files a new commit touched. A remembered `expanded` would be a second, weaker fold with no such guard, and the two would disagree on the same card.
3. **`bulk` is a directive, not a state** (`diff-bulk.tsx`): it is `{open, nonce}`, and it works by the nonce moving. Restoring one means either re-firing it on mount — which would stamp every file, overriding each one's large-file default and the Viewed folds — or restoring it inert, which remembers nothing. There is no third shape.

So: `active` alone.

## Refused: the scroll position

Out of scope in the brief, and agreed. Nothing in this codebase restores a scroll offset, and the offset here is not measurable when it would be needed: `LazyDiffBody` builds each file's editor only as its card nears the viewport, so on the way back every card is a placeholder sized from a line count and the page's real height arrives over the following frames. Re-jumping to the marked file would land on that estimate and drift as the editors mount.

The mark already meant "the file last selected" rather than "the file on screen" — a click followed by a hand scroll leaves it behind on a live tab too — so restoring it alone says nothing untrue.

## The re-mount cost

Unchanged. Returning to the tab re-lazy-mounts every editor through the IntersectionObserver at `FileDiff.tsx:210`, as it did before: this change adds no mount, no scroll and no measurement, and one `className` differs on one tree row. The cost is the tab's, not this feature's.

## Tests

- `use-active-file.test.tsx` (jsdom, StrictMode, `mountBudget`) — copies both conditions from `use-remote-resource.test.tsx`: the pull request is moved on a **live** component, and frames are recorded from a `useLayoutEffect`, never the render body.
- `pulls-prefs.test.ts` — the store's round trip, the two-pull-requests case, and the no-id / no-path guards.

Every new test was proven to bite by mutating what it guards: dropping the write, dropping the re-read, holding the marker in a **ref** instead of state (the replay trap — it dies on the live-move test, which a remount-based probe would have called green), and letting `""` leak out as a selection. Four mutants, four red runs, green on restore.

## Verified in the running app

Isolated rig (own `XDG_CONFIG_HOME`, `GH_CONFIG_DIR` kept, headless Chromium driven over CDP), against this repository's real pull requests, with the page's own `location.href` checked first so the driver could not be reading a sibling rig's browser:

- Marked `frontend/src/components/pulls/PullsList.tsx` on #389 → `lich.pulls.file.https://github.com/omartelo/lich/pull/389` written with that path.
- Tab to Overview (tree gone, 0 rows) → back to Files changed: exactly that one row marked again.
- List column moved to #390 without leaving the tab: its 18-row tree marks nothing. Back to #389: its own file marked again — the cross-pull-request case, live.

## Gate

`gofmt -l .`, `go vet ./...`, `go test ./...` (with `LICH_LISTEN_PORT` empty) clean; from `frontend/`, `biome check .`, `tsc --noEmit`, `vitest run` (1164 passed), `vite build` all exit 0.