### PR TITLE
fix: never remove a worktree lich did not create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A worktree you made yourself is never deleted by lich.** git lists every
+  worktree of a repository, so one you created by hand shows up in lich's picker
+  and hosts a session like any other — and closing that session used to offer to
+  remove the checkout, which deleted your directory, and with "force" the
+  uncommitted work in it. lich now only ever removes the worktrees it created
+  itself: closing the last session in one of your own parks the session for a
+  later resume and leaves the checkout exactly where it is, and the close dialog
+  says so instead of offering an answer that would take it away.
 - **A file preview stays inside the checkout it was opened from.** A repository
   may ship a symlink pointing out of its own tree, and clicking one in the file
   list quietly previewed whatever it landed on — a file from somewhere else on

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -481,6 +481,14 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   back has no branch to read and no session to resume: that row says `checkout gone` and offers to forget
   itself, which is the only way such a row is ever collected — `PurgeWorktreeSessions` never ran for it,
   because the removal never went through the app.
+- **A worktree lich did not create can never be removed through lich** (`internal/project.WorktreeAdopted`):
+  `git worktree list` hands back every checkout of a repository, so one the user made by hand appears in the
+  picker and hosts a session like any other — and nothing but its path tells the two apart. Everything lich
+  creates lives under the worktrees root (`reserveWorktreePath`); a canonical path outside it is adopted, and
+  `RemoveWorktree` refuses it whether or not force was asked for. What that costs is the cleanup: a hand-made
+  checkout is parked, never collected, and removing it is a `git worktree remove` the user runs themselves.
+  The test is the path and only the path — a worktree lich created and the user then moved out of the data dir
+  reads as adopted, and one made by hand inside it reads as lich's own.
 - **Parked rows are never swept, and their dropped-file copies expire on the clock instead of at the close**
   (`internal/store/mutations.go`, `internal/drop`): every close now parks a row, so the sessions table grows
   monotonically with the sessions a workspace has ever opened — a few hundred bytes each, which is a megabyte

--- a/frontend/src/components/pulls/Pulls.tsx
+++ b/frontend/src/components/pulls/Pulls.tsx
@@ -163,6 +163,13 @@ export function Pulls({ list = false }: PullsProps) {
       toast.error("Worktree has a pinned session — unpin it first.")
       return
     }
