### PR TITLE
feat: show what the last turn said, beside what it changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   verdict, so the two disagree for a few seconds after a push — the row says
   which one is the fresh reading.
 
+- **The Review panel's "Last turn" now shows what the agent said, not only what
+  it changed.** Coming back to a card told you it had news, what it cost and how
+  long you had been in it, and never what it did — catching up meant scrolling
+  the terminal. Above the turn's diff there is now the agent's own closing
+  sentence for that turn, read straight out of the provider's transcript.
+  Nothing is generated and no model is called: every agent already ends a turn
+  by saying what it did, and lich only finds that sentence. It earns its place
+  on the turn the diff cannot describe — the one that ran the suite, found three
+  failures and edited nothing, which used to read as "Nothing changed in this
+  window" and no more. The band appears only when there are words to show, and
+  scrolls in its own right, so a long report never pushes the file list off
+  screen. Read for Claude Code, Codex, Antigravity, opencode, oh-my-pi and Kiro
+  CLI; Crush and Cursor CLI report no turn boundary, so they are not offered the
+  "Last turn" mode this sits in at all.
+
 ### Changed
 
 - **"Resolve conflicts" and "Fix CI errors" now open the session they hand the

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -192,6 +192,20 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   so **Crush and Cursor CLI have no last turn at all**: neither reports a state (`docs/hooks/session-state.md`),
   so nothing ever opens or closes a window there and the switch is never drawn — a rule read off the
   session's own reports, not a list of providers, so it corrects itself the day either one starts reporting.
+- **The recap beside that diff answers to a different clock, and to a different set of providers**
+  (`internal/terminal/said.go`): the band reads the last thing the agent *said* out of the provider's own
+  transcript, where the diff beside it brackets the window a turn ran in. The two agree once a turn has
+  finished — which is the only time a diff is offered — but mid-turn the band still shows the previous
+  turn's words with no date on them, beside a diff that reads "unavailable"; nothing in the panel says
+  which turn is speaking, and only the card's spinner does. The read is a bounded tail for the reason the
+  transcript search's is (`searchTailBytes`), so a turn whose closing words sit behind more than 4 MB of
+  tool output shows none — the band simply does not appear, which is also what a turn that ended on a tool
+  call looks like. And its provider list is *not* the one the switch above it is drawn from: six of the
+  eight are read (Claude Code, Codex, Antigravity, opencode, oh-my-pi, Kiro CLI), and the two that are not
+  are the two with no last turn to begin with, so the gap is invisible today and would surface the moment
+  Crush or Cursor CLI started reporting a state. Crush is a query away — its `parts` column carries the
+  same `{type,text}` shape opencode's does — and Cursor CLI is not: it files a chat as content-addressed
+  blobs ordered by a protobuf index, with a `blobEncryptionKey` sitting in its own metadata.
 - **A finished turn is unread until its own card is watched** (`frontend/src/lib/session/session-status-store.ts`,
   `frontend/src/providers/projects.tsx`): the solid emerald ring means "back from the agent, not read yet", and it
   fades only for the session whose terminal is on screen **while the window has focus**. Two things follow. A card

--- a/frontend/src/components/diff/ReviewPanel.tsx
+++ b/frontend/src/components/diff/ReviewPanel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 import { Notice } from "@/components/common/Notice"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
-import type { LastTurn } from "@/lib/api-types"
+import type { LastSaid, LastTurn } from "@/lib/api-types"
 import { onAppEvent } from "@/lib/app-events"
 import { readDiffSource, writeDiffSource, type DiffSource } from "@/lib/dock-prefs"
 import { discardTargets, parseDiff, type DiffFile } from "@/lib/git/diff"
@@ -70,6 +70,9 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
   const [failed, setFailed] = useState(false)
   const [turnState, setTurnState] = useState<LastTurn["state"] | null>(null)
   const [endedAt, setEndedAt] = useState<number | null>(null)
+  // The agent's own closing words for the shown turn; "" whenever there are
+  // none, which is also every state the working tree is in.
+  const [said, setSaid] = useState("")
   // The revision the shown diff's new side stands at, which is what the
   // expander reads unchanged lines from: "" is the working tree, and a turn
   // carries the snapshot tree it ended on.
@@ -94,16 +97,30 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
       // The working tree wears the same shape rather than branching the whole
       // read: it is always "ok", it has no window to date, and every line below
       // then reads one source.
