### PR TITLE
feat: find a coding agent installed while lich is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   says what that rung actually leaves running on your machine. Coming back down
   is written straight through, as is clicking the rung you are already on:
   turning an automation off must never be the harder direction.
+- **Installing a coding agent no longer means restarting lich.** lich looked for
+  the agents on your machine once, at launch, so installing one while lich was
+  open changed nothing until you closed everything and started again — and the
+  first-run screen for a machine with none said as much. **Settings › Providers**
+  and that screen now both carry **Check again**, which re-runs the search on the
+  spot. One limit stays: the search covers the directories your shell's `PATH`
+  had when lich started, so an agent installed somewhere new to it still needs a
+  relaunch, or its path typed into Settings › Providers.
+- **An agent lich cannot find now links to its own install page.** Every "Not
+  found on PATH" row in Settings › Providers, and every name on the no-agents
+  screen, opens the page that documents installing that CLI.
+- **A machine with no agent installed opens a terminal instead of a dead card.**
+  **New session** used to fall back to Claude Code whatever was installed, so on a
+  machine with no agent it opened a card that died on
+  `claude: command not found`. It now opens a shell — where the install command
+  from those links can be pasted — and says so before you press it.
 - **A project tab comes back to the screen you left it on.** Stepping over to
   another project and back always dropped you onto the first project's
   terminals, whatever you had been reading there: its Settings, the pull request

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -30,6 +30,7 @@ hits it.
 | Question | How it was answered for Antigravity |
 |---|---|
 | What is the binary called? | `agy` — the name on `PATH`, not the product's |
+| Which page documents installing that CLI? | The install instructions, not the product's front door — and `curl -sI` it before it lands |
 | How does it resume a conversation by id? | `--conversation <id>` (`--help`) |
 | How does it skip permission prompts? | `--dangerously-skip-permissions` (`--help`) |
 | How is it told which model to run? | `--model <name>` (`--help`) |
@@ -53,7 +54,7 @@ tool.
 
 | File | What it holds | What a new provider adds |
 |---|---|---|
-| `internal/providers/providers.go` | the registry | an id constant, a `Registry` entry (id, display name, binary names), and a line in `AcceptsMCPServer` if it takes an MCP server on its command line |
+| `internal/providers/providers.go` | the registry | an id constant, a `Registry` entry (id, display name, binary names, install-docs URL), and a line in `AcceptsMCPServer` if it takes an MCP server on its command line |
 | `internal/terminal/command.go` | what a spawn runs | entries in `skipPermissionFlags`, `modelFlags`, `briefingFlags` and `resumeArgs` — each one optional, and absent means "no flag rather than somebody else's" |
 | `internal/terminal/resume.go` | whether a resume can be offered | a `ResumeAvailable` case answering from what that provider left on disk |
 | `internal/terminal/transcript.go`, `sessiondb.go` | where that state lives | the path resolver the case above calls |
