### PR TITLE
fix: bake OpenAI rates so an offline Codex session shows a cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A Codex session shows its cost on a machine with no network.** The price
+  table shipped in the binary carried Claude models only, so a Codex cost
+  appeared only once the remote refresh had landed — never, on a machine that
+  cannot reach it. OpenAI's rates now ship beside Claude's; the refresh still
+  overrides them when it runs, so the cost is at worst stale by a release
+  rather than missing entirely.
+
 - **lich opens in the browser you actually have.** The window used to be
   launched from a short list of binary names, so a machine running Vivaldi —
   Chromium-based, `--app` mode and all — got nothing at all. Resolution is now

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -27,12 +27,15 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   Their footer therefore carries no model or context ring. Codex rollouts carry the effective window
   selected for that session — 95% of its default or configured `model_context_window` — and, since
   `total_token_usage` is a running total lich prices from its last line, the cost rung too. But
-  `internal/pricing/prices.json` is baked with Claude models only, so a Codex model prices only after the
-  remote LiteLLM refresh (`internal/pricing/pricing.go`) — an offline machine never shows a Codex cost, and
-  a model LiteLLM has not priced either never will. **A Codex conversation that ran `/model` shows no cost
-  at all** from that turn on (`codexCostScan.mixed`): the one running total spans both models and the
-  rollout never splits it, so no rate prices it — absent, the way an unpriced line is absent, rather than
-  a number billed at whichever model happened to go last.
+  `internal/pricing/prices.json` bakes a fixed slice of OpenAI rates beside the Claude ones, copied by hand
+  from the same LiteLLM table the refresh reads, so an offline Codex session shows a cost at the rate that
+  shipped — **stale by however long it has been since the release**, until the refresh
+  (`internal/pricing/pricing.go`) lands and overrides it. Nothing regenerates that slice: a model released
+  after the build, or one LiteLLM has not priced, still shows nothing until the refresh reaches it.
+  **A Codex conversation that ran `/model` shows no cost at all** from that turn on
+  (`codexCostScan.mixed`): the one running total spans both models and the rollout never splits it, so no
+  rate prices it — absent, the way an unpriced line is absent, rather than a number billed at whichever
+  model happened to go last.
 - **Hands-on time is read off three signals, and one of them is not universal**
   (`internal/terminal/handson.go`, `noteOutput`, `closableState`): the figure beside the cost
   counts the gap between consecutive signs of life in a session — a session-state report, a

--- a/internal/pricing/prices.json
+++ b/internal/pricing/prices.json
@@ -163,5 +163,163 @@
     "cacheRead": 2e-07,
     "cacheWrite": 2.5e-06,
     "cacheWrite1h": 4e-06
