### PR TITLE
feat: bring a project tab back to the screen it was left on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **A project tab comes back to the screen you left it on.** Stepping over to
+  another project and back always dropped you onto the first project's
+  terminals, whatever you had been reading there: its Settings, the pull request
+  you had open, the list of them. Each tab now returns to the screen its project
+  was last showing, and to its terminals only when that is where you were.
+
 ## [0.42.0] - 2026-08-27
 
 ### Changed

--- a/frontend/src/components/tabs/HomeTab.tsx
+++ b/frontend/src/components/tabs/HomeTab.tsx
@@ -1,28 +1,28 @@
-import { NavLink } from "react-router-dom"
+import { Link } from "react-router-dom"
 import { Home } from "lucide-react"
 import { cn } from "@/lib/utils"
 
 interface HomeTabProps {
-  projectId: string
+  // The screen Home was last showing (project-route), like every other tab.
+  to: string
+  active: boolean
 }
 
 // HomeTab is the pinned, non-closable first tab: a plain shell at the system
 // home directory. Icon-only and rendered outside the project reorder list, so
 // it is never draggable and never closable.
-export function HomeTab({ projectId }: HomeTabProps) {
+export function HomeTab({ to, active }: HomeTabProps) {
   return (
-    <NavLink
-      to={`/projects/${projectId}`}
+    <Link
+      to={to}
       title="Home"
       aria-label="Home"
-      className={({ isActive }) =>
-        cn(
-          "flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground",
-          isActive && "bg-accent text-accent-foreground",
-        )
-      }
+      className={cn(
+        "flex size-8 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground",
+        active && "bg-accent text-accent-foreground",
+      )}
     >
       <Home className="size-4" />
-    </NavLink>
+    </Link>
   )
 }

--- a/frontend/src/components/tabs/ProjectTab.tsx
+++ b/frontend/src/components/tabs/ProjectTab.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from "react-router-dom"
+import { Link } from "react-router-dom"
 import { Bell, Check, LoaderCircle } from "lucide-react"
 import { useSortable } from "@dnd-kit/sortable"
 import { CloseButton } from "@/components/common/CloseButton"
@@ -10,11 +10,15 @@ import type { Project } from "@/lib/api-types"
 interface ProjectTabProps {
   project: Project
   sessionIds: readonly string[]
+  // Where the tab leads: the screen this project was last showing, which is not
+  // always its terminals (project-route).
+  to: string
+  active: boolean
   onClose: () => void
 }
 
 // The tab is its own drag grip for reordering the strip — no separate handle.
-export function ProjectTab({ project, sessionIds, onClose }: ProjectTabProps) {
+export function ProjectTab({ project, sessionIds, to, active, onClose }: ProjectTabProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: project.id,
   })
@@ -22,6 +26,7 @@ export function ProjectTab({ project, sessionIds, onClose }: ProjectTabProps) {
   // active tab never badges: its cards are already on screen saying the same
   // thing, in more detail and per session.
   const status = useProjectStatus(sessionIds)
+  const badge = active ? null : status
 
   return (
     <div
@@ -31,37 +36,28 @@ export function ProjectTab({ project, sessionIds, onClose }: ProjectTabProps) {
       {...attributes}
       {...listeners}
     >
-      <NavLink
-        to={`/projects/${project.id}`}
+      <Link
+        to={to}
         title={project.path}
-        className={({ isActive }) =>
-          cn(
-            "group flex h-8 max-w-52 items-center gap-2 rounded-md px-3 text-sm text-muted-foreground transition-colors hover:text-foreground",
-            isActive && "bg-accent font-medium text-accent-foreground",
-          )
-        }
+        className={cn(
+          "group flex h-8 max-w-52 items-center gap-2 rounded-md px-3 text-sm text-muted-foreground transition-colors hover:text-foreground",
+          active && "bg-accent font-medium text-accent-foreground",
+        )}
       >
-        {({ isActive }) => {
-          const badge = isActive ? null : status
-          return (
-            <>
-              {badge === "busy" && <LoaderCircle className="size-3 shrink-0 animate-spin" />}
-              {badge === "done" && <Check className="size-3 shrink-0 text-emerald-500" />}
-              {badge === "waiting" && <Bell className="size-3 shrink-0 text-amber-500" />}
-              <span className="truncate">{project.name}</span>
-              {/* preventDefault, not stopPropagation: the parent is a NavLink,
-                  and the click must not navigate to the tab being closed. */}
-              <CloseButton
-                label={`Close ${project.name}`}
-                onClick={(event) => {
-                  event.preventDefault()
-                  onClose()
-                }}
-              />
-            </>
-          )
-        }}
-      </NavLink>
+        {badge === "busy" && <LoaderCircle className="size-3 shrink-0 animate-spin" />}
+        {badge === "done" && <Check className="size-3 shrink-0 text-emerald-500" />}
+        {badge === "waiting" && <Bell className="size-3 shrink-0 text-amber-500" />}
+        <span className="truncate">{project.name}</span>
+        {/* preventDefault, not stopPropagation: the parent is a link, and the
+            click must not navigate to the tab being closed. */}
+        <CloseButton
+          label={`Close ${project.name}`}
+          onClick={(event) => {
+            event.preventDefault()
+            onClose()
+          }}
+        />
+      </Link>
     </div>
   )
 }

--- a/frontend/src/components/tabs/ProjectTabs.tsx
+++ b/frontend/src/components/tabs/ProjectTabs.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react"
-import { useMatch, useNavigate } from "react-router-dom"
+import { useEffect, useState } from "react"
+import { useLocation, useMatch, useNavigate } from "react-router-dom"
 import { GitPullRequestArrow, Settings } from "lucide-react"
 import { DndContext, closestCenter } from "@dnd-kit/core"
 import { SortableContext, horizontalListSortingStrategy } from "@dnd-kit/sortable"
@@ -12,6 +12,7 @@ import { runningSessions } from "@/lib/session/use-session-status"
 import type { Project } from "@/lib/api-types"
 import { openSettings } from "@/lib/settings-card-store"
 import { openPullsList } from "@/lib/pulls-list-card-store"
+import { projectRoute, rememberProjectRoute } from "@/lib/project-route"
 import { useSettings } from "@/providers/settings"
 import { useHotkey } from "@/lib/use-hotkey"
 import { NotificationsButton } from "./NotificationsButton"
@@ -30,7 +31,22 @@ export function ProjectTabs() {
   const [pending, setPending] = useState<{ project: Project; running: number } | null>(null)
   // The project the settings gear targets: whichever one is in view, falling
   // back to Home when the app is on the bare landing screen.
-  const activeProjectId = useMatch("/projects/:projectId/*")?.params.projectId ?? homeId
+  const routedProjectId = useMatch("/projects/:projectId/*")?.params.projectId
+  const activeProjectId = routedProjectId ?? homeId
+  // Every tab remembers the screen its project was last on, so leaving a project
+  // to glance at another and coming back lands where it was left — its Settings,
+  // a pull request — instead of dropping onto its terminals every time.
+  const { pathname } = useLocation()
+  useEffect(() => {
+    if (routedProjectId) {
+      rememberProjectRoute(routedProjectId, pathname)
+    }
+  }, [routedProjectId, pathname])
+  // The active tab points at the live location rather than what was remembered
+  // for it: the memory is written a render later, and a tab that navigated away
+  // from the screen under it would be a click that undoes itself.
+  const tabRoute = (projectId: string) =>
+    projectId === routedProjectId ? pathname : projectRoute(projectId)
   const onSettings = !!useMatch("/projects/:projectId/settings")
   const onPulls = !!useMatch("/projects/:projectId/pulls/all/*")
 
@@ -81,7 +97,9 @@ export function ProjectTabs() {
     <>
       <div className="flex h-10 shrink-0 items-center gap-1 border-b border-border bg-sidebar px-2">
         <div className="flex flex-1 items-center gap-1 overflow-x-auto overflow-y-hidden">
-          {showHome && homeId && <HomeTab projectId={homeId} />}
+          {showHome && homeId && (
+            <HomeTab to={tabRoute(homeId)} active={homeId === routedProjectId} />
+          )}
           <DndContext
             sensors={sensors}
             collisionDetection={closestCenter}
@@ -94,6 +112,8 @@ export function ProjectTabs() {
                   key={project.id}
                   project={project}
                   sessionIds={sessionsOf(sessions, project.id).map((s) => s.id)}
+                  to={tabRoute(project.id)}
+                  active={project.id === routedProjectId}
                   onClose={() => requestClose(project)}
                 />
               ))}

--- a/frontend/src/lib/project-route.test.ts
+++ b/frontend/src/lib/project-route.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+import { projectRoute, rememberProjectRoute } from "./project-route"
+
+describe("projectRoute", () => {
+  it("falls back to the project's own route until a screen is remembered", () => {
+    expect(projectRoute("unseen")).toBe("/projects/unseen")
+  })
+
+  it("returns the screen the project was last on", () => {
+    rememberProjectRoute("a", "/projects/a/settings")
+    expect(projectRoute("a")).toBe("/projects/a/settings")
+  })
+
+  it("keeps one route per project, latest wins", () => {
+    rememberProjectRoute("b", "/projects/b/settings")
+    rememberProjectRoute("b", "/projects/b/pulls/all/12")
+    expect(projectRoute("b")).toBe("/projects/b/pulls/all/12")
+    expect(projectRoute("a")).toBe("/projects/a/settings")
+  })
+})

--- a/frontend/src/lib/project-route.ts
+++ b/frontend/src/lib/project-route.ts
@@ -1,0 +1,17 @@
+// The screen each project was last showing, so its tab returns to it instead of
+// to the project's terminals: switching to another project and back is a glance
+// away, not a decision to leave Settings — or a pull request — behind.
+//
+// Keyed by project id and never persisted, like the parked cards these screens
+// belong to (card-store): a restart starts on the terminals.
+const routes = new Map<string, string>()
+
+export function rememberProjectRoute(projectId: string, path: string): void {
+  routes.set(projectId, path)
+}
+
+// The route a project's tab opens: the screen it was last on, falling back to
+// the project itself — whichever session it has active.
+export function projectRoute(projectId: string): string {
+  return routes.get(projectId) ?? `/projects/${projectId}`
+}


### PR DESCRIPTION
Reported from use: switching to another project and back never returned to the
screen you were on — not the Settings pane, not the pull request, not the list
of them. It always landed on the project's terminals.

The session was never the part that was lost: `activeId` is per project and
persisted, so the terminal you came back to was the right one. The route was
the part with no memory — every tab pointed at `/projects/:id`, and that route
*is* the terminals.

## What changed

- `frontend/src/lib/project-route.ts` — the screen each project was last
  showing, keyed by project id. A module-level map with the two functions that
  read and write it, in the shape the other stores here already have. Not
  persisted, like the parked cards these screens belong to (`card-store`): a
  restart starts on the terminals.
- `ProjectTabs.tsx` — records the route of whichever project is in view, and
  hands each tab its own. The active tab gets the live location instead: the
  memory is written a render later, so a tab reading it for the project already
  in view would navigate away from the screen under it.
- `ProjectTab.tsx` / `HomeTab.tsx` — `NavLink` → `Link` with an explicit
  `active` prop. `NavLink` derives `isActive` from the path in `to`, which is
  now a subroute, so the tab would have gone unhighlighted the moment its
  project was showing anything but the terminals.

A card closed from the sidebar still navigates to `/projects/:id`, which is
recorded like any other move — so closing Settings is also what forgets it.

## Test plan

- [x] `project-route.test.ts`: the fallback, the remembered screen, latest write
      wins per project.
- [x] `pnpm check`, `tsc`, `pnpm build`, 1208 frontend tests.
- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` (backend untouched).
- [ ] By hand: open a project's Settings, switch to another tab, come back —
      Settings. Same from `/pulls/all/:number`. Then click a session card, leave,
      come back — the terminal.