### PR TITLE
feat: fork a session's conversation into a worktree of its own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A session can now be forked into a worktree of its own.**
+  Right-click a card and pick *Fork to worktree…*: the New worktree dialog opens
+  saying which conversation it will carry, and the session it creates starts on a
+  copy of that conversation and keeps going from there. The card you forked is
+  untouched — same branch, same history, still running — so it is the way to try
+  a second direction without losing the first, or to hand a long conversation to
+  a clean checkout. The new card wears the *from …* line delegated sessions
+  already have, so which session it came out of stays on screen. It runs the
+  provider the conversation belongs to rather than the project's default, and it
+  is named at birth like any other session — a fork used to inherit the name of
+  the card it came from, which left two of them answering to one name.
+  Offered for Claude Code, Codex and opencode, the three whose CLI can branch a
+  conversation; the item is absent on the other five, which only reopen one. If
+  the provider has since pruned the conversation, lich says so instead of making
+  a checkout for a session that would fail to start.
+
 - **The palette searches what was said in Codex, oh-my-pi, Kiro CLI and
   Antigravity sessions too.** The `Messages` group read Claude Code conversations
   and nothing else, so on any other provider the one thing you actually remember

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -59,8 +59,8 @@ tool.
 
 | File | What it holds | What a new provider adds |
 |---|---|---|
-| `internal/providers/providers.go` | the registry | an id constant, a `Registry` entry (id, display name, binary names, install-docs URL), and a line in `AcceptsMCPServer` if it takes an MCP server on its command line |
-| `internal/terminal/command.go` | what a spawn runs | entries in `skipPermissionFlags`, `modelFlags`, `briefingFlags` and `resumeArgs` — each one optional, and absent means "no flag rather than somebody else's" — plus a `subcommandArgs` arm if the session is a subcommand rather than the bare binary |
+| `internal/providers/providers.go` | the registry | an id constant, a `Registry` entry (id, display name, binary names, install-docs URL), a line in `AcceptsMCPServer` if it takes an MCP server on its command line, and one in `SupportsFork` — that one is a table every provider must appear in, so a new id fails its test until it is answered |
+| `internal/terminal/command.go` | what a spawn runs | entries in `skipPermissionFlags`, `modelFlags`, `briefingFlags` and `resumeArgs` (with a fork arm there if the CLI branches a conversation) — each one optional, and absent means "no flag rather than somebody else's" — plus a `subcommandArgs` arm if the session is a subcommand rather than the bare binary |
 | `internal/terminal/resume.go` | whether a resume can be offered | a `ResumeAvailable` case answering from what that provider left on disk |
 | `internal/terminal/transcript.go`, `sessiondb.go` | where that state lives | the path resolver the case above calls |
 | `internal/terminal/usage.go` | the footer's session readout | a `usageSourceFor` arm, plus a `sessionCost` arm reading whatever that provider records about spend — and a `contextUsageFor` arm only if it also records the model's context window. Which rung that lands the provider on is a row in `docs/ceilings.md`, in the same PR |
