### PR TITLE
fix: say what the hands-on clock heard, per rung

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   not the product. With no browser at all, the dialog carries the URL instead
   of lich exiting in silence.
 
+### Changed
+
+- **The hands-on tooltip now says what the clock actually heard in that
+  session.** It described every session the same way — typed at, reporting, or
+  running a turn — but a Crush or Cursor CLI session never opens a turn, so on
+  those cards the sentence named something that does not happen there. Those
+  two now read "typed at, or reporting a tool call"; every other session keeps
+  the wording it had.
+
 ### Fixed
 
 - **A Crush card's hands-on time now counts the work, not the typing.** The

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -63,8 +63,11 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   prompt and the reply, is worth only the gap the prompt itself closed. A plain shell session is
   keystrokes-only by design and not a gap: there is no agent in it whose work could be missed.
   The trap is reading the number as exactly comparable across cards — a toolless turn is time on
-  a Claude Code card and nothing on a Crush one, and nothing on screen says which rung a card is
-  on.
+  a Claude Code card and nothing on a Crush one. **The tooltip under the figure says which rung
+  the session is on** (`handsOnDetail`, `frontend/src/lib/session/hands-on.ts`), in the same two
+  sentences on both, by naming what the clock listened to: a turn, or a tool call. What it does
+  not say is how much the rung cost this figure — nothing can know that without inventing the
+  turns it never heard.
 - **A split stage puts every pane on the visible cadence** (`internal/terminal/coalescer.go`,
   `frontend/src/components/TerminalHost.tsx`): the coalescer batches a *visible* session's output every
   8ms and a hidden one's every 250ms, and until the stage could divide, exactly one session per window

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -16,9 +16,10 @@ import { DropService, Terminal as TerminalService } from "@/lib/rpc"
 import type { DockTab } from "@/components/dock/RightDock"
 import { useActiveSession } from "@/lib/session/use-active-session"
 import { useSessionUsage } from "@/lib/session/use-session-usage"
+import { useSessionAgent } from "@/lib/session/use-session-agent"
 import { useCostReadout } from "@/lib/use-cost-readout"
 import { COST_MISS_REASON, budgetShare, formatCost } from "@/lib/session/session-cost"
-import { formatHandsOn, spellHandsOn } from "@/lib/session/hands-on"
+import { formatHandsOn, handsOnDetail, spellHandsOn } from "@/lib/session/hands-on"
 import { useRemoteResource } from "@/lib/use-remote-resource"
 import { baseName, displayPath } from "@/lib/paths"
 import { isWindows } from "@/lib/platform"
@@ -93,6 +94,10 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
   // Context-window occupancy of the active session, read off its transcript at
   // each turn's end (null until the first turn of a supported session lands).
   const usage = useSessionUsage(sessionId)
+  // Which provider the clock is listening to, resolved the way the card and
+  // SessionModel resolve it: a CLI started by hand inside a shell wins over the
+  // session's persisted kind. It is what the hands-on tooltip reads its rung off.
+  const provider = useSessionAgent(sessionId) ?? kind
   // The footer context readout is opt-out (Settings › Providers); the cost
   // beside it is opt-in, and off for everyone not billed per token.
   const { showContextUsage, costBudget } = useSettings()
@@ -217,11 +222,7 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
           <span className="font-mono text-xs text-muted-foreground">
             {spellHandsOn(handsOn.data)}
           </span>
-          {/* Keep in sync with handsOnIdleGap in internal/terminal/handson.go. */}
-          <span className="text-xs text-muted-foreground">
-            How long this session has been worked on — typed at, reporting, or running a turn. A gap
-            longer than 15 minutes counts as time away.
-          </span>
+          <span className="text-xs text-muted-foreground">{handsOnDetail(provider)}</span>
         </div>
       </TooltipContent>
     </Tooltip>

