### PR TITLE
fix: make the subprocess timeouts bound the call, not just the child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   picked up never gained the version manager's Node or the CLIs installed under
   it. Providers under a version manager now show up in Settings › Providers on
   the first check.
+- **A git or gh call can no longer wait forever on a question nobody sees.**
+  Started from a terminal, lich hands that terminal to every git and gh it runs,
+  so a call that stops to ask for a username asks there — behind the window,
+  with nobody reading it — and the screen waiting on that read never gets an
+  answer. Neither is allowed to ask now: the call fails and says so. A
+  credential helper or an askpass program still answers as before, which is how
+  a machine set up for this answers with nobody typing.
+- **A call that runs out of time comes back.** The deadline on every call lich
+  makes to the network — eight seconds to read a pull request, ninety to check
+  one out — bounded the command and not the call: anything git or gh left
+  running behind it held the output pipe open, and lich went on waiting for as
+  long as that process lived, deadline or none. The deadline now ends the call
+  itself.
 
 ## [0.42.0] - 2026-08-27
 

--- a/internal/agentplugin/agentplugin.go
+++ b/internal/agentplugin/agentplugin.go
@@ -58,6 +58,10 @@ const (
 	// prompt behind a CLI that never answers.
 	cmdTimeout  = 130 * time.Second
 	readTimeout = 10 * time.Second
+	// waitDelay is how long past the CLI's own exit Wait may still block on
+	// anything the CLI left running on its output pipe. Without it the timeouts
+	// above bound the CLI and not the call — see internal/project's waitDelay.
+	waitDelay   = 2 * time.Second
 	httpTimeout = 5 * time.Second
 )
 
@@ -350,6 +354,7 @@ func (s *Service) exec(provider string, timeout time.Duration, args ...string) (
 	defer cancel()
 	cmd := exec.CommandContext(ctx, s.bin(provider), args...)
 	winexec.Hide(cmd)
+	cmd.WaitDelay = waitDelay
 	out, err := cmd.CombinedOutput()
 	return string(out), err
 }

--- a/internal/project/git.go
+++ b/internal/project/git.go
@@ -3,27 +3,66 @@ package project
 import (
 	"bytes"
 	"context"
+	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/omartelo/lich/internal/winexec"
 )
 
-// command builds an exec.Cmd for a child console tool (git, gh) with its
-// console window suppressed on Windows — lich's GUI-subsystem binary would
-// otherwise pop one per spawn (winexec.Hide). Used across this package instead
-// of exec.Command so no call site can forget it.
+// waitDelay caps how long a call keeps this process after the child itself is
+// gone. A pipe reaches EOF only when its last writer closes it, so a grandchild
+// that inherited the child's stdout keeps Wait blocked long after the child and
+// its deadline are gone: the context kills the child it named and the call waits
+// on regardless — a budget of 200ms measured at ten seconds, reporting success.
+// WaitDelay ends that wait: the pipes are closed and Wait reports
+// exec.ErrWaitDelay.
+//
+// Nothing here is known to do it. The three that come to mind — an ssh
+// ControlMaster left alive by a fetch, git's credential cache daemon, the
+// gc --auto git detaches — were each measured still running after their call
+// returned at once, because openssh and git both hand back stdio before they
+// detach. This holds the budget against one that does not.
+//
+// Two seconds is generous because the clock only starts once the child is dead,
+// where draining what is left in a pipe takes microseconds.
+const waitDelay = 2 * time.Second
+
+// noPromptEnv is what keeps a child from stopping on a question nobody will
+// answer. Started from a terminal, lich inherits it and hands it to every child
+// here, so a git that stops to ask for a username asks *there* — behind the
+// window, where the answer never comes: measured, git waits at that prompt until
+// it is killed, and fails on its own in a second and a half with this set. The
+// calls that take no context have no budget to end the wait for them.
+//
+// The terminal prompt alone: a credential helper and an askpass program still
+// answer, and those are how a machine set up for this answers with nobody at the
+// keyboard.
+var noPromptEnv = []string{"GIT_TERMINAL_PROMPT=0", "GH_PROMPT_DISABLED=1"}
+
+// command builds an exec.Cmd for a child console tool (git, gh). Used across
+// this package instead of exec.Command so no call site can forget what prepare
+// applies.
 func command(name string, args ...string) *exec.Cmd {
-	cmd := exec.Command(name, args...)
-	winexec.Hide(cmd)
-	return cmd
+	return prepare(exec.Command(name, args...))
 }
 
 // commandContext is command for a call that must be killed if it outlives ctx —
 // anything reaching the network, where "slow" has no upper bound.
 func commandContext(ctx context.Context, name string, args ...string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, name, args...)
