### PR TITLE
fix: answer the conflicting-file list where it was answering wrong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   session on the branch. The screen answers it now: under the status line, the
   conflicting paths, six of them with the rest a click away. lich computes the
   answer rather than asking for it, merging the pull request's head and its base
-  in git's object database (`git merge-tree`), so nothing touches a worktree,
-  an index or HEAD. The list is what your clone merges right now and the chip
-  above it is GitHub's own verdict, so the two disagree for a few seconds after
-  a push — the row says which one is the fresh reading.
+  in git's object database (`git merge-tree`), so nothing touches a worktree, an
+  index or HEAD — which takes git 2.38 or newer, and says so rather than
+  reporting a merge it could not compute as a clean one. The commits are fetched
+  from the remote the pull request itself names, so a clone of a fork reads the
+  repository the pull request was opened against rather than the fork. The list
+  is what your clone merges right now and the chip above it is GitHub's own
+  verdict, so the two disagree for a few seconds after a push — the row says
+  which one is the fresh reading.
 
 ## [0.44.0] - 2026-09-03
 

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -269,7 +269,10 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   repository, unannounced, for as long as a card is on screen. Naming a conflicting pull request's files is the
   second, made when that pull request is opened on the Pulls screen: it fetches GitHub's `refs/pull/<n>/head`
   and the base branch into `refs/lich/pr/<n>/head` and `refs/lich/pr/<n>/base`, and never deletes them — they
-  outlive the answer, and a `git push --mirror` carries them to the remote.
+  outlive the answer, and a `git push --mirror` carries them to the remote. The remote fetched from is the one
+  whose URL matches the pull request's own, origin when none does — lich reads gh's base repository off that URL
+  rather than asking gh again, so a clone whose remotes all name a different repository than the pull request
+  lives on falls back to origin and fails there.
 - **Persistence is hybrid**: UI prefs in the page's localStorage (`lich.*` keys — the reason the listener port is
   pinned at 47821; `LICH_LISTEN_PORT` overrides it, `LICH_PORT` is the distinct per-session hook variable), the
   workspace in SQLite (`<config-dir>/lich/lich.db`, `internal/store`). Closing a session deletes its row; keeping a

--- a/frontend/src/components/pulls/PullRequestView.tsx
+++ b/frontend/src/components/pulls/PullRequestView.tsx
@@ -421,11 +421,7 @@ export function PullRequestView({
           ) : (
             <ChecksStat checks={detail.checks} />
           )}
-          <MergeableStat
-            mergeable={detail.mergeable}
-            base={detail.baseRefName}
-            state={detail.state}
-          />
+          <MergeableStat detail={detail} />
           <ReviewStat decision={detail.reviewDecision} />
         </div>
 

--- a/frontend/src/components/pulls/PullsConflicts.tsx
+++ b/frontend/src/components/pulls/PullsConflicts.tsx
@@ -1,12 +1,8 @@
 import { useState } from "react"
 import type { PullRequestDetail } from "@/lib/api-types"
+import { foldConflicts, splitConflictPath } from "@/lib/pulls/conflict-files"
 import { conflictsWithBase } from "@/lib/pulls/merge-gate"
 import { usePullRequestConflicts } from "@/lib/pulls/use-pull-request-conflicts"
-
-// How many paths the row names before it folds the rest away. Six fills one
-// line of the header at an ordinary window width; past that the row stops
-// answering faster and starts pushing the tabs down the screen.
-const NAMED = 6
 
 // PullsConflicts names the files a conflicting pull request collides with its
 // base on, under the status line that says it conflicts at all. GitHub's own
