### PR TITLE
Count a Crush turn as hands-on time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not the product. With no browser at all, the dialog carries the URL instead
   of lich exiting in silence.
 
+### Fixed
+
+- **A Crush card's hands-on time now counts the work, not the typing.** The
+  clock beat on the session-state report, and Crush reports no state — so an
+  hour a Crush session worked while you watched read as the few seconds you
+  typed into it. Every hook a session sends now beats it, and Crush's one hook
+  event fires once per tool call, which puts its figure on the same rung as
+  Cursor CLI's. Nothing to reinstall: the reports were already arriving.
+
 ## [0.43.1] - 2026-09-01
 
 ### Fixed

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -35,20 +35,25 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   a number billed at whichever model happened to go last.
 - **Hands-on time is read off three signals, and one of them is not universal**
   (`internal/terminal/handson.go`, `noteOutput`, `closableState`): the figure beside the cost
-  counts the gap between consecutive signs of life in a session — a session-state report, a
+  counts the gap between consecutive signs of life in a session — any hook report naming it, a
   keystroke at its PTY, or its own output while a turn is open — and drops any gap longer than
   `handsOnIdleGap`. The output signal is the one that carries an unattended turn, and it is
   gated on the provider having reported `busy`, because a `tail -f`, a dev server or a TUI
-  repainting would otherwise bill hours nobody worked. **Crush reports no state at all**
-  (`docs/hooks/session-state.md`), so nothing ever opens a turn there and a Crush session
-  accrues from the user's keystrokes alone: an hour it spent working while the user watched
-  reads as the few seconds they typed in. **Cursor CLI is the near miss** — it delivers
-  `PreToolUse` and `PostToolUse`, and those beat even though `closableState` refuses to publish
-  them, so a Cursor turn is counted through its tool calls; what it still cannot count is a turn
-  that calls no tool at all. A plain shell session is keystrokes-only by design and not a gap:
-  there is no agent in it whose work could be missed. The trap is reading the number as
-  comparable across cards — the same hour of work is a smaller figure on Crush than on Claude
-  Code, and nothing on screen says which rung a card is on.
+  repainting would otherwise bill hours nobody worked. **Which turns get counted therefore
+  depends on what a provider's hooks report at all**, and there are two rungs. On the top one —
+  Claude Code, Codex, Antigravity, opencode, oh-my-pi — the turn opens, so a turn nobody
+  touches is counted from its own output. On the lower one — **Crush and Cursor CLI** — no turn
+  ever opens (`docs/hooks/session-state.md`), and the turn is counted through the reports its
+  tool calls fire: Cursor's `PreToolUse`/`PostToolUse` state reports, which beat even though
+  `closableState` refuses to publish them, and Crush's `/session-start`, which its only hook
+  event (`PreToolUse`) fires once per tool call — measured 2026-09-03 against Crush 0.88.0, three
+  tool calls in one turn, three POSTs. **What that rung cannot count is a turn that calls no tool
+  at all**: a long answer written straight out, with no keystroke and no report between the
+  prompt and the reply, is worth only the gap the prompt itself closed. A plain shell session is
+  keystrokes-only by design and not a gap: there is no agent in it whose work could be missed.
+  The trap is reading the number as exactly comparable across cards — a toolless turn is time on
+  a Claude Code card and nothing on a Crush one, and nothing on screen says which rung a card is
+  on.
 - **A split stage puts every pane on the visible cadence** (`internal/terminal/coalescer.go`,
   `frontend/src/components/TerminalHost.tsx`): the coalescer batches a *visible* session's output every
   8ms and a hidden one's every 250ms, and until the stage could divide, exactly one session per window

