### PR TITLE
Widen browser detection and degrade to a tab when none is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **lich opens in the browser you actually have.** The window used to be
+  launched from a short list of binary names, so a machine running Vivaldi —
+  Chromium-based, `--app` mode and all — got nothing at all. Resolution is now
+  a ladder: `--browser` / `LICH_BROWSER` pin one outright, then the desktop's
+  own default browser when it is Chromium-family, then a scan that knows
+  Vivaldi, Brave, Edge, Thorium and ungoogled-chromium alongside Chromium and
+  Chrome, then Flatpak (the profile moves inside the sandbox, where it can be
+  written). `lich doctor` and `lich rage` name the browser *and* the step that
+  found it, so a window in the wrong browser is one line to diagnose.
+
+- **No Chromium-family browser is no longer a dead end.** lich hands its URL
+  to whatever browser is installed, raises a desktop notification saying it is
+  running and where, prints the URL, and goes on serving until it is stopped.
+  The window of its own is what is lost — Firefox has no `--app` equivalent —
+  not the product. With no browser at all, the dialog carries the URL instead
+  of lich exiting in silence.
+
 ## [0.43.1] - 2026-09-01
 
 ### Fixed

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -18,15 +18,24 @@ Pick your system:
 **Runtime dependencies** — lich opens its window in a Chromium-family browser;
 none is bundled. This is a decision, not a gap: lich rejected Electron and
 moved off Wails to stay one static Go binary that drives the browser already
-on your machine ([docs/chromium-shell.md](docs/chromium-shell.md)), so a
-Chromium-family browser is a hard runtime requirement — without one, lich
-cannot open its window and says so in a dialog and in the log. On Linux any of
-`chromium`, `google-chrome`, `helium-browser` or `brave`
-satisfies it, and `zenity` provides the folder picker. On macOS, Chrome,
-Chromium, Edge or Brave are looked up as `.app` bundles under `/Applications`
-(and `~/Applications`), and the folder picker is native. On Windows, Chrome,
-Edge or Brave are found via their conventional install paths (Edge ships with
-Windows) and the folder picker is native.
+on your machine ([docs/chromium-shell.md](docs/chromium-shell.md)). It looks
+for one in this order: the browser you pinned with `--browser` or
+`LICH_BROWSER`, your desktop's default browser when it is Chromium-family,
+the browsers installed on the machine, then Flatpak. On Linux that scan covers
+`chromium`, `chrome`, `brave`, `vivaldi`, `edge`, `thorium`,
+`ungoogled-chromium` and `helium`, and `zenity` provides the folder picker. On
+macOS, Chrome, Chromium, Edge, Brave and Vivaldi are looked up as `.app`
+bundles under `/Applications` (and `~/Applications`), and the folder picker is
+native. On Windows, Chrome, Edge, Brave and Vivaldi are found via their
+conventional install paths (Edge ships with Windows) and the folder picker is
+native. A browser installed somewhere else entirely is what `--browser` is for.
+
+With **no** Chromium-family browser, lich does not fail: it opens a plain tab
+in whatever browser you do have, tells you so in a desktop notification, and
+goes on running until you stop it. What is lost is the window of its own —
+Firefox has no equivalent of Chromium's `--app` mode, so a tab is the honest
+best. `lich doctor` reports which browser was resolved and which of the steps
+above found it.
 
 **git and the GitHub CLI** — every version control surface shells out to
 `git`, and lich does not bundle it: without `git` on your `PATH`, branches,

--- a/build/linux/aur/lich-bin.install
+++ b/build/linux/aur/lich-bin.install
@@ -3,13 +3,19 @@
 # the browser stays an optdepends and this hook is the install-time check:
 # lich bundles no browser runtime (no Electron, no webview) and opens its
 # window in a Chromium-family browser already on the machine.