-      const turn: LastTurn =
-        source === "turn"
-          ? await Terminal.LastTurnDiff(sessionId)
-          : { state: "ok", diff: await ProjectService.DiffText(path) }
+      //
+      // The words are read beside the diff rather than after it — they are two
+      // reads of the same moment — and their own failure is swallowed: a recap
+      // lich could not find is a band that does not appear, never a panel that
+      // reports it could not read the turn.
+      let turn: LastTurn
+      let words = ""
+      if (source === "turn") {
+        const [diff, said] = await Promise.all([
+          Terminal.LastTurnDiff(sessionId),
+          Terminal.LastTurnSaid(sessionId).catch(() => ({}) as LastSaid),
+        ])
+        turn = diff
+        words = said.text ?? ""
+      } else {
+        turn = { state: "ok", diff: await ProjectService.DiffText(path) }
+      }
       if (mine !== seq.current) {
         return
       }
       setFailed(false)
       setTurnState(turn.state)
       setEndedAt(turn.endedAt ?? null)
+      setSaid(words)
       setRef(source === "turn" ? (turn.after ?? "") : "")
       const text = turn.diff ?? ""
       if (text === lastText.current) {
@@ -131,6 +148,7 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
     setFiles(null)
     setTurnState(null)
     setEndedAt(null)
+    setSaid("")
     setRef("")
   }, [source, path, sessionId])
 
@@ -186,6 +204,7 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
   return (
     <div className="flex h-full flex-col">
       {switchable && <SourceRow source={source} onSource={changeSource} endedAt={endedAt} />}
+      {source === "turn" && said !== "" && <SaidBand text={said} />}
       <div className="flex-1 overflow-y-auto">
         <PanelBody
           source={source}
@@ -208,6 +227,26 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
         onCancel={() => setPendingDiscard(null)}
         onDiscard={() => void discard()}
       />
+    </div>
+  )
+}
+
+// SaidBand is the agent's own closing words for the shown turn, above the files
+// it changed. A band rather than a card: it shares the panel's edges and is set
+// apart by its ground alone, because the diff below is the object that carries
+// the hierarchy.
+//
+// It sits outside the scrolling body and scrolls in its own right, so a turn
+// that ended in a long report cannot push the file list off screen. The text is
+// rendered as text — the agent writes markdown, and a panel that parsed it would
+// be claiming to know which provider's flavour this is.
+function SaidBand({ text }: { text: string }) {
+  return (
+    <div className="flex shrink-0 flex-col gap-1 border-b border-border bg-muted px-2.5 pt-2 pb-2.5">
+      <span className="text-[0.625rem] font-medium tracking-wider text-muted-foreground uppercase">
+        Said
+      </span>
+      <p className="max-h-32 overflow-y-auto whitespace-pre-wrap text-xs">{text}</p>
     </div>
   )
 }

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -532,3 +532,12 @@ export interface LastTurn {
    * with a diff. */
   after?: string
 }