--- a/frontend/src/lib/session/hands-on.test.ts
+++ b/frontend/src/lib/session/hands-on.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { formatHandsOn, spellHandsOn } from "./hands-on"
+import { formatHandsOn, handsOnDetail, spellHandsOn } from "./hands-on"
 
 describe("formatHandsOn", () => {
   // Under a minute is not a small number, it is no number: the store is up to a
@@ -47,5 +47,45 @@ describe("spellHandsOn", () => {
     expect(spellHandsOn(3600 + 12 * 60)).toBe("1h 12m")
     expect(spellHandsOn(48 * 60)).toBe("48m")
     expect(spellHandsOn(30)).toBe("")
+  })
+})
+
+describe("handsOnDetail", () => {
+  // The two rungs, pinned as the literals the tooltip renders. A provider that
+  // opens a turn is counted through it; one that never does is heard only when
+  // a tool call reports.
+  it("names the turn for a provider whose hooks open one", () => {
+    expect(handsOnDetail("claude")).toBe(
+      "How long this session has been worked on — typed at, reporting, or running a turn. A gap longer than 15 minutes counts as time away.",
+    )
+    expect(handsOnDetail("codex")).toBe(handsOnDetail("claude"))
+    expect(handsOnDetail("antigravity")).toBe(handsOnDetail("claude"))
+    expect(handsOnDetail("opencode")).toBe(handsOnDetail("claude"))
+    expect(handsOnDetail("omp")).toBe(handsOnDetail("claude"))
+  })
+
+  it("names the tool call for a provider that never opens a turn", () => {
+    expect(handsOnDetail("crush")).toBe(
+      "How long this session has been worked on — typed at, or reporting a tool call. A gap longer than 15 minutes counts as time away.",
+    )
+    expect(handsOnDetail("cursor")).toBe(handsOnDetail("crush"))
+  })
+
+  // The shape is the contract: same two sentences on both rungs. A third
+  // sentence on one provider, or a longer one, is lich explaining itself.
+  it("says it in the same two sentences on both rungs", () => {
+    const sentences = (text: string) => text.split(". ").length
+    expect(sentences(handsOnDetail("claude"))).toBe(2)
+    expect(sentences(handsOnDetail("crush"))).toBe(2)
+    expect(
+      Math.abs(handsOnDetail("crush").length - handsOnDetail("claude").length),
+    ).toBeLessThanOrEqual(8)
+  })
+
+  // A shell has no hooks on either rung, and no session at all is still a
+  // tooltip that has to read.
+  it("keeps the turn wording for a shell and for no session", () => {
+    expect(handsOnDetail("shell")).toBe(handsOnDetail("claude"))
+    expect(handsOnDetail("")).toBe(handsOnDetail("claude"))
   })
 })

--- a/frontend/src/lib/session/hands-on.ts
+++ b/frontend/src/lib/session/hands-on.ts
@@ -1,3 +1,5 @@
+import type { ProviderKind, SessionKind } from "./sessions"
+
 // formatHandsOn renders how long a session has been worked on, for the footer,
 // where it sits beside the cost figure at 12px and is glanced at rather than
 // read: "48m", "1h12m", "14h05m".
