### PR TITLE
Show a session cost for the providers that record no context window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **oh-my-pi, opencode and Crush sessions now show what they cost.** All three
+  price every turn as they run it, but none of them records the model's context
+  window, and the footer read that as nothing to show — so a session spending
+  real money showed an empty corner. The cost now stands on its own: the figure
+  is the provider's own, exactly as its own interface reports it, and the
+  context ring simply is not drawn. Five of the seven providers are now on the
+  readout, and `docs/ceilings.md` carries the table of which rung each one is on
+  and why.
+
 - **A Codex session shows its cost on a machine with no network.** The price
   table shipped in the binary carried Claude models only, so a Codex cost
   appeared only once the remote refresh had landed — never, on a machine that

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -58,6 +58,7 @@ tool.
 | `internal/terminal/command.go` | what a spawn runs | entries in `skipPermissionFlags`, `modelFlags`, `briefingFlags` and `resumeArgs` — each one optional, and absent means "no flag rather than somebody else's" |
 | `internal/terminal/resume.go` | whether a resume can be offered | a `ResumeAvailable` case answering from what that provider left on disk |
 | `internal/terminal/transcript.go`, `sessiondb.go` | where that state lives | the path resolver the case above calls |
+| `internal/terminal/usage.go` | the footer's session readout | a `usageSourceFor` arm, plus a `sessionCost` arm reading whatever that provider records about spend — and a `contextUsageFor` arm only if it also records the model's context window. Which rung that lands the provider on is a row in `docs/ceilings.md`, in the same PR |
 | `internal/sandbox/sandbox.go` | what a confined session can still reach | a `stateDirs` case — a provider missing here confines to a home with no credentials, which is a session that opens and cannot log in |
 | `internal/agentplugin/` | the companion plugin | a `<provider>.go` with install / installed-version, plus the four switches and the `supported` list in `agentplugin.go` |
 | `internal/cli/mcp.go` | the `open_session` tool schema | the new id in the `kind` description |

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -22,18 +22,43 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   only when the reason is standing (`costMiss.spoken` in `internal/terminal/usage_cost.go`): a transcript that
   merely could not be read this turn says nothing and keeps the last figure, so a reader cannot tell that
   absence from a session still on its first turn.
-- **The session readout understands Claude Code and Codex transcripts only**
-  (`internal/terminal/usage_claude.go`, `internal/terminal/usage_codex.go`): oh-my-pi, opencode and Crush record
-  token usage but not the model's context-window size, so lich cannot turn those counts into a trustworthy
-  percentage, and Antigravity and Cursor CLI file their conversations as SQLite rather than as a transcript lich
-  reads at all.
-  Their footer therefore carries no model or context ring. Codex rollouts carry the effective window
-  selected for that session — 95% of its default or configured `model_context_window` — and, since
-  `total_token_usage` is a running total lich prices from its last line, the cost rung too. But
-  `internal/pricing/prices.json` bakes a fixed slice of OpenAI rates beside the Claude ones, copied by hand
-  from the same LiteLLM table the refresh reads, so an offline Codex session shows a cost at the rate that
-  shipped — **stale by however long it has been since the release**, until the refresh
-  (`internal/pricing/pricing.go`) lands and overrides it. Nothing regenerates that slice, so what is left
+- **The session readout sits on three rungs, and only two providers reach the top one**
+  (`internal/terminal/usage.go`, `usageSourceFor`). Which rung a provider is on is decided by what it writes
+  down, not by what lich chose to read:
+
+  | Provider | Rung | Why |
+  | --- | --- | --- |
+  | Claude Code | full readout | per-turn token counts, and a model whose window is named (`windowForModel`) |
+  | Codex | full readout | the effective `model_context_window`, and a running `total_token_usage` |
+  | oh-my-pi | cost only | a USD total on every assistant turn; no line carries a context window |
+  | opencode | cost only | `session.cost` per conversation; no window recorded with it |
+  | Crush | cost only | `sessions.cost` per conversation; no window recorded with it |
+  | Antigravity | nothing | conversation filed as SQLite lich has no reader for |
+  | Cursor CLI | nothing | chat filed as SQLite lich has no reader for |
+
+  The cost-only rung's footer shows the figure and nothing else: its usage event carries a zero window, and a
+  zero window is what tells `FooterBar` to drop the ring and `SessionModel` to render nothing rather than a
+  provider glyph beside a model nobody reported. **Those three figures are the providers' own arithmetic, never
+  re-priced here** — they bill models `internal/pricing` has never heard of, so a second opinion would only be a
+  second, disagreeing number — and each therefore inherits what its own accounting leaves out. oh-my-pi's total
+  is the sum of its assistant turns, the same walk its own status line makes, so a `task` sub-agent's spend is
+  missing from lich's figure exactly as it is from omp's. opencode files each sub-agent as a session of its own
+  and does *not* roll it into the parent, so the read walks the `parent_id` chain; Crush does roll it in
+  (`updateParentSessionCost`), so summing its children would bill them twice. **Both of those are measured
+  behaviour of another tool's schema, not a promise it made** — the day either changes its mind about the
+  rollup, the footer is silently wrong in one direction or the other, with nothing on screen saying so. A zero
+  from any of the three is an answer and not a gap: it is what they record for a free model and for a
+  subscription — while an oh-my-pi turn written with no total at all withholds the session's whole number and
+  borrows the `unpriced-model` marker, whose tooltip then blames a network that would not have helped. That
+  branch has never been seen in the wild and gets no reason of its own until it is. The two bottom-rung
+  providers get no bullet beyond their row — a reader for either means a reader for its own SQLite schema, and
+  neither schema is a contract anybody promised to keep.
+  The Codex window in that table is 95% of the rollout's default or configured `model_context_window`, and
+  Codex is the one rung lich prices itself. `internal/pricing/prices.json` bakes a fixed slice of OpenAI rates
+  beside the Claude ones, copied by hand from the same LiteLLM table the refresh reads, so an offline Codex
+  session shows a cost at the rate that shipped — **stale by however long it has been since the release**,
+  until the refresh (`internal/pricing/pricing.go`) lands and overrides it. Nothing regenerates that slice, so
+  what is left
   with no price at all is a model newer than the build, or one LiteLLM never priced — and with no network
   the refresh that would settle it never runs. A Codex conversation that ran `/model` has no cost from that
   turn on (`codexCostScan.mixed`): the one running total spans both models and the rollout never splits it,

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -228,9 +228,13 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
   ) : null
 
   // The context-window readout — the ring plus percent, with a detailed
-  // tooltip. Null when the user turned it off (Settings › Providers).
+  // tooltip. Null when the user turned it off (Settings › Providers), and null
+  // for a provider that reports no window at all: oh-my-pi, opencode and Crush
+  // record what a turn spent but not what it spent it against, so the footer
+  // degrades to the cost beside it rather than drawing a 0% ring around
+  // "0 / 0 tokens" (docs/ceilings.md).
   const contextReadout =