--- a/internal/terminal/handson_wiring_test.go
+++ b/internal/terminal/handson_wiring_test.go
@@ -9,6 +9,9 @@ package terminal
 
 import (
 	"errors"
+	"fmt"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -168,5 +171,50 @@ func TestClosingASessionWritesWhatItWasWorked(t *testing.T) {
 
 	if store.handsOn["s1"] != 20 {
 		t.Errorf("closing wrote %ds, want 20", store.handsOn["s1"])
+	}
+}
+
+// TestEveryHookReportBeats is the rung Crush is on. Its only hook event is
+// `PreToolUse`, and neither script the plugin registers there reports a state
+// (docs/hooks/session-state.md) — so a Crush turn reaches lich as
+// `/session-start`, once per tool call (measured 2026-09-03 against Crush
+// 0.88.0, three tool calls in one turn, three POSTs). A beat wired to the state
+// report alone counts that turn as nothing at all, and the hour the user
+// watched it work reads as the seconds they typed in.
+//
+// Driven over the transport rather than by calling beatHandsOn, because the
+// wiring is the whole claim: the beat has to survive being written into a
+// callback that is about something else.
+func TestEveryHookReportBeats(t *testing.T) {
+	for _, tc := range []struct{ name, path, body string }{
+		{"session-start", "/session-start", `{"session_id":"s1","provider_session_id":"u9","provider":"crush"}`},
+		{"session-title", "/session-title", `{"session_id":"s1","title":"Explore this directory"}`},
+		{"session-touched", "/session-touched", `{"session_id":"s1"}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clock := newFakeClock()
+			svc := newQuietService(stubBins{}, clock)
+			if svc.ws == nil {
+				t.Fatalf("transport did not start: %v", svc.wsErr)
+			}
+			url := fmt.Sprintf("http://127.0.0.1:%d%s?token=%s", svc.ws.port, tc.path, svc.ws.token)
+			post := func() {
+				resp, err := http.Post(url, "application/json", strings.NewReader(tc.body))
+				if err != nil {
+					t.Fatalf("post %s: %v", tc.path, err)
+				}
+				_ = resp.Body.Close()
+				if resp.StatusCode != http.StatusNoContent {
+					t.Fatalf("%s status = %d, want 204", tc.path, resp.StatusCode)
+				}
+			}
+			post()
+			clock.advance(2 * time.Minute)
+			post()
+
+			if got := drainSeconds(&svc.hands, "s1"); got != 120 {
+				t.Errorf("two reports two minutes apart counted %ds, want 120", got)
+			}
+		})
 	}
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -366,12 +366,15 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 			}
 		},
 		func(req hookRequest) {
-			// Ahead of every filter below, because this one is not about what
-			// the card can draw. A report lich refuses to publish still proves
-			// the session was being worked: Cursor CLI's tool reports are
-			// dropped a line down for want of anything that could end the
-			// spinner they would start, and they are the only proof a Cursor
-			// turn is running at all (see closableState).
+			// Ahead of every filter below, because a beat is not about what the
+			// card can draw: any hook naming a session is proof that session was
+			// being worked, whatever endpoint it arrived on and whether or not
+			// lich publishes it. That is why the other three callbacks beat too
+			// — a provider whose hooks report no state has no other way to say
+			// its agent is running. Cursor CLI's tool reports are dropped a line
+			// down for want of anything that could end the spinner they would
+			// start, and they are the only proof a Cursor turn is running at all
+			// (see closableState).
 			s.beatHandsOn(req.SessionID, 0)
 			// Dropped where the harness cannot close it, before the turn log
 			// ever sees it: a state nothing ends outlives what it describes.
@@ -410,6 +413,12 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 			}
 		},
 		func(sessionID, providerSessionID, provider string) error {
+			// The beat above, on the one report Crush can make. Its only hook
+			// event is PreToolUse and neither script it registers there reports
+			// a state (docs/hooks/session-state.md), so this arrives once per
+			// tool call — measured 2026.09.03 against Crush 0.88.0 — and is the
+			// only proof a Crush turn is running.
+			s.beatHandsOn(sessionID, 0)
 			if err := store.SetProviderSession(sessionID, providerSessionID); err != nil {
 				return err
 			}
@@ -429,6 +438,7 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 			return nil
 		},
 		func(id, title string) error {
+			s.beatHandsOn(id, 0)
 			applied, err := store.SetSessionTitle(id, title)
 			if err != nil {
 				return err
@@ -439,6 +449,7 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 			return nil
 		},
 		func(id string) {
+			s.beatHandsOn(id, 0)
 			hub.Emit(touchedEventName, touchedEvent{ID: id})
 		},
 	)


### PR DESCRIPTION
Direction 2 of #430, and it made direction 1 smaller rather than unnecessary: one rung closed, one still there to name.

## What was measured

Isolated rig — own `HOME`/`XDG_CONFIG_HOME`/`XDG_DATA_HOME`, own crush socket, a fake OpenAI-compatible provider driving the turn, a stub listener standing in for lich, and the hook scripts from the real install. Crush 0.88.0, 2026-09-03.

- **Crush's `PreToolUse` beats.** One turn, three tool calls, three hook firings — and the block lich writes into `crushrc` today posted `/session-start` three times, each carrying `LICH_SESSION_ID`. The payload is `{event, session_id, cwd, tool_name, tool_input}`.
- **Nothing else fires.** `PostToolUse`, `UserPromptSubmit`, `Stop`, `SessionStart`, `SessionEnd`, `Notification` were all registered in `crushrc` — accepted without a word, never delivered. `docs/hooks/session-state.md` was right about the event list.
- **`report-state.sh busy` on that event produces the contract body verbatim**, so registering it would have worked too.

## What changed

Not that. The registration was the wrong end: those three POSTs were already reaching lich, and lich was throwing the beat away.

`Service.beatHandsOn` was wired to the state callback alone. But the gate was never that the report is a *state* report — it is that a hook naming a session is proof that session was being worked, which is already the stated reason Cursor CLI's tool reports beat ahead of the filter that refuses to publish them. So all four hook callbacks beat now.

Crush therefore lands on Cursor's rung with **nothing to reinstall** and no extra subprocess per tool call — and registering a report whose only purpose would be to be dropped by `closableState` is avoided. No plugin change; `lich-plugin` is untouched.

## What is left

The rung itself. Neither Crush nor Cursor opens a turn, so a turn that calls **no tool at all** — a long answer written straight out — is worth only the gap the prompt closed. `docs/ceilings.md` now names two rungs instead of three signals and says what the lower one cannot count. Nothing is averaged, extrapolated or filled in.

Direction 1 (the tooltip marker) is untouched — deliberately: it is another session's file, and the sentence it has to say is now shorter.

## Test plan

- [x] `TestEveryHookReportBeats` drives `/session-start`, `/session-title` and `/session-touched` over the real transport and asserts the counted gap. Red on all three sub-tests with the beats removed, green with them.
- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` (2070 pass), `pnpm check`, `pnpm test` (1339 pass), `pnpm build`.
- [x] Cross-compile loop over linux/darwin/windows, build and vet.

Closes nothing on its own — #430 stays open for direction 1.