+
+/** internal/terminal.LastSaid — the prose the agent ended its last turn with,
+ * read out of the provider's own transcript. Absent for every absence there is:
+ * a turn that ended on a tool call, a provider whose conversation lich cannot
+ * read, a transcript still being written. The panel draws nothing either way,
+ * which is why there is no reason field to render. */
+export interface LastSaid {
+  text?: string
+}

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -12,6 +12,7 @@ import type {
   BinaryCheck,
   BranchRules,
   ClosedSession,
+  LastSaid,
   LastTurn,
   Branches,
   CommitIdentity,
@@ -157,6 +158,10 @@ export const Terminal = {
   /** What changed on disk while this session's last finished turn ran — a
    * window of time, not an attribution (see internal/terminal.LastTurnDiff). */
   LastTurnDiff: (id: string) => call<LastTurn>("terminal.LastTurnDiff", [id]),
+  /** The last thing the agent said in this session's conversation — its own
+   * closing words, not a summary of them (see internal/terminal.LastTurnSaid).
+   * `text` is absent whenever there are none to show. */
+  LastTurnSaid: (id: string) => call<LastSaid>("terminal.LastTurnSaid", [id]),
 }
 
 export const DropService = {

--- a/internal/terminal/said.go
+++ b/internal/terminal/said.go
@@ -1,0 +1,314 @@
+package terminal
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// saidRuneCap bounds the closing words the panel is handed. A turn can end in a
+// full report, and the panel is polled while it is open, so the whole of one is
+// not worth pushing over the socket every two seconds. What is cut is the middle
+// of a long answer, never the start — the first paragraph is the recap.
+const saidRuneCap = 4000
+
+// LastSaid is the prose the agent ended its last turn with, as the Review
+// panel's "Last turn" shows it beside the diff. Text is empty for every absence
+// there is — a provider whose conversation lich cannot read, a turn that ended
+// in a tool call, a transcript still being written — because the panel draws
+// nothing either way and a reason it cannot act on is a reason not worth wiring.
+type LastSaid struct {
+	Text string `json:"text,omitempty"`
+}
+
+// LastTurnSaid returns the last thing the agent said in this session's
+// conversation, as plain text.
+//
+// It answers the half of "what happened while I was away" that the diff beside
+// it cannot: a turn that ran the suite and reported three failures changed
+// nothing on disk, and that is exactly the turn worth catching up on. Nothing
+// here summarises anything — the agent wrote this sentence itself, and lich only
+// finds it.
+//
+// It is the last message on record, not the last message of the turn the diff
+// brackets. The two agree whenever a turn has finished, which is the only time
+// the panel offers a diff at all; mid-turn this is still the previous turn's
+// words while the diff reads "unavailable", and the card's own spinner is what
+// says why.
+func (s *Service) LastTurnSaid(id string) (LastSaid, error) {
+	providerSessionID, err := s.store.ProviderSession(id)
+	if err != nil {
+		return LastSaid{}, fmt.Errorf("read provider session: %w", err)
+	}
+	if providerSessionID == "" {
+		return LastSaid{}, nil
+	}
+	src, ok := usageSourceFor(providerSessionID, s.spawnOf(id).cwd)
+	if !ok {
+		return LastSaid{}, nil
+	}
+	return LastSaid{Text: capRunes(saidFor(src), saidRuneCap)}, nil
+}
+
+// saidFor reads one conversation's closing words out of whatever the provider
+// files them in. Empty for every miss, and for the two providers that reach here
+// with nothing to read — Cursor CLI files its chat as a content-addressed blob
+// store, and neither it nor Crush reports a turn boundary, so neither is ever
+// offered the panel this feeds (docs/ceilings.md).
+func saidFor(src usageSource) string {
+	switch src.kind {
+	case providers.Claude:
+		return lastSaidInTail(src.path, claudeSaid)
+	case providers.Codex:
+		return lastSaidInTail(src.path, codexSaid)
+	case providers.OMP:
+		return lastSaidInTail(src.path, ompSaid)
+	case providers.Kiro:
+		return lastSaidInTail(kiroTranscriptPath(src.path), kiroSaid)
+	case providers.Antigravity:
+		return lastSaidInTail(src.path, antigravitySaid)
+	case providers.OpenCode:
+		return sessionDBSaid(src.path, opencodeSaidQuery, src.id)
+	}
+	return ""
+}
+
+// lastSaidInTail walks a JSONL transcript's tail and keeps the last line say
+// reads a message out of. The tail is bounded for the reason the transcript
+// search bounds its own (searchTailBytes): a long conversation runs to tens of
+// megabytes of tool output, and this is re-read while the panel is open.
+//
+// Ceiling: a turn whose closing words fall outside that tail reads as no words
+// at all. It takes a single tool result larger than the bound to do it, and the
+// honest answer then is the empty one — the alternative is showing an older
+// turn's words under this turn's heading.
+func lastSaidInTail(path string, say func([]byte) (string, bool)) string {
+	if path == "" {
+		return ""
+	}
+	tail, ok := readTail(path, searchTailBytes)
+	if !ok {
+		return ""
+	}
+	var last string
+	for _, line := range strings.Split(string(tail), "\n") {
+		// A tail cut mid-line fails to parse like any malformed one, which is
+		// why nothing here distinguishes the two.
+		if text, ok := say([]byte(line)); ok {
+			last = text
+		}
+	}
+	return strings.TrimSpace(last)
+}
+
+// claudeSaid reads a Claude transcript line. Sidechain lines — a sub-agent's own
+// conversation — are skipped for the reason the transcript search skips them:
+// they are not the conversation the user had, so their last word is not the
+// session's.
+func claudeSaid(line []byte) (string, bool) {
+	var entry struct {
+		Type        string `json:"type"`
+		IsSidechain bool   `json:"isSidechain"`
+		Message     struct {
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(line, &entry); err != nil {
+		return "", false
+	}
+	if entry.Type != "assistant" || entry.IsSidechain {
+		return "", false
+	}
+	return joinText(entry.Message.Content)
+}
+
+// codexSaid reads a Codex rollout line: the assistant's own message items, whose
+// blocks are `output_text` rather than `text` (measured against a real rollout —
+// every assistant block in it was that one type).
+func codexSaid(line []byte) (string, bool) {
+	var entry struct {
+		Type    string `json:"type"`
+		Payload struct {
+			Type    string `json:"type"`
+			Role    string `json:"role"`
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"payload"`
+	}
+	if err := json.Unmarshal(line, &entry); err != nil {
+		return "", false
+	}
+	if entry.Type != "response_item" || entry.Payload.Type != "message" ||
+		entry.Payload.Role != "assistant" {
+		return "", false
+	}
+	var parts []string
+	for _, block := range entry.Payload.Content {
+		if block.Type == "output_text" && block.Text != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	if len(parts) == 0 {
+		return "", false
+	}
+	return strings.Join(parts, "\n"), true
+}
+
+// ompSaid reads an oh-my-pi transcript line. Its assistant turns are mostly
+// thinking plus a tool call — only the turn that ends the run carries a `text`
+// block, which is exactly the one wanted here.
+func ompSaid(line []byte) (string, bool) {
+	var entry struct {
+		Type    string `json:"type"`
+		Message struct {
+			Role    string `json:"role"`
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(line, &entry); err != nil {
+		return "", false
+	}
+	if entry.Type != "message" || entry.Message.Role != "assistant" {
+		return "", false
+	}
+	return joinText(entry.Message.Content)
+}
+
+// kiroSaid reads a Kiro CLI transcript line. Its envelope names the entry kind
+// in PascalCase and the blocks inside it in lower case, and a block's payload
+// sits under `data` rather than under a name of its own.
+func kiroSaid(line []byte) (string, bool) {
+	var entry struct {
+		Kind string `json:"kind"`
+		Data struct {
+			Content []struct {
+				Kind string `json:"kind"`
+				Data string `json:"data"`
+			} `json:"content"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(line, &entry); err != nil {
+		return "", false
+	}
+	if entry.Kind != "AssistantMessage" {
+		return "", false
+	}
+	var parts []string
+	for _, block := range entry.Data.Content {
+		if block.Kind == "text" && block.Data != "" {
+			parts = append(parts, block.Data)
+		}
+	}
+	if len(parts) == 0 {
+		return "", false
+	}
+	return strings.Join(parts, "\n"), true
+}
+
+// antigravitySaid reads an Antigravity transcript line. `PLANNER_RESPONSE` is
+// the model's own prose and its content is a bare string; the `GENERIC` entries
+// that outnumber it carry tool output — spinner frames and command results —
+// which is what a reader matching on `source: MODEL` alone would surface
+// instead (measured against a real 1.1.19 transcript).
+func antigravitySaid(line []byte) (string, bool) {
+	var entry struct {
+		Type    string `json:"type"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(line, &entry); err != nil {
+		return "", false
+	}
+	if entry.Type != "PLANNER_RESPONSE" || entry.Content == "" {
+		return "", false
+	}
+	return entry.Content, true
+}
+
+// joinText joins the text blocks of a message whose blocks name their type
+// `type` and their text `text` — the shape Claude Code and oh-my-pi share.
+// false when the message is all thinking and tool calls, which is every
+// assistant turn but the last of a run.
+func joinText(blocks []struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}) (string, bool) {
+	var parts []string
+	for _, block := range blocks {
+		if block.Type == "text" && block.Text != "" {
+			parts = append(parts, block.Text)
+		}
+	}
+	if len(parts) == 0 {
+		return "", false
+	}
+	return strings.Join(parts, "\n"), true
+}
+
+// opencodeSaidQuery is the newest text part of the newest assistant message in
+// one opencode conversation. opencode splits a message across `part` rows and
+// keeps the role on the `message` row, so the join is what tells an assistant's
+// own words from a tool result written beside them.
+//
+// Sub-agents are left out on purpose, where the cost query walks down into them:
+// opencode files each as a session of its own, and what a sub-agent said last is
+// not what the session said last.
+const opencodeSaidQuery = `SELECT p.data FROM part p JOIN message m ON m.id = p.message_id
+	WHERE p.session_id = ? AND json_extract(m.data, '$.role') = 'assistant'
+	AND json_extract(p.data, '$.type') = 'text'
+	ORDER BY p.time_created DESC LIMIT 1`
+
+// sessionDBSaid reads one conversation's closing words out of a provider's own
+// SQLite database. Read-only and opened per call, for the reasons sessionDBCost
+// gives: lich must never write into a database another tool owns.
+func sessionDBSaid(path, query, id string) string {
+	if id == "" {
+		return ""
+	}
+	if _, err := os.Stat(path); err != nil {
+		return ""
+	}
+	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=busy_timeout(%d)", path, sessionDBBusyMS)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = db.Close() }()
+
+	var data string
+	if err := db.QueryRow(query, id).Scan(&data); err != nil {
+		return ""
+	}
+	var part struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal([]byte(data), &part); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(part.Text)
+}
+
+// capRunes trims the middle out of an over-long answer, keeping two thirds of
+// the budget from the front and the rest from the back: the recap is the first
+// paragraph, and what a report ends on — a question, a list of what is left — is
+// worth keeping too. Counted in runes so a cut never lands inside a character.
+func capRunes(text string, cap int) string {
+	runes := []rune(text)
+	if len(runes) <= cap {
+		return text
+	}
+	head := cap * 2 / 3
+	tail := cap - head
+	return string(runes[:head]) + "\n\n[…]\n\n" + string(runes[len(runes)-tail:])
+}

--- a/internal/terminal/said_test.go
+++ b/internal/terminal/said_test.go
@@ -1,0 +1,286 @@
+// The suite reuses stubBins from terminal_test.go, which is Unix-tagged for its
+// PTY spawns; this file carries the same tag so the package still builds on
+// Windows. Nothing here is platform-specific.
+//go:build !windows
+
+package terminal
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/events"
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// TestLastTurnSaidReadsTheClaudeTranscript proves the whole read the panel rides
+// on: session id → recorded provider session → transcript → the closing words.
+func TestLastTurnSaidReadsTheClaudeTranscript(t *testing.T) {
+	body := strings.Join([]string{
+		`{"type":"user","message":{"content":"run the suite"}}`,
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"On it."}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash"}]}}`,
+		`{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"hmm"},{"type":"text","text":"Three failures in parser_test.go."}]}}`,
+	}, "\n") + "\n"
+	writeTranscript(t, "uuid-abc", body)
+	svc := New(stubBins{providerSession: "uuid-abc"}, nil, events.New())
+
+	got, err := svc.LastTurnSaid("s1")
+	if err != nil {
+		t.Fatalf("LastTurnSaid: %v", err)
+	}
+	if got.Text != "Three failures in parser_test.go." {
+		t.Errorf("LastTurnSaid = %q, want the last assistant text", got.Text)
+	}
+}
+
+// TestLastTurnSaidMissesAreSilent pins that every absence reads the same empty
+// answer rather than an error the panel would have to render: the feature is a
+// convenience beside the diff, and a session lich cannot read simply shows none.
+func TestLastTurnSaidMissesAreSilent(t *testing.T) {
+	writeTranscript(t, "uuid-abc", `{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}`+"\n")
+
+	tests := []struct {
+		name  string
+		store stubBins
+	}{
+		{"no provider session reported yet", stubBins{}},
+		{"the transcript does not exist", stubBins{providerSession: "uuid-nothing"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := New(tc.store, nil, events.New())
+			got, err := svc.LastTurnSaid("s1")
+			if err != nil {
+				t.Fatalf("LastTurnSaid: %v", err)
+			}
+			if got.Text != "" {
+				t.Errorf("LastTurnSaid = %q, want empty", got.Text)
+			}
+		})
+	}
+}
+
+// TestSaidReadersPickTheLastProse walks every JSONL format lich reads. Each case
+// carries the noise its provider actually writes — tool output, thinking, a
+// sub-agent — so a reader that matched too widely would fail here rather than in
+// front of a user.
+func TestSaidReadersPickTheLastProse(t *testing.T) {
+	tests := []struct {
+		name string
+		say  func([]byte) (string, bool)
+		body []string
+		want string
+	}{
+		{
+			name: "claude skips sub-agent conversations",
+			say:  claudeSaid,
+			body: []string{
+				`{"type":"assistant","message":{"content":[{"type":"text","text":"parent speaks"}]}}`,
+				`{"type":"assistant","isSidechain":true,"message":{"content":[{"type":"text","text":"sub-agent speaks"}]}}`,
+			},
+			want: "parent speaks",
+		},
+		{
+			name: "codex reads output_text off assistant items",
+			say:  codexSaid,
+			body: []string{
+				`{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"go"}]}}`,
+				`{"type":"response_item","payload":{"type":"reasoning","summary":[]}}`,
+				`{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"All green."}]}}`,
+				`{"type":"event_msg","payload":{"type":"token_count"}}`,
+			},
+			want: "All green.",
+		},
+		{
+			name: "omp ignores the turns that are only thinking and tools",
+			say:  ompSaid,
+			body: []string{
+				`{"type":"message","message":{"role":"assistant","content":[{"type":"thinking","thinking":"x"},{"type":"toolCall","name":"bash"}]}}`,
+				`{"type":"message","message":{"role":"assistant","content":[{"type":"thinking","thinking":"y"},{"type":"text","text":"Done, 12 files."}]}}`,
+				`{"type":"message","message":{"role":"toolResult","content":[{"type":"text","text":"exit 0"}]}}`,
+			},
+			want: "Done, 12 files.",
+		},
+		{
+			name: "kiro reads lower-case text blocks out of a PascalCase envelope",
+			say:  kiroSaid,
+			body: []string{
+				`{"kind":"Prompt","version":1,"data":{"content":[{"kind":"text","data":"make a note"}]}}`,
+				`{"kind":"AssistantMessage","version":1,"data":{"content":[{"kind":"thinking","data":"z"},{"kind":"text","data":"Created note.txt."},{"kind":"toolUse","data":""}]}}`,
+				`{"kind":"ToolResults","version":1,"data":{"content":[]}}`,
+			},
+			want: "Created note.txt.",
+		},
+		{
+			name: "antigravity takes PLANNER_RESPONSE, never the tool output beside it",
+			say:  antigravitySaid,
+			body: []string{
+				`{"type":"PLANNER_RESPONSE","source":"MODEL","content":"Opened the PR."}`,
+				`{"type":"GENERIC","source":"MODEL","content":"The command exited with code 1."}`,
+				`{"type":"PLANNER_RESPONSE","source":"MODEL","content":""}`,
+			},
+			want: "Opened the PR.",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "transcript.jsonl")
+			if err := os.WriteFile(path, []byte(strings.Join(tc.body, "\n")+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if got := lastSaidInTail(path, tc.say); got != tc.want {
+				t.Errorf("lastSaidInTail = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestLastSaidInTailSkipsAHalfLine pins that a tail cut mid-line — the ordinary
+// state of a bounded read — costs the cut line and nothing else.
+func TestLastSaidInTailSkipsAHalfLine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	body := `ontent":[{"type":"text","text":"cut in half"}]}}` + "\n" +
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"whole line"}]}}` + "\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := lastSaidInTail(path, claudeSaid); got != "whole line" {
+		t.Errorf("lastSaidInTail = %q, want the whole line", got)
+	}
+}
+
+// TestSaidForRoutesByProvider walks the dispatch itself: the same source struct
+// with a different kind must reach a reader that understands that provider's
+// format, and Kiro must reach the `.jsonl` rather than the `.json` its source
+// carries — the one arm that transforms the path it is given.
+func TestSaidForRoutesByProvider(t *testing.T) {
+	tests := []struct {
+		kind string
+		// name of the file to plant; the source's path is `file` unless the
+		// provider reads a different one beside it.
+		file string
+		path string
+		line string
+	}{
+		{
+			kind: providers.Claude, file: "t.jsonl", path: "t.jsonl",
+			line: `{"type":"assistant","message":{"content":[{"type":"text","text":"claude here"}]}}`,
+		},
+		{
+			kind: providers.Codex, file: "t.jsonl", path: "t.jsonl",
+			line: `{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"codex here"}]}}`,
+		},
+		{
+			kind: providers.OMP, file: "t.jsonl", path: "t.jsonl",
+			line: `{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"omp here"}]}}`,
+		},
+		{
+			kind: providers.Antigravity, file: "t.jsonl", path: "t.jsonl",
+			line: `{"type":"PLANNER_RESPONSE","source":"MODEL","content":"antigravity here"}`,
+		},
+		{
+			// The source carries the metadata file usage.go reads; the turns are
+			// in the transcript beside it.
+			kind: providers.Kiro, file: "t.jsonl", path: "t.json",
+			line: `{"kind":"AssistantMessage","version":1,"data":{"content":[{"kind":"text","data":"kiro here"}]}}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.kind, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, tc.file), []byte(tc.line+"\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			src := usageSource{kind: tc.kind, path: filepath.Join(dir, tc.path), id: "x"}
+			want := tc.kind + " here"
+			if got := saidFor(src); got != want {
+				t.Errorf("saidFor(%s) = %q, want %q", tc.kind, got, want)
+			}
+		})
+	}
+}
+
+// TestSaidForReadsTheOpenCodeDatabase covers the one provider whose conversation
+// is a database rather than a file, against the schema opencode writes: the role
+// lives on the message row and the text on a part row beside it, so the join is
+// what keeps a tool result from being read as the agent's own words.
+func TestSaidForReadsTheOpenCodeDatabase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "opencode.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stmts := []string{
+		`CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT)`,
+		`CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT)`,
+		`INSERT INTO message VALUES ('m1','ses_1',1,'{"role":"user"}')`,
+		`INSERT INTO message VALUES ('m2','ses_1',2,'{"role":"assistant"}')`,
+		`INSERT INTO part VALUES ('p1','m1','ses_1',1,'{"type":"text","text":"do it"}')`,
+		`INSERT INTO part VALUES ('p2','m2','ses_1',2,'{"type":"text","text":"earlier"}')`,
+		`INSERT INTO part VALUES ('p3','m2','ses_1',3,'{"type":"text","text":"Shipped."}')`,
+		`INSERT INTO part VALUES ('p4','m2','ses_1',4,'{"type":"tool","tool":"bash"}')`,
+		`INSERT INTO part VALUES ('p5','m2','ses_other',9,'{"type":"text","text":"another session"}')`,
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("%s: %v", stmt, err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	src := usageSource{kind: providers.OpenCode, path: path, id: "ses_1"}
+	if got := saidFor(src); got != "Shipped." {
+		t.Errorf("saidFor = %q, want the newest assistant text part", got)
+	}
+}
+
+// TestSaidForIsEmptyForProvidersWithNoLastTurn pins the deliberate gap: neither
+// Crush nor Cursor CLI reports a turn boundary, so neither is ever offered the
+// panel this feeds, and reading their stores would be answering a question
+// nobody can ask (docs/ceilings.md).
+func TestSaidForIsEmptyForProvidersWithNoLastTurn(t *testing.T) {
+	for _, kind := range []string{providers.Crush, providers.Cursor} {
+		if got := saidFor(usageSource{kind: kind, path: "/nope", id: "x"}); got != "" {
+			t.Errorf("saidFor(%s) = %q, want empty", kind, got)
+		}
+	}
+}
+
+// TestKiroTranscriptPathAnswersOnlyForItsMetadata pins that the swap is anchored
+// on the file kiroSessionPath resolves, so no other provider's path can be
+// turned into a Kiro transcript by suffix alone.
+func TestKiroTranscriptPathAnswersOnlyForItsMetadata(t *testing.T) {
+	if got := kiroTranscriptPath("/k/sessions/cli/abc.json"); got != "/k/sessions/cli/abc.jsonl" {
+		t.Errorf("kiroTranscriptPath = %q, want the .jsonl beside it", got)
+	}
+	if got := kiroTranscriptPath("/c/rollout-abc.jsonl"); got != "" {
+		t.Errorf("kiroTranscriptPath = %q, want empty for a non-metadata path", got)
+	}
+}
+
+// TestCapRunesKeepsBothEnds pins that an over-long answer loses its middle, not
+// its tail: what a report ends on — what is left, what it is blocked by — is
+// worth as much as the recap it opens with. Counted in runes, so the cut can
+// never land inside a character.
+func TestCapRunesKeepsBothEnds(t *testing.T) {
+	text := strings.Repeat("á", 100) + "TAIL"
+	got := capRunes(text, 30)
+	if !strings.HasPrefix(got, strings.Repeat("á", 20)) {
+		t.Errorf("capRunes lost the head: %q", got)
+	}
+	if !strings.HasSuffix(got, "TAIL") {
+		t.Errorf("capRunes lost the tail: %q", got)
+	}
+	if !strings.Contains(got, "[…]") {
+		t.Errorf("capRunes = %q, want the cut marked", got)
+	}
+	if short := capRunes("short", 30); short != "short" {
+		t.Errorf("capRunes cut a text under the cap: %q", short)
+	}
+}

