### PR TITLE
Bring the right dock back the way it was left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   setting behind a switch, path and rung — paint from the last one while a fresh
   one is fetched underneath. Nothing is shown as newer than it is: every read
   still runs on every visit, and a reload starts from nothing.
+- **The right dock comes back the way you left it.** Flipping between **Code**
+  and **Review** — or closing the dock and reopening it — used to throw the
+  panel away whole. The Code tab lost the filter you had typed, the folders you
+  had opened, the file you were previewing and the row you were on, and re-read
+  the whole tree from git to show you a collapsed root; the Review tab dropped
+  back to **Working tree** every time, so reviewing turn by turn meant picking
+  **Last turn** again all day. Now each checkout keeps its own browse — filter,
+  folds, preview and marked row — and paints from the last answer while a fresh
+  one is fetched underneath, and the source you picked is remembered across
+  sessions. A session whose provider never reports its state still has no turn
+  to bracket, so it is shown the working tree and never a switch it cannot use.
+  A reload still starts from an empty browse.
 
 - **The pull request screen comes back the way you left it.** A review
   interrupted — another project, the terminal next door, a branch to check —

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -423,6 +423,25 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   which is mirrored to localStorage. Persisting these is the same argument that one already won, and the reason
   it has not been taken is the other half: a filed review clears itself on submit, while an abandoned reply on
   a thread nobody returns to would sit in storage forever with no one to collect it.
+- **The dock's remembered browse is module memory, keyed by a path and never swept**
+  (`frontend/src/lib/file-browse.ts`): every checkout the Code tab has ever browsed keeps its filter,
+  folds, preview and marked row until the page reloads — a few strings per checkout, deliberately not
+  worth a sweep, and deliberately not persisted: these are positions in a tree that is re-read on each
+  mount, and outliving a reload would mean pointing at files that have since moved. The key is the
+  checkout path with no project or session in it, so two projects sharing a path share a browse, which
+  is the same thing as saying they share a checkout. The tree and each previewed file now also file
+  their answers in `remote-cache`, whose 32-entry cap they share with the pull request screen: a browse
+  that opens more files than that evicts the oldest answers, and the panel pays a "Loading…" on the way
+  back to them.
+- **The Review tab's remembered source is a wish, not what is on screen** (`ReviewPanel`,
+  `frontend/src/lib/dock-prefs.ts`): the pref is global and holds what the user picked, while what the
+  panel shows is that choice put through `useSessionEverReported` — a session whose provider never
+  reports has no turn to bracket, so it is shown the working tree and offered no switch. Nothing writes
+  the guard's answer back, and that is the whole design: `switchable` is false after every reload until
+  the session next reports, so a panel that reset the pref instead of overriding it would erase the
+  choice before the switch had a chance to appear. The visible cost is that "Last turn" cannot be
+  restored on a session that has been quiet since the reload — it comes back the moment that session
+  reports again.
 - **The pull request screen's remembered state is read once, at mount** (`frontend/src/lib/pulls/pulls-prefs.ts`):
   the filter box, the quick filter and the selected pull request are keyed per project but seeded from
   `useState`, which holds because every route into the screen carries its own project and leaving one unmounts

