### PR TITLE
fix: a worktree on a remote base cannot hang, mislead, or take the upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A worktree on a remote base no longer hangs, misreports, or takes your
+  upstream.** Three faults in the one step that fetches the base before the
+  checkout. The fetch is the only part of creating a worktree that touches the
+  network, and it ran with no time limit and no way to refuse a prompt: a remote
+  that wanted a password or an ssh key passphrase left the dialog waiting for an
+  answer nobody could give it, for as long as lich stayed open. It now gives up
+  after a minute and says so, and never waits on a prompt in the first place.
+  The new branch was also made to track the base, so a plain `git pull` in the
+  session's terminal merged the base branch into the work and `git status` read
+  the work as "ahead of origin/main" — the branch is now left with no upstream,
+  which is the first push's to set. And a repository that only tracks some of
+  its remote's branches — anything cloned with `--single-branch`, or a remote
+  added with `-t` — lets that fetch report success while writing no branch ref
+  at all; the checkout then failed with "git could not complete the operation",
+  which named nothing you could act on. lich now checks the ref itself and says
+  which one the repository does not keep. A base is also resolved by its full
+  ref now, so a repository that happens to carry a local branch named
+  `origin/main` no longer makes every remote base ambiguous and unusable.
 - **A worktree you made yourself is never deleted by lich.** git lists every
   worktree of a repository, so one you created by hand shows up in lich's picker
   and hosts a session like any other — and closing that session used to offer to

--- a/internal/project/worktree.go
+++ b/internal/project/worktree.go
@@ -1,6 +1,7 @@
 package project
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // Worktree is a git worktree checkout: the branch it holds and its path.
@@ -198,10 +200,58 @@ func reserveWorktreePath(projectPath, projectID, name string) (string, error) {
 	return wtPath, nil
 }
 
+// baseFetchBudget caps the fetch that precedes a worktree on a remote base.
+// It is the one part of creating a worktree that reaches the network, and the
+// dialog waits on it: unbudgeted, a remote that wants a passphrase leaves the
+// create call hanging for the app's life.
+const baseFetchBudget = 60 * time.Second
+
+// fetchBase updates refs/remotes/<remote>/<branch> and reports whether the ref
+// is there afterwards, which is the question `worktree add` is about to ask.
+//
+// git's exit status does not answer it: under a narrowed refspec — a
+// --single-branch clone, `remote add -t`, a hand-edited remote.<name>.fetch —
+// `git fetch origin -- other` writes the branch to FETCH_HEAD, says "* branch
+// other -> FETCH_HEAD", and exits 0 without creating the remote-tracking ref.
+// Only the ref itself settles it, and it is checked again after a failed fetch
+// in case a concurrent one landed the ref this call needed.
+func fetchBase(projectPath, remote, branch string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), baseFetchBudget)
+	defer cancel()
+
+	args := []string{"-C", projectPath, "fetch", "--", remote, branch}
+	cmd := commandContext(ctx, "git", args...)
+	// Without these a remote that wants a credential or a key passphrase stops
+	// on a prompt with no terminal to answer it — or worse, a GUI askpass dialog
+	// behind the app window — and burns the whole budget waiting for a person.
+	cmd.Env = append(os.Environ(),
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_ASKPASS=",
+		"SSH_ASKPASS=",
+		"GCM_INTERACTIVE=never",
+	)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	fetchErr := cmd.Run()
+
+	ref := "refs/remotes/" + remote + "/" + branch
+	if _, ok := gitQuiet(projectPath, "rev-parse", "--verify", "--quiet", ref); ok {
+		return nil
+	}
+	if fetchErr != nil {
+		logToolFailure("git", args, stderr.String(), fetchErr)
+		if ctx.Err() != nil {
+			return fmt.Errorf("Fetching %s took longer than %s and was given up on.", ref, baseFetchBudget)
+		}
+		return errors.New(gitMessage(stderr.String(), fetchErr))
+	}
+	return fmt.Errorf("git fetched %s but this repository does not keep %s — its remote only tracks some branches.", branch, ref)
+}
+
 // CreateWorktree creates a git worktree named name (random when empty) under
