### PR TITLE
feat: hand the pull request's current problem to the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The pull request screen hands its current problem to the session.** Red CI
+  meant reading the Checks tab, opening each failed job in the browser and
+  typing the names back into the terminal yourself; a branch that would not
+  merge meant saying so by hand. The header now carries one button for whatever
+  is actually in the way — **Resolve conflicts** while the branch conflicts with
+  its base, **Fix CI errors** while checks are red — and writes it at the
+  agent's prompt, naming each failed check and where to read its run (the first
+  eight, and how many were left out). It is written, never sent: the Enter is
+  yours, and lich neither re-runs the checks nor asks a second time. Nothing is
+  drawn when nothing is wrong — that state is the Merge button's.
+
 ### Changed
 
 - **A project tab comes back to the screen you left it on.** Stepping over to

--- a/frontend/src/components/pulls/PullRequestView.tsx
+++ b/frontend/src/components/pulls/PullRequestView.tsx
@@ -9,6 +9,7 @@ import {
   MessageSquare,
   RefreshCw,
   SquareTerminal,
+  Wrench,
   X,
 } from "lucide-react"
 import { ProjectService, System } from "@/lib/rpc"
@@ -32,6 +33,7 @@ import {
   mergeRuleNote,
 } from "@/lib/pulls/merge-gate"
 import { readPullsTab, writePullsTab, type PullsTab } from "@/lib/pulls/pulls-prefs"
