### PR TITLE
feat: give Codex sessions the per-session cost readout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   session, so it survives a restart of lich and a parked worktree's resume, and
   every provider that reports a state counts a turn you were not watching. Crush
   reports none, so its sessions count what you typed and no more.
+- **Codex sessions get the same cost readout Claude Code has.** The footer's
+  "And cost" rung, and the spend-ceiling colour beside it, were Claude Code
+  only — Codex's Settings pane didn't even offer the option. A Codex rollout
+  reports its running token total on every turn, and lich now prices that the
+  same way it prices a Claude transcript: the number stays absent, never
+  guessed, until the model it ran is one lich's price table knows.
 
 ### Changed
 

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -25,8 +25,11 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   percentage, and Antigravity and Cursor CLI file their conversations as SQLite rather than as a transcript lich
   reads at all.
   Their footer therefore carries no model or context ring. Codex rollouts carry the effective window
-  selected for that session — 95% of its default or configured `model_context_window` — but no API-cost
-  accounting, so its setting stops at model and context while Claude Code alone offers the cost rung.
+  selected for that session — 95% of its default or configured `model_context_window` — and, since
+  `total_token_usage` is a running total lich prices from its last line, the cost rung too. But
+  `internal/pricing/prices.json` is baked with Claude models only, so a Codex model prices only after the
+  remote LiteLLM refresh (`internal/pricing/pricing.go`) — an offline machine never shows a Codex cost, and
+  a model LiteLLM has not priced either never will.
 - **Hands-on time is read off three signals, and one of them is not universal**
   (`internal/terminal/handson.go`, `noteOutput`, `closableState`): the figure beside the cost
   counts the gap between consecutive signs of life in a session — a session-state report, a

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -102,15 +102,8 @@ export function ProviderBinSettings({
   const consequence = SKIP_LEVELS.find((rung) => rung.level === level)?.consequence ?? ""
   const pendingRung = SKIP_LEVELS.find((rung) => rung.level === pendingLevel)
   const readout = footerReadout(showContextUsage, showCost)
-  const availableReadouts =
-    providerId === "codex"
-      ? FOOTER_READOUTS.filter((rung) => rung.level !== "cost")
-      : FOOTER_READOUTS
-  // Cost is a global preference but Codex has no transcript cost reader. If
-  // Claude enabled it, the Codex pane still truthfully shows its highest rung.
-  const visibleReadout = providerId === "codex" && readout === "cost" ? "context" : readout
   const readoutConsequence =
-    availableReadouts.find((rung) => rung.level === visibleReadout)?.consequence ?? ""
+    FOOTER_READOUTS.find((rung) => rung.level === readout)?.consequence ?? ""
 
   // One rung writes both settings, for the same reason the permission ladder
   // does: the pair is the storage, the rung is the choice.
@@ -168,13 +161,13 @@ export function ProviderBinSettings({
             description="How much of what a session is spending the footer carries, read from its transcript."
           >
             <ToggleGroup
-              value={[visibleReadout]}
+              value={[readout]}
               onValueChange={(next) => next[0] && setReadout(next[0] as FooterReadout)}
               spacing={1}
               aria-label="What the footer says about the session"
               className="border border-border p-[3px]"
             >
-              {availableReadouts.map((rung) => (
+              {FOOTER_READOUTS.map((rung) => (
                 <ToggleGroupItem key={rung.level} value={rung.level} size="sm">
                   {rung.label}
                 </ToggleGroupItem>
@@ -185,7 +178,7 @@ export function ProviderBinSettings({
 
           {/* A ceiling is only ever seen through the readout, so it is offered
               beside it and hidden with it. */}
-          {providerId === "claude" && readout === "cost" && (
+          {readout === "cost" && (
             <SettingBlock
               title="Spend ceiling"
               description="Colour the cost in the footer as a session approaches this many dollars — amber at 80%, red at 95%. It is a warning, not a limit: nothing is stopped, and the figure it watches is API pricing from a table. Leave empty for none."

--- a/internal/terminal/usage.go
+++ b/internal/terminal/usage.go
@@ -86,10 +86,13 @@ func contextUsageFor(providerSessionID string) (contextUsage, bool) {
 // table knows — see scanTranscriptCost for why an unpriced line stops the count
 // instead of being skipped.
 //
-// A conversation is more than one file: what its sub-agents spent is billed to
-// the same account and written to transcripts of their own, so each is counted
-// into the same session. One of them falling short withholds the whole number,
-// for the same reason a single unpriced line does.
+// Routed by provider the way contextUsageFor is: a Claude transcript is more
+// than one file — what its sub-agents spent is billed to the same account and
+// written to transcripts of their own, so each is counted into the same
+// session, and one of them falling short withholds the whole number, for the
+// same reason a single unpriced line does. A Codex rollout has no sub-agent
+// files and reports its own running total, so countCodexTranscript prices it
+// whole rather than walking a ledger.
 //
 // The accounting is persisted per transcript, so it survives both a `/clear`
 // (a new conversation under the same session, counted into its own row) and a
@@ -98,17 +101,21 @@ func (s *Service) sessionCost(id, providerSessionID string) (float64, bool) {
 	if s.prices == nil || !s.store.CostReadout() {
 		return 0, false
 	}
-	path, ok := claudeTranscriptPath(providerSessionID)
-	if !ok {
-		return 0, false
-	}
-	if !s.countTranscript(id, providerSessionID, path) {
-		return 0, false
-	}
-	for _, sub := range claudeSubagentPaths(providerSessionID) {
-		if !s.countTranscript(id, providerSessionID+"/"+filepath.Base(sub), sub) {
+	if path, ok := claudeTranscriptPath(providerSessionID); ok {
+		if !s.countTranscript(id, providerSessionID, path) {
 			return 0, false
 		}
+		for _, sub := range claudeSubagentPaths(providerSessionID) {
+			if !s.countTranscript(id, providerSessionID+"/"+filepath.Base(sub), sub) {
+				return 0, false
+			}
+		}
+	} else if path, ok := codexTranscriptPath(providerSessionID); ok {
+		if !s.countCodexTranscript(id, providerSessionID, path) {
+			return 0, false
+		}
+	} else {
+		return 0, false
 	}
 	total, err := s.store.SessionCost(id)
 	if err != nil {
@@ -116,6 +123,22 @@ func (s *Service) sessionCost(id, providerSessionID string) (float64, bool) {
 		return 0, false
 	}
 	return total, true
+}
+
+// countCodexTranscript folds one Codex rollout's cost into the session's
+// ledger. Unlike countTranscript's per-turn deltas, total_token_usage is
+// already the conversation's running total, so there is no offset to resume
+// from: each call prices the rollout whole and overwrites the stored row.
+func (s *Service) countCodexTranscript(id, transcriptID, path string) bool {
+	cost, ok := codexTranscriptCost(path, s.prices)
+	if !ok {
+		return false
+	}
+	if err := s.store.SaveCostLedger(id, transcriptID, 0, "", cost); err != nil {
+		slog.Warn("terminal: save cost ledger", "session", id, "err", err)
+		return false
+	}
+	return true
 }
 
 // countTranscript folds one transcript into the session's ledger, resuming from

--- a/internal/terminal/usage_codex.go
+++ b/internal/terminal/usage_codex.go
@@ -5,12 +5,26 @@ import (
 	"encoding/json"
 	"io"
 	"os"
+
+	"github.com/omartelo/lich/internal/pricing"
 )
 
 // A rollout line can be much larger than a normal event. Reading 64 KiB at a
 // time keeps allocations bounded without turning a long transcript into many
 // tiny reads; lines spanning blocks are carried into the next iteration.
 const codexScanBlockBytes int64 = 64 * 1024
+
+// codexTokenUsage is one info block's total_token_usage: the running total
+// for the whole conversation, unlike a Claude transcript's per-turn counters.
+// cached_input_tokens is a subset of Input and reasoning_output_tokens a
+// subset of Output, so only the four fields a rate needs are kept — the other
+// two would double-count if added in.
+type codexTokenUsage struct {
+	Input      int `json:"input_tokens"`
+	Cached     int `json:"cached_input_tokens"`
+	CacheWrite int `json:"cache_write_input_tokens"`
+	Output     int `json:"output_tokens"`
+}
 
 type codexRolloutEntry struct {
 	Type    string `json:"type"`
@@ -22,7 +36,8 @@ type codexRolloutEntry struct {
 			Last *struct {
 				Total int `json:"total_tokens"`
 			} `json:"last_token_usage"`
-			Window int `json:"model_context_window"`
+			Total  *codexTokenUsage `json:"total_token_usage"`
+			Window int              `json:"model_context_window"`
 		} `json:"info"`
 	} `json:"payload"`
 }
@@ -41,23 +56,37 @@ func codexContextUsage(providerSessionID string) (contextUsage, bool) {
 }
 
 func scanCodexContextUsage(path string) (contextUsage, bool) {
+	var usage contextUsage
+	haveTokens := false
+	if !codexReverseScan(path, func(line []byte) bool {
+		return consumeCodexUsageLine(line, &usage, &haveTokens)
+	}) {
+		return contextUsage{}, false
+	}
+	return usage, true
+}
+
+// codexReverseScan walks path from the end in codexScanBlockBytes chunks,
+// calling consume on each complete line, latest first, until consume reports
+// it found what it needs. false covers both an unreadable file and reaching
+// the start with consume never satisfied — the same "nothing to report" a
+// caller treats either way.
+func codexReverseScan(path string, consume func(line []byte) (done bool)) bool {
 	f, err := os.Open(path)
 	if err != nil {
-		return contextUsage{}, false
+		return false
 	}
 	defer f.Close()
 	info, err := f.Stat()
 	if err != nil {
-		return contextUsage{}, false
+		return false
 	}
-	var usage contextUsage
 	var suffix []byte
-	haveTokens := false
 	for end := info.Size(); end > 0; {
 		start := max(int64(0), end-codexScanBlockBytes)
 		chunk := make([]byte, end-start)
 		if _, err := f.ReadAt(chunk, start); err != nil && err != io.EOF {
-			return contextUsage{}, false
+			return false
 		}
 		lines := bytes.Split(append(chunk, suffix...), []byte("\n"))
 		first := 0
@@ -65,14 +94,14 @@ func scanCodexContextUsage(path string) (contextUsage, bool) {
 			first = 1
 		}
 		for i := len(lines) - 1; i >= first; i-- {
-			if consumeCodexUsageLine(lines[i], &usage, &haveTokens) {
-				return usage, true
+			if consume(lines[i]) {
+				return true
 			}
 		}
 		suffix = append(suffix[:0], lines[0]...)
 		end = start
 	}
-	return contextUsage{}, false
+	return false
 }
 
 func consumeCodexUsageLine(line []byte, usage *contextUsage, haveTokens *bool) bool {
@@ -97,5 +126,56 @@ func consumeCodexUsageLine(line []byte, usage *contextUsage, haveTokens *bool) b
 	}
 	usage.model = entry.Payload.Model
 	usage.effort = entry.Payload.Effort
+	return true
+}
+
+// codexTranscriptCost prices a Codex rollout's running total in USD. Unlike a
+// Claude transcript's per-turn deltas, total_token_usage is already the
+// conversation's cumulative cost, so the last line is the whole answer — no
+// ledger walk, no offset to resume from. ok is false when the rollout carries
+// no cost line yet, or when rates cannot price the model that ran it.
+func codexTranscriptCost(path string, rates rateSource) (float64, bool) {
+	var tokens pricing.Tokens
+	var model string
+	haveTokens := false
+	if !codexReverseScan(path, func(line []byte) bool {
+		return consumeCodexCostLine(line, &tokens, &model, &haveTokens)
+	}) {
+		return 0, false
+	}
+	rate, ok := rates.Rate(model)
+	if !ok {
+		return 0, false
+	}
+	return rate.Cost(tokens)
+}
+
+// consumeCodexCostLine mirrors consumeCodexUsageLine's two-phase reverse
+// walk, gathering the running token total and the model id that priced it
+// instead of the window and effort the context readout needs.
+func consumeCodexCostLine(line []byte, tokens *pricing.Tokens, model *string, haveTokens *bool) bool {
+	var entry codexRolloutEntry
+	if json.Unmarshal(line, &entry) != nil {
+		return false
+	}
+	if !*haveTokens {
+		if entry.Type != "event_msg" || entry.Payload.Type != "token_count" ||
+			entry.Payload.Info == nil || entry.Payload.Info.Total == nil {
+			return false
+		}
+		t := entry.Payload.Info.Total
+		*tokens = pricing.Tokens{
+			Input:      t.Input - t.Cached,
+			CacheRead:  t.Cached,
+			CacheWrite: t.CacheWrite,
+			Output:     t.Output,
+		}
+		*haveTokens = true
+		return false
+	}
+	if entry.Type != "turn_context" || entry.Payload.Model == "" {
+		return false
+	}
+	*model = entry.Payload.Model
 	return true
 }

--- a/internal/terminal/usage_cost_test.go
+++ b/internal/terminal/usage_cost_test.go
@@ -456,3 +456,144 @@ func nearly(got, want float64) bool {
 	diff := got - want
 	return diff < 1e-9 && diff > -1e-9
 }
+
+// codexTestRate prices the one model the Codex cost tests use, with a
+// distinct rate per counter so a total billed at the wrong one is visible.
+var codexTestRate = fixedRates{
+	"gpt-5.1-codex": {Input: 0.001, Output: 0.01, CacheRead: 0.0005, CacheWrite: 0.002},
+}
+
+// codexTokenLineJSON renders the token_count record a Codex rollout writes:
+// the cumulative total the whole conversation stands at so far, not a delta.
+// last_token_usage and model_context_window ride along beside it in a real
+// rollout, so sessionUsage's context-window read (which needs those two) is
+// satisfied by the same line the cost tests use.
+func codexTokenLineJSON(input, cached, cacheWrite, output int) string {
+	total := input + output
+	return `{"type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{` +
+		`"input_tokens":` + itoa(input) +
+		`,"cached_input_tokens":` + itoa(cached) +
+		`,"cache_write_input_tokens":` + itoa(cacheWrite) +
+		`,"output_tokens":` + itoa(output) +
+		`,"reasoning_output_tokens":0,"total_tokens":` + itoa(total) + `}` +
+		`,"last_token_usage":{"total_tokens":` + itoa(total) + `}` +
+		`,"model_context_window":258400}}}`
+}
+
+func codexTurnContextJSON(model string) string {
+	return `{"type":"turn_context","payload":{"model":"` + model + `"}}`
+}
+
+// TestCodexTranscriptCostPricesTheRunningTotal is the shape a Codex rollout
+// reports: turn_context (the model) precedes the token_count line that closes
+// the turn, and cached_input_tokens is a subset of input_tokens, so only the
+// uncached share prices at the input rate — summing both would double-count.
+func TestCodexTranscriptCostPricesTheRunningTotal(t *testing.T) {
+	path := writeFile(t,
+		codexTurnContextJSON("gpt-5.1-codex")+"\n"+codexTokenLineJSON(1000, 400, 0, 10)+"\n")
+
+	cost, ok := codexTranscriptCost(path, codexTestRate)
+
+	if !ok {
+		t.Fatal("codexTranscriptCost: want ok")
+	}
+	want := 600*0.001 + 400*0.0005 + 10*0.01
+	if !nearly(cost, want) {
+		t.Errorf("cost = %v, want %v", cost, want)
+	}
+}
+
+// TestCodexTranscriptCostIsCumulativeNotSummed pins the difference from a
+// Claude transcript: a rollout's second token_count line is the conversation's
+// whole new total, not a delta to add to the first, so only the last one read
+// backward from the end may count.
+func TestCodexTranscriptCostIsCumulativeNotSummed(t *testing.T) {
+	path := writeFile(t,
+		codexTurnContextJSON("gpt-5.1-codex")+"\n"+
+			codexTokenLineJSON(500, 0, 0, 5)+"\n"+
+			codexTurnContextJSON("gpt-5.1-codex")+"\n"+
+			codexTokenLineJSON(1000, 400, 0, 10)+"\n")
+
+	cost, ok := codexTranscriptCost(path, codexTestRate)
+
+	if !ok {
+		t.Fatal("codexTranscriptCost: want ok")
+	}
+	want := 600*0.001 + 400*0.0005 + 10*0.01
+	if !nearly(cost, want) {
+		t.Errorf("cost = %v, want %v — only the last (cumulative) line counts", cost, want)
+	}
+}
+
+// TestCodexTranscriptCostWithholdsForAnUnpricedModel carries the money rule
+// over from the Claude scan: a model nothing can price yields no number,
+// never a guess.
+func TestCodexTranscriptCostWithholdsForAnUnpricedModel(t *testing.T) {
+	path := writeFile(t,
+		codexTurnContextJSON("model-from-the-future")+"\n"+codexTokenLineJSON(1000, 0, 0, 10)+"\n")
+
+	if _, ok := codexTranscriptCost(path, codexTestRate); ok {
+		t.Error("codexTranscriptCost: want a miss for an unpriced model")
+	}
+}
+
+func TestCodexTranscriptCostMissesWithoutATokenLine(t *testing.T) {
+	path := writeFile(t, codexTurnContextJSON("gpt-5.1-codex")+"\n")
+
+	if _, ok := codexTranscriptCost(path, codexTestRate); ok {
+		t.Error("codexTranscriptCost: want a miss with no token_count line")
+	}
+}
+
+// TestSessionCostRidesOnTheUsageEventForCodex is the end-to-end wiring for the
+// provider sessionCost routes to when a Claude transcript is not the one that
+// matches — a Codex rollout, priced from its own cumulative total.
+func TestSessionCostRidesOnTheUsageEventForCodex(t *testing.T) {
+	writeCodexTranscript(t, "uuid-codex-cost",
+		codexTurnContextJSON("gpt-5.1-codex")+"\n"+codexTokenLineJSON(1000, 400, 0, 10)+"\n")
+	svc := New(newCostStore("uuid-codex-cost"), nil, events.New())
+	svc.prices = codexTestRate
+
+	got, ok := svc.sessionUsage("s1")
+
+	if !ok {
+		t.Fatal("sessionUsage: want ok")
+	}
+	if got.CostUSD == nil {
+		t.Fatal("CostUSD is absent, want the session's cost")
+	}
+	want := 600*0.001 + 400*0.0005 + 10*0.01
+	if !nearly(*got.CostUSD, want) {
+		t.Errorf("CostUSD = %v, want %v", *got.CostUSD, want)
+	}
+}
+
+// TestCodexCostAccumulatesAcrossConversations is the Codex side of the
+// `/clear` case: a Codex rollout is replaced by a new one under the same
+// session, and the session keeps what the previous rollout cost.
+func TestCodexCostAccumulatesAcrossConversations(t *testing.T) {
+	store := newCostStore("uuid-codex-first")
+	writeCodexTranscript(t, "uuid-codex-first",
+		codexTurnContextJSON("gpt-5.1-codex")+"\n"+codexTokenLineJSON(100, 0, 0, 0)+"\n")
+	svc := New(store, nil, events.New())
+	svc.prices = codexTestRate
+	if _, ok := svc.sessionUsage("s1"); !ok {
+		t.Fatal("sessionUsage: want ok on the first conversation")
+	}
+
+	writeCodexTranscript(t, "uuid-codex-second",
+		codexTurnContextJSON("gpt-5.1-codex")+"\n"+codexTokenLineJSON(300, 0, 0, 0)+"\n")
+	store.providerSession = "uuid-codex-second"
+	svc = New(store, nil, events.New())
+	svc.prices = codexTestRate
+
+	got, ok := svc.sessionUsage("s1")
+
+	if !ok {
+		t.Fatal("sessionUsage: want ok after the second rollout")
+	}
+	want := 100*0.001 + 300*0.001
+	if got.CostUSD == nil || !nearly(*got.CostUSD, want) {
+		t.Errorf("CostUSD = %v, want %v — the first rollout's cost still counts", got.CostUSD, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Routes `sessionCost` by provider the way `contextUsageFor` already does: a Claude transcript still walks its per-turn ledger, while a Codex rollout is priced from `payload.info.total_token_usage` — measured to be the conversation's cumulative running total, not a per-turn delta — so it's priced whole on each read and the stored row is overwritten rather than resumed from an offset.
- Extends `codexRolloutEntry` with the `total_token_usage` breakdown and refactors the reverse-chunk scan in `usage_codex.go` into a shared `codexReverseScan` helper, reused by both the context-window read and the new cost read.
- Removes the Codex-specific hides in `ProviderBinSettings.tsx`: the "And cost" footer rung and the spend-ceiling setting beside it now show for Codex the same as Claude Code.
- Corrects the stale `docs/ceilings.md` bullet claiming Codex has no API-cost accounting, and replaces it with the real ceiling: `internal/pricing/prices.json` bakes Claude models only, so a Codex model prices only after the remote LiteLLM refresh — an offline machine never shows a Codex cost.

## What I measured

On `~/.codex/sessions/**/rollout-*.jsonl`, every `event_msg`/`token_count` record carries `payload.info.total_token_usage = {input_tokens, cached_input_tokens, cache_write_input_tokens, output_tokens, reasoning_output_tokens, total_tokens}`, cumulative for the whole conversation (unlike Claude's per-message usage — no ledger walk, no offset resume, no sub-agent files needed). `cached_input_tokens` is a subset of `input_tokens` and `reasoning_output_tokens` a subset of `output_tokens`; summing all six double-counts. `turn_context` (carrying the model id) always precedes the `token_count` line that closes a turn, which the existing reverse-scan in `usage_codex.go` already relies on for the context-window read.

## Decided differently from the brief

- Also un-hid the **spend-ceiling** setting for Codex, not just the "And cost" rung. It was gated the same way (`providerId === "claude"`) for the same root cause — no Codex cost accounting — so leaving it Claude-only would have been a fresh, unjustified asymmetry the moment cost started working for both.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean (linux/darwin/windows cross-compile)
- [x] `go test ./...` green (`LICH_LISTEN_PORT=`)
- [x] `cd frontend && pnpm check` clean
- [x] `cd frontend && pnpm test` green
- [x] `cd frontend && pnpm build` succeeds
- [x] New Go tests: `codexTranscriptCost` pure-function cases (running total, not summed across lines, unpriced model withholds, no token line yet) plus end-to-end `sessionUsage` cases (Codex cost rides the event, accumulates across `/clear`-equivalent rollout swaps)