+  },
+  "codex-mini-latest": {
+    "input": 1.5e-06,
+    "output": 6e-06,
+    "cacheRead": 3.75e-07
+  },
+  "gpt-5": {
+    "input": 1.25e-06,
+    "output": 1e-05,
+    "cacheRead": 1.25e-07
+  },
+  "gpt-5-chat": {
+    "input": 1.25e-06,
+    "output": 1e-05,
+    "cacheRead": 1.25e-07
+  },
+  "gpt-5-chat-latest": {
+    "input": 1.25e-06,
+    "output": 1e-05,
+    "cacheRead": 1.25e-07
+  },
+  "gpt-5-codex": {
+    "input": 1.25e-06,
+    "output": 1e-05,
+    "cacheRead": 1.25e-07
+  },
+  "gpt-5-mini": {
+    "input": 2.5e-07,
+    "output": 2e-06,
+    "cacheRead": 2.5e-08
+  },
+  "gpt-5-nano": {
+    "input": 5e-08,
+    "output": 4e-07,
+    "cacheRead": 5e-09
+  },
+  "gpt-5-pro": {
+    "input": 1.5e-05,
+    "output": 0.00012
+  },
+  "gpt-5-search-api": {
+    "input": 1.25e-06,
+    "output": 1e-05,
+    "cacheRead": 1.25e-07
+  },
+  "gpt-5.1": {
+    "input": 1.25e-06,
+    "output": 1e-05,
+    "cacheRead": 1.25e-07
+  },
+  "gpt-5.1-chat-latest": {
+    "input": 1.25e-06,
+    "output": 1e-05,
+    "cacheRead": 1.25e-07
+  },
+  "gpt-5.1-codex": {
+    "input": 1.25e-06,
+    "output": 1e-05,
+    "cacheRead": 1.25e-07
+  },
+  "gpt-5.1-codex-max": {
+    "input": 1.25e-06,
+    "output": 1e-05,
+    "cacheRead": 1.25e-07
+  },
+  "gpt-5.1-codex-mini": {
+    "input": 2.5e-07,
+    "output": 2e-06,
+    "cacheRead": 2.5e-08
+  },
+  "gpt-5.2": {
+    "input": 1.75e-06,
+    "output": 1.4e-05,
+    "cacheRead": 1.75e-07
+  },
+  "gpt-5.2-chat-latest": {
+    "input": 1.75e-06,
+    "output": 1.4e-05,
+    "cacheRead": 1.75e-07
+  },
+  "gpt-5.2-codex": {
+    "input": 1.75e-06,
+    "output": 1.4e-05,
+    "cacheRead": 1.75e-07
+  },
+  "gpt-5.2-pro": {
+    "input": 2.1e-05,
+    "output": 0.000168
+  },
+  "gpt-5.3-chat-latest": {
+    "input": 1.75e-06,
+    "output": 1.4e-05,
+    "cacheRead": 1.75e-07
+  },
+  "gpt-5.3-codex": {
+    "input": 1.75e-06,
+    "output": 1.4e-05,
+    "cacheRead": 1.75e-07
+  },
+  "gpt-5.4": {
+    "input": 2.5e-06,
+    "output": 1.5e-05,
+    "cacheRead": 2.5e-07
+  },
+  "gpt-5.4-mini": {
+    "input": 7.5e-07,
+    "output": 4.5e-06,
+    "cacheRead": 7.5e-08
+  },
+  "gpt-5.4-nano": {
+    "input": 2e-07,
+    "output": 1.25e-06,
+    "cacheRead": 2e-08
+  },
+  "gpt-5.4-pro": {
+    "input": 3e-05,
+    "output": 0.00018,
+    "cacheRead": 3e-06
+  },
+  "gpt-5.5": {
+    "input": 5e-06,
+    "output": 3e-05,
+    "cacheRead": 5e-07
+  },
+  "gpt-5.5-pro": {
+    "input": 3e-05,
+    "output": 0.00018,
+    "cacheRead": 3e-06
+  },
+  "gpt-5.6": {
+    "input": 4e-06,
+    "output": 2e-05,
+    "cacheRead": 4e-07,
+    "cacheWrite": 5e-06
+  },
+  "gpt-5.6-cyber": {
+    "input": 1.25e-05,
+    "output": 7.5e-05,
+    "cacheRead": 1.25e-06,
+    "cacheWrite": 1.5625e-05
+  },
+  "gpt-5.6-luna": {
+    "input": 2e-07,
+    "output": 1.2e-06,
+    "cacheRead": 2e-08,
+    "cacheWrite": 2.5e-07
+  },
+  "gpt-5.6-sol": {
+    "input": 4e-06,
+    "output": 2e-05,
+    "cacheRead": 4e-07,
+    "cacheWrite": 5e-06
+  },
+  "gpt-5.6-terra": {
+    "input": 2e-06,
+    "output": 1.2e-05,
+    "cacheRead": 2e-07,
+    "cacheWrite": 2.5e-06
   }
 }

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -2,14 +2,16 @@
 // per-session cost readout. It is keyed by model id and knows nothing about who
 // ran the model: a second provider's reader gets its prices from the same table.
 //
