### PR TITLE
feat: ask for a plain tab instead of a window of its own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the checked-in copy no longer matches them — a schema that drifts rejects
   valid themes, which is worse than shipping none.
 
+- **lich can now run without a window of its own, on purpose.** It opens its
+  window in a Chromium-family browser, and until now the plain-tab mode was
+  only what you got when the machine had none — so anyone who would rather not
+  run Chromium had no way to say so. `lich --no-window` (or `LICH_NO_WINDOW=1`,
+  which a desktop launcher can carry) now asks for it: lich serves itself and
+  hands the URL to your default browser, Firefox included. The trade is the one
+  it always was — a tab is not a window, so closing it leaves lich running, and
+  you stop it with Ctrl-C. `lich doctor` no longer reports a missing
+  Chromium-family browser as a failure when the launch never wanted one.
+
 - **A screen or panel that breaks no longer takes the window with it.** A single
   rendering bug anywhere in the interface used to blank lich entirely — sidebar,
   terminals, footer and all — while the agents kept running behind it with

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -37,6 +37,12 @@ Firefox has no equivalent of Chromium's `--app` mode, so a tab is the honest
 best. `lich doctor` reports which browser was resolved and which of the steps
 above found it.
 
+That tab is also a choice, not only a fallback: `lich --no-window` (or
+`LICH_NO_WINDOW=1`, which a `.desktop` launcher can carry) skips the window on
+a machine that *has* a Chromium-family browser but whose owner would rather not
+run one. lich serves itself and hands the URL to your default browser; closing
+the tab leaves it running, so stop it with Ctrl-C or by signalling the process.
+
 **git and the GitHub CLI** — every version control surface shells out to
 `git`, and lich does not bundle it: without `git` on your `PATH`, branches,
 diffs and worktrees stay empty, though sessions still run. Pull requests,

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -779,12 +779,13 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   benign case, and the common one. A wide version gap meets Chromium's own guard against a profile from a
   newer build instead, which refuses to start; lich then dies on a browser exit code and its dialog can only
   say `exit status 1`, naming nothing. `LICH_BROWSER` pins the answer; nothing else does.
-- **With no Chromium-family browser there is no window lifecycle** (`main.go`, `openWithoutWindow`): lich opens
-  a plain tab and then runs until it is signalled, because a tab it did not spawn cannot be waited on. Closing
-  the tab leaves lich serving, and `/restart` — which frees the pinned port by terminating "the window" — is
-  handed this process instead. On Windows that terminate is a `taskkill` WM_CLOSE against a process that has
-  no window, so an in-place update on a browserless Windows leaves the successor racing a port that never
-  frees.
+- **Without a Chromium `--app` window there is no window lifecycle** (`main.go`, `openWithoutWindow`) —
+  reached with no Chromium-family browser installed, or on purpose with `--no-window`/`LICH_NO_WINDOW`. lich
+  opens a plain tab and then runs until it is signalled, because a tab it did not spawn cannot be waited on.
+  Closing the tab leaves lich serving, and `/restart` — which frees the pinned port by terminating "the
+  window" — is handed this process instead. On Windows that terminate is a `taskkill` WM_CLOSE against a
+  process that has no window, so an in-place update leaves the successor racing a port that never frees:
+  a `--no-window` launch now buys that trap on a machine that could have had a window.
 - **The tab fallback cannot tell "opened" from "nothing happened"** (`internal/system.OpenURL`): `xdg-open`,
   `open` and `rundll32` are started and never waited on — waiting would block for the life of the browser they
   hand off to. A desktop with a URL handler installed but no browser behind it therefore looks like success:

--- a/internal/chromium/resolve.go
+++ b/internal/chromium/resolve.go
@@ -27,6 +27,13 @@ var ErrNoBrowser = errors.New(
 // browser a launch here would actually open.
 const OverrideEnv = "LICH_BROWSER"
 
+// NoWindowEnv opens lich as a plain tab in the default browser instead of a
+// Chromium --app window — the answer for a machine whose owner would rather not
+// run a Chromium-family browser at all, Firefox users among them. It carries
+// the --no-window flag the same way OverrideEnv carries --browser, so the
+// restart successor keeps the choice.
+const NoWindowEnv = "LICH_NO_WINDOW"
+
 // The rung of the ladder that answered, as the diagnostics name it.
 const (
 	stepPinned  = "pinned by LICH_BROWSER"
@@ -273,15 +280,18 @@ func flatpakBrowser(env Env) (Result, bool) {
 }
 
 // ParseFlags splits lich's own launch arguments: --browser <name-or-path> pins
-// the browser to open the window in, and everything after `--` passes through
-// to that browser. The flag wins over LICH_BROWSER because the caller writes it
-// into the environment (main.go), which is also what carries it to the restart
+// the browser to open the window in, --no-window trades that window for a plain
+// tab, and everything after `--` passes through to the browser. The flags win
+// over their environment variables because the caller writes them into the
+// environment (main.go), which is also what carries them to the restart
 // successor.
-func ParseFlags(args []string) (pinned string, extra []string) {
+func ParseFlags(args []string) (pinned string, noWindow bool, extra []string) {
 	for i := 0; i < len(args); i++ {
 		switch arg := args[i]; {
 		case arg == "--":
-			return pinned, args[i+1:]
+			return pinned, noWindow, args[i+1:]
+		case arg == "--no-window":
+			noWindow = true
 		case arg == "--browser" && i+1 < len(args):
 			i++
 			pinned = args[i]
@@ -289,5 +299,5 @@ func ParseFlags(args []string) (pinned string, extra []string) {
 			pinned = strings.TrimPrefix(arg, "--browser=")
 		}
 	}
-	return pinned, nil
+	return pinned, noWindow, nil
 }

--- a/internal/chromium/resolve_test.go
+++ b/internal/chromium/resolve_test.go
@@ -203,10 +203,11 @@ func TestDescribe(t *testing.T) {
 
 func TestParseFlags(t *testing.T) {
 	tests := []struct {
-		name   string
-		args   []string
-		pinned string
-		extra  []string
+		name     string
+		args     []string
+		pinned   string
+		noWindow bool
+		extra    []string
 	}{
 		{name: "nothing"},
 		{name: "separate value", args: []string{"--browser", "vivaldi"}, pinned: "vivaldi"},
@@ -230,12 +231,29 @@ func TestParseFlags(t *testing.T) {
 			extra: []string{"--browser=chromium"},
 		},
 		{name: "value missing", args: []string{"--browser"}},
+		{name: "no window", args: []string{"--no-window"}, noWindow: true},
+		// The two flags answer different questions and must not cancel each
+		// other: --browser still names who opens the tab.
+		{
+			name:     "no window with a pinned browser",
+			args:     []string{"--no-window", "--browser", "firefox"},
+			pinned:   "firefox",
+			noWindow: true,
+		},
+		{
+			name:  "no window after the separator is the browser's",
+			args:  []string{"--", "--no-window"},
+			extra: []string{"--no-window"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pinned, extra := ParseFlags(tt.args)
+			pinned, noWindow, extra := ParseFlags(tt.args)
 			if pinned != tt.pinned {
 				t.Fatalf("pinned = %q, want %q", pinned, tt.pinned)
+			}
+			if noWindow != tt.noWindow {
+				t.Fatalf("noWindow = %v, want %v", noWindow, tt.noWindow)
 			}
 			if !slices.Equal(extra, tt.extra) {
 				t.Fatalf("extra = %v, want %v", extra, tt.extra)

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -120,12 +120,17 @@ const helpFooter = `
 
 Every command takes --help for its own flags.
 
-With no command, lich opens its window. Two flags belong to that launch:
+With no command, lich opens its window. Three flags belong to that launch:
 
   lich --browser <name-or-path>
       Open the window in this browser instead of the one lich would find.
       LICH_BROWSER says the same thing; the flag wins. Either way lich fails
       loudly when it is not there, rather than opening a different browser.
+
+  lich --no-window
+      Skip the window and open lich as a plain tab in your default browser —
+      Firefox included. LICH_NO_WINDOW says the same thing. Closing the tab
+      leaves lich running; stop it with Ctrl-C or by signalling the process.
 
   lich -- <flags>
       Pass everything after -- to the browser (e.g. --ozone-platform=wayland).

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/omartelo/lich/internal/chromium"
 	"github.com/omartelo/lich/internal/logging"
 	"github.com/omartelo/lich/internal/providers"
 	"github.com/omartelo/lich/internal/singleton"
@@ -71,6 +72,7 @@ type Doctor struct {
 	detect   func() []providers.Detected
 	store    func() (io.Closer, error)
 	lookPath func(string) (string, error)
+	getenv   func(string) string
 }
 
 // New returns a Doctor for this machine. configDir is the OS config dir, and
@@ -85,6 +87,7 @@ func New(configDir string, getenv func(string) string) *Doctor {
 		detect:    Providers,
 		store:     func() (io.Closer, error) { return store.New() },
 		lookPath:  exec.LookPath,
+		getenv:    getenv,
 	}
 }
 
@@ -185,10 +188,15 @@ func (d *Doctor) checkStore(info *singleton.Info, running bool) (Status, string)
 }
 
 // checkBrowser resolves the Chromium-family binary the window is. Its absence
-// is the one failure where lich runs perfectly and shows nothing.
+// is the one failure where lich runs perfectly and shows nothing — unless the
+// launch asked for no window, which is the one case where there is nothing to
+// resolve and nothing wrong.
 func (d *Doctor) checkBrowser() (Status, string) {
 	path, err := d.browser()
-	if err != nil {
+	switch {
+	case err != nil && d.getenv(chromium.NoWindowEnv) != "":
+		return OK, "not used — " + chromium.NoWindowEnv + " opens a plain tab in the default browser"
+	case err != nil:
 		return Fail, err.Error()
 	}
 	return OK, path

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/omartelo/lich/internal/chromium"
 	"github.com/omartelo/lich/internal/providers"
 	"github.com/omartelo/lich/internal/singleton"
 )
@@ -216,6 +217,29 @@ func TestADatabaseThatWillNotCloseWarns(t *testing.T) {
 type closerFunc func() error
 
 func (c closerFunc) Close() error { return c() }
+
+// A --no-window launch resolves no browser on purpose, so the absence that
+// stops every other launch must not fail this one — otherwise doctor tells a
+// Firefox user to install Chromium and exits non-zero on a machine that runs.
+func TestNoWindowMakesAMissingBrowserFine(t *testing.T) {
+	d := healthy(t)
+	d.browser = func() (string, error) { return "", errors.New("no chromium-family browser found") }
+	d.getenv = func(key string) string {
+		if key == chromium.NoWindowEnv {
+			return "1"
+		}
+		return ""
+	}
+
+	checks := statuses(d.Run())
+
+	if checks["browser"].Status != OK {
+		t.Errorf("browser = %s, want ok — the launch asked for no window", checks["browser"].Status)
+	}
+	if !strings.Contains(checks["browser"].Detail, chromium.NoWindowEnv) {
+		t.Errorf("browser detail = %q, want it to name %s", checks["browser"].Detail, chromium.NoWindowEnv)
+	}
+}
 
 func TestAMissingBrowserStopsALaunchAndMissingProvidersDoNot(t *testing.T) {
 	d := healthy(t)

--- a/main.go
+++ b/main.go
@@ -64,13 +64,20 @@ func main() {
 		os.Exit(code)
 	}
 
-	// --browser is carried in the environment rather than passed down: the
-	// restart successor inherits it, and `lich doctor` then reports the browser
-	// a launch here would really open. Everything after `--` is the browser's.
-	pinnedBrowser, chromiumArgs := chromium.ParseFlags(os.Args[1:])
+	// --browser and --no-window are carried in the environment rather than passed
+	// down: the restart successor inherits them (it is re-executed with no
+	// arguments), and `lich doctor` then reports the browser a launch here would
+	// really open. Everything after `--` is the browser's.
+	pinnedBrowser, noWindow, chromiumArgs := chromium.ParseFlags(os.Args[1:])
 	if pinnedBrowser != "" {
 		if err := os.Setenv(chromium.OverrideEnv, pinnedBrowser); err != nil {
 			slog.Error("set "+chromium.OverrideEnv, "err", err)
+			os.Exit(1)
+		}
+	}
+	if noWindow {
+		if err := os.Setenv(chromium.NoWindowEnv, "1"); err != nil {
+			slog.Error("set "+chromium.NoWindowEnv, "err", err)
 			os.Exit(1)
 		}
 	}
@@ -303,6 +310,13 @@ func runChromium(term *terminal.Service, configDir string, extra []string, coord
 		// capture the dev window.
 		class = "lichdev"
 	}
+	// Asked for no window at all: serve and hand the URL to whatever browser the
+	// user does use. Same path as having no Chromium, reached on purpose.
+	if os.Getenv(chromium.NoWindowEnv) != "" {
+		openWithoutWindow(url, addr, configDir, coord, true)
+		return
+	}
+
 	slog.Info("chromium shell opening", "addr", addr)
 
 	err = chromium.Run(url, profileDir, class, extra, coord.SetWindow)
@@ -310,7 +324,7 @@ func runChromium(term *terminal.Service, configDir string, extra []string, coord
 	case err == nil:
 		slog.Info("window closed, exiting")
 	case errors.Is(err, chromium.ErrNoBrowser):
-		openWithoutWindow(url, addr, configDir, coord)
+		openWithoutWindow(url, addr, configDir, coord, false)
 	default:
 		slog.Error("chromium shell", "err", err)
 		// Same silence as handleBindFailure: a launcher start has no terminal,
@@ -337,28 +351,39 @@ func runChromium(term *terminal.Service, configDir string, extra []string, coord
 // Every other launch ends when the window closes; a tab lich did not spawn
 // cannot be waited on, so nothing here ends on its own — closing the tab leaves
 // lich running, which the notification says.
-func openWithoutWindow(url, addr, configDir string, coord *restart.Coordinator) {
-	slog.Warn("no chromium-family browser found, opening a plain tab", "addr", addr)
+func openWithoutWindow(url, addr, configDir string, coord *restart.Coordinator, chosen bool) {
+	// Why there is no window decides the whole message: a machine with no
+	// Chromium is missing something and should hear about it, a --no-window
+	// launch got exactly what it asked for.
+	if chosen {
+		slog.Info("--no-window, opening a plain tab", "addr", addr)
+	} else {
+		slog.Warn("no chromium-family browser found, opening a plain tab", "addr", addr)
+	}
 	// stdout rather than the log: the URL carries the session token, and the
 	// log file outlives this run (see the addr/url split above). A terminal
 	// launch reads it here; a launcher launch reads the notification below.
 	fmt.Println("lich is running at", url)
 
+	hint := "For a window of its own, install a Chromium-family browser " +
+		"(chromium, chrome, brave, vivaldi, edge)."
+	lost := "No Chromium-family browser here, so it has no window of its own"
+	if chosen {
+		hint = "lich was started with --no-window, so it did not try to open one itself."
+		lost = "Started with --no-window, so it has no window of its own"
+	}
 	if err := system.OpenURL(url); err != nil {
 		slog.Error("no browser to open at all", "err", err)
 		_ = zenity.Error(fmt.Sprintf(
 			"lich is running, but found no browser to show it in.\n\n"+
-				"Open this URL in any browser:\n%s\n\n"+
-				"For a window of its own, install a Chromium-family browser "+
-				"(chromium, chrome, brave, vivaldi, edge).\n\nLog: %s",
-			url, logging.Path(filepath.Join(configDir, "lich"))),
+				"Open this URL in any browser:\n%s\n\n%s\n\nLog: %s",
+			url, hint, logging.Path(filepath.Join(configDir, "lich"))),
 			zenity.Title("lich"))
 		os.Exit(1)
 	}
 	_ = zenity.Notify(
 		"lich is running at "+addr+" — opened in your default browser. "+
-			"No Chromium-family browser here, so it has no window of its own: "+
-			"closing the tab leaves lich running.",
+			lost+": closing the tab leaves lich running.",
 		zenity.Title("lich"))
 
 	// The window's exit is the app lifecycle everywhere else, and /restart


### PR DESCRIPTION
Three users said they will not run lich because it opens its window in a Chromium-family browser. The mode they want already existed — `openWithoutWindow` in `main.go` serves lich, hands the URL to the default browser, notifies, and runs until signalled — but it was only reachable by *accident*, when the resolver came back with `ErrNoBrowser`. Anyone who has Chromium installed and would rather not run it never got there, and nothing documented that the path existed.

`lich --no-window` asks for it.

## What is here

- **`internal/chromium/resolve.go`** — `--no-window` joins `--browser` in `ParseFlags`, plus `NoWindowEnv = "LICH_NO_WINDOW"`. The choice rides the environment rather than the argument list for the same reason `--browser` does: the restart successor is re-executed with no arguments (`exec.Command(exe)`), so a flag alone would put the Chromium window back at the first `/restart`. It also lets a `.desktop` launcher carry the choice, which matters — the users in question start lich from an icon, not a shell.
- **`main.go`** — `runChromium` takes the existing branch before it resolves a browser. The messages now say *which* of the two roads led here: a machine with no Chromium is missing something and should hear about it, a `--no-window` launch got exactly what it asked for.
- **`internal/doctor/doctor.go`** — `checkBrowser` no longer fails a launch that never wanted a browser. Without this, `lich doctor` tells a Firefox user to install Chromium and exits non-zero on a machine that runs perfectly.
- Docs: `lich --help`, `INSTALL.md`, `docs/ceilings.md`, `CHANGELOG.md`.

## Ceiling this buys

`docs/ceilings.md` already recorded that a plain tab has no window lifecycle. The entry now covers both roads to it, and names what is new: on Windows, `/restart` frees the pinned port with a `taskkill` WM_CLOSE against "the window" — a `--no-window` launch hands it a process with none, on a machine that could have had one.

## Test plan

- [x] `go test ./...`, `go vet ./...`, `gofmt -l .` clean.
- [x] Cross-compile loop: `GOOS=linux/darwin/windows` build + vet clean.
- [x] `TestParseFlags` covers the flag alone, alongside `--browser`, and after `--` (where it belongs to the browser, not to lich).
- [x] `TestNoWindowMakesAMissingBrowserFine` pins the doctor verdict.
- [x] End-to-end on a machine that **has** Chromium, in an isolated rig (own `XDG_CONFIG_HOME`, free port, `xdg-open`/`zenity` shims): the tab path ran by choice, `xdg-open` got the tokenised URL, the notification named `--no-window`, the frontend served (HTTP 200 on the real `index.html`), the process outlived the tab and exited cleanly on SIGTERM.
- [x] `lich doctor` without the env: `fail browser`. With it: `ok browser — not used — LICH_NO_WINDOW opens a plain tab in the default browser`.

Frontend untouched.

https://claude.ai/code/session_01KMWpSR3mtu9aAwHrjN74ez