### PR TITLE
fix: spawn Kiro through its chat subcommand

### DIFF
--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -15,7 +15,12 @@ Two rules govern the whole exercise, and both are in
 - **Every table here is read off that CLI's own `--help` or a real run.** A flag
   guessed from a sibling is a spawn that dies before the session exists, and an
   event name copied from another harness is a report that silently never fires.
-  Nothing below is inferred from a provider's documentation alone.
+  Nothing below is inferred from a provider's documentation alone. Read the
+  `--help` of the command lich actually spawns: a CLI with subcommands has one
+  parser per level, and a flag that exists under one is rejected by the other.
+  Kiro CLI is the worked example — `--agent` and `--resume-id` are its root's,
+  `--model` and `--trust-all-tools` its `chat` subcommand's, so lich spawns
+  `kiro-cli chat` and `subcommandArgs` puts that word first.
 - **A gap is allowed; a silent one is not.** Equal behaviour across providers is
   often impossible. Where the new provider cannot do something the others can,
   the same PR adds a [`ceilings.md`](ceilings.md) bullet naming what is out and
@@ -55,7 +60,7 @@ tool.
 | File | What it holds | What a new provider adds |
 |---|---|---|
 | `internal/providers/providers.go` | the registry | an id constant, a `Registry` entry (id, display name, binary names, install-docs URL), and a line in `AcceptsMCPServer` if it takes an MCP server on its command line |
-| `internal/terminal/command.go` | what a spawn runs | entries in `skipPermissionFlags`, `modelFlags`, `briefingFlags` and `resumeArgs` — each one optional, and absent means "no flag rather than somebody else's" |
+| `internal/terminal/command.go` | what a spawn runs | entries in `skipPermissionFlags`, `modelFlags`, `briefingFlags` and `resumeArgs` — each one optional, and absent means "no flag rather than somebody else's" — plus a `subcommandArgs` arm if the session is a subcommand rather than the bare binary |
 | `internal/terminal/resume.go` | whether a resume can be offered | a `ResumeAvailable` case answering from what that provider left on disk |
 | `internal/terminal/transcript.go`, `sessiondb.go` | where that state lives | the path resolver the case above calls |
 | `internal/terminal/usage.go` | the footer's session readout | a `usageSourceFor` arm, plus a `sessionCost` arm reading whatever that provider records about spend — and a `contextUsageFor` arm only if it also records the model's context window. Which rung that lands the provider on is a row in `docs/ceilings.md`, in the same PR |

--- a/internal/agentplugin/crush.go
+++ b/internal/agentplugin/crush.go
@@ -77,7 +77,7 @@ func (s *Service) crushInstall() error {
 	if err != nil {
 		return err
 	}
-	dir, err := pluginScriptDir()
+	dir, err := pluginScriptDir(providers.Crush)
 	if err != nil {
 		return err
 	}
@@ -324,14 +324,21 @@ func (s *Service) crushrcPath() (string, error) {
 	return filepath.Join(dir, "crushrc"), nil
 }
 
-// pluginScriptDir is where lich keeps the hook scripts it installs: its own
-// config directory, not the harness's. They are lich's copy of another
-// repository's files, and a harness that never installed them should not be
-// carrying them. Shared with the Kiro install, which ships the same scripts.
-func pluginScriptDir() (string, error) {
+// pluginScriptDir is where lich keeps the hook scripts it installs for one
+// file-shipped harness: its own config directory, not the harness's. They are
+// lich's copy of another repository's files, and a harness that never installed
+// them should not be carrying them.
+//
+// One directory per provider, even though Crush and Kiro ship the same scripts.
+// releaseVersion resolves whatever the plugin repository has released, not the
+// version of the lich running the install, so a shared directory would let a
+// Kiro install fetched today overwrite the scripts a Crush install fetched at an
+// older release — leaving Crush's marker naming a version that is no longer on
+// disk, which is the one thing that marker exists to answer.
+func pluginScriptDir(provider string) (string, error) {
 	dir, err := os.UserConfigDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve config directory: %w", err)
 	}
-	return filepath.Join(dir, "lich", "plugin", "hooks"), nil
+	return filepath.Join(dir, "lich", "plugin", "hooks", provider), nil
 }

--- a/internal/agentplugin/files_test.go
+++ b/internal/agentplugin/files_test.go
@@ -470,7 +470,7 @@ func installCrush(t *testing.T, s *Service, existingRC string) (string, string) 
 	if err != nil {
 		t.Fatalf("read crushrc: %v", err)
 	}
-	return string(data), filepath.Join(lichConfig, "lich", "plugin", "hooks")
+	return string(data), filepath.Join(lichConfig, "lich", "plugin", "hooks", providers.Crush)
 }
 
 func crushFiles() map[string]string {

--- a/internal/agentplugin/kiro.go
+++ b/internal/agentplugin/kiro.go
@@ -78,7 +78,7 @@ func (s *Service) kiroInstall() error {
 	if err != nil {
 		return err
 	}
-	dir, err := pluginScriptDir()
+	dir, err := pluginScriptDir(providers.Kiro)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func (s *Service) kiroInstall() error {
 			return err
 		}
 	}
-	path, err := kiroAgentPath()
+	path, err := providers.KiroAgentPath()
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func kiroAgentFile(version, scriptDir string) ([]byte, error) {
 		Hooks:          hooks,
 	}, "", "  ")
 	if err != nil {
-		return nil, fmt.Errorf("encode %s: %w", filepath.Base(providers.KiroAgentName), err)
+		return nil, fmt.Errorf("encode the %s agent: %w", providers.KiroAgentName, err)
 	}
 	return append(body, '\n'), nil
 }
