### PR TITLE
Total the cost per project and window on the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   readout, and `docs/ceilings.md` carries the table of which rung each one is on
   and why.
 
+- **`lich cost` totals what a project or a window of time has spent.** The cost
+  figure was per session and nothing summed it, so the only way to ask what a
+  project cost this week was to read the cards one at a time and add them up.
+  The command reports a row per project with `--project`, `--provider` and
+  `--since 7d` narrowing it, and `--json` / `--csv` taking the number out of
+  lich. The total always says how many sessions it could **not** price: with
+  any of those it is a lower bound, and a sum that quietly omitted them would be
+  the one thing that makes the number not worth reading.
+
 - **A Codex session shows its cost on a machine with no network.** The price
   table shipped in the binary carried Claude models only, so a Codex cost
   appeared only once the remote refresh had landed — never, on a machine that

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -69,6 +69,23 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   release froze reads as an ordinary figure with nothing beside it. The marker also names the reason and
   never the model or the turn, so a session whose sub-agent alone is unpriced looks like one whose every
   turn is.
+- **`lich cost --since` windows on sessions, never on days** (`store.CostTotals`): the ledger is a running
+  total per `(session, transcript)` with no per-turn history behind it, so the only date a session's spend
+  carries is when it was last counted. A window therefore selects *sessions active in it* and counts each one
+  whole — a session that ran through the boundary brings every dollar of its life into the window, and one
+  idle since before it brings none. Reading a windowed total as "what was spent that week" overstates a
+  long-lived card by however long it has been running. A session with nothing counted has no ledger to date
+  it at all and falls back on its own life: parked, it is dated by the close; open, it is dated *now*, so it
+  is unpriced in every window ending today. Slicing money by day would need a second ledger keyed by day, and
+  there is none.
+- **A `lich cost` total adds lich's own arithmetic to three other tools'** (`store.CostTotals`): five providers
+  write to the same ledger, but only Claude Code and Codex are priced here. oh-my-pi, opencode and Crush each
+  hand over a figure they computed themselves, carrying the omission their own accounting has — the rungs above
+  name one per provider — and the sum says nothing about the difference. A dollar lich derived from token
+  counts and a dollar Crush reported read identically in the table, in `--json` and in `--csv`, so how close a
+  project's number is depends on which providers ran under it, with nothing on any of those surfaces saying
+  which did. The `unpriced` count answers the other question — what is missing outright — and cannot answer
+  this one.
 - **Hands-on time is read off three signals, and one of them is not universal**
   (`internal/terminal/handson.go`, `noteOutput`, `closableState`): the figure beside the cost
   counts the gap between consecutive signs of life in a session — any hook report naming it, a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -94,8 +94,8 @@ guess at the one it resembles, and exit 1 — a typo does not open a window.
 Arguments the app itself takes still do: bare `lich`, and `lich --` with the
 Chromium flags behind it.
 
-`--json` on `sessions`, `send`, `wait`, `open`, `close` and `worktrees` replaces
-the prose with one JSON line: the peer array, the result object and the session
+`--json` on `sessions`, `send`, `wait`, `open`, `close`, `worktrees` and `cost`
+replaces the prose with one JSON line: the peer array, the result object and the session
 object exactly as this document describes them. An empty roster is `[]`, never
 `null` — a script should not have to tell those apart. One line is the contract:
 `open --prompt` does two things and still prints one object (see below).
@@ -403,9 +403,89 @@ one whose fate that session's close decides, and a checkout with none is one
 nobody is working in. The project's own directory is not listed — it is the
 checkout every project has and the one that cannot be removed.
 
+### `lich cost [--project <name>] [--provider <provider>] [--since <window>] [--json|--csv]`
+
+What the sessions lich still remembers have cost, at API prices, one row per
+project and a total under them:
+
+```
+project	sessions	unpriced	cost
+lich	12	2	$4.31
+revu	3	0	$0.88
+total	15	2	$5.19
+Lower bound: 2 unpriced of 15 sessions — their spend is not in this total.
+```
+
+**The last line is the contract.** A session lich never priced holds no ledger
+row and contributes nothing, so a sum over a unit containing one is a *lower
+bound* — and nothing else on screen would say so. The count travels with the
+money on every surface: the `unpriced` column, the line under the table, the
+`unpriced` field in `--json`, the `unpriced` column in `--csv`. With none, the
+line reads `Complete: every session in this total is priced.` instead.
+
+Why a session has no price is not reported here. That is the live scan's
+`costMiss` (`internal/terminal/usage_cost.go`), decided per turn and never
+persisted, so the ledger can only say a session carries no price — an
+unreadable transcript, an unpriced model, a provider lich has no reader for
+(Antigravity and Cursor CLI), or a session that ran while the readout was off
+all land in the same count.
+
+The money it *does* carry comes from two kinds of accounting, and the report
+does not separate them: lich prices Claude Code and Codex itself from their
+token counts, while oh-my-pi, opencode and Crush each report a figure they
+computed themselves, with the omission their own accounting has. How close a
+project's total is therefore depends on which providers ran under it —
+`docs/ceilings.md` has the rung each is on and what each one leaves out.
+
+With the cost readout switched off, no transcript is ever summed and every
+session is unpriced, so the total can only be `$0.00`. That case adds a second
+line naming the setting, because a zero on a machine that was never asked to
+count reads exactly like a machine that spent nothing.
+
+The filters:
+
+- `--project <name>` — one project, matched case-insensitively the way every
+  other command matches one. A name no session sits under is **refused**, not
+  answered with a zero: about money, a typo that reads as "that project cost
+  nothing" is worse than no answer.
+- `--provider <provider>` — one session kind (`claude`, `codex`, `crush`, …).
+  Combined with the total line this is what a provider cost across the machine.
+  An unknown provider is not refused; it matches nothing and the report is
+  empty.
+- `--since <window>` — `7d`, `24h`, `90m`. Sessions **active** in the window,
+  counted whole: a session's activity is its last counted turn, and a session
+  that ran through the boundary brings all of its cost with it. The ledger is a
+  running total with no per-turn history behind it, so this is a filter over
+  sessions, never a slice of the money by day. A session with nothing counted is
+  dated by when it was parked, or by now while it is still open.
+
+`--csv` writes the per-project rows and no total — the totals are a sum of the
+columns, `unpriced` included, so the bound survives the export:
+
+```
+project,sessions,unpriced,cost_usd
+lich,12,2,4.312500
+revu,3,0,0.880000
+```
+
+`--json` is the whole report on one line — `projects`, the summed `sessions`,
+`unpriced` and `costUsd`, and `readout` for whether anything is being counted
+at all.
+
+It is not registered as an MCP tool. Every tool definition is in the prompt of
+every session lich spawns whether or not it is used (see the ceiling below), and
+a total nobody asked for is not worth that on every turn — an agent that wants
+it runs the command.
+
+There is no `--model` breakdown. The ledger records what a `(session,
+transcript)` pair cost and never which model each priced turn ran under, and
+the model on a session row is the one selected now — so a per-model total would
+have to be a second accounting path, not a filter on this one.
+
 ### `lich mcp`
 
