### PR TITLE
fix: resolve the login shell's environment on a pty, not a pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   target text rather than the target's contents. The preview now says the path
   leaves the checkout instead of following it. Links that stay inside the tree
   read exactly as before.
+- **An agent installed under a version manager (nvm, fnm, …) is found again.**
+  lich reads your shell's rc file to learn the PATH it needs, but ran it with
+  its input piped rather than attached to a terminal — so an rc file that only
+  runs its body when it detects an interactive terminal (the common guard
+  around a version manager's setup) skipped straight past it, and the PATH lich
+  picked up never gained the version manager's Node or the CLIs installed under
+  it. Providers under a version manager now show up in Settings › Providers on
+  the first check.
 
 ## [0.42.0] - 2026-08-27
 

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -120,6 +120,26 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   `pty_windows.go`): closing a card signals the agent and gives it `closeGrace` to leave, so its exit path runs —
   hooks, transcripts, whatever it writes on the way out. A ConPTY has no signal to deliver, so the same close on
   Windows is still abrupt: an agent that saves state on exit loses it there, and nothing on screen says so.
+- **The shell-env pty read is bounded by silence, not by the child's exit, and Windows never gets one**
+  (`internal/terminal/shellenv_unix.go`, `runShellDump`): resolving PATH and friends runs the login shell on a
+  pty rather than a pipe so an rc guarded on `[ -t 0 ]`/`tty -s` (nvm's and fnm's own init, among others) loads —
+  but neither closing that pty from another goroutine nor `SetReadDeadline` interrupts a read already blocked in
+  it (both measured directly against a blocked read: Close returns without error and the read stays parked in
+  the kernel regardless, and the deadline is never enforced on this fd). So the read is driven from a goroutine
+  free to outlive the call, and the result is decided by `shellDumpQuiet`: once real output has started, 300ms
+  of silence is taken as "done", which is what lets an rc that backgrounds a job (an `ssh-agent`/`gpg-agent`
+  eval, a prompt tool) after printing still hand back what it printed instead of paying the full
+  `shellEnvTimeout` for nothing. Three edges follow. A background job that keeps printing on its own schedule
+  (a spinner, a periodic notice) keeps resetting that timer, so a shell like that is bounded by the 5s ceiling
+  instead of the 300ms one — the same outcome as a genuinely hung shell, and nothing distinguishes the two. A
+  quiet-window or ctx timeout leaves the reader goroutine running for whatever still holds the pty, and it is
+  never collected: the fd, the goroutine and the zombie child persist until that holder exits on its own or
+  lich itself does, whichever comes first — one leak per lich launch that hits this edge, not a recurring one.
+  And **Windows gets none of this**: `SHELL` is normally unset there, so `ResolveShellEnv` returns before
+  `shellenv_windows.go`'s pipe-based `runShellDump` ever runs — but on a machine where the user sets it anyway
+  (Git Bash, a POSIX-ish shell reached through PATH), that path still runs over a pipe, so an rc guarded the
+  same way is skipped there exactly as it was everywhere before this fix, with no ConPTY wired in to close the
+  gap.
 - **A terminal entrypoint reaches shell sessions only, and reads a different rc on each OS**
   (`internal/terminal/entrypoint.go`): the menu item is absent on a provider card. On Linux and macOS the command
   runs through the shell's `-c`, which loads no interactive rc: an alias defined in `.zshrc` is not a command that

--- a/internal/terminal/shellenv.go
+++ b/internal/terminal/shellenv.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"log/slog"
 	"os"
-	"os/exec"
 	"strings"
 	"time"
 )
@@ -24,7 +23,8 @@ const shellEnvSentinel = "__LICH_SHELL_ENV__"
 // hides this because the shell we spawn sources those rc files itself; a provider
 // spawned directly (claude/codex/...) does not, so its ${VAR} expansions in
 // .mcp.json come up empty. We run the user's shell the way a terminal emulator
-// does and merge its environment over base.
+// does — attached to a pty, see runShellDump — and merge its environment over
+// base.
 //
 // SHELL unset (normal Windows: cmd.exe has no rc) or any failure returns base
 // unchanged — the resolution is best-effort, never load-bearing.
