### PR TITLE
fix: keep a file preview inside the checkout it was opened from

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   you had open, the list of them. Each tab now returns to the screen its project
   was last showing, and to its terminals only when that is where you were.
 
+### Fixed
+
+- **A file preview stays inside the checkout it was opened from.** A repository
+  may ship a symlink pointing out of its own tree, and clicking one in the file
+  list quietly previewed whatever it landed on — a file from somewhere else on
+  the machine, shown as though it were the project's, and described by the diff
+  beside it as something else entirely, since git records such an entry as its
+  target text rather than the target's contents. The preview now says the path
+  leaves the checkout instead of following it. Links that stay inside the tree
+  read exactly as before.
+
 ## [0.42.0] - 2026-08-27
 
 ### Changed

--- a/internal/project/tree.go
+++ b/internal/project/tree.go
@@ -133,15 +133,17 @@ func lsFiles(path string, args ...string) ([]string, error) {
 }
 
 // ReadFile returns the text content of one repo-relative file for the read-only
-// preview. rel is validated against traversal (internal/relpath, shared with
-// DiscardFile and the editor launch) before it is joined onto the work-tree
-// root. Binaries, irregular files, and files above maxReadFileSize are refused —
+// preview. rel goes through relpath.Resolve rather than the lexical Validate
+// its neighbours use, because this is the surface that reads bytes: a checkout
+// can ship a symlink out of the tree, and a preview that followed one would
+// print a file the diff beside it describes as the link's target text.
+// Binaries, irregular files, and files above maxReadFileSize are refused —
 // the preview is for source, not blobs.
 func (s *Service) ReadFile(path, rel string) (string, error) {
-	if err := relpath.Validate(rel); err != nil {
+	full, err := relpath.Resolve(path, rel)
+	if err != nil {
 		return "", err
 	}
-	full := filepath.Join(path, rel)
 	info, err := os.Stat(full)
 	if err != nil {
 		return "", fmt.Errorf("stat %s: %w", rel, err)

--- a/internal/project/tree_test.go
+++ b/internal/project/tree_test.go
@@ -138,6 +138,27 @@ func TestReadFileRejectsEscape(t *testing.T) {
 	}
 }
 
+// TestReadFileRejectsALinkOutOfTheCheckout pins ReadFile on relpath.Resolve
+// rather than the lexical Validate. Every other escape test here is refused
+// before the filesystem is reached; this one is a legal work-tree path whose
+// escape exists only on disk, so it is the one that fails if this caller is
+// ever moved back to the cheaper guard. The link is the shape a repository can
+// genuinely ship — git records it as its target text, and a preview that
+// followed it would print a file the diff beside it never mentions.
+func TestReadFileRejectsALinkOutOfTheCheckout(t *testing.T) {
+	repo, _ := initRepo(t)
+	outside := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(outside, []byte("not the repository's\n"), 0o600); err != nil {
+		t.Fatalf("write outside: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(repo, "escape.txt")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if got, err := New(nil).ReadFile(repo, "escape.txt"); err == nil {
+		t.Errorf("ReadFile(escape.txt) = %q, want an error", got)
+	}
+}
+
 // TestReadFileRejectsBinary proves a NUL-bearing file is refused rather than
 // streamed into the text preview.
 func TestReadFileRejectsBinary(t *testing.T) {

--- a/internal/relpath/relpath.go
+++ b/internal/relpath/relpath.go
@@ -3,6 +3,12 @@
 // output — before they are joined onto a work-tree root. It is the one copy of
 // that rule: every surface that opens, reads or deletes a file by relative path
 // answers to it, so an escape closed here is closed everywhere.
+//
+// Two rules, because the callers do not all want the same one. Validate is the
+// lexical rule and answers for the path as written — what a caller passing rel
+// to git or unlinking it needs. Resolve adds the filesystem: it follows the
+// links and proves the result is still in the tree, which only a caller that
+// reads the file's bytes has to care about.
 package relpath
 
 import (
@@ -25,6 +31,38 @@ func Validate(rel string) error {
 		return fmt.Errorf("invalid repository path %q", rel)
 	}
 	return nil
+}
+
+// Resolve validates rel, joins it onto root and returns the real path to open:
+// every symlink resolved, and proven to still be inside root. Validate alone
+// answers the path as written, which is the whole rule for a caller that hands
+// rel to git or unlinks it — but not for one that reads bytes, because a
+// checkout may ship a link and following it lands wherever the link points.
+//
+// git stores such an entry as its target text, so the diff beside a preview
+// says `../../etc/hosts` while the preview would print that file. Refusing here
+// is what keeps the two telling the same story about the same tree.
+//
+// Both sides are resolved before they are compared: a checkout is routinely
+// reached through a link itself (macOS `/var` is `/private/var`), and measuring
+// a resolved target against an unresolved root calls every file an escape.
+func Resolve(root, rel string) (string, error) {
+	if err := Validate(rel); err != nil {
+		return "", err
+	}
+	realRoot, err := filepath.EvalSymlinks(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve checkout %s: %w", root, err)
+	}
+	full, err := filepath.EvalSymlinks(filepath.Join(root, rel))
+	if err != nil {
+		return "", fmt.Errorf("resolve %s: %w", rel, err)
+	}
+	inside, err := filepath.Rel(realRoot, full)
+	if err != nil || inside == ".." || strings.HasPrefix(inside, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("%q leaves the checkout", rel)
+	}
+	return full, nil
 }
 
 // isRooted reports whether a cleaned path starts at a root. IsAbs alone is not

--- a/internal/relpath/relpath_test.go
+++ b/internal/relpath/relpath_test.go
@@ -2,6 +2,7 @@ package relpath
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -50,6 +51,90 @@ func TestValidateAcceptsWorkTreePaths(t *testing.T) {
 	for _, rel := range []string{"a.txt", "internal/rpc/rpc.go", "src/main.go", "a/b/../c.txt"} {
 		if err := Validate(rel); err != nil {
 			t.Errorf("Validate(%q): want nil, got %v", rel, err)
+		}
+	}
+}
+
+// linkTree lays out a checkout holding one real file, one link to it, and one
+// link pointing out of the tree, and returns the checkout and the outside file.
+// It skips where the OS refuses to make a symlink at all: an unprivileged
+// Windows runner without developer mode, where os.Symlink is the thing that
+// fails rather than the rule under test.
+func linkTree(t *testing.T) (root, outside string) {
+	t.Helper()
+	base := t.TempDir()
+	root = filepath.Join(base, "checkout")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatalf("mkdir checkout: %v", err)
+	}
+	outside = filepath.Join(base, "secret.txt")
+	for path, content := range map[string]string{
+		outside:                         "not the repository's\n",
+		filepath.Join(root, "real.txt"): "the repository's\n",
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+	if err := os.Symlink("real.txt", filepath.Join(root, "inside.txt")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "escape.txt")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	return root, outside
+}
+
+// TestResolveRefusesALinkOutOfTheTree is the rule Validate cannot state: the
+// path is lexically a work-tree path and the escape is on disk. git records
+// such an entry as its target text, so a reader that followed it would print a
+// file the diff beside it never mentions.
+func TestResolveRefusesALinkOutOfTheTree(t *testing.T) {
+	root, _ := linkTree(t)
+	if err := Validate("escape.txt"); err != nil {
+		t.Fatalf("Validate(%q): the lexical rule is meant to pass here, got %v", "escape.txt", err)
+	}
+	if got, err := Resolve(root, "escape.txt"); err == nil {
+		t.Errorf("Resolve(escape.txt) = %q, want an error", got)
+	}
+}
+
+// TestResolveFollowsALinkInsideTheTree proves the refusal is about leaving, not
+// about links: a checkout that ships one (this repository's own AGENTS.md is a
+// link to CLAUDE.md) still reads.
+func TestResolveFollowsALinkInsideTheTree(t *testing.T) {
+	root, _ := linkTree(t)
+	got, err := Resolve(root, "inside.txt")
+	if err != nil {
+		t.Fatalf("Resolve(inside.txt): %v", err)
+	}
+	if want := filepath.Join(root, "real.txt"); got != want {
+		t.Errorf("Resolve(inside.txt) = %q, want %q", got, want)
+	}
+}
+
+// TestResolveAcceptsARootReachedThroughALink is the case that makes resolving
+// BOTH sides load-bearing: macOS hands out /var, which is /private/var, so a
+// resolved target measured against an unresolved root reads every file in the
+// checkout as an escape.
+func TestResolveAcceptsARootReachedThroughALink(t *testing.T) {
+	root, _ := linkTree(t)
+	linked := filepath.Join(t.TempDir(), "via-link")
+	if err := os.Symlink(root, linked); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if _, err := Resolve(linked, "real.txt"); err != nil {
+		t.Errorf("Resolve through a linked root: %v", err)
+	}
+}
+
+// TestResolveKeepsTheLexicalRule proves Resolve did not trade the cheap check
+// away: a traversal is refused before the filesystem is touched at all.
+func TestResolveKeepsTheLexicalRule(t *testing.T) {
+	root, _ := linkTree(t)
+	for _, rel := range []string{"..", "../secret.txt", ".", ""} {
+		if _, err := Resolve(root, rel); err == nil {
+			t.Errorf("Resolve(%q): want error, got nil", rel)
 		}
 	}
 }

--- a/internal/relpath/relpath_test.go
+++ b/internal/relpath/relpath_test.go
@@ -102,14 +102,25 @@ func TestResolveRefusesALinkOutOfTheTree(t *testing.T) {
 // TestResolveFollowsALinkInsideTheTree proves the refusal is about leaving, not
 // about links: a checkout that ships one (this repository's own AGENTS.md is a
 // link to CLAUDE.md) still reads.
+//
+// It asserts the bytes at the returned path rather than the path's spelling,
+// because the spelling is exactly what Resolve is entitled to change: what it
+// promises is the REAL path, and every runner spells that differently from the
+// root it was handed — macOS resolves /var to /private/var, and Windows expands
+// the 8.3 short name (RUNNER~1) to runneradmin. Pinning the string asserted
+// something the contract never promised, and passed only on Linux.
 func TestResolveFollowsALinkInsideTheTree(t *testing.T) {
 	root, _ := linkTree(t)
 	got, err := Resolve(root, "inside.txt")
 	if err != nil {
 		t.Fatalf("Resolve(inside.txt): %v", err)
 	}
-	if want := filepath.Join(root, "real.txt"); got != want {
-		t.Errorf("Resolve(inside.txt) = %q, want %q", got, want)
+	content, err := os.ReadFile(got)
+	if err != nil {
+		t.Fatalf("read the resolved path %q: %v", got, err)
+	}
+	if want := "the repository's\n"; string(content) != want {
+		t.Errorf("Resolve(inside.txt) landed on %q holding %q, want %q", got, content, want)
 	}
 }
 


### PR DESCRIPTION
## What

A repository may ship a symlink pointing out of its own tree. Clicking one in the file list previewed whatever it landed on — a file from elsewhere on the machine, rendered as though it were the project's.

The diff beside it disagreed, and that is the part worth naming: git records a symlink as its *target text*, so the diff said `../../etc/hosts` while the preview printed that file's contents. Two panels describing the same entry, one of them wrong.

## Why the fix is in `relpath` and not in `ReadFile`

`relpath.Validate` is a **lexical** rule. It answers for the path as written, which is the entire story for a caller that hands `rel` to git or unlinks it, and no story at all for one that reads bytes.

So `relpath.Resolve` joins the two: `Validate` first, then the filesystem — every link followed, and the result proven still inside the root. It returns the real path to open, which also leaves nothing for the caller to re-resolve.

Both sides are resolved before they are compared. A checkout is routinely reached *through* a link (macOS hands out `/var`, which is `/private/var`), so measuring a resolved target against an unresolved root reads every file in the tree as an escape. There is a test for that direction specifically, because it is the way this fix breaks if someone simplifies it.

## Only `ReadFile` moves

The other three callers of `Validate` keep it, and the reason is per-caller rather than per-package:

- `DiscardFile` unlinks with `os.Remove`, which takes the link and not its target, and passes `rel` to git, which works the index.
- `OpenInEditor` hands the path to the user's own editor.

None of them reads a file into a lich surface, so `Validate` stays and is still the right rule for them.

`FileLines` needed nothing: with an empty ref it routes through `ReadFile` and is covered here, and with an oid it reads a git object or GitHub's answer, where a symlink is already just its target text.

## Test plan

Both guards are mutation-checked — each was removed and the naming test observed to fail, then restored:

- `relpath`: a link out of the tree refused while `Validate` still passes it (the two rules disagreeing is the point), a link *inside* the tree still followed, a root reached through a link still accepted, and the lexical rule still refusing traversal before the filesystem is touched.
- `project`: `ReadFile` refusing that link at the caller, which is what fails if this surface is ever moved back to `Validate`. Every other escape test there is refused before the filesystem is reached, so none of them would have noticed.

Symlink tests skip where the OS refuses to create one (an unprivileged Windows runner without developer mode) rather than failing on the setup instead of the rule.

Local gate green: `gofmt`, `go vet`, `go test ./...` (1990), `biome check`, `vitest` (1230), `tsc` + `vite build`, and the `GOOS=linux/darwin/windows` build + vet loop — path code, so the loop was run even though no build tag moved.