@@ -240,7 +240,7 @@ func (s *Service) kiroRegisterMCP() error {
 // kiroInstalledVersion reads the version off the agent lich wrote, or ("",
 // false) when it is absent, unreadable, or was not written by lich.
 func (s *Service) kiroInstalledVersion() (string, bool) {
-	path, err := kiroAgentPath()
+	path, err := providers.KiroAgentPath()
 	if err != nil {
 		return "", false
 	}
@@ -249,16 +249,4 @@ func (s *Service) kiroInstalledVersion() (string, bool) {
 		return "", false
 	}
 	return versionOf(data, `"description": "Installed by`)
-}
-
-// kiroAgentPath is the agent config lich owns, in Kiro's global agents
-// directory. That root hangs off the home alone — 2.21.0 honours no environment
-// variable for it — and internal/terminal resolves the same file the same way to
-// decide whether to name it at spawn.
-func kiroAgentPath() (string, error) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("resolve home directory: %w", err)
-	}
-	return filepath.Join(home, ".kiro", "agents", providers.KiroAgentName+".json"), nil
 }

--- a/internal/agentplugin/kiro_test.go
+++ b/internal/agentplugin/kiro_test.go
@@ -318,7 +318,7 @@ func TestKiroInstallWritesTheAgentAndTheScripts(t *testing.T) {
 	if err := json.Unmarshal(data, &agent); err != nil {
 		t.Fatalf("installed agent is not JSON: %v", err)
 	}
-	scriptDir := filepath.Join(configDir, "lich", "plugin", "hooks")
+	scriptDir := filepath.Join(configDir, "lich", "plugin", "hooks", providers.Kiro)
 	for _, script := range kiroScripts() {
 		installed := filepath.Join(scriptDir, filepath.Base(script))
 		info, err := os.Stat(installed)

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -6,7 +6,12 @@
 // browser detection.
 package providers
 
-import "os/exec"
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
 
 // Provider ids. Each id is also the session kind (store column + terminal.Start)
 // that runs the provider. Kept in sync with frontend/src/lib/session/sessions.ts.
@@ -62,6 +67,19 @@ var Registry = []Provider{
 // internal/agentplugin, named on the command line by internal/terminal, and
 // spelled once here so those two cannot drift apart.
 const KiroAgentName = "lich"
+
+// KiroAgentPath is the file that agent lives in, inside Kiro's global agents
+// directory. That root hangs off the home alone — 2.21.0 honours no environment
+// variable for it. Resolved here rather than in either caller so the install
+// that writes the file (internal/agentplugin) and the spawn that decides whether
+// to name it (internal/terminal) cannot drift to different paths.
+func KiroAgentPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	return filepath.Join(home, ".kiro", "agents", KiroAgentName+".json"), nil
+}
 
 // Known reports whether id names a registered provider. It guards a provider id
 // that arrives from outside lich — a hook payload — before it is used as one.

--- a/internal/terminal/command.go
+++ b/internal/terminal/command.go
@@ -46,6 +46,15 @@ const (
 	kiroResumeFlag        = "--resume-id"
 )
 
+// kiroChatSubcmd is the subcommand a Kiro session runs, and it is not optional.
+// Kiro splits the flags lich passes across two parsers: its root takes --agent
+// and --resume-id, but --model and --trust-all-tools belong to `chat` alone, and
+// either one at the root exits 2 with `unexpected argument` before the session
+// exists (measured on 2.21.0). `chat` takes every flag the root does, so lich
+// spawns it whether or not those two are set rather than assembling a different
+// command per setting.
+const kiroChatSubcmd = "chat"
+
 // kiroAgentFlag picks the agent profile a Kiro session runs. lich passes it only
 // to reach the hooks: Kiro keeps them inside an agent config and its built-in
 // `kiro_default` cannot be shadowed by a file (measured on 2.21.0 — a
@@ -222,14 +231,16 @@ func flagValue(value string) (string, bool) {
 }
 
 // providerArgs assembles the whole argument list for one spawn. Ordering is
-// decided here rather than by appending in call order, because the two
-// providers constrain it in opposite directions: Codex spells resume as a
-// subcommand, so its global options have to come first, while Claude Code's
-// --mcp-config is variadic and reads everything after it as another config
-// path, so it has to come last.
+// decided here rather than by appending in call order, because the providers
+// constrain it in opposite directions: Codex spells resume as a subcommand, so
+// its global options have to come first, while Claude Code's --mcp-config is
+// variadic and reads everything after it as another config path, so it has to
+// come last. Kiro's subcommand opens the session rather than a conversation, so
+// it comes before every flag.
 func providerArgs(kind, name, resume, model, lichBin, agent string, skipPermissions bool) []string {
 	mcp := mcpArgs(kind, lichBin)
-	args := append([]string{}, nameArgs(kind, name, resume)...)
+	args := append([]string{}, subcommandArgs(kind)...)
+	args = append(args, nameArgs(kind, name, resume)...)
 	args = append(args, agentArgs(kind, agent)...)
 	args = append(args, resumeArgs(kind, resume)...)
 	args = append(args, skipPermissionArgs(kind, skipPermissions)...)
@@ -239,6 +250,20 @@ func providerArgs(kind, name, resume, model, lichBin, agent string, skipPermissi
 		return append(mcp, args...)
 	}
 	return append(args, mcp...)
+}
+
+// subcommandArgs returns the subcommand that opens a session, or nil when the
+// provider's root command is the session. Kiro CLI is the only one that needs
+// it, and it goes first: the flags after it are split across Kiro's two parsers
+// and only `chat` accepts them all (kiroChatSubcmd).
+//
+// Codex spells a subcommand too, but its is `resume` — a way of opening one
+// conversation rather than the session itself — so it rides resumeArgs.
+func subcommandArgs(kind string) []string {
+	if kind != providers.Kiro {
+		return nil
+	}
+	return []string{kiroChatSubcmd}
 }
 
 // agentArgs returns the arguments that pick the agent profile a provider runs,

--- a/internal/terminal/command_kiro_test.go
+++ b/internal/terminal/command_kiro_test.go
@@ -1,0 +1,149 @@
+package terminal
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// The Kiro CLI side of a spawn: which agent it is told to run, and the shape of
+// the command line that carries it. The readout tests are in usage_kiro_test.go.
+
+// kiroHome redirects the home Kiro's directories hang off — it answers to no
+// environment variable of its own — and returns it. The resolved path is
+// asserted to be under the redirect before anything is written: a variable this
+// misses on some platform would leave the test writing an agent into the real
+// user's ~/.kiro and passing while it did.
+func kiroHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	got, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("resolve home directory: %v", err)
+	}
+	if got != home {
+		t.Fatalf("home resolved to %q, outside the test's temp dir %q", got, home)
+	}
+	return home
+}
+
+// TestKiroPluginAgentNamesTheAgentOnlyOnceInstalled proves the spawn asks for
+// `--agent lich` exactly when there is one to ask for. Both directions cost
+// something real: without the agent every report goes missing, and naming one
+// Kiro cannot find puts a fallback warning on the first line of every session a
+// user who never installed the plugin opens.
+func TestKiroPluginAgentNamesTheAgentOnlyOnceInstalled(t *testing.T) {
+	home := kiroHome(t)
+
+	if got := kiroPluginAgent(providers.Kiro); got != "" {
+		t.Errorf("kiroPluginAgent with nothing installed = %q, want \"\"", got)
+	}
+
+	dir := filepath.Join(home, ".kiro", "agents")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "lich.json"), []byte(`{"name":"lich"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := kiroPluginAgent(providers.Kiro); got != providers.KiroAgentName {
+		t.Errorf("kiroPluginAgent with the plugin installed = %q, want %q", got, providers.KiroAgentName)
+	}
+}
+
+// TestKiroPluginAgentIsNeverAskedForByAnotherProvider proves the flag stays
+// Kiro's. `--agent` means something else to Antigravity and nothing at all to a
+// shell, so a lookup that answered on kind alone would hand one provider
+// another's flag — the failure skipPermissionFlags is pinned against.
+func TestKiroPluginAgentIsNeverAskedForByAnotherProvider(t *testing.T) {
+	home := kiroHome(t)
+	dir := filepath.Join(home, ".kiro", "agents")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "lich.json"), []byte(`{"name":"lich"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, kind := range []string{providers.Claude, providers.Antigravity, providers.Cursor, KindShell} {
+		if got := kiroPluginAgent(kind); got != "" {
+			t.Errorf("kiroPluginAgent(%q) = %q, want \"\"", kind, got)
+		}
+	}
+}
+
+// TestAgentArgsIsKiroOnly is the spawn side of the same rule, and pins that an
+// unusable name is dropped rather than passed on: a value starting with a dash
+// would be read by Kiro as another flag.
+func TestAgentArgsIsKiroOnly(t *testing.T) {
+	tests := []struct {
+		name, kind, agent string
+		want              []string
+	}{
+		{"kiro with the plugin", providers.Kiro, "lich", []string{"--agent", "lich"}},
+		{"kiro without it", providers.Kiro, "", nil},
+		{"a name that reads as a flag", providers.Kiro, "--dangerous", nil},
+		{"claude never gets one", providers.Claude, "lich", nil},
+		{"antigravity never gets one", providers.Antigravity, "lich", nil},
+		{"a shell never gets one", KindShell, "lich", nil},
+	}
+	for _, tt := range tests {
+		if got := agentArgs(tt.kind, tt.agent); !slices.Equal(got, tt.want) {
+			t.Errorf("%s: agentArgs(%q, %q) = %v, want %v", tt.name, tt.kind, tt.agent, got, tt.want)
+		}
+	}
+}
+
+// TestKiroSpawnsTheChatSubcommandBeforeEveryFlag pins the split that a table of
+// flags alone cannot see: `kiro-cli`'s root parser takes --agent and
+// --resume-id, but --model and --trust-all-tools belong to its `chat`
+// subcommand, and either one handed to the root exits 2 with `unexpected
+// argument` before the session exists (measured on 2.21.0). So the subcommand is
+// not conditional on which settings a session happens to carry — it is argv[0]
+// on every Kiro spawn, ahead of all of them.
+func TestKiroSpawnsTheChatSubcommandBeforeEveryFlag(t *testing.T) {
+	tests := []struct {
+		name            string
+		agent           string
+		resume          string
+		model           string
+		skipPermissions bool
+		want            []string
+	}{
+		{name: "a bare session", want: []string{"chat"}},
+		{name: "with the plugin installed", agent: "lich", want: []string{"chat", "--agent", "lich"}},
+		{name: "resuming a conversation", agent: "lich", resume: "s1",
+			want: []string{"chat", "--agent", "lich", "--resume-id", "s1"}},
+		// The two that only `chat` accepts, each on its own: either one is a
+		// dead spawn when the subcommand goes missing.
+		{name: "on a chosen model", model: "auto", want: []string{"chat", "--model", "auto"}},
+		{name: "with permissions skipped", skipPermissions: true,
+			want: []string{"chat", "--trust-all-tools"}},
+		{name: "everything at once", agent: "lich", resume: "s1", model: "auto", skipPermissions: true,
+			want: []string{"chat", "--agent", "lich", "--resume-id", "s1", "--trust-all-tools", "--model", "auto"}},
+	}
+	for _, tt := range tests {
+		got := providerArgs(providers.Kiro, "", tt.resume, tt.model, "/usr/bin/lich", tt.agent, tt.skipPermissions)
+		if !slices.Equal(got, tt.want) {
+			t.Errorf("%s: args = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+// TestSubcommandArgsIsKiroOnly proves no other provider grew one. A word at
+// argv[0] that the harness has no subcommand for is a spawn that dies before the
+// session exists, which is the same failure from the other direction.
+func TestSubcommandArgsIsKiroOnly(t *testing.T) {
+	for _, kind := range []string{
+		providers.Claude, providers.Codex, providers.Antigravity, providers.OpenCode,
+		providers.OMP, providers.Crush, providers.Cursor, KindShell,
+	} {
+		if got := subcommandArgs(kind); got != nil {
+			t.Errorf("subcommandArgs(%q) = %v, want nil", kind, got)
+		}
+	}
+}

--- a/internal/terminal/transcript.go
+++ b/internal/terminal/transcript.go
@@ -200,7 +200,8 @@ func kiroSessionPath(providerSessionID string) (string, bool) {
 // kiroPluginAgent is the name of the agent lich spawns Kiro CLI with, or "" when
 // the plugin was never installed into it. Only the name crosses into the spawn
 // (command.go, agentArgs): the file it points at is written by
-// internal/agentplugin, which owns its contents.
+// internal/agentplugin, which owns its contents, and both resolve it through
+// providers.KiroAgentPath so they cannot drift to different files.
 //
 // The check is a stat rather than a stored flag because the file is a user's to
 // delete: an agent lich still names after that is a warning line on every
@@ -209,24 +210,12 @@ func kiroPluginAgent(kind string) string {
 	if kind != providers.Kiro {
 		return ""
 	}
-	path, ok := kiroAgentPath()
-	if !ok {
+	path, err := providers.KiroAgentPath()
+	if err != nil {
 		return ""
 	}
 	if _, err := os.Stat(path); err != nil {
 		return ""
 	}
 	return providers.KiroAgentName
-}
-
-// kiroAgentPath is where that agent config lives: Kiro's global agents
-// directory, which hangs off the home alone — 2.21.0 honours no environment
-// variable for it. Shared with internal/agentplugin through providers so the two
-// cannot drift to different files.
-func kiroAgentPath() (string, bool) {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "", false
-	}
-	return filepath.Join(home, ".kiro", "agents", providers.KiroAgentName+".json"), true
 }

--- a/internal/terminal/usage_kiro_test.go
+++ b/internal/terminal/usage_kiro_test.go
@@ -3,11 +3,8 @@ package terminal
 import (
 	"os"
 	"path/filepath"
-	"slices"
 	"strconv"
 	"testing"
-
-	"github.com/omartelo/lich/internal/providers"
 )
 
 // kiroSessionFile writes a Kiro session metadata file holding state and returns
@@ -119,91 +116,5 @@ func TestKiroContextUsageUnreadable(t *testing.T) {
 	}
 	if _, ok := kiroContextUsage(path); ok {
 		t.Errorf("kiroContextUsage(truncated) = _, true, want a miss")
-	}
-}
-
-// kiroHome redirects the home Kiro's directories hang off — it answers to no
-// environment variable of its own — and returns it. The resolved path is
-// asserted to be under the redirect before anything is written: a variable this
-// misses on some platform would leave the test writing an agent into the real
-// user's ~/.kiro and passing while it did.
-func kiroHome(t *testing.T) string {
-	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home)
-	got, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatalf("resolve home directory: %v", err)
-	}
-	if got != home {
-		t.Fatalf("home resolved to %q, outside the test's temp dir %q", got, home)
-	}
-	return home
-}
-
-// TestKiroPluginAgentNamesTheAgentOnlyOnceInstalled proves the spawn asks for
-// `--agent lich` exactly when there is one to ask for. Both directions cost
-// something real: without the agent every report goes missing, and naming one
-// Kiro cannot find puts a fallback warning on the first line of every session a
-// user who never installed the plugin opens.
-func TestKiroPluginAgentNamesTheAgentOnlyOnceInstalled(t *testing.T) {
-	home := kiroHome(t)
-
-	if got := kiroPluginAgent(providers.Kiro); got != "" {
-		t.Errorf("kiroPluginAgent with nothing installed = %q, want \"\"", got)
-	}
-
-	dir := filepath.Join(home, ".kiro", "agents")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "lich.json"), []byte(`{"name":"lich"}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	if got := kiroPluginAgent(providers.Kiro); got != providers.KiroAgentName {
-		t.Errorf("kiroPluginAgent with the plugin installed = %q, want %q", got, providers.KiroAgentName)
-	}
-}
-
-// TestKiroPluginAgentIsNeverAskedForByAnotherProvider proves the flag stays
-// Kiro's. `--agent` means something else to Antigravity and nothing at all to a
-// shell, so a lookup that answered on kind alone would hand one provider
-// another's flag — the failure skipPermissionFlags is pinned against.
-func TestKiroPluginAgentIsNeverAskedForByAnotherProvider(t *testing.T) {
-	home := kiroHome(t)
-	dir := filepath.Join(home, ".kiro", "agents")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, "lich.json"), []byte(`{"name":"lich"}`), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	for _, kind := range []string{providers.Claude, providers.Antigravity, providers.Cursor, KindShell} {
-		if got := kiroPluginAgent(kind); got != "" {
-			t.Errorf("kiroPluginAgent(%q) = %q, want \"\"", kind, got)
-		}
-	}
-}
-
-// TestAgentArgsIsKiroOnly is the spawn side of the same rule, and pins that an
-// unusable name is dropped rather than passed on: a value starting with a dash
-// would be read by Kiro as another flag.
-func TestAgentArgsIsKiroOnly(t *testing.T) {
-	tests := []struct {
-		name, kind, agent string
-		want              []string
-	}{
-		{"kiro with the plugin", providers.Kiro, "lich", []string{"--agent", "lich"}},
-		{"kiro without it", providers.Kiro, "", nil},
-		{"a name that reads as a flag", providers.Kiro, "--dangerous", nil},
-		{"claude never gets one", providers.Claude, "lich", nil},
-		{"antigravity never gets one", providers.Antigravity, "lich", nil},
-		{"a shell never gets one", KindShell, "lich", nil},
-	}
-	for _, tt := range tests {
-		if got := agentArgs(tt.kind, tt.agent); !slices.Equal(got, tt.want) {
-			t.Errorf("%s: agentArgs(%q, %q) = %v, want %v", tt.name, tt.kind, tt.agent, got, tt.want)
-		}
 	}
 }


### PR DESCRIPTION
A quality audit of #442 against the `kiro-cli 2.21.0` on this machine turned up
one dead spawn and four smaller things.

## The spawn

A Kiro session died before it existed whenever a model was picked or the danger
rung was on:

```
$ kiro-cli --agent lich --trust-all-tools --model auto
error: unexpected argument '--trust-all-tools' found
$ echo $?
2
```

`kiro-cli` splits the flags lich passes across two parsers. Its root takes
`--agent` and `--resume-id` — which is why resume worked and hid this — but
`--model` and `--trust-all-tools` belong to the `chat` subcommand alone. The
flag tables landed in #442 were read off `kiro-cli chat --help` while the spawn
ran the bare binary.

`chat` takes every flag the root does, so `subcommandArgs` puts that word at
argv[0] on every Kiro spawn rather than assembling a different command per
setting. `TestKiroSpawnsTheChatSubcommandBeforeEveryFlag` pins the whole argv
across the six shapes a session can take; with the subcommand removed, all six
fail.

## Beside it

- **The agent config path was built twice**, in `internal/agentplugin` and in
  `internal/terminal`, from duplicated `.kiro`/`agents` literals — under a
  comment claiming the two could not drift to different files. It resolves
  through `providers.KiroAgentPath` now, which is what that comment described.
- **Crush and Kiro shared one hook script directory**, and `releaseVersion`
  resolves whatever the plugin repository has released rather than the version
  of the lich running the install. A Kiro install could overwrite the scripts a
  Crush install fetched at an older release, leaving Crush's marker naming a
  version no longer on disk — the one thing that marker exists to answer. One
  directory per provider (`hooks/<provider>`).
- `filepath.Base` on a bare agent name is a no-op that implies a path.
- The Kiro spawn tests lived in `usage_kiro_test.go`, which tests the footer
  readout. They are in `command_kiro_test.go` now.

`docs/adding-a-provider.md` carries the trap for the ninth provider: read the
`--help` of the command lich actually spawns, because a CLI with subcommands has
one parser per level and a flag that exists under one is rejected by the other.

No `CHANGELOG.md` entry — Kiro is still under `[Unreleased]`, so none of this
reached a published version.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...`
- [x] `cd frontend && ./node_modules/.bin/biome check .`
- [x] `for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done`
- [x] The failing argv reproduced against the real `kiro-cli 2.21.0`, and the
      new test proven to fail without the fix
- [ ] A real Kiro session opened from a card with a model set and the danger rung on

https://claude.ai/code/session_01VbdKgN3z5k3Ap6cVVR9doL