### PR TITLE
feat: name the account a session's plan gauge is measuring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The plan gauge now names the account it is measuring.** lich has always
+  drawn the gauge and never said whose plan it was drawing — which matters
+  precisely because a session can be spawned from a binary of your own that
+  points Claude Code or Codex at a second account. The tooltip carries the
+  account under the plan now: read from Claude's own profile route, and from the
+  id token Codex writes beside its access token, both on the reading the gauge
+  already takes rather than a request of their own. A login that will not say
+  which account it is keeps the gauge and shows no name — a session signed in
+  with `claude setup-token` is one, and so is every provider lich reads no plan
+  from.
+
 - **A conflicting pull request now names the files it conflicts on.** GitHub
   publishes one word — the pull request conflicts with its base — and never
   which files, so the way to find out was opening the PR on github.com or a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **The plan gauge now names the account it is measuring.** lich has always
   drawn the gauge and never said whose plan it was drawing — which matters
   precisely because a session can be spawned from a binary of your own that
-  points Claude Code or Codex at a second account. The tooltip carries the
-  account under the plan now: read from Claude's own profile route, and from the
-  id token Codex writes beside its access token, both on the reading the gauge
-  already takes rather than a request of their own. A login that will not say
-  which account it is keeps the gauge and shows no name — a session signed in
-  with `claude setup-token` is one, and so is every provider lich reads no plan
+  points Claude Code or Codex at a second account. The gauge's tooltip carries
+  the account at its foot now, under the windows, and Settings shows it under
+  the plan it read: taken from Claude's own profile route, and from the id token
+  Codex writes beside its access token, both on the reading the gauge already
+  takes rather than a request of their own. A login that will not say which
+  account it is keeps the gauge and shows no name — a session signed in with
+  `claude setup-token` is one, and so is every provider lich reads no plan
   from.
 
 - **A conflicting pull request now names the files it conflicts on.** GitHub

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -499,6 +499,36 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   the API rejects an OAuth token without it — the same coupling as the user agent, and it fails closed, as a
   failed reading. Headers carry the two account-wide windows and no plan name, so such a session shows no
   model-scoped weekly cap and no "Max 5x" badge.