--- a/internal/terminal/transcript.go
+++ b/internal/terminal/transcript.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/omartelo/lich/internal/providers"
 )
@@ -84,9 +85,9 @@ func codexTranscriptPath(providerSessionID string) (string, bool) {
 // honour here but the home itself.
 //
 // It is not a transcript: Antigravity files the conversation as SQLite and
-// writes its JSONL under `brain/<id>/`, a path the hook payload hands over
-// rather than one lich reconstructs. This resolves the one file whose existence
-// answers "can this id still be reopened".
+// writes its JSONL beside it under `brain/<id>/` (antigravityTranscriptPath).
+// This resolves the one file whose existence answers "can this id still be
+// reopened".
 func antigravityConversationPath(providerSessionID string) (string, bool) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -97,6 +98,40 @@ func antigravityConversationPath(providerSessionID string) (string, bool) {
 		return "", false
 	}
 	return path, true
+}
+
+// antigravityTranscriptPath locates the JSONL Antigravity writes a conversation
+// to, beside the SQLite file that proves the conversation exists.
+//
+// The directory under `brain/` is named after the conversation id itself, so the
+// path is reconstructed here rather than taken off a hook payload — measured
+// against 1.1.19, where every `conversations/<id>.db` had a `brain/<id>/` of its
+// own. `transcript_full.jsonl` sits next to it and is the same conversation with
+// nothing elided; the shorter file is the one read, for the same reason every
+// other provider's tail is bounded.
+func antigravityTranscriptPath(providerSessionID string) (string, bool) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", false
+	}
+	path := filepath.Join(home, ".gemini", "antigravity-cli", "brain", providerSessionID,
+		".system_generated", "logs", "transcript.jsonl")
+	if _, err := os.Stat(path); err != nil {
+		return "", false
+	}
+	return path, true
+}
+
+// kiroTranscriptPath is the conversation beside the metadata file
+// kiroSessionPath resolves: Kiro writes the turns to `<id>.jsonl` and the model
+// and context accounting to the `<id>.json` usage.go reads. Empty for anything
+// that is not that metadata path, so a caller can never turn some other
+// provider's file into a Kiro one by suffix alone.
+func kiroTranscriptPath(sessionPath string) string {
+	if !strings.HasSuffix(sessionPath, ".json") {
+		return ""
+	}
+	return strings.TrimSuffix(sessionPath, ".json") + ".jsonl"
 }
 
 // cursorChatStore is the database Cursor CLI keeps one chat in, under its own