-Serves the commands above as MCP tools over stdio: one JSON-RPC 2.0 message per
+Serves the session commands above as MCP tools over stdio — `cost` is not one
+of them: one JSON-RPC 2.0 message per
 line, `initialize` / `tools/list` / `tools/call` / `ping`. stdout carries
 protocol and nothing else.
 
@@ -713,6 +793,10 @@ whoever asked.
 
 ## Known ceilings
 
+- **`cost` only sees the sessions lich still holds a row for.** A session
+  deleted for good took its ledger with it (`ON DELETE CASCADE`), so its spend
+  is in no total and in no unpriced count either — it is not excluded, it is
+  invisible. A parked session is still counted; a removed one never happened.
 - **Closing has no undo.** The window offers one for ten seconds after a close;
   nothing here does. A removed checkout is gone from disk, and a deleted session
   row with it. `--force` on a dirty checkout is the only step that asks for

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -25,6 +25,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -43,6 +44,7 @@ import (
 	"github.com/omartelo/lich/internal/relay"
 	"github.com/omartelo/lich/internal/singleton"
 	"github.com/omartelo/lich/internal/spawn"
+	"github.com/omartelo/lich/internal/store"
 )
 
 // NotACommand is returned when the arguments name no lich subcommand at all,
@@ -116,6 +118,8 @@ func dispatch(args []string, c *client) int {
 		return c.run(c.rename, args[1:])
 	case "worktrees":
 		return c.run(c.worktrees, args[1:])
+	case "cost":
+		return c.run(c.cost, args[1:])
 	case "mcp":
 		return c.run(c.serveMCP, args[1:])
 	case "rage":
@@ -641,6 +645,130 @@ func (c *client) worktrees(args []string) error {
 			sessions = strings.Join(wt.Sessions, ", ")
 		}
 		fmt.Fprintf(c.stdout, "%s\t%s\t%s\n", wt.Name, state, sessions)
+	}
+	return nil
+}
+
+func (c *client) cost(args []string) error {
+	flags := newFlagSet("cost")
+	project := flags.String("project", "", "only this project, by name")
+	provider := flags.String("provider", "", "only sessions running this provider")
+	since := flags.String("since", "", "only sessions active within this window, e.g. 7d or 12h")
+	asJSON := flags.Bool("json", false, "print the whole report as JSON")
+	asCSV := flags.Bool("csv", false, "print the per-project rows as CSV")
+	if err := c.parse(flags, args); err != nil {
+		return err
+	}
+	// One format or the other: asked for both, there is no answer to print that
+	// is not half of each.
+	if flags.NArg() != 0 || (*asJSON && *asCSV) {
+		return usageError("cost")
+	}
+	from, err := windowStart(*since)
+	if err != nil {
+		return err
+	}
+
+	var report store.CostReport
+	if err := c.call("store.CostTotals", []any{*project, *provider, from}, shortCall, &report); err != nil {
+		return err
+	}
+	report.Projects = asList(report.Projects)
+	switch {
+	case *asJSON:
+		return c.emit(report)
+	case *asCSV:
+		return c.emitCSV(report)
+	}
+	return c.printCost(report)
+}
+
+// windowStart turns a --since value into the unix second the report starts at,
+// or 0 for no window at all. Days are spelled out here because Go's duration
+// parser stops at hours and "what did this week cost" is the question the
+// command is asked.
+func windowStart(value string) (int64, error) {
+	if value == "" {
+		return 0, nil
+	}
+	span, err := parseSpan(value)
+	if err != nil || span <= 0 {
+		return 0, fmt.Errorf("--since takes a window like 7d, 24h or 90m, not %q", value)
+	}
+	return time.Now().Add(-span).Unix(), nil
+}
+
+func parseSpan(value string) (time.Duration, error) {
+	if days, ok := strings.CutSuffix(value, "d"); ok {
+		n, err := strconv.Atoi(days)
+		if err != nil {
+			return 0, err
+		}
+		return time.Duration(n) * 24 * time.Hour, nil
+	}
+	return time.ParseDuration(value)
+}
+
+// printCost writes the report as a table and then the line the total is never
+// printed without: what it leaves out. A sum over sessions lich could not price
+// is a lower bound, and one that says so is the difference between a number
+// worth acting on and a number that quietly reads as the whole bill.
+func (c *client) printCost(report store.CostReport) error {
+	if report.Sessions == 0 {
+		fmt.Fprintln(c.stdout, "No sessions matched.")
+		return nil
+	}
+	fmt.Fprintln(c.stdout, "project\tsessions\tunpriced\tcost")
+	for _, row := range report.Projects {
+		fmt.Fprintf(c.stdout, "%s\t%d\t%d\t%s\n", row.Project, row.Sessions, row.Unpriced, money(row.CostUSD))
+	}
+	fmt.Fprintf(c.stdout, "total\t%d\t%d\t%s\n", report.Sessions, report.Unpriced, money(report.CostUSD))
+	fmt.Fprintln(c.stdout, exclusion(report))
+	return nil
+}
+
+// exclusion words what the total does not cover. Off readout gets its own
+// sentence: it is the reason every session is unpriced, and without it a
+// machine that has simply never been asked to count reads as one that spent
+// nothing.
+func exclusion(report store.CostReport) string {
+	line := "Complete: every session in this total is priced."
+	if report.Unpriced > 0 {
+		line = fmt.Sprintf(
+			"Lower bound: %d unpriced of %d sessions — their spend is not in this total.",
+			report.Unpriced, report.Sessions,
+		)
+	}
+	if !report.Readout {
+		line += "\nThe cost readout is off, so nothing is being priced — turn on" +
+			` Settings › "Session readout in the footer" › "And cost".`
+	}
+	return line
+}
+
+// money is a figure as a command line shows it. Two places because that is what
+// a bill reads in; --json and --csv carry the exact number, which is what a
+// script adding these up needs.
+func money(usd float64) string {
+	return fmt.Sprintf("$%.2f", usd)
+}
+
+// emitCSV writes the per-project rows and no total: a total is the sum of the
+// columns, and the unpriced column travels beside the money, so what the number
+// leaves out survives the export rather than staying behind in lich.
+func (c *client) emitCSV(report store.CostReport) error {
+	rows := [][]string{{"project", "sessions", "unpriced", "cost_usd"}}
+	for _, row := range report.Projects {
+		rows = append(rows, []string{
+			row.Project,
+			strconv.Itoa(row.Sessions),
+			strconv.Itoa(row.Unpriced),
+			strconv.FormatFloat(row.CostUSD, 'f', 6, 64),
+		})
+	}
+	w := csv.NewWriter(c.stdout)
+	if err := w.WriteAll(rows); err != nil {
+		return fmt.Errorf("write the rows: %w", err)
 	}
 	return nil
 }

