### PR TITLE
fix: the split hotkey, the stage entry's label, and six audits under them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,7 +79,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only — Codex's Settings pane didn't even offer the option. A Codex rollout
   reports its running token total on every turn, and lich now prices that the
   same way it prices a Claude transcript: the number stays absent, never
-  guessed, until the model it ran is one lich's price table knows.
+  guessed, until the model it ran is one lich's price table knows — and a
+  conversation you moved to a different model with `/model` keeps it absent,
+  because that one running total covers both and the rollout never says which
+  tokens are whose.
 
 ### Changed
 

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -29,7 +29,10 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   `total_token_usage` is a running total lich prices from its last line, the cost rung too. But
   `internal/pricing/prices.json` is baked with Claude models only, so a Codex model prices only after the
   remote LiteLLM refresh (`internal/pricing/pricing.go`) — an offline machine never shows a Codex cost, and
-  a model LiteLLM has not priced either never will.
+  a model LiteLLM has not priced either never will. **A Codex conversation that ran `/model` shows no cost
+  at all** from that turn on (`codexCostScan.mixed`): the one running total spans both models and the
+  rollout never splits it, so no rate prices it — absent, the way an unpriced line is absent, rather than
+  a number billed at whichever model happened to go last.
 - **Hands-on time is read off three signals, and one of them is not universal**
   (`internal/terminal/handson.go`, `noteOutput`, `closableState`): the figure beside the cost
   counts the gap between consecutive signs of life in a session — a session-state report, a

