### PR TITLE
One section per kind in the Unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **What you were typing on a pull request stays typed.** A description being
-  rewritten, a comment being composed and a reply to a review thread all used to
-  be destroyed by a click on another tab — go and check a line in Files changed,
-  come back, and the box was empty with nothing said about it. The same went for
-  folding the file a thread was on, and for a new commit landing while you wrote:
-  the diff redraws, and the reply went with it. All three now survive every one
-  of those, and leaving the screen entirely. They are still held in the page, so
-  a reload starts fresh — what is gone is losing them to a tab you clicked on
-  purpose.
-
 ### Changed
 
 - **Settings comes back the way you left it.** Stepping out of Settings — into a
@@ -72,6 +60,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   remembered — the tab reopens at the top, as it always has.
 
 ### Fixed
+
+- **What you were typing on a pull request stays typed.** A description being
+  rewritten, a comment being composed and a reply to a review thread all used to
+  be destroyed by a click on another tab — go and check a line in Files changed,
+  come back, and the box was empty with nothing said about it. The same went for
+  folding the file a thread was on, and for a new commit landing while you wrote:
+  the diff redraws, and the reply went with it. All three now survive every one
+  of those, and leaving the screen entirely. They are still held in the page, so
+  a reload starts fresh — what is gone is losing them to a tab you clicked on
+  purpose.
 
 - **Opening Settings › Sandbox no longer blanks the whole lich window on a
   machine with no ssh agent.** That pane lists what your agent holds beside the


### PR DESCRIPTION
Six branches landed in a row, each adding its entry under its own section heading. Every merge was resolved additively — correctly, entry by entry — but nothing was reconciling the *headings*, so `[Unreleased]` ended up with two `### Fixed` blocks separated by `### Changed`.

No entry is added, removed or reworded: the seven bullets are the same seven, gathered under one `### Changed` and one `### Fixed`, in the Keep a Changelog order the release checklist in `CLAUDE.md` requires. The release job greps that block and ships it verbatim, so the duplicate heading would have gone out in the notes.

Worth naming for the next stack: the additive keep-both resolution that got six PRs through their conflicts is right for the entries and blind to the structure around them. Landing a stack means reading the assembled section once at the end.

`git diff --stat`: 10 insertions, 12 deletions, one file.