### PR TITLE
feat: expand the unchanged lines a diff left out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   eight, and how many were left out). It is written, never sent: the Enter is
   yours, and lich neither re-runs the checks nor asks a second time. Nothing is
   drawn when nothing is wrong — that state is the Merge button's.
+- **Read the lines a diff left out, without leaving the diff.** git prints three
+  lines of context either side of a change, so judging one usually meant opening
+  the file somewhere else. Every gap between two hunks — and the run above the
+  first one — now carries a row saying how many lines are hidden there, and one
+  click pulls them in where they belong, numbered and highlighted like the rest.
+  Nothing is fetched until you ask for it, one gap at a time, and the diff itself
+  is never cropped: the hunks stay whole, so nothing can be hidden by what you
+  chose to open. It works on the review dock's working tree and last turn, and on
+  a pull request's Files changed — including a pull request whose branch this
+  clone has never fetched.
 
 ### Changed
 

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -42,6 +42,19 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   fires there. And an errand the relay delivered survives an interrupt on purpose: stopping a turn is not
   answering the request, so the sender keeps waiting for the target's next turn rather than being told the work
   is over.
+- **A diff's context expander reads GitHub, one round-trip per gap** (`internal/project/filelines.go`):
+  `FileLines` tries the local object first and asks the contents API when the clone does not have it, which
+  on the Pulls screen is the normal case — the branch under review is usually not one this clone ever
+  fetched. The call site is a promise from an RPC, so nothing there says a click costs a network round-trip
+  and a rate-limit unit against the project's gh token. Anything that multiplies the clicks multiplies
+  that: prefetching a file's gaps on mount, incremental ±20 stepping, or an "expand everything" control
+  would each turn one reader's file into dozens of calls. The per-request line cap is the only bound, and
+  a gap wider than it is several calls already. Two things follow from the same shape. The expander needs
+  the revision the diff's new side stands at, so a source that cannot name one has no expander at all
+  rather than a wrong one — a last-turn record from before `LastTurn.After` existed, or a pull request
+  whose detail carries no commits. And there is no expanding *past the last hunk*: a unified diff carries
+  no file length, so nothing here knows whether anything follows it, and an affordance drawn there would
+  be a no-op on every file whose change reaches the end.
 - **The Review panel's "Last turn" is a window of wall-clock time, and it lives in memory**
   (`internal/terminal/turnsnap.go`, `internal/project/turnsnap.go`): the panel brackets a turn with two
   `git write-tree` snapshots taken against an index of lich's own, so what it shows is everything that

--- a/frontend/src/components/diff/FileDiff.tsx
+++ b/frontend/src/components/diff/FileDiff.tsx
@@ -1,20 +1,25 @@
 import { ChevronDown, ChevronRight, MessageSquare, Paperclip, Undo2 } from "lucide-react"