--- a/frontend/src/components/diff/FileDiff.tsx
+++ b/frontend/src/components/diff/FileDiff.tsx
@@ -8,8 +8,8 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { gapExpanders } from "@/lib/codemirror"
 import { threadSlots, type SlotElements, type ThreadSlot } from "@/lib/codemirror-threads"
 import {
+  appendExpansion,
   buildFileDoc,
-  contextLines,
   formatLineRef,
   newLineRange,
   type DiffFile,
@@ -141,16 +141,7 @@ export function FileDiff({
         if (!texts || texts.length === 0) {
           return
         }
-        setExpansions((held) => {
-          const next = new Map(held)
-          // Appended, never replaced: a gap wider than the backend's cap comes
-          // in several answers, each starting where the last one stopped.
-          next.set(gap.key, [
-            ...(held.get(gap.key) ?? []),
-            ...contextLines(texts, gap.from, gap.oldFrom),
-          ])
-          return next
-        })
+        setExpansions((held) => appendExpansion(held, gap, texts))
       } catch (error) {
         toast.error(`Couldn't read ${file.newPath}`, { description: errorText(error) })
       }

--- a/frontend/src/components/settings/ProviderRefreshButton.tsx
+++ b/frontend/src/components/settings/ProviderRefreshButton.tsx
@@ -1,7 +1,9 @@
 import { RefreshCw } from "lucide-react"
 import { useState } from "react"
+import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { refreshProviders } from "@/lib/providers-store"
+import { errorText } from "@/lib/utils"
 
 // The re-probe both provider surfaces offer, so an agent installed with lich
 // already open shows up without a relaunch. It re-runs the PATH scan only — not
@@ -10,13 +12,22 @@ import { refreshProviders } from "@/lib/providers-store"
 export function ProviderRefreshButton({ size = "sm" }: { size?: "sm" | "default" }) {
   const [checking, setChecking] = useState(false)
 
-  const check = () => {
+  // The detect RPC can fail, and the store rethrows when it does. Unhandled, the
+  // spinner just stopped: a button that says "Check again" and answers nothing
+  // reads as "nothing was installed", which is the wrong thing to have learned.
+  const check = async () => {
     setChecking(true)
-    void refreshProviders().finally(() => setChecking(false))
+    try {
+      await refreshProviders()
+    } catch (error) {
+      toast.error(`Couldn't check for providers: ${errorText(error)}`)
+    } finally {
+      setChecking(false)
+    }
   }
 
   return (
-    <Button variant="ghost" size={size} disabled={checking} onClick={check}>
+    <Button variant="ghost" size={size} disabled={checking} onClick={() => void check()}>
       <RefreshCw data-icon="inline-start" className={checking ? "animate-spin" : undefined} />
       {checking ? "Checking…" : "Check again"}
     </Button>

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -76,12 +76,10 @@ interface SessionCardProps {
   // session nobody delegated, which is most of them (sessionOrigin).
   origin: string
   active: boolean
-  // Whether this session is on the stage at all. It is what the menu entry
-  // answers to, and it is true for a member of a wall that is parked — the block
-  // this card is drawn in is the mark, so nothing is repeated on the card.
-  onStage: boolean
   // Whether it is drawing in a pane *right now*. Never true for a member of a
-  // parked wall, which is exactly the difference the block cannot show.
+  // parked wall, which the block this card sits in shows instead. It is also
+  // what the stage entry answers to: only a card on screen can be taken off it,
+  // and one on a parked wall is put on the stage like any other.
   showing: boolean
   // Put this card on the stage, or take it off when it is already there.
   onStageToggle: () => void
@@ -122,7 +120,6 @@ export function SessionCard({
   path,
   origin,
   active,
-  onStage,
   showing,
   onStageToggle,
   delegateCount,
@@ -601,7 +598,7 @@ export function SessionCard({
           {!active && (
             <ContextMenuItem onClick={onStageToggle}>
               <Columns2 />
-              {onStage ? "Stop showing" : "Show beside"}
+              {showing ? "Stop showing" : "Show beside"}
             </ContextMenuItem>
           )}
           <ContextMenuItem onClick={() => setEditing(true)}>

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -219,7 +219,6 @@ export function SessionGroup({
                     active={session.id === activeId}
                     // Membership is the block itself; what the card still has to
                     // answer is whether that member is on screen this moment.
-                    onStage={!!stage}
                     showing={stageIds.includes(session.id)}
                     onStageToggle={() => onStageToggle(session.id)}
                     delegateCount={delegatesOf(workspace, projectId, session.id).length}

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -9,7 +9,7 @@ import { ProjectService } from "@/lib/rpc"
 import { closeSettings, isSettingsOpen, subscribeSettingsCard } from "@/lib/settings-card-store"
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
 import { delegateTargets } from "@/lib/session/delegate-targets"
-import { movingFrom, type PaneGroup, reorderGroups } from "@/lib/session/panes"
+import { type PaneGroup, reorderGroups, stageAction } from "@/lib/session/panes"
 import { ConfirmDialog } from "@/components/ConfirmDialog"
 import { usePanes } from "@/lib/session/use-panes"
 import {
@@ -155,13 +155,13 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   }
 
   const toggleStage = (sessionId: string) => {
-    const from = movingFrom(panes.groups, panes.current, sessionId)
+    const action = stageAction(panes.groups, panes.current, sessionId)
     const session = list.find((s) => s.id === sessionId)
-    if (from && session) {
-      setMoving({ session, from })
+    if (action.kind === "confirm" && session) {
+      setMoving({ session, from: action.from })
       return
     }
-    if (panes.current?.cells.includes(sessionId)) {
+    if (action.kind === "remove") {
       panes.remove(sessionId)
       return
     }
@@ -491,7 +491,14 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
       <ConfirmDialog
         open={!!moving}
         onCancel={() => setMoving(null)}
-        title={`Move ${moving?.session.label ?? ""} to this split?`}
+        // "this split" only when there is one: adding to no wall starts a new
+        // one around the active session, and naming a split the user cannot see
+        // is the same lie as the entry that promised to stop showing a card.
+        title={
+          panes.current
+            ? `Move ${moving?.session.label ?? ""} to this split?`
+            : `Show ${moving?.session.label ?? ""} beside this session?`
+        }
         description={
           moving?.from.cells.length === 1 ? (
             <>
@@ -500,8 +507,8 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
             </>
           ) : (
             <>
-              It is showing in <strong>{moving?.from.name}</strong>, and a session can only be on
-              one split at a time — it leaves that one. No session is closed either way.
+              It is on <strong>{moving?.from.name}</strong>, and a session can only be on one split
+              at a time — it leaves that one. No session is closed either way.
             </>
           )
         }

--- a/frontend/src/components/sidebar/SidebarRail.tsx
+++ b/frontend/src/components/sidebar/SidebarRail.tsx
@@ -3,7 +3,7 @@ import { PanelLeft, Plus } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useProjects } from "@/providers/projects"
 import { activeSessionId, sessionsOf, sidebarGroups, type Session } from "@/lib/session/sessions"
-import { storedGroups } from "@/lib/session/panes-store"
+import { useStoredGroups } from "@/lib/session/panes-store"
 import { useSessionAgent } from "@/lib/session/use-session-agent"
 import { useSessionStatus, useSessionUnread } from "@/lib/session/use-session-status"
 import { SessionStatusIcon } from "./SessionStatusIcon"
@@ -68,6 +68,12 @@ export function SidebarRail({ onExpand }: SidebarRailProps) {
   const match = useMatch("/projects/:projectId/*")
   const projectId = match?.params.projectId
   const navigate = useNavigate()
+  // Subscribed rather than read: a pane mutation that touches no session state —
+  // the add shortcut, a pane's ×, a drag swap — notifies this store and nothing
+  // else, so a rail holding no listener would draw yesterday's blocks until some
+  // unrelated render came along. Resolved ahead of the no-project bail below:
+  // hooks cannot sit behind it.
+  const stored = useStoredGroups(projectId ?? "")
 
   if (!projectId) {
     return null
@@ -76,7 +82,7 @@ export function SidebarRail({ onExpand }: SidebarRailProps) {
   const path = projects.find((p) => p.id === projectId)?.path ?? ""
   // Same order as the expanded sidebar, split's block and all: the rail is
   // that list with the words taken out.
-  const groups = sidebarGroups(sessionsOf(sessions, projectId), storedGroups(projectId))
+  const groups = sidebarGroups(sessionsOf(sessions, projectId), stored)
   // Unlike the open sidebar, a full-screen route (Settings, Pulls) does not put
   // the highlight out: those screens have no card of their own here to carry
   // it, so dropping it would leave the rail with nothing lit at all.

--- a/frontend/src/lib/git/diff.test.ts
+++ b/frontend/src/lib/git/diff.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest"
 import {
+  appendExpansion,
   buildFileDoc,
   contextLines,
+  type Expansions,
   discardTargets,
   docLineAt,
   formatLineRef,
@@ -336,6 +338,35 @@ describe("diff gaps", () => {
     const doc = buildFileDoc(file, new Map([[1, contextLines(["a", "b", "c", "d", "e"], 1, 1)]]))
     expect(docLineAt(doc.lineMeta, "RIGHT", 3)).toBe(3)
     expect(newLineRange(doc.lineMeta, 1, 3)).toEqual({ start: 1, end: 3 })
+  })
+})
+
+describe("appendExpansion", () => {
+  const file = parseDiff(gappedDiff)[0]
+  const gapNow = (held: Expansions) => buildFileDoc(file, held).gaps[0]
+
+  // A gap wider than the backend's cap comes in several answers, each starting
+  // where the last one stopped.
+  it("appends an answer that starts where the run ends", () => {
+    const first = appendExpansion(new Map(), gapNow(new Map()), ["a", "b"])
+    expect(first.get(1)).toEqual(contextLines(["a", "b"], 1, 1))
+
+    const second = appendExpansion(first, gapNow(first), ["c"])
+    expect(second.get(1)).toEqual(contextLines(["a", "b", "c"], 1, 1))
+  })
+
+  // Two clicks on the same expander before the first answer lands both resolve
+  // against the gap as it was. Appending the loser would write the same lines
+  // twice — duplicated text and gutter numbers, with nothing on a PR or turn
+  // diff to refetch them away.
+  it("drops an answer numbered from where the run no longer starts", () => {
+    const stale = gapNow(new Map())
+    const held = appendExpansion(new Map(), stale, ["a", "b"])
+
+    const after = appendExpansion(held, stale, ["a", "b"])
+
+    expect(after).toBe(held)
+    expect(after.get(1)).toEqual(contextLines(["a", "b"], 1, 1))
   })
 })
 

--- a/frontend/src/lib/git/diff.ts
+++ b/frontend/src/lib/git/diff.ts
@@ -234,6 +234,29 @@ export function contextLines(texts: string[], newFrom: number, oldFrom: number):
   }))
 }
 
+// appendExpansion folds one answer into what a gap has pulled in so far.
+//
+// Appended, never replaced: a gap wider than the backend's cap comes in several
+// answers, each starting where the last one stopped. Which is also why an answer
+// that does *not* start there is dropped whole — two expand clicks on the same
+// gap can be in flight at once (a PR's head is read over the network), and both
+// resolve against the gap as it was before either landed. Appending the second
+// would write the same lines twice, gutter numbers and all, with nothing on a
+// PR or turn diff to refetch them away.
+export function appendExpansion(
+  held: Expansions,
+  gap: DiffGap,
+  texts: readonly string[],
+): Expansions {
+  const pulled = held.get(gap.key) ?? []
+  if (gap.from !== gap.key + pulled.length) {
+    return held
+  }
+  const next = new Map(held)
+  next.set(gap.key, [...pulled, ...contextLines([...texts], gap.from, gap.oldFrom)])
+  return next
+}
+
 // buildFileDoc assembles the document, laying whatever has been pulled into a
 // gap where the diff left a hole. A gap that is still open keeps its separator
 // line and is reported in `gaps`; one that has been filled in whole has no

--- a/frontend/src/lib/session/panes-store.ts
+++ b/frontend/src/lib/session/panes-store.ts
@@ -37,8 +37,9 @@ const cache = new Map<string, { raw: string | null; value: PaneGroup[] }>()
 
 /** The stored groups, unreconciled — put them through resolveGroups with the
  * project's live sessions before drawing anything. Outside React too, for the
- * two readers that are not components: the collapsed rail and the neighbour
- * walk, both of which order cards the way the sidebar draws them. */
+ * neighbour walk, which orders cards the way the sidebar draws them. A component
+ * takes useStoredGroups instead: this read holds no listener, so what it returns
+ * goes stale the moment a pane moves. */
 export function storedGroups(projectId: string): PaneGroup[] {
   if (!projectId) {
     return EMPTY

--- a/frontend/src/lib/session/panes.test.ts
+++ b/frontend/src/lib/session/panes.test.ts
@@ -3,15 +3,19 @@ import {
   addToGroup,
   defaultName,
   dissolveGroup,
+  focusAfterRemove,
   formatGroups,
   groupOf,
   movingFrom,
   nextCandidate,
   type PaneGroup,
   parseGroups,
+  planAdd,
   removeFromGroups,
+  reorderCells,
   reorderGroups,
   resolveGroups,
+  stageAction,
   swapCells,
   updateGroup,
 } from "./panes"
@@ -126,6 +130,24 @@ describe("removeFromGroups", () => {
   })
 })
 
+describe("focusAfterRemove", () => {
+  it("hands the cursor to the cell that slid into the empty place", () => {
+    expect(focusAfterRemove(["a", "b", "c"], "b")).toBe("c")
+  })
+
+  it("falls back to the last cell when the last one left", () => {
+    expect(focusAfterRemove(["a", "b", "c"], "c")).toBe("b")
+  })
+
+  // "" is "leave the window where it is": nothing is left to focus, or nothing
+  // was taken away in the first place.
+  it("answers nothing when no cell was freed", () => {
+    expect(focusAfterRemove(["a"], "a")).toBe("")
+    expect(focusAfterRemove(["a", "b"], "gone")).toBe("")
+    expect(focusAfterRemove([], "a")).toBe("")
+  })
+})
+
 describe("updateGroup / dissolveGroup", () => {
   it("changes only the group named", () => {
     const groups = updateGroup([group("g1", ["a"]), group("g2", ["b"])], "g2", { name: "renamed" })
@@ -161,11 +183,116 @@ describe("defaultName", () => {
 
 describe("nextCandidate", () => {
   it("takes the first card on no wall at all", () => {
-    expect(nextCandidate(sessions, [group("g1", ["a", "b"])])).toBe("c")
+    expect(nextCandidate(sessions, [group("g1", ["a", "b"])], "d")).toBe("c")
   })
 
   it("answers nothing when every session is already on one", () => {
-    expect(nextCandidate(sessions, [group("g1", ["a", "b", "c", "d"])])).toBe("")
+    expect(nextCandidate(sessions, [group("g1", ["a", "b", "c", "d"])], "")).toBe("")
+  })
+
+  // The shortcut starts a wall around the active session, so offering that same
+  // session is offering nothing: the caller refuses an id equal to the active
+  // one, and the press did nothing at all.
+  it("skips the active session", () => {
+    expect(nextCandidate(sessions, [], "a")).toBe("b")
+    expect(nextCandidate([session("a")], [], "a")).toBe("")
+  })
+})
+
+// The refusal matrix the add affordance documents, and the two things it does
+// when it does not refuse.
+describe("planAdd", () => {
+  // A stage big enough for several panes; the height is what runs out first.
+  const roomy = { width: 3000, height: 2000 }
+  const base = { sessions, groups: [] as PaneGroup[], current: null, activeId: "a", stage: roomy }
+
+  it("starts a wall around the active session, taking the next free card", () => {
+    expect(planAdd(base)).toEqual({ kind: "start", around: "a", sessionId: "b" })
+  })
+
+  it("joins the wall the active session is already on", () => {
+    const groups = [group("g1", ["a", "b"])]
+    expect(planAdd({ ...base, groups, current: groups[0] })).toEqual({
+      kind: "join",
+      groupId: "g1",
+      sessionId: "c",
+    })
+  })
+
+  it("refuses with nothing left to show", () => {
+    const groups = [group("g1", ["a", "b", "c", "d"])]
+    expect(planAdd({ ...base, groups, current: groups[0] }).kind).toBe("none")
+  })
+
+  it("refuses with no active session to show anything beside", () => {
+    expect(planAdd({ ...base, activeId: "" }).kind).toBe("none")
+  })
+
+  it("refuses to add the active session to itself", () => {
+    expect(planAdd({ ...base, sessionId: "a" }).kind).toBe("none")
+  })
+
+  // A stage 500px wide takes two panes as two rows (neither fits beside the
+  // other), so 320px of height is exactly enough for both and 300 is not.
+  it("refuses when one more pane would be too small to read", () => {
+    expect(planAdd({ ...base, stage: { width: 500, height: 300 } }).kind).toBe("none")
+    expect(planAdd({ ...base, stage: { width: 500, height: 320 } }).kind).toBe("start")
+  })
+
+  // Taking a session off somebody else's arrangement is the user's decision, so
+  // a caller that has not asked gets a no-op rather than a silent move.
+  it("refuses a session on another wall until the move is asked for", () => {
+    const groups = [group("g1", ["b"])]
+    expect(planAdd({ ...base, groups, sessionId: "b" }).kind).toBe("none")
+    expect(planAdd({ ...base, groups, sessionId: "b", move: true })).toEqual({
+      kind: "start",
+      around: "a",
+      sessionId: "b",
+    })
+  })
+})
+
+describe("stageAction", () => {
+  // What the card's own label reads off: a session drawing in a pane right now
+  // is taken off the stage, and any other is put on it. Membership of a parked
+  // wall is not the question — that card is not showing.
+  it("takes a member of the wall on screen off it", () => {
+    const groups = [group("g1", ["a", "b"])]
+    expect(stageAction(groups, groups[0], "b")).toEqual({ kind: "remove" })
+  })
+
+  it("asks before moving a member of a parked wall", () => {
+    const groups = [group("g1", ["a", "b"]), group("g2", ["c"])]
+    expect(stageAction(groups, groups[1], "b")).toEqual({ kind: "confirm", from: groups[0] })
+    expect(stageAction(groups, null, "b")).toEqual({ kind: "confirm", from: groups[0] })
+  })
+
+  it("adds a session on no wall at all", () => {
+    expect(stageAction([group("g1", ["a"])], null, "d")).toEqual({ kind: "add" })
+  })
+})
+
+describe("reorderCells", () => {
+  it("puts a wall's panes in the order the drag named", () => {
+    const groups = [group("g1", ["a", "b", "c"]), group("g2", ["d"])]
+    expect(reorderCells(groups, "g1", ["c", "a", "b"]).map((g) => g.cells)).toEqual([
+      ["c", "a", "b"],
+      ["d"],
+    ])
+  })
+
+  // A card added to the wall while its siblings were being dragged is not in the
+  // dropped order; writing it would take that session straight back off.
+  it("drops an order that no longer names the wall's exact members", () => {
+    const groups = [group("g1", ["a", "b", "c"])]
+    expect(reorderCells(groups, "g1", ["c", "a"])[0].cells).toEqual(["a", "b", "c"])
+    expect(reorderCells(groups, "g1", ["c", "a", "b", "d"])[0].cells).toEqual(["a", "b", "c"])
+    expect(reorderCells(groups, "g1", ["a", "b", "b"])[0].cells).toEqual(["a", "b", "c"])
+  })
+
+  it("leaves the walls alone for a group that is gone", () => {
+    const groups = [group("g1", ["a"])]
+    expect(reorderCells(groups, "gone", ["a"])).toEqual(groups)
   })
 })
 

--- a/frontend/src/lib/session/panes.ts
+++ b/frontend/src/lib/session/panes.ts
@@ -26,6 +26,8 @@
 // Nothing here remembers a focused cell. The cursor is the active session and
 // its cell is wherever that id sits in the group, so focus is read rather than
 // stored and a stale one cannot outlive the cell it named.
+import { applyOrder } from "@/lib/reorder"
+import { fits } from "./pane-grid"
 import type { Session } from "./sessions"
 
 export interface PaneGroup {
@@ -217,7 +219,122 @@ export function swapCells(cells: readonly string[], from: number, to: number): s
 // the user arranged, so what arrives is the one they can predict, and skipping
 // what is already grouped keeps the shortcut from quietly moving one wall's
 // member onto another.
-export function nextCandidate(sessions: readonly Session[], groups: readonly PaneGroup[]): string {
+//
+// The active session is skipped with them, and for the same reason it is skipped
+// by the caller that refuses to add a session to itself: on no wall it is the
+// first card the search would find, and the shortcut that promises to start a
+// wall *around* it would answer with the session it is already showing.
+export function nextCandidate(
+  sessions: readonly Session[],
+  groups: readonly PaneGroup[],
+  activeId: string,
+): string {
   const taken = grouped(groups)
-  return sessions.find((session) => !taken.has(session.id))?.id ?? ""
+  return sessions.find((session) => session.id !== activeId && !taken.has(session.id))?.id ?? ""
+}
+
+/** What adding one more pane comes to: nothing, a session joining the wall on
+ * screen, or a new wall around the active session. */
+export type AddPlan =
+  | { kind: "none" }
+  | { kind: "join"; groupId: string; sessionId: string }
+  | { kind: "start"; around: string; sessionId: string }
+
+export interface AddRequest {
+  sessions: readonly Session[]
+  groups: readonly PaneGroup[]
+  /** The wall the active session is on, or null when it is on none. */
+  current: PaneGroup | null
+  activeId: string
+  /** The stage as measured, for the "would one more still be readable" guard. */
+  stage: { width: number; height: number }
+  /** The session to show, or absent for "the next card on no wall". */
+  sessionId?: string
+  /** Whether the user has agreed to take the session off another wall. */
+  move?: boolean
+}
+
+// planAdd is the whole refusal matrix of the add affordance, decided before
+// anything is written: nothing left to show, no active session to show it
+// beside, no room for one more pane, or a session on somebody else's wall with
+// no answer from the user yet. That last refusal is the guard — taking a session
+// off an arrangement the click was not aimed at is the user's decision, so a
+// caller that forgets to ask gets a no-op rather than a silent move.
+export function planAdd(request: AddRequest): AddPlan {
+  const { sessions, groups, current, activeId, stage, sessionId, move } = request
+  const id = sessionId ?? nextCandidate(sessions, groups, activeId)
+  if (!id || !activeId || id === activeId) {
+    return { kind: "none" }
+  }
+  if (movingFrom(groups, current, id) && !move) {
+    return { kind: "none" }
+  }
+  // On no wall the stage draws the active session alone, so one more makes two.
+  if (!fits((current ? current.cells.length : 1) + 1, stage.width, stage.height)) {
+    return { kind: "none" }
+  }
+  return current
+    ? { kind: "join", groupId: current.id, sessionId: id }
+    : { kind: "start", around: activeId, sessionId: id }
+}
+
+// focusAfterRemove answers where the cursor goes when the pane holding it is
+// taken away: the cell that slid into its place, or the last one when what left
+// was the last. "" is "leave the window where it is" — the wall has nothing left
+// to hold a cursor, or it never held this session and so lost no pane.
+export function focusAfterRemove(cells: readonly string[], sessionId: string): string {
+  const at = cells.indexOf(sessionId)
+  const rest = cells.filter((id) => id !== sessionId)
+  if (at < 0 || rest.length === 0) {
+    return ""
+  }
+  return rest[Math.min(at, rest.length - 1)]
+}
+
+/** What the sidebar's one stage entry does for a card, matching what its label
+ * offers. `confirm` carries the wall the session would be taken off. */
+export type StageAction =
+  | { kind: "add" }
+  | { kind: "remove" }
+  | { kind: "confirm"; from: PaneGroup }
+
+// stageAction reads the card the same way the card's own label does: a session
+// drawing in a pane right now is taken off its wall, and any other is put on the
+// one on screen. Membership of a *parked* wall is not the question — that card
+// is not showing, so the entry reads "Show beside" and this moves it here, after
+// the user has answered for the wall it leaves.
+export function stageAction(
+  groups: readonly PaneGroup[],
+  current: PaneGroup | null,
+  sessionId: string,
+): StageAction {
+  if (current?.cells.includes(sessionId)) {
+    return { kind: "remove" }
+  }
+  const from = movingFrom(groups, current, sessionId)
+  return from ? { kind: "confirm", from } : { kind: "add" }
+}
+
+// reorderCells sets one wall's whole pane order — what dragging its cards in the
+// sidebar does. An order that no longer names that wall's exact members is
+// dropped whole, the way reorderSessions drops a drag a close raced: a session
+// added to the wall while the cards were being dragged is not in the dropped
+// order, and writing it would take that session straight back off the wall.
+export function reorderCells(
+  groups: readonly PaneGroup[],
+  groupId: string,
+  ids: readonly string[],
+): PaneGroup[] {
+  const group = groups.find((candidate) => candidate.id === groupId)
+  if (!group) {
+    return [...groups]
+  }
+  // applyOrder wants items with an id; a cell is the id itself.
+  const ordered = applyOrder(
+    group.cells.map((id) => ({ id })),
+    [...ids],
+  )
+  return ordered
+    ? updateGroup(groups, groupId, { cells: ordered.map((cell) => cell.id) })
+    : [...groups]
 }

--- a/frontend/src/lib/session/use-panes.ts
+++ b/frontend/src/lib/session/use-panes.ts
@@ -4,16 +4,16 @@ import {
   addToGroup,
   defaultName,
   dissolveGroup,
+  focusAfterRemove,
   groupOf,
-  movingFrom,
-  nextCandidate,
   type PaneGroup,
+  planAdd,
   removeFromGroups,
+  reorderCells,
   resolveGroups,
   swapCells,
   updateGroup,
 } from "./panes"
-import { fits } from "./pane-grid"
 import { stageSize, useStoredGroups, writeGroups } from "./panes-store"
 
 export interface Panes {
@@ -44,7 +44,8 @@ export interface Panes {
   /** Swap two cells of the wall on screen. */
   swap: (from: number, to: number) => void
   /** Set a wall's whole pane order — what dragging its cards in the sidebar
-   * does, from the other end of the same arrangement. */
+   * does, from the other end of the same arrangement. An order that no longer
+   * names the wall's exact members is dropped. */
   reorderCells: (groupId: string, ids: string[]) => void
   /** Build a wall out of a session and the ones it delegated to. Answers how
    * many of them were left where they were, which is what the caller says out
@@ -87,10 +88,9 @@ export function usePanes(projectId: string): Panes {
     if (sessionId !== activeId) {
       return
     }
-    const rest = group.cells.filter((id) => id !== sessionId)
-    if (rest.length > 0) {
-      const at = group.cells.indexOf(sessionId)
-      activateSession(projectId, rest[Math.min(at, rest.length - 1)])
+    const next = focusAfterRemove(group.cells, sessionId)
+    if (next) {
+      activateSession(projectId, next)
     }
   }
 
@@ -116,19 +116,20 @@ export function usePanes(projectId: string): Panes {
       }
     },
     add(sessionId, opts) {
-      const id = sessionId ?? nextCandidate(list, groups)
-      const { width, height } = stageSize()
-      if (!projectId || !id || id === activeId || !activeId) {
+      const plan = planAdd({
+        sessions: list,
+        groups,
+        current,
+        activeId,
+        stage: stageSize(),
+        sessionId,
+        move: opts?.move,
+      })
+      if (!projectId || plan.kind === "none") {
         return false
       }
-      if (movingFrom(groups, current, id) && !opts?.move) {
-        return false
-      }
-      if (!fits(cells.length + 1, width, height)) {
-        return false
-      }
-      if (current) {
-        commit(addToGroup(groups, current.id, id))
+      if (plan.kind === "join") {
+        commit(addToGroup(groups, plan.groupId, plan.sessionId))
         return true
       }
       // On no wall: this starts one, named after the session it grew from —
@@ -137,12 +138,12 @@ export function usePanes(projectId: string): Panes {
       // user makes.
       const born: PaneGroup = {
         id: newGroupId(),
-        name: defaultName(list, activeId),
-        cells: [activeId, id],
+        name: defaultName(list, plan.around),
+        cells: [plan.around, plan.sessionId],
         cols: [],
         rows: [],
       }
-      commit([...removeFromGroups(groups, id), born])
+      commit([...removeFromGroups(groups, plan.sessionId), born])
       return true
     },
     remove,
@@ -155,7 +156,7 @@ export function usePanes(projectId: string): Panes {
       }
     },
     reorderCells(groupId, ids) {
-      commit(updateGroup(groups, groupId, { cells: ids }))
+      commit(reorderCells(groups, groupId, ids))
     },
     groupWith(sessionId, delegateIds) {
       const free = delegateIds.filter((id) => !groupOf(groups, id))

--- a/internal/project/worktree.go
+++ b/internal/project/worktree.go
@@ -209,22 +209,33 @@ const baseFetchBudget = 60 * time.Second
 // fetchBase updates refs/remotes/<remote>/<branch> and reports whether the ref
 // is there afterwards, which is the question `worktree add` is about to ask.
 //
-// git's exit status does not answer it: under a narrowed refspec — a
+// git's exit status alone does not answer it: under a narrowed refspec — a
 // --single-branch clone, `remote add -t`, a hand-edited remote.<name>.fetch —
 // `git fetch origin -- other` writes the branch to FETCH_HEAD, says "* branch
 // other -> FETCH_HEAD", and exits 0 without creating the remote-tracking ref.
-// Only the ref itself settles it, and it is checked again after a failed fetch
-// in case a concurrent one landed the ref this call needed.
+// So a fetch that succeeded is believed only once the ref is there.
+//
+// A fetch that *failed* is a refusal even when the ref is there, because then it
+// is whatever an earlier fetch left behind: a worktree silently based on a
+// week-old ref is worse than one that was never created. The exception is a ref
+// that moved during this call — a concurrent fetch landed what this one needed,
+// which is what two sessions creating a worktree at once do to each other. One
+// that found nothing new leaves the ref where it was and is refused with it;
+// retrying the create is the whole cost.
 func fetchBase(projectPath, remote, branch string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), baseFetchBudget)
 	defer cancel()
+
+	ref := "refs/remotes/" + remote + "/" + branch
+	before, _ := gitQuiet(projectPath, "rev-parse", "--verify", "--quiet", ref)
 
 	args := []string{"-C", projectPath, "fetch", "--", remote, branch}
 	cmd := commandContext(ctx, "git", args...)
 	// Without these a remote that wants a credential or a key passphrase stops
 	// on a prompt with no terminal to answer it — or worse, a GUI askpass dialog
 	// behind the app window — and burns the whole budget waiting for a person.
-	cmd.Env = append(os.Environ(),
+	// Appended to what prepare set, never assigned over it (git.go).
+	cmd.Env = append(cmd.Env,
 		"GIT_TERMINAL_PROMPT=0",
 		"GIT_ASKPASS=",
 		"SSH_ASKPASS=",
@@ -234,8 +245,8 @@ func fetchBase(projectPath, remote, branch string) error {
 	cmd.Stderr = &stderr
 	fetchErr := cmd.Run()
 
-	ref := "refs/remotes/" + remote + "/" + branch
-	if _, ok := gitQuiet(projectPath, "rev-parse", "--verify", "--quiet", ref); ok {
+	after, ok := gitQuiet(projectPath, "rev-parse", "--verify", "--quiet", ref)
+	if ok && (fetchErr == nil || after != before) {
 		return nil
 	}
 	if fetchErr != nil {

--- a/internal/project/worktree_test.go
+++ b/internal/project/worktree_test.go
@@ -334,6 +334,32 @@ func TestCreateWorktreeRemoteBaseAmbiguousName(t *testing.T) {
 	}
 }
 
+// TestCreateWorktreeRemoteBaseRefusesAStaleRefOffline proves a failed fetch is a
+// refusal even when refs/remotes/origin/feature is already there. It is only
+// there because an earlier fetch left it, so accepting it bases the worktree on
+// whatever the branch looked like the last time the machine had the remote —
+// silently, on a create the person asked for precisely to start from the remote
+// tip. The ref is tolerated after a failed fetch only when it *moved* during the
+// call, which is a concurrent fetch landing it rather than an old one.
+func TestCreateWorktreeRemoteBaseRefusesAStaleRefOffline(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	repo, git := initRepo(t)
+	addLocalOrigin(t, git)
+	if _, err := runGit(repo, "rev-parse", "--verify", "refs/remotes/origin/feature"); err != nil {
+		t.Fatalf("setup: want the ref an earlier fetch left behind: %v", err)
+	}
+	// The remote as an offline machine has it: a URL git cannot reach. A local
+	// path that is not a repository fails at once, with no network and no wait.
+	git("remote", "set-url", "origin", filepath.Join(t.TempDir(), "unreachable"))
+
+	svc := New(nil)
+	_, err := svc.CreateWorktree(repo, "pid", "from-remote", "origin/feature", true)
+
+	if err == nil {
+		t.Fatal("CreateWorktree(failed fetch, stale ref) = nil error, want a refusal")
+	}
+}
+
 // TestCreateWorktreeRemoteBaseNotFetched proves the guard is the ref, not git's
 // exit status. With the remote's refspec narrowed to one branch — what a
 // --single-branch clone or `remote add -t` leaves behind — `git fetch origin --

--- a/internal/terminal/usage_codex.go
+++ b/internal/terminal/usage_codex.go
@@ -133,49 +133,85 @@ func consumeCodexUsageLine(line []byte, usage *contextUsage, haveTokens *bool) b
 // Claude transcript's per-turn deltas, total_token_usage is already the
 // conversation's cumulative cost, so the last line is the whole answer — no
 // ledger walk, no offset to resume from. ok is false when the rollout carries
-// no cost line yet, or when rates cannot price the model that ran it.
+// no cost line yet, when rates cannot price the model that ran it, and when
+// more than one model did (see codexCostScan.mixed).
+//
+// The scan reaching the start of the file is the ordinary end of it, not a
+// failure: unlike the context readout, which stops at the current turn, this one
+// has to see every turn_context the total covers. A file that cannot be read
+// stops there with no token line, which is the same absent answer.
 func codexTranscriptCost(path string, rates rateSource) (float64, bool) {
-	var tokens pricing.Tokens
-	var model string
-	haveTokens := false
-	if !codexReverseScan(path, func(line []byte) bool {
-		return consumeCodexCostLine(line, &tokens, &model, &haveTokens)
-	}) {
+	var scan codexCostScan
+	codexReverseScan(path, scan.consume)
+	if !scan.haveTokens || scan.mixed || scan.model == "" {
 		return 0, false
 	}
-	rate, ok := rates.Rate(model)
+	rate, ok := rates.Rate(scan.model)
 	if !ok {
 		return 0, false
 	}
-	return rate.Cost(tokens)
+	return rate.Cost(scan.tokens)
 }
 
-// consumeCodexCostLine mirrors consumeCodexUsageLine's two-phase reverse
-// walk, gathering the running token total and the model id that priced it
-// instead of the window and effort the context readout needs.
-func consumeCodexCostLine(line []byte, tokens *pricing.Tokens, model *string, haveTokens *bool) bool {
+// codexCostScan is what pricing a rollout takes from a reverse walk: the
+// conversation's last cumulative token total, and the model that produced it.
+type codexCostScan struct {
+	tokens     pricing.Tokens
+	haveTokens bool
+	model      string
+	// mixed marks a conversation that changed model part-way through (`/model`).
+	// total_token_usage is one running total over both of them and the rollout
+	// does not split it, so pricing it at either rate bills some of the tokens
+	// wrong. The money rule the Claude scan follows for a line it cannot price
+	// (usage_cost.go) applies to a total nothing can attribute: the number stays
+	// absent rather than becoming a guess.
+	mixed bool
+}
+
+// consume mirrors consumeCodexUsageLine's two-phase reverse walk, gathering the
+// running token total and the model ids that priced it instead of the window and
+// effort the context readout needs. Done only once a second, different model is
+// found — otherwise the walk runs out the file, which is what proves there was
+// only one.
+func (c *codexCostScan) consume(line []byte) bool {
+	// Every line of the conversation passes through here, so the two records
+	// that matter are picked out by a byte scan rather than by unmarshalling
+	// each of them.
+	if !bytes.Contains(line, []byte(`"token_count"`)) &&
+		!bytes.Contains(line, []byte(`"turn_context"`)) {
+		return false
+	}
 	var entry codexRolloutEntry
 	if json.Unmarshal(line, &entry) != nil {
 		return false
 	}
-	if !*haveTokens {
+	if !c.haveTokens {
+		// turn_context lines below the last token_count belong to a turn that has
+		// billed nothing yet, so they name no model this total was priced at.
 		if entry.Type != "event_msg" || entry.Payload.Type != "token_count" ||
 			entry.Payload.Info == nil || entry.Payload.Info.Total == nil {
 			return false
 		}
 		t := entry.Payload.Info.Total
-		*tokens = pricing.Tokens{
+		c.tokens = pricing.Tokens{
 			Input:      t.Input - t.Cached,
 			CacheRead:  t.Cached,
 			CacheWrite: t.CacheWrite,
 			Output:     t.Output,
 		}
-		*haveTokens = true
+		c.haveTokens = true
 		return false
 	}
 	if entry.Type != "turn_context" || entry.Payload.Model == "" {
 		return false
 	}
-	*model = entry.Payload.Model
-	return true
+	if c.model == "" {
+		c.model = entry.Payload.Model
+		return false
+	}
+	if entry.Payload.Model != c.model {
+		c.mixed = true
+		return true
+	}
+	return false
 }

--- a/internal/terminal/usage_cost_test.go
+++ b/internal/terminal/usage_cost_test.go
@@ -537,6 +537,51 @@ func TestCodexTranscriptCostWithholdsForAnUnpricedModel(t *testing.T) {
 	}
 }
 
+// TestCodexTranscriptCostWithholdsAcrossAModelSwitch pins the money rule over a
+// rollout whose conversation ran `/model`: total_token_usage is one running
+// total spanning both models and the rollout never splits it, so pricing it at
+// either rate bills some of those tokens wrong. Absent beats a guess — the same
+// answer an unpriced line gets.
+func TestCodexTranscriptCostWithholdsAcrossAModelSwitch(t *testing.T) {
+	rates := fixedRates{
+		"gpt-5.1-codex":      {Input: 0.001, Output: 0.01, CacheRead: 0.0005, CacheWrite: 0.002},
+		"gpt-5.1-codex-mini": {Input: 0.0001, Output: 0.001, CacheRead: 0.00005, CacheWrite: 0.0002},
+	}
+	path := writeFile(t,
+		codexTurnContextJSON("gpt-5.1-codex-mini")+"\n"+
+			codexTokenLineJSON(500, 0, 0, 5)+"\n"+
+			codexTurnContextJSON("gpt-5.1-codex")+"\n"+
+			codexTokenLineJSON(1000, 400, 0, 10)+"\n")
+
+	if cost, ok := codexTranscriptCost(path, rates); ok {
+		t.Errorf("codexTranscriptCost = %v, want a miss: the total spans two models", cost)
+	}
+}
+
+// The counterpart: one model named again on every turn is still one model, and
+// the walk that reaches the start of the file without finding a second is what
+// proves it — not a failure to price.
+func TestCodexTranscriptCostPricesTheWholeTotalForOneModel(t *testing.T) {
+	path := writeFile(t,
+		codexTurnContextJSON("gpt-5.1-codex")+"\n"+
+			codexTokenLineJSON(500, 0, 0, 5)+"\n"+
+			codexTurnContextJSON("gpt-5.1-codex")+"\n"+
+			codexTokenLineJSON(1000, 400, 0, 10)+"\n"+
+			// A turn that has opened but billed nothing yet names no model the
+			// total was priced at, so it must not read as a switch.
+			codexTurnContextJSON("gpt-5.1-codex-mini")+"\n")
+
+	cost, ok := codexTranscriptCost(path, codexTestRate)
+
+	if !ok {
+		t.Fatal("codexTranscriptCost: want ok")
+	}
+	want := 600*0.001 + 400*0.0005 + 10*0.01
+	if !nearly(cost, want) {
+		t.Errorf("cost = %v, want %v", cost, want)
+	}
+}
+
 func TestCodexTranscriptCostMissesWithoutATokenLine(t *testing.T) {
 	path := writeFile(t, codexTurnContextJSON("gpt-5.1-codex")+"\n")
 


### PR DESCRIPTION
A code-quality audit of everything since v0.42.0 turned up two user-facing bugs in the
split-panes feature and eight defects under them. This PR fixes the HIGH and MEDIUM findings;
the LOW findings follow in a separate PR (`fix/audit-low`, to be rebased after this one).

## What was wrong

- **The add shortcut was a no-op from the one state it exists for.** `nextCandidate` offered the
  first card on no wall — which, with the active session on no wall, is the active session
  itself — and `add` refuses that id, so Ctrl+Shift+G did nothing until you were already on a
  wall. It now skips the active session, and the whole refusal matrix moved into a pure
  `planAdd` the suite drives.
- **"Stop showing" on a parked wall's card moved that session onto the wall in front of you** —
  the opposite of the label, offered through a dialog naming a split that was not on screen. The
  card's entry now reads what is *showing* rather than membership of any wall, so the label, the
  dialog and the action agree in all three states; the redundant `onStage` prop goes with it.
- **A Codex conversation that ran `/model` priced every token of one running total at whichever
  model went last.** The scan now walks the span the total covers and withholds the number when
  more than one model produced it — the money rule the Claude scan already follows for a line it
  cannot price. The `[Unreleased]` changelog entry and the `docs/ceilings.md` bullet move with
  it.
- **A failed base fetch left `CreateWorktree` silently based on whatever
  `refs/remotes/<remote>/<branch>` an earlier fetch had left behind** — v0.42.0 errored out; the
  concurrent-fetch tolerance let it through. The ref is now tolerated after a failure only when
  it moved during the call. The same call assigned over `cmd.Env`, dropping what `prepare` set
  (#416 missed this site).
- **Two expand clicks on one gap, both in flight, appended the same lines twice** into the diff.
  An answer that does not start where the run ends is dropped (`appendExpansion`, pure).
- **"Check again" rejected unhandled** and failed with nothing on screen — it now catches and
  toasts. **The collapsed rail read the pane groups without subscribing**, going stale on any
  pane mutation that touched no session state — it now uses `useStoredGroups`. **A pane drag
  wrote an id set that no longer named the wall's members**, dropping a session added mid-drag —
  the order is now validated the way `reorderSessions` already validates its own.
- **`use-panes.ts` had zero tests.** Its decision logic (`planAdd`, `stageAction`,
  `reorderCells`, `focusAfterRemove`) is extracted into `panes.ts`; the hook is wiring only.

## Test plan

- [x] New: `planAdd`'s refusal matrix (nothing left / no active / self / no room at the pixel
  boundary / on another wall), `stageAction`'s three states, `reorderCells`' rejection shapes,
  `focusAfterRemove`, `nextCandidate` skipping the active session (`panes.test.ts`);
  `appendExpansion` append-then-drop (`diff.test.ts`); a two-model rollout withholding the cost
  and an offline stale ref refusing the base (Go — the latter verified to fail against the old
  guard).
- [x] Full local gate: `gofmt`, `go vet`, Go tests, cross-compile loop (linux/darwin/windows),
  `pnpm check`, vitest, `tsc -b` + vite build.
- [ ] Hand check in `task dev` (render paths the node gate cannot see): the "Check again" error
  toast, and the collapsed rail following a pane mutation.