--- a/frontend/src/components/FileTree.tsx
+++ b/frontend/src/components/FileTree.tsx
@@ -23,6 +23,13 @@ interface FileTreeProps {
    * where a match has to be visible without opening its ancestors first. The
    * toggles are only suspended, so clearing the filter restores the browse. */
   expandAll?: boolean
+  /** The folders toggled *away* from `defaultOpen`, for a caller that has to
+   * outlive its own tree: the dock's browser is unmounted on every flip to the
+   * Review tab, so its folds are held outside it (file-browse). Left out — the
+   * pull request's tree, which lives as long as the tab it is on — the tree
+   * holds them itself and they go when it does. */
+  toggled?: ReadonlySet<string>
+  onToggled?: (toggled: ReadonlySet<string>) => void
   /** Per-file diff counts keyed by path; a row with an entry shows its +/-. */
   stats?: Map<string, DiffFile>
   /** Right-click → Open in editor. Absent = no file context menu, which is the
@@ -41,6 +48,8 @@ export function FileTree({
   active = null,
   defaultOpen = false,
   expandAll = false,
+  toggled: lifted,
+  onToggled: onLifted,
   stats,
   onEditor,
   className,
@@ -48,38 +57,38 @@ export function FileTree({
 }: FileTreeProps) {
   // The set holds the rows toggled *away* from defaultOpen, so a folder's state
   // survives its parent closing and reopening.
-  const [toggled, setToggled] = useState<Set<string>>(new Set())
+  const [own, setOwn] = useState<ReadonlySet<string>>(() => new Set())
+  const toggled = lifted ?? own
+  const publish = onLifted ?? setOwn
   const isOpen = (path: string) => expandAll || toggled.has(path) !== defaultOpen
 
-  const toggle = (path: string) =>
-    setToggled((prev) => {
-      const next = new Set(prev)
-      if (!next.delete(path)) {
-        next.add(path)
-      }
-      return next
-    })
+  const toggle = (path: string) => {
+    const next = new Set(toggled)
+    if (!next.delete(path)) {
+      next.add(path)
+    }
+    publish(next)
+  }
 
   // Expand/collapse a directory and every directory beneath it, the scope a
   // right-click on that folder implies. Entries are deviations from defaultOpen,
   // so "expand" adds or removes depending on which way that default points.
-  const setSubtree = (node: TreeNode, expand: boolean) =>
-    setToggled((prev) => {
-      const next = new Set(prev)
-      const walk = (n: TreeNode) => {
-        if (n.type !== "dir") {
-          return
-        }
-        if (expand === defaultOpen) {
-          next.delete(n.path)
-        } else {
-          next.add(n.path)
-        }
-        n.children.forEach(walk)
+  const setSubtree = (node: TreeNode, expand: boolean) => {
+    const next = new Set(toggled)
+    const walk = (n: TreeNode) => {
+      if (n.type !== "dir") {
+        return
       }
-      walk(node)
-      return next
-    })
+      if (expand === defaultOpen) {
+        next.delete(n.path)
+      } else {
+        next.add(n.path)
+      }
+      n.children.forEach(walk)
+    }
+    walk(node)
+    publish(next)
+  }
 
   return (
     // Names run past the panel's width on a deep tree; the rows size to their

--- a/frontend/src/components/diff/ReviewPanel.tsx
+++ b/frontend/src/components/diff/ReviewPanel.tsx
@@ -4,6 +4,7 @@ import { Notice } from "@/components/common/Notice"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import type { LastTurn } from "@/lib/api-types"
 import { onAppEvent } from "@/lib/app-events"
+import { readDiffSource, writeDiffSource, type DiffSource } from "@/lib/dock-prefs"
 import { discardTargets, parseDiff, type DiffFile } from "@/lib/git/diff"
 import { lastTurnNotice } from "@/lib/git/last-turn"
 import { addReviewComment } from "@/lib/review-comments"
@@ -28,11 +29,6 @@ import { FileDiff } from "./FileDiff"
 // counts stood still — not one tick, but indefinitely.
 const DIFF_POLL_MS = 2_000
 
-// Which changes the panel is showing. "worktree" is everything uncommitted, the
-// panel's original and default answer; "turn" narrows it to the window the
-// session's last finished turn ran in (internal/terminal.LastTurnDiff).
-type DiffSource = "worktree" | "turn"
-
 // Said in full on the option itself, because the card cannot: the pair of
 // snapshots brackets wall-clock time, so every hand that touched the checkout
 // while the turn ran is inside it. Nothing here can attribute a line, and the
@@ -55,7 +51,21 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
   // The source switch is earned, not assumed: a provider that never reports its
   // state has no turn to bracket, so it is offered the working tree alone.
   const switchable = useSessionEverReported(sessionId)
-  const [source, setSource] = useState<DiffSource>("worktree")
+  // The source the reviewer picked, read back on every mount because the dock
+  // has no shortage of them: it is a ternary between two component types, so
+  // each flip to the Code tab unmounts this panel whole (dock-prefs).
+  const [wanted, setWanted] = useState<DiffSource>(readDiffSource)
+  // A source the session cannot answer for must never be the one on screen: it
+  // would sit on an empty panel with no control anywhere to leave it by. So the
+  // guard makes what is *shown*, and nothing writes "worktree" back over the
+  // choice — `switchable` starts false after a reload and turns true only when
+  // the session next reports, so a reset would fire first and throw the
+  // remembered choice away before the switch ever appeared.
+  const source: DiffSource = switchable ? wanted : "worktree"
+  const changeSource = (next: DiffSource) => {
+    writeDiffSource(next)
+    setWanted(next)
+  }
   const [files, setFiles] = useState<DiffFile[] | null>(null)
   const [failed, setFailed] = useState(false)
   const [turnState, setTurnState] = useState<LastTurn["state"] | null>(null)
@@ -117,15 +127,6 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
     setEndedAt(null)
   }, [source, path, sessionId])
 
-  // A source the session cannot answer for must not stay selected: a resumed
-  // card, or one whose provider stopped reporting, would sit on an empty panel
-  // with no control on screen to leave it by.
-  useEffect(() => {
-    if (!switchable) {
-      setSource("worktree")
-    }
-  }, [switchable])
-
   // Two signals feeding one read: the status counts move the instant a file is
   // touched, so they invalidate immediately, and the interval covers the edits
   // they are blind to (see DIFF_POLL_MS).
@@ -168,7 +169,7 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
 
   return (
     <div className="flex h-full flex-col">
-      {switchable && <SourceRow source={source} onSource={setSource} endedAt={endedAt} />}
+      {switchable && <SourceRow source={source} onSource={changeSource} endedAt={endedAt} />}
       <div className="flex-1 overflow-y-auto">
         <PanelBody
           source={source}

--- a/frontend/src/components/dock/FilesPanel.tsx
+++ b/frontend/src/components/dock/FilesPanel.tsx
@@ -1,5 +1,5 @@
 import { ChevronLeft } from "lucide-react"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { createPortal } from "react-dom"
 import { Notice } from "@/components/common/Notice"
 import { SearchInput } from "@/components/common/SearchInput"
@@ -10,6 +10,7 @@ import { FileTree } from "@/components/FileTree"
 import { threadSlots, type SlotElements } from "@/lib/codemirror-threads"
 import { formatLineRef, parseDiff, type DiffFile } from "@/lib/git/diff"
 import { buildTree, type TreeNode } from "@/lib/git/file-tree"
+import { updateFileBrowse, useFileBrowse } from "@/lib/file-browse"
 import { COMPOSER_KEY } from "@/lib/pulls/review-slots"
 import { matchesQuery } from "@/lib/session/command-palette"
 import { addReviewComment } from "@/lib/review-comments"
@@ -19,7 +20,7 @@ import { ProjectService, System } from "@/lib/rpc"
 import { useActiveSession } from "@/lib/session/use-active-session"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { useInject } from "@/lib/use-inject"
-import { errorText } from "@/lib/utils"
+import { useRemoteResource } from "@/lib/use-remote-resource"
 import { useFileEditor } from "./useFileEditor"
 
 // FilesPanel is the Files tab of the right dock: a read-only tree of the active
@@ -37,55 +38,41 @@ export function FilesPanel() {
   const { newSession, activateSession } = useProjects()
   const inject = useInject(sessionId)
   const status = useGitStatus(path)
-  const [files, setFiles] = useState<string[] | null>(null)
-  const [stats, setStats] = useState<Map<string, DiffFile>>(new Map())
-  const [failed, setFailed] = useState(false)
-  const [open, setOpen] = useState<string | null>(null)
-  // Outlives the preview: after Back the tree still marks the file just read,
-  // which is where the eye left off.
-  const [selected, setSelected] = useState<string | null>(null)
-  const [query, setQuery] = useState("")
-
-  const refresh = useCallback(async () => {
-    if (!path) {
-      return
-    }
-    try {
+  // Everything the browse is — filter, folds, marked row, preview — lives in a
+  // store keyed by this checkout, because the dock unmounts this panel on every
+  // flip to the Review tab (see file-browse). Keying by path is also what keeps
+  // one worktree's browse off another's tree, which the panel used to do by
+  // clearing on a path change.
+  const browse = useFileBrowse(path)
+  // Same invalidation as the diff panel: the git-status poll doubles as the
+  // signal, so a new or removed file shows up without a watcher. It rides the
+  // key rather than an effect, because the key is what stands for the request.
+  const key = path
+    ? `${path} ${status?.files ?? 0} ${status?.added ?? 0} ${status?.deleted ?? 0}`
+    : ""
+  const { data, loading, error } = useRemoteResource(
+    key,
+    async () => {
       // The diff feeds each row its +/- badge; a diff failure (nothing to diff)
       // just means no badges, never a broken tree — hence the swallowed catch.
       const [files, diffText] = await Promise.all([
         ProjectService.Tree(path),
         ProjectService.DiffText(path).catch(() => ""),
       ])
-      setFiles(files ?? [])
-      setStats(diffStatsByPath(parseDiff(diffText)))
-      setFailed(false)
-    } catch {
-      setFiles([])
-      setStats(new Map())
-      setFailed(true)
-    }
-  }, [path])
+      return { files: files ?? [], stats: diffStatsByPath(parseDiff(diffText)) }
+    },
+    // resetOn is the path and not the key: a moved file count refreshes the
+    // tree in place, while a worktree switch with no answer on file must drop
+    // the previous checkout's files rather than list them under this one.
+    { empty: NO_TREE, resetOn: path, cache: `dock-tree ${path}` },
+  )
 
   // The filter reads the whole repo-relative path, so a directory name narrows
   // the tree to what is under it — one field for both halves of "find a file".
   const tree = useMemo(
-    () => (files === null ? null : buildTree(files.filter((file) => matchesQuery(file, query)))),
-    [files, query],
+    () => buildTree(data.files.filter((file) => matchesQuery(file, browse.query))),
+    [data.files, browse.query],
   )
-
-  // Same invalidation as the diff panel: the git-status poll doubles as the
-  // signal, so a new or removed file shows up without a watcher.
-  useEffect(() => {
-    void refresh()
-  }, [refresh, status?.files, status?.added, status?.deleted])
-
-  // A worktree switch changes path; drop any preview and filter from the old tree.
-  useEffect(() => {
-    setOpen(null)
-    setSelected(null)
-    setQuery("")
-  }, [path])
 
   if (!projectId) {
     return null
@@ -113,15 +100,15 @@ export function FilesPanel() {
 
   return (
     <div className="flex h-full flex-col">
-      {/* The preview covers the tree instead of replacing it: the folders that
-          were opened to reach a file — and the scroll that got there — are the
-          tree's own state, and unmounting it throws both away on every Back. */}
+      {/* The preview covers the tree instead of replacing it: the scroll that
+          reached a file is the tree's own, and nothing outside restores it, so
+          unmounting the tree would throw it away on every Back. */}
       <div className="relative flex flex-1 flex-col overflow-hidden">
         <div className="flex h-full flex-col overflow-hidden">
           <div className="shrink-0 border-b border-border p-1.5">
             <SearchInput
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
+              value={browse.query}
+              onChange={(event) => updateFileBrowse(path, { query: event.target.value })}
               placeholder="Filter by name"
               aria-label="Filter files by name"
               spellCheck={false}