@@ -26,4 +28,40 @@ export function formatHandsOn(seconds: number): string {
 // read.
 export function spellHandsOn(seconds: number): string {
   return formatHandsOn(seconds).replace("h", "h ")
+}
+
+// Which signals a provider's session can beat the hands-on clock with —
+// internal/providers.Registry is the checklist, docs/ceilings.md holds the why.
+// A "turn" provider's hooks open a turn, so a turn nobody touches is counted
+// from the session's own output; a "tool" provider never opens one, and the
+// clock hears that session only through the reports its tool calls fire. Every
+// provider is spelled out rather than defaulted, so a new one has to pick a
+// side here instead of inheriting a sentence that may not be true of it.
+const RUNG: Record<ProviderKind, "turn" | "tool"> = {
+  claude: "turn",
+  codex: "turn",
+  antigravity: "turn",
+  opencode: "turn",
+  omp: "turn",
+  crush: "tool",
+  cursor: "tool",
+}
+
+// handsOnDetail is the sentence under the figure in the tooltip: what the clock
+// listened to, and what it let go. Only the middle clause moves — naming a turn
+// on a provider that never opens one describes something that does not happen
+// there — and both rungs say it in the same two sentences, because a tooltip
+// that runs longer on one provider than another is lich explaining itself
+// rather than reading its own figure back.
+//
+// A plain shell keeps the turn wording: it reports nothing either way, and the
+// clause names what the clock listens for rather than promising the session
+// does all three.
+export function handsOnDetail(kind: SessionKind | ""): string {
+  const beats =
+    kind && kind !== "shell" && RUNG[kind] === "tool"
+      ? "typed at, or reporting a tool call"
+      : "typed at, reporting, or running a turn"
+  // Keep the 15 minutes in sync with handsOnIdleGap in internal/terminal/handson.go.
+  return `How long this session has been worked on — ${beats}. A gap longer than 15 minutes counts as time away.`
 }


### PR DESCRIPTION
Closes #430.

The figure beside the cost counts the gap between consecutive signs of life in a session, and the tooltip under it explained the figure the same way on every card: *"typed at, reporting, or running a turn."* Which turns actually get counted depends on what a provider's hooks report, and there are two rungs — on the lower one, **Crush and Cursor CLI**, no turn ever opens, and the clock hears the session only through the reports its tool calls fire. So on exactly the cards whose figure comes out short, the sentence named something that does not happen there.

### The change

The clause moves; nothing is added.

| Rung | Providers | Sentence |
|------|-----------|----------|
| turn | Claude Code, Codex, Antigravity, opencode, oh-my-pi, shell | How long this session has been worked on — **typed at, reporting, or running a turn**. A gap longer than 15 minutes counts as time away. |
| tool | Crush, Cursor CLI | How long this session has been worked on — **typed at, or reporting a tool call**. A gap longer than 15 minutes counts as time away. |

Two sentences on both, within three characters of each other. A third sentence, or a longer tooltip on one provider than another, is lich explaining itself rather than reading its own figure back — and what the lower rung cannot count (a turn that calls no tool at all) stays in `docs/ceilings.md`, which already carries it.

### Where it lives

- `frontend/src/lib/session/hands-on.ts` — `handsOnDetail(kind)`, beside `formatHandsOn`, the same shape as `COST_MISS_REASON` in `session-cost.ts`. The rung is a `Record<ProviderKind, "turn" | "tool">` with all seven spelled out rather than a default: a provider added to the registry has to pick a side here instead of inheriting a sentence that may not be true of it.
- `frontend/src/components/FooterBar.tsx` — the line that held the fixed string now calls it. Seven lines, and the `handsOnIdleGap` sync comment moved with the string.
- **The rung signal needed no new plumbing.** The provider already reaches the footer twice over: `useActiveSession().kind` (the session's persisted kind) and `useSessionAgent(sessionId)` (the CLI live in the PTY). The footer now resolves it the way `SessionModel` and the session card already do — the live agent wins — so a `crush` started by hand inside a shell session reads its own rung. No backend change, no new event.
- `docs/ceilings.md` — the paragraph closed its own trap: "nothing on screen says which rung a card is on" is no longer true, and what the tooltip still does not say is named in its place.

### Test plan

- [x] `handsOnDetail` pins both sentences as literals, all seven providers, plus shell and no-session; one test pins the *form* — same sentence count on both rungs, comparable length — since that is the contract this PR is about.
- [x] `pnpm check` clean · `vitest run` 1346 passed (111 files) · `pnpm build` clean.
- [x] `gofmt -l .` clean · `go vet ./...` clean · `go test ./...` 2077 passed (no Go touched).
- [ ] Hover the hands-on figure on a Crush card and on a Claude Code card side by side: same two sentences, different middle clause.