+    // A checkout the user made by hand is theirs: lich lists it and works in it,
+    // but it is not lich's to delete. Refused here rather than at the call,
+    // which is past the point where the sessions have already been discarded.
+    if (await ProjectService.WorktreeAdopted(wtPath).catch(() => true)) {
+      toast.error("lich did not create this worktree — remove the checkout yourself.")
+      return
+    }
     if (await ProjectService.WorktreeDirty(wtPath).catch(() => false)) {
       toast.error("Worktree has uncommitted changes — remove it from the sidebar.")
       return

--- a/frontend/src/components/sidebar/WorktreeCloseDialogs.tsx
+++ b/frontend/src/components/sidebar/WorktreeCloseDialogs.tsx
@@ -37,6 +37,8 @@ function RunningSessionDialog({ session, onCancel, onCloseAnyway }: RunningSessi
 interface CloseWorktreeDialogProps {
   /** The worktree session being closed, or null when the dialog is hidden. */
   session: Session | null
+  /** Whether lich adopted that checkout rather than creating it. */
+  adopted: boolean
   onCancel: () => void
   /** Close the session, leaving the worktree on disk. */
   onKeep: () => void
@@ -47,26 +49,46 @@ interface CloseWorktreeDialogProps {
 // CloseWorktreeDialog asks what to do with the worktree a closing session lives
 // in: keep it on disk (it reappears in the new-worktree picker) or remove the
 // checkout via git. The branch is never deleted either way.
-function CloseWorktreeDialog({ session, onCancel, onKeep, onRemove }: CloseWorktreeDialogProps) {
+//
+// A checkout lich adopted has only the one answer. The directory is the user's,
+// made outside lich and only listed by it, so the removal is refused by the
+// backend whatever this offers — and the description says so, or the missing
+// button reads as a bug rather than as the rule it is.
+function CloseWorktreeDialog({
+  session,
+  adopted,
+  onCancel,
+  onKeep,
+  onRemove,
+}: CloseWorktreeDialogProps) {
+  const path = <span className="break-all font-mono">{session?.path}</span>
   return (
     <ConfirmDialog
       open={session !== null}
       onCancel={onCancel}
       title="Close worktree session"
       description={
-        <>
-          Keep or remove the worktree at{" "}
-          <span className="break-all font-mono">{session?.path}</span>? Removing deletes the
-          checkout but keeps its branch.
-        </>
+        adopted ? (
+          <>
+            lich did not create the worktree at {path}, so it will not delete it. Closing parks the
+            session — the checkout stays exactly where it is.
+          </>
+        ) : (
+          <>
+            Keep or remove the worktree at {path}? Removing deletes the checkout but keeps its
+            branch.
+          </>
+        )
       }
     >
       <Button variant="outline" onClick={onKeep}>
-        Keep worktree
+        {adopted ? "Close session" : "Keep worktree"}
       </Button>
-      <Button variant="destructive" onClick={onRemove}>
-        Remove worktree
-      </Button>
+      {!adopted && (
+        <Button variant="destructive" onClick={onRemove}>
+          Remove worktree
+        </Button>
+      )}
     </ConfirmDialog>
   )
 }
@@ -120,6 +142,7 @@ export function WorktreeCloseDialogs({ close }: { close: WorktreeClose }) {
       />
       <CloseWorktreeDialog
         session={close.pendingClose}
+        adopted={close.pendingAdopted}
         onCancel={close.cancel}
         onKeep={close.keep}
         onRemove={close.remove}

--- a/frontend/src/components/sidebar/useWorktreeClose.ts
+++ b/frontend/src/components/sidebar/useWorktreeClose.ts
@@ -16,6 +16,12 @@ export interface WorktreeClose {
   closeAnyway: () => void
   /** The session whose keep-or-remove dialog is open, or null. */
   pendingClose: Session | null
+  /**
+   * Whether that checkout is one lich adopted rather than created, in which case
+   * it is the user's directory and removal is not on offer. True until the
+   * backend says otherwise, so the destructive answer never appears on a guess.
+   */
+  pendingAdopted: boolean
   /** The dirty worktree waiting on a --force confirmation, or null. */
   pendingForce: Session | null
   /** Dismiss whichever dialog is open, changing nothing. */
@@ -43,6 +49,7 @@ export function useWorktreeClose(
   const { closeSession, discardSession, keepSession } = useProjects()
   const [pendingRunning, setPendingRunning] = useState<Session | null>(null)
   const [pendingClose, setPendingClose] = useState<Session | null>(null)
+  const [pendingAdopted, setPendingAdopted] = useState(true)
   const [pendingForce, setPendingForce] = useState<Session | null>(null)
 
   // Close first so the PTY running inside the worktree dies before git tries
@@ -73,7 +80,15 @@ export function useWorktreeClose(
         setPendingRunning(session)
         return
       case "ask-worktree":
+        // Asked as the dialog opens rather than at the click on Remove: an
+        // adopted checkout has no removal to offer, and a button that only ever
+        // ends in a refusal is worse than the one that is not there. A failed
+        // check reads as adopted — the safe half of the answer.
+        setPendingAdopted(true)
         setPendingClose(session)
+        void ProjectService.WorktreeAdopted(session.path ?? "")
+          .catch(() => true)
+          .then(setPendingAdopted)
         return
       case "close":
         closeSession(projectId, session.id)
@@ -83,6 +98,7 @@ export function useWorktreeClose(
   return {
     pendingRunning,
     pendingClose,
+    pendingAdopted,
     pendingForce,
 
     requestClose(session) {

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -308,6 +308,7 @@ export const ProjectService = {
   RemoveWorktree: (projectPath: string, wtPath: string, force: boolean) =>
     call<null>("project.RemoveWorktree", [projectPath, wtPath, force]),
   WorktreeDirty: (wtPath: string) => call<boolean>("project.WorktreeDirty", [wtPath]),
+  WorktreeAdopted: (wtPath: string) => call<boolean>("project.WorktreeAdopted", [wtPath]),
 }
 
 export const Store = {

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -217,6 +217,8 @@ func (g *spawnGit) RemoveWorktree(_, path string, force bool) error {
 
 func (g *spawnGit) WorktreeDirty(string) (bool, error) { return g.dirty, nil }
 
+func (*spawnGit) WorktreeAdopted(string) bool { return false }
+
 type spawnTerminal struct {
 	mu     sync.Mutex
 	kind   string

--- a/internal/project/worktree.go
+++ b/internal/project/worktree.go
@@ -319,11 +319,45 @@ func (s *Service) CreateWorktreeFromPR(projectPath, projectID string, number int
 	return &Worktree{Name: head.RefName, Path: canonicalPath(wtPath)}, nil
 }
 
+// WorktreeAdopted reports whether the checkout at wtPath is one lich adopted
+// rather than created: `git worktree list` hands back every worktree of a
+// repository, so one the user made by hand appears in the picker and hosts a
+// session like any other, and nothing but its path tells the two apart.
+// Everything lich creates lives under the worktrees root reserveWorktreePath
+// builds its paths in; anything outside it is the user's own directory, which
+// lich may forget but never delete.
+//
+// Both sides go through canonicalPath, and an unresolvable root reads as
+// adopted: the answer gates a deletion, so the unknown case has to be the one
+// that keeps the checkout.
+func (s *Service) WorktreeAdopted(wtPath string) bool {
+	root, err := worktreesRoot()
+	if err != nil {
+		return true
+	}
+	// Rel, not a string prefix: "<root>-old" starts with the root spelled out
+	// and is no more lich's than any other directory next to it.
+	rel, err := filepath.Rel(canonicalPath(root), canonicalPath(wtPath))
+	if err != nil {
+		return true
+	}
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
 // RemoveWorktree removes a worktree checkout. Without force git refuses to
 // delete a dirty worktree, which is the safety net the close-session flow
 // relies on; force discards uncommitted changes after the user has confirmed.
 // The branch is never deleted either way.
+//
+// An adopted checkout is refused outright, force or not: the directory is the
+// user's, made outside lich and only listed by it, and --force would take
+// uncommitted work with it. Callers ask WorktreeAdopted before they take a
+// session apart, so this is the invariant behind them rather than the message
+// anyone reads — but it is the one that holds when a caller forgets.
 func (s *Service) RemoveWorktree(projectPath, wtPath string, force bool) error {
+	if s.WorktreeAdopted(wtPath) {
+		return fmt.Errorf("The worktree at %s was not created by lich, so lich will not delete it.", wtPath)
+	}
 	args := []string{"worktree", "remove"}
 	if force {
 		args = append(args, "--force")

--- a/internal/project/worktree_test.go
+++ b/internal/project/worktree_test.go
@@ -325,6 +325,64 @@ func TestRemoveWorktree(t *testing.T) {
 	}
 }
 
+// TestWorktreeAdopted pins where lich's own worktrees live. The root is spelled
+// out here instead of read back from worktreesRoot, so moving that layout has to
+// be a deliberate edit on both sides rather than a test that follows along.
+func TestWorktreeAdopted(t *testing.T) {
+	data := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", data)
+	svc := New(nil)
+
+	cases := []struct {
+		name    string
+		path    string
+		adopted bool
+	}{
+		{"one lich created", filepath.Join(data, "lich", "worktrees", "proj", "feature"), false},
+		{"the root itself", filepath.Join(data, "lich", "worktrees"), false},
+		{"a directory the user made", filepath.Join(data, "elsewhere", "feature"), true},
+		{"a sibling the root only prefixes", filepath.Join(data, "lich", "worktrees-old", "feature"), true},
+		{"one directory above the root", filepath.Join(data, "lich"), true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := svc.WorktreeAdopted(c.path); got != c.adopted {
+				t.Errorf("WorktreeAdopted(%q) = %v, want %v", c.path, got, c.adopted)
+			}
+		})
+	}
+}
+
+// TestRemoveWorktreeRefusesAnAdoptedCheckout proves a worktree the user made by
+// hand is never handed to `git worktree remove` — not even with force, which is
+// the call that would take uncommitted work with it. git lists it like any
+// other, so nothing but its path outside the data dir tells lich to keep away.
+func TestRemoveWorktreeRefusesAnAdoptedCheckout(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	repo, git := initRepo(t)
+	adopted := filepath.Join(t.TempDir(), "by-hand")
+	git("worktree", "add", "-b", "by-hand", adopted, "main")
+
+	svc := New(nil)
+	for _, force := range []bool{false, true} {
+		if err := svc.RemoveWorktree(repo, adopted, force); err == nil {
+			t.Fatalf("RemoveWorktree(force=%v) = nil, want a refusal", force)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(adopted, "a.txt")); err != nil {
+		t.Errorf("the user's checkout is gone: %v", err)
+	}
+	// Still registered: no `git worktree remove` ran, so the picker keeps
+	// offering it — adoption costs the removal, never the session.
+	branches, err := svc.ListBranches(repo)
+	if err != nil {
+		t.Fatalf("ListBranches: %v", err)
+	}
+	if !slices.ContainsFunc(branches.Worktrees, func(w Worktree) bool { return w.Name == "by-hand" }) {
+		t.Errorf("worktrees = %+v, want the adopted checkout still listed", branches.Worktrees)
+	}
+}
+
 // TestWorktreeDirty proves a fresh worktree reads clean, both modified and
 // untracked files read dirty, and a non-repo path errors.
 func TestWorktreeDirty(t *testing.T) {

--- a/internal/spawn/close.go
+++ b/internal/spawn/close.go
@@ -130,6 +130,17 @@ func (s *Service) Close(fromID, target, projectName, worktree string, force bool
 // the checkout does — one left behind would offer a resume into a directory that
 // no longer exists.
 func (s *Service) removeCheckout(found located, active string, force bool) error {
+	// Asked before anything is taken apart, not after: the removal itself is
+	// refused for an adopted checkout (project.RemoveWorktree), but by then the
+	// terminal is closed and the rows are gone, and the session would be lost to
+	// keep a directory that was never at risk.
+	if s.worktrees.WorktreeAdopted(found.session.Path) {
+		return fmt.Errorf(
+			"the worktree %s was not created by lich, so closing this session cannot delete it: "+
+				"say %q instead, which parks the session and leaves the checkout where it is",
+			found.session.Path, KeepWorktree,
+		)
+	}
 	// A check that cannot answer costs the message, never the work: `git worktree
 	// remove` without --force refuses a dirty checkout on its own
 	// (project.RemoveWorktree), so an unreadable status ends in git's own refusal

--- a/internal/spawn/close_test.go
+++ b/internal/spawn/close_test.go
@@ -148,6 +148,29 @@ func TestCloseRemovingAWorktreeTakesTheCheckoutWithIt(t *testing.T) {
 	}
 }
 
+// A checkout the user made by hand is theirs: lich lists it and runs sessions in
+// it, but the close that would delete it is refused before the session is taken
+// apart — the removal itself is refused too (project.RemoveWorktree), and by
+// then the row would already be gone in exchange for nothing.
+func TestCloseRefusesToRemoveAnAdoptedCheckout(t *testing.T) {
+	svc, sessions, worktrees, term, _ := closer(t)
+	worktrees.adopted = map[string]bool{"/wt/alone": true}
+
+	_, err := svc.Close("s1", "alone", "", RemoveWorktree, false)
+	if err == nil {
+		t.Fatal("removed a checkout lich never created")
+	}
+	if !strings.Contains(err.Error(), KeepWorktree) {
+		t.Errorf("error = %q, want it to name the answer that works", err)
+	}
+	if len(worktrees.removed) != 0 {
+		t.Errorf("removed = %+v, want the user's directory untouched", worktrees.removed)
+	}
+	if len(sessions.deleted) != 0 || len(sessions.purged) != 0 || len(term.closed) != 0 {
+		t.Error("took the session apart for a removal that was refused")
+	}
+}
+
 // What an uncommitted change loses is in no commit and on no remote, so it is
 // the one thing here that needs saying twice.
 func TestCloseRefusesToRemoveADirtyCheckout(t *testing.T) {

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -88,6 +88,7 @@ type Worktrees interface {
 	CreateWorktree(projectPath, projectID, name, base string, baseIsRemote bool) (*project.Worktree, error)
 	RemoveWorktree(projectPath, wtPath string, force bool) error
 	WorktreeDirty(wtPath string) (bool, error)
+	WorktreeAdopted(wtPath string) bool
 }
 
 // Terminal is the PTY side: the same spawn the window asks for when a card is

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -130,6 +130,8 @@ type fakeWorktrees struct {
 	dirty     map[string]bool
 	removed   []removedWorktree
 	removeErr error
+	// adopted names the checkouts the fixture says lich did not create.
+	adopted map[string]bool
 }
 
 type removedWorktree struct {
@@ -144,6 +146,8 @@ func (f *fakeWorktrees) ListCheckouts(string) ([]project.Worktree, error) {
 func (f *fakeWorktrees) WorktreeDirty(path string) (bool, error) {
 	return f.dirty[path], nil
 }
+
+func (f *fakeWorktrees) WorktreeAdopted(path string) bool { return f.adopted[path] }
 
 func (f *fakeWorktrees) RemoveWorktree(_, path string, force bool) error {
 	f.removed = append(f.removed, removedWorktree{path, force})


### PR DESCRIPTION
## The bug

`git worktree list` hands back every checkout of a repository, so a worktree the user created by hand already appears in lich's picker and already hosts a session — that half works and is not touched here. Nothing told it apart from one lich made: `RemoveWorktree` ran `git worktree remove` on whatever path it was given. Closing the last session in a hand-made worktree with "remove" deleted the user's directory, and with `--force` the uncommitted work in it.

## The fix

Everything lich creates lives under the worktrees root `reserveWorktreePath` builds into, so the path is the whole test. `project.WorktreeAdopted` compares canonical paths on both sides (`canonicalPath`, which exists for the macOS symlink and the Windows 8.3 form) with `filepath.Rel` rather than a string prefix, so a sibling named `<root>-old` does not pass for lich's own. An unresolvable root reads as adopted: the answer gates a deletion, so the unknown case has to be the one that keeps the checkout.

`RemoveWorktree` refuses an adopted path outright, force or not.

**Refused *and* not offered** — both, deliberately. Every caller destroys state before it calls: `spawn.removeCheckout` closes the PTY and deletes the rows, the sidebar discards the card and purges the parked rows, the Pulls cleanup does both. A refusal at the end would have traded the session for a directory that was never at risk. So each caller asks at the check point it already had, and the close dialog drops the Remove answer entirely for an adopted checkout rather than offering one that cannot work. The backend refusal is the invariant behind them, the one that holds when a caller forgets.

An adopted worktree's close is the answer that already existed: keep parks the session (`is_open=0`) for a later resume and leaves the checkout exactly where it is.

Prior art: [JetBrains/thinkrail](https://github.com/JetBrains/thinkrail) records an attached worktree as `kind: "external"` and writes the same invariant — the host may forget it, never mutate it — and enforces it in the module, "not just hidden in the UI".

## Not related

Detached worktrees (dropped by `parseWorktreeBlock`) have nothing to do with this: they hold no branch, so they never reach the picker and never become a session's path. The only detached checkout lich makes is `CreateWorktreeFromPR`'s, which `gh pr checkout` attaches a branch to moments later and which lives under the root either way.

## Test plan

- `TestWorktreeAdopted` pins the layout with literal paths rather than reading `worktreesRoot` back — including the `<root>-old` sibling and the root's own parent.
- `TestRemoveWorktreeRefusesAnAdoptedCheckout` makes a real worktree outside the data dir with `git worktree add`, proves neither call reaches `git worktree remove`, that the files are still there, and that the checkout is still listed for the picker.
- `TestCloseRefusesToRemoveAnAdoptedCheckout` proves the close refuses before the PTY, the rows or the parked rows are touched.
- Local gate green: `gofmt`, `go vet ./...`, `go test ./...` (1978), `pnpm check`, `pnpm test` (1208), `pnpm build`, and the `GOOS` cross-compile loop for linux/darwin/windows.

Dialog mockup in both themes, with lich's real tokens: https://claude.ai/code/artifact/c57e2148-65b7-4d85-a683-9e2ae58d992c