### PR TITLE
fix: keep a duplicate launch from falling back to a system browser

### DIFF
--- a/.github/actions/shell-toolchain/action.yml
+++ b/.github/actions/shell-toolchain/action.yml
@@ -1,0 +1,47 @@
+name: Window build toolchain
+description: >-
+  Rust, CEF's build dependencies and the caches the window (shell/, Rust on
+  CEF) needs. Shared by ci.yml's shell job and the release's linux job so a
+  dependency or a cache key changes in one place.
+inputs:
+  components:
+    description: rustup components to install on top of the toolchain (rustfmt, clippy)
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: ${{ inputs.components }}
+
+    # CMake and Ninja build CEF's C++ wrapper; the rest is what libcef.so
+    # links against.
+    - name: Install window build dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y --no-install-recommends \
+          cmake ninja-build pkg-config \
+          libgtk-3-dev libnss3-dev libnspr4-dev \
+          libasound2-dev libcups2-dev libdrm-dev libgbm-dev \
+          libxcomposite-dev libxdamage-dev libxfixes-dev libxrandr-dev \
+          libxkbcommon-dev libxss-dev libxtst-dev libwayland-dev
+
+    # cef-rs downloads the CEF distribution (~200 MB) into CEF_PATH, which the
+    # calling job points at .cef.
+    - name: Cache CEF
+      uses: actions/cache@v4
+      with:
+        path: .cef
+        key: cef-linux-${{ hashFiles('shell/Cargo.lock') }}
+
+    # shared-key: a release runs on a tag, and a tag can only read caches made
+    # on its own ref or on main — ci.yml's shell job on main is what makes
+    # them. The default key is per job, and the release job would never see
+    # it. With the CEF wrapper already built, cargo only compiles the crate
+    # itself: seconds, not the minutes a cold build costs.
+    - uses: Swatinem/rust-cache@v2
+      with:
+        workspaces: shell
+        shared-key: shell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,9 +80,9 @@ jobs:
         run: bash .github/scripts/go-test-summary.sh linux
 
   # The window (shell/, Rust on CEF): format, lint and the crate's suite.
-  # Linking needs the CEF distribution, so this carries the same download cache
-  # the release build does; --release shares one CEF wrapper build between
-  # clippy and the tests.
+  # Linking needs the CEF distribution, so this carries the same toolchain and
+  # caches the release build does; --release shares one CEF wrapper build
+  # between clippy and the tests.
   shell:
     runs-on: ubuntu-latest
     env:
@@ -90,33 +90,9 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: ./.github/actions/shell-toolchain
         with:
           components: rustfmt, clippy
-
-      - name: Install window build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            cmake ninja-build pkg-config \
-            libgtk-3-dev libnss3-dev libnspr4-dev \
-            libasound2-dev libcups2-dev libdrm-dev libgbm-dev \
-            libxcomposite-dev libxdamage-dev libxfixes-dev libxrandr-dev \
-            libxkbcommon-dev libxss-dev libxtst-dev libwayland-dev
-
-      - name: Cache CEF
-        uses: actions/cache@v4
-        with:
-          path: .cef
-          key: cef-linux-${{ hashFiles('shell/Cargo.lock') }}
-
-      # shared-key: a release runs on a tag, and a tag can only read caches
-      # made on its own ref or on main — this job on main is what makes them.
-      # The default key is per job, and the release job would never see it.
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: shell
-          shared-key: shell
 
       - name: Format
         working-directory: shell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,36 +40,11 @@ jobs:
           cache: pnpm
           cache-dependency-path: frontend/pnpm-lock.yaml
 
