### PR TITLE
fix: twenty-two low-severity findings from the v0.42.0 audit

### DIFF
--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -108,7 +108,7 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
   const handsOn = useRemoteResource(
     sessionId ? `${sessionId}:${now.getTime()}` : "",
     () => TerminalService.HandsOn(sessionId),
-    { empty: 0 },
+    { empty: 0, resetOn: sessionId },
   )
 
   // The picker runs on the backend (DropService.Attach), not through
@@ -197,6 +197,7 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
           <span className="font-mono text-xs text-muted-foreground">
             {spellHandsOn(handsOn.data)}
           </span>
+          {/* Keep in sync with handsOnIdleGap in internal/terminal/handson.go. */}
           <span className="text-xs text-muted-foreground">
             How long this session has been worked on — typed at, reporting, or running a turn. A gap
             longer than 15 minutes counts as time away.

--- a/frontend/src/components/PaneSeams.tsx
+++ b/frontend/src/components/PaneSeams.tsx
@@ -97,6 +97,9 @@ export function PaneSeams({
                 onCommit(next)
               }
             }}
+            onPointerCancel={() => {
+              drag.current = null
+            }}
           />
         )
       })}

--- a/frontend/src/components/TerminalHost.tsx
+++ b/frontend/src/components/TerminalHost.tsx
@@ -26,6 +26,74 @@ const probe: SpawnProbe = {
   resumeAvailable: TerminalService.ResumeAvailable,
 }
 
+interface PaneDrag {
+  from: number | null
+  over: number | null
+}
+
+interface PaneHeaderProps {
+  session: Session
+  index: number
+  focused: boolean
+  drag: PaneDrag
+  onDrag: (drag: PaneDrag) => void
+  onFocus: (index: number) => void
+  onSwap: (from: number, to: number) => void
+  onDrop: (index: number) => void
+}
+
+function paneUnder(x: number, y: number): number | null {
+  const el = document.elementFromPoint(x, y)?.closest("[data-pane]")
+  const index = Number(el?.getAttribute("data-pane"))
+  return Number.isInteger(index) ? index : null
+}
+
+function PaneHeader({
+  session,
+  index,
+  focused,
+  drag,
+  onDrag,
+  onFocus,
+  onSwap,
+  onDrop,
+}: PaneHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "group flex shrink-0 cursor-grab items-center gap-1.5 px-2.5 pb-1 pt-1.5 text-xs",
+        focused ? "text-foreground" : "text-muted-foreground",
+        drag.from === index && "cursor-grabbing opacity-60",
+        drag.over === index && drag.from !== null && drag.from !== index && "bg-accent/60",
+      )}
+      onPointerDown={(event) => {
+        event.currentTarget.setPointerCapture(event.pointerId)
+        onDrag({ from: index, over: null })
+      }}
+      onPointerMove={(event) => {
+        if (drag.from === index) {
+          onDrag({ from: index, over: paneUnder(event.clientX, event.clientY) })
+        }
+      }}
+      onPointerUp={(event) => {
+        event.currentTarget.releasePointerCapture(event.pointerId)
+        const target = paneUnder(event.clientX, event.clientY)
+        onDrag({ from: null, over: null })
+        target === null || target === index ? onFocus(index) : onSwap(index, target)
+      }}
+      onPointerCancel={() => onDrag({ from: null, over: null })}
+    >
+      <ProviderIcon kind={session.kind} size={12} />
+      <span className="min-w-0 truncate font-medium">{session.label}</span>
+      <CloseButton
+        label={`Stop showing ${session.label}`}
+        className="ml-auto"
+        onClick={() => onDrop(index)}
+      />
+    </div>
+  )
+}
+
 // TerminalHost keeps one persistent terminal per session, across every open
 // project, stacked in the same area. The router picks the active project and the
 // per-project active session decides which layer is visible — terminals are
