### PR TITLE
chore: cut the v0.43.1 changelog section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.43.1] - 2026-09-01
+
 ### Fixed
 
 - **A pane's × takes it off the wall again.** The pane header is also the handle
@@ -3624,7 +3626,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.43.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.43.1...HEAD
+[0.43.1]: https://github.com/omartelo/lich/compare/v0.43.0...v0.43.1
 [0.43.0]: https://github.com/omartelo/lich/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/omartelo/lich/compare/v0.41.0...v0.42.0
 [0.41.0]: https://github.com/omartelo/lich/compare/v0.40.1...v0.41.0


### PR DESCRIPTION
Cuts the `[Unreleased]` section into `## [0.43.1] - 2026-09-01` the Keep a Changelog way: `[Unreleased]` stays at the top, emptied, its two entries move under the new heading, and the compare links are refreshed.

Patch, not minor: everything since v0.43.0 is a fix.

- **A pane's × takes it off the wall again** (#423) — the header's drag capture swallowed the button's own click.
- **A missing browser now says so on screen** (#422, closes #409) — an error dialog instead of a silent death, plus the AUR install-time check and INSTALL.md.

The release job reads its notes from this section, so it lands before the tag.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test -race ./...` green
- [x] `biome check .`, `tsc`, `vite build` clean; `vitest run` green (111 files, 1339 tests)
- [x] Simulated the release job's `awk` extraction against the new heading — 17 lines of notes, both entries
