### PR TITLE
feat: publish a JSON Schema for custom themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A theme file can now be checked before it is imported.**
+  `themes/lich-theme.schema.json` is a JSON Schema naming every app and terminal
+  token, which color spellings each of the two blocks accepts, and the id and
+  name rules — so a token left out or an `oklch()` where the terminal wanted hex
+  is a red squiggle in the editor rather than an import error after the fact.
+  A theme opts in with a `$schema` line at the top of the file, pointed at the
+  copy in this repository; the starter written by Settings › Appearance ›
+  **Save template** already carries one. The schema is generated from the same
+  token sets and patterns the importer validates against, and a test fails when
+  the checked-in copy no longer matches them — a schema that drifts rejects
+  valid themes, which is worse than shipping none.
+
 - **A screen or panel that breaks no longer takes the window with it.** A single
   rendering bug anywhere in the interface used to blank lich entirely — sidebar,
   terminals, footer and all — while the agents kept running behind it with

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -66,6 +66,21 @@ before saving. `source` is written by lich for a theme installed from a
 repository (below) and stripped from a picked file — a standalone theme carries
 no version and is never updated in place.
 
+## Schema
+
+`themes/lich-theme.schema.json` is generated from the token sets and color
+patterns the importer itself validates against. Naming it turns the rules below
+into editor completion and errors, before the file is ever imported:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/omartelo/lich/main/themes/lich-theme.schema.json",
+  "id": "tokyo-night"
+}
+```
+
+The saved template already carries the line, and lich ignores the key on import.
+
 ## Theme Repositories
 
 A repository is the versioned way in. It is a plain git repository with a

--- a/internal/themes/schema.go
+++ b/internal/themes/schema.go
@@ -1,0 +1,108 @@
+package themes
+
+import (
+	"encoding/json"
+	"fmt"
+	"maps"
+	"slices"
+)
+
+// SchemaPath is where the generated schema lives in this repository, and the
+// tail of the raw URL a theme author points "$schema" at.
+const SchemaPath = "themes/lich-theme.schema.json"
+
+const schemaID = "https://raw.githubusercontent.com/omartelo/lich/main/" + SchemaPath
+
+// Schema renders the JSON Schema a theme file is checked against in an editor.
+// It is generated from the same token sets and patterns validateTheme reads, so
+// a token added to the bundled theme cannot leave the schema behind; the test
+// beside this file fails when the checked-in copy has drifted.
+func Schema() ([]byte, error) {
+	schema := map[string]any{
+		"$schema":              "https://json-schema.org/draft/2020-12/schema",
+		"$id":                  schemaID,
+		"title":                "lich theme",
+		"description":          "A color theme for the lich harness.",
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             []string{"id", "name", "scheme", "app", "terminal"},
+		"properties": map[string]any{
+			"$schema": map[string]any{"type": "string"},
+			"id": map[string]any{
+				"description": "Names the file the theme is stored as, so reserved ids and Windows device names are out.",
+				"type":        "string",
+				"pattern":     idPattern.String(),
+				"maxLength":   themeIDMaxLength,
+				"not":         map[string]any{"enum": rejectedIDs()},
+			},
+			"name": map[string]any{
+				"type":      "string",
+				"maxLength": themeNameMaxLength,
+				// Anchorless, so it only asks for one non-space rune anywhere:
+				// the name is rejected when it trims to nothing, not when it
+				// is short.
+				"pattern": `\S`,
+			},
+			"scheme": map[string]any{"enum": []string{SchemeLight, SchemeDark}},
+			"origin": map[string]any{
+				"description": "Written by lich on import; a hand-written value is ignored.",
+				"enum":        []string{OriginBundled, OriginCustom},
+			},
+			"source": map[string]any{
+				"description":          "Written by lich for a theme installed from a repository.",
+				"type":                 "object",
+				"additionalProperties": false,
+				"required":             []string{"url", "version"},
+				"properties": map[string]any{
+					"url":     map[string]any{"type": "string"},
+					"version": map[string]any{"type": "string", "pattern": `^v?\d+\.\d+\.\d+$`},
+				},
+			},
+			"app":      colorObject(appTokens, "#/$defs/appColor", sortedKeys(appTokens)),
+			"terminal": colorObject(terminalTokens, "#/$defs/terminalColor", []string{"background", "foreground"}),
+		},
+		"$defs": map[string]any{
+			"appColor":      colorValue(appColorPattern),
+			"terminalColor": colorValue(terminalColorPattern),
+		},
+	}
+	data, err := json.MarshalIndent(schema, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode theme schema: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func colorObject(tokens map[string]struct{}, ref string, required []string) map[string]any {
+	properties := make(map[string]any, len(tokens))
+	for token := range tokens {
+		properties[token] = map[string]any{"$ref": ref}
+	}
+	return map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"required":             required,
+		"properties":           properties,
+	}
+}
+
+func colorValue(pattern string) map[string]any {
+	return map[string]any{
+		"type":      "string",
+		"pattern":   pattern,
+		"maxLength": colorValueMaxLength,
+	}
+}
+
+// rejectedIDs is every id validateID turns down for what it means rather than
+// for its spelling.
+func rejectedIDs() []string {
+	all := make(map[string]struct{}, len(reserved)+len(windowsDeviceNames))
+	maps.Copy(all, reserved)
+	maps.Copy(all, windowsDeviceNames)
+	return sortedKeys(all)
+}
+
+func sortedKeys(tokens map[string]struct{}) []string {
+	return slices.Sorted(maps.Keys(tokens))
+}

--- a/internal/themes/schema_test.go
+++ b/internal/themes/schema_test.go
@@ -1,0 +1,79 @@
+package themes
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+var updateSchema = flag.Bool("update-schema", false, "rewrite "+SchemaPath+" from Schema()")
+
+const regenerate = "go test ./internal/themes -run TestSchemaFileMatchesGenerator -update-schema"
+
+// TestSchemaFileMatchesGenerator is the whole reason the schema is generated:
+// without it a token added to the bundled theme leaves the published schema
+// rejecting valid files, which is worse than shipping no schema at all.
+func TestSchemaFileMatchesGenerator(t *testing.T) {
+	want, err := Schema()
+	if err != nil {
+		t.Fatalf("Schema() error: %v", err)
+	}
+	path := filepath.Join("..", "..", filepath.FromSlash(SchemaPath))
+	if *updateSchema {
+		if err := os.WriteFile(path, want, 0o644); err != nil {
+			t.Fatalf("write %s: %v", SchemaPath, err)
+		}
+		return
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v (regenerate with: %s)", SchemaPath, err, regenerate)
+	}
+	// The repository carries no .gitattributes, so a Windows checkout may hand
+	// back CRLF for a file committed with LF. That is the checkout's spelling,
+	// not drift.
+	if !bytes.Equal(bytes.ReplaceAll(got, []byte("\r\n"), []byte("\n")), want) {
+		t.Fatalf("%s is stale; regenerate with: %s", SchemaPath, regenerate)
+	}
+}
+
+// TestSchemaCoversEveryToken pins what the file is worth rather than that it is
+// current: a generator that stopped reading appTokens would still round-trip
+// through the drift test above once somebody regenerated it.
+func TestSchemaCoversEveryToken(t *testing.T) {
+	data, err := Schema()
+	if err != nil {
+		t.Fatalf("Schema() error: %v", err)
+	}
+	var schema struct {
+		Properties map[string]colorGroupSchema `json:"properties"`
+	}
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Fatalf("decode generated schema: %v", err)
+	}
+	assertTokens(t, "app", schema.Properties["app"], appTokens, sortedKeys(appTokens))
+	assertTokens(t, "terminal", schema.Properties["terminal"], terminalTokens, []string{"background", "foreground"})
+}
+
+type colorGroupSchema struct {
+	AdditionalProperties bool                `json:"additionalProperties"`
+	Required             []string            `json:"required"`
+	Properties           map[string]struct{} `json:"properties"`
+}
+
+func assertTokens(t *testing.T, group string, got colorGroupSchema, tokens map[string]struct{}, required []string) {
+	t.Helper()
+	if got.AdditionalProperties {
+		t.Errorf("%s: schema accepts unknown tokens, validateColors rejects them", group)
+	}
+	if !slices.Equal(sortedKeys(got.Properties), sortedKeys(tokens)) {
+		t.Errorf("%s: schema names %v, want %v", group, sortedKeys(got.Properties), sortedKeys(tokens))
+	}
+	if !slices.Equal(got.Required, required) {
+		t.Errorf("%s: schema requires %v, want %v", group, got.Required, required)
+	}
+}

--- a/themes/lich-theme.schema.json
+++ b/themes/lich-theme.schema.json
@@ -1,0 +1,312 @@
+{
+  "$defs": {
+    "appColor": {
+      "maxLength": 128,
+      "pattern": "^(#[0-9a-fA-F]{3,8}|[a-zA-Z]{3,20}|(rgb|rgba|hsl|hsla|oklch|oklab|lab|lch|color)\\([0-9a-zA-Z.,%/ +-]*\\))$",
+      "type": "string"
+    },
+    "terminalColor": {
+      "maxLength": 128,
+      "pattern": "^#[0-9a-fA-F]{3,8}$",
+      "type": "string"
+    }
+  },
+  "$id": "https://raw.githubusercontent.com/omartelo/lich/main/themes/lich-theme.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "A color theme for the lich harness.",
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "app": {
+      "additionalProperties": false,
+      "properties": {
+        "accent": {
+          "$ref": "#/$defs/appColor"
+        },
+        "accent-foreground": {
+          "$ref": "#/$defs/appColor"
+        },
+        "background": {
+          "$ref": "#/$defs/appColor"
+        },
+        "border": {
+          "$ref": "#/$defs/appColor"
+        },
+        "card": {
+          "$ref": "#/$defs/appColor"
+        },
+        "card-foreground": {
+          "$ref": "#/$defs/appColor"
+        },
+        "chart-1": {
+          "$ref": "#/$defs/appColor"
+        },
+        "chart-2": {
+          "$ref": "#/$defs/appColor"
+        },
+        "chart-3": {
+          "$ref": "#/$defs/appColor"
+        },
+        "chart-4": {
+          "$ref": "#/$defs/appColor"
+        },
+        "chart-5": {
+          "$ref": "#/$defs/appColor"
+        },
+        "destructive": {
+          "$ref": "#/$defs/appColor"
+        },
+        "foreground": {
+          "$ref": "#/$defs/appColor"
+        },
+        "input": {
+          "$ref": "#/$defs/appColor"
+        },
+        "muted": {
+          "$ref": "#/$defs/appColor"
+        },
+        "muted-foreground": {
+          "$ref": "#/$defs/appColor"
+        },
+        "popover": {
+          "$ref": "#/$defs/appColor"
+        },
+        "popover-foreground": {
+          "$ref": "#/$defs/appColor"
+        },
+        "primary": {
+          "$ref": "#/$defs/appColor"
+        },
+        "primary-foreground": {
+          "$ref": "#/$defs/appColor"
+        },
+        "ring": {
+          "$ref": "#/$defs/appColor"
+        },
+        "secondary": {
+          "$ref": "#/$defs/appColor"
+        },
+        "secondary-foreground": {
+          "$ref": "#/$defs/appColor"
+        },
+        "sidebar": {
+          "$ref": "#/$defs/appColor"
+        },
+        "sidebar-accent": {
+          "$ref": "#/$defs/appColor"
+        },
+        "sidebar-accent-foreground": {
+          "$ref": "#/$defs/appColor"
+        },
+        "sidebar-border": {
+          "$ref": "#/$defs/appColor"
+        },
+        "sidebar-foreground": {
+          "$ref": "#/$defs/appColor"
+        },
+        "sidebar-primary": {
+          "$ref": "#/$defs/appColor"
+        },
+        "sidebar-primary-foreground": {
+          "$ref": "#/$defs/appColor"
+        },
+        "sidebar-ring": {
+          "$ref": "#/$defs/appColor"
+        }
+      },
+      "required": [
+        "accent",
+        "accent-foreground",
+        "background",
+        "border",
+        "card",
+        "card-foreground",
+        "chart-1",
+        "chart-2",
+        "chart-3",
+        "chart-4",
+        "chart-5",
+        "destructive",
+        "foreground",
+        "input",
+        "muted",
+        "muted-foreground",
+        "popover",
+        "popover-foreground",
+        "primary",
+        "primary-foreground",
+        "ring",
+        "secondary",
+        "secondary-foreground",
+        "sidebar",
+        "sidebar-accent",
+        "sidebar-accent-foreground",
+        "sidebar-border",
+        "sidebar-foreground",
+        "sidebar-primary",
+        "sidebar-primary-foreground",
+        "sidebar-ring"
+      ],
+      "type": "object"
+    },
+    "id": {
+      "description": "Names the file the theme is stored as, so reserved ids and Windows device names are out.",
+      "maxLength": 64,
+      "not": {
+        "enum": [
+          "aux",
+          "com1",
+          "com2",
+          "com3",
+          "com4",
+          "com5",
+          "com6",
+          "com7",
+          "com8",
+          "com9",
+          "con",
+          "dark",
+          "light",
+          "lpt1",
+          "lpt2",
+          "lpt3",
+          "lpt4",
+          "lpt5",
+          "lpt6",
+          "lpt7",
+          "lpt8",
+          "lpt9",
+          "match",
+          "nul",
+          "prn",
+          "system"
+        ]
+      },
+      "pattern": "^[a-z0-9][a-z0-9._-]{0,63}$",
+      "type": "string"
+    },
+    "name": {
+      "maxLength": 128,
+      "pattern": "\\S",
+      "type": "string"
+    },
+    "origin": {
+      "description": "Written by lich on import; a hand-written value is ignored.",
+      "enum": [
+        "bundled",
+        "custom"
+      ]
+    },
+    "scheme": {
+      "enum": [
+        "light",
+        "dark"
+      ]
+    },
+    "source": {
+      "additionalProperties": false,
+      "description": "Written by lich for a theme installed from a repository.",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "version": {
+          "pattern": "^v?\\d+\\.\\d+\\.\\d+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url",
+        "version"
+      ],
+      "type": "object"
+    },
+    "terminal": {
+      "additionalProperties": false,
+      "properties": {
+        "background": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "black": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "blue": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "brightBlack": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "brightBlue": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "brightCyan": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "brightGreen": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "brightMagenta": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "brightRed": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "brightWhite": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "brightYellow": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "cursor": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "cursorAccent": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "cyan": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "foreground": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "green": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "magenta": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "red": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "selectionBackground": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "selectionForeground": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "white": {
+          "$ref": "#/$defs/terminalColor"
+        },
+        "yellow": {
+          "$ref": "#/$defs/terminalColor"
+        }
+      },
+      "required": [
+        "background",
+        "foreground"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "id",
+    "name",
+    "scheme",
+    "app",
+    "terminal"
+  ],
+  "title": "lich theme",
+  "type": "object"
+}

--- a/themes/template.json
+++ b/themes/template.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/omartelo/lich/main/themes/lich-theme.schema.json",
   "id": "purple-night",
   "name": "Purple Night",
   "scheme": "dark",


### PR DESCRIPTION
A theme file is the only JSON a stranger hand-writes for lich, and until now the
only feedback was the import error after the fact — no completion, no way to
check a file before importing it.

`themes/lich-theme.schema.json` is a JSON Schema (draft 2020-12) naming every
app and terminal token, which color spellings each of the two blocks accepts,
and the `id` and `name` rules. A theme opts in with a `$schema` line at the top:

```json
{
  "$schema": "https://raw.githubusercontent.com/omartelo/lich/main/themes/lich-theme.schema.json",
  "id": "tokyo-night"
}
```

## It is generated, not written

`Schema()` in `internal/themes/schema.go` builds it from the same values
`validateTheme` reads: `appTokens` (which is `keySet(bundledThemes[0].App)` —
still the one source of truth for the token list), `terminalTokens`,
`appColorValue`, `terminalColorValue`, `themeNameMaxLength`, `idPattern`, and
the reserved ids plus the Windows device names.

`TestSchemaFileMatchesGenerator` pins the checked-in file against the generator
the way `gofmt -l` pins formatting, and prints the command that refreshes it
(`go test ./internal/themes -run TestSchemaFileMatchesGenerator -update-schema`).
That test is the point: without it the schema rots the first time a token is
added, and a schema that rejects valid themes is worse than shipping none.
Verified by hand — adding a token to `themes/light.json` fails the test.
`TestSchemaCoversEveryToken` asserts what the file is worth rather than that it
is current, so a generator that stopped reading a token set fails there instead
of round-tripping through a regeneration.

No new dependency: `encoding/json` and what `internal/themes` already knows.

## Also here

- `themes/template.json` carries the `$schema` line, so the starter written by
  Settings › Appearance › **Save template** arrives already wired to it. lich
  drops the key when it stores a theme (`encodeTheme` marshals the struct), so
  it never leaks into an installed theme.
- `docs/themes.md` gains a short **Schema** section with the line and the raw URL.

## Deliberately left out

- **`lich theme validate <file>`.** It does not fall out for free: the package
  exposes no validation entry point (`validateCustom` is unexported and `Import`
  writes to disk), so it would take a new exported function, CLI wiring, a help
  entry and its own tests. The schema plus its drift test is the deliverable.
- **The theme-repo template (`rose-pine-lich`).** It lives in another repository
  and was not touched. It should carry the `$schema` line too — the same one, on
  every theme file in the pack — and that is a one-line change per file there.
- **Top-level `additionalProperties: false`** is stricter than the Go decoder,
  which ignores unknown top-level keys. That is deliberate: it catches a
  misspelled `"scheme"` in the editor, and `$schema`, `origin` and `source` are
  declared so every file lich itself writes still validates.

## Gate

`gofmt -l .` clean · `go vet ./...` clean · `go test ./...` green · `pnpm check`
clean · `pnpm test` 1368 passed · `tsc` + `vite build` green · cross-compile loop
(linux/darwin/windows build + vet) clean · `internal/themes` coverage 87.8%.

Sanity-checked the output with a draft 2020-12 validator: the schema itself is
valid, `themes/template.json` passes, and `light.json`/`dark.json` fail on
exactly one rule — their reserved ids — which is what `validateCustom` does too.

https://claude.ai/code/session_01TQPMfxyixsGSbpiYSbhNCH