-      # The window is a Rust crate on CEF (shell/): a Rust toolchain, CMake and
-      # Ninja for CEF's C++ wrapper, and the libraries libcef.so links against.
-      # The Go binary itself stays pure Go (CGO_ENABLED=0).
-      - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install window build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            cmake ninja-build pkg-config \
-            libgtk-3-dev libnss3-dev libnspr4-dev \
-            libasound2-dev libcups2-dev libdrm-dev libgbm-dev \
-            libxcomposite-dev libxdamage-dev libxfixes-dev libxrandr-dev \
-            libxkbcommon-dev libxss-dev libxtst-dev libwayland-dev
-
-      - name: Cache CEF
-        uses: actions/cache@v4
-        with:
-          path: .cef
-          key: cef-linux-${{ hashFiles('shell/Cargo.lock') }}
-
-      # Restored from the cache ci.yml's shell job saves on main (shared-key):
-      # a tag reads main's caches and nothing else, and with the CEF wrapper
-      # already built cargo only compiles the crate itself — seconds, not the
-      # minutes a cold build costs.
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: shell
-          shared-key: shell
+      # The window is a Rust crate on CEF (shell/); the Go binary itself stays
+      # pure Go (CGO_ENABLED=0). The toolchain, CEF's build dependencies and the
+      # caches — restored from what ci.yml's shell job saves on main, the only
+      # caches a tag can read — are the composite action's.
+      - uses: ./.github/actions/shell-toolchain
 
       # Packaging needs task and nfpm.
       #

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,7 +47,7 @@ tasks:
       # The Go binary stays pure and static; the window is a separate Rust
       # binary on CEF, found beside it at run time (internal/chromium/shell.go).
       # assemble.sh strips libcef.so and keeps only the runtime files lich
-      # needs — the 1.3 GB cargo leaves in target/ becomes ~300 MB.
+      # needs — the 1.3 GB cargo leaves in target/ becomes ~480 MB.
       - cmd: cd shell && cargo build --release
       - cmd: build/linux/shell/assemble.sh shell/target/release {{.BIN_DIR}}/shell
 

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -380,8 +380,14 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   guaranteed. Until then the queue holds `writeQueueDepth` frames for the whole app, and two things still wait on
   it across sessions: a push that finds it full, and the flush a session runs before its exit banner so the banner
   cannot overtake its own last bytes.
-- **Single instance via the pinned port**: the bind is the lock (`internal/singleton`); a duplicate launch focuses
-  the running window (best-effort, untested against a real window) and exits 0.
+- **Single instance via the pinned port**: the bind is the lock (`internal/singleton`); a duplicate launch hands
+  its URL to the running window through Chromium's profile lock (`chromium.Focus`, best-effort, untested
+  against a real window) and exits 0. With the bundled window the hand-off is a second `lich-shell` on the same
+  profile: CEF reports the forward as a failed initialise, the duplicate exits 1, and `focusRunning` logs one
+  Warn per duplicate launch. Focus never climbs the ladder — a fallback there would open lich a second time, in
+  a system browser, on the profile the window owns — so a lich already running in the fallback browser is not
+  focused by it either. What the running window does with the forwarded command line, focus or a second
+  window, is unmeasured for the shell.
 - **lich appends to the agent's system prompt, for two providers only**
   (`internal/terminal/command.go`, `briefingFlags` → `relay.SpawnBriefing`): Claude Code and oh-my-pi are spawned
   with `--append-system-prompt` carrying lich's own briefing, so text the user never wrote is in every session's

