### PR TITLE
feat: search what was said in every provider that files a transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The palette searches what was said in Codex, oh-my-pi, Kiro CLI and
+  Antigravity sessions too.** The `Messages` group read Claude Code conversations
+  and nothing else, so on any other provider the one thing you actually remember
+  — a sentence from the conversation — found nothing, with no sign that the
+  search had skipped the session. It now reads every provider that files its
+  conversation as a transcript: five of the eight, your turns and the agent's,
+  the same as before. opencode and Crush keep their messages in a database
+  instead and are still searched by name only; Cursor CLI files a chat in a form
+  nothing here can read. A session on one of those three simply contributes no
+  rows, which is what a session with nothing to match has always looked like.
+
 - **`lich open` and its MCP tool now open a project, not only a session in one.**
   `--project` took the name of a project already on screen, so an agent could
   fan work out across the projects you had open and no further: putting a
@@ -126,6 +137,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   setup script still installing the checkout. The Enter stays yours.
 
 ### Fixed
+
+- **The Kiro CLI recap band was empty whenever the agent thought before it
+  spoke.** "Last turn" reads the closing words out of the provider's own
+  transcript, and Kiro types each block of a message differently — a `text` block
+  carries a string, a `thinking` block an object. Reading them all as strings
+  failed the whole line, so any turn that reasoned first — nearly every one —
+  read as a turn that said nothing, and the band did not appear.
 
 - **On Windows, an answer that named no ticket could close the wrong request.**
   `lich reply "<answer>"` and `reply_to_session` without a ticket close the

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -203,7 +203,9 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   call looks like. And its provider list is *not* the one the switch above it is drawn from: six of the
   eight are read (Claude Code, Codex, Antigravity, opencode, oh-my-pi, Kiro CLI), and the two that are not
   are the two with no last turn to begin with, so the gap is invisible today and would surface the moment
-  Crush or Cursor CLI started reporting a state. Crush is a query away — its `parts` column carries the
+  Crush or Cursor CLI started reporting a state. Kiro CLI was on that list and silent in practice until the
+  palette's search reused the same reader: its block payloads are typed per block kind, and declaring one as
+  a string failed every line where the agent thought before it spoke — which is nearly all of them. Crush is a query away — its `parts` column carries the
   same `{type,text}` shape opencode's does — and Cursor CLI is not: it files a chat as content-addressed
   blobs ordered by a protobuf index, with a `blobEncryptionKey` sitting in its own metadata.
 - **A finished turn is unread until its own card is watched** (`frontend/src/lib/session/session-status-store.ts`,
@@ -694,10 +696,19 @@ work when nobody knows it and that the call site never shows. The mechanism and 
 - **The History tab searches names, never what was said** (`internal/terminal/search.go`): the Messages tab
   reads a 4 MB tail per session per keystroke, and it is pointed at the sessions the palette can route to —
   the open ones. History is the long list, so widening the transcript search to it would put a hundred disk
-  reads behind every character typed. The parked row keeps its `provider_session_id`, so the transcript is
-  still there to be searched by whatever does it later; and that search is Claude-only today
-  (`claudeTranscriptPath`) while `canResume` locates all six providers, so widening it would inherit that gap
-  rather than close it.
+  reads behind every character typed, on a machine that can hold hundreds of transcripts and a single one
+  of 169 MB. The parked row keeps its `provider_session_id`, so the transcript is still there to be searched
+  by whatever does it later; the fix when it bites is a query, not a bigger tail.
+- **The Messages tab reads five of the eight providers, and the three it misses are the ones with no
+  transcript to walk** (`transcriptReaderFor`, `internal/terminal/said.go`): the search and the last-turn
+  recap share one reader per provider, so both reach Claude Code, Codex, oh-my-pi, Kiro CLI and Antigravity —
+  every provider that files its conversation as JSONL. opencode keeps its messages in SQLite and is a `LIKE`
+  away, but a `LIKE` is a second mechanism (a query that counts and windows its own snippet) rather than a
+  sixth reader, and it is unwritten until somebody asks for it; Crush is the same query against its `parts`
+  column. Cursor CLI is the one that is not a query: it files a chat as content-addressed blobs ordered by a
+  protobuf index, with a `blobEncryptionKey` in its own metadata. A session on any of the three contributes
+  no rows and says nothing about it — the group simply does not list it, which is what every other miss in
+  that search looks like too.
 - **A filed backend answer outlives the screen that asked, under a key its caller writes by hand**
   (`frontend/src/lib/remote-cache.ts`): a `useRemoteResource` caller that passes `cache` has its answers kept
   in module memory until the page reloads, under exactly the string it composed. Two callers that compose the

--- a/internal/terminal/said.go
+++ b/internal/terminal/said.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/omartelo/lich/internal/providers"
@@ -23,6 +24,36 @@ const saidRuneCap = 4000
 // nothing either way and a reason it cannot act on is a reason not worth wiring.
 type LastSaid struct {
 	Text string `json:"text,omitempty"`
+}
+
+// The two sides of a conversation, spelled the way Claude Code's transcript
+// spells them. Every other provider's spelling is mapped onto these by its own
+// reader, so a caller filters on one vocabulary rather than five.
+const (
+	roleUser      = "user"
+	roleAssistant = "assistant"
+)
+
+// turn is one message of a conversation, read out of whatever shape its provider
+// files: who said it, and what they said as plain text. It carries no timestamp
+// and no id — a reader walks a transcript in order, so position is what dates a
+// turn, and the two callers here (the last-turn recap, the palette's transcript
+// search) both want the words and nothing else.
+type turn struct {
+	role string
+	text string
+}
+
+// turnReader reads one line of a provider's JSONL transcript. false for every
+// line that is not a message the user or the agent wrote — tool calls and their
+// results, thinking, meta lines, and a line the tail cut in half.
+type turnReader func(line []byte) (turn, bool)
+
+// textBlock is the shape Claude Code, Codex and oh-my-pi share for one block of
+// a message: a type naming what the block is, and the text when it is prose.
+type textBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
 }
 
 // LastTurnSaid returns the last thing the agent said in this session's