-    usage && showContextUsage ? (
+    usage && showContextUsage && usage.window > 0 ? (
       <Tooltip>
         <TooltipTrigger
           render={

--- a/frontend/src/components/SessionModel.tsx
+++ b/frontend/src/components/SessionModel.tsx
@@ -15,10 +15,14 @@ interface SessionModelProps {
 // it reads its own data by id, so the slot can grow with more per-session detail
 // without touching FooterBar. A provider started inside a shell wins over the
 // card's persisted kind, matching the session card itself.
+//
+// A report can carry a cost and no model: the cost-only rung reads what a
+// conversation spent without naming what spent it (docs/ceilings.md). The slot
+// stays empty then rather than putting a provider glyph beside nothing.
 export function SessionModel({ sessionId, kind }: SessionModelProps) {
   const usage = useSessionUsage(sessionId)
   const provider = useSessionAgent(sessionId) ?? kind
-  if (!usage || !provider) {
+  if (!usage?.model || !provider) {
     return null
   }
   return (

--- a/frontend/src/components/render-budget.test.tsx
+++ b/frontend/src/components/render-budget.test.tsx
@@ -174,6 +174,19 @@ const usageEvent = (id: string) => ({
   effort: "",
 })
 
+// What the cost-only rung reports: oh-my-pi, opencode and Crush record what a
+// turn spent and no window to take it against, so every context field arrives
+// zeroed (docs/ceilings.md).
+const costOnlyUsageEvent = (id: string) => ({
+  id,
+  percent: 0,
+  tokens: 0,
+  window: 0,
+  model: "",
+  effort: "",
+  costUsd: 0.25,
+})
+
 // A busy card counts how long it has been busy, on a shared 1s clock (see
 // session-age). Left running it lands a repaint of its own in the middle of a
 // budget, so the clock is frozen. Only the timers: faking the microtask queue
@@ -278,6 +291,34 @@ test("a usage event for the active session repaints the footer, not the sidebar"
     TooltipTrigger: 8,
     TooltipContent: 4,
     TooltipPortal: 4,
+    Paperclip: 1,
+    Folder: 1,
+    Code: 1,
+    Anonymous: 3,
+  })
+  await budget.unmount()
+})
+
+test("a usage event with no context window draws no ring", async () => {
+  const budget = await mountSidebar()
+  await budget.act(() => bus.emit(USAGE_EVENT, costOnlyUsageEvent("s1")))
+  // The footer still repaints, but no ContextRing and no provider glyph: a
+  // report with no window has no percentage to draw a ring around, and the model
+  // slot renders nothing rather than naming zero of zero tokens. Against the
+  // budget above, the missing ContextRing, ProviderIcon, BrandIcon and one
+  // Separator are the whole degradation to the cost-only rung. (The cost figure
+  // itself is not here: its setting is an RPC, and every RPC hangs in this rig.)
+  expect(budget.take()).toEqual({
+    FooterBar: 1,
+    FooterButton: 2,
+    SessionModel: 1,
+    PlanQuota: 1,
+    Separator: 2,
+    Tooltip: 3,
+    TooltipRoot: 3,
+    TooltipTrigger: 6,
+    TooltipContent: 3,
+    TooltipPortal: 3,
     Paperclip: 1,
     Folder: 1,
     Code: 1,

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -65,6 +65,10 @@ export const SANDBOX_EVENT = "session-sandbox"
 // has to know about: lich cannot price this conversation, as opposed to lich
 // not pricing it (the readout is off, which is the whole design on a
 // subscription).
+//
+// All five context fields are zero for a provider that records a turn's spend
+// and no window to take it against, and a zero window is what tells the footer
+// to draw the cost without a ring (docs/ceilings.md).
 export const USAGE_EVENT = "session-usage"
 
 // Global event the backend emits while one session has a request open with

--- a/internal/terminal/sessiondb.go
+++ b/internal/terminal/sessiondb.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/omartelo/lich/internal/providers"
 	_ "modernc.org/sqlite"
 )
 
@@ -86,4 +87,70 @@ func sessionRowExists(path, table, id string) bool {
 	var found int
 	query := "SELECT 1 FROM " + table + " WHERE id = ? LIMIT 1"
 	return db.QueryRow(query, id).Scan(&found) == nil
+}
+
+// The SQL each database provider answers "what has this conversation cost" with,
+// in USD, from the figure it billed at itself. Neither is re-priced from a table
+// here: both bill models no table in lich knows, and the number on screen is the
+// one their own UI shows.
+const (
+	// opencode files each sub-agent as a session of its own and leaves the
+	// parent's cost its own turns alone — measured against 1.18.23, where a task
+	// call left the parent at $0.021 and the child at $0.0105 — so the total
+	// walks down the parent chain. Recursive rather than one level deep: a
+	// sub-agent can call the task tool again.
+	//
+	// SUM over no rows is NULL, which is how a conversation this database has
+	// never heard of is told apart from one that has genuinely cost nothing.
+	opencodeCostQuery = `WITH RECURSIVE tree(id) AS (
+		SELECT id FROM session WHERE id = ?
+		UNION SELECT s.id FROM session s JOIN tree t ON s.parent_id = t.id
+	) SELECT SUM(s.cost) FROM session s JOIN tree t ON s.id = t.id`
+
+	// Crush rolls a sub-agent's spend into the session that dispatched it
+	// (`updateParentSessionCost`), so one row is the whole number — measured
+	// against 0.88.0, where a parent billed $0.0525 against its child's $0.021.
+	crushCostQuery = `SELECT cost FROM sessions WHERE id = ?`
+)
+
+// costQueryFor is the query above for a provider id, and "" for a provider that
+// keeps no such database. sessionDBCost refuses the empty one, so a kind that
+// reaches here by mistake reads as "nothing to show" rather than as free.
+func costQueryFor(kind string) string {
+	switch kind {
+	case providers.OpenCode:
+		return opencodeCostQuery
+	case providers.Crush:
+		return crushCostQuery
+	}
+	return ""
+}
+
+// sessionDBCost reads what one conversation cost out of a provider's own
+// database. False for every failure and for a total the database cannot produce
+// — a missing file, a row that is not there, a schema that moved, a NULL sum —
+// which is the same "keep the last figure" the transcript readers answer with.
+//
+// Read-only and opened per call, for the reasons sessionRowExists gives: lich
+// must never write into a database another tool owns, and holding a handle on
+// one being migrated would be the more expensive mistake.
+func sessionDBCost(path, query, id string) (float64, bool) {
+	if id == "" || query == "" {
+		return 0, false
+	}
+	if _, err := os.Stat(path); err != nil {
+		return 0, false
+	}
+	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=busy_timeout(%d)", path, sessionDBBusyMS)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return 0, false
+	}
+	defer func() { _ = db.Close() }()
+
+	var cost sql.NullFloat64
+	if err := db.QueryRow(query, id).Scan(&cost); err != nil || !cost.Valid {
+		return 0, false
+	}
+	return cost.Float64, true
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -240,10 +240,11 @@ type Service struct {
 	// without answering (internal/relay). Guarded by mu: wired after the
 	// transport is already serving.
 	onState func(id, state string)
-	// kinds is what each live session's PTY was spawned to run — a provider id,
-	// or KindShell — keyed by session id. Read by providerKind, which is what
-	// stops a session-start report from repainting a card lich itself chose the
-	// provider for, and by the state report's own filter.
+	// spawns is how each live session's PTY was started — what it runs and where
+	// — keyed by session id. Read by providerKind, which is what stops a
+	// session-start report from repainting a card lich itself chose the provider
+	// for, by the state report's own filter, and by the cost readout, which asks
+	// where Crush keeps the database for this checkout.
 	//
 	// Deliberately not under mu, and that is the whole reason it is not simply a
 	// field on session: spawnSession holds mu across the PTY spawn, so a report
@@ -251,7 +252,7 @@ type Service struct {
 	// session's spawn — which is exactly what the note on turns below forbids.
 	// Written once per spawn and read on every report, which is what sync.Map
 	// is for.
-	kinds sync.Map
+	spawns sync.Map
 	// turns is which sessions have a turn open right now, which is what tells a
 	// `waiting` report that a human is blocking from one that only says the
 	// session is sitting at its prompt (see turnLog). It carries its own lock:
@@ -724,9 +725,9 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 		confined: inSandbox,
 	}
 	s.sessions[id] = sess
-	// Outside mu's protection by design (see Service.kinds), and stored with the
+	// Outside mu's protection by design (see Service.spawns), and stored with the
 	// registration so no report can arrive for a session whose kind is unknown.
-	s.kinds.Store(id, kind)
+	s.spawns.Store(id, spawn{kind: kind, cwd: cwd})
 	go s.stream(id, sess)
 	return sess, cwd, nil
 }
@@ -742,17 +743,29 @@ func (s *Service) providerKind(id, reported string) string {
 	return reported
 }
 
-// kindOf is what a live session's PTY was spawned to run, or "" once it is gone.
-// It never takes mu: a hook asks this on every report, and mu is held across a
-// PTY spawn (see Service.kinds).
-func (s *Service) kindOf(id string) string {
-	kind, ok := s.kinds.Load(id)
-	if !ok {
-		return ""
-	}
-	spawned, _ := kind.(string)
-	return spawned
+// spawn is how one live session's PTY was started: the kind it runs and the
+// directory it was rooted at. The cwd is the spawn directory and not the
+// foreground one the watcher follows (cwd.go) — Crush keeps its database in the
+// checkout it was started in, which a `cd` inside the session does not move.
+type spawn struct {
+	kind string
+	cwd  string
 }
+
+// spawnOf is how a live session's PTY was started, or the zero spawn once it is
+// gone. It never takes mu: a hook asks this on every report, and mu is held
+// across a PTY spawn (see Service.spawns).
+func (s *Service) spawnOf(id string) spawn {
+	v, ok := s.spawns.Load(id)
+	if !ok {
+		return spawn{}
+	}
+	started, _ := v.(spawn)
+	return started
+}
+
+// kindOf is what a live session's PTY was spawned to run, or "" once it is gone.
+func (s *Service) kindOf(id string) string { return s.spawnOf(id).kind }
 
 // closableState reports whether a state reported from inside a session of this
 // kind is one that harness can also end. A state nothing ends is worse than no
@@ -823,7 +836,7 @@ func (s *Service) stream(id string, sess *session) {
 	// respawn under this id must not drop the kind the live session was
 	// registered with.
 	if reaped {
-		s.kinds.Delete(id)
+		s.spawns.Delete(id)
 	}
 	s.mu.Unlock()
 
@@ -1058,7 +1071,7 @@ func (s *Service) Close(id string) error {
 		close(sess.done)
 	}
 	s.mu.Unlock()
-	s.kinds.Delete(id)
+	s.spawns.Delete(id)
 
 	// Before the bail below, because a card is closed far more often than it is
 	// running: its row is deleted either way, so nothing will ever ask what its

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -578,7 +578,7 @@ func TestProviderKindOutranksTheReport(t *testing.T) {
 		"shell-card":  KindShell,
 		"odd-card":    "something-else",
 	} {
-		svc.kinds.Store(id, kind)
+		svc.spawns.Store(id, spawn{kind: kind})
 	}
 	cases := []struct {
 		name, id, reported, want string
@@ -603,7 +603,7 @@ func TestProviderKindOutranksTheReport(t *testing.T) {
 // however long another session takes to spawn.
 func TestAReportNeverQueuesBehindASpawn(t *testing.T) {
 	svc := &Service{}
-	svc.kinds.Store("s1", providers.Cursor)
+	svc.spawns.Store("s1", spawn{kind: providers.Cursor})
 
 	// Stands in for a spawn in flight: the same lock, held by another session.
 	svc.mu.Lock()
@@ -625,7 +625,7 @@ func TestAReportNeverQueuesBehindASpawn(t *testing.T) {
 // that is gone, which is the one case the report is the better answer.
 func TestClosingASessionDropsItsKind(t *testing.T) {
 	svc := &Service{sessions: map[string]*session{}}
-	svc.kinds.Store("s1", providers.Cursor)
+	svc.spawns.Store("s1", spawn{kind: providers.Cursor})
 	if err := svc.Close("s1"); err != nil {
 		t.Fatalf("Close: %v", err)
 	}

--- a/internal/terminal/usage.go
+++ b/internal/terminal/usage.go
@@ -3,6 +3,8 @@ package terminal
 import (
 	"log/slog"
 	"path/filepath"
+
+	"github.com/omartelo/lich/internal/providers"
 )
 
 // usageEventName carries a session's context-window usage ({id, percent, tokens}),
@@ -16,6 +18,11 @@ const usageEventName = "session-usage"
 // context count behind it, Window the model's effective context window, Model
 // the model id, and Effort the reasoning effort level ("" when the line records
 // none).
+//
+// All five are zero for a provider that records what a turn spent but not the
+// window it spent it against — oh-my-pi, opencode and Crush, the cost-only rung
+// of docs/ceilings.md. A zero Window is the frontend's signal to draw the cost
+// alone rather than a ring around a window nobody reported.
 //
 // CostUSD is what the session has cost so far, and is omitted — not zeroed —
 // whenever there is no number worth showing: the setting is off, or a model in
@@ -62,8 +69,16 @@ func (s *Service) sessionUsage(id string) (usageEvent, bool) {
 	if providerSessionID == "" {
 		return usageEvent{}, false
 	}
-	u, ok := contextUsageFor(providerSessionID)
+	src, ok := usageSourceFor(providerSessionID, s.spawnOf(id).cwd)
 	if !ok {
+		return usageEvent{}, false
+	}
+	u, ok, supported := contextUsageFor(src)
+	// A provider whose window lich can read but has not read yet — a transcript
+	// still being written, a conversation before its first assistant line — keeps
+	// the readout's last value rather than repainting it at zero. A provider with
+	// no window to read never had one to lose, so its cost goes out alone.
+	if !ok && supported {
 		return usageEvent{}, false
 	}
 	event := usageEvent{
@@ -74,19 +89,78 @@ func (s *Service) sessionUsage(id string) (usageEvent, bool) {
 		Model:   u.model,
 		Effort:  u.effort,
 	}
-	if cost, miss, ok := s.sessionCost(id, providerSessionID); ok {
+	cost, miss, priced := s.sessionCost(id, src)
+	switch {
+	case priced:
 		event.CostUSD = &cost
-	} else if miss.spoken() {
+	case miss.spoken():
 		event.CostMiss = string(miss)
+	case !supported:
+		// Nothing to report at all: no window, and no cost either — the readout is
+		// off, or the conversation has not been priced yet. Emitting the zeroes
+		// would blank a figure the last turn earned.
+		return usageEvent{}, false
 	}
 	return event, true
 }
 
-func contextUsageFor(providerSessionID string) (contextUsage, bool) {
-	if usage, ok := claudeContextUsage(providerSessionID); ok {
-		return usage, true
+// usageSource is where one conversation's records live: which provider wrote
+// them and the one file that holds them — a transcript for Claude Code, Codex
+// and oh-my-pi, a database for opencode and Crush.
+type usageSource struct {
+	kind string
+	path string
+	// id is the provider's own conversation id, which is what keys the ledger
+	// rows and, for the two database providers, the row to read.
+	id string
+}
+
+// usageSourceFor finds the store holding a conversation, from the id alone.
+// Every provider files under a globally unique conversation id, so the store
+// that has it is the store that ran it — which is why this asks the disk rather
+// than the session's kind: a provider CLI started by hand inside a shell session
+// reports an id lich never spawned a kind for, and its footer reads the same as
+// any other.
+//
+// cwd is the session's spawn directory, needed by Crush alone: it keeps one
+// database per checkout rather than one per machine, so without a directory
+// there is no database to ask.
+func usageSourceFor(providerSessionID, cwd string) (usageSource, bool) {
+	if path, ok := claudeTranscriptPath(providerSessionID); ok {
+		return usageSource{kind: providers.Claude, path: path, id: providerSessionID}, true
 	}
-	return codexContextUsage(providerSessionID)
+	if path, ok := codexTranscriptPath(providerSessionID); ok {
+		return usageSource{kind: providers.Codex, path: path, id: providerSessionID}, true
+	}
+	if path, ok := ompTranscriptPath(providerSessionID); ok {
+		return usageSource{kind: providers.OMP, path: path, id: providerSessionID}, true
+	}
+	if path, ok := opencodeSessionDB(); ok &&
+		sessionRowExists(path, opencodeSessionTable, providerSessionID) {
+		return usageSource{kind: providers.OpenCode, path: path, id: providerSessionID}, true
+	}
+	if path, ok := crushSessionDB(cwd); ok &&
+		sessionRowExists(path, crushSessionTable, providerSessionID) {
+		return usageSource{kind: providers.Crush, path: path, id: providerSessionID}, true
+	}
+	return usageSource{}, false
+}
+
+// contextUsageFor reads how much of the model's context window a conversation
+// occupies. supported is whether this provider records a window at all: only
+// Claude Code and Codex do, and for the rest a miss is the standing state
+// rather than a read that has not landed yet (docs/ceilings.md). Antigravity and
+// Cursor CLI never reach here — they file no transcript usageSourceFor finds.
+func contextUsageFor(src usageSource) (usage contextUsage, ok, supported bool) {
+	switch src.kind {
+	case providers.Claude:
+		u, ok := claudeContextUsage(src.path)
+		return u, ok, true
+	case providers.Codex:
+		u, ok := scanCodexContextUsage(src.path)
+		return u, ok, true
+	}
+	return contextUsage{}, false, false
 }
 
 // sessionCost is what session id has cost across every conversation it has run,
@@ -96,36 +170,69 @@ func contextUsageFor(providerSessionID string) (contextUsage, bool) {
 // scanTranscriptCost for why an unpriced line stops the count instead of being
 // skipped.
 //
-// Routed by provider the way contextUsageFor is: a Claude transcript is more
-// than one file — what its sub-agents spent is billed to the same account and
-// written to transcripts of their own, so each is counted into the same
-// session, and one of them falling short withholds the whole number, for the
-// same reason a single unpriced line does. A Codex rollout has no sub-agent
-// files and reports its own running total, so countCodexTranscript prices it
-// whole rather than walking a ledger.
+// Routed by provider the way contextUsageFor is, and each rung reaches its total
+// differently:
+//
+//   - A Claude transcript is more than one file — what its sub-agents spent is
+//     billed to the same account and written to transcripts of their own, so each
+//     is counted into the same session, and one of them falling short withholds
+//     the whole number, for the same reason a single unpriced line does. Only
+//     this one resumes from an offset; the rest are read whole every turn.
+//   - A Codex rollout reports its own running token total, which lich prices
+//     from the shipped table.
+//   - oh-my-pi, opencode and Crush price their own turns as they write them, and
+//     the figure they recorded is the one lich shows: they bill models no table
+//     here knows, and re-pricing what a provider already billed would put a
+//     second, disagreeing number on screen. Whose arithmetic each is, and what
+//     it leaves out, is in the reader beside each call.
 //
 // The accounting is persisted per transcript, so it survives both a `/clear`
 // (a new conversation under the same session, counted into its own row) and a
 // restart of lich itself.
-func (s *Service) sessionCost(id, providerSessionID string) (float64, costMiss, bool) {
+//
+// A nil price table gates every rung, the three that never consult one
+// included: it is the readout's kill switch (see Service.prices), not a rate
+// lookup, and half a readout is not a state worth having.
+func (s *Service) sessionCost(id string, src usageSource) (float64, costMiss, bool) {
 	if s.prices == nil || !s.store.CostReadout() {
 		return 0, costMissNone, false
 	}
-	if path, ok := claudeTranscriptPath(providerSessionID); ok {
-		if miss, ok := s.countTranscript(id, providerSessionID, path); !ok {
+	switch src.kind {
+	case providers.Claude:
+		if miss, ok := s.countTranscript(id, src.id, src.path); !ok {
 			return 0, miss, false
 		}
-		for _, sub := range claudeSubagentPaths(providerSessionID) {
-			miss, ok := s.countTranscript(id, providerSessionID+"/"+filepath.Base(sub), sub)
+		for _, sub := range claudeSubagentPaths(src.id) {
+			miss, ok := s.countTranscript(id, src.id+"/"+filepath.Base(sub), sub)
 			if !ok {
 				return 0, miss, false
 			}
 		}
-	} else if path, ok := codexTranscriptPath(providerSessionID); ok {
-		if miss, ok := s.countCodexTranscript(id, providerSessionID, path); !ok {
+	case providers.Codex:
+		cost, miss, ok := codexTranscriptCost(src.path, s.prices)
+		if !ok {
 			return 0, miss, false
 		}
-	} else {
+		if miss, ok := s.saveWholeCost(id, src.id, cost); !ok {
+			return 0, miss, false
+		}
+	case providers.OMP:
+		cost, miss, ok := ompTranscriptCost(src.path)
+		if !ok {
+			return 0, miss, false
+		}
+		if miss, ok := s.saveWholeCost(id, src.id, cost); !ok {
+			return 0, miss, false
+		}
+	case providers.OpenCode, providers.Crush:
+		cost, ok := sessionDBCost(src.path, costQueryFor(src.kind), src.id)
+		if !ok {
+			return 0, costMissUnread, false
+		}
+		if miss, ok := s.saveWholeCost(id, src.id, cost); !ok {
+			return 0, miss, false
+		}
+	default:
 		return 0, costMissNone, false
 	}
 	total, err := s.store.SessionCost(id)
@@ -136,15 +243,12 @@ func (s *Service) sessionCost(id, providerSessionID string) (float64, costMiss, 
 	return total, costMissNone, true
 }
 
-// countCodexTranscript folds one Codex rollout's cost into the session's
-// ledger. Unlike countTranscript's per-turn deltas, total_token_usage is
-// already the conversation's running total, so there is no offset to resume
-// from: each call prices the rollout whole and overwrites the stored row.
-func (s *Service) countCodexTranscript(id, transcriptID, path string) (costMiss, bool) {
-	cost, miss, ok := codexTranscriptCost(path, s.prices)
-	if !ok {
-		return miss, false
-	}
+// saveWholeCost files what one conversation has cost so far, for every provider
+// that reports a running total rather than per-turn deltas. Unlike
+// countTranscript there is no offset to resume from: each call prices the
+// conversation whole and overwrites the stored row, so a re-read costs a scan
+// and never a double count.
+func (s *Service) saveWholeCost(id, transcriptID string, cost float64) (costMiss, bool) {
 	if err := s.store.SaveCostLedger(id, transcriptID, 0, "", cost); err != nil {
 		slog.Warn("terminal: save cost ledger", "session", id, "err", err)
 		return costMissUnread, false

--- a/internal/terminal/usage_claude.go
+++ b/internal/terminal/usage_claude.go
@@ -47,16 +47,10 @@ type contextUsage struct {
 }
 
 // claudeContextUsage reads the context-window usage of a Claude conversation
-// from its transcript. The transcript is ~/.claude/projects/<slug>/<id>.jsonl;
-// the id is a globally-unique UUID, so a glob across every project slug finds it
-// without reconstructing Claude's path-encoding of the slug. ok is false on any
-// miss (not found, unreadable, no assistant usage in the tail) — each is a "keep
-// the last value" for the caller, none worth logging once per turn.
-func claudeContextUsage(providerSessionID string) (contextUsage, bool) {
-	path, ok := claudeTranscriptPath(providerSessionID)
-	if !ok {
-		return contextUsage{}, false
-	}
+// from its transcript, which usageSourceFor already located. ok is false on any
+// miss (unreadable, no assistant usage in the tail) — each is a "keep the last
+// value" for the caller, none worth logging once per turn.
+func claudeContextUsage(path string) (contextUsage, bool) {
 	tail, ok := readTail(path, usageTailBytes)
 	if !ok {
 		return contextUsage{}, false

--- a/internal/terminal/usage_claude_test.go
+++ b/internal/terminal/usage_claude_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"testing"
+
+	"github.com/omartelo/lich/internal/providers"
 )
 
 const (
@@ -262,7 +264,9 @@ func TestReadTailMissingFile(t *testing.T) {
 }
 
 // TestClaudeContextUsageEndToEnd drives the glob-by-UUID locate through a
-// CLAUDE_CONFIG_DIR override, so no real ~/.claude is touched.
+// CLAUDE_CONFIG_DIR override, so no real ~/.claude is touched. It goes through
+// usageSourceFor, which is what turns a conversation id into the file the
+// readers take.
 func TestClaudeContextUsageEndToEnd(t *testing.T) {
 	base := t.TempDir()
 	slug := filepath.Join(base, "projects", "-home-user-proj")
@@ -279,7 +283,11 @@ func TestClaudeContextUsageEndToEnd(t *testing.T) {
 	}
 	t.Setenv("CLAUDE_CONFIG_DIR", base)
 
-	u, ok := claudeContextUsage(id)
+	src, ok := usageSourceFor(id, "")
+	if !ok || src.kind != providers.Claude {
+		t.Fatalf("usageSourceFor = %+v, ok %v, want the Claude transcript", src, ok)
+	}
+	u, ok := claudeContextUsage(src.path)
 	if !ok {
 		t.Fatal("claudeContextUsage ok = false")
 	}
@@ -287,7 +295,7 @@ func TestClaudeContextUsageEndToEnd(t *testing.T) {
 		t.Errorf("usage = %+v, want tokens 20002 percent 10 model %q", u, modelHaiku)
 	}
 
-	if _, ok := claudeContextUsage("no-such-id"); ok {
+	if _, ok := usageSourceFor("no-such-id", ""); ok {
 		t.Error("an unknown id should be not-ok")
 	}
 }

--- a/internal/terminal/usage_codex.go
+++ b/internal/terminal/usage_codex.go
@@ -42,19 +42,11 @@ type codexRolloutEntry struct {
 	} `json:"payload"`
 }
 
-// codexContextUsage reads the latest active context size, model and effort from
-// a Codex rollout. The rollout carries the effective window selected for that
-// session, including a model_context_window override. The reverse scan stops at
-// the current turn's turn_context, so an old conversation costs no more to read
-// than a new one.
-func codexContextUsage(providerSessionID string) (contextUsage, bool) {
-	path, ok := codexTranscriptPath(providerSessionID)
-	if !ok {
-		return contextUsage{}, false
-	}
-	return scanCodexContextUsage(path)
-}
-
+// scanCodexContextUsage reads the latest active context size, model and effort
+// from a Codex rollout. The rollout carries the effective window selected for
+// that session, including a model_context_window override. The reverse scan
+// stops at the current turn's turn_context, so an old conversation costs no more
+// to read than a new one.
 func scanCodexContextUsage(path string) (contextUsage, bool) {
 	var usage contextUsage
 	haveTokens := false

--- a/internal/terminal/usage_cost_error_test.go
+++ b/internal/terminal/usage_cost_error_test.go
@@ -83,7 +83,11 @@ func TestAStoreFailureShowsNoCost(t *testing.T) {
 			svc := New(store, nil, events.New())
 			svc.prices = testRate
 
-			cost, miss, ok := svc.sessionCost("s1", "uuid-cost")
+			src, ok := usageSourceFor("uuid-cost", "")
+			if !ok {
+				t.Fatal("usageSourceFor: want the planted transcript")
+			}
+			cost, miss, ok := svc.sessionCost("s1", src)
 			if ok {
 				t.Errorf("sessionCost = %v, want a miss", cost)
 			}

--- a/internal/terminal/usage_omp.go
+++ b/internal/terminal/usage_omp.go
@@ -1,0 +1,102 @@
+package terminal
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+)
+
+// ompAssistantMark is what a line has to contain before it is worth
+// unmarshalling: an oh-my-pi session file holds a line per tool result and per
+// user turn too, and each assistant line carries the model's whole provider
+// payload — tens of KB of encrypted reasoning content — so most of the file is
+// bytes the cost never reads.
+var ompAssistantMark = []byte(`"assistant"`)
+
+// ompTranscriptCost adds up what an oh-my-pi conversation has cost, in USD.
+//
+// omp prices every assistant turn as it writes it — the provider, the model and
+// a cost block sit on the message's own usage — so the total is the sum of
+// those, which is the same walk omp's own status line makes (measured against
+// 18.0.10, where every one of 1,395 assistant messages on this machine carried
+// one). No price table is consulted: omp bills models no table here knows, and
+// its zero for a free model or a subscription is an answer, not a gap.
+//
+// What that leaves out is what omp's own figure leaves out: a `task` sub-agent
+// is not an assistant message in this file, and the cost it reports lands in
+// the tool result instead. Its spend is missing from both numbers alike.
+//
+// The whole file is read every turn rather than resumed from an offset — a
+// session file runs to a few hundred KB and the prescreen above skips most of
+// it, so there is no ledger to keep in step with a rewritten file.
+//
+// ok is false when the file cannot be read at all. costMissUnpriced is a turn
+// omp wrote without a cost of its own: the money rule the rest of the readout
+// follows (usage_cost.go) says a total missing one turn is a wrong number, so
+// it withholds rather than under-reports.
+func ompTranscriptCost(path string) (float64, costMiss, bool) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, costMissUnread, false
+	}
+	defer func() { _ = f.Close() }()
+
+	total := 0.0
+	r := bufio.NewReader(f)
+	for {
+		line, err := r.ReadBytes('\n')
+		if err != nil {
+			// A trailing line with no newline is one omp is still writing; the next
+			// turn reads it whole. Any other read error stopped the scan mid-file,
+			// and a total that stops mid-file is a money number that is simply too
+			// small.
+			if err == io.EOF {
+				return total, costMissNone, true
+			}
+			return 0, costMissUnread, false
+		}
+		if !bytes.Contains(line, ompAssistantMark) {
+			continue
+		}
+		cost, ok, priced := parseOMPCostLine(line)
+		if !priced {
+			return 0, costMissUnpriced, false
+		}
+		if ok {
+			total += cost
+		}
+	}
+}
+
+// parseOMPCostLine pulls one assistant turn's cost out of a session line. ok is
+// false for every line that is not one — a user turn, a tool result, a
+// malformed line, the `"assistant"` the prescreen matched inside somebody's
+// prompt. priced is false only for a line that *is* an assistant turn and
+// carries no total for it, which is the one absence worth withholding the
+// session's number over.
+func parseOMPCostLine(line []byte) (cost float64, ok, priced bool) {
+	var entry struct {
+		Type    string `json:"type"`
+		Message struct {
+			Role  string `json:"role"`
+			Usage *struct {
+				Cost *struct {
+					Total *float64 `json:"total"`
+				} `json:"cost"`
+			} `json:"usage"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(line, &entry); err != nil {
+		return 0, false, true
+	}
+	if entry.Type != "message" || entry.Message.Role != "assistant" {
+		return 0, false, true
+	}
+	u := entry.Message.Usage
+	if u == nil || u.Cost == nil || u.Cost.Total == nil {
+		return 0, false, false
+	}
+	return *u.Cost.Total, true, true
+}

--- a/internal/terminal/usage_tokenonly_test.go
+++ b/internal/terminal/usage_tokenonly_test.go
@@ -1,0 +1,466 @@
+// The suite reuses stubBins from terminal_test.go, which is Unix-tagged for its
+// PTY spawns; this file carries the same tag so the package still builds on
+// Windows. Nothing here is platform-specific.
+//go:build !windows
+
+package terminal
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/events"
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// blankTranscriptDirs points the two transcript readers at empty directories, so
+// a test for one of the token-only providers proves the probe reached it rather
+// than tripping over a real ~/.claude on the machine running the suite.
+func blankTranscriptDirs(t *testing.T) {
+	t.Helper()
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+	t.Setenv("CODEX_HOME", t.TempDir())
+}
+
+// ompAssistant is one oh-my-pi assistant line: the shape the reader looks for,
+// with the provider's own USD total on it.
+func ompAssistant(id, model string, cost float64) string {
+	return fmt.Sprintf(
+		`{"type":"message","id":%q,"message":{"role":"assistant","provider":"rig","model":%q,`+
+			`"usage":{"input":1000,"output":500,"cost":{"input":0,"output":0,"total":%v}}}}`,
+		id, model, cost,
+	)
+}
+
+// writeOMPSession plants an oh-my-pi conversation under a throwaway agent
+// directory, in the sessions/<encoded-cwd>/<timestamp>_<id>.jsonl layout
+// ompTranscriptPath globs for.
+func writeOMPSession(t *testing.T, providerSessionID string, lines ...string) {
+	t.Helper()
+	blankTranscriptDirs(t)
+	base := t.TempDir()
+	dir := filepath.Join(base, "sessions", "-home-user-repo")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := ""
+	if len(lines) > 0 {
+		body = strings.Join(lines, "\n") + "\n"
+	}
+	path := filepath.Join(dir, "2026-09-03T12-00-00-000Z_"+providerSessionID+".jsonl")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// OMP_PROFILE wins outright over the override (see ompAgentDir), so a
+	// profile set on the machine running the suite would send the glob elsewhere.
+	t.Setenv("OMP_PROFILE", "")
+	t.Setenv("PI_CODING_AGENT_DIR", base)
+}
+
+// sessionRow is one row of a provider's own session table: its id, the parent
+// that dispatched it (empty for a top-level conversation) and what it cost.
+type sessionRow struct {
+	id     string
+	parent string
+	cost   float64
+}
+
+// writeOpenCodeDB plants opencode's single database under a throwaway
+// XDG_DATA_HOME, with the two columns the cost read touches.
+func writeOpenCodeDB(t *testing.T, rows ...sessionRow) {
+	t.Helper()
+	blankTranscriptDirs(t)
+	t.Setenv("PI_CODING_AGENT_DIR", t.TempDir())
+	base := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", base)
+	// Proves the override took: on a platform that ignored it the writes below
+	// would land beside the user's real conversations.
+	path, ok := opencodeSessionDB()
+	if !ok || !strings.HasPrefix(path, base) {
+		t.Fatalf("opencodeSessionDB = %q, want one under %q", path, base)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeSessionTable(t, path,
+		`CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT, cost REAL NOT NULL DEFAULT 0)`,
+		`INSERT INTO session (id, parent_id, cost) VALUES (?, ?, ?)`, rows,
+	)
+}
+
+// writeCrushDB plants Crush's per-checkout database under cwd and returns that
+// directory, which is what a session spawned there hands the cost read.
+func writeCrushDB(t *testing.T, rows ...sessionRow) string {
+	t.Helper()
+	blankTranscriptDirs(t)
+	t.Setenv("PI_CODING_AGENT_DIR", t.TempDir())
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	cwd := t.TempDir()
+	path, ok := crushSessionDB(cwd)
+	if !ok {
+		t.Fatal("crushSessionDB: want a path for a named checkout")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeSessionTable(t, path,
+		`CREATE TABLE sessions (id TEXT PRIMARY KEY, parent_session_id TEXT, cost REAL NOT NULL DEFAULT 0)`,
+		`INSERT INTO sessions (id, parent_session_id, cost) VALUES (?, ?, ?)`, rows,
+	)
+	return cwd
+}
+
+func writeSessionTable(t *testing.T, path, create, insert string, rows []sessionRow) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(create); err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range rows {
+		var parent any
+		if row.parent != "" {
+			parent = row.parent
+		}
+		if _, err := db.Exec(insert, row.id, parent, row.cost); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+// TestOMPCostSumsTheTurnsOMPPriced is the reader's whole contract: oh-my-pi
+// writes a USD total on every assistant turn, so the session's cost is their
+// sum, with no price table consulted.
+func TestOMPCostSumsTheTurnsOMPPriced(t *testing.T) {
+	writeOMPSession(t, "omp-1",
+		`{"type":"session","id":"omp-1"}`,
+		ompAssistant("a1", "rig/one", 0.0105),
+		`{"type":"message","id":"t1","message":{"role":"toolResult","toolName":"bash"}}`,
+		ompAssistant("a2", "rig/one", 0.25),
+	)
+	path, ok := ompTranscriptPath("omp-1")
+	if !ok {
+		t.Fatal("ompTranscriptPath: want the planted session file")
+	}
+
+	cost, miss, ok := ompTranscriptCost(path)
+
+	if !ok || miss != costMissNone {
+		t.Fatalf("ompTranscriptCost ok = %v, miss = %q", ok, miss)
+	}
+	if !nearly(cost, 0.2605) {
+		t.Errorf("cost = %v, want 0.2605", cost)
+	}
+}
+
+// TestOMPCostWithholdsAnUnpricedTurn carries the money rule into the reader: a
+// turn oh-my-pi wrote without a total of its own would make the sum quietly too
+// small, which is worse than showing nothing.
+func TestOMPCostWithholdsAnUnpricedTurn(t *testing.T) {
+	writeOMPSession(t, "omp-1",
+		ompAssistant("a1", "rig/one", 0.5),
+		`{"type":"message","id":"a2","message":{"role":"assistant","model":"rig/one","usage":{"input":9}}}`,
+	)
+	path, _ := ompTranscriptPath("omp-1")
+
+	cost, miss, ok := ompTranscriptCost(path)
+
+	if ok {
+		t.Errorf("ompTranscriptCost = %v, want a miss", cost)
+	}
+	if miss != costMissUnpriced {
+		t.Errorf("miss = %q, want %q", miss, costMissUnpriced)
+	}
+}
+
+// TestOMPCostSkipsWhatIsNotABilledTurn pins the prescreen: the word "assistant"
+// appears in prompts and tool output, and a line that merely contains it must
+// not be counted, nor treated as a turn with no price.
+func TestOMPCostSkipsWhatIsNotABilledTurn(t *testing.T) {
+	writeOMPSession(t, "omp-1",
+		`{"type":"message","id":"u1","message":{"role":"user","text":"you are an assistant"}}`,
+		`not json at all, but it says "assistant"`,
+		ompAssistant("a1", "rig/one", 0.125),
+	)
+	path, _ := ompTranscriptPath("omp-1")
+
+	cost, miss, ok := ompTranscriptCost(path)
+
+	if !ok || miss != costMissNone {
+		t.Fatalf("ompTranscriptCost ok = %v, miss = %q", ok, miss)
+	}
+	if !nearly(cost, 0.125) {
+		t.Errorf("cost = %v, want 0.125 — only the assistant turn is billable", cost)
+	}
+}
+
+// TestOMPCostIgnoresALineStillBeingWritten is the file mid-append: the last line
+// has no newline yet, so it is not a turn the reader can trust. Counting it
+// would bill half a message.
+func TestOMPCostIgnoresALineStillBeingWritten(t *testing.T) {
+	writeOMPSession(t, "omp-1", ompAssistant("a1", "rig/one", 0.4))
+	path, _ := ompTranscriptPath("omp-1")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(ompAssistant("a2", "rig/one", 99)[:40]); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+
+	cost, _, ok := ompTranscriptCost(path)
+
+	if !ok || !nearly(cost, 0.4) {
+		t.Errorf("cost = %v (ok %v), want 0.4 — the half-written line waits for its newline", cost, ok)
+	}
+}
+
+// TestOMPCostOnAMissingFile keeps the reader on the same "degrade, never break"
+// contract as every other transcript read.
+func TestOMPCostOnAMissingFile(t *testing.T) {
+	cost, miss, ok := ompTranscriptCost(filepath.Join(t.TempDir(), "nope.jsonl"))
+	if ok {
+		t.Errorf("ompTranscriptCost = %v, want a miss", cost)
+	}
+	if miss != costMissUnread {
+		t.Errorf("miss = %q, want %q", miss, costMissUnread)
+	}
+}
+
+// TestOpenCodeCostWalksTheSubAgentChain is what the measurement found: opencode
+// files each sub-agent as a session of its own and leaves the parent's cost its
+// own turns alone, so reading the parent row alone under-reports the session.
+func TestOpenCodeCostWalksTheSubAgentChain(t *testing.T) {
+	writeOpenCodeDB(t,
+		sessionRow{id: "ses_parent", cost: 0.021},
+		sessionRow{id: "ses_child", parent: "ses_parent", cost: 0.0105},
+		sessionRow{id: "ses_grandchild", parent: "ses_child", cost: 0.5},
+		sessionRow{id: "ses_stranger", cost: 100},
+	)
+	path, _ := opencodeSessionDB()
+
+	cost, ok := sessionDBCost(path, opencodeCostQuery, "ses_parent")
+
+	if !ok {
+		t.Fatal("sessionDBCost: want the parent's total")
+	}
+	if !nearly(cost, 0.5315) {
+		t.Errorf("cost = %v, want 0.5315 — the parent and every sub-agent below it", cost)
+	}
+}
+
+// TestCrushCostIsTheSessionRow is the other half of that measurement: Crush
+// rolls a sub-agent's spend into the session that dispatched it, so summing the
+// children again would bill them twice.
+func TestCrushCostIsTheSessionRow(t *testing.T) {
+	cwd := writeCrushDB(t,
+		sessionRow{id: "crush-parent", cost: 0.0525},
+		sessionRow{id: "crush-child", parent: "crush-parent", cost: 0.021},
+	)
+	path, _ := crushSessionDB(cwd)
+
+	cost, ok := sessionDBCost(path, crushCostQuery, "crush-parent")
+
+	if !ok || !nearly(cost, 0.0525) {
+		t.Errorf("cost = %v (ok %v), want 0.0525 — Crush already rolled the child in", cost, ok)
+	}
+}
+
+// TestSessionDBCostMisses covers every absence the read answers false for. Each
+// is a "keep the last figure", never a zero: a database lich cannot read has not
+// told it the session was free.
+func TestSessionDBCostMisses(t *testing.T) {
+	cwd := writeCrushDB(t, sessionRow{id: "crush-1", cost: 3})
+	path, _ := crushSessionDB(cwd)
+	tests := []struct {
+		name, path, query, id string
+	}{
+		{"no conversation id", path, crushCostQuery, ""},
+		{"a provider with no such database", path, costQueryFor(providers.Claude), "crush-1"},
+		{"a database that is not there", filepath.Join(t.TempDir(), "crush.db"), crushCostQuery, "crush-1"},
+		{"a row that is not there", path, crushCostQuery, "crush-gone"},
+		{"a table that moved", path, `SELECT cost FROM nowhere WHERE id = ?`, "crush-1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if cost, ok := sessionDBCost(tc.path, tc.query, tc.id); ok {
+				t.Errorf("sessionDBCost = %v, want a miss", cost)
+			}
+		})
+	}
+}
+
+// TestOpenCodeCostIsAbsentForAnUnknownConversation is why the sum is NULL-checked
+// rather than coalesced: SUM over no rows is zero, and a zero in the money slot
+// is a claim that the session was free.
+func TestOpenCodeCostIsAbsentForAnUnknownConversation(t *testing.T) {
+	writeOpenCodeDB(t, sessionRow{id: "ses_one", cost: 2})
+	path, _ := opencodeSessionDB()
+
+	if cost, ok := sessionDBCost(path, opencodeCostQuery, "ses_nothere"); ok {
+		t.Errorf("sessionDBCost = %v, want a miss for a conversation opencode never ran", cost)
+	}
+}
+
+// TestTheCostOnlyRungReportsWithoutAWindow is the feature: each of the three
+// providers that record a turn's spend and no window to take it against gets a
+// usage event carrying the cost, with the context fields zeroed — which is what
+// tells the footer to drop the ring instead of the whole readout.
+func TestTheCostOnlyRungReportsWithoutAWindow(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want float64
+		// plant returns the session's spawn directory, which only Crush needs.
+		plant func(t *testing.T) string
+		kind  string
+	}{
+		{
+			name: "oh-my-pi", id: "omp-1", want: 0.2605, kind: providers.OMP,
+			plant: func(t *testing.T) string {
+				writeOMPSession(t, "omp-1",
+					ompAssistant("a1", "rig/one", 0.0105), ompAssistant("a2", "rig/one", 0.25))
+				return ""
+			},
+		},
+		{
+			name: "opencode", id: "ses_one", want: 0.0315, kind: providers.OpenCode,
+			plant: func(t *testing.T) string {
+				writeOpenCodeDB(t,
+					sessionRow{id: "ses_one", cost: 0.021},
+					sessionRow{id: "ses_two", parent: "ses_one", cost: 0.0105})
+				return ""
+			},
+		},
+		{
+			name: "Crush", id: "crush-1", want: 0.0525, kind: providers.Crush,
+			plant: func(t *testing.T) string {
+				return writeCrushDB(t, sessionRow{id: "crush-1", cost: 0.0525})
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cwd := tc.plant(t)
+			src, ok := usageSourceFor(tc.id, cwd)
+			if !ok || src.kind != tc.kind {
+				t.Fatalf("usageSourceFor = %+v (ok %v), want kind %q", src, ok, tc.kind)
+			}
+			svc := New(newCostStore(tc.id), nil, events.New())
+			svc.prices = testRate
+			svc.spawns.Store("s1", spawn{kind: tc.kind, cwd: cwd})
+
+			got, ok := svc.sessionUsage("s1")
+
+			if !ok {
+				t.Fatal("sessionUsage: want ok — the cost stands without a context ring")
+			}
+			if got.CostUSD == nil || !nearly(*got.CostUSD, tc.want) {
+				t.Fatalf("CostUSD = %v, want %v", got.CostUSD, tc.want)
+			}
+			if got.Window != 0 || got.Percent != 0 || got.Tokens != 0 || got.Model != "" {
+				t.Errorf("context fields = %+v, want zeroed — no window was reported", got)
+			}
+		})
+	}
+}
+
+// TestTheCostOnlyRungStaysSilentWithoutACost is the other side of that gate: with
+// nothing to report at all, no event goes out. An event of zeroes would blank a
+// figure the last turn earned.
+func TestTheCostOnlyRungStaysSilentWithoutACost(t *testing.T) {
+	writeOMPSession(t, "omp-1", ompAssistant("a1", "rig/one", 0.5))
+	// The readout is off, which is the flag's whole job on a subscription.
+	svc := New(stubBins{providerSession: "omp-1"}, nil, events.New())
+	svc.prices = testRate
+
+	if got, ok := svc.sessionUsage("s1"); ok {
+		t.Errorf("sessionUsage = %+v, want no event when there is neither a window nor a cost", got)
+	}
+}
+
+// TestAnUnpricedOMPTurnIsSpokenOnTheFooter carries the reader's miss out to the
+// event: the number is standing gone, so the corner says so rather than reading
+// as zero spend.
+func TestAnUnpricedOMPTurnIsSpokenOnTheFooter(t *testing.T) {
+	writeOMPSession(t, "omp-1",
+		`{"type":"message","id":"a1","message":{"role":"assistant","model":"rig/one","usage":{"input":9}}}`)
+	svc := New(newCostStore("omp-1"), nil, events.New())
+	svc.prices = testRate
+
+	got, ok := svc.sessionUsage("s1")
+
+	if !ok {
+		t.Fatal("sessionUsage: want ok — the marked absence is itself the readout")
+	}
+	if got.CostUSD != nil {
+		t.Errorf("CostUSD = %v, want absent", *got.CostUSD)
+	}
+	if got.CostMiss != string(costMissUnpriced) {
+		t.Errorf("CostMiss = %q, want %q", got.CostMiss, costMissUnpriced)
+	}
+}
+
+// TestCrushWithoutASpawnDirectoryIsNotFound is the one provider the probe cannot
+// reach from the id alone: Crush keeps a database per checkout, so a session
+// whose directory lich cannot name has nothing to ask.
+func TestCrushWithoutASpawnDirectoryIsNotFound(t *testing.T) {
+	writeCrushDB(t, sessionRow{id: "crush-1", cost: 3})
+
+	if src, ok := usageSourceFor("crush-1", ""); ok {
+		t.Errorf("usageSourceFor = %+v, want a miss without a checkout to look in", src)
+	}
+}
+
+// TestTheCostOnlyRungSurvivesAStoreFailure keeps the new rung on the same
+// contract the transcript readers are held to: a ledger row that cannot be
+// written withholds the money and says nothing on screen, because the next turn
+// heals it.
+func TestTheCostOnlyRungSurvivesAStoreFailure(t *testing.T) {
+	writeOMPSession(t, "omp-1", ompAssistant("a1", "rig/one", 0.5))
+	store := newCostStore("omp-1")
+	store.saveLedgerErr = errors.New("the database is gone")
+	svc := New(store, nil, events.New())
+	svc.prices = testRate
+
+	got, ok := svc.sessionUsage("s1")
+
+	if ok {
+		t.Fatalf("sessionUsage = %+v, want no event: no window, and no cost to stand alone", got)
+	}
+	src, _ := usageSourceFor("omp-1", "")
+	cost, miss, ok := svc.sessionCost("s1", src)
+	if ok {
+		t.Errorf("sessionCost = %v, want a miss", cost)
+	}
+	if miss.spoken() {
+		t.Errorf("miss = %q, want one the footer stays quiet about", miss)
+	}
+}
+
+// TestAProviderWithNoRecordsIsPricedByNobody is the default arm: Antigravity and
+// Cursor CLI file their conversations somewhere no reader here looks, and a kind
+// that reaches the cost switch anyway must read as "nothing to show" rather than
+// as free.
+func TestAProviderWithNoRecordsIsPricedByNobody(t *testing.T) {
+	svc := New(newCostStore("agy-1"), nil, events.New())
+	svc.prices = testRate
+
+	cost, miss, ok := svc.sessionCost("s1", usageSource{kind: providers.Antigravity, id: "agy-1"})
+
+	if ok {
+		t.Errorf("sessionCost = %v, want a miss", cost)
+	}
+	if miss != costMissNone {
+		t.Errorf("miss = %q, want the unspoken one", miss)
+	}
+}


### PR DESCRIPTION
Closes #429, rung 1 only. The shaping question the issue asks is answered yes: a cost without a context ring is worth shipping.

oh-my-pi, opencode and Crush price every turn as they run it, but none of them writes down the model's context window. The footer read a missing window as nothing to show and blanked the whole readout — including the cost, which never needed a window. Five of the seven providers now carry a figure.

## What the measurement said

Measured against the installed binaries, not read off a schema. Rig in `/tmp` (a fake OpenAI-compatible server with declared per-million rates, isolated `HOME`/`XDG_*`/config for each CLI), so every number below is one lich could have shown.

| Provider | Model id | Token counts | Cost recorded | Verdict |
|---|---|---|---|---|
| oh-my-pi 18.0.10 | yes, per assistant turn | yes | **yes** — `usage.cost.total` in USD, on 1,395 of 1,395 real assistant messages | in |
| opencode 1.18.23 | yes | yes | **yes** — `session.cost` per conversation (rig: $0.0105 for 1,000 in / 500 out at $3/$15 per M) | in |
| Crush 0.88.0 | yes | yes | **yes** — `sessions.cost` per conversation (rig: $0.021 for two calls at the same rates) | in |

Two behaviours that only a rig could settle, and that decide the SQL:

- **opencode does not roll a sub-agent into its parent.** A `task` call left the parent at $0.021 and the child session at $0.0105, so reading the parent row alone under-reports. The query walks the `parent_id` chain recursively.
- **Crush does roll it in** (`updateParentSessionCost` in the binary). A parent billed $0.0525 against its child's $0.021, so one row is the whole number and summing the children would bill them twice.

Also measured: opencode explicitly zeroes cost for an OAuth (subscription) provider, and omp records `0` for a free model. A zero from either is an answer, not a gap.

## The shape

`usageSourceFor` resolves a conversation id to the store that holds it — by asking the disk, not the session's kind, so a provider CLI started by hand inside a shell session still reads. Both readers dispatch on that: `contextUsageFor` answers for Claude Code and Codex alone and reports whether it *could* have, while `sessionCost` gains one arm per new provider. A window lich can read but has not read yet still holds the last value; a provider with no window to read emits its cost with the context fields zeroed, and a zero window is what tells `FooterBar` to drop the ring and `SessionModel` to render nothing rather than a provider glyph beside a model nobody reported.

**The three new figures are the providers' own arithmetic, never re-priced here.** They bill models `internal/pricing` has never heard of, so a second opinion would only be a second, disagreeing number — and each therefore inherits what its own accounting leaves out (omp's total excludes `task` sub-agents, exactly as omp's own status line does). `costMiss` is reused rather than extended: nothing new is spoken on the footer.

`Service.kinds` becomes `Service.spawns` and carries the spawn directory beside the kind — Crush keeps one database per checkout, and the foreground cwd the watcher follows is the wrong one.

## What is deliberately out

- **Rung 2 (Antigravity, Cursor CLI).** Each needs a reader for its own SQLite schema, and neither schema is a contract anybody promised to keep. They are a named row in the ceilings table, not code.
- **The model id for the three new providers.** All three record one, but the rung is "cost only" and naming it would blur the rung the issue asks to draw. Cheap to add later.
- **A `costMiss` of its own for an oh-my-pi turn written with no total.** Never observed in the corpus; it borrows `unpriced-model`, and the tooltip mismatch is written down in `ceilings.md` rather than solved for a case nobody has seen.

## Docs

`docs/ceilings.md` carries the seven-provider rung table the issue asks for, with what each provider's own accounting leaves out and the fact that both sub-agent rollups are measured behaviour rather than a promise. `docs/adding-a-provider.md` gains the row that makes the readout part of adding a provider at all.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` — 2,098 pass; `-race` on `internal/terminal` and `internal/store`
- [x] Cross-compile loop: `GOOS=linux|darwin|windows go build ./... && go vet ./...`
- [x] `pnpm check`, `vitest run` (1,343 pass), `tsc`, `vite build`
- [x] New logic covered 90–100%: `ompTranscriptCost` 95%, `parseOMPCostLine` 91%, `sessionDBCost` 93%, `usageSourceFor` 100%, `contextUsageFor` 100%, `sessionCost` 90%, `saveWholeCost` 100%
- [x] Frontend degradation pinned in the render budget: a zero-window usage event repaints the footer with no `ContextRing`, `ProviderIcon` or `BrandIcon`