@@ -39,13 +39,10 @@ func ResolveShellEnv(base []string) []string {
 
 	// -l -i so both login profiles (bash/zsh) and interactive rc (fish's
 	// config.fish is interactive-only) run; `env` is external, so the command is
-	// identical across shells. Nil Stdin feeds EOF instead of a tty, so the
-	// interactive shell never blocks on a read.
-	cmd := exec.CommandContext(ctx, shell, "-l", "-i", "-c", "echo "+shellEnvSentinel+"; env")
-	cmd.Env = base
-	out, err := cmd.Output() // stderr, carrying rc warnings, is discarded
+	// identical across shells.
+	out, err := runShellDump(ctx, shell, "echo "+shellEnvSentinel+"; env", base)
 
-	extra := parseShellEnvDump(shellEnvSentinel, string(out))
+	extra := parseShellEnvDump(shellEnvSentinel, out)
 	if extra == nil {
 		slog.Warn("terminal: shell env resolution yielded nothing, using launch env", "shell", shell, "err", err)
 		return base

--- a/internal/terminal/shellenv_test.go
+++ b/internal/terminal/shellenv_test.go
@@ -2,6 +2,7 @@ package terminal
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -120,6 +121,33 @@ func TestResolveShellEnv(t *testing.T) {
 	}
 	if !slices.Contains(got, "PATH=/shell/bin") || slices.Contains(got, "PATH=/orig") {
 		t.Errorf("shell PATH did not override launch PATH: %v", got)
+	}
+}
+
+// TestResolveShellEnvTTYGuardedRC pins the pty fix: rc files commonly guard
+// their body on `[ -t 0 ]`/`tty -s` (nvm and fnm both ship this), and a shell
+// spawned with pipe stdio never satisfies that guard — the export it gates
+// never runs, and neither does the PATH mutation a version manager adds.
+// Measured on this repo's dev machine before the fix:
+// `zsh -lic '[ -t 0 ] && echo yes || echo no' </dev/null` prints "no".
+func TestResolveShellEnvTTYGuardedRC(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("real zsh rig is not runnable on Windows")
+	}
+	zsh, err := exec.LookPath("zsh")
+	if err != nil {
+		t.Skip("zsh not installed")
+	}
+	home := t.TempDir()
+	rc := "[ -t 0 ] || return\nexport LICH_TTY_PROBE=yes\n"
+	if err := os.WriteFile(filepath.Join(home, ".zshrc"), []byte(rc), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("SHELL", zsh)
+
+	got := ResolveShellEnv([]string{"HOME=" + home})
+	if !slices.Contains(got, "LICH_TTY_PROBE=yes") {
+		t.Fatalf("tty-guarded rc export missing: %v", got)
 	}
 }
 

--- a/internal/terminal/shellenv_unix.go
+++ b/internal/terminal/shellenv_unix.go
@@ -1,0 +1,86 @@
+//go:build !windows
+
+package terminal
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"time"
+
+	"github.com/creack/pty"
+)
+
+// shellDumpQuiet bounds how long the read waits after the last byte before
+// treating the dump as complete. It only matters once real output has
+// started — see the nil quiet channel below — so a shell that is merely slow
+// to speak (nvm/fnm's own init, among the common causes) is bounded solely
+// by ctx, same as before this file existed. Once the shell has spoken and
+// gone silent this long, whatever still holds the pty open is a background
+// job its rc left running (an agent daemon, a prompt tool) with its stdio
+// still wired to the terminal — not the shell itself still working.
+const shellDumpQuiet = 300 * time.Millisecond
+
+// runShellDump runs cmdStr under shell -l -i, attached to a pty rather than a
+// pipe: an rc file guarded on `[ -t 0 ]`/`tty -s` — the common guard around a
+// version manager's init (nvm, fnm) — only loads when stdin looks like a
+// terminal.
+//
+// The read cannot be bounded by closing the pty or by SetReadDeadline: both
+// were measured against a read genuinely blocked in the read syscall and
+// neither interrupts it — a Close from another goroutine returns without
+// error while the read stays parked in the kernel regardless (Linux does not
+// interrupt an in-flight blocking read by closing the fd from elsewhere),
+// and SetReadDeadline never reaches a syscall that never goes non-blocking
+// here. So the read is driven from a goroutine that is allowed to outlive
+// this call, and its output arrives here over a channel: the moment nothing
+// new arrives for shellDumpQuiet, or ctx expires, whichever comes first,
+// this returns whatever has accumulated so far. The goroutine is left
+// running for whatever still holds the pty — a single leaked goroutine (and
+// its fd, and its zombie child once it exits) is the cost of never blocking
+// boot past ctx.
+func runShellDump(ctx context.Context, shell, cmdStr string, env []string) (string, error) {
+	cmd := exec.Command(shell, "-l", "-i", "-c", cmdStr)
+	cmd.Env = env
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		return "", err
+	}
+
+	chunks := make(chan []byte)
+	go func() {
+		defer cmd.Wait()
+		defer ptmx.Close()
+		buf := make([]byte, 4096)
+		for {
+			n, err := ptmx.Read(buf)
+			if n > 0 {
+				cp := make([]byte, n)
+				copy(cp, buf[:n])
+				chunks <- cp
+			}
+			if err != nil {
+				close(chunks)
+				return
+			}
+		}
+	}()
+
+	var out bytes.Buffer
+	var quiet <-chan time.Time
+	for {
+		select {
+		case b, ok := <-chunks:
+			if !ok {
+				return out.String(), nil
+			}
+			out.Write(b)
+			quiet = time.After(shellDumpQuiet)
+		case <-quiet:
+			return out.String(), nil
+		case <-ctx.Done():
+			_ = cmd.Process.Kill()
+			return out.String(), ctx.Err()
+		}
+	}
+}