--- a/internal/terminal/usage.go
+++ b/internal/terminal/usage.go
@@ -105,8 +105,8 @@ func (s *Service) sessionUsage(id string) (usageEvent, bool) {
 }
 
 // usageSource is where one conversation's records live: which provider wrote
-// them and the one file that holds them — a transcript for Claude Code, Codex
-// and oh-my-pi, a database for opencode and Crush.
+// them and the one file that holds them — a transcript for Claude Code, Codex,
+// oh-my-pi, Antigravity and Kiro CLI, a database for opencode and Crush.
 type usageSource struct {
 	kind string
 	path string
@@ -135,6 +135,9 @@ func usageSourceFor(providerSessionID, cwd string) (usageSource, bool) {
 	if path, ok := ompTranscriptPath(providerSessionID); ok {
 		return usageSource{kind: providers.OMP, path: path, id: providerSessionID}, true
 	}
+	if path, ok := antigravityTranscriptPath(providerSessionID); ok {
+		return usageSource{kind: providers.Antigravity, path: path, id: providerSessionID}, true
+	}
 	if path, ok := opencodeSessionDB(); ok &&
 		sessionRowExists(path, opencodeSessionTable, providerSessionID) {
 		return usageSource{kind: providers.OpenCode, path: path, id: providerSessionID}, true
@@ -153,8 +156,8 @@ func usageSourceFor(providerSessionID, cwd string) (usageSource, bool) {
 // occupies. supported is whether this provider records a window at all: only
 // Claude Code, Codex and Kiro CLI do, and for the rest a miss is the standing
 // state rather than a read that has not landed yet (docs/ceilings.md).
-// Antigravity and Cursor CLI never reach here — they file no transcript
-// usageSourceFor finds.
+// Antigravity reaches here — its transcript is located for the last-turn recap
+// (said.go) — and falls through with the rest; Cursor CLI never does.
 //
 // Kiro is the odd one of the three: it records the percentage and the window but
 // no token count, so its arm derives the tokens rather than reading them


### PR DESCRIPTION
The Review panel's **Last turn** mode answers what moved on disk. It has never answered what the session *did* — so coming back to a card still meant scrolling the terminal, and the turn most worth catching up on read as "Nothing changed in this window".

This adds the other half: the agent's own closing sentence for that turn, above the diff.

## The lazy part

No model call, no summariser, no step log, no new telemetry, no new hook contract. Every agent already ends a turn by saying what it did — lich only finds that sentence in the provider's transcript.

Routing rides `usageSourceFor`, which already located six providers for the cost readout, the two SQLite ones included. The readers are ~15 lines each.

## Providers

| Provider | Source | |
|---|---|---|
| Claude Code | `projects/*/<id>.jsonl` | ✅ |
| Codex | `rollout-*-<id>.jsonl`, `payload.role=assistant` | ✅ |
| oh-my-pi | `sessions/*/*_<id>.jsonl` | ✅ |
| Kiro CLI | the `.jsonl` beside the `.json` usage.go reads | ✅ |
| Antigravity | `brain/<id>/.system_generated/logs/transcript.jsonl` | ✅ |
| opencode | `opencode.db`, `part` ⋈ `message` | ✅ |
| Crush | `<cwd>/.crush/crush.db`, `messages.parts[].data.text` | mapped, not wired |
| Cursor CLI | content-addressed blobs + protobuf index + `blobEncryptionKey` | mapped, refused |

The two that are out are the two that report no turn boundary (`docs/hooks/session-state.md`), so neither is offered the "Last turn" mode this sits in — the existing ceiling already covers it, and the new bullet records where their stores are for whoever closes the gap.

## Two things the measurement corrected

- **Antigravity's transcript path is reconstructable.** `transcript.go` claimed the `brain/` path only ever arrived on a hook payload. It does not: the directory is named after the conversation id, and every `conversations/<id>.db` on this machine has a `brain/<id>/`. Comment fixed, path added, and Antigravity now resolves through `usageSourceFor` (no effect on cost or context — it falls through both, as before).
- **Its prose is `PLANNER_RESPONSE`, not `source: "MODEL"`.** The `MODEL` entries are mostly `GENERIC` — tool output, spinner frames included. A reader matching on source would have shown junk; the test pins it.

## Ceiling

One new bullet: the band and the diff answer to different clocks (mid-turn it shows the previous turn's words beside an "unavailable" diff, and only the card's spinner says why), the tail is bounded like the transcript search's, and the provider list is not the one the switch above it is drawn from.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` green — `internal/terminal` at 93.9%
- [x] `pnpm check` clean, `vitest run` green (1373), `vite build` ok — frontend at 96.7%
- [x] Cross-compile loop green for linux, darwin, windows
- [x] 9 new backend tests: one per transcript format with the noise each provider actually writes, the opencode join against a real schema, the Kiro `.json` → `.jsonl` hop, a half-line tail, and the rune cap
- [ ] Eyes on the band in a live session per provider

https://claude.ai/code/session_01XvL6pUGeAQRHZWRgkzBq4R
