### PR TITLE
feat: name the files a pull request conflicts on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A conflicting pull request now names the files it conflicts on.** GitHub
+  publishes one word — the pull request conflicts with its base — and never
+  which files, so the way to find out was opening the PR on github.com or a
+  session on the branch. The screen answers it now: under the status line, the
+  conflicting paths, six of them with the rest a click away. lich computes the
+  answer rather than asking for it, merging the pull request's head and its base
+  in git's object database (`git merge-tree`), so nothing touches a worktree,
+  an index or HEAD. The list is what your clone merges right now and the chip
+  above it is GitHub's own verdict, so the two disagree for a few seconds after
+  a push — the row says which one is the fresh reading.
+
 ## [0.44.0] - 2026-09-03
 
 ### Added

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -264,9 +264,12 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   dirty count all come out of one `git status --porcelain=v2 --branch` parse. A git release that changes those
   records breaks all three together rather than one at a time, and there is no second call left to disagree with
   the first — `Branch` still asks `symbolic-ref`, but nothing on the polled path calls it.
-- **lich fetches on its own** (`internal/project/basestatus.go`) — the only git write lich makes outside the
-  worktree flows: it moves remote refs in the user's own repository, unannounced, for as long as a card is on
-  screen.
+- **lich fetches on its own** (`internal/project/basestatus.go`, `internal/project/prconflicts.go`) — the only
+  git writes lich makes outside the worktree flows: the base-branch readout moves remote refs in the user's own
+  repository, unannounced, for as long as a card is on screen. Naming a conflicting pull request's files is the
+  second, made when that pull request is opened on the Pulls screen: it fetches GitHub's `refs/pull/<n>/head`
+  and the base branch into `refs/lich/pr/<n>/head` and `refs/lich/pr/<n>/base`, and never deletes them — they
+  outlive the answer, and a `git push --mirror` carries them to the remote.
 - **Persistence is hybrid**: UI prefs in the page's localStorage (`lich.*` keys — the reason the listener port is
   pinned at 47821; `LICH_LISTEN_PORT` overrides it, `LICH_PORT` is the distinct per-session hook variable), the
   workspace in SQLite (`<config-dir>/lich/lich.db`, `internal/store`). Closing a session deletes its row; keeping a

