### PR TITLE
fix: one order for the sidebar's blocks, pinned first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A pinned session is at the top of the sidebar again.** Split groups were
+  drawn above the pinned block, so a project with a split pushed the pinned
+  card below every wall — the one thing a pin promises. Pinned is now the first
+  block, whatever else the project holds.
+
+- **A split with one session left ends instead of lingering.** Closing or
+  removing panes until a single session remained left it under a split header,
+  alone, with no way back to its checkout. A group now ends when fewer than two
+  sessions are left in it and the survivor drops back among its worktree's
+  cards; nothing is closed by it.
+
+- **Sidebar blocks reorder in one list.** Splits could only be dragged among
+  splits and checkouts among checkouts, so neither could ever pass the other.
+  Every block but the pinned one — which stays first — now drags freely among
+  the rest, and dragging cards inside a checkout works again when one of its
+  sessions is showing on a split.
+
 - **A Crush card's hands-on time now counts the work, not the typing.** The
   clock beat on the session-state report, and Crush reports no state — so an
   hour a Crush session worked while you watched read as the few seconds you

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -9,7 +9,6 @@ import { ProjectService } from "@/lib/rpc"
 import { closeSettings, isSettingsOpen, subscribeSettingsCard } from "@/lib/settings-card-store"
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
 import { delegateTargets } from "@/lib/session/delegate-targets"
-import { reorderGroups } from "@/lib/session/panes"
 import { ConfirmDialog } from "@/components/ConfirmDialog"
 import { usePanes } from "@/lib/session/use-panes"
 import { useStageToggle } from "@/lib/session/use-stage-toggle"
@@ -36,11 +35,10 @@ import { filterSessions } from "@/lib/session/session-filter"
 import { requestTerminalFocus } from "@/lib/terminal/focus-request"
 import {
   activeSessionId,
-  orderGroups,
+  dragOrder,
   reorderSubset,
   sessionsOf,
   sidebarGroups,
-  type Session,
   type SidebarGroup,
 } from "@/lib/session/sessions"
 import { useSortableList, verticalAxis, withinList } from "@/lib/use-sortable-list"
@@ -163,25 +161,20 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   // The split's own block is built from the members, not from what is on screen:
   // a parked wall is exactly the case the user could not see before.
   const groups = sidebarGroups(visible, panes.groups)
-  // The pinned block is out of the drag list entirely: it is always first, and
-  // the worktree blocks reorder among themselves. Dragging one moves its whole
-  // block of ids inside the flat list the groups are read back from — there is
-  // no separate group order to store — leaving the pinned sessions where they
-  // sit in it, so unpinning still drops a card among its old neighbours.
-  const dragKeys = groups.filter((group) => !group.pinned && !group.stage).map((group) => group.key)
+  // One drag list for every block that moves — walls and checkouts together, so
+  // a wall can be dragged below a worktree instead of being penned in a list of
+  // its own. Both kinds sit where their first card sits in the stored flat list,
+  // so a drop is one write: move that block's ids inside the list the groups are
+  // read back from.
+  //
+  // The pinned block is the only one out of it: it is always first. Its cards
+  // keep their slots in the flat list, so unpinning still drops a card among its
+  // old neighbours — which is why the drag only claims the ids its own blocks
+  // drew, and not simply every unpinned session (a pinned card on a wall is
+  // drawn in the wall, and its slot moves with it).
+  const dragKeys = groups.filter((group) => !group.pinned).map((group) => group.key)
   const { sensors, onDragEnd } = useSortableList(dragKeys, (keys) =>
-    reorderSessions(
-      projectId ?? "",
-      reorderSubset(list, orderGroups(groups, keys), (session) => !session.pinned),
-    ),
-  )
-  // The walls reorder in a list of their own. They have to: a worktree block's
-  // place is derived from where its sessions sit in the stored flat list, and a
-  // wall's is the order of the groups themselves — one drag list holding both
-  // would have to write two unrelated things depending on what was picked up.
-  const stageKeys = panes.groups.map((group) => group.id)
-  const { sensors: stageSensors, onDragEnd: onStageDragEnd } = useSortableList(stageKeys, (keys) =>
-    panes.reorder(reorderGroups(panes.groups, keys)),
+    reorderSessions(projectId ?? "", dragOrder(list, groups, keys)),
   )
   // Resolved once here, not per group: the list spans every open project, so
   // it is the same for every card in the sidebar. Memoised because the picker
