### PR TITLE
fix: let a pane's × close it instead of the header's drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A pane's × takes it off the wall again.** The pane header is also the handle
+  that drags a pane to another cell, and it took the pointer for that drag the
+  moment one went down anywhere on it — including on its own ×, whose click the
+  capture then swallowed. The button did nothing, said nothing. A gesture that
+  starts on the × is the ×'s now, and the drag begins only on the header itself.
+
 - **A missing browser now says so on screen.** lich opens its window in a
   Chromium-family browser installed on the machine — a deliberate decision
   (no Electron, no bundled runtime). Launched from a desktop launcher without

--- a/frontend/src/components/TerminalHost.tsx
+++ b/frontend/src/components/TerminalHost.tsx
@@ -42,6 +42,12 @@ interface PaneHeaderProps {
   onDrop: (index: number) => void
 }
 
+/** Whether a pointer landed on a control inside the header — its × is the only
+ * one, and it is a span with a button role (CloseButton). */
+function onControl(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest('[role="button"]') !== null
+}
+
 function paneUnder(x: number, y: number): number | null {
   const el = document.elementFromPoint(x, y)?.closest("[data-pane]")
   const index = Number(el?.getAttribute("data-pane"))
@@ -67,6 +73,14 @@ function PaneHeader({
         drag.over === index && drag.from !== null && drag.from !== index && "bg-accent/60",
       )}
       onPointerDown={(event) => {
+        // A gesture that starts on a control belongs to that control. The header
+        // captures the pointer to drag the pane, and a capture retargets the
+        // rest of the gesture — pointerup and the mouse events the click is
+        // synthesised from — at the header, so the × below never sees a click of
+        // its own and dies silently.
+        if (onControl(event.target)) {
+          return
+        }
         event.currentTarget.setPointerCapture(event.pointerId)
         onDrag({ from: index, over: null })
       }}
@@ -76,6 +90,11 @@ function PaneHeader({
         }
       }}
       onPointerUp={(event) => {
+        // No drag was started, so this is the tail of a gesture the header does
+        // not own: leave it to the control it began on.
+        if (drag.from !== index) {
+          return
+        }
         event.currentTarget.releasePointerCapture(event.pointerId)
         const target = paneUnder(event.clientX, event.clientY)
         onDrag({ from: null, over: null })


### PR DESCRIPTION
## What

Clicking the × on a split pane's header did nothing, silently.

## Why

`PaneHeader` is both the label and the drag handle: its `onPointerDown` calls `setPointerCapture` for whatever gesture starts on it. A pointer capture retargets the rest of that gesture — `pointerup`, and the mouse events a `click` is synthesised from — at the capturing element, so the `CloseButton` nested inside never received a click of its own. The header's own `pointerup` then read the release as "released over myself" and just refocused the pane, which is why nothing visible happened.

Measured in Chromium over CDP with a minimal repro of the same two elements:

- without the guard: `capture,header-click` — the button's handler never runs
- with it: `X-CLICK,header-click`

## How

A gesture that starts on a control belongs to that control: `onPointerDown` bails before capturing when the target is inside a `[role="button"]`, and `onPointerUp` ignores a gesture the header never took. `CloseButton` is the only such control in the header, and `PaneSeams` / `use-panel-width` capture on elements with no children, so this is the only site with the problem.

## Test plan

- [x] `biome check src` clean (17 pre-existing warnings, exit 0)
- [x] `vitest run` — 111 files, 1339 tests green
- [x] `tsc -b --noEmit` and `vite build` green
- [x] CDP repro above, before and after
- [ ] Manual: split a group, click a pane's × — the pane leaves the wall, the session stays open; dragging a header onto another pane still swaps them