### PR TITLE
fix: press a relayed Enter once the target has taken the paste in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A task sent to another session on Windows is sent, not left sitting at its
+  prompt.** Handing work to a Codex or Claude Code session on Windows pasted the
+  message and then failed to press Enter behind it: the request sat unsent on the
+  target's screen, and the sender waited out a ticket nobody had been asked
+  anything. Windows terminals hand a program key presses rather than the bytes
+  written to them, so the message arrives there as a burst of typing rather than
+  as a paste, and every agent's prompt has a rule for that — an Enter arriving
+  inside the burst is a new line in the message, not "send it". lich now waits for
+  the target to finish taking the message in before it presses Enter, however long
+  that takes, instead of counting a fixed moment from its own side.
 - **What you were typing on a pull request stays typed.** A description being
   rewritten, a comment being composed and a reply to a review thread all used to
   be destroyed by a click on another tab — go and check a line in Files changed,

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -153,8 +153,16 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   Enter, escape sequences skipped — it cannot see the line, so an edit that leaves it empty by another route
   (Ctrl+W, a click into the middle of it) reads as a draft that is still there, and a delivery waits out
   `draftIdle` for nothing. The stale-draft release is what keeps that a delay instead of a wedged relay. Two gaps
-  stay open: input arriving in the ~150ms between the paste and its Enter (`defaultSubmitDelay`) still rides along,
-  and a provider that takes keystrokes through anything other than this PTY is invisible here.
+  stay open: input arriving between the paste and its Enter still rides along — a window that is `defaultSubmitDelay`
+  at best and lasts until the target's PTY goes quiet at worst (`internal/relay`, `awaitSettled`) — and a provider
+  that takes keystrokes through anything other than this PTY is invisible here.
+- **A relayed Enter is timed against silence, not against the target** (`internal/relay`, `awaitSettled`): lich
+  presses Enter once the target's PTY has been quiet for `defaultSubmitDelay`, because nothing here can read a TUI's
+  screen to know it has taken the paste in. On Windows that quiet is the whole instrument — ConPTY hands a child key
+  events rather than bytes, the bracketed paste markers do not survive, and every provider TUI then guesses at where
+  a paste ends from timing alone. A target that repaints on a timer of its own never goes quiet and gets its Enter
+  at `defaultSettleLimit` regardless, which is the case this cannot tell from a paste still arriving.
+
 - **An answer that names no ticket is matched by delivery order** (`internal/relay/relay.go`,
   `errandOfLocked`): `lich reply "<answer>"` and `reply_to_session` without a ticket close the oldest message
   delivered to that session and still open, because nothing in an answer itself says which request it belongs to.

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -43,6 +43,8 @@ func (*wiredTerminal) Live(string) bool { return true }
 
 func (*wiredTerminal) Ready(string) bool { return true }
 
+func (*wiredTerminal) QuietFor(string) time.Duration { return time.Hour }
+
 func (w *wiredTerminal) Write(_, data string) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/internal/relay/compose.go