--- a/internal/terminal/shellenv_unix_test.go
+++ b/internal/terminal/shellenv_unix_test.go
@@ -1,0 +1,67 @@
+//go:build !windows
+
+package terminal
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestRunShellDumpTimeoutDegrades pins the pty trap: a pty master blocks on
+// Read until the child exits, so a hung interactive shell (a stuck rc
+// script, a shell dropped into its own prompt) must still be cut off by ctx
+// rather than hanging ResolveShellEnv past its timeout ceiling.
+func TestRunShellDumpTimeoutDegrades(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, _ = runShellDump(ctx, "/bin/sh", "sleep 30", os.Environ())
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("runShellDump took %v, want it cut off near the 200ms ctx deadline", elapsed)
+	}
+}
+
+// TestRunShellDumpBackgroundJobDoesNotBlockDeadline pins the trap a killed
+// shell alone does not cover: an rc file that backgrounds a job (an
+// ssh-agent, a prompt tool) leaves its stdio wired to the pty, so the slave
+// end stays open — and a read waiting on EOF blocks on it — after the shell
+// we spawned has already exited. Measured before this test existed: with
+// only the shell process killed on ctx, the read did not return until the
+// backgrounded sleep itself did, 30s later, ignoring a 200ms ctx entirely.
+func TestRunShellDumpBackgroundJobDoesNotBlockDeadline(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	_, _ = runShellDump(ctx, "/bin/sh", "(sleep 30 &); exit 0", os.Environ())
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("runShellDump took %v, want it cut off near the 200ms ctx deadline despite the backgrounded job", elapsed)
+	}
+}
+
+// TestRunShellDumpBackgroundJobStillYieldsOutput pins the other half: a
+// background job must not cost the resolution its output. The dump has
+// already been fully printed before the job is backgrounded, so the quiet
+// window (shellDumpQuiet) — not the far longer ctx — is what ends the read,
+// and what it returns still carries what the shell said.
+func TestRunShellDumpBackgroundJobStillYieldsOutput(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	out, err := runShellDump(ctx, "/bin/sh", "echo REAL_OUTPUT=yes; (sleep 30 &); exit 0", os.Environ())
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("runShellDump error: %v", err)
+	}
+	if !strings.Contains(out, "REAL_OUTPUT=yes") {
+		t.Fatalf("output missing despite the backgrounded job: %q", out)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("runShellDump took %v, want it end near the %v quiet window rather than the 5s ctx", elapsed, shellDumpQuiet)
+	}
+}

