### PR TITLE
chore: cut the 0.42.0 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.0] - 2026-08-27
+
 ### Changed
 
 - **Settings comes back the way you left it.** Stepping out of Settings — into a
@@ -3415,7 +3417,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.41.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.42.0...HEAD
+[0.42.0]: https://github.com/omartelo/lich/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/omartelo/lich/compare/v0.40.1...v0.41.0
 [0.40.1]: https://github.com/omartelo/lich/compare/v0.40.0...v0.40.1
 [0.40.0]: https://github.com/omartelo/lich/compare/v0.39.0...v0.40.0


### PR DESCRIPTION
Prepares the tag. `[Unreleased]` stays at the top, emptied; its entries move under `## [0.42.0] - 2026-08-27`, and the compare links pick up the new version.

Minor rather than patch: the Changed section is five pieces of new behaviour — every surface of the app now comes back the way it was left — not only repairs.

## What ships in 0.42.0

**Changed**
- Settings comes back the way you left it
- The right dock comes back the way you left it
- The pull request screen comes back the way you left it
- The sidebar remembers which session groups you folded
- The Files changed tab keeps the file you jumped to

**Fixed**
- A task sent to another session on Windows is sent, not left sitting at its prompt
- What you were typing on a pull request stays typed
- Opening Settings › Sandbox no longer blanks the whole lich window on a machine with no ssh agent

## Test plan

- [x] `gofmt -l .`, `go vet ./...` clean
- [x] `go test -race ./...` — 1970 pass
- [x] `biome check`, `vitest run` (1205 pass), `tsc -b --noEmit`, `vite build`
- [x] `grep '^## \[0.42.0\]' CHANGELOG.md` matches — the release job reads its notes from that heading
- [ ] Tag `v0.42.0` after merge