### PR TITLE
chore: cut the v0.43.0 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.43.0] - 2026-08-31
+
 ### Added
 
 - **A review note that belongs to no line.** Comments collected while reading a
@@ -3606,7 +3608,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.42.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.43.0...HEAD
+[0.43.0]: https://github.com/omartelo/lich/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/omartelo/lich/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/omartelo/lich/compare/v0.40.1...v0.41.0
 [0.40.1]: https://github.com/omartelo/lich/compare/v0.40.0...v0.40.1


### PR DESCRIPTION
Moves the [Unreleased] entries under ## [0.43.0] - 2026-08-31 the Keep a Changelog way and refreshes the compare links. Tag v0.43.0 follows on the merge commit.