### PR TITLE
Leave a prompt on a session for later

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   card with the error still on screen, and ↑ Enter is the retry. Absent on
   Windows, where the file's `sh` would be read by PowerShell.
 
+- **A prompt can now be left on a session for later.**
+  **Schedule a prompt…** on a card's menu takes what you want that session to do
+  and one of four times — 15 minutes, an hour, four hours, or tomorrow morning —
+  and types it at that prompt when the time comes, exactly as if you had typed it
+  yourself. It is the reminder that arrives as work: the release checklist at
+  nine, the rebase after the build, the thing you will not remember to ask for at
+  four. Each time button carries the wall clock it resolves to, so *Tomorrow*
+  never has to be taken on trust. The card counts down on its own line and the
+  tooltip holds the prompt and the day, so a session with something coming says
+  so before you open anything. A session holds one at a time — scheduling again
+  replaces it, and the same dialog is where you cancel. It works the same on
+  every provider, because delivering it is typing at a prompt, and a prompt that
+  comes due while that session is mid-setup, mid-sentence or without a terminal
+  waits for one rather than being dropped — including one that came due while
+  lich was closed, which lands when lich is next up.
+
 - **`lich open` and its MCP tool now open a project, not only a session in one.**
   `--project` took the name of a project already on screen, so an agent could
   fan work out across the projects you had open and no further: putting a

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -383,6 +383,16 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   a paste ends from timing alone. A target that repaints on a timer of its own never goes quiet and gets its Enter
   at `defaultSettleLimit` regardless, which is the case this cannot tell from a paste still arriving.
 
+- **A scheduled prompt is late or gone, never on time** (`internal/relay/later.go`, `deliverDue`): due prompts
+  are looked for every `scheduleTick`, and one whose session is not at a prompt — mid-setup, a draft on the
+  line, no terminal opened — is left parked for the next pass, so it lands whenever that session next has
+  somewhere to type, hours later if that is when. That covers lich having been closed at the time: the first
+  pass after launch types a prompt that came due days ago, unannounced. The other end of it is a session that
+  is closed rather than busy — a parked worktree card, a card closed for good. Its row leaves the roster
+  (`LoadState` reads open sessions only) and the resume reinserts it under a fresh id without the schedule, so
+  the prompt never fires and never comes back with the card, with nothing on screen having said it was
+  forfeited.
+
 - **An answer that names no ticket is matched by delivery order** (`internal/relay/relay.go`,
   `errandOfLocked`): `lich reply "<answer>"` and `reply_to_session` without a ticket close the oldest message
   delivered to that session and still open, because nothing in an answer itself says which request it belongs to.