-// the app data dir, branching off base. A remote base is fetched first and the
-// new branch tracks it. A branch that already exists is checked out as it
-// stands, and base is ignored. The worktree is verified usable before
+// the app data dir, branching off base. A remote base is fetched first, and the
+// new branch is left with no upstream. A branch that already exists is checked
+// out as it stands, and base is ignored. The worktree is verified usable before
 // returning, so a success here means a session can be opened at Path right away.
 func (s *Service) CreateWorktree(projectPath, projectID, name, base string, baseIsRemote bool) (*Worktree, error) {
 	if name == "" {
@@ -228,10 +278,21 @@ func (s *Service) CreateWorktree(projectPath, projectID, name, base string, base
 			if !ok {
 				return nil, fmt.Errorf("%q is not a remote branch lich can track.", base)
 			}
-			if _, err := runGit(projectPath, "fetch", "--", remote, branch); err != nil {
+			if err := fetchBase(projectPath, remote, branch); err != nil {
 				return nil, err
 			}
-			args = append(args, "--track")
+			// The full refname, never the "origin/main" shorthand: a repository
+			// that also holds a *local* branch literally named "origin/main" has
+			// two refs answering to that shorthand, and git refuses the pair
+			// outright ("ambiguous object name") — a refusal the person reading
+			// it cannot connect to a branch name they may not know exists.
+			source = "refs/remotes/" + base
+			// --no-track, because autoSetupMerge would otherwise make the base
+			// this branch's upstream: a `git pull` in the session's terminal
+			// would merge the base into the work, and `git status` would report
+			// the work as "ahead of origin/main". Which upstream a branch gets
+			// is the first push's question, and the user's to answer.
+			args = append(args, "--no-track")
 		}
 		args = append(args, "-b", name)
 	}

--- a/internal/project/worktree_test.go
+++ b/internal/project/worktree_test.go
@@ -265,8 +265,12 @@ func TestCreateWorktreeExistingBranch(t *testing.T) {
 	}
 }
 
-// TestCreateWorktreeRemoteBase proves a remote base is fetched and the new
-// branch tracks it.
+// TestCreateWorktreeRemoteBase proves a remote base is fetched, the new branch
+// starts at that remote ref, and it is left with no upstream — the base is
+// where the work starts, not what it merges with. Tracking the base would make
+// a plain `git pull` in the session's terminal merge the base into the work,
+// and `git status` read the work as "ahead of origin/feature"; which upstream
+// the branch gets belongs to its first push.
 func TestCreateWorktreeRemoteBase(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	repo, git := initRepo(t)
@@ -277,12 +281,86 @@ func TestCreateWorktreeRemoteBase(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateWorktree(remote base): %v", err)
 	}
-	upstream, err := runGit(wt.Path, "rev-parse", "--abbrev-ref", "@{u}")
-	if err != nil {
-		t.Fatalf("rev-parse @{u}: %v", err)
+	if out, ok := gitQuiet(wt.Path, "rev-parse", "--abbrev-ref", "@{u}"); ok {
+		t.Errorf("upstream = %q, want none", strings.TrimSpace(out))
 	}
-	if got := strings.TrimSpace(upstream); got != "origin/feature" {
-		t.Errorf("upstream = %q, want origin/feature", got)
+	head, err := runGit(wt.Path, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	base, err := runGit(repo, "rev-parse", "refs/remotes/origin/feature")
+	if err != nil {
+		t.Fatalf("rev-parse origin/feature: %v", err)
+	}
+	if strings.TrimSpace(head) != strings.TrimSpace(base) {
+		t.Errorf("worktree HEAD = %s, want origin/feature at %s", strings.TrimSpace(head), strings.TrimSpace(base))
+	}
+}
+
+// TestCreateWorktreeRemoteBaseAmbiguousName proves the base is resolved as a
+// full refname. A repository may hold a local branch literally called
+// "origin/feature", and the shorthand then names two refs at once: git refuses
+// the whole worktree add with "ambiguous object name", which reaches the screen
+// as lich's generic "could not complete the operation" and leaves the person
+// with a base they picked from lich's own list and no way to use it.
+func TestCreateWorktreeRemoteBaseAmbiguousName(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	repo, git := initRepo(t)
+	addLocalOrigin(t, git)
+	// A second commit gives the decoy a different tip from the remote branch's,
+	// so resolving to the wrong one shows up as a different HEAD.
+	if err := os.WriteFile(filepath.Join(repo, "a.txt"), []byte("two\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	git("commit", "-am", "second")
+	git("branch", "origin/feature", "HEAD")
+
+	svc := New(nil)
+	wt, err := svc.CreateWorktree(repo, "pid", "from-remote", "origin/feature", true)
+	if err != nil {
+		t.Fatalf("CreateWorktree(remote base): %v", err)
+	}
+	head, err := runGit(wt.Path, "rev-parse", "HEAD")
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	want, err := runGit(repo, "rev-parse", "refs/remotes/origin/feature")
+	if err != nil {
+		t.Fatalf("rev-parse refs/remotes/origin/feature: %v", err)
+	}
+	if strings.TrimSpace(head) != strings.TrimSpace(want) {
+		t.Errorf("worktree HEAD = %s, want the remote ref at %s (the local decoy branch won)",
+			strings.TrimSpace(head), strings.TrimSpace(want))
+	}
+}
+
+// TestCreateWorktreeRemoteBaseNotFetched proves the guard is the ref, not git's
+// exit status. With the remote's refspec narrowed to one branch — what a
+// --single-branch clone or `remote add -t` leaves behind — `git fetch origin --
+// feature` writes the branch to FETCH_HEAD and exits 0 without ever creating
+// refs/remotes/origin/feature. The refusal has to name that ref: leaving it to
+// `worktree add` gets the person a derived "invalid reference" that says
+// nothing about the narrowed refspec that caused it.
+func TestCreateWorktreeRemoteBaseNotFetched(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	repo, git := initRepo(t)
+	origin, originGit := initRepo(t)
+	originGit("branch", "feature")
+	// -t main is the narrowed refspec: origin/feature is reachable to fetch and
+	// never written to refs/remotes.
+	git("remote", "add", "-t", "main", "origin", origin)
+	git("fetch", "origin")
+
+	svc := New(nil)
+	_, err := svc.CreateWorktree(repo, "pid", "from-remote", "origin/feature", true)
+	if err == nil {
+		t.Fatal("CreateWorktree(unfetchable remote base) = nil error, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "refs/remotes/origin/feature") {
+		t.Errorf("error = %q, want it to name refs/remotes/origin/feature", err)
+	}
+	if strings.Contains(err.Error(), "invalid reference") {
+		t.Errorf("error = %q, want lich's own refusal, not worktree add's derived one", err)
 	}
 }
 


### PR DESCRIPTION
Creating a worktree from a remote base fetches that base first — the one step in
the flow that reaches the network. Three faults sat in the block around it
(`internal/project/worktree.go`), and they share one theme, so they share one PR.

### The fetch had no budget and no prompt hygiene

It ran through `runGit`, which takes no `context` and inherits the environment
whole. A remote that wanted a password or an ssh key passphrase stopped on a
prompt with no terminal to answer it, and the create RPC never returned — the
dialog waited for as long as lich stayed open. This is the hang behind the
`ssh_askpass` entry in `giterror.go`.

It now runs under a 60s budget through `commandContext`, with the same
credential-prompt hygiene `internal/themes/git.go` already uses for `clone`, and
a timeout gets its own message instead of falling through to the generic one.
`git.go`, `basestatus.go` and `pr.go` are untouched — the parallel `WaitDelay`
work owns those.

### `--track` handed the branch the wrong upstream

The base became the new branch's upstream, so a plain `git pull` in the session's
terminal merged the base into the work, and `git status` read the work as "ahead
of origin/main". Which upstream a branch gets belongs to its first push.

`--track` was not a defended decision: it landed in the original worktree feature
commit (`7809c9b`) described as "remote bases are fetched and tracked", and
nothing in `docs/ceilings.md` or `docs/` claims it. Nothing in lich reads the
upstream either — `BaseStatus` computes the base from `refs/remotes/origin/HEAD`
and `status.go` ignores the porcelain's upstream headers.

This reverses what `CreateWorktree`'s doc comment promised and what
`TestCreateWorktreeRemoteBase` asserted. That is a contract change made on
purpose, named here and in the commit — not a test bent to buy a green run.

### The guard was the exit code, not the ref

Measured, not assumed: with a narrowed refspec (`remote add -t main origin`),
`git fetch origin -- feature` prints `* branch feature -> FETCH_HEAD` and **exits
0** without ever creating `refs/remotes/origin/feature`. The same holds for a
`--single-branch` clone or an edited `remote.<name>.fetch`.

`worktree add` then failed with `fatal: invalid reference: …`, which does not
even reach the screen — `gitMessage` has no entry for it, so the person got
"git could not complete the operation. lich's log has what it reported."

The ref is now the guard, re-checked after a *failed* fetch too in case a
concurrent one landed it, and the refusal names the ref and the reason.

The base is also resolved by full refname instead of the `origin/main` shorthand.
A repository carrying a local branch of that literal name makes the shorthand
ambiguous, and git refuses the whole add (`fatal: ambiguous object name`) — again
as the generic message, for a base lich itself offered in the picker.

## Test plan

- [x] `TestCreateWorktreeRemoteBaseNotFetched` — narrowed refspec: fetch exits 0,
      ref absent, message must name `refs/remotes/origin/feature` and must not
      leak `worktree add`'s derived error. Pins the literal.
      Verified to fail without the guard (it reproduces the generic message).
- [x] `TestCreateWorktreeRemoteBaseAmbiguousName` — a local `origin/feature`
      decoy at a different commit; verified to fail without the full refname.
- [x] `TestCreateWorktreeRemoteBase` — flipped from asserting the upstream to
      asserting there is none, plus that HEAD sits on the remote ref.
- [x] `gofmt -l .`, `go vet ./...`, `go test ./...`, `go test -race ./internal/project/`
- [x] `go test -count=30 -run TestCreateWorktreeRemoteBase ./internal/project/`
- [x] `for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done`
- [x] frontend: `biome check`, `tsc -b --noEmit`, `vite build`, `vitest run` (1317 passed)
- [x] `CHANGELOG.md` `[Unreleased]` entry in this PR

The 60s budget is not surfaced anywhere configurable; it follows
`baseFetchTimeout`'s precedent in `basestatus.go`, which is likewise not in
`docs/ceilings.md`.