### PR TITLE
fix: catch a render throw before it blanks the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A screen or panel that breaks no longer takes the window with it.** A single
+  rendering bug anywhere in the interface used to blank lich entirely — sidebar,
+  terminals, footer and all — while the agents kept running behind it with
+  nothing on screen saying so, and a reload was the only way back. The screens
+  over the terminals and the right dock's Code and Review panels are now caught
+  where they break: what failed says so in place, with the error and a "Try
+  again", and everything around it stays where it was. The terminals themselves
+  stay outside that net on purpose — catching there would mean throwing away
+  every session's scrollback to redraw a panel.
+
 - **A conflicting pull request now names the files it conflicts on.** GitHub
   publishes one word — the pull request conflicts with its base — and never
   which files, so the way to find out was opening the PR on github.com or a

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -130,6 +130,15 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   for one terminal. The budget suite pins that adding a pane mounts one terminal and remounts none
   (`frontend/src/components/render-budget.test.tsx`); it cannot measure the cadence, because jsdom has
   no canvas to paint.
+- **The terminals are outside every error boundary, so a throw in one still takes the window**
+  (`frontend/src/components/common/ErrorBoundary.tsx`, `App.tsx`): the boundaries wrap the screens over
+  the stage and the right dock's panels, and deliberately not `TerminalHost` — catching there means
+  unmounting it, which destroys every session's xterm instance and its DOM, and no remount brings those
+  scrollbacks back. Recovering the window would cost more than the blank one it replaced. So a render
+  throw anywhere under `TerminalHost` — a pane, a terminal's own chrome, the stage's grid — is still
+  the whole tree going, and the only way back is a reload, while the sessions keep running behind it.
+  The trap is reading "lich has error boundaries" as "a render bug can no longer blank the window": the
+  one subtree that owns the most state is the one nothing catches.
 - **The grid follows the window, so the layout you dragged is not always the one you get back**
   (`frontend/src/lib/session/panes.ts`, `tracks`): how many panes sit across is computed from the
   stage's measured width, so collapsing the sidebar, opening the dock or moving the window to another

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react"
-import { HashRouter, Outlet, Route, Routes, useMatch } from "react-router-dom"
+import { HashRouter, Outlet, Route, Routes, useLocation, useMatch } from "react-router-dom"
 import { SettingsProvider, useSettings } from "@/providers/settings"
 import { useHotkey } from "@/lib/use-hotkey"
 import { parseBoolPref, readPref, writePref } from "@/lib/prefs"
@@ -15,6 +15,7 @@ import { ProjectTabs } from "@/components/tabs/ProjectTabs"
 import { SessionSidebar } from "@/components/sidebar/SessionSidebar"
 import { SidebarRail } from "@/components/sidebar/SidebarRail"
 import { TerminalHost } from "@/components/TerminalHost"
+import { ErrorBoundary } from "@/components/common/ErrorBoundary"
 import { RightDock, type DockTab } from "@/components/dock/RightDock"
 import { FooterBar } from "@/components/FooterBar"
 import { Home } from "@/components/Home"
