### PR TITLE
fix(desktop): add generic name to desktop entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   leaves the checkout instead of following it. Links that stay inside the tree
   read exactly as before.
 
+- **The Linux launcher no longer says "lich" twice.** The packaged desktop entry
+  carried a name and nothing else, so an application menu with a second line to
+  print about an entry had nothing to put there and repeated the name as its own
+  description. It now carries both of the lines a menu may look for — what lich
+  is, and what it does — so it reads the way every other application on the
+  machine does.
+
 ## [0.42.0] - 2026-08-27
 
 ### Changed

--- a/build/linux/lich.desktop
+++ b/build/linux/lich.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=lich
+GenericName=Terminal-first coding agent harness
 Exec=lich
 Icon=lich
 Categories=Development;

--- a/build/linux/lich.desktop
+++ b/build/linux/lich.desktop
@@ -1,7 +1,8 @@
 [Desktop Entry]
 Type=Application
 Name=lich
-GenericName=Terminal-first coding agent harness
+GenericName=Coding Agent Harness
+Comment=Run and watch AI coding agents side by side
 Exec=lich
 Icon=lich
 Categories=Development;


### PR DESCRIPTION
Adds a generic name to the desktop entry so Linux application launchers don't display lich as both the application name and description.
<img width="610" height="197" alt="image" src="https://github.com/user-attachments/assets/26cddbb3-e057-4ed5-8c43-90d84ec3b6d1" />
<img width="604" height="195" alt="image" src="https://github.com/user-attachments/assets/3968fcbd-3ca7-4901-ac34-1f8f32e6de1c" />