+import { pullRequestHandoff } from "@/lib/pulls/pr-handoff"
 import { useBranchRules } from "@/lib/pulls/use-branch-rules"
 import { cn, errorText } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -141,6 +143,18 @@ export function PullRequestView({
   const editableMethods = methods.filter((method) => method !== "rebase")
   const ruleNote = mergeRuleNote(detail, rules)
   const bypass = canAdminOverride(detail, rules)
+  const handoff = pullRequestHandoff(detail)
+
+  // The problem in the way, written at the agent's prompt and nothing more:
+  // lich pastes it and stops there — no run, no watch, no second attempt when
+  // the checks come back red again. The comments are the user's own text and
+  // survive a failed send (CommentBatch); this is derived from the pull request
+  // and can simply be asked for again, so a session-less click only says so.
+  const handOff = () => {
+    if (handoff && !onInject(handoff.prompt)) {
+      toast.error("Open a session to send this to")
+    }
+  }
 
   const merge = async (method: MergeMethod, subject = "", body = "", admin = false) => {
     setMerging(true)
@@ -239,6 +253,25 @@ export function PullRequestView({
                 {session.busy ? "Opening…" : session.label}
               </Button>
             </span>
+            {/* Whatever is wrong with this pull request, handed to the session
+                that would fix it — a conflict first, red CI after it. Nothing
+                is drawn when nothing is wrong: that state is the Merge button's
+                to own. Blocked for the same reason opening a session is, and
+                with the same sentence: a fork that refuses maintainer edits has
+                nowhere to put the work. */}
+            {handoff && (
+              <span title={session.blocked ?? undefined}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={session.blocked !== null}
+                  onClick={handOff}
+                >
+                  <Wrench />
+                  {handoff.label}
+                </Button>
+              </span>
+            )}
             {/* With nothing written, reviewing is the one-click approval it has
                 always been. The moment a comment is waiting, the same control
                 becomes the way to send the review it belongs to — and says how

--- a/frontend/src/lib/pulls/pr-handoff.test.ts
+++ b/frontend/src/lib/pulls/pr-handoff.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest"
+import { pullRequestHandoff } from "./pr-handoff"
+import type { CheckItem, PullRequestDetail } from "@/lib/api-types"
+
+const detail = (over: Partial<PullRequestDetail> = {}): PullRequestDetail => ({
+  number: 130,
+  url: "https://github.com/o/l/pull/130",
+  title: "feat: something",
+  body: "",
+  author: "omartelo",
+  state: "OPEN",
+  isDraft: false,
+  mergeable: "MERGEABLE",
+  mergeStateStatus: "CLEAN",
+  reviewDecision: "",
+  reviewers: null,
+  baseRefName: "main",
+  headRefName: "quiet-willow",
+  changedFiles: 1,
+  isCrossRepository: false,
+  maintainerCanModify: false,
+  checks: { total: 0, passed: 0, failed: 0, pending: 0 },
+  checkRuns: null,
+  commits: null,
+  ...over,
+})
+
+const run = (name: string, state: CheckItem["state"] = "failed"): CheckItem => ({
+  name,
+  state,
+  description: "",
+  url: `https://github.com/o/l/runs/${name}`,
+  startedAt: "",
+  completedAt: "",
+})
+
+const red = (names: string[]): Partial<PullRequestDetail> => ({
+  checks: { total: names.length, passed: 0, failed: names.length, pending: 0 },
+  checkRuns: names.map((name) => run(name)),
+})
+
+describe("pullRequestHandoff", () => {
+  it("has nothing to hand over on a clean pull request", () => {
+    expect(pullRequestHandoff(detail())).toBeNull()
+  })
+
+  it("says nothing about a pull request that is over", () => {
+    expect(pullRequestHandoff(detail({ state: "MERGED", ...red(["build"]) }))).toBeNull()
+  })
+
+  it("names the conflict, from either field", () => {
+    for (const over of [{ mergeStateStatus: "DIRTY" }, { mergeable: "CONFLICTING" }]) {
+      const action = pullRequestHandoff(detail(over))
+      expect(action?.label).toBe("Resolve conflicts")
+      expect(action?.prompt).toContain("#130 (quiet-willow) has merge conflicts with main")
+    }
+  })
+
+  it("puts the conflict ahead of red CI", () => {
+    const action = pullRequestHandoff(detail({ mergeStateStatus: "DIRTY", ...red(["build"]) }))
+    expect(action?.label).toBe("Resolve conflicts")
+  })
+
+  it("names the failed checks and their runs", () => {
+    const action = pullRequestHandoff(detail(red(["build", "test"])))
+    expect(action?.label).toBe("Fix CI errors")
+    expect(action?.prompt).toContain("- build — https://github.com/o/l/runs/build")
+    expect(action?.prompt).toContain("- test — https://github.com/o/l/runs/test")
+    expect(action?.prompt).not.toContain("not listed")
+  })
+
+  it("leaves the passing checks out", () => {
+    const action = pullRequestHandoff(
+      detail({
+        checks: { total: 2, passed: 1, failed: 1, pending: 0 },
+        checkRuns: [run("build"), run("lint", "passed")],
+      }),
+    )
+    expect(action?.prompt).toContain("- build")
+    expect(action?.prompt).not.toContain("lint")
+  })
+
+  it("caps the list and says how many it left out", () => {
+    const names = Array.from({ length: 11 }, (_, i) => `job-${i}`)
+    const prompt = pullRequestHandoff(detail(red(names)))?.prompt ?? ""
+    expect(prompt).toContain("- job-7")
+    expect(prompt).not.toContain("- job-8")
+    expect(prompt).toContain("…and 3 more failing checks not listed.")
+  })
+
+  it("falls back to the count when gh reported no runs", () => {
+    const action = pullRequestHandoff(
+      detail({ checks: { total: 3, passed: 0, failed: 1, pending: 2 }, checkRuns: null }),
+    )
+    expect(action?.prompt).toContain("1 check is red")
+  })
+
+  it("wraps the prompt as one paste, so a newline is not a send", () => {
+    const prompt = pullRequestHandoff(detail(red(["build"])))?.prompt ?? ""
+    expect(prompt.startsWith("\x1b[200~")).toBe(true)
+    expect(prompt.endsWith("\x1b[201~")).toBe(true)
+  })
+})

--- a/frontend/src/lib/pulls/pr-handoff.ts
+++ b/frontend/src/lib/pulls/pr-handoff.ts
@@ -1,0 +1,61 @@
+import type { PullRequestDetail } from "@/lib/api-types"
+import { bracketedPaste } from "@/lib/terminal/bracketed-paste"
+
+// How many failed checks the prompt names before it stops and says how many it
+// left out. A rollup can carry dozens of red jobs on a matrix build, and the
+// prompt is the agent's starting point, not the CI page's index — a hundred
+// URLs pasted into a terminal is the log by another route.
+const NAMED_CHECKS = 8
+
+/** One thing wrong with a pull request, and the prompt that hands it over. */
+export interface PullRequestHandoff {
+  label: string
+  /** Ready to write into a PTY: the prompt as one bracketed paste. */
+  prompt: string
+}
+
+// pullRequestHandoff names the pull request's current problem, worst first: a
+// conflict before red CI, because a branch that will not merge is the thing to
+// fix and its checks are about to be re-run over the resolution anyway. Null
+// when nothing is wrong — the Merge button already owns that state.
+//
+// It only writes a prompt. Nothing here runs, re-runs or watches anything: what
+// the agent does with it, and whether it was worth asking, stays the reader's.
+export function pullRequestHandoff(detail: PullRequestDetail): PullRequestHandoff | null {
+  if (detail.state !== "OPEN") {
+    return null
+  }
+  // Both fields, for the reason mergeBlockedReason reads both: mergeable is
+  // what an older gh reports, mergeStateStatus what a current one does.
+  if (detail.mergeStateStatus === "DIRTY" || detail.mergeable === "CONFLICTING") {
+    return {
+      label: "Resolve conflicts",
+      prompt: bracketedPaste(
+        `Pull request #${detail.number} (${detail.headRefName}) has merge conflicts with ${detail.baseRefName}. Resolve them.`,
+      ),
+    }
+  }
+  if (detail.checks.failed > 0) {
+    return { label: "Fix CI errors", prompt: bracketedPaste(checksPrompt(detail)) }
+  }
+  return null
+}
+
+function checksPrompt(detail: PullRequestDetail): string {
+  const head = `CI is failing on pull request #${detail.number} (${detail.headRefName}).`
+  const failed = (detail.checkRuns ?? []).filter((run) => run.state === "failed")
+  // gh reports the counts and the runs from the same rollup, but the runs are
+  // the half that can come back empty — a status context with no name, an older
+  // gh. The count is what the header showed, so it is what the prompt owes.
+  if (failed.length === 0) {
+    return `${head} ${detail.checks.failed} ${detail.checks.failed === 1 ? "check is" : "checks are"} red; find out which and fix them.`
+  }
+  const named = failed.slice(0, NAMED_CHECKS)
+  const lines = named.map((run) => `- ${run.name}${run.url ? ` — ${run.url}` : ""}`)
+  const omitted = failed.length - named.length
+  const tail =
+    omitted > 0
+      ? `\n\n…and ${omitted} more failing ${omitted === 1 ? "check" : "checks"} not listed.`
+      : ""
+  return `${head} Fix these checks:\n\n${lines.join("\n")}${tail}`
+}


### PR DESCRIPTION
## What

One action in the pull request header for whatever is actually in the way, chosen by priority from state the screen already fetches:

1. **Resolve conflicts** — `mergeStateStatus DIRTY` or `mergeable CONFLICTING`
2. **Fix CI errors** — `checks.failed > 0`; the prompt names each failed check and where to read its run
3. nothing wrong — nothing is drawn; that state is the Merge button's

It writes a prompt at the agent's own prompt (`onInject`, bracketed paste, unsent) and stops there. No poll, no re-dispatch, no automation — the Enter is the reader's, and lich never runs the loop.

## Shape

- `frontend/src/lib/pulls/pr-handoff.ts` — `pullRequestHandoff(detail)`, the priority and the two prompts. Pure; tested.
- `PullRequestView.tsx` — one ghost button beside "Open in Session", disabled with the same sentence when `session.blocked` (a fork that refuses maintainer edits), and a toast when no session took the write (CommentBatch's shape).

The CI prompt is bounded: the first 8 failed checks by name and URL, then "…and N more failing checks not listed." A matrix build must not paste the CI index into a terminal. Where gh reports counts but no runs, it falls back to the count.

## Deliberately not here

- **No "Fix PR comments" action.** Review comments are conversation, not a work order; inferring they are actionable is the mistake this borrows *from*. The per-thread batch inject already covers the case where the reader decides.
- **No chevron menu behind the first action.** Only two actions exist and one strictly precedes the other: while a branch conflicts, its checks are about to be re-run over the resolution, so the second item would be a click out of order. The next problem surfaces on its own once the first is gone.

## Test plan

- [x] `pr-handoff.test.ts` — priority, both conflict fields, the cap and its remainder, passing checks excluded, the no-runs fallback, the paste wrapper
- [x] `gofmt -l .` / `go vet ./...` clean, `go test ./...` green (1970)
- [x] `biome check` clean (only the standing a11y backlog), `vitest run` green (1217), `tsc && vite build` green
- [ ] By hand in `task dev`: a conflicting PR, a PR with red checks, a clean PR, and a click with no session open

The `CHANGELOG.md` entry lands here; two sibling worktrees are writing there too, so expect a conflict on merge — rebase, not broken CI.