### PR TITLE
fix: say why a session cannot be priced instead of dropping the cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   event fires once per tool call, which puts its figure on the same rung as
   Cursor CLI's. Nothing to reinstall: the reports were already arriving.
 
+- **A cost lich cannot work out now says so instead of vanishing.** The footer
+  used to simply drop the figure whenever a session could not be priced, which
+  reads as a session that has spent nothing. It now shows `$—` with a tooltip
+  naming the reason: a conversation that switched models carries one running
+  token total over both and no rate can attribute it, and a model with no known
+  price is one neither the rates in this build nor the refresh have reached.
+  Turning the readout off, and a subscription, still show nothing at all: that
+  is the design, not a failure.
+
 ## [0.43.1] - 2026-09-01
 
 ### Fixed

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -18,7 +18,10 @@ work when nobody knows it and that the call site never shows. The mechanism and 
 - **The cost readout bills per `(session, transcript)`** (`internal/pricing`, `internal/terminal/usage_cost.go`): a
   conversation forked inside the PTY bills its copied history twice — lich's own resume continues the same
   transcript and is unaffected — and each sub-agent's own transcript is counted in, so one unreadable or
-  unpriceable sub-agent withholds the whole session's number.
+  unpriceable sub-agent withholds the whole session's number. A withheld number is marked `$—` on the footer
+  only when the reason is standing (`costMiss.spoken` in `internal/terminal/usage_cost.go`): a transcript that
+  merely could not be read this turn says nothing and keeps the last figure, so a reader cannot tell that
+  absence from a session still on its first turn.
 - **The session readout understands Claude Code and Codex transcripts only**
   (`internal/terminal/usage_claude.go`, `internal/terminal/usage_codex.go`): oh-my-pi, opencode and Crush record
   token usage but not the model's context-window size, so lich cannot turn those counts into a trustworthy
@@ -30,12 +33,17 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   `internal/pricing/prices.json` bakes a fixed slice of OpenAI rates beside the Claude ones, copied by hand
   from the same LiteLLM table the refresh reads, so an offline Codex session shows a cost at the rate that
   shipped — **stale by however long it has been since the release**, until the refresh
-  (`internal/pricing/pricing.go`) lands and overrides it. Nothing regenerates that slice: a model released
-  after the build, or one LiteLLM has not priced, still shows nothing until the refresh reaches it.
-  **A Codex conversation that ran `/model` shows no cost at all** from that turn on
-  (`codexCostScan.mixed`): the one running total spans both models and the rollout never splits it, so no
-  rate prices it — absent, the way an unpriced line is absent, rather than a number billed at whichever
-  model happened to go last.
+  (`internal/pricing/pricing.go`) lands and overrides it. Nothing regenerates that slice, so what is left
+  with no price at all is a model newer than the build, or one LiteLLM never priced — and with no network
+  the refresh that would settle it never runs. A Codex conversation that ran `/model` has no cost from that
+  turn on (`codexCostScan.mixed`): the one running total spans both models and the rollout never splits it,
+  so no rate prices it — absent, the way an unpriced line is absent, rather than a number billed at
+  whichever model happened to go last. **Those two absences are spoken; the staleness is not.** A session
+  lich cannot price draws `$—` with a tooltip naming which of the two it is (`usageEvent.CostMiss`,
+  `COST_MISS_REASON` in `frontend/src/lib/session/session-cost.ts`), while a cost billed at a rate the
+  release froze reads as an ordinary figure with nothing beside it. The marker also names the reason and
+  never the model or the turn, so a session whose sub-agent alone is unpriced looks like one whose every
+  turn is.
 - **Hands-on time is read off three signals, and one of them is not universal**
   (`internal/terminal/handson.go`, `noteOutput`, `closableState`): the figure beside the cost
   counts the gap between consecutive signs of life in a session — any hook report naming it, a

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -17,7 +17,7 @@ import type { DockTab } from "@/components/dock/RightDock"
 import { useActiveSession } from "@/lib/session/use-active-session"
 import { useSessionUsage } from "@/lib/session/use-session-usage"
 import { useCostReadout } from "@/lib/use-cost-readout"
-import { budgetShare, formatCost } from "@/lib/session/session-cost"
+import { COST_MISS_REASON, budgetShare, formatCost } from "@/lib/session/session-cost"
 import { formatHandsOn, spellHandsOn } from "@/lib/session/hands-on"
 import { useRemoteResource } from "@/lib/use-remote-resource"
 import { baseName, displayPath } from "@/lib/paths"
@@ -142,11 +142,10 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
   }
 
   // What the session has cost, beside the ring. Rendered only when the backend
