### PR TITLE
ci: keep the AUR push under the 488KiB blob limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,6 +301,12 @@ jobs:
           pkgbuild: ./PKGBUILD
           assets: build/linux/aur/lich-bin.install
           updpkgsums: true
+          # updpkgsums downloads the sources into the AUR checkout, and passing
+          # `assets` switches the action from `git add PKGBUILD .SRCINFO` to
+          # `git add --all` — which commits the 20MB binary and trips the AUR's
+          # 488.28KiB blob limit. post_process runs after .SRCINFO, before the
+          # commit.
+          post_process: rm -f lich-v*-linux-amd64 lich-*.desktop lich-*.png
           commit_username: omartelo
           commit_email: meopedevts@proton.me
           ssh_private_key: ${{ secrets.AUR_SSH_PRIVATE_KEY }}


### PR DESCRIPTION
The `aur` job failed on the `v0.43.1` tag:

```
remote: error: maximum blob size (488.28KiB) exceeded
remote: error: hook declined to update refs/heads/master
```

Shipping `lich-bin.install` as an `asset` (#422) is what changed: without
`assets`, the deploy action stages `git add PKGBUILD .SRCINFO`; with it, it
falls back to `git add --all`. `updpkgsums` runs from inside the AUR checkout,
so the `source=()` downloads — a 20MB binary among them — land there and get
committed, and the AUR's hook refuses any blob over 488.28KiB.

`post_process` runs after `.SRCINFO` is regenerated and before the commit, so
deleting the downloads there keeps the checksums and drops the blobs.

## Test plan

- [x] `lich-bin` 0.43.1 published to the AUR by hand, with the same three files
      this job now pushes (`PKGBUILD`, `.SRCINFO`, `lich-bin.install`) and the
      binary checksum matching `checksums.txt` of the release.
- [ ] Next tag's `aur` job pushes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156LZ4Z2Naof767poSmRoKW