+++ b/internal/relay/compose.go
@@ -145,19 +145,21 @@ func paste(text string) string {
 // submit is the Enter that sends what paste put at the prompt.
 const submit = "\r"
 
-// defaultSubmitDelay is how long the relay waits between the paste and the
-// Enter that sends it.
+// defaultSubmitDelay is how long a target's PTY has to stay quiet before the
+// relay presses the Enter that sends what it pasted (see awaitSettled).
 //
 // Everything else lich pastes into a prompt is left for the user to send, so
 // this is the only place that presses Enter itself — and a carriage return
-// riding in the same write as the paste is swallowed. Claude Code collapses a
-// multi-line paste into a "[Pasted text #2 +7 lines]" placeholder, and the
-// Enter arriving inside that same burst goes into building the placeholder
-// rather than sending it: the message sat unsent at the target's prompt, seen
-// only when someone opened that session by hand. Nothing here can read the
-// target's screen to know when it has settled, so the delay is the instrument,
-// and it is generous on purpose — a tenth of a second nobody notices against a
-// message that otherwise never arrives.
+// arriving while the TUI is still taking the paste in is swallowed. Claude Code
+// collapses a multi-line paste into a "[Pasted text #2 +7 lines]" placeholder
+// and the Enter goes into building the placeholder rather than sending it;
+// Codex, on a terminal that gave it no paste event, spends 120ms deciding
+// whether an Enter belongs inside the burst. Both were the same bug on screen:
+// the message sitting unsent at the target's prompt, seen only when someone
+// opened that session by hand.
+//
+// It has to outlast the longest of those windows, and it is what a settled
+// terminal is measured against, so it is the whole instrument in both roles.
 const defaultSubmitDelay = 150 * time.Millisecond
 
 // sanitize strips the control characters that would either break out of the

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -64,6 +64,12 @@ const (
 	// setup script runs for tens of seconds at least, so this only has to be
 	// quick against a human's patience, not against the machine.
 	readyPoll = 250 * time.Millisecond
+	// defaultSettleLimit caps how long a delivery waits for the target to finish
+	// taking a paste in before it presses Enter anyway (see awaitSettled). It
+	// only has to outlast a drain — the whole message is already in the PTY —
+	// and it sits well inside the receipt window, so a target that never goes
+	// quiet still gets its Enter in time to report reading it.
+	defaultSettleLimit = 5 * time.Second
 )
 
 // How lich's own MCP server (internal/cli) is registered and what it calls its
@@ -182,6 +188,10 @@ type Terminal interface {
 	Live(id string) bool
 	Ready(id string) bool
 	Write(id, data string) error
+	// QuietFor is how long that session's PTY has produced nothing, which is
+	// how a delivery knows the target has finished taking the paste in before
+	// it presses Enter behind it (see awaitSettled).
+	QuietFor(id string) time.Duration
 }
 
 // Peer is one session a caller may address: the label it is addressed by, the
@@ -324,6 +334,9 @@ type Service struct {
 	// nudgeDelay is the debounce before a nudge is typed (defaultNudgeDelay).
 	// A field for the same reason.
 	nudgeDelay time.Duration
+	// settleLimit caps the wait for a target to finish taking a paste in
+	// (defaultSettleLimit). A field for the same reason.
+	settleLimit time.Duration
 	// plugins answers what a provider's sessions can do, which depends on state
 	// this package has none of: whether the companion plugin is installed there,
 	// and whether it is new enough to carry lich's own operations. Nil — the
@@ -364,6 +377,7 @@ func New(sessions Sessions, term Terminal, events Events) *Service {
 		receiptWindow: defaultReceiptWindow,
 		deliveryLimit: defaultDeliveryLimit,
 		nudgeDelay:    defaultNudgeDelay,
+		settleLimit:   defaultSettleLimit,
 	}
 }
 
@@ -558,8 +572,39 @@ func (s *Service) deliver(sessionID, message string) error {
 	if err := s.term.Write(sessionID, paste(message)); err != nil {
 		return err
 	}
-	time.Sleep(s.submitDelay)
+	s.awaitSettled(sessionID)
 	return s.term.Write(sessionID, submit)
+}
+
+// awaitSettled holds the Enter back until the target has finished taking the
+// paste in — until its PTY has been quiet for submitDelay, not until
+// submitDelay has passed since lich wrote.
+//
+// The two are the same thing only where the paste arrives as one event. They
+// are not on Windows: ConPTY hands a child key events rather than the bytes
+// written to it, and a bracketed paste is not a key, so the markers are dropped
+// and the message reaches the TUI as a stream of typed characters. Every
+// provider TUI has a heuristic for that — Codex suppresses Enter for 120ms
+// after the last character of a burst, so it lands as a newline inside the
+// paste instead of sending it — and the stream is still arriving when a write
+// on this side has long returned. The message sat unsent at the target's
+// prompt, which is where users found it.
+//
+// The quiet is the drain: a TUI redraws as it takes the characters in, so its
+// silence is the first moment nothing more is coming. Waiting for it costs
+// nothing where the paste was one event — the terminal was already quiet — and
+// costs exactly the drain where it was not.
+//
+// Bounded because a TUI that repaints on a timer of its own would never go
+// quiet, and an Enter that is late is better than one that never comes.
+func (s *Service) awaitSettled(sessionID string) {
+	deadline := s.now().Add(s.settleLimit)
+	for {
+		time.Sleep(s.submitDelay)
+		if s.term.QuietFor(sessionID) >= s.submitDelay || !s.now().Before(deadline) {
+			return
+		}
+	}
 }
 
 // awaitFree blocks while a session's prompt belongs to somebody else — the

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -30,7 +30,11 @@ type fakeTerminal struct {
 	settingUp map[string]bool
 	// typing is whether the person at that session has a half-written line at its
 	// prompt, which the terminal service reports through the same Ready.
-	typing   map[string]bool
+	typing map[string]bool
+	// noisy is how many more QuietFor calls a session answers as still drawing,
+	// and drained counts the ones it spent.
+	noisy    map[string]int
+	drained  map[string]int
 	writes   map[string][]string
 	writeErr error
 	refused  int
@@ -43,6 +47,7 @@ func newFakeTerminal(live ...string) *fakeTerminal {
 	t := &fakeTerminal{
 		live: map[string]bool{}, writes: map[string][]string{},
 		settingUp: map[string]bool{}, typing: map[string]bool{},
+		noisy: map[string]int{}, drained: map[string]int{},
 	}
 	for _, id := range live {
 		t.live[id] = true
@@ -79,6 +84,36 @@ func (f *fakeTerminal) setUp(id string, running bool) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.settingUp[id] = running
+}
+
+// QuietFor reports the terminal as settled unless a test says otherwise: the
+// fake has no TUI drawing into it, so there is nothing here to wait out.
+// noise makes one session busy for the next n answers, which is how a delivery
+// that has to wait for the drain is written.
+func (f *fakeTerminal) QuietFor(id string) time.Duration {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.noisy[id] > 0 {
+		f.noisy[id]--
+		f.drained[id]++
+		return 0
+	}
+	return time.Hour
+}
+
+// noise makes a session answer QuietFor as still drawing for the next n calls,
+// standing in for a TUI taking a paste in character by character.
+func (f *fakeTerminal) noise(id string, n int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.noisy[id] = n
+}
+
+// drains counts how many times a delivery found the session still drawing.
+func (f *fakeTerminal) drains(id string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.drained[id]
 }
 
 func (f *fakeTerminal) Write(id, data string) error {
@@ -354,6 +389,52 @@ func TestPeersReportsAStoreFailure(t *testing.T) {
 
 	if _, err := svc.Peers("s1"); err == nil {
 		t.Fatal("want an error when the workspace cannot be read")
+	}
+}
+
+// TestTheEnterWaitsForTheTargetToFinishTakingThePasteIn pins the delivery to
+// the target's own quiet rather than to a wall-clock guess on this side. A
+// terminal that hands the TUI a paste one character at a time — every Windows
+// ConPTY, where the bracketed paste markers never survive — is still drawing
+// when a write here has returned, and an Enter pressed into that burst is read
+// as a newline inside the paste instead of as "send it".
+func TestTheEnterWaitsForTheTargetToFinishTakingThePasteIn(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, nil)
+	svc.submitDelay = time.Millisecond
+	term.noise("s2", 3)
+
+	go svc.Send("s1", "docs", "", "run the tests", 1)
+
+	if !awaitWritten(term, "s2", submit) {
+		t.Fatal("the Enter never arrived")
+	}
+	if got := term.drains("s2"); got != 3 {
+		t.Errorf("waited out %d draws, want 3 — the Enter did not wait for the target to settle", got)
+	}
+	writes := term.written("s2")
+	if !strings.HasSuffix(writes, submit) {
+		t.Errorf("last write = %q, want the Enter behind the paste", writes)
+	}
+}
+
+// TestASilentTargetIsSentItsEnterAnyway pins the other half: a TUI that
+// repaints on a timer of its own would never go quiet, and an errand that hangs
+// on that is worse than one whose Enter is late.
+func TestASilentTargetIsSentItsEnterAnyway(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, nil)
+	svc.submitDelay = time.Millisecond
+	svc.settleLimit = 20 * time.Millisecond
+	term.noise("s2", 1_000_000)
+
+	start := time.Now()
+	svc.awaitSettled("s2")
+	if elapsed := time.Since(start); elapsed >= time.Second {
+		t.Fatalf("waited %s on a terminal that never settles, want it capped at %s", elapsed, svc.settleLimit)
+	}
+	if term.drains("s2") == 0 {
+		t.Error("gave up without waiting at all")
 	}
 }
 

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"os"
 	"runtime"
@@ -983,6 +984,30 @@ func (s *Service) Ready(id string) bool {
 	}
 	return false
 }
+
+// QuietFor reports how long a session's PTY has produced nothing, which is the
+// only way from outside to tell that the program on the other end has finished
+// taking in what was typed at it. A session that has never written a byte — and
+// one nobody knows — is as quiet as a session gets.
+//
+// Ready answers a coarser version of the same question once, and latches; this
+// one is asked again in the middle of a delivery, where the quiet that matters
+// is the one happening right now (internal/relay, awaitSettled).
+func (s *Service) QuietFor(id string) time.Duration {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[id]
+	if !ok || sess.lastOut.IsZero() {
+		return quietForever
+	}
+	return time.Since(sess.lastOut)
+}
+
+// quietForever is the answer for a session with no output to time from. Large
+// enough that every caller reads it as "settled", and a duration rather than a
+// second return value because there is nothing here a caller would do
+// differently.
+const quietForever = time.Duration(math.MaxInt64)
 
 // Close terminates a session's shell, if any.
 func (s *Service) Close(id string) error {


### PR DESCRIPTION
A task handed to another session on Windows pasted and was never sent. The message sat at the target's prompt, and the sender waited out a ticket nobody had been asked anything. Reported again after the Windows shell moved from `cmd.exe` to PowerShell, which was a different bug.

## What is actually happening

ConPTY hands a child **key events**, not the bytes written to it. `\x1b[200~`/`\x1b[201~` are not keys, so conhost drops them: the message reaches the TUI as a burst of typing rather than as a paste. Every provider has a heuristic for that, and the one in Codex says so in its own first paragraph — `codex-rs/tui/src/bottom_pane/paste_burst.rs`:

> Paste-burst detection for terminals without bracketed paste. On some platforms (notably Windows), pastes often arrive as a rapid stream of `KeyCode::Char` and `KeyCode::Enter` key events rather than as a single "paste" event. […] Ensure Enter is treated as a newline *inside the paste*, not as "submit the message".

Its numbers: `PASTE_ENTER_SUPPRESS_WINDOW = 120ms`, counted from the **last character the TUI consumed**, and a `PASTE_BURST_ACTIVE_IDLE_TIMEOUT` that is `8ms` everywhere and `60ms` on Windows because "slower paste bursts have been observed in Windows environments".

`defaultSubmitDelay` was 150ms counted from **this side's write returning** — the moment the bytes entered the pipe, not the moment the target finished reading them. For the Enter to land clear of the suppression window, the entire drain of a ~1KB message through conhost's input translation had to fit in 30ms. Sometimes it did. Hence "sometimes".

Claude Code fails the same way for its own reason: the Enter is spent building the `[Pasted text #N]` placeholder rather than sending it. That was the case `defaultSubmitDelay` was written for, and it is the same shape.

## The change

Time the Enter against the target's own silence instead of against a moment on this clock.

- `terminal.QuietFor(id)` reports how long a session's PTY has produced nothing, off the `lastOut` stamp `Ready` already keeps.
- `relay.awaitSettled` replaces the blind `time.Sleep`: it waits for that quiet to reach `submitDelay`, capped at `defaultSettleLimit`. A TUI redraws as it takes characters in, so its silence is the first moment nothing more is coming.

Costs nothing where the paste arrived as one event — the terminal was already quiet — and costs exactly the drain where it did not. Provider-agnostic: the delivery path is one for all seven.

## Ceilings

`docs/ceilings.md` gains the bullet for what this cannot tell apart — a TUI repainting on a timer of its own never goes quiet and gets its Enter at `defaultSettleLimit` regardless — and the `draft.go` bullet's "~150ms window" is now a window that lasts until the target settles.

## Test plan

- [x] `gofmt -l .`, `go vet ./...` clean
- [x] `go test ./...` — 1970 pass
- [x] Cross-compile loop for linux/darwin/windows: `go build` + `go vet`
- [x] Two new tests: the Enter waits out a target still drawing, and a target that never settles is sent its Enter anyway. `-count=50` green.
- [ ] Windows runner (backend suite runs there on this PR)
- [ ] Real check the CI cannot make: on a Windows box, relay a task into a Codex session and watch it submit.