### PR TITLE
feat: read is_active and locked_reason off Claude's usage payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   terminals, whatever you had been reading there: its Settings, the pull request
   you had open, the list of them. Each tab now returns to the screen its project
   was last showing, and to its terminals only when that is where you were.
+- **Claude's plan gauge reads the window your account is actually locked to,
+  and says so when spending is blocked.** The footer used to guess which window
+  to show by picking whichever one read fullest; it now defers to the account's
+  own verdict on which window is binding, falling back to the fullest only when
+  the account carries no such verdict. A window your plan has locked past its
+  reset used to read as a bare, misleadingly spendable percentage — it now says
+  **Locked**, with the reason in a tooltip.
 
 ### Fixed
 

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -316,6 +316,21 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   those logins and never writes them: it does not refresh the token, so an expired one reads as signed out until
   the provider's own CLI rotates it. A reading is cached for five minutes because both endpoints rate-limit hard —
   the number on screen is up to that old, and nothing on it says so.
+- **Two more fields of Claude's usage payload are read no further than measuring them**
+  (`internal/quota/claude.go`, `limits[].severity` and the top-level `extra_usage`/`spend` blocks): every
+  `severity` observed on a live account reads `"normal"`, so its scale — what a non-normal value looks like,
+  whether it maps to a colour — is unknown, and swapping the local usage-based colour ramp (`usageColor`) for
+  it would be a guess dressed as a reading of the source. `extra_usage` and `spend` are the credits that cover
+  spend past a full window; both exist in the payload but come back entirely null/disabled on every account
+  measured, so their filled shape — what a partially-spent credit balance actually contains — cannot be built
+  against here. A gauge built on an unobserved shape is the same failure `is_active`/`locked_reason` fixed
+  around, repeated. The payload's top level is otherwise a graveyard of null codenames — `nimbus_quill`,
+  `tangelo`, `iguana_necktie`, `omelette_promotional`, `cinder_cove`, `amber_ladder`, `juniper_tide`,
+  `seven_day_omelette`, `seven_day_cowork` — every one of them unpopulated on every account measured, which is
+  the standing evidence that reading `limits[]` and silently skipping a kind lich has no name for is the right
+  default, not a gap to close. Codex's `wham` usage route carries no equivalent to any of this — no per-window
+  active flag, no lock reason, no credit block — so this ceiling is Claude-only by the shape of the payload,
+  not a choice.
 - **Which account a session spends is read from its process, and only Linux answers**
   (`internal/quota`, `internal/terminal/account.go`): the reading follows `/proc/<pid>/environ` of the process in
   the session's PTY, so a wrapper binary that exports a login of its own is seen only there. macOS could answer

--- a/frontend/src/components/QuotaGauge.tsx
+++ b/frontend/src/components/QuotaGauge.tsx
@@ -2,6 +2,7 @@ import type { QuotaWindow } from "@/lib/api-types"
 import { formatWindow, timeLeft } from "@/lib/quota/quota-format"
 import { cn } from "@/lib/utils"
 import { usageColor } from "./ContextRing"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 
 // Every column is fixed but the bar's. Sized to its own text, the readout gave a
 // window with no reset time the width the rows beside it spent on "6d 18h", and
@@ -39,6 +40,11 @@ export function QuotaGauge({ window: quota, now, stacked }: QuotaGaugeProps) {
       />
     </span>
   )
