### PR TITLE
chore: cut the 0.44.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.44.0] - 2026-09-03
+
 ### Added
 
 - **Kiro CLI is the eighth provider.** Point lich at `kiro-cli` and it runs in a
@@ -3732,7 +3734,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.43.1...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.44.0...HEAD
+[0.44.0]: https://github.com/omartelo/lich/compare/v0.43.1...v0.44.0
 [0.43.1]: https://github.com/omartelo/lich/compare/v0.43.0...v0.43.1
 [0.43.0]: https://github.com/omartelo/lich/compare/v0.42.0...v0.43.0
 [0.42.0]: https://github.com/omartelo/lich/compare/v0.41.0...v0.42.0


### PR DESCRIPTION
Moves everything under `[Unreleased]` to a `## [0.44.0] - 2026-09-03` heading and
refreshes the compare links. `[Unreleased]` stays at the top, emptied, so the
next entry has somewhere to land.

Minor rather than patch: the section adds an eighth provider (Kiro CLI), a cost
readout for oh-my-pi, opencode and Crush, a new `lich cost` command, and the
browser resolution ladder. Last tag is `v0.43.1`.

The release job greps `^## \[0.44.0\]` for the notes it ships, so the heading is
bracketed, ISO-dated and carries no `v`.

## Release checklist

- [x] `gofmt -l .`, `go vet ./...`
- [x] `LICH_LISTEN_PORT= go test -race ./...`
- [x] `frontend`: biome, `vitest run` (1350 tests), `tsc --noEmit`, `vite build`
- [x] `[Unreleased]` emptied and kept at the top, sections in canonical order,
      compare links refreshed
- [ ] Push the `v0.44.0` tag once this merges — `.github/workflows/release.yml`
      does the rest

https://claude.ai/code/session_01VbdKgN3z5k3Ap6cVVR9doL