### PR TITLE
feat: confirm before loosening a standing safety setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Loosening a safety setting asks once; tightening one never does.** Both
+  standing safety ladders in Settings — how far a provider runs without asking,
+  and which of its sessions run confined — were written the moment you clicked a
+  rung, in either direction. Climbing to a riskier rung now confirms first, and
+  says what that rung actually leaves running on your machine. Coming back down
+  is written straight through, as is clicking the rung you are already on:
+  turning an automation off must never be the harder direction.
 - **A project tab comes back to the screen you left it on.** Stepping over to
   another project and back always dropped you onto the first project's
   terminals, whatever you had been reading there: its Settings, the pull request

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -1,11 +1,13 @@
 import { useState } from "react"
 import {
+  climbsToRiskier,
   footerReadout,
   footerReadoutPair,
   skipLevel,
   skipLevelPair,
   skipPermissionFlags,
   skipPermissionsKey,
+  SKIP_RISK_ORDER,
   type FooterReadout,
   type SkipLevel,
 } from "@/lib/providers-store"
@@ -13,8 +15,10 @@ import { useSettings } from "@/providers/settings"
 import { setCostReadout } from "@/lib/cost-readout-store"
 import { useCostReadout } from "@/lib/use-cost-readout"
 import { useStoredFlag } from "@/lib/use-stored-setting"
+import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { ConfirmDialog } from "@/components/ConfirmDialog"
 import { PlanUsageSetting } from "./PlanUsageSetting"
 import { ProviderBinary } from "./ProviderBinary"
 import { SettingBlock } from "./SettingBlock"
@@ -90,9 +94,13 @@ export function ProviderBinSettings({
     skipPermissionsKey(providerId, true),
     GLOBAL_SCOPE,
   )
+  // The rung a click asked for and the write is waiting on. Null while nothing
+  // is pending, which is every click that does not climb.
+  const [pendingLevel, setPendingLevel] = useState<SkipLevel | null>(null)
   const skipFlag = skipPermissionFlags[providerId]
   const level = skipLevel(skipHere, skipInWorktrees)
   const consequence = SKIP_LEVELS.find((rung) => rung.level === level)?.consequence ?? ""
+  const pendingRung = SKIP_LEVELS.find((rung) => rung.level === pendingLevel)
   const readout = footerReadout(showContextUsage, showCost)
   const availableReadouts =
     providerId === "codex"
@@ -119,6 +127,17 @@ export function ProviderBinSettings({
     const pair = skipLevelPair(next)
     setSkipHere(pair.here)
     setSkipInWorktrees(pair.worktrees)
+  }
+
+  // Climbing hands the agent more of the machine and is confirmed once; coming
+  // back down is written straight through, because taking the automation away
+  // must never be the harder direction.
+  const chooseLevel = (next: SkipLevel) => {
+    if (climbsToRiskier(SKIP_RISK_ORDER, level, next)) {
+      setPendingLevel(next)
+      return
+    }
+    setLevel(next)
   }
 
   const persistBudget = (value: string) => {
@@ -200,7 +219,7 @@ export function ProviderBinSettings({
             value={[level]}
             // An empty array is the pressed rung being pressed again. There is
             // no fourth answer to fall back to, so it stays where it was.
-            onValueChange={(next) => next[0] && setLevel(next[0] as SkipLevel)}
+            onValueChange={(next) => next[0] && chooseLevel(next[0] as SkipLevel)}
             spacing={1}
             aria-label={`How far ${providerName} runs without asking`}
             className="border border-border p-[3px]"
@@ -212,6 +231,25 @@ export function ProviderBinSettings({
             ))}
           </ToggleGroup>
           <p className="mt-2 text-xs text-muted-foreground">{consequence}</p>
+
+          <ConfirmDialog
+            open={pendingRung !== undefined}
+            onCancel={() => setPendingLevel(null)}
+            title={`Skip permission prompts: ${pendingRung?.label.toLowerCase()}`}
+            description={`${providerName} will edit files, run commands and install things unconfirmed, spawned with ${skipFlag}. ${pendingRung?.consequence}`}
+          >
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (pendingRung) {
+                  setLevel(pendingRung.level)
+                }
+                setPendingLevel(null)
+              }}
+            >
+              Skip prompts
+            </Button>
+          </ConfirmDialog>
         </SettingBlock>
       )}
     </>

--- a/frontend/src/components/settings/SandboxSettings.tsx
+++ b/frontend/src/components/settings/SandboxSettings.tsx
@@ -1,10 +1,13 @@
+import { useState } from "react"
 import { System } from "@/lib/rpc"
 import {
+  climbsToRiskier,
   enabledProviders,
   sandboxKey,
   sandboxLevel,
   useProviders,
   GH_TOKEN_KEY,
+  SANDBOX_RISK_ORDER,
   SSH_AGENT_KEY,
   type SandboxLevel,
 } from "@/lib/providers-store"
@@ -15,7 +18,9 @@ import { splitAccount } from "@/lib/gh-account"
 import { useRemoteResource } from "@/lib/use-remote-resource"
 import { useStoredSetting } from "@/lib/use-stored-setting"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
