### PR TITLE
feat: count how long each session has been worked on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   chose to open. It works on the review dock's working tree and last turn, and on
   a pull request's Files changed — including a pull request whose branch this
   clone has never fetched.
+- **The footer says how long you have been at a session.** Beside the cost, each
+  session now carries the time it has actually been worked on — `$4.20 · 1h12m`,
+  or just `1h12m` where the cost readout is off. It is not how long the card has
+  been open: the count only moves while something is happening in the session —
+  you typing at it, the agent reporting in, or the agent's own output while a
+  turn is running — and any gap longer than fifteen minutes counts as time away
+  and adds nothing at all, so a session left open overnight reports the hour you
+  worked rather than the fourteen it sat there. The total is kept with the
+  session, so it survives a restart of lich and a parked worktree's resume, and
+  every provider that reports a state counts a turn you were not watching. Crush
+  reports none, so its sessions count what you typed and no more.
 
 ### Changed
 

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -27,6 +27,22 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   Their footer therefore carries no model or context ring. Codex rollouts carry the effective window
   selected for that session — 95% of its default or configured `model_context_window` — but no API-cost
   accounting, so its setting stops at model and context while Claude Code alone offers the cost rung.
+- **Hands-on time is read off three signals, and one of them is not universal**
+  (`internal/terminal/handson.go`, `noteOutput`, `closableState`): the figure beside the cost
+  counts the gap between consecutive signs of life in a session — a session-state report, a
+  keystroke at its PTY, or its own output while a turn is open — and drops any gap longer than
+  `handsOnIdleGap`. The output signal is the one that carries an unattended turn, and it is
+  gated on the provider having reported `busy`, because a `tail -f`, a dev server or a TUI
+  repainting would otherwise bill hours nobody worked. **Crush reports no state at all**
+  (`docs/hooks/session-state.md`), so nothing ever opens a turn there and a Crush session
+  accrues from the user's keystrokes alone: an hour it spent working while the user watched
+  reads as the few seconds they typed in. **Cursor CLI is the near miss** — it delivers
+  `PreToolUse` and `PostToolUse`, and those beat even though `closableState` refuses to publish
+  them, so a Cursor turn is counted through its tool calls; what it still cannot count is a turn
+  that calls no tool at all. A plain shell session is keystrokes-only by design and not a gap:
+  there is no agent in it whose work could be missed. The trap is reading the number as
+  comparable across cards — the same hour of work is a smaller figure on Crush than on Claude
+  Code, and nothing on screen says which rung a card is on.
 - **A dropped file has no path, so lich guesses it** (`internal/drop`): a file under neither the session directory
   nor home is *copied*, so an agent told to edit it edits the copy — and that copy is deleted 3 days on, so a path
   pasted into a prompt eventually stops resolving.

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -10,6 +10,7 @@ import {
   Paperclip,
   Diff,
   GitPullRequestArrow,
+  Timer,
 } from "lucide-react"
 import { DropService, Terminal as TerminalService } from "@/lib/rpc"
 import type { DockTab } from "@/components/dock/RightDock"
@@ -17,6 +18,8 @@ import { useActiveSession } from "@/lib/session/use-active-session"
 import { useSessionUsage } from "@/lib/session/use-session-usage"
 import { useCostReadout } from "@/lib/use-cost-readout"
 import { budgetShare, formatCost } from "@/lib/session/session-cost"
+import { formatHandsOn, spellHandsOn } from "@/lib/session/hands-on"
+import { useRemoteResource } from "@/lib/use-remote-resource"
 import { baseName, displayPath } from "@/lib/paths"
 import { isWindows } from "@/lib/platform"
 import { composeDroppedPaths } from "@/lib/terminal/drop-files"
@@ -97,6 +100,16 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
   const status = useGitStatus(path)
   const pr = usePullRequest(path, status?.branch ?? "", status?.head ?? "")
   const now = useNow()
+  // How long the active session has been worked on. Re-read off the footer's
+  // own clock rather than pushed: the figure is minutes, `now` already ticks on
+  // the minute, and keying the lookup by it is the whole refresh loop — no
+  // event, no store, and a reload paints the number on its first render instead
+  // of waiting out a flush.
+  const handsOn = useRemoteResource(
+    sessionId ? `${sessionId}:${now.getTime()}` : "",
+    () => TerminalService.HandsOn(sessionId),
+    { empty: 0 },
+  )
 
   // The picker runs on the backend (DropService.Attach), not through
   // ProjectService: a confined session cannot open a file outside its checkout,
@@ -162,6 +175,36 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
         </TooltipContent>
       </Tooltip>
     ) : null
+
+  // How long this session has been worked on, in the same group as the cost so
+  // the two read as one fact about the session. Unlike the cost it has no
+  // ceiling to be near, so it never takes the amber/red ramp: colouring it
+  // would be an opinion about how long is too long, and lich does not have one.
+  //
+  // The glyph is not decoration. The cost figure is opt-in and Claude-only
+  // while this is measured for every session, so the number usually stands
+  // alone — and a bare "1h12m" in this strip reads as a quota window, which is
+  // drawn two segments to the left.
+  const handsOnReadout = formatHandsOn(handsOn.data) ? (
+    <Tooltip>
+      <TooltipTrigger render={<span className="flex items-center gap-1.5 tabular-nums" />}>
+        <Timer className="size-3.5 shrink-0" aria-hidden="true" />
+        {formatHandsOn(handsOn.data)}
+      </TooltipTrigger>
+      <TooltipContent side="top" className="border border-border bg-card text-foreground">
+        <div className="flex max-w-64 flex-col gap-1">
+          <span className="font-medium">Hands-on time</span>
+          <span className="font-mono text-xs text-muted-foreground">
+            {spellHandsOn(handsOn.data)}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            How long this session has been worked on — typed at, reporting, or running a turn. A gap
+            longer than 15 minutes counts as time away.
+          </span>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  ) : null
 
   // The context-window readout — the ring plus percent, with a detailed
   // tooltip. Null when the user turned it off (Settings › Providers).
@@ -250,9 +293,15 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
       <span className="ml-auto flex items-center gap-4">
         {showContextUsage && <SessionModel sessionId={sessionId} kind={kind} />}
         <PlanQuota kind={kind} sessionId={sessionId} />
-        {costReadout}
+        {(costReadout || handsOnReadout) && (
+          <span className="flex items-center gap-1.5">
+            {costReadout}
+            {costReadout && handsOnReadout && <span className="opacity-50">·</span>}
+            {handsOnReadout}
+          </span>
+        )}
         {contextReadout}