@@ -240,9 +233,16 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
       panes.reorderCells(group.stage.id, ids)
       return
     }
-    const member = (session: Session) =>
-      group.pinned ? !!session.pinned : !session.pinned && (session.path ?? "") === group.path
-    reorderSessions(projectId, reorderSubset(list, ids, member))
+    // The slots the drag may fill are the cards this block drew, asked of the
+    // block itself rather than restated as a rule about pins and paths: a
+    // checkout whose sibling sits on a wall has that card in neither, and a
+    // predicate that claimed it anyway would hand reorderSubset one id too many
+    // — an id-set mismatch, which reorderSessions drops whole.
+    const drawn = new Set(group.sessions.map((session) => session.id))
+    reorderSessions(
+      projectId,
+      reorderSubset(list, ids, (session) => drawn.has(session.id)),
+    )
   }
 
   const createWorktree = async (
@@ -439,20 +439,9 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
             No sessions match “{query.trim()}”. The active session stays.
           </Notice>
         )}
-        {/* The walls first, in their own drag list, then everything else in
-            the one whose order lives in the stored session list. */}
-        {stageKeys.length > 0 && (
-          <DndContext
-            sensors={stageSensors}
-            collisionDetection={closestCenter}
-            modifiers={[verticalAxis, withinList]}
-            onDragEnd={onStageDragEnd}
-          >
-            <SortableContext items={stageKeys} strategy={verticalListSortingStrategy}>
-              {groups.filter((group) => group.stage).map(renderGroup)}
-            </SortableContext>
-          </DndContext>
-        )}
+        {/* Every block in one list, in the order sidebarGroups drew them: the
+            pinned one first and fixed, the rest — walls and checkouts alike —
+            sortable among each other. */}
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
@@ -460,7 +449,7 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
           onDragEnd={onDragEnd}
         >
           <SortableContext items={dragKeys} strategy={verticalListSortingStrategy}>
-            {groups.filter((group) => !group.stage).map(renderGroup)}
+            {groups.map(renderGroup)}
           </SortableContext>
         </DndContext>
       </div>