+# The list mirrors chromiumNames in internal/chromium/resolve.go.
 post_install() {
-  for b in chromium chromium-browser google-chrome-stable google-chrome helium-browser brave; do
+  for b in chromium chromium-browser google-chrome google-chrome-stable \
+           google-chrome-beta helium-browser brave brave-browser vivaldi \
+           vivaldi-stable microsoft-edge microsoft-edge-stable \
+           thorium-browser ungoogled-chromium chrome; do
     command -v "$b" >/dev/null 2>&1 && return 0
   done
   echo "==> lich opens its window in a Chromium-family browser installed on this"
-  echo "==> machine; none was found on PATH. Install one before launching lich:"
-  echo "==>   chromium, google-chrome, brave, or helium-browser"
+  echo "==> machine; none was found on PATH. Without one lich still runs, but it"
+  echo "==> opens in a plain browser tab instead of a window of its own."
+  echo "==> For the window, install one of: chromium, google-chrome, brave,"
+  echo "==> vivaldi, microsoft-edge or helium-browser."
 }
 
 post_upgrade() {

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -608,3 +608,21 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   pull request's file on the next one's tree. The re-read is held in state and never in a ref, for the replay
   reason `use-remote-resource.ts` documents, and `use-active-file.test.tsx` pins it by moving the pull
   request on a live component — a probe that remounted instead would call the ref version green.
+- **One Chromium profile serves whichever browser resolution picked**
+  (`internal/chromium/resolve.go`): `<config>/lich/chromium-profile` is not keyed by browser, and the ladder's
+  answer can move under a user who installs a second Chromium-family browser or changes their desktop default
+  — the new browser then inherits a profile another one wrote. Chromium refuses a profile written by a build
+  newer than itself, and the frontend's `lich.*` settings live in that profile's localStorage, so the visible
+  symptom is settings that reset or a window that will not open, with nothing naming the browser swap as the
+  cause. `LICH_BROWSER` pins the answer; nothing else does.
+- **With no Chromium-family browser there is no window lifecycle** (`main.go`, `openWithoutWindow`): lich opens
+  a plain tab and then runs until it is signalled, because a tab it did not spawn cannot be waited on. Closing
+  the tab leaves lich serving, and `/restart` — which frees the pinned port by terminating "the window" — is
+  handed this process instead. On Windows that terminate is a `taskkill` WM_CLOSE against a process that has
+  no window, so an in-place update on a browserless Windows leaves the successor racing a port that never
+  frees.
+- **The tab fallback cannot tell "opened" from "nothing happened"** (`internal/system.OpenURL`): `xdg-open`,
+  `open` and `rundll32` are started and never waited on — waiting would block for the life of the browser they
+  hand off to. A desktop with a URL handler installed but no browser behind it therefore looks like success:
+  lich stays up with a notification and nothing on screen. Only a machine missing the opener itself reaches
+  the dialog that carries the URL.

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -609,12 +609,15 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   reason `use-remote-resource.ts` documents, and `use-active-file.test.tsx` pins it by moving the pull
   request on a live component — a probe that remounted instead would call the ref version green.
 - **One Chromium profile serves whichever browser resolution picked**
-  (`internal/chromium/resolve.go`): `<config>/lich/chromium-profile` is not keyed by browser, and the ladder's
-  answer can move under a user who installs a second Chromium-family browser or changes their desktop default
-  — the new browser then inherits a profile another one wrote. Chromium refuses a profile written by a build
-  newer than itself, and the frontend's `lich.*` settings live in that profile's localStorage, so the visible
-  symptom is settings that reset or a window that will not open, with nothing naming the browser swap as the
-  cause. `LICH_BROWSER` pins the answer; nothing else does.
+  (`internal/chromium/resolve.go`): `<config>/lich/chromium-profile` is not keyed by browser, so the ladder's
+  answer moving — a second Chromium-family browser installed, a new desktop default — hands one browser's
+  profile to another. Only a machine with *several* of them can move at all: with one installed, the default
+  rung and the scan land on the same binary. Measured across a patch-level gap (a profile written by Chromium
+  151.0.7922.169, opened by Helium's 151.0.7922.137): the fork adopts it in silence, the window opens, the UI
+  preferences in its localStorage survive, and the profile's recorded version is rewritten *downwards* — the
+  benign case, and the common one. A wide version gap meets Chromium's own guard against a profile from a
+  newer build instead, which refuses to start; lich then dies on a browser exit code and its dialog can only
+  say `exit status 1`, naming nothing. `LICH_BROWSER` pins the answer; nothing else does.
 - **With no Chromium-family browser there is no window lifecycle** (`main.go`, `openWithoutWindow`): lich opens
   a plain tab and then runs until it is signalled, because a tab it did not spawn cannot be waited on. Closing
   the tab leaves lich serving, and `/restart` — which frees the pinned port by terminating "the window" — is

--- a/internal/chromium/candidates_unix.go
+++ b/internal/chromium/candidates_unix.go
@@ -2,18 +2,12 @@
 
 package chromium
 
-// browserCandidates lists candidate binaries in preference order. Any
-// Chromium gives the same compositor; the preference only picks the most
-// conventional install. All bare names — Linux/BSD installs live on PATH.
-// macOS keeps browsers in .app bundles off PATH, so it has its own list
-// (candidates_darwin.go).
+// browserCandidates lists candidate binaries in preference order — the shared
+// chromiumNames list (resolve.go), since every Linux/BSD install lands on PATH
+// under one of those names. Any Chromium gives the same compositor; the
+// preference only picks the most conventional install. macOS keeps browsers in
+// .app bundles off PATH and Windows under versioned install roots, so both have
+// their own list.
 func browserCandidates() []string {
-	return []string{
-		"chromium",
-		"chromium-browser",
-		"google-chrome-stable",
-		"google-chrome",
-		"helium-browser",
-		"brave",
-	}
+	return chromiumNames
 }

--- a/internal/chromium/candidates_unix_test.go
+++ b/internal/chromium/candidates_unix_test.go
@@ -9,9 +9,10 @@ import (
 
 // TestUnixBrowserCandidates pins the exact Linux/BSD candidate list in
 // preference order: bare PATH names (Linux/BSD installs live on PATH), Chromium
-// first, Helium probed before Brave. It mirrors the exact-list style of
-// TestWindowsBrowserCandidates / TestDarwinBrowserCandidates — a membership
-// check would miss an order regression or a stray entry.
+// first. It mirrors the exact-list style of TestWindowsBrowserCandidates /
+// TestDarwinBrowserCandidates — a membership check would miss an order
+// regression or a stray entry — and it spells the list out rather than reading
+// chromiumNames, which is the thing under test.
 //
 // The build tag matches candidates_unix.go (`!windows && !darwin`) on purpose:
 // under a bare `!windows` this test also compiles into the darwin build, where
@@ -21,10 +22,19 @@ func TestUnixBrowserCandidates(t *testing.T) {
 	want := []string{
 		"chromium",
 		"chromium-browser",
-		"google-chrome-stable",
 		"google-chrome",
+		"google-chrome-stable",
+		"google-chrome-beta",
 		"helium-browser",
 		"brave",
+		"brave-browser",
+		"vivaldi",
+		"vivaldi-stable",
+		"microsoft-edge",
+		"microsoft-edge-stable",
+		"thorium-browser",
+		"ungoogled-chromium",
+		"chrome",
 	}
 	if got := browserCandidates(); !slices.Equal(got, want) {
 		t.Fatalf("browserCandidates() = %v, want %v", got, want)

--- a/internal/chromium/chromium.go
+++ b/internal/chromium/chromium.go
@@ -4,33 +4,21 @@
 package chromium
 
 import (
-	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"os/exec"
 )
 
-// FindBrowser returns the first Chromium-family binary that resolves, trying
-// this OS's candidates (candidates_unix.go / candidates_windows.go) in
-// preference order. lookPath is injectable for tests (production passes
-// exec.LookPath, which also accepts the absolute paths the Windows list uses).
-func FindBrowser(lookPath func(name string) (string, error)) (string, error) {
-	candidates := browserCandidates()
-	for _, name := range candidates {
-		if path, err := lookPath(name); err == nil {
-			return path, nil
-		}
-	}
-	return "", errors.New("no chromium-family browser found (tried " +
-		fmt.Sprint(candidates) + "); install chromium, chrome, edge, brave, or helium")
-}
-
 // windowsBrowserCandidates builds the Windows candidate list: chrome, then
-// edge (present on every Windows), then brave, each under the install roots
-// Windows exposes as environment variables, with bare PATH names last.
-// Paths are joined with a literal backslash so the pure logic tests the same
-// on any OS. Kept out of the build-tagged file for exactly that reason.
+// edge (present on every Windows), then brave and vivaldi, each under the
+// install roots Windows exposes as environment variables, with bare PATH names
+// last. Paths are joined with a literal backslash so the pure logic tests the
+// same on any OS. Kept out of the build-tagged file for exactly that reason.
+//
+// No registry read behind it: StartMenuInternet would name a browser installed
+// somewhere else entirely, and reaching for it costs a dependency for the
+// install nobody has. LICH_BROWSER covers that machine in one variable.
 func windowsBrowserCandidates(getenv func(string) string) []string {
 	roots := []struct{ env, rel string }{
 		{"ProgramFiles", `Google\Chrome\Application\chrome.exe`},
@@ -39,6 +27,9 @@ func windowsBrowserCandidates(getenv func(string) string) []string {
 		{"ProgramFiles(x86)", `Microsoft\Edge\Application\msedge.exe`},
 		{"ProgramFiles", `Microsoft\Edge\Application\msedge.exe`},
 		{"ProgramFiles", `BraveSoftware\Brave-Browser\Application\brave.exe`},
+		{"LocalAppData", `BraveSoftware\Brave-Browser\Application\brave.exe`},
+		{"ProgramFiles", `Vivaldi\Application\vivaldi.exe`},
+		{"LocalAppData", `Vivaldi\Application\vivaldi.exe`},
 	}
 	var out []string
 	for _, r := range roots {
@@ -50,7 +41,7 @@ func windowsBrowserCandidates(getenv func(string) string) []string {
 }
 
 // darwinBrowserCandidates builds the macOS candidate list: chrome, then
-// chromium, then edge, then brave, each as its .app executable under the
+// chromium, then edge, then brave, then vivaldi, each as its .app executable under the
 // system (/Applications) and per-user (~/Applications) install roots, with
 // bare PATH names last for a Homebrew-formula install. Paths are joined with a
 // literal slash so the pure logic tests the same on any OS. Kept out of the
@@ -61,6 +52,7 @@ func darwinBrowserCandidates(getenv func(string) string) []string {
 		"Chromium.app/Contents/MacOS/Chromium",
 		"Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
 		"Brave Browser.app/Contents/MacOS/Brave Browser",
+		"Vivaldi.app/Contents/MacOS/Vivaldi",
 	}
 	roots := []string{"/Applications"}
 	if home := getenv("HOME"); home != "" {
@@ -104,15 +96,20 @@ func Args(url, dataDir, class string, extra []string) []string {
 }
 
 // Run opens the window and blocks until the user closes it — the browser
-// process exiting is the app lifecycle. Extra args pass through to Chromium
-// (e.g. --ozone-platform=wayland). onStart, when non-nil, receives the browser
-// process once launched, so the caller can close the window itself (the restart
-// flow terminates it to relaunch lich); it is called before the blocking wait.
+// process exiting is the app lifecycle. The browser is whatever Resolve found;
+// ErrNoBrowser comes back untouched, because the answer to a machine with no
+// Chromium-family browser on it is not this function's to give. Extra args pass
+// through to Chromium (e.g. --ozone-platform=wayland). onStart, when non-nil,
+// receives the browser process once launched, so the caller can close the window
+// itself (the restart flow terminates it to relaunch lich); it is called before
+// the blocking wait.
 func Run(url, dataDir, class string, extra []string, onStart func(*os.Process)) error {
-	browser, err := FindBrowser(exec.LookPath)
+	browser, err := Resolve(RealEnv())
 	if err != nil {
 		return err
 	}
+	slog.Info("browser resolved", "browser", browser.Describe())
+	dataDir = browser.ProfileDir(dataDir)
 	// The data dir is required to launch at all; the prefs inside it only
 	// decide how quiet the window is.
 	if err := os.MkdirAll(dataDir, 0o700); err != nil {
@@ -124,11 +121,12 @@ func Run(url, dataDir, class string, extra []string, onStart func(*os.Process)) 
 		// refuse to open the window.
 		slog.Warn("chromium profile prefs", "err", err)
 	}
-	cmd := exec.Command(browser, Args(url, dataDir, class, extra)...)
+	argv := append(append([]string{}, browser.Prefix...), Args(url, dataDir, class, extra)...)
+	cmd := exec.Command(browser.Path, argv...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("launch %s: %w", browser, err)
+		return fmt.Errorf("launch %s: %w", browser.Path, err)
 	}
 	if onStart != nil {
 		onStart(cmd.Process)

--- a/internal/chromium/chromium_test.go
+++ b/internal/chromium/chromium_test.go
@@ -1,58 +1,31 @@
 package chromium
 
 import (
-	"errors"
 	"slices"
 	"testing"
 )
 
-// TestFindBrowserPicksFirstHit proves missing candidates are skipped and
-// preference order decides among the installed ones — against whichever
-// candidate list this OS compiles in.
-func TestFindBrowserPicksFirstHit(t *testing.T) {
-	candidates := browserCandidates()
-	if len(candidates) < 2 {
-		t.Fatal("candidate list too short to prove ordering")
-	}
-	hits := map[string]bool{candidates[1]: true, candidates[len(candidates)-1]: true}
-	lookPath := func(name string) (string, error) {
-		if hits[name] {
-			return "/resolved/" + name, nil
-		}
-		return "", errors.New("not found")
-	}
-	got, err := FindBrowser(lookPath)
-	if err != nil {
-		t.Fatalf("FindBrowser: %v", err)
-	}
-	if want := "/resolved/" + candidates[1]; got != want {
-		t.Fatalf("FindBrowser = %q, want the earliest installed candidate %q", got, want)
-	}
-}
-
-func TestFindBrowserErrorsWhenNoneInstalled(t *testing.T) {
-	lookPath := func(string) (string, error) { return "", errors.New("not found") }
-	if _, err := FindBrowser(lookPath); err == nil {
-		t.Fatal("want error when no browser is on PATH")
-	}
-}
-
 // TestWindowsBrowserCandidates proves the Windows list expands only the
-// install roots present in the environment, prefers chrome > edge > brave,
-// and always ends with the bare PATH names as a last resort.
+// install roots present in the environment, prefers chrome > edge > brave >
+// vivaldi, and always ends with the bare PATH names as a last resort.
 func TestWindowsBrowserCandidates(t *testing.T) {
 	env := map[string]string{
 		"ProgramFiles":      `C:\Program Files`,
 		"ProgramFiles(x86)": `C:\Program Files (x86)`,
+		"LocalAppData":      `C:\Users\u\AppData\Local`,
 	}
 	got := windowsBrowserCandidates(func(k string) string { return env[k] })
 
 	want := []string{
 		`C:\Program Files\Google\Chrome\Application\chrome.exe`,
 		`C:\Program Files (x86)\Google\Chrome\Application\chrome.exe`,
+		`C:\Users\u\AppData\Local\Google\Chrome\Application\chrome.exe`,
 		`C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe`,
 		`C:\Program Files\Microsoft\Edge\Application\msedge.exe`,
 		`C:\Program Files\BraveSoftware\Brave-Browser\Application\brave.exe`,
+		`C:\Users\u\AppData\Local\BraveSoftware\Brave-Browser\Application\brave.exe`,
+		`C:\Program Files\Vivaldi\Application\vivaldi.exe`,
+		`C:\Users\u\AppData\Local\Vivaldi\Application\vivaldi.exe`,
 		"chrome",
 		"msedge",
 	}
@@ -62,7 +35,7 @@ func TestWindowsBrowserCandidates(t *testing.T) {
 }
 
 // TestWindowsBrowserCandidatesEmptyEnv proves a bare environment still leaves
-// the PATH names, so FindBrowser never iterates an empty list.
+// the PATH names, so the scan never iterates an empty list.
 func TestWindowsBrowserCandidatesEmptyEnv(t *testing.T) {
 	got := windowsBrowserCandidates(func(string) string { return "" })
 	if !slices.Equal(got, []string{"chrome", "msedge"}) {
@@ -72,7 +45,7 @@ func TestWindowsBrowserCandidatesEmptyEnv(t *testing.T) {
 
 // TestDarwinBrowserCandidates proves the macOS list expands each browser under
 // both the system and per-user Applications roots, prefers chrome > chromium >
-// edge > brave, and ends with the bare PATH names.
+// edge > brave > vivaldi, and ends with the bare PATH names.
 func TestDarwinBrowserCandidates(t *testing.T) {
 	got := darwinBrowserCandidates(func(k string) string {
 		if k == "HOME" {
@@ -90,6 +63,8 @@ func TestDarwinBrowserCandidates(t *testing.T) {
 		"/Users/u/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
 		"/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
 		"/Users/u/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+		"/Applications/Vivaldi.app/Contents/MacOS/Vivaldi",
+		"/Users/u/Applications/Vivaldi.app/Contents/MacOS/Vivaldi",
 		"chromium",
 		"google-chrome",
 	}
@@ -99,7 +74,7 @@ func TestDarwinBrowserCandidates(t *testing.T) {
 }
 
 // TestDarwinBrowserCandidatesNoHome proves a missing HOME drops the per-user
-// root but still leaves the system paths and PATH names, so FindBrowser never
+// root but still leaves the system paths and PATH names, so the scan never
 // iterates an empty list.
 func TestDarwinBrowserCandidatesNoHome(t *testing.T) {
 	got := darwinBrowserCandidates(func(string) string { return "" })
@@ -108,6 +83,7 @@ func TestDarwinBrowserCandidatesNoHome(t *testing.T) {
 		"/Applications/Chromium.app/Contents/MacOS/Chromium",
 		"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
 		"/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+		"/Applications/Vivaldi.app/Contents/MacOS/Vivaldi",
 		"chromium",
 		"google-chrome",
 	}

--- a/internal/chromium/resolve.go
+++ b/internal/chromium/resolve.go
@@ -1,0 +1,286 @@
+package chromium
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ErrNoBrowser is the machine having no Chromium-family browser at all. It is a
+// sentinel because the caller answers it differently from every other
+// resolution failure: without one lich still runs, in a plain tab of whatever
+// browser is installed (main.go's openWithoutWindow), while a browser the user
+// *named* and lich could not find is an error the user has to see.
+var ErrNoBrowser = errors.New(
+	"no chromium-family browser found — install chromium, chrome, brave, vivaldi or edge, " +
+		"or point LICH_BROWSER at one")
+
+// OverrideEnv pins the browser to launch, by PATH name or by path. The
+// --browser flag is carried in it rather than passed down as an argument, so
+// the restart successor inherits the choice and `lich doctor` reports the
+// browser a launch here would actually open.
+const OverrideEnv = "LICH_BROWSER"
+
+// The rung of the ladder that answered, as the diagnostics name it.
+const (
+	stepPinned  = "pinned by LICH_BROWSER"
+	stepDefault = "the desktop's default browser"
+	stepPath    = "installed"
+	stepFlatpak = "flatpak"
+)
+
+// probeTimeout bounds the helpers resolution shells out to. They run on the
+// path to the window: one that hangs would hang the launch, and a launch that
+// opens nothing is the failure this whole file exists to answer.
+const probeTimeout = 3 * time.Second
+
+// Env is everything resolution reads from the machine. Every probe is a field
+// so the whole ladder is table-testable on one machine with no browser
+// installed — the exec at the end is the only part that is not.
+type Env struct {
+	LookPath   func(name string) (string, error)
+	Getenv     func(key string) string
+	Output     func(name string, args ...string) ([]byte, error)
+	Candidates func() []string
+}
+
+// RealEnv reaches the machine lich is running on.
+func RealEnv() Env {
+	return Env{
+		LookPath: exec.LookPath,
+		Getenv:   os.Getenv,
+		Output: func(name string, args ...string) ([]byte, error) {
+			ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, name, args...)
+			// The context kills the process; without this the read of its
+			// output pipe outlives the kill, and the timeout bounds nothing.
+			cmd.WaitDelay = time.Second
+			return cmd.Output()
+		},
+		Candidates: browserCandidates,
+	}
+}
+
+// Result is a resolved launch: which executable, what has to precede lich's own
+// arguments, and where the profile may live.
+type Result struct {
+	// Path is the executable to run.
+	Path string
+	// Prefix goes before lich's arguments — `run <app-id>` for Flatpak, empty
+	// for a browser installed on the machine itself.
+	Prefix []string
+	// Step names the rung that answered, for `lich doctor` and `lich rage`.
+	Step string
+	// ProfileRoot relocates the Chromium profile directory, and is set only
+	// where the browser cannot see the one lich keeps under its config dir: a
+	// Flatpak sandbox reliably writes under its own ~/.var/app/<id> and little
+	// else. Empty means the caller's directory stands.
+	ProfileRoot string
+}
+
+// Describe is the resolution as a diagnostic prints it: the command, and the
+// rung that produced it.
+func (r Result) Describe() string {
+	command := strings.Join(append([]string{r.Path}, r.Prefix...), " ")
+	return fmt.Sprintf("%s (%s)", command, r.Step)
+}
+
+// ProfileDir is where this browser's profile goes, given the directory lich
+// would use. Only a sandboxed browser moves it, and it keeps the directory's
+// name so the dev shell still gets a profile of its own.
+func (r Result) ProfileDir(dir string) string {
+	if r.ProfileRoot == "" {
+		return dir
+	}
+	return filepath.Join(r.ProfileRoot, filepath.Base(dir))
+}
+
+// chromiumNames are the Chromium-family executables lich knows, in preference
+// order. It is the Linux/BSD candidate list (candidates_unix.go) and the set
+// that decides whether a browser lich did *not* pick — the desktop's default,
+// $BROWSER — can be driven in --app mode at all.
+var chromiumNames = []string{
+	"chromium",
+	"chromium-browser",
+	"google-chrome",
+	"google-chrome-stable",
+	"google-chrome-beta",
+	"helium-browser",
+	"brave",
+	"brave-browser",
+	"vivaldi",
+	"vivaldi-stable",
+	"microsoft-edge",
+	"microsoft-edge-stable",
+	"thorium-browser",
+	"ungoogled-chromium",
+	"chrome",
+}
+
+// knownChromium is chromiumNames as a set, plus the spellings the other two
+// platforms install under. Membership is what stops lich handing --app= to a
+// Firefox the user set as their default: Firefox has no app mode, so the flag
+// is ignored and the launch opens nothing.
+var knownChromium = func() map[string]bool {
+	set := map[string]bool{"msedge": true, "brave-browser-stable": true}
+	for _, name := range chromiumNames {
+		set[name] = true
+	}
+	return set
+}()
+
+// desktopExec is the .desktop ids whose name is not the executable's. Only the
+// ones that differ belong here: the freedesktop id and the binary agree for
+// every other browser lich knows (chromium.desktop, vivaldi-stable.desktop,
+// microsoft-edge.desktop). The general answer is parsing the entry's Exec= line
+// out of XDG_DATA_DIRS, which is a lot of code and a lot of quoting rules for a
+// map that has one row.
+var desktopExec = map[string]string{"helium": "helium-browser"}
+
+// flatpakIDs are the Chromium-family Flatpak applications, in the same
+// preference order as the PATH scan.
+var flatpakIDs = []string{
+	"org.chromium.Chromium",
+	"com.google.Chrome",
+	"com.brave.Browser",
+	"com.vivaldi.Vivaldi",
+	"com.microsoft.Edge",
+}
+
+// Resolve finds the browser to be the window, climbing the ladder in order: the
+// browser the user pinned, the desktop's default when it is one lich can drive,
+// this platform's candidates, then Flatpak. It returns ErrNoBrowser when the
+// machine has none, which is a fallback and not a failure — see that variable.
+func Resolve(env Env) (Result, error) {
+	if pinned := strings.TrimSpace(env.Getenv(OverrideEnv)); pinned != "" {
+		path, err := env.LookPath(pinned)
+		if err != nil {
+			// Loud, and never a fall-through to the scan below: the user named
+			// this browser, and quietly opening a different one is the whole
+			// class of bug the override exists to rule out.
+			return Result{}, fmt.Errorf("%s=%s: %w", OverrideEnv, pinned, err)
+		}
+		return Result{Path: path, Step: stepPinned}, nil
+	}
+	if found, ok := defaultBrowser(env); ok {
+		return found, nil
+	}
+	for _, name := range env.Candidates() {
+		if path, err := env.LookPath(name); err == nil {
+			return Result{Path: path, Step: stepPath}, nil
+		}
+	}
+	if found, ok := flatpakBrowser(env); ok {
+		return found, nil
+	}
+	return Result{}, ErrNoBrowser
+}
+
+// defaultBrowser is the browser the user already chose, when it happens to be
+// one lich can drive. It outranks the scan on purpose: a machine with three
+// Chromium-family browsers installed has one the user actually uses, and lich
+// picking a different one by list order is a window in the wrong browser with
+// none of the user's extensions or window rules.
+func defaultBrowser(env Env) (Result, bool) {
+	for _, name := range defaultNames(env) {
+		// A .desktop id is usually the executable plus that suffix
+		// (vivaldi-stable.desktop); the ones where it is not are aliased, and
+		// anything still unrecognised simply misses here, leaving the scan
+		// below to answer.
+		exe := strings.TrimSuffix(name, ".desktop")
+		base := strings.ToLower(strings.TrimSuffix(filepath.Base(exe), ".exe"))
+		if alias, ok := desktopExec[base]; ok {
+			exe, base = alias, alias
+		}
+		if !knownChromium[base] {
+			continue
+		}
+		if path, err := env.LookPath(exe); err == nil {
+			return Result{Path: path, Step: stepDefault}, true
+		}
+	}
+	return Result{}, false
+}
+
+// defaultNames lists what the desktop calls its default browser, best first:
+// xdg-settings is the freedesktop answer, $BROWSER the older POSIX convention
+// (a colon-separated list, whose entries may carry a %s for the URL — lich
+// takes the command and passes its own arguments).
+func defaultNames(env Env) []string {
+	var names []string
+	if xdg, err := env.LookPath("xdg-settings"); err == nil {
+		if out, err := env.Output(xdg, "get", "default-web-browser"); err == nil {
+			names = append(names, strings.TrimSpace(string(out)))
+		}
+	}
+	for _, entry := range strings.Split(env.Getenv("BROWSER"), ":") {
+		if fields := strings.Fields(entry); len(fields) > 0 {
+			names = append(names, fields[0])
+		}
+	}
+	return names
+}
+
+// flatpakBrowser is the last rung that still gives a real app window: on an
+// immutable distribution the only Chromium on the machine is a Flatpak, and
+// nothing about it is on PATH.
+func flatpakBrowser(env Env) (Result, bool) {
+	flatpak, err := env.LookPath("flatpak")
+	if err != nil {
+		return Result{}, false
+	}
+	// The profile has to land where the sandbox can write it, and HOME is what
+	// names that directory. Without one the rung is skipped rather than
+	// launched at a --user-data-dir the browser cannot create — which is a
+	// window that never opens.
+	home := env.Getenv("HOME")
+	if home == "" {
+		return Result{}, false
+	}
+	out, err := env.Output(flatpak, "list", "--app", "--columns=application")
+	if err != nil {
+		return Result{}, false
+	}
+	installed := map[string]bool{}
+	for line := range strings.SplitSeq(string(out), "\n") {
+		installed[strings.TrimSpace(line)] = true
+	}
+	for _, id := range flatpakIDs {
+		if !installed[id] {
+			continue
+		}
+		return Result{
+			Path:        flatpak,
+			Prefix:      []string{"run", id},
+			Step:        stepFlatpak,
+			ProfileRoot: filepath.Join(home, ".var", "app", id, "config"),
+		}, true
+	}
+	return Result{}, false
+}
+
+// ParseFlags splits lich's own launch arguments: --browser <name-or-path> pins
+// the browser to open the window in, and everything after `--` passes through
+// to that browser. The flag wins over LICH_BROWSER because the caller writes it
+// into the environment (main.go), which is also what carries it to the restart
+// successor.
+func ParseFlags(args []string) (pinned string, extra []string) {
+	for i := 0; i < len(args); i++ {
+		switch arg := args[i]; {
+		case arg == "--":
+			return pinned, args[i+1:]
+		case arg == "--browser" && i+1 < len(args):
+			i++
+			pinned = args[i]
+		case strings.HasPrefix(arg, "--browser="):
+			pinned = strings.TrimPrefix(arg, "--browser=")
+		}
+	}
+	return pinned, nil
+}

--- a/internal/chromium/resolve.go
+++ b/internal/chromium/resolve.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -94,11 +95,17 @@ func (r Result) Describe() string {
 // ProfileDir is where this browser's profile goes, given the directory lich
 // would use. Only a sandboxed browser moves it, and it keeps the directory's
 // name so the dev shell still gets a profile of its own.
+//
+// Slashes, not filepath: a ProfileRoot is only ever set by the Flatpak rung,
+// and a Flatpak path is a Linux path whatever this binary was built for.
+// filepath here would follow the *build* OS and hand a Linux sandbox a
+// backslash-joined directory — the same trap the two candidate builders in
+// chromium.go join by hand to stay out of.
 func (r Result) ProfileDir(dir string) string {
 	if r.ProfileRoot == "" {
 		return dir
 	}
-	return filepath.Join(r.ProfileRoot, filepath.Base(dir))
+	return r.ProfileRoot + "/" + path.Base(dir)
 }
 
 // chromiumNames are the Chromium-family executables lich knows, in preference
@@ -259,7 +266,7 @@ func flatpakBrowser(env Env) (Result, bool) {
 			Path:        flatpak,
 			Prefix:      []string{"run", id},
 			Step:        stepFlatpak,
-			ProfileRoot: filepath.Join(home, ".var", "app", id, "config"),
+			ProfileRoot: home + "/.var/app/" + id + "/config",
 		}, true
 	}
 	return Result{}, false

--- a/internal/chromium/resolve_test.go
+++ b/internal/chromium/resolve_test.go
@@ -1,0 +1,263 @@
+package chromium
+
+import (
+	"errors"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+// fakeEnv is a machine described by what is on it: which names resolve, what
+// the environment says, and what the two helpers print. Every rung of the
+// ladder is reachable from here, which is the point — none of them needs a
+// browser installed on the machine running the tests.
+type fakeEnv struct {
+	installed map[string]bool
+	vars      map[string]string
+	output    map[string]string
+	names     []string
+}
+
+func (f fakeEnv) env() Env {
+	return Env{
+		LookPath: func(name string) (string, error) {
+			if f.installed[name] {
+				return "/usr/bin/" + name, nil
+			}
+			return "", errors.New("not found")
+		},
+		Getenv: func(key string) string { return f.vars[key] },
+		Output: func(name string, args ...string) ([]byte, error) {
+			out, ok := f.output[filepath.Base(name)]
+			if !ok {
+				return nil, errors.New("no such command")
+			}
+			return []byte(out), nil
+		},
+		Candidates: func() []string {
+			if f.names != nil {
+				return f.names
+			}
+			return chromiumNames
+		},
+	}
+}
+
+func TestResolvePinnedWins(t *testing.T) {
+	machine := fakeEnv{
+		installed: map[string]bool{"chromium": true, "vivaldi": true},
+		vars:      map[string]string{OverrideEnv: "vivaldi"},
+	}
+	got, err := Resolve(machine.env())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Path != "/usr/bin/vivaldi" {
+		t.Fatalf("Resolve = %q, want the pinned browser even though chromium is installed", got.Path)
+	}
+	if got.Step != stepPinned {
+		t.Fatalf("step = %q, want %q", got.Step, stepPinned)
+	}
+}
+
+// TestResolvePinnedMissingIsLoud proves a pinned browser that is not there
+// fails rather than falling through to the scan: the user named a browser, and
+// silently opening a different one is what the override exists to rule out.
+func TestResolvePinnedMissingIsLoud(t *testing.T) {
+	machine := fakeEnv{
+		installed: map[string]bool{"chromium": true},
+		vars:      map[string]string{OverrideEnv: "/opt/vivaldi/vivaldi"},
+	}
+	_, err := Resolve(machine.env())
+	if err == nil {
+		t.Fatal("want an error when the pinned browser is missing")
+	}
+	if errors.Is(err, ErrNoBrowser) {
+		t.Fatal("a pinned browser that is missing must not report as ErrNoBrowser: that one degrades to a tab")
+	}
+}
+
+func TestResolvePrefersDesktopDefault(t *testing.T) {
+	machine := fakeEnv{
+		installed: map[string]bool{"chromium": true, "vivaldi-stable": true, "xdg-settings": true},
+		output:    map[string]string{"xdg-settings": "vivaldi-stable.desktop\n"},
+	}
+	got, err := Resolve(machine.env())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Path != "/usr/bin/vivaldi-stable" {
+		t.Fatalf("Resolve = %q, want the desktop default over the scan order", got.Path)
+	}
+	if got.Step != stepDefault {
+		t.Fatalf("step = %q, want %q", got.Step, stepDefault)
+	}
+}
+
+// TestResolveSkipsNonChromiumDefault is the reason the known-name set exists:
+// Firefox has no --app mode, so handing it the flag opens nothing at all.
+func TestResolveSkipsNonChromiumDefault(t *testing.T) {
+	machine := fakeEnv{
+		installed: map[string]bool{"firefox": true, "chromium": true, "xdg-settings": true},
+		output:    map[string]string{"xdg-settings": "firefox.desktop\n"},
+	}
+	got, err := Resolve(machine.env())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Path != "/usr/bin/chromium" {
+		t.Fatalf("Resolve = %q, want the scan to answer past a Firefox default", got.Path)
+	}
+}
+
+// TestResolveReadsBrowserEnv proves the POSIX convention is honoured: a
+// colon-separated list whose entries may carry a %s placeholder.
+func TestResolveReadsBrowserEnv(t *testing.T) {
+	machine := fakeEnv{
+		installed: map[string]bool{"firefox": true, "brave-browser": true, "chromium": true},
+		vars:      map[string]string{"BROWSER": "firefox %s:brave-browser %s"},
+	}
+	got, err := Resolve(machine.env())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Path != "/usr/bin/brave-browser" {
+		t.Fatalf("Resolve = %q, want the first chromium-family entry of $BROWSER", got.Path)
+	}
+}
+
+func TestResolveScansInPreferenceOrder(t *testing.T) {
+	machine := fakeEnv{installed: map[string]bool{"vivaldi": true, "brave": true}}
+	got, err := Resolve(machine.env())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Path != "/usr/bin/brave" {
+		t.Fatalf("Resolve = %q, want the earlier candidate %q", got.Path, "/usr/bin/brave")
+	}
+	if got.Step != stepPath {
+		t.Fatalf("step = %q, want %q", got.Step, stepPath)
+	}
+}
+
+// TestResolveFlatpak covers the immutable-distribution machine: nothing
+// Chromium-family on PATH, and the browser only installed as a Flatpak.
+func TestResolveFlatpak(t *testing.T) {
+	machine := fakeEnv{
+		installed: map[string]bool{"flatpak": true, "firefox": true},
+		vars:      map[string]string{"HOME": "/home/u"},
+		output:    map[string]string{"flatpak": "org.gnome.Loupe\ncom.vivaldi.Vivaldi\n"},
+	}
+	got, err := Resolve(machine.env())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Path != "/usr/bin/flatpak" || !slices.Equal(got.Prefix, []string{"run", "com.vivaldi.Vivaldi"}) {
+		t.Fatalf("Resolve = %q %v, want a flatpak run of the installed browser", got.Path, got.Prefix)
+	}
+	// The profile has to land inside the sandbox's own directory, and keep the
+	// name it had so the dev shell still gets a profile of its own.
+	want := "/home/u/.var/app/com.vivaldi.Vivaldi/config/chromium-profile-dev"
+	if dir := got.ProfileDir("/home/u/.config/lich/chromium-profile-dev"); dir != want {
+		t.Fatalf("ProfileDir = %q, want %q", dir, want)
+	}
+}
+
+// TestResolveFlatpakNeedsHome proves the rung is skipped rather than launched
+// at a profile directory it cannot name — which would be a window that never
+// opens, the exact failure this file answers.
+func TestResolveFlatpakNeedsHome(t *testing.T) {
+	machine := fakeEnv{
+		installed: map[string]bool{"flatpak": true},
+		output:    map[string]string{"flatpak": "com.vivaldi.Vivaldi\n"},
+	}
+	if _, err := Resolve(machine.env()); !errors.Is(err, ErrNoBrowser) {
+		t.Fatalf("Resolve error = %v, want ErrNoBrowser", err)
+	}
+}
+
+func TestResolveNoBrowser(t *testing.T) {
+	machine := fakeEnv{installed: map[string]bool{"firefox": true}}
+	_, err := Resolve(machine.env())
+	if !errors.Is(err, ErrNoBrowser) {
+		t.Fatalf("Resolve error = %v, want ErrNoBrowser — the caller degrades to a tab on that one", err)
+	}
+}
+
+// TestProfileDirUnchanged proves the relocation is Flatpak's alone: every other
+// browser reads the directory lich chose.
+func TestProfileDirUnchanged(t *testing.T) {
+	dir := "/home/u/.config/lich/chromium-profile"
+	if got := (Result{Path: "/usr/bin/chromium"}).ProfileDir(dir); got != dir {
+		t.Fatalf("ProfileDir = %q, want %q", got, dir)
+	}
+}
+
+func TestDescribe(t *testing.T) {
+	got := Result{Path: "/usr/bin/flatpak", Prefix: []string{"run", "com.brave.Browser"}, Step: stepFlatpak}.Describe()
+	want := "/usr/bin/flatpak run com.brave.Browser (flatpak)"
+	if got != want {
+		t.Fatalf("Describe = %q, want %q", got, want)
+	}
+}
+
+func TestParseFlags(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   []string
+		pinned string
+		extra  []string
+	}{
+		{name: "nothing"},
+		{name: "separate value", args: []string{"--browser", "vivaldi"}, pinned: "vivaldi"},
+		{name: "joined value", args: []string{"--browser=/opt/x/x"}, pinned: "/opt/x/x"},
+		{
+			name:   "both forms of argument",
+			args:   []string{"--browser", "brave", "--", "--ozone-platform=wayland"},
+			pinned: "brave",
+			extra:  []string{"--ozone-platform=wayland"},
+		},
+		{
+			name:  "passthrough only",
+			args:  []string{"--", "--ozone-platform=wayland"},
+			extra: []string{"--ozone-platform=wayland"},
+		},
+		// Everything after `--` belongs to the browser, including a word that
+		// spells one of lich's own flags.
+		{
+			name:  "flag after the separator is the browser's",
+			args:  []string{"--", "--browser=chromium"},
+			extra: []string{"--browser=chromium"},
+		},
+		{name: "value missing", args: []string{"--browser"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pinned, extra := ParseFlags(tt.args)
+			if pinned != tt.pinned {
+				t.Fatalf("pinned = %q, want %q", pinned, tt.pinned)
+			}
+			if !slices.Equal(extra, tt.extra) {
+				t.Fatalf("extra = %v, want %v", extra, tt.extra)
+			}
+		})
+	}
+}
+
+// TestResolveDesktopAlias covers the .desktop id that is not its executable's
+// name: helium.desktop launches helium-browser. Without the alias the default
+// misses and lich opens some other installed browser — the user's own choice
+// ignored, with nothing saying why.
+func TestResolveDesktopAlias(t *testing.T) {
+	machine := fakeEnv{
+		installed: map[string]bool{"helium-browser": true, "chromium": true, "xdg-settings": true},
+		output:    map[string]string{"xdg-settings": "helium.desktop\n"},
+	}
+	got, err := Resolve(machine.env())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got.Path != "/usr/bin/helium-browser" {
+		t.Fatalf("Resolve = %q, want the aliased default browser", got.Path)
+	}
+}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -110,6 +110,16 @@ const helpFooter = `
 
 Every command takes --help for its own flags.
 
+With no command, lich opens its window. Two flags belong to that launch:
+
+  lich --browser <name-or-path>
+      Open the window in this browser instead of the one lich would find.
+      LICH_BROWSER says the same thing; the flag wins. Either way lich fails
+      loudly when it is not there, rather than opening a different browser.
+
+  lich -- <flags>
+      Pass everything after -- to the browser (e.g. --ozone-platform=wayland).
+
 Run inside a lich session these address the sessions beside it. Run anywhere
 else on the machine they find the running lich on their own, and what they
 relay is attributed to the command line rather than to a session.

--- a/internal/doctor/probes.go
+++ b/internal/doctor/probes.go
@@ -1,8 +1,6 @@
 package doctor
 
 import (
-	"os/exec"
-
 	"github.com/omartelo/lich/internal/chromium"
 	"github.com/omartelo/lich/internal/providers"
 	"github.com/omartelo/lich/internal/singleton"
@@ -13,9 +11,15 @@ import (
 // They live here, exported, because a probe that drifted between the two tools
 // would have them describe two different machines.
 
-// Browser resolves the Chromium-family binary the window is launched as.
+// Browser resolves the browser the window is launched as, and says which rung
+// of the resolution ladder produced it — a machine where lich opens the "wrong"
+// browser is diagnosed by that step and by nothing else.
 func Browser() (string, error) {
-	return chromium.FindBrowser(exec.LookPath)
+	found, err := chromium.Resolve(chromium.RealEnv())
+	if err != nil {
+		return "", err
+	}
+	return found.Describe(), nil
 }
 
 // Providers lists the harnesses on PATH. A detection that fails outright is

--- a/internal/system/open_darwin.go
+++ b/internal/system/open_darwin.go
@@ -9,10 +9,11 @@ func (s *Service) openDefault(full string) error {
 	return s.run("open", "-t", full)
 }
 
-// openURL hands an external URL to the default browser. No -t here: that flag
-// forces the text editor, which is right for a source file and wrong for a link.
-func (s *Service) openURL(rawURL string) error {
-	return s.run("open", rawURL)
+// urlOpenArgv is how macOS opens a URL in the default browser. No -t here: that
+// flag forces the text editor, which is right for a source file and wrong for a
+// link.
+func urlOpenArgv(rawURL string) []string {
+	return []string{"open", rawURL}
 }
 
 // quoteForShell quotes a path for the POSIX shell a macOS session runs.

--- a/internal/system/open_linux.go
+++ b/internal/system/open_linux.go
@@ -8,10 +8,10 @@ func (s *Service) openDefault(full string) error {
 	return s.run("xdg-open", full)
 }
 
-// openURL hands an external URL to the desktop's default browser — the same
-// resolver, and the reason a link opens outside the app window.
-func (s *Service) openURL(rawURL string) error {
-	return s.run("xdg-open", rawURL)
+// urlOpenArgv is how this desktop opens a URL in the user's browser — the same
+// resolver as openDefault, and the reason a link opens outside the app window.
+func urlOpenArgv(rawURL string) []string {
+	return []string{"xdg-open", rawURL}
 }
 
 // quoteForShell quotes a path for the POSIX shell a Linux session runs.

--- a/internal/system/open_windows.go
+++ b/internal/system/open_windows.go
@@ -21,12 +21,13 @@ func (s *Service) quoteForShell(full string) string {
 	return shquote.QuotePwsh(full)
 }
 
-// openURL hands an external URL to the default browser. Deliberately not the
-// `cmd /c start` above: cmd parses metacharacters out of its command line before
-// start ever sees them, so a `&` in a query string would end the command and run
-// what follows it. rundll32 is launched directly, with no shell in between.
-func (s *Service) openURL(rawURL string) error {
-	return s.run("rundll32", "url.dll,FileProtocolHandler", rawURL)
+// urlOpenArgv is how Windows opens a URL in the default browser. Deliberately
+// not the `cmd /c start` above: cmd parses metacharacters out of its command
+// line before start ever sees them, so a `&` in a query string would end the
+// command and run what follows it. rundll32 is launched directly, with no shell
+// in between.
+func urlOpenArgv(rawURL string) []string {
+	return []string{"rundll32", "url.dll,FileProtocolHandler", rawURL}
 }
 
 // openFolder shows a directory in File Explorer. Same launcher as openDefault,

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -153,7 +153,19 @@ func (s *Service) OpenExternal(rawURL string) error {
 	if err := ValidateExternalURL(rawURL); err != nil {
 		return err
 	}
-	return s.openURL(rawURL)
+	argv := urlOpenArgv(rawURL)
+	return s.run(argv[0], argv[1:]...)
+}
+
+// OpenURL hands a URL to the desktop's default browser, through the same
+// per-OS launcher OpenExternal uses. It is package-level because the launch
+// path needs it before any service exists: a machine with no Chromium-family
+// browser gets no app window, and lich degrades to a plain tab in whatever
+// browser it does have (main.go). No scheme gate here — the only caller passes
+// lich's own loopback URL, not one a page handed it.
+func OpenURL(rawURL string) error {
+	argv := urlOpenArgv(rawURL)
+	return exec.Command(argv[0], argv[1:]...).Start()
 }
 
 // OpenInEditor decides how to open a work-tree file. rel is validated against

--- a/main.go
+++ b/main.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	"embed"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
+	"syscall"
 
 	"github.com/ncruces/zenity"
 	"github.com/omartelo/lich/internal/agentplugin"
@@ -59,6 +62,17 @@ func main() {
 	// including `lich -- <chromium flags>` — falls through and opens the app.
 	if code := cli.Run(os.Args[1:], version, os.Getenv, os.Stdout, os.Stderr); code != cli.NotACommand {
 		os.Exit(code)
+	}
+
+	// --browser is carried in the environment rather than passed down: the
+	// restart successor inherits it, and `lich doctor` then reports the browser
+	// a launch here would really open. Everything after `--` is the browser's.
+	pinnedBrowser, chromiumArgs := chromium.ParseFlags(os.Args[1:])
+	if pinnedBrowser != "" {
+		if err := os.Setenv(chromium.OverrideEnv, pinnedBrowser); err != nil {
+			slog.Error("set "+chromium.OverrideEnv, "err", err)
+			os.Exit(1)
+		}
 	}
 
 	// Snapshot before any env tweaks: spawned terminal sessions must inherit
@@ -193,7 +207,7 @@ func main() {
 	coord := restart.New(exe, os.Environ())
 	term.SetRestart(coord.Do)
 
-	runChromium(term, configDir, coord)
+	runChromium(term, configDir, chromiumArgs, coord)
 }
 
 // denyInternal hides the methods that exist for Go callers inside this process
@@ -249,7 +263,7 @@ func denyInternal(d *rpc.Handler) {
 // LICH_DEV_URL points the window at the Vite dev server instead of the
 // embedded frontend (see `task dev`); the token and the backend port ride the
 // query string so the page can find the RPC listener across the origin split.
-func runChromium(term *terminal.Service, configDir string, coord *restart.Coordinator) {
+func runChromium(term *terminal.Service, configDir string, extra []string, coord *restart.Coordinator) {
 	info := term.Transport()
 	if info.Port == 0 {
 		handleBindFailure(configDir, term.TransportError()) // never returns
@@ -291,16 +305,18 @@ func runChromium(term *terminal.Service, configDir string, coord *restart.Coordi
 	}
 	slog.Info("chromium shell opening", "addr", addr)
 
-	var extra []string
-	if args := os.Args[1:]; len(args) > 1 && args[0] == "--" {
-		extra = args[1:]
-	}
-	if err := chromium.Run(url, profileDir, class, extra, coord.SetWindow); err != nil {
+	err = chromium.Run(url, profileDir, class, extra, coord.SetWindow)
+	switch {
+	case err == nil:
+		slog.Info("window closed, exiting")
+	case errors.Is(err, chromium.ErrNoBrowser):
+		openWithoutWindow(url, addr, configDir, coord)
+	default:
 		slog.Error("chromium shell", "err", err)
 		// Same silence as handleBindFailure: a launcher start has no terminal,
-		// so without a dialog a missing browser reads as lich doing nothing
-		// (#409). Best effort — where no dialog backend answers, the log line
-		// above still has the story.
+		// so without a dialog a browser that will not launch reads as lich
+		// doing nothing (#409). Best effort — where no dialog backend answers,
+		// the log line above still has the story.
 		_ = zenity.Error(fmt.Sprintf(
 			"lich could not open its window.\n\n%v\n\n"+
 				"lich does not bundle a browser runtime; it opens its window in "+
@@ -310,7 +326,53 @@ func runChromium(term *terminal.Service, configDir string, coord *restart.Coordi
 			zenity.Title("lich"))
 		os.Exit(1)
 	}
-	slog.Info("window closed, exiting")
+}
+
+// openWithoutWindow is the last rung of browser resolution, and the one that
+// keeps a product on a machine with no Chromium-family browser: lich hands its
+// URL to whatever browser the user does have and goes on serving it. The
+// chromeless window is lost, lich is not.
+//
+// It returns when the process is signalled, so the caller's defers still run.
+// Every other launch ends when the window closes; a tab lich did not spawn
+// cannot be waited on, so nothing here ends on its own — closing the tab leaves
+// lich running, which the notification says.
+func openWithoutWindow(url, addr, configDir string, coord *restart.Coordinator) {
+	slog.Warn("no chromium-family browser found, opening a plain tab", "addr", addr)
+	// stdout rather than the log: the URL carries the session token, and the
+	// log file outlives this run (see the addr/url split above). A terminal
+	// launch reads it here; a launcher launch reads the notification below.
+	fmt.Println("lich is running at", url)
+
+	if err := system.OpenURL(url); err != nil {
+		slog.Error("no browser to open at all", "err", err)
+		_ = zenity.Error(fmt.Sprintf(
+			"lich is running, but found no browser to show it in.\n\n"+
+				"Open this URL in any browser:\n%s\n\n"+
+				"For a window of its own, install a Chromium-family browser "+
+				"(chromium, chrome, brave, vivaldi, edge).\n\nLog: %s",
+			url, logging.Path(filepath.Join(configDir, "lich"))),
+			zenity.Title("lich"))
+		os.Exit(1)
+	}
+	_ = zenity.Notify(
+		"lich is running at "+addr+" — opened in your default browser. "+
+			"No Chromium-family browser here, so it has no window of its own: "+
+			"closing the tab leaves lich running.",
+		zenity.Title("lich"))
+
+	// The window's exit is the app lifecycle everywhere else, and /restart
+	// terminates that window to free the pinned port for its successor. With no
+	// window, this process is what has to go — so it is what the coordinator is
+	// handed, and the signal it sends is the one waited on here.
+	if self, err := os.FindProcess(os.Getpid()); err == nil {
+		coord.SetWindow(self)
+	}
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+	slog.Info("serving without a window", "addr", addr)
+	<-stop
+	slog.Info("signal received, exiting")
 }
 
 // handleBindFailure runs when the pinned listener would not bind, and never
@@ -368,5 +430,10 @@ func focusRunning(configDir string, running *singleton.Info) {
 	url := fmt.Sprintf("http://127.0.0.1:%d/?token=%s", running.Port, running.Token)
 	if err := chromium.Run(url, profileDir, "lich", nil, nil); err != nil {
 		slog.Warn("focus existing window", "err", err)
+		// The running lich has no window of its own either (it is serving a
+		// tab); the honest "focus" is another tab pointed at it.
+		if errors.Is(err, chromium.ErrNoBrowser) {
+			_ = system.OpenURL(url)
+		}
 	}
 }


### PR DESCRIPTION
A machine running **Vivaldi** got no lich window and no message: the launcher scanned six binary names, none of them Vivaldi's, and the error only reached a log nobody had open. Two things were wrong — the list, and the assumption that failure is visible.

## Resolution is a ladder now

`internal/chromium/resolve.go`, in order:

1. **Pinned** — `--browser <name-or-path>` or `LICH_BROWSER`. The flag writes the env var, so the restart successor and `lich doctor` resolve the same browser. A pinned browser that is not there fails **loudly** and never falls through to the scan: the user named a browser, and quietly opening a different one is the class of bug the override exists to rule out.
2. **The desktop's own default**, when it is one lich can drive — `xdg-settings get default-web-browser`, then `$BROWSER` (colon list, `%s` placeholders stripped). A Firefox default is skipped rather than handed an `--app=` it ignores.
3. **The scan**, widened: Vivaldi, Brave, Edge, Thorium and ungoogled-chromium beside Chromium, Chrome and Helium — plus Vivaldi's `.app` bundle on macOS and its install roots (and Brave's `LocalAppData`) on Windows.
4. **Flatpak** — `flatpak run <id>`, with the profile relocated under `~/.var/app/<id>/config/` where the sandbox can actually write it. Without that relocation the `--user-data-dir` is unwritable, and an adopted window means the spawned process exits at once and takes lich's lifecycle with it.

Every probe on that ladder is an injected field, so the whole thing is table-tested without installing eight browsers; the `exec` is the only untested part.

## No Chromium-family browser is no longer a dead end

lich hands its URL to the desktop's own opener, raises a desktop notification saying it is running and where, prints the URL to stdout, and goes on serving until it is signalled. The chromeless window is what is lost — Firefox has no `--app` equivalent — not the product. With no opener either, the error dialog carries the URL instead of lich exiting in silence.

`lich doctor` and `lich rage` report the browser **and** the rung that produced it:

```
  ok    browser       49ms  /usr/bin/helium-browser (the desktop's default browser)
  ok    browser       <1ms  /usr/bin/chromium (pinned by LICH_BROWSER)
  fail  browser       <1ms  LICH_BROWSER=nope: exec: "nope": executable file not found in $PATH
```

## Deliberately not here

- **No Firefox site-specific-browser.** `userChrome.css` is unsupported by Mozilla and breaks on updates; the tab fallback already gives Firefox-only users a working lich.
- **No `epiphany --application-mode` rung.** A second chrome-hiding strategy on a WebKitGTK engine nothing else here is tested against, to save one rung of degradation.
- **No Windows registry read.** `StartMenuInternet` would name a browser installed somewhere else entirely; `--browser` covers that machine in one variable, without a dependency.

## Ceilings recorded

The profile directory is not keyed by browser (changing your default browser hands one browser's profile to another); tab mode has no window lifecycle, so closing the tab leaves lich running and `/restart` on a browserless *Windows* cannot free the port; and the desktop opener is fire-and-forget, so "opened" and "nothing happened" look alike.

**One behaviour change worth naming:** rung 2 means lich now opens in your *default* browser when it is Chromium-family, which on a machine with several installed may not be the one it used before. `LICH_BROWSER` pins it back.

## Test plan

- `go test ./...` — 2066 pass, including the new resolution table (pinned/loud, desktop default, non-Chromium default skipped, `$BROWSER`, scan order, Flatpak + profile relocation, Flatpak without `HOME`, no browser, flag parsing).
- `gofmt -l .`, `go vet ./...` clean; `for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done` all green.
- Real machine: `lich doctor` resolves through the default rung, the pinned rung and a bad pin (output above). No frontend files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)