--- a/frontend/src/components/render-budget.test.tsx
+++ b/frontend/src/components/render-budget.test.tsx
@@ -160,6 +160,7 @@ const workspace: ProjectsValue = {
   activateSession: noop,
   renameSession: noop,
   setEntrypoint: noop,
+  scheduleSession: noop,
   pinSession: noop,
   reorderProjects: noop,
   reorderSessions: noop,

--- a/frontend/src/components/sidebar/SchedulePromptDialog.tsx
+++ b/frontend/src/components/sidebar/SchedulePromptDialog.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Textarea } from "@/components/ui/textarea"
+import { clockAt, scheduleChoices, scheduledFor } from "@/lib/session/schedule"
+
+interface SchedulePromptDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** The card this lands in, named so the dialog can say where it will be typed. */
+  label: string
+  /** The prompt already parked on this session, "" when nothing is. */
+  prompt: string
+  /** When that one is due, in unix seconds; 0 when nothing is parked. */
+  at: number
+  onSchedule: (at: number, prompt: string) => void
+}
+
+// SchedulePromptDialog parks one prompt on a session for later. The time is the
+// submit: picking one schedules and closes, which is why there is no Save
+// button to reach past four choices that already say what they do.
+//
+// Each choice carries the wall clock it resolves to, so "Tomorrow" never has to
+// be taken on trust — and the times are resolved once per opening rather than
+// on a timer: they are a minute stale at worst, against shortcuts a quarter of
+// an hour apart at their closest.
+export function SchedulePromptDialog({
+  open,
+  onOpenChange,
+  label,
+  prompt,
+  at,
+  onSchedule,
+}: SchedulePromptDialogProps) {
+  const [value, setValue] = useState(prompt)
+  const [now, setNow] = useState(() => new Date())
+
+  // Reseeded on every open, like the entrypoint dialog: the component outlives
+  // one visit, and a session reopened after a cancel would otherwise hold the
+  // abandoned text and yesterday's clock.
+  useEffect(() => {
+    if (open) {
+      setValue(prompt)
+      setNow(new Date())
+    }
+  }, [open, prompt])
+
+  const commit = (when: number) => {
+    const next = value.trim()
+    if (!next) {
+      return
+    }
+    onOpenChange(false)
+    onSchedule(when, next)
+  }
+
+  const clear = () => {
+    onOpenChange(false)
+    onSchedule(0, "")
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Schedule a prompt</DialogTitle>
+          <DialogDescription>
+            Typed at <span className="font-medium text-foreground">{label}</span> when the time
+            comes, as if you had typed it yourself.
+          </DialogDescription>
+        </DialogHeader>
+        <Textarea
+          value={value}
+          onChange={(event) => setValue(event.target.value)}
+          placeholder="run the release checklist"
+          autoFocus
+          rows={3}
+          className="max-h-40"
+        />
+        <div className="grid grid-cols-4 gap-1.5">
+          {scheduleChoices(now).map((choice) => (
+            <Button
+              key={choice.label}
+              variant="secondary"
+              disabled={!value.trim()}
+              onClick={() => commit(choice.at)}
+              className="h-auto flex-col gap-0 py-1.5"
+            >
+              <span className="text-sm font-medium">{choice.label}</span>
+              <span className="text-xs font-normal tabular-nums text-muted-foreground">
+                {clockAt(choice.at)}
+              </span>
+            </Button>
+          ))}
+        </div>
+        {at > 0 && (
+          // Only the second visit draws this: it is both what is already parked
+          // and the only way to take it off, so a session with nothing waiting
+          // has no cancel to misread.
+          <DialogFooter className="items-center justify-between sm:justify-between">
+            <span className="text-xs text-muted-foreground">
+              Scheduled for {scheduledFor(at, now)}
+            </span>
+            <Button variant="ghost" size="sm" onClick={clear}>
+              Cancel it
+            </Button>
+          </DialogFooter>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -5,6 +5,7 @@ import {
   ArrowLeft,
   ArrowRight,
   CircleQuestionMark,
+  Clock,
   Copy,
   CornerDownLeft,
   FolderCode,
@@ -66,8 +67,10 @@ import { bracketedPaste } from "@/lib/terminal/bracketed-paste"
 import { requestTerminalFocus } from "@/lib/terminal/focus-request"
 import { useSessionIntent } from "@/lib/use-sidebar-intent"
 import { useProjects } from "@/providers/projects"
+import { timeUntil } from "@/lib/session/schedule"
 import { SessionTargetPicker } from "./SessionTargetPicker"
 import { EntrypointDialog } from "./EntrypointDialog"
+import { SchedulePromptDialog } from "./SchedulePromptDialog"
 
 interface SessionCardProps {
   session: Session
@@ -137,12 +140,13 @@ export function SessionCard({
   // Read here rather than threaded down as a prop: the `lich send` line names
   // the project only when another session shares this card's label, and that is
   // a question about every open project — not about the one this card sits in.
-  const { projects, sessions } = useProjects()
+  const { projects, sessions, scheduleSession } = useProjects()
   const pinned = !!session.pinned
   const pathRef = useRef<HTMLSpanElement>(null)
   const [pathOverflow, setPathOverflow] = useState(false)
   const [editing, setEditing] = useState(false)
   const [delegatePickerOpen, setDelegatePickerOpen] = useState(false)
+  const [scheduleOpen, setScheduleOpen] = useState(false)
   const [entrypointOpen, setEntrypointOpen] = useState(false)
   // Processing state reported by the lich Claude Code hook, drawn as a ring
   // around the provider icon: a spinning ring while Claude produces output,
@@ -178,6 +182,18 @@ export function SessionCard({
   // tasks it delegated, uncollected. Zero — the usual case — draws nothing.
   const inbox = useSessionInbox(session.id)
   const ToolGlyph = tool && toolGlyph(tool.name)
+  // The prompt parked on this card, and how far off it is. Read at render
+  // rather than counted down on a timer of its own: a card redraws often enough
+  // that "in 3h" is never wrong by anything a person reads, and a clock ticking
+  // per card would cost the sidebar a render a second to say the same thing.
+  // null once it is due, which is the state the rung words differently.
+  const scheduledAt = session.scheduledAt ?? 0
+  const scheduledIn = scheduledAt ? timeUntil(scheduledAt, new Date()) : null
+  const scheduleItem = !scheduledAt
+    ? "Schedule a prompt…"
+    : scheduledIn
+      ? `Scheduled ${scheduledIn}…`
+      : "Scheduled…"
   // The live working directory the backend's cwd watcher reports ("" until it
   // does): a `cd` in the terminal moves the card with it. Falls back to the
   // session's static start path — a worktree session lives in its own checkout,
@@ -403,9 +419,10 @@ export function SessionCard({
                   </span>
                 </span>
               )}
-              {/* One line, five rungs: an open request, then a session blocked
+              {/* One line, six rungs: an open request, then a session blocked
                   on the user, then results waiting to be collected, then the
-                  tool, then where the session came from. A request in flight
+                  tool, then a prompt scheduled for later, then where the session
+                  came from. A request in flight
                   explains the whole turn — a card working because another
                   session asked it to, or one stalled waiting on a card
                   elsewhere in the list. A block outranks the rest for the
@@ -418,7 +435,11 @@ export function SessionCard({
                   because it is never news: it says something that has been true
                   since the card was created, so it surfaces only once the card
                   is quiet, which is when somebody scanning the sidebar is
-                  working out where a card came from. Only one rung ever draws,
+                  working out where a card came from. A scheduled prompt sits
+                  just above it for half that reason: it is not what this session
+                  is doing, so it never takes the line from the turn — but it is
+                  the one rung about something that has not happened yet, and a
+                  quiet card is exactly where that is worth reading. Only one rung ever draws,
                   so the card grows by one row at most. */}
               {relay ? (
                 <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">
@@ -472,6 +493,21 @@ export function SessionCard({
                     <span className="min-w-0 shrink-[9999] truncate font-mono">
                       <span className="opacity-50">·</span> {tool.detail}
                     </span>
+                  )}
+                </span>
+              ) : scheduledAt ? (
+                <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">
+                  <Clock className="size-3 shrink-0" />
+                  {scheduledIn ? (
+                    <span className="truncate">
+                      Scheduled <span className="font-medium text-foreground">{scheduledIn}</span>
+                    </span>
+                  ) : (
+                    // Due and still here: the prompt is waiting on somewhere to
+                    // be typed — a setup script still running, a half-written
+                    // line at that prompt, a card whose terminal was never
+                    // opened — and it goes in the moment there is one.
+                    <span className="truncate">Waiting for a prompt</span>
                   )}
                 </span>
               ) : (
@@ -583,6 +619,15 @@ export function SessionCard({
               Delegate to session…
             </ContextMenuItem>
           )}
+          {/* Under delegation, because the two are the same move a beat apart:
+              hand this work to somebody else, or hand it to this session later.
+              One item either way — it names what is already parked rather than
+              growing a second one to cancel with, which is what the dialog is
+              for. */}
+          <ContextMenuItem onClick={() => setScheduleOpen(true)}>
+            <Clock />
+            {scheduleItem}
+          </ContextMenuItem>
           <ContextMenuItem onClick={copySendCommand}>
             <Copy />
             Copy send command
@@ -651,6 +696,19 @@ export function SessionCard({
           groups={delegateGroups}
           onPick={(target) => delegate(target.label)}
           onPickWorktree={delegateWorktree}
+        />
+      )}
+      {/* Mounted only while it is open, unlike the entrypoint dialog beside it:
+          this one is offered on every card, and a dialog per card is a render
+          per card the sidebar was not paying before (render-budget.test.tsx). */}
+      {scheduleOpen && (
+        <SchedulePromptDialog
+          open
+          onOpenChange={setScheduleOpen}
+          label={session.label}
+          prompt={session.scheduledPrompt ?? ""}
+          at={scheduledAt}
+          onSchedule={(at, prompt) => scheduleSession(session.id, at, prompt)}
         />
       )}
       {session.kind === "shell" && (

--- a/frontend/src/components/sidebar/SessionTooltip.tsx
+++ b/frontend/src/components/sidebar/SessionTooltip.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowLeft,
   ArrowRight,
+  Clock,
   GitBranch,
   GitPullRequestArrow,
   Play,
@@ -10,6 +11,7 @@ import {
 import type { Session } from "@/lib/session/sessions"
 import { useSessionCwd } from "@/lib/session/use-session-cwd"
 import { useSessionRelay } from "@/lib/session/use-session-relay"
+import { scheduledFor } from "@/lib/session/schedule"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { baseReadout } from "@/lib/git/base-status"
 import { usePullRequest } from "@/lib/pulls/use-pull-request"
@@ -78,6 +80,26 @@ export function SessionTooltip({ session, path }: SessionTooltipProps) {
                 {`lich reply ${relay.ticket} "…"`}
               </span>
             )}
+          </span>
+        )}
+        {/* The prompt parked on this session. The card counts down to it; the
+            day and the wording are here, because "in 2d" is not a time anyone
+            can plan around and the prompt itself is the part the user has to
+            recognise to know whether to leave it there. */}
+        {session.scheduledAt && (
+          <span className="flex flex-col gap-0.5">
+            <span className="flex items-center gap-1.5 text-muted-foreground">
+              <Clock className="size-3 shrink-0" />
+              <span>
+                Scheduled for{" "}
+                <span className="font-medium text-foreground">
+                  {scheduledFor(session.scheduledAt, new Date())}
+                </span>
+              </span>
+            </span>
+            <span className="line-clamp-2 text-muted-foreground italic">
+              {session.scheduledPrompt}
+            </span>
           </span>
         )}
         {/* The command this terminal opens into. The card's label already says

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import type * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "field-sizing-content flex min-h-16 w-full rounded-md border border-input bg-transparent px-2.5 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -312,6 +312,12 @@ export interface StoredSession {
   originSessionId: string
   /** What that session was called at the time; all that survives its close. */
   originLabel: string
+  /** When the prompt below is due, in unix seconds; 0 for a session with
+   * nothing waiting. One slot per session — scheduling again replaces it. */
+  scheduledAt: number
+  /** The prompt to type at this session when that time comes, as the user
+   * wrote it. Empty when nothing is scheduled. */
+  scheduledPrompt: string
 }
 
 /** internal/store.ClosedSession — one parked session offered for resuming. What

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -406,6 +406,11 @@ export const Store = {
    * shell. The store refuses it on anything but a shell session. */
   SetSessionEntrypoint: (sessionID: string, entrypoint: string) =>
     call<null>("store.SetSessionEntrypoint", [sessionID, entrypoint]),
+  /** Park a prompt to be typed at a session later, at unix second `at`. A 0
+   * time, or an empty prompt, clears whatever was parked — a session holds one
+   * scheduled prompt at a time, and scheduling again replaces it. */
+  SetSessionSchedule: (sessionID: string, at: number, prompt: string) =>
+    call<null>("store.SetSessionSchedule", [sessionID, at, prompt]),
   /** Whether this one session runs confined, overriding the provider's rung for
    * it alone: "on", "off", or "" to follow the setting. Read on every later
    * spawn, so a reload and a resume keep the answer the session opened with. */

--- a/frontend/src/lib/session/schedule.test.ts
+++ b/frontend/src/lib/session/schedule.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+import { clockAt, scheduleChoices, scheduledFor, timeUntil } from "./schedule"
+
+// A Wednesday afternoon, so "tomorrow" is a different weekday from "today" and
+// the two readouts cannot pass for each other.
+const NOW = new Date(2026, 8, 2, 14, 30, 0)
+const seconds = (date: Date) => Math.floor(date.getTime() / 1000)
+
+describe("scheduleChoices", () => {
+  it("offers the four times, each resolved against now", () => {
+    const choices = scheduleChoices(NOW)
+    expect(choices.map((c) => c.label)).toEqual(["15 min", "1 hour", "4 hours", "Tomorrow"])
+    expect(choices[0].at).toBe(seconds(NOW) + 900)
+    expect(choices[1].at).toBe(seconds(NOW) + 3600)
+    expect(choices[2].at).toBe(seconds(NOW) + 4 * 3600)
+    expect(choices[3].at).toBe(seconds(new Date(2026, 8, 3, 9, 0, 0)))
+  })
+
+  // The one case where the word could lie: in the small hours, 9am is still
+  // today, and a button that says Tomorrow must not mean six hours from now.
+  it("keeps Tomorrow on tomorrow's date at 3am", () => {
+    const smallHours = new Date(2026, 8, 2, 3, 0, 0)
+    expect(scheduleChoices(smallHours)[3].at).toBe(seconds(new Date(2026, 8, 3, 9, 0, 0)))
+  })
+})
+
+describe("timeUntil", () => {
+  it("counts down in the unit the distance calls for", () => {
+    expect(timeUntil(seconds(NOW) + 30, NOW)).toBe("in 1m")
+    expect(timeUntil(seconds(NOW) + 45 * 60, NOW)).toBe("in 45m")
+    expect(timeUntil(seconds(NOW) + 3 * 3600, NOW)).toBe("in 3h")
+    expect(timeUntil(seconds(NOW) + 47 * 3600, NOW)).toBe("in 2d")
+  })
+
+  it("says nothing about a prompt that is already due", () => {
+    expect(timeUntil(seconds(NOW), NOW)).toBeNull()
+    expect(timeUntil(seconds(NOW) - 3600, NOW)).toBeNull()
+  })
+})
+
+describe("scheduledFor", () => {
+  it("names the day only when it is not today", () => {
+    const today = seconds(new Date(2026, 8, 2, 21, 0, 0))
+    expect(scheduledFor(today, NOW)).toBe(`today ${clockAt(today)}`)
+
+    const tomorrow = seconds(new Date(2026, 8, 3, 9, 0, 0))
+    expect(scheduledFor(tomorrow, NOW)).not.toContain("today")
+    expect(scheduledFor(tomorrow, NOW)).toContain(clockAt(tomorrow))
+  })
+})

--- a/frontend/src/lib/session/schedule.ts
+++ b/frontend/src/lib/session/schedule.ts
@@ -1,0 +1,85 @@
+// The four times a prompt can be parked for, and the words the card says about
+// one that is parked. Kept out of the components because both of them — the
+// dialog that offers the times and the card that counts one down — need the
+// same arithmetic, and because it is the half of this feature that can be
+// tested without a DOM.
+
+/** One offer in the dialog: a name, and the moment picking it resolves to. */
+export interface ScheduleChoice {
+  label: string
+  /** Unix seconds, which is what the store keeps and the backend compares. */
+  at: number
+}
+
+const MINUTE = 60
+const HOUR = 60 * MINUTE
+
+// The hour a prompt left for "Tomorrow" lands on. Morning rather than midnight:
+// what is parked overnight is picked up at the start of a working day, and a
+// prompt typed at a session at 00:00 is one nobody is there to read.
+const TOMORROW_HOUR = 9
+
+/**
+ * The times on offer, resolved against now (a Date, so a test can stand still).
+ *
+ * Tomorrow is tomorrow's date at TOMORROW_HOUR, never today's — at 3am "in the
+ * morning" and "tomorrow morning" are different days, and the button says
+ * tomorrow. Every choice carries the clock time it resolves to, so the label
+ * never has to be trusted.
+ */
+export function scheduleChoices(now: Date): ScheduleChoice[] {
+  const seconds = Math.floor(now.getTime() / 1000)
+  const tomorrow = new Date(now)
+  tomorrow.setDate(tomorrow.getDate() + 1)
+  tomorrow.setHours(TOMORROW_HOUR, 0, 0, 0)
+  return [
+    { label: "15 min", at: seconds + 15 * MINUTE },
+    { label: "1 hour", at: seconds + HOUR },
+    { label: "4 hours", at: seconds + 4 * HOUR },
+    { label: "Tomorrow", at: Math.floor(tomorrow.getTime() / 1000) },
+  ]
+}
+
+/** The wall clock a choice lands on, in the user's own locale — "09:00". */
+export function clockAt(at: number): string {
+  return new Date(at * 1000).toLocaleTimeString(undefined, {
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+/**
+ * How far off a scheduled prompt is, for the rung on the card: "in 45m", "in
+ * 3h", "in 2d". Null once it is due — the card has something else to say then,
+ * because a prompt that is due and still parked is one waiting for a prompt to
+ * be typed at.
+ */
+export function timeUntil(at: number, now: Date): string | null {
+  const seconds = at - Math.floor(now.getTime() / 1000)
+  if (seconds <= 0) {
+    return null
+  }
+  if (seconds < HOUR) {
+    // Rounded up, so a prompt 30 seconds out says "in 1m" rather than "in 0m".
+    return `in ${Math.ceil(seconds / MINUTE)}m`
+  }
+  if (seconds < 24 * HOUR) {
+    return `in ${Math.round(seconds / HOUR)}h`
+  }
+  return `in ${Math.round(seconds / (24 * HOUR))}d`
+}
+
+/**
+ * When a scheduled prompt lands, spelled for the tooltip: the clock alone for
+ * today, the weekday in front of it for any other day. The date is what the
+ * countdown on the card cannot say — "in 2d" is not a time anyone can plan
+ * around.
+ */
+export function scheduledFor(at: number, now: Date): string {
+  const when = new Date(at * 1000)
+  const clock = clockAt(at)
+  if (when.toDateString() === now.toDateString()) {
+    return `today ${clock}`
+  }
+  return `${when.toLocaleDateString(undefined, { weekday: "short" })} ${clock}`
+}

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -72,6 +72,13 @@ export const SANDBOX_EVENT = "session-sandbox"
 // to draw the cost without a ring (docs/ceilings.md).
 export const USAGE_EVENT = "session-usage"
 
+// Global event the backend emits when a session's scheduled prompt has been
+// typed at it (see relay.ScheduleEventName). Payload: { id, at } — at is 0,
+// because the prompt has just been delivered and nothing is waiting anymore.
+// The window is the only other writer of that row and already knows what it
+// wrote; this is what the clock did.
+export const SCHEDULE_EVENT = "session-schedule"
+
 // Global event the backend emits while one session has a request open with
 // another (see relay.RelayEventName). Payload: { id, peer, direction, ticket } —
 // the session whose card changes, the label at the other end, which way the
@@ -226,6 +233,10 @@ export function isIdEvent(data: unknown): data is { id: string } {
   return (
     typeof data === "object" && data !== null && typeof (data as { id?: unknown }).id === "string"
   )
+}
+
+export function isScheduleEvent(data: unknown): data is { id: string; at: number } {
+  return isIdEvent(data) && typeof (data as { at?: unknown }).at === "number"
 }
 
 export function isSandboxEvent(data: unknown): data is { id: string; confined: boolean } {

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -28,6 +28,7 @@ import {
   setSessionEntrypoint,
   setSessionPinned,
   setSessionSandboxed,
+  setSessionSchedule,
   delegatesOf,
   sidebarGroups,
   type Session,
@@ -1036,6 +1037,39 @@ describe("dropClosedSession", () => {
     const before = buildState(2)
     expect(dropClosedSession(before, P, "ghost", "s1")).toBe(before)
     expect(dropClosedSession(before, "other", "s1", "")).toBe(before)
+  })
+})
+
+describe("setSessionSchedule", () => {
+  const state = () => buildState(2)
+
+  it("parks the prompt on the session it names, and nowhere else", () => {
+    const next = setSessionSchedule(state(), "s1", 1700000000, "run the checklist")
+    expect(next[P]?.sessions[0]?.scheduledAt).toBe(1700000000)
+    expect(next[P]?.sessions[0]?.scheduledPrompt).toBe("run the checklist")
+    expect(next[P]?.sessions[1]?.scheduledAt).toBeUndefined()
+  })
+
+  it("replaces what was parked rather than queueing behind it", () => {
+    const first = setSessionSchedule(state(), "s1", 1700000000, "first")
+    const next = setSessionSchedule(first, "s1", 1700000060, "second")
+    expect(next[P]?.sessions[0]?.scheduledAt).toBe(1700000060)
+    expect(next[P]?.sessions[0]?.scheduledPrompt).toBe("second")
+  })
+
+  // Both keys leave together — a cancel and a prompt the backend has just typed
+  // arrive the same way, and one field left behind would outlive the other.
+  it("leaves no key behind when it is cleared", () => {
+    const parked = setSessionSchedule(buildState(1), "s1", 1700000000, "run it")
+    const cleared = setSessionSchedule(parked, "s1", 0, "")
+    const session = cleared[P]?.sessions[0]
+    expect(session && "scheduledAt" in session).toBe(false)
+    expect(session && "scheduledPrompt" in session).toBe(false)
+  })
+
+  it("ignores a session it does not know", () => {
+    const current = state()
+    expect(setSessionSchedule(current, "gone", 1700000000, "run it")).toBe(current)
   })
 })
 

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -64,6 +64,12 @@ export interface Session {
   // is closed. Read them through sessionOrigin, never on their own.
   originSessionId?: string
   originLabel?: string
+  // A prompt parked to be typed at this session later, and when it is due in
+  // unix seconds. Both absent when nothing is waiting; the backend types the
+  // prompt and clears the pair (internal/relay, deliverDue), which reaches the
+  // card as SCHEDULE_EVENT.
+  scheduledAt?: number
+  scheduledPrompt?: string
 }
 
 export interface ProjectSessions {
@@ -284,6 +290,38 @@ export function setSessionSandboxed(
         // no key at all — the shape the two hydration paths produce.
         const { sandboxed: _was, ...rest } = s
         return sandboxed ? { ...rest, sandboxed: true } : rest
+      }),
+    },
+  }
+}
+
+// setSessionSchedule parks a prompt on a session, or takes one off it: at 0
+// clears both keys, which is what a cancel and a delivered prompt both are.
+// Unknown ids leave the state untouched.
+export function setSessionSchedule(
+  state: SessionState,
+  sessionId: string,
+  at: number,
+  prompt: string,
+): SessionState {
+  const projectId = projectOfSession(state, sessionId)
+  const current = projectId ? state[projectId] : undefined
+  if (!projectId || !current || !current.sessions.some((s) => s.id === sessionId)) {
+    return state
+  }
+  return {
+    ...state,
+    [projectId]: {
+      ...current,
+      sessions: current.sessions.map((s) => {
+        if (s.id !== sessionId) {
+          return s
+        }
+        // Dropped rather than zeroed, for the reason setSessionSandboxed drops
+        // its key: a session with nothing scheduled is the shape hydration
+        // produces, and one field left behind would outlive the other.
+        const { scheduledAt: _at, scheduledPrompt: _prompt, ...rest } = s
+        return at > 0 && prompt ? { ...rest, scheduledAt: at, scheduledPrompt: prompt } : rest
       }),
     },
   }

--- a/frontend/src/providers/project-workspace.test.ts
+++ b/frontend/src/providers/project-workspace.test.ts
@@ -8,6 +8,8 @@ const storedSession = (overrides: Partial<StoredSession> = {}): StoredSession =>
   id: "s1",
   label: "Session 1",
   kind: "claude",
+  scheduledAt: 0,
+  scheduledPrompt: "",
   path: "",
   providerSessionId: "",
   entrypoint: "",

--- a/frontend/src/providers/project-workspace.ts
+++ b/frontend/src/providers/project-workspace.ts
@@ -20,6 +20,9 @@ export function buildSessionState(loaded: StoredProject[]): SessionState {
       ...(session.originSessionId
         ? { originSessionId: session.originSessionId, originLabel: session.originLabel }
         : {}),
+      ...(session.scheduledAt
+        ? { scheduledAt: session.scheduledAt, scheduledPrompt: session.scheduledPrompt }
+        : {}),
     }))
     state[project.id] = {
       sessions,

--- a/frontend/src/providers/projects-context.ts
+++ b/frontend/src/providers/projects-context.ts
@@ -52,6 +52,9 @@ export interface ProjectsValue {
   // Record the command a terminal session opens into, "" to clear it. Refused
   // by the store on anything but a shell session.
   setEntrypoint: (projectId: string, sessionId: string, entrypoint: string) => void
+  // Park a prompt to be typed at a session at unix second `at`, or clear the
+  // one it holds with at 0. One per session: this replaces what was there.
+  scheduleSession: (sessionId: string, at: number, prompt: string) => void
   /** Pin a session to the head of its project's list, or unpin it. */
   pinSession: (projectId: string, sessionId: string, pinned: boolean) => void
   /** Rearrange the project tabs to the given id order. */

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -26,6 +26,7 @@ import {
   setSessionEntrypoint as recordEntrypoint,
   setSessionPinned,
   setSessionSandboxed,
+  setSessionSchedule,
   type Session,
   type SessionKind,
   type SessionState,
@@ -39,12 +40,14 @@ import {
   projectNewSessionKind,
 } from "@/lib/providers-store"
 import { resolveNewSessionKind } from "@/lib/session/new-session-kind"
+import { scheduledFor, timeUntil } from "@/lib/session/schedule"
 import {
   CLOSED_EVENT,
   OPENED_EVENT,
   PROJECT_OPENED_EVENT,
   RELAY_STALLED_EVENT,
   SANDBOX_EVENT,
+  SCHEDULE_EVENT,
   STATUS_EVENT,
   TITLE_EVENT,
   TOUCHED_EVENT,
@@ -52,6 +55,7 @@ import {
   isIdEvent,
   isRelayStalledEvent,
   isSandboxEvent,
+  isScheduleEvent,
   isStatusEvent,
   isTitleEvent,
   shouldToastAttention,
@@ -219,6 +223,22 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
         return
       }
       const next = setSessionSandboxed(sessionsRef.current, data.id, data.confined)
+      if (next !== sessionsRef.current) {
+        commit(next)
+      }
+    })
+    return () => off()
+  }, [])
+
+  // A scheduled prompt has been typed at its session, so the mark comes off the
+  // card at that moment rather than at the next reload. The row is already
+  // cleared on the backend's side of it, so this never writes back.
+  useEffect(() => {
+    const off = onAppEvent(SCHEDULE_EVENT, (data) => {
+      if (!isScheduleEvent(data)) {
+        return
+      }
+      const next = setSessionSchedule(sessionsRef.current, data.id, data.at, "")
       if (next !== sessionsRef.current) {
         commit(next)
       }
@@ -875,6 +895,21 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       .catch((error: unknown) => toast.error(`Could not save the entrypoint: ${errorText(error)}`))
   }, [])
 
+  // scheduleSession is written through and mirrored like every other session
+  // mutation. It takes no project id: the schedule belongs to one card, the
+  // state helper finds the project it sits in, and the dialog is the same call
+  // whichever list that card was drawn in.
+  const scheduleSession = useCallback((sessionId: string, at: number, prompt: string) => {
+    Store.SetSessionSchedule(sessionId, at, prompt)
+      .then(() => {
+        commit(setSessionSchedule(sessionsRef.current, sessionId, at, prompt))
+        toast.success(at ? `Scheduled ${timeUntil(at, new Date()) ?? "now"}` : "Schedule cleared", {
+          description: at ? scheduledFor(at, new Date()) : undefined,
+        })
+      })
+      .catch((error: unknown) => toast.error(`Could not schedule it: ${errorText(error)}`))
+  }, [])
+
   const pinSession = useCallback((projectId: string, sessionId: string, pinned: boolean) => {
     const next = setSessionPinned(sessionsRef.current, projectId, sessionId, pinned)
     if (next === sessionsRef.current) {
@@ -903,6 +938,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       activateSession,
       renameSession,
       setEntrypoint,
+      scheduleSession,
       pinSession,
       reorderProjects,
       reorderSessions,
@@ -925,6 +961,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       activateSession,
       renameSession,
       setEntrypoint,
+      scheduleSession,
       pinSession,
       reorderProjects,
       reorderSessions,

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -32,6 +32,9 @@ func (wiredSessions) LoadState() ([]store.Project, error) {
 	}}}, nil
 }
 
+// Nothing here schedules a prompt; the relay only ever calls this to clear one.
+func (wiredSessions) SetSessionSchedule(string, int64, string) error { return nil }
+
 type wiredTerminal struct {
 	mu    sync.Mutex
 	typed string

--- a/internal/relay/later.go
+++ b/internal/relay/later.go
@@ -1,0 +1,98 @@
+package relay
+
+import (
+	"log/slog"
+	"time"
+)
+
+// A scheduled prompt is the user's own words parked on a session to be typed at
+// it later — a reminder that arrives as work, not a job runner. One per
+// session, held on the session row itself (internal/store, sessions.scheduled_at):
+// scheduling again replaces what was there, which is what keeps the card able
+// to say the whole of it in a line.
+//
+// It lives in this package because delivery is the whole of the feature and the
+// delivery is already here: the paste, the wait for the target to take it in,
+// and the Enter behind it (see deliver) — the one path that gets a TUI to
+// accept a message on every provider and on Windows too. What it deliberately
+// does not reuse is the message the relay composes around a task: there is no
+// sender, no ticket and nobody to report back to. The user is the one waiting.
+
+// scheduleTick is how often due prompts are looked for. The window's shortest
+// shortcut is a quarter of an hour, so this is already far finer than anything
+// that can be asked for, and it costs one read of the open sessions.
+const scheduleTick = 30 * time.Second
+
+// ScheduleEventName is emitted when a session's scheduled prompt is delivered,
+// so the card drops its mark at the moment the prompt is typed rather than at
+// the next reload. Payload: ScheduleEvent. The window is the only other writer
+// of that row, and it already knows what it wrote — this event says what the
+// clock did.
+const ScheduleEventName = "session-schedule"
+
+// ScheduleEvent is the payload of ScheduleEventName: the session whose mark
+// changed, and when its prompt is now due. At is 0 for every event this package
+// emits — the prompt has just been typed and nothing is waiting — and is in the
+// payload anyway because the mark is a time, and an event that only ever means
+// "clear" would have to be replaced the first time anything else moves one.
+type ScheduleEvent struct {
+	ID string `json:"id"`
+	At int64  `json:"at"`
+}
+
+// RunSchedules types due prompts at their sessions until the process ends.
+// Started once at launch: it holds nothing, so a workspace that never schedules
+// anything pays one read every scheduleTick and nothing else.
+func (s *Service) RunSchedules() {
+	ticker := time.NewTicker(scheduleTick)
+	defer ticker.Stop()
+	for range ticker.C {
+		s.deliverDue()
+	}
+}
+
+// deliverDue types every prompt whose time has come, one session at a time.
+//
+// A session that is not at a prompt is left for the next pass rather than
+// failed: the row is the only record the prompt exists, and dropping it would
+// take the card's mark away with nothing typed anywhere. That covers the
+// session still running its setup script, the one whose user is mid-sentence,
+// and the card whose terminal was never opened — none of which is an error, and
+// all of which end by themselves.
+//
+// A prompt that came due while lich was closed is delivered late, on the first
+// pass after launch. Late is what this feature promises; silently dropping the
+// only copy of what the user wrote is not.
+func (s *Service) deliverDue() {
+	projects, err := s.sessions.LoadState()
+	if err != nil {
+		slog.Warn("relay: read scheduled prompts", "err", err)
+		return
+	}
+	now := s.now().Unix()
+	for _, p := range projects {
+		for _, sess := range p.Sessions {
+			if sess.ScheduledPrompt == "" || sess.ScheduledAt == 0 || sess.ScheduledAt > now {
+				continue
+			}
+			if !s.term.Ready(sess.ID) {
+				continue
+			}
+			// Cleared before the write, not after: deliver blocks while the paste
+			// settles, and a pass slow enough to overlap the next one would type the
+			// same prompt twice. A write that then fails costs a prompt the user can
+			// still see on their own screen and retype; two unasked-for turns cannot
+			// be taken back.
+			if err := s.sessions.SetSessionSchedule(sess.ID, 0, ""); err != nil {
+				slog.Warn("relay: clear scheduled prompt", "session", sess.Label, "err", err)
+				continue
+			}
+			if s.events != nil {
+				s.events.Emit(ScheduleEventName, ScheduleEvent{ID: sess.ID})
+			}
+			if err := s.deliver(sess.ID, sess.ScheduledPrompt); err != nil {
+				slog.Warn("relay: scheduled prompt not delivered", "session", sess.Label, "err", err)
+			}
+		}
+	}
+}

--- a/internal/relay/later_test.go
+++ b/internal/relay/later_test.go
@@ -1,0 +1,182 @@
+package relay
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/omartelo/lich/internal/store"
+)
+
+// scheduleWriter records what deliverDue wrote back to the session rows.
+type scheduleWriter struct {
+	mu      sync.Mutex
+	cleared []string
+	err     error
+}
+
+func (w *scheduleWriter) set(sessionID string, at int64, prompt string) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.err != nil {
+		return w.err
+	}
+	if at == 0 && prompt == "" {
+		w.cleared = append(w.cleared, sessionID)
+	}
+	return nil
+}
+
+func (w *scheduleWriter) clearedRows() []string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return append([]string(nil), w.cleared...)
+}
+
+// scheduled is a workspace holding one session with a prompt parked on it.
+func scheduled(at int64, prompt string, writer *scheduleWriter) fakeSessions {
+	return fakeSessions{
+		projects: []store.Project{{ID: "p1", Name: "lich", Sessions: []store.Session{
+			{ID: "s1", Label: "docs", Kind: "claude", ScheduledAt: at, ScheduledPrompt: prompt},
+		}}},
+		schedule: writer.set,
+	}
+}
+
+// at is a clock stopped at a unix second, so a test says when "now" is rather
+// than waiting for it.
+func at(unix int64) func() time.Time {
+	return func() time.Time { return time.Unix(unix, 0) }
+}
+
+func TestDeliverDueTypesThePromptAndClearsTheRow(t *testing.T) {
+	writer := &scheduleWriter{}
+	term := newFakeTerminal("s1")
+	events := &fakeEvents{}
+	svc := newRelay(scheduled(1000, "run the release checklist", writer), term, events)
+	svc.now = at(1000)
+
+	svc.deliverDue()
+
+	written := term.written("s1")
+	if !strings.Contains(written, "run the release checklist") {
+		t.Fatalf("typed at s1 = %q, want the scheduled prompt", written)
+	}
+	if !strings.HasSuffix(written, submit) {
+		t.Fatalf("typed at s1 = %q, want it sent", written)
+	}
+	if got := writer.clearedRows(); len(got) != 1 || got[0] != "s1" {
+		t.Fatalf("cleared = %v, want [s1]", got)
+	}
+	if got := events.schedules(); len(got) != 1 || got[0].ID != "s1" || got[0].At != 0 {
+		t.Fatalf("schedule events = %+v, want one clearing s1", got)
+	}
+}
+
+// The prompt is typed as the user wrote it: no sender, no ticket, none of the
+// envelope a relayed task carries. A scheduled prompt has nobody to report to.
+func TestDeliverDueTypesNoEnvelope(t *testing.T) {
+	term := newFakeTerminal("s1")
+	svc := newRelay(scheduled(1000, "ship it", &scheduleWriter{}), term, nil)
+	svc.now = at(1000)
+
+	svc.deliverDue()
+
+	if got := term.written("s1"); strings.Contains(got, "ticket") || strings.Contains(got, ToolReply) {
+		t.Fatalf("typed at s1 = %q, want the prompt alone", got)
+	}
+}
+
+func TestDeliverDueLeavesAPromptThatIsNotDueYet(t *testing.T) {
+	writer := &scheduleWriter{}
+	term := newFakeTerminal("s1")
+	svc := newRelay(scheduled(1001, "later", writer), term, nil)
+	svc.now = at(1000)
+
+	svc.deliverDue()
+
+	if got := term.writesTo("s1"); len(got) != 0 {
+		t.Fatalf("typed at s1 = %v, want nothing a second early", got)
+	}
+	if got := writer.clearedRows(); len(got) != 0 {
+		t.Fatalf("cleared = %v, want the row left alone", got)
+	}
+}
+
+// Overdue is delivered, not dropped: this is the prompt that came due while
+// lich was closed.
+func TestDeliverDueTypesAnOverduePrompt(t *testing.T) {
+	term := newFakeTerminal("s1")
+	svc := newRelay(scheduled(1000, "the overdue one", &scheduleWriter{}), term, nil)
+	svc.now = at(1000 + 3*24*60*60)
+
+	svc.deliverDue()
+
+	if !strings.Contains(term.written("s1"), "the overdue one") {
+		t.Fatalf("typed at s1 = %q, want the overdue prompt", term.written("s1"))
+	}
+}
+
+// A session with no prompt to type at keeps its schedule: the row is the only
+// copy of what the user wrote, and the next pass is when it lands.
+func TestDeliverDueKeepsThePromptWhileTheSessionIsNotReady(t *testing.T) {
+	cases := map[string]func(*fakeTerminal){
+		"no PTY":         func(term *fakeTerminal) { term.live["s1"] = false },
+		"setting up":     func(term *fakeTerminal) { term.settingUp["s1"] = true },
+		"user is typing": func(term *fakeTerminal) { term.typing["s1"] = true },
+	}
+	for name, park := range cases {
+		t.Run(name, func(t *testing.T) {
+			writer := &scheduleWriter{}
+			term := newFakeTerminal("s1")
+			park(term)
+			svc := newRelay(scheduled(1000, "wait for me", writer), term, nil)
+			svc.now = at(1000)
+
+			svc.deliverDue()
+
+			if got := term.writesTo("s1"); len(got) != 0 {
+				t.Fatalf("typed at s1 = %v, want nothing", got)
+			}
+			if got := writer.clearedRows(); len(got) != 0 {
+				t.Fatalf("cleared = %v, want the schedule kept", got)
+			}
+		})
+	}
+}
+
+// The clear is what stops a second pass typing the same prompt again, so a
+// clear that fails has to stop the delivery with it.
+func TestDeliverDueSkipsWhenTheRowCannotBeCleared(t *testing.T) {
+	writer := &scheduleWriter{err: errors.New("database is locked")}
+	term := newFakeTerminal("s1")
+	svc := newRelay(scheduled(1000, "run it", writer), term, nil)
+	svc.now = at(1000)
+
+	svc.deliverDue()
+
+	if got := term.writesTo("s1"); len(got) != 0 {
+		t.Fatalf("typed at s1 = %v, want nothing typed against an unclearable row", got)
+	}
+}
+
+func TestDeliverDueIgnoresSessionsWithNothingScheduled(t *testing.T) {
+	term := newFakeTerminal("s1", "s2", "s3", "s4")
+	svc := newRelay(workspace(), term, nil)
+	svc.now = at(1000)
+
+	svc.deliverDue()
+
+	for _, id := range []string{"s1", "s2", "s3", "s4"} {
+		if got := term.writesTo(id); len(got) != 0 {
+			t.Fatalf("typed at %s = %v, want nothing", id, got)
+		}
+	}
+}
+
+func TestDeliverDueSurvivesAnUnreadableWorkspace(t *testing.T) {
+	svc := newRelay(fakeSessions{err: errors.New("no database")}, newFakeTerminal("s1"), nil)
+	svc.deliverDue()
+}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -172,6 +172,10 @@ type RelayEvent struct {
 // may address. The store implements it.
 type Sessions interface {
 	LoadState() ([]store.Project, error)
+	// SetSessionSchedule clears a scheduled prompt once it has been typed at its
+	// session (see deliverDue). Only ever called to clear here: the window is
+	// what parks one.
+	SetSessionSchedule(sessionID string, at int64, prompt string) error
 }
 
 // Events is where the relay announces a request in flight. The app's event hub

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -16,9 +16,19 @@ import (
 type fakeSessions struct {
 	projects []store.Project
 	err      error
+	// schedule, when set, takes the scheduled-prompt writes deliverDue makes. A
+	// test that does not schedule anything leaves it nil, which accepts them.
+	schedule func(sessionID string, at int64, prompt string) error
 }
 
 func (f fakeSessions) LoadState() ([]store.Project, error) { return f.projects, f.err }
+
+func (f fakeSessions) SetSessionSchedule(sessionID string, at int64, prompt string) error {
+	if f.schedule == nil {
+		return nil
+	}
+	return f.schedule(sessionID, at, prompt)
+}
 
 // fakeTerminal records what was typed at which session, and answers Live from
 // an explicit set so a test can park a session without a PTY.
@@ -168,6 +178,7 @@ type fakeEvents struct {
 	sent  []RelayEvent
 	halts []StalledEvent
 	inbox []InboxEvent
+	marks []ScheduleEvent
 }
 
 func (f *fakeEvents) Emit(name string, data any) {
@@ -182,11 +193,22 @@ func (f *fakeEvents) Emit(name string, data any) {
 		if name == StalledEventName {
 			f.halts = append(f.halts, event)
 		}
+	case ScheduleEvent:
+		if name == ScheduleEventName {
+			f.marks = append(f.marks, event)
+		}
 	case InboxEvent:
 		if name == InboxEventName {
 			f.inbox = append(f.inbox, event)
 		}
 	}
+}
+
+// schedules is every scheduled-prompt mark the relay moved, in order.
+func (f *fakeEvents) schedules() []ScheduleEvent {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]ScheduleEvent(nil), f.marks...)
 }
 
 func (f *fakeEvents) stalled() []StalledEvent {

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -510,6 +510,38 @@ func (s *Service) SetSessionEntrypoint(sessionID, entrypoint string) error {
 	return nil
 }
 
+// schedulePromptLimit bounds a scheduled prompt. It is typed into a TUI a
+// character at a time when it comes due — the same delivery a relayed message
+// gets, and the same reason that one is bounded (internal/relay, promptLimit):
+// a megabyte of it is a hang, not a prompt. Checked here rather than at
+// delivery so the person writing it is told while they can still shorten it.
+const schedulePromptLimit = 8192
+
+// SetSessionSchedule parks a prompt to be typed at a session later. at is unix
+// seconds; 0, or an empty prompt, clears whatever was there — there is nothing
+// else to cancel, because a session holds one scheduled prompt at a time and
+// scheduling again replaces it.
+//
+// A session whose row is gone matches nothing and is not an error: the schedule
+// belongs to the card, and a card that is gone has taken its schedule with it.
+func (s *Service) SetSessionSchedule(sessionID string, at int64, prompt string) error {
+	prompt = strings.TrimSpace(prompt)
+	if len(prompt) > schedulePromptLimit {
+		return fmt.Errorf("scheduled prompt is %d bytes, over the %d limit",
+			len(prompt), schedulePromptLimit)
+	}
+	if at <= 0 || prompt == "" {
+		at, prompt = 0, ""
+	}
+	if _, err := s.db.Exec(
+		`UPDATE sessions SET scheduled_at = ?, scheduled_prompt = ? WHERE id = ?`,
+		at, prompt, sessionID,
+	); err != nil {
+		return fmt.Errorf("set schedule on %q: %w", sessionID, err)
+	}
+	return nil
+}
+
 // SessionEntrypoint returns the command recorded for a session, or "" for none —
 // which is what every provider session has, and what leaves a terminal on a
 // plain shell. A read failure answers "" for the same reason SessionModel does:

--- a/internal/store/schedule_test.go
+++ b/internal/store/schedule_test.go
@@ -1,0 +1,89 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSetSessionScheduleParksOnePromptPerSession pins the shape the card is
+// drawn from: one slot, replaced rather than queued, and read back through the
+// same hydration call every other session field arrives on.
+func TestSetSessionScheduleParksOnePromptPerSession(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "s1", "Session 1", "claude", "", 2, "")
+
+	if err := svc.SetSessionSchedule("s1", 1700000000, "  run the release checklist\n"); err != nil {
+		t.Fatalf("SetSessionSchedule: %v", err)
+	}
+	if err := svc.SetSessionSchedule("gone", 1700000000, "nobody"); err != nil {
+		t.Fatalf("SetSessionSchedule on a missing session errored: %v", err)
+	}
+	got := onlySession(t, svc)
+	if got.ScheduledAt != 1700000000 || got.ScheduledPrompt != "run the release checklist" {
+		t.Fatalf("scheduled = %d %q, want the trimmed prompt at 1700000000",
+			got.ScheduledAt, got.ScheduledPrompt)
+	}
+
+	_ = svc.SetSessionSchedule("s1", 1700000060, "and the changelog")
+	if got := onlySession(t, svc); got.ScheduledAt != 1700000060 || got.ScheduledPrompt != "and the changelog" {
+		t.Fatalf("scheduled = %d %q, want the second one to have replaced the first",
+			got.ScheduledAt, got.ScheduledPrompt)
+	}
+}
+
+// Both halves have to clear it: the window cancels by sending no time, and a
+// prompt of nothing but whitespace is not something to type at anyone.
+func TestSetSessionScheduleClears(t *testing.T) {
+	for name, clear := range map[string]func(*Service) error{
+		"no time":   func(svc *Service) error { return svc.SetSessionSchedule("s1", 0, "still here") },
+		"no prompt": func(svc *Service) error { return svc.SetSessionSchedule("s1", 1700000000, "   ") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			svc := newTestStore(t)
+			_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+			_ = svc.AddSession("p1", "s1", "Session 1", "claude", "", 2, "")
+			_ = svc.SetSessionSchedule("s1", 1700000000, "run it")
+
+			if err := clear(svc); err != nil {
+				t.Fatalf("clear: %v", err)
+			}
+			if got := onlySession(t, svc); got.ScheduledAt != 0 || got.ScheduledPrompt != "" {
+				t.Fatalf("scheduled = %d %q, want it cleared", got.ScheduledAt, got.ScheduledPrompt)
+			}
+		})
+	}
+}
+
+// The prompt is typed into a TUI a character at a time when it comes due, so
+// the size it is refused at is a real boundary — pinned as a literal either
+// side of it rather than derived from the constant, which would follow the
+// constant wherever it moved.
+func TestSetSessionScheduleRefusesAnOversizedPrompt(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "s1", "Session 1", "claude", "", 2, "")
+
+	if err := svc.SetSessionSchedule("s1", 1700000000, strings.Repeat("x", 8192)); err != nil {
+		t.Fatalf("8192 bytes refused: %v", err)
+	}
+	if err := svc.SetSessionSchedule("s1", 1700000000, strings.Repeat("x", 8193)); err == nil {
+		t.Fatal("8193 bytes accepted, want it refused before it reaches a PTY")
+	}
+	if got := onlySession(t, svc); len(got.ScheduledPrompt) != 8192 {
+		t.Fatalf("stored prompt is %d bytes, want the refused one not to have landed",
+			len(got.ScheduledPrompt))
+	}
+}
+
+func onlySession(t *testing.T, svc *Service) Session {
+	t.Helper()
+	projects, err := svc.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if len(projects) != 1 || len(projects[0].Sessions) != 1 {
+		t.Fatalf("LoadState = %+v, want one project with one session", projects)
+	}
+	return projects[0].Sessions[0]
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -75,7 +75,13 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- fresh id — so the history the palette lists would reorder itself every
     -- time a session came back. Seconds, not a counter like projects.closed_seq:
     -- that list only had to order, and this one has to say when.
-    closed_at           INTEGER NOT NULL DEFAULT 0
+    closed_at           INTEGER NOT NULL DEFAULT 0,
+    -- A prompt to type at this session later, and when, in unix seconds. One
+    -- slot rather than a queue: scheduling again replaces what was there, which
+    -- is what keeps the card able to say the whole of it in a line and this
+    -- feature a reminder rather than a job runner. 0 means nothing is waiting.
+    scheduled_at        INTEGER NOT NULL DEFAULT 0,
+    scheduled_prompt    TEXT    NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
 
@@ -182,6 +188,12 @@ type Session struct {
 	Pinned          bool   `json:"pinned"`
 	OriginSessionID string `json:"originSessionId"`
 	OriginLabel     string `json:"originLabel"`
+	// ScheduledAt is when the prompt below is due, in unix seconds, 0 for a
+	// session with nothing waiting. It rides the session row so the card that
+	// draws the countdown and the relay that delivers it read the same hydration
+	// call, and neither needs a channel of its own.
+	ScheduledAt     int64  `json:"scheduledAt"`
+	ScheduledPrompt string `json:"scheduledPrompt"`
 }
 
 // Project is a persisted project together with its restorable session state.
@@ -251,6 +263,8 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN origin_label TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN sandbox TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN closed_at INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE sessions ADD COLUMN scheduled_at INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE sessions ADD COLUMN scheduled_prompt TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN closed_seq INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE session_costs ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0`,
@@ -517,7 +531,7 @@ func (s *Service) ProjectAt(path string) (string, string) {
 func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	rows, err := s.db.Query(
 		`SELECT id, label, kind, path, provider_session_id, entrypoint, sandbox, pinned,
-		        origin_session_id, origin_label
+		        origin_session_id, origin_label, scheduled_at, scheduled_prompt
 		   FROM sessions WHERE project_id = ? AND is_open = 1 ORDER BY position, rowid`,
 		projectID,
 	)
@@ -532,6 +546,7 @@ func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 		if err := rows.Scan(
 			&sess.ID, &sess.Label, &sess.Kind, &sess.Path, &sess.ProviderSessionID,
 			&sess.Entrypoint, &sess.Sandbox, &sess.Pinned, &sess.OriginSessionID, &sess.OriginLabel,
+			&sess.ScheduledAt, &sess.ScheduledPrompt,
 		); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}

--- a/main.go
+++ b/main.go
@@ -192,6 +192,9 @@ func main() {
 	// report at all, and whether they can answer with a tool — are about what
 	// the plugin put there.
 	rl.SetPlugins(plugins)
+	// The scheduled prompts are the relay's other clock: nobody calls in for
+	// them, they come due.
+	go rl.RunSchedules()
 	dispatcher.Register("relay", rl)
 	// Its caller is not the window either: opening a session for an agent starts
 	// the PTY here rather than waiting for someone to click the card.
@@ -235,6 +238,10 @@ func main() {
 //   - terminal.SessionAccount hands back the environment of the process a
 //     session runs, credentials and all, so the quota reader can tell which
 //     account that session spends.
+//   - relay.RunSchedules is the scheduled-prompt loop, started once at launch
+//     and never returning: called over /rpc/ it holds that request open for the
+//     life of the process and starts a second loop racing the first for every
+//     due prompt.
 //   - relay.SetPlugins, project.SetAccounts, project.SetProjects,
 //     quota.SetSessions, store.SetSessionGone and terminal.SetDropDir are
 //     startup wiring. Called with [null] they silently nil what they wired
@@ -251,6 +258,7 @@ func denyInternal(d *rpc.Handler) {
 		"drop.Purge",
 		"drop.SetPicker",
 		"relay.Observe",
+		"relay.RunSchedules",
 		"relay.SetPlugins",
 		"project.SetAccounts",
 		"project.SetProjects",

--- a/main_test.go
+++ b/main_test.go
@@ -28,6 +28,7 @@ var denied = map[string]reflect.Type{
 	"drop.Purge":           reflect.TypeFor[*drop.Service](),
 	"drop.SetPicker":       reflect.TypeFor[*drop.Service](),
 	"relay.Observe":        reflect.TypeFor[*relay.Service](),
+	"relay.RunSchedules":   reflect.TypeFor[*relay.Service](),
 	"relay.SetPlugins":     reflect.TypeFor[*relay.Service](),
 	"project.SetAccounts":  reflect.TypeFor[*project.Service](),
 	"project.SetProjects":  reflect.TypeFor[*project.Service](),
@@ -46,6 +47,7 @@ func (stubService) Save() error           { return nil }
 func (stubService) Purge() error          { return nil }
 func (stubService) SetPicker() error      { return nil }
 func (stubService) Observe() error        { return nil }
+func (stubService) RunSchedules() error   { return nil }
 func (stubService) SetPlugins() error     { return nil }
 func (stubService) SetAccounts() error    { return nil }
 func (stubService) SetProjects() error    { return nil }


### PR DESCRIPTION
A card's menu now takes what you want that session to do and one of four times — 15 minutes, an hour, four hours, or tomorrow morning — and lich types it at that prompt when the time comes, exactly as if you had typed it. The reminder that arrives as work: the release checklist at nine, the rebase after the build, the thing you will not remember to ask for at four.

Third of the competitor-gap triage items (codexia, arbor, wmux, openchamber, cc-haha all schedule work). The hypothesis it was scoped against — a scheduled prompt per session, not a cron engine — held: no recurrence, no `[[tasks]]` file, no job runner.

### What it is

- **One slot per session.** `sessions.scheduled_at` + `scheduled_prompt`, not a table of jobs. Scheduling again replaces what was there, which is what keeps the card able to say the whole of it in a line and the dialog able to be the only place it is cancelled.
- **Delivery is the relay's own** (`internal/relay/later.go` reusing `deliver`): the paste, the wait for the target to take it in, and the Enter behind it. That is what makes it work identically on all eight providers and on Windows, where ConPTY drops the bracketed-paste markers. What it deliberately does **not** reuse is the envelope a relayed task carries — no sender, no ticket, nobody to report back to.
- **Late, never dropped.** Due prompts are looked for every 30s; one whose session is not at a prompt (mid-setup, a draft on the line, no terminal opened) stays parked for the next pass and lands when there is somewhere to type — including one that came due while lich was closed. The row is cleared *before* the write, so a slow pass cannot type the same prompt twice.
- **The card says so.** A clock rung under the live tool and over the origin — `Scheduled in 3h`, or `Waiting for a prompt` once it is due and still parked — and the tooltip holds the day and the prompt itself.
- **Each time button carries the wall clock it resolves to**, so *Tomorrow* never has to be taken on trust; it is tomorrow's date at 09:00, never today's, even at 3am.

`relay.RunSchedules` is added to `denyInternal`: it never returns, so one `/rpc/` call would hold a request open for the life of the process and start a second loop racing the first.

### Ceiling

`docs/ceilings.md` gains the trap this sets: a schedule on a session that is **closed** rather than busy leaves the roster with it and does not come back on resume — the row is reinserted under a fresh id without it — so the prompt never fires and nothing on screen says it was forfeited.

### Not in this

No recurrence (the upgrade is one more column, not a cron engine), no CLI or MCP verb for an agent to schedule its own wake-up, no arbitrary time picker.

### Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` green; cross-compile loop (linux/darwin/windows build + vet) green.
- [x] `pnpm check`, `pnpm test` (1382), `pnpm build` green.
- [x] `deliverDue`: types the prompt and clears the row, no envelope, not a second early, overdue still delivered, kept parked for a session with no PTY / mid-setup / with a draft, skipped when the row cannot be cleared.
- [x] Store: one slot replaced not queued, both ways of clearing, the 8192-byte boundary pinned either side.
- [x] `schedule.ts`: the four times, Tomorrow at 3am, the countdown units, today vs. weekday.
- [x] The dialog is mounted only while open — a dialog per card would have cost the sidebar a render per card (`render-budget.test.tsx` catches it).
- [x] Watched a real prompt land in a session at its time: isolated rig (own XDG, own port, `--no-window`),
      a shell session scheduled `touch <file>` 20s out — the file appeared, the row cleared itself, nothing
      warned. A second card with no PTY, scheduled an hour in the past, kept its prompt and typed nothing.

https://claude.ai/code/session_01T5PFaD2aHNTPTJbMSTejvk