@@ -74,14 +142,7 @@ export function TerminalHost() {
   // The pane a dragged one is hovering over, for the drop hint. The drag itself
   // is a pointer gesture on the label rather than HTML5 drag-and-drop, which the
   // window already spends on files dropped into a terminal.
-  const [dragFrom, setDragFrom] = useState<number | null>(null)
-  const [dragOver, setDragOver] = useState<number | null>(null)
-
-  const paneUnder = (x: number, y: number): number | null => {
-    const el = document.elementFromPoint(x, y)?.closest("[data-pane]")
-    const index = Number(el?.getAttribute("data-pane"))
-    return Number.isInteger(index) ? index : null
-  }
+  const [paneDrag, setPaneDrag] = useState<PaneDrag>({ from: null, over: null })
 
   // The close an exited session's banner raises, on its own instance of the
   // sidebar's flow — the sidebar is not always mounted (collapsed to the rail)
@@ -234,45 +295,16 @@ export function TerminalHost() {
               onPointerDownCapture={visible && !focused ? () => stage.focusCell(index) : undefined}
             >
               {split && visible && (
-                <div
-                  className={cn(
-                    "group flex shrink-0 cursor-grab items-center gap-1.5 px-2.5 pb-1 pt-1.5 text-xs",
-                    focused ? "text-foreground" : "text-muted-foreground",
-                    dragFrom === index && "cursor-grabbing opacity-60",
-                    dragOver === index && dragFrom !== null && dragFrom !== index && "bg-accent/60",
-                  )}
-                  // The label is the grip: a pointer gesture on the terminal
-                  // itself is a text selection, and one on the pane is how the
-                  // cursor moves into it.
-                  onPointerDown={(event) => {
-                    event.currentTarget.setPointerCapture(event.pointerId)
-                    setDragFrom(index)
-                  }}
-                  onPointerMove={(event) => {
-                    if (dragFrom === index) {
-                      setDragOver(paneUnder(event.clientX, event.clientY))
-                    }
-                  }}
-                  onPointerUp={(event) => {
-                    event.currentTarget.releasePointerCapture(event.pointerId)
-                    const target = paneUnder(event.clientX, event.clientY)
-                    setDragFrom(null)
-                    setDragOver(null)
-                    if (target === null || target === index) {
-                      stage.focusCell(index)
-                      return
-                    }
-                    stage.swap(index, target)
-                  }}
-                >
-                  <ProviderIcon kind={session.kind} size={12} />
-                  <span className="min-w-0 truncate font-medium">{session.label}</span>
-                  <CloseButton
-                    label={`Stop showing ${session.label}`}
-                    className="ml-auto"
-                    onClick={() => stage.drop(index)}
-                  />
-                </div>
+                <PaneHeader
+                  session={session}
+                  index={index}
+                  focused={focused}
+                  drag={paneDrag}
+                  onDrag={setPaneDrag}
+                  onFocus={stage.focusCell}
+                  onSwap={stage.swap}
+                  onDrop={stage.drop}
+                />
               )}
               <div className="relative min-h-0 flex-1">
                 <TerminalView

--- a/frontend/src/components/diff/CommentBatch.tsx
+++ b/frontend/src/components/diff/CommentBatch.tsx
@@ -42,14 +42,19 @@ export function CommentBatch({ target, onInject }: CommentBatchProps) {
     setNote("")
   }
 
+  const clear = () => {
+    clearReviewComments(target)
+    setNote("")
+  }
+
   // Comments are the one thing here the user typed, so they survive a failed
   // send: only a write the session took clears them.
   const send = () => {
-    if (!onInject(composeReviewComments(comments))) {
+    if (!onInject(composeReviewComments(comments, note))) {
       toast.error("Open a session to send these comments to")
       return
     }
-    clearReviewComments(target)
+    clear()
   }
 
   return (
@@ -99,7 +104,7 @@ export function CommentBatch({ target, onInject }: CommentBatchProps) {
           {comments.length} {comments.length === 1 ? "comment" : "comments"}
         </span>
         <span className="ml-auto flex items-center gap-1">
-          <Button variant="ghost" size="sm" onClick={() => clearReviewComments(target)}>
+          <Button variant="ghost" size="sm" onClick={clear}>
             Clear
           </Button>
           <Button

--- a/frontend/src/components/diff/FileDiff.tsx
+++ b/frontend/src/components/diff/FileDiff.tsx
@@ -10,6 +10,7 @@ import { threadSlots, type SlotElements, type ThreadSlot } from "@/lib/codemirro
 import {
   buildFileDoc,
   contextLines,
+  docLineAt,
   formatLineRef,
   newLineRange,
   type DiffFile,
@@ -345,16 +346,13 @@ function DiffBody({ doc, path, onInject, onSessionComment, review, onExpandGap }
     return layers.length > 0 ? layers : undefined
   }, [gapped, slots, doc, onExpandGap])
   const { containerRef, getSelectedDocLines, view } = useDiffEditor(doc, path, extra)
-  // Both halves of the resolved selection: the file lines a comment is filed
-  // against, and the doc line a composer hangs under. They differ — a selection
-  // ending on a deleted line has a doc line but no new-file one.
+  // The resolved new-file lines a comment is filed against.
   const [selection, setSelection] = useState<DiffSelection | null>(null)
   const [composer, setComposer] = useState<Composer | null>(null)
 
-  // Where the gaps go, never what is in them: keyed off the composer's line
-  // rather than the composer, so typing into it does not re-dispatch the whole
-  // slot set on every keystroke.
-  const composerLine = composer?.docLine ?? 0
+  // Map the stable file line on every render: expanding a gap shifts document
+  // lines, while the line the comment is filed against does not move.
+  const composerLine = composer ? (docLineAt(doc.lineMeta, "RIGHT", composer.range.end) ?? 0) : 0
   const wanted = useMemo((): ThreadSlot[] => {
     const built = review
       ? reviewSlots({
@@ -363,8 +361,6 @@ function DiffBody({ doc, path, onInject, onSessionComment, review, onExpandGap }
           drafts: review.drafts.map(({ comment }) => comment),
         })
       : []
-    // The composer is placed by doc line, not by file line: it belongs under
-    // the last line the selection covered, whichever side that line came from.
     return composerLine > 0 ? [...built, { key: COMPOSER_KEY, docLine: composerLine }] : built
   }, [review, doc.lineMeta, composerLine])
 
@@ -415,9 +411,7 @@ function DiffBody({ doc, path, onInject, onSessionComment, review, onExpandGap }
           }
           const selected = getSelectedDocLines()
           const range = selected ? newLineRange(doc.lineMeta, selected.from, selected.to) : null
-          setSelection(
-            selected && range ? { lines: formatLineRef(range), range, docLine: selected.to } : null,
-          )
+          setSelection(selected && range ? { lines: formatLineRef(range), range } : null)
         }}
         onInject={onInject}
         // Both items are offered whenever their destination exists, not only

--- a/frontend/src/components/diff/ReviewSlots.tsx
+++ b/frontend/src/components/diff/ReviewSlots.tsx
@@ -19,14 +19,16 @@ export interface DiffReview {
   onRemove: (index: number) => void
 }
 
-/** A resolved selection: what to call the lines, which new-file lines they are,
- * and the document line a composer opened on it hangs under. A selection that
+/** A resolved selection: what to call the lines and which new-file lines they are.
+ * A selection that
  * covers only deleted lines has no new-file range and so never becomes one of
  * these — commenting on the other side needs its own gesture. */
 export interface DiffSelection {
   lines: string
   range: NewLineRange
-  docLine: number
+  /** Full-file previews have no expandable gaps, so their document line is a
+   * stable anchor. Diff composers remap range.end instead. */
+  docLine?: number
 }
 
 /** The comment being written, and where it goes when it is filed. Held by the

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -207,41 +207,44 @@ export function SessionGroup({
           >
             <SortableContext items={ids} strategy={verticalListSortingStrategy}>
               <div className="flex flex-col gap-1.5">
-                {sessions.map((session) => (
-                  <SessionCard
-                    key={session.id}
-                    session={session}
-                    path={projectPath}
-                    // Resolved here rather than in the card: the parent can be a
-                    // session in another project, which only the workspace-wide
-                    // state knows about.
-                    origin={sessionOrigin(workspace, session)}
-                    active={session.id === activeId}
-                    // Membership is the block itself; what the card still has to
-                    // answer is whether that member is on screen this moment.
-                    onStage={!!stage}
-                    showing={stageIds.includes(session.id)}
-                    onStageToggle={() => onStageToggle(session.id)}
-                    delegateCount={delegatesOf(workspace, projectId, session.id).length}
-                    onGroupDelegates={() =>
-                      onGroupDelegates(
-                        session.id,
-                        delegatesOf(workspace, projectId, session.id).map((s) => s.id),
-                      )
-                    }
-                    onSelect={() => select(session.id)}
-                    onClose={() => onClose(session)}
-                    onRename={(label) => renameSession(projectId, session.id, label)}
-                    onSetEntrypoint={(entrypoint) =>
-                      setEntrypoint(projectId, session.id, entrypoint)
-                    }
-                    onPin={(pinned) => pinSession(projectId, session.id, pinned)}
-                    onOpenTerminal={(cwd) => newSession(projectId, "shell", cwd)}
-                    onPulls={onPulls}
-                    sortable={sortable}
-                    delegateGroups={delegateGroups}
-                  />
-                ))}
+                {sessions.map((session) => {
+                  const delegates = delegatesOf(workspace, projectId, session.id)
+                  return (
+                    <SessionCard
+                      key={session.id}
+                      session={session}
+                      path={projectPath}
+                      // Resolved here rather than in the card: the parent can be a
+                      // session in another project, which only the workspace-wide
+                      // state knows about.
+                      origin={sessionOrigin(workspace, session)}
+                      active={session.id === activeId}
+                      // Membership is the block itself; what the card still has to
+                      // answer is whether that member is on screen this moment.
+                      onStage={!!stage}
+                      showing={stageIds.includes(session.id)}
+                      onStageToggle={() => onStageToggle(session.id)}
+                      delegateCount={delegates.length}
+                      onGroupDelegates={() =>
+                        onGroupDelegates(
+                          session.id,
+                          delegates.map((delegate) => delegate.id),
+                        )
+                      }
+                      onSelect={() => select(session.id)}
+                      onClose={() => onClose(session)}
+                      onRename={(label) => renameSession(projectId, session.id, label)}
+                      onSetEntrypoint={(entrypoint) =>
+                        setEntrypoint(projectId, session.id, entrypoint)
+                      }
+                      onPin={(pinned) => pinSession(projectId, session.id, pinned)}
+                      onOpenTerminal={(cwd) => newSession(projectId, "shell", cwd)}
+                      onPulls={onPulls}
+                      sortable={sortable}
+                      delegateGroups={delegateGroups}
+                    />
+                  )
+                })}
               </div>
             </SortableContext>
           </DndContext>

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -9,9 +9,10 @@ import { ProjectService } from "@/lib/rpc"
 import { closeSettings, isSettingsOpen, subscribeSettingsCard } from "@/lib/settings-card-store"
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
 import { delegateTargets } from "@/lib/session/delegate-targets"
-import { movingFrom, type PaneGroup, reorderGroups } from "@/lib/session/panes"
+import { reorderGroups } from "@/lib/session/panes"
 import { ConfirmDialog } from "@/components/ConfirmDialog"
 import { usePanes } from "@/lib/session/use-panes"
+import { useStageToggle } from "@/lib/session/use-stage-toggle"
 import {
   closePullsList,
   isPullsListOpen,
@@ -138,7 +139,7 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   // somebody else's arrangement, changed by a click aimed at this one. So the
   // decision goes to the user rather than being made under them; `add` refuses
   // the move until they have answered.
-  const [moving, setMoving] = useState<{ session: Session; from: PaneGroup } | null>(null)
+  const { moving, toggleStage, cancelMove, confirmMove } = useStageToggle(panes, list)
   // Gathering an orchestrator and its workers is the one action that builds a
   // whole wall at once. A delegate already on another wall stays there — it is
   // the user's arrangement and taking it is the destructive reading — so the
@@ -148,25 +149,12 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
     if (skipped > 0) {
       toast(
         skipped === 1
-          ? "1 delegate stayed on the split it was already in"
-          : `${skipped} delegates stayed on the splits they were already in`,
+          ? "1 delegate could not be added to the split"
+          : `${skipped} delegates could not be added to the split`,
       )
     }
   }
 
-  const toggleStage = (sessionId: string) => {
-    const from = movingFrom(panes.groups, panes.current, sessionId)
-    const session = list.find((s) => s.id === sessionId)
-    if (from && session) {
-      setMoving({ session, from })
-      return
-    }
-    if (panes.current?.cells.includes(sessionId)) {
-      panes.remove(sessionId)
-      return
-    }
-    panes.add(sessionId)
-  }
   // The query narrows the flat list before the groups are built from it, so
   // grouping, the pinned block and the stored order all keep working on the
   // survivors without knowing a filter exists.
@@ -490,7 +478,7 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
       <WorktreeCloseDialogs close={worktreeClose} />
       <ConfirmDialog
         open={!!moving}
-        onCancel={() => setMoving(null)}
+        onCancel={cancelMove}
         title={`Move ${moving?.session.label ?? ""} to this split?`}
         description={
           moving?.from.cells.length === 1 ? (
@@ -506,16 +494,7 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
           )
         }
       >
-        <Button
-          onClick={() => {
-            if (moving) {
-              panes.add(moving.session.id, { move: true })
-            }
-            setMoving(null)
-          }}
-        >
-          Move it
-        </Button>
+        <Button onClick={confirmMove}>Move it</Button>
       </ConfirmDialog>
 
       <ResizeHandle edge="right" label="Resize sidebar" handleProps={handleProps} />

--- a/frontend/src/components/sidebar/useWorktreeClose.ts
+++ b/frontend/src/components/sidebar/useWorktreeClose.ts
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useRef, useState } from "react"
 import { toast } from "sonner"
 import { ProjectService, Store } from "@/lib/rpc"
 import { closeIntent } from "@/lib/session/close-intent"
@@ -51,6 +51,7 @@ export function useWorktreeClose(
   const [pendingClose, setPendingClose] = useState<Session | null>(null)
   const [pendingAdopted, setPendingAdopted] = useState(true)
   const [pendingForce, setPendingForce] = useState<Session | null>(null)
+  const adoptedProbe = useRef(0)
 
   // Close first so the PTY running inside the worktree dies before git tries
   // to remove it. A refused removal surfaces as a toast; the checkout stays on
@@ -79,17 +80,23 @@ export function useWorktreeClose(
       case "confirm-running":
         setPendingRunning(session)
         return
-      case "ask-worktree":
+      case "ask-worktree": {
         // Asked as the dialog opens rather than at the click on Remove: an
         // adopted checkout has no removal to offer, and a button that only ever
         // ends in a refusal is worse than the one that is not there. A failed
         // check reads as adopted — the safe half of the answer.
         setPendingAdopted(true)
         setPendingClose(session)
+        const sequence = ++adoptedProbe.current
         void ProjectService.WorktreeAdopted(session.path ?? "")
           .catch(() => true)
-          .then(setPendingAdopted)
+          .then((adopted) => {
+            if (sequence === adoptedProbe.current) {
+              setPendingAdopted(adopted)
+            }
+          })
         return
+      }
       case "close":
         closeSession(projectId, session.id)
     }
@@ -116,6 +123,7 @@ export function useWorktreeClose(
     },
 
     cancel() {
+      adoptedProbe.current++
       setPendingRunning(null)
       setPendingClose(null)
       setPendingForce(null)

--- a/frontend/src/lib/review-comments.test.ts
+++ b/frontend/src/lib/review-comments.test.ts
@@ -84,6 +84,14 @@ describe("review-comments", () => {
     )
   })
 
+  it("includes an uncommitted note when the batch is sent", () => {
+    const t = target("pending-note")
+    addReviewComment(t, "src/a.ts", "12", "leaks the listener")
+    expect(composeReviewComments(reviewComments(t), "  same bug everywhere  ")).toContain(
+      "- same bug everywhere\x1b[201~",
+    )
+  })
+
   it("drops a blank note like a blank comment", () => {
     const t = target("blank-note")
     addReviewNote(t, "  \n ")

--- a/frontend/src/lib/review-comments.ts
+++ b/frontend/src/lib/review-comments.ts
@@ -101,12 +101,15 @@ export function subscribeReviewComments(listener: () => void): () => void {
  * send — one per line, so the agent would answer the first comment while the
  * rest were still being typed.
  */
-export function composeReviewComments(list: readonly ReviewComment[]): string {
+export function composeReviewComments(list: readonly ReviewComment[], note = ""): string {
   const items = list.map((c) =>
     c.path === ""
       ? `- ${continuation(c.text)}`
       : `- ${c.path}:${c.lines} — ${continuation(c.text)}`,
   )
+  if (note.trim() !== "") {
+    items.push(`- ${continuation(note.trim())}`)
+  }
   return bracketedPaste(`Review comments:\n\n${items.join("\n")}`)
 }
 

--- a/frontend/src/lib/session/pane-grid.ts
+++ b/frontend/src/lib/session/pane-grid.ts
@@ -12,7 +12,7 @@
 // wrapping stops being readable rather than merely tight. Height only has to
 // keep a pane from becoming a caption.
 export const MIN_PANE_WIDTH = 420
-export const MIN_PANE_HEIGHT = 160
+const MIN_PANE_HEIGHT = 160
 
 /** The smallest share of an axis one row or column may be dragged down to. */
 export const MIN_TRACK = 0.12
@@ -76,6 +76,7 @@ export function tracks(stored: readonly number[], count: number): number[] {
   const usable =
     stored.length === count &&
     stored.every((value) => Number.isFinite(value) && value >= MIN_TRACK) &&
+    // Floating-point accumulation tolerance for normalized track fractions.
     Math.abs(stored.reduce((sum, value) => sum + value, 0) - 1) < 0.01
   return usable ? [...stored] : Array.from({ length: count }, () => 1 / count)
 }

--- a/frontend/src/lib/session/panes.ts
+++ b/frontend/src/lib/session/panes.ts
@@ -144,7 +144,7 @@ export function movingFrom(
 }
 
 /** Every session on any wall — what the add shortcut must not offer again. */
-export function grouped(groups: readonly PaneGroup[]): Set<string> {
+function grouped(groups: readonly PaneGroup[]): Set<string> {
   return new Set(groups.flatMap((group) => group.cells))
 }
 

--- a/frontend/src/lib/session/use-panes.ts
+++ b/frontend/src/lib/session/use-panes.ts
@@ -159,13 +159,16 @@ export function usePanes(projectId: string): Panes {
     },
     groupWith(sessionId, delegateIds) {
       const free = delegateIds.filter((id) => !groupOf(groups, id))
-      if (!projectId || free.length === 0) {
+      const { width, height } = stageSize()
+      const firstOverflow = free.findIndex((_, index) => !fits(index + 2, width, height))
+      const shown = firstOverflow < 0 ? free : free.slice(0, firstOverflow)
+      if (!projectId || shown.length === 0) {
         return delegateIds.length
       }
       const born: PaneGroup = {
         id: newGroupId(),
         name: defaultName(list, sessionId),
-        cells: [sessionId, ...free],
+        cells: [sessionId, ...shown],
         cols: [],
         rows: [],
       }
@@ -174,7 +177,7 @@ export function usePanes(projectId: string): Panes {
       commit([...removeFromGroups(groups, sessionId), born])
       // And the window goes there, or the wall is built out of sight.
       activateSession(projectId, sessionId)
-      return delegateIds.length - free.length
+      return delegateIds.length - shown.length
     },
     rename(groupId, name) {
       const trimmed = name.trim()

--- a/frontend/src/lib/session/use-stage-toggle.ts
+++ b/frontend/src/lib/session/use-stage-toggle.ts
@@ -1,0 +1,34 @@
+import { useState } from "react"
+import { movingFrom, type PaneGroup } from "./panes"
+import type { Session } from "./sessions"
+import type { Panes } from "./use-panes"
+
+interface StageMove {
+  session: Session
+  from: PaneGroup
+}
+
+export function useStageToggle(panes: Panes, sessions: Session[]) {
+  const [moving, setMoving] = useState<StageMove | null>(null)
+
+  const toggleStage = (sessionId: string) => {
+    const from = movingFrom(panes.groups, panes.current, sessionId)
+    const session = sessions.find((held) => held.id === sessionId)
+    if (from && session) {
+      setMoving({ session, from })
+    } else if (panes.current?.cells.includes(sessionId)) {
+      panes.remove(sessionId)
+    } else {
+      panes.add(sessionId)
+    }
+  }
+
+  const confirmMove = () => {
+    if (moving) {
+      panes.add(moving.session.id, { move: true })
+    }
+    setMoving(null)
+  }
+
+  return { moving, toggleStage, cancelMove: () => setMoving(null), confirmMove }
+}

--- a/internal/gitutil/env.go
+++ b/internal/gitutil/env.go
@@ -1,0 +1,13 @@
+// Package gitutil holds the small process rules shared by git callers.
+package gitutil
+
+// NoPrompt adds every setting needed to stop git and its credential helpers
+// from opening a terminal or GUI prompt nobody can answer.
+func NoPrompt(env []string) []string {
+	return append(env,
+		"GIT_TERMINAL_PROMPT=0",
+		"GIT_ASKPASS=",
+		"SSH_ASKPASS=",
+		"GCM_INTERACTIVE=never",
+	)
+}

--- a/internal/project/filelines.go
+++ b/internal/project/filelines.go
@@ -57,7 +57,15 @@ func (s *Service) fileAt(path, rel, ref string) (string, error) {
 	}
 	// gitQuiet and not runGit: an object this clone does not have is the
 	// expected answer for a pull request's head, not a failure to report.
-	if out, ok := gitQuiet(path, "show", ref+":"+rel); ok {
+	object := ref + ":" + rel
+	if kind, ok := gitQuiet(path, "cat-file", "-t", object); ok {
+		if strings.TrimSpace(kind) != "blob" {
+			return "", fmt.Errorf("%s is not a regular file", rel)
+		}
+		out, ok := gitQuiet(path, "cat-file", "blob", object)
+		if !ok {
+			return "", fmt.Errorf("read %s at %s", rel, ref)
+		}
 		return checkedText(rel, out)
 	}
 	out, err := s.gh(prReadTimeout, path, "api", "-H", ghRawAccept, contentsPath(rel, ref))

--- a/internal/project/filelines_test.go
+++ b/internal/project/filelines_test.go
@@ -145,6 +145,34 @@ func TestFileLinesLocalObject(t *testing.T) {
 	}
 }
 
+func TestFileLinesLocalObjectRejectsADirectory(t *testing.T) {
+	repo, git := initRepo(t)
+	write(t, repo, "src/a.txt", "one\n")
+	git("add", "src/a.txt")
+	git("commit", "-m", "tree")
+	tree := strings.TrimSpace(git("rev-parse", "HEAD^{tree}"))
+	gh := &fakeGH{out: []byte("should not be asked\n")}
+
+	if _, err := withGH(gh).FileLines(repo, "src", tree, 1, 2); err == nil {
+		t.Fatal("directory at object: want error, got nil")
+	}
+	if gh.calls != 0 {
+		t.Errorf("gh called %d times for a local tree, want 0", gh.calls)
+	}
+}
+
+func TestFileLinesLocalObjectRejectsBinary(t *testing.T) {
+	repo, git := initRepo(t)
+	write(t, repo, "blob.bin", "text\x00more")
+	git("add", "blob.bin")
+	git("commit", "-m", "binary")
+	tree := strings.TrimSpace(git("rev-parse", "HEAD^{tree}"))
+
+	if _, err := New(nil).FileLines(repo, "blob.bin", tree, 1, 2); err == nil {
+		t.Fatal("binary object: want error, got nil")
+	}
+}
+
 // An oid the clone does not have is a pull request's head: GitHub answers for
 // it, through the contents API rather than through git.
 func TestFileLinesMissingObjectAsksGitHub(t *testing.T) {
@@ -165,6 +193,15 @@ func TestFileLinesMissingObjectAsksGitHub(t *testing.T) {
 	}
 	if gh.dir != repo {
 		t.Errorf("gh dir = %q, want %q", gh.dir, repo)
+	}
+}
+
+func TestFileLinesGitHubRejectsOversize(t *testing.T) {
+	repo, _ := initRepo(t)
+	gh := &fakeGH{out: []byte(strings.Repeat("x", maxReadFileSize+1))}
+
+	if _, err := withGH(gh).FileLines(repo, "a.txt", strings.Repeat("d", 40), 1, 2); err == nil {
+		t.Fatal("oversize GitHub payload: want error, got nil")
 	}
 }
 

--- a/internal/project/tree.go
+++ b/internal/project/tree.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
@@ -142,7 +143,11 @@ func lsFiles(path string, args ...string) ([]string, error) {
 func (s *Service) ReadFile(path, rel string) (string, error) {
 	full, err := relpath.Resolve(path, rel)
 	if err != nil {
-		return "", err
+		var pathErr *os.PathError
+		if !errors.As(err, &pathErr) {
+			return "", err
+		}
+		return "", fmt.Errorf("stat %s: %w", rel, pathErr.Err)
 	}
 	info, err := os.Stat(full)
 	if err != nil {

--- a/internal/project/tree_test.go
+++ b/internal/project/tree_test.go
@@ -214,6 +214,8 @@ func TestReadFileMissing(t *testing.T) {
 	repo, _ := initRepo(t)
 	if _, err := New(nil).ReadFile(repo, "nope.txt"); err == nil {
 		t.Error("ReadFile(missing): want error, got nil")
+	} else if got := err.Error(); strings.Contains(got, repo) || !strings.HasPrefix(got, "stat nope.txt:") {
+		t.Errorf("ReadFile(missing) error = %q, want only the relative path", got)
 	}
 }
 

--- a/internal/project/worktree.go
+++ b/internal/project/worktree.go
@@ -11,6 +11,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/omartelo/lich/internal/gitutil"
+	"github.com/omartelo/lich/internal/relpath"
 )
 
 // Worktree is a git worktree checkout: the branch it holds and its path.
@@ -224,12 +227,7 @@ func fetchBase(projectPath, remote, branch string) error {
 	// Without these a remote that wants a credential or a key passphrase stops
 	// on a prompt with no terminal to answer it — or worse, a GUI askpass dialog
 	// behind the app window — and burns the whole budget waiting for a person.
-	cmd.Env = append(os.Environ(),
-		"GIT_TERMINAL_PROMPT=0",
-		"GIT_ASKPASS=",
-		"SSH_ASKPASS=",
-		"GCM_INTERACTIVE=never",
-	)
+	cmd.Env = gitutil.NoPrompt(cmd.Env)
 	var stderr strings.Builder
 	cmd.Stderr = &stderr
 	fetchErr := cmd.Run()
@@ -402,7 +400,7 @@ func (s *Service) WorktreeAdopted(wtPath string) bool {
 	if err != nil {
 		return true
 	}
-	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
+	return relpath.Escapes(rel)
 }
 
 // RemoveWorktree removes a worktree checkout. Without force git refuses to

--- a/internal/quota/quota_test.go
+++ b/internal/quota/quota_test.go
@@ -147,14 +147,14 @@ func TestClaudeRequestCarriesTheHeadersTheEndpointDemands(t *testing.T) {
 
 func TestClaudeFallsBackToTheOriginalWindowPair(t *testing.T) {
 	writeCreds(t, claudeCredsJSON, "")
-	body := `{"five_hour":{"utilization":63,"resets_at":"2026-08-17T23:20:00Z"},
+	body := `{"five_hour":{"utilization":63,"resets_at":"2026-08-17T23:20:00Z","locked_reason":"past_limit"},
 		"seven_day":{"utilization":7,"resets_at":"2026-08-24T15:00:00Z"},"limits":[]}`
 	url, _ := serve(t, http.StatusOK, body)
 
 	got := newService(url, "", time.Now()).claudePlan(lichEnv())
 
 	want := []Window{
-		{Label: "Session", Seconds: 18000, Percent: 63, ResetsAt: "2026-08-17T23:20:00Z"},
+		{Label: "Session", Seconds: 18000, Percent: 63, ResetsAt: "2026-08-17T23:20:00Z", LockedReason: "past_limit"},
 		{Label: "Weekly", Seconds: 604800, Percent: 7, ResetsAt: "2026-08-24T15:00:00Z"},
 	}
 	if len(got.Windows) != 2 || got.Windows[0] != want[0] || got.Windows[1] != want[1] {

--- a/internal/relpath/relpath.go
+++ b/internal/relpath/relpath.go
@@ -26,8 +26,7 @@ import (
 // cleans to, so a missing argument stops here rather than at the git call.
 func Validate(rel string) error {
 	clean := filepath.Clean(rel)
-	if clean == "." || isRooted(clean) || clean == ".." ||
-		strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+	if clean == "." || isRooted(clean) || Escapes(clean) {
 		return fmt.Errorf("invalid repository path %q", rel)
 	}
 	return nil
@@ -59,10 +58,16 @@ func Resolve(root, rel string) (string, error) {
 		return "", fmt.Errorf("resolve %s: %w", rel, err)
 	}
 	inside, err := filepath.Rel(realRoot, full)
-	if err != nil || inside == ".." || strings.HasPrefix(inside, ".."+string(filepath.Separator)) {
+	if err != nil || Escapes(inside) {
 		return "", fmt.Errorf("%q leaves the checkout", rel)
 	}
 	return full, nil
+}
+
+// Escapes reports whether a relative path names the parent or anything below
+// it. Callers use filepath.Rel first when they begin with absolute paths.
+func Escapes(rel string) bool {
+	return rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 // isRooted reports whether a cleaned path starts at a root. IsAbs alone is not

--- a/internal/store/handson.go
+++ b/internal/store/handson.go
@@ -35,24 +35,18 @@ func (s *Service) AddHandsOn(sessionID string, seconds int64) error {
 // nothing has been counted for yet answers 0, which is the right starting point,
 // so a missing row is not an error.
 func (s *Service) HandsOn(sessionID string) (int64, error) {
-	var seconds int64
-	err := s.db.QueryRow(
-		`SELECT seconds FROM session_hands_on WHERE session_id = ?`, sessionID,
-	).Scan(&seconds)
-	if errors.Is(err, sql.ErrNoRows) {
-		return 0, nil
-	}
-	if err != nil {
-		return 0, fmt.Errorf("read hands-on time for %q: %w", sessionID, err)
-	}
-	return seconds, nil
+	return handsOnOf(s.db, sessionID)
 }
 
-// handsOnOf reads a session's total inside a transaction, for the delete and
-// reinsert a parked session's resume performs (see reopen).
-func handsOnOf(tx *sql.Tx, sessionID string) (int64, error) {
+type rowQuerier interface {
+	QueryRow(query string, args ...any) *sql.Row
+}
+
+// handsOnOf reads a session's total, including inside the transaction that
+// re-keys a parked session on resume.
+func handsOnOf(db rowQuerier, sessionID string) (int64, error) {
 	var seconds int64
-	err := tx.QueryRow(
+	err := db.QueryRow(
 		`SELECT seconds FROM session_hands_on WHERE session_id = ?`, sessionID,
 	).Scan(&seconds)
 	if errors.Is(err, sql.ErrNoRows) {

--- a/internal/terminal/handson.go
+++ b/internal/terminal/handson.go
@@ -10,6 +10,7 @@ import (
 // between them, only beats and the gaps between consecutive ones.
 const (
 	// handsOnIdleGap is the longest silence that still counts as working time.
+	// Keep the matching tooltip in frontend/src/components/FooterBar.tsx in sync.
 	// A gap under it is time the user spent reading, thinking or waiting on the
 	// agent, which is time on this session; a gap over it is lunch, another
 	// window or another day, and it contributes nothing at all — which is what
@@ -140,6 +141,16 @@ func (h *handsOn) drain() map[string]int64 {
 		out[id] = seconds
 	}
 	return out
+}
+
+// restore puts a failed write back into the arrears. A beat may have landed
+// since drain, so it adds under the same lock rather than replacing the entry.
+func (h *handsOn) restore(id string, seconds int64) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	entry := h.entries[id]
+	entry.pending += time.Duration(seconds) * time.Second
+	h.entries[id] = entry
 }
 
 // forget drops what is remembered about a session, so the gap across a card's

--- a/internal/terminal/handson_wiring_test.go
+++ b/internal/terminal/handson_wiring_test.go
@@ -8,11 +8,24 @@
 package terminal
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/omartelo/lich/internal/events"
 )
+
+type failingHandsOnStore struct {
+	stubBins
+	err error
+}
+
+func (s *failingHandsOnStore) AddHandsOn(sessionID string, seconds int64) error {
+	if s.err != nil {
+		return s.err
+	}
+	return s.stubBins.AddHandsOn(sessionID, seconds)
+}
 
 // newQuietService is a Service on a hand-wound clock with the debounced write
 // disarmed. A beat that crosses the flush window spawns a writer goroutine of
@@ -115,6 +128,26 @@ func TestFlushWritesThroughToTheStore(t *testing.T) {
 	}
 	if total != 120 {
 		t.Errorf("two minutes over two flushes read back as %ds, want 120", total)
+	}
+}
+
+func TestFlushRestoresTimeAfterAStoreFailure(t *testing.T) {
+	clock := newFakeClock()
+	store := &failingHandsOnStore{
+		stubBins: stubBins{handsOn: map[string]int64{}},
+		err:      errors.New("busy"),
+	}
+	svc := newQuietService(store, clock)
+	svc.beatHandsOn("s1", 0)
+	clock.advance(time.Minute)
+	svc.beatHandsOn("s1", 0)
+
+	svc.FlushHandsOn()
+	store.err = nil
+	svc.FlushHandsOn()
+
+	if got := store.handsOn["s1"]; got != 60 {
+		t.Errorf("retry wrote %ds, want the failed 60s restored", got)
 	}
 }
 

--- a/internal/terminal/shellenv_unix.go
+++ b/internal/terminal/shellenv_unix.go
@@ -5,7 +5,10 @@ package terminal
 import (
 	"bytes"
 	"context"
+	"errors"
+	"io"
 	"os/exec"
+	"syscall"
 	"time"
 
 	"github.com/creack/pty"
@@ -47,20 +50,29 @@ func runShellDump(ctx context.Context, shell, cmdStr string, env []string) (stri
 		return "", err
 	}
 
-	chunks := make(chan []byte)
+	type result struct {
+		chunk []byte
+		err   error
+	}
+	results := make(chan result)
 	go func() {
-		defer cmd.Wait()
 		defer ptmx.Close()
 		buf := make([]byte, 4096)
 		for {
-			n, err := ptmx.Read(buf)
+			n, readErr := ptmx.Read(buf)
 			if n > 0 {
 				cp := make([]byte, n)
 				copy(cp, buf[:n])
-				chunks <- cp
+				results <- result{chunk: cp}
 			}
-			if err != nil {
-				close(chunks)
+			if readErr != nil {
+				waitErr := cmd.Wait()
+				if waitErr != nil {
+					readErr = waitErr
+				} else if errors.Is(readErr, io.EOF) || errors.Is(readErr, syscall.EIO) {
+					readErr = nil
+				}
+				results <- result{err: readErr}
 				return
 			}
 		}
@@ -70,11 +82,11 @@ func runShellDump(ctx context.Context, shell, cmdStr string, env []string) (stri
 	var quiet <-chan time.Time
 	for {
 		select {
-		case b, ok := <-chunks:
-			if !ok {
-				return out.String(), nil
+		case result := <-results:
+			if result.err != nil || result.chunk == nil {
+				return out.String(), result.err
 			}
-			out.Write(b)
+			out.Write(result.chunk)
 			quiet = time.After(shellDumpQuiet)
 		case <-quiet:
 			return out.String(), nil

--- a/internal/terminal/shellenv_unix_test.go
+++ b/internal/terminal/shellenv_unix_test.go
@@ -65,3 +65,12 @@ func TestRunShellDumpBackgroundJobStillYieldsOutput(t *testing.T) {
 		t.Fatalf("runShellDump took %v, want it end near the %v quiet window rather than the 5s ctx", elapsed, shellDumpQuiet)
 	}
 }
+
+func TestRunShellDumpSurfacesShellFailure(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if _, err := runShellDump(ctx, "/bin/sh", "exit 7", os.Environ()); err == nil {
+		t.Fatal("runShellDump: want the shell's exit error")
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -1081,6 +1081,7 @@ func (s *Service) HandsOn(id string) (int64, error) {
 func (s *Service) FlushHandsOn() {
 	for id, seconds := range s.hands.drain() {
 		if err := s.store.AddHandsOn(id, seconds); err != nil {
+			s.hands.restore(id, seconds)
 			slog.Warn("terminal: save hands-on time", "session", id, "err", err)
 		}
 	}

--- a/internal/terminal/usage_cost_test.go
+++ b/internal/terminal/usage_cost_test.go
@@ -490,14 +490,14 @@ func codexTurnContextJSON(model string) string {
 // uncached share prices at the input rate — summing both would double-count.
 func TestCodexTranscriptCostPricesTheRunningTotal(t *testing.T) {
 	path := writeFile(t,
-		codexTurnContextJSON("gpt-5.1-codex")+"\n"+codexTokenLineJSON(1000, 400, 0, 10)+"\n")
+		codexTurnContextJSON("gpt-5.1-codex")+"\n"+codexTokenLineJSON(1000, 400, 25, 10)+"\n")
 
 	cost, ok := codexTranscriptCost(path, codexTestRate)
 
 	if !ok {
 		t.Fatal("codexTranscriptCost: want ok")
 	}
-	want := 600*0.001 + 400*0.0005 + 10*0.01
+	want := 600*0.001 + 400*0.0005 + 25*0.002 + 10*0.01
 	if !nearly(cost, want) {
 		t.Errorf("cost = %v, want %v", cost, want)
 	}

--- a/internal/themes/git.go
+++ b/internal/themes/git.go
@@ -14,7 +14,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/omartelo/lich/internal/gitutil"
 	"github.com/omartelo/lich/internal/semver"
+	"github.com/omartelo/lich/internal/winexec"
 )
 
 const (
@@ -183,14 +185,10 @@ func clone(ctx context.Context, url, dir string) error {
 		"-c", "protocol.ext.allow=never",
 		"-c", "credential.helper=",
 		"clone", "--depth", "1", "--single-branch", "--no-tags", "--", url, dir)
+	winexec.Hide(cmd)
 	// Without these a private repository stops on a credential prompt that has
 	// no terminal to answer it, and the install hangs until the timeout.
-	cmd.Env = append(os.Environ(),
-		"GIT_TERMINAL_PROMPT=0",
-		"GIT_ASKPASS=",
-		"SSH_ASKPASS=",
-		"GCM_INTERACTIVE=never",
-	)
+	cmd.Env = gitutil.NoPrompt(os.Environ())
 	cmd.WaitDelay = cloneWait
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
The LOW-severity half of the code-quality audit of everything since v0.42.0 — 22 findings, all
fixed, none skipped. The HIGH/MEDIUM half is `fix/audit-high-medium`; that PR merges first and
this branch expects a rebase over it (both touch `worktree.go`, `FileDiff.tsx`, `use-panes.ts`,
`panes.ts`, `SessionSidebar.tsx`).

## Backend

- **Hands-on time survives a store error**: a failed `AddHandsOn` write requeues the drained
  seconds instead of logging them away, keeping the documented at-most-one-flush loss bound.
- **A crashed shell env dump names its error**: the PTY reader's read/`Wait` failure reaches the
  "yielded nothing" warn instead of `err=nil`.
- **A directory at an oid is refused**: `git show <oid>:<dir>` exits 0 with a tree listing, which
  `FileLines` returned as file lines; the git-object path now rejects trees, and the oversize and
  binary refusals are tested through it rather than only through the working tree.
- **A preview error names the relative path again**, not the absolute one `relpath.Resolve`
  stats.
- **Test gaps closed**: a Codex fixture with nonzero cache-write tokens, a locked reason on the
  fallback window pair, and `checkedText`'s bad paths via git/gh.
- **Deduplication**: the `..`-escape predicate lives once in `relpath`; the no-prompt env block
  is shared between `project` and `themes`; `HandsOn`/`handsOnOf` collapse onto one
  `QueryRow` implementation.
- **The theme clone hides its console on Windows** (`winexec.Hide`), the same seam every other
  child process already goes through.

## Frontend

- **A note typed but not entered is no longer dropped by Send**, and the draft clears with the
  batch instead of resurfacing later.
- **The comment composer keeps its anchor** when a gap above it is expanded.
- **A cancelled close dialog's late "adopted" probe no longer lands on the next dialog**
  (staleness guard), so the destructive button cannot show for the wrong checkout.
- **The footer's hands-on readout resets on session switch** (`resetOn`), instead of captioning
  the previous session's time as the new one's.
- **Both new drags handle `pointercancel`**, so an interrupted drag cannot leave a buttonless
  hover resizing tracks.
- **`groupWith` now enforces the same `fits` guard `add` does**, counting what did not fit as
  skipped — the toast already reports it.
- **Cleanups**: dead exports un-exported (`MIN_PANE_HEIGHT`, `grouped`), `delegatesOf` computed
  once per card, the pane-grid `0.01` tolerance and the footer's "15 minutes" ↔
  `handsOnIdleGap` mirror both commented, `PaneHeader` extracted out of `TerminalHost`'s
  five-deep JSX, and the move-dialog state extracted from `SessionSidebar`.

## Test plan

- [x] New tests: hands-on requeue on write failure, shellenv error propagation, tree/oversize/
  binary refusals through the git-object path, Codex cache-write pricing, locked reason on the
  fallback pair, plus the frontend guards where extractable pure.
- [x] Full local gate: `gofmt`, `go vet`, Go tests, `pnpm check`, 1,320 frontend tests,
  production build, and the linux/darwin/windows build+vet loop (this touches an OS seam).
- [ ] Rebase over `fix/audit-high-medium` once it lands.