@@ -23,6 +19,7 @@ export function PullsConflicts({ path, detail }: { path: string; detail: PullReq
     path,
     detail.number,
     detail.baseRefName,
+    detail.url,
     conflicting,
   )
 
@@ -42,46 +39,68 @@ export function PullsConflicts({ path, detail }: { path: string; detail: PullReq
     return <Row>No file conflicts here now — GitHub may not have caught up.</Row>
   }
 
-  const hidden = files.length - NAMED
+  const { shown, hidden } = foldConflicts(files, all)
   return (
     <>
       <div className="mt-1.5 flex flex-wrap items-baseline gap-x-3 gap-y-1 text-xs">
         <span className="text-muted-foreground">
           {files.length} conflicting {files.length === 1 ? "file" : "files"}
         </span>
-        {!all && files.slice(0, NAMED).map((file) => <ConflictPath key={file} file={file} />)}
-        {hidden > 0 && (
-          <button
-            type="button"
-            onClick={() => setAll(!all)}
-            className="text-muted-foreground underline underline-offset-2 transition-colors hover:text-foreground"
-          >
-            {all ? "Show fewer" : `+${hidden} more`}
-          </button>
-        )}
+        {shown.map((file) => (
+          <ConflictPath key={file} file={file} />
+        ))}
+        <MoreButton hidden={hidden} all={all} onToggle={() => setAll(!all)} />
       </div>
-      {/* One per line once it is open, and bounded: a merge gone this wrong can
-          name dozens of files, and the header is not the place to scroll for
-          them — the count above is the reading that matters by then. */}
-      {all && (
-        <div className="mt-1.5 flex max-h-20 flex-col gap-0.5 overflow-y-auto text-xs">
-          {files.map((file) => (
-            <ConflictPath key={file} file={file} />
-          ))}
-        </div>
-      )}
+      {all && <ConflictList files={files} />}
     </>
   )
 }
 
-// One path, with its directory dimmed. A monorepo's conflicting files share
-// most of their path, and the half that tells them apart is the last segment.
+// The rest of the list, and the way back. Nothing is drawn while every path is
+// already named: a button offering to unfold what is open is a dead click.
+function MoreButton({
+  hidden,
+  all,
+  onToggle,
+}: {
+  hidden: number
+  all: boolean
+  onToggle: () => void
+}) {
+  if (hidden === 0) {
+    return null
+  }
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="text-muted-foreground underline underline-offset-2 transition-colors hover:text-foreground"
+    >
+      {all ? "Show fewer" : `+${hidden} more`}
+    </button>
+  )
+}
+
+// One per line once the list is open, and bounded: a merge gone this wrong can
+// name dozens of files, and the header is not the place to scroll for them — the
+// count above is the reading that matters by then.
+function ConflictList({ files }: { files: string[] }) {
+  return (
+    <div className="mt-1.5 flex max-h-20 flex-col gap-0.5 overflow-y-auto text-xs">
+      {files.map((file) => (
+        <ConflictPath key={file} file={file} />
+      ))}
+    </div>
+  )
+}
+
+// One path, with its directory dimmed (conflict-files).
 function ConflictPath({ file }: { file: string }) {
-  const cut = file.lastIndexOf("/") + 1
+  const { dir, name } = splitConflictPath(file)
   return (
     <span className="font-mono text-destructive">
-      {cut > 0 && <span className="opacity-70">{file.slice(0, cut)}</span>}
-      {file.slice(cut)}
+      {dir && <span className="opacity-70">{dir}</span>}
+      {name}
     </span>
   )
 }

--- a/frontend/src/components/pulls/PullsStats.tsx
+++ b/frontend/src/components/pulls/PullsStats.tsx
@@ -8,7 +8,8 @@ import {
   X,
   type LucideIcon,
 } from "lucide-react"
-import type { ChecksRollup } from "@/lib/api-types"
+import type { ChecksRollup, PullRequestDetail } from "@/lib/api-types"
+import { conflictsWithBase } from "@/lib/pulls/merge-gate"
 import { cn } from "@/lib/utils"
 
 // The pull request's status line, one reading per item: where it stands, what
@@ -113,28 +114,24 @@ export function ReviewStat({ decision }: { decision: string }) {
   )
 }
 