+  const reading = quota.lockedReason ? (
+    <LockedReading reason={quota.lockedReason} />
+  ) : (
+    `${quota.percent}%`
+  )
 
   if (stacked) {
     return (
@@ -46,7 +52,8 @@ export function QuotaGauge({ window: quota, now, stacked }: QuotaGaugeProps) {
         <div className="flex items-baseline justify-between gap-3">
           <span className="text-muted-foreground">{label}</span>
           <span className="tabular-nums">
-            {quota.percent}%{left && ` · ${left}`}
+            {reading}
+            {left && ` · ${left}`}
           </span>
         </div>
         {bar}
@@ -57,8 +64,26 @@ export function QuotaGauge({ window: quota, now, stacked }: QuotaGaugeProps) {
     <div className={cn(gaugeGrid, "text-xs", usageColor(quota.percent))}>
       <span className="truncate text-muted-foreground">{label}</span>
       {bar}
-      <span className="text-right tabular-nums">{quota.percent}%</span>
+      <span className="text-right tabular-nums">{reading}</span>
       <span className="text-right tabular-nums text-muted-foreground">{left}</span>
     </div>
+  )
+}
+
+// LockedReading replaces the bare percentage when the provider says a window
+// is locked regardless of how full it reads — the percentage alone would look
+// like headroom that spending cannot actually reach. The reason travels to a
+// tooltip rather than inline, since the provider's wording is not written for
+// the width a gauge row has.
+function LockedReading({ reason }: { reason: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger render={<span className="cursor-help underline decoration-dotted" />}>
+        Locked
+      </TooltipTrigger>
+      <TooltipContent side="top" className="border border-border bg-card text-foreground">
+        {reason}
+      </TooltipContent>
+    </Tooltip>
   )
 }

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -488,6 +488,12 @@ export interface QuotaWindow {
   seconds: number
   percent: number
   resetsAt?: string
+  /** The provider's own verdict on which window is binding, when it reports
+   * one at all — absent (false) means it didn't say. */
+  active?: boolean
+  /** Present only when the provider says this window is locked regardless of
+   * its percentage; the reason travels to the tooltip verbatim. */
+  lockedReason?: string
 }
 
 /** internal/quota.Plan — one provider's quota reading. Windows are empty for

--- a/frontend/src/lib/quota/quota-format.test.ts
+++ b/frontend/src/lib/quota/quota-format.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest"
 import type { QuotaPlan } from "@/lib/api-types"
 import { formatWindow, hottestWindow, shortWindow, timeLeft } from "./quota-format"
 
-const plan = (...windows: Array<{ label: string; percent: number }>): QuotaPlan => ({
+const plan = (
+  ...windows: Array<{ label: string; percent: number; active?: boolean }>
+): QuotaPlan => ({
   provider: "claude",
   name: "Claude Code",
   status: "ok",
@@ -22,6 +24,20 @@ describe("hottestWindow", () => {
       plan({ label: "Session", percent: 50 }, { label: "Weekly", percent: 50 }),
     )
     expect(got?.label).toBe("Session")
+  })
+
+  it("prefers the window the provider marks active over the fullest one", () => {
+    const got = hottestWindow(
+      plan({ label: "Session", percent: 4, active: true }, { label: "Weekly", percent: 84 }),
+    )
+    expect(got?.label).toBe("Session")
+  })
+
+  it("falls back to the fullest window when none is marked active", () => {
+    const got = hottestWindow(
+      plan({ label: "Session", percent: 4 }, { label: "Weekly", percent: 84 }),
+    )
+    expect(got?.label).toBe("Weekly")
   })
 
   it("is null for a plan with no windows", () => {

--- a/frontend/src/lib/quota/quota-format.ts
+++ b/frontend/src/lib/quota/quota-format.ts
@@ -3,13 +3,21 @@ import type { QuotaPlan, QuotaWindow } from "@/lib/api-types"
 const HOUR_S = 60 * 60
 const DAY_S = 24 * HOUR_S
 
-// hottestWindow is the window a plan is closest to spending — the one a single
-// readout has to show, because a weekly cap about to run out must not hide
-// behind a session window that just reset. Ties keep the first, which is the
-// order the provider reported. Null for a plan with no windows.
+// hottestWindow is the window a single readout has to show. The provider's own
+// `is_active` verdict wins when it names one — that is the window actually
+// binding the account, not a local guess — falling back to the window closest
+// to spent (so a weekly cap about to run out does not hide behind a session
+// window that just reset) when nothing is marked active, which is every
+// payload shape that carries no such verdict at all. Ties in the fallback keep
+// the first, the order the provider reported. Null for a plan with no windows.
 export function hottestWindow(plan: QuotaPlan): QuotaWindow | null {
+  const windows = plan.windows ?? []
+  const active = windows.find((window) => window.active)
+  if (active) {
+    return active
+  }
   let hottest: QuotaWindow | null = null
-  for (const window of plan.windows ?? []) {
+  for (const window of windows) {
     if (!hottest || window.percent > hottest.percent) {
       hottest = window
     }

--- a/internal/quota/claude.go
+++ b/internal/quota/claude.go
@@ -86,14 +86,16 @@ type claudeUsage struct {
 }
 
 type claudeWindow struct {
-	Utilization float64 `json:"utilization"`
-	ResetsAt    string  `json:"resets_at"`
+	Utilization  float64 `json:"utilization"`
+	ResetsAt     string  `json:"resets_at"`
+	LockedReason string  `json:"locked_reason"`
 }
 
 type claudeLimit struct {
 	Kind     string   `json:"kind"`
 	Percent  *float64 `json:"percent"`
 	ResetsAt string   `json:"resets_at"`
+	IsActive bool     `json:"is_active"`
 	Scope    *struct {
 		Model *struct {
 			DisplayName string `json:"display_name"`
@@ -212,10 +214,12 @@ func (u claudeUsage) windows() []Window {
 			continue
 		}
 		out = append(out, Window{
-			Label:    label,
-			Seconds:  seconds,
-			Percent:  percent(*limit.Percent),
-			ResetsAt: timestamp(limit.ResetsAt),
+			Label:        label,
+			Seconds:      seconds,
+			Percent:      percent(*limit.Percent),
+			ResetsAt:     timestamp(limit.ResetsAt),
+			Active:       limit.IsActive,
+			LockedReason: u.lockedReason(limit.Kind),
 		})
 	}
 	if len(out) > 0 {
@@ -233,13 +237,32 @@ func (u claudeUsage) windows() []Window {
 			continue
 		}
 		out = append(out, Window{
-			Label:    w.label,
-			Seconds:  w.seconds,
-			Percent:  percent(w.window.Utilization),
-			ResetsAt: timestamp(w.window.ResetsAt),
+			Label:        w.label,
+			Seconds:      w.seconds,
+			Percent:      percent(w.window.Utilization),
+			ResetsAt:     timestamp(w.window.ResetsAt),
+			LockedReason: w.window.LockedReason,
 		})
 	}
 	return out
+}
+
+// lockedReason answers the top-level pair for a limits[] entry's kind:
+// locked_reason lives only on five_hour/seven_day, never on limits[] itself —
+// session mirrors five_hour and weekly_all mirrors seven_day. A model-scoped
+// weekly cap has no pair of its own and never reports a lock.
+func (u claudeUsage) lockedReason(kind string) string {
+	switch kind {
+	case "session":
+		if u.FiveHour != nil {
+			return u.FiveHour.LockedReason
+		}
+	case "weekly_all":
+		if u.SevenDay != nil {
+			return u.SevenDay.LockedReason
+		}
+	}
+	return ""
 }
 
 // window names one limit entry and gives its length. An empty label is an entry

--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -101,11 +101,16 @@ var accountVars = append([]string{
 // the display name of the model a scoped window belongs to. Seconds is its
 // length, so the frontend can print the window it is looking at; 0 when the
 // provider does not report one. ResetsAt is RFC 3339, empty when unreported.
+// Active is the provider's own verdict on which window is the binding one, when
+// it reports one at all. LockedReason is non-empty only when the provider says
+// this window cannot be spent past regardless of its percentage.
 type Window struct {
-	Label    string `json:"label"`
-	Seconds  int    `json:"seconds"`
-	Percent  int    `json:"percent"`
-	ResetsAt string `json:"resetsAt,omitempty"`
+	Label        string `json:"label"`
+	Seconds      int    `json:"seconds"`
+	Percent      int    `json:"percent"`
+	ResetsAt     string `json:"resetsAt,omitempty"`
+	Active       bool   `json:"active,omitempty"`
+	LockedReason string `json:"lockedReason,omitempty"`
 }
 
 // Plan is one provider's quota reading. Provider is a providers.Registry id, so

--- a/internal/quota/quota_test.go
+++ b/internal/quota/quota_test.go
@@ -180,6 +180,37 @@ func TestClaudeSkipsEntriesItCannotDraw(t *testing.T) {
 	}
 }
 
+func TestClaudeReadsIsActiveAndLockedReason(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	body := `{
+		"five_hour": {"utilization": 12, "resets_at": "2026-08-30T20:29:59Z", "locked_reason": "past_limit"},
+		"seven_day": {"utilization": 32, "resets_at": "2026-08-31T15:00:00Z", "locked_reason": null},
+		"limits": [
+			{"kind":"session","percent":12,"resets_at":"2026-08-30T20:29:59Z","is_active":false},
+			{"kind":"weekly_all","percent":32,"resets_at":"2026-08-31T15:00:00Z","is_active":true},
+			{"kind":"weekly_scoped","percent":7,"resets_at":"2026-08-31T14:59:59Z","is_active":false,
+			 "scope":{"model":{"display_name":"Fable"}}}
+		]
+	}`
+	url, _ := serve(t, http.StatusOK, body)
+
+	got := newService(url, "", time.Now()).claudePlan(lichEnv())
+
+	want := []Window{
+		{Label: "Session", Seconds: sessionWindow, Percent: 12, ResetsAt: "2026-08-30T20:29:59Z", LockedReason: "past_limit"},
+		{Label: "Weekly", Seconds: weeklyWindow, Percent: 32, ResetsAt: "2026-08-31T15:00:00Z", Active: true},
+		{Label: "Fable", Seconds: weeklyWindow, Percent: 7, ResetsAt: "2026-08-31T14:59:59Z"},
+	}
+	if len(got.Windows) != len(want) {
+		t.Fatalf("windows = %+v, want %+v", got.Windows, want)
+	}
+	for i, w := range want {
+		if got.Windows[i] != w {
+			t.Errorf("window %d = %+v, want %+v", i, got.Windows[i], w)
+		}
+	}
+}
+
 func TestClaudeDropsAnUnparseableResetTime(t *testing.T) {
 	writeCreds(t, claudeCredsJSON, "")
 	body := `{"limits":[{"kind":"session","percent":5,"resets_at":"whenever"}]}`


### PR DESCRIPTION
## Summary

- The plan gauge picked the fullest window as a local heuristic (`hottestWindow`); it now prefers the window the server itself marks binding (`limits[].is_active`), falling back to the fullest window only when the server names none. On the account this was measured against the two coincide, so this is not a visible bug fixed today — it replaces a guess with the source's own authority.
- `locked_reason` — carried only on the top-level `five_hour`/`seven_day` pair, never on `limits[]` (`session` mirrors `five_hour`, `weekly_all` mirrors `seven_day`) — now travels through: a locked window reads **Locked** instead of a bare, misleadingly spendable percentage, with the reason in a tooltip. An empty/absent reason is never treated as a lock.
- Recorded in `docs/ceilings.md`, not built on: `severity` (only ever observed as `"normal"` — its scale is unknown, so swapping the local colour ramp for it would be a guess) and `extra_usage`/`spend` (the credits that cover spend past a full window — both blocks exist but are entirely null/disabled on every account measured, so their filled shape can't be built against here). Also noted: the payload's top level carries a graveyard of null codenames (`nimbus_quill`, `tangelo`, `iguana_necktie`, `omelette_promotional`, `cinder_cove`, `amber_ladder`, `juniper_tide`, `seven_day_omelette`, `seven_day_cowork`) — evidence that reading `limits[]` and silently skipping an unknown kind is the right default. Codex's `wham` usage route has no equivalent to any of this (no active flag, no lock reason, no credit block), so this ceiling is Claude-only by the shape of the payload.

## What the live payload actually returned

```
GET https://api.anthropic.com/api/oauth/usage
```
`limits`: session 25% `is_active:false`, weekly_all 33% `is_active:true`, weekly_scoped (Fable) — all `locked_reason:null`, `severity:"normal"`. `extra_usage.is_enabled:false`, `spend.enabled:false`. Confirms the measured shape in the task brief.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean (after `pnpm build` populated `frontend/dist`)
- [x] `go test ./...` green, `LICH_LISTEN_PORT` unset
- [x] `pnpm check` (biome) clean — no new errors, pre-existing warnings only
- [x] `pnpm test` (vitest, direct binary) green — 1249 tests, including new `hottestWindow` active-preference cases and a Go test for `is_active`/`locked_reason`
- [x] `pnpm build` succeeds
- [x] Rebased onto `origin/main` (6 commits ahead) — no conflicts