@@ -54,39 +85,58 @@ func (s *Service) LastTurnSaid(id string) (LastSaid, error) {
 	return LastSaid{Text: capRunes(saidFor(src), saidRuneCap)}, nil
 }
 
+// transcriptReaderFor pairs a conversation's JSONL transcript with the reader
+// that parses its lines. It is the whole of what lich knows about reading a
+// provider's conversation, and both readers of one go through it: the last-turn
+// recap below, and the palette's transcript search (search.go).
+//
+// false for the two providers with no JSONL to walk. opencode keeps its messages
+// in SQLite, which each caller queries for what it needs; Cursor CLI files a
+// chat as a content-addressed blob store whose order lives in a protobuf index,
+// so nothing here reaches it at all (docs/ceilings.md).
+func transcriptReaderFor(src usageSource) (string, turnReader, bool) {
+	switch src.kind {
+	case providers.Claude:
+		return src.path, claudeTurn, true
+	case providers.Codex:
+		return src.path, codexTurn, true
+	case providers.OMP:
+		return src.path, ompTurn, true
+	case providers.Kiro:
+		// usageSourceFor resolves the metadata `.json` the context readout
+		// needs; the turns are in the `.jsonl` beside it.
+		return kiroTranscriptPath(src.path), kiroTurn, true
+	case providers.Antigravity:
+		return src.path, antigravityTurn, true
+	}
+	return "", nil, false
+}
+
 // saidFor reads one conversation's closing words out of whatever the provider
 // files them in. Empty for every miss, and for the two providers that reach here
 // with nothing to read — Cursor CLI files its chat as a content-addressed blob
 // store, and neither it nor Crush reports a turn boundary, so neither is ever
 // offered the panel this feeds (docs/ceilings.md).
 func saidFor(src usageSource) string {
-	switch src.kind {
-	case providers.Claude:
-		return lastSaidInTail(src.path, claudeSaid)
-	case providers.Codex:
-		return lastSaidInTail(src.path, codexSaid)
-	case providers.OMP:
-		return lastSaidInTail(src.path, ompSaid)
-	case providers.Kiro:
-		return lastSaidInTail(kiroTranscriptPath(src.path), kiroSaid)
-	case providers.Antigravity:
-		return lastSaidInTail(src.path, antigravitySaid)
-	case providers.OpenCode:
+	if path, read, ok := transcriptReaderFor(src); ok {
+		return lastSaidInTail(path, read)
+	}
+	if src.kind == providers.OpenCode {
 		return sessionDBSaid(src.path, opencodeSaidQuery, src.id)
 	}
 	return ""
 }
 
-// lastSaidInTail walks a JSONL transcript's tail and keeps the last line say
-// reads a message out of. The tail is bounded for the reason the transcript
-// search bounds its own (searchTailBytes): a long conversation runs to tens of
+// lastSaidInTail walks a JSONL transcript's tail and keeps the last thing the
+// agent said in it. The tail is bounded for the reason the transcript search
+// bounds its own (searchTailBytes): a long conversation runs to tens of
 // megabytes of tool output, and this is re-read while the panel is open.
 //
 // Ceiling: a turn whose closing words fall outside that tail reads as no words
 // at all. It takes a single tool result larger than the bound to do it, and the
 // honest answer then is the empty one — the alternative is showing an older
 // turn's words under this turn's heading.
-func lastSaidInTail(path string, say func([]byte) (string, bool)) string {
+func lastSaidInTail(path string, read turnReader) string {
 	if path == "" {
 		return ""
 	}
@@ -98,155 +148,173 @@ func lastSaidInTail(path string, say func([]byte) (string, bool)) string {
 	for _, line := range strings.Split(string(tail), "\n") {
 		// A tail cut mid-line fails to parse like any malformed one, which is
 		// why nothing here distinguishes the two.
-		if text, ok := say([]byte(line)); ok {
-			last = text
+		if t, ok := read([]byte(line)); ok && t.role == roleAssistant {
+			last = t.text
 		}
 	}
 	return strings.TrimSpace(last)
 }
 
-// claudeSaid reads a Claude transcript line. Sidechain lines — a sub-agent's own
-// conversation — are skipped for the reason the transcript search skips them:
-// they are not the conversation the user had, so their last word is not the
-// session's.
-func claudeSaid(line []byte) (string, bool) {
+// claudeTurn reads a Claude transcript line. Sidechain lines — a sub-agent's own
+// conversation — are skipped because they are not the conversation the user had:
+// their last word is not the session's, and a search hit in one points at a
+// message the session never showed.
+func claudeTurn(line []byte) (turn, bool) {
 	var entry struct {
 		Type        string `json:"type"`
 		IsSidechain bool   `json:"isSidechain"`
 		Message     struct {
-			Content []struct {
-				Type string `json:"type"`
-				Text string `json:"text"`
-			} `json:"content"`
+			Content json.RawMessage `json:"content"`
 		} `json:"message"`
 	}
 	if err := json.Unmarshal(line, &entry); err != nil {
-		return "", false
+		return turn{}, false
 	}
-	if entry.Type != "assistant" || entry.IsSidechain {
-		return "", false
+	if entry.IsSidechain || (entry.Type != roleUser && entry.Type != roleAssistant) {
+		return turn{}, false
 	}
-	return joinText(entry.Message.Content)
+	// A user turn is usually a bare string; an assistant turn is always a block
+	// list, and so is a user turn carrying tool results.
+	var plain string
+	if err := json.Unmarshal(entry.Message.Content, &plain); err == nil {
+		return turn{role: entry.Type, text: plain}, plain != ""
+	}
+	var blocks []textBlock
+	if err := json.Unmarshal(entry.Message.Content, &blocks); err != nil {
+		return turn{}, false
+	}
+	text, ok := joinText(blocks, "text")
+	return turn{role: entry.Type, text: text}, ok
 }
 
-// codexSaid reads a Codex rollout line: the assistant's own message items, whose
-// blocks are `output_text` rather than `text` (measured against a real rollout —
-// every assistant block in it was that one type).
-func codexSaid(line []byte) (string, bool) {
+// codexTurn reads a Codex rollout line. The two sides name their blocks
+// differently — the agent writes `output_text` and the user's turn arrives as
+// `input_text` — and both are taken here, because the reader that only knew one
+// would be blind to half the conversation.
+//
+// The `developer` role is left out on purpose: Codex files the system prompt and
+// the skills preamble under it, which is not something anybody said (measured
+// against a real rollout).
+func codexTurn(line []byte) (turn, bool) {
 	var entry struct {
 		Type    string `json:"type"`
 		Payload struct {
-			Type    string `json:"type"`
-			Role    string `json:"role"`
-			Content []struct {
-				Type string `json:"type"`
-				Text string `json:"text"`
-			} `json:"content"`
+			Type    string      `json:"type"`
+			Role    string      `json:"role"`
+			Content []textBlock `json:"content"`
 		} `json:"payload"`
 	}
 	if err := json.Unmarshal(line, &entry); err != nil {
-		return "", false
+		return turn{}, false
 	}
+	role := entry.Payload.Role
 	if entry.Type != "response_item" || entry.Payload.Type != "message" ||
-		entry.Payload.Role != "assistant" {
-		return "", false
+		(role != roleUser && role != roleAssistant) {
+		return turn{}, false
 	}
-	var parts []string
-	for _, block := range entry.Payload.Content {
-		if block.Type == "output_text" && block.Text != "" {
-			parts = append(parts, block.Text)
-		}
-	}
-	if len(parts) == 0 {
-		return "", false
-	}
-	return strings.Join(parts, "\n"), true
+	text, ok := joinText(entry.Payload.Content, "output_text", "input_text")
+	return turn{role: role, text: text}, ok
 }
 
-// ompSaid reads an oh-my-pi transcript line. Its assistant turns are mostly
+// ompTurn reads an oh-my-pi transcript line. Its assistant turns are mostly
 // thinking plus a tool call — only the turn that ends the run carries a `text`
-// block, which is exactly the one wanted here.
-func ompSaid(line []byte) (string, bool) {
+// block. The role is on the message rather than on the envelope, and a tool
+// result arrives under a role of its own, so neither side is guessed here.
+func ompTurn(line []byte) (turn, bool) {
 	var entry struct {
 		Type    string `json:"type"`
 		Message struct {
-			Role    string `json:"role"`
-			Content []struct {
-				Type string `json:"type"`
-				Text string `json:"text"`
-			} `json:"content"`
+			Role    string      `json:"role"`
+			Content []textBlock `json:"content"`
 		} `json:"message"`
 	}
 	if err := json.Unmarshal(line, &entry); err != nil {
-		return "", false
+		return turn{}, false
 	}
-	if entry.Type != "message" || entry.Message.Role != "assistant" {
-		return "", false
+	role := entry.Message.Role
+	if entry.Type != "message" || (role != roleUser && role != roleAssistant) {
+		return turn{}, false
 	}
-	return joinText(entry.Message.Content)
+	text, ok := joinText(entry.Message.Content, "text")
+	return turn{role: role, text: text}, ok
 }
 
-// kiroSaid reads a Kiro CLI transcript line. Its envelope names the entry kind
+// kiroTurn reads a Kiro CLI transcript line. Its envelope names the entry kind
 // in PascalCase and the blocks inside it in lower case, and a block's payload
 // sits under `data` rather than under a name of its own.
-func kiroSaid(line []byte) (string, bool) {
+//
+// That payload is typed per block kind — a `text` block's is a string, and a
+// `thinking` block's is an object — so it is decoded per block rather than
+// declared as a string on the struct. Declaring it fails the whole line the
+// moment a turn thinks before it speaks, which is most of them: the text is
+// parsed and then thrown away with the error (measured against a real 2.21.0
+// transcript, where every assistant turn but the first carried both).
+func kiroTurn(line []byte) (turn, bool) {
 	var entry struct {
 		Kind string `json:"kind"`
 		Data struct {
 			Content []struct {
-				Kind string `json:"kind"`
-				Data string `json:"data"`
+				Kind string          `json:"kind"`
+				Data json.RawMessage `json:"data"`
 			} `json:"content"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(line, &entry); err != nil {
-		return "", false
+		return turn{}, false
 	}
-	if entry.Kind != "AssistantMessage" {
-		return "", false
+	var role string
+	switch entry.Kind {
+	case "AssistantMessage":
+		role = roleAssistant
+	case "Prompt":
+		role = roleUser
+	default:
+		return turn{}, false
 	}
 	var parts []string
 	for _, block := range entry.Data.Content {
-		if block.Kind == "text" && block.Data != "" {
-			parts = append(parts, block.Data)
+		var text string
+		if block.Kind != "text" || json.Unmarshal(block.Data, &text) != nil || text == "" {
+			continue
 		}
+		parts = append(parts, text)
 	}
 	if len(parts) == 0 {
-		return "", false
+		return turn{}, false
 	}
-	return strings.Join(parts, "\n"), true
+	return turn{role: role, text: strings.Join(parts, "\n")}, true
 }
 
-// antigravitySaid reads an Antigravity transcript line. `PLANNER_RESPONSE` is
-// the model's own prose and its content is a bare string; the `GENERIC` entries
-// that outnumber it carry tool output — spinner frames and command results —
-// which is what a reader matching on `source: MODEL` alone would surface
-// instead (measured against a real 1.1.19 transcript).
-func antigravitySaid(line []byte) (string, bool) {
+// antigravityTurn reads an Antigravity transcript line. `PLANNER_RESPONSE` is
+// the model's own prose and `USER_INPUT` the prompt it answered; both carry a
+// bare string. The `GENERIC` entries that outnumber them carry tool output —
+// spinner frames and command results — which is what a reader matching on
+// `source: MODEL` alone would surface instead (measured against a real 1.1.19
+// transcript).
+func antigravityTurn(line []byte) (turn, bool) {
 	var entry struct {
 		Type    string `json:"type"`
 		Content string `json:"content"`
 	}
-	if err := json.Unmarshal(line, &entry); err != nil {
-		return "", false
+	if err := json.Unmarshal(line, &entry); err != nil || entry.Content == "" {
+		return turn{}, false
 	}
-	if entry.Type != "PLANNER_RESPONSE" || entry.Content == "" {
-		return "", false
+	switch entry.Type {
+	case "PLANNER_RESPONSE":
+		return turn{role: roleAssistant, text: entry.Content}, true
+	case "USER_INPUT":
+		return turn{role: roleUser, text: entry.Content}, true
 	}
-	return entry.Content, true
+	return turn{}, false
 }
 
-// joinText joins the text blocks of a message whose blocks name their type
-// `type` and their text `text` — the shape Claude Code and oh-my-pi share.
-// false when the message is all thinking and tool calls, which is every
-// assistant turn but the last of a run.
-func joinText(blocks []struct {
-	Type string `json:"type"`
-	Text string `json:"text"`
-}) (string, bool) {
+// joinText joins the blocks of a message whose type is one of want. false when
+// the message holds none of them — an assistant turn that is all thinking and
+// tool calls, or a user turn that is a tool result.
+func joinText(blocks []textBlock, want ...string) (string, bool) {
 	var parts []string
 	for _, block := range blocks {
-		if block.Type == "text" && block.Text != "" {
+		if block.Text != "" && slices.Contains(want, block.Type) {
 			parts = append(parts, block.Text)
 		}
 	}

--- a/internal/terminal/said_test.go
+++ b/internal/terminal/said_test.go
@@ -71,13 +71,13 @@ func TestLastTurnSaidMissesAreSilent(t *testing.T) {
 func TestSaidReadersPickTheLastProse(t *testing.T) {
 	tests := []struct {
 		name string
-		say  func([]byte) (string, bool)
+		read turnReader
 		body []string
 		want string
 	}{
 		{
 			name: "claude skips sub-agent conversations",
-			say:  claudeSaid,
+			read: claudeTurn,
 			body: []string{
 				`{"type":"assistant","message":{"content":[{"type":"text","text":"parent speaks"}]}}`,
 				`{"type":"assistant","isSidechain":true,"message":{"content":[{"type":"text","text":"sub-agent speaks"}]}}`,
@@ -86,7 +86,7 @@ func TestSaidReadersPickTheLastProse(t *testing.T) {
 		},
 		{
 			name: "codex reads output_text off assistant items",
-			say:  codexSaid,
+			read: codexTurn,
 			body: []string{
 				`{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"go"}]}}`,
 				`{"type":"response_item","payload":{"type":"reasoning","summary":[]}}`,
@@ -97,7 +97,7 @@ func TestSaidReadersPickTheLastProse(t *testing.T) {
 		},
 		{
 			name: "omp ignores the turns that are only thinking and tools",
-			say:  ompSaid,
+			read: ompTurn,
 			body: []string{
 				`{"type":"message","message":{"role":"assistant","content":[{"type":"thinking","thinking":"x"},{"type":"toolCall","name":"bash"}]}}`,
 				`{"type":"message","message":{"role":"assistant","content":[{"type":"thinking","thinking":"y"},{"type":"text","text":"Done, 12 files."}]}}`,
@@ -106,18 +106,18 @@ func TestSaidReadersPickTheLastProse(t *testing.T) {
 			want: "Done, 12 files.",
 		},
 		{
-			name: "kiro reads lower-case text blocks out of a PascalCase envelope",
-			say:  kiroSaid,
+			name: "kiro reads text past the blocks whose payload is an object",
+			read: kiroTurn,
 			body: []string{
 				`{"kind":"Prompt","version":1,"data":{"content":[{"kind":"text","data":"make a note"}]}}`,
-				`{"kind":"AssistantMessage","version":1,"data":{"content":[{"kind":"thinking","data":"z"},{"kind":"text","data":"Created note.txt."},{"kind":"toolUse","data":""}]}}`,
+				`{"kind":"AssistantMessage","version":1,"data":{"content":[{"kind":"thinking","data":{"text":"z","signature":null}},{"kind":"text","data":"Created note.txt."},{"kind":"toolUse","data":{"name":"fs_write"}}]}}`,
 				`{"kind":"ToolResults","version":1,"data":{"content":[]}}`,
 			},
 			want: "Created note.txt.",
 		},
 		{
 			name: "antigravity takes PLANNER_RESPONSE, never the tool output beside it",
-			say:  antigravitySaid,
+			read: antigravityTurn,
 			body: []string{
 				`{"type":"PLANNER_RESPONSE","source":"MODEL","content":"Opened the PR."}`,
 				`{"type":"GENERIC","source":"MODEL","content":"The command exited with code 1."}`,
@@ -132,7 +132,7 @@ func TestSaidReadersPickTheLastProse(t *testing.T) {
 			if err := os.WriteFile(path, []byte(strings.Join(tc.body, "\n")+"\n"), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			if got := lastSaidInTail(path, tc.say); got != tc.want {
+			if got := lastSaidInTail(path, tc.read); got != tc.want {
 				t.Errorf("lastSaidInTail = %q, want %q", got, tc.want)
 			}
 		})
@@ -148,7 +148,7 @@ func TestLastSaidInTailSkipsAHalfLine(t *testing.T) {
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := lastSaidInTail(path, claudeSaid); got != "whole line" {
+	if got := lastSaidInTail(path, claudeTurn); got != "whole line" {
 		t.Errorf("lastSaidInTail = %q, want the whole line", got)
 	}
 }

--- a/internal/terminal/search.go
+++ b/internal/terminal/search.go
@@ -2,7 +2,6 @@ package terminal
 
 import (
 	"bytes"
-	"encoding/json"
 	"log/slog"
 	"strings"
 	"unicode"
@@ -47,8 +46,9 @@ type TranscriptMatch struct {
 // `/clear` is in a transcript this does not reach.
 //
 // Every miss is silent and simply contributes no match — a session with no
-// provider id yet (a shell, or a provider that reports none), a transcript that
-// is gone, a half-written line.
+// provider id yet (a shell, or a provider that reports none), a provider whose
+// conversation lich cannot walk (transcriptReaderFor), a transcript that is
+// gone, a half-written line.
 func (s *Service) SearchTranscripts(ids []string, query string) []TranscriptMatch {
 	q := strings.ToLower(strings.TrimSpace(query))
 	if utf8.RuneCountInString(q) < minSearchQuery {
@@ -64,7 +64,11 @@ func (s *Service) SearchTranscripts(ids []string, query string) []TranscriptMatc
 		if providerSessionID == "" {
 			continue
 		}
-		path, ok := claudeTranscriptPath(providerSessionID)
+		src, ok := usageSourceFor(providerSessionID, s.spawnOf(id).cwd)
+		if !ok {
+			continue
+		}
+		path, read, ok := transcriptReaderFor(src)
 		if !ok {
 			continue
 		}
@@ -72,7 +76,7 @@ func (s *Service) SearchTranscripts(ids []string, query string) []TranscriptMatc
 		if !ok {
 			continue
 		}
-		match, ok := searchTranscript(tail, q)
+		match, ok := searchTranscript(tail, q, read)
 		if !ok {
 			continue
 		}
@@ -84,23 +88,25 @@ func (s *Service) SearchTranscripts(ids []string, query string) []TranscriptMatc
 
 // searchTranscript counts the messages in a transcript tail that mention q
 // (already lowercased and non-empty) and keeps the newest one as the snippet —
-// what a session is saying about the query now is what identifies it.
+// what a session is saying about the query now is what identifies it. read is
+// the provider's own line reader (said.go), which is the only part of this that
+// differs from one provider to the next.
 //
 // The cheap bytes check first is what makes the scan affordable: only a line
 // that could match is parsed, so a transcript full of tool output is walked
 // without unmarshalling any of it.
-func searchTranscript(tail []byte, q string) (TranscriptMatch, bool) {
+func searchTranscript(tail []byte, q string, read turnReader) (TranscriptMatch, bool) {
 	needle := []byte(q)
 	var match TranscriptMatch
 	for line := range bytes.SplitSeq(tail, []byte("\n")) {
 		if !bytes.Contains(bytes.ToLower(line), needle) {
 			continue
 		}
-		text, ok := transcriptText(line)
+		t, ok := read(line)
 		if !ok {
 			continue
 		}
-		snippet, ok := snippetAround(text, q)
+		snippet, ok := snippetAround(t.text, q)
 		if !ok {
 			// The query is somewhere in the JSON but not in what was said — a
 			// tool's arguments, a file path, an id. Not a message about it.
@@ -110,51 +116,6 @@ func searchTranscript(tail []byte, q string) (TranscriptMatch, bool) {
 		match.Count++
 	}
 	return match, match.Count > 0
-}
-
-// transcriptText is what a transcript line actually says: the text of a user or
-// assistant message, blocks joined. false for everything else, which is most of
-// a transcript — tool calls and their results, meta lines, and a line the tail
-// cut in half.
-//
-// Sidechain lines (a Task sub-agent's own conversation) are left out for the
-// same reason the context readout skips them: they are not the conversation the
-// user had, and a search that surfaces them points at a message the session
-// never showed.
-func transcriptText(line []byte) (string, bool) {
-	var entry struct {
-		Type        string `json:"type"`
-		IsSidechain bool   `json:"isSidechain"`
-		Message     struct {
-			Content json.RawMessage `json:"content"`
-		} `json:"message"`
-	}
-	if err := json.Unmarshal(line, &entry); err != nil {
-		return "", false
-	}
-	if entry.IsSidechain || (entry.Type != "user" && entry.Type != "assistant") {
-		return "", false
-	}
-	// A user turn is usually a bare string; an assistant turn is always a block
-	// list, and so is a user turn carrying tool results.
-	var plain string
-	if err := json.Unmarshal(entry.Message.Content, &plain); err == nil {
-		return plain, plain != ""
-	}
-	var blocks []struct {
-		Type string `json:"type"`
-		Text string `json:"text"`
-	}
-	if err := json.Unmarshal(entry.Message.Content, &blocks); err != nil {
-		return "", false
-	}
-	parts := make([]string, 0, len(blocks))
-	for _, block := range blocks {
-		if block.Type == "text" && block.Text != "" {
-			parts = append(parts, block.Text)
-		}
-	}
-	return strings.Join(parts, " "), len(parts) > 0
 }
 
 // snippetAround renders the stretch of text around the first mention of q as

--- a/internal/terminal/search_e2e_test.go
+++ b/internal/terminal/search_e2e_test.go
@@ -78,6 +78,49 @@ func TestSearchTranscriptsWalksEverySession(t *testing.T) {
 	}
 }
 
+// TestSearchTranscriptsFindsANonClaudeSession proves the chain a search rides for
+// a provider that is not Claude Code: the id resolves to no Claude
+// transcript, usageSourceFor finds the Codex rollout filed under it instead, and
+// the rollout's own block names are read. Planting both stores at once is the
+// point — the search asks the disk which provider ran a conversation, exactly as
+// the cost and context readouts do.
+func TestSearchTranscriptsFindsANonClaudeSession(t *testing.T) {
+	plantTranscripts(t, map[string]string{"uuid-claude": userLine("a claude worktree turn") + "\n"})
+	plantCodexRollout(t, "uuid-codex",
+		`{"type":"response_item","payload":{"type":"message","role":"assistant",`+
+			`"content":[{"type":"output_text","text":"The worktree port is a hash."}]}}`+"\n")
+	store := searchStore{providerSessions: map[string]string{
+		"s-claude": "uuid-claude",
+		"s-codex":  "uuid-codex",
+	}}
+	svc := New(store, nil, events.New())
+
+	got := svc.SearchTranscripts([]string{"s-claude", "s-codex"}, "worktree")
+	want := []TranscriptMatch{
+		{ID: "s-claude", Snippet: "a claude worktree turn", Count: 1},
+		{ID: "s-codex", Snippet: "The worktree port is a hash.", Count: 1},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("SearchTranscripts = %+v, want %+v", got, want)
+	}
+}
+
+// plantCodexRollout writes one rollout under a throwaway CODEX_HOME, in the
+// dated directory Codex files them in.
+func plantCodexRollout(t *testing.T, providerSessionID, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	sessions := filepath.Join(dir, "sessions", "2026", "09", "05")
+	if err := os.MkdirAll(sessions, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(sessions, "rollout-2026-09-05T10-00-00-"+providerSessionID+".jsonl")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CODEX_HOME", dir)
+}
+
 // TestSnippetAroundSurvivesGrowingCaseFolding pins the offset contract of the
 // snippet: lowercasing "Ⱥ" yields a longer rune, so a match offset taken from a
 // lowered copy runs past the end of the text it is meant to index.

--- a/internal/terminal/search_test.go
+++ b/internal/terminal/search_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"unicode/utf8"
+
+	"github.com/omartelo/lich/internal/providers"
 )
 
 // userLine and assistantText build the two transcript shapes a search reads: a
@@ -100,7 +102,7 @@ func TestSearchTranscript(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			match, ok := searchTranscript([]byte(test.tail), test.query)
+			match, ok := searchTranscript([]byte(test.tail), test.query, claudeTurn)
 			if ok != test.wantOK {
 				t.Fatalf("ok = %v, want %v", ok, test.wantOK)
 			}
@@ -175,6 +177,92 @@ func TestSearchTranscriptsRejectsAShortQuery(t *testing.T) {
 	for _, query := range []string{"", "  ", "wo", " w "} {
 		if got := s.SearchTranscripts([]string{"session"}, query); got != nil {
 			t.Errorf("query %q returned %v, want nil", query, got)
+		}
+	}
+}
+
+// TestSearchTranscriptReadsEveryProviderFormat walks the formats a search now
+// reaches. Each case carries both sides of one exchange plus the noise its
+// provider writes around them, because a search is asked from either side: the
+// words somebody remembers are as often their own prompt as the agent's answer.
+func TestSearchTranscriptReadsEveryProviderFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		read turnReader
+		body []string
+		want int
+	}{
+		{
+			name: "codex takes both block names and leaves the system prompt out",
+			read: codexTurn,
+			body: []string{
+				`{"type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"You are Codex. Never mention the worktree."}]}}`,
+				`{"type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"port the worktree hash"}]}}`,
+				`{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"The worktree port is a hash."}]}}`,
+				`{"type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\"command\":\"grep worktree\"}"}}`,
+			},
+			want: 2,
+		},
+		{
+			name: "omp skips the thinking and the tool result around the prose",
+			read: ompTurn,
+			body: []string{
+				`{"type":"message","message":{"role":"user","content":[{"type":"text","text":"where is the worktree port kept"}]}}`,
+				`{"type":"message","message":{"role":"assistant","content":[{"type":"thinking","thinking":"the worktree port"},{"type":"toolCall","name":"bash"}]}}`,
+				`{"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"In the worktree_ports table."}]}}`,
+				`{"type":"message","message":{"role":"toolResult","content":[{"type":"text","text":"worktreeport.go:1"}]}}`,
+			},
+			want: 2,
+		},
+		{
+			name: "kiro reads a prompt and an answer that thought first",
+			read: kiroTurn,
+			body: []string{
+				`{"kind":"Prompt","version":1,"data":{"content":[{"kind":"text","data":"explain the worktree port"}]}}`,
+				`{"kind":"AssistantMessage","version":1,"data":{"content":[{"kind":"thinking","data":{"text":"x"}},{"kind":"text","data":"It hashes the worktree path."}]}}`,
+				`{"kind":"ToolResults","version":1,"data":{"content":[]}}`,
+			},
+			want: 2,
+		},
+		{
+			name: "antigravity leaves the tool output beside the prose alone",
+			read: antigravityTurn,
+			body: []string{
+				`{"type":"USER_INPUT","source":"USER_EXPLICIT","content":"<USER_REQUEST>\nfix the worktree port\n</USER_REQUEST>"}`,
+				`{"type":"PLANNER_RESPONSE","source":"MODEL","content":"Fixed the worktree port."}`,
+				`{"type":"GENERIC","source":"MODEL","content":"grep worktree: 3 matches"}`,
+			},
+			want: 2,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			match, ok := searchTranscript([]byte(strings.Join(tc.body, "\n")+"\n"), "worktree", tc.read)
+			if !ok {
+				t.Fatal("no match")
+			}
+			if match.Count != tc.want {
+				t.Errorf("count = %d, want %d (snippet %q)", match.Count, tc.want, match.Snippet)
+			}
+		})
+	}
+}
+
+// TestTranscriptReaderForNamesTheProvidersWithAJSONL pins which providers the
+// two transcript readers reach, and which are deliberately out. The gap is the
+// one docs/ceilings.md carries: opencode files its messages in SQLite and Cursor
+// CLI in a blob store, so neither has a line for a reader to walk.
+func TestTranscriptReaderForNamesTheProvidersWithAJSONL(t *testing.T) {
+	for _, kind := range []string{
+		providers.Claude, providers.Codex, providers.OMP, providers.Kiro, providers.Antigravity,
+	} {
+		if _, read, ok := transcriptReaderFor(usageSource{kind: kind, path: "/t.json"}); !ok || read == nil {
+			t.Errorf("transcriptReaderFor(%s) has no reader", kind)
+		}
+	}
+	for _, kind := range []string{providers.OpenCode, providers.Crush, providers.Cursor, "shell"} {
+		if _, _, ok := transcriptReaderFor(usageSource{kind: kind, path: "/t.db"}); ok {
+			t.Errorf("transcriptReaderFor(%s) claims a transcript it cannot walk", kind)
 		}
 	}
 }


### PR DESCRIPTION
## What

The palette's `Messages` group read Claude Code conversations and nothing else. On any other provider the one thing a user actually remembers — a sentence from the conversation — found nothing, and nothing said the search had skipped the session.

It now reads every provider that files its conversation as a JSONL transcript: **Claude Code, Codex, oh-my-pi, Kiro CLI and Antigravity**, both sides of the conversation, as before.

## How

#455 already built one reader per provider for the last-turn recap — the missing half was on disk, the readers just only answered "what did the agent say last". They return the turn's role alongside its text now: the recap filters on `assistant`, the search takes both. `SearchTranscripts` resolves its store through `usageSourceFor` (the resolver the cost and context readouts already ask) and walks the tail with `transcriptReaderFor`'s reader.

No new mechanism, no index, no second copy of any parser. `transcriptText` is gone, folded into `claudeTurn`.

## What stays out, and why

`docs/ceilings.md` carries this:

- **opencode** and **Crush** keep their messages in SQLite. That is a `LIKE` — a query that counts and windows its own snippet — not a sixth reader, and it is unwritten until somebody asks.
- **Cursor CLI** files a chat as content-addressed blobs ordered by a protobuf index, with a `blobEncryptionKey` in its own metadata.

A session on one of the three contributes no rows, which is what every other miss in that search already looks like.

## Bug this turned up

Reusing the readers found one. Kiro types each block of a message per kind — a `text` block's payload is a string, a `thinking` block's is an object — and the recap declared it a string, so `json.Unmarshal` failed the **whole line** for every turn that thought before it spoke. Nearly all of them: the Kiro "Last turn" band was silently empty in practice. Decoded per block kind now, and the fixture carries the shape a real 2.21.0 transcript writes rather than the string it was written against.

Both new Kiro tests were confirmed to fail against the old reader (`lastSaidInTail = ""`, search count 1 instead of 2).

## Test plan

- [x] `go test ./...` green; `gofmt -l .` and `go vet ./...` clean
- [x] `biome check`, `tsc`, `vitest run` (1373 tests) green — no frontend change was needed, the UI already exists
- [x] Cross-compile loop (`linux`/`darwin`/`windows` build + vet)
- [x] New: one search case per transcript format, carrying the noise each provider really writes (Codex's `developer` system prompt, omp's thinking-only turns, Kiro's object payloads, Antigravity's `GENERIC` tool output)
- [x] New: `transcriptReaderFor` pins which providers are in and which are deliberately out
- [x] New e2e: a Claude store and a Codex store planted side by side, proving the search asks the disk which provider ran a conversation

Formats were measured against the eight CLIs installed on this machine, not assumed.

https://claude.ai/code/session_01G5P7QckcRVKs3vHuTnucTm