### PR TITLE
feat: open a project by naming its directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`lich open` and its MCP tool now open a project, not only a session in one.**
+  `--project` took the name of a project already on screen, so an agent could
+  fan work out across the projects you had open and no further: putting a
+  directory on screen was yours to do, through the window's own picker. It takes
+  a directory path now — `lich open --project ~/src/revu` — and a path lich is
+  not holding open becomes a project first, with the session in it. A directory
+  it had open before comes back the way reopening it from the window does: same
+  id, same name, and the sessions it was closed with parked on their cards,
+  because the row is matched by path through the workspace's history rather than
+  created again. The tab appears without a reload and without stealing the view,
+  like a session opened beside you. The path must be absolute — there is no
+  shell at lich's end, and a relative one would resolve against the directory the
+  window was launched from rather than yours — and a leading `~` is expanded,
+  because an MCP tool call reaches lich through no shell at all. `close`,
+  `rename` and `worktrees` read `--project` the same way, but only narrow with
+  it: opening a project is something only `open` does.
+
 - **A theme file can now be checked before it is imported.**
   `themes/lich-theme.schema.json` is a JSON Schema naming every app and terminal
   token, which color spellings each of the two blocks accepts, and the id and

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -289,6 +289,21 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   gone relocates it instead, keeping the stored id its sessions and its worktree directory hang off. Only the 25
   most recent closes are offered back (`recentLimit`, `internal/store/store.go`) — the row survives, but past that
   a project is reachable only through the directory picker, and neither the menu nor the palette says so.
+- **A project opened from outside the window is matched by the spelling of its path**
+  (`internal/project/project.go`, `Identify`; `internal/spawn/projects.go`): `lich open --project <dir>` normalizes
+  what it is handed — `~` expanded, cleaned, refused unless absolute — and then matches that string against the
+  open projects and the workspace's history. It stops there. A symlink to a directory, or a bind mount of it, is a
+  different string and opens a second project on the same real directory: two rows, two ids, two tabs, and every
+  path-addressed lookup lich makes (which project a checkout belongs to, which gh account its calls run as)
+  answering with whichever the query reached first. The window's picker has the same hole — it takes the path
+  zenity hands back — so resolving symlinks here would make the two surfaces disagree about which project a
+  directory *is*, which is worse than the duplicate. The trap is a workspace where `/home/you/work` and
+  `/home/you/src/work` are the same checkout: nothing on screen says the two tabs are one directory.
+  It also moves a boundary that used to be the window's: until this, an agent could reach only the projects
+  somebody had opened in front of it. Any directory on the machine is now one `open_session` away from a tab, with
+  no confirmation on the way. It is not a new privilege — the agent already runs as you, in a shell that can read
+  the same disk — but it is new visibility, and a card it opens there is a card with a PTY in it.
+
 - **A hotkey is taken from the agent, and its rebind lives only in the page** (`frontend/src/lib/use-hotkey.ts`,
   `hotkeys.ts`): every bound combo is caught in the window capture phase and stopped there, so the chord never
   reaches the PTY — the defaults spend chords no TUI can bind, but a rebind is checked against nothing, and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -239,7 +239,7 @@ tasks to its agent in; a task still queued for a prompt that has not received it
 is never picked. Outside a session, or with nothing open, it is an error rather
 than a guess, and the ticket is still the way to name a specific errand.
 
-### `lich open [--project <name>] [--kind <provider>] [--worktree <branch>] [--base <branch>] [--model <model>] [--prompt <task>]`
+### `lich open [--project <name-or-path>] [--kind <provider>] [--worktree <branch>] [--base <branch>] [--model <model>] [--prompt <task>]`
 
 Opens a new session, starts it, and prints the two names it is addressed by:
 
@@ -251,6 +251,22 @@ It answers to "auth-fix" and to "auth-fix-9f8e". Its agent may still be starting
 - `--project` names the project it lands in; the default is the caller's own.
   **Outside a session there is no default** and the project must be named — the
   error lists what is open.
+  It takes a **name or a directory path**, and a path is the only way to reach a
+  project the window is not already holding: lich opens the directory as a
+  project first, then the session in it. A directory it had open before comes
+  back the way reopening it from the window does — same id, same name, and the
+  sessions it was closed with parked on their cards — because the row is matched
+  by path through the workspace's history rather than created again. A directory
+  it has never seen becomes a new project, and its tab appears without a reload.
+  The path must be **absolute**: there is no shell at lich's end, so a relative
+  one would resolve against the directory the window was launched from rather
+  than the caller's, and open a project somewhere else without saying so. A
+  leading `~` is expanded, because an MCP tool call reaches lich through no
+  shell at all. A bare word with no separator in it is always read as a project
+  name, never as a path.
+  Every other `--project` — `close`, `rename`, `worktrees` — takes a path in the
+  same spelling, but only narrows with it: opening a project is something only
+  `open` does.
 - `--kind` is what the session runs: any provider id (`claude`, `codex`,
   `antigravity`, `opencode`, `omp`, `crush`, `cursor`, `kiro`) or `shell`. The default is the caller's own
   provider, so an agent opening a worker gets another of itself; a caller that
@@ -499,7 +515,7 @@ at lich.
 | `send_to_session` | `session`, `prompt`, optional `project` and `timeout_seconds`. |
 | `wait_for_answer` | optional `ticket` and `timeout_seconds` — with a ticket, `lich wait <ticket>`; without one, the collect: everything ready at once. |
 | `reply_to_session` | `answer`, optional `ticket` — what a relayed message asks for; without a ticket, the request open against the calling session. |