-        {(contextReadout || costReadout) && (status?.branch || path) && (
+        {(contextReadout || costReadout || handsOnReadout) && (status?.branch || path) && (
           <Separator orientation="vertical" className="h-4" />
         )}
         {status?.branch && (

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -137,6 +137,11 @@ export const Terminal = {
   SetVisible: (id: string, visible: boolean) => call<null>("terminal.SetVisible", [id, visible]),
   // Base64 tail of a session's output, to reseed scrollback after a reload.
   Replay: (id: string) => call<string>("terminal.Replay", [id]),
+  /** How long a session has been worked on, in whole seconds — typed at,
+   * reporting, or producing output for an open turn, minus every silence longer
+   * than the idle gap. 0 for a session nothing has been counted for yet, and up
+   * to one flush behind what has been measured (internal/terminal.handsOn). */
+  HandsOn: (id: string) => call<number>("terminal.HandsOn", [id]),
   /** Which of these sessions have talked about the query, and what they said.
    * Empty for a query under three characters, and for a session whose current
    * conversation the backend cannot read. */

--- a/frontend/src/lib/session/hands-on.test.ts
+++ b/frontend/src/lib/session/hands-on.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+import { formatHandsOn, spellHandsOn } from "./hands-on"
+
+describe("formatHandsOn", () => {
+  // Under a minute is not a small number, it is no number: the store is up to a
+  // flush behind, and "0m" reads as a readout that broke rather than as a
+  // session that just opened.
+  it("shows nothing below a minute", () => {
+    expect(formatHandsOn(0)).toBe("")
+    expect(formatHandsOn(59)).toBe("")
+  })
+
+  it("starts at the first whole minute", () => {
+    expect(formatHandsOn(60)).toBe("1m")
+    expect(formatHandsOn(119)).toBe("1m")
+  })
+
+  it("counts minutes up to the hour", () => {
+    expect(formatHandsOn(48 * 60)).toBe("48m")
+    expect(formatHandsOn(59 * 60 + 59)).toBe("59m")
+  })
+
+  // Zero-padded past the hour: "1h5m" and "1h50m" differ by one glyph in a
+  // strip nobody stops to parse.
+  it("pads the minutes once there are hours in front of them", () => {
+    expect(formatHandsOn(3600)).toBe("1h00m")
+    expect(formatHandsOn(3600 + 5 * 60)).toBe("1h05m")
+    expect(formatHandsOn(3600 + 12 * 60)).toBe("1h12m")
+  })
+
+  it("keeps counting hours rather than rolling into days", () => {
+    expect(formatHandsOn(14 * 3600 + 5 * 60)).toBe("14h05m")
+    expect(formatHandsOn(100 * 3600)).toBe("100h00m")
+  })
+
+  // The backend answers 0 on every miss, but the RPC layer is typed, not
+  // validated: a garbage number must render as nothing, never as "NaNm".
+  it("renders nothing for a figure that is not a number", () => {
+    expect(formatHandsOn(Number.NaN)).toBe("")
+    expect(formatHandsOn(Number.POSITIVE_INFINITY)).toBe("")
+    expect(formatHandsOn(-60)).toBe("")
+  })
+})
+
+describe("spellHandsOn", () => {
+  it("gives the tooltip the space the strip cannot spare", () => {
+    expect(spellHandsOn(3600 + 12 * 60)).toBe("1h 12m")
+    expect(spellHandsOn(48 * 60)).toBe("48m")
+    expect(spellHandsOn(30)).toBe("")
+  })
+})

--- a/frontend/src/lib/session/hands-on.ts
+++ b/frontend/src/lib/session/hands-on.ts
@@ -1,0 +1,29 @@
+// formatHandsOn renders how long a session has been worked on, for the footer,
+// where it sits beside the cost figure at 12px and is glanced at rather than
+// read: "48m", "1h12m", "14h05m".
+//
+// Minutes are the floor. A session under one is a session that has counted
+// nothing worth a figure — the store is up to a flush behind besides — and "0m"
+// reads as a broken readout rather than as a new session, so it renders as
+// nothing at all and the segment does not appear.
+//
+// The minutes are zero-padded once there are hours in front of them, because
+// "1h5m" and "1h50m" differ by one glyph in a strip nobody stops to parse.
+export function formatHandsOn(seconds: number): string {
+  if (!Number.isFinite(seconds) || seconds < 60) {
+    return ""
+  }
+  const minutes = Math.floor(seconds / 60)
+  const hours = Math.floor(minutes / 60)
+  if (hours === 0) {
+    return `${minutes}m`
+  }
+  return `${hours}h${String(minutes % 60).padStart(2, "0")}m`
+}
+
+// spellHandsOn is the same figure with room to breathe, for the tooltip: "1h
+// 12m", "48m". Same rules, one space — the strip is scanned, the tooltip is
+// read.
+export function spellHandsOn(seconds: number): string {
+  return formatHandsOn(seconds).replace("h", "h ")
+}

--- a/internal/store/handson.go
+++ b/internal/store/handson.go
@@ -1,0 +1,79 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// AddHandsOn folds another stretch of hands-on time into a session's total, in
+// whole seconds. The accumulator that measures it holds no absolute figure of
+// its own (internal/terminal.handsOn), so this adds rather than sets: a lich
+// that restarts resumes counting onto what the last one wrote instead of
+// starting the session over at zero.
+//
+// The SELECT ... WHERE EXISTS writes nothing for a session whose row is already
+// gone — closed while its last stretch was still being written — for the same
+// reason SaveCostLedger does it: that is a race, not a failure.
+func (s *Service) AddHandsOn(sessionID string, seconds int64) error {
+	if seconds <= 0 {
+		return nil
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO session_hands_on (session_id, seconds)
+		 SELECT ?, ? WHERE EXISTS (SELECT 1 FROM sessions WHERE id = ?)
+		 ON CONFLICT(session_id) DO UPDATE SET seconds = seconds + excluded.seconds`,
+		sessionID, seconds, sessionID,
+	)
+	if err != nil {
+		return fmt.Errorf("add hands-on time for %q: %w", sessionID, err)
+	}
+	return nil
+}
+
+// HandsOn is how long a session has been worked on, in whole seconds. A session
+// nothing has been counted for yet answers 0, which is the right starting point,
+// so a missing row is not an error.
+func (s *Service) HandsOn(sessionID string) (int64, error) {
+	var seconds int64
+	err := s.db.QueryRow(
+		`SELECT seconds FROM session_hands_on WHERE session_id = ?`, sessionID,
+	).Scan(&seconds)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read hands-on time for %q: %w", sessionID, err)
+	}
+	return seconds, nil
+}
+
+// handsOnOf reads a session's total inside a transaction, for the delete and
+// reinsert a parked session's resume performs (see reopen).
+func handsOnOf(tx *sql.Tx, sessionID string) (int64, error) {
+	var seconds int64
+	err := tx.QueryRow(
+		`SELECT seconds FROM session_hands_on WHERE session_id = ?`, sessionID,
+	).Scan(&seconds)
+	if errors.Is(err, sql.ErrNoRows) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("read hands-on time for %q: %w", sessionID, err)
+	}
+	return seconds, nil
+}
+
+// restoreHandsOn re-keys a total onto a session id.
+func restoreHandsOn(tx *sql.Tx, sessionID string, seconds int64) error {
+	if seconds <= 0 {
+		return nil
+	}
+	if _, err := tx.Exec(
+		`INSERT INTO session_hands_on (session_id, seconds) VALUES (?, ?)`,
+		sessionID, seconds,
+	); err != nil {
+		return fmt.Errorf("restore hands-on time for %q: %w", sessionID, err)
+	}
+	return nil
+}

--- a/internal/store/handson_test.go
+++ b/internal/store/handson_test.go
@@ -1,0 +1,121 @@
+package store
+
+import "testing"
+
+// TestAnUnworkedSessionReadsZero pins the starting point: a session nothing has
+// been counted for yet has no row, and that has to read as zero rather than as
+// an error — every session begins there.
+func TestAnUnworkedSessionReadsZero(t *testing.T) {
+	svc := newCostSession(t)
+
+	seconds, err := svc.HandsOn("s1")
+
+	if err != nil {
+		t.Fatalf("HandsOn: %v", err)
+	}
+	if seconds != 0 {
+		t.Errorf("HandsOn = %d, want 0", seconds)
+	}
+}
+
+// TestHandsOnAccumulates is the contract the accumulator depends on: it holds
+// only the arrears since its last write, so the store has to add rather than
+// set — otherwise a restart would restate the session at whatever the next
+// flush happened to be carrying.
+func TestHandsOnAccumulates(t *testing.T) {
+	svc := newCostSession(t)
+
+	for _, seconds := range []int64{30, 30, 45} {
+		if err := svc.AddHandsOn("s1", seconds); err != nil {
+			t.Fatalf("AddHandsOn: %v", err)
+		}
+	}
+
+	total, err := svc.HandsOn("s1")
+	if err != nil {
+		t.Fatalf("HandsOn: %v", err)
+	}
+	if total != 105 {
+		t.Errorf("HandsOn = %d, want 105", total)
+	}
+}
+
+// TestAddingNothingWritesNothing proves a drain with no whole second in it
+// costs no write at all — the debounce fires on a timer, not on there being
+// something to say.
+func TestAddingNothingWritesNothing(t *testing.T) {
+	svc := newCostSession(t)
+
+	if err := svc.AddHandsOn("s1", 0); err != nil {
+		t.Fatalf("AddHandsOn: %v", err)
+	}
+
+	var rows int
+	if err := svc.db.QueryRow(
+		`SELECT COUNT(*) FROM session_hands_on WHERE session_id = 's1'`,
+	).Scan(&rows); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if rows != 0 {
+		t.Errorf("a zero-second add wrote %d rows, want none", rows)
+	}
+}
+
+// TestAddingToAGoneSessionIsNotAnError pins the same race SaveCostLedger takes:
+// a card closed while its last stretch was still being written has no row left
+// to add to, and the foreign key must not turn that into a failure.
+func TestAddingToAGoneSessionIsNotAnError(t *testing.T) {
+	svc := newCostSession(t)
+
+	if err := svc.AddHandsOn("ghost", 60); err != nil {
+		t.Errorf("AddHandsOn for a session that is gone: %v", err)
+	}
+}
+
+// TestDeletingASessionTakesItsHandsOnRow proves the cascade: the row hangs off
+// the session and must not outlive it.
+func TestDeletingASessionTakesItsHandsOnRow(t *testing.T) {
+	svc := newCostSession(t)
+	if err := svc.AddHandsOn("s1", 90); err != nil {
+		t.Fatalf("AddHandsOn: %v", err)
+	}
+
+	if err := svc.DeleteSession("p1", "s1", ""); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+
+	var rows int
+	if err := svc.db.QueryRow(`SELECT COUNT(*) FROM session_hands_on`).Scan(&rows); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if rows != 0 {
+		t.Errorf("%d hands-on rows outlived the session they belong to", rows)
+	}
+}
+
+// TestResumingAWorktreeSessionKeepsItsHandsOnTime proves the total survives the
+// delete-and-reinsert a resume performs. A session parked at lunch and resumed
+// after must not come back reading zero: the hours are the user's, and the new
+// id is lich's own bookkeeping.
+func TestResumingAWorktreeSessionKeepsItsHandsOnTime(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2, "")
+	_ = svc.AddSession("p1", "wt1", "worktree", "claude", "/wt/foo", 3, "")
+	if err := svc.AddHandsOn("wt1", 4200); err != nil {
+		t.Fatalf("AddHandsOn: %v", err)
+	}
+	_ = svc.CloseSession("p1", "wt1", "base")
+
+	if _, err := svc.ReopenWorktreeSession("p1", "/wt/foo", "wt2"); err != nil {
+		t.Fatalf("ReopenWorktreeSession: %v", err)
+	}
+
+	total, err := svc.HandsOn("wt2")
+	if err != nil {
+		t.Fatalf("HandsOn: %v", err)
+	}
+	if total != 4200 {
+		t.Errorf("a resumed session reads %ds, want the 4200 it was worked", total)
+	}
+}

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -305,6 +305,14 @@ func (s *Service) reopen(newSessionID, where string, args ...any) (*Session, err
 		if err != nil {
 			return err
 		}
+		// Hands-on time rides along for the same reason, one row over: the work
+		// this session was worked through is the user's, and a resume that
+		// dropped it would restart the clock on a session they have been at all
+		// day.
+		handsOn, err := handsOnOf(tx, old.ID)
+		if err != nil {
+			return err
+		}
 		if _, err := tx.Exec(`DELETE FROM sessions WHERE id = ?`, old.ID); err != nil {
 			return fmt.Errorf("drop parked session %q: %w", old.ID, err)
 		}
@@ -322,6 +330,9 @@ func (s *Service) reopen(newSessionID, where string, args ...any) (*Session, err
 			return fmt.Errorf("reinsert session %q: %w", newSessionID, err)
 		}
 		if err := restoreCostLedgers(tx, newSessionID, ledgers); err != nil {
+			return err
+		}
+		if err := restoreHandsOn(tx, newSessionID, handsOn); err != nil {
 			return err
 		}
 		if err := setActiveSession(tx, projectID, newSessionID); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -99,6 +99,15 @@ CREATE TABLE IF NOT EXISTS session_costs (
     cost_usd        REAL NOT NULL DEFAULT 0,
     PRIMARY KEY (session_id, transcript_id)
 );
+
+CREATE TABLE IF NOT EXISTS session_hands_on (
+    session_id TEXT NOT NULL PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    -- Whole seconds this session has been worked on, summed across every run of
+    -- lich it has survived. Seconds rather than a finer unit because the readout
+    -- is minutes: the accumulator keeps the sub-second remainder in memory and
+    -- only ever hands whole seconds down (internal/terminal.handsOn).
+    seconds    INTEGER NOT NULL DEFAULT 0
+);
 `
 
 // busyTimeoutMS is how long a write waits on SQLite's lock before failing.

--- a/internal/terminal/handson.go
+++ b/internal/terminal/handson.go
@@ -1,0 +1,153 @@
+package terminal
+
+import (
+	"sync"
+	"time"
+)
+
+// How the hands-on clock is read. Three constants, and each of them is the
+// whole design: there are no sessions to open and close and no timer running
+// between them, only beats and the gaps between consecutive ones.
+const (
+	// handsOnIdleGap is the longest silence that still counts as working time.
+	// A gap under it is time the user spent reading, thinking or waiting on the
+	// agent, which is time on this session; a gap over it is lunch, another
+	// window or another day, and it contributes nothing at all — which is what
+	// makes a session left open overnight report the hour it was worked rather
+	// than the fourteen it was on screen.
+	handsOnIdleGap = 15 * time.Minute
+	// handsOnOutputBeat is how rarely a session's own output may beat. It is
+	// load-bearing, not a performance knob: PTY output arrives in bursts of a
+	// few bytes, and an unthrottled beat per burst would turn any stream —
+	// `tail -f`, a dev server, a TUI repainting its spinner — into an unbroken
+	// chain of tiny gaps that never reaches handsOnIdleGap, and so into hours
+	// of "work" nobody did.
+	handsOnOutputBeat = 30 * time.Second
+	// handsOnFlush is how long counted time may sit in memory before a beat
+	// carries it to the store. Losing a beat to a crash costs at most this
+	// much per session, which is the trade the readout is worth.
+	handsOnFlush = 30 * time.Second
+)
+
+// handsOnEntry is one session's accounting: when it last beat, and what has
+// been counted but not yet written.
+type handsOnEntry struct {
+	last    time.Time
+	pending time.Duration
+}
+
+// handsOn measures how long each session has actually been worked on, without
+// ever deciding when a stretch of work starts or ends.
+//
+// The whole method is beat-and-gap: something happens in a session, and the
+// time since the previous thing that happened in it is added to the total —
+// unless that gap is longer than handsOnIdleGap, in which case it is a silence
+// and adds nothing. Nothing is scheduled, nothing has to be closed, and a lich
+// that dies mid-turn leaves no session open behind it: the next beat after a
+// restart simply finds no previous one and starts the chain again.
+//
+// It holds no absolute total. What it keeps is the arrears — whole seconds not
+// yet handed to the store, which owns the figure the readout comes from (see
+// store.AddHandsOn). That is what lets a beat write with `seconds + ?` and
+// makes a lost flush cost only what it was carrying.
+//
+// The zero value is ready to use, like turnLog beside it: a bare Service is a
+// state the tests build, and one that panicked on the first keystroke would be
+// a trap set by a readout.
+type handsOn struct {
+	mu sync.Mutex
+	// now is the clock, and nil is the wall clock. The tests set it so a
+	// fifteen-minute gap is a line of code rather than a sleep.
+	now       func() time.Time
+	entries   map[string]handsOnEntry
+	lastFlush time.Time
+}
+
+// clock reads the injected time source, falling back to the wall clock.
+func (h *handsOn) clock() time.Time {
+	if h.now == nil {
+		return time.Now()
+	}
+	return h.now()
+}
+
+// beat records one moment of activity in session id and reports whether the
+// arrears are due a write.
+//
+// minGap is the throttle: a beat closer than that to the previous one is
+// dropped whole, which is how the output path (handsOnOutputBeat) keeps a
+// streaming program from beating its way to a number nobody worked. Pass 0 for
+// a beat that is already rare — a state report, a keystroke — and the only
+// thing dropped is a clock that went backwards.
+//
+// The first beat of a session counts nothing: there is no previous one to
+// measure a gap against, and inventing a start would credit the session with
+// however long lich had been running.
+func (h *handsOn) beat(id string, minGap time.Duration) (flush bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	now := h.clock()
+	entry := h.entries[id]
+	if !entry.last.IsZero() {
+		gap := now.Sub(entry.last)
+		if gap < minGap {
+			return false
+		}
+		if gap > 0 && gap <= handsOnIdleGap {
+			entry.pending += gap
+		}
+	}
+	entry.last = now
+	if h.entries == nil {
+		h.entries = make(map[string]handsOnEntry)
+	}
+	h.entries[id] = entry
+	return h.due(now)
+}
+
+// due reports whether handsOnFlush has passed since the last write, and arms
+// the next window in the same breath — so of every beat that crosses the line,
+// exactly one caller is told to write. Callers hold h.mu.
+func (h *handsOn) due(now time.Time) bool {
+	if now.Sub(h.lastFlush) < handsOnFlush {
+		return false
+	}
+	h.lastFlush = now
+	return true
+}
+
+// drain hands back the whole seconds each session has run up since the last
+// drain, and keeps the remainder. Keeping it is what stops the readout drifting
+// low: at two flushes a minute, rounding the leftover away each time would lose
+// most of a minute every hour.
+//
+// Sessions with nothing to write are left out, so an app full of idle cards
+// drains to nothing and writes nothing.
+func (h *handsOn) drain() map[string]int64 {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	var out map[string]int64
+	for id, entry := range h.entries {
+		seconds := int64(entry.pending / time.Second)
+		if seconds == 0 {
+			continue
+		}
+		entry.pending -= time.Duration(seconds) * time.Second
+		h.entries[id] = entry
+		if out == nil {
+			out = make(map[string]int64)
+		}
+		out[id] = seconds
+	}
+	return out
+}
+
+// forget drops what is remembered about a session, so the gap across a card's
+// close — or across a PTY respawned under the same id — is never counted into
+// whatever comes next. Callers drain first: the sub-second remainder this
+// throws away is the whole cost of not doing so.
+func (h *handsOn) forget(id string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delete(h.entries, id)
+}

--- a/internal/terminal/handson_test.go
+++ b/internal/terminal/handson_test.go
@@ -1,0 +1,278 @@
+package terminal
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeClock is a hand-wound clock: the accumulator's whole contract is about
+// gaps of minutes, and a test that slept through them would be the slowest in
+// the suite and still flaky.
+type fakeClock struct {
+	mu sync.Mutex
+	at time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{at: time.Date(2026, 8, 28, 9, 0, 0, 0, time.UTC)}
+}
+
+func (c *fakeClock) now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.at
+}
+
+func (c *fakeClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.at = c.at.Add(d)
+}
+
+// drainSeconds is what one drain would write for a session, in whole seconds.
+func drainSeconds(h *handsOn, id string) int64 {
+	return h.drain()[id]
+}
+
+// TestFirstBeatCountsNothing proves a session's first beat opens the chain and
+// credits nothing: there is no earlier beat to measure against, and inventing a
+// start would bill the session for however long lich had been running.
+func TestFirstBeatCountsNothing(t *testing.T) {
+	clock := newFakeClock()
+	h := &handsOn{now: clock.now}
+
+	h.beat("s1", 0)
+
+	if got := drainSeconds(h, "s1"); got != 0 {
+		t.Errorf("first beat counted %ds, want 0", got)
+	}
+}
+
+// TestGapUnderIdleGapCounts proves the ordinary case: two beats a few minutes
+// apart are minutes at the keyboard, and the whole gap is credited.
+func TestGapUnderIdleGapCounts(t *testing.T) {
+	clock := newFakeClock()
+	h := &handsOn{now: clock.now}
+
+	h.beat("s1", 0)
+	clock.advance(5 * time.Minute)
+	h.beat("s1", 0)
+
+	if got := drainSeconds(h, "s1"); got != 300 {
+		t.Errorf("a 5m gap counted %ds, want 300", got)
+	}
+}
+
+// TestGapAtIdleGapCounts pins the boundary itself: exactly handsOnIdleGap is
+// still work. The literal is written out rather than derived from the constant,
+// so moving the constant fails this test instead of silently moving the rule
+// with it.
+func TestGapAtIdleGapCounts(t *testing.T) {
+	clock := newFakeClock()
+	h := &handsOn{now: clock.now}
+
+	h.beat("s1", 0)
+	clock.advance(15 * time.Minute)
+	h.beat("s1", 0)
+
+	if got := drainSeconds(h, "s1"); got != 900 {
+		t.Errorf("a gap of exactly the idle gap counted %ds, want 900", got)
+	}
+}
+
+// TestGapOverIdleGapCountsNothing is the rule the whole readout rests on: a
+// silence longer than the idle gap is time away, and it contributes zero rather
+// than a capped amount — a session left open overnight must not bill the night.
+func TestGapOverIdleGapCountsNothing(t *testing.T) {
+	clock := newFakeClock()
+	h := &handsOn{now: clock.now}
+
+	h.beat("s1", 0)
+	clock.advance(15*time.Minute + time.Second)
+	h.beat("s1", 0)
+
+	if got := drainSeconds(h, "s1"); got != 0 {
+		t.Errorf("a gap past the idle gap counted %ds, want 0", got)
+	}
+}
+
+// TestSilenceStillRearmsTheChain proves a long silence costs only itself: the
+// beat that ends it is the start of the next stretch, and the work after it is
+// counted in full.
+func TestSilenceStillRearmsTheChain(t *testing.T) {
+	clock := newFakeClock()
+	h := &handsOn{now: clock.now}
+
+	h.beat("s1", 0)
+	clock.advance(2 * time.Hour)
+	h.beat("s1", 0)
+	clock.advance(3 * time.Minute)
+	h.beat("s1", 0)
+
+	if got := drainSeconds(h, "s1"); got != 180 {
+		t.Errorf("work after a long silence counted %ds, want 180", got)
+	}
+}
+
+// TestThrottleDropsCloseBeats proves the gate the output path depends on: beats
+// closer together than minGap are dropped whole — neither counted nor recorded
+// as the previous beat — so a stream of them cannot chain its way to a total.
+func TestThrottleDropsCloseBeats(t *testing.T) {
+	clock := newFakeClock()
+	h := &handsOn{now: clock.now}
+
+	h.beat("s1", handsOnOutputBeat)
+	for range 100 {
+		clock.advance(time.Second)
+		h.beat("s1", handsOnOutputBeat)
+	}
+
+	// 100 seconds of steady output, throttled to a beat every 30: three gaps of
+	// 30 seconds land, and the last 10 seconds are still waiting for their beat.
+	if got := drainSeconds(h, "s1"); got != 90 {
+		t.Errorf("100s of throttled output counted %ds, want 90", got)
+	}
+}
+
+// TestThrottleAdmitsBeatAtTheGap pins the throttle's own boundary: a beat
+// exactly minGap after the last one is admitted, not dropped.
+func TestThrottleAdmitsBeatAtTheGap(t *testing.T) {
+	clock := newFakeClock()
+	h := &handsOn{now: clock.now}
+
+	h.beat("s1", handsOnOutputBeat)
+	clock.advance(30 * time.Second)
+	h.beat("s1", handsOnOutputBeat)
+
+	if got := drainSeconds(h, "s1"); got != 30 {
+		t.Errorf("a beat at exactly the throttle counted %ds, want 30", got)
+	}
+}
+
+// TestBackwardsClockCountsNothing proves a clock that jumps back — an NTP step,
+// a laptop resuming — neither credits negative time nor corrupts the chain.
+func TestBackwardsClockCountsNothing(t *testing.T) {
+	clock := newFakeClock()
+	h := &handsOn{now: clock.now}
+
+	h.beat("s1", 0)
+	clock.advance(-time.Hour)
+	h.beat("s1", 0)
+	clock.advance(time.Hour + 2*time.Minute)
+	h.beat("s1", 0)
+
+	if got := drainSeconds(h, "s1"); got != 120 {
+		t.Errorf("a backwards clock left %ds counted, want 120", got)
+	}
+}
+
+// TestDrainKeepsTheRemainder proves the sub-second leftover survives a drain.
+// At two flushes a minute, throwing it away would lose most of a minute an hour
+// and the readout would drift quietly low.
+func TestDrainKeepsTheRemainder(t *testing.T) {
+	clock := newFakeClock()
+	h := &handsOn{now: clock.now}
+
+	h.beat("s1", 0)
+	clock.advance(1500 * time.Millisecond)
+	h.beat("s1", 0)
+	if got := drainSeconds(h, "s1"); got != 1 {
+		t.Fatalf("first drain wrote %ds, want 1", got)
+	}
+
+	clock.advance(1500 * time.Millisecond)
+	h.beat("s1", 0)
+	if got := drainSeconds(h, "s1"); got != 2 {
+		t.Errorf("second drain wrote %ds, want 2 — the remainder was dropped", got)
+	}
+}
+
+// TestDrainSkipsQuietSessions proves an app full of idle cards drains to
+// nothing, so the debounced write touches no row it has nothing to say about.
+func TestDrainSkipsQuietSessions(t *testing.T) {
+	clock := newFakeClock()
+	h := &handsOn{now: clock.now}
+
+	h.beat("quiet", 0)
+	h.beat("worked", 0)
+	clock.advance(time.Minute)
+	h.beat("worked", 0)
+
+	drained := h.drain()
+	if _, ok := drained["quiet"]; ok {
+		t.Error("a session that counted nothing was drained")
+	}
+	if drained["worked"] != 60 {
+		t.Errorf("worked drained %ds, want 60", drained["worked"])
+	}
+}
+
+// TestSessionsAreCountedApart proves the accumulator keys everything by session:
+// one card's beats never advance another's chain.
+func TestSessionsAreCountedApart(t *testing.T) {
+	clock := newFakeClock()
+	h := &handsOn{now: clock.now}
+
+	h.beat("s1", 0)
+	clock.advance(time.Minute)
+	h.beat("s2", 0)
+	clock.advance(time.Minute)
+	h.beat("s1", 0)
+
+	drained := h.drain()
+	if drained["s1"] != 120 {
+		t.Errorf("s1 counted %ds, want 120", drained["s1"])
+	}
+	if _, ok := drained["s2"]; ok {
+		t.Errorf("s2 counted %ds off its own first beat, want nothing", drained["s2"])
+	}
+}
+
+// TestFlushIsDueOncePerWindow proves exactly one beat per window is told to
+// write: the debounce is armed by whoever crosses the line, so two beats a
+// millisecond apart cannot both spawn a writer.
+func TestFlushIsDueOncePerWindow(t *testing.T) {
+	clock := newFakeClock()
+	h := &handsOn{now: clock.now, lastFlush: clock.now()}
+
+	if h.beat("s1", 0) {
+		t.Error("a beat inside the window asked for a write")
+	}
+	clock.advance(handsOnFlush)
+	if !h.beat("s1", 0) {
+		t.Fatal("the beat that crossed the window did not ask for a write")
+	}
+	if h.beat("s2", 0) {
+		t.Error("a second beat in the same window asked for a write too")
+	}
+}
+
+// TestForgetBreaksTheChain proves a card closed and reopened under the same id
+// does not count the gap it was gone for.
+func TestForgetBreaksTheChain(t *testing.T) {
+	clock := newFakeClock()
+	h := &handsOn{now: clock.now}
+
+	h.beat("s1", 0)
+	h.forget("s1")
+	clock.advance(time.Minute)
+	h.beat("s1", 0)
+
+	if got := drainSeconds(h, "s1"); got != 0 {
+		t.Errorf("the gap across a forget counted %ds, want 0", got)
+	}
+}
+
+// TestZeroValueAccumulatorWorks proves the zero value is usable, which is the
+// state every bare Service the tests build is in — a readout must never be the
+// reason a keystroke panics.
+func TestZeroValueAccumulatorWorks(t *testing.T) {
+	var h handsOn
+
+	h.beat("s1", 0)
+	h.forget("s1")
+	if got := h.drain(); len(got) != 0 {
+		t.Errorf("a zero-value accumulator drained %v, want nothing", got)
+	}
+}

--- a/internal/terminal/handson_wiring_test.go
+++ b/internal/terminal/handson_wiring_test.go
@@ -1,0 +1,139 @@
+// These cover the accumulator wired into the Service, which needs the suite's
+// Store stub — and that stub lives in terminal_test.go, which is Unix-only for
+// its real PTY spawns. Nothing here spawns anything; the tag is the stub's,
+// not this file's. The accumulator's own logic is in handson_test.go and runs
+// on every OS.
+//go:build !windows
+
+package terminal
+
+import (
+	"testing"
+	"time"
+
+	"github.com/omartelo/lich/internal/events"
+)
+
+// newQuietService is a Service on a hand-wound clock with the debounced write
+// disarmed. A beat that crosses the flush window spawns a writer goroutine of
+// its own (see Service.beatHandsOn), and a test that both beats and reads the
+// accumulator would be racing that writer for the same seconds — which is a
+// flaky test, not a flaky product. Pushing lastFlush past anything a test winds
+// the clock to leaves the arrears where the assertion can see them; the flush
+// itself is exercised deliberately, by calling it.
+func newQuietService(store Store, clock *fakeClock) *Service {
+	svc := New(store, nil, events.New())
+	svc.hands.now = clock.now
+	svc.hands.lastFlush = clock.now().Add(24 * time.Hour)
+	return svc
+}
+
+// TestOutputCountsOnlyWhileBusy is the gate that keeps the readout honest.
+// A session's own output is not proof anybody is working — a `tail -f`, a dev
+// server, a TUI repainting its spinner all draw forever — so it counts only
+// while the provider's own report says a turn is open.
+func TestOutputCountsOnlyWhileBusy(t *testing.T) {
+	clock := newFakeClock()
+	svc := newQuietService(stubBins{}, clock)
+	sess := &session{}
+
+	// Streaming with no turn open: an hour of it, and nothing is counted.
+	for range 120 {
+		svc.noteOutput("s1", sess, []byte("waiting for changes..."))
+		clock.advance(30 * time.Second)
+	}
+	if got := drainSeconds(&svc.hands, "s1"); got != 0 {
+		t.Fatalf("an idle session streaming output counted %ds, want 0", got)
+	}
+
+	// The same output, with the provider reporting a turn: now it is the agent
+	// working, and it counts.
+	svc.turns.report("s1", statusBusy)
+	svc.noteOutput("s1", sess, []byte("thinking..."))
+	clock.advance(30 * time.Second)
+	svc.noteOutput("s1", sess, []byte("thinking..."))
+
+	if got := drainSeconds(&svc.hands, "s1"); got != 30 {
+		t.Errorf("a busy session's output counted %ds, want 30", got)
+	}
+}
+
+// TestOutputBeatsAreThrottled proves the burst rate of a PTY never reaches the
+// accumulator: output arrives in fragments, and one beat per fragment would
+// chain gaps too small to ever look like a silence.
+func TestOutputBeatsAreThrottled(t *testing.T) {
+	clock := newFakeClock()
+	svc := newQuietService(stubBins{}, clock)
+	svc.turns.report("s1", statusBusy)
+	sess := &session{}
+
+	// One second of output, a fragment every 100ms — well inside the throttle.
+	for range 10 {
+		svc.noteOutput("s1", sess, []byte("."))
+		clock.advance(100 * time.Millisecond)
+	}
+
+	if got := svc.hands.drain(); len(got) != 0 {
+		t.Errorf("a burst of output fragments counted %v, want nothing", got)
+	}
+}
+
+// TestKeystrokesCountWithoutAnyProviderReport proves the one beat source every
+// session has: a shell, and a provider that reports no state at all, are
+// counted from the user's own typing.
+func TestKeystrokesCountWithoutAnyProviderReport(t *testing.T) {
+	clock := newFakeClock()
+	svc := newQuietService(stubBins{}, clock)
+
+	svc.beatHandsOn("s1", 0)
+	clock.advance(2 * time.Minute)
+	svc.beatHandsOn("s1", 0)
+
+	if got := drainSeconds(&svc.hands, "s1"); got != 120 {
+		t.Errorf("typing counted %ds, want 120", got)
+	}
+}
+
+// TestFlushWritesThroughToTheStore proves the arrears reach the row, and reach
+// it as an addition — a second flush must not restate the first.
+func TestFlushWritesThroughToTheStore(t *testing.T) {
+	clock := newFakeClock()
+	store := stubBins{handsOn: map[string]int64{}}
+	svc := newQuietService(store, clock)
+
+	svc.beatHandsOn("s1", 0)
+	clock.advance(time.Minute)
+	svc.beatHandsOn("s1", 0)
+	svc.FlushHandsOn()
+	clock.advance(time.Minute)
+	svc.beatHandsOn("s1", 0)
+	svc.FlushHandsOn()
+
+	total, err := svc.HandsOn("s1")
+	if err != nil {
+		t.Fatalf("HandsOn: %v", err)
+	}
+	if total != 120 {
+		t.Errorf("two minutes over two flushes read back as %ds, want 120", total)
+	}
+}
+
+// TestClosingASessionWritesWhatItWasWorked proves the close flushes before the
+// window deletes the row: a write that loses that race is dropped silently, and
+// this is a closed card's last chance to keep its number.
+func TestClosingASessionWritesWhatItWasWorked(t *testing.T) {
+	clock := newFakeClock()
+	store := stubBins{handsOn: map[string]int64{}}
+	svc := newQuietService(store, clock)
+
+	svc.beatHandsOn("s1", 0)
+	clock.advance(20 * time.Second)
+	svc.beatHandsOn("s1", 0)
+	if err := svc.Close("s1"); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if store.handsOn["s1"] != 20 {
+		t.Errorf("closing wrote %ds, want 20", store.handsOn["s1"])
+	}
+}

--- a/internal/terminal/hookstate.go
+++ b/internal/terminal/hookstate.go
@@ -51,6 +51,15 @@ func (l *turnLog) report(id, state string) bool {
 	return true
 }
 
+// busy reports whether a turn is open in this session right now — the provider's
+// own word for "the agent is working", which is what qualifies its output as
+// work rather than as a program repainting (see Service.noteOutput).
+func (l *turnLog) busy(id string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.open[id]
+}
+
 // forget drops a session's turn, so a PTY respawned under the same id is read
 // against its own reports rather than against those of the provider that left.
 func (l *turnLog) forget(id string) {

--- a/internal/terminal/spawn_test.go
+++ b/internal/terminal/spawn_test.go
@@ -66,7 +66,7 @@ func TestTheSetupMarkerSurvivesASplitRead(t *testing.T) {
 	svc.mu.Unlock()
 
 	head, tail := setupDone[:8], setupDone[8:]
-	svc.noteOutput(sess, []byte("added 551 packages"+head))
+	svc.noteOutput("s1", sess, []byte("added 551 packages"+head))
 	svc.mu.Lock()
 	stillSettingUp := sess.settingUp
 	svc.mu.Unlock()
@@ -74,7 +74,7 @@ func TestTheSetupMarkerSurvivesASplitRead(t *testing.T) {
 		t.Fatal("half a marker ended the setup")
 	}
 
-	svc.noteOutput(sess, []byte(tail+"\x1b[?25l"))
+	svc.noteOutput("s1", sess, []byte(tail+"\x1b[?25l"))
 
 	svc.mu.Lock()
 	defer svc.mu.Unlock()
@@ -91,7 +91,7 @@ func TestAPartialMarkerNeverEndsTheSetup(t *testing.T) {
 	sess := &session{settingUp: true}
 
 	for range 3 {
-		svc.noteOutput(sess, []byte(setupDone[:len(setupDone)-1]))
+		svc.noteOutput("s1", sess, []byte(setupDone[:len(setupDone)-1]))
 	}
 
 	svc.mu.Lock()

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -209,6 +209,8 @@ type Store interface {
 	CostLedger(sessionID, transcriptID string) (int64, string, float64, error)
 	SaveCostLedger(sessionID, transcriptID string, offset int64, lastMessage string, cost float64) error
 	SessionCost(sessionID string) (float64, error)
+	AddHandsOn(sessionID string, seconds int64) error
+	HandsOn(sessionID string) (int64, error)
 }
 
 // Service manages PTY-backed shell sessions keyed by session ID.
@@ -256,6 +258,11 @@ type Service struct {
 	// nothing else about a report needs mu, and a hook must never queue behind a
 	// PTY spawn.
 	turns turnLog
+	// hands is how long each session has been worked on, measured off the same
+	// three signals the card is already drawing — a state report, a keystroke,
+	// output while the agent is busy (see handsOn). It carries its own lock for
+	// the reason turns does: a hook must never queue behind a PTY spawn.
+	hands handsOn
 	// snaps brackets each session's turn with a tree snapshot of its checkout,
 	// which is what the Review panel's "Last turn" mode diffs (see turnSnaps).
 	// It reads the same boundary turns does and carries its own lock for the
@@ -346,6 +353,11 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 	}
 	ws, err := newTransport(
 		func(id string, data []byte) {
+			// Only this callback, never writeBytes: what arrives here is the
+			// window's own input frames, which is a person at the keyboard. A
+			// relayed message another session pasted through Write is that
+			// session's work, not this one's.
+			s.beatHandsOn(id, 0)
 			if s.noteInput(id, data) {
 				s.noteInterrupt(id)
 			}
@@ -354,6 +366,13 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 			}
 		},
 		func(req hookRequest) {
+			// Ahead of every filter below, because this one is not about what
+			// the card can draw. A report lich refuses to publish still proves
+			// the session was being worked: Cursor CLI's tool reports are
+			// dropped a line down for want of anything that could end the
+			// spinner they would start, and they are the only proof a Cursor
+			// turn is running at all (see closableState).
+			s.beatHandsOn(req.SessionID, 0)
 			// Dropped where the harness cannot close it, before the turn log
 			// ever sees it: a state nothing ends outlives what it describes.
 			if !closableState(s.kindOf(req.SessionID), req.State) {
@@ -757,7 +776,7 @@ func (s *Service) stream(id string, sess *session) {
 	for {
 		n, err := p.Read(buf)
 		if n > 0 {
-			s.noteOutput(sess, buf[:n])
+			s.noteOutput(id, sess, buf[:n])
 			sess.replay.append(buf[:n])
 			sess.out.Write(buf[:n])
 		}
@@ -888,11 +907,12 @@ func (s *Service) Resize(id string, cols, rows int) error {
 	return p.Resize(cols, rows)
 }
 
-// noteOutput reads one chunk of a session's output for the two things lich has
-// to know about it from outside: whether the worktree setup script is still the
-// program on the other end of this PTY (see setupDone), and whether that
-// program has ever stopped drawing (see Ready).
-func (s *Service) noteOutput(sess *session, chunk []byte) {
+// noteOutput reads one chunk of a session's output for the three things lich
+// has to know about it from outside: whether the worktree setup script is still
+// the program on the other end of this PTY (see setupDone), whether that
+// program has ever stopped drawing (see Ready), and whether the agent is
+// working right now (see handsOn).
+func (s *Service) noteOutput(id string, sess *session, chunk []byte) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	// The quiet is recorded as it passes, never sampled when somebody finally
@@ -918,6 +938,15 @@ func (s *Service) noteOutput(sess *session, chunk []byte) {
 		// which is the write that lands on screen as literal paste markers.
 		sess.ready = false
 		sess.lastOut = time.Time{}
+	}
+	// Output is the one beat source that has to be qualified, because a
+	// terminal draws for reasons that are nobody's work: a `tail -f`, a dev
+	// server logging requests, a TUI repainting its own spinner. An open turn
+	// is what separates the agent working from a program talking to itself —
+	// so nothing here counts unless the session's own last report said `busy`,
+	// and even then only once every handsOnOutputBeat.
+	if s.turns.busy(id) {
+		s.beatHandsOn(id, handsOnOutputBeat)
 	}
 }
 
@@ -1025,10 +1054,45 @@ func (s *Service) Close(id string) error {
 	// last turn changed — and its snapshot index would otherwise outlive it on
 	// disk for the rest of the machine's life.
 	s.snaps.forget(id)
+	// Synchronously, and before the row that the window is about to delete goes:
+	// a write that loses that race is dropped silently (store.AddHandsOn), and
+	// this is the last chance a closed card gets to keep what it was worked.
+	s.FlushHandsOn()
+	s.hands.forget(id)
 	if !ok {
 		return nil
 	}
 	return sess.pty.Close()
+}
+
+// HandsOn is how long session id has been worked on, in whole seconds: the time
+// it was reporting, being typed at or producing output for an open turn, minus
+// every silence longer than handsOnIdleGap (see handsOn). Zero for a session
+// nothing has been counted for yet, and up to handsOnFlush behind what has
+// actually been measured — the readout is in minutes, so the debounce never
+// shows.
+func (s *Service) HandsOn(id string) (int64, error) {
+	return s.store.HandsOn(id)
+}
+
+// FlushHandsOn writes what every session has been worked since the last write.
+// Called off the debounce, when a card closes and once on the way out, so a
+// session's hours outlive the process that counted them.
+func (s *Service) FlushHandsOn() {
+	for id, seconds := range s.hands.drain() {
+		if err := s.store.AddHandsOn(id, seconds); err != nil {
+			slog.Warn("terminal: save hands-on time", "session", id, "err", err)
+		}
+	}
+}
+
+// beatHandsOn records activity in session id, and writes the arrears off the
+// caller's goroutine once the debounce is up — a hook must never wait on
+// SQLite, and neither must the PTY reader.
+func (s *Service) beatHandsOn(id string, minGap time.Duration) {
+	if s.hands.beat(id, minGap) {
+		go s.FlushHandsOn()
+	}
 }
 
 // Live reports whether a session has a process running right now. It is the

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -49,6 +49,10 @@ type stubBins struct {
 	costOn          bool
 	ledgers         map[string]stubLedger
 	ports           map[string]int
+	// Whole seconds per session, the shape store.AddHandsOn accumulates into.
+	// Nil until a test cares: the flush only ever writes for a session the
+	// accumulator actually counted something for.
+	handsOn map[string]int64
 	// One field per cost method, because the three failures are three different
 	// stories: a ledger that cannot be read, one that cannot be written, and a
 	// total that cannot be summed. A single error field would let a test claim
@@ -152,6 +156,15 @@ func (s stubBins) SessionCost(sessionID string) (float64, error) {
 	}
 	return total, nil
 }
+
+func (s stubBins) AddHandsOn(sessionID string, seconds int64) error {
+	if s.handsOn != nil {
+		s.handsOn[sessionID] += seconds
+	}
+	return nil
+}
+
+func (s stubBins) HandsOn(sessionID string) (int64, error) { return s.handsOn[sessionID], nil }
 
 // TestChildEnvStripsAppImageVars proves the AppImage runtime variables that break
 // mise/asdf shims are dropped while the real user environment is passed through.
@@ -1363,7 +1376,7 @@ func TestReadyWaitsForTheSetupScript(t *testing.T) {
 	svc.mu.Lock()
 	sess := svc.sessions["s1"]
 	svc.mu.Unlock()
-	svc.noteOutput(sess, []byte("Progress: resolved 551"+setupDone))
+	svc.noteOutput("s1", sess, []byte("Progress: resolved 551"+setupDone))
 
 	// The marker is the exec, not the prompt: the provider draws its opening
 	// screen from here, and a message written into that is the one that landed
@@ -1384,7 +1397,7 @@ func TestReadyWaitsForTheProviderToStopDrawing(t *testing.T) {
 	svc := New(stubBins{}, nil, events.New())
 	sess := &session{}
 
-	svc.noteOutput(sess, []byte("Claude Code v2.1.227"))
+	svc.noteOutput("s1", sess, []byte("Claude Code v2.1.227"))
 	svc.mu.Lock()
 	svc.sessions["s1"] = sess
 	svc.mu.Unlock()
@@ -1411,7 +1424,7 @@ func TestReadyStaysTrueThroughABusyTurn(t *testing.T) {
 	if !svc.Ready("s1") {
 		t.Fatal("a settled session was not ready")
 	}
-	svc.noteOutput(sess, []byte("...thinking..."))
+	svc.noteOutput("s1", sess, []byte("...thinking..."))
 	if !svc.Ready("s1") {
 		t.Error("a session that started working again stopped accepting work")
 	}
@@ -1430,9 +1443,9 @@ func TestTheWaitForTheProviderToStartIsNotItsQuiet(t *testing.T) {
 	svc.sessions["s1"] = sess
 	svc.mu.Unlock()
 
-	svc.noteOutput(sess, []byte("Progress: resolved 551"+setupDone))
+	svc.noteOutput("s1", sess, []byte("Progress: resolved 551"+setupDone))
 	time.Sleep(readySettle + 100*time.Millisecond)
-	svc.noteOutput(sess, []byte("Claude Code v2.1.227"))
+	svc.noteOutput("s1", sess, []byte("Claude Code v2.1.227"))
 	if svc.Ready("s1") {
 		t.Error("the wait for the provider to start was credited as the provider going quiet")
 	}
@@ -1457,12 +1470,12 @@ func TestReadyRemembersAQuietThatAlreadyPassed(t *testing.T) {
 	svc.sessions["s1"] = sess
 	svc.mu.Unlock()
 
-	svc.noteOutput(sess, []byte("Claude Code v2.1.227"))
+	svc.noteOutput("s1", sess, []byte("Claude Code v2.1.227"))
 	time.Sleep(readySettle + 100*time.Millisecond)
 	// The turn starts. From here the PTY never goes quiet again, and this is the
 	// first time anyone asks whether the session can be given work.
-	svc.noteOutput(sess, []byte("...thinking..."))
-	svc.noteOutput(sess, []byte("...thinking..."))
+	svc.noteOutput("s1", sess, []byte("...thinking..."))
+	svc.noteOutput("s1", sess, []byte("...thinking..."))
 
 	if !svc.Ready("s1") {
 		t.Error("a session that sat at its prompt for a whole turn was refused work")

--- a/main.go
+++ b/main.go
@@ -108,6 +108,10 @@ func main() {
 	// listener yet (the window is still starting) and the event is dropped.
 	hub := events.New()
 	term := terminal.New(db, env, hub)
+	// After db's own defer, so it runs before the database closes: what every
+	// session was worked in this run is still in memory until something writes
+	// it (internal/terminal.handsOn).
+	defer term.FlushHandsOn()
 	proj := project.New(project.ZenityPicker{})
 	// gh has one active account per host; a project can name a different one.
 	proj.SetAccounts(db.GHAccountForPath)


### PR DESCRIPTION
The footer now carries a session's **hands-on time** beside its cost — `$4.20 · 1h12m`, or the time alone where the cost readout is off, which is most sessions.

<!-- mockup of both themes, reviewed before any component was touched:
     https://claude.ai/code/artifact/5d945247-8f55-49d0-9864-e73d2e7544cf -->

## The algorithm

No sessions to open and close, no timer running between them. Something happens in a session, and the gap since the previous thing that happened in it is counted — unless that gap is longer than fifteen minutes, in which case it is a silence and adds nothing at all.

That single rule is what makes the number honest: a session left open overnight reports the hour it was worked, not the fourteen it sat there, and a lich that dies mid-turn leaves nothing open behind it — the next beat after a restart simply finds no previous one and starts the chain again.

## The three beat sources, all of which already existed

| Source | Where | Note |
|---|---|---|
| Session-state report | `New`'s hook callback | Taken **ahead of every filter** the window's own indicator applies |
| Keystroke at the PTY | the transport's input callback | Not `Write` — a relayed message is the *sending* session's work |
| The session's own output | `noteOutput` | Only while a turn is open, and at most once every 30s |

Beating ahead of `closableState` is what gets Cursor CLI counted at all. It delivers `PreToolUse` and `PostToolUse`; lich drops both for want of anything that could end the spinner they would start, but they are still proof the session is being worked.

The output gate is load-bearing, not a performance knob. PTY output arrives in bursts of a few bytes; an unthrottled beat per burst would turn a `tail -f`, a dev server or a TUI repainting its own spinner into an unbroken chain of gaps too small to ever reach the idle gap — hours of work nobody did.

## Persistence

A row beside `session_costs`, cascading with the session and riding along through the delete-and-reinsert a parked worktree's resume performs.

The store owns the total and the accumulator only the arrears since its last write, so `AddHandsOn` **adds** rather than sets: a crash costs at most one debounce window, and a restart resumes onto the figure rather than restating it. Whole seconds go down and the sub-second remainder stays in memory — at two flushes a minute, rounding it away would lose most of a minute an hour.

Writes hang off the beat that crosses the window rather than off a ticker of its own (nothing to own, nothing to stop), plus one on a card's close — synchronously, ahead of the row the window is about to delete — and one on the way out.

## The readout

Re-read off the footer's own minute clock. The figure is minutes, `useNow` already ticks on the minute, and keying the lookup by it is the entire refresh loop: no event, no store, no poll, and a reload paints the number on its first render instead of waiting out a flush. Under a minute renders as nothing rather than `0m`, which would read as a readout that broke.

No colour ramp — cost and context go amber against a ceiling, and this has none to be near. Colouring it would be an opinion about how long is too long.

## Provider symmetry

| | State beats | Output beats | Keystrokes |
|---|---|---|---|
| Claude Code, Codex, Antigravity, opencode, oh-my-pi | ✅ | ✅ | ✅ |
| Cursor CLI | ✅ via its tool reports | ❌ (nothing ever opens a turn) | ✅ |
| Crush | ❌ reports no state at all | ❌ | ✅ |

Cursor still cannot count a turn that calls no tool; Crush counts what the user typed and no more. Both land as a `docs/ceilings.md` bullet in this PR, along with the trap that follows: the same hour of work is a smaller figure on Crush than on Claude Code, and nothing on screen says which rung a card is on. A plain shell session is keystrokes-only by design — no agent in it whose work could be missed.

## Test plan

- [x] `handsOn` unit-tested against an injected clock: first beat, gap under/at/over the idle gap, the throttle and its own boundary, a backwards clock, the drain remainder, per-session isolation, the flush debounce, `forget`, and the zero value. 100% of the accumulator.
- [x] Wiring: output counts only while `busy`, output bursts are throttled, keystrokes count with no provider report at all, the flush accumulates across two writes, a close writes what the card was worked.
- [x] Store: zero for an unworked session, accumulation, no write for zero seconds, no error for a session already gone, the cascade, and the resume carry-over.
- [x] `go test -race ./...` green; the hands-on tests at `-count=50 -race`.
- [x] `gofmt -l .` · `go vet ./...` · `go test ./...` · `pnpm check` · `vitest run` · `pnpm build`.
- [x] Cross-compile loop green for linux/darwin/windows — the Service-level tests live in their own `!windows` file, because the suite's `Store` stub does.