-export function MergeableStat({
-  mergeable,
-  base,
-  state,
-}: {
-  mergeable: string
-  base: string
-  state: string
-}) {
+export function MergeableStat({ detail }: { detail: PullRequestDetail }) {
   // gh reports UNKNOWN for a pull request that is over, and "Checking
   // mergeability…" against something already merged reads as a stuck screen.
-  if (state !== "OPEN") {
+  if (detail.state !== "OPEN") {
     return null
   }
-  if (mergeable === "CONFLICTING") {
+  // The pair, the way every other reader of a conflict reads it (merge-gate):
+  // the chip is what the conflicting-file list below it captions itself against,
+  // and a chip still checking mergeability over a list of colliding files is the
+  // screen disagreeing with itself.
+  if (conflictsWithBase(detail)) {
     return (
       <Stat icon={X} tone="fail">
-        Conflicts with {base}
+        Conflicts with {detail.baseRefName}
       </Stat>
     )
   }
-  if (mergeable === "MERGEABLE") {
+  if (detail.mergeable === "MERGEABLE") {
     return (
       <Stat icon={GitMerge} tone="pass">
         Mergeable

--- a/frontend/src/lib/pulls/conflict-files.test.ts
+++ b/frontend/src/lib/pulls/conflict-files.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import { foldConflicts, NAMED, splitConflictPath } from "./conflict-files"
+
+describe("foldConflicts", () => {
+  it("names every file when they all fit", () => {
+    const files = ["a.txt", "b.txt"]
+    expect(foldConflicts(files, false)).toEqual({ shown: files, hidden: 0 })
+  })
+
+  it("names six and holds the seventh back", () => {
+    const files = ["1", "2", "3", "4", "5", "6", "7"]
+    expect(foldConflicts(files, false)).toEqual({ shown: files.slice(0, 6), hidden: 1 })
+  })
+
+  it("holds nothing back at exactly the limit", () => {
+    const files = ["1", "2", "3", "4", "5", "6"]
+    expect(foldConflicts(files, false).hidden).toBe(0)
+    expect(foldConflicts(files, false).shown).toHaveLength(NAMED)
+  })
+
+  it("names none inline once the whole list is open", () => {
+    expect(foldConflicts(["1", "2", "3", "4", "5", "6", "7"], true).shown).toEqual([])
+  })
+
+  it("answers for a list that is empty", () => {
+    expect(foldConflicts([], false)).toEqual({ shown: [], hidden: 0 })
+  })
+})
+
+describe("splitConflictPath", () => {
+  it("cuts where the directory ends", () => {
+    expect(splitConflictPath("internal/project/pr.go")).toEqual({
+      dir: "internal/project/",
+      name: "pr.go",
+    })
+  })
+
+  it("makes a file at the root all name", () => {
+    expect(splitConflictPath("CHANGELOG.md")).toEqual({ dir: "", name: "CHANGELOG.md" })
+  })
+
+  it("makes a path ending in a separator all directory", () => {
+    expect(splitConflictPath("docs/")).toEqual({ dir: "docs/", name: "" })
+  })
+
+  it("answers for the empty path", () => {
+    expect(splitConflictPath("")).toEqual({ dir: "", name: "" })
+  })
+})

--- a/frontend/src/lib/pulls/conflict-files.ts
+++ b/frontend/src/lib/pulls/conflict-files.ts
@@ -1,0 +1,24 @@
+// How many paths the conflict row names before it folds the rest away. Six fills
+// one line of the header at an ordinary window width; past that the row stops
+// answering faster and starts pushing the tabs down the screen.
+export const NAMED = 6
+
+// foldConflicts splits the list into what the row names inline and how many it
+// is holding back — never a negative count, so the caller reads one number
+// rather than a number and a comparison. Unfolded, the inline half is empty: the full list is drawn
+// below it, and naming the first six twice would read as a repeat rather than as
+// the same list opened.
+export function foldConflicts(files: string[], all: boolean): { shown: string[]; hidden: number } {
+  return { shown: all ? [] : files.slice(0, NAMED), hidden: Math.max(0, files.length - NAMED) }
+}
+
+// splitConflictPath cuts a path where the directory ends. A monorepo's
+// conflicting files share most of their path, and the half that tells them apart
+// is the last segment — so the two are drawn at different weights.
+//
+// A path with no directory is all name, and a path ending in a separator is all
+// directory: neither is what GitHub sends, and both have to render as something.
+export function splitConflictPath(file: string): { dir: string; name: string } {
+  const cut = file.lastIndexOf("/") + 1
+  return { dir: file.slice(0, cut), name: file.slice(cut) }
+}

--- a/frontend/src/lib/pulls/use-pull-request-conflicts.test.tsx
+++ b/frontend/src/lib/pulls/use-pull-request-conflicts.test.tsx
@@ -9,11 +9,13 @@ import { StrictMode, createElement, useLayoutEffect } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { usePullRequestConflicts } from "./use-pull-request-conflicts"
 
+const PR_URL = "https://github.com/owner/repo/pull/7"
+
 const conflicts = vi.fn()
 vi.mock("@/lib/rpc", () => ({
   ProjectService: {
-    PullRequestConflicts: (path: string, number: number, base: string) =>
-      conflicts(path, number, base),
+    PullRequestConflicts: (path: string, number: number, base: string, url: string) =>
+      conflicts(path, number, base, url),
   },
 }))
 
@@ -21,7 +23,7 @@ vi.mock("@/lib/rpc", () => ({
 // React discarded is not counted as one the screen saw.
 function panel(seen: string[][], conflicting: boolean, number = 7, base = "main") {
   function Panel() {
-    const { files } = usePullRequestConflicts("/repo", number, base, conflicting)
+    const { files } = usePullRequestConflicts("/repo", number, base, PR_URL, conflicting)
     useLayoutEffect(() => {
       seen.push(files)
     })
@@ -41,7 +43,7 @@ describe("usePullRequestConflicts", () => {
     const mounted = await mountBudget(panel(seen, true))
     await mounted.act(() => {})
 
-    expect(conflicts).toHaveBeenCalledWith("/repo", 7, "main")
+    expect(conflicts).toHaveBeenCalledWith("/repo", 7, "main", PR_URL)
     expect(seen[seen.length - 1]).toEqual(["internal/project/pr.go", "CHANGELOG.md"])
   })
 

--- a/frontend/src/lib/pulls/use-pull-request-conflicts.ts
+++ b/frontend/src/lib/pulls/use-pull-request-conflicts.ts
@@ -16,6 +16,11 @@ export interface PullRequestConflicts {
 // conflicts — because the answer is computed by fetching both commits, which is
 // a network round trip a clean pull request has no reason to pay for.
 //
+// The base is in the cache key as well as the request key: a retargeted pull
+// request asks a different question, and one entry answering both would paint
+// the old base's files under the new base's name with no loading state to
+// disown them.
+//
 // Keyed by the pull request and its base alone: what makes the answer stale is
 // a push to either side, and both of those arrive as a re-read of the detail
 // that flips `conflicting` or moves the base. Not refetched on focus for the
@@ -24,13 +29,16 @@ export function usePullRequestConflicts(
   path: string,
   number: number,
   base: string,
+  url: string,
   conflicting: boolean,
 ): PullRequestConflicts {
   const { data, loading, error } = useRemoteResource(
-    conflicting && path && number > 0 && base ? `${path} ${number} ${base}` : "",
+    conflicting && path && number > 0 && base ? `${path} ${number} ${base} ${url}` : "",
     () =>
-      ProjectService.PullRequestConflicts(path, number, base).then((files) => files ?? NO_FILES),
-    { empty: NO_FILES, cache: `pulls.conflicts ${path} #${number}` },
+      ProjectService.PullRequestConflicts(path, number, base, url).then(
+        (files) => files ?? NO_FILES,
+      ),
+    { empty: NO_FILES, cache: `pulls.conflicts ${path} #${number} ${base}` },
   )
   return { files: data, loading, error }
 }

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -233,9 +233,11 @@ export const ProjectService = {
     call<PullRequestDetail | null>("project.PullRequestDetail", [path, number]),
   /** Which files a conflicting PR collides with its base on — GitHub answers
    * that a pull request conflicts and never where. A network round trip (it
-   * fetches both commits), so it is asked only once mergeable says CONFLICTING. */
-  PullRequestConflicts: (path: string, number: number, base: string) =>
-    call<string[] | null>("project.PullRequestConflicts", [path, number, base]),
+   * fetches both commits), so it is asked only once mergeable says CONFLICTING.
+   * `url` is the PR's own: it names the repository the PR lives on, which is not
+   * origin in a clone of a fork. */
+  PullRequestConflicts: (path: string, number: number, base: string, url: string) =>
+    call<string[] | null>("project.PullRequestConflicts", [path, number, base, url]),
   /** Merge a PR on GitHub (0 = the checkout's branch). The backend allow-lists
    * the method. `admin` merges with administrator privileges — GitHub's own
    * bypass of the rules on the base branch, and the only way gh calls GitHub at

--- a/internal/project/basestatus.go
+++ b/internal/project/basestatus.go
@@ -89,7 +89,7 @@ func readBaseStatus(path, head, base string) *BaseStatus {
 	// collide with — and skipping merge-tree here is what keeps the common case
 	// (every worktree, most of the day) down to one extra subprocess.
 	if behind > 0 {
-		status.Conflicts = mergeConflicts(path, base, head)
+		status.Conflicts, _ = mergeConflicts(path, base, head)
 	}
 	return &status
 }
@@ -118,18 +118,26 @@ func commitsBehind(path, base, head string) (int, bool) {
 
 // mergeConflicts lists the files a merge of base into head would conflict on,
 // without touching the worktree, the index or HEAD: merge-tree computes the
-// merge in the object database alone. Exit status 1 is its answer for "merged
-// with conflicts" and the only status carrying a file list; anything else —
-// including a git too old to know --write-tree — reports none, which degrades
-// the readout to ahead/behind rather than failing it.
-func mergeConflicts(dir, base, head string) []string {
+// merge in the object database alone. Exit status 0 is a clean merge and 1 is
+// "merged with conflicts", the only status carrying a file list.
+//
+// The bool separates those two answers from a merge-tree that never answered —
+// a git too old to know --write-tree exits 129, measured. Both come back with
+// no files, and the difference decides whether a caller may say so out loud:
+// the polled readout degrades to ahead/behind (it has a second reading to fall
+// back on), while a screen whose whole answer is this list has to report that
+// it could not be computed rather than call the merge clean.
+func mergeConflicts(dir, base, head string) ([]string, bool) {
 	out, err := command("git", "-C", dir,
 		"merge-tree", "--write-tree", "--name-only", "-z", base, head).Output()
+	if err == nil {
+		return nil, true
+	}
 	var exit *exec.ExitError
 	if !errors.As(err, &exit) || exit.ExitCode() != 1 {
-		return nil
+		return nil, false
 	}
-	return conflictPaths(string(out))
+	return conflictPaths(string(out)), true
 }
 
 // conflictPaths reads merge-tree's -z output: the merged tree's OID, then the

--- a/internal/project/prconflicts.go
+++ b/internal/project/prconflicts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -24,18 +25,86 @@ const prConflictBudget = 60 * time.Second
 // nil means the merge is clean, so this is asked only once GitHub has said it
 // is not: the fetch is a network round trip, not something to poll.
 //
-// origin is the remote and refs/pull/<n>/head is GitHub's own ref — a fork's
-// pull request included, since GitHub keeps that ref on the base repository.
-func (s *Service) PullRequestConflicts(path string, number int, base string) ([]string, error) {
+// prURL is the pull request's own URL, which names the repository it lives on —
+// see prRemote. refs/pull/<n>/head is GitHub's own ref, a fork's pull request
+// included, since GitHub keeps that ref on the base repository.
+func (s *Service) PullRequestConflicts(path string, number int, base, prURL string) ([]string, error) {
 	if number <= 0 || base == "" {
 		return nil, errors.New("Listing the conflicting files needs a pull request number and its base branch.")
 	}
 	head := fmt.Sprintf("refs/lich/pr/%d/head", number)
 	baseRef := fmt.Sprintf("refs/lich/pr/%d/base", number)
-	if err := fetchPRPair(path, number, base, head, baseRef); err != nil {
+	if err := fetchPRPair(path, number, base, head, baseRef, prRemote(path, prURL)); err != nil {
 		return nil, err
 	}
-	return mergeConflicts(path, baseRef, head), nil
+	files, ok := mergeConflicts(path, baseRef, head)
+	if !ok {
+		return nil, fmt.Errorf("This git could not merge pull request #%d to see where it collides; naming the files needs git 2.38 or newer.", number)
+	}
+	return files, nil
+}
+
+// prRemote names the remote holding the pull request. Not origin by assumption:
+// in a clone of a fork, origin is the fork and the pull request — refs/pull and
+// the base branch both — lives on the repository it was opened against. Every
+// other pull request flow rides gh's own resolution of that repository; this one
+// reads it back off the pull request's URL, which the screen already has, rather
+// than spending a second round trip asking gh again.
+//
+// Falls back to origin: that is what a clone with one remote has, and a URL
+// nothing matches is better fetched from the remote that usually holds it than
+// not fetched at all.
+func prRemote(path, prURL string) string {
+	repo := repoFromPRURL(prURL)
+	if repo == "" {
+		return "origin"
+	}
+	out, ok := gitQuiet(path, "remote", "-v")
+	if !ok {
+		return "origin"
+	}
+	for _, line := range splitLines(out) {
+		name, remoteURL, found := strings.Cut(line, "\t")
+		if !found {
+			continue
+		}
+		if remoteRepo(remoteURL) == repo {
+			return name
+		}
+	}
+	return "origin"
+}
+
+// repoFromPRURL reads "owner/name" out of a pull request URL
+// (https://host/owner/name/pull/7), lowercased so it compares against a remote
+// the way GitHub itself treats the pair: case-insensitively.
+func repoFromPRURL(prURL string) string {
+	parsed, err := url.Parse(prURL)
+	if err != nil {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return ""
+	}
+	return strings.ToLower(parts[0] + "/" + parts[1])
+}
+
+// remoteRepo reads the same "owner/name" out of a remote's URL, in either
+// spelling git accepts: git@host:owner/name.git and https://host/owner/name.
+// The " (fetch)"/" (push)" tail `git remote -v` writes goes with it.
+func remoteRepo(remoteURL string) string {
+	fields := strings.Fields(remoteURL)
+	if len(fields) == 0 {
+		return ""
+	}
+	trimmed := strings.TrimSuffix(fields[0], ".git")
+	trimmed = strings.ReplaceAll(trimmed, ":", "/")
+	parts := strings.Split(strings.Trim(trimmed, "/"), "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	return strings.ToLower(parts[len(parts)-2] + "/" + parts[len(parts)-1])
 }
 
 // fetchPRPair brings the pull request's head and the tip of its base branch into
@@ -46,10 +115,10 @@ func (s *Service) PullRequestConflicts(path string, number int, base string) ([]
 // from a background goroutine, so two answers would mix into one. They are
 // forced because the refs are scratch space holding the previous answer, which
 // the new tip is routinely not a fast-forward of.
-func fetchPRPair(path string, number int, base, head, baseRef string) error {
+func fetchPRPair(path string, number int, base, head, baseRef, remote string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), prConflictBudget)
 	defer cancel()
-	args := []string{"-C", path, "fetch", "--quiet", "--no-tags", "--force", "origin",
+	args := []string{"-C", path, "fetch", "--quiet", "--no-tags", "--force", remote,
 		fmt.Sprintf("refs/pull/%d/head:%s", number, head),
 		"refs/heads/" + base + ":" + baseRef,
 	}

--- a/internal/project/prconflicts.go
+++ b/internal/project/prconflicts.go
@@ -90,16 +90,18 @@ func repoFromPRURL(prURL string) string {
 	return strings.ToLower(parts[0] + "/" + parts[1])
 }
 
-// remoteRepo reads the same "owner/name" out of a remote's URL, in either
-// spelling git accepts: git@host:owner/name.git and https://host/owner/name.
-// The " (fetch)"/" (push)" tail `git remote -v` writes goes with it.
+// remoteURLSeparators makes one separator of the three a remote URL can put
+// owner/name behind: the colon of git@host:owner/name, the slash of
+// https://host/owner/name, and the backslash of a local path on Windows — which
+// is a remote like any other, and the one a clone made by a test has.
+var remoteURLSeparators = strings.NewReplacer(":", "/", "\\", "/")
+
+// remoteRepo reads the same "owner/name" out of a remote's URL. The
+// " (fetch)"/" (push)" tail `git remote -v` writes is taken off by name rather
+// than by splitting on spaces: a path remote may hold one.
 func remoteRepo(remoteURL string) string {
-	fields := strings.Fields(remoteURL)
-	if len(fields) == 0 {
-		return ""
-	}
-	trimmed := strings.TrimSuffix(fields[0], ".git")
-	trimmed = strings.ReplaceAll(trimmed, ":", "/")
+	trimmed := strings.TrimSuffix(strings.TrimSuffix(remoteURL, " (fetch)"), " (push)")
+	trimmed = remoteURLSeparators.Replace(strings.TrimSuffix(trimmed, ".git"))
 	parts := strings.Split(strings.Trim(trimmed, "/"), "/")
 	if len(parts) < 2 {
 		return ""

--- a/internal/project/prconflicts_test.go
+++ b/internal/project/prconflicts_test.go
@@ -115,6 +115,8 @@ func TestRemoteRepoReadsBothSpellings(t *testing.T) {
 		{"https://github.com/owner/repo.git (push)", "owner/repo"},
 		{"https://github.com/owner/repo", "owner/repo"},
 		{"ssh://git@github.com/owner/repo.git", "owner/repo"},
+		{`C:\Users\runner\Temp\001\origin (fetch)`, "001/origin"},
+		{"/home/someone/my repos/001/origin", "001/origin"},
 		{"", ""},
 		{"weird", ""},
 	} {

--- a/internal/project/prconflicts_test.go
+++ b/internal/project/prconflicts_test.go
@@ -2,7 +2,9 @@ package project
 
 import (
 	"fmt"
+	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -26,7 +28,7 @@ func TestPullRequestConflictsNamesTheFiles(t *testing.T) {
 	clone, origin, originGit := pullRequestOrigin(t, 7)
 	commitFile(t, origin, originGit, "a.txt", "the base branch's line\n", "base edits a")
 
-	got, err := New(nil).PullRequestConflicts(clone, 7, "main")
+	got, err := New(nil).PullRequestConflicts(clone, 7, "main", "")
 	if err != nil {
 		t.Fatalf("PullRequestConflicts: %v", err)
 	}
@@ -39,7 +41,7 @@ func TestPullRequestConflictsNoneWhenTheMergeIsClean(t *testing.T) {
 	clone, origin, originGit := pullRequestOrigin(t, 7)
 	commitFile(t, origin, originGit, "b.txt", "elsewhere\n", "base adds b")
 
-	got, err := New(nil).PullRequestConflicts(clone, 7, "main")
+	got, err := New(nil).PullRequestConflicts(clone, 7, "main", "")
 	if err != nil {
 		t.Fatalf("PullRequestConflicts: %v", err)
 	}
@@ -51,10 +53,10 @@ func TestPullRequestConflictsNoneWhenTheMergeIsClean(t *testing.T) {
 func TestPullRequestConflictsRefusesAnUnaddressedPullRequest(t *testing.T) {
 	clone, _, _ := pullRequestOrigin(t, 7)
 
-	if _, err := New(nil).PullRequestConflicts(clone, 0, "main"); err == nil {
+	if _, err := New(nil).PullRequestConflicts(clone, 0, "main", ""); err == nil {
 		t.Error("want an error for pull request 0 — this has no branch fallback")
 	}
-	if _, err := New(nil).PullRequestConflicts(clone, 7, ""); err == nil {
+	if _, err := New(nil).PullRequestConflicts(clone, 7, "", ""); err == nil {
 		t.Error("want an error with no base branch")
 	}
 }
@@ -62,7 +64,70 @@ func TestPullRequestConflictsRefusesAnUnaddressedPullRequest(t *testing.T) {
 func TestPullRequestConflictsReportsAFetchItCannotMake(t *testing.T) {
 	clone, _, _ := pullRequestOrigin(t, 7)
 
-	if _, err := New(nil).PullRequestConflicts(clone, 404, "main"); err == nil {
+	if _, err := New(nil).PullRequestConflicts(clone, 404, "main", ""); err == nil {
 		t.Error("want an error for a pull request origin does not have")
+	}
+}
+
+// A merge-tree that never answered is not a clean merge: the screen whose whole
+// content is this list has to say it could not be computed. A directory that is
+// no repository is the reachable stand-in for the git too old to know
+// --write-tree, which exits the same way — anything but 0 or 1.
+func TestMergeConflictsReportsAMergeItCannotCompute(t *testing.T) {
+	if _, ok := mergeConflicts(t.TempDir(), "refs/heads/main", "refs/heads/pr"); ok {
+		t.Error("want ok=false where merge-tree could not run — a clean merge and an unanswered one must not read alike")
+	}
+}
+
+func TestPullRequestConflictsFetchesTheRemoteTheURLNames(t *testing.T) {
+	clone, origin, originGit := pullRequestOrigin(t, 7)
+	commitFile(t, origin, originGit, "a.txt", "the base branch's line\n", "base edits a")
+	// The clone of a fork lich has to answer for: the pull request lives on a
+	// remote nobody called origin. The URL is spelled from the origin path's own
+	// last two segments, because owner/name is what the two are matched on.
+	gitIn(t, clone)("remote", "rename", "origin", "upstream")
+	parts := strings.Split(filepath.ToSlash(origin), "/")
+	prURL := fmt.Sprintf("https://github.com/%s/%s/pull/7", parts[len(parts)-2], parts[len(parts)-1])
+
+	got, err := New(nil).PullRequestConflicts(clone, 7, "main", prURL)
+	if err != nil {
+		t.Fatalf("PullRequestConflicts: %v", err)
+	}
+	if !slices.Equal(got, []string{"a.txt"}) {
+		t.Fatalf("conflicts = %v, want [a.txt] — the fetch has to reach the remote the URL names", got)
+	}
+}
+
+func TestPRRemoteFallsBackToOrigin(t *testing.T) {
+	clone, _, _ := pullRequestOrigin(t, 7)
+
+	if got := prRemote(clone, ""); got != "origin" {
+		t.Errorf("prRemote with no URL = %q, want origin", got)
+	}
+	if got := prRemote(clone, "https://github.com/nobody/else/pull/7"); got != "origin" {
+		t.Errorf("prRemote for a repository no remote holds = %q, want origin", got)
+	}
+}
+
+func TestRemoteRepoReadsBothSpellings(t *testing.T) {
+	for _, tc := range []struct{ url, want string }{
+		{"git@github.com:Owner/Repo.git (fetch)", "owner/repo"},
+		{"https://github.com/owner/repo.git (push)", "owner/repo"},
+		{"https://github.com/owner/repo", "owner/repo"},
+		{"ssh://git@github.com/owner/repo.git", "owner/repo"},
+		{"", ""},
+		{"weird", ""},
+	} {
+		if got := remoteRepo(tc.url); got != tc.want {
+			t.Errorf("remoteRepo(%q) = %q, want %q", tc.url, got, tc.want)
+		}
+	}
+}
+
+func TestRepoFromPRURLRefusesWhatItCannotRead(t *testing.T) {
+	for _, bad := range []string{"", "https://github.com/owner", "not a url at all", "://"} {
+		if got := repoFromPRURL(bad); got != "" {
+			t.Errorf("repoFromPRURL(%q) = %q, want empty", bad, got)
+		}
 	}
 }


### PR DESCRIPTION
An audit of #445's own list, not of what it names.

### merge-tree failing read as a clean merge

`mergeConflicts` returned no files whether the merge was clean or the tool never
ran — a git older than 2.38 does not know `--write-tree` and exits 129 (measured
here; Ubuntu 22.04 LTS still ships 2.34). The base readout can live with that,
it degrades to ahead/behind. The pull request screen could not: its whole
content is that list, so it was telling the reader there is nothing to resolve
and blaming GitHub for being slow.

`mergeConflicts` now returns `([]string, bool)`. `BaseStatus` ignores the bool
and keeps degrading; `PullRequestConflicts` reports the merge it could not
compute.

### The fetch went to `origin` by name

Which is the fork, in a clone of one. Every other pull request flow rides gh's
resolution of the base repository — `pr view`, `gh pr checkout` — so this one
reads that repository off the pull request's own URL, already on screen and
costing no second round trip, and picks the remote whose URL matches it. Origin
when none does.

### The rest

- Fold and path-split move to `lib/pulls/conflict-files.ts`, where a test reaches
  what the row is drawn from: a file at the root, a path ending in a separator,
  exactly six, an empty list.
- The cache key gains the base branch — a retargeted pull request was painting
  the old base's files under the new base's name, with no loading state to
  disown them.
- `MergeableStat` reads the same conflict pair every other reader does, rather
  than `mergeable` alone.
- `PullsConflicts` down to 43 lines, with the fold button and the open list as
  their own components.

`docs/ceilings.md` records which remote the fetch reaches and where that falls
back; the `[Unreleased]` entry gains the git 2.38 floor and the fork remote.

### Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...`
- [x] `for os in linux darwin windows` build + vet
- [x] `pnpm check` (no new warning), `vitest` 1366/1366, `tsc -b` + `vite build`
- [x] New: `TestMergeConflictsReportsAMergeItCannotCompute`,
      `TestPullRequestConflictsFetchesTheRemoteTheURLNames`,
      `TestPRRemoteFallsBackToOrigin`, `TestRemoteRepoReadsBothSpellings`,
      `TestRepoFromPRURLRefusesWhatItCannotRead`, `conflict-files.test.ts`

https://claude.ai/code/session_01VbdKgN3z5k3Ap6cVVR9doL