-  // sent a number: on a subscription — and for a model no price table knows —
-  // there is nothing here at all, which is the point of the setting. With a
-  // spend ceiling set it takes the same colour ramp as the context ring, so a
-  // session running long shows it in the corner of the eye rather than only to
-  // whoever reads the figure.
+  // sent a number: on a subscription there is nothing here at all, which is the
+  // point of the setting. With a spend ceiling set it takes the same colour ramp
+  // as the context ring, so a session running long shows it in the corner of the
+  // eye rather than only to whoever reads the figure.
   const costReadout =
     usage && showCost && usage.costUsd !== null ? (
       <Tooltip>
@@ -170,6 +169,27 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
             <span className="text-xs text-muted-foreground">
               API pricing for every turn this session has run, this conversation and the ones it
               cleared.
+            </span>
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    ) : null
+
+  // The same slot when there is a number lich cannot produce rather than none to
+  // show. An empty corner reads as zero spend, so the absence gets a mark of its
+  // own and the tooltip names which of the two standing reasons it is. Muted and
+  // never on the budget ramp: nothing is known to be near a ceiling.
+  const costMissReadout =
+    usage && showCost && usage.costUsd === null && usage.costMiss ? (
+      <Tooltip>
+        <TooltipTrigger render={<span className="tabular-nums text-muted-foreground" />}>
+          $&mdash;
+        </TooltipTrigger>
+        <TooltipContent side="top" className="border border-border bg-card text-foreground">
+          <div className="flex max-w-64 flex-col gap-1">
+            <span className="font-medium">Cost unavailable</span>
+            <span className="text-xs text-muted-foreground">
+              {COST_MISS_REASON[usage.costMiss]}
             </span>
           </div>
         </TooltipContent>
@@ -294,17 +314,18 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
       <span className="ml-auto flex items-center gap-4">
         {showContextUsage && <SessionModel sessionId={sessionId} kind={kind} />}
         <PlanQuota kind={kind} sessionId={sessionId} />
-        {(costReadout || handsOnReadout) && (
+        {(costReadout || costMissReadout || handsOnReadout) && (
           <span className="flex items-center gap-1.5">
-            {costReadout}
-            {costReadout && handsOnReadout && <span className="opacity-50">·</span>}
+            {costReadout ?? costMissReadout}
+            {(costReadout || costMissReadout) && handsOnReadout && (
+              <span className="opacity-50">·</span>
+            )}
             {handsOnReadout}
           </span>
         )}
         {contextReadout}
-        {(contextReadout || costReadout || handsOnReadout) && (status?.branch || path) && (
-          <Separator orientation="vertical" className="h-4" />
-        )}
+        {(contextReadout || costReadout || costMissReadout || handsOnReadout) &&
+          (status?.branch || path) && <Separator orientation="vertical" className="h-4" />}
         {status?.branch && (
           <span className="flex items-center gap-1">
             <GitBranch className="size-3.5" />

--- a/frontend/src/lib/session/session-cost.test.ts
+++ b/frontend/src/lib/session/session-cost.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { budgetShare, formatCost } from "./session-cost"
+import { COST_MISS_REASON, budgetShare, formatCost } from "./session-cost"
 
 describe("formatCost", () => {
   it("shows cents once there are dollars to anchor them", () => {
@@ -57,5 +57,15 @@ describe("budgetShare", () => {
     expect(budgetShare(Number.NaN, 10)).toBe(0)
     expect(budgetShare(-1, 10)).toBe(0)
     expect(budgetShare(1, Number.POSITIVE_INFINITY)).toBe(0)
+  })
+})
+
+// Every reason the backend can send has a sentence here: a marker the user
+// cannot read is no better than the blank it replaced.
+describe("COST_MISS_REASON", () => {
+  it("has a sentence for every reason the contract carries", () => {
+    for (const reason of ["mixed-models", "unpriced-model"] as const) {
+      expect(COST_MISS_REASON[reason]).toMatch(/\S/)
+    }
   })
 })

--- a/frontend/src/lib/session/session-cost.ts
+++ b/frontend/src/lib/session/session-cost.ts
@@ -1,3 +1,5 @@
+import type { CostMiss } from "./session-events"
+
 // formatCost renders a session's spend for the footer, where it sits beside the
 // context percent at 12px and has to stay readable at a glance.
 //
@@ -33,4 +35,18 @@ export function budgetShare(usd: number, budget: number): number {
     return 0
   }
   return Math.min((usd / budget) * 100, 100)
+}
+
+// COST_MISS_REASON is what the readout says in place of a figure it cannot
+// produce. Each of these is a number that is not coming back on its own — the
+// user would otherwise read the blank as zero spend — so the marker names it
+// rather than leaving the corner empty.
+//
+// One sentence each, and it answers the only question the blank raises: did
+// this cost nothing, or does lich not know? Why the total cannot be attributed
+// and how rates are refreshed are lich explaining itself, and they lived here
+// until a mockup showed the tooltip running three lines at footer size.
+export const COST_MISS_REASON: Record<CostMiss, string> = {
+  "mixed-models": "This conversation switched models, so lich cannot price it.",
+  "unpriced-model": "No price for this model yet — lich needs the network to fetch one.",
 }

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -61,7 +61,10 @@ export const SANDBOX_EVENT = "session-sandbox"
 // model its id, effort the reasoning level ("" when the turn records none) —
 // plus an optional costUsd, which is present only when the cost readout is on
 // and every model in the session has a known price. Its absence is the answer,
-// not a zero.
+// not a zero — and an optional costMiss names the one kind of absence the user
+// has to know about: lich cannot price this conversation, as opposed to lich
+// not pricing it (the readout is off, which is the whole design on a
+// subscription).
 export const USAGE_EVENT = "session-usage"
 
 // Global event the backend emits while one session has a request open with
@@ -147,10 +150,19 @@ export function toSessionRelay(data: unknown): SessionRelay | null {
   }
 }
 
+// Why a session has no cost figure, when the reason is one the user can do
+// nothing about and no turn will heal — the backend's costMiss (see
+// internal/terminal/usage_cost.go). Every other absence sends nothing.
+const COST_MISSES = ["mixed-models", "unpriced-model"] as const
+
+export type CostMiss = (typeof COST_MISSES)[number]
+
 // A session's context-window occupancy as the footer shows it, and what the
 // session has cost so far. costUsd is null whenever the backend sent no number:
 // the setting is off (the case on a subscription, where the figure is noise) or
-// a model has no price yet. Nothing is rendered for it then.
+// a model has no price yet. costMiss is that second kind of absence, named — a
+// money readout that simply vanishes is read as zero spend — and stays null for
+// the first, where there is nothing to say.
 export interface SessionUsage {
   percent: number
   tokens: number
@@ -158,6 +170,7 @@ export interface SessionUsage {
   model: string
   effort: string
   costUsd: number | null
+  costMiss: CostMiss | null
 }
 
 // The states a card renders an indicator for. The contract also defines "idle"
@@ -335,6 +348,7 @@ export function isUsageEvent(data: unknown): data is {
   model: string
   effort: string
   costUsd?: number
+  costMiss?: string
 } {
   return (
     isIdEvent(data) &&
@@ -352,6 +366,16 @@ export function isUsageEvent(data: unknown): data is {
 // a total is either trustworthy or not rendered.
 export function usageCost(data: { costUsd?: unknown }): number | null {
   return typeof data.costUsd === "number" && Number.isFinite(data.costUsd) ? data.costUsd : null
+}
+
+// usageCostMiss reads the named absence off a usage payload. A reason this
+// build has no sentence for — one added by a newer backend — reads as no
+// reason: an unlabelled marker says less than the missing number already does.
+export function usageCostMiss(data: { costMiss?: unknown }): CostMiss | null {
+  const { costMiss } = data
+  return typeof costMiss === "string" && (COST_MISSES as readonly string[]).includes(costMiss)
+    ? (costMiss as CostMiss)
+    : null
 }
 
 // shouldToastAttention decides whether a session needing the user deserves the

--- a/frontend/src/lib/session/session-usage-store.test.ts
+++ b/frontend/src/lib/session/session-usage-store.test.ts
@@ -48,6 +48,7 @@ describe("createSessionUsageStore", () => {
       model: opus,
       effort: eff,
       costUsd: null,
+      costMiss: null,
     })
     expect(store.get("s2")).toEqual({
       percent: 5,
@@ -56,6 +57,7 @@ describe("createSessionUsageStore", () => {
       model: opus,
       effort: eff,
       costUsd: null,
+      costMiss: null,
     })
   })
 
@@ -95,6 +97,7 @@ describe("createSessionUsageStore", () => {
       model: opus,
       effort: "xhigh",
       costUsd: null,
+      costMiss: null,
     })
   })
 
@@ -110,6 +113,7 @@ describe("createSessionUsageStore", () => {
       model: opus,
       effort: eff,
       costUsd: null,
+      costMiss: null,
     })
   })
 
@@ -166,6 +170,36 @@ describe("createSessionUsageStore", () => {
 
     emit({ ...base, percent: 12, costUsd: Number.NaN })
     expect(store.get("s1")?.costUsd).toBeNull()
+  })
+
+  // The reason travels beside the missing number, and only when it is one this
+  // build has a sentence for: an unlabelled marker would say less than the
+  // blank it replaces.
+  it("keeps the reason a cost is missing, and drops one it cannot name", () => {
+    const { store, emit } = harness()
+    const base = { id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus, effort: eff }
+
+    emit({ ...base, costMiss: "mixed-models" })
+    expect(store.get("s1")?.costMiss).toBe("mixed-models")
+
+    emit({ ...base, percent: 11, costMiss: "unpriced-model" })
+    expect(store.get("s1")?.costMiss).toBe("unpriced-model")
+
+    emit({ ...base, percent: 12, costMiss: "a-reason-from-a-newer-backend" })
+    expect(store.get("s1")?.costMiss).toBeNull()
+
+    emit({ ...base, percent: 13 })
+    expect(store.get("s1")?.costMiss).toBeNull()
+  })
+
+  it("re-renders when only the reason moved", () => {
+    const { store, emit } = harness()
+    let calls = 0
+    store.subscribe("s1", () => calls++)
+    const base = { id: "s1", percent: 10, tokens: 20000, window: 200000, model: opus, effort: eff }
+    emit({ ...base, costMiss: "mixed-models" })
+    emit({ ...base, costMiss: "unpriced-model" })
+    expect(calls).toBe(2)
   })
 
   it("re-renders when only the cost moved", () => {

--- a/frontend/src/lib/session/session-usage-store.ts
+++ b/frontend/src/lib/session/session-usage-store.ts
@@ -4,6 +4,7 @@ import {
   isIdleEvent,
   isUsageEvent,
   usageCost,
+  usageCostMiss,
   type SessionEventSource,
   type SessionUsage,
 } from "./session-events"
@@ -20,7 +21,8 @@ const sameUsage = (a: SessionUsage | null, b: SessionUsage | null): boolean =>
     a.window === b.window &&
     a.model === b.model &&
     a.effort === b.effort &&
-    a.costUsd === b.costUsd)
+    a.costUsd === b.costUsd &&
+    a.costMiss === b.costMiss)
 
 // createSessionUsageStore keeps the last reported context-window usage of every
 // session, keyed by session id, fed by subscriptions taken at creation — before
@@ -44,6 +46,7 @@ export function createSessionUsageStore(
       model: data.model,
       effort: data.effort,
       costUsd: usageCost(data),
+      costMiss: usageCostMiss(data),
     })
   })
   agentSource((data) => {

--- a/internal/terminal/usage.go
+++ b/internal/terminal/usage.go
@@ -21,14 +21,21 @@ const usageEventName = "session-usage"
 // whenever there is no number worth showing: the setting is off, or a model in
 // the transcript has no known price. The readout is for API billing, so on a
 // subscription the field never appears at all and the footer shows nothing.
+//
+// CostMiss says why, and only when the answer is "lich cannot price this
+// conversation" — a costMiss.spoken() one. It stays empty for the readout being
+// off, which is not a failure but the design above, and for a miss the next turn
+// heals. Without it a session that cannot be priced and a session that is not
+// being priced look identical, and an empty footer reads as zero spend.
 type usageEvent struct {
-	ID      string   `json:"id"`
-	Percent int      `json:"percent"`
-	Tokens  int      `json:"tokens"`
-	Window  int      `json:"window"`
-	Model   string   `json:"model"`
-	Effort  string   `json:"effort"`
-	CostUSD *float64 `json:"costUsd,omitempty"`
+	ID       string   `json:"id"`
+	Percent  int      `json:"percent"`
+	Tokens   int      `json:"tokens"`
+	Window   int      `json:"window"`
+	Model    string   `json:"model"`
+	Effort   string   `json:"effort"`
+	CostUSD  *float64 `json:"costUsd,omitempty"`
+	CostMiss string   `json:"costMiss,omitempty"`
 }
 
 // emitUsage reads the context-window usage of the provider conversation running
@@ -67,8 +74,10 @@ func (s *Service) sessionUsage(id string) (usageEvent, bool) {
 		Model:   u.model,
 		Effort:  u.effort,
 	}
-	if cost, ok := s.sessionCost(id, providerSessionID); ok {
+	if cost, miss, ok := s.sessionCost(id, providerSessionID); ok {
 		event.CostUSD = &cost
+	} else if miss.spoken() {
+		event.CostMiss = string(miss)
 	}
 	return event, true
 }
@@ -81,10 +90,11 @@ func contextUsageFor(providerSessionID string) (contextUsage, bool) {
 }
 
 // sessionCost is what session id has cost across every conversation it has run,
-// or ok=false for "no number to show". That covers the flag being off (nothing
-// is even read then), a transcript that cannot be reached, and a model no price
-// table knows — see scanTranscriptCost for why an unpriced line stops the count
-// instead of being skipped.
+// or ok=false for "no number to show", with the costMiss saying which kind of
+// absence it is. That covers the flag being off (nothing is even read then), a
+// transcript that cannot be reached, and a model no price table knows — see
+// scanTranscriptCost for why an unpriced line stops the count instead of being
+// skipped.
 //
 // Routed by provider the way contextUsageFor is: a Claude transcript is more
 // than one file — what its sub-agents spent is billed to the same account and
@@ -97,76 +107,78 @@ func contextUsageFor(providerSessionID string) (contextUsage, bool) {
 // The accounting is persisted per transcript, so it survives both a `/clear`
 // (a new conversation under the same session, counted into its own row) and a
 // restart of lich itself.
-func (s *Service) sessionCost(id, providerSessionID string) (float64, bool) {
+func (s *Service) sessionCost(id, providerSessionID string) (float64, costMiss, bool) {
 	if s.prices == nil || !s.store.CostReadout() {
-		return 0, false
+		return 0, costMissNone, false
 	}
 	if path, ok := claudeTranscriptPath(providerSessionID); ok {
-		if !s.countTranscript(id, providerSessionID, path) {
-			return 0, false
+		if miss, ok := s.countTranscript(id, providerSessionID, path); !ok {
+			return 0, miss, false
 		}
 		for _, sub := range claudeSubagentPaths(providerSessionID) {
-			if !s.countTranscript(id, providerSessionID+"/"+filepath.Base(sub), sub) {
-				return 0, false
+			miss, ok := s.countTranscript(id, providerSessionID+"/"+filepath.Base(sub), sub)
+			if !ok {
+				return 0, miss, false
 			}
 		}
 	} else if path, ok := codexTranscriptPath(providerSessionID); ok {
-		if !s.countCodexTranscript(id, providerSessionID, path) {
-			return 0, false
+		if miss, ok := s.countCodexTranscript(id, providerSessionID, path); !ok {
+			return 0, miss, false
 		}
 	} else {
-		return 0, false
+		return 0, costMissNone, false
 	}
 	total, err := s.store.SessionCost(id)
 	if err != nil {
 		slog.Warn("terminal: read session cost", "session", id, "err", err)
-		return 0, false
+		return 0, costMissUnread, false
 	}
-	return total, true
+	return total, costMissNone, true
 }
 
 // countCodexTranscript folds one Codex rollout's cost into the session's
 // ledger. Unlike countTranscript's per-turn deltas, total_token_usage is
 // already the conversation's running total, so there is no offset to resume
 // from: each call prices the rollout whole and overwrites the stored row.
-func (s *Service) countCodexTranscript(id, transcriptID, path string) bool {
-	cost, ok := codexTranscriptCost(path, s.prices)
+func (s *Service) countCodexTranscript(id, transcriptID, path string) (costMiss, bool) {
+	cost, miss, ok := codexTranscriptCost(path, s.prices)
 	if !ok {
-		return false
+		return miss, false
 	}
 	if err := s.store.SaveCostLedger(id, transcriptID, 0, "", cost); err != nil {
 		slog.Warn("terminal: save cost ledger", "session", id, "err", err)
-		return false
+		return costMissUnread, false
 	}
-	return true
+	return costMissNone, true
 }
 
 // countTranscript folds one transcript into the session's ledger, resuming from
 // where the last turn stopped and saving how far this one got. false is "this
 // file has no total to contribute yet" — it could not be read, its accounting
-// could not be stored, or the scan stopped at a line it cannot price.
+// could not be stored, or the scan stopped at a line it cannot price — and the
+// costMiss beside it is which of those, for the footer to say the last one.
 //
 // transcriptID is what the ledger row is keyed by, which is the provider's
 // conversation id for the conversation itself and that id plus the file name for
 // each sub-agent beside it: one row per file, so a re-read resumes per file.
-func (s *Service) countTranscript(id, transcriptID, path string) bool {
+func (s *Service) countTranscript(id, transcriptID, path string) (costMiss, bool) {
 	offset, lastMessage, cost, err := s.store.CostLedger(id, transcriptID)
 	if err != nil {
 		slog.Warn("terminal: read cost ledger", "session", id, "err", err)
-		return false
+		return costMissUnread, false
 	}
 	from := costLedger{offset: offset, lastMessage: lastMessage, cost: cost}
-	ledger, complete, ok := scanTranscriptCost(path, from, s.prices)
+	ledger, miss, ok := scanTranscriptCost(path, from, s.prices)
 	if !ok {
-		return false
+		return miss, false
 	}
 	if ledger != from {
 		if err := s.store.SaveCostLedger(
 			id, transcriptID, ledger.offset, ledger.lastMessage, ledger.cost,
 		); err != nil {
 			slog.Warn("terminal: save cost ledger", "session", id, "err", err)
-			return false
+			return costMissUnread, false
 		}
 	}
-	return complete
+	return miss, miss == costMissNone
 }

--- a/internal/terminal/usage_codex.go
+++ b/internal/terminal/usage_codex.go
@@ -134,23 +134,33 @@ func consumeCodexUsageLine(line []byte, usage *contextUsage, haveTokens *bool) b
 // conversation's cumulative cost, so the last line is the whole answer — no
 // ledger walk, no offset to resume from. ok is false when the rollout carries
 // no cost line yet, when rates cannot price the model that ran it, and when
-// more than one model did (see codexCostScan.mixed).
+// more than one model did (see codexCostScan.mixed) — the last two name themselves
+// through costMiss, because they are standing, not a turn away from healing.
 //
 // The scan reaching the start of the file is the ordinary end of it, not a
 // failure: unlike the context readout, which stops at the current turn, this one
 // has to see every turn_context the total covers. A file that cannot be read
 // stops there with no token line, which is the same absent answer.
-func codexTranscriptCost(path string, rates rateSource) (float64, bool) {
+func codexTranscriptCost(path string, rates rateSource) (float64, costMiss, bool) {
 	var scan codexCostScan
 	codexReverseScan(path, scan.consume)
-	if !scan.haveTokens || scan.mixed || scan.model == "" {
-		return 0, false
+	// mixed is checked first: the walk stops the moment it finds the second
+	// model, so it is the reason even though the tokens were read.
+	if scan.mixed {
+		return 0, costMissMixed, false
+	}
+	if !scan.haveTokens || scan.model == "" {
+		return 0, costMissNone, false
 	}
 	rate, ok := rates.Rate(scan.model)
 	if !ok {
-		return 0, false
+		return 0, costMissUnpriced, false
 	}
-	return rate.Cost(scan.tokens)
+	cost, priced := rate.Cost(scan.tokens)
+	if !priced {
+		return 0, costMissUnpriced, false
+	}
+	return cost, costMissNone, true
 }
 
 // codexCostScan is what pricing a rollout takes from a reverse walk: the

--- a/internal/terminal/usage_cost.go
+++ b/internal/terminal/usage_cost.go
@@ -16,6 +16,34 @@ type rateSource interface {
 	Rate(model string) (pricing.Rate, bool)
 }
 
+// costMiss names why a session has no cost figure. "" is the ordinary absence:
+// a total that is complete, or a miss the next turn heals on its own. The two
+// named ones are what the footer says out loud, because nothing the user waits
+// for brings the number back — and a money readout that simply disappears is
+// read as zero spend.
+type costMiss string
+
+const (
+	costMissNone costMiss = ""
+	// A model in the conversation has no price: the baked table is Claude-only,
+	// and the LiteLLM refresh has not landed or cannot (an offline machine, a
+	// model LiteLLM never priced).
+	costMissUnpriced costMiss = "unpriced-model"
+	// A Codex conversation ran `/model`: one running token total over two
+	// models, which the rollout never splits (codexCostScan.mixed).
+	costMissMixed costMiss = "mixed-models"
+	// The scan stopped where it will not stop next time — an unreadable file, a
+	// read error mid-transcript, a ledger row that could not be stored. It
+	// withholds the number like the rest and says nothing: a reason that heals
+	// itself is noise on screen.
+	costMissUnread costMiss = "unread-transcript"
+)
+
+// spoken reports whether a miss is worth putting in front of the user, which is
+// the whole difference between "lich cannot price this" and "there is nothing
+// to show". Only the two standing ones qualify.
+func (m costMiss) spoken() bool { return m == costMissUnpriced || m == costMissMixed }
+
 // costLedger is how far one transcript has been accounted for and what that
 // stretch cost, mirroring the row the store keeps (see store.CostLedger). It
 // travels through a scan: in as where to resume, out as where to resume next
@@ -43,22 +71,23 @@ type costLine struct {
 // the last scan stopped so a turn re-reads only what was appended since. ok is
 // false when the file cannot be read at all.
 //
-// complete reports that the scan reached the end of the file. It is false when
-// a line names a model nothing can price yet: the scan stops there rather than
-// skipping the line, because a total missing one turn is a wrong number, and a
-// wrong number about money is worse than none. The lookup that missed schedules
-// the price refresh that may unblock it, so the next turn resumes from the same
-// line — this heals itself or stays absent, and never guesses.
-func scanTranscriptCost(path string, from costLedger, rates rateSource) (costLedger, bool, bool) {
+// costMissNone reports that the scan reached the end of the file. It is
+// costMissUnpriced when a line names a model nothing can price yet: the scan
+// stops there rather than skipping the line, because a total missing one turn
+// is a wrong number, and a wrong number about money is worse than none. The
+// lookup that missed schedules the price refresh that may unblock it, so the
+// next turn resumes from the same line — this heals itself or stays absent, and
+// never guesses.
+func scanTranscriptCost(path string, from costLedger, rates rateSource) (costLedger, costMiss, bool) {
 	f, err := os.Open(path)
 	if err != nil {
-		return from, false, false
+		return from, costMissUnread, false
 	}
 	defer func() { _ = f.Close() }()
 
 	info, err := f.Stat()
 	if err != nil {
-		return from, false, false
+		return from, costMissUnread, false
 	}
 	// A transcript shorter than what was already counted is not the file that
 	// was counted: it was replaced or truncated, so the row it backs is rebuilt
@@ -67,10 +96,10 @@ func scanTranscriptCost(path string, from costLedger, rates rateSource) (costLed
 		from = costLedger{}
 	}
 	if _, err := f.Seek(from.offset, io.SeekStart); err != nil {
-		return from, false, false
+		return from, costMissUnread, false
 	}
-	ledger, complete := accumulate(bufio.NewReader(f), from, rates)
-	return ledger, complete, true
+	ledger, miss := accumulate(bufio.NewReader(f), from, rates)
+	return ledger, miss, true
 }
 
 // accumulate walks complete lines from r, folding each priced assistant message
@@ -81,11 +110,14 @@ func scanTranscriptCost(path string, from costLedger, rates rateSource) (costLed
 // somewhere in the middle, and a total that stops in the middle of a transcript
 // is a money number that is simply too small — the caller shows nothing and the
 // next turn resumes from the same offset.
-func accumulate(r *bufio.Reader, ledger costLedger, rates rateSource) (costLedger, bool) {
+func accumulate(r *bufio.Reader, ledger costLedger, rates rateSource) (costLedger, costMiss) {
 	for {
 		line, err := r.ReadBytes('\n')
 		if err != nil {
-			return ledger, err == io.EOF
+			if err == io.EOF {
+				return ledger, costMissNone
+			}
+			return ledger, costMissUnread
 		}
 		entry, ok := parseCostLine(line)
 		// An id is what makes a repeat recognisable; a line carrying none is
@@ -100,13 +132,13 @@ func accumulate(r *bufio.Reader, ledger costLedger, rates rateSource) (costLedge
 		}
 		rate, priced := rates.Rate(entry.model)
 		if !priced {
-			return ledger, false
+			return ledger, costMissUnpriced
 		}
 		// A rate that cannot price every counter on the line is the same miss as
 		// no rate at all — see Rate.Cost for the counter that can be missing.
 		cost, complete := rate.Cost(entry.tokens)
 		if !complete {
-			return ledger, false
+			return ledger, costMissUnpriced
 		}
 		ledger.cost += cost
 		ledger.lastMessage = entry.messageID

--- a/internal/terminal/usage_cost_error_test.go
+++ b/internal/terminal/usage_cost_error_test.go
@@ -38,10 +38,10 @@ func TestAFailedReadIsNotACompleteScan(t *testing.T) {
 	body := costLineJSON("m1", modelOpus, 100, 0, 0, 0) + "\n"
 	r := &haltingReader{body: []byte(body), err: errors.New("input/output error")}
 
-	ledger, complete := accumulate(bufio.NewReader(r), costLedger{}, testRate)
+	ledger, miss := accumulate(bufio.NewReader(r), costLedger{}, testRate)
 
-	if complete {
-		t.Error("a scan stopped by a read error reported itself complete")
+	if miss != costMissUnread {
+		t.Errorf("miss = %q, want %q: a read error is not the end of the file", miss, costMissUnread)
 	}
 	if ledger.cost == 0 {
 		t.Error("the lines that were read were dropped, want them kept for the next resume")
@@ -54,8 +54,8 @@ func TestReachingTheEndIsACompleteScan(t *testing.T) {
 	body := costLineJSON("m1", modelOpus, 100, 0, 0, 0) + "\n"
 	r := &haltingReader{body: []byte(body), err: io.EOF}
 
-	if _, complete := accumulate(bufio.NewReader(r), costLedger{}, testRate); !complete {
-		t.Error("a scan that reached the end of the file reported itself incomplete")
+	if _, miss := accumulate(bufio.NewReader(r), costLedger{}, testRate); miss != costMissNone {
+		t.Errorf("miss = %q, want none: the scan reached the end of the file", miss)
 	}
 }
 
@@ -83,8 +83,14 @@ func TestAStoreFailureShowsNoCost(t *testing.T) {
 			svc := New(store, nil, events.New())
 			svc.prices = testRate
 
-			if cost, ok := svc.sessionCost("s1", "uuid-cost"); ok {
+			cost, miss, ok := svc.sessionCost("s1", "uuid-cost")
+			if ok {
 				t.Errorf("sessionCost = %v, want a miss", cost)
+			}
+			// A store that failed is a miss that heals: nothing is said on
+			// screen, unlike a rate that is never coming.
+			if miss.spoken() {
+				t.Errorf("miss = %q, want one the footer stays quiet about", miss)
 			}
 			// The context readout beside it is unaffected: only the money is
 			// missing, and the card still reports its window.
@@ -94,6 +100,9 @@ func TestAStoreFailureShowsNoCost(t *testing.T) {
 			}
 			if got.CostUSD != nil {
 				t.Errorf("CostUSD = %v, want absent", *got.CostUSD)
+			}
+			if got.CostMiss != "" {
+				t.Errorf("CostMiss = %q, want empty", got.CostMiss)
 			}
 		})
 	}

--- a/internal/terminal/usage_cost_test.go
+++ b/internal/terminal/usage_cost_test.go
@@ -82,10 +82,10 @@ func TestCostSumsEveryAssistantLine(t *testing.T) {
 			`{"type":"user","message":{"content":"hi"}}`+"\n"+
 			costLineJSON("m2", modelOpus, 200, 20, 0, 0)+"\n")
 
-	ledger, complete, ok := scanTranscriptCost(path, costLedger{}, testRate)
+	ledger, miss, ok := scanTranscriptCost(path, costLedger{}, testRate)
 
-	if !ok || !complete {
-		t.Fatalf("scan: ok=%v complete=%v, want both true", ok, complete)
+	if !ok || miss != costMissNone {
+		t.Fatalf("scan: ok=%v miss=%q, want ok and no miss", ok, miss)
 	}
 	want := 300*0.001 + 30*0.01
 	if !nearly(ledger.cost, want) {
@@ -124,10 +124,10 @@ func TestAPartialLineIsLeftForTheNextScan(t *testing.T) {
 	whole := costLineJSON("m1", modelOpus, 100, 0, 0, 0) + "\n"
 	path := writeFile(t, whole+`{"type":"assistant","message":{"id":"m2"`)
 
-	ledger, complete, ok := scanTranscriptCost(path, costLedger{}, testRate)
+	ledger, miss, ok := scanTranscriptCost(path, costLedger{}, testRate)
 
-	if !ok || !complete {
-		t.Fatalf("scan: ok=%v complete=%v, want both true", ok, complete)
+	if !ok || miss != costMissNone {
+		t.Fatalf("scan: ok=%v miss=%q, want ok and no miss", ok, miss)
 	}
 	if ledger.offset != int64(len(whole)) {
 		t.Errorf("offset = %d, want %d — the partial line must stay unread", ledger.offset, len(whole))
@@ -179,13 +179,14 @@ func TestAnUnpricedModelStopsTheCount(t *testing.T) {
 			costLineJSON("m2", "model-from-the-future", 900, 0, 0, 0)+"\n"+
 			costLineJSON("m3", modelOpus, 100, 0, 0, 0)+"\n")
 
-	ledger, complete, ok := scanTranscriptCost(path, costLedger{}, testRate)
+	ledger, miss, ok := scanTranscriptCost(path, costLedger{}, testRate)
 
 	if !ok {
 		t.Fatal("scan: want ok")
 	}
-	if complete {
-		t.Error("complete = true, want false — an unpriced line must withhold the total")
+	if miss != costMissUnpriced {
+		t.Errorf("miss = %q, want %q — an unpriced line must withhold the total and name why",
+			miss, costMissUnpriced)
 	}
 	if !nearly(ledger.cost, 0.1) {
 		t.Errorf("cost = %v, want only the priced line before the stop", ledger.cost)
@@ -194,9 +195,9 @@ func TestAnUnpricedModelStopsTheCount(t *testing.T) {
 	// The price lands (the miss scheduled the refresh) and the same line is
 	// picked up from where the scan stopped.
 	taught := fixedRates{modelOpus: testRate[modelOpus], "model-from-the-future": {Input: 0.001}}
-	next, complete, _ := scanTranscriptCost(path, ledger, taught)
-	if !complete {
-		t.Error("complete = false after the price landed, want true")
+	next, miss, _ := scanTranscriptCost(path, ledger, taught)
+	if miss != costMissNone {
+		t.Errorf("miss = %q after the price landed, want none", miss)
 	}
 	if !nearly(next.cost, 0.1+0.9+0.1) {
 		t.Errorf("cost = %v, want every line counted once the model was priced", next.cost)
@@ -211,10 +212,10 @@ func TestASyntheticLineIsNotAModelToPrice(t *testing.T) {
 		costLineJSON("m1", "<synthetic>", 0, 0, 0, 0)+"\n"+
 			costLineJSON("m2", modelOpus, 100, 0, 0, 0)+"\n")
 
-	ledger, complete, ok := scanTranscriptCost(path, costLedger{}, testRate)
+	ledger, miss, ok := scanTranscriptCost(path, costLedger{}, testRate)
 
-	if !ok || !complete {
-		t.Fatalf("scan: ok=%v complete=%v, want both true", ok, complete)
+	if !ok || miss != costMissNone {
+		t.Fatalf("scan: ok=%v miss=%q, want ok and no miss", ok, miss)
 	}
 	if !nearly(ledger.cost, 0.1) {
 		t.Errorf("cost = %v, want 0.1 — the synthetic line must be passed over", ledger.cost)
@@ -246,10 +247,10 @@ func TestACacheWriteIsPricedByHowLongItIsKept(t *testing.T) {
 			if tc.hour < 0 {
 				line = costLineJSON("m1", modelOpus, 0, 0, 0, tc.cacheCreate)
 			}
-			ledger, complete, ok := scanTranscriptCost(writeFile(t, line+"\n"), costLedger{}, testRate)
+			ledger, miss, ok := scanTranscriptCost(writeFile(t, line+"\n"), costLedger{}, testRate)
 
-			if !ok || !complete {
-				t.Fatalf("scan: ok=%v complete=%v, want both true", ok, complete)
+			if !ok || miss != costMissNone {
+				t.Fatalf("scan: ok=%v miss=%q, want ok and no miss", ok, miss)
 			}
 			if !nearly(ledger.cost, tc.want) {
 				t.Errorf("cost = %v, want %v", ledger.cost, tc.want)
@@ -266,13 +267,14 @@ func TestAnUnpricedCacheLifetimeStopsTheCount(t *testing.T) {
 	fiveMinuteOnly := fixedRates{modelOpus: {Input: 0.001, Output: 0.01, CacheRead: 0.001, CacheWrite: 0.001}}
 	path := writeFile(t, cacheLineJSON("m1", modelOpus, 1000, 1000)+"\n")
 
-	ledger, complete, ok := scanTranscriptCost(path, costLedger{}, fiveMinuteOnly)
+	ledger, miss, ok := scanTranscriptCost(path, costLedger{}, fiveMinuteOnly)
 
 	if !ok {
 		t.Fatal("scan: want ok")
 	}
-	if complete {
-		t.Error("complete = true, want false — an hour-long write with no price must withhold the total")
+	if miss != costMissUnpriced {
+		t.Errorf("miss = %q, want %q — an hour-long write with no price must withhold the total",
+			miss, costMissUnpriced)
 	}
 	if ledger.cost != 0 {
 		t.Errorf("cost = %v, want nothing counted past the line it cannot price", ledger.cost)
@@ -492,7 +494,7 @@ func TestCodexTranscriptCostPricesTheRunningTotal(t *testing.T) {
 	path := writeFile(t,
 		codexTurnContextJSON("gpt-5.1-codex")+"\n"+codexTokenLineJSON(1000, 400, 25, 10)+"\n")
 
-	cost, ok := codexTranscriptCost(path, codexTestRate)
+	cost, _, ok := codexTranscriptCost(path, codexTestRate)
 
 	if !ok {
 		t.Fatal("codexTranscriptCost: want ok")
@@ -514,7 +516,7 @@ func TestCodexTranscriptCostIsCumulativeNotSummed(t *testing.T) {
 			codexTurnContextJSON("gpt-5.1-codex")+"\n"+
 			codexTokenLineJSON(1000, 400, 0, 10)+"\n")
 
-	cost, ok := codexTranscriptCost(path, codexTestRate)
+	cost, _, ok := codexTranscriptCost(path, codexTestRate)
 
 	if !ok {
 		t.Fatal("codexTranscriptCost: want ok")
@@ -532,8 +534,12 @@ func TestCodexTranscriptCostWithholdsForAnUnpricedModel(t *testing.T) {
 	path := writeFile(t,
 		codexTurnContextJSON("model-from-the-future")+"\n"+codexTokenLineJSON(1000, 0, 0, 10)+"\n")
 
-	if _, ok := codexTranscriptCost(path, codexTestRate); ok {
+	_, miss, ok := codexTranscriptCost(path, codexTestRate)
+	if ok {
 		t.Error("codexTranscriptCost: want a miss for an unpriced model")
+	}
+	if miss != costMissUnpriced {
+		t.Errorf("miss = %q, want %q", miss, costMissUnpriced)
 	}
 }
 
@@ -553,8 +559,12 @@ func TestCodexTranscriptCostWithholdsAcrossAModelSwitch(t *testing.T) {
 			codexTurnContextJSON("gpt-5.1-codex")+"\n"+
 			codexTokenLineJSON(1000, 400, 0, 10)+"\n")
 
-	if cost, ok := codexTranscriptCost(path, rates); ok {
+	cost, miss, ok := codexTranscriptCost(path, rates)
+	if ok {
 		t.Errorf("codexTranscriptCost = %v, want a miss: the total spans two models", cost)
+	}
+	if miss != costMissMixed {
+		t.Errorf("miss = %q, want %q — the footer has to say the switch happened", miss, costMissMixed)
 	}
 }
 
@@ -571,7 +581,7 @@ func TestCodexTranscriptCostPricesTheWholeTotalForOneModel(t *testing.T) {
 			// total was priced at, so it must not read as a switch.
 			codexTurnContextJSON("gpt-5.1-codex-mini")+"\n")
 
-	cost, ok := codexTranscriptCost(path, codexTestRate)
+	cost, _, ok := codexTranscriptCost(path, codexTestRate)
 
 	if !ok {
 		t.Fatal("codexTranscriptCost: want ok")
@@ -585,8 +595,14 @@ func TestCodexTranscriptCostPricesTheWholeTotalForOneModel(t *testing.T) {
 func TestCodexTranscriptCostMissesWithoutATokenLine(t *testing.T) {
 	path := writeFile(t, codexTurnContextJSON("gpt-5.1-codex")+"\n")
 
-	if _, ok := codexTranscriptCost(path, codexTestRate); ok {
+	_, miss, ok := codexTranscriptCost(path, codexTestRate)
+	if ok {
 		t.Error("codexTranscriptCost: want a miss with no token_count line")
+	}
+	// A rollout that has billed nothing yet is not one lich cannot price:
+	// nothing is said, and the next turn brings the number.
+	if miss.spoken() {
+		t.Errorf("miss = %q, want one the footer stays quiet about", miss)
 	}
 }
 
@@ -640,5 +656,119 @@ func TestCodexCostAccumulatesAcrossConversations(t *testing.T) {
 	want := 100*0.001 + 300*0.001
 	if got.CostUSD == nil || !nearly(*got.CostUSD, want) {
 		t.Errorf("CostUSD = %v, want %v — the first rollout's cost still counts", got.CostUSD, want)
+	}
+}
+
+// The usage event's CostMiss is the whole point of the reason travelling up:
+// a footer that just loses the number reads as zero spend. It carries only the
+// standing reasons, which is what separates "lich cannot price this" from
+// "there is nothing to show".
+func TestTheUsageEventNamesWhyACostIsMissing(t *testing.T) {
+	tests := []struct {
+		name       string
+		transcript func(t *testing.T)
+		rates      rateSource
+		want       string
+	}{
+		{
+			// #427: the conversation ran `/model`, so one running total spans
+			// two models and no rate can attribute it.
+			name: "a Codex conversation that switched models",
+			transcript: func(t *testing.T) {
+				writeCodexTranscript(t, "uuid-cost",
+					codexTurnContextJSON("gpt-5.1-codex-mini")+"\n"+
+						codexTokenLineJSON(500, 0, 0, 5)+"\n"+
+						codexTurnContextJSON("gpt-5.1-codex")+"\n"+
+						codexTokenLineJSON(1000, 400, 0, 10)+"\n")
+			},
+			rates: fixedRates{
+				"gpt-5.1-codex":      {Input: 0.001, Output: 0.01},
+				"gpt-5.1-codex-mini": {Input: 0.0001, Output: 0.001},
+			},
+			want: string(costMissMixed),
+		},
+		{
+			// #428: an offline machine, or a model LiteLLM never priced. Same
+			// silence before, and the same sentence needed.
+			name: "a model no price table knows",
+			transcript: func(t *testing.T) {
+				writeCodexTranscript(t, "uuid-cost",
+					codexTurnContextJSON("model-from-the-future")+"\n"+
+						codexTokenLineJSON(1000, 0, 0, 10)+"\n")
+			},
+			rates: codexTestRate,
+			want:  string(costMissUnpriced),
+		},
+		{
+			name: "a Claude transcript stopped at an unpriced line",
+			transcript: func(t *testing.T) {
+				writeTranscript(t, "uuid-cost",
+					costLineJSON("m1", modelOpus, 100, 0, 0, 0)+"\n"+
+						costLineJSON("m2", "model-from-the-future", 900, 0, 0, 0)+"\n")
+			},
+			rates: testRate,
+			want:  string(costMissUnpriced),
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.transcript(t)
+			svc := New(newCostStore("uuid-cost"), nil, events.New())
+			svc.prices = tc.rates
+
+			got, ok := svc.sessionUsage("s1")
+
+			if !ok {
+				t.Fatal("sessionUsage: want ok — only the money is missing")
+			}
+			if got.CostUSD != nil {
+				t.Errorf("CostUSD = %v, want absent", *got.CostUSD)
+			}
+			if got.CostMiss != tc.want {
+				t.Errorf("CostMiss = %q, want %q", got.CostMiss, tc.want)
+			}
+		})
+	}
+}
+
+// The readout being off is not a failure to price, and a subscription is the
+// case it exists for: the field never appears, so the footer says nothing at
+// all rather than inventing a reason for the design.
+func TestACostReadoutTurnedOffNamesNoReason(t *testing.T) {
+	writeCodexTranscript(t, "uuid-cost",
+		codexTurnContextJSON("model-from-the-future")+"\n"+codexTokenLineJSON(1000, 0, 0, 10)+"\n")
+	store := newCostStore("uuid-cost")
+	store.costOn = false
+	svc := New(store, nil, events.New())
+	svc.prices = codexTestRate
+
+	got, ok := svc.sessionUsage("s1")
+
+	if !ok {
+		t.Fatal("sessionUsage: want ok")
+	}
+	if got.CostUSD != nil || got.CostMiss != "" {
+		t.Errorf("CostUSD = %v, CostMiss = %q, want both absent", got.CostUSD, got.CostMiss)
+	}
+}
+
+// A conversation lich can price says nothing beside the number: the marker is
+// for an absence, and one riding along with a total would be noise.
+func TestAPricedSessionCarriesNoMissReason(t *testing.T) {
+	writeCodexTranscript(t, "uuid-cost",
+		codexTurnContextJSON("gpt-5.1-codex")+"\n"+codexTokenLineJSON(1000, 400, 0, 10)+"\n")
+	svc := New(newCostStore("uuid-cost"), nil, events.New())
+	svc.prices = codexTestRate
+
+	got, ok := svc.sessionUsage("s1")
+
+	if !ok {
+		t.Fatal("sessionUsage: want ok")
+	}
+	if got.CostUSD == nil {
+		t.Fatal("CostUSD is absent, want the session's cost")
+	}
+	if got.CostMiss != "" {
+		t.Errorf("CostMiss = %q, want empty beside a number", got.CostMiss)
 	}
 }


### PR DESCRIPTION
Closes #427, closes #428 — the one piece both asked for, landing once.

## The problem

`Service.sessionCost` answered `(float64, bool)`, and that `bool` flattened
every reason into the same silence. `usageEvent.CostUSD` was omitted and the
footer went blank, so three different situations looked identical:

- a Codex conversation that ran `/model` (`codexCostScan.mixed`) — one running
  total over two models, which the rollout never splits;
- a model with no rate in the table — the baked slice is Claude-only, so an
  offline machine, or a model LiteLLM never priced, never gets one;
- the readout being off, which is the design on a subscription.

The money readout exists for API billing. A blank where a figure used to be
reads as zero spend.

## What changed

`costMiss` (`internal/terminal/usage_cost.go`) travels from the scan up to the
usage event, and only the two *standing* reasons are spoken —
`costMiss.spoken()`. The event gains `costMiss` beside `costUsd`, mirrored in
`frontend/src/lib/session/session-events.ts` (the events contract; nothing in
`api-types.ts` moves — the usage payload does not live there).

The footer draws `$—` in the cost slot with a tooltip naming the reason
(`COST_MISS_REASON`, `frontend/src/lib/session/session-cost.ts`).

Deliberately left silent:

- **The readout being off.** No reason is invented for it — on a subscription
  the number is noise by design, and saying anything would be a lie about a
  choice the user made.
- **A miss that heals.** An unreadable transcript, a half-written line, a store
  error: the next turn brings the number, and a marker for it would be noise.
- **A number.** Nothing is guessed. Pricing a mixed total at whichever model
  went last is still refused (#427 rules it out explicitly), and a missing rate
  is still the background refresh's to land (#428, directions 1–2, untouched
  here — `internal/pricing/*` is someone else's change).

`docs/ceilings.md` moves in the same commit: both entries now name what is said
on screen, and the trap that remains — the marker names the reason, never the
model or the turn, so a session whose sub-agent alone is unpriced looks like
one whose every turn is.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` (2072 pass)
- [x] Cross-compile loop (`_test.go` touched): linux / darwin / windows build + vet
- [x] `pnpm check`, `vitest run` (1342 pass), `pnpm build`
- [x] `internal/terminal` coverage 94.1%; new logic covered end to end —
      `TestTheUsageEventNamesWhyACostIsMissing` (three shapes),
      `TestACostReadoutTurnedOffNamesNoReason`,
      `TestAPricedSessionCarriesNoMissReason`, and the store/copy tests on the
      frontend side.