+- **A token-only login has a gauge and no name** (`internal/quota/claude.go`): the same
+  `claude setup-token` scope that keeps the usage route out of reach keeps `/api/oauth/profile` out of reach —
+  it wants `user:profile`, and `user:inference` is all that token has — so the profile route is not asked at
+  all on that path rather than asked once per cache window for a 403. Such a session shows its windows under
+  the provider's name with no account line, which is the same thing a session on a provider that names nobody
+  shows, and nothing on screen tells the two apart.
+- **Only two providers name the account a session spends, and the reasons the other six do not are not one
+  reason** (`internal/quota`, `Plan.Account`): Claude Code answers a profile route with the credentials token,
+  and Codex carries an `email` claim in the OIDC id token beside its access token (read unverified, and
+  discarded once its `exp` has passed — the CLI can rotate the access token without rewriting the id one, and a
+  gauge under a login the user has left is worse than one under no name). opencode, Crush and oh-my-pi run on
+  the user's own API keys: there is no plan account to name, which is the same reason they have no gauge.
+  Antigravity's `~/.gemini/oauth_creds.json` *does* carry the same `email` claim and it is deliberately not
+  read: there is no `antigravityPlan`, so a `Plan` naming an account with no window in it renders nothing at
+  all (`PlanQuota` draws only a reading with a window) — the name arrives with the gauge or not at all. Cursor
+  CLI and Kiro CLI were measured on 2026-09-04 and carry no such claim: Cursor's `~/.config/cursor/auth.json`
+  token is a JWT whose `sub` is an opaque `github|user_…` and whose claims contain no email, and Kiro's login
+  is a row in `~/.local/share/kiro-cli/data.sqlite3` holding an opaque `aoa…` token, a `github` provider label
+  and an AWS profile ARN — nothing a person recognises as their account. Naming either would take a network
+  call against an unmeasured route, for a provider that has no gauge to hang the name under.
+- **`CLAUDE_SECURESTORAGE_CONFIG_DIR` decides which Keychain item a Claude login is, and lich reads it
+  nowhere** (`internal/quota/claude.go`, confirmed by grep — the variable appears in no file here): Claude Code
+  looks for its secure storage under that variable whenever it is *defined*, empty string included, and only
+  falls back to `CLAUDE_CONFIG_DIR`; the value is NFC-normalised and hashed into the Keychain service name, so
+  two values that differ by a combining accent are two different logins. Today this changes nothing: on Linux
+  the credential is the plaintext file under the config dir, and on macOS no session's environment is readable
+  at all (`envReadable`), so the question never arises. The trap is the day somebody writes the macOS
+  `KERN_PROCARGS2` reading promised above and resolves the credential from `CLAUDE_CONFIG_DIR` alone — that
+  reads the wrong Keychain item and reports, with a gauge and an account name under it, a login the session is
+  not spending. Resolve the pair in that order, or report `unknown`.
 - **The sandbox confines a working agent, not hostile code** (`internal/sandbox`): namespaces and mounts on
   Linux, a path policy on macOS, and nothing else — no seccomp filter, no Landlock ruleset. The network is
   never cut (the agent needs its API and the plugin's hooks report over loopback), so anything readable

--- a/frontend/src/components/PlanQuota.tsx
+++ b/frontend/src/components/PlanQuota.tsx
@@ -20,10 +20,12 @@ interface PlanQuotaProps {
 // subscription is spent, with every window behind a tooltip. Self-contained like
 // SessionModel — it resolves its own reading from the provider id.
 //
-// The tooltip names the account the reading was taken against under the plan,
-// where the provider says which — a session spawned from a wrapper binary
-// spends a login lich's own environment does not name, which is the whole
-// reason that line exists. It is absent for a provider that names nobody.
+// The account the reading was taken against sits at the foot, under a seam:
+// a session spawned from a wrapper binary spends a login lich's own environment
+// does not name, which is the whole reason it is said at all. It is provenance
+// rather than part of the plan's name, so it reads last and in the mono the app
+// gives every other identifier. Absent for a provider that names nobody, which
+// is what the gauge has always looked like.
 //
 // One window is shown, and it is the fullest one: a weekly cap about to run out
 // must not hide behind a session window that reset an hour ago. Nothing renders
@@ -55,15 +57,17 @@ export function PlanQuota({ kind, sessionId }: PlanQuotaProps) {
       </TooltipTrigger>
       <TooltipContent side="top" className="border border-border bg-card text-foreground">
         <div className="flex min-w-52 flex-col gap-2.5">
-          <div className="flex flex-col">
-            <span className="font-medium">
-              {plan.plan ? `${plan.name} · ${plan.plan}` : plan.name}
-            </span>
-            {plan.account && <span className="text-muted-foreground text-xs">{plan.account}</span>}
-          </div>
+          <span className="font-medium">
+            {plan.plan ? `${plan.name} · ${plan.plan}` : plan.name}
+          </span>
           {(plan.windows ?? []).map((w) => (
             <QuotaGauge key={w.label} window={w} now={now} stacked />
           ))}
+          {plan.account && (
+            <span className="break-all border-border border-t pt-2 font-mono text-[11px] text-muted-foreground">
+              {plan.account}
+            </span>
+          )}
         </div>
       </TooltipContent>
     </Tooltip>

--- a/frontend/src/components/PlanQuota.tsx
+++ b/frontend/src/components/PlanQuota.tsx
@@ -20,6 +20,11 @@ interface PlanQuotaProps {
 // subscription is spent, with every window behind a tooltip. Self-contained like
 // SessionModel — it resolves its own reading from the provider id.
 //
+// The tooltip names the account the reading was taken against under the plan,
+// where the provider says which — a session spawned from a wrapper binary
+// spends a login lich's own environment does not name, which is the whole
+// reason that line exists. It is absent for a provider that names nobody.
+//
 // One window is shown, and it is the fullest one: a weekly cap about to run out
 // must not hide behind a session window that reset an hour ago. Nothing renders
 // at all for a provider that meters no subscription, while the reading is
@@ -50,9 +55,12 @@ export function PlanQuota({ kind, sessionId }: PlanQuotaProps) {
       </TooltipTrigger>
       <TooltipContent side="top" className="border border-border bg-card text-foreground">
         <div className="flex min-w-52 flex-col gap-2.5">
-          <span className="font-medium">
-            {plan.plan ? `${plan.name} · ${plan.plan}` : plan.name}
-          </span>
+          <div className="flex flex-col">
+            <span className="font-medium">
+              {plan.plan ? `${plan.name} · ${plan.plan}` : plan.name}
+            </span>
+            {plan.account && <span className="text-muted-foreground text-xs">{plan.account}</span>}
+          </div>
           {(plan.windows ?? []).map((w) => (
             <QuotaGauge key={w.label} window={w} now={now} stacked />
           ))}

--- a/frontend/src/components/settings/PlanUsageSetting.tsx
+++ b/frontend/src/components/settings/PlanUsageSetting.tsx
@@ -77,6 +77,13 @@ function PlanBody({ plan, now }: { plan: QuotaPlan; now: Date }) {
       {(plan.windows ?? []).map((window) => (
         <QuotaGauge key={window.label} window={window} now={now} />
       ))}
+      {/* The login this reading was taken against. Settings asks the machine-wide
+          question, so this is lich's own — never a session's wrapper binary. */}
+      {plan.account && (
+        <span className="break-all font-mono text-[11px] text-muted-foreground">
+          {plan.account}
+        </span>
+      )}
     </div>
   )
 }

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -504,6 +504,9 @@ export interface QuotaPlan {
   provider: string
   name: string
   plan?: string
+  /** The login the windows were read against, where the provider names one —
+   * absent is an unnamed account, never a failed reading. */
+  account?: string
   windows?: QuotaWindow[]
   status: "ok" | "signed-out" | "error" | "unknown"
 }

--- a/internal/quota/claude.go
+++ b/internal/quota/claude.go
@@ -21,6 +21,11 @@ const (
 	// claudeAPIVersion is the dated API contract the probe request is written
 	// against; the usage route above needs none.
 	claudeAPIVersion = "2023-06-01"
+	// claudeProfileURL names the account a login belongs to. It is a second
+	// request, taken beside the usage one and cached with it, because the access
+	// token itself is opaque (`sk-ant-oat01-`, no claims to read) — unlike the
+	// OIDC id tokens the other providers write beside theirs.
+	claudeProfileURL = "https://api.anthropic.com/api/oauth/profile"
 )
 
 // The environment variables a session's own process names its Claude login
@@ -74,6 +79,15 @@ func (c claudeCredentials) planLabel() string {
 		}
 	}
 	return name
+}
+
+// claudeProfile is the part of the OAuth profile route lich reads: the email of
+// the account this login spends. The organization and the two uuids beside it
+// are of no use to a gauge that has one line to name an account on.
+type claudeProfile struct {
+	Account struct {
+		Email string `json:"email"`
+	} `json:"account"`
 }
 
 // claudeUsage is the response of the OAuth usage route. Every field is optional:
@@ -139,12 +153,34 @@ func (s *Service) claudePlan(a Account) Plan {
 	if len(p.Windows) == 0 {
 		return failed(p)
 	}
+	p.Account = s.claudeAccount(creds.OAuth.AccessToken)
 	return p
 }
 
+// claudeAccount names the account a credentials login spends. Every failure is
+// an unnamed account rather than a failed reading: the gauge is the answer the
+// user asked for and the name is the label on it, so a route that changed shape
+// or refused the token must not take the numbers down with it.
+//
+// It is only reached on the credentials path. A `claude setup-token` login
+// carries `user:inference` alone, which this route refuses exactly as the usage
+// one does, so asking would spend a round trip per cache window on a 403 that
+// is already known (docs/ceilings.md).
+func (s *Service) claudeAccount(token string) string {
+	var profile claudeProfile
+	if _, err := s.readJSON(s.profileURL, token, map[string]string{
+		"anthropic-beta": claudeBetaHeader,
+		"User-Agent":     claudeUserAgent,
+	}, &profile); err != nil {
+		return ""
+	}
+	return profile.Account.Email
+}
+
 // claudeProbe measures a token that can only infer: it sends the probe request
-// and reads the windows off the response headers. The plan name stays empty —
-// the headers carry the spend, never the subscription it is spent against.
+// and reads the windows off the response headers. The plan name and the account
+// both stay empty — the headers carry the spend, never the subscription it is
+// spent against nor whose it is.
 func (s *Service) claudeProbe(p Plan, token string) Plan {
 	resp, authOK, err := s.send(http.MethodPost, s.probeURL, token, claudeProbeBody, map[string]string{
 		"anthropic-beta":    claudeBetaHeader,

--- a/internal/quota/codex.go
+++ b/internal/quota/codex.go
@@ -1,6 +1,9 @@
 package quota
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/omartelo/lich/internal/providers"
@@ -17,10 +20,13 @@ const (
 )
 
 // codexCredentials is the part of ~/.codex/auth.json lich reads. As with
-// Claude, the refresh token beside it is left alone.
+// Claude, the refresh token beside it is left alone. IDToken is the OIDC id
+// token the login wrote for its own use, and is read for the account name
+// alone (jwtEmail) — never sent anywhere.
 type codexCredentials struct {
 	Tokens struct {
 		AccessToken string `json:"access_token"`
+		IDToken     string `json:"id_token"`
 	} `json:"tokens"`
 }
 
@@ -67,6 +73,7 @@ func (s *Service) codexPlan(a Account) Plan {
 		return failed(p)
 	}
 	p.Plan = title(usage.PlanType)
+	p.Account = jwtEmail(creds.Tokens.IDToken, s.now())
 	p.Windows = usage.windows()
 	if len(p.Windows) == 0 {
 		return failed(p)
@@ -108,6 +115,36 @@ func codexLabel(seconds int) string {
 	default:
 		return "Monthly"
 	}
+}
+
+// jwtEmail reads the `email` claim off an OIDC id token, and nothing about the
+// token is verified: the signature says who issued it, and lich is not deciding
+// anything on the answer — it already trusts this file for the access token it
+// authenticates with, and the claim is a label under a gauge, not a permission.
+// Decoding the payload alone is why this needs no dependency.
+//
+// The expiry is the one claim that is checked, and it is not ceremony: the CLI
+// rotates the access token beside this one without necessarily rewriting it, so
+// a stale id token can name the account the user was signed in as *before* the
+// login they are spending now. A gauge under the wrong name is worse than a
+// gauge under none, so an expired token names nobody.
+func jwtEmail(token string, now time.Time) string {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		return ""
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(parts[1], "="))
+	if err != nil {
+		return ""
+	}
+	var claims struct {
+		Email string `json:"email"`
+		Exp   int64  `json:"exp"`
+	}
+	if json.Unmarshal(payload, &claims) != nil || claims.Exp <= 0 || now.Unix() >= claims.Exp {
+		return ""
+	}
+	return claims.Email
 }
 
 // unixTimestamp renders a Unix-seconds reset as the RFC 3339 the frontend

--- a/internal/quota/identity_test.go
+++ b/internal/quota/identity_test.go
@@ -1,0 +1,250 @@
+package quota
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// claudeProfileBody is what the OAuth profile route answers, trimmed to the one
+// field lich reads out of it.
+const claudeProfileBody = `{"account":{"uuid":"acc-1","email":"dev@example.com"},
+	"organization":{"uuid":"org-1"}}`
+
+// idToken mints an unsigned id token carrying the given claims. The signature
+// is the literal "sig" because nothing reads it — which is the property under
+// test as much as a convenience.
+func idToken(t *testing.T, claims map[string]any) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	head := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"RS256"}`))
+	return head + "." + base64.RawURLEncoding.EncodeToString(payload) + ".sig"
+}
+
+// codexUsageBody is a paid plan's usage, enough to leave a reading with windows
+// while the account name is what is under test.
+const codexUsageBody = `{"plan_type":"pro","rate_limit":{
+	"primary_window":{"used_percent":12,"limit_window_seconds":18000,"reset_at":0}}}`
+
+// codexCredsWith is the auth.json shape with an id token beside the access one.
+func codexCredsWith(idTok string) string {
+	return `{"tokens":{"access_token":"tok-codex","id_token":"` + idTok + `"}}`
+}
+
+// serveRoutes answers each path with its body, so one server can stand in for
+// both the usage and the profile route.
+func serveRoutes(t *testing.T, bodies map[string]string) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, ok := bodies[r.URL.Path]
+		if !ok {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestClaudeNamesTheAccountItsLoginSpends(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	server := serveRoutes(t, map[string]string{
+		"/usage":   claudeLimitsBody,
+		"/profile": claudeProfileBody,
+	})
+	svc := newService(server.URL+"/usage", "", time.Now())
+	svc.profileURL = server.URL + "/profile"
+
+	got := svc.claudePlan(lichEnv())
+
+	if got.Account != "dev@example.com" {
+		t.Errorf("account = %q, want the email the profile route reports", got.Account)
+	}
+	if got.Status != StatusOK || len(got.Windows) == 0 {
+		t.Errorf("reading = %+v, want the windows unaffected", got)
+	}
+}
+
+func TestClaudeSendsTheProfileRouteTheHeadersTheUsageRouteNeeds(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	var got http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/profile") {
+			got = r.Header.Clone()
+			_, _ = w.Write([]byte(claudeProfileBody))
+			return
+		}
+		_, _ = w.Write([]byte(claudeLimitsBody))
+	}))
+	defer server.Close()
+	svc := newService(server.URL+"/usage", "", time.Now())
+	svc.profileURL = server.URL + "/profile"
+
+	svc.claudePlan(lichEnv())
+
+	if auth := got.Get("Authorization"); auth != "Bearer tok-claude" {
+		t.Errorf("Authorization = %q, want the credentials token", auth)
+	}
+	if beta := got.Get("anthropic-beta"); beta != claudeBetaHeader {
+		t.Errorf("anthropic-beta = %q, want %q", beta, claudeBetaHeader)
+	}
+	if agent := got.Get("User-Agent"); agent != claudeUserAgent {
+		t.Errorf("User-Agent = %q, want %q", agent, claudeUserAgent)
+	}
+}
+
+// A refused or broken profile route must cost the name and nothing else: the
+// gauge is what was asked for, the account is the label on it.
+func TestClaudeKeepsItsGaugeWhenTheProfileRouteWillNotAnswer(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		status int
+		body   string
+	}{
+		{name: "scope refused", status: http.StatusForbidden, body: `{}`},
+		{name: "route gone", status: http.StatusNotFound, body: `{}`},
+		{name: "not the json it should be", status: http.StatusOK, body: `<html>`},
+		{name: "no email in the payload", status: http.StatusOK, body: `{"account":{"uuid":"a"}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			writeCreds(t, claudeCredsJSON, "")
+			usage := serveRoutes(t, map[string]string{"/usage": claudeLimitsBody})
+			profile := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tc.status)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer profile.Close()
+			svc := newService(usage.URL+"/usage", "", time.Now())
+			svc.profileURL = profile.URL
+
+			got := svc.claudePlan(lichEnv())
+
+			if got.Account != "" {
+				t.Errorf("account = %q, want none", got.Account)
+			}
+			if got.Status != StatusOK {
+				t.Errorf("status = %q, want the reading to survive", got.Status)
+			}
+			if len(got.Windows) != 3 {
+				t.Errorf("windows = %+v, want the three the usage route reported", got.Windows)
+			}
+		})
+	}
+}
+
+// A token-only login is never asked: the profile route refuses `user:inference`
+// exactly as the usage route does, so the probe path spends no request on it.
+func TestClaudeProbeAsksTheProfileRouteNothing(t *testing.T) {
+	url, _ := serveProbe(t, probeHeaders)
+	asked := false
+	profile := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		asked = true
+		_, _ = w.Write([]byte(claudeProfileBody))
+	}))
+	defer profile.Close()
+	svc := newService("", "", time.Now())
+	svc.probeURL, svc.profileURL = url, profile.URL
+
+	got := svc.claudePlan(Account{Env: map[string]string{claudeTokenVar: "tok-long-lived"}, Read: true})
+
+	if asked {
+		t.Error("the probe path asked the profile route, which cannot answer that scope")
+	}
+	if got.Account != "" {
+		t.Errorf("account = %q, want none", got.Account)
+	}
+	if len(got.Windows) != 2 {
+		t.Errorf("windows = %+v, want the two the headers carry", got.Windows)
+	}
+}
+
+func TestCodexNamesTheAccountItsIDTokenCarries(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	writeCreds(t, "", codexCredsWith(idToken(t, map[string]any{
+		"email": "dev@example.com",
+		"exp":   now.Unix() + 3600,
+	})))
+	url, _ := serve(t, http.StatusOK, codexUsageBody)
+
+	got := newService("", url, now).codexPlan(lichEnv())
+
+	if got.Account != "dev@example.com" {
+		t.Errorf("account = %q, want the email claim", got.Account)
+	}
+	if got.Status != StatusOK || len(got.Windows) == 0 {
+		t.Errorf("reading = %+v, want the windows unaffected", got)
+	}
+}
+
+// The id token can go stale while the CLI rotates the access token beside it,
+// and naming an account the user has since left is worse than naming none.
+func TestCodexRefusesToNameAnAccountFromAnExpiredIDToken(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	writeCreds(t, "", codexCredsWith(idToken(t, map[string]any{
+		"email": "stale@example.com",
+		"exp":   now.Unix() - 1,
+	})))
+	url, _ := serve(t, http.StatusOK, codexUsageBody)
+
+	got := newService("", url, now).codexPlan(lichEnv())
+
+	if got.Account != "" {
+		t.Errorf("account = %q, want none from an expired token", got.Account)
+	}
+	if got.Status != StatusOK || len(got.Windows) == 0 {
+		t.Errorf("reading = %+v, want the gauge to survive the missing name", got)
+	}
+}
+
+func TestJWTEmailReadsOnlyWhatItCanTrust(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	fresh := map[string]any{"email": "dev@example.com", "exp": now.Unix() + 60}
+	for _, tc := range []struct {
+		name  string
+		token string
+		want  string
+	}{
+		{name: "fresh", token: idToken(t, fresh), want: "dev@example.com"},
+		{name: "expiring next second", token: idToken(t, map[string]any{
+			"email": "dev@example.com", "exp": now.Unix() + 1,
+		}), want: "dev@example.com"},
+		{name: "expiring this second", token: idToken(t, map[string]any{
+			"email": "dev@example.com", "exp": now.Unix(),
+		}), want: ""},
+		{name: "no expiry claim", token: idToken(t, map[string]any{"email": "dev@example.com"}), want: ""},
+		{name: "no email claim", token: idToken(t, map[string]any{"exp": now.Unix() + 60}), want: ""},
+		{name: "absent", token: "", want: ""},
+		{name: "not three segments", token: "header.payload", want: ""},
+		{name: "payload not base64url", token: "h.!!!.sig", want: ""},
+		{name: "payload not json", token: "h." + base64.RawURLEncoding.EncodeToString([]byte("nope")) + ".s", want: ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := jwtEmail(tc.token, now); got != tc.want {
+				t.Errorf("jwtEmail = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Padded base64url is not what a JWT is spelled in, but an encoder that pads is
+// a name lost for no reason.
+func TestJWTEmailReadsAPaddedPayload(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0)
+	payload, err := json.Marshal(map[string]any{"email": "dev@example.com", "exp": now.Unix() + 60})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	token := "h." + base64.URLEncoding.EncodeToString(payload) + ".sig"
+
+	if got := jwtEmail(token, now); got != "dev@example.com" {
+		t.Errorf("jwtEmail = %q, want the claim read through the padding", got)
+	}
+}

--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -20,6 +20,12 @@
 // read that from, yet knows runs a binary it did not choose, is reported as
 // StatusUnknown: a gauge drawn for the wrong account is worse than no gauge.
 //
+// That login is also named where the provider will say: Claude's own profile
+// route, and the OIDC id token Codex writes beside its access token. Neither is
+// a second reading — both ride the cache the windows do. A provider that names
+// nobody reports an empty Plan.Account, which is the gauge lich has always
+// drawn, not a failure.
+//
 // lich reads those credentials and never writes them. Token rotation belongs to
 // the CLI that owns the login: a refresh whose write-back fails spends the
 // stored refresh token and logs the user out of their agent, which is a far
@@ -115,10 +121,17 @@ type Window struct {
 
 // Plan is one provider's quota reading. Provider is a providers.Registry id, so
 // the frontend resolves the icon and the login command it already knows.
+//
+// Account names the login the windows were read against — the whole point of
+// the custom-binary path being that a session can spend an account lich's own
+// environment does not name. It is empty whenever the provider will not say
+// which, which is a reading without a name and never an error: a gauge that
+// cannot name its account is exactly what lich drew before this field existed.
 type Plan struct {
 	Provider string   `json:"provider"`
 	Name     string   `json:"name"`
 	Plan     string   `json:"plan,omitempty"`
+	Account  string   `json:"account,omitempty"`
 	Windows  []Window `json:"windows,omitempty"`
 	Status   string   `json:"status"`
 }
@@ -174,11 +187,12 @@ type Sessions func(sessionID string) Account
 // Service reads plan quota, caching one reading per account.
 type Service struct {
 	http *http.Client
-	// claudeURL, codexURL and probeURL are the endpoints, fields so tests drive
-	// the parsers against a local server.
-	claudeURL string
-	codexURL  string
-	probeURL  string
+	// claudeURL, codexURL, probeURL and profileURL are the endpoints, fields so
+	// tests drive the parsers against a local server.
+	claudeURL  string
+	codexURL   string
+	probeURL   string
+	profileURL string
 
 	// now is time.Now, a field so a test can age the cache without sleeping.
 	now func() time.Time
@@ -203,12 +217,13 @@ type reading struct {
 // New returns a Service pointed at the live endpoints.
 func New() *Service {
 	return &Service{
-		http:      &http.Client{Timeout: httpTimeout},
-		claudeURL: claudeUsageURL,
-		codexURL:  codexUsageURL,
-		probeURL:  claudeProbeURL,
-		now:       time.Now,
-		cache:     make(map[string]reading),
+		http:       &http.Client{Timeout: httpTimeout},
+		claudeURL:  claudeUsageURL,
+		codexURL:   codexUsageURL,
+		probeURL:   claudeProbeURL,
+		profileURL: claudeProfileURL,
+		now:        time.Now,
+		cache:      make(map[string]reading),
 	}
 }
 

--- a/internal/quota/quota_test.go
+++ b/internal/quota/quota_test.go
@@ -64,6 +64,10 @@ func serve(t *testing.T, status int, body string) (url string, calls *int) {
 }
 
 // newService builds a Service pointed at the given endpoints with a fixed clock.
+// newService points a Service at local servers. profileURL is left unset, so a
+// reading names no account unless the test asks for one — which is also the
+// production behaviour when the route cannot be reached, and keeps every test
+// about windows counting the requests it meant to.
 func newService(claudeURL, codexURL string, now time.Time) *Service {
 	return &Service{
 		http:      &http.Client{Timeout: httpTimeout},


### PR DESCRIPTION
The footer gauge has always drawn a plan and never said whose. That matters most exactly where lich already knows it might not be the obvious one: a session spawned from a binary the user configured can export a `CLAUDE_CONFIG_DIR` or a `CODEX_HOME` of its own and spend a second account — the reason the reading is already taken against that session's own process environment rather than lich's.

`Plan.Account` carries the answer. Empty is an unnamed account, never an error.

## Where it reads

Placement was picked off a [mockup of three options](https://claude.ai/code/artifact/de6824a9-7e68-407d-896f-633e554f31c9) drawn with the real tokens in both themes, not chosen here.

- **The gauge tooltip** — at the foot, under a hairline, below the windows. The account is where the reading came from rather than part of the plan's name, so it reads as provenance and not as a subtitle to the provider line. Set in the mono the app already gives session ids and paths, and `break-all` because an email has no space for the tooltip's `max-w-xs` to wrap at.
- **Settings › Plan usage** — the same line under the gauges. That surface asks the machine-wide question, so it names the login lich itself is signed in as; it is also where a login gets fixed, which is a fair place to say which one.
- **A reading with no name stays silent.** Nothing distinguishes "lich could not name this account" from "this provider names none", and a line saying so is a sentence nobody asked for under a gauge that reads correctly either way.

## Where each name comes from

- **Claude Code** — `GET /api/oauth/profile` with the same credentials token the usage route already uses. Its access token is opaque (`sk-ant-oat01-`, no claims), so there is nothing to read off disk. The request rides the reading the gauge already takes and therefore the same five-minute cache, not a call per render.
- **Codex** — the `email` claim of the OIDC id token beside the access token in `auth.json`. Payload decoded with `encoding/base64` + `encoding/json`, no dependency, and **nothing is verified**: it is a file lich already trusts for the token it authenticates with, and the claim is a label under a gauge rather than a permission.

Every failure — route refused, shape changed, payload not JSON, no email in it — costs the name and leaves the windows alone. The token-only path is not asked at all: a `claude setup-token` login carries `user:inference`, which the profile route refuses exactly as the usage route does, so asking would spend a round trip per cache window on a known 403.

## The measurement this ships without

**Whether the `email` claim survives a token refresh** — Codex and Antigravity both rotate the access token beside the id token, and it has not been measured here whether the id token is rewritten with it or left behind. The `exp` guard is what makes shipping without that measurement safe: an id token whose expiry has passed names nobody, so the failure mode of a stale one is the gauge lich has always drawn, not a gauge under the wrong person's name. If the measurement later shows the claim goes stale *before* its own `exp`, that is a second guard, not a redesign.

## Every provider, per invariant 5

| Provider | Names the account | Why |
| --- | --- | --- |
| Claude Code | yes | profile route |
| Codex | yes | id token `email` claim |
| Antigravity | no | `~/.gemini/oauth_creds.json` carries the same claim, but there is no `antigravityPlan`; a reading with an account and no window renders nothing at all. The name arrives with the gauge or not at all. |
| opencode, Crush, oh-my-pi | no | the user's own API key — no plan account to name, the same reason they have no gauge |
| Cursor CLI | no | measured 2026-09-04: `~/.config/cursor/auth.json` holds a JWT whose claims are `aud/exp/iss/randomness/scope/sub/time/type` — `sub` is an opaque `github\|user_…` and no email anywhere |
| Kiro CLI | no | measured 2026-09-04: the login is a row in `~/.local/share/kiro-cli/data.sqlite3` (`kirocli:social:token`) holding an opaque `aoa…` token, a `github` provider label and an AWS profile ARN — no JWT, nothing a person recognises as their account |

The four "no" rows are written into `docs/ceilings.md` with those reasons.

## Also in `docs/ceilings.md`

- A token-only login shows a gauge and no name, and nothing on screen distinguishes that from a provider that names nobody.
- **`CLAUDE_SECURESTORAGE_CONFIG_DIR`** — Claude Code looks for its secure storage under this variable whenever it is *defined*, empty string included, and only then falls back to `CLAUDE_CONFIG_DIR`; the value is NFC-normalised and hashed into the Keychain service name. lich reads it nowhere (confirmed by grep) and today that changes nothing — on Linux the credential is the plaintext file, and on macOS no session's environment is readable at all. The trap is the day somebody writes the macOS `KERN_PROCARGS2` reading already promised in the bullet above it and resolves the credential from `CLAUDE_CONFIG_DIR` alone: that reads the wrong Keychain item and reports a login the session is not spending, with a name under it.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean; `GOOS` build+vet loop green for linux/darwin/windows
- [x] `go test ./...` green — `internal/quota` at 95.6%
- [x] `pnpm check` clean, `vitest run` 1368 green, `tsc -b` + `vite build` clean
- [x] New tests: the profile route named and its headers; the gauge surviving a refused/broken/emailless profile route; the probe path asking it nothing; Codex naming from a fresh id token and refusing an expired one; `jwtEmail` against the malformed, unpadded, padded, expiring-this-second and expiring-next-second cases
- [ ] Not covered by the suite: the tooltip's second line is a render path, and the frontend gate is node-only

https://claude.ai/code/session_013PZjmRYQ1AMN5oKJeaqoQd