--- a/frontend/src/components/pulls/PullRequestView.tsx
+++ b/frontend/src/components/pulls/PullRequestView.tsx
@@ -47,6 +47,7 @@ import {
 import { MergeMessageDialog, mergeEditFor, type MergeEdit } from "./MergeMessageDialog"
 import { PullsChecks } from "./PullsChecks"
 import { PullsCommits } from "./PullsCommits"
+import { PullsConflicts } from "./PullsConflicts"
 import { PullsConversation } from "./PullsConversation"
 import { PullsFiles } from "./PullsFiles"
 import { PullsOverview } from "./PullsOverview"
@@ -427,6 +428,11 @@ export function PullRequestView({
           />
           <ReviewStat decision={detail.reviewDecision} />
         </div>
+
+        {/* Keyed by the pull request: whether the whole list is unfolded is a
+            reading of this one, and carrying it to the next PR opened would
+            unfold a list nobody asked to see. */}
+        <PullsConflicts key={detail.url} path={path} detail={detail} />
 
         <div role="tablist" className="mt-4 flex gap-1">
           <TabButton active={tab === "overview"} onClick={() => showTab("overview")}>

--- a/frontend/src/components/pulls/PullsConflicts.tsx
+++ b/frontend/src/components/pulls/PullsConflicts.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react"
+import type { PullRequestDetail } from "@/lib/api-types"
+import { conflictsWithBase } from "@/lib/pulls/merge-gate"
+import { usePullRequestConflicts } from "@/lib/pulls/use-pull-request-conflicts"
+
+// How many paths the row names before it folds the rest away. Six fills one
+// line of the header at an ordinary window width; past that the row stops
+// answering faster and starts pushing the tabs down the screen.
+const NAMED = 6
+
+// PullsConflicts names the files a conflicting pull request collides with its
+// base on, under the status line that says it conflicts at all. GitHub's own
+// answer is the one word the chip above already carries — this is the half that
+// sent the reader to github.com or into a session to find out which files it
+// meant.
+//
+// Nothing is drawn for a pull request that merges: the row exists only while
+// something is in the way, like every other reading on that line.
+export function PullsConflicts({ path, detail }: { path: string; detail: PullRequestDetail }) {
+  const [all, setAll] = useState(false)
+  const conflicting = detail.state === "OPEN" && conflictsWithBase(detail)
+  const { files, loading, error } = usePullRequestConflicts(
+    path,
+    detail.number,
+    detail.baseRefName,
+    conflicting,
+  )
+
+  if (!conflicting) {
+    return null
+  }
+  if (loading) {
+    return <Row>Working out which files conflict…</Row>
+  }
+  if (error) {
+    return <Row>Couldn’t work out which files conflict: {error}</Row>
+  }
+  // GitHub recomputes mergeability on its own clock, so a resolution that has
+  // just landed reads as a conflict up here and as a clean merge down there.
+  // Saying which of the two is the fresh one beats a list that silently empties.
+  if (files.length === 0) {
+    return <Row>No file conflicts here now — GitHub may not have caught up.</Row>
+  }
+
+  const hidden = files.length - NAMED
+  return (
+    <>
+      <div className="mt-1.5 flex flex-wrap items-baseline gap-x-3 gap-y-1 text-xs">
+        <span className="text-muted-foreground">
+          {files.length} conflicting {files.length === 1 ? "file" : "files"}
+        </span>
+        {!all && files.slice(0, NAMED).map((file) => <ConflictPath key={file} file={file} />)}
+        {hidden > 0 && (
+          <button
+            type="button"
+            onClick={() => setAll(!all)}
+            className="text-muted-foreground underline underline-offset-2 transition-colors hover:text-foreground"
+          >
+            {all ? "Show fewer" : `+${hidden} more`}
+          </button>
+        )}
+      </div>
+      {/* One per line once it is open, and bounded: a merge gone this wrong can
+          name dozens of files, and the header is not the place to scroll for
+          them — the count above is the reading that matters by then. */}
+      {all && (
+        <div className="mt-1.5 flex max-h-20 flex-col gap-0.5 overflow-y-auto text-xs">
+          {files.map((file) => (
+            <ConflictPath key={file} file={file} />
+          ))}
+        </div>
+      )}
+    </>
+  )
+}
+
+// One path, with its directory dimmed. A monorepo's conflicting files share
+// most of their path, and the half that tells them apart is the last segment.
+function ConflictPath({ file }: { file: string }) {
+  const cut = file.lastIndexOf("/") + 1
+  return (
+    <span className="font-mono text-destructive">
+      {cut > 0 && <span className="opacity-70">{file.slice(0, cut)}</span>}
+      {file.slice(cut)}
+    </span>
+  )
+}
+
+// The row's other three states — reading, failed, nothing left — all say one
+// sentence in the same place the paths would have gone.
+function Row({ children }: { children: React.ReactNode }) {
+  return <div className="mt-1.5 text-xs text-muted-foreground">{children}</div>
+}

--- a/frontend/src/lib/pulls/merge-gate.test.ts
+++ b/frontend/src/lib/pulls/merge-gate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
   allowedMergeMethods,
   canAdminOverride,
+  conflictsWithBase,
   mergeBlockedReason,
   mergeRuleNote,
 } from "./merge-gate"
@@ -266,5 +267,21 @@ describe("mergeRuleNote", () => {
     expect(mergeRuleNote(blocked, null)).toBeNull()
     expect(mergeRuleNote(blocked, rules())).toBeNull()
     expect(mergeRuleNote(blocked, rules({ commitPatterns: [] }))).toBeNull()
+  })
+})
+
+describe("conflictsWithBase", () => {
+  it("reads the field an older gh answers with", () => {
+    expect(conflictsWithBase(detail({ mergeable: "CONFLICTING" }))).toBe(true)
+  })
+
+  it("reads the field a current gh answers with", () => {
+    expect(conflictsWithBase(detail({ mergeStateStatus: "DIRTY" }))).toBe(true)
+  })
+
+  it("says no while GitHub is still recomputing", () => {
+    expect(conflictsWithBase(detail({ mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" }))).toBe(
+      false,
+    )
   })
 })

--- a/frontend/src/lib/pulls/merge-gate.ts
+++ b/frontend/src/lib/pulls/merge-gate.ts
@@ -19,6 +19,16 @@ export function allowedMergeMethods(rules: BranchRules | null): MergeMethod[] {
   return allowed.length > 0 ? allowed : EVERY_METHOD
 }
 
+// conflictsWithBase reports whether GitHub says this pull request collides with
+// the branch it would merge into. Both fields, because they answer at different
+// times: mergeable is what an older gh reports, mergeStateStatus what a current
+// one does — and everything that reacts to a conflict (the dead Merge button,
+// the handoff prompt, the list of conflicting files) has to read the pair the
+// same way or they disagree on screen.
+export function conflictsWithBase(detail: PullRequestDetail): boolean {
+  return detail.mergeStateStatus === "DIRTY" || detail.mergeable === "CONFLICTING"
+}
+
 // The review verdicts that keep a BLOCKED pull request blocked. An approval —
 // or a repository that asks for none — leaves BLOCKED meaning only that a rule
 // applies to the base branch, which GitHub merges from every day.
@@ -52,9 +62,7 @@ export function mergeBlockedReason(detail: PullRequestDetail): string | null {
   if (detail.isDraft) {
     return "Pull request is a draft"
   }
-  // Both fields, because they answer at different times: mergeable is what an
-  // older gh reports, mergeStateStatus what a current one does.
-  if (detail.mergeStateStatus === "DIRTY" || detail.mergeable === "CONFLICTING") {
+  if (conflictsWithBase(detail)) {
     return `Conflicts with ${detail.baseRefName}`
   }
   if (detail.mergeStateStatus === "BEHIND") {
@@ -89,9 +97,9 @@ export function canAdminOverride(detail: PullRequestDetail, rules: BranchRules |
   if (detail.state !== "OPEN" || detail.isDraft) {
     return false
   }
-  // Both fields again, for the reason mergeBlockedReason reads both: GitHub
-  // answers BLOCKED over a conflict while its merge state is still stale, and a
-  // bypass offered there is the dead click this whole gate exists to remove.
+  // The narrow read on purpose, not conflictsWithBase: GitHub answers BLOCKED
+  // over a conflict while its merge state is still stale, and a bypass offered
+  // there is the dead click this whole gate exists to remove.
   if (detail.mergeable === "CONFLICTING") {
     return false
   }

--- a/frontend/src/lib/pulls/pr-handoff.ts
+++ b/frontend/src/lib/pulls/pr-handoff.ts
@@ -1,4 +1,5 @@
 import type { PullRequestDetail } from "@/lib/api-types"
+import { conflictsWithBase } from "@/lib/pulls/merge-gate"
 import { bracketedPaste } from "@/lib/terminal/bracketed-paste"
 
 // How many failed checks the prompt names before it stops and says how many it
@@ -25,9 +26,7 @@ export function pullRequestHandoff(detail: PullRequestDetail): PullRequestHandof
   if (detail.state !== "OPEN") {
     return null
   }
-  // Both fields, for the reason mergeBlockedReason reads both: mergeable is
-  // what an older gh reports, mergeStateStatus what a current one does.
-  if (detail.mergeStateStatus === "DIRTY" || detail.mergeable === "CONFLICTING") {
+  if (conflictsWithBase(detail)) {
     return {
       label: "Resolve conflicts",
       prompt: bracketedPaste(

--- a/frontend/src/lib/pulls/use-pull-request-conflicts.test.tsx
+++ b/frontend/src/lib/pulls/use-pull-request-conflicts.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+//
+// What this hook has to get right is when it stays quiet: naming the conflicting
+// files costs a git fetch, and a pull request that merges cleanly must never pay
+// for it. That is a count of calls, so the RPC is stubbed and the hook is
+// mounted for real.
+import { mountBudget } from "@/test/render-budget"
+import { StrictMode, createElement, useLayoutEffect } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { usePullRequestConflicts } from "./use-pull-request-conflicts"
+
+const conflicts = vi.fn()
+vi.mock("@/lib/rpc", () => ({
+  ProjectService: {
+    PullRequestConflicts: (path: string, number: number, base: string) =>
+      conflicts(path, number, base),
+  },
+}))
+
+// Records every answer the hook committed, from a layout effect so a render
+// React discarded is not counted as one the screen saw.
+function panel(seen: string[][], conflicting: boolean, number = 7, base = "main") {
+  function Panel() {
+    const { files } = usePullRequestConflicts("/repo", number, base, conflicting)
+    useLayoutEffect(() => {
+      seen.push(files)
+    })
+    return null
+  }
+  return createElement(StrictMode, null, createElement(Panel))
+}
+
+beforeEach(() => {
+  conflicts.mockReset()
+  conflicts.mockResolvedValue(["internal/project/pr.go", "CHANGELOG.md"])
+})
+
+describe("usePullRequestConflicts", () => {
+  it("names the files GitHub would not", async () => {
+    const seen: string[][] = []
+    const mounted = await mountBudget(panel(seen, true))
+    await mounted.act(() => {})
+
+    expect(conflicts).toHaveBeenCalledWith("/repo", 7, "main")
+    expect(seen[seen.length - 1]).toEqual(["internal/project/pr.go", "CHANGELOG.md"])
+  })
+
+  it("asks nothing of a pull request that merges cleanly", async () => {
+    const seen: string[][] = []
+    const mounted = await mountBudget(panel(seen, false))
+    await mounted.act(() => {})
+
+    expect(conflicts).not.toHaveBeenCalled()
+    expect(seen[seen.length - 1]).toEqual([])
+  })
+
+  it("asks nothing before the pull request is addressed", async () => {
+    const seen: string[][] = []
+    const mounted = await mountBudget(panel(seen, true, 0))
+    await mounted.act(() => {})
+
+    expect(conflicts).not.toHaveBeenCalled()
+    expect(seen[seen.length - 1]).toEqual([])
+  })
+
+  it("asks nothing without a base branch to merge into", async () => {
+    const seen: string[][] = []
+    const mounted = await mountBudget(panel(seen, true, 7, ""))
+    await mounted.act(() => {})
+
+    expect(conflicts).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/lib/pulls/use-pull-request-conflicts.ts
+++ b/frontend/src/lib/pulls/use-pull-request-conflicts.ts
@@ -1,0 +1,36 @@
+import { ProjectService } from "@/lib/rpc"
+import { useRemoteResource } from "@/lib/use-remote-resource"
+
+// Module-level, as useRemoteResource asks: a fresh array per render would be a
+// new answer on every failed lookup.
+const NO_FILES: string[] = []
+
+export interface PullRequestConflicts {
+  files: string[]
+  loading: boolean
+  error: string | null
+}
+
+// usePullRequestConflicts names the files a pull request collides with its base
+// on. Asked only while `conflicting` holds — GitHub has already said the merge
+// conflicts — because the answer is computed by fetching both commits, which is
+// a network round trip a clean pull request has no reason to pay for.
+//
+// Keyed by the pull request and its base alone: what makes the answer stale is
+// a push to either side, and both of those arrive as a re-read of the detail
+// that flips `conflicting` or moves the base. Not refetched on focus for the
+// same reason — the fetch is the expensive kind an alt-tab must not trigger.
+export function usePullRequestConflicts(
+  path: string,
+  number: number,
+  base: string,
+  conflicting: boolean,
+): PullRequestConflicts {
+  const { data, loading, error } = useRemoteResource(
+    conflicting && path && number > 0 && base ? `${path} ${number} ${base}` : "",
+    () =>
+      ProjectService.PullRequestConflicts(path, number, base).then((files) => files ?? NO_FILES),
+    { empty: NO_FILES, cache: `pulls.conflicts ${path} #${number}` },
+  )
+  return { files: data, loading, error }
+}

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -231,6 +231,11 @@ export const ProjectService = {
   /** One open PR in full (title, body, checks): the given number, or 0 for the checkout's own branch. */
   PullRequestDetail: (path: string, number: number) =>
     call<PullRequestDetail | null>("project.PullRequestDetail", [path, number]),
+  /** Which files a conflicting PR collides with its base on — GitHub answers
+   * that a pull request conflicts and never where. A network round trip (it
+   * fetches both commits), so it is asked only once mergeable says CONFLICTING. */
+  PullRequestConflicts: (path: string, number: number, base: string) =>
+    call<string[] | null>("project.PullRequestConflicts", [path, number, base]),
   /** Merge a PR on GitHub (0 = the checkout's branch). The backend allow-lists
    * the method. `admin` merges with administrator privileges — GitHub's own
    * bypass of the rules on the base branch, and the only way gh calls GitHub at

--- a/internal/project/prconflicts.go
+++ b/internal/project/prconflicts.go
@@ -1,0 +1,67 @@
+package project
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// prConflictBudget caps the fetch behind the conflicting-file list. Both commits
+// have to be here before anything can be merged, and that fetch is the one part
+// of this answer that reaches the network.
+const prConflictBudget = 60 * time.Second
+
+// PullRequestConflicts lists the files a merge of pull request number into base
+// would collide on. GitHub publishes that a pull request conflicts and never
+// where: its answer is one word (mergeable: CONFLICTING), which left the reader
+// opening github.com or a session to find out which files it meant. This
+// computes it instead — both commits are fetched into refs lich owns and merged
+// in the object database alone (mergeConflicts), never in a worktree, an index
+// or HEAD.
+//
+// nil means the merge is clean, so this is asked only once GitHub has said it
+// is not: the fetch is a network round trip, not something to poll.
+//
+// origin is the remote and refs/pull/<n>/head is GitHub's own ref — a fork's
+// pull request included, since GitHub keeps that ref on the base repository.
+func (s *Service) PullRequestConflicts(path string, number int, base string) ([]string, error) {
+	if number <= 0 || base == "" {
+		return nil, errors.New("Listing the conflicting files needs a pull request number and its base branch.")
+	}
+	head := fmt.Sprintf("refs/lich/pr/%d/head", number)
+	baseRef := fmt.Sprintf("refs/lich/pr/%d/base", number)
+	if err := fetchPRPair(path, number, base, head, baseRef); err != nil {
+		return nil, err
+	}
+	return mergeConflicts(path, baseRef, head), nil
+}
+
+// fetchPRPair brings the pull request's head and the tip of its base branch into
+// lich's own refs, in one round trip.
+//
+// Named destinations rather than FETCH_HEAD: that file is shared by every
+// worktree of the repository and the base-status fetch (basestatus.go) writes it
+// from a background goroutine, so two answers would mix into one. They are
+// forced because the refs are scratch space holding the previous answer, which
+// the new tip is routinely not a fast-forward of.
+func fetchPRPair(path string, number int, base, head, baseRef string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), prConflictBudget)
+	defer cancel()
+	args := []string{"-C", path, "fetch", "--quiet", "--no-tags", "--force", "origin",
+		fmt.Sprintf("refs/pull/%d/head:%s", number, head),
+		"refs/heads/" + base + ":" + baseRef,
+	}
+	cmd := commandContext(ctx, "git", args...)
+	var stderr strings.Builder
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		logToolFailure("git", args, stderr.String(), err)
+		if ctx.Err() != nil {
+			return fmt.Errorf("Reading pull request #%d took longer than %s and was given up on.", number, prConflictBudget)
+		}
+		return errors.New(gitMessage(stderr.String(), err))
+	}
+	return nil
+}

--- a/internal/project/prconflicts_test.go
+++ b/internal/project/prconflicts_test.go
@@ -1,0 +1,68 @@
+package project
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+)
+
+// pullRequestOrigin builds what a pull request looks like from a clone's side: a
+// branch that exists on origin alone, published under GitHub's own
+// refs/pull/<n>/head and editing a.txt. It hands back the origin so the test can
+// move the base branch itself — that is the half deciding whether the merge
+// conflicts, and none of it is in the clone until the fetch under test runs.
+func pullRequestOrigin(t *testing.T, number int) (clone, origin string, originGit func(args ...string) string) {
+	t.Helper()
+	clone, _, originGit = initClone(t)
+	origin = originGit("rev-parse", "--show-toplevel")
+	originGit("checkout", "--quiet", "-b", "pr")
+	commitFile(t, origin, originGit, "a.txt", "the pull request's line\n", "pr edits a")
+	originGit("checkout", "--quiet", "main")
+	originGit("update-ref", fmt.Sprintf("refs/pull/%d/head", number), "refs/heads/pr")
+	return clone, origin, originGit
+}
+
+func TestPullRequestConflictsNamesTheFiles(t *testing.T) {
+	clone, origin, originGit := pullRequestOrigin(t, 7)
+	commitFile(t, origin, originGit, "a.txt", "the base branch's line\n", "base edits a")
+
+	got, err := New(nil).PullRequestConflicts(clone, 7, "main")
+	if err != nil {
+		t.Fatalf("PullRequestConflicts: %v", err)
+	}
+	if !slices.Equal(got, []string{"a.txt"}) {
+		t.Fatalf("conflicts = %v, want [a.txt] — both sides rewrote that line", got)
+	}
+}
+
+func TestPullRequestConflictsNoneWhenTheMergeIsClean(t *testing.T) {
+	clone, origin, originGit := pullRequestOrigin(t, 7)
+	commitFile(t, origin, originGit, "b.txt", "elsewhere\n", "base adds b")
+
+	got, err := New(nil).PullRequestConflicts(clone, 7, "main")
+	if err != nil {
+		t.Fatalf("PullRequestConflicts: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("conflicts = %v, want none — the two sides touch different files", got)
+	}
+}
+
+func TestPullRequestConflictsRefusesAnUnaddressedPullRequest(t *testing.T) {
+	clone, _, _ := pullRequestOrigin(t, 7)
+
+	if _, err := New(nil).PullRequestConflicts(clone, 0, "main"); err == nil {
+		t.Error("want an error for pull request 0 — this has no branch fallback")
+	}
+	if _, err := New(nil).PullRequestConflicts(clone, 7, ""); err == nil {
+		t.Error("want an error with no base branch")
+	}
+}
+
+func TestPullRequestConflictsReportsAFetchItCannotMake(t *testing.T) {
+	clone, _, _ := pullRequestOrigin(t, 7)
+
+	if _, err := New(nil).PullRequestConflicts(clone, 404, "main"); err == nil {
+		t.Error("want an error for a pull request origin does not have")
+	}
+}


### PR DESCRIPTION
GitHub answers **that** a pull request conflicts with its base — `mergeable: CONFLICTING` — and never **where**. The Pulls screen carried that verdict and stopped there, so finding out which files meant opening the PR on github.com or a session on the branch.

## What lands

Under the status line, the conflicting paths: six of them, with `+N more` unfolding the rest one per line. The directory is dimmed and the file name is not, which is what makes fourteen monorepo paths readable. The row also carries its own three other states — reading, failed, and "no file conflicts here now", for the seconds after a push where GitHub's verdict is the stale half.

## How the answer is computed

`PullRequestConflicts` fetches the pull request's head (`refs/pull/<n>/head`, so a fork's PR works too) and the tip of its base into `refs/lich/pr/<n>/*`, then runs `git merge-tree --write-tree --name-only` — `mergeConflicts`, the call already behind a session card's conflict alert. Nothing touches a worktree, an index or HEAD.

Named refs rather than `FETCH_HEAD`: that file is shared by every worktree and the base-status fetch writes it from a background goroutine, so two answers would mix into one.

It is asked only while `mergeable` says the merge conflicts — the answer costs a network round trip, so a clean pull request never pays for it, and it is not polled or refetched on focus.

`conflictsWithBase` is extracted in `merge-gate.ts` because three places now read the `mergeable` / `mergeStateStatus` pair and they must agree; `canAdminOverride` keeps its narrower read, with the reason in the comment.

## Deliberately out

- Clicking a path to jump to that file in Files changed.
- Naming the files inside the **Resolve conflicts** prompt (it still says only "has merge conflicts with main").
- The refs under `refs/lich/pr/<n>/` are never deleted — they outlive the answer and ride a `git push --mirror`. `docs/ceilings.md` says so, beside the base-status fetch it now joins as lich's second git write outside the worktree flows.

## Test plan

- [x] `internal/project/prconflicts_test.go` — a conflicting PR named file by file, a clean one, and the two refusals (no number, no base), built from a real clone whose origin publishes `refs/pull/7/head`.
- [x] `use-pull-request-conflicts.test.tsx` — the RPC is called for a conflicting PR and **not** called for a clean one, an unaddressed number, or a missing base.
- [x] `conflictsWithBase` pinned in `merge-gate.test.ts`.
- [x] Probed against this repository's real remote (PR #442): the refspec pair reaches GitHub and merge-tree named seven files in ~2s.
- [x] Local gate: `gofmt`, `go vet`, `go test ./...`, `biome check`, `vitest run` (1357), `tsc` + `vite build`.

https://claude.ai/code/session_01VbdKgN3z5k3Ap6cVVR9doL