--- a/internal/chromium/chromium.go
+++ b/internal/chromium/chromium.go
@@ -1,9 +1,11 @@
-// Package chromium launches the app window as a system Chromium in --app
-// mode, pointed at the loopback listener that serves the frontend and the
-// RPC/terminal transports — option 1 of docs/chromium-shell.md.
+// Package chromium launches the app window: a Chromium in --app mode — lich's
+// own on Linux (shell.go), a system browser elsewhere — pointed at the loopback
+// listener that serves the frontend and the RPC/terminal transports
+// (docs/chromium-shell.md).
 package chromium
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -120,7 +122,37 @@ const startupGrace = 10 * time.Second
 // with a dialog and no lich, so the ladder is climbed again without it — a
 // system browser, or ErrNoBrowser and the tab that answers it.
 func Run(url, dataDir, class string, extra []string, onStart func(*os.Process)) error {
-	env := RealEnv()
+	start := func(browser Result) error {
+		return launch(browser, url, dataDir, class, extra, onStart)
+	}
+	return run(RealEnv(), start, notifyDesktop)
+}
+
+// Focus hands url to the browser a running lich has its window in and waits
+// for the hand-off to end. It is Run without the ladder: the process is a
+// second instance that Chromium's profile lock forwards to the first, and its
+// exit is not a window failing to open — CEF reports the forward as a failed
+// initialise, so the bundled window's duplicate exits 1 by design. Falling
+// back on that would open lich a second time, in a system browser, on a
+// profile the window owns.
+func Focus(url, dataDir, class string) error {
+	browser, err := Resolve(RealEnv())
+	if err != nil {
+		return err
+	}
+	return launch(browser, url, dataDir, class, nil, nil)
+}
+
+// notifyDesktop is the fallback's desktop notification. Best effort: a window
+// that quietly opened in Chrome instead of as lich's own would otherwise read
+// as lich having changed its mind.
+func notifyDesktop(text string) {
+	_ = zenity.Notify(text, zenity.Title("lich"))
+}
+
+// run is Run's walk of the ladder, with the launch and the notification as
+// seams so the fallback is testable without a browser.
+func run(env Env, start func(Result) error, notify func(string)) error {
 	browser, err := Resolve(env)
 	if err != nil {
 		return err
@@ -133,35 +165,37 @@ func Run(url, dataDir, class string, extra []string, onStart func(*os.Process)) 
 			"browser", browser.Path)
 	}
 	started := time.Now()
-	err = launch(browser, url, dataDir, class, extra, onStart)
+	err = start(browser)
 	if !fallsBack(browser.Step, err, time.Since(started)) {
 		return err
 	}
-	slog.Warn("bundled window died at startup, opening a system browser instead", "err", err)
 	env.Shell = func() string { return "" }
 	fallback, rerr := Resolve(env)
 	if rerr != nil {
 		// No browser either. ErrNoBrowser reaches main.go's tab path, which
-		// keeps lich reachable; the crash itself is above, in the log.
-		slog.Error("bundled window failed and no system browser found", "err", err)
+		// keeps lich reachable; the crash itself is here, in the log.
+		slog.Error("bundled window died at startup and no system browser found", "err", err)
 		return rerr
 	}
-	slog.Info("browser resolved", "browser", fallback.Describe())
-	// Best effort: a window that quietly opened in Chrome instead of as lich's
-	// own would otherwise read as lich having changed its mind.
-	_ = zenity.Notify(
-		"lich's own window failed to open, so this one is "+filepath.Base(fallback.Path)+
-			". `lich rage` has the log.",
-		zenity.Title("lich"))
-	return launch(fallback, url, dataDir, class, extra, onStart)
+	slog.Warn("bundled window died at startup, opening a system browser instead",
+		"err", err, "browser", fallback.Describe())
+	notify("lich's own window failed to open, so this one is " + filepath.Base(fallback.Path) +
+		". `lich rage` has the log.")
+	return start(fallback)
 }
 
 // fallsBack is whether a launch that has ended is the bundled window failing to
 // open: only the bundled window (a pin is the user's word, a system browser has
 // nothing below it to fall to), only an error exit, and only within startupGrace.
+// A profile directory that could not be made is no exit at all — the window
+// never ran, and the next rung would fail on the same directory.
 func fallsBack(step string, err error, elapsed time.Duration) bool {
-	return step == stepShell && err != nil && elapsed < startupGrace
+	return step == stepShell && err != nil && !errors.Is(err, errProfileDir) && elapsed < startupGrace
 }
