### PR TITLE
feat: show a wall of sessions on one screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Two sessions on screen at once.** Watching an agent used to mean watching
+- **A wall of sessions on one screen.** Watching an agent used to mean watching
   nothing else: the cards say what every session is *doing*, and only one of them
-  ever showed what it was *saying*. A card's menu now offers **Open beside**,
-  which puts that session in a second pane next to the one you are on —
-  <kbd>Ctrl/Cmd+Shift+O</kbd> splits with the next card and closes the split
-  again, <kbd>Ctrl/Cmd+Shift+G</kbd> moves the cursor across, and clicking a pane
-  focuses it. Drag the seam to divide the space, and both panes come back the way
-  you left them. A pane is a view of a card, never a session of its own: its ×
-  stops showing that session and closes nothing, and closing the session itself
-  hands the whole width back to the survivor.
+  ever showed what it was *saying*. A card's menu now offers **Show beside**,
+  which adds that session to the stage — <kbd>Ctrl/Cmd+Shift+G</kbd> adds the
+  next card, <kbd>Ctrl/Cmd+Shift+F</kbd> moves the cursor along, and clicking a
+  pane focuses it. lich lays the panes out itself, from how many there are and
+  how much room the window has: eight of them on a 34" ultrawide land four
+  across and two down, the same eight on a laptop come out two across, and lich
+  declines the one that would leave them all too small to read. Drag a pane by
+  its name to swap it with another, drag the seams to divide the space, and the
+  whole arrangement comes back the way you left it. A pane is a view of a card,
+  never a session of its own: its × stops showing that session and closes
+  nothing, and closing the session itself hands its room back to the rest.
 
 - **The pull request screen hands its current problem to the session.** Red CI
   meant reading the Checks tab, opening each failed job in the browser and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that would leave them all too small to read.
   A wall is a group you made and named, and a project holds as many as you like —
   an orchestrator with the three worktrees it spawned is one, the next
-  investigation with its own is another. Each gets a block of its own at the top
+  investigation with its own is another. That first one takes a single click:
+  a session that handed work to others offers **Show beside its 3 delegates**,
+  which builds the wall around it, named after it. A delegate you had already put
+  on another split stays where it is, and lich says how many did. Each gets a block of its own at the top
   of the sidebar, so you read its membership instead of rediscovering it: fold
   it, drag it above the others, rename it or take it apart from its header, and
   drag a card inside it to rearrange the panes. Opening a session that is on no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it, drag it above the others, rename it or take it apart from its header, and
   drag a card inside it to rearrange the panes. Opening a session that is on no
   wall shows it on its own and sets every wall aside, whole, until you go back to
-  one of their sessions. A pane is a view of a card, never a session of its own:
-  its × stops showing that session and closes nothing, and closing the session
-  itself hands its room back to the rest.
+  one of their sessions. A session can be on one wall at a time, so putting one
+  on a second asks first, naming the group it would leave and whether that group
+  ends with it. A pane is a view of a card, never a session of its own: its ×
+  stops showing that session and closes nothing, and closing the session itself
+  hands its room back to the rest.
 
 - **The pull request screen hands its current problem to the session.** Red CI
   meant reading the Checks tab, opening each failed job in the browser and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whole arrangement comes back the way you left it. A pane is a view of a card,
   never a session of its own: its × stops showing that session and closes
   nothing, and closing the session itself hands its room back to the rest.
+  The wall is yours and only **Show beside** adds to it — opening any other
+  session shows that one on its own and sets the wall aside, whole, until you go
+  back to any session in it.
 
 - **The pull request screen hands its current problem to the session.** Red CI
   meant reading the Checks tab, opening each failed job in the browser and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   nothing, and closing the session itself hands its room back to the rest.
   The wall is yours and only **Show beside** adds to it — opening any other
   session shows that one on its own and sets the wall aside, whole, until you go
-  back to any session in it.
+  back to any session in it. The sidebar gathers its sessions into a **Split**
+  block of their own at the top, the way pinned ones already are, so which
+  sessions are in the wall is something you read rather than rediscover by
+  clicking: the block folds like any other, and dragging a card inside it
+  rearranges the panes.
 
 - **The pull request screen hands its current problem to the session.** Red CI
   meant reading the Checks tab, opening each failed job in the browser and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Two sessions on screen at once.** Watching an agent used to mean watching
+  nothing else: the cards say what every session is *doing*, and only one of them
+  ever showed what it was *saying*. A card's menu now offers **Open beside**,
+  which puts that session in a second pane next to the one you are on —
+  <kbd>Ctrl/Cmd+Shift+O</kbd> splits with the next card and closes the split
+  again, <kbd>Ctrl/Cmd+Shift+G</kbd> moves the cursor across, and clicking a pane
+  focuses it. Drag the seam to divide the space, and both panes come back the way
+  you left them. A pane is a view of a card, never a session of its own: its ×
+  stops showing that session and closes nothing, and closing the session itself
+  hands the whole width back to the survivor.
+
 - **The pull request screen hands its current problem to the session.** Red CI
   meant reading the Checks tab, opening each failed job in the browser and
   typing the names back into the terminal yourself; a branch that would not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,26 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **A wall of sessions on one screen.** Watching an agent used to mean watching
-  nothing else: the cards say what every session is *doing*, and only one of them
-  ever showed what it was *saying*. A card's menu now offers **Show beside**,
-  which adds that session to the stage — <kbd>Ctrl/Cmd+Shift+G</kbd> adds the
-  next card, <kbd>Ctrl/Cmd+Shift+F</kbd> moves the cursor along, and clicking a
-  pane focuses it. lich lays the panes out itself, from how many there are and
-  how much room the window has: eight of them on a 34" ultrawide land four
-  across and two down, the same eight on a laptop come out two across, and lich
-  declines the one that would leave them all too small to read. Drag a pane by
-  its name to swap it with another, drag the seams to divide the space, and the
-  whole arrangement comes back the way you left it. A pane is a view of a card,
-  never a session of its own: its × stops showing that session and closes
-  nothing, and closing the session itself hands its room back to the rest.
-  The wall is yours and only **Show beside** adds to it — opening any other
-  session shows that one on its own and sets the wall aside, whole, until you go
-  back to any session in it. The sidebar gathers its sessions into a **Split**
-  block of their own at the top, the way pinned ones already are, so which
-  sessions are in the wall is something you read rather than rediscover by
-  clicking: the block folds like any other, and dragging a card inside it
-  rearranges the panes.
+- **Walls of sessions, as many as you keep.** Watching an agent used to mean
+  watching nothing else: the cards say what every session is *doing*, and only
+  one of them ever showed what it was *saying*. A card's menu now offers **Show
+  beside**, which puts that session on a wall next to the one you are in —
+  <kbd>Ctrl/Cmd+Shift+G</kbd> adds the next free card,
+  <kbd>Ctrl/Cmd+Shift+F</kbd> moves the cursor along, and clicking a pane
+  focuses it. lich lays the panes out itself, from how many there are and how
+  much room the window has: eight on a 34" ultrawide land four across and two
+  down, the same eight on a laptop come out two across, and lich declines the one
+  that would leave them all too small to read.
+  A wall is a group you made and named, and a project holds as many as you like —
+  an orchestrator with the three worktrees it spawned is one, the next
+  investigation with its own is another. Each gets a block of its own at the top
+  of the sidebar, so you read its membership instead of rediscovering it: fold
+  it, drag it above the others, rename it or take it apart from its header, and
+  drag a card inside it to rearrange the panes. Opening a session that is on no
+  wall shows it on its own and sets every wall aside, whole, until you go back to
+  one of their sessions. A pane is a view of a card, never a session of its own:
+  its × stops showing that session and closes nothing, and closing the session
+  itself hands its room back to the rest.
 
 - **The pull request screen hands its current problem to the session.** Red CI
   meant reading the Checks tab, opening each failed job in the browser and

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -43,16 +43,23 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   there is no agent in it whose work could be missed. The trap is reading the number as
   comparable across cards — the same hour of work is a smaller figure on Crush than on Claude
   Code, and nothing on screen says which rung a card is on.
-- **A split stage puts two sessions on the visible cadence** (`internal/terminal/coalescer.go`,
+- **A split stage puts every pane on the visible cadence** (`internal/terminal/coalescer.go`,
   `frontend/src/components/TerminalHost.tsx`): the coalescer batches a *visible* session's output every
-  8ms and a hidden one's every 250ms, and until panes existed exactly one session per window was ever
-  visible — `Service.SetVisible` had one true at a time. A split makes two, deliberately: the second pane
-  is never demoted, because watching it is the entire point of opening it. So the window's hot path — the
-  event bridge, its base64 and the WASM parse behind it — carries twice the frames it was measured with,
-  and anything reasoning about that cadence from the constants alone will read the wrong number. The
-  budget suite pins that splitting mounts one new terminal and remounts none
-  (`frontend/src/components/render-budget.test.tsx`); it cannot measure the cadence, because jsdom has no
-  canvas to paint.
+  8ms and a hidden one's every 250ms, and until the stage could divide, exactly one session per window
+  was ever visible — `Service.SetVisible` had one true at a time. A wall of eight makes eight,
+  deliberately: a pane nobody demoted is the entire point of opening it. So the window's hot path — the
+  event bridge, its base64 and the WASM parse behind it — carries as many streams as there are panes,
+  and anything reasoning about that cadence from the constants alone will read a number that was true
+  for one terminal. The budget suite pins that adding a pane mounts one terminal and remounts none
+  (`frontend/src/components/render-budget.test.tsx`); it cannot measure the cadence, because jsdom has
+  no canvas to paint.
+- **The grid follows the window, so the layout you dragged is not always the one you get back**
+  (`frontend/src/lib/session/panes.ts`, `tracks`): how many panes sit across is computed from the
+  stage's measured width, so collapsing the sidebar, opening the dock or moving the window to another
+  monitor can reshape the wall under you. Track sizes are stored for the grid they were dragged on and
+  fall back to equal shares whenever the shape no longer matches — which reads as a resize being
+  silently forgotten, and is the alternative to restoring a four-column layout onto three columns. The
+  cells themselves and their order always survive; only the sizes do not.
 - **A dropped file has no path, so lich guesses it** (`internal/drop`): a file under neither the session directory
   nor home is *copied*, so an agent told to edit it edits the copy — and that copy is deleted 3 days on, so a path
   pasted into a prompt eventually stops resolving.

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -53,12 +53,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   for one terminal. The budget suite pins that adding a pane mounts one terminal and remounts none
   (`frontend/src/components/render-budget.test.tsx`); it cannot measure the cadence, because jsdom has
   no canvas to paint.
-- **A session is on at most one wall, so adding it to another moves it silently**
-  (`frontend/src/lib/session/panes.ts`, `addToGroup`): the rule is what keeps "which wall is on
-  screen" from ever being ambiguous — the one holding the active session — but it means **Show
-  beside** on a card that already belongs to another group takes it out of that group with no
-  warning, and the group it left ends outright if it was its last member. The sidebar's blocks are
-  the only thing that shows it happened, after the fact.
 - **The grid follows the window, so the layout you dragged is not always the one you get back**
   (`frontend/src/lib/session/panes.ts`, `tracks`): how many panes sit across is computed from the
   stage's measured width, so collapsing the sidebar, opening the dock or moving the window to another

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -43,6 +43,16 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   there is no agent in it whose work could be missed. The trap is reading the number as
   comparable across cards — the same hour of work is a smaller figure on Crush than on Claude
   Code, and nothing on screen says which rung a card is on.
+- **A split stage puts two sessions on the visible cadence** (`internal/terminal/coalescer.go`,
+  `frontend/src/components/TerminalHost.tsx`): the coalescer batches a *visible* session's output every
+  8ms and a hidden one's every 250ms, and until panes existed exactly one session per window was ever
+  visible — `Service.SetVisible` had one true at a time. A split makes two, deliberately: the second pane
+  is never demoted, because watching it is the entire point of opening it. So the window's hot path — the
+  event bridge, its base64 and the WASM parse behind it — carries twice the frames it was measured with,
+  and anything reasoning about that cadence from the constants alone will read the wrong number. The
+  budget suite pins that splitting mounts one new terminal and remounts none
+  (`frontend/src/components/render-budget.test.tsx`); it cannot measure the cadence, because jsdom has no
+  canvas to paint.
 - **A dropped file has no path, so lich guesses it** (`internal/drop`): a file under neither the session directory
   nor home is *copied*, so an agent told to edit it edits the copy — and that copy is deleted 3 days on, so a path
   pasted into a prompt eventually stops resolving.

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -53,12 +53,12 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   for one terminal. The budget suite pins that adding a pane mounts one terminal and remounts none
   (`frontend/src/components/render-budget.test.tsx`); it cannot measure the cadence, because jsdom has
   no canvas to paint.
-- **One split per project, and starting another replaces it** (`frontend/src/lib/session/use-panes.ts`,
-  `add`): the stage is a group the user assembled, so activating a session outside it shows that
-  session alone and leaves the arrangement stored rather than torn down — the sidebar's Split block is
-  what says the wall is still there. But **Show beside** from a session outside the wall starts a new
-  one over the old, and the block is the only warning: the members that were in it stop being drawn
-  under that header the moment the new one is written, and nothing asks first.
+- **A session is on at most one wall, so adding it to another moves it silently**
+  (`frontend/src/lib/session/panes.ts`, `addToGroup`): the rule is what keeps "which wall is on
+  screen" from ever being ambiguous — the one holding the active session — but it means **Show
+  beside** on a card that already belongs to another group takes it out of that group with no
+  warning, and the group it left ends outright if it was its last member. The sidebar's blocks are
+  the only thing that shows it happened, after the fact.
 - **The grid follows the window, so the layout you dragged is not always the one you get back**
   (`frontend/src/lib/session/panes.ts`, `tracks`): how many panes sit across is computed from the
   stage's measured width, so collapsing the sidebar, opening the dock or moving the window to another

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -53,13 +53,12 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   for one terminal. The budget suite pins that adding a pane mounts one terminal and remounts none
   (`frontend/src/components/render-budget.test.tsx`); it cannot measure the cadence, because jsdom has
   no canvas to paint.
-- **A parked wall is invisible until you go back to it** (`frontend/src/lib/session/panes.ts`,
-  `resolveStage`): the stage is a group the user assembled, so activating a session that is not in it
-  shows that session alone and leaves the arrangement stored rather than torn down. Nothing on screen
-  says a wall is waiting — that is deliberate, a badge for it would be chrome for a state the next
-  click resolves — but it means **Show beside** from outside the wall starts a new one *over* the old,
-  and the arrangement that was parked is gone with no warning. One stage per project, and the last
-  thing written is the one that comes back.
+- **One split per project, and starting another replaces it** (`frontend/src/lib/session/use-panes.ts`,
+  `add`): the stage is a group the user assembled, so activating a session outside it shows that
+  session alone and leaves the arrangement stored rather than torn down — the sidebar's Split block is
+  what says the wall is still there. But **Show beside** from a session outside the wall starts a new
+  one over the old, and the block is the only warning: the members that were in it stop being drawn
+  under that header the moment the new one is written, and nothing asks first.
 - **The grid follows the window, so the layout you dragged is not always the one you get back**
   (`frontend/src/lib/session/panes.ts`, `tracks`): how many panes sit across is computed from the
   stage's measured width, so collapsing the sidebar, opening the dock or moving the window to another

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -53,6 +53,13 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   for one terminal. The budget suite pins that adding a pane mounts one terminal and remounts none
   (`frontend/src/components/render-budget.test.tsx`); it cannot measure the cadence, because jsdom has
   no canvas to paint.
+- **A parked wall is invisible until you go back to it** (`frontend/src/lib/session/panes.ts`,
+  `resolveStage`): the stage is a group the user assembled, so activating a session that is not in it
+  shows that session alone and leaves the arrangement stored rather than torn down. Nothing on screen
+  says a wall is waiting — that is deliberate, a badge for it would be chrome for a state the next
+  click resolves — but it means **Show beside** from outside the wall starts a new one *over* the old,
+  and the arrangement that was parked is gone with no warning. One stage per project, and the last
+  thing written is the one that comes back.
 - **The grid follows the window, so the layout you dragged is not always the one you get back**
   (`frontend/src/lib/session/panes.ts`, `tracks`): how many panes sit across is computed from the
   stage's measured width, so collapsing the sidebar, opening the dock or moving the window to another

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import { useHotkey } from "@/lib/use-hotkey"
 import { parseBoolPref, readPref, writePref } from "@/lib/prefs"
 import { ProjectsProvider, useProjects } from "@/providers/projects"
 import { activeSessionId, sessionsOf } from "@/lib/session/sessions"
+import { usePanes } from "@/lib/session/use-panes"
 import {
   requestSessionIntent,
   requestWorktreeDialog,
@@ -91,6 +92,16 @@ function Layout() {
     }
   }, [dock])
   useHotkey(hotkeys.toggleDock, () => setDock((cur) => (cur ? null : lastTab.current)))
+  // A project of one session has nothing to put beside it, and switching panes
+  // with no second pane is not a thing to do: both decline rather than being
+  // swallowed for nothing, the rule every card shortcut above follows.
+  const panes = usePanes(projectId)
+  useHotkey(hotkeys.splitBeside, () => {
+    if (!panes.toggle()) {
+      return false
+    }
+  })
+  useHotkey(hotkeys.otherPane, () => panes.split && panes.focusOther())
   return (
     <div className="flex h-screen w-screen flex-col bg-background">
       <ProjectTabs />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -92,16 +92,16 @@ function Layout() {
     }
   }, [dock])
   useHotkey(hotkeys.toggleDock, () => setDock((cur) => (cur ? null : lastTab.current)))