+	return prepare(exec.CommandContext(ctx, name, args...))
+}
+
+// prepare applies what every child of this package gets: no console window on
+// Windows, which lich's GUI-subsystem binary would otherwise pop one of per
+// spawn (winexec.Hide); no wait on a grandchild (waitDelay); no prompt
+// (noPromptEnv). A call site with a variable of its own appends to cmd.Env —
+// assigning over it drops these.
+func prepare(cmd *exec.Cmd) *exec.Cmd {
 	winexec.Hide(cmd)
+	cmd.WaitDelay = waitDelay
+	cmd.Env = append(os.Environ(), noPromptEnv...)
 	return cmd
 }
 

--- a/internal/project/pr.go
+++ b/internal/project/pr.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -49,7 +48,7 @@ func runGH(timeout time.Duration, dir, token string, args ...string) ([]byte, er
 	cmd := commandContext(ctx, "gh", args...)
 	cmd.Dir = dir
 	if token != "" {
-		cmd.Env = append(os.Environ(), "GH_TOKEN="+token)
+		cmd.Env = append(cmd.Env, "GH_TOKEN="+token)
 	}
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/internal/project/turnsnap.go
+++ b/internal/project/turnsnap.go
@@ -62,7 +62,7 @@ func TreeDiff(dir, before, after string) (string, error) {
 // that fails costs the panel a whole turn, and the reason has to reach the log.
 func snapGit(dir, index string, args ...string) (string, error) {
 	cmd := command("git", append([]string{"-C", dir}, args...)...)
-	cmd.Env = append(os.Environ(), "GIT_INDEX_FILE="+index)
+	cmd.Env = append(cmd.Env, "GIT_INDEX_FILE="+index)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	out, err := cmd.Output()

--- a/internal/project/waitdelay_test.go
+++ b/internal/project/waitdelay_test.go
@@ -1,0 +1,53 @@
+package project
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// helperEnv selects which half of the process tree a helper run plays.
+const helperEnv = "LICH_WAITDELAY_HELPER"
+
+// TestSubprocessHelper is not a test of anything: it is the child and the
+// grandchild TestSubprocessBudgetOutlivesAGrandchild spawns, re-executing this
+// binary because a shell one-liner would not run on Windows. As "child" it
+// starts a grandchild on its own stdout — the pipe the parent is reading — and
+// exits at once; as "grandchild" it holds that pipe open far past any budget
+// the parent could set. A plain run does nothing.
+func TestSubprocessHelper(t *testing.T) {
+	switch os.Getenv(helperEnv) {
+	case "child":
+		grandchild := exec.Command(os.Args[0], "-test.run=TestSubprocessHelper")
+		grandchild.Env = append(os.Environ(), helperEnv+"=grandchild")
+		grandchild.Stdout = os.Stdout
+		if err := grandchild.Start(); err != nil {
+			t.Fatalf("start grandchild: %v", err)
+		}
+		os.Exit(0)
+	case "grandchild":
+		time.Sleep(10 * time.Second)
+		os.Exit(0)
+	}
+}
+
+// A budget is only real if it bounds the call rather than the child. The child
+// here exits immediately and the grandchild behind it keeps stdout open for ten
+// seconds: with nothing closing that pipe, Output waits all ten and reports
+// success, deadline or none.
+func TestSubprocessBudgetOutlivesAGrandchild(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	cmd := commandContext(ctx, os.Args[0], "-test.run=TestSubprocessHelper")
+	cmd.Env = append(cmd.Env, helperEnv+"=child")
+
+	start := time.Now()
+	_, err := cmd.Output()
+	elapsed := time.Since(start)
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("Output blocked %s on a grandchild holding the pipe, err %v: the 200ms budget bounded the child alone", elapsed, err)
+	}
+}

--- a/internal/themes/git.go
+++ b/internal/themes/git.go
@@ -18,7 +18,11 @@ import (
 )
 
 const (
-	cloneTimeout     = 90 * time.Second
+	cloneTimeout = 90 * time.Second
+	// cloneWait is how long past git's own exit the clone may still block on
+	// anything git left running on its output pipe. Without it cloneTimeout
+	// bounds git and not the call — see internal/project's waitDelay.
+	cloneWait        = 2 * time.Second
 	remoteMaxLength  = 512
 	maxThemesPerPack = 32
 )
@@ -187,6 +191,7 @@ func clone(ctx context.Context, url, dir string) error {
 		"SSH_ASKPASS=",
 		"GCM_INTERACTIVE=never",
 	)
+	cmd.WaitDelay = cloneWait
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		if ctx.Err() != nil {


### PR DESCRIPTION
Every git and gh call in `internal/project`, the theme clone and the provider CLI reads carry a deadline. None of them bounded the call.

`exec.CommandContext` kills the child it named. `Output`/`Wait` then block until the stdout pipe reaches EOF, and EOF only arrives when the *last* writer closes it — including a grandchild that inherited the descriptor. Measured, with a child that exits at once behind a 10s grandchild, under a 200ms budget:

```
Output, no WaitDelay         elapsed=10s   err=<nil>
Output, WaitDelay=1s         elapsed=1s    err=exec: WaitDelay expired before I/O complete
Run(nil pipes), no delay     elapsed=0s    err=<nil>
```

Ten seconds and a reported *success*, on a call capped at 200 milliseconds.

## The fix

`cmd.WaitDelay` (stdlib, one field): once the process is gone or the context cancelled it, the pipes are closed and Wait returns `exec.ErrWaitDelay`. Two seconds, because the clock starts only after the child is dead, where draining what is left of a pipe takes microseconds. Measured: a 1MB command still returns in 0s with no error, and the ordinary timeout path is untouched (`signal: killed`, context deadline exceeded, at the budget).

A process group of our own is what the same fix costs a runtime *without* `WaitDelay` — and it costs the child its controlling terminal. Not needed here.

It lands in `internal/project`'s two shared constructors rather than at the call sites, so no future caller can forget it, plus the two other runners that hold a budget of their own: the theme `git clone` and the provider CLI reads.

## What is *not* claimed

No leftover process on this machine reproduces the leak. All three usual suspects were measured, and every one hands its output back before detaching:

| suspect | measured |
|---|---|
| ssh `ControlMaster` left alive by `git fetch` | fetch returned in 1.61s / 610ms, `err=nil`, master confirmed still alive |
| `git credential-cache--daemon` | `credential approve` returned in 10ms, `err=nil`, daemon confirmed still running |
| the `gc --auto` git detaches | returned in 10ms, `err=nil`, `git repack` confirmed still running |

openssh and git both redirect a detaching process's stdio first, which is exactly the discipline this depends on. So the budget here is fixed for the class, not for a symptom in hand — and the same measurements are why the change has no visible effect on any path in use today.

## Prompt hygiene, same root cause — and this half *is* a symptom in hand

Started from a terminal, lich inherits it, and a git that stops to ask asks there, behind the window. Measured against a terminal that stays open:

```
GIT_TERMINAL_PROMPT=1   blocked at "Username for 'https://github.com':" until killed
GIT_TERMINAL_PROMPT=0   failed on its own in 1.37s
```

`runGit`/`gitQuiet` take no context, so that wait has no budget behind it at all. Both constructors set `GIT_TERMINAL_PROMPT=0` and gh's `GH_PROMPT_DISABLED=1` for that reason — the unbounded runner is where a prompt hang is fatal rather than slow.

Only the terminal prompt is disabled. A credential helper and an askpass program still answer, and those are how a machine here is set up to answer with nobody at the keyboard. (`internal/themes/git.go` keeps its stricter set — a theme install from an arbitrary URL should not reach for anyone's credentials.)

## Correction to the report this came from

`basestatus.go`'s badge fetch was named as a third leak. It is not one: it uses `cmd.Run()` with `Stdout`/`Stderr` left nil, so `os/exec` opens `/dev/null` instead of a pipe and starts no copying goroutine — measured at 0s above. It gets `WaitDelay` anyway by sharing the constructor, and would need it the moment someone reads its output.

## Test

`TestSubprocessBudgetOutlivesAGrandchild` builds the tree that matters — a child exiting at once behind a grandchild holding the stdout pipe for 10s, under a pinned 200ms budget — by re-executing the test binary, so it runs on Windows too. Verified red before the fix (10.01s, `err=<nil>`) and green after (2.00s).

## Gate

`gofmt` / `go vet` clean, `go test ./...` green, `pnpm check` / `pnpm test` (1317) / `pnpm build` green, cross-compile+vet loop green for linux, darwin and windows.