### PR TITLE
feat: take a review note that belongs to no line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A review note that belongs to no line.** Comments collected while reading a
+  review anchor to the lines they were written on, and some of what you want to
+  say does not: that the four notes are one bug, that the approach is wrong
+  before any of the lines are. The batch's strip now takes a note about the
+  whole change, which travels in the same prompt as the rest, in the order you
+  wrote it. Offered once there is a batch to join — a remark with nothing else
+  pending is a sentence the session's own prompt already takes.
+
 - **Walls of sessions, as many as you keep.** Watching an agent used to mean
   watching nothing else: the cards say what every session is *doing*, and only
   one of them ever showed what it was *saying*. A card's menu now offers **Show

--- a/frontend/src/components/diff/CommentBatch.tsx
+++ b/frontend/src/components/diff/CommentBatch.tsx
@@ -1,10 +1,12 @@
 import { Send, X } from "lucide-react"
-import { useSyncExternalStore } from "react"
+import { useState, useSyncExternalStore } from "react"
 import { toast } from "sonner"
 import { IconAction } from "@/components/common/IconAction"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
 import { splitPath } from "@/lib/git/lang-badge"
 import {
+  addReviewNote,
   clearReviewComments,
   composeReviewComments,
   removeReviewComment,
@@ -25,9 +27,19 @@ interface CommentBatchProps {
 // prompt. Nothing at all until the first comment is written.
 export function CommentBatch({ target, onInject }: CommentBatchProps) {
   const comments = useSyncExternalStore(subscribeReviewComments, () => reviewComments(target))
+  const [note, setNote] = useState("")
 
   if (comments.length === 0) {
     return null
+  }
+
+  // A note about the change as a whole, for the remark that belongs with the
+  // comments rather than after them. It rides the strip, so it is offered only
+  // once there is a batch to join: alone it would be a prompt written the long
+  // way round.
+  const addNote = () => {
+    addReviewNote(target, note)
+    setNote("")
   }
 
   // Comments are the one thing here the user typed, so they survive a failed
@@ -48,9 +60,11 @@ export function CommentBatch({ target, onInject }: CommentBatchProps) {
             key={comment.id}
             className="flex items-center gap-2 rounded-md px-1.5 py-1 text-xs hover:bg-accent/50"
           >
-            <span className="shrink-0 font-mono text-muted-foreground" title={comment.path}>
-              {splitPath(comment.path).base}:{comment.lines}
-            </span>
+            {comment.path !== "" && (
+              <span className="shrink-0 font-mono text-muted-foreground" title={comment.path}>
+                {splitPath(comment.path).base}:{comment.lines}
+              </span>
+            )}
             <span className="truncate" title={comment.text}>
               {comment.text}
             </span>
@@ -65,6 +79,21 @@ export function CommentBatch({ target, onInject }: CommentBatchProps) {
           </li>
         ))}
       </ul>
+      <div className="px-2 pt-1">
+        <Input
+          value={note}
+          onChange={(event) => setNote(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault()
+              addNote()
+            }
+          }}
+          placeholder="A note about the whole change…"
+          aria-label="A note about the whole change"
+          className="h-7 text-xs"
+        />
+      </div>
       <div className="flex items-center gap-2 px-2 pt-1 pb-2">
         <span className="text-xs text-muted-foreground tabular-nums">
           {comments.length} {comments.length === 1 ? "comment" : "comments"}

--- a/frontend/src/lib/review-comments.test.ts
+++ b/frontend/src/lib/review-comments.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 import {
   addReviewComment,
+  addReviewNote,
   clearReviewComments,
   composeReviewComments,
   removeReviewComment,
@@ -70,6 +71,23 @@ describe("review-comments", () => {
         "- src/a.ts:12-30 — leaks the listener\n" +
         "- src/b.tsx:44 — rename to X\x1b[201~",
     )
+  })
+
+  it("composes a note about the whole change with no anchor, in the order written", () => {
+    const t = target("note")
+    addReviewComment(t, "src/a.ts", "12", "leaks the listener")
+    addReviewNote(t, "these are all the same bug")
+    expect(composeReviewComments(reviewComments(t))).toBe(
+      "\x1b[200~Review comments:\n\n" +
+        "- src/a.ts:12 — leaks the listener\n" +
+        "- these are all the same bug\x1b[201~",
+    )
+  })
+
+  it("drops a blank note like a blank comment", () => {
+    const t = target("blank-note")
+    addReviewNote(t, "  \n ")
+    expect(reviewComments(t)).toEqual([])
   })
 
   it("keeps a multi-line comment as one list item", () => {

--- a/frontend/src/lib/review-comments.ts
+++ b/frontend/src/lib/review-comments.ts
@@ -24,8 +24,9 @@ import { bracketedPaste } from "./terminal/bracketed-paste"
 export interface ReviewComment {
   /** Identity for the list and for removal; carries no meaning of its own. */
   id: string
+  /** The file the note was written on; empty for a note about the change as a whole. */
   path: string
-  /** The selection's new-file lines, git-style: "19" or "12-30". */
+  /** The selection's new-file lines, git-style: "19" or "12-30"; empty with an empty path. */
   lines: string
   text: string
 }
@@ -57,6 +58,16 @@ export function addReviewComment(target: string, path: string, lines: string, te
   const comment: ReviewComment = { id: String(nextId++), path, lines, text: trimmed }
   byTarget.set(target, [...reviewComments(target), comment])
   notify()
+}
+
+/**
+ * A remark about the change as a whole rather than a place in it: no file, no
+ * lines. It joins the same batch so it reaches the session in the same prompt —
+ * which is the whole of what it buys, since a remark with nothing else pending
+ * is a sentence the session's own prompt already takes.
+ */
+export function addReviewNote(target: string, text: string): void {
+  addReviewComment(target, "", "", text)
 }
 
 export function removeReviewComment(target: string, id: string): void {
@@ -91,7 +102,11 @@ export function subscribeReviewComments(listener: () => void): () => void {
  * rest were still being typed.
  */
 export function composeReviewComments(list: readonly ReviewComment[]): string {
-  const items = list.map((c) => `- ${c.path}:${c.lines} — ${continuation(c.text)}`)
+  const items = list.map((c) =>
+    c.path === ""
+      ? `- ${continuation(c.text)}`
+      : `- ${c.path}:${c.lines} — ${continuation(c.text)}`,
+  )
   return bracketedPaste(`Review comments:\n\n${items.join("\n")}`)
 }
 


### PR DESCRIPTION
Comments written while reading a review anchor to the lines they were written on, and part of what a reviewer wants to say does not: that the four notes are one bug, that the approach is wrong before any single line is. Said in the session's prompt instead, it is a second send — the agent starts on the comments while the sentence framing them is still being typed.

So the batch takes one more kind of entry: a note with no file and no lines, added from the strip that already holds the batch, travelling in the same paste and in the order it was written. `composeReviewComments` renders it as a bare bullet, and the strip leaves off the anchor it has nothing to print.

It is offered only once a batch exists, which is the whole of what it buys. A remark with nothing pending to join is a sentence the session's own prompt already takes, and an input standing on an empty panel would be inviting the long way round to it.

Borrowed from JetBrains/thinkrail's review model, where the same thing is a comment keyed by the empty string, pinned like a file so the discussion it opens can be followed up. The rest of that model — re-anchoring, an anchor-state axis, an archive, one chat per file — lich already declined.

## Test plan

- [x] `review-comments.test.ts` grows two cases: a note composes as a bare bullet in the order written among anchored comments, and a blank note is dropped like a blank comment (8 → 10).
- [x] Local gate green: `gofmt`, `go vet`, `go test ./...`, `biome check`, `tsc`, `vitest` (1319), `vite build`.
- [ ] Visual: the input sits between the list and the Clear/Send row, only while a batch exists. The render path is not covered by the node-only frontend gate — worth an eye in `task dev`.