+import { Button } from "@/components/ui/button"
 import { Switch } from "@/components/ui/switch"
+import { ConfirmDialog } from "@/components/ConfirmDialog"
 import { SettingBlock } from "./SettingBlock"
 
 const GLOBAL_SCOPE = ""
@@ -36,6 +41,16 @@ const RUNGS: { level: SandboxLevel; label: string }[] = [
   { level: "worktrees", label: "Worktrees" },
   { level: "everywhere", label: "Everywhere" },
 ]
+
+// What each rung leaves running on the machine, said only when it is being
+// climbed to. "Everywhere" has no line because it is the safest rung: it is
+// never the answer to "are you sure", so a caption for it would be copy nobody
+// ever reads.
+const EXPOSES: Partial<Record<SandboxLevel, string>> = {
+  off: "Every session runs on the machine.",
+  ask: "Nothing is confined unless you tick the box in the New worktree dialog.",
+  worktrees: "Sessions in the project directory run on the machine.",
+}
 
 // A module-level constant, as every array `empty` has to be: a fresh one per
 // render would notify subscribers on every failed read.
@@ -176,13 +191,28 @@ function Rung({
   scope: string
 }) {
   const [stored, setStored] = useStoredSetting(sandboxKey(providerId), scope, "off")
+  // The rung a click asked for and the write is waiting on. Null while nothing
+  // is pending, which is every click that does not loosen the confinement.
+  const [pending, setPending] = useState<SandboxLevel | null>(null)
+  const level = sandboxLevel(stored)
+
+  // Loosening confinement is confirmed once; tightening it is written straight
+  // through, because putting a session back inside the sandbox must never be
+  // the harder direction.
+  const choose = (next: SandboxLevel) => {
+    if (climbsToRiskier(SANDBOX_RISK_ORDER, level, next)) {
+      setPending(next)
+      return
+    }
+    setStored(next)
+  }
 
   return (
     <div className="flex items-center justify-between gap-4 border-t border-border py-2.5 first:border-t-0 first:pt-0">
       <span className="text-sm font-medium text-foreground">{providerName}</span>
       <ToggleGroup
-        value={[sandboxLevel(stored)]}
-        onValueChange={(next) => next[0] && setStored(next[0])}
+        value={[level]}
+        onValueChange={(next) => next[0] && choose(next[0] as SandboxLevel)}
         spacing={1}
         aria-label={`Which ${providerName} sessions run confined`}
         className="shrink-0 border border-border p-[3px]"
@@ -193,6 +223,25 @@ function Rung({
           </ToggleGroupItem>
         ))}
       </ToggleGroup>
+
+      <ConfirmDialog
+        open={pending !== null}
+        onCancel={() => setPending(null)}
+        title={`Confine fewer ${providerName} sessions`}
+        description={`${RUNGS.find((rung) => rung.level === pending)?.label} — ${pending ? EXPOSES[pending] : ""}`}
+      >
+        <Button
+          variant="destructive"
+          onClick={() => {
+            if (pending) {
+              setStored(pending)
+            }
+            setPending(null)
+          }}
+        >
+          Leave unconfined
+        </Button>
+      </ConfirmDialog>
     </div>
   )
 }

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -3,6 +3,7 @@ import type { DetectedProvider } from "./api-types"
 import {
   binKey,
   binOffKey,
+  climbsToRiskier,
   createProvidersStore,
   enabledKey,
   enabledProviders,
@@ -18,6 +19,8 @@ import {
   skipLevelPair,
   skipPermissionFlags,
   skipPermissionsKey,
+  SANDBOX_RISK_ORDER,
+  SKIP_RISK_ORDER,
   type ProviderState,
   type SandboxLevel,
 } from "./providers-store"
@@ -92,6 +95,43 @@ describe("the skip-permissions ladder", () => {
     for (const level of ["never", "worktrees", "everywhere"] as const) {
       const pair = skipLevelPair(level)
       expect(skipLevel(pair.here, pair.worktrees)).toBe(level)
+    }
+  })
+})
+
+describe("the confirmation gate on a standing safety setting", () => {
+  it("asks on the way up the skip ladder", () => {
+    expect(climbsToRiskier(SKIP_RISK_ORDER, "never", "worktrees")).toBe(true)
+    expect(climbsToRiskier(SKIP_RISK_ORDER, "never", "everywhere")).toBe(true)
+    expect(climbsToRiskier(SKIP_RISK_ORDER, "worktrees", "everywhere")).toBe(true)
+  })
+
+  // The whole point of the gate: taking the automation away is never the harder
+  // direction, so every step down writes straight through.
+  it("never asks on the way down the skip ladder", () => {
+    expect(climbsToRiskier(SKIP_RISK_ORDER, "everywhere", "worktrees")).toBe(false)
+    expect(climbsToRiskier(SKIP_RISK_ORDER, "everywhere", "never")).toBe(false)
+    expect(climbsToRiskier(SKIP_RISK_ORDER, "worktrees", "never")).toBe(false)
+  })
+
+  // Less confinement is more exposure, so the sandbox ladder is read backwards
+  // from the order it is drawn in: "off" is its riskiest rung, not its first.
+  it("reads the sandbox ladder safest first", () => {
+    expect([...SANDBOX_RISK_ORDER]).toEqual(["everywhere", "worktrees", "ask", "off"])
+    expect(climbsToRiskier(SANDBOX_RISK_ORDER, "everywhere", "off")).toBe(true)
+    expect(climbsToRiskier(SANDBOX_RISK_ORDER, "worktrees", "ask")).toBe(true)
+    expect(climbsToRiskier(SANDBOX_RISK_ORDER, "off", "everywhere")).toBe(false)
+    expect(climbsToRiskier(SANDBOX_RISK_ORDER, "ask", "worktrees")).toBe(false)
+  })
+
+  // Pressing the rung already chosen is not a move, and a dialog about a write
+  // that changes nothing is the cost the gate exists to avoid paying twice.
+  it("does not ask for the rung already chosen", () => {
+    for (const level of SKIP_RISK_ORDER) {
+      expect(climbsToRiskier(SKIP_RISK_ORDER, level, level)).toBe(false)
+    }
+    for (const level of SANDBOX_RISK_ORDER) {
+      expect(climbsToRiskier(SANDBOX_RISK_ORDER, level, level)).toBe(false)
     }
   })
 })

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -84,6 +84,23 @@ export function skipLevelPair(level: SkipLevel): { here: boolean; worktrees: boo
   return { here: level === "everywhere", worktrees: level !== "never" }
 }
 