--- a/internal/cli/cost_test.go
+++ b/internal/cli/cost_test.go
@@ -1,0 +1,171 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// costBody is a report the fake lich hands back: two projects, one session in
+// them that lich could not price.
+const costBody = `{"projects":[` +
+	`{"project":"lich","sessions":3,"unpriced":1,"costUsd":4.3125},` +
+	`{"project":"revu","sessions":1,"unpriced":0,"costUsd":0.5}],` +
+	`"sessions":4,"unpriced":1,"costUsd":4.8125,"readout":true}`
+
+// TestCostPrintsTheTableAndWhatItLeavesOut is the contract of the whole
+// command: the money never appears without the count of what is missing from
+// it, because a sum over sessions lich could not price is a lower bound and a
+// reader has no other way to know.
+func TestCostPrintsTheTableAndWhatItLeavesOut(t *testing.T) {
+	f := newFakeLich(t, costBody)
+
+	code, stdout, stderr := run(t, f, "cost")
+
+	if code != 0 {
+		t.Fatalf("exit = %d (%s)", code, stderr)
+	}
+	for _, want := range []string{
+		"project\tsessions\tunpriced\tcost",
+		"lich\t3\t1\t$4.31",
+		"revu\t1\t0\t$0.50",
+		"total\t4\t1\t$4.81",
+		"Lower bound: 1 unpriced of 4 sessions",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout = %q, want it to carry %q", stdout, want)
+		}
+	}
+	if call := f.only(t); call.method != "store.CostTotals" {
+		t.Errorf("method = %q, want store.CostTotals", call.method)
+	}
+}
+
+// A total with nothing missing says so rather than staying silent: "no warning"
+// and "nothing to warn about" are the two readings an empty line leaves open.
+func TestACompleteTotalSaysItIsComplete(t *testing.T) {
+	f := newFakeLich(t, `{"projects":[{"project":"lich","sessions":2,"unpriced":0,"costUsd":1}],`+
+		`"sessions":2,"unpriced":0,"costUsd":1,"readout":true}`)
+
+	_, stdout, _ := run(t, f, "cost")
+
+	if !strings.Contains(stdout, "Complete: every session in this total is priced.") {
+		t.Errorf("stdout = %q, want the complete line", stdout)
+	}
+	if strings.Contains(stdout, "Lower bound") {
+		t.Errorf("stdout = %q, want no lower-bound warning", stdout)
+	}
+}
+
+// With the readout off nothing has ever been counted, so a $0.00 would read as
+// a machine that spent nothing. The line says which it is, and where to change
+// it.
+func TestCostSaysWhenTheReadoutIsOff(t *testing.T) {
+	f := newFakeLich(t, `{"projects":[{"project":"lich","sessions":2,"unpriced":2,"costUsd":0}],`+
+		`"sessions":2,"unpriced":2,"costUsd":0,"readout":false}`)
+
+	_, stdout, _ := run(t, f, "cost")
+
+	if !strings.Contains(stdout, "The cost readout is off") {
+		t.Errorf("stdout = %q, want the readout to be named", stdout)
+	}
+}
+
+func TestCostReportsAnEmptyWorkspace(t *testing.T) {
+	f := newFakeLich(t, `{"projects":[],"sessions":0,"unpriced":0,"costUsd":0,"readout":true}`)
+
+	code, stdout, _ := run(t, f, "cost")
+
+	if code != 0 || strings.TrimSpace(stdout) != "No sessions matched." {
+		t.Errorf("cost over nothing = %d %q", code, stdout)
+	}
+}
+
+// The filters ride to the store as they were typed; --since arrives as the
+// unix second the window opens at, which is the only form the query can use.
+func TestCostPassesItsFilters(t *testing.T) {
+	f := newFakeLich(t, costBody)
+
+	if code, _, stderr := run(t, f, "cost", "--project", "lich", "--provider", "codex", "--since", "7d"); code != 0 {
+		t.Fatalf("exit = %d (%s)", code, stderr)
+	}
+
+	args := f.only(t).args
+	if len(args) != 3 || args[0] != "lich" || args[1] != "codex" {
+		t.Fatalf("args = %#v, want the project and provider through", args)
+	}
+	from, ok := args[2].(float64)
+	if !ok {
+		t.Fatalf("since = %#v, want a unix second", args[2])
+	}
+	want := time.Now().Add(-7 * 24 * time.Hour).Unix()
+	if diff := int64(from) - want; diff < -5 || diff > 5 {
+		t.Errorf("since = %d, want about %d (7d ago)", int64(from), want)
+	}
+}
+
+// A window nothing can be made of stops before the call: a report over the
+// wrong stretch of time is a wrong number, and money is what this prints.
+func TestCostRefusesAWindowItCannotRead(t *testing.T) {
+	for _, window := range []string{"last week", "7", "-3d", "0h", "d"} {
+		f := newFakeLich(t, costBody)
+
+		code, _, stderr := run(t, f, "cost", "--since", window)
+
+		if code != 1 {
+			t.Errorf("--since %q exited %d, want 1", window, code)
+		}
+		if !strings.Contains(stderr, "--since takes a window") {
+			t.Errorf("--since %q said %q, want the accepted spellings", window, stderr)
+		}
+		if len(f.calls) != 0 {
+			t.Errorf("--since %q still called the store: %+v", window, f.calls)
+		}
+	}
+}
+
+// --json is the whole report, totals and readout flag included, so a script
+// piping this anywhere gets the exclusion with the money.
+func TestCostEmitsJSON(t *testing.T) {
+	f := newFakeLich(t, costBody)
+
+	code, stdout, _ := run(t, f, "cost", "--json")
+
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	for _, want := range []string{`"unpriced":1`, `"costUsd":4.8125`, `"readout":true`} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout = %q, want it to carry %q", stdout, want)
+		}
+	}
+}
+
+// --csv carries the unpriced column beside the money, which is how the bound
+// survives leaving lich. The exact figure goes out, not the two places the
+// table rounds to.
+func TestCostEmitsCSV(t *testing.T) {
+	f := newFakeLich(t, costBody)
+
+	code, stdout, _ := run(t, f, "cost", "--csv")
+
+	if code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	want := "project,sessions,unpriced,cost_usd\nlich,3,1,4.312500\nrevu,1,0,0.500000\n"
+	if stdout != want {
+		t.Errorf("stdout = %q, want %q", stdout, want)
+	}
+}
+
+// Two formats is no format: there is one stdout and the answer would be half
+// of each.
+func TestCostRefusesTwoFormatsAtOnce(t *testing.T) {
+	f := newFakeLich(t, costBody)
+
+	code, _, stderr := run(t, f, "cost", "--json", "--csv")
+
+	if code != 1 || !strings.Contains(stderr, "usage: lich cost") {
+		t.Errorf("cost --json --csv = %d %q, want the usage line", code, stderr)
+	}
+}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -80,11 +80,21 @@ var commands = []command{
 			"sessions are open in it.",
 	},
 	{
+		name: "cost",
+		args: "[--project <name>] [--provider <provider>] [--since <window>]\n" +
+			"            [--json|--csv]",
+		about: "What the sessions lich remembers have cost, per project, at API prices.\n" +
+			"--since keeps the ones active in a window (7d, 24h, 90m). The total\n" +
+			"always says how many sessions it could not price: with any of those,\n" +
+			"it is a lower bound.",
+	},
+	{
 		name: "mcp",
 		args: "",
-		about: "Serve the commands above as MCP tools over stdio. lich registers this\n" +
-			"itself for the providers that support it; you only run it by hand to\n" +
-			"point another MCP client at lich.",
+		about: "Serve the session commands above as MCP tools over stdio — cost is\n" +
+			"not one of them. lich registers this itself for the providers that\n" +
+			"support it; you only run it by hand to point another MCP client at\n" +
+			"lich.",
 	},
 	{
 		name: "rage",

--- a/internal/store/cost.go
+++ b/internal/store/cost.go
@@ -35,7 +35,9 @@ func (s *Service) CostLedger(sessionID, transcriptID string) (int64, string, flo
 	return offset, lastMessage, cost, nil
 }
 
-// SaveCostLedger records the position and total of one transcript's accounting.
+// SaveCostLedger records the position and total of one transcript's accounting,
+// stamped with the moment it was written — the only date a session's spend ever
+// carries, and what CostTotals windows on.
 // The SELECT ... WHERE EXISTS writes nothing for a session whose row is already
 // gone (closed while its last turn was still being counted) instead of letting
 // the foreign key raise: that is a race, not a failure, and it is the same
@@ -44,12 +46,15 @@ func (s *Service) SaveCostLedger(
 	sessionID, transcriptID string, offset int64, lastMessage string, cost float64,
 ) error {
 	_, err := s.db.Exec(
-		`INSERT INTO session_costs (session_id, transcript_id, byte_offset, last_message_id, cost_usd)
-		 SELECT ?, ?, ?, ?, ? WHERE EXISTS (SELECT 1 FROM sessions WHERE id = ?)
+		`INSERT INTO session_costs
+		     (session_id, transcript_id, byte_offset, last_message_id, cost_usd, updated_at)
+		 SELECT ?, ?, ?, ?, ?, CAST(strftime('%s', 'now') AS INTEGER)
+		 WHERE EXISTS (SELECT 1 FROM sessions WHERE id = ?)
 		 ON CONFLICT(session_id, transcript_id) DO UPDATE SET
 		     byte_offset = excluded.byte_offset,
 		     last_message_id = excluded.last_message_id,
-		     cost_usd = excluded.cost_usd`,
+		     cost_usd = excluded.cost_usd,
+		     updated_at = excluded.updated_at`,
 		sessionID, transcriptID, offset, lastMessage, cost, sessionID,
 	)
 	if err != nil {
@@ -65,12 +70,16 @@ type costRow struct {
 	offset       int64
 	lastMessage  string
 	cost         float64
+	// When the row was last counted. Carried rather than re-stamped: a resume
+	// moves old spend onto a new session id, and re-dating it would move that
+	// money into today's window.
+	updatedAt int64
 }
 
 // costLedgers reads every ledger a session holds.
 func costLedgers(tx *sql.Tx, sessionID string) ([]costRow, error) {
 	rows, err := tx.Query(
-		`SELECT transcript_id, byte_offset, last_message_id, cost_usd
+		`SELECT transcript_id, byte_offset, last_message_id, cost_usd, updated_at
 		   FROM session_costs WHERE session_id = ?`, sessionID,
 	)
 	if err != nil {
@@ -81,7 +90,9 @@ func costLedgers(tx *sql.Tx, sessionID string) ([]costRow, error) {
 	var ledgers []costRow
 	for rows.Next() {
 		var row costRow
-		if err := rows.Scan(&row.transcriptID, &row.offset, &row.lastMessage, &row.cost); err != nil {
+		if err := rows.Scan(
+			&row.transcriptID, &row.offset, &row.lastMessage, &row.cost, &row.updatedAt,
+		); err != nil {
 			return nil, fmt.Errorf("scan cost ledger for %q: %w", sessionID, err)
 		}
 		ledgers = append(ledgers, row)
@@ -93,9 +104,10 @@ func costLedgers(tx *sql.Tx, sessionID string) ([]costRow, error) {
 func restoreCostLedgers(tx *sql.Tx, sessionID string, ledgers []costRow) error {
 	for _, row := range ledgers {
 		if _, err := tx.Exec(
-			`INSERT INTO session_costs (session_id, transcript_id, byte_offset, last_message_id, cost_usd)
-			 VALUES (?, ?, ?, ?, ?)`,
-			sessionID, row.transcriptID, row.offset, row.lastMessage, row.cost,
+			`INSERT INTO session_costs
+			     (session_id, transcript_id, byte_offset, last_message_id, cost_usd, updated_at)
+			 VALUES (?, ?, ?, ?, ?, ?)`,
+			sessionID, row.transcriptID, row.offset, row.lastMessage, row.cost, row.updatedAt,
 		); err != nil {
 			return fmt.Errorf("restore cost ledger for %q: %w", sessionID, err)
 		}
@@ -116,4 +128,110 @@ func (s *Service) SessionCost(sessionID string) (float64, error) {
 		return 0, fmt.Errorf("read session cost for %q: %w", sessionID, err)
 	}
 	return cost.Float64, nil
+}
+
+// CostTotal is what one project's sessions have cost. Sessions is every session
+// in the unit; Unpriced is how many of them carry no price at all, so the money
+// covers Sessions-Unpriced of them.
+type CostTotal struct {
+	Project  string  `json:"project"`
+	Sessions int     `json:"sessions"`
+	Unpriced int     `json:"unpriced"`
+	CostUSD  float64 `json:"costUsd"`
+}
+
+// CostReport is CostTotals' answer: a row per project, and the same three
+// numbers summed across every row.
+//
+// The money is a **lower bound** whenever Unpriced is not zero. A session lich
+// never priced holds no ledger row at all — its provider files its conversation
+// where lich has no reader, a model in it has no price, or the readout was off
+// while it ran — and nothing here can guess what it spent. Shipping that count
+// beside the sum
+// is the whole difference between "this is what it cost" and "this is what lich
+// could add up", and a total that omitted it in silence would be the one
+// failure mode that makes the number not worth reading.
+//
+// Why the row is missing is not in here on purpose: that is costMiss
+// (internal/terminal/usage_cost.go), which is decided by the live scan and
+// never persisted, so the ledger can only say that a session has no price —
+// not which of the reasons it was.
+//
+// Readout is whether the cost readout is on at all. Off, no transcript is ever
+// summed, so every session is unpriced and the total can only be zero — which a
+// caller has to be able to say instead of printing a $0.00 that reads as free.
+type CostReport struct {
+	Projects []CostTotal `json:"projects"`
+	Sessions int         `json:"sessions"`
+	Unpriced int         `json:"unpriced"`
+	CostUSD  float64     `json:"costUsd"`
+	Readout  bool        `json:"readout"`
+}
+
+// CostTotals sums the ledger by project. project narrows it to one by name,
+// case-insensitively; provider to one session kind; either empty means all of
+// them. since, in unix seconds, keeps only the sessions active on or after it,
+// and 0 keeps every session lich still remembers.
+//
+// A session's activity is its last counted turn, because that is the only date
+// the ledger carries — the row is a running total with no per-turn history
+// behind it. So a window selects *sessions active in it*, counted whole, rather
+// than slicing each session's money by day: a session that ran through the
+// boundary brings all of its cost with it. A session with nothing counted is
+// dated by when it was parked, or by now while it is open, so an unpriced
+// session that is still running is unpriced in every window ending today.
+//
+// Only sessions lich still holds a row for are in reach at all: a deleted
+// session took its ledger with it (ON DELETE CASCADE) and is in no total,
+// neither counted nor excluded.
+func (s *Service) CostTotals(project, provider string, since int64) (CostReport, error) {
+	// Read before the rows are open: the store holds a single connection, and a
+	// second query while one is being walked waits on a connection its own
+	// caller is holding.
+	report := CostReport{Projects: []CostTotal{}, Readout: s.CostReadout()}
+	rows, err := s.db.Query(
+		`SELECT p.name,
+		        COUNT(*),
+		        SUM(CASE WHEN c.cost IS NULL THEN 1 ELSE 0 END),
+		        COALESCE(SUM(c.cost), 0)
+		   FROM sessions s
+		   JOIN projects p ON p.id = s.project_id
+		   LEFT JOIN (SELECT session_id, SUM(cost_usd) AS cost, MAX(updated_at) AS seen
+		                FROM session_costs GROUP BY session_id) c ON c.session_id = s.id
+		  WHERE (? = '' OR LOWER(p.name) = LOWER(?))
+		    AND (? = '' OR s.kind = ?)
+		    AND (? = 0 OR COALESCE(
+		                    NULLIF(c.seen, 0),
+		                    CASE WHEN s.is_open = 1
+		                         THEN CAST(strftime('%s', 'now') AS INTEGER)
+		                         ELSE s.closed_at END) >= ?)
+		  GROUP BY p.id, p.name
+		  ORDER BY COALESCE(SUM(c.cost), 0) DESC, p.name`,
+		project, project, provider, provider, since, since,
+	)
+	if err != nil {
+		return CostReport{}, fmt.Errorf("read cost totals: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		var row CostTotal
+		if err := rows.Scan(&row.Project, &row.Sessions, &row.Unpriced, &row.CostUSD); err != nil {
+			return CostReport{}, fmt.Errorf("scan cost total: %w", err)
+		}
+		report.Projects = append(report.Projects, row)
+		report.Sessions += row.Sessions
+		report.Unpriced += row.Unpriced
+		report.CostUSD += row.CostUSD
+	}
+	if err := rows.Err(); err != nil {
+		return CostReport{}, fmt.Errorf("iterate cost totals: %w", err)
+	}
+	// A name that matched nothing is refused rather than answered with a zero:
+	// this is money, and a typo that reads as "that project cost nothing" is
+	// worse than no answer at all.
+	if project != "" && len(report.Projects) == 0 {
+		return CostReport{}, fmt.Errorf("no sessions in a project named %q", project)
+	}
+	return report, nil
 }

--- a/internal/store/cost_totals_test.go
+++ b/internal/store/cost_totals_test.go
@@ -1,0 +1,238 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+// costWorkspace opens a store with two projects and the sessions named, so a
+// totals test can say who is billed where in one line.
+func costWorkspace(t *testing.T) *Service {
+	t.Helper()
+	svc := newTestStore(t)
+	for _, p := range []struct{ id, name string }{{"p1", "alpha"}, {"p2", "beta"}} {
+		if err := svc.AddProject(p.id, p.name, "/tmp/"+p.name); err != nil {
+			t.Fatalf("AddProject: %v", err)
+		}
+	}
+	return svc
+}
+
+// bill adds a session of the given kind to a project and charges it.
+func bill(t *testing.T, svc *Service, projectID, sessionID, kind string, cost float64) {
+	t.Helper()
+	if err := svc.AddSession(projectID, sessionID, sessionID, kind, "", 2, ""); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+	if err := svc.SaveCostLedger(sessionID, "uuid-"+sessionID, 10, "m1", cost); err != nil {
+		t.Fatalf("SaveCostLedger: %v", err)
+	}
+}
+
+// TestCostTotalsSumsPerProject is the unit the command reports in: every
+// session a project holds, across every conversation each has run.
+func TestCostTotalsSumsPerProject(t *testing.T) {
+	svc := costWorkspace(t)
+	bill(t, svc, "p1", "s1", "claude", 1.25)
+	bill(t, svc, "p1", "s2", "codex", 0.75)
+	bill(t, svc, "p2", "s3", "claude", 0.50)
+	// A second conversation under the same session, the `/clear` case.
+	if err := svc.SaveCostLedger("s1", "uuid-second", 10, "m2", 0.50); err != nil {
+		t.Fatalf("SaveCostLedger: %v", err)
+	}
+
+	report, err := svc.CostTotals("", "", 0)
+	if err != nil {
+		t.Fatalf("CostTotals: %v", err)
+	}
+	if len(report.Projects) != 2 {
+		t.Fatalf("projects = %+v, want one row each", report.Projects)
+	}
+	// Ordered by spend, so the expensive project reads first.
+	if got := report.Projects[0]; got.Project != "alpha" || got.Sessions != 2 || got.CostUSD != 2.50 {
+		t.Errorf("first row = %+v, want alpha with 2 sessions at 2.50", got)
+	}
+	if got := report.Projects[1]; got.Project != "beta" || got.CostUSD != 0.50 {
+		t.Errorf("second row = %+v, want beta at 0.50", got)
+	}
+	if report.Sessions != 3 || report.CostUSD != 3.00 {
+		t.Errorf("total = %d sessions at %v, want 3 at 3.00", report.Sessions, report.CostUSD)
+	}
+}
+
+// TestCostTotalsCountsWhatItCannotPrice is the contract the whole command turns
+// on: a session with no ledger row is not silently dropped from the sum, it is
+// counted beside it, which is what makes the total legible as a lower bound.
+func TestCostTotalsCountsWhatItCannotPrice(t *testing.T) {
+	svc := costWorkspace(t)
+	bill(t, svc, "p1", "s1", "claude", 2.00)
+	if err := svc.AddSession("p1", "s2", "unpriced", "crush", "", 3, ""); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+
+	report, err := svc.CostTotals("", "", 0)
+	if err != nil {
+		t.Fatalf("CostTotals: %v", err)
+	}
+	row := report.Projects[0]
+	if row.Sessions != 2 || row.Unpriced != 1 || row.CostUSD != 2.00 {
+		t.Errorf("row = %+v, want 2 sessions, 1 unpriced, 2.00 counted", row)
+	}
+	if report.Unpriced != 1 {
+		t.Errorf("total unpriced = %d, want 1", report.Unpriced)
+	}
+}
+
+// TestCostTotalsNarrowsByProjectAndProvider pins the two filters that come out
+// of the same query. The project name is matched the way every other command
+// matches one — case-insensitively.
+func TestCostTotalsNarrowsByProjectAndProvider(t *testing.T) {
+	svc := costWorkspace(t)
+	bill(t, svc, "p1", "s1", "claude", 1.00)
+	bill(t, svc, "p1", "s2", "codex", 2.00)
+	bill(t, svc, "p2", "s3", "claude", 4.00)
+
+	byProject, err := svc.CostTotals("ALPHA", "", 0)
+	if err != nil {
+		t.Fatalf("CostTotals: %v", err)
+	}
+	if len(byProject.Projects) != 1 || byProject.CostUSD != 3.00 {
+		t.Errorf("by project = %+v at %v, want alpha alone at 3.00", byProject.Projects, byProject.CostUSD)
+	}
+
+	byProvider, err := svc.CostTotals("", "claude", 0)
+	if err != nil {
+		t.Fatalf("CostTotals: %v", err)
+	}
+	if byProvider.Sessions != 2 || byProvider.CostUSD != 5.00 {
+		t.Errorf("by provider = %d sessions at %v, want 2 at 5.00", byProvider.Sessions, byProvider.CostUSD)
+	}
+}
+
+// TestCostTotalsRefusesAProjectItCannotFind: a mistyped name answered with a
+// zero would read as "that project cost nothing", which is the wrong answer to
+// give about money.
+func TestCostTotalsRefusesAProjectItCannotFind(t *testing.T) {
+	svc := costWorkspace(t)
+	bill(t, svc, "p1", "s1", "claude", 1.00)
+
+	if _, err := svc.CostTotals("alfa", "", 0); err == nil {
+		t.Fatal("CostTotals accepted a project name nothing matches")
+	}
+	// An unfiltered report over an empty workspace is not a failure — it is a
+	// machine that has run nothing yet.
+	empty, err := newTestStore(t).CostTotals("", "", 0)
+	if err != nil {
+		t.Fatalf("CostTotals on an empty workspace: %v", err)
+	}
+	if len(empty.Projects) != 0 || empty.Sessions != 0 {
+		t.Errorf("empty report = %+v, want nothing", empty)
+	}
+}
+
+// TestCostTotalsWindowsOnTheLastCountedTurn pins what --since selects: a
+// session whose ledger last moved before the window is out of it, and the
+// window takes the whole of what a session inside it has spent.
+func TestCostTotalsWindowsOnTheLastCountedTurn(t *testing.T) {
+	svc := costWorkspace(t)
+	bill(t, svc, "p1", "s1", "claude", 1.00)
+	bill(t, svc, "p1", "s2", "claude", 2.00)
+	stale := time.Now().Add(-30 * 24 * time.Hour).Unix()
+	if _, err := svc.db.Exec(
+		`UPDATE session_costs SET updated_at = ? WHERE session_id = 's2'`, stale,
+	); err != nil {
+		t.Fatalf("age the ledger: %v", err)
+	}
+
+	week := time.Now().Add(-7 * 24 * time.Hour).Unix()
+	report, err := svc.CostTotals("", "", week)
+	if err != nil {
+		t.Fatalf("CostTotals: %v", err)
+	}
+	if report.Sessions != 1 || report.CostUSD != 1.00 {
+		t.Errorf("window = %d sessions at %v, want the recent one alone at 1.00", report.Sessions, report.CostUSD)
+	}
+
+	all, err := svc.CostTotals("", "", 0)
+	if err != nil {
+		t.Fatalf("CostTotals: %v", err)
+	}
+	if all.CostUSD != 3.00 {
+		t.Errorf("no window = %v, want both at 3.00", all.CostUSD)
+	}
+}
+
+// TestAnUnpricedSessionIsDatedByItsOwnLife: a session with no ledger has no
+// counted turn to date it, and dropping it out of every window would hide the
+// count that makes the total honest. An open one is unpriced now; a parked one
+// is dated by when it was parked.
+func TestAnUnpricedSessionIsDatedByItsOwnLife(t *testing.T) {
+	svc := costWorkspace(t)
+	bill(t, svc, "p1", "s1", "claude", 1.00)
+	if err := svc.AddSession("p1", "live", "live", "crush", "", 3, ""); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+	if err := svc.AddSession("p1", "parked", "parked", "crush", "", 4, ""); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+	stale := time.Now().Add(-30 * 24 * time.Hour).Unix()
+	if _, err := svc.db.Exec(
+		`UPDATE sessions SET is_open = 0, closed_at = ? WHERE id = 'parked'`, stale,
+	); err != nil {
+		t.Fatalf("park the session: %v", err)
+	}
+
+	report, err := svc.CostTotals("", "", time.Now().Add(-7*24*time.Hour).Unix())
+	if err != nil {
+		t.Fatalf("CostTotals: %v", err)
+	}
+	if report.Sessions != 2 || report.Unpriced != 1 {
+		t.Errorf("window = %d sessions with %d unpriced, want the live pair with one unpriced",
+			report.Sessions, report.Unpriced)
+	}
+}
+
+// TestCostTotalsCarriesTheReadoutFlag: with the readout off nothing is ever
+// summed, so a zero is not a machine that spent nothing. The report says which.
+func TestCostTotalsCarriesTheReadoutFlag(t *testing.T) {
+	svc := costWorkspace(t)
+	bill(t, svc, "p1", "s1", "claude", 1.00)
+
+	off, err := svc.CostTotals("", "", 0)
+	if err != nil {
+		t.Fatalf("CostTotals: %v", err)
+	}
+	if off.Readout {
+		t.Error("readout reported on with the setting unset")
+	}
+	if err := svc.SetSetting(costReadoutKey, globalScope, "true"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	on, err := svc.CostTotals("", "", 0)
+	if err != nil {
+		t.Fatalf("CostTotals: %v", err)
+	}
+	if !on.Readout {
+		t.Error("readout reported off with the setting on")
+	}
+}
+
+// TestSavingALedgerStampsIt is what dates a session's spend at all: without the
+// stamp every window is empty or everything is in it.
+func TestSavingALedgerStampsIt(t *testing.T) {
+	svc := newCostSession(t)
+	before := time.Now().Unix()
+	if err := svc.SaveCostLedger("s1", "uuid-a", 10, "m1", 1.00); err != nil {
+		t.Fatalf("SaveCostLedger: %v", err)
+	}
+
+	var stamped int64
+	if err := svc.db.QueryRow(
+		`SELECT updated_at FROM session_costs WHERE session_id = 's1'`,
+	).Scan(&stamped); err != nil {
+		t.Fatalf("read the stamp: %v", err)
+	}
+	if stamped < before || stamped > time.Now().Unix()+1 {
+		t.Errorf("stamp = %d, want it inside [%d, now]", stamped, before)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -97,6 +97,12 @@ CREATE TABLE IF NOT EXISTS session_costs (
     byte_offset     INTEGER NOT NULL DEFAULT 0,
     last_message_id TEXT NOT NULL DEFAULT '',
     cost_usd        REAL NOT NULL DEFAULT 0,
+    -- When this ledger last counted a turn, in unix seconds. It is what dates a
+    -- session's spend, and the only thing that can: the row is a running total
+    -- with no per-turn history behind it, so a window over it selects sessions
+    -- by their last counted turn rather than slicing the money by day. 0 on a
+    -- row written before the column existed, which no window can place.
+    updated_at      INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (session_id, transcript_id)
 );
 
@@ -247,6 +253,7 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN closed_at INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN closed_seq INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE session_costs ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.Exec(stmt); err != nil && !migrationApplied(err) {


### PR DESCRIPTION
Closes #431.

The cost readout answered one question — what *this session* has cost — and
nothing summed it. Asking what a project cost this week meant reading the cards
one at a time and adding them up.

## `lich cost`

```
project	sessions	unpriced	cost
lich	12	2	$4.31
revu	3	0	$0.88
total	15	2	$5.19
Lower bound: 2 unpriced of 15 sessions — their spend is not in this total.
```

- **Units: project and time window.** `--project <name>` (case-insensitive, and
  a name nothing matches is *refused* rather than answered with a zero — about
  money a typo that reads as "that project cost nothing" is the wrong answer)
  and `--since 7d|24h|90m`.
- **Provider came free**, so it is in: `--provider codex`. Combined with the
  total line that is what a provider cost across the machine, without a second
  grouping.
- **Export:** `--json` (the whole report, totals and all) and `--csv` (the
  per-project rows; the totals are a sum of the columns).

## The total says what it excludes

This is the part that is not negotiable, and it is on every surface: the
`unpriced` column, the line under the table, the `unpriced` field in `--json`,
the `unpriced` column in `--csv`. A session lich never priced holds no ledger
row and contributes nothing, so any total containing one is a lower bound and
says so. With none, the line reads `Complete: every session in this total is
priced.` — silence would leave "no warning" and "nothing to warn about"
indistinguishable.

With the cost readout **off** nothing is ever counted, so the report carries a
`readout` flag and the CLI names the setting: a `$0.00` on a machine that was
never asked to count reads exactly like a machine that spent nothing.

**No second vocabulary for "unpriceable".** `costMiss` (#436) names *why* a
scan could not price a turn, but it is decided live and never persisted — so the
ledger can only say a session carries no price, and the docs say that plainly
rather than restating those reasons where they cannot be known.

## What it took: one column, not a new accounting path

The sum is the ledger that already exists (`session_costs`). The only thing
missing was a date — the row is a running total with no per-turn history — so
`SaveCostLedger` now stamps `updated_at`, carried (not re-stamped) across the
delete/reinsert a parked session's resume performs.

That makes `--since` a filter over **sessions active in the window, counted
whole**, never a slice of the money by day: a session that ran through the
boundary brings all of its cost with it. A session with nothing counted is dated
by when it was parked, or by *now* while it is open — so an unpriced session
that is still running is unpriced in every window ending today, which is exactly
what the count has to say. Written up in `docs/ceilings.md`.

## Deliberately out

- **`--model`.** The ledger records what a `(session, transcript)` pair cost and
  never which model each priced turn ran under; the model on a session row is
  the one selected *now*. A per-model total is a second accounting path, not a
  filter on this one.
- **A panel or a Settings screen.** The issue names the CLI as the cheapest
  surface and the only one that makes the number scriptable.
- **A project budget.** `costBudget` stays per session; the seam is there but
  reusing it needs a scope this round does not open.
- **An MCP tool.** Every tool definition is in the prompt of every session lich
  spawns, used or not (an existing ceiling in `docs/cli.md`); a total nobody
  asked for is not worth that on every turn.
- Nothing in `internal/terminal/usage*.go` — #429 is widening which providers
  get a cost at all, and this is agnostic to how that lands: a provider that
  starts writing ledger rows is simply priced instead of counted as unpriced.

## Ceilings named

- `docs/ceilings.md` — `--since` windows on sessions, never on days.
- `docs/cli.md` — a session deleted for good took its ledger with it, so its
  spend is in no total and in no unpriced count either.

## Test plan

- [x] `internal/store`: per-project sums across `/clear` conversations, the
  unpriced count, both filters, the refused project name, the window on the last
  counted turn, an unpriced session dated by its own life, the readout flag, and
  the stamp itself.
- [x] `internal/cli`: the table and its lower-bound line, the complete line, the
  readout-off line, the empty workspace, the filters reaching the RPC (`--since`
  as a unix second), five malformed windows refused before the call, `--json`,
  `--csv`, and `--json --csv` refused.
- [x] Gate: `gofmt -l .`, `go vet ./...`, `go test ./...`, `pnpm check`,
  `pnpm test`, `pnpm build`, and the `GOOS=linux|darwin|windows` build/vet loop
  (new `_test.go` files).


---

## Rebased onto #440 and #438

The conflict was `CHANGELOG.md` (both entries coexist) and `docs/ceilings.md`, where #440 rewrote the cost area and changed the fact my text stood on: oh-my-pi, opencode and Crush now write to the same ledger, so the `unpriced` count shrank.

Rewritten rather than stacked, and the seam earned a ceiling of its own:

> **A `lich cost` total adds lich's own arithmetic to three other tools'.** Five providers write to the same ledger, but only Claude Code and Codex are priced here. The other three hand over a figure they computed themselves, carrying the omission their own accounting has, and the sum says nothing about the difference — a dollar lich derived from token counts and a dollar Crush reported read identically in the table, in `--json` and in `--csv`. The `unpriced` count answers the other question, what is missing outright, and cannot answer this one.

`docs/cli.md` gained the same warning in one paragraph, and two sentences that had gone stale were fixed: "a provider lich reads no transcript for" is now "a provider lich has no reader for (Antigravity and Cursor CLI)" — opencode and Crush file SQLite that lich *does* read now. No code changed in the rebase: every provider goes through `SaveCostLedger`, so the new three are stamped and totalled with no arm of their own.

Gate re-run green on the new base, cross-compile loop included.