-  // A project of one session has nothing to put beside it, and switching panes
-  // with no second pane is not a thing to do: both decline rather than being
-  // swallowed for nothing, the rule every card shortcut above follows.
+  // Nothing left to show, no room left to show it in, or no second pane to move
+  // the cursor to: each declines rather than being swallowed for nothing, the
+  // rule every card shortcut above follows.
   const panes = usePanes(projectId)
   useHotkey(hotkeys.splitBeside, () => {
-    if (!panes.toggle()) {
+    if (!panes.add()) {
       return false
     }
   })
-  useHotkey(hotkeys.otherPane, () => panes.split && panes.focusOther())
+  useHotkey(hotkeys.otherPane, () => panes.split && panes.focusStep(1))
   return (
     <div className="flex h-screen w-screen flex-col bg-background">
       <ProjectTabs />

--- a/frontend/src/components/PaneSeams.tsx
+++ b/frontend/src/components/PaneSeams.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react"
 import type { PointerEvent as ReactPointerEvent } from "react"
-import { dragTrack, offsetOf } from "@/lib/session/panes"
+import { dragTrack, offsetOf } from "@/lib/session/pane-grid"
 
 interface PaneSeamsProps {
   /** Share of the axis each track takes; a seam sits between adjacent pairs. */

--- a/frontend/src/components/PaneSeams.tsx
+++ b/frontend/src/components/PaneSeams.tsx
@@ -1,0 +1,105 @@
+import { useRef } from "react"
+import type { PointerEvent as ReactPointerEvent } from "react"
+import { dragTrack, offsetOf } from "@/lib/session/panes"
+
+interface PaneSeamsProps {
+  /** Share of the axis each track takes; a seam sits between adjacent pairs. */
+  tracks: number[]
+  /** Which way the boundary is dragged: columns move left and right. */
+  axis: "cols" | "rows"
+  /** Size of the stage along the dragged axis, in pixels. */
+  extent: number
+  /** Where the seams start and how far they reach across the other axis, as
+   * shares of it — a column seam only spans the row it divides. */
+  from?: number
+  span?: number
+  /** During the drag, so the panes follow the pointer. */
+  onChange: (tracks: number[]) => void
+  /** On release, which is when the layout is written down. */
+  onCommit: (tracks: number[]) => void
+}
+
+// The grab strips between panes. They are drawn over the terminals rather than
+// between them because the panes are absolutely positioned layers, not a flex
+// row — the seam is a handle at a computed offset, and the hairline the user
+// sees is the border on the pane beside it.
+//
+// Dragging is pointer-based, like every other resize in the app, and the value
+// only reaches the store on release: a drag would otherwise put a hundred writes
+// through localStorage. The live value belongs to the stage, not to this
+// component — the panes have to move with the pointer too.
+export function PaneSeams({
+  tracks,
+  axis,
+  extent,
+  from = 0,
+  span = 1,
+  onChange,
+  onCommit,
+}: PaneSeamsProps) {
+  // The tracks as they were when the drag started: every move is measured from
+  // that, so a pointer returning to where it began restores the original sizes
+  // rather than accumulating rounding.
+  const drag = useRef<{ index: number; start: number; tracks: number[] } | null>(null)
+  const vertical = axis === "cols"
+
+  const at = (event: ReactPointerEvent<HTMLElement>) => (vertical ? event.clientX : event.clientY)
+
+  const move = (event: ReactPointerEvent<HTMLElement>): number[] | null => {
+    const current = drag.current
+    if (!current || extent <= 0) {
+      return null
+    }
+    return dragTrack(current.tracks, current.index, (at(event) - current.start) / extent)
+  }
+
+  return (
+    <>
+      {tracks.slice(0, -1).map((_, index) => {
+        const offset = offsetOf(tracks, index + 1)
+        return (
+          <div
+            // A boundary is its place in the axis: the seam between the first
+            // and second column is that seam, and the tracks either side of it
+            // are what a drag changes. Keying it by a value would remount it
+            // mid-drag, which is the one thing a handle must not do.
+            // biome-ignore lint/suspicious/noArrayIndexKey: the index is the identity here
+            key={`${axis}-${index}`}
+            role="separator"
+            aria-orientation={vertical ? "vertical" : "horizontal"}
+            aria-label={vertical ? "Resize the columns" : "Resize the rows"}
+            className={
+              vertical
+                ? "absolute z-10 w-1.5 -translate-x-1/2 cursor-col-resize touch-none transition-colors hover:bg-accent"
+                : "absolute z-10 h-1.5 -translate-y-1/2 cursor-row-resize touch-none transition-colors hover:bg-accent"
+            }
+            style={
+              vertical
+                ? { left: `${offset * 100}%`, top: `${from * 100}%`, height: `${span * 100}%` }
+                : { top: `${offset * 100}%`, left: `${from * 100}%`, width: `${span * 100}%` }
+            }
+            onPointerDown={(event) => {
+              event.preventDefault()
+              drag.current = { index, start: at(event), tracks: [...tracks] }
+              event.currentTarget.setPointerCapture(event.pointerId)
+            }}
+            onPointerMove={(event) => {
+              const next = move(event)
+              if (next) {
+                onChange(next)
+              }
+            }}
+            onPointerUp={(event) => {
+              const next = move(event)
+              drag.current = null
+              event.currentTarget.releasePointerCapture(event.pointerId)
+              if (next) {
+                onCommit(next)
+              }
+            }}
+          />
+        )
+      })}
+    </>
+  )
+}

--- a/frontend/src/components/TerminalHost.tsx
+++ b/frontend/src/components/TerminalHost.tsx
@@ -13,8 +13,7 @@ import { activeSessionId, hasSession, resumableSession, sessionsOf } from "@/lib
 import { paletteSessions } from "@/lib/session/command-palette"
 import { spawnDecision, type SpawnProbe } from "@/lib/session/spawn-gate"
 import { PaneSeams } from "./PaneSeams"
-import { cellAt, grid, offsetOf, rowLength, rowTracks, tracks } from "@/lib/session/panes"
-import { useStoredCols, useStoredRows, writeCols, writeRows } from "@/lib/session/panes-store"
+import { cellAt, grid, offsetOf, rowLength, rowTracks, tracks } from "@/lib/session/pane-grid"
 import { usePanes } from "@/lib/session/use-panes"
 import { useStageSize } from "@/lib/session/use-stage-size"
 import { cn } from "@/lib/utils"
@@ -67,10 +66,10 @@ export function TerminalHost() {
   // panes have to move with the pointer, and only the release is written down.
   const [liveCols, setLiveCols] = useState<number[] | null>(null)
   const [liveRows, setLiveRows] = useState<number[] | null>(null)
-  const storedCols = useStoredCols()
-  const storedRows = useStoredRows()
-  const cols = liveCols ?? tracks(storedCols, layout.cols)
-  const rows = liveRows ?? tracks(storedRows, layout.rows)
+  // The shares belong to the wall being drawn, not to the window: arranging one
+  // group 60/40 must not carry into the next one the user opens.
+  const cols = liveCols ?? tracks(stage.current?.cols ?? [], layout.cols)
+  const rows = liveRows ?? tracks(stage.current?.rows ?? [], layout.rows)
 
   // The pane a dragged one is hovering over, for the drop hint. The drag itself
   // is a pointer gesture on the label rather than HTML5 drag-and-drop, which the
@@ -314,7 +313,9 @@ export function TerminalHost() {
               onChange={setLiveCols}
               onCommit={(next) => {
                 setLiveCols(null)
-                writeCols(next)
+                if (stage.current) {
+                  stage.setTracks(stage.current.id, { cols: next })
+                }
               }}
             />
           ) : null,
@@ -327,7 +328,9 @@ export function TerminalHost() {
           onChange={setLiveRows}
           onCommit={(next) => {
             setLiveRows(null)
-            writeRows(next)
+            if (stage.current) {
+              stage.setTracks(stage.current.id, { rows: next })
+            }
           }}
         />
       )}

--- a/frontend/src/components/TerminalHost.tsx
+++ b/frontend/src/components/TerminalHost.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState } from "react"
-import type { PointerEvent as ReactPointerEvent } from "react"
 import { useMatch } from "react-router-dom"
 import { toast } from "sonner"
 import { TerminalView } from "./TerminalView"
@@ -13,9 +12,11 @@ import { useProjects } from "@/providers/projects"
 import { activeSessionId, hasSession, resumableSession, sessionsOf } from "@/lib/session/sessions"
 import { paletteSessions } from "@/lib/session/command-palette"
 import { spawnDecision, type SpawnProbe } from "@/lib/session/spawn-gate"
-import { dragRatio, other, type Side } from "@/lib/session/panes"
-import { closeBeside, setPaneRatio, usePaneRatio } from "@/lib/session/panes-store"
+import { PaneSeams } from "./PaneSeams"
+import { cellAt, grid, offsetOf, rowLength, rowTracks, tracks } from "@/lib/session/panes"
+import { useStoredCols, useStoredRows, writeCols, writeRows } from "@/lib/session/panes-store"
 import { usePanes } from "@/lib/session/use-panes"
+import { useStageSize } from "@/lib/session/use-stage-size"
 import { cn } from "@/lib/utils"
 import type { Session } from "@/lib/session/sessions"
 
@@ -24,23 +25,6 @@ import type { Session } from "@/lib/session/sessions"
 const probe: SpawnProbe = {
   workdirMissing: TerminalService.WorkdirMissing,
   resumeAvailable: TerminalService.ResumeAvailable,
-}
-
-// Where a layer sits on the stage. Percentages rather than a flex row because
-// every session is an absolutely positioned layer stacked in the same area —
-// splitting moves two of them into their halves and leaves the rest alone.
-type Lane = "full" | Side
-
-// The ratio is the seam's distance from the left edge, so the left lane owns it
-// and the right lane starts there — whichever session is drawing in each.
-function laneStyle(lane: Lane, ratio: number): { left: string; width?: string; right?: string } {
-  if (lane === "left") {
-    return { left: "0", width: `${ratio * 100}%` }
-  }
-  if (lane === "right") {
-    return { left: `${ratio * 100}%`, right: "0" }
-  }
-  return { left: "0", right: "0" }
 }
 
 // TerminalHost keeps one persistent terminal per session, across every open
@@ -64,58 +48,40 @@ export function TerminalHost() {
   const match = useMatch("/projects/:projectId")
   const activeProjectId = match?.params.projectId ?? null
 
-  const visibleSessionId = activeProjectId ? activeSessionId(sessions, activeProjectId) : ""
+  // The stage: an ordered list of sessions, the grid computed from how many
+  // there are and how wide the window is, and the cursor in one of the cells.
+  // The focused cell always draws the project's active session, so the footer,
+  // the dock, the sidebar highlight and every card shortcut go on reading
+  // activeId and none of them needed a line.
+  const stage = usePanes(activeProjectId ?? "")
+  const [stageRef, size] = useStageSize()
+  // Until the stage has been measured there is no grid to lay out — the first
+  // paint of a window that opens onto a split would otherwise stack the panes
+  // for one frame and then jump. Unmeasured draws the focused session alone,
+  // which is what the stage looked like before any of this.
+  const measured = size.width > 0
+  const split = measured && stage.split
+  const layout = grid(measured ? stage.cells.length : 1, size.width)
 
-  // The second pane. Focus is not a third piece of state: the focused pane *is*
-  // the project's active session, so the footer, the dock, the sidebar highlight
-  // and every card shortcut keep reading activeId and needed no change here.
-  const {
-    beside: besideSessionId,
-    besideSide,
-    split,
-    focusOther,
-    promoteOther,
-  } = usePanes(activeProjectId ?? "")
-  const ratio = usePaneRatio()
+  // Track sizes come from the store, except while a seam is being dragged: the
+  // panes have to move with the pointer, and only the release is written down.
+  const [liveCols, setLiveCols] = useState<number[] | null>(null)
+  const [liveRows, setLiveRows] = useState<number[] | null>(null)
+  const storedCols = useStoredCols()
+  const storedRows = useStoredRows()
+  const cols = liveCols ?? tracks(storedCols, layout.cols)
+  const rows = liveRows ?? tracks(storedRows, layout.rows)
 
-  // The seam's ratio is held in state while dragging and written on release —
-  // the panel-resize precedent (use-panel-width.ts), which keeps a drag from
-  // putting a hundred writes through localStorage.
-  const [dragging, setDragging] = useState<number | null>(null)
-  const seamRef = useRef<{ startX: number; startRatio: number; width: number } | null>(null)
-  const paneRatio = dragging ?? ratio
+  // The pane a dragged one is hovering over, for the drop hint. The drag itself
+  // is a pointer gesture on the label rather than HTML5 drag-and-drop, which the
+  // window already spends on files dropped into a terminal.
+  const [dragFrom, setDragFrom] = useState<number | null>(null)
+  const [dragOver, setDragOver] = useState<number | null>(null)
 
-  const onSeamDown = (event: ReactPointerEvent<HTMLDivElement>) => {
-    event.preventDefault()
-    seamRef.current = {
-      startX: event.clientX,
-      startRatio: ratio,
-      width: event.currentTarget.parentElement?.clientWidth ?? 0,
-    }
-    event.currentTarget.setPointerCapture(event.pointerId)
-  }
-
-  const seamAt = (clientX: number): number | null => {
-    const drag = seamRef.current
-    return drag ? dragRatio(drag.startRatio, drag.startX, clientX, drag.width) : null
-  }
-
-  const onSeamMove = (event: ReactPointerEvent<HTMLDivElement>) => {
-    const next = seamAt(event.clientX)
-    if (next !== null) {
-      setDragging(next)
-    }
-  }
-
-  const onSeamUp = (event: ReactPointerEvent<HTMLDivElement>) => {
-    const next = seamAt(event.clientX)
-    if (next === null) {
-      return
-    }
-    seamRef.current = null
-    event.currentTarget.releasePointerCapture(event.pointerId)
-    setDragging(null)
-    setPaneRatio(next)
+  const paneUnder = (x: number, y: number): number | null => {
+    const el = document.elementFromPoint(x, y)?.closest("[data-pane]")
+    const index = Number(el?.getAttribute("data-pane"))
+    return Number.isInteger(index) ? index : null
   }
 
   // The close an exited session's banner raises, on its own instance of the
@@ -149,11 +115,11 @@ export function TerminalHost() {
   const projectsRef = useRef(projects)
   projectsRef.current = projects
 
-  // Which session the gate below is working on. Both panes spawn lazily and the
+  // Which session the gate below is working on. Every pane spawns lazily and the
   // gate is written for one session at a time — its resume prompt is a single
-  // dialog — so they are taken in order: the second pane's turn comes once the
-  // first has landed in `spawned` and this recomputes.
-  const pending = [visibleSessionId, besideSessionId].find((id) => id && !spawned.has(id)) ?? ""
+  // dialog — so the stage is taken in order: the next cell's turn comes once the
+  // one before it has landed in `spawned` and this recomputes.
+  const pending = stage.cells.find((id) => id && !spawned.has(id)) ?? ""
 
   useEffect(() => {
     if (!activeProjectId || !pending) {
@@ -226,7 +192,7 @@ export function TerminalHost() {
   }
 
   return (
-    <>
+    <div ref={stageRef} className="absolute inset-0">
       {projects.flatMap((project) => {
         const projectActiveId = activeSessionId(sessions, project.id)
         return sessionsOf(sessions, project.id).map((session) => {
@@ -234,39 +200,78 @@ export function TerminalHost() {
             return null
           }
           const onStage = project.id === activeProjectId
-          const focused = onStage && session.id === projectActiveId
-          const beside = onStage && session.id === besideSessionId
-          const visible = focused || beside
+          const index = onStage ? stage.cells.indexOf(session.id) : -1
+          const focused = index >= 0 && session.id === projectActiveId
+          const visible = focused || (measured && index >= 0)
           // A hidden layer keeps the whole stage: its terminal is destroyed
           // while hidden and refitted on the way back, so the size it holds
-          // meanwhile is the one it would have unsplit — and nothing measures it.
-          const lane: Lane = !split || !visible ? "full" : beside ? besideSide : other(besideSide)
+          // meanwhile is not a size anything measures.
+          const place = cellAt(Math.max(index, 0), layout)
+          const row = rowTracks(cols, rowLength(place.row, stage.cells.length, layout))
+          const box = visible
+            ? {
+                left: `${offsetOf(row, place.col) * 100}%`,
+                width: `${(row[place.col] ?? 1) * 100}%`,
+                top: `${offsetOf(rows, place.row) * 100}%`,
+                height: `${(rows[place.row] ?? 1) * 100}%`,
+              }
+            : { left: "0", right: "0", top: "0", bottom: "0" }
           return (
             <div
               key={session.id}
+              data-pane={visible ? index : undefined}
               className={cn(
-                "absolute inset-y-0 flex flex-col",
-                lane === "right" && "border-l border-border",
+                "absolute flex flex-col",
+                // Seams between panes are the one place DESIGN.md allows a
+                // border: a hairline on every cell that has a neighbour behind
+                // it, so the grid reads as divided rather than as boxes.
+                visible && place.col > 0 && "border-l border-border",
+                visible && place.row > 0 && "border-t border-border",
               )}
-              style={{ ...laneStyle(lane, paneRatio), visibility: visible ? "visible" : "hidden" }}
+              style={{ ...box, visibility: visible ? "visible" : "hidden" }}
               aria-hidden={!visible}
               // Capture, so a click lands on the pane before xterm takes it for
               // a selection: clicking a terminal is how you focus its pane.
-              onPointerDownCapture={beside ? focusOther : undefined}
+              onPointerDownCapture={visible && !focused ? () => stage.focusCell(index) : undefined}
             >
               {split && visible && (
                 <div
                   className={cn(
-                    "group flex shrink-0 items-center gap-1.5 px-2.5 pb-1 pt-1.5 text-xs",
+                    "group flex shrink-0 cursor-grab items-center gap-1.5 px-2.5 pb-1 pt-1.5 text-xs",
                     focused ? "text-foreground" : "text-muted-foreground",
+                    dragFrom === index && "cursor-grabbing opacity-60",
+                    dragOver === index && dragFrom !== null && dragFrom !== index && "bg-accent/60",
                   )}
+                  // The label is the grip: a pointer gesture on the terminal
+                  // itself is a text selection, and one on the pane is how the
+                  // cursor moves into it.
+                  onPointerDown={(event) => {
+                    event.currentTarget.setPointerCapture(event.pointerId)
+                    setDragFrom(index)
+                  }}
+                  onPointerMove={(event) => {
+                    if (dragFrom === index) {
+                      setDragOver(paneUnder(event.clientX, event.clientY))
+                    }
+                  }}
+                  onPointerUp={(event) => {
+                    event.currentTarget.releasePointerCapture(event.pointerId)
+                    const target = paneUnder(event.clientX, event.clientY)
+                    setDragFrom(null)
+                    setDragOver(null)
+                    if (target === null || target === index) {
+                      stage.focusCell(index)
+                      return
+                    }
+                    stage.swap(index, target)
+                  }}
                 >
                   <ProviderIcon kind={session.kind} size={12} />
                   <span className="min-w-0 truncate font-medium">{session.label}</span>
                   <CloseButton
                     label={`Stop showing ${session.label}`}
                     className="ml-auto"
-                    onClick={() => (focused ? promoteOther() : closeBeside(activeProjectId ?? ""))}
+                    onClick={() => stage.drop(index)}
                   />
                 </div>
               )}
@@ -289,16 +294,41 @@ export function TerminalHost() {
           )
         })
       })}
+      {/* Column seams are drawn per row so they stop at the row they divide,
+          and a short last row — which spreads its cells over the whole width —
+          has none: the boundary it would offer is not one of the columns the
+          stored track sizes describe. */}
+      {split &&
+        rows.map((_, row) =>
+          rowLength(row, stage.cells.length, layout) === layout.cols ? (
+            <PaneSeams
+              // A row is its place in the grid, and the seams under it divide
+              // that row and nothing else.
+              // biome-ignore lint/suspicious/noArrayIndexKey: the index is the identity here
+              key={`row-${row}`}
+              tracks={cols}
+              axis="cols"
+              extent={size.width}
+              from={offsetOf(rows, row)}
+              span={rows[row]}
+              onChange={setLiveCols}
+              onCommit={(next) => {
+                setLiveCols(null)
+                writeCols(next)
+              }}
+            />
+          ) : null,
+        )}
       {split && (
-        <div
-          role="separator"
-          aria-orientation="vertical"
-          aria-label="Resize the panes"
-          className="absolute inset-y-0 z-10 w-1.5 -translate-x-1/2 cursor-col-resize touch-none transition-colors hover:bg-accent"
-          style={{ left: `${paneRatio * 100}%` }}
-          onPointerDown={onSeamDown}
-          onPointerMove={onSeamMove}
-          onPointerUp={onSeamUp}
+        <PaneSeams
+          tracks={rows}
+          axis="rows"
+          extent={size.height}
+          onChange={setLiveRows}
+          onCommit={(next) => {
+            setLiveRows(null)
+            writeRows(next)
+          }}
         />
       )}
       <ResumeSessionDialog
@@ -307,6 +337,6 @@ export function TerminalHost() {
         onResume={() => asking && answerResume(asking, asking.providerSessionId ?? "")}
       />
       <WorktreeCloseDialogs close={worktreeClose} />
-    </>
+    </div>
   )
 }

--- a/frontend/src/components/TerminalHost.tsx
+++ b/frontend/src/components/TerminalHost.tsx
@@ -1,8 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react"
+import type { PointerEvent as ReactPointerEvent } from "react"
 import { useMatch } from "react-router-dom"
 import { toast } from "sonner"
 import { TerminalView } from "./TerminalView"
 import { ResumeSessionDialog } from "./ResumeSessionDialog"
+import { ProviderIcon } from "./ProviderIcon"
+import { CloseButton } from "./common/CloseButton"
 import { WorktreeCloseDialogs } from "./sidebar/WorktreeCloseDialogs"
 import { useWorktreeClose } from "./sidebar/useWorktreeClose"
 import { Terminal as TerminalService } from "@/lib/rpc"
@@ -10,6 +13,10 @@ import { useProjects } from "@/providers/projects"
 import { activeSessionId, hasSession, resumableSession, sessionsOf } from "@/lib/session/sessions"
 import { paletteSessions } from "@/lib/session/command-palette"
 import { spawnDecision, type SpawnProbe } from "@/lib/session/spawn-gate"
+import { dragRatio, other, type Side } from "@/lib/session/panes"
+import { closeBeside, setPaneRatio, usePaneRatio } from "@/lib/session/panes-store"
+import { usePanes } from "@/lib/session/use-panes"
+import { cn } from "@/lib/utils"
 import type { Session } from "@/lib/session/sessions"
 
 // The gate's two backend checks. Module-level so the effect below never takes a
@@ -17,6 +24,23 @@ import type { Session } from "@/lib/session/sessions"
 const probe: SpawnProbe = {
   workdirMissing: TerminalService.WorkdirMissing,
   resumeAvailable: TerminalService.ResumeAvailable,
+}
+
+// Where a layer sits on the stage. Percentages rather than a flex row because
+// every session is an absolutely positioned layer stacked in the same area —
+// splitting moves two of them into their halves and leaves the rest alone.
+type Lane = "full" | Side
+
+// The ratio is the seam's distance from the left edge, so the left lane owns it
+// and the right lane starts there — whichever session is drawing in each.
+function laneStyle(lane: Lane, ratio: number): { left: string; width?: string; right?: string } {
+  if (lane === "left") {
+    return { left: "0", width: `${ratio * 100}%` }
+  }
+  if (lane === "right") {
+    return { left: `${ratio * 100}%`, right: "0" }
+  }
+  return { left: "0", right: "0" }
 }
 
 // TerminalHost keeps one persistent terminal per session, across every open
@@ -41,6 +65,58 @@ export function TerminalHost() {
   const activeProjectId = match?.params.projectId ?? null
 
   const visibleSessionId = activeProjectId ? activeSessionId(sessions, activeProjectId) : ""
+
+  // The second pane. Focus is not a third piece of state: the focused pane *is*
+  // the project's active session, so the footer, the dock, the sidebar highlight
+  // and every card shortcut keep reading activeId and needed no change here.
+  const {
+    beside: besideSessionId,
+    besideSide,
+    split,
+    focusOther,
+    promoteOther,
+  } = usePanes(activeProjectId ?? "")
+  const ratio = usePaneRatio()
+
+  // The seam's ratio is held in state while dragging and written on release —
+  // the panel-resize precedent (use-panel-width.ts), which keeps a drag from
+  // putting a hundred writes through localStorage.
+  const [dragging, setDragging] = useState<number | null>(null)
+  const seamRef = useRef<{ startX: number; startRatio: number; width: number } | null>(null)
+  const paneRatio = dragging ?? ratio
+
+  const onSeamDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    seamRef.current = {
+      startX: event.clientX,
+      startRatio: ratio,
+      width: event.currentTarget.parentElement?.clientWidth ?? 0,
+    }
+    event.currentTarget.setPointerCapture(event.pointerId)
+  }
+
+  const seamAt = (clientX: number): number | null => {
+    const drag = seamRef.current
+    return drag ? dragRatio(drag.startRatio, drag.startX, clientX, drag.width) : null
+  }
+
+  const onSeamMove = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const next = seamAt(event.clientX)
+    if (next !== null) {
+      setDragging(next)
+    }
+  }
+
+  const onSeamUp = (event: ReactPointerEvent<HTMLDivElement>) => {
+    const next = seamAt(event.clientX)
+    if (next === null) {
+      return
+    }
+    seamRef.current = null
+    event.currentTarget.releasePointerCapture(event.pointerId)
+    setDragging(null)
+    setPaneRatio(next)
+  }
 
   // The close an exited session's banner raises, on its own instance of the
   // sidebar's flow — the sidebar is not always mounted (collapsed to the rail)
@@ -73,12 +149,18 @@ export function TerminalHost() {
   const projectsRef = useRef(projects)
   projectsRef.current = projects
 
+  // Which session the gate below is working on. Both panes spawn lazily and the
+  // gate is written for one session at a time — its resume prompt is a single
+  // dialog — so they are taken in order: the second pane's turn comes once the
+  // first has landed in `spawned` and this recomputes.
+  const pending = [visibleSessionId, besideSessionId].find((id) => id && !spawned.has(id)) ?? ""
+
   useEffect(() => {
-    if (!activeProjectId || !visibleSessionId || spawnedRef.current.has(visibleSessionId)) {
+    if (!activeProjectId || !pending) {
       return
     }
     const projectId = activeProjectId
-    const sessionId = visibleSessionId
+    const sessionId = pending
     const session = sessionsOf(sessionsRef.current, projectId).find((s) => s.id === sessionId)
     const project = projectsRef.current.find((p) => p.id === projectId)
     const resumable = resumableSession(sessionsRef.current, projectId, sessionId)
@@ -108,7 +190,7 @@ export function TerminalHost() {
     return () => {
       live = false
     }
-  }, [activeProjectId, visibleSessionId, keepSession])
+  }, [activeProjectId, pending, keepSession])
 
   // A session that left the workspace leaves both maps with it. Its id can come
   // back — an undone close restores the very same one — and its terminal did
@@ -151,30 +233,74 @@ export function TerminalHost() {
           if (!spawned.has(session.id)) {
             return null
           }
-          const visible = project.id === activeProjectId && session.id === projectActiveId
+          const onStage = project.id === activeProjectId
+          const focused = onStage && session.id === projectActiveId
+          const beside = onStage && session.id === besideSessionId
+          const visible = focused || beside
+          // A hidden layer keeps the whole stage: its terminal is destroyed
+          // while hidden and refitted on the way back, so the size it holds
+          // meanwhile is the one it would have unsplit — and nothing measures it.
+          const lane: Lane = !split || !visible ? "full" : beside ? besideSide : other(besideSide)
           return (
             <div
               key={session.id}
-              className="absolute inset-0"
-              style={{ visibility: visible ? "visible" : "hidden" }}
+              className={cn(
+                "absolute inset-y-0 flex flex-col",
+                lane === "right" && "border-l border-border",
+              )}
+              style={{ ...laneStyle(lane, paneRatio), visibility: visible ? "visible" : "hidden" }}
               aria-hidden={!visible}
+              // Capture, so a click lands on the pane before xterm takes it for
+              // a selection: clicking a terminal is how you focus its pane.
+              onPointerDownCapture={beside ? focusOther : undefined}
             >
-              <TerminalView
-                sessionId={session.id}
-                projectId={project.id}
-                cwd={session.path || project.path}
-                kind={session.kind}
-                resume={resuming[session.id] ?? ""}
-                roster={roster}
-                visible={visible}
-                sandboxed={session.sandboxed ?? false}
-                onClose={() => worktreeClose.requestClose(session)}
-                stillInWorkspace={() => hasSession(sessionsRef.current, session.id)}
-              />
+              {split && visible && (
+                <div
+                  className={cn(
+                    "group flex shrink-0 items-center gap-1.5 px-2.5 pb-1 pt-1.5 text-xs",
+                    focused ? "text-foreground" : "text-muted-foreground",
+                  )}
+                >
+                  <ProviderIcon kind={session.kind} size={12} />
+                  <span className="min-w-0 truncate font-medium">{session.label}</span>
+                  <CloseButton
+                    label={`Stop showing ${session.label}`}
+                    className="ml-auto"
+                    onClick={() => (focused ? promoteOther() : closeBeside(activeProjectId ?? ""))}
+                  />
+                </div>
+              )}
+              <div className="relative min-h-0 flex-1">
+                <TerminalView
+                  sessionId={session.id}
+                  projectId={project.id}
+                  cwd={session.path || project.path}
+                  kind={session.kind}
+                  resume={resuming[session.id] ?? ""}
+                  roster={roster}
+                  visible={visible}
+                  focused={focused}
+                  sandboxed={session.sandboxed ?? false}
+                  onClose={() => worktreeClose.requestClose(session)}
+                  stillInWorkspace={() => hasSession(sessionsRef.current, session.id)}
+                />
+              </div>
             </div>
           )
         })
       })}
+      {split && (
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize the panes"
+          className="absolute inset-y-0 z-10 w-1.5 -translate-x-1/2 cursor-col-resize touch-none transition-colors hover:bg-accent"
+          style={{ left: `${paneRatio * 100}%` }}
+          onPointerDown={onSeamDown}
+          onPointerMove={onSeamMove}
+          onPointerUp={onSeamUp}
+        />
+      )}
       <ResumeSessionDialog
         session={asking}
         onStartNew={() => asking && answerResume(asking, "")}

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -93,6 +93,13 @@ export interface TerminalViewProps {
   roster: readonly PaletteSession[]
   visible: boolean
   /**
+   * Whether this is the pane the keyboard belongs to. Split from `visible` by
+   * panes: two sessions paint at once, and exactly one of them owns the cursor,
+   * the Ctrl+F chord and everything else a keypress can reach. Without a split
+   * the two are the same boolean — one session is visible and it is focused.
+   */
+  focused: boolean
+  /**
    * Whether this session's PTY runs confined (internal/sandbox). Only the drop
    * reads it here: a confined session's home is an empty private one, so a file
    * dragged in from outside its checkout has to arrive as a copy.
@@ -130,6 +137,7 @@ export function TerminalView({
   resume,
   roster,
   visible,
+  focused,
   sandboxed,
   onClose,
   stillInWorkspace,
@@ -155,11 +163,13 @@ export function TerminalView({
   const carriedModesRef = useRef("")
   const replayRef = useRef(makeReplayBuffer())
   const visibleRef = useRef(visible)
+  const focusedRef = useRef(focused)
   const stillInWorkspaceRef = useRef(stillInWorkspace)
   const fontRef = useRef(font)
   const fontSizeRef = useRef(terminalFontSize)
   const themeRef = useRef(terminalColors)
   visibleRef.current = visible
+  focusedRef.current = focused
   stillInWorkspaceRef.current = stillInWorkspace
   fontRef.current = font
   fontSizeRef.current = terminalFontSize
@@ -492,10 +502,12 @@ export function TerminalView({
 
     // Ctrl+F must be caught in the window capture phase to beat Chromium's Find
     // accelerator in --app mode (the same pattern the zoom hotkeys use in
-    // settings.tsx); xterm's own key handler runs too late. Only the visible
-    // session's terminal claims it — one is visible at a time.
+    // settings.tsx); xterm's own key handler runs too late. Only the *focused*
+    // session's terminal claims it: a split paints two at once, and a chord this
+    // window swallows has to be answered by exactly one of them or the find box
+    // opens on a terminal nobody is typing into.
     const onSearchKey = (event: KeyboardEvent) => {
-      if (!visibleRef.current || !isSearchOpenChord(event)) {
+      if (!focusedRef.current || !isSearchOpenChord(event)) {
         return
       }
       const target = event.target as HTMLElement | null
@@ -627,7 +639,9 @@ export function TerminalView({
         void Service.Write(sessionId, paste)
       }
       if (visibleRef.current) {
-        live.term.focus()
+        if (focusedRef.current) {
+          live.term.focus()
+        }
       } else {
         // Navigated away while the font load was in flight: enter the hidden
         // state (serialize + destroy) and demote the backend session.
@@ -686,8 +700,21 @@ export function TerminalView({
       fitTerminal(live.term, containerRef.current)
     }
     void Service.Resize(sessionId, live.term.cols, live.term.rows)
-    live.term.focus()
+    if (focusedRef.current) {
+      live.term.focus()
+    }
   }, [visible, sessionId])
+
+  // Focus on its own, because it now moves without visibility: switching panes
+  // leaves both terminals painting and only changes which one has the cursor.
+  // Guarded on visible so the pass that runs while a session is hidden — every
+  // other project's, on every focus change — cannot pull the cursor into a
+  // terminal nobody can see.
+  useEffect(() => {
+    if (focused && visible) {
+      liveRef.current?.term.focus()
+    }
+  }, [focused, visible])
 
   // The sidebar writes a delegate request at this session's prompt and then
   // asks for the cursor back, so the user carries on typing where they already

--- a/frontend/src/components/render-budget.test.tsx
+++ b/frontend/src/components/render-budget.test.tsx
@@ -353,7 +353,7 @@ test("switching project re-renders the mounted terminals but never remounts one"
 test("adding a pane mounts its terminal and never remounts the ones already up", async () => {
   window.location.hash = "#/projects/p1"
   const { TerminalHost } = await import("./TerminalHost")
-  const { writeStage } = await import("@/lib/session/panes-store")
+  const { writeGroups } = await import("@/lib/session/panes-store")
   const budget = await mountBudget(
     createElement(
       HashRouter,
@@ -370,7 +370,9 @@ test("adding a pane mounts its terminal and never remounts the ones already up",
   // with the tests above, and what this pins is what *this* action did to it.
   const before = { ...terminalMounts.counts }
 
-  await budget.act(() => writeStage("p1", ["s1", "s2"]))
+  await budget.act(() =>
+    writeGroups("p1", [{ id: "g1", name: "wall", cells: ["s1", "s2"], cols: [], rows: [] }]),
+  )
 
   // The second pane's terminal is born once, and the first pane's is not thrown
   // away and rebuilt around it — a split that re-keyed its layers would kill the

--- a/frontend/src/components/render-budget.test.tsx
+++ b/frontend/src/components/render-budget.test.tsx
@@ -99,6 +99,24 @@ vi.mock("@/components/TerminalView", () => ({
   },
 }))
 
+// jsdom reports every element at zero, and the terminal stage lays its panes out
+// from its own measured width — unmeasured, it draws the focused session alone.
+// So the observer answers with a window big enough for the grid to be a grid;
+// which layout that produces is panes.test.ts's business, not this file's.
+const STAGE = { width: 1200, height: 800 }
+class FakeResizeObserver {
+  constructor(private readonly callback: ResizeObserverCallback) {}
+  observe() {
+    this.callback(
+      [{ contentRect: STAGE } as unknown as ResizeObserverEntry],
+      this as unknown as ResizeObserver,
+    )
+  }
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal("ResizeObserver", FakeResizeObserver)
+
 // HashRouter follows history, not the hash property, so a test moves the route
 // the way the browser's back button does.
 const navigate = (to: string) => {
@@ -332,10 +350,10 @@ test("switching project re-renders the mounted terminals but never remounts one"
   await budget.unmount()
 })
 
-test("splitting mounts the second pane's terminal and never remounts the first", async () => {
+test("adding a pane mounts its terminal and never remounts the ones already up", async () => {
   window.location.hash = "#/projects/p1"
   const { TerminalHost } = await import("./TerminalHost")
-  const { openBeside } = await import("@/lib/session/panes-store")
+  const { writeStage } = await import("@/lib/session/panes-store")
   const budget = await mountBudget(
     createElement(
       HashRouter,
@@ -352,15 +370,18 @@ test("splitting mounts the second pane's terminal and never remounts the first",
   // with the tests above, and what this pins is what *this* action did to it.
   const before = { ...terminalMounts.counts }
 
-  await budget.act(() => openBeside("p1", { id: "s2", side: "right" }))
+  await budget.act(() => writeStage("p1", ["s1", "s2"], 0))
 
   // The second pane's terminal is born once, and the first pane's is not thrown
   // away and rebuilt around it — a split that re-keyed its layers would kill the
   // very PTY it was opened to watch, and a remount is indistinguishable from a
   // re-render without this counter.
   expect(terminalMounts.counts).toEqual({ ...before, s2: (before.s2 ?? 0) + 1 })
-  // And the stage really divided. The node-environment gate cannot render, so
-  // this file is where a split's own chrome gets to prove it draws at all.
-  expect(document.querySelector('[aria-label="Resize the panes"]')).not.toBeNull()
+  // And the stage really divided: two cells drawn side by side on a 1200px
+  // stage, with a column seam between them. The node-environment gate cannot
+  // render, so this file is where the stage's own chrome gets to prove it draws
+  // at all.
+  expect(document.querySelectorAll("[data-pane]")).toHaveLength(2)
+  expect(document.querySelector('[aria-label="Resize the columns"]')).not.toBeNull()
   await budget.unmount()
 })

--- a/frontend/src/components/render-budget.test.tsx
+++ b/frontend/src/components/render-budget.test.tsx
@@ -165,6 +165,9 @@ beforeEach(() => {
 })
 afterEach(() => {
   vi.useRealTimers()
+  // The split is a pref, so a test that opens one would otherwise hand the next
+  // one a stage already divided.
+  localStorage.clear()
 })
 
 async function mountSidebar() {
@@ -326,5 +329,38 @@ test("switching project re-renders the mounted terminals but never remounts one"
   // The point of the whole test: two round trips, one mount each. A terminal
   // that remounted would have thrown away its PTY and its scrollback.
   expect(terminalMounts.counts).toEqual({ s1: 1, s4: 1 })
+  await budget.unmount()
+})
+
+test("splitting mounts the second pane's terminal and never remounts the first", async () => {
+  window.location.hash = "#/projects/p1"
+  const { TerminalHost } = await import("./TerminalHost")
+  const { openBeside } = await import("@/lib/session/panes-store")
+  const budget = await mountBudget(
+    createElement(
+      HashRouter,
+      null,
+      createElement(
+        ProjectsContext.Provider,
+        { value: workspace },
+        createElement(TerminalHost, null),
+      ),
+    ),
+  )
+  budget.take()
+  // A delta rather than the whole map: the mounts counter is module state shared
+  // with the tests above, and what this pins is what *this* action did to it.
+  const before = { ...terminalMounts.counts }
+
+  await budget.act(() => openBeside("p1", { id: "s2", side: "right" }))
+
+  // The second pane's terminal is born once, and the first pane's is not thrown
+  // away and rebuilt around it — a split that re-keyed its layers would kill the
+  // very PTY it was opened to watch, and a remount is indistinguishable from a
+  // re-render without this counter.
+  expect(terminalMounts.counts).toEqual({ ...before, s2: (before.s2 ?? 0) + 1 })
+  // And the stage really divided. The node-environment gate cannot render, so
+  // this file is where a split's own chrome gets to prove it draws at all.
+  expect(document.querySelector('[aria-label="Resize the panes"]')).not.toBeNull()
   await budget.unmount()
 })

--- a/frontend/src/components/render-budget.test.tsx
+++ b/frontend/src/components/render-budget.test.tsx
@@ -370,7 +370,7 @@ test("adding a pane mounts its terminal and never remounts the ones already up",
   // with the tests above, and what this pins is what *this* action did to it.
   const before = { ...terminalMounts.counts }
 
-  await budget.act(() => writeStage("p1", ["s1", "s2"], 0))
+  await budget.act(() => writeStage("p1", ["s1", "s2"]))
 
   // The second pane's terminal is born once, and the first pane's is not thrown
   // away and rebuilt around it — a split that re-keyed its layers would kill the

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -85,6 +85,10 @@ interface SessionCardProps {
   showing: boolean
   // Put this card on the stage, or take it off when it is already there.
   onStageToggle: () => void
+  // How many sessions this one delegated work to, and the action that gathers
+  // them into a wall around it. Zero is the usual case and offers nothing.
+  delegateCount: number
+  onGroupDelegates: () => void
   onSelect: () => void
   onClose: () => void
   onRename: (label: string) => void
@@ -121,6 +125,8 @@ export function SessionCard({
   onStage,
   showing,
   onStageToggle,
+  delegateCount,
+  onGroupDelegates,
   onSelect,
   onClose,
   onRename,
@@ -584,6 +590,14 @@ export function SessionCard({
             <Copy />
             Copy send command
           </ContextMenuItem>
+          {delegateCount > 0 && (
+            <ContextMenuItem onClick={onGroupDelegates}>
+              <Columns2 />
+              {delegateCount === 1
+                ? "Show beside its 1 delegate"
+                : `Show beside its ${delegateCount} delegates`}
+            </ContextMenuItem>
+          )}
           {!active && (
             <ContextMenuItem onClick={onStageToggle}>
               <Columns2 />

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -76,12 +76,12 @@ interface SessionCardProps {
   // session nobody delegated, which is most of them (sessionOrigin).
   origin: string
   active: boolean
-  // Whether this card is the one showing in the second pane. Never true at the
-  // same time as `active`: one card cannot hold both panes (panes.ts).
-  beside: boolean
-  // Put this card in the second pane, or take it back out when it is already
-  // there. Never offered on the active card — that one is the first pane.
-  onBeside: () => void
+  // Whether this card is drawing in one of the stage's panes. The active card is
+  // always in one when the stage is split, so this and `active` do overlap — the
+  // mark below is what the two of them together decide.
+  onStage: boolean
+  // Put this card on the stage, or take it off when it is already there.
+  onStageToggle: () => void
   onSelect: () => void
   onClose: () => void
   onRename: (label: string) => void
@@ -115,8 +115,8 @@ export function SessionCard({
   path,
   origin,
   active,
-  beside,
-  onBeside,
+  onStage,
+  onStageToggle,
   onSelect,
   onClose,
   onRename,
@@ -346,7 +346,7 @@ export function SessionCard({
                       active && "bg-accent text-accent-foreground",
                       // Showing, but not the pane the keyboard is in: one step
                       // down the same fill, never a second kind of mark.
-                      beside && "bg-accent/55",
+                      onStage && !active && "bg-accent/55",
                     )}
                   />
                 }
@@ -581,9 +581,9 @@ export function SessionCard({
             Copy send command
           </ContextMenuItem>
           {!active && (
-            <ContextMenuItem onClick={onBeside}>
+            <ContextMenuItem onClick={onStageToggle}>
               <Columns2 />
-              {beside ? "Close beside" : "Open beside"}
+              {onStage ? "Stop showing" : "Show beside"}
             </ContextMenuItem>
           )}
           <ContextMenuItem onClick={() => setEditing(true)}>

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -76,10 +76,13 @@ interface SessionCardProps {
   // session nobody delegated, which is most of them (sessionOrigin).
   origin: string
   active: boolean
-  // Whether this card is drawing in one of the stage's panes. The active card is
-  // always in one when the stage is split, so this and `active` do overlap — the
-  // mark below is what the two of them together decide.
+  // Whether this session is on the stage at all. It is what the menu entry
+  // answers to, and it is true for a member of a wall that is parked — the block
+  // this card is drawn in is the mark, so nothing is repeated on the card.
   onStage: boolean
+  // Whether it is drawing in a pane *right now*. Never true for a member of a
+  // parked wall, which is exactly the difference the block cannot show.
+  showing: boolean
   // Put this card on the stage, or take it off when it is already there.
   onStageToggle: () => void
   onSelect: () => void
@@ -116,6 +119,7 @@ export function SessionCard({
   origin,
   active,
   onStage,
+  showing,
   onStageToggle,
   onSelect,
   onClose,
@@ -344,9 +348,9 @@ export function SessionCard({
                     className={cn(
                       "group relative flex w-full flex-col items-start gap-0.5 rounded-md px-2.5 py-2 text-left transition-colors hover:bg-accent/60",
                       active && "bg-accent text-accent-foreground",
-                      // Showing, but not the pane the keyboard is in: one step
+                      // On screen, but not the pane the keyboard is in: one step
                       // down the same fill, never a second kind of mark.
-                      onStage && !active && "bg-accent/55",
+                      showing && !active && "bg-accent/55",
                     )}
                   />
                 }

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -13,6 +13,7 @@ import {
   GitPullRequestArrow,
   Inbox,
   Pencil,
+  Columns2,
   Pin,
   PinOff,
   Play,
@@ -75,6 +76,12 @@ interface SessionCardProps {
   // session nobody delegated, which is most of them (sessionOrigin).
   origin: string
   active: boolean
+  // Whether this card is the one showing in the second pane. Never true at the
+  // same time as `active`: one card cannot hold both panes (panes.ts).
+  beside: boolean
+  // Put this card in the second pane, or take it back out when it is already
+  // there. Never offered on the active card — that one is the first pane.
+  onBeside: () => void
   onSelect: () => void
   onClose: () => void
   onRename: (label: string) => void
@@ -108,6 +115,8 @@ export function SessionCard({
   path,
   origin,
   active,
+  beside,
+  onBeside,
   onSelect,
   onClose,
   onRename,
@@ -335,6 +344,9 @@ export function SessionCard({
                     className={cn(
                       "group relative flex w-full flex-col items-start gap-0.5 rounded-md px-2.5 py-2 text-left transition-colors hover:bg-accent/60",
                       active && "bg-accent text-accent-foreground",
+                      // Showing, but not the pane the keyboard is in: one step
+                      // down the same fill, never a second kind of mark.
+                      beside && "bg-accent/55",
                     )}
                   />
                 }
@@ -568,6 +580,12 @@ export function SessionCard({
             <Copy />
             Copy send command
           </ContextMenuItem>
+          {!active && (
+            <ContextMenuItem onClick={onBeside}>
+              <Columns2 />
+              {beside ? "Close beside" : "Open beside"}
+            </ContextMenuItem>
+          )}
           <ContextMenuItem onClick={() => setEditing(true)}>
             <Pencil />
             Rename

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -34,8 +34,6 @@ interface SessionGroupProps {
   // or none — means it is not split.
   stageIds: string[]
   onStageToggle: (sessionId: string) => void
-  // Move the cursor into a pane, for a click on the card already drawing in one.
-  onFocusCell: (sessionId: string) => void
   // A divider label is drawn only when the sidebar holds more than one group; a
   // lone project with no worktrees keeps its old flat, header-less list. The
   // header doubles as the group's drag handle, so a lone group is also the case
@@ -87,7 +85,6 @@ export function SessionGroup({
   activeId,
   stageIds,
   onStageToggle,
-  onFocusCell,
   showHeader,
   sortable,
   onReorder,
@@ -131,16 +128,12 @@ export function SessionGroup({
   }
 
   const select = (id: string) => {
-    // A card already drawing on the stage is selected by moving the cursor into
-    // its pane. Activating it alone would work — the focused cell follows
-    // activeId — but it would also drag that session into whichever cell held
-    // the cursor, leaving the wall rearranged by a click that only meant "look
-    // at this one".
-    if (stageIds.length > 1 && stageIds.includes(id)) {
-      onFocusCell(id)
-      navigate(`/projects/${projectId}`)
-      return
-    }
+    // One path for every card, on the stage or off it: activating a session is
+    // the whole of what selecting one means. A card in a pane moves the cursor
+    // there because the focused cell is read from the active session, and a card
+    // outside the wall parks it and takes the screen — neither needs a branch
+    // here, and the version of this that had one was the bug where opening any
+    // session shoved it into the grid.
     activateSession(projectId, id)
     // From the settings screen this returns to the terminal; on the project
     // route it is a no-op.

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -8,6 +8,7 @@ import { checkoutLabel } from "@/lib/git/checkout-label"
 import type { ProviderState } from "@/lib/providers-store"
 import type { DelegateGroup } from "@/lib/session/delegate-targets"
 import { readGroupCollapsed, writeGroupCollapsed } from "@/lib/session/group-prefs"
+import type { PaneGroup } from "@/lib/session/panes"
 import { type Session, sessionOrigin } from "@/lib/session/sessions"
 import { useProjects } from "@/providers/projects"
 import { SessionCard } from "./SessionCard"
@@ -24,10 +25,14 @@ interface SessionGroupProps {
   // the pin rather than a worktree, no pull request of its own, and never
   // dragged — it is always the first block.
   pinned: boolean
-  // The split's block, gathered the same way and drawn above the pinned one. A
-  // drag inside it reorders the panes rather than the stored session list, which
-  // is the sidebar's half of arranging the wall.
-  stage: boolean
+  // The wall this block draws, or null for a checkout's block and the pinned
+  // one. A drag inside it reorders the panes rather than the stored session
+  // list, which is the sidebar's half of arranging that wall.
+  stage: PaneGroup | null
+  // Rename the wall, and take it apart. Both are the header's, because both are
+  // about the group rather than any session in it.
+  onRenameGroup: (name: string) => void
+  onDissolveGroup: () => void
   // "" for the project's own root or the pinned block, else the worktree
   // checkout path.
   path: string
@@ -84,6 +89,8 @@ export function SessionGroup({
   sortId,
   pinned,
   stage,
+  onRenameGroup,
+  onDissolveGroup,
   path,
   sessions,
   projectPath,
@@ -117,8 +124,8 @@ export function SessionGroup({
   const { sensors, onDragEnd } = useSortableList(ids, onReorder)
   // Neither of the gathered blocks is a checkout, so neither is dragged among
   // the others and neither has a worktree's name to wear.
-  const fixed = pinned || stage
-  const name = stage ? "Split" : pinned ? "Pinned" : checkoutLabel(path, projectPath, projectId)
+  const fixed = pinned
+  const name = stage ? stage.name : pinned ? "Pinned" : checkoutLabel(path, projectPath, projectId)
   const group = useSortable({ id: sortId, disabled: !sortable || !showHeader || fixed })
   // The PR card keys off the group's real checkout — the project root for the
   // root group (empty path), else the worktree — so a root project on a feature
@@ -161,6 +168,11 @@ export function SessionGroup({
         <SessionGroupHeader
           name={name}
           fixed={fixed}
+          // A wall has nowhere to open a new session — it is not a checkout —
+          // but it does reorder among the other walls, so it keeps its handle.
+          launch={!fixed && !stage}
+          onRename={stage ? onRenameGroup : undefined}
+          onDissolve={stage ? onDissolveGroup : undefined}
           collapsed={collapsed}
           isDragging={group.isDragging}
           providers={providers}
@@ -204,7 +216,7 @@ export function SessionGroup({
                     active={session.id === activeId}
                     // Membership is the block itself; what the card still has to
                     // answer is whether that member is on screen this moment.
-                    onStage={stage}
+                    onStage={!!stage}
                     showing={stageIds.includes(session.id)}
                     onStageToggle={() => onStageToggle(session.id)}
                     onSelect={() => select(session.id)}

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -30,11 +30,12 @@ interface SessionGroupProps {
   sessions: Session[]
   projectPath: string
   activeId: string
-  // The card in the second pane, "" when the stage is not split.
-  besideId: string
-  onBeside: (sessionId: string) => void
-  // Move the cursor into the second pane, for a click on the card already there.
-  onFocusBeside: () => void
+  // Every session currently drawing on the stage, in layout order; one entry —
+  // or none — means it is not split.
+  stageIds: string[]
+  onStageToggle: (sessionId: string) => void
+  // Move the cursor into a pane, for a click on the card already drawing in one.
+  onFocusCell: (sessionId: string) => void
   // A divider label is drawn only when the sidebar holds more than one group; a
   // lone project with no worktrees keeps its old flat, header-less list. The
   // header doubles as the group's drag handle, so a lone group is also the case
@@ -84,9 +85,9 @@ export function SessionGroup({
   sessions,
   projectPath,
   activeId,
-  besideId,
-  onBeside,
-  onFocusBeside,
+  stageIds,
+  onStageToggle,
+  onFocusCell,
   showHeader,
   sortable,
   onReorder,
@@ -130,12 +131,13 @@ export function SessionGroup({
   }
 
   const select = (id: string) => {
-    // A card already drawing in the second pane is selected by focusing that
-    // pane, not by activating it: activating alone would make it the focused
-    // session with itself still stored as the beside one, which resolves to no
-    // split at all — the card the user clicked would swallow the stage.
-    if (id === besideId) {
-      onFocusBeside()
+    // A card already drawing on the stage is selected by moving the cursor into
+    // its pane. Activating it alone would work — the focused cell follows
+    // activeId — but it would also drag that session into whichever cell held
+    // the cursor, leaving the wall rearranged by a click that only meant "look
+    // at this one".
+    if (stageIds.length > 1 && stageIds.includes(id)) {
+      onFocusCell(id)
       navigate(`/projects/${projectId}`)
       return
     }
@@ -199,8 +201,8 @@ export function SessionGroup({
                     // state knows about.
                     origin={sessionOrigin(workspace, session)}
                     active={session.id === activeId}
-                    beside={session.id === besideId}
-                    onBeside={() => onBeside(session.id)}
+                    onStage={stageIds.length > 1 && stageIds.includes(session.id)}
+                    onStageToggle={() => onStageToggle(session.id)}
                     onSelect={() => select(session.id)}
                     onClose={() => onClose(session)}
                     onRename={(label) => renameSession(projectId, session.id, label)}

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -30,6 +30,11 @@ interface SessionGroupProps {
   sessions: Session[]
   projectPath: string
   activeId: string
+  // The card in the second pane, "" when the stage is not split.
+  besideId: string
+  onBeside: (sessionId: string) => void
+  // Move the cursor into the second pane, for a click on the card already there.
+  onFocusBeside: () => void
   // A divider label is drawn only when the sidebar holds more than one group; a
   // lone project with no worktrees keeps its old flat, header-less list. The
   // header doubles as the group's drag handle, so a lone group is also the case
@@ -79,6 +84,9 @@ export function SessionGroup({
   sessions,
   projectPath,
   activeId,
+  besideId,
+  onBeside,
+  onFocusBeside,
   showHeader,
   sortable,
   onReorder,
@@ -122,6 +130,15 @@ export function SessionGroup({
   }
 
   const select = (id: string) => {
+    // A card already drawing in the second pane is selected by focusing that
+    // pane, not by activating it: activating alone would make it the focused
+    // session with itself still stored as the beside one, which resolves to no
+    // split at all — the card the user clicked would swallow the stage.
+    if (id === besideId) {
+      onFocusBeside()
+      navigate(`/projects/${projectId}`)
+      return
+    }
     activateSession(projectId, id)
     // From the settings screen this returns to the terminal; on the project
     // route it is a no-op.
@@ -182,6 +199,8 @@ export function SessionGroup({
                     // state knows about.
                     origin={sessionOrigin(workspace, session)}
                     active={session.id === activeId}
+                    beside={session.id === besideId}
+                    onBeside={() => onBeside(session.id)}
                     onSelect={() => select(session.id)}
                     onClose={() => onClose(session)}
                     onRename={(label) => renameSession(projectId, session.id, label)}

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -24,6 +24,10 @@ interface SessionGroupProps {
   // the pin rather than a worktree, no pull request of its own, and never
   // dragged — it is always the first block.
   pinned: boolean
+  // The split's block, gathered the same way and drawn above the pinned one. A
+  // drag inside it reorders the panes rather than the stored session list, which
+  // is the sidebar's half of arranging the wall.
+  stage: boolean
   // "" for the project's own root or the pinned block, else the worktree
   // checkout path.
   path: string
@@ -79,6 +83,7 @@ export function SessionGroup({
   projectId,
   sortId,
   pinned,
+  stage,
   path,
   sessions,
   projectPath,
@@ -110,8 +115,11 @@ export function SessionGroup({
   const [collapsed, setCollapsed] = useState(() => readGroupCollapsed(projectId, sortId))
   const ids = sessions.map((session) => session.id)
   const { sensors, onDragEnd } = useSortableList(ids, onReorder)
-  const name = pinned ? "Pinned" : checkoutLabel(path, projectPath, projectId)
-  const group = useSortable({ id: sortId, disabled: !sortable || !showHeader || pinned })
+  // Neither of the gathered blocks is a checkout, so neither is dragged among
+  // the others and neither has a worktree's name to wear.
+  const fixed = pinned || stage
+  const name = stage ? "Split" : pinned ? "Pinned" : checkoutLabel(path, projectPath, projectId)
+  const group = useSortable({ id: sortId, disabled: !sortable || !showHeader || fixed })
   // The PR card keys off the group's real checkout — the project root for the
   // root group (empty path), else the worktree — so a root project on a feature
   // branch parks its card too, not only worktrees.
@@ -152,15 +160,15 @@ export function SessionGroup({
       {showHeader && (
         <SessionGroupHeader
           name={name}
-          pinned={pinned}
+          fixed={fixed}
           collapsed={collapsed}
           isDragging={group.isDragging}
           providers={providers}
           activatorRef={group.setActivatorNodeRef}
-          // The pinned block is never dragged, and dnd-kit answers a disabled
+          // A fixed block is never dragged, and dnd-kit answers a disabled
           // sortable with aria-disabled + aria-roledescription="draggable" —
           // which would announce a working collapse button as a dead handle.
-          activatorProps={pinned ? {} : { ...group.attributes, ...group.listeners }}
+          activatorProps={fixed ? {} : { ...group.attributes, ...group.listeners }}
           onToggle={toggle}
           onNewSession={(kind) => newSession(projectId, kind, path)}
         />
@@ -194,7 +202,10 @@ export function SessionGroup({
                     // state knows about.
                     origin={sessionOrigin(workspace, session)}
                     active={session.id === activeId}
-                    onStage={stageIds.length > 1 && stageIds.includes(session.id)}
+                    // Membership is the block itself; what the card still has to
+                    // answer is whether that member is on screen this moment.
+                    onStage={stage}
+                    showing={stageIds.includes(session.id)}
                     onStageToggle={() => onStageToggle(session.id)}
                     onSelect={() => select(session.id)}
                     onClose={() => onClose(session)}

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -9,7 +9,7 @@ import type { ProviderState } from "@/lib/providers-store"
 import type { DelegateGroup } from "@/lib/session/delegate-targets"
 import { readGroupCollapsed, writeGroupCollapsed } from "@/lib/session/group-prefs"
 import type { PaneGroup } from "@/lib/session/panes"
-import { type Session, sessionOrigin } from "@/lib/session/sessions"
+import { delegatesOf, type Session, sessionOrigin } from "@/lib/session/sessions"
 import { useProjects } from "@/providers/projects"
 import { SessionCard } from "./SessionCard"
 import { PullRequestCard } from "./PullRequestCard"
@@ -43,6 +43,8 @@ interface SessionGroupProps {
   // or none — means it is not split.
   stageIds: string[]
   onStageToggle: (sessionId: string) => void
+  // Gather a session and the ones it delegated to into a wall of their own.
+  onGroupDelegates: (sessionId: string, delegateIds: string[]) => void
   // A divider label is drawn only when the sidebar holds more than one group; a
   // lone project with no worktrees keeps its old flat, header-less list. The
   // header doubles as the group's drag handle, so a lone group is also the case
@@ -97,6 +99,7 @@ export function SessionGroup({
   activeId,
   stageIds,
   onStageToggle,
+  onGroupDelegates,
   showHeader,
   sortable,
   onReorder,
@@ -219,6 +222,13 @@ export function SessionGroup({
                     onStage={!!stage}
                     showing={stageIds.includes(session.id)}
                     onStageToggle={() => onStageToggle(session.id)}
+                    delegateCount={delegatesOf(workspace, projectId, session.id).length}
+                    onGroupDelegates={() =>
+                      onGroupDelegates(
+                        session.id,
+                        delegatesOf(workspace, projectId, session.id).map((s) => s.id),
+                      )
+                    }
                     onSelect={() => select(session.id)}
                     onClose={() => onClose(session)}
                     onRename={(label) => renameSession(projectId, session.id, label)}

--- a/frontend/src/components/sidebar/SessionGroupHeader.tsx
+++ b/frontend/src/components/sidebar/SessionGroupHeader.tsx
@@ -1,5 +1,12 @@
-import type { ComponentPropsWithoutRef } from "react"
-import { ChevronRight, Plus } from "lucide-react"
+import { useState } from "react"
+import type { ComponentPropsWithoutRef, KeyboardEvent } from "react"
+import { ChevronRight, Pencil, Plus, Ungroup } from "lucide-react"
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuTrigger,
+} from "@/components/ui/context-menu"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -13,10 +20,16 @@ import { SessionLaunchMenuItems } from "./SessionLaunchMenuItems"
 
 interface SessionGroupHeaderProps {
   name: string
-  // A block that is not a checkout — the pinned sessions, or the split. It has
-  // nowhere to open a new session and never moves, so it offers neither the
-  // launch menu nor a drag handle.
+  // A block that never moves among the others: the pinned sessions. It has no
+  // drag handle, so its title is a plain button.
   fixed: boolean
+  // Whether the block can open a new session in itself — true for a checkout,
+  // false for the gathered blocks, which have no directory to open one in.
+  launch: boolean
+  // Present on a wall's header only: renaming happens in place, and dissolving
+  // takes the wall apart without touching a session in it.
+  onRename?: (name: string) => void
+  onDissolve?: () => void
   collapsed: boolean
   isDragging: boolean
   providers: ProviderState[]
@@ -73,6 +86,9 @@ function SessionGroupTitleButton({
 export function SessionGroupHeader({
   name,
   fixed,
+  launch,
+  onRename,
+  onDissolve,
   collapsed,
   isDragging,
   providers,
@@ -81,7 +97,43 @@ export function SessionGroupHeader({
   onToggle,
   onNewSession,
 }: SessionGroupHeaderProps) {
-  return (
+  const [editing, setEditing] = useState(false)
+
+  const commit = (value: string) => {
+    setEditing(false)
+    const trimmed = value.trim()
+    if (trimmed && trimmed !== name) {
+      onRename?.(trimmed)
+    }
+  }
+
+  const onEditKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      commit(event.currentTarget.value)
+    }
+    if (event.key === "Escape") {
+      setEditing(false)
+    }
+  }
+
+  if (editing) {
+    return (
+      <div className="flex items-center gap-1 px-1 pb-0.5 pt-1.5">
+        <input
+          // biome-ignore lint/a11y/noAutofocus: the field replaces the title only once renaming starts.
+          autoFocus
+          defaultValue={name}
+          aria-label="Group name"
+          onFocus={(event) => event.currentTarget.select()}
+          onKeyDown={onEditKeyDown}
+          onBlur={(event) => commit(event.currentTarget.value)}
+          className="w-full rounded-sm bg-transparent px-1 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wider text-foreground outline-none ring-1 ring-accent-foreground/30"
+        />
+      </div>
+    )
+  }
+
+  const header = (
     <div className="flex items-center gap-1 px-1 pb-0.5 pt-1.5">
       <SessionGroupTitleButton
         name={name}
@@ -91,7 +143,7 @@ export function SessionGroupHeader({
         activatorProps={activatorProps}
         onClick={() => !isDragging && onToggle()}
       />
-      {!fixed && (
+      {launch && (
         <DropdownMenu>
           <DropdownMenuTrigger
             aria-label={`New session in ${name}`}
@@ -110,5 +162,30 @@ export function SessionGroupHeader({
         </DropdownMenu>
       )}
     </div>
+  )
+
+  // A wall is the only block with anything to say about itself. The others get
+  // no menu rather than an empty one.
+  if (!onRename && !onDissolve) {
+    return header
+  }
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger render={<div />}>{header}</ContextMenuTrigger>
+      <ContextMenuContent>
+        {onRename && (
+          <ContextMenuItem onClick={() => setEditing(true)}>
+            <Pencil />
+            Rename group
+          </ContextMenuItem>
+        )}
+        {onDissolve && (
+          <ContextMenuItem onClick={onDissolve}>
+            <Ungroup />
+            Ungroup
+          </ContextMenuItem>
+        )}
+      </ContextMenuContent>
+    </ContextMenu>
   )
 }

--- a/frontend/src/components/sidebar/SessionGroupHeader.tsx
+++ b/frontend/src/components/sidebar/SessionGroupHeader.tsx
@@ -13,7 +13,10 @@ import { SessionLaunchMenuItems } from "./SessionLaunchMenuItems"
 
 interface SessionGroupHeaderProps {
   name: string
-  pinned: boolean
+  // A block that is not a checkout — the pinned sessions, or the split. It has
+  // nowhere to open a new session and never moves, so it offers neither the
+  // launch menu nor a drag handle.
+  fixed: boolean
   collapsed: boolean
   isDragging: boolean
   providers: ProviderState[]
@@ -25,7 +28,7 @@ interface SessionGroupHeaderProps {
 
 interface SessionGroupTitleButtonProps {
   name: string
-  pinned: boolean
+  fixed: boolean
   collapsed: boolean
   activatorRef: (element: HTMLElement | null) => void
   activatorProps: ComponentPropsWithoutRef<"button">
@@ -34,7 +37,7 @@ interface SessionGroupTitleButtonProps {
 
 function SessionGroupTitleButton({
   name,
-  pinned,
+  fixed,
   collapsed,
   activatorRef,
   activatorProps,
@@ -50,7 +53,7 @@ function SessionGroupTitleButton({
       onClick={onClick}
       className={cn(
         "group/collapse -ml-1 flex min-w-0 flex-1 items-center gap-1.5 rounded-sm px-1 py-0.5 text-left transition-colors hover:bg-accent/50",
-        pinned ? "cursor-pointer" : "cursor-grab",
+        fixed ? "cursor-pointer" : "cursor-grab",
       )}
     >
       <ChevronRight
@@ -69,7 +72,7 @@ function SessionGroupTitleButton({
 
 export function SessionGroupHeader({
   name,
-  pinned,
+  fixed,
   collapsed,
   isDragging,
   providers,
@@ -82,13 +85,13 @@ export function SessionGroupHeader({
     <div className="flex items-center gap-1 px-1 pb-0.5 pt-1.5">
       <SessionGroupTitleButton
         name={name}
-        pinned={pinned}
+        fixed={fixed}
         collapsed={collapsed}
         activatorRef={activatorRef}
         activatorProps={activatorProps}
         onClick={() => !isDragging && onToggle()}
       />
-      {!pinned && (
+      {!fixed && (
         <DropdownMenu>
           <DropdownMenuTrigger
             aria-label={`New session in ${name}`}

--- a/frontend/src/components/sidebar/SessionGroupHeader.tsx
+++ b/frontend/src/components/sidebar/SessionGroupHeader.tsx
@@ -1,12 +1,7 @@
 import { useState } from "react"
 import type { ComponentPropsWithoutRef, KeyboardEvent } from "react"
-import { ChevronRight, Pencil, Plus, Ungroup } from "lucide-react"
-import {
-  ContextMenu,
-  ContextMenuContent,
-  ContextMenuItem,
-  ContextMenuTrigger,
-} from "@/components/ui/context-menu"
+import { ChevronRight, MoreHorizontal, Pencil, Plus, Ungroup } from "lucide-react"
+import { DropdownMenuItem } from "@/components/ui/dropdown-menu"
 import { Button } from "@/components/ui/button"
 import {
   DropdownMenu,
@@ -116,9 +111,14 @@ export function SessionGroupHeader({
     }
   }
 
-  if (editing) {
-    return (
-      <div className="flex items-center gap-1 px-1 pb-0.5 pt-1.5">
+  return (
+    <div className="flex items-center gap-1 px-1 pb-0.5 pt-1.5">
+      {/* Only the title swaps for the field. Replacing the whole header would
+          unmount the menu the rename was chosen from, and the menu restores
+          focus to a trigger that is no longer there — which lands on the fresh
+          input as a blur, commits the name unchanged, and reads as a rename that
+          does nothing. */}
+      {editing ? (
         <input
           // biome-ignore lint/a11y/noAutofocus: the field replaces the title only once renaming starts.
           autoFocus
@@ -127,22 +127,18 @@ export function SessionGroupHeader({
           onFocus={(event) => event.currentTarget.select()}
           onKeyDown={onEditKeyDown}
           onBlur={(event) => commit(event.currentTarget.value)}
-          className="w-full rounded-sm bg-transparent px-1 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wider text-foreground outline-none ring-1 ring-accent-foreground/30"
+          className="min-w-0 flex-1 rounded-sm bg-transparent px-1 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wider text-foreground outline-none ring-1 ring-accent-foreground/30"
         />
-      </div>
-    )
-  }
-
-  const header = (
-    <div className="flex items-center gap-1 px-1 pb-0.5 pt-1.5">
-      <SessionGroupTitleButton
-        name={name}
-        fixed={fixed}
-        collapsed={collapsed}
-        activatorRef={activatorRef}
-        activatorProps={activatorProps}
-        onClick={() => !isDragging && onToggle()}
-      />
+      ) : (
+        <SessionGroupTitleButton
+          name={name}
+          fixed={fixed}
+          collapsed={collapsed}
+          activatorRef={activatorRef}
+          activatorProps={activatorProps}
+          onClick={() => !isDragging && onToggle()}
+        />
+      )}
       {launch && (
         <DropdownMenu>
           <DropdownMenuTrigger
@@ -161,31 +157,35 @@ export function SessionGroupHeader({
           </DropdownMenuContent>
         </DropdownMenu>
       )}
+      {/* A wall is the only block with anything to say about itself, and it says
+          it through a button rather than a right-click: the block beside it
+          carries a visible + for its own action, so a menu reachable only by
+          right-click is one nobody finds. */}
+      {(onRename || onDissolve) && (
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            aria-label={`Options for ${name}`}
+            title={`Options for ${name}`}
+            render={<Button variant="ghost" size="icon-xs" />}
+          >
+            <MoreHorizontal />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {onRename && (
+              <DropdownMenuItem onClick={() => setEditing(true)}>
+                <Pencil />
+                Rename group
+              </DropdownMenuItem>
+            )}
+            {onDissolve && (
+              <DropdownMenuItem onClick={onDissolve}>
+                <Ungroup />
+                Ungroup
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
     </div>
-  )
-
-  // A wall is the only block with anything to say about itself. The others get
-  // no menu rather than an empty one.
-  if (!onRename && !onDissolve) {
-    return header
-  }
-  return (
-    <ContextMenu>
-      <ContextMenuTrigger render={<div />}>{header}</ContextMenuTrigger>
-      <ContextMenuContent>
-        {onRename && (
-          <ContextMenuItem onClick={() => setEditing(true)}>
-            <Pencil />
-            Rename group
-          </ContextMenuItem>
-        )}
-        {onDissolve && (
-          <ContextMenuItem onClick={onDissolve}>
-            <Ungroup />
-            Ungroup
-          </ContextMenuItem>
-        )}
-      </ContextMenuContent>
-    </ContextMenu>
   )
 }

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -8,7 +8,8 @@ import { ProjectService } from "@/lib/rpc"
 import { closeSettings, isSettingsOpen, subscribeSettingsCard } from "@/lib/settings-card-store"
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
 import { delegateTargets } from "@/lib/session/delegate-targets"
-import { reorderGroups } from "@/lib/session/panes"
+import { movingFrom, type PaneGroup, reorderGroups } from "@/lib/session/panes"
+import { ConfirmDialog } from "@/components/ConfirmDialog"
 import { usePanes } from "@/lib/session/use-panes"
 import {
   closePullsList,
@@ -132,8 +133,19 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   // The menu entry is a toggle on one card: a session already on the stage takes
   // itself off it, any other joins it. Adding is refused — quietly, the way the
   // shortcut is — when one more pane would leave them all too small to read.
+  // Adding a session that is already on another wall takes it off that one —
+  // somebody else's arrangement, changed by a click aimed at this one. So the
+  // decision goes to the user rather than being made under them; `add` refuses
+  // the move until they have answered.
+  const [moving, setMoving] = useState<{ session: Session; from: PaneGroup } | null>(null)
   const toggleStage = (sessionId: string) => {
-    if (panes.groups.some((group) => group.cells.includes(sessionId))) {
+    const from = movingFrom(panes.groups, panes.current, sessionId)
+    const session = list.find((s) => s.id === sessionId)
+    if (from && session) {
+      setMoving({ session, from })
+      return
+    }
+    if (panes.current?.cells.includes(sessionId)) {
       panes.remove(sessionId)
       return
     }
@@ -459,6 +471,35 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
         onResume={resumeWorktree}
       />
       <WorktreeCloseDialogs close={worktreeClose} />
+      <ConfirmDialog
+        open={!!moving}
+        onCancel={() => setMoving(null)}
+        title={`Move ${moving?.session.label ?? ""} to this split?`}
+        description={
+          moving?.from.cells.length === 1 ? (
+            <>
+              It is the only session in <strong>{moving.from.name}</strong>, so that group ends when
+              it leaves. No session is closed either way.
+            </>
+          ) : (
+            <>
+              It is showing in <strong>{moving?.from.name}</strong>, and a session can only be on
+              one split at a time — it leaves that one. No session is closed either way.
+            </>
+          )
+        }
+      >
+        <Button
+          onClick={() => {
+            if (moving) {
+              panes.add(moving.session.id, { move: true })
+            }
+            setMoving(null)
+          }}
+        >
+          Move it
+        </Button>
+      </ConfirmDialog>
 
       <ResizeHandle edge="right" label="Resize sidebar" handleProps={handleProps} />
     </aside>

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -8,6 +8,8 @@ import { ProjectService } from "@/lib/rpc"
 import { closeSettings, isSettingsOpen, subscribeSettingsCard } from "@/lib/settings-card-store"
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
 import { delegateTargets } from "@/lib/session/delegate-targets"
+import { usePanes } from "@/lib/session/use-panes"
+import { closeBeside, openBeside } from "@/lib/session/panes-store"
 import {
   closePullsList,
   isPullsListOpen,
@@ -126,6 +128,19 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   const list = sessionsOf(sessions, projectId ?? "")
   const worktreeClose = useWorktreeClose(projectId ?? "", path, list)
   const realActiveId = activeSessionId(sessions, projectId ?? "")
+  const panes = usePanes(projectId ?? "")
+  // The menu entry is a toggle on one card: the one already beside takes itself
+  // out, any other takes the pane over from whoever held it.
+  const toggleBeside = (sessionId: string) => {
+    if (!projectId) {
+      return
+    }
+    if (sessionId === panes.beside) {
+      closeBeside(projectId)
+      return
+    }
+    openBeside(projectId, { id: sessionId, side: "right" })
+  }
   // The query narrows the flat list before the groups are built from it, so
   // grouping, the pinned block and the stored order all keep working on the
   // survivors without knowing a filter exists.
@@ -185,6 +200,9 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   // No session card highlights while a full-screen route (Settings, Pulls) owns
   // the view; its own sidebar entry reads as active instead.
   const activeId = onSettings || onPullsRoute ? "" : realActiveId
+  // Same rule as activeId: with a full-screen route over the terminals there are
+  // no panes on show, so no card wears the mark of one.
+  const besideId = onSettings || onPullsRoute ? "" : panes.beside
 
   // A drag reorders one block only; hand its new order to that block's own
   // sessions inside the flat list and persist the whole thing. reorderSessions
@@ -355,6 +373,9 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
                   sessions={group.sessions}
                   projectPath={path}
                   activeId={activeId}
+                  besideId={besideId}
+                  onBeside={(sessionId) => toggleBeside(sessionId)}
+                  onFocusBeside={panes.focusOther}
                   // The divider only earns its place once a worktree — or a pin
                   // — splits the list; a lone group keeps the old flat,
                   // header-less look. A filter is the exception: which checkout

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -9,7 +9,6 @@ import { closeSettings, isSettingsOpen, subscribeSettingsCard } from "@/lib/sett
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
 import { delegateTargets } from "@/lib/session/delegate-targets"
 import { usePanes } from "@/lib/session/use-panes"
-import { closeBeside, openBeside } from "@/lib/session/panes-store"
 import {
   closePullsList,
   isPullsListOpen,
@@ -129,17 +128,16 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   const worktreeClose = useWorktreeClose(projectId ?? "", path, list)
   const realActiveId = activeSessionId(sessions, projectId ?? "")
   const panes = usePanes(projectId ?? "")
-  // The menu entry is a toggle on one card: the one already beside takes itself
-  // out, any other takes the pane over from whoever held it.
-  const toggleBeside = (sessionId: string) => {
-    if (!projectId) {
+  // The menu entry is a toggle on one card: a session already on the stage takes
+  // itself off it, any other joins it. Adding is refused — quietly, the way the
+  // shortcut is — when one more pane would leave them all too small to read.
+  const toggleStage = (sessionId: string) => {
+    const at = panes.cells.indexOf(sessionId)
+    if (at >= 0) {
+      panes.drop(at)
       return
     }
-    if (sessionId === panes.beside) {
-      closeBeside(projectId)
-      return
-    }
-    openBeside(projectId, { id: sessionId, side: "right" })
+    panes.add(sessionId)
   }
   // The query narrows the flat list before the groups are built from it, so
   // grouping, the pinned block and the stored order all keep working on the
@@ -202,7 +200,7 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   const activeId = onSettings || onPullsRoute ? "" : realActiveId
   // Same rule as activeId: with a full-screen route over the terminals there are
   // no panes on show, so no card wears the mark of one.
-  const besideId = onSettings || onPullsRoute ? "" : panes.beside
+  const stageIds = onSettings || onPullsRoute ? [] : panes.cells
 
   // A drag reorders one block only; hand its new order to that block's own
   // sessions inside the flat list and persist the whole thing. reorderSessions
@@ -373,9 +371,9 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
                   sessions={group.sessions}
                   projectPath={path}
                   activeId={activeId}
-                  besideId={besideId}
-                  onBeside={(sessionId) => toggleBeside(sessionId)}
-                  onFocusBeside={panes.focusOther}
+                  stageIds={stageIds}
+                  onStageToggle={toggleStage}
+                  onFocusCell={(sessionId) => panes.focusCell(panes.cells.indexOf(sessionId))}
                   // The divider only earns its place once a worktree — or a pin
                   // — splits the list; a lone group keeps the old flat,
                   // header-less look. A filter is the exception: which checkout

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -373,7 +373,6 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
                   activeId={activeId}
                   stageIds={stageIds}
                   onStageToggle={toggleStage}
-                  onFocusCell={(sessionId) => panes.focusCell(panes.cells.indexOf(sessionId))}
                   // The divider only earns its place once a worktree — or a pin
                   // — splits the list; a lone group keeps the old flat,
                   // header-less look. A filter is the exception: which checkout

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -4,6 +4,7 @@ import { useMatch, useNavigate } from "react-router-dom"
 import { DndContext, closestCenter } from "@dnd-kit/core"
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import { GitPullRequestArrow, PanelLeftClose, Plus, Search } from "lucide-react"
+import { toast } from "sonner"
 import { ProjectService } from "@/lib/rpc"
 import { closeSettings, isSettingsOpen, subscribeSettingsCard } from "@/lib/settings-card-store"
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
@@ -138,6 +139,21 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   // decision goes to the user rather than being made under them; `add` refuses
   // the move until they have answered.
   const [moving, setMoving] = useState<{ session: Session; from: PaneGroup } | null>(null)
+  // Gathering an orchestrator and its workers is the one action that builds a
+  // whole wall at once. A delegate already on another wall stays there — it is
+  // the user's arrangement and taking it is the destructive reading — so the
+  // toast names how many were left rather than letting them go missing quietly.
+  const groupDelegates = (sessionId: string, delegateIds: string[]) => {
+    const skipped = panes.groupWith(sessionId, delegateIds)
+    if (skipped > 0) {
+      toast(
+        skipped === 1
+          ? "1 delegate stayed on the split it was already in"
+          : `${skipped} delegates stayed on the splits they were already in`,
+      )
+    }
+  }
+
   const toggleStage = (sessionId: string) => {
     const from = movingFrom(panes.groups, panes.current, sessionId)
     const session = list.find((s) => s.id === sessionId)
@@ -284,6 +300,7 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
         activeId={activeId}
         stageIds={stageIds}
         onStageToggle={toggleStage}
+        onGroupDelegates={groupDelegates}
         // The divider only earns its place once a worktree — or a pin
         // — splits the list; a lone group keeps the old flat,
         // header-less look. A filter is the exception: which checkout

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -9,6 +9,7 @@ import { closeSettings, isSettingsOpen, subscribeSettingsCard } from "@/lib/sett
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
 import { delegateTargets } from "@/lib/session/delegate-targets"
 import { usePanes } from "@/lib/session/use-panes"
+import { writeStage } from "@/lib/session/panes-store"
 import {
   closePullsList,
   isPullsListOpen,
@@ -132,9 +133,8 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   // itself off it, any other joins it. Adding is refused — quietly, the way the
   // shortcut is — when one more pane would leave them all too small to read.
   const toggleStage = (sessionId: string) => {
-    const at = panes.cells.indexOf(sessionId)
-    if (at >= 0) {
-      panes.drop(at)
+    if (panes.members.includes(sessionId)) {
+      panes.remove(sessionId)
       return
     }
     panes.add(sessionId)
@@ -144,7 +144,9 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   // survivors without knowing a filter exists.
   const filtering = query.trim() !== ""
   const { sessions: visible, matched } = filterSessions(list, query, path, realActiveId)
-  const groups = sidebarGroups(visible)
+  // The split's own block is built from the members, not from what is on screen:
+  // a parked wall is exactly the case the user could not see before.
+  const groups = sidebarGroups(visible, panes.members)
   // The pinned block is out of the drag list entirely: it is always first, and
   // the worktree blocks reorder among themselves. Dragging one moves its whole
   // block of ids inside the flat list the groups are read back from — there is
@@ -207,6 +209,13 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   // bails on any id-set mismatch, so a close that raced the drop drops the
   // stale order.
   const commitGroupOrder = (group: SidebarGroup, ids: string[]) => {
+    // The split's block is the panes, so a drag in it arranges the wall rather
+    // than the stored session list — which is what the drag inside the stage
+    // itself does, from the other end.
+    if (group.stage) {
+      writeStage(projectId, ids)
+      return
+    }
     const member = (session: Session) =>
       group.pinned ? !!session.pinned : !session.pinned && (session.path ?? "") === group.path
     reorderSessions(projectId, reorderSubset(list, ids, member))
@@ -366,6 +375,7 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
                   key={`${projectId}:${group.key}`}
                   sortId={group.key}
                   pinned={group.pinned}
+                  stage={group.stage}
                   projectId={projectId}
                   path={group.path}
                   sessions={group.sessions}

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -8,8 +8,8 @@ import { ProjectService } from "@/lib/rpc"
 import { closeSettings, isSettingsOpen, subscribeSettingsCard } from "@/lib/settings-card-store"
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
 import { delegateTargets } from "@/lib/session/delegate-targets"
+import { reorderGroups } from "@/lib/session/panes"
 import { usePanes } from "@/lib/session/use-panes"
-import { writeStage } from "@/lib/session/panes-store"
 import {
   closePullsList,
   isPullsListOpen,
@@ -133,7 +133,7 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   // itself off it, any other joins it. Adding is refused — quietly, the way the
   // shortcut is — when one more pane would leave them all too small to read.
   const toggleStage = (sessionId: string) => {
-    if (panes.members.includes(sessionId)) {
+    if (panes.groups.some((group) => group.cells.includes(sessionId))) {
       panes.remove(sessionId)
       return
     }
@@ -146,18 +146,26 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   const { sessions: visible, matched } = filterSessions(list, query, path, realActiveId)
   // The split's own block is built from the members, not from what is on screen:
   // a parked wall is exactly the case the user could not see before.
-  const groups = sidebarGroups(visible, panes.members)
+  const groups = sidebarGroups(visible, panes.groups)
   // The pinned block is out of the drag list entirely: it is always first, and
   // the worktree blocks reorder among themselves. Dragging one moves its whole
   // block of ids inside the flat list the groups are read back from — there is
   // no separate group order to store — leaving the pinned sessions where they
   // sit in it, so unpinning still drops a card among its old neighbours.
-  const dragKeys = groups.filter((group) => !group.pinned).map((group) => group.key)
+  const dragKeys = groups.filter((group) => !group.pinned && !group.stage).map((group) => group.key)
   const { sensors, onDragEnd } = useSortableList(dragKeys, (keys) =>
     reorderSessions(
       projectId ?? "",
       reorderSubset(list, orderGroups(groups, keys), (session) => !session.pinned),
     ),
+  )
+  // The walls reorder in a list of their own. They have to: a worktree block's
+  // place is derived from where its sessions sit in the stored flat list, and a
+  // wall's is the order of the groups themselves — one drag list holding both
+  // would have to write two unrelated things depending on what was picked up.
+  const stageKeys = panes.groups.map((group) => group.id)
+  const { sensors: stageSensors, onDragEnd: onStageDragEnd } = useSortableList(stageKeys, (keys) =>
+    panes.reorder(reorderGroups(panes.groups, keys)),
   )
   // Resolved once here, not per group: the list spans every open project, so
   // it is the same for every card in the sidebar. Memoised because the picker
@@ -209,11 +217,11 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   // bails on any id-set mismatch, so a close that raced the drop drops the
   // stale order.
   const commitGroupOrder = (group: SidebarGroup, ids: string[]) => {
-    // The split's block is the panes, so a drag in it arranges the wall rather
-    // than the stored session list — which is what the drag inside the stage
-    // itself does, from the other end.
+    // A split block is a wall, so a drag in it arranges that wall rather than
+    // the stored session list — the same arrangement the drag inside the stage
+    // itself makes, from the other end.
     if (group.stage) {
-      writeStage(projectId, ids)
+      panes.reorderCells(group.stage.id, ids)
       return
     }
     const member = (session: Session) =>
@@ -239,6 +247,64 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   const resumeWorktree = (wt: { name: string; path: string }) => {
     void reopenWorktreeSession(projectId, wt)
     setWorktreeOpen(false)
+  }
+
+  // One block, rendered the same whichever drag list it belongs to.
+  const renderGroup = (group: SidebarGroup) => {
+    const groupActive = group.sessions.some((s) => s.id === realActiveId)
+    return (
+      <SessionGroup
+        // The project is in the React key, not only in the props: two
+        // projects both have a root block and a pinned one under the
+        // same key, so without it React reuses one project's group
+        // component for the other's — carrying its fold across with it,
+        // and never re-reading the fold the switched-to project stored.
+        key={`${projectId}:${group.key}`}
+        sortId={group.key}
+        pinned={group.pinned}
+        stage={group.stage}
+        onRenameGroup={(name) => group.stage && panes.rename(group.stage.id, name)}
+        onDissolveGroup={() => group.stage && panes.dissolve(group.stage.id)}
+        projectId={projectId}
+        path={group.path}
+        sessions={group.sessions}
+        projectPath={path}
+        activeId={activeId}
+        stageIds={stageIds}
+        onStageToggle={toggleStage}
+        // The divider only earns its place once a worktree — or a pin
+        // — splits the list; a lone group keeps the old flat,
+        // header-less look. A filter is the exception: which checkout
+        // a surviving card sits in is the thing the query was typed to
+        // find out, so the title stays even for a lone group.
+        showHeader={groups.length > 1 || filtering}
+        // A drop computed from a filtered view hands reorderSubset an
+        // id set that does not name the group's members, and
+        // reorderSessions rejects the whole order — so the gesture
+        // would be a silent no-op. Take it away instead of leaving a
+        // dead one on screen.
+        sortable={!filtering}
+        onReorder={(ids) => commitGroupOrder(group, ids)}
+        onClose={worktreeClose.requestClose}
+        pullsActive={onPullsRoute && groupActive}
+        onPulls={() => {
+          openPulls(group.path || path)
+          const target = groupActive ? realActiveId : group.sessions[0]?.id
+          if (target) {
+            activateSession(projectId, target)
+          }
+          navigate(`/projects/${projectId}/pulls`)
+        }}
+        onClosePulls={() => {
+          closePulls(group.path || path)
+          if (onPullsRoute && groupActive) {
+            navigate(`/projects/${projectId}`)
+          }
+        }}
+        delegateGroups={delegateGroups}
+        providers={enabled}
+      />
+    )
   }
 
   return (
@@ -356,6 +422,20 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
             No sessions match “{query.trim()}”. The active session stays.
           </Notice>
         )}
+        {/* The walls first, in their own drag list, then everything else in
+            the one whose order lives in the stored session list. */}
+        {stageKeys.length > 0 && (
+          <DndContext
+            sensors={stageSensors}
+            collisionDetection={closestCenter}
+            modifiers={[verticalAxis, withinList]}
+            onDragEnd={onStageDragEnd}
+          >
+            <SortableContext items={stageKeys} strategy={verticalListSortingStrategy}>
+              {groups.filter((group) => group.stage).map(renderGroup)}
+            </SortableContext>
+          </DndContext>
+        )}
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
@@ -363,60 +443,7 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
           onDragEnd={onDragEnd}
         >
           <SortableContext items={dragKeys} strategy={verticalListSortingStrategy}>
-            {groups.map((group) => {
-              const groupActive = group.sessions.some((s) => s.id === realActiveId)
-              return (
-                <SessionGroup
-                  // The project is in the React key, not only in the props: two
-                  // projects both have a root block and a pinned one under the
-                  // same key, so without it React reuses one project's group
-                  // component for the other's — carrying its fold across with it,
-                  // and never re-reading the fold the switched-to project stored.
-                  key={`${projectId}:${group.key}`}
-                  sortId={group.key}
-                  pinned={group.pinned}
-                  stage={group.stage}
-                  projectId={projectId}
-                  path={group.path}
-                  sessions={group.sessions}
-                  projectPath={path}
-                  activeId={activeId}
-                  stageIds={stageIds}
-                  onStageToggle={toggleStage}
-                  // The divider only earns its place once a worktree — or a pin
-                  // — splits the list; a lone group keeps the old flat,
-                  // header-less look. A filter is the exception: which checkout
-                  // a surviving card sits in is the thing the query was typed to
-                  // find out, so the title stays even for a lone group.
-                  showHeader={groups.length > 1 || filtering}
-                  // A drop computed from a filtered view hands reorderSubset an
-                  // id set that does not name the group's members, and
-                  // reorderSessions rejects the whole order — so the gesture
-                  // would be a silent no-op. Take it away instead of leaving a
-                  // dead one on screen.
-                  sortable={!filtering}
-                  onReorder={(ids) => commitGroupOrder(group, ids)}
-                  onClose={worktreeClose.requestClose}
-                  pullsActive={onPullsRoute && groupActive}
-                  onPulls={() => {
-                    openPulls(group.path || path)
-                    const target = groupActive ? realActiveId : group.sessions[0]?.id
-                    if (target) {
-                      activateSession(projectId, target)
-                    }
-                    navigate(`/projects/${projectId}/pulls`)
-                  }}
-                  onClosePulls={() => {
-                    closePulls(group.path || path)
-                    if (onPullsRoute && groupActive) {
-                      navigate(`/projects/${projectId}`)
-                    }
-                  }}
-                  delegateGroups={delegateGroups}
-                  providers={enabled}
-                />
-              )
-            })}
+            {groups.filter((group) => !group.stage).map(renderGroup)}
           </SortableContext>
         </DndContext>
       </div>

--- a/frontend/src/components/sidebar/SidebarRail.tsx
+++ b/frontend/src/components/sidebar/SidebarRail.tsx
@@ -3,7 +3,7 @@ import { PanelLeft, Plus } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useProjects } from "@/providers/projects"
 import { activeSessionId, sessionsOf, sidebarGroups, type Session } from "@/lib/session/sessions"
-import { storedStage } from "@/lib/session/panes-store"
+import { storedGroups } from "@/lib/session/panes-store"
 import { useSessionAgent } from "@/lib/session/use-session-agent"
 import { useSessionStatus, useSessionUnread } from "@/lib/session/use-session-status"
 import { SessionStatusIcon } from "./SessionStatusIcon"
@@ -76,7 +76,7 @@ export function SidebarRail({ onExpand }: SidebarRailProps) {
   const path = projects.find((p) => p.id === projectId)?.path ?? ""
   // Same order as the expanded sidebar, split's block and all: the rail is
   // that list with the words taken out.
-  const groups = sidebarGroups(sessionsOf(sessions, projectId), storedStage(projectId))
+  const groups = sidebarGroups(sessionsOf(sessions, projectId), storedGroups(projectId))
   // Unlike the open sidebar, a full-screen route (Settings, Pulls) does not put
   // the highlight out: those screens have no card of their own here to carry
   // it, so dropping it would leave the rail with nothing lit at all.

--- a/frontend/src/components/sidebar/SidebarRail.tsx
+++ b/frontend/src/components/sidebar/SidebarRail.tsx
@@ -3,6 +3,7 @@ import { PanelLeft, Plus } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useProjects } from "@/providers/projects"
 import { activeSessionId, sessionsOf, sidebarGroups, type Session } from "@/lib/session/sessions"
+import { storedStage } from "@/lib/session/panes-store"
 import { useSessionAgent } from "@/lib/session/use-session-agent"
 import { useSessionStatus, useSessionUnread } from "@/lib/session/use-session-status"
 import { SessionStatusIcon } from "./SessionStatusIcon"
@@ -73,7 +74,9 @@ export function SidebarRail({ onExpand }: SidebarRailProps) {
   }
 
   const path = projects.find((p) => p.id === projectId)?.path ?? ""
-  const groups = sidebarGroups(sessionsOf(sessions, projectId))
+  // Same order as the expanded sidebar, split's block and all: the rail is
+  // that list with the words taken out.
+  const groups = sidebarGroups(sessionsOf(sessions, projectId), storedStage(projectId))
   // Unlike the open sidebar, a full-screen route (Settings, Pulls) does not put
   // the highlight out: those screens have no card of their own here to carry
   // it, so dropping it would leave the rail with nothing lit at all.

--- a/frontend/src/lib/hotkeys.ts
+++ b/frontend/src/lib/hotkeys.ts
@@ -174,24 +174,24 @@ export const HOTKEY_ACTIONS: readonly HotkeyAction[] = [
     group: "view",
     combo: { mod: true, shift: true, alt: false, key: "d" },
   },
-  // O for "open beside", G for "go across". Both are letters on purpose: the
-  // family note above is measured for Ctrl+Shift+*letter*, and the chord this
-  // pair wants to spell — Ctrl+Shift+\, the editors' split — is not a letter, so
-  // whether xterm's mapping lets it through is a question nobody here has put to
-  // a `cat -v`. Two free letters that are certainly silent beat one that reads
-  // better and might arrive. J is the one to keep off: Chromium answers it with
-  // DevTools, which the --app window does open.
+  // G for the grid the stage lays out, F for the focus moving along it. Letters
+  // on purpose: the family note above is measured for Ctrl+Shift+*letter*, and
+  // the chord this pair wants to spell — Ctrl+Shift+\, the editors' split — is
+  // not one, so whether xterm's mapping lets it through is a question nobody
+  // here has put to a `cat -v`. G and F are what the list above leaves: O reads
+  // better for "open beside" and is Chromium's own, and Ctrl+F without Shift is
+  // the terminal's find, which is a different chord and stays the terminal's.
   {
     id: "splitBeside",
-    label: "Show a second session beside this one",
+    label: "Show another session beside this one",
     group: "view",
-    combo: { mod: true, shift: true, alt: false, key: "o" },
+    combo: { mod: true, shift: true, alt: false, key: "g" },
   },
   {
     id: "otherPane",
-    label: "Focus the other pane",
+    label: "Focus the next pane",
     group: "view",
-    combo: { mod: true, shift: true, alt: false, key: "g" },
+    combo: { mod: true, shift: true, alt: false, key: "f" },
   },
   {
     id: "commandPalette",

--- a/frontend/src/lib/hotkeys.ts
+++ b/frontend/src/lib/hotkeys.ts
@@ -24,6 +24,8 @@ export type HotkeyId =
   | "prevProject"
   | "toggleSidebar"
   | "toggleDock"
+  | "splitBeside"
+  | "otherPane"
   | "settings"
   | "pulls"
   | "shortcuts"
@@ -171,6 +173,25 @@ export const HOTKEY_ACTIONS: readonly HotkeyAction[] = [
     label: "Toggle the right dock",
     group: "view",
     combo: { mod: true, shift: true, alt: false, key: "d" },
+  },
+  // O for "open beside", G for "go across". Both are letters on purpose: the
+  // family note above is measured for Ctrl+Shift+*letter*, and the chord this
+  // pair wants to spell — Ctrl+Shift+\, the editors' split — is not a letter, so
+  // whether xterm's mapping lets it through is a question nobody here has put to
+  // a `cat -v`. Two free letters that are certainly silent beat one that reads
+  // better and might arrive. J is the one to keep off: Chromium answers it with
+  // DevTools, which the --app window does open.
+  {
+    id: "splitBeside",
+    label: "Show a second session beside this one",
+    group: "view",
+    combo: { mod: true, shift: true, alt: false, key: "o" },
+  },
+  {
+    id: "otherPane",
+    label: "Focus the other pane",
+    group: "view",
+    combo: { mod: true, shift: true, alt: false, key: "g" },
   },
   {
     id: "commandPalette",

--- a/frontend/src/lib/session/pane-grid.test.ts
+++ b/frontend/src/lib/session/pane-grid.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest"
+import {
+  cellAt,
+  dragTrack,
+  fits,
+  grid,
+  MIN_PANE_WIDTH,
+  MIN_TRACK,
+  offsetOf,
+  rowLength,
+  rowTracks,
+  tracks,
+} from "./pane-grid"
+
+// The two stages the layout is actually argued about: a laptop window with the
+// sidebar and the dock taking their share, and a 34" ultrawide.
+const LAPTOP = 900
+const ULTRAWIDE = 3100
+
+describe("grid", () => {
+  it("keeps one pane whole", () => {
+    expect(grid(1, LAPTOP)).toEqual({ cols: 1, rows: 1 })
+  })
+
+  it("puts eight panes four across on an ultrawide and two across on a laptop", () => {
+    expect(grid(8, ULTRAWIDE)).toEqual({ cols: 4, rows: 2 })
+    expect(grid(8, LAPTOP)).toEqual({ cols: 2, rows: 4 })
+  })
+
+  it("splits two side by side on a laptop and stacks them on a narrow window", () => {
+    expect(grid(2, LAPTOP)).toEqual({ cols: 2, rows: 1 })
+    expect(grid(2, 700)).toEqual({ cols: 1, rows: 2 })
+  })
+
+  // The literal is pinned rather than derived from the constant: this width is
+  // the readability argument the whole layout rests on, and a test that read the
+  // constant would follow it wherever it moved instead of noticing.
+  it("takes another row exactly when a pane would fall under the readable width", () => {
+    expect(MIN_PANE_WIDTH).toBe(420)
+    expect(grid(2, 840)).toEqual({ cols: 2, rows: 1 })
+    expect(grid(2, 839)).toEqual({ cols: 1, rows: 2 })
+  })
+
+  it("stacks when nothing fits side by side at all", () => {
+    expect(grid(3, 300)).toEqual({ cols: 1, rows: 3 })
+  })
+})
+
+describe("fits", () => {
+  it("allows another pane while they all stay readable", () => {
+    expect(fits(8, ULTRAWIDE, 800)).toBe(true)
+  })
+
+  it("refuses one that would leave them too short", () => {
+    expect(fits(8, LAPTOP, 600)).toBe(false)
+  })
+})
+
+describe("cellAt / rowLength", () => {
+  it("fills rows left to right in list order", () => {
+    const layout = { cols: 4, rows: 2 }
+    expect(cellAt(0, layout)).toEqual({ col: 0, row: 0 })
+    expect(cellAt(4, layout)).toEqual({ col: 0, row: 1 })
+    expect(cellAt(7, layout)).toEqual({ col: 3, row: 1 })
+  })
+
+  it("reports a short last row", () => {
+    const layout = { cols: 4, rows: 2 }
+    expect(rowLength(0, 7, layout)).toBe(4)
+    expect(rowLength(1, 7, layout)).toBe(3)
+  })
+})
+
+describe("tracks", () => {
+  it("spreads equally when nothing usable is stored", () => {
+    expect(tracks([], 4)).toEqual([0.25, 0.25, 0.25, 0.25])
+  })
+
+  it("keeps a stored layout that still describes this many tracks", () => {
+    expect(tracks([0.6, 0.4], 2)).toEqual([0.6, 0.4])
+  })
+
+  // The grid reshapes whenever a pane is added or the window resizes, and a
+  // layout dragged for four columns says nothing about three.
+  it("falls back to equal when the stored layout is for another grid", () => {
+    expect(tracks([0.6, 0.4], 3)).toEqual([1 / 3, 1 / 3, 1 / 3])
+  })
+
+  it("refuses a stored layout that does not add up, or that hides a pane", () => {
+    expect(tracks([0.9, 0.9], 2)).toEqual([0.5, 0.5])
+    expect(tracks([0.99, 0.01], 2)).toEqual([0.5, 0.5])
+  })
+})
+
+describe("rowTracks", () => {
+  it("spreads a short row over the whole width", () => {
+    expect(rowTracks([0.4, 0.3, 0.3], 3)).toEqual([0.4, 0.3, 0.3])
+    const short = rowTracks([0.5, 0.25, 0.25], 2)
+    expect(short[0]).toBeCloseTo(2 / 3)
+    expect(short.reduce((sum, value) => sum + value, 0)).toBeCloseTo(1)
+  })
+})
+
+describe("offsetOf", () => {
+  it("measures a track's leading edge", () => {
+    expect(offsetOf([0.5, 0.25, 0.25], 0)).toBe(0)
+    expect(offsetOf([0.5, 0.25, 0.25], 2)).toBeCloseTo(0.75)
+  })
+})
+
+describe("dragTrack", () => {
+  it("takes from one track and gives to its neighbour", () => {
+    const next = dragTrack([0.5, 0.5], 0, 0.1)
+    expect(next[0]).toBeCloseTo(0.6)
+    expect(next[1]).toBeCloseTo(0.4)
+  })
+
+  it("never collapses a pane, so the session in it stays reachable", () => {
+    expect(dragTrack([0.5, 0.5], 0, -1)).toEqual([MIN_TRACK, 1 - MIN_TRACK])
+    expect(dragTrack([0.5, 0.5], 0, 1)).toEqual([1 - MIN_TRACK, MIN_TRACK])
+  })
+
+  it("leaves every other track alone", () => {
+    const next = dragTrack([0.25, 0.25, 0.5], 0, 0.05)
+    expect(next[2]).toBe(0.5)
+  })
+
+  it("ignores a boundary that is not between two tracks", () => {
+    expect(dragTrack([0.5, 0.5], 1, 0.1)).toEqual([0.5, 0.5])
+    expect(dragTrack([1], 0, 0.1)).toEqual([1])
+  })
+})

--- a/frontend/src/lib/session/pane-grid.ts
+++ b/frontend/src/lib/session/pane-grid.ts
@@ -1,0 +1,116 @@
+// The layout arithmetic behind a wall of panes: how many rows and columns a
+// number of sessions takes on a stage of a given width, where each cell lands,
+// and what a drag on a seam does to the shares either side of it.
+//
+// Pure, and deliberately knowing nothing about which sessions are in a group —
+// panes.ts owns that. The two questions move for entirely different reasons: one
+// changes when the window is resized, the other when the user arranges a group.
+
+// The narrowest a pane may be laid out before the grid takes another row, and
+// the shortest before the stage refuses to add one at all. Width is the binding
+// one: an agent TUI wraps its own output, and around fifty columns is where that
+// wrapping stops being readable rather than merely tight. Height only has to
+// keep a pane from becoming a caption.
+export const MIN_PANE_WIDTH = 420
+export const MIN_PANE_HEIGHT = 160
+
+/** The smallest share of an axis one row or column may be dragged down to. */
+export const MIN_TRACK = 0.12
+
+export interface Grid {
+  cols: number
+  rows: number
+}
+
+// grid picks the layout for a number of panes on a stage of this width: the
+// fewest rows that still leave every pane readable.
+//
+// It is the same arithmetic that once argued for a hard cap of two, applied
+// continuously instead of frozen at one screen: a 3440px ultrawide fits four
+// across, so eight panes there land as 4×2, and the same eight on a laptop come
+// out 2×4. Nothing to configure, and the answer follows the window rather than a
+// number somebody typed once.
+export function grid(count: number, width: number): Grid {
+  if (count <= 1) {
+    return { cols: 1, rows: 1 }
+  }
+  for (let rows = 1; rows <= count; rows++) {
+    const cols = Math.ceil(count / rows)
+    if (width / cols >= MIN_PANE_WIDTH) {
+      return { cols, rows }
+    }
+  }
+  // Nothing fits side by side — a very narrow window — so stack them and let
+  // the panes be as wide as the stage is.
+  return { cols: 1, rows: count }
+}
+
+// fits reports whether one more pane would still leave every one of them big
+// enough to read, which is what stops a held-down shortcut from tiling a group
+// into slivers. Height is the limit that bites here: the grid answers a narrow
+// stage by taking another row, and rows are what run out.
+export function fits(count: number, width: number, height: number): boolean {
+  const { rows } = grid(count, width)
+  return height / rows >= MIN_PANE_HEIGHT
+}
+
+/** Where a cell sits in the grid. Rows fill left to right, in list order. */
+export function cellAt(index: number, { cols }: Grid): { col: number; row: number } {
+  return { col: index % cols, row: Math.floor(index / cols) }
+}
+
+/** How many cells that row actually holds — the last one may be short. */
+export function rowLength(row: number, count: number, { cols }: Grid): number {
+  return Math.min(cols, count - row * cols)
+}
+
+// tracks returns the share of an axis each row or column takes: the stored
+// fractions when they still describe this many tracks, and equal shares
+// otherwise. A stored vector of the wrong length is not an error — the grid
+// reshapes itself whenever a pane is added or the window is resized, and a
+// layout the user dragged for four columns says nothing about three.
+export function tracks(stored: readonly number[], count: number): number[] {
+  if (count <= 0) {
+    return []
+  }
+  const usable =
+    stored.length === count &&
+    stored.every((value) => Number.isFinite(value) && value >= MIN_TRACK) &&
+    Math.abs(stored.reduce((sum, value) => sum + value, 0) - 1) < 0.01
+  return usable ? [...stored] : Array.from({ length: count }, () => 1 / count)
+}
+
+// rowTracks narrows the column shares to the cells a short last row has, kept
+// in proportion so a row of three under a grid of four spreads across the whole
+// width instead of leaving a gap where the fourth would have been.
+export function rowTracks(cols: readonly number[], length: number): number[] {
+  const used = cols.slice(0, length)
+  const total = used.reduce((sum, value) => sum + value, 0)
+  return total > 0 ? used.map((value) => value / total) : used
+}
+
+/** The offset of a track's leading edge, as a share of the axis. */
+export function offsetOf(tracks: readonly number[], index: number): number {
+  return tracks.slice(0, index).reduce((sum, value) => sum + value, 0)
+}
+
+// dragTrack moves the boundary between track `index` and the one after it,
+// taking from one and giving to the other so the axis still sums to one. Neither
+// may be pushed below MIN_TRACK, which is what keeps a drag from collapsing a
+// pane to nothing and stranding the session inside it.
+export function dragTrack(
+  start: readonly number[],
+  index: number,
+  delta: number,
+  min = MIN_TRACK,
+): number[] {
+  if (index < 0 || index >= start.length - 1) {
+    return [...start]
+  }
+  const pair = start[index] + start[index + 1]
+  const first = Math.min(pair - min, Math.max(min, start[index] + delta))
+  const next = [...start]
+  next[index] = first
+  next[index + 1] = pair - first
+  return next
+}

--- a/frontend/src/lib/session/panes-store.ts
+++ b/frontend/src/lib/session/panes-store.ts
@@ -1,15 +1,14 @@
 import { useSyncExternalStore } from "react"
-import { readPref, removePref, writePref } from "@/lib/prefs"
-import { COLS_KEY, ROWS_KEY, stageKey } from "./panes"
+import { readPref, writePref } from "@/lib/prefs"
+import { formatGroups, groupsKey, type PaneGroup, parseGroups } from "./panes"
 
-// Where the stage lives between mounts. localStorage is the store itself, not a
-// cache in front of one: the values are a list of ids, an index and two vectors
-// of fractions, reads are a map lookup, and a second copy in module state would
-// be one more thing that can disagree with the pref it was written from.
+// Where the split groups live between mounts. localStorage is the store itself,
+// not a cache in front of one: a second copy in module state would be one more
+// thing that can disagree with the pref it was written from.
 //
 // UI preference, so the page's localStorage rather than the workspace database
-// (root CLAUDE.md) — the stage is a property of this window, the way the
-// sidebar's width and the dock's tab are.
+// (root CLAUDE.md) — a wall is a property of this window, the way the sidebar's
+// width and the dock's tab are.
 //
 // One listener set rather than one per project: the subscribers are the terminal
 // host, the sidebar and the layout's shortcuts, and a fan-out keyed by project
@@ -30,57 +29,49 @@ function subscribe(listener: () => void): () => void {
 }
 
 // Snapshots must be stable across calls or useSyncExternalStore re-renders
-// forever, and every read here parses a string into a fresh array. So each key's
-// last parse is kept beside the raw string it came from and handed back until
-// that string changes — the cache is for React's identity check, never for the
-// value, which still comes from the pref on every read.
-function parsed<T>(parse: (raw: string | null) => T): (key: string) => T {
-  const seen = new Map<string, { raw: string | null; value: T }>()
-  return (key: string) => {
-    const raw = readPref(key)
-    const last = seen.get(key)
-    if (last && last.raw === raw) {
-      return last.value
-    }
-    const value = parse(raw)
-    seen.set(key, { raw, value })
-    return value
+// forever, and every read here parses a string into fresh objects. So the last
+// parse is kept beside the raw string it came from and handed back until that
+// string changes — the cache is for React's identity check, never for the value,
+// which still comes from the pref on every read.
+const cache = new Map<string, { raw: string | null; value: PaneGroup[] }>()
+
+/** The stored groups, unreconciled — put them through resolveGroups with the
+ * project's live sessions before drawing anything. Outside React too, for the
+ * two readers that are not components: the collapsed rail and the neighbour
+ * walk, both of which order cards the way the sidebar draws them. */
+export function storedGroups(projectId: string): PaneGroup[] {
+  if (!projectId) {
+    return EMPTY
   }
+  const key = groupsKey(projectId)
+  const raw = readPref(key)
+  const last = cache.get(key)
+  if (last && last.raw === raw) {
+    return last.value
+  }
+  const value = parseGroups(raw)
+  cache.set(key, { raw, value })
+  return value
 }
 
-const readList = parsed<string[]>((raw) => (raw ? raw.split(",").filter((id) => id !== "") : []))
+// One frozen array for every project with nothing stored, so the snapshot of a
+// project with no walls is identity-stable too.
+const EMPTY: PaneGroup[] = []
 
-const readNumbers = parsed<number[]>((raw) =>
-  raw ? raw.split(",").map(Number).filter(Number.isFinite) : [],
-)
-
-/** The stored cells outside React, for the two readers that are not components:
- * the collapsed rail and the neighbour walk, both of which have to order cards
- * the way the sidebar draws them. */
-export function storedStage(projectId: string): string[] {
-  return projectId ? readList(stageKey(projectId)) : EMPTY
+export function useStoredGroups(projectId: string): PaneGroup[] {
+  return useSyncExternalStore(subscribe, () => storedGroups(projectId))
 }
 
-/** The stored cells, unreconciled — put them through resolveStage with the
- * project's live sessions before drawing anything. */
-export function useStoredStage(projectId: string): string[] {
-  return useSyncExternalStore(subscribe, () => (projectId ? readList(stageKey(projectId)) : EMPTY))
+export function writeGroups(projectId: string, groups: readonly PaneGroup[]): void {
+  if (!projectId) {
+    return
+  }
+  writePref(groupsKey(projectId), formatGroups(groups))
+  notify()
 }
 
-// One frozen array for every project with nothing stored, so the snapshot of an
-// empty stage is identity-stable too.
-const EMPTY: string[] = []
-
-export function useStoredCols(): number[] {
-  return useSyncExternalStore(subscribe, () => readNumbers(COLS_KEY))
-}
-
-export function useStoredRows(): number[] {
-  return useSyncExternalStore(subscribe, () => readNumbers(ROWS_KEY))
-}
-
-// The stage's measured size, kept here rather than passed around: the element
-// is measured in the terminal host and the guard that needs it — would one more
+// The stage's measured size, kept here rather than passed around: the element is
+// measured in the terminal host and the guard that needs it — would one more
 // pane still be readable — is asked from the layout's shortcuts, two subtrees
 // away. Not reactive, and deliberately: nothing renders from it, one caller asks
 // it a yes-or-no question at the moment a key is pressed.
@@ -92,28 +83,4 @@ export function setStageSize(width: number, height: number): void {
 
 export function stageSize(): { width: number; height: number } {
   return stage
-}
-
-export function writeStage(projectId: string, cells: readonly string[]): void {
-  if (!projectId) {
-    return
-  }
-  if (cells.length <= 1) {
-    // One pane is no wall at all: leaving a single id stored would keep bringing
-    // that arrangement back for a session that is simply the active one.
-    removePref(stageKey(projectId))
-  } else {
-    writePref(stageKey(projectId), cells.join(","))
-  }
-  notify()
-}
-
-export function writeCols(cols: readonly number[]): void {
-  writePref(COLS_KEY, cols.join(","))
-  notify()
-}
-
-export function writeRows(rows: readonly number[]): void {
-  writePref(ROWS_KEY, rows.join(","))
-  notify()
 }

--- a/frontend/src/lib/session/panes-store.ts
+++ b/frontend/src/lib/session/panes-store.ts
@@ -1,19 +1,19 @@
 import { useSyncExternalStore } from "react"
-import { parseNumberPref, readPref, removePref, writePref } from "@/lib/prefs"
-import { type Beside, clampRatio, formatBeside, paneKey, RATIO_DEFAULT, RATIO_KEY } from "./panes"
+import { readPref, removePref, writePref } from "@/lib/prefs"
+import { COLS_KEY, focusKey, ROWS_KEY, stageKey } from "./panes"
 
-// Where the split lives between mounts. localStorage is the store itself, not a
-// cache in front of one: both values are a string and a number, reads are a map
-// lookup, and a second copy in module state would be one more thing that can
-// disagree with the pref it was written from.
+// Where the stage lives between mounts. localStorage is the store itself, not a
+// cache in front of one: the values are a list of ids, an index and two vectors
+// of fractions, reads are a map lookup, and a second copy in module state would
+// be one more thing that can disagree with the pref it was written from.
 //
 // UI preference, so the page's localStorage rather than the workspace database
-// (root CLAUDE.md) — the split is a property of this window, the way the
+// (root CLAUDE.md) — the stage is a property of this window, the way the
 // sidebar's width and the dock's tab are.
 //
-// One listener set rather than one per project: the subscribers are the
-// terminal host, the sidebar and the layout's shortcuts, and a fan-out keyed by
-// project would be machinery for three of them.
+// One listener set rather than one per project: the subscribers are the terminal
+// host, the sidebar and the layout's shortcuts, and a fan-out keyed by project
+// would be machinery for three of them.
 const listeners = new Set<() => void>()
 
 function notify(): void {
@@ -29,37 +29,96 @@ function subscribe(listener: () => void): () => void {
   }
 }
 
-/** The stored beside id, unreconciled — pass it through resolveBeside with the
- * project's live sessions before showing anything. */
-export function useStoredBeside(projectId: string): string {
-  return useSyncExternalStore(subscribe, () =>
-    projectId ? (readPref(paneKey(projectId)) ?? "") : "",
-  )
-}
-
-export function usePaneRatio(): number {
-  return useSyncExternalStore(subscribe, () =>
-    parseNumberPref(readPref(RATIO_KEY), RATIO_DEFAULT, clampRatio),
-  )
-}
-
-export function openBeside(projectId: string, beside: Beside): void {
-  if (!projectId || !beside.id) {
-    return
+// Snapshots must be stable across calls or useSyncExternalStore re-renders
+// forever, and every read here parses a string into a fresh array. So each key's
+// last parse is kept beside the raw string it came from and handed back until
+// that string changes — the cache is for React's identity check, never for the
+// value, which still comes from the pref on every read.
+function parsed<T>(parse: (raw: string | null) => T): (key: string) => T {
+  const seen = new Map<string, { raw: string | null; value: T }>()
+  return (key: string) => {
+    const raw = readPref(key)
+    const last = seen.get(key)
+    if (last && last.raw === raw) {
+      return last.value
+    }
+    const value = parse(raw)
+    seen.set(key, { raw, value })
+    return value
   }
-  writePref(paneKey(projectId), formatBeside(beside))
-  notify()
 }
 
-export function closeBeside(projectId: string): void {
+const readList = parsed<string[]>((raw) => (raw ? raw.split(",").filter((id) => id !== "") : []))
+
+const readNumbers = parsed<number[]>((raw) =>
+  raw ? raw.split(",").map(Number).filter(Number.isFinite) : [],
+)
+
+const readIndex = (key: string): number => {
+  const value = Number(readPref(key))
+  return Number.isInteger(value) && value >= 0 ? value : 0
+}
+
+/** The stored cells, unreconciled — put them through resolveStage with the
+ * project's live sessions before drawing anything. */
+export function useStoredStage(projectId: string): string[] {
+  return useSyncExternalStore(subscribe, () => (projectId ? readList(stageKey(projectId)) : EMPTY))
+}
+
+// One frozen array for every project with nothing stored, so the snapshot of an
+// empty stage is identity-stable too.
+const EMPTY: string[] = []
+
+export function useStoredFocus(projectId: string): number {
+  return useSyncExternalStore(subscribe, () => (projectId ? readIndex(focusKey(projectId)) : 0))
+}
+
+export function useStoredCols(): number[] {
+  return useSyncExternalStore(subscribe, () => readNumbers(COLS_KEY))
+}
+
+export function useStoredRows(): number[] {
+  return useSyncExternalStore(subscribe, () => readNumbers(ROWS_KEY))
+}
+
+// The stage's measured size, kept here rather than passed around: the element
+// is measured in the terminal host and the guard that needs it — would one more
+// pane still be readable — is asked from the layout's shortcuts, two subtrees
+// away. Not reactive, and deliberately: nothing renders from it, one caller asks
+// it a yes-or-no question at the moment a key is pressed.
+let stage = { width: 0, height: 0 }
+
+export function setStageSize(width: number, height: number): void {
+  stage = { width, height }
+}
+
+export function stageSize(): { width: number; height: number } {
+  return stage
+}
+
+export function writeStage(projectId: string, cells: readonly string[], focus: number): void {
   if (!projectId) {
     return
   }
-  removePref(paneKey(projectId))
+  if (cells.length <= 1) {
+    // One pane is the unsplit stage: leaving a single id stored would keep a
+    // project pinned to the session that happened to be focused when the last
+    // pane was closed, rather than following the active one again.
+    removePref(stageKey(projectId))
+    removePref(focusKey(projectId))
+  } else {
+    writePref(stageKey(projectId), cells.join(","))
+    writePref(focusKey(projectId), Math.max(0, focus))
+  }
   notify()
 }
 
-export function setPaneRatio(ratio: number): void {
-  writePref(RATIO_KEY, clampRatio(ratio))
+export function writeCols(cols: readonly number[]): void {
+  writePref(COLS_KEY, cols.join(","))
+  notify()
+}
+
+export function writeRows(rows: readonly number[]): void {
+  writePref(ROWS_KEY, rows.join(","))
   notify()
 }

--- a/frontend/src/lib/session/panes-store.ts
+++ b/frontend/src/lib/session/panes-store.ts
@@ -1,6 +1,6 @@
 import { useSyncExternalStore } from "react"
 import { readPref, removePref, writePref } from "@/lib/prefs"
-import { COLS_KEY, focusKey, ROWS_KEY, stageKey } from "./panes"
+import { COLS_KEY, ROWS_KEY, stageKey } from "./panes"
 
 // Where the stage lives between mounts. localStorage is the store itself, not a
 // cache in front of one: the values are a list of ids, an index and two vectors
@@ -54,11 +54,6 @@ const readNumbers = parsed<number[]>((raw) =>
   raw ? raw.split(",").map(Number).filter(Number.isFinite) : [],
 )
 
-const readIndex = (key: string): number => {
-  const value = Number(readPref(key))
-  return Number.isInteger(value) && value >= 0 ? value : 0
-}
-
 /** The stored cells, unreconciled — put them through resolveStage with the
  * project's live sessions before drawing anything. */
 export function useStoredStage(projectId: string): string[] {
@@ -68,10 +63,6 @@ export function useStoredStage(projectId: string): string[] {
 // One frozen array for every project with nothing stored, so the snapshot of an
 // empty stage is identity-stable too.
 const EMPTY: string[] = []
-
-export function useStoredFocus(projectId: string): number {
-  return useSyncExternalStore(subscribe, () => (projectId ? readIndex(focusKey(projectId)) : 0))
-}
 
 export function useStoredCols(): number[] {
   return useSyncExternalStore(subscribe, () => readNumbers(COLS_KEY))
@@ -96,19 +87,16 @@ export function stageSize(): { width: number; height: number } {
   return stage
 }
 
-export function writeStage(projectId: string, cells: readonly string[], focus: number): void {
+export function writeStage(projectId: string, cells: readonly string[]): void {
   if (!projectId) {
     return
   }
   if (cells.length <= 1) {
-    // One pane is the unsplit stage: leaving a single id stored would keep a
-    // project pinned to the session that happened to be focused when the last
-    // pane was closed, rather than following the active one again.
+    // One pane is no wall at all: leaving a single id stored would keep bringing
+    // that arrangement back for a session that is simply the active one.
     removePref(stageKey(projectId))
-    removePref(focusKey(projectId))
   } else {
     writePref(stageKey(projectId), cells.join(","))
-    writePref(focusKey(projectId), Math.max(0, focus))
   }
   notify()
 }

--- a/frontend/src/lib/session/panes-store.ts
+++ b/frontend/src/lib/session/panes-store.ts
@@ -54,6 +54,13 @@ const readNumbers = parsed<number[]>((raw) =>
   raw ? raw.split(",").map(Number).filter(Number.isFinite) : [],
 )
 
+/** The stored cells outside React, for the two readers that are not components:
+ * the collapsed rail and the neighbour walk, both of which have to order cards
+ * the way the sidebar draws them. */
+export function storedStage(projectId: string): string[] {
+  return projectId ? readList(stageKey(projectId)) : EMPTY
+}
+
 /** The stored cells, unreconciled — put them through resolveStage with the
  * project's live sessions before drawing anything. */
 export function useStoredStage(projectId: string): string[] {

--- a/frontend/src/lib/session/panes-store.ts
+++ b/frontend/src/lib/session/panes-store.ts
@@ -1,0 +1,65 @@
+import { useSyncExternalStore } from "react"
+import { parseNumberPref, readPref, removePref, writePref } from "@/lib/prefs"
+import { type Beside, clampRatio, formatBeside, paneKey, RATIO_DEFAULT, RATIO_KEY } from "./panes"
+
+// Where the split lives between mounts. localStorage is the store itself, not a
+// cache in front of one: both values are a string and a number, reads are a map
+// lookup, and a second copy in module state would be one more thing that can
+// disagree with the pref it was written from.
+//
+// UI preference, so the page's localStorage rather than the workspace database
+// (root CLAUDE.md) — the split is a property of this window, the way the
+// sidebar's width and the dock's tab are.
+//
+// One listener set rather than one per project: the subscribers are the
+// terminal host, the sidebar and the layout's shortcuts, and a fan-out keyed by
+// project would be machinery for three of them.
+const listeners = new Set<() => void>()
+
+function notify(): void {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+/** The stored beside id, unreconciled — pass it through resolveBeside with the
+ * project's live sessions before showing anything. */
+export function useStoredBeside(projectId: string): string {
+  return useSyncExternalStore(subscribe, () =>
+    projectId ? (readPref(paneKey(projectId)) ?? "") : "",
+  )
+}
+
+export function usePaneRatio(): number {
+  return useSyncExternalStore(subscribe, () =>
+    parseNumberPref(readPref(RATIO_KEY), RATIO_DEFAULT, clampRatio),
+  )
+}
+
+export function openBeside(projectId: string, beside: Beside): void {
+  if (!projectId || !beside.id) {
+    return
+  }
+  writePref(paneKey(projectId), formatBeside(beside))
+  notify()
+}
+
+export function closeBeside(projectId: string): void {
+  if (!projectId) {
+    return
+  }
+  removePref(paneKey(projectId))
+  notify()
+}
+
+export function setPaneRatio(ratio: number): void {
+  writePref(RATIO_KEY, clampRatio(ratio))
+  notify()
+}

--- a/frontend/src/lib/session/panes.test.ts
+++ b/frontend/src/lib/session/panes.test.ts
@@ -65,11 +65,11 @@ describe("fits", () => {
 
 describe("resolveStage", () => {
   it("answers the active session alone when nothing is stored", () => {
-    expect(resolveStage([], 0, sessions, "a")).toEqual({ cells: ["a"], focus: 0 })
+    expect(resolveStage([], sessions, "a")).toEqual({ cells: ["a"], focus: 0 })
   })
 
   it("keeps the stored order and finds the focused cell in it", () => {
-    expect(resolveStage(["a", "b", "c"], 0, sessions, "b")).toEqual({
+    expect(resolveStage(["a", "b", "c"], sessions, "b")).toEqual({
       cells: ["a", "b", "c"],
       focus: 1,
     })
@@ -79,23 +79,25 @@ describe("resolveStage", () => {
   // removal, an undone create — all end here, which is why the cells are derived
   // on read instead of maintained by each of them.
   it("drops cells whose session is gone, and duplicates", () => {
-    expect(resolveStage(["a", "gone", "b", "b"], 0, sessions, "a")).toEqual({
+    expect(resolveStage(["a", "gone", "b", "b"], sessions, "a")).toEqual({
       cells: ["a", "b"],
       focus: 0,
     })
   })
 
-  // This is what lets the palette, a session link and an MCP call all land in
-  // the pane the user was looking at without knowing the stage exists.
-  it("puts a session activated from elsewhere into the focused cell", () => {
-    expect(resolveStage(["a", "b", "c"], 2, sessions, "d")).toEqual({
-      cells: ["a", "b", "d"],
-      focus: 2,
-    })
+  // The wall is a group the user assembled, so nothing but the add affordance
+  // may put a session in it: activating one from outside shows that session
+  // alone rather than editing an arrangement built on purpose.
+  it("shows a session from outside the wall on its own", () => {
+    expect(resolveStage(["a", "b", "c"], sessions, "d")).toEqual({ cells: ["d"], focus: 0 })
   })
 
-  it("clamps a stored focus that no longer names a cell", () => {
-    expect(resolveStage(["a", "b"], 9, sessions, "d")).toEqual({ cells: ["a", "d"], focus: 1 })
+  // And parks rather than tears down — the stored cells are untouched, which is
+  // what lets the arrangement come back whole.
+  it("brings the whole wall back when a member is activated again", () => {
+    const stored = ["a", "b", "c"]
+    expect(resolveStage(stored, sessions, "d").cells).toEqual(["d"])
+    expect(resolveStage(stored, sessions, "c")).toEqual({ cells: stored, focus: 2 })
   })
 })
 

--- a/frontend/src/lib/session/panes.test.ts
+++ b/frontend/src/lib/session/panes.test.ts
@@ -5,6 +5,7 @@ import {
   dissolveGroup,
   formatGroups,
   groupOf,
+  movingFrom,
   nextCandidate,
   type PaneGroup,
   parseGroups,
@@ -74,6 +75,27 @@ describe("groupOf", () => {
     const groups = [group("g1", ["a", "b"]), group("g2", ["c"])]
     expect(groupOf(groups, "b")?.id).toBe("g1")
     expect(groupOf(groups, "d")).toBeNull()
+  })
+})
+
+describe("movingFrom", () => {
+  const groups = [group("g1", ["a", "b"]), group("g2", ["c"])]
+
+  it("names the wall a session would be taken off", () => {
+    expect(movingFrom(groups, groups[1], "a")?.id).toBe("g1")
+  })
+
+  // Nothing to ask about: the session is on no wall, or already on this one.
+  it("answers null when nothing else loses a member", () => {
+    expect(movingFrom(groups, groups[0], "a")).toBeNull()
+    expect(movingFrom(groups, groups[0], "d")).toBeNull()
+    expect(movingFrom(groups, null, "d")).toBeNull()
+  })
+
+  // Starting a wall around a session that is on another one is still a move,
+  // even though there is no current wall to move it into yet.
+  it("still names it when the user is on no wall at all", () => {
+    expect(movingFrom(groups, null, "c")?.id).toBe("g2")
   })
 })
 

--- a/frontend/src/lib/session/panes.test.ts
+++ b/frontend/src/lib/session/panes.test.ts
@@ -1,200 +1,149 @@
 import { describe, expect, it } from "vitest"
 import {
-  cellAt,
-  dragTrack,
-  fits,
-  grid,
-  MIN_PANE_WIDTH,
-  MIN_TRACK,
+  addToGroup,
+  defaultName,
+  dissolveGroup,
+  formatGroups,
+  groupOf,
   nextCandidate,
-  offsetOf,
-  resolveStage,
-  rowLength,
-  rowTracks,
+  type PaneGroup,
+  parseGroups,
+  removeFromGroups,
+  reorderGroups,
+  resolveGroups,
   swapCells,
-  tracks,
+  updateGroup,
 } from "./panes"
 import type { Session } from "./sessions"
 
-const session = (id: string): Session => ({ id, label: id, kind: "claude" })
+const session = (id: string): Session => ({ id, label: id.toUpperCase(), kind: "claude" })
 const sessions = [session("a"), session("b"), session("c"), session("d")]
 
-// The two stages the layout is actually argued about: a laptop window with the
-// sidebar and the dock taking their share, and a 34" ultrawide.
-const LAPTOP = 900
-const ULTRAWIDE = 3100
+const group = (id: string, cells: string[], name = id): PaneGroup => ({
+  id,
+  name,
+  cells,
+  cols: [],
+  rows: [],
+})
 
-describe("grid", () => {
-  it("keeps one pane whole", () => {
-    expect(grid(1, LAPTOP)).toEqual({ cols: 1, rows: 1 })
+describe("parseGroups", () => {
+  it("reads what formatGroups wrote", () => {
+    const groups = [group("g1", ["a", "b"], "orchestrator"), group("g2", ["c"])]
+    expect(parseGroups(formatGroups(groups))).toEqual(groups)
   })
 
-  it("puts eight panes four across on an ultrawide and two across on a laptop", () => {
-    expect(grid(8, ULTRAWIDE)).toEqual({ cols: 4, rows: 2 })
-    expect(grid(8, LAPTOP)).toEqual({ cols: 2, rows: 4 })
+  // A pref must never be able to break a launch, so anything unreadable costs
+  // the user their arrangement and nothing else.
+  it("answers no groups for anything it cannot read", () => {
+    expect(parseGroups(null)).toEqual([])
+    expect(parseGroups("")).toEqual([])
+    expect(parseGroups("{oh no")).toEqual([])
+    expect(parseGroups('{"id":"g1"}')).toEqual([])
   })
 
-  it("splits two side by side on a laptop and stacks them on a narrow window", () => {
-    expect(grid(2, LAPTOP)).toEqual({ cols: 2, rows: 1 })
-    expect(grid(2, 700)).toEqual({ cols: 1, rows: 2 })
-  })
-
-  // The literal is pinned rather than derived from the constant: this width is
-  // the readability argument the whole layout rests on, and a test that read the
-  // constant would follow it wherever it moved instead of noticing.
-  it("takes another row exactly when a pane would fall under the readable width", () => {
-    expect(MIN_PANE_WIDTH).toBe(420)
-    expect(grid(2, 840)).toEqual({ cols: 2, rows: 1 })
-    expect(grid(2, 839)).toEqual({ cols: 1, rows: 2 })
-  })
-
-  it("stacks when nothing fits side by side at all", () => {
-    expect(grid(3, 300)).toEqual({ cols: 1, rows: 3 })
+  it("drops entries that are not groups and keeps the ones that are", () => {
+    expect(parseGroups('[{"nope":1},{"id":"g1","cells":["a"]}]')).toEqual([
+      { id: "g1", name: "", cells: ["a"], cols: [], rows: [] },
+    ])
   })
 })
 
-describe("fits", () => {
-  it("allows another pane while they all stay readable", () => {
-    expect(fits(8, ULTRAWIDE, 800)).toBe(true)
+describe("resolveGroups", () => {
+  it("drops cells whose session is gone", () => {
+    expect(resolveGroups([group("g1", ["a", "gone", "b"])], sessions)[0].cells).toEqual(["a", "b"])
   })
 
-  it("refuses one that would leave them too short", () => {
-    expect(fits(8, LAPTOP, 600)).toBe(false)
-  })
-})
-
-describe("resolveStage", () => {
-  it("answers the active session alone when nothing is stored", () => {
-    expect(resolveStage([], sessions, "a")).toEqual({ cells: ["a"], focus: 0, members: [] })
+  // A group of one is still something the user named and can add to; a group of
+  // none has nothing left for the name to be about.
+  it("keeps a group of one and drops a group of none", () => {
+    const groups = resolveGroups([group("g1", ["a"]), group("g2", ["gone"])], sessions)
+    expect(groups.map((g) => g.id)).toEqual(["g1"])
   })
 
-  it("keeps the stored order and finds the focused cell in it", () => {
-    expect(resolveStage(["a", "b", "c"], sessions, "b")).toEqual({
-      cells: ["a", "b", "c"],
-      focus: 1,
-      members: ["a", "b", "c"],
-    })
-  })
-
-  // The four ways a session leaves the workspace — a close, a park, a worktree
-  // removal, an undone create — all end here, which is why the cells are derived
-  // on read instead of maintained by each of them.
-  it("drops cells whose session is gone, and duplicates", () => {
-    expect(resolveStage(["a", "gone", "b", "b"], sessions, "a")).toEqual({
-      cells: ["a", "b"],
-      focus: 0,
-      members: ["a", "b"],
-    })
-  })
-
-  // The wall is a group the user assembled, so nothing but the add affordance
-  // may put a session in it: activating one from outside shows that session
-  // alone rather than editing an arrangement built on purpose.
-  // The members survive it, which is what the sidebar's own block is built from:
-  // a wall you cannot see the membership of is one you rediscover by clicking.
-  it("shows a session from outside the wall on its own, and keeps the members", () => {
-    expect(resolveStage(["a", "b", "c"], sessions, "d")).toEqual({
-      cells: ["d"],
-      focus: 0,
-      members: ["a", "b", "c"],
-    })
-  })
-
-  // And parks rather than tears down — the stored cells are untouched, which is
-  // what lets the arrangement come back whole.
-  it("brings the whole wall back when a member is activated again", () => {
-    const stored = ["a", "b", "c"]
-    expect(resolveStage(stored, sessions, "d").cells).toEqual(["d"])
-    expect(resolveStage(stored, sessions, "c")).toEqual({
-      cells: stored,
-      focus: 2,
-      members: stored,
-    })
+  // The one-group rule is enforced on read too, so a stored value that somehow
+  // holds a session twice cannot put it on two walls.
+  it("gives a session to the first group that claims it", () => {
+    const groups = resolveGroups([group("g1", ["a", "b"]), group("g2", ["b", "c"])], sessions)
+    expect(groups.map((g) => g.cells)).toEqual([["a", "b"], ["c"]])
   })
 })
 
-describe("cellAt / rowLength", () => {
-  it("fills rows left to right in list order", () => {
-    const layout = { cols: 4, rows: 2 }
-    expect(cellAt(0, layout)).toEqual({ col: 0, row: 0 })
-    expect(cellAt(4, layout)).toEqual({ col: 0, row: 1 })
-    expect(cellAt(7, layout)).toEqual({ col: 3, row: 1 })
-  })
-
-  it("reports a short last row", () => {
-    const layout = { cols: 4, rows: 2 }
-    expect(rowLength(0, 7, layout)).toBe(4)
-    expect(rowLength(1, 7, layout)).toBe(3)
+describe("groupOf", () => {
+  it("finds the wall a session is on, and answers null for one on none", () => {
+    const groups = [group("g1", ["a", "b"]), group("g2", ["c"])]
+    expect(groupOf(groups, "b")?.id).toBe("g1")
+    expect(groupOf(groups, "d")).toBeNull()
   })
 })
 
-describe("tracks", () => {
-  it("spreads equally when nothing usable is stored", () => {
-    expect(tracks([], 4)).toEqual([0.25, 0.25, 0.25, 0.25])
+describe("addToGroup", () => {
+  it("appends to the named group", () => {
+    expect(addToGroup([group("g1", ["a"])], "g1", "b")[0].cells).toEqual(["a", "b"])
   })
 
-  it("keeps a stored layout that still describes this many tracks", () => {
-    expect(tracks([0.6, 0.4], 2)).toEqual([0.6, 0.4])
+  // At most one group per session, so adding is also a move.
+  it("takes the session off whatever wall had it", () => {
+    const groups = addToGroup([group("g1", ["a", "b"]), group("g2", ["c"])], "g2", "b")
+    expect(groups.map((g) => g.cells)).toEqual([["a"], ["c", "b"]])
   })
 
-  // The grid reshapes whenever a pane is added or the window resizes, and a
-  // layout dragged for four columns says nothing about three.
-  it("falls back to equal when the stored layout is for another grid", () => {
-    expect(tracks([0.6, 0.4], 3)).toEqual([1 / 3, 1 / 3, 1 / 3])
-  })
-
-  it("refuses a stored layout that does not add up, or that hides a pane", () => {
-    expect(tracks([0.9, 0.9], 2)).toEqual([0.5, 0.5])
-    expect(tracks([0.99, 0.01], 2)).toEqual([0.5, 0.5])
+  it("drops a group the move emptied", () => {
+    const groups = addToGroup([group("g1", ["b"]), group("g2", ["c"])], "g2", "b")
+    expect(groups.map((g) => g.id)).toEqual(["g2"])
   })
 })
 
-describe("rowTracks", () => {
-  it("spreads a short row over the whole width", () => {
-    expect(rowTracks([0.4, 0.3, 0.3], 3)).toEqual([0.4, 0.3, 0.3])
-    const short = rowTracks([0.5, 0.25, 0.25], 2)
-    expect(short[0]).toBeCloseTo(2 / 3)
-    expect(short.reduce((sum, value) => sum + value, 0)).toBeCloseTo(1)
+describe("removeFromGroups", () => {
+  it("keeps the group at one member", () => {
+    expect(removeFromGroups([group("g1", ["a", "b"])], "b")[0].cells).toEqual(["a"])
+  })
+
+  it("ends the group when its last member leaves", () => {
+    expect(removeFromGroups([group("g1", ["a"])], "a")).toEqual([])
   })
 })
 
-describe("offsetOf", () => {
-  it("measures a track's leading edge", () => {
-    expect(offsetOf([0.5, 0.25, 0.25], 0)).toBe(0)
-    expect(offsetOf([0.5, 0.25, 0.25], 2)).toBeCloseTo(0.75)
+describe("updateGroup / dissolveGroup", () => {
+  it("changes only the group named", () => {
+    const groups = updateGroup([group("g1", ["a"]), group("g2", ["b"])], "g2", { name: "renamed" })
+    expect(groups.map((g) => g.name)).toEqual(["g1", "renamed"])
+  })
+
+  it("takes a wall apart without touching the others", () => {
+    expect(dissolveGroup([group("g1", ["a"]), group("g2", ["b"])], "g1").map((g) => g.id)).toEqual([
+      "g2",
+    ])
   })
 })
 
-describe("dragTrack", () => {
-  it("takes from one track and gives to its neighbour", () => {
-    const next = dragTrack([0.5, 0.5], 0, 0.1)
-    expect(next[0]).toBeCloseTo(0.6)
-    expect(next[1]).toBeCloseTo(0.4)
+describe("reorderGroups", () => {
+  it("puts the walls in the order the drag named", () => {
+    const groups = [group("g1", ["a"]), group("g2", ["b"]), group("g3", ["c"])]
+    expect(reorderGroups(groups, ["g3", "g1", "g2"]).map((g) => g.id)).toEqual(["g3", "g1", "g2"])
   })
 
-  it("never collapses a pane, so the session in it stays reachable", () => {
-    expect(dragTrack([0.5, 0.5], 0, -1)).toEqual([MIN_TRACK, 1 - MIN_TRACK])
-    expect(dragTrack([0.5, 0.5], 0, 1)).toEqual([1 - MIN_TRACK, MIN_TRACK])
+  // An id set that raced a dissolve must not cost the user a group.
+  it("keeps a wall the drag did not name", () => {
+    const groups = [group("g1", ["a"]), group("g2", ["b"])]
+    expect(reorderGroups(groups, ["g2"]).map((g) => g.id)).toEqual(["g2", "g1"])
   })
+})
 
-  it("leaves every other track alone", () => {
-    const next = dragTrack([0.25, 0.25, 0.5], 0, 0.05)
-    expect(next[2]).toBe(0.5)
-  })
-
-  it("ignores a boundary that is not between two tracks", () => {
-    expect(dragTrack([0.5, 0.5], 1, 0.1)).toEqual([0.5, 0.5])
-    expect(dragTrack([1], 0, 0.1)).toEqual([1])
+describe("defaultName", () => {
+  it("names a wall after the session it grew from", () => {
+    expect(defaultName(sessions, "b")).toBe("B")
+    expect(defaultName(sessions, "gone")).toBe("Split")
   })
 })
 
 describe("nextCandidate", () => {
-  it("takes the first card not already up", () => {
-    expect(nextCandidate(sessions, ["a", "c"])).toBe("b")
+  it("takes the first card on no wall at all", () => {
+    expect(nextCandidate(sessions, [group("g1", ["a", "b"])])).toBe("c")
   })
 
-  it("answers nothing when the whole project is on the stage", () => {
-    expect(nextCandidate(sessions, ["a", "b", "c", "d"])).toBe("")
+  it("answers nothing when every session is already on one", () => {
+    expect(nextCandidate(sessions, [group("g1", ["a", "b", "c", "d"])])).toBe("")
   })
 })
 

--- a/frontend/src/lib/session/panes.test.ts
+++ b/frontend/src/lib/session/panes.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest"
+import {
+  besideCandidate,
+  clampRatio,
+  dragRatio,
+  formatBeside,
+  NO_BESIDE,
+  parseBeside,
+  RATIO_MAX,
+  RATIO_MIN,
+  resolveBeside,
+} from "./panes"
+import type { Session } from "./sessions"
+
+const session = (id: string): Session => ({ id, label: id, kind: "claude" })
+const sessions = [session("a"), session("b"), session("c")]
+
+describe("clampRatio", () => {
+  it("passes a ratio inside the bounds through", () => {
+    expect(clampRatio(0.5)).toBe(0.5)
+  })
+
+  // The literals are pinned rather than derived from the constants: this is the
+  // boundary the readable-width argument bought, and a test that reads the
+  // constant would follow it wherever it moved instead of noticing.
+  it("clamps either pane to a quarter of the stage", () => {
+    expect(clampRatio(0.1)).toBe(0.25)
+    expect(clampRatio(0.9)).toBe(0.75)
+    expect(RATIO_MIN).toBe(0.25)
+    expect(RATIO_MAX).toBe(0.75)
+  })
+})
+
+describe("parseBeside", () => {
+  it("reads a bare id as the right-hand pane", () => {
+    expect(parseBeside("b")).toEqual({ id: "b", side: "right" })
+  })
+
+  it("reads the stored side", () => {
+    expect(parseBeside("b@left")).toEqual({ id: "b", side: "left" })
+  })
+
+  // A pref must never be able to break a launch, so anything unrecognised reads
+  // as the default rather than as a third side.
+  it("answers the default for nothing and for a value it does not know", () => {
+    expect(parseBeside(null)).toEqual(NO_BESIDE)
+    expect(parseBeside("")).toEqual(NO_BESIDE)
+    expect(parseBeside("b@sideways")).toEqual({ id: "b", side: "right" })
+  })
+
+  it("round-trips through the stored form", () => {
+    for (const beside of [
+      { id: "b", side: "right" },
+      { id: "b", side: "left" },
+    ] as const) {
+      expect(parseBeside(formatBeside(beside))).toEqual(beside)
+    }
+  })
+})
+
+describe("resolveBeside", () => {
+  it("keeps a stored id that is still a card, on the side it was left", () => {
+    expect(resolveBeside("b", sessions, "a")).toEqual({ id: "b", side: "right" })
+    expect(resolveBeside("b@left", sessions, "a")).toEqual({ id: "b", side: "left" })
+  })
+
+  it("answers nothing when nothing is stored", () => {
+    expect(resolveBeside("", sessions, "a")).toEqual(NO_BESIDE)
+  })
+
+  // The four ways a session leaves the workspace — a close, a park, a worktree
+  // removal, an undone create — all end here, which is why the id is derived on
+  // read instead of maintained by each of them.
+  it("drops an id that is no longer in the project", () => {
+    expect(resolveBeside("gone", sessions, "a")).toEqual(NO_BESIDE)
+  })
+
+  it("drops an id that has become the active one", () => {
+    expect(resolveBeside("a", sessions, "a")).toEqual(NO_BESIDE)
+    expect(resolveBeside("a@left", sessions, "a")).toEqual(NO_BESIDE)
+  })
+})
+
+describe("besideCandidate", () => {
+  it("takes the next card in the project's own order", () => {
+    expect(besideCandidate(sessions, "a")).toBe("b")
+  })
+
+  it("wraps past the last card", () => {
+    expect(besideCandidate(sessions, "c")).toBe("a")
+  })
+
+  it("declines when there is nothing to put beside", () => {
+    expect(besideCandidate([session("a")], "a")).toBe("")
+    expect(besideCandidate([], "")).toBe("")
+  })
+
+  it("starts at the first card when the active one is not in the list", () => {
+    expect(besideCandidate(sessions, "gone")).toBe("a")
+  })
+})
+
+describe("dragRatio", () => {
+  it("moves the seam with the pointer", () => {
+    expect(dragRatio(0.5, 100, 200, 1000)).toBeCloseTo(0.6)
+    expect(dragRatio(0.5, 200, 100, 1000)).toBeCloseTo(0.4)
+  })
+
+  it("clamps a drag that would collapse a pane", () => {
+    expect(dragRatio(0.5, 0, 900, 1000)).toBe(RATIO_MAX)
+    expect(dragRatio(0.5, 900, 0, 1000)).toBe(RATIO_MIN)
+  })
+
+  it("holds the ratio when the container has no width to divide by", () => {
+    expect(dragRatio(0.5, 0, 400, 0)).toBe(0.5)
+  })
+})

--- a/frontend/src/lib/session/panes.test.ts
+++ b/frontend/src/lib/session/panes.test.ts
@@ -65,13 +65,14 @@ describe("fits", () => {
 
 describe("resolveStage", () => {
   it("answers the active session alone when nothing is stored", () => {
-    expect(resolveStage([], sessions, "a")).toEqual({ cells: ["a"], focus: 0 })
+    expect(resolveStage([], sessions, "a")).toEqual({ cells: ["a"], focus: 0, members: [] })
   })
 
   it("keeps the stored order and finds the focused cell in it", () => {
     expect(resolveStage(["a", "b", "c"], sessions, "b")).toEqual({
       cells: ["a", "b", "c"],
       focus: 1,
+      members: ["a", "b", "c"],
     })
   })
 
@@ -82,14 +83,21 @@ describe("resolveStage", () => {
     expect(resolveStage(["a", "gone", "b", "b"], sessions, "a")).toEqual({
       cells: ["a", "b"],
       focus: 0,
+      members: ["a", "b"],
     })
   })
 
   // The wall is a group the user assembled, so nothing but the add affordance
   // may put a session in it: activating one from outside shows that session
   // alone rather than editing an arrangement built on purpose.
-  it("shows a session from outside the wall on its own", () => {
-    expect(resolveStage(["a", "b", "c"], sessions, "d")).toEqual({ cells: ["d"], focus: 0 })
+  // The members survive it, which is what the sidebar's own block is built from:
+  // a wall you cannot see the membership of is one you rediscover by clicking.
+  it("shows a session from outside the wall on its own, and keeps the members", () => {
+    expect(resolveStage(["a", "b", "c"], sessions, "d")).toEqual({
+      cells: ["d"],
+      focus: 0,
+      members: ["a", "b", "c"],
+    })
   })
 
   // And parks rather than tears down — the stored cells are untouched, which is
@@ -97,7 +105,11 @@ describe("resolveStage", () => {
   it("brings the whole wall back when a member is activated again", () => {
     const stored = ["a", "b", "c"]
     expect(resolveStage(stored, sessions, "d").cells).toEqual(["d"])
-    expect(resolveStage(stored, sessions, "c")).toEqual({ cells: stored, focus: 2 })
+    expect(resolveStage(stored, sessions, "c")).toEqual({
+      cells: stored,
+      focus: 2,
+      members: stored,
+    })
   })
 })
 

--- a/frontend/src/lib/session/panes.test.ts
+++ b/frontend/src/lib/session/panes.test.ts
@@ -1,117 +1,196 @@
 import { describe, expect, it } from "vitest"
 import {
-  besideCandidate,
-  clampRatio,
-  dragRatio,
-  formatBeside,
-  NO_BESIDE,
-  parseBeside,
-  RATIO_MAX,
-  RATIO_MIN,
-  resolveBeside,
+  cellAt,
+  dragTrack,
+  fits,
+  grid,
+  MIN_PANE_WIDTH,
+  MIN_TRACK,
+  nextCandidate,
+  offsetOf,
+  resolveStage,
+  rowLength,
+  rowTracks,
+  swapCells,
+  tracks,
 } from "./panes"
 import type { Session } from "./sessions"
 
 const session = (id: string): Session => ({ id, label: id, kind: "claude" })
-const sessions = [session("a"), session("b"), session("c")]
+const sessions = [session("a"), session("b"), session("c"), session("d")]
 
-describe("clampRatio", () => {
-  it("passes a ratio inside the bounds through", () => {
-    expect(clampRatio(0.5)).toBe(0.5)
+// The two stages the layout is actually argued about: a laptop window with the
+// sidebar and the dock taking their share, and a 34" ultrawide.
+const LAPTOP = 900
+const ULTRAWIDE = 3100
+
+describe("grid", () => {
+  it("keeps one pane whole", () => {
+    expect(grid(1, LAPTOP)).toEqual({ cols: 1, rows: 1 })
   })
 
-  // The literals are pinned rather than derived from the constants: this is the
-  // boundary the readable-width argument bought, and a test that reads the
+  it("puts eight panes four across on an ultrawide and two across on a laptop", () => {
+    expect(grid(8, ULTRAWIDE)).toEqual({ cols: 4, rows: 2 })
+    expect(grid(8, LAPTOP)).toEqual({ cols: 2, rows: 4 })
+  })
+
+  it("splits two side by side on a laptop and stacks them on a narrow window", () => {
+    expect(grid(2, LAPTOP)).toEqual({ cols: 2, rows: 1 })
+    expect(grid(2, 700)).toEqual({ cols: 1, rows: 2 })
+  })
+
+  // The literal is pinned rather than derived from the constant: this width is
+  // the readability argument the whole layout rests on, and a test that read the
   // constant would follow it wherever it moved instead of noticing.
-  it("clamps either pane to a quarter of the stage", () => {
-    expect(clampRatio(0.1)).toBe(0.25)
-    expect(clampRatio(0.9)).toBe(0.75)
-    expect(RATIO_MIN).toBe(0.25)
-    expect(RATIO_MAX).toBe(0.75)
+  it("takes another row exactly when a pane would fall under the readable width", () => {
+    expect(MIN_PANE_WIDTH).toBe(420)
+    expect(grid(2, 840)).toEqual({ cols: 2, rows: 1 })
+    expect(grid(2, 839)).toEqual({ cols: 1, rows: 2 })
+  })
+
+  it("stacks when nothing fits side by side at all", () => {
+    expect(grid(3, 300)).toEqual({ cols: 1, rows: 3 })
   })
 })
 
-describe("parseBeside", () => {
-  it("reads a bare id as the right-hand pane", () => {
-    expect(parseBeside("b")).toEqual({ id: "b", side: "right" })
+describe("fits", () => {
+  it("allows another pane while they all stay readable", () => {
+    expect(fits(8, ULTRAWIDE, 800)).toBe(true)
   })
 
-  it("reads the stored side", () => {
-    expect(parseBeside("b@left")).toEqual({ id: "b", side: "left" })
-  })
-
-  // A pref must never be able to break a launch, so anything unrecognised reads
-  // as the default rather than as a third side.
-  it("answers the default for nothing and for a value it does not know", () => {
-    expect(parseBeside(null)).toEqual(NO_BESIDE)
-    expect(parseBeside("")).toEqual(NO_BESIDE)
-    expect(parseBeside("b@sideways")).toEqual({ id: "b", side: "right" })
-  })
-
-  it("round-trips through the stored form", () => {
-    for (const beside of [
-      { id: "b", side: "right" },
-      { id: "b", side: "left" },
-    ] as const) {
-      expect(parseBeside(formatBeside(beside))).toEqual(beside)
-    }
+  it("refuses one that would leave them too short", () => {
+    expect(fits(8, LAPTOP, 600)).toBe(false)
   })
 })
 
-describe("resolveBeside", () => {
-  it("keeps a stored id that is still a card, on the side it was left", () => {
-    expect(resolveBeside("b", sessions, "a")).toEqual({ id: "b", side: "right" })
-    expect(resolveBeside("b@left", sessions, "a")).toEqual({ id: "b", side: "left" })
+describe("resolveStage", () => {
+  it("answers the active session alone when nothing is stored", () => {
+    expect(resolveStage([], 0, sessions, "a")).toEqual({ cells: ["a"], focus: 0 })
   })
 
-  it("answers nothing when nothing is stored", () => {
-    expect(resolveBeside("", sessions, "a")).toEqual(NO_BESIDE)
+  it("keeps the stored order and finds the focused cell in it", () => {
+    expect(resolveStage(["a", "b", "c"], 0, sessions, "b")).toEqual({
+      cells: ["a", "b", "c"],
+      focus: 1,
+    })
   })
 
   // The four ways a session leaves the workspace — a close, a park, a worktree
-  // removal, an undone create — all end here, which is why the id is derived on
-  // read instead of maintained by each of them.
-  it("drops an id that is no longer in the project", () => {
-    expect(resolveBeside("gone", sessions, "a")).toEqual(NO_BESIDE)
+  // removal, an undone create — all end here, which is why the cells are derived
+  // on read instead of maintained by each of them.
+  it("drops cells whose session is gone, and duplicates", () => {
+    expect(resolveStage(["a", "gone", "b", "b"], 0, sessions, "a")).toEqual({
+      cells: ["a", "b"],
+      focus: 0,
+    })
   })
 
-  it("drops an id that has become the active one", () => {
-    expect(resolveBeside("a", sessions, "a")).toEqual(NO_BESIDE)
-    expect(resolveBeside("a@left", sessions, "a")).toEqual(NO_BESIDE)
-  })
-})
-
-describe("besideCandidate", () => {
-  it("takes the next card in the project's own order", () => {
-    expect(besideCandidate(sessions, "a")).toBe("b")
+  // This is what lets the palette, a session link and an MCP call all land in
+  // the pane the user was looking at without knowing the stage exists.
+  it("puts a session activated from elsewhere into the focused cell", () => {
+    expect(resolveStage(["a", "b", "c"], 2, sessions, "d")).toEqual({
+      cells: ["a", "b", "d"],
+      focus: 2,
+    })
   })
 
-  it("wraps past the last card", () => {
-    expect(besideCandidate(sessions, "c")).toBe("a")
-  })
-
-  it("declines when there is nothing to put beside", () => {
-    expect(besideCandidate([session("a")], "a")).toBe("")
-    expect(besideCandidate([], "")).toBe("")
-  })
-
-  it("starts at the first card when the active one is not in the list", () => {
-    expect(besideCandidate(sessions, "gone")).toBe("a")
+  it("clamps a stored focus that no longer names a cell", () => {
+    expect(resolveStage(["a", "b"], 9, sessions, "d")).toEqual({ cells: ["a", "d"], focus: 1 })
   })
 })
 
-describe("dragRatio", () => {
-  it("moves the seam with the pointer", () => {
-    expect(dragRatio(0.5, 100, 200, 1000)).toBeCloseTo(0.6)
-    expect(dragRatio(0.5, 200, 100, 1000)).toBeCloseTo(0.4)
+describe("cellAt / rowLength", () => {
+  it("fills rows left to right in list order", () => {
+    const layout = { cols: 4, rows: 2 }
+    expect(cellAt(0, layout)).toEqual({ col: 0, row: 0 })
+    expect(cellAt(4, layout)).toEqual({ col: 0, row: 1 })
+    expect(cellAt(7, layout)).toEqual({ col: 3, row: 1 })
   })
 
-  it("clamps a drag that would collapse a pane", () => {
-    expect(dragRatio(0.5, 0, 900, 1000)).toBe(RATIO_MAX)
-    expect(dragRatio(0.5, 900, 0, 1000)).toBe(RATIO_MIN)
+  it("reports a short last row", () => {
+    const layout = { cols: 4, rows: 2 }
+    expect(rowLength(0, 7, layout)).toBe(4)
+    expect(rowLength(1, 7, layout)).toBe(3)
+  })
+})
+
+describe("tracks", () => {
+  it("spreads equally when nothing usable is stored", () => {
+    expect(tracks([], 4)).toEqual([0.25, 0.25, 0.25, 0.25])
   })
 
-  it("holds the ratio when the container has no width to divide by", () => {
-    expect(dragRatio(0.5, 0, 400, 0)).toBe(0.5)
+  it("keeps a stored layout that still describes this many tracks", () => {
+    expect(tracks([0.6, 0.4], 2)).toEqual([0.6, 0.4])
+  })
+
+  // The grid reshapes whenever a pane is added or the window resizes, and a
+  // layout dragged for four columns says nothing about three.
+  it("falls back to equal when the stored layout is for another grid", () => {
+    expect(tracks([0.6, 0.4], 3)).toEqual([1 / 3, 1 / 3, 1 / 3])
+  })
+
+  it("refuses a stored layout that does not add up, or that hides a pane", () => {
+    expect(tracks([0.9, 0.9], 2)).toEqual([0.5, 0.5])
+    expect(tracks([0.99, 0.01], 2)).toEqual([0.5, 0.5])
+  })
+})
+
+describe("rowTracks", () => {
+  it("spreads a short row over the whole width", () => {
+    expect(rowTracks([0.4, 0.3, 0.3], 3)).toEqual([0.4, 0.3, 0.3])
+    const short = rowTracks([0.5, 0.25, 0.25], 2)
+    expect(short[0]).toBeCloseTo(2 / 3)
+    expect(short.reduce((sum, value) => sum + value, 0)).toBeCloseTo(1)
+  })
+})
+
+describe("offsetOf", () => {
+  it("measures a track's leading edge", () => {
+    expect(offsetOf([0.5, 0.25, 0.25], 0)).toBe(0)
+    expect(offsetOf([0.5, 0.25, 0.25], 2)).toBeCloseTo(0.75)
+  })
+})
+
+describe("dragTrack", () => {
+  it("takes from one track and gives to its neighbour", () => {
+    const next = dragTrack([0.5, 0.5], 0, 0.1)
+    expect(next[0]).toBeCloseTo(0.6)
+    expect(next[1]).toBeCloseTo(0.4)
+  })
+
+  it("never collapses a pane, so the session in it stays reachable", () => {
+    expect(dragTrack([0.5, 0.5], 0, -1)).toEqual([MIN_TRACK, 1 - MIN_TRACK])
+    expect(dragTrack([0.5, 0.5], 0, 1)).toEqual([1 - MIN_TRACK, MIN_TRACK])
+  })
+
+  it("leaves every other track alone", () => {
+    const next = dragTrack([0.25, 0.25, 0.5], 0, 0.05)
+    expect(next[2]).toBe(0.5)
+  })
+
+  it("ignores a boundary that is not between two tracks", () => {
+    expect(dragTrack([0.5, 0.5], 1, 0.1)).toEqual([0.5, 0.5])
+    expect(dragTrack([1], 0, 0.1)).toEqual([1])
+  })
+})
+
+describe("nextCandidate", () => {
+  it("takes the first card not already up", () => {
+    expect(nextCandidate(sessions, ["a", "c"])).toBe("b")
+  })
+
+  it("answers nothing when the whole project is on the stage", () => {
+    expect(nextCandidate(sessions, ["a", "b", "c", "d"])).toBe("")
+  })
+})
+
+describe("swapCells", () => {
+  it("trades two places", () => {
+    expect(swapCells(["a", "b", "c"], 0, 2)).toEqual(["c", "b", "a"])
+  })
+
+  it("leaves the list alone for a drop that goes nowhere", () => {
+    expect(swapCells(["a", "b"], 1, 1)).toEqual(["a", "b"])
+    expect(swapCells(["a", "b"], 0, 5)).toEqual(["a", "b"])
   })
 })

--- a/frontend/src/lib/session/panes.ts
+++ b/frontend/src/lib/session/panes.ts
@@ -1,0 +1,128 @@
+// Splitting the terminal area in two. The whole model is one sentence: a pane
+// is a viewport onto a card that already exists, never a session it owns.
+//
+// That is what makes this unlike a terminal emulator's split, where a pane *is*
+// a shell and closing it kills one. lich already has as many sessions as the
+// user wants and the sidebar is the multiplexer; the only thing a split buys is
+// seeing two of them at once. So the second pane holds a second session id and
+// nothing else — closing it closes no session, and every session it can show is
+// already a card.
+//
+// The focused pane is the project's active session, not a third piece of state.
+// Switching panes swaps which id is active and which is beside, so the footer,
+// the dock, the sidebar highlight and every card shortcut keep following
+// activeId exactly as they did before this existed.
+//
+// Which is why the stored id carries the *side* it sits on. Without it the lanes
+// would be read off the swap — the active session drawing left, the beside one
+// right — and focusing the right pane would fling its terminal across the stage
+// to take the left lane, with the other one sliding under the cursor to replace
+// it. The side is what holds both panes still while only the cursor moves.
+//
+// This file is the pure half — the reconciliation and the drag arithmetic. The
+// stored side is panes-store.ts.
+import type { Session } from "./sessions"
+
+/** How narrow either pane may be dragged. An agent TUI wants ~80 columns and
+ * the stage is what is left after the sidebar and the dock, so a quarter is
+ * already the point where the narrower pane stops being readable. */
+export const RATIO_MIN = 0.25
+export const RATIO_MAX = 0.75
+export const RATIO_DEFAULT = 0.5
+
+/** The beside session and the side it draws on, per project. The ratio is
+ * deliberately not per project:
+ * how wide the reader likes the second pane is a habit of theirs, the way the
+ * dock's source is (dock-prefs.ts), not a property of one checkout. */
+export const paneKey = (projectId: string): string => `lich.panes.${projectId}`
+export const RATIO_KEY = "lich.panes.ratio"
+
+export function clampRatio(ratio: number): number {
+  return Math.min(RATIO_MAX, Math.max(RATIO_MIN, ratio))
+}
+
+/** Which half of the stage the beside session draws on; the focused session
+ * takes the other. */
+export type Side = "left" | "right"
+
+export interface Beside {
+  id: string
+  side: Side
+}
+
+export const NO_BESIDE: Beside = { id: "", side: "right" }
+
+export const other = (side: Side): Side => (side === "left" ? "right" : "left")
+
+/** Stored as `<id>` or `<id>@left`. A bare id is the right-hand default, which
+ * is what "open beside" means before anything has been swapped — and what a
+ * value written by a build that predates sides reads as. */
+export function formatBeside(beside: Beside): string {
+  return beside.side === "left" ? `${beside.id}@left` : beside.id
+}
+
+export function parseBeside(raw: string | null): Beside {
+  if (!raw) {
+    return NO_BESIDE
+  }
+  const [id, side] = raw.split("@")
+  return { id, side: side === "left" ? "left" : "right" }
+}
+
+// resolveBeside is the one guard the whole feature needs against a stale id.
+//
+// The second pane is derived on every read rather than maintained on every
+// mutation: a session leaves the workspace through a close, a park, a worktree
+// removal and an undone create, and a field kept in step with all four is four
+// chances to leave a pane pointing at a dead id. Answering "is it still in the
+// list" at read time is right for every one of those paths, including the ones
+// added after this.
+//
+// An id equal to activeId resolves to nothing for the same reason: a swap
+// writes both halves and one card can never hold both panes, so the moment they
+// agree the split is over rather than showing the same terminal twice.
+export function resolveBeside(
+  stored: string,
+  sessions: readonly Session[],
+  activeId: string,
+): Beside {
+  const beside = parseBeside(stored)
+  if (!beside.id || beside.id === activeId) {
+    return NO_BESIDE
+  }
+  return sessions.some((session) => session.id === beside.id) ? beside : NO_BESIDE
+}
+
+// besideCandidate picks what the split shortcut opens beside the active session:
+// the next card in the project's own order, wrapping to the first. The sidebar's
+// order is the one the user arranged, so "the next one" is the one under the
+// card they are on rather than an id nobody can predict.
+//
+// Nothing to answer with — a project of one session — returns "", and the
+// shortcut then declines rather than splitting a pane against itself.
+export function besideCandidate(sessions: readonly Session[], activeId: string): string {
+  if (sessions.length < 2) {
+    return ""
+  }
+  const at = sessions.findIndex((session) => session.id === activeId)
+  if (at < 0) {
+    return sessions[0].id
+  }
+  return sessions[(at + 1) % sessions.length].id
+}
+
+// dragRatio resolves the split during a seam drag. Pixels in, ratio out: the
+// seam moves with the pointer, and the pane it is dragged into shrinks.
+// A container with no width yet (a drag that raced a layout) keeps the ratio it
+// started at rather than dividing by zero.
+export function dragRatio(
+  startRatio: number,
+  startX: number,
+  clientX: number,
+  containerWidth: number,
+): number {
+  if (containerWidth <= 0) {
+    return clampRatio(startRatio)
+  }
+  return clampRatio(startRatio + (clientX - startX) / containerWidth)
+}

--- a/frontend/src/lib/session/panes.ts
+++ b/frontend/src/lib/session/panes.ts
@@ -10,15 +10,22 @@
 // a card.
 //
 // The stage is an ordered list *including* the focused session, and the grid is
-// computed from how many cells there are and how wide the stage is. Two things
-// fall out of that, and both are the reason it is a list rather than a tree:
+// computed from how many cells there are and how wide the stage is. A cell's
+// place is its index, so moving the cursor between panes reorders nothing and no
+// terminal ever slides out from under it.
 //
-//   - a cell's place is its index, so moving the cursor between panes reorders
-//     nothing and no terminal ever slides out from under it;
-//   - the focused cell always draws activeId, so a session activated from
-//     anywhere — the sidebar, the palette, a link in another session's output,
-//     an MCP call — lands in the cell the user was looking at, and none of those
-//     paths has to know the stage exists.
+// What the list is, though, is a *group the user assembled*, and only the add
+// affordance puts a session in it. Activating something else — a card outside
+// the wall, a new session, a link in another session's output, an MCP call —
+// shows that session on its own and parks the wall where it is. It comes back
+// whole the moment any of its members is activated again. The alternative, and
+// what this first did, is to drop the newcomer into whichever cell held the
+// cursor: that turns every click in the sidebar into an edit of an arrangement
+// the user built on purpose.
+//
+// Which is also why nothing here remembers a focused index. The cursor is
+// activeId and its cell is wherever that id sits in the list, so the focus is
+// read rather than stored, and a stale one cannot outlive the cell it named.
 //
 // This file is the pure half: the reconciliation, the grid and the drag
 // arithmetic. The stored side is panes-store.ts.
@@ -36,7 +43,6 @@ export const MIN_PANE_HEIGHT = 160
 export const MIN_TRACK = 0.12
 
 export const stageKey = (projectId: string): string => `lich.panes.${projectId}`
-export const focusKey = (projectId: string): string => `lich.panes.${projectId}.focus`
 /** Track sizes are a habit rather than a property of one checkout, the way the
  * dock's source is (dock-prefs.ts), so they are not keyed by project. */
 export const COLS_KEY = "lich.panes.cols"
@@ -86,8 +92,8 @@ export function fits(count: number, width: number, height: number): boolean {
   return height / rows >= MIN_PANE_HEIGHT
 }
 
-// resolveStage reconciles the stored cells against the project as it is now, and
-// is the one guard the whole feature needs.
+// resolveStage answers what is on screen right now, and is the one guard the
+// whole feature needs.
 //
 // The cells are derived on every read rather than maintained on every mutation:
 // a session leaves the workspace through a close, a park, a worktree removal and
@@ -96,14 +102,13 @@ export function fits(count: number, width: number, height: number): boolean {
 // read time is right for every one of those paths, including the ones added
 // after this.
 //
-// Then the focused cell is made to agree with activeId — by moving the focus
-// when that session is already on the stage, and by replacing the focused cell's
-// occupant when it is not. That second case is what lets a card selected
-// anywhere in the app land in the pane the user was looking at, with the rest of
-// the wall untouched.
+// The active session decides whether the wall is up at all. Inside it, the wall
+// draws and that session's cell is the focused one. Outside it — a card the user
+// picked, a session just created, somewhere an MCP call sent them — the wall is
+// not torn down, it is simply not what is on screen; the stored cells are left
+// untouched, so activating any member brings the whole arrangement back.
 export function resolveStage(
   stored: readonly string[],
-  storedFocus: number,
   sessions: readonly Session[],
   activeId: string,
 ): Stage {
@@ -117,17 +122,8 @@ export function resolveStage(
   if (!activeId) {
     return { cells, focus: 0 }
   }
-  if (cells.length === 0) {
-    return { cells: [activeId], focus: 0 }
-  }
   const at = cells.indexOf(activeId)
-  if (at >= 0) {
-    return { cells, focus: at }
-  }
-  const focus = Math.min(Math.max(storedFocus, 0), cells.length - 1)
-  const replaced = [...cells]
-  replaced[focus] = activeId
-  return { cells: replaced, focus }
+  return at >= 0 ? { cells, focus: at } : { cells: [activeId], focus: 0 }
 }
 
 /** Where a cell sits in the grid. Rows fill left to right, in list order. */

--- a/frontend/src/lib/session/panes.ts
+++ b/frontend/src/lib/session/panes.ts
@@ -1,204 +1,186 @@
-// Splitting the terminal area into a wall of sessions. The whole model is one
-// sentence: a pane is a viewport onto a card that already exists, never a
-// session it owns.
+// Split groups: named walls of sessions the user assembles, several per project.
 //
-// That is what makes this unlike a terminal emulator's split, where a pane *is*
-// a shell and closing it kills one. lich already has as many sessions as the
-// user wants and the sidebar is the multiplexer; the only thing the stage buys
-// is seeing several of them at once. So a cell holds a session id and nothing
-// else — closing it closes no session, and every session it can show is already
-// a card.
+// The model is one sentence: a pane is a viewport onto a card that already
+// exists, never a session it owns. That is what makes this unlike a terminal
+// emulator's split, where a pane *is* a shell because there is nowhere else to
+// keep one — lich already has as many sessions as the user wants and the sidebar
+// is the multiplexer, so the only thing a wall buys is seeing several at once.
+// A pane's × stops showing a session and closes nothing.
 //
-// The stage is an ordered list *including* the focused session, and the grid is
-// computed from how many cells there are and how wide the stage is. A cell's
-// place is its index, so moving the cursor between panes reorders nothing and no
-// terminal ever slides out from under it.
+// A group is a thing the user made, not the current arrangement of the window.
+// It has a name, it survives its members being closed down to the last one, and
+// it ends only when they dissolve it or when nothing is left in it. Which is why
+// a project holds a list of them: an orchestrator and the three worktrees it
+// spawned are one group, the next investigation and its two are another, and
+// neither is "the" split.
 //
-// What the list is, though, is a *group the user assembled*, and only the add
-// affordance puts a session in it. Activating something else — a card outside
-// the wall, a new session, a link in another session's output, an MCP call —
-// shows that session on its own and parks the wall where it is. It comes back
-// whole the moment any of its members is activated again. The alternative, and
-// what this first did, is to drop the newcomer into whichever cell held the
-// cursor: that turns every click in the sidebar into an edit of an arrangement
-// the user built on purpose.
+// Two rules keep "which wall is on screen" from ever being ambiguous:
 //
-// Which is also why nothing here remembers a focused index. The cursor is
-// activeId and its cell is wherever that id sits in the list, so the focus is
-// read rather than stored, and a stale one cannot outlive the cell it named.
+//   - a session belongs to at most one group, so adding it to another moves it;
+//   - the group on screen is the one holding the active session, and none is
+//     when the active session is in no group. A session activated from anywhere
+//     — a card, the palette, a link in another session's output, an MCP call —
+//     therefore shows on its own and parks whatever wall was up, whole. Only the
+//     add affordance ever puts a session in a group.
 //
-// This file is the pure half: the reconciliation, the grid and the drag
-// arithmetic. The stored side is panes-store.ts.
+// Nothing here remembers a focused cell. The cursor is the active session and
+// its cell is wherever that id sits in the group, so focus is read rather than
+// stored and a stale one cannot outlive the cell it named.
 import type { Session } from "./sessions"
 
-// The narrowest a pane may be laid out before the grid takes another row, and
-// the shortest before the stage refuses to add one at all. Width is the binding
-// one: an agent TUI wraps its own output, and around fifty columns is where that
-// wrapping stops being readable rather than merely tight. Height only has to
-// keep a pane from becoming a caption.
-export const MIN_PANE_WIDTH = 420
-export const MIN_PANE_HEIGHT = 160
-
-/** The smallest share of an axis one row or column may be dragged down to. */
-export const MIN_TRACK = 0.12
-
-export const stageKey = (projectId: string): string => `lich.panes.${projectId}`
-/** Track sizes are a habit rather than a property of one checkout, the way the
- * dock's source is (dock-prefs.ts), so they are not keyed by project. */
-export const COLS_KEY = "lich.panes.cols"
-export const ROWS_KEY = "lich.panes.rows"
-
-export interface Grid {
-  cols: number
-  rows: number
-}
-
-export interface Stage {
-  /** Session ids, in the order they are laid out; always holds the focused one. */
+export interface PaneGroup {
+  /** Stable across renames and reorders: the sidebar keys its block, its fold
+   * and its drag off this, and a name the user can retype is none of those. */
+  id: string
+  name: string
+  /** Session ids, in the order they are laid out. */
   cells: string[]
-  /** Index of the cell drawing the active session. */
-  focus: number
-  /** The stored group, reconciled — every session the user put on the stage,
-   * whether or not it is what the window is showing. The sidebar marks these:
-   * a group nobody can see the membership of is one the user has to click
-   * around to rediscover, which is how it read before this existed. */
-  members: string[]
+  /** Column and row shares, belonging to the group rather than to the window:
+   * arranging one wall 60/40 must not carry into the next one. */
+  cols: number[]
+  rows: number[]
 }
 
-// grid picks the layout for a number of panes on a stage of this width: the
-// fewest rows that still leave every pane readable.
-//
-// It is the same arithmetic that used to argue for a hard cap of two, applied
-// continuously instead of frozen at one screen: a 3440px ultrawide fits four
-// across, so eight panes there land as 4×2, and the same eight on a laptop come
-// out 2×4. Nothing to configure, and the answer follows the window rather than a
-// number somebody typed once.
-export function grid(count: number, width: number): Grid {
-  if (count <= 1) {
-    return { cols: 1, rows: 1 }
+export const groupsKey = (projectId: string): string => `lich.panes.${projectId}`
+
+function numbers(value: unknown): number[] {
+  return Array.isArray(value) ? value.filter((n): n is number => typeof n === "number") : []
+}
+
+// parseGroups reads the stored value, and answers "no groups" for anything it
+// does not recognise. A pref must never be able to break a launch (prefs.ts), so
+// a truncated write, a value from another build, or hand-edited JSON costs the
+// user their arrangement and nothing else.
+export function parseGroups(raw: string | null): PaneGroup[] {
+  if (!raw) {
+    return []
   }
-  for (let rows = 1; rows <= count; rows++) {
-    const cols = Math.ceil(count / rows)
-    if (width / cols >= MIN_PANE_WIDTH) {
-      return { cols, rows }
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) {
+      return []
     }
+    return parsed.flatMap((value) => {
+      const group = value as Partial<PaneGroup>
+      if (typeof group?.id !== "string" || !Array.isArray(group.cells)) {
+        return []
+      }
+      return [
+        {
+          id: group.id,
+          name: typeof group.name === "string" ? group.name : "",
+          cells: group.cells.filter((id): id is string => typeof id === "string"),
+          cols: numbers(group.cols),
+          rows: numbers(group.rows),
+        },
+      ]
+    })
+  } catch {
+    return []
   }
-  // Nothing fits side by side — a very narrow window — so stack them and let
-  // the panes be as wide as the stage is.
-  return { cols: 1, rows: count }
 }
 
-// fits reports whether one more pane would still leave every one of them big
-// enough to read, which is what stops a held-down shortcut from tiling a project
-// into slivers. Height is the limit that bites here: the grid answers a narrow
-// stage by taking another row, and rows are what run out.
-export function fits(count: number, width: number, height: number): boolean {
-  const { rows } = grid(count, width)
-  return height / rows >= MIN_PANE_HEIGHT
+export function formatGroups(groups: readonly PaneGroup[]): string {
+  return JSON.stringify(groups)
 }
 
-// resolveStage answers what is on screen right now, and is the one guard the
-// whole feature needs.
+// resolveGroups reconciles what is stored against the project as it is now, and
+// is the one guard the whole feature needs.
 //
-// The cells are derived on every read rather than maintained on every mutation:
+// Membership is derived on every read rather than maintained on every mutation:
 // a session leaves the workspace through a close, a park, a worktree removal and
 // an undone create, and a list kept in step with all four is four chances to
 // leave a pane pointing at a dead id. Answering "is it still in the list" at
 // read time is right for every one of those paths, including the ones added
-// after this.
+// after this. The same pass enforces the one-group rule, so a stored value that
+// somehow holds a session twice cannot put it on two walls.
 //
-// The active session decides whether the wall is up at all. Inside it, the wall
-// draws and that session's cell is the focused one. Outside it — a card the user
-// picked, a session just created, somewhere an MCP call sent them — the wall is
-// not torn down, it is simply not what is on screen; the stored cells are left
-// untouched, so activating any member brings the whole arrangement back.
-export function resolveStage(
-  stored: readonly string[],
+// A group of one survives: it is still something the user named and can add to.
+// A group of none does not — its last member is gone, so there is nothing left
+// for the name to be about.
+export function resolveGroups(
+  stored: readonly PaneGroup[],
   sessions: readonly Session[],
-  activeId: string,
-): Stage {
+): PaneGroup[] {
   const live = new Set(sessions.map((session) => session.id))
-  const cells: string[] = []
-  for (const id of stored) {
-    if (live.has(id) && !cells.includes(id)) {
-      cells.push(id)
+  const claimed = new Set<string>()
+  const groups: PaneGroup[] = []
+  for (const group of stored) {
+    const cells: string[] = []
+    for (const id of group.cells) {
+      if (live.has(id) && !claimed.has(id)) {
+        claimed.add(id)
+        cells.push(id)
+      }
+    }
+    if (cells.length > 0) {
+      groups.push({ ...group, cells })
     }
   }
-  if (!activeId) {
-    return { cells, focus: 0, members: cells }
-  }
-  const at = cells.indexOf(activeId)
-  return at >= 0
-    ? { cells, focus: at, members: cells }
-    : { cells: [activeId], focus: 0, members: cells }
+  return groups
 }
 
-/** Where a cell sits in the grid. Rows fill left to right, in list order. */
-export function cellAt(index: number, { cols }: Grid): { col: number; row: number } {
-  return { col: index % cols, row: Math.floor(index / cols) }
+/** The group a session belongs to, or null. */
+export function groupOf(groups: readonly PaneGroup[], sessionId: string): PaneGroup | null {
+  return groups.find((group) => group.cells.includes(sessionId)) ?? null
 }
 
-/** How many cells that row actually holds — the last one may be short. */
-export function rowLength(row: number, count: number, { cols }: Grid): number {
-  return Math.min(cols, count - row * cols)
+/** Every session on any wall — what the add shortcut must not offer again. */
+export function grouped(groups: readonly PaneGroup[]): Set<string> {
+  return new Set(groups.flatMap((group) => group.cells))
 }
 
-// tracks returns the share of an axis each row or column takes: the stored
-// fractions when they still describe this many tracks, and equal shares
-// otherwise. A stored vector of the wrong length is not an error — the grid
-// reshapes itself whenever a pane is added or the window is resized, and a
-// layout the user dragged for four columns says nothing about three.
-export function tracks(stored: readonly number[], count: number): number[] {
-  if (count <= 0) {
-    return []
-  }
-  const usable =
-    stored.length === count &&
-    stored.every((value) => Number.isFinite(value) && value >= MIN_TRACK) &&
-    Math.abs(stored.reduce((sum, value) => sum + value, 0) - 1) < 0.01
-  return usable ? [...stored] : Array.from({ length: count }, () => 1 / count)
+// defaultName is the label of the session the group was started from, which in
+// the flow this exists for is the orchestrator that spawned the rest. A name the
+// user can read beats "Split 2", and one they can retype beats a name lich
+// insists on.
+export function defaultName(sessions: readonly Session[], sessionId: string): string {
+  return sessions.find((session) => session.id === sessionId)?.label || "Split"
 }
 
-// rowTracks narrows the column shares to the cells a short last row has, kept
-// in proportion so a row of three under a grid of four spreads across the whole
-// width instead of leaving a gap where the fourth would have been.
-export function rowTracks(cols: readonly number[], length: number): number[] {
-  const used = cols.slice(0, length)
-  const total = used.reduce((sum, value) => sum + value, 0)
-  return total > 0 ? used.map((value) => value / total) : used
+/** Put a session on a wall, taking it off whatever wall had it. */
+export function addToGroup(
+  groups: readonly PaneGroup[],
+  groupId: string,
+  sessionId: string,
+): PaneGroup[] {
+  return groups
+    .map((group) =>
+      group.id === groupId
+        ? { ...group, cells: [...group.cells.filter((id) => id !== sessionId), sessionId] }
+        : { ...group, cells: group.cells.filter((id) => id !== sessionId) },
+    )
+    .filter((group) => group.cells.length > 0)
 }
 
-/** The offset of a track's leading edge, as a share of the axis. */
-export function offsetOf(tracks: readonly number[], index: number): number {
-  return tracks.slice(0, index).reduce((sum, value) => sum + value, 0)
+/** Take a session off whatever wall it is on. The group stays, even at one
+ * member; only its last member leaving ends it. */
+export function removeFromGroups(groups: readonly PaneGroup[], sessionId: string): PaneGroup[] {
+  return groups
+    .map((group) => ({ ...group, cells: group.cells.filter((id) => id !== sessionId) }))
+    .filter((group) => group.cells.length > 0)
 }
 
-// dragTrack moves the boundary between track `index` and the one after it,
-// taking from one and giving to the other so the axis still sums to one. Neither
-// may be pushed below MIN_TRACK, which is what keeps a drag from collapsing a
-// pane to nothing and stranding the session inside it.
-export function dragTrack(
-  start: readonly number[],
-  index: number,
-  delta: number,
-  min = MIN_TRACK,
-): number[] {
-  if (index < 0 || index >= start.length - 1) {
-    return [...start]
-  }
-  const pair = start[index] + start[index + 1]
-  const first = Math.min(pair - min, Math.max(min, start[index] + delta))
-  const next = [...start]
-  next[index] = first
-  next[index + 1] = pair - first
-  return next
+export function updateGroup(
+  groups: readonly PaneGroup[],
+  groupId: string,
+  change: Partial<Omit<PaneGroup, "id">>,
+): PaneGroup[] {
+  return groups.map((group) => (group.id === groupId ? { ...group, ...change } : group))
 }
 
-// nextCandidate picks what the split shortcut adds: the first card in the
-// project's own order that is not already on the stage. The sidebar's order is
-// the one the user arranged, so what arrives is the one they can predict.
-export function nextCandidate(sessions: readonly Session[], cells: readonly string[]): string {
-  return sessions.find((session) => !cells.includes(session.id))?.id ?? ""
+export function dissolveGroup(groups: readonly PaneGroup[], groupId: string): PaneGroup[] {
+  return groups.filter((group) => group.id !== groupId)
+}
+
+/** Reorder the groups themselves, which is what dragging their blocks does. */
+export function reorderGroups(groups: readonly PaneGroup[], ids: readonly string[]): PaneGroup[] {
+  const byId = new Map(groups.map((group) => [group.id, group]))
+  const moved = ids.flatMap((id) => byId.get(id) ?? [])
+  // Anything the drag did not name keeps its place, at the end rather than being
+  // dropped: an id set that raced a dissolve must not cost the user a group.
+  const named = new Set(ids)
+  return [...moved, ...groups.filter((group) => !named.has(group.id))]
 }
 
 /** Swap two cells — what a pane dropped on another one does. */
@@ -210,4 +192,14 @@ export function swapCells(cells: readonly string[], from: number, to: number): s
   next[from] = cells[to]
   next[to] = cells[from]
   return next
+}
+
+// nextCandidate picks what the add shortcut shows: the first card in the
+// project's own order that is on no wall at all. The sidebar's order is the one
+// the user arranged, so what arrives is the one they can predict, and skipping
+// what is already grouped keeps the shortcut from quietly moving one wall's
+// member onto another.
+export function nextCandidate(sessions: readonly Session[], groups: readonly PaneGroup[]): string {
+  const taken = grouped(groups)
+  return sessions.find((session) => !taken.has(session.id))?.id ?? ""
 }

--- a/frontend/src/lib/session/panes.ts
+++ b/frontend/src/lib/session/panes.ts
@@ -1,128 +1,210 @@
-// Splitting the terminal area in two. The whole model is one sentence: a pane
-// is a viewport onto a card that already exists, never a session it owns.
+// Splitting the terminal area into a wall of sessions. The whole model is one
+// sentence: a pane is a viewport onto a card that already exists, never a
+// session it owns.
 //
 // That is what makes this unlike a terminal emulator's split, where a pane *is*
 // a shell and closing it kills one. lich already has as many sessions as the
-// user wants and the sidebar is the multiplexer; the only thing a split buys is
-// seeing two of them at once. So the second pane holds a second session id and
-// nothing else — closing it closes no session, and every session it can show is
-// already a card.
+// user wants and the sidebar is the multiplexer; the only thing the stage buys
+// is seeing several of them at once. So a cell holds a session id and nothing
+// else — closing it closes no session, and every session it can show is already
+// a card.
 //
-// The focused pane is the project's active session, not a third piece of state.
-// Switching panes swaps which id is active and which is beside, so the footer,
-// the dock, the sidebar highlight and every card shortcut keep following
-// activeId exactly as they did before this existed.
+// The stage is an ordered list *including* the focused session, and the grid is
+// computed from how many cells there are and how wide the stage is. Two things
+// fall out of that, and both are the reason it is a list rather than a tree:
 //
-// Which is why the stored id carries the *side* it sits on. Without it the lanes
-// would be read off the swap — the active session drawing left, the beside one
-// right — and focusing the right pane would fling its terminal across the stage
-// to take the left lane, with the other one sliding under the cursor to replace
-// it. The side is what holds both panes still while only the cursor moves.
+//   - a cell's place is its index, so moving the cursor between panes reorders
+//     nothing and no terminal ever slides out from under it;
+//   - the focused cell always draws activeId, so a session activated from
+//     anywhere — the sidebar, the palette, a link in another session's output,
+//     an MCP call — lands in the cell the user was looking at, and none of those
+//     paths has to know the stage exists.
 //
-// This file is the pure half — the reconciliation and the drag arithmetic. The
-// stored side is panes-store.ts.
+// This file is the pure half: the reconciliation, the grid and the drag
+// arithmetic. The stored side is panes-store.ts.
 import type { Session } from "./sessions"
 
-/** How narrow either pane may be dragged. An agent TUI wants ~80 columns and
- * the stage is what is left after the sidebar and the dock, so a quarter is
- * already the point where the narrower pane stops being readable. */
-export const RATIO_MIN = 0.25
-export const RATIO_MAX = 0.75
-export const RATIO_DEFAULT = 0.5
+// The narrowest a pane may be laid out before the grid takes another row, and
+// the shortest before the stage refuses to add one at all. Width is the binding
+// one: an agent TUI wraps its own output, and around fifty columns is where that
+// wrapping stops being readable rather than merely tight. Height only has to
+// keep a pane from becoming a caption.
+export const MIN_PANE_WIDTH = 420
+export const MIN_PANE_HEIGHT = 160
 
-/** The beside session and the side it draws on, per project. The ratio is
- * deliberately not per project:
- * how wide the reader likes the second pane is a habit of theirs, the way the
- * dock's source is (dock-prefs.ts), not a property of one checkout. */
-export const paneKey = (projectId: string): string => `lich.panes.${projectId}`
-export const RATIO_KEY = "lich.panes.ratio"
+/** The smallest share of an axis one row or column may be dragged down to. */
+export const MIN_TRACK = 0.12
 
-export function clampRatio(ratio: number): number {
-  return Math.min(RATIO_MAX, Math.max(RATIO_MIN, ratio))
+export const stageKey = (projectId: string): string => `lich.panes.${projectId}`
+export const focusKey = (projectId: string): string => `lich.panes.${projectId}.focus`
+/** Track sizes are a habit rather than a property of one checkout, the way the
+ * dock's source is (dock-prefs.ts), so they are not keyed by project. */
+export const COLS_KEY = "lich.panes.cols"
+export const ROWS_KEY = "lich.panes.rows"
+
+export interface Grid {
+  cols: number
+  rows: number
 }
 
-/** Which half of the stage the beside session draws on; the focused session
- * takes the other. */
-export type Side = "left" | "right"
-
-export interface Beside {
-  id: string
-  side: Side
+export interface Stage {
+  /** Session ids, in the order they are laid out; always holds the focused one. */
+  cells: string[]
+  /** Index of the cell drawing the active session. */
+  focus: number
 }
 
-export const NO_BESIDE: Beside = { id: "", side: "right" }
-
-export const other = (side: Side): Side => (side === "left" ? "right" : "left")
-
-/** Stored as `<id>` or `<id>@left`. A bare id is the right-hand default, which
- * is what "open beside" means before anything has been swapped — and what a
- * value written by a build that predates sides reads as. */
-export function formatBeside(beside: Beside): string {
-  return beside.side === "left" ? `${beside.id}@left` : beside.id
-}
-
-export function parseBeside(raw: string | null): Beside {
-  if (!raw) {
-    return NO_BESIDE
+// grid picks the layout for a number of panes on a stage of this width: the
+// fewest rows that still leave every pane readable.
+//
+// It is the same arithmetic that used to argue for a hard cap of two, applied
+// continuously instead of frozen at one screen: a 3440px ultrawide fits four
+// across, so eight panes there land as 4×2, and the same eight on a laptop come
+// out 2×4. Nothing to configure, and the answer follows the window rather than a
+// number somebody typed once.
+export function grid(count: number, width: number): Grid {
+  if (count <= 1) {
+    return { cols: 1, rows: 1 }
   }
-  const [id, side] = raw.split("@")
-  return { id, side: side === "left" ? "left" : "right" }
+  for (let rows = 1; rows <= count; rows++) {
+    const cols = Math.ceil(count / rows)
+    if (width / cols >= MIN_PANE_WIDTH) {
+      return { cols, rows }
+    }
+  }
+  // Nothing fits side by side — a very narrow window — so stack them and let
+  // the panes be as wide as the stage is.
+  return { cols: 1, rows: count }
 }
 
-// resolveBeside is the one guard the whole feature needs against a stale id.
+// fits reports whether one more pane would still leave every one of them big
+// enough to read, which is what stops a held-down shortcut from tiling a project
+// into slivers. Height is the limit that bites here: the grid answers a narrow
+// stage by taking another row, and rows are what run out.
+export function fits(count: number, width: number, height: number): boolean {
+  const { rows } = grid(count, width)
+  return height / rows >= MIN_PANE_HEIGHT
+}
+
+// resolveStage reconciles the stored cells against the project as it is now, and
+// is the one guard the whole feature needs.
 //
-// The second pane is derived on every read rather than maintained on every
-// mutation: a session leaves the workspace through a close, a park, a worktree
-// removal and an undone create, and a field kept in step with all four is four
-// chances to leave a pane pointing at a dead id. Answering "is it still in the
-// list" at read time is right for every one of those paths, including the ones
-// added after this.
+// The cells are derived on every read rather than maintained on every mutation:
+// a session leaves the workspace through a close, a park, a worktree removal and
+// an undone create, and a list kept in step with all four is four chances to
+// leave a pane pointing at a dead id. Answering "is it still in the list" at
+// read time is right for every one of those paths, including the ones added
+// after this.
 //
-// An id equal to activeId resolves to nothing for the same reason: a swap
-// writes both halves and one card can never hold both panes, so the moment they
-// agree the split is over rather than showing the same terminal twice.
-export function resolveBeside(
-  stored: string,
+// Then the focused cell is made to agree with activeId — by moving the focus
+// when that session is already on the stage, and by replacing the focused cell's
+// occupant when it is not. That second case is what lets a card selected
+// anywhere in the app land in the pane the user was looking at, with the rest of
+// the wall untouched.
+export function resolveStage(
+  stored: readonly string[],
+  storedFocus: number,
   sessions: readonly Session[],
   activeId: string,
-): Beside {
-  const beside = parseBeside(stored)
-  if (!beside.id || beside.id === activeId) {
-    return NO_BESIDE
+): Stage {
+  const live = new Set(sessions.map((session) => session.id))
+  const cells: string[] = []
+  for (const id of stored) {
+    if (live.has(id) && !cells.includes(id)) {
+      cells.push(id)
+    }
   }
-  return sessions.some((session) => session.id === beside.id) ? beside : NO_BESIDE
+  if (!activeId) {
+    return { cells, focus: 0 }
+  }
+  if (cells.length === 0) {
+    return { cells: [activeId], focus: 0 }
+  }
+  const at = cells.indexOf(activeId)
+  if (at >= 0) {
+    return { cells, focus: at }
+  }
+  const focus = Math.min(Math.max(storedFocus, 0), cells.length - 1)
+  const replaced = [...cells]
+  replaced[focus] = activeId
+  return { cells: replaced, focus }
 }
 
-// besideCandidate picks what the split shortcut opens beside the active session:
-// the next card in the project's own order, wrapping to the first. The sidebar's
-// order is the one the user arranged, so "the next one" is the one under the
-// card they are on rather than an id nobody can predict.
-//
-// Nothing to answer with — a project of one session — returns "", and the
-// shortcut then declines rather than splitting a pane against itself.
-export function besideCandidate(sessions: readonly Session[], activeId: string): string {
-  if (sessions.length < 2) {
-    return ""
-  }
-  const at = sessions.findIndex((session) => session.id === activeId)
-  if (at < 0) {
-    return sessions[0].id
-  }
-  return sessions[(at + 1) % sessions.length].id
+/** Where a cell sits in the grid. Rows fill left to right, in list order. */
+export function cellAt(index: number, { cols }: Grid): { col: number; row: number } {
+  return { col: index % cols, row: Math.floor(index / cols) }
 }
 
-// dragRatio resolves the split during a seam drag. Pixels in, ratio out: the
-// seam moves with the pointer, and the pane it is dragged into shrinks.
-// A container with no width yet (a drag that raced a layout) keeps the ratio it
-// started at rather than dividing by zero.
-export function dragRatio(
-  startRatio: number,
-  startX: number,
-  clientX: number,
-  containerWidth: number,
-): number {
-  if (containerWidth <= 0) {
-    return clampRatio(startRatio)
+/** How many cells that row actually holds — the last one may be short. */
+export function rowLength(row: number, count: number, { cols }: Grid): number {
+  return Math.min(cols, count - row * cols)
+}
+
+// tracks returns the share of an axis each row or column takes: the stored
+// fractions when they still describe this many tracks, and equal shares
+// otherwise. A stored vector of the wrong length is not an error — the grid
+// reshapes itself whenever a pane is added or the window is resized, and a
+// layout the user dragged for four columns says nothing about three.
+export function tracks(stored: readonly number[], count: number): number[] {
+  if (count <= 0) {
+    return []
   }
-  return clampRatio(startRatio + (clientX - startX) / containerWidth)
+  const usable =
+    stored.length === count &&
+    stored.every((value) => Number.isFinite(value) && value >= MIN_TRACK) &&
+    Math.abs(stored.reduce((sum, value) => sum + value, 0) - 1) < 0.01
+  return usable ? [...stored] : Array.from({ length: count }, () => 1 / count)
+}
+
+// rowTracks narrows the column shares to the cells a short last row has, kept
+// in proportion so a row of three under a grid of four spreads across the whole
+// width instead of leaving a gap where the fourth would have been.
+export function rowTracks(cols: readonly number[], length: number): number[] {
+  const used = cols.slice(0, length)
+  const total = used.reduce((sum, value) => sum + value, 0)
+  return total > 0 ? used.map((value) => value / total) : used
+}
+
+/** The offset of a track's leading edge, as a share of the axis. */
+export function offsetOf(tracks: readonly number[], index: number): number {
+  return tracks.slice(0, index).reduce((sum, value) => sum + value, 0)
+}
+
+// dragTrack moves the boundary between track `index` and the one after it,
+// taking from one and giving to the other so the axis still sums to one. Neither
+// may be pushed below MIN_TRACK, which is what keeps a drag from collapsing a
+// pane to nothing and stranding the session inside it.
+export function dragTrack(
+  start: readonly number[],
+  index: number,
+  delta: number,
+  min = MIN_TRACK,
+): number[] {
+  if (index < 0 || index >= start.length - 1) {
+    return [...start]
+  }
+  const pair = start[index] + start[index + 1]
+  const first = Math.min(pair - min, Math.max(min, start[index] + delta))
+  const next = [...start]
+  next[index] = first
+  next[index + 1] = pair - first
+  return next
+}
+
+// nextCandidate picks what the split shortcut adds: the first card in the
+// project's own order that is not already on the stage. The sidebar's order is
+// the one the user arranged, so what arrives is the one they can predict.
+export function nextCandidate(sessions: readonly Session[], cells: readonly string[]): string {
+  return sessions.find((session) => !cells.includes(session.id))?.id ?? ""
+}
+
+/** Swap two cells — what a pane dropped on another one does. */
+export function swapCells(cells: readonly string[], from: number, to: number): string[] {
+  if (from === to || from < 0 || to < 0 || from >= cells.length || to >= cells.length) {
+    return [...cells]
+  }
+  const next = [...cells]
+  next[from] = cells[to]
+  next[to] = cells[from]
+  return next
 }

--- a/frontend/src/lib/session/panes.ts
+++ b/frontend/src/lib/session/panes.ts
@@ -125,6 +125,24 @@ export function groupOf(groups: readonly PaneGroup[], sessionId: string): PaneGr
   return groups.find((group) => group.cells.includes(sessionId)) ?? null
 }
 
+// movingFrom answers the one question adding a session has to ask first: is it
+// already on somebody else's wall? Taking it off that one is a change to an
+// arrangement the click was not aimed at, so it is the user's decision and not
+// lich's — the group it would leave is returned so they can be told which, and
+// whether losing this member ends it.
+//
+// One definition, because both halves need the same answer: the sidebar asks it
+// to raise the prompt, and `add` asks it to refuse until that prompt has been
+// answered. A caller that forgets to ask gets a no-op rather than a silent move.
+export function movingFrom(
+  groups: readonly PaneGroup[],
+  current: PaneGroup | null,
+  sessionId: string,
+): PaneGroup | null {
+  const held = groupOf(groups, sessionId)
+  return held && held !== current ? held : null
+}
+
 /** Every session on any wall — what the add shortcut must not offer again. */
 export function grouped(groups: readonly PaneGroup[]): Set<string> {
   return new Set(groups.flatMap((group) => group.cells))

--- a/frontend/src/lib/session/panes.ts
+++ b/frontend/src/lib/session/panes.ts
@@ -58,6 +58,11 @@ export interface Stage {
   cells: string[]
   /** Index of the cell drawing the active session. */
   focus: number
+  /** The stored group, reconciled — every session the user put on the stage,
+   * whether or not it is what the window is showing. The sidebar marks these:
+   * a group nobody can see the membership of is one the user has to click
+   * around to rediscover, which is how it read before this existed. */
+  members: string[]
 }
 
 // grid picks the layout for a number of panes on a stage of this width: the
@@ -120,10 +125,12 @@ export function resolveStage(
     }
   }
   if (!activeId) {
-    return { cells, focus: 0 }
+    return { cells, focus: 0, members: cells }
   }
   const at = cells.indexOf(activeId)
-  return at >= 0 ? { cells, focus: at } : { cells: [activeId], focus: 0 }
+  return at >= 0
+    ? { cells, focus: at, members: cells }
+    : { cells: [activeId], focus: 0, members: cells }
 }
 
 /** Where a cell sits in the grid. Rows fill left to right, in list order. */

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -27,6 +27,7 @@ import {
   setSessionEntrypoint,
   setSessionPinned,
   setSessionSandboxed,
+  delegatesOf,
   sidebarGroups,
   type Session,
   type SessionKind,
@@ -323,6 +324,37 @@ describe("reorderSessions", () => {
     const state = buildState(3)
     reorderSessions(state, P, ["s3", "s2", "s1"])
     expect(sessionsOf(state, P).map((s) => s.id)).toEqual(["s1", "s2", "s3"])
+  })
+})
+
+describe("delegatesOf", () => {
+  const withOrigin = (state: SessionState, id: string, origin: string): SessionState => ({
+    ...state,
+    [P]: {
+      ...state[P],
+      sessions: state[P].sessions.map((s) => (s.id === id ? { ...s, originSessionId: origin } : s)),
+    },
+  })
+
+  it("answers the sessions this one handed work to, in the project's order", () => {
+    let state = buildState(4)
+    state = withOrigin(state, "s3", "s1")
+    state = withOrigin(state, "s2", "s1")
+    expect(delegatesOf(state, P, "s1").map((s) => s.id)).toEqual(["s2", "s3"])
+  })
+
+  // Direct delegates only: a grandchild is downstream of one the user watched
+  // being spawned, not one this session made.
+  it("does not walk past the sessions it made itself", () => {
+    let state = buildState(3)
+    state = withOrigin(state, "s2", "s1")
+    state = withOrigin(state, "s3", "s2")
+    expect(delegatesOf(state, P, "s1").map((s) => s.id)).toEqual(["s2"])
+  })
+
+  it("answers nothing for a session nobody was delegated from", () => {
+    expect(delegatesOf(buildState(2), P, "s1")).toEqual([])
+    expect(delegatesOf(buildState(2), P, "")).toEqual([])
   })
 })
 

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -28,7 +28,6 @@ import {
   setSessionPinned,
   setSessionSandboxed,
   sidebarGroups,
-  STAGE_GROUP_KEY,
   type Session,
   type SessionKind,
   type SessionState,
@@ -330,6 +329,7 @@ describe("reorderSessions", () => {
 describe("sidebarGroups", () => {
   const ids = (groups: ReturnType<typeof sidebarGroups>) =>
     groups.map((group) => [group.key, group.sessions.map((s) => s.id)])
+  const wall = (id: string, cells: string[]) => ({ id, name: id, cells, cols: [], rows: [] })
 
   it("draws one block per worktree when nothing is pinned", () => {
     let state = addSession({}, P, "s1")
@@ -363,35 +363,44 @@ describe("sidebarGroups", () => {
     ])
   })
 
-  // The split's block answers the question the wall could not: which sessions
-  // are in it. It is built from the members, not from what is on screen, so it
-  // stands whether or not the wall is the thing being drawn.
-  it("lifts the split's sessions into a block above everything, in pane order", () => {
+  // The blocks answer the question a wall could not: which sessions are in it.
+  // They are built from the groups, not from what is on screen, so they stand
+  // whether or not any of those walls is the thing being drawn.
+  it("lifts each wall into a block above everything, in the order it was arranged", () => {
     let state = addSession({}, P, "s1")
     state = addSession(state, P, "a1", "claude", "/wt/a")
     state = addSession(state, P, "b1", "claude", "/wt/b")
-    expect(ids(sidebarGroups(sessionsOf(state, P), ["b1", "s1"]))).toEqual([
-      [STAGE_GROUP_KEY, ["b1", "s1"]],
+    expect(ids(sidebarGroups(sessionsOf(state, P), [wall("g1", ["b1", "s1"])]))).toEqual([
+      ["g1", ["b1", "s1"]],
       ["/wt/a", ["a1"]],
     ])
   })
 
-  it("draws the split above the pinned block and takes its cards out of it", () => {
+  // Several walls per project is the whole point: an orchestrator and the
+  // worktrees it spawned are one, the next investigation and its own another.
+  it("draws every wall, each as its own block", () => {
+    const state = buildState(4)
+    expect(
+      ids(sidebarGroups(sessionsOf(state, P), [wall("g1", ["s1", "s2"]), wall("g2", ["s3"])])),
+    ).toEqual([
+      ["g1", ["s1", "s2"]],
+      ["g2", ["s3"]],
+      [ROOT_GROUP_KEY, ["s4"]],
+    ])
+  })
+
+  it("draws the walls above the pinned block and takes their cards out of it", () => {
     let state = setSessionPinned(buildState(3), P, "s1", true)
     state = setSessionPinned(state, P, "s2", true)
-    expect(ids(sidebarGroups(sessionsOf(state, P), ["s2", "s3"]))).toEqual([
-      [STAGE_GROUP_KEY, ["s2", "s3"]],
+    expect(ids(sidebarGroups(sessionsOf(state, P), [wall("g1", ["s2", "s3"])]))).toEqual([
+      ["g1", ["s2", "s3"]],
       [PINNED_GROUP_KEY, ["s1"]],
     ])
   })
 
-  // One pane is no split, and a member whose session is gone is not one either.
-  it("draws no split block for fewer than two live members", () => {
+  it("draws no block for a wall with nothing live left in it", () => {
     const state = buildState(2)
-    expect(ids(sidebarGroups(sessionsOf(state, P), ["s1"]))).toEqual([
-      [ROOT_GROUP_KEY, ["s1", "s2"]],
-    ])
-    expect(ids(sidebarGroups(sessionsOf(state, P), ["s1", "gone"]))).toEqual([
+    expect(ids(sidebarGroups(sessionsOf(state, P), [wall("g1", ["gone"])]))).toEqual([
       [ROOT_GROUP_KEY, ["s1", "s2"]],
     ])
   })

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -28,6 +28,7 @@ import {
   setSessionPinned,
   setSessionSandboxed,
   sidebarGroups,
+  STAGE_GROUP_KEY,
   type Session,
   type SessionKind,
   type SessionState,
@@ -359,6 +360,39 @@ describe("sidebarGroups", () => {
       [PINNED_GROUP_KEY, ["a1"]],
       [ROOT_GROUP_KEY, ["s1"]],
       ["/wt/b", ["b1"]],
+    ])
+  })
+
+  // The split's block answers the question the wall could not: which sessions
+  // are in it. It is built from the members, not from what is on screen, so it
+  // stands whether or not the wall is the thing being drawn.
+  it("lifts the split's sessions into a block above everything, in pane order", () => {
+    let state = addSession({}, P, "s1")
+    state = addSession(state, P, "a1", "claude", "/wt/a")
+    state = addSession(state, P, "b1", "claude", "/wt/b")
+    expect(ids(sidebarGroups(sessionsOf(state, P), ["b1", "s1"]))).toEqual([
+      [STAGE_GROUP_KEY, ["b1", "s1"]],
+      ["/wt/a", ["a1"]],
+    ])
+  })
+
+  it("draws the split above the pinned block and takes its cards out of it", () => {
+    let state = setSessionPinned(buildState(3), P, "s1", true)
+    state = setSessionPinned(state, P, "s2", true)
+    expect(ids(sidebarGroups(sessionsOf(state, P), ["s2", "s3"]))).toEqual([
+      [STAGE_GROUP_KEY, ["s2", "s3"]],
+      [PINNED_GROUP_KEY, ["s1"]],
+    ])
+  })
+
+  // One pane is no split, and a member whose session is gone is not one either.
+  it("draws no split block for fewer than two live members", () => {
+    const state = buildState(2)
+    expect(ids(sidebarGroups(sessionsOf(state, P), ["s1"]))).toEqual([
+      [ROOT_GROUP_KEY, ["s1", "s2"]],
+    ])
+    expect(ids(sidebarGroups(sessionsOf(state, P), ["s1", "gone"]))).toEqual([
+      [ROOT_GROUP_KEY, ["s1", "s2"]],
     ])
   })
 

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -328,39 +328,77 @@ export function setSessionEntrypoint(
 // collide with no worktree — those paths are absolute.
 export const PINNED_GROUP_KEY = "__pinned__"
 
-// One block of the sidebar: the pinned sessions, or one worktree's.
+// The split's block, on the same footing and for the same reason: the sessions
+// on the stage come from any checkout, so no worktree path can collide with it.
+export const STAGE_GROUP_KEY = "__stage__"
+
+// One block of the sidebar: the split, the pinned sessions, or one worktree's.
 export interface SidebarGroup {
   key: string
   // True for the pinned block. It is not a checkout — no path of its own, no
   // pull request, and it never moves: it is always drawn first.
   pinned: boolean
+  // True for the split's block: the sessions the user put on the stage, drawn
+  // together at the top whether or not the wall is what the window is showing.
+  // Which is the whole point of it — membership was otherwise a thing you found
+  // out by clicking a card and watching four panes appear.
+  stage: boolean
   // The checkout root ("" for the project's own directory), empty for pinned.
   path: string
   sessions: Session[]
 }
 
 // sidebarGroups splits a project's sessions into the blocks the sidebar draws:
-// the pinned ones first, in one block of their own, then one block per worktree
-// in first-appearance order. Each block keeps the stored (drag) order inside.
+// the split's block first, then the pinned ones, then one block per worktree in
+// first-appearance order. Each block keeps the stored (drag) order inside —
+// except the split's, which keeps the order of the panes it draws.
 //
-// Pinning never rewrites the stored list — it only lifts a card into this first
-// block — which is what lets an unpinned session drop back among its old
-// neighbours instead of being stranded on top. The store hands that same order
-// back, so a reload draws what the pin did live.
-export function sidebarGroups(sessions: Session[]): SidebarGroup[] {
-  const groups: SidebarGroup[] = groupByWorktree(sessions.filter((s) => !s.pinned)).map(
-    (group) => ({
-      key: groupKey(group.path),
-      pinned: false,
-      path: group.path,
-      sessions: group.sessions,
-    }),
-  )
-  const pinned = sessions.filter((s) => s.pinned)
-  if (pinned.length === 0) {
-    return groups
+// Neither the split nor a pin rewrites the stored list; both only lift a card
+// into a block at the top, which is what lets a session dropped from either
+// land back among its old neighbours instead of being stranded. The store hands
+// that same order back, so a reload draws what the live change did.
+//
+// A session both pinned and on the stage is drawn in the split's block: the pin
+// promises the top of the list rather than one particular block, and it keeps
+// its own mark on the card either way.
+export function sidebarGroups(sessions: Session[], stage: readonly string[] = []): SidebarGroup[] {
+  const staged = stage
+    .map((id) => sessions.find((session) => session.id === id))
+    .filter((session): session is Session => !!session)
+  // One pane is no split, so it earns no block — and its session must stay in
+  // the worktree block it came from rather than being lifted out of the sidebar
+  // into a block nothing draws.
+  const drawStage = staged.length > 1
+  const onStage = new Set(drawStage ? staged.map((session) => session.id) : [])
+  const rest = sessions.filter((session) => !onStage.has(session.id))
+
+  const groups: SidebarGroup[] = groupByWorktree(rest.filter((s) => !s.pinned)).map((group) => ({
+    key: groupKey(group.path),
+    pinned: false,
+    stage: false,
+    path: group.path,
+    sessions: group.sessions,
+  }))
+  const pinned = rest.filter((s) => s.pinned)
+  if (pinned.length > 0) {
+    groups.unshift({
+      key: PINNED_GROUP_KEY,
+      pinned: true,
+      stage: false,
+      path: "",
+      sessions: pinned,
+    })
   }
-  return [{ key: PINNED_GROUP_KEY, pinned: true, path: "", sessions: pinned }, ...groups]
+  if (drawStage) {
+    groups.unshift({
+      key: STAGE_GROUP_KEY,
+      pinned: false,
+      stage: true,
+      path: "",
+      sessions: staged,
+    })
+  }
+  return groups
 }
 
 // reorderSubset returns the full id order that hands `ids` to the sessions the
@@ -389,15 +427,18 @@ export function reorderSubset(
 // The order is the grouped one, not the stored flat list: a session opened in
 // the project root after a worktree one sits between its own group's cards in
 // the state and under them on screen, so walking the flat list would jump a
-// divider and come back. Pinned cards are walked where they are drawn — in the
-// block at the top, not in the worktree they belong to.
+// divider and come back. Pinned cards, and the split's, are walked where they
+// are drawn — in the block at the top, not in the worktree they belong to.
 export function neighborSessionId(
   state: SessionState,
   projectId: string,
   sessionId: string,
   step: 1 | -1,
+  stage: readonly string[] = [],
 ): string {
-  const sessions = sidebarGroups(sessionsOf(state, projectId)).flatMap((group) => group.sessions)
+  const sessions = sidebarGroups(sessionsOf(state, projectId), stage).flatMap(
+    (group) => group.sessions,
+  )
   if (sessions.length < 2) {
     return ""
   }

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -639,6 +639,22 @@ export function sessionOrigin(state: SessionState, session: Session): string {
   return parent?.label ?? session.originLabel ?? ""
 }
 
+// delegatesOf returns the sessions this one handed work to, in the project's own
+// order. Direct delegates only: `originSessionId` records who asked, and walking
+// the chain further would gather grandchildren the user never watched being
+// spawned — "its delegates" is the ones it made, not everything downstream of
+// them.
+//
+// Scoped to one project, unlike sessionOrigin: a wall draws sessions of the
+// project it belongs to, so a delegate in another project is not something the
+// stage could show even if the delegation crossed over.
+export function delegatesOf(state: SessionState, projectId: string, sessionId: string): Session[] {
+  if (!sessionId) {
+    return []
+  }
+  return sessionsOf(state, projectId).filter((session) => session.originSessionId === sessionId)
+}
+
 export function activeSessionId(state: SessionState, projectId: string): string {
   return state[projectId]?.activeId ?? ""
 }

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -7,6 +7,7 @@
 // input — which keeps the reducer logic testable without React or a PTY.
 
 import { applyOrder } from "@/lib/reorder"
+import type { PaneGroup } from "./panes"
 
 // Provider ids that can back a session, mirrored from internal/providers.Registry
 // (Go) — keep in sync. A session's kind is one of these or the plain shell.
@@ -328,77 +329,72 @@ export function setSessionEntrypoint(
 // collide with no worktree — those paths are absolute.
 export const PINNED_GROUP_KEY = "__pinned__"
 
-// The split's block, on the same footing and for the same reason: the sessions
-// on the stage come from any checkout, so no worktree path can collide with it.
-export const STAGE_GROUP_KEY = "__stage__"
-
-// One block of the sidebar: the split, the pinned sessions, or one worktree's.
+// One block of the sidebar: a split group, the pinned sessions, or one
+// worktree's.
 export interface SidebarGroup {
   key: string
   // True for the pinned block. It is not a checkout — no path of its own, no
-  // pull request, and it never moves: it is always drawn first.
+  // pull request — and it never moves among the others.
   pinned: boolean
-  // True for the split's block: the sessions the user put on the stage, drawn
-  // together at the top whether or not the wall is what the window is showing.
-  // Which is the whole point of it — membership was otherwise a thing you found
-  // out by clicking a card and watching four panes appear.
-  stage: boolean
-  // The checkout root ("" for the project's own directory), empty for pinned.
+  // The split group this block draws, or null. Its sessions come from any
+  // checkout, so it is keyed by the group's own id and can collide with no
+  // worktree path. A project has as many of these as the user has made, drawn
+  // above everything else in the order they arranged.
+  stage: PaneGroup | null
+  // The checkout root ("" for the project's own directory), empty for the
+  // gathered blocks.
   path: string
   sessions: Session[]
 }
 
 // sidebarGroups splits a project's sessions into the blocks the sidebar draws:
-// the split's block first, then the pinned ones, then one block per worktree in
-// first-appearance order. Each block keeps the stored (drag) order inside —
-// except the split's, which keeps the order of the panes it draws.
+// the split groups first in the order the user arranged them, then the pinned
+// ones, then one block per worktree in first-appearance order. Each block keeps
+// the stored (drag) order inside — except a split's, which keeps the order of
+// the panes it draws.
 //
-// Neither the split nor a pin rewrites the stored list; both only lift a card
-// into a block at the top, which is what lets a session dropped from either
-// land back among its old neighbours instead of being stranded. The store hands
-// that same order back, so a reload draws what the live change did.
+// Neither a split nor a pin rewrites the stored session list; both only lift a
+// card into a block above, which is what lets a session dropped from either land
+// back among its old neighbours instead of being stranded. The store hands that
+// same order back, so a reload draws what the live change did.
 //
-// A session both pinned and on the stage is drawn in the split's block: the pin
-// promises the top of the list rather than one particular block, and it keeps
-// its own mark on the card either way.
-export function sidebarGroups(sessions: Session[], stage: readonly string[] = []): SidebarGroup[] {
-  const staged = stage
-    .map((id) => sessions.find((session) => session.id === id))
-    .filter((session): session is Session => !!session)
-  // One pane is no split, so it earns no block — and its session must stay in
-  // the worktree block it came from rather than being lifted out of the sidebar
-  // into a block nothing draws.
-  const drawStage = staged.length > 1
-  const onStage = new Set(drawStage ? staged.map((session) => session.id) : [])
-  const rest = sessions.filter((session) => !onStage.has(session.id))
+// A session both pinned and on a wall is drawn in the wall's block: the pin
+// promises the top of the list rather than one particular header, and the card
+// keeps its own mark either way. A group whose sessions are all gone draws
+// nothing — resolveGroups has already dropped it from what is stored.
+export function sidebarGroups(
+  sessions: Session[],
+  stage: readonly PaneGroup[] = [],
+): SidebarGroup[] {
+  const byId = new Map(sessions.map((session) => [session.id, session]))
+  const blocks: SidebarGroup[] = []
+  const claimed = new Set<string>()
+  for (const group of stage) {
+    const members = group.cells.flatMap((id) => byId.get(id) ?? [])
+    if (members.length === 0) {
+      continue
+    }
+    for (const member of members) {
+      claimed.add(member.id)
+    }
+    blocks.push({ key: group.id, pinned: false, stage: group, path: "", sessions: members })
+  }
 
-  const groups: SidebarGroup[] = groupByWorktree(rest.filter((s) => !s.pinned)).map((group) => ({
-    key: groupKey(group.path),
-    pinned: false,
-    stage: false,
-    path: group.path,
-    sessions: group.sessions,
-  }))
+  const rest = sessions.filter((session) => !claimed.has(session.id))
   const pinned = rest.filter((s) => s.pinned)
   if (pinned.length > 0) {
-    groups.unshift({
-      key: PINNED_GROUP_KEY,
-      pinned: true,
-      stage: false,
-      path: "",
-      sessions: pinned,
-    })
+    blocks.push({ key: PINNED_GROUP_KEY, pinned: true, stage: null, path: "", sessions: pinned })
   }
-  if (drawStage) {
-    groups.unshift({
-      key: STAGE_GROUP_KEY,
+  for (const group of groupByWorktree(rest.filter((s) => !s.pinned))) {
+    blocks.push({
+      key: groupKey(group.path),
       pinned: false,
-      stage: true,
-      path: "",
-      sessions: staged,
+      stage: null,
+      path: group.path,
+      sessions: group.sessions,
     })
   }
-  return groups
+  return blocks
 }
 
 // reorderSubset returns the full id order that hands `ids` to the sessions the
@@ -434,7 +430,7 @@ export function neighborSessionId(
   projectId: string,
   sessionId: string,
   step: 1 | -1,
-  stage: readonly string[] = [],
+  stage: readonly PaneGroup[] = [],
 ): string {
   const sessions = sidebarGroups(sessionsOf(state, projectId), stage).flatMap(
     (group) => group.sessions,

--- a/frontend/src/lib/session/use-panes.ts
+++ b/frontend/src/lib/session/use-panes.ts
@@ -1,0 +1,71 @@
+import { useProjects } from "@/providers/projects"
+import { activeSessionId, sessionsOf } from "./sessions"
+import { besideCandidate, other, resolveBeside, type Side } from "./panes"
+import { closeBeside, openBeside, useStoredBeside } from "./panes-store"
+
+export interface Panes {
+  /** The session in the second pane, "" when the stage is not split. */
+  beside: string
+  /** Which half that session draws on; the focused one takes the other. */
+  besideSide: Side
+  split: boolean
+  /** Swap which pane holds the keyboard. */
+  focusOther: () => void
+  /** Drop the focused pane and keep the one beside it. */
+  promoteOther: () => void
+  /** Split with the next card, or close the split when there is one. False when
+   * the project has nothing to put beside — the shortcut then declines rather
+   * than splitting a pane against itself. */
+  toggle: () => boolean
+}
+
+// The one definition of what the panes do, shared by the stage that draws them
+// and the layout that binds their shortcuts. Both halves would otherwise carry
+// their own copy of the swap, which is the pair of writes most likely to drift:
+// focusing the other pane is *two* stores agreeing — the project's active
+// session and the beside id trade places — and a second implementation that
+// wrote only one of them would leave a card showing in both panes.
+export function usePanes(projectId: string): Panes {
+  const { sessions, activateSession } = useProjects()
+  const list = sessionsOf(sessions, projectId)
+  const activeId = activeSessionId(sessions, projectId)
+  const beside = resolveBeside(useStoredBeside(projectId), list, activeId)
+
+  return {
+    beside: beside.id,
+    besideSide: beside.side,
+    split: beside.id !== "",
+    // The two writes are one move: the session that was focused becomes the
+    // beside one *on the side it was already drawing on*, so the terminals hold
+    // still and only the cursor crosses over.
+    focusOther() {
+      if (!projectId || !beside.id) {
+        return
+      }
+      openBeside(projectId, { id: activeId, side: other(beside.side) })
+      activateSession(projectId, beside.id)
+    },
+    promoteOther() {
+      if (!projectId || !beside.id) {
+        return
+      }
+      activateSession(projectId, beside.id)
+      closeBeside(projectId)
+    },
+    toggle() {
+      if (!projectId) {
+        return false
+      }
+      if (beside.id) {
+        closeBeside(projectId)
+        return true
+      }
+      const next = besideCandidate(list, activeId)
+      if (!next) {
+        return false
+      }
+      openBeside(projectId, { id: next, side: "right" })
+      return true
+    },
+  }
+}

--- a/frontend/src/lib/session/use-panes.ts
+++ b/frontend/src/lib/session/use-panes.ts
@@ -1,107 +1,170 @@
 import { useProjects } from "@/providers/projects"
 import { activeSessionId, sessionsOf } from "./sessions"
-import { fits, nextCandidate, resolveStage, swapCells } from "./panes"
-import { stageSize, useStoredStage, writeStage } from "./panes-store"
+import {
+  addToGroup,
+  defaultName,
+  dissolveGroup,
+  groupOf,
+  nextCandidate,
+  type PaneGroup,
+  removeFromGroups,
+  resolveGroups,
+  swapCells,
+  updateGroup,
+} from "./panes"
+import { fits } from "./pane-grid"
+import { stageSize, useStoredGroups, writeGroups } from "./panes-store"
 
 export interface Panes {
-  /** Every session on the stage, whether or not the wall is what is on screen —
-   * what the sidebar marks. */
-  members: string[]
-  /** Session ids in layout order, always holding the focused one. */
+  /** Every wall in this project, reconciled, in the order the sidebar draws. */
+  groups: PaneGroup[]
+  /** The wall the active session belongs to, or null when it is on none. */
+  current: PaneGroup | null
+  /** Session ids the window is drawing, and where the cursor is among them. */
   cells: string[]
-  /** Index of the cell drawing the active session. */
   focus: number
   split: boolean
-  /** Move the cursor to a cell. */
+  /** Move the cursor to a cell of the wall on screen. */
   focusCell: (index: number) => void
   /** Move the cursor one cell along, wrapping. */
   focusStep: (step: number) => void
-  /** Show one more session — a named one, or the next card not already up.
-   * False when there is none left to show, or when one more would leave them
-   * all too small to read. */
+  /** Show one more session — a named one, or the next card on no wall. Adds to
+   * the wall the active session is on, or starts a new one around it. False when
+   * there is nothing left to show, or when one more would leave them all too
+   * small to read. */
   add: (sessionId?: string) => boolean
-  /** Stop showing the session in this cell. Never closes it. */
-  drop: (index: number) => void
-  /** Take a session off the stage by id — the card's own way off, which has to
-   * work while the wall is parked and there are no cells to index. */
+  /** Take a session off its wall. Never closes it. */
   remove: (sessionId: string) => void
-  /** Swap two cells, which is what a pane dropped on another one does. */
+  /** Take the session in this cell of the wall on screen off it. */
+  drop: (index: number) => void
+  /** Swap two cells of the wall on screen. */
   swap: (from: number, to: number) => void
+  /** Set a wall's whole pane order — what dragging its cards in the sidebar
+   * does, from the other end of the same arrangement. */
+  reorderCells: (groupId: string, ids: string[]) => void
+  rename: (groupId: string, name: string) => void
+  dissolve: (groupId: string) => void
+  /** Persist a wall's dragged column or row shares. */
+  setTracks: (groupId: string, change: { cols?: number[]; rows?: number[] }) => void
+  /** Reorder the walls themselves, which is what dragging their blocks does. */
+  reorder: (groups: PaneGroup[]) => void
 }
 
-// The one definition of what the stage does, shared by the terminals that draw
-// it and the layout that binds its shortcuts. Every move here is the same two
-// writes — the cells and which one holds the cursor — and a second copy of that
-// pair somewhere else is the thing most likely to drift.
+// The one definition of what the walls do, shared by the terminals that draw one
+// and the sidebar that lists them all. Every move is the same single write —
+// the whole list of groups — and a second copy of that anywhere else is the
+// thing most likely to drift.
 export function usePanes(projectId: string): Panes {
   const { sessions, activateSession } = useProjects()
   const list = sessionsOf(sessions, projectId)
   const activeId = activeSessionId(sessions, projectId)
-  const { cells, focus, members } = resolveStage(useStoredStage(projectId), list, activeId)
+  const groups = resolveGroups(useStoredGroups(projectId), list)
+  const current = activeId ? groupOf(groups, activeId) : null
+  const cells = current ? current.cells : activeId ? [activeId] : []
+  const focus = Math.max(cells.indexOf(activeId), 0)
 
-  // Moving the cursor is one write, and it is not to the stage: the focused cell
-  // is wherever the active session sits in the list, so activating that session
-  // is the whole move.
-  const focusCell = (index: number) => {
-    const id = cells[index]
-    if (!projectId || !id || index === focus) {
-      return
-    }
-    activateSession(projectId, id)
-  }
+  const commit = (next: PaneGroup[]) => writeGroups(projectId, next)
 
   const remove = (sessionId: string) => {
-    if (!projectId || !members.includes(sessionId)) {
+    const group = groupOf(groups, sessionId)
+    if (!projectId || !group) {
       return
     }
-    const next = members.filter((id) => id !== sessionId)
-    writeStage(projectId, next)
+    commit(removeFromGroups(groups, sessionId))
     // Taking away the pane that held the cursor hands it to what is still up,
     // rather than leaving the window on a session it no longer draws. Only when
-    // that pane *was* the cursor: removing a parked member changes nothing about
-    // what is on screen.
-    if (sessionId === activeId && next.length > 0) {
-      const at = members.indexOf(sessionId)
-      activateSession(projectId, next[Math.min(at, next.length - 1)])
+    // that pane *was* the cursor: removing a member of a parked wall changes
+    // nothing about what is on screen.
+    if (sessionId !== activeId) {
+      return
+    }
+    const rest = group.cells.filter((id) => id !== sessionId)
+    if (rest.length > 0) {
+      const at = group.cells.indexOf(sessionId)
+      activateSession(projectId, rest[Math.min(at, rest.length - 1)])
     }
   }
 
   return {
-    members,
+    groups,
+    current,
     cells,
     focus,
     split: cells.length > 1,
-    focusCell,
+    focusCell(index) {
+      const id = cells[index]
+      if (projectId && id && index !== focus) {
+        activateSession(projectId, id)
+      }
+    },
     focusStep(step) {
       if (cells.length < 2) {
         return
       }
-      focusCell((focus + step + cells.length) % cells.length)
+      const id = cells[(focus + step + cells.length) % cells.length]
+      if (projectId && id) {
+        activateSession(projectId, id)
+      }
     },
     add(sessionId) {
-      const id = sessionId ?? nextCandidate(list, cells)
+      const id = sessionId ?? nextCandidate(list, groups)
       const { width, height } = stageSize()
-      if (!projectId || !id || cells.includes(id)) {
+      if (!projectId || !id || id === activeId || !activeId) {
         return false
       }
       if (!fits(cells.length + 1, width, height)) {
         return false
       }
-      writeStage(projectId, [...cells, id])
+      if (current) {
+        commit(addToGroup(groups, current.id, id))
+        return true
+      }
+      // On no wall: this starts one, named after the session it grew from —
+      // which in the flow this exists for is the orchestrator that spawned the
+      // rest. It never replaces another group; the project keeps as many as the
+      // user makes.
+      const born: PaneGroup = {
+        id: newGroupId(),
+        name: defaultName(list, activeId),
+        cells: [activeId, id],
+        cols: [],
+        rows: [],
+      }
+      commit([...removeFromGroups(groups, id), born])
       return true
     },
+    remove,
     drop(index) {
       remove(cells[index] ?? "")
     },
-    remove,
     swap(from, to) {
-      if (!projectId || from === to) {
-        return
+      if (projectId && current && from !== to) {
+        commit(updateGroup(groups, current.id, { cells: swapCells(current.cells, from, to) }))
       }
-      // The cursor follows the pane it was in rather than the place it sat,
-      // which needs no move of its own: the focused cell is read from where the
-      // active session lands in the new order.
-      writeStage(projectId, swapCells(cells, from, to))
+    },
+    reorderCells(groupId, ids) {
+      commit(updateGroup(groups, groupId, { cells: ids }))
+    },
+    rename(groupId, name) {
+      const trimmed = name.trim()
+      if (projectId && trimmed) {
+        commit(updateGroup(groups, groupId, { name: trimmed }))
+      }
+    },
+    dissolve(groupId) {
+      commit(dissolveGroup(groups, groupId))
+    },
+    setTracks(groupId, change) {
+      commit(updateGroup(groups, groupId, change))
+    },
+    reorder(next) {
+      commit(next)
     },
   }
+}
+
+// Group ids only have to be unique inside one project's pref, and they are minted
+// where the impurity belongs — panes.ts stays a pure module the suite can drive.
+function newGroupId(): string {
+  return `g${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`
 }

--- a/frontend/src/lib/session/use-panes.ts
+++ b/frontend/src/lib/session/use-panes.ts
@@ -5,6 +5,7 @@ import {
   defaultName,
   dissolveGroup,
   groupOf,
+  movingFrom,
   nextCandidate,
   type PaneGroup,
   removeFromGroups,
@@ -30,9 +31,12 @@ export interface Panes {
   focusStep: (step: number) => void
   /** Show one more session — a named one, or the next card on no wall. Adds to
    * the wall the active session is on, or starts a new one around it. False when
-   * there is nothing left to show, or when one more would leave them all too
-   * small to read. */
-  add: (sessionId?: string) => boolean
+   * there is nothing left to show, when one more would leave them all too small
+   * to read, or when that session is on another wall and `move` was not asked
+   * for. That last refusal is the guard: taking a session off somebody else's
+   * arrangement is a decision for the user, so a caller has to have asked them
+   * first — one that forgets gets a no-op rather than a silent move. */
+  add: (sessionId?: string, opts?: { move?: boolean }) => boolean
   /** Take a session off its wall. Never closes it. */
   remove: (sessionId: string) => void
   /** Take the session in this cell of the wall on screen off it. */
@@ -106,10 +110,13 @@ export function usePanes(projectId: string): Panes {
         activateSession(projectId, id)
       }
     },
-    add(sessionId) {
+    add(sessionId, opts) {
       const id = sessionId ?? nextCandidate(list, groups)
       const { width, height } = stageSize()
       if (!projectId || !id || id === activeId || !activeId) {
+        return false
+      }
+      if (movingFrom(groups, current, id) && !opts?.move) {
         return false
       }
       if (!fits(cells.length + 1, width, height)) {

--- a/frontend/src/lib/session/use-panes.ts
+++ b/frontend/src/lib/session/use-panes.ts
@@ -1,71 +1,100 @@
 import { useProjects } from "@/providers/projects"
 import { activeSessionId, sessionsOf } from "./sessions"
-import { besideCandidate, other, resolveBeside, type Side } from "./panes"
-import { closeBeside, openBeside, useStoredBeside } from "./panes-store"
+import { fits, nextCandidate, resolveStage, swapCells } from "./panes"
+import { stageSize, useStoredFocus, useStoredStage, writeStage } from "./panes-store"
 
 export interface Panes {
-  /** The session in the second pane, "" when the stage is not split. */
-  beside: string
-  /** Which half that session draws on; the focused one takes the other. */
-  besideSide: Side
+  /** Session ids in layout order, always holding the focused one. */
+  cells: string[]
+  /** Index of the cell drawing the active session. */
+  focus: number
   split: boolean
-  /** Swap which pane holds the keyboard. */
-  focusOther: () => void
-  /** Drop the focused pane and keep the one beside it. */
-  promoteOther: () => void
-  /** Split with the next card, or close the split when there is one. False when
-   * the project has nothing to put beside — the shortcut then declines rather
-   * than splitting a pane against itself. */
-  toggle: () => boolean
+  /** Move the cursor to a cell. */
+  focusCell: (index: number) => void
+  /** Move the cursor one cell along, wrapping. */
+  focusStep: (step: number) => void
+  /** Show one more session — a named one, or the next card not already up.
+   * False when there is none left to show, or when one more would leave them
+   * all too small to read. */
+  add: (sessionId?: string) => boolean
+  /** Stop showing the session in this cell. Never closes it. */
+  drop: (index: number) => void
+  /** Swap two cells, which is what a pane dropped on another one does. */
+  swap: (from: number, to: number) => void
 }
 
-// The one definition of what the panes do, shared by the stage that draws them
-// and the layout that binds their shortcuts. Both halves would otherwise carry
-// their own copy of the swap, which is the pair of writes most likely to drift:
-// focusing the other pane is *two* stores agreeing — the project's active
-// session and the beside id trade places — and a second implementation that
-// wrote only one of them would leave a card showing in both panes.
+// The one definition of what the stage does, shared by the terminals that draw
+// it and the layout that binds its shortcuts. Every move here is the same two
+// writes — the cells and which one holds the cursor — and a second copy of that
+// pair somewhere else is the thing most likely to drift.
 export function usePanes(projectId: string): Panes {
   const { sessions, activateSession } = useProjects()
   const list = sessionsOf(sessions, projectId)
   const activeId = activeSessionId(sessions, projectId)
-  const beside = resolveBeside(useStoredBeside(projectId), list, activeId)
+  const { cells, focus } = resolveStage(
+    useStoredStage(projectId),
+    useStoredFocus(projectId),
+    list,
+    activeId,
+  )
+
+  // Focus is two writes that are one move: which cell holds the cursor, and the
+  // session that cell draws becoming the project's active one. Both, always —
+  // writing the index alone would leave the cursor on a cell that then repaints
+  // with somebody else's session in it.
+  const focusCell = (index: number) => {
+    const id = cells[index]
+    if (!projectId || !id || index === focus) {
+      return
+    }
+    writeStage(projectId, cells, index)
+    activateSession(projectId, id)
+  }
 
   return {
-    beside: beside.id,
-    besideSide: beside.side,
-    split: beside.id !== "",
-    // The two writes are one move: the session that was focused becomes the
-    // beside one *on the side it was already drawing on*, so the terminals hold
-    // still and only the cursor crosses over.
-    focusOther() {
-      if (!projectId || !beside.id) {
+    cells,
+    focus,
+    split: cells.length > 1,
+    focusCell,
+    focusStep(step) {
+      if (cells.length < 2) {
         return
       }
-      openBeside(projectId, { id: activeId, side: other(beside.side) })
-      activateSession(projectId, beside.id)
+      focusCell((focus + step + cells.length) % cells.length)
     },
-    promoteOther() {
-      if (!projectId || !beside.id) {
-        return
-      }
-      activateSession(projectId, beside.id)
-      closeBeside(projectId)
-    },
-    toggle() {
-      if (!projectId) {
+    add(sessionId) {
+      const id = sessionId ?? nextCandidate(list, cells)
+      const { width, height } = stageSize()
+      if (!projectId || !id || cells.includes(id)) {
         return false
       }
-      if (beside.id) {
-        closeBeside(projectId)
-        return true
-      }
-      const next = besideCandidate(list, activeId)
-      if (!next) {
+      if (!fits(cells.length + 1, width, height)) {
         return false
       }
-      openBeside(projectId, { id: next, side: "right" })
+      writeStage(projectId, [...cells, id], focus)
       return true
+    },
+    drop(index) {
+      if (!projectId || index < 0 || index >= cells.length) {
+        return
+      }
+      const rest = cells.filter((_, at) => at !== index)
+      // Dropping the focused pane hands the cursor to its neighbour rather than
+      // leaving the window on a session it no longer draws.
+      const next = Math.min(focus, rest.length - 1)
+      writeStage(projectId, rest, next)
+      if (index === focus && rest[next]) {
+        activateSession(projectId, rest[next])
+      }
+    },
+    swap(from, to) {
+      if (!projectId || from === to) {
+        return
+      }
+      const next = swapCells(cells, from, to)
+      // The cursor follows the pane it was in, not the place that pane sat.
+      const moved = focus === from ? to : focus === to ? from : focus
+      writeStage(projectId, next, moved)
     },
   }
 }

--- a/frontend/src/lib/session/use-panes.ts
+++ b/frontend/src/lib/session/use-panes.ts
@@ -1,7 +1,7 @@
 import { useProjects } from "@/providers/projects"
 import { activeSessionId, sessionsOf } from "./sessions"
 import { fits, nextCandidate, resolveStage, swapCells } from "./panes"
-import { stageSize, useStoredFocus, useStoredStage, writeStage } from "./panes-store"
+import { stageSize, useStoredStage, writeStage } from "./panes-store"
 
 export interface Panes {
   /** Session ids in layout order, always holding the focused one. */
@@ -31,23 +31,16 @@ export function usePanes(projectId: string): Panes {
   const { sessions, activateSession } = useProjects()
   const list = sessionsOf(sessions, projectId)
   const activeId = activeSessionId(sessions, projectId)
-  const { cells, focus } = resolveStage(
-    useStoredStage(projectId),
-    useStoredFocus(projectId),
-    list,
-    activeId,
-  )
+  const { cells, focus } = resolveStage(useStoredStage(projectId), list, activeId)
 
-  // Focus is two writes that are one move: which cell holds the cursor, and the
-  // session that cell draws becoming the project's active one. Both, always —
-  // writing the index alone would leave the cursor on a cell that then repaints
-  // with somebody else's session in it.
+  // Moving the cursor is one write, and it is not to the stage: the focused cell
+  // is wherever the active session sits in the list, so activating that session
+  // is the whole move.
   const focusCell = (index: number) => {
     const id = cells[index]
     if (!projectId || !id || index === focus) {
       return
     }
-    writeStage(projectId, cells, index)
     activateSession(projectId, id)
   }
 
@@ -71,7 +64,7 @@ export function usePanes(projectId: string): Panes {
       if (!fits(cells.length + 1, width, height)) {
         return false
       }
-      writeStage(projectId, [...cells, id], focus)
+      writeStage(projectId, [...cells, id])
       return true
     },
     drop(index) {
@@ -82,7 +75,7 @@ export function usePanes(projectId: string): Panes {
       // Dropping the focused pane hands the cursor to its neighbour rather than
       // leaving the window on a session it no longer draws.
       const next = Math.min(focus, rest.length - 1)
-      writeStage(projectId, rest, next)
+      writeStage(projectId, rest)
       if (index === focus && rest[next]) {
         activateSession(projectId, rest[next])
       }
@@ -91,10 +84,10 @@ export function usePanes(projectId: string): Panes {
       if (!projectId || from === to) {
         return
       }
-      const next = swapCells(cells, from, to)
-      // The cursor follows the pane it was in, not the place that pane sat.
-      const moved = focus === from ? to : focus === to ? from : focus
-      writeStage(projectId, next, moved)
+      // The cursor follows the pane it was in rather than the place it sat,
+      // which needs no move of its own: the focused cell is read from where the
+      // active session lands in the new order.
+      writeStage(projectId, swapCells(cells, from, to))
     },
   }
 }

--- a/frontend/src/lib/session/use-panes.ts
+++ b/frontend/src/lib/session/use-panes.ts
@@ -4,6 +4,9 @@ import { fits, nextCandidate, resolveStage, swapCells } from "./panes"
 import { stageSize, useStoredStage, writeStage } from "./panes-store"
 
 export interface Panes {
+  /** Every session on the stage, whether or not the wall is what is on screen —
+   * what the sidebar marks. */
+  members: string[]
   /** Session ids in layout order, always holding the focused one. */
   cells: string[]
   /** Index of the cell drawing the active session. */
@@ -19,6 +22,9 @@ export interface Panes {
   add: (sessionId?: string) => boolean
   /** Stop showing the session in this cell. Never closes it. */
   drop: (index: number) => void
+  /** Take a session off the stage by id — the card's own way off, which has to
+   * work while the wall is parked and there are no cells to index. */
+  remove: (sessionId: string) => void
   /** Swap two cells, which is what a pane dropped on another one does. */
   swap: (from: number, to: number) => void
 }
@@ -31,7 +37,7 @@ export function usePanes(projectId: string): Panes {
   const { sessions, activateSession } = useProjects()
   const list = sessionsOf(sessions, projectId)
   const activeId = activeSessionId(sessions, projectId)
-  const { cells, focus } = resolveStage(useStoredStage(projectId), list, activeId)
+  const { cells, focus, members } = resolveStage(useStoredStage(projectId), list, activeId)
 
   // Moving the cursor is one write, and it is not to the stage: the focused cell
   // is wherever the active session sits in the list, so activating that session
@@ -44,7 +50,24 @@ export function usePanes(projectId: string): Panes {
     activateSession(projectId, id)
   }
 
+  const remove = (sessionId: string) => {
+    if (!projectId || !members.includes(sessionId)) {
+      return
+    }
+    const next = members.filter((id) => id !== sessionId)
+    writeStage(projectId, next)
+    // Taking away the pane that held the cursor hands it to what is still up,
+    // rather than leaving the window on a session it no longer draws. Only when
+    // that pane *was* the cursor: removing a parked member changes nothing about
+    // what is on screen.
+    if (sessionId === activeId && next.length > 0) {
+      const at = members.indexOf(sessionId)
+      activateSession(projectId, next[Math.min(at, next.length - 1)])
+    }
+  }
+
   return {
+    members,
     cells,
     focus,
     split: cells.length > 1,
@@ -68,18 +91,9 @@ export function usePanes(projectId: string): Panes {
       return true
     },
     drop(index) {
-      if (!projectId || index < 0 || index >= cells.length) {
-        return
-      }
-      const rest = cells.filter((_, at) => at !== index)
-      // Dropping the focused pane hands the cursor to its neighbour rather than
-      // leaving the window on a session it no longer draws.
-      const next = Math.min(focus, rest.length - 1)
-      writeStage(projectId, rest)
-      if (index === focus && rest[next]) {
-        activateSession(projectId, rest[next])
-      }
+      remove(cells[index] ?? "")
     },
+    remove,
     swap(from, to) {
       if (!projectId || from === to) {
         return

--- a/frontend/src/lib/session/use-panes.ts
+++ b/frontend/src/lib/session/use-panes.ts
@@ -46,6 +46,11 @@ export interface Panes {
   /** Set a wall's whole pane order — what dragging its cards in the sidebar
    * does, from the other end of the same arrangement. */
   reorderCells: (groupId: string, ids: string[]) => void
+  /** Build a wall out of a session and the ones it delegated to. Answers how
+   * many of them were left where they were, which is what the caller says out
+   * loud — a delegate the user had already put on another wall is theirs, and
+   * taking it is the destructive reading of "group these". */
+  groupWith: (sessionId: string, delegateIds: readonly string[]) => number
   rename: (groupId: string, name: string) => void
   dissolve: (groupId: string) => void
   /** Persist a wall's dragged column or row shares. */
@@ -151,6 +156,25 @@ export function usePanes(projectId: string): Panes {
     },
     reorderCells(groupId, ids) {
       commit(updateGroup(groups, groupId, { cells: ids }))
+    },
+    groupWith(sessionId, delegateIds) {
+      const free = delegateIds.filter((id) => !groupOf(groups, id))
+      if (!projectId || free.length === 0) {
+        return delegateIds.length
+      }
+      const born: PaneGroup = {
+        id: newGroupId(),
+        name: defaultName(list, sessionId),
+        cells: [sessionId, ...free],
+        cols: [],
+        rows: [],
+      }
+      // The session this was asked of leaves whatever wall it was on: it is the
+      // subject of the action, not a bystander moved by it.
+      commit([...removeFromGroups(groups, sessionId), born])
+      // And the window goes there, or the wall is built out of sight.
+      activateSession(projectId, sessionId)
+      return delegateIds.length - free.length
     },
     rename(groupId, name) {
       const trimmed = name.trim()

--- a/frontend/src/lib/session/use-stage-size.ts
+++ b/frontend/src/lib/session/use-stage-size.ts
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from "react"
+import { setStageSize } from "./panes-store"
+
+export interface StageSize {
+  width: number
+  height: number
+}
+
+// The stage's own pixel size, which is what decides the grid: how many panes fit
+// across before the layout takes another row, and whether one more would leave
+// them too small to read at all.
+//
+// Measured rather than derived from the window, because the sidebar collapses,
+// the dock opens and both come out of the same width — a number computed from
+// the viewport would be wrong for most of the states the window is actually in.
+export function useStageSize(): [React.MutableRefObject<HTMLDivElement | null>, StageSize] {
+  const ref = useRef<HTMLDivElement | null>(null)
+  const [size, setSize] = useState<StageSize>({ width: 0, height: 0 })
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) {
+      return
+    }
+    const observer = new ResizeObserver(([entry]) => {
+      const { width, height } = entry.contentRect
+      // Rounded, so a fractional layout change cannot spin the grid between two
+      // answers; the thresholds it feeds are hundreds of pixels apart.
+      setStageSize(Math.round(width), Math.round(height))
+      setSize((current) =>
+        current.width === Math.round(width) && current.height === Math.round(height)
+          ? current
+          : { width: Math.round(width), height: Math.round(height) },
+      )
+    })
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+
+  return [ref, size]
+}

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -7,7 +7,7 @@ import type { ClosedSession, Project, RecentProject } from "@/lib/api-types"
 import type { StoredProject as StoreProject, StoredSession } from "@/lib/api-types"
 import { ProjectService, Store, System } from "@/lib/rpc"
 import { onAppEvent } from "@/lib/app-events"
-import { storedStage } from "@/lib/session/panes-store"
+import { storedGroups } from "@/lib/session/panes-store"
 import {
   activeSessionId,
   addSession,
@@ -577,7 +577,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       step,
       // The walk follows what the sidebar draws, and the split's block is drawn
       // first: without it the step would jump a divider and come back.
-      storedStage(activeProjectId),
+      storedGroups(activeProjectId),
     )
     if (target) {
       activateSession(activeProjectId, target)

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -7,6 +7,7 @@ import type { ClosedSession, Project, RecentProject } from "@/lib/api-types"
 import type { StoredProject as StoreProject, StoredSession } from "@/lib/api-types"
 import { ProjectService, Store, System } from "@/lib/rpc"
 import { onAppEvent } from "@/lib/app-events"
+import { storedStage } from "@/lib/session/panes-store"
 import {
   activeSessionId,
   addSession,
@@ -574,6 +575,9 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       activeProjectId,
       activeSessionId(current, activeProjectId),
       step,
+      // The walk follows what the sidebar draws, and the split's block is drawn
+      // first: without it the step would jump a divider and come back.
+      storedStage(activeProjectId),
     )
     if (target) {
       activateSession(activeProjectId, target)


### PR DESCRIPTION
Watching an agent meant watching nothing else. The sidebar says what every session is *doing*; exactly one of them ever showed what it was *saying*.

A card's menu now offers **Show beside**, which adds that session to the stage. `⌘⇧G` adds the next card, `⌘⇧F` moves the cursor along, clicking a pane focuses it, dragging a pane by its name swaps it with another, and the seams divide the space. The whole arrangement comes back the way you left it.

> **Shipped in this PR twice.** The first pass capped the stage at two panes, on the arithmetic below. Testing it on a 34" ultrawide showed the cap was the wrong output of the right rule — see *Why a grid*. The second commit removes the cap and keeps the rule.

## The one decision everything follows from

**A pane is a viewport onto a card, never a session it owns.** That is the difference from a terminal emulator's split, where a pane *is* a shell because there is nowhere else to keep one — lich already has as many sessions as you want, so the only thing the stage can add is seeing several at once. A pane's × stops showing a session and closes nothing; closing the session itself hands its room back to the rest.

**The stage is an ordered list that includes the focused session.** Two things fall out of that:

- a cell's place is its index, so moving the cursor between panes reorders nothing and no terminal slides out from under it;
- the focused cell always draws `activeId`, so a session activated from anywhere — the sidebar, the palette, a link in another session's output, an MCP call — lands in the cell the user was looking at, and **none of those paths had to learn that the stage exists**. The footer, the dock, the sidebar highlight and every card shortcut go on reading `activeId` unchanged.

## Why a grid, and why it computes itself

Eighty columns a pane; a stage of ~900px once the sidebar and the dock have taken theirs; therefore two. The arithmetic is right and it was run on one screen — a 34" ultrawide leaves ~3100px, which is four across with room to spare.

So the cap is gone and the rule stays, applied continuously: **the fewest rows that still leave every pane readable at the width the stage actually has.** Eight sessions land 4×2 on the ultrawide and 2×4 on a laptop; the same window reshapes when the sidebar collapses or the dock opens; and the pane that would fall under the readable size is refused rather than drawn, which is what stops a held-down shortcut from tiling a project into slivers. Nothing to configure.

## Derived, not synchronised

The cells are resolved from the stored ids on every read rather than kept in step by each path that removes a session. A close, a park, a worktree removal and an undone create all end at the same question, and answering *is this still in the list* once is right for the paths added after this too.

## Resizing

Columns are shared down the grid, so they are one vector of shares rather than a ratio per pane; rows are the other. A short last row spreads its cells over the whole width instead of leaving a gap. Sizes are stored for the grid they were dragged on and fall back to equal shares when the shape no longer matches — named in `docs/ceilings.md`, because it reads like a resize being forgotten.

## Shortcuts

Moved off `O` in the second commit: the note in `hotkeys.ts` lists it among the letters Chromium keeps for itself, and the comment the first commit added claimed the opposite two screens below the list saying so. `G` for the grid, `F` for the focus moving along it — `Ctrl+F` without Shift stays the terminal's find.

## Ceilings

Two bullets. The stage puts **every** pane on the coalescer's *visible* cadence — `SetVisible` had one true at a time until now, and a pane nobody demoted is the point of opening it. And the grid follows the window, so a dragged layout is restored only while its shape still matches; the cells and their order always survive, the sizes do not.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` — 2017 passed
- [x] `biome check` — 0 errors (17 warnings: the standing a11y backlog, the seams in the documented `role="separator"` category)
- [x] `vitest run` — 1276 passed in 110 files, cache cleared
- [x] `tsc` + `vite build` clean
- [x] `panes.test.ts` (28 cases) covers the grid on both screens, the readable-width boundary, the reconciliation, track fallback, the drag clamp and the swap
- [x] `render-budget.test.tsx` stubs the observer with a real stage size and pins that adding a pane mounts one terminal, remounts none, and draws two cells with a column seam
- [x] Hands-on: two panes, one session prompting another over MCP with both rendered
- [ ] Hands-on: a wall of 4+ on the ultrawide, drag to swap, drag both axes, close panes, close a session that is in one