@@ -43,6 +44,7 @@ function Layout() {
   const { hotkeys } = useSettings()
   const { sessions } = useProjects()
   const match = useMatch("/projects/:projectId/*")
+  const location = useLocation()
   const projectId = match?.params.projectId ?? ""
   const [dock, setDock] = useState<DockTab | null>(null)
   const [sidebar, setSidebar] = useState(() => parseBoolPref(readPref(SIDEBAR_KEY), true))
@@ -118,10 +120,25 @@ function Layout() {
           {/* relative: RightDock overlays this area when in full screen. */}
           <div className="relative flex flex-1 overflow-hidden">
             <div className="relative flex-1 overflow-hidden">
+              {/* TerminalHost is outside on purpose — unmounting it destroys
+                  every session's xterm, and no remount brings those back
+                  (docs/ceilings.md). The screens over it are what is caught:
+                  the fallback takes the same overlay they do, and the route
+                  resets it, so navigating away from a blown screen is enough. */}
               <TerminalHost />
-              <Outlet />
+              <ErrorBoundary
+                label="This screen"
+                resetKey={location.pathname}
+                className="absolute inset-0 z-10"
+              >
+                <Outlet />
+              </ErrorBoundary>
             </div>
-            {dock && <RightDock tab={dock} onTab={setDock} onClose={() => setDock(null)} />}
+            {dock && (
+              <ErrorBoundary label="The panel" className="w-80 shrink-0 border-l border-border">
+                <RightDock tab={dock} onTab={setDock} onClose={() => setDock(null)} />
+              </ErrorBoundary>
+            )}
           </div>
           <FooterBar dock={dock} onDock={toggleDock} />
         </main>

--- a/frontend/src/components/common/ErrorBoundary.test.tsx
+++ b/frontend/src/components/common/ErrorBoundary.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+//
+// The bug class this file exists for is the one the node gate cannot see: a
+// component throws while rendering, nothing catches it, and React unmounts the
+// whole tree — in lich's case the window, sidebar and terminals included. So
+// the assertions are about what is left standing, not about the boundary's own
+// state: the sibling subtree, and a child that renders again after a retry.
+//
+// The harness has to be imported before anything that reaches react-dom, which
+// is why it is first here (see @/test/render-budget).
+import { mountBudget } from "@/test/render-budget"
+import { afterEach, beforeEach, expect, test, vi } from "vitest"
+import { ErrorBoundary } from "./ErrorBoundary"
+
+const MESSAGE = "files.map is not a function"
+
+// Read at render time rather than taken as a prop: the boundary is showing its
+// fallback when the flag flips, so nothing it holds would be re-read until the
+// retry re-renders the child.
+let crash = true
+
+function Panel() {
+  if (crash) {
+    throw new Error(MESSAGE)
+  }
+  return <p>panel content</p>
+}
+
+function tree() {
+  return (
+    <div>
+      <ErrorBoundary label="The panel">
+        <Panel />
+      </ErrorBoundary>
+      <p>the sidebar</p>
+    </div>
+  )
+}
+
+function retryButton(): HTMLButtonElement {
+  const button = [...document.querySelectorAll("button")].find(
+    (candidate) => candidate.textContent?.trim() === "Try again",
+  )
+  if (!button) {
+    throw new Error("the fallback offers no retry")
+  }
+  return button
+}
+
+// React 18 rethrows a caught error through a DOM event so devtools can break on
+// it, and jsdom prints every unhandled one — a caught error would read as a
+// failed run. Marking it handled is what makes the suite's output honest.
+const swallow = (event: ErrorEvent) => event.preventDefault()
+
+beforeEach(() => {
+  window.addEventListener("error", swallow)
+})
+
+afterEach(() => {
+  window.removeEventListener("error", swallow)
+  crash = true
+  vi.restoreAllMocks()
+})
+
+test("a throwing child leaves its siblings alive, and retry re-renders it", async () => {
+  // React reports every caught error on its own; the fallback is what the test
+  // reads, and an unmocked console.error would only make the run look failed.
+  vi.spyOn(console, "error").mockImplementation(() => {})
+
+  const mounted = await mountBudget(tree())
+  expect(document.body.textContent).toContain("The panel stopped rendering")
+  // On screen, not only in the console: the window it would have been read in
+  // is the one this fallback stands in for.
+  expect(document.body.textContent).toContain(MESSAGE)
+  expect(document.body.textContent).toContain("the sidebar")
+  expect(document.body.textContent).not.toContain("panel content")
+
+  crash = false
+  await mounted.act(() => {
+    retryButton().click()
+  })
+  expect(document.body.textContent).toContain("panel content")
+  expect(document.body.textContent).not.toContain("The panel stopped rendering")
+  expect(document.body.textContent).toContain("the sidebar")
+
+  await mounted.unmount()
+})

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,71 @@
+import { RotateCcw, TriangleAlert } from "lucide-react"
+import { Component, type ErrorInfo, type ReactNode } from "react"
+import { Notice } from "@/components/common/Notice"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+interface ErrorBoundaryProps {
+  /** Names the area that stopped rendering — the fallback is all the user is left with. */
+  label: string
+  children: ReactNode
+  /** Clears the error when it changes: the subtree swapped in is not the one that threw. */
+  resetKey?: string
+  /** Positioning for the fallback, whose default is to fill whatever it is handed. */
+  className?: string
+}
+
+interface ErrorBoundaryState {
+  error: Error | null
+}
+
+// The one thing standing between a render throw and a blank window. Nothing
+// catching means React unmounts at the root, and lich's root is the window: the
+// sidebar, the terminals and the footer all go with the screen that threw,
+// while the sessions themselves keep running with nothing on screen saying so.
+// A class is not a style choice here — React offers no hook that catches.
+//
+// Deliberately never around TerminalHost; docs/ceilings.md says what that costs.
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error }
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error(`${this.props.label} failed to render`, error, info.componentStack)
+  }
+
+  componentDidUpdate(previous: ErrorBoundaryProps) {
+    if (this.state.error !== null && previous.resetKey !== this.props.resetKey) {
+      this.setState({ error: null })
+    }
+  }
+
+  render() {
+    const { error } = this.state
+    if (error === null) {
+      return this.props.children
+    }
+    return (
+      <div
+        className={cn(
+          "flex h-full w-full flex-col items-center justify-center gap-2 bg-background p-6 text-center",
+          this.props.className,
+        )}
+      >
+        <TriangleAlert className="size-8 text-muted-foreground" />
+        <p className="text-sm text-foreground">{this.props.label} stopped rendering</p>
+        {/* The message, not just a console line: the window it would have been
+            read in is the one this fallback is standing in for. */}
+        <Notice className="max-w-md py-0 font-mono break-words">
+          {error.message || String(error)}
+        </Notice>
+        <Button variant="ghost" size="sm" onClick={() => this.setState({ error: null })}>
+          <RotateCcw data-icon="inline-start" />
+          Try again
+        </Button>
+      </div>
+    )
+  }
+}