-import { useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { createPortal } from "react-dom"
+import { toast } from "sonner"
 import { IconAction } from "@/components/common/IconAction"
 import { DiffStat } from "@/components/DiffStat"
 import { Checkbox } from "@/components/ui/checkbox"
+import { gapExpanders } from "@/lib/codemirror"
 import { threadSlots, type SlotElements, type ThreadSlot } from "@/lib/codemirror-threads"
 import {
   buildFileDoc,
+  contextLines,
   formatLineRef,
   newLineRange,
   type DiffFile,
+  type DiffGap,
+  type Expansions,
   type FileDoc,
 } from "@/lib/git/diff"
 import { languageAbbr, splitPath } from "@/lib/git/lang-badge"
 import { COMPOSER_KEY, isAnchored, reviewSlots } from "@/lib/pulls/review-slots"
-import { cn } from "@/lib/utils"
+import { cn, errorText } from "@/lib/utils"
 import type { DiffBulk } from "./diff-bulk"
 import { InjectMenu } from "./InjectMenu"
 import { useDiffEditor } from "./useDiffEditor"
@@ -32,6 +37,9 @@ const LINE_HEIGHT_PX = 17
 // How far outside the viewport a file's editor is built, so scrolling meets a
 // rendered diff rather than a gap.
 const MOUNT_MARGIN = "600px 0px"
+
+// One shared empty map, so a file nobody expanded holds no state of its own.
+const NO_EXPANSIONS: Expansions = new Map()
 
 interface FileDiffProps {
   file: DiffFile
@@ -54,6 +62,10 @@ interface FileDiffProps {
    * waiting to be sent, and what a new comment does. Absent for the working
    * diff, which has no pull request behind it. */
   review?: DiffReview
+  /** Read the file's unchanged lines around the hunks, from..to inclusive and
+   * numbered against the new side. Absent = no expanders, for a panel whose
+   * diff has no revision to read them from. */
+  onExpand?: (path: string, from: number, to: number) => Promise<string[] | null>
 }
 
 // The card must not clip overflow — a clipping ancestor would break the
@@ -67,9 +79,21 @@ export function FileDiff({
   viewed,
   onViewed,
   review,
+  onExpand,
 }: FileDiffProps) {
-  const doc = useMemo(() => buildFileDoc(file), [file])
-  const openByDefault = !file.binary && doc.lineMeta.length <= LARGE_FILE_LINES
+  // What the reader has pulled into this file's gaps. Held here, above the
+  // editor, because the document is built from it: an expanded gap is context
+  // lines in the doc, never a second document cropped to a range.
+  const [expansions, setExpansions] = useState<Expansions>(NO_EXPANSIONS)
+  // The diff as git printed it, and the diff as it is being read. They are the
+  // same object until something is expanded, so a file nobody expanded pays
+  // nothing, and the identity check below stays on the printed one.
+  const printed = useMemo(() => buildFileDoc(file), [file])
+  const doc = useMemo(
+    () => (expansions.size === 0 ? printed : buildFileDoc(file, expansions)),
+    [file, printed, expansions],
+  )
+  const openByDefault = !file.binary && printed.lineMeta.length <= LARGE_FILE_LINES
   const [expanded, setExpanded] = useState(openByDefault)
   // The card outlives its content: the panel keys files by path, so a refetch
   // that rewrites this file reuses this component. Without the re-sync, a file
@@ -80,13 +104,16 @@ export function FileDiff({
   // Keyed on the text and not on the doc object: every refetch builds a fresh
   // one, so a reference check would reopen every hand-folded file on each
   // window focus. Only the content actually changing counts as a new file.
-  const lastText = useRef(doc.text)
+  const lastText = useRef(printed.text)
   useEffect(() => {
-    if (lastText.current !== doc.text) {
-      lastText.current = doc.text
+    if (lastText.current !== printed.text) {
+      lastText.current = printed.text
       setExpanded(openByDefault)
+      // The gaps moved with the content, and what was pulled into the old ones
+      // is numbered against a file that no longer exists.
+      setExpansions(NO_EXPANSIONS)
     }
-  }, [doc.text, openByDefault])
+  }, [printed.text, openByDefault])
   // The nonce guard skips the initial mount so each file keeps its own
   // large-file default until the user actually triggers a bulk action.
   const lastNonce = useRef(bulk?.nonce)
@@ -96,6 +123,41 @@ export function FileDiff({
       setExpanded(bulk.open)
     }
   }, [bulk])
+  // The prop is read through a ref so the handler can be stable: it rides the
+  // editor's identity through gapExpanders, and a new one per render would
+  // rebuild every expanded file's view on every render of the panel.
+  const latestExpand = useRef(onExpand)
+  useEffect(() => {
+    latestExpand.current = onExpand
+  })
+  const expandGap = useCallback(
+    async (gap: DiffGap): Promise<void> => {
+      const read = latestExpand.current
+      if (!read) {
+        return
+      }
+      try {
+        const texts = await read(file.newPath, gap.from, gap.to)
+        if (!texts || texts.length === 0) {
+          return
+        }
+        setExpansions((held) => {
+          const next = new Map(held)
+          // Appended, never replaced: a gap wider than the backend's cap comes
+          // in several answers, each starting where the last one stopped.
+          next.set(gap.key, [
+            ...(held.get(gap.key) ?? []),
+            ...contextLines(texts, gap.from, gap.oldFrom),
+          ])
+          return next
+        })
+      } catch (error) {
+        toast.error(`Couldn't read ${file.newPath}`, { description: errorText(error) })
+      }
+    },
+    [file.newPath],
+  )
+
   const Chevron = expanded ? ChevronDown : ChevronRight
   const badge = languageAbbr(file.newPath)
   const { dir, base } = splitPath(file.newPath)
@@ -186,6 +248,7 @@ export function FileDiff({
             onInject={onInject}
             onSessionComment={onSessionComment}
             review={review}
+            onExpandGap={onExpand && expandGap}
           />
         ))}
     </section>
@@ -198,6 +261,8 @@ interface DiffBodyProps {
   onInject: (text: string) => void
   onSessionComment?: (path: string, lines: string, text: string) => void
   review?: DiffReview
+  /** Pull one gap's lines in. Absent = the diff draws no expanders. */
+  onExpandGap?: (gap: DiffGap) => void
 }
 
 // A panel holds one CodeMirror view per expanded file, and a wide diff (a PR
@@ -205,7 +270,14 @@ interface DiffBodyProps {
 // page. LazyDiffBody defers each one until its card comes near the viewport;
 // once built, the editor stays, so scrolling back keeps its selection and
 // highlighting. Collapsing the file still destroys it.
-function LazyDiffBody({ doc, path, onInject, onSessionComment, review }: DiffBodyProps) {
+function LazyDiffBody({
+  doc,
+  path,
+  onInject,
+  onSessionComment,
+  review,
+  onExpandGap,
+}: DiffBodyProps) {
   const placeholder = useRef<HTMLDivElement>(null)
   const [mounted, setMounted] = useState(false)
 
@@ -238,6 +310,7 @@ function LazyDiffBody({ doc, path, onInject, onSessionComment, review }: DiffBod
         onInject={onInject}
         onSessionComment={onSessionComment}
         review={review}
+        onExpandGap={onExpandGap}
       />
     )
   }
@@ -254,7 +327,7 @@ const NO_SLOTS: SlotElements = new Map()
 // A diff's document is not the file: the selection lands on doc lines, which
 // newLineRange maps back to the line numbers an inject writes, a session comment
 // anchors to, and GitHub files a review comment against.
-function DiffBody({ doc, path, onInject, onSessionComment, review }: DiffBodyProps) {
+function DiffBody({ doc, path, onInject, onSessionComment, review, onExpandGap }: DiffBodyProps) {
   // One slot extension per view. It is memoised because it *is* part of the
   // view's identity: a new one would rebuild the editor on every render.
   const [elements, setElements] = useState<SlotElements>(NO_SLOTS)
@@ -262,11 +335,16 @@ function DiffBody({ doc, path, onInject, onSessionComment, review }: DiffBodyPro
   // The gaps exist wherever a comment can be written, which on the dock's
   // working diff is the session's alone.
   const gapped = Boolean(review || onSessionComment)
-  const { containerRef, getSelectedDocLines, view } = useDiffEditor(
-    doc,
-    path,
-    gapped ? slots.extension : undefined,
-  )
+  // Both layers ride the view's identity, so they are memoised together and the
+  // editor is rebuilt only when the document behind it actually moved.
+  const extra = useMemo(() => {
+    const layers = gapped ? [slots.extension] : []
+    if (onExpandGap) {
+      layers.push(gapExpanders(doc.lineMeta, doc.gaps, onExpandGap))
+    }
+    return layers.length > 0 ? layers : undefined
+  }, [gapped, slots, doc, onExpandGap])
+  const { containerRef, getSelectedDocLines, view } = useDiffEditor(doc, path, extra)
   // Both halves of the resolved selection: the file lines a comment is filed
   // against, and the doc line a composer hangs under. They differ — a selection
   // ending on a deleted line has a doc line but no new-file one.

--- a/frontend/src/components/diff/ReviewPanel.tsx
+++ b/frontend/src/components/diff/ReviewPanel.tsx
@@ -70,6 +70,10 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
   const [failed, setFailed] = useState(false)
   const [turnState, setTurnState] = useState<LastTurn["state"] | null>(null)
   const [endedAt, setEndedAt] = useState<number | null>(null)
+  // The revision the shown diff's new side stands at, which is what the
+  // expander reads unchanged lines from: "" is the working tree, and a turn
+  // carries the snapshot tree it ended on.
+  const [ref, setRef] = useState("")
   const [pendingDiscard, setPendingDiscard] = useState<DiffFile | null>(null)
 
   // The text behind what is on screen, and the id of the newest read — a reply
@@ -100,6 +104,7 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
       setFailed(false)
       setTurnState(turn.state)
       setEndedAt(turn.endedAt ?? null)
+      setRef(source === "turn" ? (turn.after ?? "") : "")
       const text = turn.diff ?? ""
       if (text === lastText.current) {
         return
@@ -113,6 +118,7 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
       lastText.current = null
       setFiles([])
       setFailed(true)
+      setRef("")
     }
   }, [path, sessionId, source])
 
@@ -125,6 +131,7 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
     setFiles(null)
     setTurnState(null)
     setEndedAt(null)
+    setRef("")
   }, [source, path, sessionId])
 
   // Two signals feeding one read: the status counts move the instant a file is
@@ -148,6 +155,15 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
     const timer = setInterval(() => void refresh(), DIFF_POLL_MS)
     return () => clearInterval(timer)
   }, [refresh, source, sessionId, status?.files, status?.added, status?.deleted])
+
+  // A turn's diff is against a snapshot, so it is expandable only once that
+  // snapshot's oid has arrived — reading the working tree instead would show
+  // lines the diff was never computed against, and say nothing about it.
+  const expandable = source === "worktree" || ref !== ""
+  const expand = useCallback(
+    (rel: string, from: number, to: number) => ProjectService.FileLines(path, rel, ref, from, to),
+    [path, ref],
+  )
 
   // Reverting a rename touches both paths (new removed, old restored); the
   // panel refreshes immediately instead of waiting for the next poll tick.
@@ -182,6 +198,7 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
           // working tree's own view. Offered on a finished turn it would read as
           // an undo for that turn, which is not what it does.
           onDiscard={source === "worktree" ? setPendingDiscard : undefined}
+          onExpand={expandable ? expand : undefined}
           bulk={bulk}
         />
       </div>
@@ -265,6 +282,8 @@ interface PanelBodyProps {
   onSessionComment: (path: string, lines: string, text: string) => void
   /** Absent when discarding does not belong to this source. */
   onDiscard?: (file: DiffFile) => void
+  /** Read a file's unchanged lines at the revision this source shows. */
+  onExpand?: (path: string, from: number, to: number) => Promise<string[] | null>
   bulk: DiffBulk
 }
 
@@ -276,6 +295,7 @@ function PanelBody({
   onInject,
   onSessionComment,
   onDiscard,
+  onExpand,
   bulk,
 }: PanelBodyProps) {
   if (failed) {
@@ -323,6 +343,7 @@ function PanelBody({
           onInject={onInject}
           onSessionComment={onSessionComment}
           onDiscard={onDiscard && (() => onDiscard(file))}
+          onExpand={onExpand}
           bulk={bulk}
         />
       ))}

--- a/frontend/src/components/pulls/PullRequestView.tsx
+++ b/frontend/src/components/pulls/PullRequestView.tsx
@@ -462,6 +462,9 @@ export function PullRequestView({
           <PullsFiles
             path={path}
             number={detail.number}
+            // The last commit is the head: gh lists them oldest first, and the
+            // detail already carries them, so the expander costs no extra call.
+            headOid={detail.commits?.[detail.commits.length - 1]?.oid ?? ""}
             head={head}
             pullRequest={detail.url}
             onInject={onInject}

--- a/frontend/src/components/pulls/PullsFiles.tsx
+++ b/frontend/src/components/pulls/PullsFiles.tsx
@@ -1,5 +1,5 @@
 import { PanelLeftClose, PanelLeftOpen } from "lucide-react"
-import { useMemo, useRef, useSyncExternalStore } from "react"
+import { useCallback, useMemo, useRef, useSyncExternalStore } from "react"
 import { IconAction } from "@/components/common/IconAction"
 import { ResizeHandle } from "@/components/common/ResizeHandle"
 import { Notice } from "@/components/common/Notice"
@@ -32,6 +32,7 @@ import {
 import { useActiveFile } from "@/lib/pulls/use-active-file"
 import { usePullRequestDiff } from "@/lib/pulls/use-pull-request-diff"
 import { addReviewComment } from "@/lib/review-comments"
+import { ProjectService } from "@/lib/rpc"
 import { usePanelVisible } from "@/lib/use-panel-visible"
 import { usePanelWidth } from "@/lib/use-panel-width"
 
@@ -100,6 +101,10 @@ interface PullsFilesProps {
   path: string
   /** Which pull request's diff to fetch. */
   number: number
+  /** The commit the diff's new side stands at — the PR's head, which the
+   * expander reads unchanged lines from. "" while the detail has no commit to
+   * name, and then the diff shows what git printed and nothing more. */
+  headOid: string
   /** The checkout's HEAD; a new commit refetches the diff. */
   head: string
   /** Identity of the pull request being reviewed (its URL) — what the Viewed
@@ -122,6 +127,7 @@ interface PullsFilesProps {
 export function PullsFiles({
   path,
   number,
+  headOid,
   head,
   pullRequest,
   onInject,
@@ -129,6 +135,14 @@ export function PullsFiles({
   actions,
 }: PullsFilesProps) {
   const { files, error } = usePullRequestDiff(path, head, number)
+  // Read against the PR's head and never against the checkout: the branch under
+  // review is usually not the one on disk, and often not in this clone at all
+  // (project.FileLines then asks GitHub for it).
+  const expand = useCallback(
+    (rel: string, from: number, to: number) =>
+      ProjectService.FileLines(path, rel, headOid, from, to),
+    [path, headOid],
+  )
   const rows = useRef<Map<string, HTMLElement>>(new Map())
   const [active, selectFile] = useActiveFile(pullRequest)
   const review = useSyncExternalStore(subscribePendingReview, () => pendingReview(pullRequest))
@@ -262,6 +276,7 @@ export function PullsFiles({
                     setViewed(pullRequest, file.newPath, fingerprints.get(file.newPath) ?? "", next)
                   }
                   review={reviews.get(file.newPath)}
+                  onExpand={headOid ? expand : undefined}
                 />
               </div>
             ))}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -185,6 +185,29 @@
   );
 }
 
+/* A separator carrying an expander drops the rule: the button says what the
+   line is, and a rule behind its text reads as a strikethrough. */
+.cm-diff-sep.cm-diff-gap {
+  background-image: none;
+}
+
+/* The expander itself — the unchanged lines git left out, one click away. Prose
+   in a code viewer, so it takes the app's font like a review thread does. */
+.cm-diff-expand {
+  border-radius: 0.25rem;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  font-family: var(--font-sans);
+  font-size: 0.6875rem;
+  line-height: 1.2;
+  padding: 0 0.375rem;
+}
+
+.cm-diff-expand:hover {
+  background-color: var(--accent);
+  color: var(--accent-foreground);
+}
+
 /* Syntax highlighting palette for @lezer/highlight's classHighlighter.
    Muted hues legible on both themes; dark overrides lift the lightness. */
 .tok-keyword { color: oklch(0.45 0.17 305); }

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -512,4 +512,8 @@ export interface LastTurn {
   state: "ok" | "empty" | "unavailable"
   diff?: string
   endedAt?: number
+  /** The snapshot tree the diff's new side stands at — the revision the panel
+   * expands unchanged lines against (ProjectService.FileLines). Present only
+   * with a diff. */
+  after?: string
 }

--- a/frontend/src/lib/codemirror.test.ts
+++ b/frontend/src/lib/codemirror.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+import { buildGapDecorations } from "./codemirror"
+import { buildFileDoc, parseDiff, type DiffGap } from "./git/diff"
+
+// The widget's own DOM is a framework boundary and is left to the app; what is
+// tested here is where its decorations land, and that adding two of them to one
+// position is an order a RangeSetBuilder accepts — it throws otherwise, and a
+// throw building the diff takes the window down with it.
+
+const gapped = `diff --git a/src/app.ts b/src/app.ts
+--- a/src/app.ts
++++ b/src/app.ts
+@@ -6,2 +6,2 @@ function head() {
+-  const b = 2
++  const b = 3
+@@ -20,1 +20,2 @@ function tail() {
+   const z = 9
++  const w = 10`
+
+function offsets(gaps: DiffGap[], lineMeta: ReturnType<typeof buildFileDoc>["lineMeta"]): number[] {
+  const set = buildGapDecorations(lineMeta, gaps, () => {})
+  const found: number[] = []
+  set.between(0, 1e6, (from) => {
+    found.push(from)
+  })
+  return found
+}
+
+describe("buildGapDecorations", () => {
+  it("addresses each open gap at its separator's character offset", () => {
+    const doc = buildFileDoc(parseDiff(gapped)[0])
+    // Head gap on doc line 1 (offset 0); the second separator follows the empty
+    // line and the hunk's two lines.
+    expect(doc.gaps.map((gap) => gap.docLine)).toEqual([1, 4])
+    const second = 1 + "  const b = 2".length + 1 + "  const b = 3".length + 1
+    // Two decorations per gap — the line class and the widget — on one offset.
+    expect(offsets(doc.gaps, doc.lineMeta)).toEqual([0, 0, second, second])
+  })
+
+  it("draws nothing when no gap is open", () => {
+    const doc = buildFileDoc(parseDiff(gapped)[0])
+    expect(offsets([], doc.lineMeta)).toEqual([])
+  })
+})

--- a/frontend/src/lib/codemirror.ts
+++ b/frontend/src/lib/codemirror.ts
@@ -8,13 +8,15 @@ import { languages } from "@codemirror/language-data"
 import { classHighlighter } from "@lezer/highlight"
 import {
   Decoration,
+  type DecorationSet,
   EditorView,
   GutterMarker,
+  WidgetType,
   gutterLineClass,
   lineNumberWidgetMarker,
   lineNumbers,
 } from "@codemirror/view"
-import { gutterNumber, type DiffLine } from "@/lib/git/diff"
+import { gutterNumber, type DiffGap, type DiffLine } from "@/lib/git/diff"
 
 // diffTheme styles the editor with the app's CSS variables, so the `.dark`
 // class on <html> restyles every view without any JS synchronization.
@@ -193,4 +195,76 @@ export function diffGutter(lineMeta: DiffLine[]): Extension {
     }),
     blockWidgetGutter(),
   ]
+}
+
+// ExpandWidget is the affordance sitting on a hunk separator: the lines git
+// never printed, one click away. It rides the separator's own empty line rather
+// than a block widget of its own, so the row it draws is the row that was
+// already there and the gutter needs to know nothing new about it.
+class ExpandWidget extends WidgetType {
+  constructor(
+    readonly gap: DiffGap,
+    readonly onExpand: (gap: DiffGap) => void,
+  ) {
+    super()
+  }
+
+  // What the button says is the whole of its identity: the same gap, still the
+  // same size, is the same button.
+  eq(other: ExpandWidget): boolean {
+    return other.gap.from === this.gap.from && other.gap.to === this.gap.to
+  }
+
+  toDOM(): HTMLElement {
+    const count = this.gap.to - this.gap.from + 1
+    const button = document.createElement("button")
+    button.type = "button"
+    button.className = "cm-diff-expand"
+    button.textContent = `Expand ${count} unchanged line${count === 1 ? "" : "s"}`
+    button.title = `Show lines ${this.gap.from}–${this.gap.to}`
+    button.addEventListener("click", () => this.onExpand(this.gap))
+    return button
+  }
+}
+
+const expandableSeparator = Decoration.line({ class: "cm-diff-gap" })
+
+// buildGapDecorations walks lineMeta the way buildLineDecorations does, turning
+// each open gap's document line into the character offset a decoration is
+// addressed by. A RangeSet has to be built in document order, and gaps arrive
+// in it: they are collected as the document is assembled.
+//
+// Exported for the suite. The two decorations landing on one position are the
+// part a RangeSetBuilder throws over if they are ever added the wrong way
+// round, and a throw here takes the whole window with it.
+export function buildGapDecorations(
+  lineMeta: DiffLine[],
+  gaps: DiffGap[],
+  onExpand: (gap: DiffGap) => void,
+): DecorationSet {
+  const byDocLine = new Map(gaps.map((gap) => [gap.docLine, gap]))
+  const builder = new RangeSetBuilder<Decoration>()
+  let pos = 0
+  for (const [index, meta] of lineMeta.entries()) {
+    const gap = byDocLine.get(index + 1)
+    if (gap) {
+      // The line class first, as the builder wants its ranges: it drops the
+      // separator's rule, which would otherwise run through the button.
+      builder.add(pos, pos, expandableSeparator)
+      builder.add(pos, pos, Decoration.widget({ widget: new ExpandWidget(gap, onExpand), side: 1 }))
+    }
+    pos += meta.text.length + 1 // +1 for the newline
+  }
+  return builder.finish()
+}
+
+// gapExpanders draws one expander per open gap. Nothing is fetched here and
+// nothing is fetched on mount: a gap is read only when its own button is
+// pressed, which is what keeps a wide diff's cost the cost of its hunks.
+export function gapExpanders(
+  lineMeta: DiffLine[],
+  gaps: DiffGap[],
+  onExpand: (gap: DiffGap) => void,
+): Extension {
+  return EditorView.decorations.of(buildGapDecorations(lineMeta, gaps, onExpand))
 }

--- a/frontend/src/lib/git/diff.test.ts
+++ b/frontend/src/lib/git/diff.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   buildFileDoc,
+  contextLines,
   discardTargets,
   docLineAt,
   formatLineRef,
@@ -262,5 +263,87 @@ describe("docLineAt", () => {
     expect(docLineAt(meta, "LEFT", 500)).toBeNull()
     // A thread GitHub could not re-anchor arrives with line 0.
     expect(docLineAt(meta, "RIGHT", 0)).toBeNull()
+  })
+})
+
+// A file whose changes start well past the top: the reader sees neither what is
+// above the first hunk nor what runs between the two.
+const gappedDiff = `diff --git a/src/app.ts b/src/app.ts
+index 1111111..2222222 100644
+--- a/src/app.ts
++++ b/src/app.ts
+@@ -6,3 +6,3 @@ function head() {
+   const a = 1
+-  const b = 2
++  const b = 3
+   return a
+@@ -20,2 +20,3 @@ function tail() {
+   const z = 9
++  const w = 10`
+
+describe("diff gaps", () => {
+  it("reports the head gap and the gap between hunks", () => {
+    const doc = buildFileDoc(parseDiff(gappedDiff)[0])
+    expect(doc.gaps).toEqual([
+      { key: 1, docLine: 1, from: 1, to: 5, oldFrom: 1 },
+      { key: 9, docLine: 6, from: 9, to: 19, oldFrom: 9 },
+    ])
+    // Each gap keeps its separator line, and every separator is a gap's.
+    expect(doc.text.split("\n")[0]).toBe("")
+    expect(doc.lineMeta[5].kind).toBe("meta")
+  })
+
+  it("leaves no gap where the diff already starts at line 1", () => {
+    const doc = buildFileDoc(parseDiff(modifiedTwoHunks)[0])
+    // The head is on screen; only the run between the two hunks is missing.
+    expect(doc.gaps).toEqual([{ key: 5, docLine: 6, from: 5, to: 10, oldFrom: 4 }])
+  })
+
+  it("numbers no gap on a deleted file, which has no new side to read", () => {
+    expect(buildFileDoc(parseDiff(deletedFileDiff)[0]).gaps).toEqual([])
+    expect(buildFileDoc(parseDiff(newFileDiff)[0]).gaps).toEqual([])
+  })
+
+  it("lays an expansion into the doc as context lines and closes its gap", () => {
+    const file = parseDiff(gappedDiff)[0]
+    const head = buildFileDoc(file).gaps[0]
+    const expansions = new Map([[head.key, contextLines(["a", "b", "c", "d", "e"], 1, 1)]])
+    const doc = buildFileDoc(file, expansions)
+
+    const docLines = doc.text.split("\n")
+    expect(docLines.slice(0, 5)).toEqual(["a", "b", "c", "d", "e"])
+    expect(docLines).toHaveLength(doc.lineMeta.length)
+    expect(doc.lineMeta[0]).toMatchObject({ kind: "context", oldLine: 1, newLine: 1 })
+    expect(doc.lineMeta[4]).toMatchObject({ kind: "context", oldLine: 5, newLine: 5 })
+    // Filled in whole, the head gap is gone — and so is the rule that stood for
+    // it, because the text either side of it is now continuous.
+    expect(doc.lineMeta[5]).toMatchObject({ kind: "context", newLine: 6 })
+    expect(doc.gaps.map((gap) => gap.key)).toEqual([9])
+    // The hunks are untouched: expanding never crops the diff to a range.
+    expect(doc.lineMeta.filter((line) => line.kind === "add")).toHaveLength(2)
+  })
+
+  it("keeps a partly filled gap open, counting from where it stopped", () => {
+    const file = parseDiff(gappedDiff)[0]
+    const expansions = new Map([[1, contextLines(["a", "b"], 1, 1)]])
+    const doc = buildFileDoc(file, expansions)
+    expect(doc.gaps[0]).toEqual({ key: 1, docLine: 3, from: 3, to: 5, oldFrom: 3 })
+    expect(doc.lineMeta[2].kind).toBe("meta")
+  })
+
+  it("maps an expanded line back to the file line it renders", () => {
+    const file = parseDiff(gappedDiff)[0]
+    const doc = buildFileDoc(file, new Map([[1, contextLines(["a", "b", "c", "d", "e"], 1, 1)]]))
+    expect(docLineAt(doc.lineMeta, "RIGHT", 3)).toBe(3)
+    expect(newLineRange(doc.lineMeta, 1, 3)).toEqual({ start: 1, end: 3 })
+  })
+})
+
+describe("contextLines", () => {
+  it("numbers both sides in step from the gap's start", () => {
+    expect(contextLines(["x", "y"], 11, 7)).toEqual([
+      { kind: "context", text: "x", oldLine: 7, newLine: 11 },
+      { kind: "context", text: "y", oldLine: 8, newLine: 12 },
+    ])
   })
 })

--- a/frontend/src/lib/git/diff.ts
+++ b/frontend/src/lib/git/diff.ts
@@ -178,30 +178,102 @@ export function parseDiff(text: string): DiffFile[] {
 export interface FileDoc {
   text: string
   lineMeta: DiffLine[]
+  /** The unchanged runs git never printed, in document order — what the panel
+   * offers to pull in. Empty when every gap is either closed or unnumberable. */
+  gaps: DiffGap[]
 }
+
+/** One run of unchanged lines missing from the diff: the space between two
+ * hunks, or the head of the file above the first one. The tail is not among
+ * them — a diff carries no file length, so nothing here knows whether there is
+ * anything past the last hunk. */
+export interface DiffGap {
+  /** The new-file line this gap opened at, before anything was pulled in. It
+   * is the gap's identity: the doc is rebuilt around every expansion, and this
+   * is what still names the same gap afterwards. */
+  key: number
+  /** 1-based document line the separator sits on — where the affordance goes. */
+  docLine: number
+  /** New-file lines still missing, inclusive. */
+  from: number
+  to: number
+  /** The old-file line pairing with `from`. Unchanged text advances both sides
+   * in step, and a line pulled in has to be numbered on both. */
+  oldFrom: number
+}
+
+/** What has been pulled into each gap so far, keyed by DiffGap.key and always
+ * counting from the gap's own start. */
+export type Expansions = ReadonlyMap<number, DiffLine[]>
 
 const hunkSeparator: DiffLine = { kind: "meta", text: "", oldLine: null, newLine: null }
 
-export function buildFileDoc(file: DiffFile): FileDoc {
+// gapBefore measures the unchanged run between two hunk headers — or above the
+// first one, with `previous` null. It answers null when there is nothing to
+// pull in, and also when the two sides disagree about the run's length: a gap
+// is unchanged text, so old and new must advance by the same amount, and a
+// header pair saying otherwise is one this cannot number.
+function gapBefore(previous: DiffHunk | null, hunk: DiffHunk): DiffGap | null {
+  const from = previous ? previous.newStart + previous.newCount : 1
+  const oldFrom = previous ? previous.oldStart + previous.oldCount : 1
+  const to = hunk.newStart - 1
+  if (to < from || hunk.oldStart - oldFrom !== hunk.newStart - from) {
+    return null
+  }
+  return { key: from, docLine: 0, from, to, oldFrom }
+}
+
+// contextLines numbers text pulled out of the file into the diff's own line
+// shape: unchanged lines, present on both sides, starting at newFrom/oldFrom.
+export function contextLines(texts: string[], newFrom: number, oldFrom: number): DiffLine[] {
+  return texts.map((text, index) => ({
+    kind: "context" as const,
+    text,
+    oldLine: oldFrom + index,
+    newLine: newFrom + index,
+  }))
+}
+
+// buildFileDoc assembles the document, laying whatever has been pulled into a
+// gap where the diff left a hole. A gap that is still open keeps its separator
+// line and is reported in `gaps`; one that has been filled in whole has no
+// separator left, because the text either side of it is now continuous.
+export function buildFileDoc(file: DiffFile, expansions?: Expansions): FileDoc {
   const lines: string[] = []
   const lineMeta: DiffLine[] = []
+  const gaps: DiffGap[] = []
+  const push = (line: DiffLine): void => {
+    lines.push(line.text)
+    lineMeta.push(line)
+  }
   for (const [index, hunk] of file.hunks.entries()) {
-    if (index > 0) {
-      lines.push("")
-      lineMeta.push(hunkSeparator)
+    const gap = gapBefore(index === 0 ? null : file.hunks[index - 1], hunk)
+    const pulled = gap ? (expansions?.get(gap.key) ?? []) : []
+    for (const line of pulled) {
+      push(line)
+    }
+    const open = gap && {
+      ...gap,
+      from: gap.from + pulled.length,
+      oldFrom: gap.oldFrom + pulled.length,
+    }
+    // Adjacent hunks (no numberable gap) keep the separator they always had.
+    if (open ? open.from <= open.to : index > 0) {
+      push(hunkSeparator)
+      if (open) {
+        gaps.push({ ...open, docLine: lineMeta.length })
+      }
     }
     for (const line of hunk.lines) {
       if (line.kind === "meta") {
         continue
       }
-      const text = line.text.slice(1)
-      lines.push(text)
       // lineMeta's text must equal the doc's, so decoration position math
       // (pos += text.length + 1) stays in step.
-      lineMeta.push({ ...line, text })
+      push({ ...line, text: line.text.slice(1) })
     }
   }
-  return { text: lines.join("\n"), lineMeta }
+  return { text: lines.join("\n"), lineMeta, gaps }
 }
 
 // discardTargets lists the repo-relative paths a "discard changes" on this

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -194,6 +194,13 @@ export const ProjectService = {
   /** Tracked files, repo-relative and slash-separated, sorted (git ls-files). */
   Tree: (path: string) => call<string[] | null>("project.Tree", [path]),
   ReadFile: (path: string, rel: string) => call<string>("project.ReadFile", [path, rel]),
+  /** Lines from..to (1-based, inclusive) of one file for the diff's context
+   * expander. ref is the revision the diff's new side stands at: "" for the
+   * working tree, otherwise a git oid — a local object when the checkout has
+   * it, GitHub's copy when it does not (a pull request's head). The backend
+   * caps one answer, so a caller wanting more asks again from where it ended. */
+  FileLines: (path: string, rel: string, ref: string, from: number, to: number) =>
+    call<string[] | null>("project.FileLines", [path, rel, ref, from, to]),
   DiscardFile: (path: string, rel: string) => call<null>("project.DiscardFile", [path, rel]),
   ListBranches: (path: string) => call<Branches>("project.ListBranches", [path]),
   /** The setup script a new worktree of this project will run, or the

--- a/internal/project/filelines.go
+++ b/internal/project/filelines.go
@@ -1,0 +1,132 @@
+package project
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/omartelo/lich/internal/relpath"
+)
+
+// maxExpandLines caps one FileLines answer. The diff's expander asks for a
+// whole gap at once and a gap can be the rest of the file, so the cap is what
+// keeps one click bounded; the affordance stays over whatever is left, which
+// turns a larger gap into several clicks rather than one unbounded response.
+const maxExpandLines = 500
+
+// ghRawAccept asks the contents API for the file itself rather than the JSON
+// envelope, whose base64 body is refused above 1MB.
+const ghRawAccept = "Accept: application/vnd.github.raw"
+
+// FileLines returns lines from..to of one repo-relative file — 1-based and
+// inclusive, the numbering a diff's gutter shows — for the review panel's
+// context expander: the unchanged text around a hunk, which git never printed.
+//
+// ref names the revision the diff's new side stands at, and the panels differ
+// in which one they have: "" is the working tree, an oid is a git object this
+// checkout holds (a turn's snapshot tree), and a pull request's head is an oid
+// this clone need not hold at all — measured, the head oids `gh pr list`
+// reports are absent from a clone that never checked those branches out, so a
+// local read alone would leave the Pulls screen's expander dead. The object is
+// tried first because it costs nothing; GitHub answers for the rest.
+//
+// rel is validated against traversal like every other file-by-path surface, and
+// binaries and oversize files are refused the way ReadFile refuses them: this
+// is a source viewer, and a blob has no lines to show.
+func (s *Service) FileLines(path, rel, ref string, from, to int) ([]string, error) {
+	if err := relpath.Validate(rel); err != nil {
+		return nil, err
+	}
+	if from < 1 || to < from {
+		return nil, fmt.Errorf("invalid line range %d..%d", from, to)
+	}
+	text, err := s.fileAt(path, rel, ref)
+	if err != nil {
+		return nil, err
+	}
+	return sliceLines(text, from, to), nil
+}
+
+// fileAt reads one file whole at ref. See FileLines for what a ref can be.
+func (s *Service) fileAt(path, rel, ref string) (string, error) {
+	if ref == "" {
+		return s.ReadFile(path, rel)
+	}
+	if !isOID(ref) {
+		return "", fmt.Errorf("invalid revision %q", ref)
+	}
+	// gitQuiet and not runGit: an object this clone does not have is the
+	// expected answer for a pull request's head, not a failure to report.
+	if out, ok := gitQuiet(path, "show", ref+":"+rel); ok {
+		return checkedText(rel, out)
+	}
+	out, err := s.gh(prReadTimeout, path, "api", "-H", ghRawAccept, contentsPath(rel, ref))
+	if err != nil {
+		return "", err
+	}
+	return checkedText(rel, string(out))
+}
+
+// checkedText applies ReadFile's two refusals to text that never passed through
+// it — a git object, or GitHub's answer.
+func checkedText(rel, text string) (string, error) {
+	if len(text) > maxReadFileSize {
+		return "", fmt.Errorf("%s is too large to expand (%d bytes)", rel, len(text))
+	}
+	if isBinary([]byte(text)) {
+		return "", fmt.Errorf("%s is a binary file", rel)
+	}
+	return text, nil
+}
+
+// contentsPath addresses one file of the checkout's repository at a commit.
+// {owner} and {repo} are gh's own placeholders, filled from the remote, and a
+// fork's commit is reachable there too: GitHub keeps every pull request's head
+// in the base repository.
+func contentsPath(rel, ref string) string {
+	segments := strings.Split(rel, "/")
+	for i, segment := range segments {
+		segments[i] = url.PathEscape(segment)
+	}
+	return fmt.Sprintf(
+		"repos/{owner}/{repo}/contents/%s?ref=%s",
+		strings.Join(segments, "/"), url.QueryEscape(ref),
+	)
+}
+
+// isOID reports whether ref is a git object name — the only revision the page
+// ever names, and the guard that keeps a value from the page out of git's
+// option parsing and out of GitHub's URL.
+func isOID(ref string) bool {
+	if len(ref) < 7 || len(ref) > 64 {
+		return false
+	}
+	for _, char := range ref {
+		if (char < '0' || char > '9') && (char < 'a' || char > 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// sliceLines takes lines from..to (1-based, inclusive) out of a file's text,
+// clamped to maxExpandLines and to the end of the file. It is never nil: an
+// empty answer means the range starts past the last line, and it has to cross
+// the wire as [] rather than as JSON null.
+func sliceLines(text string, from, to int) []string {
+	lines := strings.Split(text, "\n")
+	// A trailing newline ends the last line; it does not open another.
+	if last := len(lines) - 1; last >= 0 && lines[last] == "" {
+		lines = lines[:last]
+	}
+	if from > len(lines) {
+		return []string{}
+	}
+	if to > len(lines) {
+		to = len(lines)
+	}
+	if to-from+1 > maxExpandLines {
+		to = from + maxExpandLines - 1
+	}
+	return lines[from-1 : to]
+}

--- a/internal/project/filelines_test.go
+++ b/internal/project/filelines_test.go
@@ -1,0 +1,177 @@
+package project
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// numbered builds a file whose every line names its own number, so a slice's
+// content proves which lines came back and not merely how many.
+func numbered(n int) string {
+	var out strings.Builder
+	for i := 1; i <= n; i++ {
+		fmt.Fprintf(&out, "line %d\n", i)
+	}
+	return out.String()
+}
+
+func TestSliceLines(t *testing.T) {
+	text := "a\nb\nc\nd\n"
+	tests := []struct {
+		name     string
+		text     string
+		from, to int
+		want     []string
+	}{
+		{"inner range", text, 2, 3, []string{"b", "c"}},
+		{"single line", text, 1, 1, []string{"a"}},
+		{"trailing newline opens no line", text, 4, 4, []string{"d"}},
+		{"no trailing newline", "a\nb", 1, 2, []string{"a", "b"}},
+		{"clamped to the last line", text, 3, 99, []string{"c", "d"}},
+		{"past the end is empty, never nil", text, 9, 12, []string{}},
+		{"blank lines are lines", "a\n\nc\n", 1, 3, []string{"a", "", "c"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sliceLines(tt.text, tt.from, tt.to); !slices.Equal(got, tt.want) {
+				t.Errorf("sliceLines(%q, %d, %d) = %q, want %q", tt.text, tt.from, tt.to, got, tt.want)
+			}
+		})
+	}
+}
+
+// The cap is pinned to a literal and probed on both sides of it, so a change to
+// maxExpandLines has to move this test rather than ride along with it.
+func TestSliceLinesCap(t *testing.T) {
+	if maxExpandLines != 500 {
+		t.Fatalf("maxExpandLines = %d, want 500 — the wire contract moved", maxExpandLines)
+	}
+	text := numbered(1200)
+	got := sliceLines(text, 1, 500)
+	if len(got) != 500 || got[499] != "line 500" {
+		t.Fatalf("500 lines: got %d ending %q", len(got), got[len(got)-1])
+	}
+	got = sliceLines(text, 1, 501)
+	if len(got) != 500 || got[0] != "line 1" || got[499] != "line 500" {
+		t.Fatalf("501 asked: got %d lines %q..%q", len(got), got[0], got[len(got)-1])
+	}
+	// The caller resumes where the cap stopped, which is what turns a gap
+	// larger than the cap into several clicks instead of a truncated answer.
+	got = sliceLines(text, 501, 1200)
+	if len(got) != 500 || got[0] != "line 501" {
+		t.Fatalf("resumed: got %d lines starting %q", len(got), got[0])
+	}
+}
+
+func TestIsOID(t *testing.T) {
+	valid := []string{"a4dbc1f", strings.Repeat("0", 40), "533f1af9fc740d2335cb3b4aae0e6481acfc5211"}
+	for _, ref := range valid {
+		if !isOID(ref) {
+			t.Errorf("isOID(%q) = false, want true", ref)
+		}
+	}
+	invalid := []string{"", "HEAD", "main", "a4dbc1", "--upload-pack=x", "A4DBC1F", "../etc", strings.Repeat("a", 65)}
+	for _, ref := range invalid {
+		if isOID(ref) {
+			t.Errorf("isOID(%q) = true, want false", ref)
+		}
+	}
+}
+
+func TestContentsPath(t *testing.T) {
+	got := contentsPath("internal/rpc/rpc go.md", "abcdef1234567890")
+	want := "repos/{owner}/{repo}/contents/internal/rpc/rpc%20go.md?ref=abcdef1234567890"
+	if got != want {
+		t.Errorf("contentsPath = %q, want %q", got, want)
+	}
+}
+
+func TestFileLinesWorkTree(t *testing.T) {
+	repo, _ := initRepo(t)
+	write(t, repo, "src/app.ts", "one\ntwo\nthree\nfour\n")
+
+	svc := New(nil)
+	lines, err := svc.FileLines(repo, "src/app.ts", "", 2, 3)
+	if err != nil {
+		t.Fatalf("FileLines: %v", err)
+	}
+	if want := []string{"two", "three"}; !slices.Equal(lines, want) {
+		t.Errorf("lines = %q, want %q", lines, want)
+	}
+
+	if _, err := svc.FileLines(repo, "../escape.ts", "", 1, 2); err == nil {
+		t.Error("traversal: want error, got nil")
+	}
+	if _, err := svc.FileLines(repo, "src/app.ts", "", 0, 3); err == nil {
+		t.Error("zero start: want error, got nil")
+	}
+	if _, err := svc.FileLines(repo, "src/app.ts", "", 4, 2); err == nil {
+		t.Error("reversed range: want error, got nil")
+	}
+	write(t, repo, "blob.bin", "text\x00more\n")
+	if _, err := svc.FileLines(repo, "blob.bin", "", 1, 2); err == nil {
+		t.Error("binary: want error, got nil")
+	}
+}
+
+// A local object is read by git, and never costs a gh call — the turn diff's
+// snapshot tree is the case, and it is the reason the local read comes first.
+func TestFileLinesLocalObject(t *testing.T) {
+	repo, git := initRepo(t)
+	write(t, repo, "a.txt", "one\ntwo\nthree\n")
+	git("add", "a.txt")
+	git("commit", "-m", "three lines")
+	tree := strings.TrimSpace(git("rev-parse", "HEAD^{tree}"))
+	// The working tree moves on; the object must not.
+	write(t, repo, "a.txt", "rewritten\n")
+
+	gh := &fakeGH{out: []byte("should not be asked\n")}
+	svc := withGH(gh)
+	lines, err := svc.FileLines(repo, "a.txt", tree, 2, 3)
+	if err != nil {
+		t.Fatalf("FileLines: %v", err)
+	}
+	if want := []string{"two", "three"}; !slices.Equal(lines, want) {
+		t.Errorf("lines = %q, want %q", lines, want)
+	}
+	if gh.calls != 0 {
+		t.Errorf("gh called %d times for a local object, want 0", gh.calls)
+	}
+	if _, err := svc.FileLines(repo, "a.txt", "HEAD", 1, 2); err == nil {
+		t.Error("non-oid revision: want error, got nil")
+	}
+}
+
+// An oid the clone does not have is a pull request's head: GitHub answers for
+// it, through the contents API rather than through git.
+func TestFileLinesMissingObjectAsksGitHub(t *testing.T) {
+	repo, _ := initRepo(t)
+	missing := strings.Repeat("b", 40)
+
+	gh := &fakeGH{out: []byte("alpha\nbeta\ngamma\n")}
+	lines, err := withGH(gh).FileLines(repo, "a.txt", missing, 2, 9)
+	if err != nil {
+		t.Fatalf("FileLines: %v", err)
+	}
+	if want := []string{"beta", "gamma"}; !slices.Equal(lines, want) {
+		t.Errorf("lines = %q, want %q", lines, want)
+	}
+	want := []string{"api", "-H", ghRawAccept, contentsPath("a.txt", missing)}
+	if !slices.Equal(gh.args, want) {
+		t.Errorf("gh args = %v, want %v", gh.args, want)
+	}
+	if gh.dir != repo {
+		t.Errorf("gh dir = %q, want %q", gh.dir, repo)
+	}
+}
+
+func TestFileLinesGitHubFailureSurfaces(t *testing.T) {
+	repo, _ := initRepo(t)
+	gh := &fakeGH{err: errors.New("gh: not found")}
+	if _, err := withGH(gh).FileLines(repo, "a.txt", strings.Repeat("c", 40), 1, 5); err == nil {
+		t.Error("gh failure: want error, got nil")
+	}
+}

--- a/internal/terminal/turnsnap.go
+++ b/internal/terminal/turnsnap.go
@@ -32,6 +32,11 @@ type LastTurn struct {
 	State   string `json:"state"`
 	Diff    string `json:"diff,omitempty"`
 	EndedAt int64  `json:"endedAt,omitempty"`
+	// After is the snapshot tree the diff's new side stands at, and it travels
+	// so the panel can expand the unchanged lines around a hunk against the
+	// same revision it is reading (project.FileLines). Set only with a diff:
+	// the other two states have no side to read.
+	After string `json:"after,omitempty"`
 }
 
 // turnPair is one closed turn: the trees on either side of the window it ran in,
@@ -305,5 +310,5 @@ func (s *Service) LastTurnDiff(id string) (LastTurn, error) {
 	if err != nil {
 		return LastTurn{}, err
 	}
-	return LastTurn{State: turnDiffOK, Diff: text, EndedAt: ended}, nil
+	return LastTurn{State: turnDiffOK, Diff: text, EndedAt: ended, After: pair.after}, nil
 }


### PR DESCRIPTION
## What

git prints three lines of context either side of a hunk, so judging a change in lich meant leaving the panel and opening the file. Every gap between two hunks — and the run above the first one — now carries a row saying how many lines are hidden there, and one click pulls them in as context rows, numbered and highlighted like the rest of the diff.

It works on all three diff surfaces: the review dock's working tree, its last turn, and a pull request's **Files changed** — including a pull request whose branch this clone has never fetched.

## The two constraints this was built around

- **A hunk is never cropped to a range.** An expansion is laid into the document where the separator was (`buildFileDoc(file, expansions)`), so the hunks stay whole and what the reader chose to open can never hide a change from them. Line arrays stay in step, and `docLineAt`/`newLineRange` keep mapping selections and review threads correctly across an expansion.
- **Lazy mounting is untouched.** Nothing is read until a button inside a mounted editor is pressed, one gap at a time. `LazyDiffBody`'s `IntersectionObserver` is unchanged and there is no prefetch anywhere.

## Backend

`project.FileLines(path, rel, ref, from, to)` (`internal/project/filelines.go`):

- `rel` goes through `internal/relpath` like every other file-by-path surface.
- The range is capped per request (`maxExpandLines`), and a caller resumes where the cap stopped — which is what turns a gap wider than the cap into several clicks rather than a truncated answer.
- Binaries and oversize files are refused the way `ReadFile` refuses them.
- `ref` names the revision the diff's new side stands at: `""` is the working tree, an oid is a local object (a turn's snapshot tree — `LastTurn` now carries it), and an oid the clone does not have is a pull request's head. Measured: the head oids `gh pr list` reports are absent from a clone that never checked those branches out, so `git show` alone would have left the Pulls expander dead. git is tried first because it costs nothing, GitHub's contents API answers for the rest.
- Only a hex oid is accepted as a ref, so a value from the page cannot reach git's option parsing or GitHub's URL.

## What was skipped, deliberately

- **No expanding past the last hunk.** A unified diff carries no file length, so nothing here knows whether anything follows it — an affordance drawn there would be a no-op on every file whose change reaches the end.
- **No incremental ±20 stepping.** A gap opens whole, bounded only by the per-request cap. Adding stepping multiplies gh round-trips on the Pulls screen.
- **No expanders on a deleted file**, which has no new side to read.

Both of the first two, and the round-trip cost that governs them, are in `docs/ceilings.md`.

## Test plan

- `internal/project/filelines_test.go`: the slice and its cap (pinned to a literal, probed either side), the oid guard, the contents path, the work-tree read with traversal/range/binary refusals, the local-object read proving gh is *not* called, the GitHub fallback with its exact argv, and a gh failure surfacing.
- `frontend/src/lib/git/diff.test.ts`: head and between-hunk gaps, no gap on added/deleted files, an expansion laid in with the hunks intact, a partly filled gap counting from where it stopped, and selection mapping over expanded lines.
- `frontend/src/lib/codemirror.test.ts`: where the decorations land, and that two on one position is an order `RangeSetBuilder` accepts — it throws otherwise, and a throw building the diff takes the window down.
- Local gate green: `gofmt`, `go vet`, `go test ./...` (1985), `biome check`, `vitest` (1217), `tsc` + `vite build`, and the `GOOS=linux/darwin/windows` build+vet loop.
- Driven for real against PR #341 in a headless rig: three expanders with the right counts, clicking one filled the head gap in place, its row disappeared, the gutter numbered from line 1, and no exception or console error. That PR's branch is not in this clone, so it exercised the GitHub path.