-| `open_session` | optional `project`, `kind`, `worktree`, `base`, `model` — `lich open` — plus optional `prompt` — `lich open --prompt`, the same hand-off in the same call. |
+| `open_session` | optional `project` (a name, or an absolute directory path, which is opened as a project first), `kind`, `worktree`, `base`, `model` — `lich open` — plus optional `prompt` — `lich open --prompt`, the same hand-off in the same call. |
 | `close_session` | `session`, optional `project`, `worktree` (`keep`/`remove`), `force`. |
 | `rename_session` | `label`, optional `session` (omitted renames the caller's own) and `project` — `lich rename`. |
 | `list_worktrees` | optional `project` — the checkouts, as JSON. |

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -5,6 +5,7 @@
 // alone. Kept pure (no bindings, no React) so the provider and the card only
 // wire it up.
 
+import type { StoredProject, StoredSession } from "@/lib/api-types"
 import { isSessionKind, projectOfSession, type SessionKind, type SessionState } from "./sessions"
 
 // A subscription to one of the global session events, injected so every store
@@ -83,6 +84,16 @@ export const RELAY_EVENT = "session-relay"
 // Payload: the whole session, because the card is drawn from it rather than
 // looked up: the row is already written and its PTY is already running.
 export const OPENED_EVENT = "session-opened"
+
+// Global event the backend emits when a project was opened outside the window —
+// an agent naming a directory rather than a project already on screen (see
+// spawn.ProjectOpenedEventName). Payload: the whole store.Project, sessions
+// included, because the tab is drawn from it rather than looked up — and because
+// a project reopened from the history comes back with the cards it was closed
+// with. It arrives before the session event that follows it, and has to be
+// applied without waiting on anything: a session-opened whose project is not on
+// screen yet is dropped (adoptSession).
+export const PROJECT_OPENED_EVENT = "project-opened"
 
 // Global event the backend emits when a session was closed outside the window —
 // an agent running `lich close` or its MCP tool (see spawn.ClosedEventName).
@@ -310,6 +321,42 @@ export function toOpenedSession(data: unknown): OpenedSession | null {
     nextSeq: typeof nextSeq === "number" ? nextSeq : 1,
     originSessionId: typeof originSessionId === "string" ? originSessionId : "",
     originLabel: typeof originLabel === "string" ? originLabel : "",
+  }
+}
+
+// toOpenedProject narrows a project-opened payload to the row the workspace
+// draws a tab from, or null when it names no project this window can place.
+// Everything past the identity is left to buildSessionState, which already
+// tolerates a missing session list and a kind this build does not know; a card
+// with no id is dropped here, because that is the one field nothing downstream
+// can do without.
+export function toOpenedProject(data: unknown): StoredProject | null {
+  // isIdEvent only asks for a string; an empty one would key the workspace's
+  // session state under "" and put a tab on screen that no session can reach.
+  if (!isIdEvent(data) || data.id === "") {
+    return null
+  }
+  const { name, path, nextSeq, activeSessionId, defaultProvider, sessions } = data as {
+    name?: unknown
+    path?: unknown
+    nextSeq?: unknown
+    activeSessionId?: unknown
+    defaultProvider?: unknown
+    sessions?: unknown
+  }
+  if (typeof name !== "string" || name === "" || typeof path !== "string" || path === "") {
+    return null
+  }
+  return {
+    id: data.id,
+    name,
+    path,
+    nextSeq: typeof nextSeq === "number" ? nextSeq : 1,
+    activeSessionId: typeof activeSessionId === "string" ? activeSessionId : "",
+    defaultProvider: typeof defaultProvider === "string" ? defaultProvider : "",
+    sessions: Array.isArray(sessions)
+      ? (sessions as StoredSession[]).filter((s) => typeof s?.id === "string" && s.id !== "")
+      : null,
   }
 }
 

--- a/frontend/src/providers/project-workspace.test.ts
+++ b/frontend/src/providers/project-workspace.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest"
 import type { StoredProject, StoredSession } from "@/lib/api-types"