--- a/internal/terminal/shellenv_windows.go
+++ b/internal/terminal/shellenv_windows.go
@@ -1,0 +1,21 @@
+//go:build windows
+
+package terminal
+
+import (
+	"context"
+	"os/exec"
+)
+
+// runShellDump runs cmdStr under shell -l -i with pipe stdio. SHELL is
+// normally unset on Windows — cmd.exe has no rc file to guard on a tty, so
+// ResolveShellEnv returns before this ever runs — and no shell shipped here
+// is known to gate its rc on `[ -t 0 ]`, so wiring up ConPTY buys nothing a
+// pipe doesn't already give; ctx's cancellation kills the process (see
+// exec.CommandContext).
+func runShellDump(ctx context.Context, shell, cmdStr string, env []string) (string, error) {
+	cmd := exec.CommandContext(ctx, shell, "-l", "-i", "-c", cmdStr)
+	cmd.Env = env
+	out, err := cmd.Output() // stderr, carrying rc warnings, is discarded
+	return string(out), err
+}


### PR DESCRIPTION
## Summary

- `ResolveShellEnv` ran the login shell with piped stdio, so an rc file guarded on `[ -t 0 ]`/`tty -s` — the common guard around a version manager's init (nvm, fnm) — never loaded its body, and the PATH lich pinned into itself never gained that manager's Node or the CLIs installed under it. Providers under a version manager reported "Not found on PATH" no matter how many times Settings › Providers checked again.
- The resolution shell now runs attached to a pty (`internal/terminal/shellenv_unix.go`), reusing the project's existing OS-seam pattern rather than a new dependency. Windows keeps the prior pipe-based path (`shellenv_windows.go`): `SHELL` is normally unset there, and no shell shipped there is known to guard its rc on a tty, so ConPTY buys nothing here.
- Getting a real pty surfaced two traps that had to be handled, not assumed: neither closing the pty from another goroutine nor `SetReadDeadline` interrupts a read already blocked in it (measured directly against a genuinely blocked read). The read is instead driven from a goroutine allowed to outlive the call, bounded by a short silence window once real output starts — which is what lets a shell that backgrounds a job after printing (an `ssh-agent` eval, a prompt tool) still hand back what it printed, instead of the whole resolution paying the full 5s ceiling for nothing.
- The remaining ceiling (a background job that keeps printing resets the silence window and falls back to the 5s ceiling; the reader goroutine and its zombie child are never collected if that happens; Windows never gets the pty fix even if a POSIX-ish shell is set there) is written up in `docs/ceilings.md`.

## Measured before/after

```
$ zsh -lic '[ -t 0 ] && echo yes || echo no' </dev/null
no
```

With a throwaway `HOME` whose `.zshrc` is `[ -t 0 ] || return` followed by an export:
- **Before** (piped shell, matching today's `ResolveShellEnv` shape): the export is absent — `grep -c` on the dump finds `0` matches.
- **After** (real `ResolveShellEnv`, pty-attached): the export is present (`TestResolveShellEnvTTYGuardedRC`, pinned in `shellenv_test.go`).

## Test plan

- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` green (`LICH_LISTEN_PORT=`), including new regression tests:
  - `TestResolveShellEnvTTYGuardedRC` — real zsh, tty-guarded rc, pins the fix
  - `TestRunShellDumpTimeoutDegrades` — a fully silent hung shell is still cut off near the ctx ceiling
  - `TestRunShellDumpBackgroundJobDoesNotBlockDeadline` — a backgrounded job with no further output doesn't block past ctx
  - `TestRunShellDumpBackgroundJobStillYieldsOutput` — a backgrounded job left running *after* real output still yields that output, well under the ctx ceiling
- [x] Cross-compile loop (`GOOS=linux/darwin/windows`, build + vet) clean
- [x] `cd frontend && pnpm check / pnpm test / pnpm build` clean (untouched by this change; rebuilt after rebasing onto main)
- [x] `CHANGELOG.md` `[Unreleased]` entry added, deduplicated against the two sibling PRs merged during this work (#410, #411)