@@ -130,25 +117,25 @@ export function FilesPanel() {
           </div>
           <TreeBody
             tree={tree}
-            query={query}
-            active={selected}
-            stats={stats}
-            failed={failed}
-            onOpen={(rel) => {
-              setOpen(rel)
-              setSelected(rel)
-            }}
+            query={browse.query}
+            active={browse.selected}
+            toggled={browse.toggled}
+            onToggled={(toggled) => updateFileBrowse(path, { toggled })}
+            stats={data.stats}
+            loading={loading}
+            failed={error !== null}
+            onOpen={(rel) => updateFileBrowse(path, { open: rel, selected: rel })}
             onEditor={openInEditor}
           />
         </div>
-        {open !== null && (
+        {browse.open !== "" && (
           <div className="absolute inset-0 z-10 bg-sidebar">
             <FilePreview
               path={path}
-              rel={open}
-              onBack={() => setOpen(null)}
+              rel={browse.open}
+              onBack={() => updateFileBrowse(path, { open: "" })}
               onInject={inject}
-              onComment={(lines, text) => addReviewComment(path, open, lines, text)}
+              onComment={(lines, text) => addReviewComment(path, browse.open, lines, text)}
             />
           </div>
         )}
@@ -158,6 +145,13 @@ export function FilesPanel() {
       <CommentBatch target={path} onInject={inject} />
     </div>
   )
+}
+
+// What the tree holds before its first answer, and after a failed lookup. A
+// module-level constant because useRemoteResource compares it by identity.
+const NO_TREE: { files: string[]; stats: Map<string, DiffFile> } = {
+  files: [],
+  stats: new Map(),
 }
 
 // diffStatsByPath keys each changed file's +/- counts by its current path so a
@@ -175,23 +169,39 @@ function diffStatsByPath(files: DiffFile[]): Map<string, DiffFile> {
 }
 
 interface TreeBodyProps {
-  tree: TreeNode[] | null
+  tree: TreeNode[]
   /** The filter the tree was narrowed by; empty means the whole checkout. */
   query: string
   /** The file last opened, so Back lands on a row that reads as current. */
-  active: string | null
+  active: string
+  toggled: ReadonlySet<string>
+  onToggled: (toggled: ReadonlySet<string>) => void
   stats: Map<string, DiffFile>
+  /** A read with nothing on screen yet. False through a refetch that has last
+   * time's tree to stand on, which is what keeps a poll tick from flashing. */
+  loading: boolean
   failed: boolean
   onOpen: (rel: string) => void
   onEditor: (rel: string) => void
 }
 
-function TreeBody({ tree, query, active, stats, failed, onOpen, onEditor }: TreeBodyProps) {
+function TreeBody({
+  tree,
+  query,
+  active,
+  toggled,
+  onToggled,
+  stats,
+  loading,
+  failed,
+  onOpen,
+  onEditor,
+}: TreeBodyProps) {
   const filtering = query.trim() !== ""
   if (failed) {
     return <Notice>Could not read this folder</Notice>
   }
-  if (tree === null) {
+  if (loading) {
     return <Notice>Loading…</Notice>
   }
   if (tree.length === 0) {
@@ -204,6 +214,8 @@ function TreeBody({ tree, query, active, stats, failed, onOpen, onEditor }: Tree
       // Suspended, not replaced: clearing the filter gives back the folders the
       // browse had open rather than a tree collapsed to the root.
       expandAll={filtering}
+      toggled={toggled}
+      onToggled={onToggled}
       stats={stats}
       onEditor={onEditor}
       className="h-full"
@@ -222,28 +234,19 @@ interface FilePreviewProps {
 }
 
 function FilePreview({ path, rel, onBack, onInject, onComment }: FilePreviewProps) {
-  const [text, setText] = useState<string | null>(null)
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    let alive = true
-    setText(null)
-    setError(null)
-    ProjectService.ReadFile(path, rel)
-      .then((content) => {
-        if (alive) {
-          setText(content)
-        }
-      })
-      .catch((err: unknown) => {
-        if (alive) {
-          setError(errorText(err))
-        }
-      })
-    return () => {
-      alive = false
-    }
-  }, [path, rel])
+  // Filed like the tree above it: a preview left open is restored on the way
+  // back from the Review tab, and painting it from a skeleton every time would
+  // undo half of what restoring it was for. resetOn keeps one file's text from
+  // appearing for a moment under another file's name.
+  const {
+    data: text,
+    loading,
+    error,
+  } = useRemoteResource(`${path} ${rel}`, () => ProjectService.ReadFile(path, rel), {
+    empty: "",
+    resetOn: rel,
+    cache: `dock-file ${path} ${rel}`,
+  })
 
   return (
     <div className="flex h-full flex-col">
@@ -266,7 +269,7 @@ function FilePreview({ path, rel, onBack, onInject, onComment }: FilePreviewProp
       <div className="flex-1 overflow-y-auto">
         {error !== null ? (
           <Notice>{error}</Notice>
-        ) : text === null ? (
+        ) : loading ? (
           <Notice>Loading…</Notice>
         ) : (
           <PreviewBody text={text} rel={rel} onInject={onInject} onComment={onComment} />

--- a/frontend/src/lib/dock-prefs.test.ts
+++ b/frontend/src/lib/dock-prefs.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { readDiffSource, writeDiffSource } from "./dock-prefs"
+
+// The suite runs in node, which has no localStorage. This is the pref that has
+// to survive the dock unmounting, so the storage is stubbed and the round trip
+// through it is what is checked.
+const stored = new Map<string, string>()
+
+vi.stubGlobal("localStorage", {
+  getItem: (key: string) => stored.get(key) ?? null,
+  setItem: (key: string, value: string) => {
+    stored.set(key, value)
+  },
+  removeItem: (key: string) => {
+    stored.delete(key)
+  },
+})
+
+beforeEach(() => {
+  stored.clear()
+})
+
+describe("the Review tab's source", () => {
+  it("is the working tree until one is chosen", () => {
+    expect(readDiffSource()).toBe("worktree")
+  })
+
+  it("comes back the way the panel was left", () => {
+    writeDiffSource("turn")
+    expect(readDiffSource()).toBe("turn")
+    writeDiffSource("worktree")
+    expect(readDiffSource()).toBe("worktree")
+  })
+
+  // A source this build cannot render would leave the panel asking for a diff
+  // nothing answers, with a switch showing a value it does not have.
+  it("reads a value from another build as the working tree", () => {
+    stored.set("lich.dock.source", "staged")
+    expect(readDiffSource()).toBe("worktree")
+  })
+})

--- a/frontend/src/lib/dock-prefs.ts
+++ b/frontend/src/lib/dock-prefs.ts
@@ -1,0 +1,29 @@
+import { parseEnumPref, readPref, writePref } from "@/lib/prefs"
+
+// What the right dock remembers between its mounts. The dock is a ternary
+// between two component types and sits behind a close button, so every
+// Code↔Review switch and every close destroys the panel — a choice made once
+// was a choice re-made all day.
+//
+// UI preferences, so the page's localStorage rather than the workspace database
+// (see the root CLAUDE.md). Parsing is the half kept pure and tested; reading
+// and writing the key stays a two-line wrapper, the split prefs.ts describes.
+//
+// Global rather than per session, by the rule pulls-prefs states: which changes
+// a reviewer wants in front of them is a habit of theirs, the way the pull
+// request sort is, and not a property of one checkout's content.
+const SOURCE_KEY = "lich.dock.source"
+
+/** Which changes the Review tab shows. "worktree" is everything uncommitted,
+ * the panel's original and default answer; "turn" narrows it to the window the
+ * session's last finished turn ran in (internal/terminal.LastTurnDiff). */
+export const DIFF_SOURCES = ["worktree", "turn"] as const
+export type DiffSource = (typeof DIFF_SOURCES)[number]
+
+export function readDiffSource(): DiffSource {
+  return parseEnumPref(readPref(SOURCE_KEY), DIFF_SOURCES, "worktree")
+}
+
+export function writeDiffSource(source: DiffSource): void {
+  writePref(SOURCE_KEY, source)
+}

--- a/frontend/src/lib/file-browse.test.ts
+++ b/frontend/src/lib/file-browse.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from "vitest"
+import { fileBrowse, updateFileBrowse } from "./file-browse"
+
+const A = "/checkouts/one"
+const B = "/checkouts/two"
+
+// Nothing clears the store, so each case works on paths of its own rather than
+// on what the case before it left behind.
+let seq = 0
+let a = A
+let b = B
+
+beforeEach(() => {
+  seq++
+  a = `${A}/${seq}`
+  b = `${B}/${seq}`
+})
+
+describe("a checkout's browse", () => {
+  it("is all defaults for one never browsed", () => {
+    expect(fileBrowse(a)).toEqual({ query: "", open: "", selected: "", toggled: new Set() })
+  })
+
+  // The point of the store: a tab switch unmounts the panel, so each half of
+  // the browse is written by whichever handler moved it and none of them may
+  // take the others down with it.
+  it("keeps the rest of itself when one part moves", () => {
+    updateFileBrowse(a, { query: "store" })
+    updateFileBrowse(a, { toggled: new Set(["src", "src/lib"]) })
+    updateFileBrowse(a, {
+      open: "src/lib/git-status-store.ts",
+      selected: "src/lib/git-status-store.ts",
+    })
+    updateFileBrowse(a, { open: "" })
+
+    expect(fileBrowse(a)).toEqual({
+      query: "store",
+      open: "",
+      selected: "src/lib/git-status-store.ts",
+      toggled: new Set(["src", "src/lib"]),
+    })
+  })
+
+  // The rule the panel used to keep by clearing on a path change: one worktree's
+  // filter and folds must never narrow another worktree's tree.
+  it("belongs to one checkout and never to the next", () => {
+    updateFileBrowse(a, { query: "store", selected: "src/lib/rpc.ts" })
+    expect(fileBrowse(b)).toEqual({ query: "", open: "", selected: "", toggled: new Set() })
+
+    updateFileBrowse(b, { query: "panel" })
+    expect(fileBrowse(a).query).toBe("store")
+    expect(fileBrowse(b).selected).toBe("")
+  })
+
+  // A panel with no session yet has no checkout to file this under, and one
+  // shared empty key would hand the next checkout the last one's browse.
+  it("writes nothing for a panel with no checkout", () => {
+    updateFileBrowse("", { query: "store" })
+    expect(fileBrowse("")).toEqual({ query: "", open: "", selected: "", toggled: new Set() })
+  })
+})

--- a/frontend/src/lib/file-browse.ts
+++ b/frontend/src/lib/file-browse.ts
@@ -1,0 +1,56 @@
+import { createKeyedStore } from "@/lib/keyed-store"
+import { useKeyedStore } from "@/lib/use-keyed-store"
+
+// Where the Code tab's browse was left: the filter box, the folders opened to
+// reach a file, the row that reads as current, and the file the preview is
+// covering the tree with.
+//
+// It lives out here because the panel does not. RightDock swaps one component
+// type for the other between its tabs, so flipping over to read a diff — and
+// closing the dock at all — unmounts the browser and everything it held: the
+// filter emptied, the tree collapsed back to the root, the preview gone.
+//
+// Keyed by the checkout path, which is the rule the panel already had: a
+// worktree switch shows that checkout's own browse and never the previous
+// one's. Coming back to the first checkout is the part that is new — it used to
+// clear, and now it is where it was left.
+//
+// In memory only, like the comment batch next door: every entry here is a
+// position in a tree that is re-read on each mount, and outliving a reload
+// would mean pointing at files that have since moved.
+export interface FileBrowse {
+  /** The filter box, verbatim — it is free text, so anything held is valid. */
+  query: string
+  /** The file the preview covers the tree with, or "" for the tree itself. */
+  open: string
+  /** The row that reads as current. It outlives the preview: after Back the
+   * tree still marks the file just read, which is where the eye left off. */
+  selected: string
+  /** The folders FileTree has toggled away from its default (see FileTree). */
+  toggled: ReadonlySet<string>
+}
+
+const NO_BROWSE: FileBrowse = { query: "", open: "", selected: "", toggled: new Set() }
+
+const store = createKeyedStore<FileBrowse>(NO_BROWSE)
+
+/** Move part of a checkout's browse, leaving the rest of it where it is. A
+ * panel with no checkout yet writes nothing rather than filing everyone's
+ * browse under one empty key. */
+export function updateFileBrowse(path: string, patch: Partial<FileBrowse>): void {
+  if (!path) {
+    return
+  }
+  store.set(path, { ...store.get(path), ...patch })
+}
+
+/** How this checkout was left browsing, all defaults for one never browsed. */
+export function fileBrowse(path: string): FileBrowse {
+  return store.get(path)
+}
+
+/** The same, subscribed: the panel re-renders when this checkout's browse moves
+ * and stays put while any other one does. */
+export function useFileBrowse(path: string): FileBrowse {
+  return useKeyedStore(store, path)
+}


### PR DESCRIPTION
Stacked on #389 (`feat/remember-the-pull-request-screen`) — it reuses that PR's `remote-cache.ts`, the `cache` option on `useRemoteResource`, and the prefs split `pulls-prefs.ts` worked out. **Review after #389 merges; base changes to `main` then.**

## The cause

`RightDock.tsx:103` is a ternary between two component types, so every Code↔Review tab switch unmounts the panel whole; `App.tsx:113` (`{dock && <RightDock/>}`) does the same on close. The dock survives a route change — it is a sibling of the `Outlet` — so this is purely the tab switch and the close.

## A — the Code tab's browse

`FilesPanel` held `files`, `stats`, `open`, `selected` and `query` in mount-local `useState`, and `FileTree` held `toggled`. Filtering to "store", opening a file, flipping to Review and flipping back gave an empty filter, a tree collapsed to the root, no preview, no marked row — and a refetch of `ProjectService.Tree` (three git subprocesses) plus `DiffText`.

- The filter, preview, marked row and folds now live in `frontend/src/lib/file-browse.ts`, a `createKeyedStore` keyed by the checkout path. That key preserves the panel's old rule for free — a worktree switch shows that checkout's own browse, never the previous one's — and it drops the effect at `FilesPanel.tsx:84-88` that used to clear on a path change. Returning to a checkout now finds it as it was left, where it used to clear.
- The hand-rolled fetch at `FilesPanel.tsx:49` goes through `useRemoteResource` with a `cache` key, as does the file preview's own read. `resetOn` is the path, not the key: a moved file count refreshes the tree in place while a worktree switch with no filed answer drops the old checkout's files rather than listing them under the new one.
- `FileTree`'s folds are lifted **opt-in**: the prop is optional and the tree keeps its `useState` by default, so `PullsFiles.tsx` is untouched and its call site does not change.

## B — the Review tab's source

`ReviewPanel.tsx:58` reset `source` to `worktree` on every mount. It is a pref now (`frontend/src/lib/dock-prefs.ts`, `lich.dock.source`), global by the rule `pulls-prefs` states: which changes a reviewer wants in front of them is a habit, not a property of a checkout's content.

It stays behind the existing `switchable` guard, but as a **derivation rather than a reset**: `source = switchable ? wanted : "worktree"`, and nothing writes the guard's answer back to the pref. That direction is load-bearing and replaces the `useEffect` that used to call `setSource("worktree")`. `useSessionEverReported` is false after every reload until the session next reports, so the old reset would have fired on the first frame and erased the remembered choice before the switch ever appeared. As it stands, a session that has not reported is shown the working tree with no switch — never stranded on an empty panel — and the moment it reports, the remembered "Last turn" takes effect.

## Tests

`frontend/src/lib/file-browse.test.ts` and `dock-prefs.test.ts`. Both proved to bite by mutating the code they guard: dropping the patch spread, dropping the empty-path guard, and reading the pref without `parseEnumPref` each turn exactly one test red. The hook's own caching contract is already pinned by `use-remote-resource.test.tsx`; nothing here re-tests it.

## Verified in the running app

The suite is node-only, so this was driven headless over CDP against an isolated `go run .` (own `XDG_CONFIG_HOME`, `GH_CONFIG_DIR` kept, reserved ports), with `location.href` checked against the port that was started before any measurement:

- Filter + an expanded folder + an open preview + a marked row: byte-identical state across Code→Review→Code **and** across close→reopen.
- A `MutationObserver` over the whole gesture records **zero** `Loading…` frames returning to Code. The one it does see belongs to the Review panel, which holds its diff in `useState` and is not a `useRemoteResource` caller — out of this PR's scope.
- Review source: picking **Last turn** survives the tab switch and the close/reopen, and lands in `localStorage`.
- The guard, end to end: with `lich.dock.source=turn` stored and the session not yet reporting after a reload, the switch is absent, the working tree is shown, and the pref is **not** erased; after one status report the switch appears with **Last turn** selected and the panel correctly says "No last turn recorded" — with a control on screen to leave by.

## Gate

`gofmt -l .` clean, `go vet ./...` clean, `go test ./...` pass (run with `LICH_LISTEN_PORT` empty), `biome check .` 0 errors, `tsc --noEmit` clean, `vitest run` 1163 pass / 99 files, `vite build` succeeds. Exit codes read directly, not through a wrapper.

A `CHANGELOG.md` conflict with the sibling PRs off this base is expected; rebase, not broken CI.