+
+// errProfileDir marks a launch that ended before the browser ran: its profile
+// directory could not be created.
+var errProfileDir = errors.New("chromium profile dir")
 
 // launch starts one resolved browser on the profile and waits for it to exit.
 func launch(browser Result, url, dataDir, class string, extra []string, onStart func(*os.Process)) error {
@@ -169,7 +203,7 @@ func launch(browser Result, url, dataDir, class string, extra []string, onStart 
 	// The data dir is required to launch at all; the prefs inside it only
 	// decide how quiet the window is.
 	if err := os.MkdirAll(dataDir, 0o700); err != nil {
-		return fmt.Errorf("chromium profile dir: %w", err)
+		return fmt.Errorf("%w: %w", errProfileDir, err)
 	}
 	// The bundled window keeps its own profile under this directory and has
 	// no Google account or translate bubble to silence; the prefs are for a

--- a/internal/chromium/shell_test.go
+++ b/internal/chromium/shell_test.go
@@ -2,31 +2,30 @@ package chromium
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
+	"testing/fstest"
 	"time"
 )
 
-// fakeInfo is the one thing findShell asks of a stat result.
-type fakeInfo struct{ dir bool }
-
-func (f fakeInfo) Name() string       { return "" }
-func (f fakeInfo) Size() int64        { return 0 }
-func (f fakeInfo) Mode() fs.FileMode  { return 0 }
-func (f fakeInfo) ModTime() time.Time { return time.Time{} }
-func (f fakeInfo) IsDir() bool        { return f.dir }
-func (f fakeInfo) Sys() any           { return nil }
-
+// statOf is os.Stat over a map of paths, true for a directory; a slash-rooted
+// path is what shellPaths builds on every OS, fstest wants it unrooted.
 func statOf(files map[string]bool) func(string) (os.FileInfo, error) {
-	return func(path string) (os.FileInfo, error) {
-		dir, ok := files[path]
-		if !ok {
-			return nil, errors.New("not found")
+	fsys := fstest.MapFS{}
+	for path, dir := range files {
+		var mode fs.FileMode
+		if dir {
+			mode = fs.ModeDir
 		}
-		return fakeInfo{dir: dir}, nil
+		fsys[strings.TrimPrefix(filepath.ToSlash(path), "/")] = &fstest.MapFile{Mode: mode}
+	}
+	return func(path string) (os.FileInfo, error) {
+		return fs.Stat(fsys, strings.TrimPrefix(filepath.ToSlash(path), "/"))
 	}
 }
 
@@ -70,12 +69,15 @@ func TestFindShellSkipsDirectoriesAndMissing(t *testing.T) {
 	}
 }
 
-// TestFallsBack pins the three conditions: only the bundled window, only an
-// error exit, only inside the startup grace. A close (nil error) never falls
-// back, a pinned browser never does, and a crash after the grace is the window
-// lifecycle ending.
+// TestFallsBack pins the conditions: only the bundled window, only an error
+// exit, only inside the startup grace, and only once the window ran. A close
+// (nil error) never falls back, a pinned browser never does, a crash after the
+// grace is the window lifecycle ending, and a profile directory that could not
+// be made is the next rung's failure too. The grace is the literal ten seconds
+// the CHANGELOG promises, not the constant: a change to one must fail here.
 func TestFallsBack(t *testing.T) {
 	crashed := errors.New("signal: segmentation fault")
+	noDir := fmt.Errorf("%w: %w", errProfileDir, fs.ErrPermission)
 	cases := []struct {
 		name    string
 		step    string
@@ -84,9 +86,10 @@ func TestFallsBack(t *testing.T) {
 		want    bool
 	}{
 		{"shell crashes at startup", stepShell, crashed, 2 * time.Second, true},
-		{"shell crashes just inside the grace", stepShell, crashed, startupGrace - time.Millisecond, true},
+		{"shell crashes just inside the grace", stepShell, crashed, 10*time.Second - time.Millisecond, true},
 		{"shell closed by the user", stepShell, nil, 2 * time.Second, false},
-		{"shell crashes after the grace", stepShell, crashed, startupGrace, false},
+		{"shell crashes after the grace", stepShell, crashed, 10 * time.Second, false},
+		{"shell profile dir cannot be made", stepShell, noDir, time.Second, false},
 		{"pinned browser crashes", stepPinned, crashed, time.Second, false},
 		{"system browser crashes", stepDefault, crashed, time.Second, false},
 	}
@@ -94,5 +97,82 @@ func TestFallsBack(t *testing.T) {
 		if got := fallsBack(c.step, c.err, c.elapsed); got != c.want {
 			t.Errorf("%s: fallsBack = %v, want %v", c.name, got, c.want)
 		}
+	}
+}
+
+// TestRunLadder walks Run's ladder with the launch faked: which browsers get
+// started, in what order, what comes back, and whether the desktop is told.
+func TestRunLadder(t *testing.T) {
+	const shell = "/usr/local/lib/lich/shell/lich-shell"
+	crashed := errors.New("exit status 1")
+	noDir := fmt.Errorf("%w: %w", errProfileDir, fs.ErrPermission)
+	withChromium := map[string]bool{"chromium": true}
+	cases := []struct {
+		name     string
+		machine  fakeEnv
+		exits    map[string]error
+		wantErr  error
+		wantRuns []string
+		wantNote bool
+	}{
+		{
+			name:     "bundled window dies, the machine's browser answers",
+			machine:  fakeEnv{installed: withChromium, shell: shell},
+			exits:    map[string]error{shell: crashed},
+			wantRuns: []string{shell, "/usr/bin/chromium"},
+			wantNote: true,
+		},
+		{
+			name:     "bundled window dies, no browser at all",
+			machine:  fakeEnv{shell: shell},
+			exits:    map[string]error{shell: crashed},
+			wantErr:  ErrNoBrowser,
+			wantRuns: []string{shell},
+		},
+		{
+			name:     "bundled window closed by the user",
+			machine:  fakeEnv{installed: withChromium, shell: shell},
+			wantRuns: []string{shell},
+		},
+		{
+			name: "pinned browser dies",
+			machine: fakeEnv{
+				installed: map[string]bool{"vivaldi": true},
+				vars:      map[string]string{OverrideEnv: "vivaldi"},
+				shell:     shell,
+			},
+			exits:    map[string]error{"/usr/bin/vivaldi": crashed},
+			wantErr:  crashed,
+			wantRuns: []string{"/usr/bin/vivaldi"},
+		},
+		{
+			name:     "profile directory cannot be made",
+			machine:  fakeEnv{installed: withChromium, shell: shell},
+			exits:    map[string]error{shell: noDir},
+			wantErr:  errProfileDir,
+			wantRuns: []string{shell},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var runs []string
+			var note string
+			err := run(c.machine.env(), func(b Result) error {
+				runs = append(runs, b.Path)
+				return c.exits[b.Path]
+			}, func(text string) { note = text })
+			if !errors.Is(err, c.wantErr) {
+				t.Fatalf("run = %v, want %v", err, c.wantErr)
+			}
+			if !slices.Equal(runs, c.wantRuns) {
+				t.Fatalf("launched %v, want %v", runs, c.wantRuns)
+			}
+			if (note != "") != c.wantNote {
+				t.Fatalf("notification %q, want one: %v", note, c.wantNote)
+			}
+			if c.wantNote && !strings.Contains(note, "chromium") {
+				t.Fatalf("notification %q does not name the browser", note)
+			}
+		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -271,8 +271,9 @@ func denyInternal(d *rpc.Handler) {
 }
 
 // runChromium serves the embedded frontend on the loopback listener and opens
-// it in the system Chromium's --app mode; the browser process exiting is the
-// app lifecycle. Extra CLI args after `--` pass through to Chromium
+// it in a Chromium --app window — lich's own on Linux, the system browser
+// elsewhere (internal/chromium); the browser process exiting is the app
+// lifecycle. Extra CLI args after `--` pass through to Chromium
 // (e.g. `lich -- --ozone-platform=wayland`).
 //
 // LICH_DEV_URL points the window at the Vite dev server instead of the
@@ -340,10 +341,7 @@ func runChromium(term *terminal.Service, configDir string, extra []string, coord
 		// doing nothing (#409). Best effort — where no dialog backend answers,
 		// the log line above still has the story.
 		_ = zenity.Error(fmt.Sprintf(
-			"lich could not open its window.\n\n%v\n\n"+
-				"lich does not bundle a browser runtime; it opens its window in "+
-				"a Chromium-family browser installed on this machine.\n\n"+
-				"Log: %s",
+			"lich could not open its window.\n\n%v\n\nLog: %s",
 			err, logging.Path(filepath.Join(configDir, "lich"))),
 			zenity.Title("lich"))
 		os.Exit(1)
@@ -461,7 +459,7 @@ func focusRunning(configDir string, running *singleton.Info) {
 	}
 	profileDir := filepath.Join(configDir, "lich", "chromium-profile")
 	url := fmt.Sprintf("http://127.0.0.1:%d/?token=%s", running.Port, running.Token)
-	if err := chromium.Run(url, profileDir, "lich", nil, nil); err != nil {
+	if err := chromium.Focus(url, profileDir, "lich"); err != nil {
 		slog.Warn("focus existing window", "err", err)
 		// The running lich has no window of its own either (it is serving a
 		// tab); the honest "focus" is another tab pointed at it.

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -45,6 +45,9 @@ fn main() {
     // exists, so a missing --app= is a subprocess, not an error.
     let launch = parse(std::env::args().skip(1));
     let mut app = App::url(launch.url.unwrap_or_else(|| "about:blank".into()))
+        // Only reached without --user-data-dir, which lich always passes: a
+        // shell launched by hand gets a profile under its own name rather than
+        // kurogane's default.
         .profile_id("lich")
         .window_title(TITLE)
         // CEF's Chrome runtime loads the extensions a distribution installs


### PR DESCRIPTION
Audit follow-up for the bundled window (#454): `/code-quality-audit` over that commit, all findings applied.

## What changed

- **A duplicate `lich` no longer falls back to a system browser.** `focusRunning` reused `chromium.Run`, which now carries the fallback ladder. A second `lich` launched a second `lich-shell` on the same profile; CEF's process singleton reports the hand-off as a failed initialise, kurogane exits 1, and inside the ten-second grace that read as the window failing to open — a "lich's own window failed to open" notification plus a system Chromium opened on the profile CEF owns. `chromium.Focus` resolves and launches once, with no ladder. `docs/ceilings.md`'s single-instance bullet says what the duplicate does with the bundled window and what is still unmeasured.
- **`Run`'s ladder is tested.** `run(env, start, notify)` takes the launch and the notification as seams; `TestRunLadder` walks the five paths. `internal/chromium` coverage: 67.3% → 75.4% (what is left is `launch`, `RealEnv`, `bundledShell` — the boundary).
- **A profile directory that cannot be made is not "the window died at startup".** `errProfileDir` marks it and `fallsBack` excludes it: the window never ran, and the next rung fails on the same directory. The fallback's two log lines fold into one naming the browser that answered.
- **The launch-failure dialog** drops "lich does not bundle a browser runtime", false on Linux since #454.
- **`.github/actions/shell-toolchain`** holds Rust, CEF's apt list and the CEF/cargo caches once; `ci.yml`'s shell job and the release's linux job use it instead of two verbatim copies.
- Small: `TestFallsBack` pins the literal ten seconds the CHANGELOG promises; `fstest.MapFS` replaces the hand-rolled `FileInfo`; `profile_id`, the package doc, `runChromium`'s doc and the Taskfile's size figure catch up with the window.

## Read, not measured

No `lich-shell` build here. From kurogane's source: `ctrlc` carries `termination`, so `/restart`'s SIGTERM closes the browsers and exits 0 (no fallback); `root_cache_path` is the `--user-data-dir`, so the singleton is on lich's profile and the duplicate exits 1. Both are worth one run each once a shell build exists.

## Gate

- `gofmt -l .`, `go vet ./...` clean; GOOS linux/darwin/windows build + vet loop clean
- `go test ./...` green (32 packages), `cargo fmt --check` clean
- Not run: `cargo clippy` / `cargo test` (need the CEF download; CI's shell job covers them), frontend gate (untouched)
- No CHANGELOG entry: the window is still under `[Unreleased]`, nothing published changed