+import { toOpenedProject } from "@/lib/session/session-events"
+import { adoptSession } from "@/lib/session/sessions"
 import { buildSessionState, toProject } from "./project-workspace"
 
 const storedSession = (overrides: Partial<StoredSession> = {}): StoredSession => ({
@@ -145,5 +147,59 @@ describe("confined sessions", () => {
       ])
       expect(state.p1?.sessions[0]?.sandboxed).toBeUndefined()
     }
+  })
+})
+
+// The two halves of an agent opening a project it had to put on screen first:
+// the tab arrives as a payload rather than a reload, and the session event right
+// behind it has to find the project already there — adoptSession drops a card
+// whose project it does not know.
+describe("a project opened outside the window", () => {
+  const payload = (): unknown => ({
+    id: "p9",
+    name: "revu",
+    path: "/src/revu",
+    nextSeq: 7,
+    activeSessionId: "parked",
+    defaultProvider: "",
+    sessions: [storedSession({ id: "parked", label: "Session 6" })],
+  })
+
+  it("takes the tab in with the sessions it was closed with", () => {
+    const project = toOpenedProject(payload())
+    expect(project).not.toBeNull()
+    const state = buildSessionState([project as StoredProject])
+    expect(state.p9).toMatchObject({ activeId: "parked", nextSeq: 7 })
+    expect(state.p9?.sessions).toHaveLength(1)
+  })
+
+  it("holds the session that follows it", () => {
+    const project = toOpenedProject(payload()) as StoredProject
+    const state = { ...buildSessionState([project]) }
+    const next = adoptSession(state, "p9", { id: "new", label: "Session 7", kind: "claude" }, 8)
+    expect(next.p9?.sessions.map((s) => s.id)).toEqual(["parked", "new"])
+    expect(next.p9?.nextSeq).toBe(8)
+  })
+
+  it("refuses a payload with no project in it", () => {
+    expect(toOpenedProject({ id: "", name: "revu", path: "/src/revu" })).toBeNull()
+    expect(toOpenedProject({ id: "p9", name: "", path: "/src/revu" })).toBeNull()
+    expect(toOpenedProject({ id: "p9", name: "revu", path: "" })).toBeNull()
+  })
+
+  // A brand-new project has no sessions, and they cross as null rather than []
+  // — a nil slice in Go.
+  it("reads a project with no sessions", () => {
+    const project = toOpenedProject({
+      ...(payload() as object),
+      sessions: null,
+      activeSessionId: "",
+      nextSeq: 1,
+    })
+    expect(buildSessionState([project as StoredProject]).p9).toMatchObject({
+      sessions: [],
+      activeId: "",
+      nextSeq: 1,
+    })
   })
 })

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -42,6 +42,7 @@ import { resolveNewSessionKind } from "@/lib/session/new-session-kind"
 import {
   CLOSED_EVENT,
   OPENED_EVENT,
+  PROJECT_OPENED_EVENT,
   RELAY_STALLED_EVENT,
   SANDBOX_EVENT,
   STATUS_EVENT,
@@ -56,6 +57,7 @@ import {
   shouldToastAttention,
   statusReason,
   toClosedSession,
+  toOpenedProject,
   toOpenedSession,
   toSessionStatus,
   type SessionStatus,
@@ -220,6 +222,29 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       if (next !== sessionsRef.current) {
         commit(next)
       }
+    })
+    return () => off()
+  }, [])
+
+  // A project an agent opened through the CLI or its MCP tools by naming a
+  // directory: the row is written, so nothing is persisted here — the tab is
+  // drawn from the payload, which carries the sessions a project reopened from
+  // the history comes back with.
+  //
+  // Nothing here waits on a reload, and that is load-bearing rather than an
+  // optimisation: the session event that follows lands in this project, and a
+  // card whose project is not on screen yet is dropped (adoptSession). Nor is it
+  // navigated to — nobody in front of the window asked for this tab, and an
+  // agent opening three would otherwise drag the view along three times.
+  useEffect(() => {
+    const off = onAppEvent(PROJECT_OPENED_EVENT, (data) => {
+      const project = toOpenedProject(data)
+      if (!project || projectsRef.current.some((p) => p.id === project.id)) {
+        return
+      }
+      hydrateProjectProviderDefaults([project])
+      setProjects((prev) => [...prev, toProject(project)])
+      commit({ ...sessionsRef.current, ...buildSessionState([project]) })
     })
     return () => off()
   }, [])

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -255,7 +255,10 @@ func sessionState(state string) string {
 
 func (c *client) send(args []string) error {
 	flags := newFlagSet("send")
-	project := flags.String("project", "", "narrow the target to one project when the label is ambiguous")
+	project := flags.String(
+		"project", "",
+		"narrow the target to one project, by name or by directory path, when the label is ambiguous",
+	)
 	timeout := flags.Int("timeout", 0, "seconds to wait for an answer before handing back a ticket")
 	asJSON := flags.Bool("json", false, "print the result as JSON")
 	if err := c.parse(flags, args); err != nil {
@@ -327,7 +330,11 @@ func (c *client) reply(args []string) error {
 
 func (c *client) open(args []string) error {
 	flags := newFlagSet("open")
-	project := flags.String("project", "", "project to open the session in; defaults to the caller's own")
+	project := flags.String(
+		"project", "",
+		"project to open the session in, by name or by directory path; a path lich is "+
+			"not holding open is opened first. Defaults to the caller's own",
+	)
 	kind := flags.String("kind", "", "what the session runs; defaults to the caller's own provider")
 	worktree := flags.String("worktree", "", "branch name of a git worktree to root the session in; an existing branch is checked out as it stands")
 	base := flags.String("base", "", "branch a new worktree starts from; defaults to the project's current branch, ignored when the branch exists")
@@ -531,7 +538,10 @@ func archiveRoot(path string) string {
 
 func (c *client) close(args []string) error {
 	flags := newFlagSet("close")
-	project := flags.String("project", "", "narrow the target to one project when the label is ambiguous")
+	project := flags.String(
+		"project", "",
+		"narrow the target to one project, by name or by directory path, when the label is ambiguous",
+	)
 	worktree := flags.String("worktree", "",
 		"what to do with the checkout when this is its last session: keep or remove")
 	force := flags.Bool("force", false, "remove a checkout that still has uncommitted work")
@@ -577,7 +587,10 @@ func closedText(closed spawn.Closed) string {
 // is doing, not what its card is called); a target before it renames that one.
 func (c *client) rename(args []string) error {
 	flags := newFlagSet("rename")
-	project := flags.String("project", "", "narrow the target to one project when the label is ambiguous")
+	project := flags.String(
+		"project", "",
+		"narrow the target to one project, by name or by directory path, when the label is ambiguous",
+	)
 	asJSON := flags.Bool("json", false, "print the result as JSON")
 	if err := c.parse(flags, args); err != nil {
 		return err
@@ -613,7 +626,9 @@ func renamedText(renamed spawn.Renamed) string {
 
 func (c *client) worktrees(args []string) error {
 	flags := newFlagSet("worktrees")
-	project := flags.String("project", "", "project to list; defaults to the caller's own")
+	project := flags.String(
+		"project", "", "project to list, by name or by directory path; defaults to the caller's own",
+	)
 	asJSON := flags.Bool("json", false, "print the result as JSON")
 	if err := c.parse(flags, args); err != nil {
 		return err

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -51,31 +51,34 @@ var commands = []command{
 	},
 	{
 		name: "open",
-		args: "[--project <name>] [--kind <provider>] [--worktree <branch>]\n" +
+		args: "[--project <name-or-path>] [--kind <provider>] [--worktree <branch>]\n" +
 			"            [--base <branch>] [--model <model>] [--prompt <task>] [--json]",
-		about: "Open a new session and start it. --worktree creates a git worktree of\n" +
-			"that branch name first and roots the session in it. --model runs the\n" +
-			"provider on that model, in the provider's own spelling. --prompt hands\n" +
-			"the new session that task as soon as its agent is up, so opening a\n" +
-			"worker for a task is one command rather than two. Prints the name the\n" +
-			"new session is addressed by.",
+		about: "Open a new session and start it. --project takes a project already open,\n" +
+			"by name, or the absolute path of a directory, which is opened as a\n" +
+			"project first — one lich closed comes back with the sessions it was\n" +
+			"closed with. --worktree creates a git worktree of that branch name first\n" +
+			"and roots the session in it. --model runs the provider on that model, in\n" +
+			"the provider's own spelling. --prompt hands the new session that task as\n" +
+			"soon as its agent is up, so opening a worker for a task is one command\n" +
+			"rather than two. Prints the name the new session is addressed by.",
 	},
 	{
 		name: "close",
-		args: "[--project <name>] [--worktree keep|remove] [--force] [--json] <session>",
+		args: "[--project <name-or-path>] [--worktree keep|remove] [--force] [--json]\n" +
+			"            <session>",
 		about: "Close a session. Closing the last one in a worktree needs --worktree to\n" +
 			"say whether the checkout stays; removing a dirty one needs --force.",
 	},
 	{
 		name: "rename",
-		args: "[--project <name>] [--json] [<session>] <label>",
+		args: "[--project <name-or-path>] [--json] [<session>] <label>",
 		about: "Rename a session's card. With <session> it renames that one, with only a\n" +
 			"name it renames the session the command runs in. The name becomes the\n" +
 			"user's: the provider's auto-title never overwrites it again.",
 	},
 	{
 		name: "worktrees",
-		args: "[--project <name>] [--json]",
+		args: "[--project <name-or-path>] [--json]",
 		about: "List a project's git worktrees: what is uncommitted in each and which\n" +
 			"sessions are open in it.",
 	},

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -390,7 +390,10 @@ var mcpTools = []mcpTool{
 			"as send_to_session returns one.",
 		Schema: schema(map[string]any{
 			"project": property("string",
-				"Project to open the session in, by name. Defaults to your own project."),
+				"Project to open the session in: the name of one already open, or the "+
+					"absolute path of a directory, which is opened as a project first — a "+
+					"directory lich closed comes back with the sessions it was closed with. "+
+					"Defaults to your own project."),
 			"kind": property("string",
 				"What the session runs: claude, codex, antigravity, opencode, omp, crush, "+
 					"cursor, kiro, or shell. Defaults to the same agent you are."),
@@ -439,7 +442,8 @@ var mcpTools = []mcpTool{
 			"session": property("string",
 				"The session to close, by the label on its card or the name it answers to."),
 			"project": property("string",
-				"Project to narrow to, when the same label exists in more than one."),
+				"Project to narrow to, by name or by directory path, when the same label "+
+					"exists in more than one."),
 			"worktree": property("string",
 				"Required when this is the last session in a worktree: \"keep\" leaves the "+
 					"checkout on disk, \"remove\" deletes it."),
@@ -472,7 +476,8 @@ var mcpTools = []mcpTool{
 				"Session to rename, by the label on its card or the name it answers to. "+
 					"Omit to rename the session you are running in."),
 			"project": property("string",
-				"Project to narrow to, when the same label exists in more than one."),
+				"Project to narrow to, by name or by directory path, when the same label "+
+					"exists in more than one."),
 		}, "label"),
 		Run: func(c *client, args mcpArgs) (string, error) {
 			var renamed spawn.Renamed
@@ -490,7 +495,8 @@ var mcpTools = []mcpTool{
 			"session on a branch (one that is already checked out is opened, not created) " +
 			"and before closing one (the last session in a checkout decides its fate).",
 		Schema: schema(map[string]any{
-			"project": property("string", "Project to list. Defaults to your own."),
+			"project": property("string",
+				"Project to list, by name or by directory path. Defaults to your own."),
 		}),
 		ReadOnly: true,
 		Run: func(c *client, args mcpArgs) (string, error) {

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -187,6 +187,12 @@ func (s *spawnStore) RenameSession(sessionID, label string) error {
 
 func (*spawnStore) CloseSession(_, _, _ string) error { return nil }
 
+func (*spawnStore) RecentProjects() ([]store.Recent, error) { return nil, nil }
+
+// The wire tests never open a project: what they prove is the arguments a
+// command posts, and the workspace this fixture answers with is already open.
+func (*spawnStore) AddProject(_, _, _ string) error { return nil }
+
 func (*spawnStore) PurgeWorktreeSessions(_, _ string) error { return nil }
 
 // spawnGit stands in for the repository: creating a checkout is refused because

--- a/internal/project/identify_test.go
+++ b/internal/project/identify_test.go
@@ -1,0 +1,94 @@
+package project
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestIdentifyMatchesThePicker proves a path typed at a command line lands on
+// the same identity the dialog would have produced for that directory: the id is
+// what a project's sessions and its worktree directory hang off, so a second one
+// for the same directory is a second project on top of the first.
+func TestIdentifyMatchesThePicker(t *testing.T) {
+	dir := t.TempDir()
+
+	p, err := Identify(dir)
+	if err != nil {
+		t.Fatalf("Identify: %v", err)
+	}
+	if want := newProject(dir); *p != *want {
+		t.Errorf("Identify(%q) = %+v, want %+v", dir, p, want)
+	}
+}
+
+// TestIdentifyNormalizes proves the spellings of one directory that a person or
+// an agent actually types all reach that one project. The id is a hash of the
+// path string, so anything left un-normalized here opens a duplicate.
+func TestIdentifyNormalizes(t *testing.T) {
+	dir := t.TempDir()
+	inner := filepath.Join(dir, "repo")
+	if err := os.Mkdir(inner, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	home := t.TempDir()
+	// os.UserHomeDir reads HOME on Unix and USERPROFILE on Windows.
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	want := newProject(inner).ID
+	for _, spelling := range []string{
+		inner,
+		inner + string(filepath.Separator),
+		filepath.Join(dir, "repo", "..", "repo"),
+		" " + inner + " ",
+	} {
+		got, err := Identify(spelling)
+		if err != nil {
+			t.Fatalf("Identify(%q): %v", spelling, err)
+		}
+		if got.ID != want {
+			t.Errorf("Identify(%q).ID = %q, want %q", spelling, got.ID, want)
+		}
+	}
+
+	// A tilde reaches lich literally through an MCP call: there is no shell at
+	// that end to expand it.
+	got, err := Identify("~")
+	if err != nil {
+		t.Fatalf("Identify(~): %v", err)
+	}
+	if got.Path != filepath.Clean(home) {
+		t.Errorf("Identify(~).Path = %q, want %q", got.Path, home)
+	}
+}
+
+// TestIdentifyRefuses proves the boundary answers rather than opening the wrong
+// project. A relative path is the one that matters: it resolves against the lich
+// window's own directory, not the caller's, so accepting it would silently open
+// somewhere else.
+func TestIdentifyRefuses(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	for _, tc := range []struct{ name, path, want string }{
+		{"relative", filepath.Join(".", "repo"), "relative path"},
+		{"empty", "   ", "no path given"},
+		{"missing", filepath.Join(dir, "nope"), "no directory at"},
+		{"file", file, "is a file"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := Identify(tc.path)
+			if err == nil {
+				t.Fatalf("Identify(%q) = %+v, want an error", tc.path, p)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("Identify(%q) said %q, want it to name %q", tc.path, err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -321,3 +321,48 @@ func projectID(path string) string {
 	sum := sha256.Sum256([]byte(path))
 	return hex.EncodeToString(sum[:projectIDBytes])
 }
+
+// Identify turns a directory path into the same identity the picker would give
+// it: the id its sessions and its worktree directory hang off, and the name its
+// tab wears. It is the path a caller outside the window hands in — the `lich`
+// command line and its MCP tools — so it normalizes what a person or an agent
+// types, and validates it here rather than letting a typo become a project.
+//
+// A leading ~ is expanded because an MCP tool call reaches lich through no shell
+// at all: the tilde arrives literally, and a project named "~" is nobody's
+// intent. ~user is not expanded — the home directory of another user is not a
+// path this ever means.
+//
+// A relative path is refused rather than resolved. There is no shell at this end
+// either: Abs would resolve it against the directory the lich window was
+// launched from, which is not the caller's, and the project that opened would be
+// a different one than the one asked for with nothing on screen saying so.
+func Identify(path string) (*Project, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, fmt.Errorf("no path given")
+	}
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("resolve home dir: %w", err)
+		}
+		path = filepath.Join(home, strings.TrimPrefix(path[1:], "/"))
+	}
+	if !filepath.IsAbs(path) {
+		return nil, fmt.Errorf(
+			"%q is a relative path, and lich would resolve it against its own window's "+
+				"directory rather than yours — give the absolute path",
+			path,
+		)
+	}
+	path = filepath.Clean(path)
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, fmt.Errorf("no directory at %q", path)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%q is a file, and a project is a directory", path)
+	}
+	return newProject(path), nil
+}

--- a/internal/spawn/close.go
+++ b/internal/spawn/close.go
@@ -209,9 +209,16 @@ func findSession(projects []store.Project, target, projectName string) (located,
 		return located{}, fmt.Errorf("no session given to close")
 	}
 
+	// Resolved once rather than per project: a path argument stats the
+	// directory it names, and this loop runs over every project open.
+	inProject, err := projectFilter(projectName)
+	if err != nil {
+		return located{}, err
+	}
+
 	var byLabel, byName []located
 	for _, p := range projects {
-		if projectName != "" && !strings.EqualFold(p.Name, projectName) {
+		if !inProject(p) {
 			continue
 		}
 		for _, sess := range p.Sessions {

--- a/internal/spawn/projects.go
+++ b/internal/spawn/projects.go
@@ -1,0 +1,122 @@
+package spawn
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/omartelo/lich/internal/project"
+	"github.com/omartelo/lich/internal/store"
+)
+
+// ensureProject resolves the project a session is being opened in, and is the
+// one caller allowed to put a new tab on screen. A name reaches only what the
+// window is already holding; a path reaches a directory that is not open yet —
+// closed into the workspace's history, or never opened at all — which is what
+// opening a project from outside the window means.
+//
+// It answers with the project list the rest of the open reads, reloaded when a
+// row was written: a project reopened from the history comes back with the
+// sessions it was closed with, and its label counter is the one the new card
+// takes its number from.
+func (s *Service) ensureProject(
+	projects []store.Project, fromID, name string,
+) ([]store.Project, store.Project, error) {
+	if !looksLikePath(name) {
+		target, err := resolveProject(projects, fromID, name)
+		return projects, target, err
+	}
+	identity, err := project.Identify(name)
+	if err != nil {
+		return nil, store.Project{}, err
+	}
+	for _, p := range projects {
+		if p.Path == identity.Path {
+			return projects, p, nil
+		}
+	}
+	return s.adoptProject(identity)
+}
+
+// adoptProject opens a directory the window is not holding: the row it already
+// has in the history, or a new one.
+//
+// The id is matched through the history by path rather than derived from it,
+// because the two only agree until a project is relocated — a checkout that
+// moved keeps the id its sessions and its worktree directory hang off, and
+// deriving a fresh one from the new path would open a second project on the same
+// directory. That is the duplicate the window's own relocate refuses, and it has
+// to be refused from this side too: every path-addressed lookup lich makes —
+// which project a checkout belongs to, which gh account its calls run as —
+// answers with whichever of the two rows the query reached first.
+func (s *Service) adoptProject(identity *project.Project) ([]store.Project, store.Project, error) {
+	id, name := identity.ID, identity.Name
+	recents, err := s.sessions.RecentProjects()
+	if err != nil {
+		return nil, store.Project{}, fmt.Errorf("read the closed projects: %w", err)
+	}
+	for _, r := range recents {
+		if r.Path == identity.Path {
+			id, name = r.ID, r.Name
+			break
+		}
+	}
+	if err := s.sessions.AddProject(id, name, identity.Path); err != nil {
+		return nil, store.Project{}, err
+	}
+	reloaded, err := s.sessions.LoadState()
+	if err != nil {
+		return nil, store.Project{}, fmt.Errorf("read the workspace: %w", err)
+	}
+	for _, p := range reloaded {
+		if p.ID != id {
+			continue
+		}
+		// Announced before the session that follows it, and read by the window
+		// in that order: a card is dropped when its project is not on screen
+		// yet, so the tab has to land first.
+		if s.events != nil {
+			s.events.Emit(ProjectOpenedEventName, p)
+		}
+		return reloaded, p, nil
+	}
+	return nil, store.Project{}, fmt.Errorf("project %q was opened but is not in the workspace", name)
+}
+
+// looksLikePath says whether a --project argument names a directory rather than
+// a project on screen. A project's name is the base name of its directory, so it
+// holds no separator; a path that holds none — a bare "repo" — is a name, and is
+// resolved as one.
+//
+// A relative path that carries a separator is a path here, and refused by
+// project.Identify rather than falling through to be looked up as a name: what
+// "./repo" is wrong about is where it would resolve, and that is the answer the
+// caller needs. A bare "repo" is a name either way, and is answered as one — the
+// two readings are genuinely ambiguous there, and the project on screen is the
+// one the argument has always meant.
+func looksLikePath(name string) bool {
+	return strings.ContainsRune(name, '/') ||
+		strings.ContainsRune(name, filepath.Separator) ||
+		name == "~" || strings.HasPrefix(name, "~/")
+}
+
+// projectFilter turns a --project argument into the test that narrows a search
+// to it: a directory path matches the project rooted there, anything else
+// matches by name, and an empty argument narrows nothing.
+//
+// One reading of the argument for every command that takes it. A path resolves
+// the same everywhere — it just cannot open a project anywhere but an open, and
+// nothing else here writes.
+func projectFilter(name string) (func(store.Project) bool, error) {
+	if name == "" {
+		return func(store.Project) bool { return true }, nil
+	}
+	if !looksLikePath(name) {
+		return func(p store.Project) bool { return strings.EqualFold(p.Name, name) }, nil
+	}
+	identity, err := project.Identify(name)
+	if err != nil {
+		return nil, err
+	}
+	return func(p store.Project) bool { return p.Path == identity.Path }, nil
+}

--- a/internal/spawn/projects_test.go
+++ b/internal/spawn/projects_test.go
@@ -1,0 +1,183 @@
+package spawn
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/project"
+	"github.com/omartelo/lich/internal/store"
+)
+
+// emittedNames is the order the window is told things in, which is the whole
+// contract between a project event and the session event behind it.
+func emittedNames(events *fakeEvents) []string {
+	names := make([]string, 0, len(events.events))
+	for _, e := range events.events {
+		names = append(names, e.name)
+	}
+	return names
+}
+
+// TestOpenAdoptsADirectoryNotOnScreen proves the one thing a path can do that a
+// name cannot: put a project the window is not holding on screen, and open the
+// session in it.
+func TestOpenAdoptsADirectoryNotOnScreen(t *testing.T) {
+	dir := t.TempDir()
+	svc, sessions, _, term, events := newService(t)
+
+	opened, err := svc.Open("s1", dir, "", "", "", "")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	want, err := project.Identify(dir)
+	if err != nil {
+		t.Fatalf("Identify: %v", err)
+	}
+	if opened.ProjectID != want.ID || opened.Project != want.Name {
+		t.Errorf("opened in %q (%q), want %q (%q)", opened.Project, opened.ProjectID, want.Name, want.ID)
+	}
+	// A brand-new project starts its own counter rather than continuing the
+	// caller's.
+	if opened.Label != "Session 1" || opened.NextSeq != 2 {
+		t.Errorf("label %q, next %d; want Session 1 and 2", opened.Label, opened.NextSeq)
+	}
+	if len(term.spawns) != 1 || term.spawns[0].cwd != want.Path {
+		t.Errorf("started %+v, want one PTY in %q", term.spawns, want.Path)
+	}
+	if len(sessions.rows) != 1 || sessions.rows[0].projectID != want.ID {
+		t.Errorf("wrote %+v, want one row in %q", sessions.rows, want.ID)
+	}
+	// The tab has to land before the card: a session-opened whose project is
+	// not on screen yet is dropped by the window (adoptSession).
+	if names := emittedNames(events); len(names) != 2 ||
+		names[0] != ProjectOpenedEventName || names[1] != OpenedEventName {
+		t.Fatalf("emitted %v, want the project before the session", names)
+	}
+	announced, ok := events.events[0].data.(store.Project)
+	if !ok || announced.ID != want.ID || announced.Path != want.Path {
+		t.Errorf("announced %+v, want the whole project row", events.events[0].data)
+	}
+}
+
+// TestOpenReopensAProjectFromTheHistory proves a closed project is reopened
+// rather than duplicated — with the sessions it was closed with, and under the
+// id it was closed under. The fixture's id is not the one this path hashes to,
+// which is what a relocated project looks like: the row keeps the id its
+// sessions and its worktree directory hang off, and deriving a fresh one from
+// the path would open a second project on the same directory.
+func TestOpenReopensAProjectFromTheHistory(t *testing.T) {
+	dir := t.TempDir()
+	svc, sessions, _, _, events := newService(t)
+	sessions.closed = []store.Project{{
+		ID: "relocated", Name: "revu", Path: dir, NextSeq: 7,
+		Sessions: []store.Session{{ID: "parked", Label: "Session 6", Kind: "claude"}},
+	}}
+
+	opened, err := svc.Open("s1", dir, "", "", "", "")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	if opened.ProjectID != "relocated" || opened.Project != "revu" {
+		t.Errorf("opened in %q (%q), want the stored row", opened.Project, opened.ProjectID)
+	}
+	// The label continues the counter the project was closed with; a session
+	// that repeats a live label is one `lich send` cannot address.
+	if opened.Label != "Session 7" || opened.NextSeq != 8 {
+		t.Errorf("label %q, next %d; want Session 7 and 8", opened.Label, opened.NextSeq)
+	}
+	announced, ok := events.events[0].data.(store.Project)
+	if !ok || len(announced.Sessions) != 1 || announced.Sessions[0].ID != "parked" {
+		t.Errorf("announced %+v, want the parked session with it", events.events[0].data)
+	}
+}
+
+// TestOpenFindsAnOpenProjectByPath proves a path that names a project already on
+// screen opens a session in it and nothing else: no second row, no tab event.
+func TestOpenFindsAnOpenProjectByPath(t *testing.T) {
+	dir := t.TempDir()
+	svc, sessions, _, _, events := newService(t)
+	sessions.projects[1].Path = dir
+
+	opened, err := svc.Open("s1", dir+string(filepath.Separator), "", "", "", "")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	if opened.ProjectID != "p2" {
+		t.Errorf("opened in %q, want the project already holding that directory", opened.ProjectID)
+	}
+	if names := emittedNames(events); len(names) != 1 || names[0] != OpenedEventName {
+		t.Errorf("emitted %v, want only the session", names)
+	}
+}
+
+// TestOpenRefusesAPathItCannotTrust proves the boundary answers before anything
+// is written. A relative path is the one that matters: lich would resolve it
+// against its own window's directory rather than the caller's, so a project
+// would open — just not the one asked for.
+func TestOpenRefusesAPathItCannotTrust(t *testing.T) {
+	svc, sessions, _, term, events := newService(t)
+
+	for _, tc := range []struct{ name, path, want string }{
+		{"relative", "./repo", "relative path"},
+		{"missing", filepath.Join(t.TempDir(), "nope"), "no directory at"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := svc.Open("s1", tc.path, "", "", "", ""); err == nil ||
+				!strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Open(%q) = %v, want it to name %q", tc.path, err, tc.want)
+			}
+		})
+	}
+	if len(sessions.rows) != 0 || len(term.spawns) != 0 || len(events.events) != 0 {
+		t.Errorf("a refused path still wrote %+v / %+v / %+v", sessions.rows, term.spawns, events.events)
+	}
+}
+
+// TestNarrowingTakesAPathToo proves --project reads the same wherever it only
+// narrows a search: the session lives in the project at that directory.
+func TestNarrowingTakesAPathToo(t *testing.T) {
+	dir := t.TempDir()
+	svc, sessions, _, _, _ := newService(t)
+	sessions.projects[1].Path = dir
+	sessions.projects[1].Sessions = []store.Session{{ID: "s2", Label: "Session 3"}}
+
+	// "Session 3" is a label both projects hold, which is what --project is for.
+	renamed, err := svc.Rename("s1", "Session 3", dir, "review")
+	if err != nil {
+		t.Fatalf("Rename: %v", err)
+	}
+	if renamed.ID != "s2" {
+		t.Errorf("renamed %q, want the session in the project at that path", renamed.ID)
+	}
+}
+
+// TestWorktreesTakeAPathToo proves --project reads the same on every command
+// that has one: a path reaches a project on screen, and only an open is allowed
+// to put one there.
+func TestWorktreesTakeAPathToo(t *testing.T) {
+	dir := t.TempDir()
+	svc, sessions, worktrees, _, _ := newService(t)
+	sessions.projects[1].Path = dir
+	worktrees.checkouts = []project.Worktree{{Name: "feature", Path: "/wt/feature"}}
+
+	found, err := svc.Worktrees("s1", dir)
+	if err != nil {
+		t.Fatalf("Worktrees: %v", err)
+	}
+	if len(found) != 1 || found[0].Name != "feature" {
+		t.Errorf("Worktrees = %+v, want the checkout of the project at that path", found)
+	}
+
+	elsewhere := t.TempDir()
+	if _, err := svc.Worktrees("s1", elsewhere); err == nil ||
+		!strings.Contains(err.Error(), "no open project at") {
+		t.Errorf("Worktrees(%q) = %v, want it to say no project is open there", elsewhere, err)
+	}
+	if len(sessions.projects) != 2 {
+		t.Errorf("listing worktrees opened a project: %+v", sessions.projects)
+	}
+}

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -38,6 +38,14 @@ import (
 // is the workspace state, which outlives any one card.
 const OpenedEventName = "session-opened"
 
+// ProjectOpenedEventName carries a project opened outside the window — an agent
+// naming a directory rather than a project already on screen — so its tab
+// appears without a reload. Its payload is the whole store.Project, sessions
+// included: a reopened project brings back the cards it was closed with, and the
+// session this open is about to announce lands in a tab the window has to be
+// holding already (frontend/src/lib/session/sessions.ts, adoptSession).
+const ProjectOpenedEventName = "project-opened"
+
 // ClosedEventName carries a session closed outside the window, so the card goes
 // away without a reload. Its payload is ClosedEvent.
 const ClosedEventName = "session-closed"
@@ -70,6 +78,8 @@ const (
 // a later resume. The store implements it.
 type Sessions interface {
 	LoadState() ([]store.Project, error)
+	RecentProjects() ([]store.Recent, error)
+	AddProject(id, name, path string) error
 	AddSessionFrom(
 		projectID, sessionID, label, kind, path string, nextSeq int, originID, originLabel string,
 	) error
@@ -157,6 +167,10 @@ func New(sessions Sessions, worktrees Worktrees, term Terminal, events Events) *
 // request that created it: the card says where it came from for as long as it
 // exists.
 //
+// projectName is a project already on screen, by name, or a directory path — and
+// a path is the only way to reach a project the window is not holding, which is
+// what opening one from the command line means. See ensureProject.
+//
 // worktree, when given, is the branch name of a new git worktree created off
 // base (the project's current branch when base is empty); the session is rooted
 // there, labelled after it, and runs the project's worktree setup script before
@@ -184,7 +198,7 @@ func (s *Service) Open(fromID, projectName, kind, worktree, base, model string) 
 	if err != nil {
 		return Session{}, fmt.Errorf("read the workspace: %w", err)
 	}
-	target, err := resolveProject(projects, fromID, projectName)
+	projects, target, err := s.ensureProject(projects, fromID, projectName)
 	if err != nil {
 		return Session{}, err
 	}
@@ -366,7 +380,9 @@ func (s *Service) resolveBase(target store.Project, base string) (string, bool, 
 }
 
 // resolveProject picks the project the session lands in: the one named, or the
-// caller's own when nothing is named.
+// caller's own when nothing is named. A name reaches only the projects the
+// window is holding, and so does a path — opening one that is not on screen is
+// ensureProject's, and only an open does it.
 func resolveProject(projects []store.Project, fromID, name string) (store.Project, error) {
 	if name == "" {
 		for _, p := range projects {
@@ -382,9 +398,13 @@ func resolveProject(projects []store.Project, fromID, name string) (store.Projec
 		)
 	}
 
+	match, err := projectFilter(name)
+	if err != nil {
+		return store.Project{}, err
+	}
 	var matches []store.Project
 	for _, p := range projects {
-		if strings.EqualFold(p.Name, name) {
+		if match(p) {
 			matches = append(matches, p)
 		}
 	}
@@ -392,6 +412,9 @@ func resolveProject(projects []store.Project, fromID, name string) (store.Projec
 	case 1:
 		return matches[0], nil
 	case 0:
+		if looksLikePath(name) {
+			return store.Project{}, fmt.Errorf("no open project at %q. %s", name, knownProjects(projects))
+		}
 		return store.Project{}, fmt.Errorf("no open project named %q. %s", name, knownProjects(projects))
 	default:
 		return store.Project{}, fmt.Errorf(

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -25,8 +25,14 @@ type added struct {
 type fakeSessions struct {
 	projects []store.Project
 	loadErr  error
-	rows     []added
-	addErr   error
+	// closed is the workspace's history: projects with is_open = 0, which
+	// RecentProjects offers back and AddProject reopens with their sessions
+	// intact, exactly as the store does.
+	closed     []store.Project
+	recentErr  error
+	addProjErr error
+	rows       []added
+	addErr     error
 	// models records the model written on each session row, keyed by session id.
 	models   map[string]string
 	modelErr error
@@ -76,6 +82,42 @@ func (f *fakeSessions) PurgeWorktreeSessions(_, path string) error {
 
 func (f *fakeSessions) LoadState() ([]store.Project, error) {
 	return f.projects, f.loadErr
+}
+
+func (f *fakeSessions) RecentProjects() ([]store.Recent, error) {
+	if f.recentErr != nil {
+		return nil, f.recentErr
+	}
+	recents := make([]store.Recent, 0, len(f.closed))
+	for _, p := range f.closed {
+		recents = append(recents, store.Recent{ID: p.ID, Name: p.Name, Path: p.Path})
+	}
+	return recents, nil
+}
+
+// AddProject mirrors the store's upsert: a closed project's row is reopened as
+// it stands — its sessions, its label counter and its name all come back — and
+// an id nothing holds opens as a new project.
+func (f *fakeSessions) AddProject(id, name, path string) error {
+	if f.addProjErr != nil {
+		return f.addProjErr
+	}
+	for i, p := range f.projects {
+		if p.ID == id {
+			f.projects[i].Name, f.projects[i].Path = name, path
+			return nil
+		}
+	}
+	for i, p := range f.closed {
+		if p.ID == id {
+			p.Name, p.Path = name, path
+			f.closed = append(f.closed[:i], f.closed[i+1:]...)
+			f.projects = append(f.projects, p)
+			return nil
+		}
+	}
+	f.projects = append(f.projects, store.Project{ID: id, Name: name, Path: path, NextSeq: 1})
+	return nil
 }
 
 func (f *fakeSessions) AddSessionFrom(


### PR DESCRIPTION
`lich open --project` took the name of a project already on screen. An agent could fan work out across the projects the user had open and no further — putting a directory on screen was the window's own picker to do, so neither the CLI nor the MCP tools could reach a project in lich's history, let alone a path it had never seen.

`--project` takes a directory path now, and every command that has the flag reads it the same way — but only `open` may act on one:

```
lich open --project ~/src/revu --prompt "rebase onto main"
```

A path lich is not holding open becomes a project first, with the session in it. A directory it had open before is matched **by path through the workspace's history** and reopened under its own id, so a relocated checkout is not duplicated and the sessions it was closed with come back parked on their cards — the same thing reopening it from the window does. `close`, `rename` and `worktrees` take a path too, but only narrow with it.

The tab appears without a reload and without stealing the view. It is announced whole — the `store.Project`, sessions included — rather than as a nudge to reload, because the `session-opened` event right behind it lands in that project and a card whose project is not on screen yet is dropped (`adoptSession`).

The path is normalized (`~` expanded, cleaned) and **refused unless absolute**: there is no shell at lich's end, so a relative one would resolve against the directory the window was launched from rather than the caller's, and open a project somewhere else without saying so. A bare word with no separator is still read as a project name.

## What is not in this

Listing what lich remembers. An agent reaches a project from the history by naming its path; there is still no `lich projects` / `list_projects` to discover one it does not already know about. Separate PR.

## Ceilings

`docs/ceilings.md` gains the bullet: the match is the **spelling** of the path, so a symlink to a directory opens a second project on the same real directory — the window's picker has the same hole, and resolving symlinks on one surface only would make the two disagree about which project a directory *is*. The same bullet records the boundary that moved: any directory on the machine is now one `open_session` away from a tab. Not a new privilege — the agent already runs as the user — but new visibility.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` (with `LICH_LISTEN_PORT` empty)
- [x] `biome check .`, `vitest run` (1372 tests), `tsc && vite build`
- [x] Cross-compile loop for linux/darwin/windows (new `_test.go` files carry no build tag)
- [x] Coverage: spawn 93.8%, project 91.9%, cli 91.0%
- [ ] By hand: `lich open --project <new dir>`, then close the project and `lich open --project <same dir>` — the parked sessions come back

https://claude.ai/code/session_01PtEwnAim3a7KzYgjzguF8u