--- a/frontend/src/components/dock/RightDock.tsx
+++ b/frontend/src/components/dock/RightDock.tsx
@@ -1,5 +1,6 @@
 import { Code, FileDiff, Maximize2, Minimize2, X } from "lucide-react"
 import { useState } from "react"
+import { ErrorBoundary } from "@/components/common/ErrorBoundary"
 import { IconAction } from "@/components/common/IconAction"
 import { ResizeHandle } from "@/components/common/ResizeHandle"
 import { CollapseAllAction, useDiffBulk } from "@/components/diff/diff-bulk"
@@ -100,7 +101,15 @@ export function RightDock({ tab, onTab, onClose }: RightDockProps) {
         </span>
       </div>
       <div className="flex flex-1 flex-col overflow-hidden">
-        {tab === "files" ? <FilesPanel /> : <ReviewPanel bulk={bulk} />}
+        {/* Below the header, so a panel that throws leaves the tab bar, the
+            full-screen toggle and the close button reachable — and switching
+            tab is itself a way out, which is what the reset key buys. */}
+        <ErrorBoundary
+          label={tab === "files" ? "The file tree" : "The review panel"}
+          resetKey={tab}
+        >
+          {tab === "files" ? <FilesPanel /> : <ReviewPanel bulk={bulk} />}
+        </ErrorBoundary>
       </div>
       {!fullscreen && <ResizeHandle edge="left" label="Resize panel" handleProps={handleProps} />}
     </aside>


### PR DESCRIPTION
## The bug

lich's React tree *is* the window. Nothing in `frontend/src` caught a throw during
render — `grep -rl "ErrorBoundary\|componentDidCatch" frontend/src` returned zero —
so one bad `.map()` unmounted everything: the session sidebar, every terminal, the
footer. The agents kept running behind a blank window with nothing on screen saying
so, and a reload was the only way back.

A live cause of exactly that shape: a nil slice from Go serializes to `null` while
`frontend/src/lib/api-types.ts` declares the field as an array, so the `.map()` on
it throws and the type never warned.

## What landed

- **`common/ErrorBoundary.tsx`** — the class React still requires for this
  (`getDerivedStateFromError` + `componentDidCatch`). The fallback follows the
  `common/` vocabulary rather than inventing panel chrome: glyph, what failed, the
  error in a `Notice`, one ghost "Try again". The message goes **on screen**, not
  only into a console the user cannot open.
- **Mounted around `<Outlet />` and the right dock** in `App.tsx`, and around each
  tab's body in `RightDock.tsx`. A blown Pulls screen or Files panel now leaves the
  sidebar, terminals, footer, dock tab bar and close button alive.
- **Recovery without a remount.** `resetKey` clears the error when the route or the
  dock tab changes, so navigating away from a blown screen is enough; it is a prop
  rather than a `key` so the recovered subtree keeps its state.
- **`docs/ceilings.md`** — `TerminalHost` is deliberately outside every boundary.
  Catching there means unmounting it, which destroys every session's xterm instance
  and its scrollback, and no remount brings those back. So a throw under the terminals
  still takes the window, and the bullet says so: "lich has error boundaries" must not
  be read as "a render bug can no longer blank the window".

## Tests

The frontend gate is node-only and renders none of these paths — which is precisely
why this bug class ships green. `ErrorBoundary.test.tsx` opts into jsdom and asserts
the two things that matter: the sibling subtree still renders after the throw, and
retry re-renders the child.

Verified in a real browser besides (headless Chromium over CDP, Vite dev): a throwing
screen and a throwing `FilesPanel`, each showing the fallback in place while the tab
bar, sidebar, terminal and footer stayed up.

## Gate

`gofmt -l .` · `go vet ./...` · `go test ./...` · `pnpm check` · `pnpm test`
(115 files, 1369 tests) · `pnpm build` — all green.

https://claude.ai/code/session_014FwY8by5FR14eLWGgPoc3G