@@ -76,7 +76,7 @@ everything on the id (`provider.<id>.bin`, `.enabled`, `.sandbox`,
 
 | File | What a new provider adds |
 |---|---|
-| `frontend/src/lib/session/sessions.ts` | the id in `PROVIDER_KINDS`, and in `RESUMABLE_KINDS` if its CLI reopens a conversation |
+| `frontend/src/lib/session/sessions.ts` | the id in `PROVIDER_KINDS`, in `RESUMABLE_KINDS` if its CLI reopens a conversation, and in `FORKABLE_KINDS` if it branches one |
 | `frontend/src/lib/providers-store.ts` | its `skipPermissionFlags` spelling — the switch in Settings is hidden for a provider absent here, which is what stops the UI promising a flag the spawn has none for |
 | `frontend/src/components/ProviderIcon.tsx` | a brand path, or a lucide fallback |
 | `frontend/src/lib/session/delegate-prompt.ts` | `TOOL_KINDS` only if it is handed lich's tools at spawn |

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -266,7 +266,30 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   at. And `.lich/setup-worktree.sh` is one file, versioned and shared by every checkout, holding sh — so a
   Windows session skips it rather than feeding it to PowerShell, which would run the leading words of every line
   as commands. A worktree opens there with its setup silently not done.
-- **A session is named at birth, never on resume** (`internal/terminal/command.go`, `nameArgs`): the trap is that
+- **A fork is offered by three providers of eight, and the other five never grow one**
+  (`internal/providers.SupportsFork`, `internal/terminal/command.go`, `resumeArgs`): Claude Code, Codex and
+  opencode branch a conversation themselves, so lich asks them to. The other five keep resume and no fork, and
+  lich will not forge one: a copy would mean writing into that harness's own private store — two SQLite
+  schemas with triggers (Crush's per-checkout `.crush/crush.db`, Antigravity's one database per conversation),
+  a blob store keyed on the md5 of the checkout (Cursor), and two JSONL formats with the id and cwd written
+  inside them (oh-my-pi, Kiro CLI) — none of them documented, each versioned by its own CLI, and the blast
+  radius of getting one wrong is the user's real history. The trap is that the menu item is simply absent
+  there, with nothing saying why, so a user who forks a Claude Code card and then looks for the same thing on
+  their Crush card finds no answer on screen.
+- **opencode files a fork under the parent's directory, not the new checkout's** (measured on 1.18.23): the
+  copied session's `directory` column is the one the original ran in, and its `parent_id` is left empty, so
+  opencode's own session list places a fork in the checkout it came from and records no lineage. lich's own
+  card is right — it carries the worktree it was opened in, and `origin_session_id` names the parent — but the
+  two disagree, and only lich's side is visible in lich.
+- **A fork is billed as a second conversation from its first turn** (`internal/pricing`,
+  `internal/terminal/usage_cost.go`): the copy is a transcript of its own carrying every token of the history
+  it was branched from, so the pair reports roughly twice what one conversation spent. It is the same
+  arithmetic as the `(session, transcript)` bullet above, arrived at deliberately rather than by accident —
+  a lich-driven fork makes that path ordinary.
+- **A session is named at birth, and a fork is a birth** (`internal/terminal/command.go`, `nameArgs`): a
+  resume never renames — Claude Code restores the name from the transcript, including a `/rename` typed inside
+  the session — but a fork does, because the conversation it opens is new and inherits the parent's name
+  otherwise (measured on 2.1.261). The trap is that
   lich still *derives* that name (`internal/relay/rostername.go`, its page-side half
   `frontend/src/lib/session/peer-name.ts`) for the relay to resolve against, and the derived string goes stale the
   moment anyone renames — it then addresses a session that no longer answers to it. Nothing reads the real name

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -13,6 +13,7 @@ import { ensureTransport, onSessionData, sendInput } from "@/lib/terminal/term-t
 import { chordSequence, isSearchOpenChord } from "@/lib/terminal/term-keys"
 import { makeReplayBuffer } from "@/lib/terminal/replay-buffer"
 import { takePaste } from "@/lib/terminal/paste-queue"
+import { takeFork } from "@/lib/terminal/fork-queue"
 import { takeSetup } from "@/lib/terminal/setup-queue"
 import { peerName } from "@/lib/session/peer-name"
 import type { PaletteSession } from "@/lib/session/command-palette"
@@ -252,6 +253,7 @@ export function TerminalView({
       kind,
       "",
       peerName(cwd, sessionId),
+      false,
       false,
       live.term.cols,
       live.term.rows,
@@ -592,14 +594,19 @@ export function TerminalView({
         resizeObserver.disconnect()
       })
 
+      // A queued fork carries the conversation to branch, which stands in for
+      // the resume id this spawn would otherwise have had: a card born of a
+      // fork has none of its own yet, and one that does is not being forked.
+      const fork = takeFork(sessionId)
       try {
         await Service.Start(
           sessionId,
           projectId,
           cwd,
           kind,
-          resume,
+          fork || resume,
           peerName(cwd, sessionId),
+          fork !== "",
           takeSetup(sessionId),
           live.term.cols,
           live.term.rows,

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -10,6 +10,7 @@ import {
   FolderCode,
   FolderOpen,
   GitBranch,
+  GitFork,
   GitPullRequestArrow,
   Inbox,
   Pencil,
@@ -27,7 +28,7 @@ import { toast } from "sonner"
 import { cn, errorText } from "@/lib/utils"
 import { dragStyle } from "@/lib/use-sortable-list"
 import { displayPath } from "@/lib/paths"
-import type { Session } from "@/lib/session/sessions"
+import { forkableSession, type Session } from "@/lib/session/sessions"
 import {
   useSessionStatus,
   useSessionStatusAge,
@@ -87,6 +88,11 @@ interface SessionCardProps {
   // them into a wall around it. Zero is the usual case and offers nothing.
   delegateCount: number
   onGroupDelegates: () => void
+  // Branch this session's conversation into a checkout of its own. Offered only
+  // where the provider can fork one (forkableSession) — the card does not ask
+  // whether the conversation is still on disk, which is the fork flow's own
+  // first question.
+  onFork: () => void
   onSelect: () => void
   onClose: () => void
   onRename: (label: string) => void
@@ -124,6 +130,7 @@ export function SessionCard({
   onStageToggle,
   delegateCount,
   onGroupDelegates,
+  onFork,
   onSelect,
   onClose,
   onRename,
@@ -254,6 +261,7 @@ export function SessionCard({
   // as an agent is started and quit by hand offers no action the user can rely
   // on being there.
   const canDelegate = active && session.kind !== "shell"
+  const canFork = forkableSession(session) !== null
 
   // The picker is only rendered while the card can delegate, so losing that
   // unmounts it — and an open flag left behind would spring the dialog back up
@@ -577,6 +585,12 @@ export function SessionCard({
           <SessionTooltip session={session} path={path} />
         </Tooltip>
         <ContextMenuContent>
+          {canFork && (
+            <ContextMenuItem onClick={onFork}>
+              <GitFork />
+              Fork to worktree…
+            </ContextMenuItem>
+          )}
           {canDelegate && (
             <ContextMenuItem onClick={() => setDelegatePickerOpen(true)}>
               <ArrowRight />

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -45,6 +45,8 @@ interface SessionGroupProps {
   onStageToggle: (sessionId: string) => void
   // Gather a session and the ones it delegated to into a wall of their own.
   onGroupDelegates: (sessionId: string, delegateIds: string[]) => void
+  /** Branch this session's conversation into a checkout of its own. */
+  onFork: (session: Session) => void
   // A divider label is drawn only when the sidebar holds more than one group; a
   // lone project with no worktrees keeps its old flat, header-less list. The
   // header doubles as the group's drag handle, so a lone group is also the case
@@ -103,6 +105,7 @@ export function SessionGroup({
   stageIds,
   onStageToggle,
   onGroupDelegates,
+  onFork,
   showHeader,
   sortable,
   onReorder,
@@ -229,6 +232,7 @@ export function SessionGroup({
                       showing={stageIds.includes(session.id)}
                       onStageToggle={() => onStageToggle(session.id)}
                       delegateCount={delegates.length}
+                      onFork={() => onFork(session)}
                       onGroupDelegates={() =>
                         onGroupDelegates(
                           session.id,

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -5,7 +5,7 @@ import { DndContext, closestCenter } from "@dnd-kit/core"
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import { GitPullRequestArrow, PanelLeftClose, Plus, Search } from "lucide-react"
 import { toast } from "sonner"
-import { ProjectService, Spawn } from "@/lib/rpc"
+import { ProjectService, Spawn, Terminal as TerminalService } from "@/lib/rpc"
 import { isWindows } from "@/lib/platform"
 import { errorText } from "@/lib/utils"
 import { closeSettings, isSettingsOpen, subscribeSettingsCard } from "@/lib/settings-card-store"
@@ -32,6 +32,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { useProjects } from "@/providers/projects"
+import { queueFork } from "@/lib/terminal/fork-queue"
 import { queueSetup } from "@/lib/terminal/setup-queue"
 import { filterSessions } from "@/lib/session/session-filter"
 import { requestTerminalFocus } from "@/lib/terminal/focus-request"
@@ -39,6 +40,7 @@ import {
   activeSessionId,
   dragOrder,
   reorderSubset,
+  type Session,
   sessionsOf,
   sidebarGroups,
   type SidebarGroup,
@@ -135,6 +137,11 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
       stale = true
     }
   }, [path, worktreeOpen])
+
+  // The session the open worktree dialog is forking, or null when it was opened
+  // to make an ordinary checkout. It is state rather than a flag because the
+  // dialog names the session, and the create below has to hand it over.
+  const [forking, setForking] = useState<Session | null>(null)
   // The filter over this project's cards. Deliberately neither persisted nor a
   // store: the sidebar's width and collapsed state survive a restart because
   // they are layout, but a filter is a lens held while working — a lich that
@@ -151,7 +158,10 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   // the menu item is disabled without a branch: git status may still be loading
   // on the render this mounts in, and the dialog reports git's own error in
   // place anyway.
-  useWorktreeDialogIntent(projectId ?? "", () => setWorktreeOpen(true))
+  useWorktreeDialogIntent(projectId ?? "", () => {
+    setForking(null)
+    setWorktreeOpen(true)
+  })
   // Resolved ahead of the no-project bail below: hooks cannot sit behind it.
   const list = sessionsOf(sessions, projectId ?? "")
   const worktreeClose = useWorktreeClose(projectId ?? "", path, list)
@@ -280,11 +290,37 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   ) => {
     const wt = await ProjectService.CreateWorktree(path, projectId, name, base, baseIsRemote)
     if (wt) {
+      const opened = newWorktreeSession(projectId, wt, sandbox, forking)
+      // Queued before the card mounts, so the first spawn branches the parent's
+      // conversation instead of opening an empty one (fork-queue.ts).
+      if (forking?.providerSessionId) {
+        queueFork(opened, forking.providerSessionId)
+      }
       // A fresh checkout is the one moment the project's setup script runs;
       // reopening an existing worktree never queues it.
-      queueSetup(newWorktreeSession(projectId, wt, sandbox))
+      queueSetup(opened)
     }
     setWorktreeOpen(false)
+  }
+
+  // Fork a session's conversation into a checkout of its own. The dialog does
+  // the asking; the offer itself is the card's, and only for a provider that
+  // can branch a conversation at all (forkableSession).
+  //
+  // Whether the provider still has that conversation is asked here rather than
+  // on the card: it is a stat per call, and a card that asked on every render
+  // would ask for every session in the sidebar, forever. A conversation the
+  // provider has pruned dies in the PTY with its own error otherwise, after the
+  // user has already named a branch and made a checkout.
+  const forkSession = async (session: Session) => {
+    const cwd = session.path || path || ""
+    const conversation = session.providerSessionId ?? ""
+    if (!(await TerminalService.ResumeAvailable(session.kind, conversation, cwd))) {
+      toast.error(`${session.label} has no conversation left to fork — ${session.kind} pruned it.`)
+      return
+    }
+    setForking(session)
+    setWorktreeOpen(true)
   }
 
   const resumeWorktree = (wt: { name: string; path: string }) => {
@@ -316,6 +352,7 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
         stageIds={stageIds}
         onStageToggle={toggleStage}
         onGroupDelegates={groupDelegates}
+        onFork={(session) => void forkSession(session)}
         // The divider only earns its place once a worktree — or a pin
         // — splits the list; a lone group keeps the old flat,
         // header-less look. A filter is the exception: which checkout
@@ -389,7 +426,10 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
               onNewSession={(kind) => newSession(projectId, kind)}
               worktree={{
                 disabled: !git?.branch,
-                onSelect: () => setWorktreeOpen(true),
+                onSelect: () => {
+                  setForking(null)
+                  setWorktreeOpen(true)
+                },
               }}
             />
           </DropdownMenuContent>
@@ -501,6 +541,7 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
         currentBranch={git?.branch ?? ""}
         onCreate={createWorktree}
         onResume={resumeWorktree}
+        forkOf={forking}
       />
       <WorktreeCloseDialogs close={worktreeClose} />
       <ConfirmDialog

--- a/frontend/src/components/sidebar/WorktreeDialog.tsx
+++ b/frontend/src/components/sidebar/WorktreeDialog.tsx
@@ -42,6 +42,12 @@ interface WorktreeDialogProps {
   ) => Promise<void>
   /** Reopen a session on an already-existing worktree. */
   onResume: (wt: { name: string; path: string }) => void
+  /** The session whose conversation this worktree's session will carry, when
+   * the dialog was opened by a fork rather than by the + button. It only
+   * changes what the dialog says: the branching itself is the caller's, and
+   * the base list, the setup row and the confinement row are the same either
+   * way. */
+  forkOf?: { label: string } | null
 }
 
 // Row values carry their group so one string identifies the selection:
@@ -123,6 +129,7 @@ export function WorktreeDialog({
   currentBranch,
   onCreate,
   onResume,
+  forkOf = null,
 }: WorktreeDialogProps) {
   const [branches, setBranches] = useState<Branches | null>(null)
   const [name, setName] = useState("")
@@ -240,13 +247,32 @@ export function WorktreeDialog({
     <Dialog open={open} onOpenChange={onOpenChange}>
       {/* Fixed-height dialog: the base-branch section takes the leftover row
         (minmax(0,1fr)) so its list scrolls instead of growing the modal. */}
-      <DialogContent className="h-[85vh] grid-rows-[auto_auto_minmax(0,1fr)_auto_auto_auto] sm:max-w-2xl">
+      <DialogContent
+        className={cn(
+          "h-[85vh] sm:max-w-2xl",
+          forkOf
+            ? "grid-rows-[auto_auto_auto_minmax(0,1fr)_auto_auto_auto]"
+            : "grid-rows-[auto_auto_minmax(0,1fr)_auto_auto_auto]",
+        )}
+      >
         <DialogHeader>
-          <DialogTitle>New worktree</DialogTitle>
+          <DialogTitle>
+            {forkOf ? `Fork ${forkOf.label} to a new worktree` : "New worktree"}
+          </DialogTitle>
           <DialogDescription>
             Pick a base branch and (optionally) a name for the new worktree.
           </DialogDescription>
         </DialogHeader>
+
+        {forkOf && (
+          <div className="border-l-2 border-primary/60 pl-3">
+            <div className="text-sm font-medium">Carries the conversation</div>
+            <span className="text-xs text-muted-foreground">
+              The new session opens on a copy of {forkOf.label}&rsquo;s history and keeps going from
+              there. The original card is untouched.
+            </span>
+          </div>
+        )}
 
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="worktree-name" className="text-xs uppercase tracking-wide">
@@ -292,10 +318,14 @@ export function WorktreeDialog({
           >
             <Group
               title="Worktrees"
-              items={vis.worktrees.map((wt) => ({
-                value: rowValue("worktree", wt.path),
-                label: wt.name,
-              }))}
+              items={
+                forkOf
+                  ? []
+                  : vis.worktrees.map((wt) => ({
+                      value: rowValue("worktree", wt.path),
+                      label: wt.name,
+                    }))
+              }
               base={base}
               onSelect={setBase}
             />
@@ -343,7 +373,13 @@ export function WorktreeDialog({
         <DialogFooter>
           <DialogClose render={<Button variant="ghost" />}>Cancel</DialogClose>
           <Button onClick={() => void submit()} disabled={!base || submitting}>
-            {submitting ? "Creating…" : isResume ? "Open worktree" : "Create worktree"}
+            {submitting
+              ? "Creating…"
+              : isResume
+                ? "Open worktree"
+                : forkOf
+                  ? "Fork"
+                  : "Create worktree"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -119,6 +119,9 @@ export const Terminal = {
   /** resume: a provider session id to reopen (--resume); "" starts fresh.
    * name: what the session answers to in its provider's peer roster (lib/session/peer-name);
    * only Claude Code has one, every other kind ignores it.
+   * fork: branch that conversation instead of continuing it — the copy is this
+   * session's, the original is left where it is. Only for the three kinds whose
+   * CLI can (lib/session/sessions.forkableSession), and always with a resume id.
    * setup: run the project's worktree setup script ahead of the provider —
    * passed once, by the first Start after the worktree is created. */
   Start: (
@@ -128,10 +131,12 @@ export const Terminal = {
     kind: string,
     resume: string,
     name: string,
+    fork: boolean,
     setup: boolean,
     cols: number,
     rows: number,
-  ) => call<null>("terminal.Start", [id, projectID, cwd, kind, resume, name, setup, cols, rows]),
+  ) =>
+    call<null>("terminal.Start", [id, projectID, cwd, kind, resume, name, fork, setup, cols, rows]),
   Write: (id: string, data: string) => call<null>("terminal.Write", [id, data]),
   /** Whether this session can be given work: its provider is the program
    * reading the PTY — not the checkout's setup script, not a TUI still taking

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  forkableSession,
   activeSessionId,
   dragOrder,
   activeTarget,
@@ -597,6 +598,30 @@ describe("setSessionPinned", () => {
     const state = buildState(3)
     setSessionPinned(state, P, "s3", true)
     expect(sessionsOf(state, P)[2].pinned).toBeUndefined()
+  })
+})
+
+describe("forkableSession", () => {
+  // The three the CLIs themselves branch (providers.SupportsFork).
+  it.each(["claude", "codex", "opencode"] as const)("offers a %s session", (kind) => {
+    const state = withClaudeSession(buildState(2), "s1", "conv-1", kind)
+    expect(forkableSession(state[P].sessions[0])).toMatchObject({ id: "s1", kind })
+  })
+
+  // The five with resume and no fork. Listed one by one rather than looped over
+  // the kind union: a provider that grows a fork must be added here on purpose,
+  // and a provider that loses one must fail here.
+  it.each(["antigravity", "omp", "crush", "cursor", "kiro", "shell"] as const)(
+    "withholds the offer from a %s session",
+    (kind) => {
+      const state = withClaudeSession(buildState(2), "s1", "conv-1", kind)
+      expect(forkableSession(state[P].sessions[0])).toBeNull()
+    },
+  )
+
+  // Nothing to branch: the card has never reported a conversation.
+  it("returns null without a provider session id", () => {
+    expect(forkableSession(buildState(2)[P].sessions[0])).toBeNull()
   })
 })
 

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -544,6 +544,27 @@ const RESUMABLE_KINDS: readonly SessionKind[] = [
   "kiro",
 ]
 
+// The provider kinds whose CLI can branch a conversation rather than only
+// reopen it, mirrored from providers.SupportsFork (Go) — keep in sync. Three of
+// the eight, and the rest is not a gap lich can close from this side: the offer
+// is withheld where the CLI has no verb for it.
+const FORKABLE_KINDS: readonly SessionKind[] = ["claude", "codex", "opencode"]
+
+// forkableSession returns the session a "Fork to worktree" offer can be made
+// for: one running a provider that forks, carrying the conversation to branch.
+// Null for every other card, which is what keeps the menu item off it — a row
+// that could only fail is worse than no row.
+//
+// Whether that conversation is still on disk is the backend's answer
+// (ResumeAvailable), asked by the caller when the offer is taken up rather than
+// on every render of every card.
+export function forkableSession(session: Session): Session | null {
+  if (!FORKABLE_KINDS.includes(session.kind) || !session.providerSessionId) {
+    return null
+  }
+  return session
+}
+
 // resumableSession returns the session whose PTY should ask before it spawns,
 // because it carries the provider conversation it ran before the last restart.
 // Null for everything with nothing to resume: unknown ids, sessions created in

--- a/frontend/src/lib/terminal/fork-queue.test.ts
+++ b/frontend/src/lib/terminal/fork-queue.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest"
+import { queueFork, takeFork } from "./fork-queue"
+
+describe("fork queue", () => {
+  it("hands the queued parent conversation to the first spawn", () => {
+    queueFork("s1", "conv-parent")
+    expect(takeFork("s1")).toBe("conv-parent")
+  })
+
+  // One-shot: the second spawn of that card — a restart, a respawn after a
+  // reload — must open its own conversation, not branch the parent again.
+  it("is spent after one take", () => {
+    queueFork("s2", "conv-parent")
+    takeFork("s2")
+    expect(takeFork("s2")).toBe("")
+  })
+
+  it("answers empty for a session nobody forked", () => {
+    expect(takeFork("never-queued")).toBe("")
+  })
+
+  it("keeps one mark per session", () => {
+    queueFork("s3", "conv-a")
+    queueFork("s4", "conv-b")
+    expect(takeFork("s4")).toBe("conv-b")
+    expect(takeFork("s3")).toBe("conv-a")
+  })
+})

--- a/frontend/src/lib/terminal/fork-queue.ts
+++ b/frontend/src/lib/terminal/fork-queue.ts
@@ -1,0 +1,22 @@
+// One-shot "branch this conversation" marks, keyed by session id: the value is
+// the *parent's* provider conversation id, set by the fork flow before the new
+// session's PTY exists and consumed once by TerminalView on the first Start.
+// After that spawn the card has a conversation of its own — the provider
+// assigns it, the session-start hook reports it — so nothing here is persisted.
+//
+// Lives in the page, like the setup queue beside it: a reload between creating
+// the worktree and mounting its terminal drops the mark, and the session opens
+// on an empty conversation instead of a copied one.
+
+const pending = new Map<string, string>()
+
+export function queueFork(sessionId: string, parentConversationId: string): void {
+  pending.set(sessionId, parentConversationId)
+}
+
+/** The parent conversation to branch on this spawn, or "" for an ordinary one. */
+export function takeFork(sessionId: string): string {
+  const parent = pending.get(sessionId) ?? ""
+  pending.delete(sessionId)
+  return parent
+}

--- a/frontend/src/providers/projects-context.ts
+++ b/frontend/src/providers/projects-context.ts
@@ -1,6 +1,6 @@
 import { createContext, useContext } from "react"
 import type { ClosedSession, Project, RecentProject } from "@/lib/api-types"
-import type { SessionKind, SessionState } from "@/lib/session/sessions"
+import type { Session, SessionKind, SessionState } from "@/lib/session/sessions"
 
 export interface ProjectsValue {
   projects: Project[]
@@ -24,11 +24,13 @@ export interface ProjectsValue {
   newSession: (projectId: string, kind?: SessionKind, path?: string) => string
   /** Open a project-default session rooted at a git worktree, labeled after it,
    * returning its id. sandbox is the dialog's confinement answer ("on"/"off"),
-   * "" to follow the provider's rung. */
+   * "" to follow the provider's rung. from is the session being forked into this
+   * checkout, which lends the new card its provider and its lineage. */
   newWorktreeSession: (
     projectId: string,
     wt: { name: string; path: string },
     sandbox?: string,
+    from?: Session | null,
   ) => string
   /** Resume a worktree: reopen its parked session when one exists, else open a
    * fresh session on it. Answers with the session either way, for a caller with

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -399,14 +399,37 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
 
   // sandbox is the answer the new-worktree dialog collected: "on", "off", or ""
   // when the machine cannot confine anything and nothing was asked.
+  //
+  // from is the session this one is being forked out of, when it is: it decides
+  // the provider the new card runs — a fork has to spawn the CLI that wrote the
+  // conversation it carries, not whatever the project defaults to — and records
+  // the lineage the sidebar already draws for a delegate ("from <parent>").
   const newWorktreeSession = useCallback(
-    (projectId: string, wt: { name: string; path: string }, sandbox = "") => {
+    (
+      projectId: string,
+      wt: { name: string; path: string },
+      sandbox = "",
+      from: Session | null = null,
+    ) => {
       const sessionId = newSessionId()
-      const kind = projectNewSessionKind(projectId)
+      const kind = from?.kind ?? projectNewSessionKind(projectId)
       const next = addSession(sessionsRef.current, projectId, sessionId, kind, wt.path, wt.name)
       const project = next[projectId]
       const created = project.sessions[project.sessions.length - 1]
       commit(next)
+      if (from) {
+        void Store.AddSessionFrom(
+          projectId,
+          sessionId,
+          created.label,
+          kind,
+          wt.path,
+          project.nextSeq,
+          from.id,
+          from.label,
+        )
+        return sessionId
+      }
       void Store.AddSession(
         projectId,
         sessionId,

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -234,7 +234,7 @@ type spawnTerminal struct {
 	closed string
 }
 
-func (s *spawnTerminal) Start(_, _, cwd, kind, _, _ string, _ bool, _, _ int) error {
+func (s *spawnTerminal) Start(_, _, cwd, kind, _, _ string, _, _ bool, _, _ int) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.cwd, s.kind = cwd, kind

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -109,6 +109,23 @@ func AcceptsMCPServer(id string) bool {
 	return id == Claude || id == Codex
 }
 
+// SupportsFork reports whether a provider can branch an existing conversation
+// into a second one — the copy carries the history, the original is left
+// untouched — so lich can offer to carry a session's conversation into a new
+// checkout instead of only reopening it where it was.
+//
+// Three of the eight spell it themselves and lich forks through no other route:
+// Claude Code's `--fork-session` rides its `--resume`, Codex swaps its `resume`
+// subcommand for `fork`, and opencode's `--fork` rides its `--session`
+// (measured on 2.1.261, 0.151.0 and 1.18.23). The other five keep no such verb
+// — oh-my-pi, Crush, Cursor CLI, Kiro CLI and Antigravity offer resume alone —
+// and forging a fork for them would mean writing a copy of the conversation
+// into that harness's own private store, which docs/ceilings.md names along
+// with what it would cost.
+func SupportsFork(id string) bool {
+	return id == Claude || id == Codex || id == OpenCode
+}
+
 // DefaultBinary returns a provider's preferred executable name, or "" for an
 // unknown id.
 func DefaultBinary(id string) string {

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -135,3 +135,34 @@ func TestDetectCarriesTheDocs(t *testing.T) {
 		}
 	}
 }
+
+// TestSupportsFork pins the three providers that can branch a conversation and,
+// more importantly, the five that cannot: a false turning true here is a fork
+// flag reaching a CLI with no verb for it, which kills the spawn before the
+// session exists. Every id is listed rather than looped over the Registry, so a
+// provider added without an answer fails this test instead of inheriting one.
+func TestSupportsFork(t *testing.T) {
+	cases := map[string]bool{
+		Claude:      true,
+		Codex:       true,
+		OpenCode:    true,
+		Antigravity: false,
+		OMP:         false,
+		Crush:       false,
+		Cursor:      false,
+		Kiro:        false,
+		"shell":     false,
+		"nope":      false,
+		"":          false,
+	}
+	for _, p := range Registry {
+		if _, listed := cases[p.ID]; !listed {
+			t.Errorf("provider %q has no fork answer — add one to this table", p.ID)
+		}
+	}
+	for id, want := range cases {
+		if got := SupportsFork(id); got != want {
+			t.Errorf("SupportsFork(%q) = %v, want %v", id, got, want)
+		}
+	}
+}

--- a/internal/spawn/run.go
+++ b/internal/spawn/run.go
@@ -89,10 +89,11 @@ func (s *Service) Run(projectID, cwd string) (Session, error) {
 	if s.events != nil {
 		s.events.Emit(OpenedEventName, opened)
 	}
-	// setup is false: the run card opens in a checkout that already exists, and
-	// the setup script belongs to the session that created it.
+	// fork and setup are both false: the run card opens a shell in a checkout
+	// that already exists — it has no conversation to branch, and the setup
+	// script belongs to the session that created the checkout.
 	if err := s.term.Start(
-		id, target.ID, cwd, opened.Kind, "", "", false, startCols, startRows,
+		id, target.ID, cwd, opened.Kind, "", "", false, false, startCols, startRows,
 	); err != nil {
 		return Session{}, fmt.Errorf("the run card was created but its terminal did not start: %w", err)
 	}

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -106,7 +106,7 @@ type Worktrees interface {
 // first viewed, and the same close it asks for when a card goes away. The
 // terminal service implements it.
 type Terminal interface {
-	Start(id, projectID, cwd, kind, resume, name string, setup bool, cols, rows int) error
+	Start(id, projectID, cwd, kind, resume, name string, fork, setup bool, cols, rows int) error
 	Close(id string) error
 }
 
@@ -277,7 +277,7 @@ func (s *Service) Open(fromID, projectName, kind, worktree, base, model string) 
 			)
 		}
 	}
-	if err := s.term.Start(id, target.ID, cwd, kind, "", opened.Name, setup, startCols, startRows); err != nil {
+	if err := s.term.Start(id, target.ID, cwd, kind, "", opened.Name, false, setup, startCols, startRows); err != nil {
 		return Session{}, fmt.Errorf("session %q was created but its terminal did not start: %w", label, err)
 	}
 	if modelErr != nil {

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -252,7 +252,7 @@ func (f *fakeTerminal) Close(id string) error {
 }
 
 func (f *fakeTerminal) Start(
-	id, projectID, cwd, kind, _, name string, setup bool, cols, rows int,
+	id, projectID, cwd, kind, _, name string, _, setup bool, cols, rows int,
 ) error {
 	f.spawns = append(f.spawns, started{id, projectID, cwd, kind, name, setup, cols, rows})
 	return f.err

--- a/internal/terminal/account_linux_test.go
+++ b/internal/terminal/account_linux_test.go
@@ -25,7 +25,7 @@ func TestSessionAccountReadsWhatTheWrapperExecsInto(t *testing.T) {
 	}
 	svc := New(stubBins{bin: bin}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, false, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 

--- a/internal/terminal/command.go
+++ b/internal/terminal/command.go
@@ -46,6 +46,21 @@ const (
 	kiroResumeFlag        = "--resume-id"
 )
 
+// How the three providers that can branch a conversation spell it
+// (providers.SupportsFork). Two of them add a flag to the resume they already
+// take; Codex replaces the subcommand, because its `fork` and `resume` are
+// siblings with the same argument shape — `codex fork <SESSION_ID>` (0.151.0).
+//
+// A fork asks the provider to copy the conversation into a new one of its own,
+// so the id lich holds names the *parent* for exactly one spawn: the copy gets
+// an id the provider assigns, and lich learns it the way it learns every other
+// one, from that session's own session-start report.
+const (
+	claudeForkFlag   = "--fork-session"
+	codexForkSubcmd  = "fork"
+	opencodeForkFlag = "--fork"
+)
+
 // kiroChatSubcmd is the subcommand a Kiro session runs, and it is not optional.
 // Kiro splits the flags lich passes across two parsers: its root takes --agent
 // and --resume-id, but --model and --trust-all-tools belong to `chat` alone, and
@@ -206,8 +221,15 @@ func resolveBin(kind, bin string) string {
 // carrying no name at all — a spawn whose name flagValue rejected — which
 // resumes into Claude Code's own fallback, the working directory, and that is
 // the same string for every session in one checkout.
-func nameArgs(kind, name, resume string) []string {
-	if kind != providers.Claude || resume != "" {
+//
+// A fork is a birth, which is why it names one despite carrying a resume id.
+// The conversation the provider is about to write is new, so there is no
+// /rename inside it to undo — and the copy inherits the parent's name (measured
+// on 2.1.261: the forked transcript carries the parent's `agent-name` line), so
+// staying silent here is what would leave two cards answering to one string in
+// the roster the relay resolves against.
+func nameArgs(kind, name, resume string, fork bool) []string {
+	if kind != providers.Claude || (resume != "" && !fork) {
 		return nil
 	}
 	name, ok := flagValue(name)
@@ -237,12 +259,14 @@ func flagValue(value string) (string, bool) {
 // variadic and reads everything after it as another config path, so it has to
 // come last. Kiro's subcommand opens the session rather than a conversation, so
 // it comes before every flag.
-func providerArgs(kind, name, resume, model, lichBin, agent string, skipPermissions bool) []string {
+func providerArgs(
+	kind, name, resume, model, lichBin, agent string, fork, skipPermissions bool,
+) []string {
 	mcp := mcpArgs(kind, lichBin)
 	args := append([]string{}, subcommandArgs(kind)...)
-	args = append(args, nameArgs(kind, name, resume)...)
+	args = append(args, nameArgs(kind, name, resume, fork)...)
 	args = append(args, agentArgs(kind, agent)...)
-	args = append(args, resumeArgs(kind, resume)...)
+	args = append(args, resumeArgs(kind, resume, fork)...)
 	args = append(args, skipPermissionArgs(kind, skipPermissions)...)
 	args = append(args, modelArgs(kind, model)...)
 	args = append(args, briefingArgs(kind)...)
@@ -384,20 +408,37 @@ func claudeMCPConfig(lichBin string) string {
 // and a provider with no spelling here never grows one — the frontend only
 // passes a resume id for a kind it knows resumes, but a stray one must not reach
 // a shell either.
-func resumeArgs(kind, resume string) []string {
+//
+// fork asks for the conversation to be branched rather than continued, and it
+// is honoured only where the provider has a verb for it: a fork flag invented
+// for one that has none would kill the spawn before the session exists, so the
+// three that do are spelled below and every other kind resumes as it always
+// did. providers.SupportsFork is what stops the offer reaching here at all.
+func resumeArgs(kind, resume string, fork bool) []string {
 	if resume == "" {
 		return nil
 	}
 	switch kind {
 	case providers.Claude:
+		if fork {
+			return []string{claudeResumeFlag, resume, claudeForkFlag}
+		}
 		return []string{claudeResumeFlag, resume}
 	case providers.Codex:
+		if fork {
+			return []string{codexForkSubcmd, resume}
+		}
 		return []string{codexResumeSubcmd, resume}
+	case providers.OpenCode:
+		if fork {
+			return []string{sessionResumeFlag, resume, opencodeForkFlag}
+		}
+		return []string{sessionResumeFlag, resume}
 	case providers.Antigravity:
 		return []string{antigravityResumeFlag, resume}
 	case providers.OMP:
 		return []string{ompResumeFlag, resume}
-	case providers.OpenCode, providers.Crush:
+	case providers.Crush:
 		return []string{sessionResumeFlag, resume}
 	case providers.Cursor:
 		return []string{cursorResumeFlag, resume}

--- a/internal/terminal/command_kiro_test.go
+++ b/internal/terminal/command_kiro_test.go
@@ -127,7 +127,10 @@ func TestKiroSpawnsTheChatSubcommandBeforeEveryFlag(t *testing.T) {
 			want: []string{"chat", "--agent", "lich", "--resume-id", "s1", "--trust-all-tools", "--model", "auto"}},
 	}
 	for _, tt := range tests {
-		got := providerArgs(providers.Kiro, "", tt.resume, tt.model, "/usr/bin/lich", tt.agent, tt.skipPermissions)
+		got := providerArgs(
+			providers.Kiro, "", tt.resume, tt.model, "/usr/bin/lich", tt.agent,
+			false, tt.skipPermissions,
+		)
 		if !slices.Equal(got, tt.want) {
 			t.Errorf("%s: args = %v, want %v", tt.name, got, tt.want)
 		}

--- a/internal/terminal/respawn_test.go
+++ b/internal/terminal/respawn_test.go
@@ -31,7 +31,7 @@ const reapSettle = 250 * time.Millisecond
 // is all that goroutine has left to do.
 func respawn(t *testing.T, svc *Service, id string) *session {
 	t.Helper()
-	if err := svc.Start(id, "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
+	if err := svc.Start(id, "p1", t.TempDir(), "claude", "", "", false, false, 80, 24); err != nil {
 		t.Fatalf("first start: %v", err)
 	}
 	svc.mu.Lock()
@@ -44,7 +44,7 @@ func respawn(t *testing.T, svc *Service, id string) *session {
 	if err := svc.Close(id); err != nil {
 		t.Fatalf("close: %v", err)
 	}
-	if err := svc.Start(id, "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
+	if err := svc.Start(id, "p1", t.TempDir(), "claude", "", "", false, false, 80, 24); err != nil {
 		t.Fatalf("second start: %v", err)
 	}
 
@@ -108,7 +108,7 @@ func TestExitEventCarriesTheExitCode(t *testing.T) {
 	svc := New(stubBins{bin: exitBin(t, 3)}, nil, hub)
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, false, 80, 24); err != nil {
 		t.Fatalf("start: %v", err)
 	}
 
@@ -138,7 +138,7 @@ func TestExitEventOmitsAnUnobservedStatus(t *testing.T) {
 	svc := New(stubBins{bin: echoBin(t)}, nil, hub)
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, false, 80, 24); err != nil {
 		t.Fatalf("start: %v", err)
 	}
 	// Killed behind the service's back: Close would evict the session first and

--- a/internal/terminal/sandbox_spawn_linux_test.go
+++ b/internal/terminal/sandbox_spawn_linux_test.go
@@ -36,7 +36,7 @@ func TestAConfinedSessionRunsInItsPTY(t *testing.T) {
 	svc := New(stubBins{sandboxOn: true}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", cwd, KindShell, "", "", false, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", cwd, KindShell, "", "", false, false, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 	// Both markers are assembled from two shell variables, so the PTY's echo of

--- a/internal/terminal/spawn_test.go
+++ b/internal/terminal/spawn_test.go
@@ -25,7 +25,7 @@ func TestASetupSpawnWithNoScriptIsReadyAnyway(t *testing.T) {
 	svc := New(stubBins{}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), KindShell, "", "", true, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), KindShell, "", "", false, true, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
@@ -44,7 +44,7 @@ func TestASetupSpawnWithAScriptWaitsForItsMarker(t *testing.T) {
 	svc := New(stubBins{projectPath: projectWithSetup(t, "sleep 30")}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), KindShell, "", "", true, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), KindShell, "", "", false, true, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
@@ -110,7 +110,7 @@ func TestAPartialMarkerNeverEndsTheSetup(t *testing.T) {
 func TestStartReportsAPtyThatCannotSpawn(t *testing.T) {
 	svc := New(stubBins{bin: "/nonexistent/lich-test-provider"}, nil, events.New())
 
-	err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24)
+	err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, false, 80, 24)
 
 	if err == nil {
 		t.Fatal("Start = nil, want the spawn failure")
@@ -130,7 +130,7 @@ func TestASpawnWithNoDirectoryStartsAtHome(t *testing.T) {
 	svc := New(stubBins{bin: stayAliveBin(t)}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	_, cwd, err := svc.spawnSession("s1", "p1", "", "claude", "", "", false, 80, 24)
+	_, cwd, err := svc.spawnSession("s1", "p1", "", "claude", "", "", false, false, 80, 24)
 	if err != nil {
 		t.Fatalf("spawnSession = %v, want nil", err)
 	}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -615,6 +615,14 @@ const readBufSize = 32 * 1024
 // that slips through (pruned between the check and the spawn) fails in the PTY
 // like any other bad invocation — the user sees the provider's own error.
 //
+// fork turns that resume into a branch: the provider copies the conversation
+// into a new one of its own and leaves the original alone, so the card that ran
+// it stays where it is with its history intact. Only the three kinds
+// providers.SupportsFork names can do it, and only alongside a resume id — the
+// conversation being branched is the one that id points at. The copy's own id
+// is the provider's to assign, and reaches lich through this session's
+// session-start report like any other.
+//
 // name is what the session answers to in its provider's peer roster (Claude
 // Code's `/list-agents`), passed by the frontend so the roster names the card
 // the user sees. Only Claude Code has a roster; every other kind ignores it.
@@ -625,8 +633,10 @@ const readBufSize = 32 * 1024
 // installs its dependencies in view. A respawn or resume never sets it. The
 // script runs in the session's own environment, so it reads the same
 // LICH_WORKTREE_PORT the provider will.
-func (s *Service) Start(id, projectID, cwd, kind, resume, name string, setup bool, cols, rows int) error {
-	sess, cwd, err := s.spawnSession(id, projectID, cwd, kind, resume, name, setup, cols, rows)
+func (s *Service) Start(
+	id, projectID, cwd, kind, resume, name string, fork, setup bool, cols, rows int,
+) error {
+	sess, cwd, err := s.spawnSession(id, projectID, cwd, kind, resume, name, fork, setup, cols, rows)
 	if err != nil || sess == nil {
 		return err
 	}
@@ -648,7 +658,9 @@ func (s *Service) Start(id, projectID, cwd, kind, resume, name string, setup boo
 // registration. A nil session with a nil error means id was already running.
 // The returned cwd is the effective start directory (the input, or the
 // resolved home when it was empty).
-func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, setup bool, cols, rows int) (*session, string, error) {
+func (s *Service) spawnSession(
+	id, projectID, cwd, kind, resume, name string, fork, setup bool, cols, rows int,
+) (*session, string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -680,8 +692,11 @@ func (s *Service) spawnSession(id, projectID, cwd, kind, resume, name string, se
 	// spawn this session ever gets: the window's first view, a respawn after a
 	// reload, and the resume of a parked worktree session all arrive here.
 	spec := ptySpec{
-		bin:  resolveCommand(kind, s.store.ProviderBin(kind, projectID), userShell()),
-		args: providerArgs(kind, name, resume, s.store.SessionModel(id), mcpBin, kiroPluginAgent(kind), skipPermissions),
+		bin: resolveCommand(kind, s.store.ProviderBin(kind, projectID), userShell()),
+		args: providerArgs(
+			kind, name, resume, s.store.SessionModel(id), mcpBin, kiroPluginAgent(kind),
+			fork, skipPermissions,
+		),
 		dir:  cwd,
 		env:  s.sessionEnv(id, projectID, cwd),
 		cols: cols,

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -363,7 +363,7 @@ func TestStartIsNoopWhenAlreadyRunning(t *testing.T) {
 	sess := spawnSession(t)
 	svc.sessions["s1"] = sess
 
-	if err := svc.Start("s1", "p1", "", "", "", "", false, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", "", "", "", "", false, false, 80, 24); err != nil {
 		t.Errorf("Start(running) = %v, want nil", err)
 	}
 	if svc.sessions["s1"] != sess {
@@ -415,7 +415,7 @@ func TestStartPassesResumeToTheProcess(t *testing.T) {
 	svc := New(stubBins{bin: bin}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "abc-123", "", false, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "abc-123", "", false, false, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
@@ -430,6 +430,27 @@ func TestStartPassesResumeToTheProcess(t *testing.T) {
 	spawnPins(t, got, want...)
 }
 
+// TestStartForksIntoItsOwnConversation proves the fork reaches argv with the
+// parent's id — and that the fork is *named*, which is the one place a spawn
+// carrying a resume id still gets --name (nameArgs).
+func TestStartForksIntoItsOwnConversation(t *testing.T) {
+	bin := stayAliveBin(t)
+	svc := New(stubBins{bin: bin}, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1") })
+
+	err := svc.Start("s1", "p1", t.TempDir(), "claude", "abc-123", "lich-9c1b", true, false, 80, 24)
+	if err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+
+	svc.mu.Lock()
+	got := spawnedArgs(t, svc, "s1")
+	svc.mu.Unlock()
+
+	want := []string{bin, "--name", "lich-9c1b", "--resume", "abc-123", "--fork-session", "--mcp-config"}
+	spawnPins(t, got, want...)
+}
+
 // TestStartWithoutResumeSpawnsBare proves a session with no id to resume spawns
 // the binary alone, with no dangling flag.
 func TestStartWithoutResumeSpawnsBare(t *testing.T) {
@@ -437,7 +458,7 @@ func TestStartWithoutResumeSpawnsBare(t *testing.T) {
 	svc := New(stubBins{bin: bin}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, false, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
@@ -461,7 +482,7 @@ func TestStartCarriesTheBriefingIntoTheSpawn(t *testing.T) {
 	svc := New(stubBins{bin: bin}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, false, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
@@ -486,7 +507,7 @@ func TestStartWithSetupWrapsTheSpawn(t *testing.T) {
 	svc := New(stubBins{bin: bin, projectPath: projectWithSetup(t, "echo setup-ran")}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", true, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, true, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
@@ -511,7 +532,7 @@ func TestStartWithSetupButNoScriptSpawnsBare(t *testing.T) {
 	svc := New(stubBins{bin: bin}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", true, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, true, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
@@ -641,35 +662,54 @@ func TestClosingASessionDropsItsKind(t *testing.T) {
 func TestResumeArgs(t *testing.T) {
 	cases := []struct {
 		name, kind, resume string
+		fork               bool
 		want               []string
 	}{
-		{"claude fresh", "claude", "", nil},
-		{"claude resume", "claude", "abc-123", []string{"--resume", "abc-123"}},
-		{"codex fresh", "codex", "", nil},
-		{"codex resume", "codex", "abc-123", []string{"resume", "abc-123"}},
-		{"antigravity fresh", "antigravity", "", nil},
-		{"antigravity resume", "antigravity", "abc-123", []string{"--conversation", "abc-123"}},
-		{"omp fresh", "omp", "", nil},
-		{"omp resume", "omp", "abc-123", []string{"-r", "abc-123"}},
-		{"opencode fresh", "opencode", "", nil},
-		{"opencode resume", "opencode", "ses_0031a382dffe", []string{"--session", "ses_0031a382dffe"}},
-		{"crush fresh", "crush", "", nil},
-		{"crush resume", "crush", "abc-123", []string{"--session", "abc-123"}},
-		{"cursor fresh", "cursor", "", nil},
+		{"claude fresh", "claude", "", false, nil},
+		{"claude resume", "claude", "abc-123", false, []string{"--resume", "abc-123"}},
+		{"claude fork", "claude", "abc-123", true,
+			[]string{"--resume", "abc-123", "--fork-session"}},
+		{"codex fresh", "codex", "", false, nil},
+		{"codex resume", "codex", "abc-123", false, []string{"resume", "abc-123"}},
+		// Codex's fork replaces the subcommand rather than adding a flag, so a
+		// forked spawn must not carry `resume` at all.
+		{"codex fork", "codex", "abc-123", true, []string{"fork", "abc-123"}},
+		{"antigravity fresh", "antigravity", "", false, nil},
+		{"antigravity resume", "antigravity", "abc-123", false,
+			[]string{"--conversation", "abc-123"}},
+		{"omp fresh", "omp", "", false, nil},
+		{"omp resume", "omp", "abc-123", false, []string{"-r", "abc-123"}},
+		{"opencode fresh", "opencode", "", false, nil},
+		{"opencode resume", "opencode", "ses_0031a382dffe", false,
+			[]string{"--session", "ses_0031a382dffe"}},
+		{"opencode fork", "opencode", "ses_0031a382dffe", true,
+			[]string{"--session", "ses_0031a382dffe", "--fork"}},
+		{"crush fresh", "crush", "", false, nil},
+		{"crush resume", "crush", "abc-123", false, []string{"--session", "abc-123"}},
+		// A fork asked of a provider with no verb for it resumes instead of
+		// growing an invented flag, which would kill the spawn: the offer is
+		// withheld upstream (providers.SupportsFork), and a stray true that
+		// slips through must still land on a command the CLI accepts.
+		{"crush fork falls back to resume", "crush", "abc-123", true,
+			[]string{"--session", "abc-123"}},
+		{"kiro fork falls back to resume", "kiro", "abc-123", true,
+			[]string{"--resume-id", "abc-123"}},
+		{"cursor fresh", "cursor", "", false, nil},
 		// Cursor spells it exactly as Claude Code does, and is pinned here for
 		// the same reason Antigravity's skip-permissions flag is: a shared
 		// literal is what makes a lookup returning the wrong provider's flag
 		// invisible everywhere else. Its own value is optional — `--resume`
 		// alone opens a picker — so an empty id must never reach argv.
-		{"cursor resume", "cursor", "abc-123", []string{"--resume", "abc-123"}},
-		{"shell never resumes", KindShell, "abc-123", nil},
-		{"shell fresh", KindShell, "", nil},
+		{"cursor resume", "cursor", "abc-123", false, []string{"--resume", "abc-123"}},
+		{"shell never resumes", KindShell, "abc-123", false, nil},
+		{"shell never forks", KindShell, "abc-123", true, nil},
+		{"shell fresh", KindShell, "", false, nil},
 	}
 	for _, tc := range cases {
-		got := resumeArgs(tc.kind, tc.resume)
+		got := resumeArgs(tc.kind, tc.resume, tc.fork)
 		if !slices.Equal(got, tc.want) {
-			t.Errorf("%s: resumeArgs(%q, %q) = %v, want %v",
-				tc.name, tc.kind, tc.resume, got, tc.want)
+			t.Errorf("%s: resumeArgs(%q, %q, %v) = %v, want %v",
+				tc.name, tc.kind, tc.resume, tc.fork, got, tc.want)
 		}
 	}
 }
@@ -682,23 +722,32 @@ func TestResumeArgs(t *testing.T) {
 func TestNameArgs(t *testing.T) {
 	cases := []struct {
 		name, kind, peer, resume string
+		fork                     bool
 		want                     []string
 	}{
-		{"claude named", "claude", "lich-4f2a", "", []string{"--name", "lich-4f2a"}},
-		{"claude unnamed", "claude", "", "", nil},
-		{"claude blank name", "claude", "   ", "", nil},
-		{"claude name trimmed", "claude", " lich-4f2a ", "", []string{"--name", "lich-4f2a"}},
-		{"claude flag-like name", "claude", "--dangerously-skip-permissions", "", nil},
-		{"claude resuming keeps its own name", "claude", "lich-4f2a", "conv-1", nil},
-		{"codex has no roster", "codex", "lich-4f2a", "", nil},
-		{"opencode has no roster", "opencode", "lich-4f2a", "", nil},
-		{"shell has no roster", KindShell, "lich-4f2a", "", nil},
+		{"claude named", "claude", "lich-4f2a", "", false, []string{"--name", "lich-4f2a"}},
+		{"claude unnamed", "claude", "", "", false, nil},
+		{"claude blank name", "claude", "   ", "", false, nil},
+		{"claude name trimmed", "claude", " lich-4f2a ", "", false,
+			[]string{"--name", "lich-4f2a"}},
+		{"claude flag-like name", "claude", "--dangerously-skip-permissions", "", false, nil},
+		{"claude resuming keeps its own name", "claude", "lich-4f2a", "conv-1", false, nil},
+		// A fork carries a resume id and is still a birth: the conversation the
+		// provider is about to write has no /rename in it to overwrite, and the
+		// copy inherits the parent's name unless this one lands.
+		{"claude fork is named", "claude", "lich-9c1b", "conv-1", true,
+			[]string{"--name", "lich-9c1b"}},
+		{"claude fork with no usable name", "claude", "  ", "conv-1", true, nil},
+		{"codex has no roster", "codex", "lich-4f2a", "", false, nil},
+		{"codex fork has no roster", "codex", "lich-4f2a", "conv-1", true, nil},
+		{"opencode has no roster", "opencode", "lich-4f2a", "", false, nil},
+		{"shell has no roster", KindShell, "lich-4f2a", "", false, nil},
 	}
 	for _, tc := range cases {
-		got := nameArgs(tc.kind, tc.peer, tc.resume)
+		got := nameArgs(tc.kind, tc.peer, tc.resume, tc.fork)
 		if !slices.Equal(got, tc.want) {
-			t.Errorf("%s: nameArgs(%q, %q, %q) = %v, want %v",
-				tc.name, tc.kind, tc.peer, tc.resume, got, tc.want)
+			t.Errorf("%s: nameArgs(%q, %q, %q, %v) = %v, want %v",
+				tc.name, tc.kind, tc.peer, tc.resume, tc.fork, got, tc.want)
 		}
 	}
 }
@@ -756,7 +805,7 @@ func TestStartPassesSkipPermissionsToTheProcess(t *testing.T) {
 	svc := New(stubBins{bin: bin, skipPerms: true}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, false, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
@@ -778,7 +827,7 @@ func TestStartPassesNameToTheProcess(t *testing.T) {
 	svc := New(stubBins{bin: bin}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "lich-4f2a", false, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "lich-4f2a", false, false, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
@@ -857,7 +906,7 @@ func TestStartPassesTheStoredModelToTheProcess(t *testing.T) {
 	svc := New(stubBins{bin: bin, model: "opus"}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, false, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 
@@ -1006,7 +1055,7 @@ func spawnPins(t *testing.T, got []string, want ...string) {
 func TestProviderArgsRegistersTheMCPServer(t *testing.T) {
 	const bin = "/usr/bin/lich"
 
-	claude := providerArgs(providers.Claude, "", "", "", bin, "", false)
+	claude := providerArgs(providers.Claude, "", "", "", bin, "", false, false)
 	at := slices.Index(claude, "--mcp-config")
 	if at < 0 || at+1 >= len(claude) {
 		t.Fatalf("claude args = %v", claude)
@@ -1031,7 +1080,7 @@ func TestProviderArgsRegistersTheMCPServer(t *testing.T) {
 		t.Errorf("a secret reached the argv, which /proc exposes: %q", claude[at+1])
 	}
 
-	codex := providerArgs(providers.Codex, "", "", "", bin, "", false)
+	codex := providerArgs(providers.Codex, "", "", "", bin, "", false, false)
 	want := []string{
 		"-c", `mcp_servers.lich.command="/usr/bin/lich"`,
 		"-c", `mcp_servers.lich.args=["mcp"]`,
@@ -1046,7 +1095,7 @@ func TestProviderArgsRegistersTheMCPServer(t *testing.T) {
 // follows it, and Codex reads resume as a subcommand that every global option
 // must precede.
 func TestProviderArgsOrdersEachProvidersConstraint(t *testing.T) {
-	claude := providerArgs(providers.Claude, "lich-4f2a", "conv-1", "", "/usr/bin/lich", "", true)
+	claude := providerArgs(providers.Claude, "lich-4f2a", "conv-1", "", "/usr/bin/lich", "", false, true)
 	if claude[len(claude)-2] != "--mcp-config" {
 		t.Errorf("--mcp-config is not last, so it eats what follows: %v", claude)
 	}
@@ -1058,7 +1107,7 @@ func TestProviderArgsOrdersEachProvidersConstraint(t *testing.T) {
 
 	// A resuming session is not named (nameArgs), so --name is pinned on the
 	// spawn that carries it: a session being born.
-	born := providerArgs(providers.Claude, "lich-4f2a", "", "", "/usr/bin/lich", "", true)
+	born := providerArgs(providers.Claude, "lich-4f2a", "", "", "/usr/bin/lich", "", false, true)
 	if born[len(born)-2] != "--mcp-config" {
 		t.Errorf("--mcp-config is not last, so it eats what follows: %v", born)
 	}
@@ -1066,7 +1115,7 @@ func TestProviderArgsOrdersEachProvidersConstraint(t *testing.T) {
 		t.Errorf("claude args lost --name: %v", born)
 	}
 
-	codex := providerArgs(providers.Codex, "", "conv-1", "", "/usr/bin/lich", "", false)
+	codex := providerArgs(providers.Codex, "", "conv-1", "", "/usr/bin/lich", "", false, false)
 	resume := slices.Index(codex, "resume")
 	if resume < 0 {
 		t.Fatalf("codex args lost the resume subcommand: %v", codex)
@@ -1082,7 +1131,7 @@ func TestProviderArgsOrdersEachProvidersConstraint(t *testing.T) {
 	// (`codex resume --help` lists it), and it goes after: a flag the resumed
 	// conversation's own parser accepts is one less thing riding on where the
 	// global options end.
-	resumed := providerArgs(providers.Codex, "", "conv-1", "gpt-5.2", "/usr/bin/lich", "", false)
+	resumed := providerArgs(providers.Codex, "", "conv-1", "gpt-5.2", "/usr/bin/lich", "", false, false)
 	model := slices.Index(resumed, "--model")
 	if model < 0 || model < slices.Index(resumed, "resume") {
 		t.Errorf("codex args = %v, want --model after the resume subcommand", resumed)
@@ -1111,7 +1160,7 @@ func TestProviderArgsWithoutARegistration(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			args := providerArgs(tt.kind, "", "", "", tt.bin, "", false)
+			args := providerArgs(tt.kind, "", "", "", tt.bin, "", false, false)
 			if tt.bare && len(args) != 0 {
 				t.Errorf("args = %v, want none", args)
 			}
@@ -1136,7 +1185,7 @@ func TestTheBriefingGoesToTheProvidersThatTakeOne(t *testing.T) {
 	}
 	for kind, want := range briefed {
 		t.Run(kind, func(t *testing.T) {
-			args := providerArgs(kind, "", "", "", "/usr/bin/lich", "", false)
+			args := providerArgs(kind, "", "", "", "/usr/bin/lich", "", false, false)
 			flag := slices.Index(args, "--append-system-prompt")
 			if flag < 0 || flag+1 >= len(args) {
 				t.Fatalf("args = %v, want a briefing", args)
@@ -1149,7 +1198,7 @@ func TestTheBriefingGoesToTheProvidersThatTakeOne(t *testing.T) {
 
 	for _, kind := range []string{providers.Codex, providers.OpenCode, providers.Crush, KindShell} {
 		t.Run(kind+" takes none", func(t *testing.T) {
-			args := providerArgs(kind, "", "", "", "/usr/bin/lich", "", false)
+			args := providerArgs(kind, "", "", "", "/usr/bin/lich", "", false, false)
 			if slices.Contains(args, "--append-system-prompt") {
 				t.Errorf("args = %v, want no briefing: %s has no flag that appends one", args, kind)
 			}
@@ -1345,10 +1394,10 @@ func TestStartWithoutASizeCopiesTheWindow(t *testing.T) {
 	svc := New(stubBins{bin: bin}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1"); _ = svc.Close("s2") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 174, 51); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, false, 174, 51); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
-	if err := svc.Start("s2", "p1", t.TempDir(), "claude", "", "", false, 0, 0); err != nil {
+	if err := svc.Start("s2", "p1", t.TempDir(), "claude", "", "", false, false, 0, 0); err != nil {
 		t.Fatalf("Start without a size = %v, want nil", err)
 	}
 
@@ -1368,7 +1417,7 @@ func TestReadyWaitsForTheSetupScript(t *testing.T) {
 	svc := New(stubBins{bin: bin, projectPath: projectWithSetup(t, "echo installing")}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", true, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, true, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 	if !svc.Live("s1") {
@@ -1492,7 +1541,7 @@ func TestReadyWaitsOnlyTheSettleWithoutASetupScript(t *testing.T) {
 	svc := New(stubBins{bin: bin}, nil, events.New())
 	t.Cleanup(func() { _ = svc.Close("s1") })
 
-	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, 80, 24); err != nil {
+	if err := svc.Start("s1", "p1", t.TempDir(), "claude", "", "", false, false, 80, 24); err != nil {
 		t.Fatalf("Start = %v, want nil", err)
 	}
 	// No setup script to wait out, but the provider still has to take the


### PR DESCRIPTION
Right-click a card, pick **Fork to worktree…**, and the New worktree dialog opens saying which conversation it will carry. The session it creates starts on a copy of that conversation and keeps going from there; the card it came from is left running, on its branch, with its history.

The new card wears the *from …* line delegated sessions already have, runs the provider the conversation belongs to rather than the project's default, and is named at birth like any other session.

## Which providers, and why only those

Three of the eight branch a conversation themselves, and lich forks through no other route. Every spelling was read off the installed CLI:

| Provider | Fork | What a fork spawns |
| --- | --- | --- |
| Claude Code 2.1.261 | yes | `claude --resume <id> --fork-session` |
| Codex 0.151.0 | yes | `codex fork <id>` — a subcommand swap, not a flag |
| opencode 1.18.23 | yes | `opencode --session <id> --fork` |
| oh-my-pi 18.0.10 · Crush 0.88.0 · Cursor CLI 2026.08.11 · Kiro CLI 2.21.0 · Antigravity 1.1.25 | no | resume only |

The other five keep no such verb, and lich will not forge one: a copy would mean writing into that harness's own private store — two SQLite schemas with triggers, a blob store keyed on the md5 of the checkout, and two JSONL formats with the id and cwd written inside them — none documented, each versioned by its own CLI, with the user's real history as the blast radius. The menu item is simply absent there rather than disabled, and `docs/ceilings.md` carries the gap.

Measured on the way in: a Claude fork copies the whole history, rewrites `cwd` to the new checkout, and leaves the original byte-identical; Codex finds a rollout recorded in another directory and forks it; opencode copies the messages but files the fork under the **parent's** directory and records no `parent_id` — both of those are new `docs/ceilings.md` bullets.

## How it is wired

lich copies nothing. The new card is spawned with the parent's conversation id and a fork flag, and the copy's own id is the provider's to assign — it reaches lich through the session-start hook like every other one. The pieces were already here:

- `providers.SupportsFork` — a table every provider must appear in, so a new one fails its test until answered.
- `resumeArgs(kind, resume, fork)` — the three spellings; a fork asked of a provider with no verb resumes instead of inventing a flag.
- A one-shot page-side queue, twin of the setup queue, hands the parent's id to the first `Start`.
- `AddSessionFrom` for the lineage; the *from …* line is unchanged.

**`nameArgs` now names a fork despite its resume id.** A resume must not rename — Claude Code restores the name from the transcript, including a `/rename` typed inside the session — but a fork opens a *new* conversation with no rename in it, and the copy inherits the parent's `agent-name` otherwise (measured), leaving two cards answering to one string in the roster the relay resolves against.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test -race ./...` green.
- [x] Cross-compile loop green for linux, darwin, windows (build + vet).
- [x] `pnpm check`, `pnpm test` (1387), `tsc --noEmit`, `vite build` green.
- [x] New coverage: `SupportsFork` (all eight ids pinned, and a Registry entry with no answer fails), `resumeArgs`/`nameArgs` fork axes, the argv-level fork spawn, `forkableSession`, the fork queue.
- [x] Rendered by hand in an isolated headless window: the menu item appears on a Claude card and is absent on a Kiro one, the dialog draws its notice and keeps its scrolling base list, zero console errors.

https://claude.ai/code/session_0124aKSXeBqjxmzpMPRsq6oj