-// The table has two layers. A small baked one (prices.json, the Claude models
-// known at build time) is the floor, so a fresh install prices correctly with no
-// network at all. A model the floor has never heard of — one released after this
-// build — triggers a single remote refresh, whose result is cached under the
-// config dir and overlays the floor from then on. Nothing here blocks a caller:
-// the refresh runs in the background and the lookup that missed simply reports
-// "unknown", which the readout renders as absent rather than as zero. Pricing a
-// model at nothing is the one answer this package must never give.
+// The table has two layers. A small baked one (prices.json, the Claude and
+// OpenAI models known at build time) is the floor, so a fresh install prices
+// correctly with no network at all — a machine that never reaches the network
+// still shows a Codex session's cost, at the rate that shipped. A model the
+// floor has never heard of — one released after this build — triggers a single
+// remote refresh, whose result is cached under the config dir and overlays the
+// floor from then on. Nothing here blocks a caller: the refresh runs in the
+// background and the lookup that missed simply reports "unknown", which the
+// readout renders as absent rather than as zero. Pricing a model at nothing is
+// the one answer this package must never give.
 package pricing
 
 import (

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -59,6 +59,28 @@ func TestBakedTablePricesAShippedModel(t *testing.T) {
 	}
 }
 
+// TestBakedTablePricesACodexModel proves the floor is not Claude-only: a Codex
+// session on a machine that has never reached the network still shows a cost.
+// The rates are pinned, not read from the table, so regenerating the baked slice
+// without OpenAI in it fails here instead of going quiet in the footer.
+func TestBakedTablePricesACodexModel(t *testing.T) {
+	table := newTable("http://0.0.0.0:0", filepath.Join(t.TempDir(), "prices.json"), http.DefaultClient)
+
+	rate, ok := table.Rate("gpt-5.1-codex")
+	if !ok {
+		t.Fatal("Rate(gpt-5.1-codex): want a price from the baked table")
+	}
+	if rate.Input != 1.25e-06 || rate.Output != 1e-05 || rate.CacheRead != 1.25e-07 {
+		t.Errorf("Rate = %+v, want the published gpt-5.1-codex rates", rate)
+	}
+	// OpenAI does not bill for writing the cache, and the Codex scan never
+	// reports an hour-long write — so a rate with neither must still price a
+	// turn rather than report the missing-1h refusal Cost gives a Claude rate.
+	if _, ok := rate.Cost(Tokens{Input: 1000, Output: 100, CacheRead: 500}); !ok {
+		t.Error("Cost: an OpenAI rate with no cache-write price must still price a turn")
+	}
+}
+
 // TestDatedModelIdResolvesToItsFamily proves the id a transcript records
 // ("…-20251101", pinning a release) prices off the undated entry. Without it
 // every dated id would read as unknown and the readout would never appear.


### PR DESCRIPTION
Direction 1 of #428, on its own.

## What was wrong

`internal/pricing/prices.json` — the table embedded in the binary — shipped Claude models only. A Codex model priced only after the remote LiteLLM refresh succeeded, so a machine that never reaches the network never showed a Codex cost, no matter how long the session ran.

## What changed

The file now carries an OpenAI slice beside the Claude one: every bare `openai` entry in the gpt-5 families plus `codex-mini-latest`, copied from the same LiteLLM table `pricing.go` refreshes from. Nothing in the repo regenerates that file — it has always been hand-maintained — so this is a hand-copied slice, and `docs/ceilings.md` names the staleness that buys: at worst wrong by a release, against no number at all, and the refresh still overlays it the moment it lands.

`TestBakedTablePricesACodexModel` pins the rates as literals rather than reading them back off the table, so regenerating the slice without OpenAI in it fails the suite instead of going quiet in the footer. It also asserts an OpenAI rate — which carries no cache-write price, because OpenAI does not bill one — still prices a turn, rather than tripping `Cost`'s missing-1h refusal.

## Out of scope

- Direction 2 (caching the last refresh to disk) — untouched. Worth noting it already exists: `newTable` reads `<config-dir>/lich/prices.json` and `writeCache` writes it, so the issue's second direction may already be done.
- Direction 3 (saying it on screen when a rate is unknown) — shared with the `/model` issue, and the footer is another session's work this round.
- `internal/terminal/usage*.go` and the frontend: not touched.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` green (2067 tests, 33 packages)
- [x] `TestBakedTablePricesACodexModel` fails when the OpenAI slice is stripped from `prices.json` (verified by stripping it and re-running)