@@ -488,10 +477,10 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
             : `Show ${moving?.session.label ?? ""} beside this session?`
         }
         description={
-          moving?.from.cells.length === 1 ? (
+          moving?.from.cells.length === 2 ? (
             <>
-              It is the only session in <strong>{moving.from.name}</strong>, so that group ends when
-              it leaves. No session is closed either way.
+              It is one of only two sessions in <strong>{moving.from.name}</strong>, so that group
+              ends when it leaves. No session is closed either way.
             </>
           ) : (
             <>

--- a/frontend/src/components/sidebar/SidebarRail.tsx
+++ b/frontend/src/components/sidebar/SidebarRail.tsx
@@ -3,6 +3,7 @@ import { PanelLeft, Plus } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useProjects } from "@/providers/projects"
 import { activeSessionId, sessionsOf, sidebarGroups, type Session } from "@/lib/session/sessions"
+import { resolveGroups } from "@/lib/session/panes"
 import { useStoredGroups } from "@/lib/session/panes-store"
 import { useSessionAgent } from "@/lib/session/use-session-agent"
 import { useSessionStatus, useSessionUnread } from "@/lib/session/use-session-status"
@@ -81,8 +82,11 @@ export function SidebarRail({ onExpand }: SidebarRailProps) {
 
   const path = projects.find((p) => p.id === projectId)?.path ?? ""
   // Same order as the expanded sidebar, split's block and all: the rail is
-  // that list with the words taken out.
-  const groups = sidebarGroups(sessionsOf(sessions, projectId), stored)
+  // that list with the words taken out. Reconciled the same way too — the
+  // stored value is not the truth on its own, and a rail drawing a wall the
+  // open sidebar has already dropped is the same list disagreeing with itself.
+  const list = sessionsOf(sessions, projectId)
+  const groups = sidebarGroups(list, resolveGroups(stored, list))
   // Unlike the open sidebar, a full-screen route (Settings, Pulls) does not put
   // the highlight out: those screens have no card of their own here to carry
   // it, so dropping it would leave the rail with nothing lit at all.

--- a/frontend/src/lib/session/panes.test.ts
+++ b/frontend/src/lib/session/panes.test.ts
@@ -13,7 +13,6 @@ import {
   planAdd,
   removeFromGroups,
   reorderCells,
-  reorderGroups,
   resolveGroups,
   stageAction,
   swapCells,
@@ -59,18 +58,24 @@ describe("resolveGroups", () => {
     expect(resolveGroups([group("g1", ["a", "gone", "b"])], sessions)[0].cells).toEqual(["a", "b"])
   })
 
-  // A group of one is still something the user named and can add to; a group of
-  // none has nothing left for the name to be about.
-  it("keeps a group of one and drops a group of none", () => {
-    const groups = resolveGroups([group("g1", ["a"]), group("g2", ["gone"])], sessions)
+  // A wall of one draws nothing a solo session does not, so it stops being a
+  // group and its survivor goes back among its checkout's cards.
+  it("drops a group left with fewer than two live sessions", () => {
+    const groups = resolveGroups(
+      [group("g1", ["a", "b"]), group("g2", ["c", "gone"]), group("g3", ["gone"])],
+      sessions,
+    )
     expect(groups.map((g) => g.id)).toEqual(["g1"])
   })
 
   // The one-group rule is enforced on read too, so a stored value that somehow
   // holds a session twice cannot put it on two walls.
   it("gives a session to the first group that claims it", () => {
-    const groups = resolveGroups([group("g1", ["a", "b"]), group("g2", ["b", "c"])], sessions)
-    expect(groups.map((g) => g.cells)).toEqual([["a", "b"], ["c"]])
+    const groups = resolveGroups([group("g1", ["a", "b"]), group("g2", ["b", "c", "d"])], sessions)
+    expect(groups.map((g) => g.cells)).toEqual([
+      ["a", "b"],
+      ["c", "d"],
+    ])
   })
 })
 
@@ -105,28 +110,33 @@ describe("movingFrom", () => {
 
 describe("addToGroup", () => {
   it("appends to the named group", () => {
-    expect(addToGroup([group("g1", ["a"])], "g1", "b")[0].cells).toEqual(["a", "b"])
+    expect(addToGroup([group("g1", ["a", "b"])], "g1", "c")[0].cells).toEqual(["a", "b", "c"])
   })
 
   // At most one group per session, so adding is also a move.
   it("takes the session off whatever wall had it", () => {
-    const groups = addToGroup([group("g1", ["a", "b"]), group("g2", ["c"])], "g2", "b")
-    expect(groups.map((g) => g.cells)).toEqual([["a"], ["c", "b"]])
+    const groups = addToGroup([group("g1", ["a", "b", "d"]), group("g2", ["c"])], "g2", "b")
+    expect(groups.map((g) => g.cells)).toEqual([
+      ["a", "d"],
+      ["c", "b"],
+    ])
   })
 
-  it("drops a group the move emptied", () => {
-    const groups = addToGroup([group("g1", ["b"]), group("g2", ["c"])], "g2", "b")
+  it("ends a group the move left below two", () => {
+    const groups = addToGroup([group("g1", ["a", "b"]), group("g2", ["c", "d"])], "g2", "b")
     expect(groups.map((g) => g.id)).toEqual(["g2"])
   })
 })
 
 describe("removeFromGroups", () => {
-  it("keeps the group at one member", () => {
-    expect(removeFromGroups([group("g1", ["a", "b"])], "b")[0].cells).toEqual(["a"])
+  it("keeps a group that still has two members", () => {
+    expect(removeFromGroups([group("g1", ["a", "b", "c"])], "b")[0].cells).toEqual(["a", "c"])
   })
 
-  it("ends the group when its last member leaves", () => {
-    expect(removeFromGroups([group("g1", ["a"])], "a")).toEqual([])
+  // The pane that leaves takes the group with it: one session is not a split,
+  // and the survivor belongs back among its own checkout's cards.
+  it("ends the group when only one member would be left", () => {
+    expect(removeFromGroups([group("g1", ["a", "b"])], "a")).toEqual([])
   })
 })
 
@@ -158,19 +168,6 @@ describe("updateGroup / dissolveGroup", () => {
     expect(dissolveGroup([group("g1", ["a"]), group("g2", ["b"])], "g1").map((g) => g.id)).toEqual([
       "g2",
     ])
-  })
-})
-
-describe("reorderGroups", () => {
-  it("puts the walls in the order the drag named", () => {
-    const groups = [group("g1", ["a"]), group("g2", ["b"]), group("g3", ["c"])]
-    expect(reorderGroups(groups, ["g3", "g1", "g2"]).map((g) => g.id)).toEqual(["g3", "g1", "g2"])
-  })
-
-  // An id set that raced a dissolve must not cost the user a group.
-  it("keeps a wall the drag did not name", () => {
-    const groups = [group("g1", ["a"]), group("g2", ["b"])]
-    expect(reorderGroups(groups, ["g2"]).map((g) => g.id)).toEqual(["g2", "g1"])
   })
 })
 

--- a/frontend/src/lib/session/panes.ts
+++ b/frontend/src/lib/session/panes.ts
@@ -8,8 +8,9 @@
 // A pane's × stops showing a session and closes nothing.
 //
 // A group is a thing the user made, not the current arrangement of the window.
-// It has a name, it survives its members being closed down to the last one, and
-// it ends only when they dissolve it or when nothing is left in it. Which is why
+// It has a name, it survives any one member leaving, and it ends when they
+// dissolve it or when fewer than two members are left — a wall of one is a
+// session on its own, and the survivor goes back to its checkout. Which is why
 // a project holds a list of them: an orchestrator and the three worktrees it
 // spawned are one group, the next investigation and its two are another, and
 // neither is "the" split.
@@ -97,9 +98,11 @@ export function formatGroups(groups: readonly PaneGroup[]): string {
 // after this. The same pass enforces the one-group rule, so a stored value that
 // somehow holds a session twice cannot put it on two walls.
 //
-// A group of one survives: it is still something the user named and can add to.
-// A group of none does not — its last member is gone, so there is nothing left
-// for the name to be about.
+// A group needs two live members to still be a group. A wall of one draws
+// nothing a solo session does not, so its survivor is better off back among its
+// own checkout's cards than alone under a header it cannot fill — and the group
+// the pane left is gone whichever way it emptied: a close, a park, a worktree
+// removal, a move onto another wall.
 export function resolveGroups(
   stored: readonly PaneGroup[],
   sessions: readonly Session[],
@@ -115,7 +118,7 @@ export function resolveGroups(
         cells.push(id)
       }
     }
-    if (cells.length > 0) {
+    if (cells.length > 1) {
       groups.push({ ...group, cells })
     }
   }
@@ -158,7 +161,8 @@ export function defaultName(sessions: readonly Session[], sessionId: string): st
   return sessions.find((session) => session.id === sessionId)?.label || "Split"
 }
 
-/** Put a session on a wall, taking it off whatever wall had it. */
+/** Put a session on a wall, taking it off whatever wall had it — and ending
+ * that one if this leaves it below two. */
 export function addToGroup(
   groups: readonly PaneGroup[],
   groupId: string,
@@ -170,15 +174,15 @@ export function addToGroup(
         ? { ...group, cells: [...group.cells.filter((id) => id !== sessionId), sessionId] }
         : { ...group, cells: group.cells.filter((id) => id !== sessionId) },
     )
-    .filter((group) => group.cells.length > 0)
+    .filter((group) => group.cells.length > 1)
 }
 
-/** Take a session off whatever wall it is on. The group stays, even at one
- * member; only its last member leaving ends it. */
+/** Take a session off whatever wall it is on. A wall left with one member ends
+ * with it: there is no split left to be a group about. */
 export function removeFromGroups(groups: readonly PaneGroup[], sessionId: string): PaneGroup[] {
   return groups
     .map((group) => ({ ...group, cells: group.cells.filter((id) => id !== sessionId) }))
-    .filter((group) => group.cells.length > 0)
+    .filter((group) => group.cells.length > 1)
 }
 
 export function updateGroup(
@@ -191,16 +195,6 @@ export function updateGroup(
 
 export function dissolveGroup(groups: readonly PaneGroup[], groupId: string): PaneGroup[] {
   return groups.filter((group) => group.id !== groupId)
-}
-
-/** Reorder the groups themselves, which is what dragging their blocks does. */
-export function reorderGroups(groups: readonly PaneGroup[], ids: readonly string[]): PaneGroup[] {
-  const byId = new Map(groups.map((group) => [group.id, group]))
-  const moved = ids.flatMap((id) => byId.get(id) ?? [])
-  // Anything the drag did not name keeps its place, at the end rather than being
-  // dropped: an id set that raced a dissolve must not cost the user a group.
-  const named = new Set(ids)
-  return [...moved, ...groups.filter((group) => !named.has(group.id))]
 }
 
 /** Swap two cells — what a pane dropped on another one does. */

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   activeSessionId,
+  dragOrder,
   activeTarget,
   addSession,
   adoptSession,
@@ -398,7 +399,7 @@ describe("sidebarGroups", () => {
   // The blocks answer the question a wall could not: which sessions are in it.
   // They are built from the groups, not from what is on screen, so they stand
   // whether or not any of those walls is the thing being drawn.
-  it("lifts each wall into a block above everything, in the order it was arranged", () => {
+  it("lifts a wall into a block of its own, in the order its panes are laid out", () => {
     let state = addSession({}, P, "s1")
     state = addSession(state, P, "a1", "claude", "/wt/a")
     state = addSession(state, P, "b1", "claude", "/wt/b")
@@ -413,20 +414,35 @@ describe("sidebarGroups", () => {
   it("draws every wall, each as its own block", () => {
     const state = buildState(4)
     expect(
-      ids(sidebarGroups(sessionsOf(state, P), [wall("g1", ["s1", "s2"]), wall("g2", ["s3"])])),
+      ids(
+        sidebarGroups(sessionsOf(state, P), [wall("g1", ["s1", "s3"]), wall("g2", ["s2", "s4"])]),
+      ),
     ).toEqual([
-      ["g1", ["s1", "s2"]],
-      ["g2", ["s3"]],
-      [ROOT_GROUP_KEY, ["s4"]],
+      ["g1", ["s1", "s3"]],
+      ["g2", ["s2", "s4"]],
     ])
   })
 
-  it("draws the walls above the pinned block and takes their cards out of it", () => {
+  // A wall is not pinned to the top: it sits where its first card sits in the
+  // stored list, which is what lets a drag move it past a checkout's block.
+  it("puts a wall where its first card sits among the other blocks", () => {
+    let state = addSession({}, P, "a1", "claude", "/wt/a")
+    state = addSession(state, P, "s1")
+    state = addSession(state, P, "s2")
+    expect(ids(sidebarGroups(sessionsOf(state, P), [wall("g1", ["s1", "s2"])]))).toEqual([
+      ["/wt/a", ["a1"]],
+      ["g1", ["s1", "s2"]],
+    ])
+  })
+
+  // A pin promises the top of the list, so nothing is drawn above it — a wall
+  // included. Its own cards still come out of it: they are drawn in the wall.
+  it("draws the pinned block above the walls and takes their cards out of it", () => {
     let state = setSessionPinned(buildState(3), P, "s1", true)
     state = setSessionPinned(state, P, "s2", true)
     expect(ids(sidebarGroups(sessionsOf(state, P), [wall("g1", ["s2", "s3"])]))).toEqual([
-      ["g1", ["s2", "s3"]],
       [PINNED_GROUP_KEY, ["s1"]],
+      ["g1", ["s2", "s3"]],
     ])
   })
 
@@ -857,6 +873,47 @@ describe("orderGroups", () => {
   // drops the whole stale order instead of taking its sessions with it.
   it("contributes nothing for a key naming no group", () => {
     expect(orderGroups(groups, ["/wt/gone"])).toEqual([])
+  })
+})
+
+describe("dragOrder", () => {
+  const s = (id: string, extra: Partial<Session> = {}): Session => ({
+    id,
+    label: id,
+    kind: "shell",
+    ...extra,
+  })
+  const wall = (id: string, cells: string[]) => ({ id, name: id, cells, cols: [], rows: [] })
+
+  it("moves a wall past a checkout's block, carrying its cards", () => {
+    const stored = [s("a1", { path: "/wt/a" }), s("r1"), s("r2")]
+    const groups = sidebarGroups(stored, [wall("g1", ["r1", "r2"])])
+    expect(groups.map((g) => g.key)).toEqual(["/wt/a", "g1"])
+    expect(dragOrder(stored, groups, ["g1", "/wt/a"])).toEqual(["r1", "r2", "a1"])
+  })
+
+  // The pinned block never moves, so its cards keep their slots and an unpinned
+  // card still lands back among the neighbours it was lifted over.
+  it("leaves the pinned block's cards where the stored order has them", () => {
+    const stored = [s("p1", { pinned: true }), s("r1"), s("a1", { path: "/wt/a" })]
+    const groups = sidebarGroups(stored)
+    expect(dragOrder(stored, groups, ["/wt/a", ROOT_GROUP_KEY])).toEqual(["p1", "a1", "r1"])
+  })
+
+  // A pinned card on a wall is drawn in the wall, so its slot travels with the
+  // wall. Claiming only unpinned sessions would leave it out of the order and
+  // reorderSessions would drop the whole drop as an id-set mismatch.
+  it("carries a pinned card that is drawn on a wall", () => {
+    const stored = [s("p1", { pinned: true }), s("r1"), s("a1", { path: "/wt/a" })]
+    const groups = sidebarGroups(stored, [wall("g1", ["p1", "r1"])])
+    expect(groups.map((g) => g.key)).toEqual(["g1", "/wt/a"])
+    const ids = dragOrder(stored, groups, ["/wt/a", "g1"])
+    expect(ids).toEqual(["a1", "p1", "r1"])
+    expect(
+      reorderSessions({ [P]: { sessions: stored, activeId: "r1", nextSeq: 4 } }, P, ids)[
+        P
+      ].sessions.map((x) => x.id),
+    ).toEqual(["a1", "p1", "r1"])
   })
 })
 

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -348,51 +348,69 @@ export interface SidebarGroup {
 }
 
 // sidebarGroups splits a project's sessions into the blocks the sidebar draws:
-// the split groups first in the order the user arranged them, then the pinned
-// ones, then one block per worktree in first-appearance order. Each block keeps
-// the stored (drag) order inside — except a split's, which keeps the order of
-// the panes it draws.
+// the pinned ones first — that is what a pin promises — then the walls and the
+// worktrees interleaved, each block landing where its first card sits in the
+// stored list. Each block keeps that stored (drag) order inside, except a
+// wall's, which keeps the order of the panes it draws.
 //
-// Neither a split nor a pin rewrites the stored session list; both only lift a
-// card into a block above, which is what lets a session dropped from either land
-// back among its old neighbours instead of being stranded. The store hands that
-// same order back, so a reload draws what the live change did.
+// One order for both kinds of block, read off the one list, is what lets a drag
+// move a wall past a worktree: block order is nowhere else, so moving a block is
+// moving its cards inside the flat list and nothing has a second opinion.
+//
+// Neither a split nor a pin rewrites that list; both only lift a card into a
+// block, which is what lets a session dropped from either land back among its
+// old neighbours instead of being stranded. The store hands the same order back,
+// so a reload draws what the live change did.
 //
 // A session both pinned and on a wall is drawn in the wall's block: the pin
 // promises the top of the list rather than one particular header, and the card
-// keeps its own mark either way. A group whose sessions are all gone draws
+// keeps its own mark either way. A wall whose sessions are all gone draws
 // nothing — resolveGroups has already dropped it from what is stored.
 export function sidebarGroups(
   sessions: Session[],
   stage: readonly PaneGroup[] = [],
 ): SidebarGroup[] {
   const byId = new Map(sessions.map((session) => [session.id, session]))
-  const blocks: SidebarGroup[] = []
-  const claimed = new Set<string>()
+  const wallOf = new Map<string, PaneGroup>()
   for (const group of stage) {
-    const members = group.cells.flatMap((id) => byId.get(id) ?? [])
-    if (members.length === 0) {
-      continue
+    for (const id of group.cells) {
+      if (byId.has(id)) {
+        wallOf.set(id, group)
+      }
     }
-    for (const member of members) {
-      claimed.add(member.id)
-    }
-    blocks.push({ key: group.id, pinned: false, stage: group, path: "", sessions: members })
   }
-
-  const rest = sessions.filter((session) => !claimed.has(session.id))
-  const pinned = rest.filter((s) => s.pinned)
+  const blocks: SidebarGroup[] = []
+  const pinned = sessions.filter((s) => s.pinned && !wallOf.has(s.id))
   if (pinned.length > 0) {
     blocks.push({ key: PINNED_GROUP_KEY, pinned: true, stage: null, path: "", sessions: pinned })
   }
-  for (const group of groupByWorktree(rest.filter((s) => !s.pinned))) {
-    blocks.push({
-      key: groupKey(group.path),
-      pinned: false,
-      stage: null,
-      path: group.path,
-      sessions: group.sessions,
-    })
+
+  const loose = sessions.filter((s) => !s.pinned && !wallOf.has(s.id))
+  const byPath = new Map(
+    groupByWorktree(loose).map((group) => [groupKey(group.path), group] as const),
+  )
+  const drawn = new Set<string>()
+  for (const session of sessions) {
+    const wall = wallOf.get(session.id)
+    const key = wall ? wall.id : session.pinned ? "" : groupKey(session.path ?? "")
+    if (!key || drawn.has(key)) {
+      continue
+    }
+    drawn.add(key)
+    if (wall) {
+      blocks.push({
+        key,
+        pinned: false,
+        stage: wall,
+        path: "",
+        sessions: wall.cells.flatMap((id) => byId.get(id) ?? []),
+      })
+      continue
+    }
+    const group = byPath.get(key)
+    if (group) {
+      blocks.push({ key, pinned: false, stage: null, path: group.path, sessions: group.sessions })
+    }
   }
   return blocks
 }
@@ -412,6 +430,22 @@ export function reorderSubset(
 ): string[] {
   const queue = [...ids]
   return stored.map((session) => (member(session) ? (queue.shift() ?? session.id) : session.id))
+}
+
+// dragOrder returns the stored id order that lays the sidebar's movable blocks
+// out in `keys` — every block but the pinned one, walls and checkouts alike,
+// since they share one drag list and one place to be stored.
+//
+// The slots it may fill are the cards those blocks actually drew, which is not
+// "every unpinned session": a pinned card on a wall is drawn in the wall, so its
+// slot travels with the wall while the pinned block's own cards stay put. Get
+// that set wrong and reorderSessions rejects the whole order — the drop becomes
+// a silent no-op — which is why it is derived from the blocks rather than
+// restated.
+export function dragOrder(stored: Session[], groups: SidebarGroup[], keys: string[]): string[] {
+  const movable = groups.filter((group) => !group.pinned)
+  const moved = new Set(movable.flatMap((group) => group.sessions.map((s) => s.id)))
+  return reorderSubset(stored, orderGroups(movable, keys), (session) => moved.has(session.id))
 }
 
 // neighborSessionId returns the session one step from `sessionId` in the order

--- a/frontend/src/lib/session/use-panes.ts
+++ b/frontend/src/lib/session/use-panes.ts
@@ -57,8 +57,6 @@ export interface Panes {
   dissolve: (groupId: string) => void
   /** Persist a wall's dragged column or row shares. */
   setTracks: (groupId: string, change: { cols?: number[]; rows?: number[] }) => void
-  /** Reorder the walls themselves, which is what dragging their blocks does. */
-  reorder: (groups: PaneGroup[]) => void
 }
 
 // The one definition of what the walls do, shared by the terminals that draw one
@@ -192,9 +190,6 @@ export function usePanes(projectId: string): Panes {
     },
     setTracks(groupId, change) {
       commit(updateGroup(groups, groupId, change))
-    },
-    reorder(next) {
-      commit(next)
     },
   }
 }


### PR DESCRIPTION
Three reports about the same list — a pinned session pushed below the splits, a
split group of one that would not end, and blocks that could only be dragged
past their own kind. They share a cause: block order lived in two places and was
drawn in two passes.

### Pinned is first again

`sidebarGroups` emitted the walls first, and the sidebar rendered them in a
`DndContext` of their own above everything else. A project with a split pushed
the pinned card below every wall — the one thing a pin promises.

### A wall of one ends

`resolveGroups` kept a group down to its last member, on the reading that the
user had named it and could add to it. In practice that leaves a session alone
under a split header with nothing to be split with, and no way back to its
checkout; a group is born with two panes, so one is never a state the user asked
for. A group now ends below two members — however the member left: a close, a
park, a worktree removal, a move onto another wall — and the survivor drops back
among its own checkout's cards. Nothing is closed by it.

The threshold is enforced on read, so a stored group already down to one
dissolves on the next load. No migration.

### One drag list

Walls and checkouts were two drag lists because they were two orders: a
checkout's place is derived from where its sessions sit in the stored flat list,
a wall's was the order of the groups themselves. `sidebarGroups` now reads both
off the one list — a block lands where its first card sits — so there is a
single list to drag in and every block but the pinned one moves freely in it.
`reorderGroups` and `panes.reorder` are dead and go.

### Two things that fell out of the same read

- Dragging cards inside a checkout was a silent no-op whenever one of that
  checkout's sessions was showing on a wall. The predicate picking the slots a
  drop may fill restated the rule as "unpinned, and in this path", claiming the
  walled sibling's slot too — an id-set mismatch, which `reorderSessions` drops
  whole. It asks the block what it drew instead.
- `SidebarRail` drew the stored groups unreconciled, so the collapsed rail could
  show a wall the open sidebar had already dropped.

## Test plan

- [x] `resolveGroups` drops a group left with fewer than two live sessions;
      `addToGroup` / `removeFromGroups` end one the move left below two.
- [x] `sidebarGroups` puts the pinned block above the walls, and a wall where
      its first card sits among the other blocks.
- [x] New `dragOrder` covers the drop: a wall moved past a checkout carries its
      cards, the pinned block's cards keep their slots, and a pinned card drawn
      on a wall travels with the wall — the case that would otherwise be an
      id-set mismatch and a silent no-op.
- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` (2077), `pnpm check`,
      `pnpm test` (1344), `pnpm build`.
- [ ] By hand: pin a card in a project holding a split, drag a wall below a
      worktree block, then take panes off the wall until one is left.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BfKZLMNKD8j8aTTv9Wxk9U