+// The skip ladder read as exposure, safest first — which is the order it is
+// already declared in. Both standing safety settings are gated against their own
+// order by climbsToRiskier below.
+export const SKIP_RISK_ORDER: readonly SkipLevel[] = ["never", "worktrees", "everywhere"]
+
+// climbsToRiskier answers whether a click moves toward more exposure, the only
+// direction a standing safety setting asks about: turning an automation off must
+// never be the harder direction. Re-clicking the chosen rung is not a move and
+// answers false, so nothing is confirmed that changes nothing.
+export function climbsToRiskier<T extends string>(
+  order: readonly T[],
+  current: T,
+  next: T,
+): boolean {
+  return order.indexOf(next) > order.indexOf(current)
+}
+
 // sandboxKey holds which sessions of a provider run confined (mirrors
 // store.sandboxKey in Go, which is what the spawn reads). Scoped like binKey —
 // a project value wins over the global one — because the checkout full of
@@ -120,6 +137,12 @@ const SANDBOX_LEVELS: readonly SandboxLevel[] = ["off", "ask", "worktrees", "eve
 export function sandboxLevel(value: string): SandboxLevel {
   return SANDBOX_LEVELS.find((level) => level === value) ?? "off"
 }
+
+// SANDBOX_LEVELS read the other way round: exposure is the inverse of
+// confinement, so the safest rung is "everywhere" and the riskiest is "off".
+// Derived rather than written out twice — a rung added to the ladder is a rung
+// the gate already knows the risk of.
+export const SANDBOX_RISK_ORDER: readonly SandboxLevel[] = [...SANDBOX_LEVELS].reverse()
 
 // sandboxDefaultFor is what the new-session dialog arrives showing: the rung
 // applied to the checkout the session will start in. It is the frontend's copy


### PR DESCRIPTION
Climbing to a riskier rung on a standing safety setting confirms once; stepping back to a safer one never does. Borrowed from [Lody](https://github.com/LodyAI/Lody), whose rule is *stopping an automation must never be the harder direction*.

Two ladders in Settings are standing modes that survive a restart, both already ordered by risk, and both were written straight through on click in either direction:

- **Skip permission prompts** (`Never` / `Worktrees only` / `Everywhere`)
- **Which sessions run confined** (`Everywhere` / `Worktrees` / `Ask` / `Off` — exposure is the inverse of confinement, so `Off` is its riskiest rung)

Now a click that moves toward more exposure holds the write and confirms first, naming what the chosen rung actually allows. A click toward less exposure writes immediately. A click on the rung already selected is not a move and never prompts — it cannot even reach the gate, since the toggle group answers an empty array there, and `climbsToRiskier` answers `false` for it anyway.

The segmented controls are untouched: this is a gate on the write, not a new shape.

### Copy

The skip dialog reuses the `consequence` line already written for each rung in `SKIP_LEVELS`. The sandbox ladder had no per-rung copy — labels only, deliberately — so `EXPOSES` adds one line per climbable rung, used in the dialog only; the control still shows labels alone, and the safest rung has no line because it is never the answer to "are you sure".

### Test plan

- [x] `climbsToRiskier` covered on both ladders in `providers-store.test.ts`: every step up asks, every step down does not, the sandbox order is read safest-first, and the rung already chosen never asks.
- [x] `gofmt -l .` and `go vet ./...` clean; `go test ./...` green.
- [x] `pnpm check` clean, `pnpm test` green (1212), `pnpm build` succeeds.
- [ ] The dialog-open render path is node-untestable here (base-ui `Dialog`); the composition is the shipped `ConfirmDialog` + destructive `Button` already used by `DiscardDialog`.