@@ -74,6 +75,16 @@ everything on the id (`provider.<id>.bin`, `.enabled`, `.sandbox`,
 | `frontend/src/components/ProviderIcon.tsx` | a brand path, or a lucide fallback |
 | `frontend/src/lib/session/delegate-prompt.ts` | `TOOL_KINDS` only if it is handed lich's tools at spawn |
 | `frontend/src/lib/session/tool-label.ts` | a rule only if it spells MCP tool names in a shape not already handled |
+| `frontend/src/lib/api-types.ts` | nothing, unless the change moves a JSON tag — the `DetectedProvider` mirror is hand-owned and moves in the same commit |
+
+`Registry.Docs` is the one field with a check outside the compiler: it is what the
+"Not found on PATH" row and the no-agents dialog link to, so a blank or dead one
+turns the screen a user without that agent meets back into the dead end the field
+exists to close. Verify it against the live web before landing it —
+`curl -sI -o /dev/null -w '%{http_code} %{redirect_url}\n' <url>` — follow every
+redirect to the final address, and record the date you checked in the commit body.
+`TestEveryProviderDocumentsItsInstall` fails on an empty one; nothing but that
+curl catches a page that has moved.
 
 The two `skipPermissionFlags` tables — Go and TypeScript — are the one place a
 provider is spelled twice on purpose. Both are pinned in tests as literals

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -114,6 +114,20 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   live re-resolve would mean re-running the login shell under the running process. The check is
   `exec.LookPath` — it proves the binary exists and runs, never that it works, so a git that fails on the
   repository itself keeps failing the old silent way.
+- **Check again re-scans the boot `PATH`, never the login shell** (`internal/providers.Detect`,
+  `frontend/src/lib/providers-store.ts`, `refresh`): the provider surfaces re-probe on demand, so an agent
+  installed into a directory that `PATH` already carried appears without a relaunch — and one installed into a
+  directory that `PATH` did not carry never appears at all, however many times the button is pressed. The scan
+  itself is not what would break: re-resolving `PATH` means re-running `$SHELL -lic env` (`ResolveShellEnv`), and
+  a login shell that hangs on a prompt would hang the button rather than the boot. That machine's way in is a
+  relaunch, or a binary path in Settings › Providers — and nothing at the button says so.
+- **A machine with no agent on PATH opens terminals, and a custom binary path looks like one**
+  (`frontend/src/lib/providers-store.ts`, `resolveImplicitSessionKind`): with nothing installed, every implicit
+  new session — the empty screen's button, the hotkey, a new worktree — spawns a shell, because the provider
+  fallback still resolves to Claude and that card would die on `claude: command not found`. Detection only ever
+  scans `PATH`, so a user whose only agent is reached through a `provider.<id>.bin` override reads as that same
+  bare machine and gets a terminal they did not want. Their agent is still one click away in the New Session
+  menu, which is filtered by the enabled flag and not by install state.
 - **git status is polled** — one shared poller per repository path (`frontend/src/lib/git/git-status-store.ts`); the
   lich plugin's `session-touched` hook nudges an immediate refresh.
 - **The status badge has a single source** (`internal/project/status.go`): the branch, the HEAD commit and the

--- a/frontend/src/components/EmptySessions.tsx
+++ b/frontend/src/components/EmptySessions.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom"
 import { EmptyScreen } from "@/components/common/EmptyScreen"
 import { Button } from "@/components/ui/button"
 import { useProjects } from "@/providers/projects"
+import { useNoProviderInstalled } from "@/lib/providers-store"
 import { sessionsOf } from "@/lib/session/sessions"
 
 // A sessionless project is a legal state: the user is asked for a session rather
@@ -12,6 +13,10 @@ import { sessionsOf } from "@/lib/session/sessions"
 export function EmptySessions() {
   const { sessions, newSession } = useProjects()
   const { projectId = "" } = useParams()
+  // What the button will actually spawn is decided in the store, for every
+  // implicit entry point at once. This only reads the same answer, so the label
+  // cannot promise an agent the machine has not got.
+  const noAgent = useNoProviderInstalled()
 
   if (sessionsOf(sessions, projectId).length > 0) {
     return null
@@ -21,11 +26,15 @@ export function EmptySessions() {
     <EmptyScreen
       icon={SquareTerminal}
       title="No session open"
-      description="Open a session to start working in this project."
+      description={
+        noAgent
+          ? "No coding agent is installed, so this opens a terminal — install one from Settings › Providers."
+          : "Open a session to start working in this project."
+      }
     >
       <Button onClick={() => newSession(projectId)}>
-        <Plus data-icon="inline-start" />
-        New session
+        {noAgent ? <SquareTerminal data-icon="inline-start" /> : <Plus data-icon="inline-start" />}
+        {noAgent ? "New terminal" : "New session"}
       </Button>
     </EmptyScreen>
   )

--- a/frontend/src/components/ProviderSetupDialog.tsx
+++ b/frontend/src/components/ProviderSetupDialog.tsx
@@ -1,3 +1,6 @@
+import { ExternalLink } from "lucide-react"
+import { ProviderIcon } from "@/components/ProviderIcon"
+import { ProviderRefreshButton } from "@/components/settings/ProviderRefreshButton"
 import { ProvidersSettings } from "@/components/settings/ProvidersSettings"
 import { Button } from "@/components/ui/button"
 import {
@@ -8,12 +11,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
+import type { ProviderState } from "@/lib/providers-store"
+import { System } from "@/lib/rpc"
 
 interface ProviderSetupDialogProps {
   /** Whether any harness was found on PATH. The dialog has two shapes. */
   hasInstalled: boolean
-  /** Display names of every harness lich knows, for the nothing-installed shape. */
-  knownNames: string[]
+  /** Every harness lich knows, for the nothing-installed shape: each row opens
+   * the page documenting how to install that one. */
+  known: ProviderState[]
   /** Confirm — the gate records the default, which is what closes it for good. */
   onDone: () => void
 }
@@ -26,11 +32,7 @@ interface ProviderSetupDialogProps {
 // choice it exists to collect: no close button, and `open` is pinned true while
 // onOpenChange swallows Escape and the backdrop (base-ui has no dismissible flag
 // on Dialog — a controlled root that refuses to close is the equivalent).
-export function ProviderSetupDialog({
-  hasInstalled,
-  knownNames,
-  onDone,
-}: ProviderSetupDialogProps) {
+export function ProviderSetupDialog({ hasInstalled, known, onDone }: ProviderSetupDialogProps) {
   return (
     <Dialog open onOpenChange={() => {}}>
       <DialogContent showCloseButton={false}>
@@ -41,16 +43,30 @@ export function ProviderSetupDialog({
           <DialogDescription>
             {hasInstalled
               ? "lich found these on your machine. Turn on the ones you use — the rest stay out of the New Session menu."
-              : "lich runs the agents already installed on your machine, and found none. Install one and lich picks it up on the next launch."}
+              : "lich runs the agents already installed on your machine, and found none. Install one, then check again."}
           </DialogDescription>
         </DialogHeader>
-        {/* Nothing installed means nothing to pick, so the panel would be five
-            dead switches under a default nobody can honour. The list of names is
-            the whole answer that shape owes. */}
+        {/* Nothing installed means nothing to pick, so the panel would be seven
+            dead switches under a default nobody can honour. The names are the
+            whole answer that shape owes — each one linking to its own install
+            page, which is what makes the screen a way out rather than a wall. */}
         {hasInstalled ? (
           <ProvidersSettings installedOnly />
         ) : (
-          <DialogDescription>lich looks for {knownNames.join(", ")}.</DialogDescription>
+          <div className="grid grid-cols-2 gap-x-4">
+            {known.map((provider) => (
+              <button
+                key={provider.id}
+                type="button"
+                className="group -mx-2 flex items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground hover:bg-accent/60"
+                onClick={() => void System.OpenExternal(provider.docs)}
+              >
+                <ProviderIcon kind={provider.id} />
+                {provider.name}
+                <ExternalLink className="ml-auto size-3 text-muted-foreground opacity-0 group-hover:opacity-100" />
+              </button>
+            ))}
+          </div>
         )}
         <DialogDescription>
           {hasInstalled
@@ -58,6 +74,7 @@ export function ProviderSetupDialog({
             : "Already have one installed? Point lich at its binary in Settings › Providers."}
         </DialogDescription>
         <DialogFooter>
+          {!hasInstalled && <ProviderRefreshButton size="default" />}
           <Button onClick={onDone}>Continue</Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/components/ProviderSetupGate.tsx
+++ b/frontend/src/components/ProviderSetupGate.tsx
@@ -17,37 +17,41 @@ export function ProviderSetupGate() {
   const providers = useProviders()
   const storedDefault = useStoredDefaultProvider()
   const resolvedDefault = useDefaultProvider()
-  // Set at open and never recomputed: the dialog's shape must not change under
-  // the user, and every toggle inside it moves the state the decision reads.
   const [hasInstalled, setHasInstalled] = useState<boolean | null>(null)
-  const opened = useRef(false)
+  const applied = useRef(false)
 
   const decision = decideProviderSetup(providers, storedDefault)
   const show = decision.kind === "show"
   const preselect = decision.kind === "show" ? decision.preselect : null
 
   useEffect(() => {
-    if (opened.current || !show) {
+    if (applied.current || !show) {
+      return
+    }
+    if (!preselect) {
+      // Nothing installed: no switches to write, so nothing to latch — and the
+      // dialog's Check again has to be able to turn this shape into the other
+      // one once the user installs an agent without leaving lich.
+      setHasInstalled(false)
       return
     }
     // The ref is the latch, not the state below: setProviderEnabled emits
     // synchronously, so useSyncExternalStore re-enters this effect before any
     // setState has landed. A state guard would recurse until React gives up.
-    opened.current = true
+    // It is armed only here, so the picking shape is what freezes — every toggle
+    // inside it moves the state the decision reads.
+    applied.current = true
     // Claude is enabled by default even when it is not on PATH (readEnabled), so
     // on a Codex-only machine it would sit outside this list and still be offered
     // in New Session. Writing the absent ones off is what makes the list the
-    // whole truth. Skipped when nothing is installed: there is no list to be true
-    // to, and turning everything off would leave the user no provider at all.
-    if (preselect) {
-      for (const provider of providers) {
-        if (!provider.installed && provider.enabled) {
-          setProviderEnabled(provider.id, false)
-        }
+    // whole truth.
+    for (const provider of providers) {
+      if (!provider.installed && provider.enabled) {
+        setProviderEnabled(provider.id, false)
       }
-      setProviderEnabled(preselect, true)
     }
-    setHasInstalled(preselect !== null)
+    setProviderEnabled(preselect, true)
+    setHasInstalled(true)
   }, [show, preselect, providers])
 
   if (hasInstalled === null) {
@@ -59,11 +63,5 @@ export function ProviderSetupGate() {
     setHasInstalled(null)
   }
 
-  return (
-    <ProviderSetupDialog
-      hasInstalled={hasInstalled}
-      knownNames={providers.map((provider) => provider.name)}
-      onDone={finish}
-    />
-  )
+  return <ProviderSetupDialog hasInstalled={hasInstalled} known={providers} onDone={finish} />
 }

--- a/frontend/src/components/settings/ProviderDocsLink.tsx
+++ b/frontend/src/components/settings/ProviderDocsLink.tsx
@@ -1,0 +1,23 @@
+import { ExternalLink } from "lucide-react"
+import type { ProviderState } from "@/lib/providers-store"
+import { System } from "@/lib/rpc"
+
+// What a provider lich could not find owes the user: the page that documents
+// installing it. Opened in the real browser (System.OpenExternal), like every
+// other outbound link in the app — the Chromium shell has no second window to
+// hand it to.
+export function ProviderDocsLink({ provider }: { provider: ProviderState }) {
+  if (provider.docs === "") {
+    return null
+  }
+  return (
+    <button
+      type="button"
+      className="inline-flex items-center gap-1 underline-offset-2 hover:text-foreground hover:underline"
+      onClick={() => void System.OpenExternal(provider.docs)}
+    >
+      How to install
+      <ExternalLink className="size-3" aria-label={`Install ${provider.name}`} />
+    </button>
+  )
+}

--- a/frontend/src/components/settings/ProviderRefreshButton.tsx
+++ b/frontend/src/components/settings/ProviderRefreshButton.tsx
@@ -1,0 +1,24 @@
+import { RefreshCw } from "lucide-react"
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { refreshProviders } from "@/lib/providers-store"
+
+// The re-probe both provider surfaces offer, so an agent installed with lich
+// already open shows up without a relaunch. It re-runs the PATH scan only — not
+// the login shell that produced that PATH, which would hang the button as
+// readily as it hangs a boot (docs/ceilings.md).
+export function ProviderRefreshButton({ size = "sm" }: { size?: "sm" | "default" }) {
+  const [checking, setChecking] = useState(false)
+
+  const check = () => {
+    setChecking(true)
+    void refreshProviders().finally(() => setChecking(false))
+  }
+
+  return (
+    <Button variant="ghost" size={size} disabled={checking} onClick={check}>
+      <RefreshCw data-icon="inline-start" className={checking ? "animate-spin" : undefined} />
+      {checking ? "Checking…" : "Check again"}
+    </Button>
+  )
+}

--- a/frontend/src/components/settings/ProvidersSettings.tsx
+++ b/frontend/src/components/settings/ProvidersSettings.tsx
@@ -6,6 +6,8 @@ import {
   useProviders,
 } from "@/lib/providers-store"
 import { ProviderIcon } from "@/components/ProviderIcon"
+import { ProviderDocsLink } from "./ProviderDocsLink"
+import { ProviderRefreshButton } from "./ProviderRefreshButton"
 import { SettingBlock } from "./SettingBlock"
 import { Switch } from "@/components/ui/switch"
 import { ProviderSelect } from "./ProviderSelect"
@@ -50,6 +52,12 @@ export function ProvidersSettings({ installedOnly = false }: ProvidersSettingsPr
           />
         </SettingBlock>
       )}
+      <div className="flex items-center justify-between pb-1.5 pt-4">
+        <h2 className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          Detected on PATH
+        </h2>
+        <ProviderRefreshButton />
+      </div>
       <div className="flex flex-col divide-y divide-border">
         {listed.map((provider) => (
           <div key={provider.id} className="flex items-center justify-between gap-4 py-4">
@@ -57,8 +65,16 @@ export function ProvidersSettings({ installedOnly = false }: ProvidersSettingsPr
               <ProviderIcon kind={provider.id} />
               <div className="min-w-0">
                 <div className="text-sm font-medium text-foreground">{provider.name}</div>
-                <div className="text-xs text-muted-foreground">
-                  {provider.installed ? "Installed" : "Not found on PATH"}
+                <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                  {provider.installed ? (
+                    "Installed"
+                  ) : (
+                    <>
+                      <span>Not found on PATH</span>
+                      <span aria-hidden>·</span>
+                      <ProviderDocsLink provider={provider} />
+                    </>
+                  )}
                 </div>
               </div>
             </div>

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -468,6 +468,9 @@ export interface DetectedProvider {
   binary: string
   installed: boolean
   path: string
+  /** The page documenting how to install this CLI. Carried on every entry: the
+   * row with somewhere to send the user is the one that found nothing. */
+  docs: string
 }
 
 /** internal/providers.Check — what a configured binary resolves to. `path` is

--- a/frontend/src/lib/provider-setup.test.ts
+++ b/frontend/src/lib/provider-setup.test.ts
@@ -8,6 +8,7 @@ const p = (id: string, installed: boolean): ProviderState => ({
   binary: id,
   installed,
   enabled: false,
+  docs: `https://example.test/${id}`,
 })
 
 describe("decideProviderSetup", () => {

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -10,7 +10,9 @@ import {
   footerReadout,
   footerReadoutPair,
   readEnabled,
+  noProviderInstalled,
   resolveDefaultProvider,
+  resolveImplicitSessionKind,
   resolveProjectDefaultProvider,
   sandboxDefaultFor,
   sandboxKey,
@@ -184,6 +186,7 @@ describe("enabledProviders", () => {
     binary: id,
     installed,
     enabled,
+    docs: `https://example.test/${id}`,
   })
 
   it("keeps enabled providers regardless of install state", () => {
@@ -200,6 +203,7 @@ describe("resolveDefaultProvider", () => {
     binary: id,
     installed: true,
     enabled,
+    docs: `https://example.test/${id}`,
   })
 
   it("uses the stored default when it names an enabled provider", () => {
@@ -225,6 +229,7 @@ describe("resolveProjectDefaultProvider", () => {
     binary: id,
     installed: true,
     enabled,
+    docs: `https://example.test/${id}`,
   })
 
   it("prefers an enabled project override to the global default", () => {
@@ -243,6 +248,51 @@ describe("resolveProjectDefaultProvider", () => {
   })
 })
 
+// The zero-agent machine: every fallback below still lands on Claude, so the
+// gate in front of them is what stops an implicit session opening on
+// `claude: command not found`.
+describe("noProviderInstalled / resolveImplicitSessionKind", () => {
+  const p = (id: string, installed: boolean, enabled: boolean): ProviderState => ({
+    id: id as ProviderState["id"],
+    name: id,
+    binary: id,
+    installed,
+    enabled,
+    docs: `https://example.test/${id}`,
+  })
+
+  it("reads an empty list as detection not having answered, never as a bare machine", () => {
+    expect(noProviderInstalled([])).toBe(false)
+    expect(resolveImplicitSessionKind([], "", "")).toBe("claude")
+  })
+
+  it("spots the machine with nothing on PATH", () => {
+    expect(noProviderInstalled([p("claude", false, true), p("codex", false, false)])).toBe(true)
+    expect(noProviderInstalled([p("claude", false, true), p("codex", true, false)])).toBe(false)
+  })
+
+  // Claude is enabled by default (readEnabled) even with no binary anywhere, so
+  // this is the exact list a first run on a bare machine produces.
+  it("spawns a shell when no provider is installed, whatever the stored default says", () => {
+    const bare = [p("claude", false, true), p("codex", false, false)]
+    expect(resolveImplicitSessionKind(bare, "", "")).toBe("shell")
+    expect(resolveImplicitSessionKind(bare, "claude", "codex")).toBe("shell")
+  })
+
+  it("defers to the project resolution the moment one provider is installed", () => {
+    const list = [p("claude", true, true), p("codex", true, true)]
+    expect(resolveImplicitSessionKind(list, "claude", "codex")).toBe("codex")
+    expect(resolveImplicitSessionKind(list, "codex", "")).toBe("codex")
+  })
+
+  // A custom binary path leaves installed=false on every row, so this machine
+  // gets a terminal it did not need. Deliberate, and in docs/ceilings.md.
+  it("still resolves the enabled provider once anything else is on PATH", () => {
+    const list = [p("claude", false, true), p("crush", true, false)]
+    expect(resolveImplicitSessionKind(list, "claude", "")).toBe("claude")
+  })
+})
+
 describe("createProvidersStore", () => {
   const detected: DetectedProvider[] = [
     {
@@ -251,10 +301,19 @@ describe("createProvidersStore", () => {
       binary: "claude",
       installed: true,
       path: "/usr/bin/claude",
+      docs: "https://code.claude.com/docs/en/setup",
     },
     // A binary that is not the id, which is what antigravity ships as.
-    { id: "codex", name: "Codex", binary: "cdx", installed: false, path: "" },
-    { id: "mystery", name: "Mystery", binary: "mystery", installed: true, path: "/x" }, // unknown id
+    {
+      id: "codex",
+      name: "Codex",
+      binary: "cdx",
+      installed: false,
+      path: "",
+      docs: "https://d/codex",
+    },
+    // unknown id
+    { id: "mystery", name: "Mystery", binary: "mystery", installed: true, path: "/x", docs: "" },
   ]
 
   function build(enabledValues: Record<string, string> = {}, defaultValue = "") {
@@ -323,6 +382,91 @@ describe("createProvidersStore", () => {
     store.ensureLoaded()
     await vi.waitFor(() => expect(store.getSnapshot().length).toBe(2))
     expect(detect).toHaveBeenCalledTimes(1)
+  })
+
+  it("carries each provider's install page onto the snapshot", async () => {
+    const { store } = build()
+    await store.load()
+    expect(store.getSnapshot().find((p) => p.id === "claude")?.docs).toBe(
+      "https://code.claude.com/docs/en/setup",
+    )
+  })
+
+  // The whole point of the button: a provider installed while lich is open shows
+  // up without a relaunch.
+  it("refresh re-probes PATH and notifies", async () => {
+    let probe: DetectedProvider[] = [
+      {
+        id: "claude",
+        name: "Claude Code",
+        binary: "claude",
+        installed: false,
+        path: "",
+        docs: "d",
+      },
+    ]
+    const store = createProvidersStore({
+      detect: async () => probe,
+      getEnabled: async () => "",
+      persistEnabled: vi.fn(),
+      getDefault: async () => "",
+      persistDefault: vi.fn(),
+      persistProjectDefault: vi.fn(),
+    })
+    await store.load()
+    expect(store.getSnapshot()[0].installed).toBe(false)
+
+    const seen = vi.fn()
+    store.subscribe(seen)
+    probe = [
+      {
+        id: "claude",
+        name: "Claude Code",
+        binary: "claude",
+        installed: true,
+        path: "/usr/bin/claude",
+        docs: "d",
+      },
+    ]
+    await store.refresh()
+    expect(store.getSnapshot()[0].installed).toBe(true)
+    expect(seen).toHaveBeenCalledTimes(1)
+  })
+
+  // A toggle persists through a fire-and-forget write, so re-reading the settings
+  // on every refresh would let a slow write flip the switch back under the user.
+  it("refresh keeps the enabled flags and the default it already has", async () => {
+    const getEnabled = vi.fn(async () => "")
+    const store = createProvidersStore({
+      detect: async () => detected,
+      getEnabled,
+      persistEnabled: vi.fn(),
+      getDefault: async () => "codex",
+      persistDefault: vi.fn(),
+      persistProjectDefault: vi.fn(),
+    })
+    await store.load()
+    store.setEnabled("codex", true)
+    const reads = getEnabled.mock.calls.length
+
+    await store.refresh()
+    expect(store.getSnapshot().find((p) => p.id === "codex")?.enabled).toBe(true)
+    expect(store.getDefaultSnapshot()).toBe("codex")
+    expect(getEnabled).toHaveBeenCalledTimes(reads)
+  })
+
+  it("refresh drops a provider id this build does not know", async () => {
+    const { store } = build()
+    await store.refresh()
+    expect(store.getSnapshot().map((p) => p.id)).toEqual(["claude", "codex"])
+  })
+
+  it("getProjectSessionKind falls to the shell only while nothing is installed", async () => {
+    const { store } = build({ claude: "1" })
+    await store.load()
+    // codex is the only not-installed row; claude is on PATH, so a project with
+    // no override gets the provider.
+    expect(store.getProjectSessionKind("proj")).toBe("claude")
   })
 
   it("loads the stored default provider", async () => {

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -1,7 +1,8 @@
 // Shared provider state: which providers are installed on the machine and which
 // the user enabled. Both the New Session menu and the Settings screen read it,
 // so a toggle in one place is reflected in the other without a refetch. Detection
-// runs once (providers.Detect); enabled flags are global settings ("1"/"0").
+// runs on first use and again on demand (providers.Detect, refresh); enabled
+// flags are global settings ("1"/"0").
 //
 // The store is a dependency-injected factory (its RPC calls are passed in) so it
 // is testable without React or the network, mirroring git-status-store. A module
@@ -9,7 +10,7 @@
 import { useCallback, useEffect, useSyncExternalStore } from "react"
 import type { DetectedProvider } from "./api-types"
 import { Providers, Store } from "./rpc"
-import { PROVIDER_KINDS, type ProviderKind } from "@/lib/session/sessions"
+import { PROVIDER_KINDS, type ProviderKind, type SessionKind } from "@/lib/session/sessions"
 
 const GLOBAL_SCOPE = ""
 
@@ -191,6 +192,9 @@ export interface ProviderState {
   binary: string
   installed: boolean
   enabled: boolean
+  /** The page documenting how to install this CLI — offered on the rows that
+   * found nothing, which are the only rows that need it. */
+  docs: string
 }
 
 // enabledProviders are the ones offered in New Session. Not filtered by install
@@ -224,8 +228,40 @@ export function resolveProjectDefaultProvider(
   return chosen?.id ?? resolveDefaultProvider(list, globalDefaultId)
 }
 
+// noProviderInstalled reports the one machine state in which spawning the
+// resolved default is guaranteed to fail: detection has answered and found no
+// binary at all. An empty list is detection not having answered yet — never
+// this, exactly as in decideProviderSetup.
+export function noProviderInstalled(list: ProviderState[]): boolean {
+  return list.length > 0 && !list.some((provider) => provider.installed)
+}
+
+// resolveImplicitSessionKind is what a session nobody picked a kind for spawns:
+// the empty screen's button, the new-session hotkey, a new worktree. It is
+// resolveProjectDefaultProvider with one gate in front, because on a machine
+// with no agent installed every fallback below still lands on Claude — readEnabled
+// leaves Claude enabled by default, so the card opens on `claude: command not
+// found`. A shell spawns with zero providers, and it is where the install command
+// from the provider's docs link gets pasted.
+export function resolveImplicitSessionKind(
+  list: ProviderState[],
+  globalDefaultId: string,
+  projectDefaultId: string,
+): SessionKind {
+  if (noProviderInstalled(list)) {
+    return "shell"
+  }
+  return resolveProjectDefaultProvider(list, globalDefaultId, projectDefaultId)
+}
+
 function isProviderKind(id: string): id is ProviderKind {
   return (PROVIDER_KINDS as readonly string[]).includes(id)
+}
+
+// A provider the backend knows and this build does not is dropped rather than
+// carried as a kind nothing can spawn.
+function isDetectedKind(provider: DetectedProvider): boolean {
+  return isProviderKind(provider.id)
 }
 
 export interface ProvidersDeps {
@@ -245,6 +281,7 @@ export interface HydratedProjectDefault {
 export interface ProvidersStore {
   load: () => Promise<void>
   ensureLoaded: () => void
+  refresh: () => Promise<void>
   setEnabled: (id: ProviderKind, enabled: boolean) => void
   setDefault: (id: ProviderKind) => void
   hydrateProjectDefaults: (projects: readonly HydratedProjectDefault[]) => void
@@ -254,6 +291,7 @@ export interface ProvidersStore {
   getDefaultSnapshot: () => string
   getProjectDefaultSnapshot: (projectId: string) => string
   getProjectProviderKind: (projectId: string) => ProviderKind
+  getProjectSessionKind: (projectId: string) => SessionKind
 }
 
 class ProviderStoreImpl implements ProvidersStore {
@@ -288,6 +326,24 @@ class ProviderStoreImpl implements ProvidersStore {
   // ensureLoaded runs load once; a failed attempt resets so a later mount retries.
   ensureLoaded = (): void => {
     void this.load().catch(() => undefined)
+  }
+
+  // refresh re-probes PATH and nothing else: the enabled flags and the default
+  // stay as they are in memory, so a toggle the user just made cannot be undone
+  // by a settings read racing its own write. What it cannot see is a provider
+  // installed outside the PATH lich resolved at boot (docs/ceilings.md).
+  refresh = async (): Promise<void> => {
+    const detected = (await this.deps.detect()) ?? []
+    const enabled = new Map(this.providers.map((provider) => [provider.id, provider.enabled]))
+    this.providers = detected.filter(isDetectedKind).map((provider) => ({
+      id: provider.id as ProviderKind,
+      name: provider.name,
+      binary: provider.binary,
+      installed: provider.installed,
+      docs: provider.docs,
+      enabled: enabled.get(provider.id as ProviderKind) ?? readEnabled(provider.id, ""),
+    }))
+    this.emit()
   }
 
   setEnabled = (id: ProviderKind, enabled: boolean): void => {
@@ -332,6 +388,12 @@ class ProviderStoreImpl implements ProvidersStore {
       this.defaultId,
       this.getProjectDefaultSnapshot(projectId),
     )
+  getProjectSessionKind = (projectId: string): SessionKind =>
+    resolveImplicitSessionKind(
+      this.providers,
+      this.defaultId,
+      this.getProjectDefaultSnapshot(projectId),
+    )
 
   private async performLoad(): Promise<void> {
     const [detected, storedDefault] = await Promise.all([
@@ -339,15 +401,14 @@ class ProviderStoreImpl implements ProvidersStore {
       this.deps.getDefault(),
     ])
     this.providers = await Promise.all(
-      detected
-        .filter((provider) => isProviderKind(provider.id))
-        .map(async (provider) => ({
-          id: provider.id as ProviderKind,
-          name: provider.name,
-          binary: provider.binary,
-          installed: provider.installed,
-          enabled: readEnabled(provider.id, await this.deps.getEnabled(provider.id)),
-        })),
+      detected.filter(isDetectedKind).map(async (provider) => ({
+        id: provider.id as ProviderKind,
+        name: provider.name,
+        binary: provider.binary,
+        installed: provider.installed,
+        docs: provider.docs,
+        enabled: readEnabled(provider.id, await this.deps.getEnabled(provider.id)),
+      })),
     )
     this.defaultId = storedDefault
     this.state = "ready"
@@ -392,6 +453,13 @@ export function loadProviders(): Promise<void> {
   return store.load()
 }
 
+// refreshProviders re-probes PATH for the surfaces that offer it: the first-run
+// dialog and Settings › Providers. It lives here rather than in either caller so
+// both get the same answer without either owning the scan.
+export function refreshProviders(): Promise<void> {
+  return store.refresh()
+}
+
 // hydrateProjectProviderDefaults accepts the overrides delivered with workspace
 // state. It is synchronous so restoring projects never waits on provider
 // detection or performs one settings request per project.
@@ -408,6 +476,14 @@ export function setProjectProviderDefault(projectId: string, id: ProviderKind | 
 // disabled override delegates to the same global fallback rules.
 export function projectDefaultProviderKind(projectId: string): ProviderKind {
   return store.getProjectProviderKind(projectId)
+}
+
+// projectNewSessionKind is what an implicit new session spawns in this project.
+// Every implicit entry point routes through it — the empty screen, the hotkey, a
+// new worktree — so a machine with no agent installed opens a shell everywhere
+// rather than in whichever caller remembered to check.
+export function projectNewSessionKind(projectId: string): SessionKind {
+  return store.getProjectSessionKind(projectId)
 }
 
 // useProviders returns the known providers with their install + enabled state,
@@ -435,6 +511,14 @@ export function useDefaultProvider(): ProviderKind {
   const defaultId = useSyncExternalStore(store.subscribe, store.getDefaultSnapshot)
   useEffect(store.ensureLoaded, [])
   return resolveDefaultProvider(providers, defaultId)
+}
+
+// useNoProviderInstalled reports the machine with no agent on PATH, which is
+// what a surface offering an implicit session shows a terminal for.
+export function useNoProviderInstalled(): boolean {
+  const providers = useSyncExternalStore(store.subscribe, store.getSnapshot)
+  useEffect(store.ensureLoaded, [])
+  return noProviderInstalled(providers)
 }
 
 // useStoredProjectDefaultProvider returns the unresolved project value. Empty

--- a/frontend/src/lib/session/new-session-kind.ts
+++ b/frontend/src/lib/session/new-session-kind.ts
@@ -1,10 +1,12 @@
-import type { ProviderKind, SessionKind } from "./sessions"
+import type { SessionKind } from "./sessions"
 
 // resolveNewSessionKind keeps explicit terminal/provider choices intact and
-// applies the project's already-resolved default only to implicit creation.
+// applies the project's already-resolved default only to implicit creation. That
+// default is a SessionKind rather than a ProviderKind because a machine with no
+// agent installed resolves it to the shell (providers-store).
 export function resolveNewSessionKind(
   requestedKind: SessionKind | undefined,
-  projectDefault: ProviderKind,
+  projectDefault: SessionKind,
 ): SessionKind {
   return requestedKind ?? projectDefault
 }

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -35,7 +35,7 @@ import { errorText } from "@/lib/utils"
 import {
   hydrateProjectProviderDefaults,
   loadProviders,
-  projectDefaultProviderKind,
+  projectNewSessionKind,
 } from "@/lib/providers-store"
 import { resolveNewSessionKind } from "@/lib/session/new-session-kind"
 import {
@@ -362,7 +362,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
 
   const newSession = useCallback((projectId: string, kind?: SessionKind, path = "") => {
     const sessionId = newSessionId()
-    const resolvedKind = resolveNewSessionKind(kind, projectDefaultProviderKind(projectId))
+    const resolvedKind = resolveNewSessionKind(kind, projectNewSessionKind(projectId))
     const next = addSession(sessionsRef.current, projectId, sessionId, resolvedKind, path)
     const project = next[projectId]
     const created = project.sessions[project.sessions.length - 1]
@@ -376,7 +376,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
   const newWorktreeSession = useCallback(
     (projectId: string, wt: { name: string; path: string }, sandbox = "") => {
       const sessionId = newSessionId()
-      const kind = projectDefaultProviderKind(projectId)
+      const kind = projectNewSessionKind(projectId)
       const next = addSession(sessionsRef.current, projectId, sessionId, kind, wt.path, wt.name)
       const project = next[projectId]
       const created = project.sessions[project.sessions.length - 1]

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -20,12 +20,19 @@ const (
 	Cursor      = "cursor"
 )
 
-// Provider is a known harness: a stable id, a display name, and the executable
-// names to look for on PATH (in preference order).
+// Provider is a known harness: a stable id, a display name, the executable
+// names to look for on PATH (in preference order), and the page that documents
+// installing that CLI.
+//
+// Docs is the page a user who has not got the provider is sent to, so it is the
+// install instructions rather than the product's front door — and it is checked
+// against the live web when it lands (docs/adding-a-provider.md), because a link
+// offered by a "not found" row is worth less than nothing if it 404s.
 type Provider struct {
 	ID       string
 	Name     string
 	Binaries []string
+	Docs     string
 }
 
 // Registry is every provider lich knows about, in display order. Claude Code is
@@ -37,13 +44,13 @@ type Provider struct {
 // provider is spelled at each of those tables, and AcceptsMCPServer below is
 // the one split this file owns.
 var Registry = []Provider{
-	{ID: Claude, Name: "Claude Code", Binaries: []string{"claude"}},
-	{ID: Codex, Name: "Codex", Binaries: []string{"codex"}},
-	{ID: Antigravity, Name: "Antigravity", Binaries: []string{"agy"}},
-	{ID: OpenCode, Name: "opencode", Binaries: []string{"opencode"}},
-	{ID: OMP, Name: "oh-my-pi", Binaries: []string{"omp"}},
-	{ID: Crush, Name: "Crush", Binaries: []string{"crush"}},
-	{ID: Cursor, Name: "Cursor CLI", Binaries: []string{"cursor-agent"}},
+	{ID: Claude, Name: "Claude Code", Binaries: []string{"claude"}, Docs: "https://code.claude.com/docs/en/setup"},
+	{ID: Codex, Name: "Codex", Binaries: []string{"codex"}, Docs: "https://learn.chatgpt.com/docs/codex/cli"},
+	{ID: Antigravity, Name: "Antigravity", Binaries: []string{"agy"}, Docs: "https://antigravity.google/docs/cli/getting-started"},
+	{ID: OpenCode, Name: "opencode", Binaries: []string{"opencode"}, Docs: "https://opencode.ai/docs/"},
+	{ID: OMP, Name: "oh-my-pi", Binaries: []string{"omp"}, Docs: "https://github.com/can1357/oh-my-pi"},
+	{ID: Crush, Name: "Crush", Binaries: []string{"crush"}, Docs: "https://github.com/charmbracelet/crush"},
+	{ID: Cursor, Name: "Cursor CLI", Binaries: []string{"cursor-agent"}, Docs: "https://cursor.com/docs/cli/installation"},
 }
 
 // Known reports whether id names a registered provider. It guards a provider id
@@ -89,12 +96,15 @@ func DefaultBinary(id string) string {
 // Binary is the executable name a session spawns (DefaultBinary), which the
 // settings screen needs even when nothing was found: a provider id is not its
 // command — Antigravity's is `agy`.
+// Docs is carried on every entry, installed or not: the row that has somewhere
+// to send the user is exactly the one that found nothing.
 type Detected struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`
 	Binary    string `json:"binary"`
 	Installed bool   `json:"installed"`
 	Path      string `json:"path"`
+	Docs      string `json:"docs"`
 }
 
 // Service detects installed providers. lookPath is injected so tests drive
@@ -113,7 +123,7 @@ func New() *Service {
 func (s *Service) Detect() ([]Detected, error) {
 	out := make([]Detected, 0, len(Registry))
 	for _, p := range Registry {
-		d := Detected{ID: p.ID, Name: p.Name, Binary: DefaultBinary(p.ID)}
+		d := Detected{ID: p.ID, Name: p.Name, Binary: DefaultBinary(p.ID), Docs: p.Docs}
 		for _, name := range p.Binaries {
 			if path, err := s.lookPath(name); err == nil {
 				d.Installed = true

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"errors"
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -104,6 +105,33 @@ func TestKnown(t *testing.T) {
 	for _, id := range []string{"", "shell", "gemini", "Claude"} {
 		if Known(id) {
 			t.Errorf("Known(%q) = true, want false", id)
+		}
+	}
+}
+
+// TestEveryProviderDocumentsItsInstall pins the field the "not found on PATH"
+// rows link to. A blank one there is a row that names a missing agent and offers
+// nothing, which is the dead end the field exists to close — so provider number
+// eight fails here until it brings its page.
+func TestEveryProviderDocumentsItsInstall(t *testing.T) {
+	for _, p := range Registry {
+		if !strings.HasPrefix(p.Docs, "https://") {
+			t.Errorf("%s docs = %q, want an https install page", p.ID, p.Docs)
+		}
+	}
+}
+
+// TestDetectCarriesTheDocs: the link travels on the detection result, installed
+// or not — the row with somewhere to send the user is the one that found nothing.
+func TestDetectCarriesTheDocs(t *testing.T) {
+	svc := &Service{lookPath: func(string) (string, error) { return "", exec.ErrNotFound }}
+	got, err := svc.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	for i, d := range got {
+		if d.Docs != Registry[i].Docs || d.Docs == "" {
+			t.Errorf("%s docs = %q, want %q", d.ID, d.Docs, Registry[i].Docs)
 		}
 	}
 }


### PR DESCRIPTION
Detection ran once, at boot, so installing an agent mid-session changed nothing until the next launch — and the first-run screen for a machine with none said exactly that, and offered no way forward. Three changes, one story.

## Re-probe on demand

`providers-store` gains `refresh()`, exposed on both surfaces that read the store: **Settings › Providers** (the mid-session case) and the first-run dialog. It re-probes PATH and nothing else — the enabled flags and the default stay as they are in memory, so a toggle cannot be undone by a settings read racing its own fire-and-forget write. The "lich picks it up on the next launch" line is gone: once the button exists, that sentence is a lie.

The first-run gate's latch moved with it. It used to freeze the dialog's shape at open; now only the *picking* shape latches (every switch inside it moves the state the decision reads). The no-agents shape has no switches, so **Check again** can turn it into the other one without a relaunch — which is the whole point of putting the button there.

**Deliberate limit, in `docs/ceilings.md`:** the re-probe scans the PATH lich resolved at boot. Re-resolving it means re-running `$SHELL -lic env` (`ResolveShellEnv`), and a login shell that hangs on a prompt would hang the button as readily as it hangs a boot. So an agent installed into a directory PATH never carried still needs a relaunch, or a binary path in Settings.

## A docs URL per provider

`providers.Provider` carries `Docs`, `Detected` carries it as JSON `docs`, and `api-types.ts` mirrors it by hand. It renders on the "Not found on PATH" rows and on every name in the no-agents dialog, opened through `System.OpenExternal` like every other outbound link.

All seven verified with `curl -sI -o /dev/null -w '%{http_code} %{redirect_url}\n'` on **2026-08-28** — each 200 with no redirect left, each the page that documents installing the CLI rather than the product's front door:

| Provider | URL | Status |
| --- | --- | --- |
| Claude Code | https://code.claude.com/docs/en/setup | 200 |
| Codex | https://learn.chatgpt.com/docs/codex/cli | 200 |
| Antigravity | https://antigravity.google/docs/cli/getting-started | 200 |
| opencode | https://opencode.ai/docs/ | 200 |
| oh-my-pi | https://github.com/can1357/oh-my-pi | 200 |
| Crush | https://github.com/charmbracelet/crush | 200 |
| Cursor CLI | https://cursor.com/docs/cli/installation | 200 |

`docs/adding-a-provider.md` gains the field and that check, so provider number eight ships with its link instead of a blank; `TestEveryProviderDocumentsItsInstall` fails on an empty one.

## The empty state offers a button that works

`readEnabled` leaves Claude enabled with no binary anywhere, so on a machine with nothing installed every fallback resolved to `claude` and **New session** opened a card that died on `claude: command not found` — the same bug class `provider-setup.ts` already fixed one step earlier.

The gate is `resolveImplicitSessionKind` in the store, beside `resolveDefaultProvider`, so all three implicit entry points reach it through the one `projectNewSessionKind` they already routed through — the empty screen's button, the new-session hotkey, and a new worktree session. `EmptySessions` only *reads* the same answer to label itself, rather than being patched on its own. `resolveDefaultProvider` is untouched, so the Settings selects still get a `ProviderKind`.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` — 1992 passed
- [x] `pnpm check` clean (14 pre-existing a11y warnings), `pnpm build` (tsc + vite) succeeds
- [x] `vitest run` — 1240 passed, cache cleared first
- [x] `for os in linux darwin windows` build + vet loop clean
- [x] New unit tests: `refresh` re-probes and notifies; `refresh` keeps the enabled flags and the default (no settings re-read); an unknown provider id is dropped on refresh; `docs` reaches the snapshot; `noProviderInstalled` reads an empty list as detection-pending, never as a bare machine; `resolveImplicitSessionKind` gives the shell only when nothing is on PATH
- [x] Render paths smoked in jsdom before committing (both dialog shapes, the settings pane), then the throwaway suite deleted — the gate is node-only

## Left out on purpose

- A user whose only agent is reached through a `provider.<id>.bin` override reads as a bare machine (detection only scans PATH) and gets a terminal for the implicit action. Their agent stays one click away in the New Session menu, which is filtered by the enabled flag and not by install state. Both this and the PATH limit above are `docs/ceilings.md` bullets.
- No in-app installer. lich runs the agents on your machine; it does not fetch them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F7T3Zf8wLbbWL7pfv2pna8