### PR TITLE
fix: raise a dialog when no Chromium-family browser is found

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,6 +299,7 @@ jobs:
         with:
           pkgname: lich-bin
           pkgbuild: ./PKGBUILD
+          assets: build/linux/aur/lich-bin.install
           updpkgsums: true
           commit_username: omartelo
           commit_email: meopedevts@proton.me

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A missing browser now says so on screen.** lich opens its window in a
+  Chromium-family browser installed on the machine — a deliberate decision
+  (no Electron, no bundled runtime). Launched from a desktop launcher without
+  one, it used to die in silence, the explanation only in a terminal nobody
+  had open. That failure now raises an error dialog naming what is missing
+  and where the log is, the AUR package checks for a browser at install time,
+  and INSTALL.md spells the requirement out. (#409)
+
 ## [0.43.0] - 2026-08-31
 
 ### Added

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,12 @@ Pick your system:
 - [If it does not start](#if-it-does-not-start)
 
 **Runtime dependencies** — lich opens its window in a Chromium-family browser;
-none is bundled. On Linux any of `chromium`, `google-chrome`, `helium-browser` or `brave`
+none is bundled. This is a decision, not a gap: lich rejected Electron and
+moved off Wails to stay one static Go binary that drives the browser already
+on your machine ([docs/chromium-shell.md](docs/chromium-shell.md)), so a
+Chromium-family browser is a hard runtime requirement — without one, lich
+cannot open its window and says so in a dialog and in the log. On Linux any of
+`chromium`, `google-chrome`, `helium-browser` or `brave`
 satisfies it, and `zenity` provides the folder picker. On macOS, Chrome,
 Chromium, Edge or Brave are looked up as `.app` bundles under `/Applications`
 (and `~/Applications`), and the folder picker is native. On Windows, Chrome,

--- a/build/linux/aur/PKGBUILD.tpl
+++ b/build/linux/aur/PKGBUILD.tpl
@@ -10,7 +10,8 @@ url="https://github.com/omartelo/lich"
 license=('AGPL-3.0-only')
 provides=('lich')
 conflicts=('lich')
-optdepends=('chromium: app window (any Chromium-family browser works: chromium, google-chrome, brave)'
+install=lich-bin.install
+optdepends=('chromium: app window (any Chromium-family browser works: chromium, google-chrome, brave, helium-browser)'
             'zenity: native folder picker')
 source=("lich-v${pkgver}-linux-amd64::${url}/releases/download/v${pkgver}/lich-v${pkgver}-linux-amd64"
         "lich-${pkgver}.desktop::https://raw.githubusercontent.com/omartelo/lich/v${pkgver}/build/linux/lich.desktop"

--- a/build/linux/aur/lich-bin.install
+++ b/build/linux/aur/lich-bin.install
@@ -1,0 +1,17 @@
+# Shipped to the AUR next to the PKGBUILD by .github/workflows/release.yml.
+# pacman cannot express "any one of these packages" as a hard dependency, so
+# the browser stays an optdepends and this hook is the install-time check:
+# lich bundles no browser runtime (no Electron, no webview) and opens its
+# window in a Chromium-family browser already on the machine.
+post_install() {
+  for b in chromium chromium-browser google-chrome-stable google-chrome helium-browser brave; do
+    command -v "$b" >/dev/null 2>&1 && return 0
+  done
+  echo "==> lich opens its window in a Chromium-family browser installed on this"
+  echo "==> machine; none was found on PATH. Install one before launching lich:"
+  echo "==>   chromium, google-chrome, brave, or helium-browser"
+}
+
+post_upgrade() {
+  post_install
+}

--- a/main.go
+++ b/main.go
@@ -297,6 +297,17 @@ func runChromium(term *terminal.Service, configDir string, coord *restart.Coordi
 	}
 	if err := chromium.Run(url, profileDir, class, extra, coord.SetWindow); err != nil {
 		slog.Error("chromium shell", "err", err)
+		// Same silence as handleBindFailure: a launcher start has no terminal,
+		// so without a dialog a missing browser reads as lich doing nothing
+		// (#409). Best effort — where no dialog backend answers, the log line
+		// above still has the story.
+		_ = zenity.Error(fmt.Sprintf(
+			"lich could not open its window.\n\n%v\n\n"+
+				"lich does not bundle a browser runtime; it opens its window in "+
+				"a Chromium-family browser installed on this machine.\n\n"+
+				"Log: %s",
+			err, logging.Path(filepath.Join(configDir, "lich"))),
+			zenity.Title("lich"))
 		os.Exit(1)
 	}
 	slog.Info("window closed, exiting")


### PR DESCRIPTION
Fixes #409.

Launched from a desktop launcher without a Chromium-family browser, lich died in silence: the error only reached the terminal and the log, and nothing on screen said a log exists. Reported by @bayleaf1nl-afk in #409.

## What changed

- **`main.go`**: the `chromium.Run` failure path now mirrors `handleBindFailure`'s best-effort `zenity.Error` dialog, naming the error and the log path. Where no dialog backend answers, the log line still has the story.
- **AUR (`PKGBUILD.tpl` + new `lich-bin.install`)**: pacman cannot express an any-of dependency, so the browser stays `optdepends`; a `post_install`/`post_upgrade` hook now checks PATH for the same candidate list the binary tries and warns when none is found. `release.yml` ships the install file to the AUR repo via the action's `assets` input.
- **`INSTALL.md`**: the runtime-dependencies section now states the decision behind the requirement: lich rejected Electron and moved off Wails to stay one static Go binary driving the browser already on the machine (docs/chromium-shell.md).
- **`CHANGELOG.md`**: Unreleased entry.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` green (2048 passed, 33 packages)
- [x] `bash -n` on `lich-bin.install`
- [x] Manual: rename the browser off PATH, launch from a launcher, dialog appears

No frontend changes. The dialog itself is an OS boundary (zenity subprocess), covered by the documented coverage exception.
