### PR TITLE
feat: let a release open the What's new dialog with its own headline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> [!IMPORTANT]
+> **Linux users: lich now opens in its own window.** No browser needs to be
+> installed. If the window fails on your machine, lich falls back to a
+> Chromium-family browser and says so.
+
+> [!NOTE]
+> **NVIDIA under Wayland opens on XWayland by default.**
+> `lich -- --ozone-platform=wayland` opens it native.
+
 ### Added
 
 - **On Linux, lich now brings its own window: no browser needs to be installed.**
@@ -202,6 +211,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "Last turn" mode this sits in at all.
 
 ### Changed
+
+- **The What's new dialog opens on the release's headline and lists the rest
+  as rows.** A release can now carry its own announcement: an alert block
+  written under its heading in the changelog (`> [!IMPORTANT]`, the same
+  syntax GitHub renders as a callout on the release page) opens the dialog as
+  a headline, and a `> [!WARNING]` or `> [!NOTE]` follows it as a callout.
+  Below them every entry shows the bold sentence it opens with, and the
+  paragraph behind it opens on click, so a release with twenty entries is
+  scanned rather than scrolled. The header is one line — name, version and how
+  many entries were added, changed and fixed. The update toast is unchanged:
+  it says a release exists, and the dialog is where the release speaks.
 
 - **The Linux packages are ~120 MB to download and ~480 MB installed, up from
   ~10 MB.** That is the embedded Chromium: `libcef.so` stripped of its debug

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,4 +84,10 @@ The version comes from the git tag (`git describe` in the Taskfile, env `VERSION
       greps `^## \[X.Y.Z\]` and ships empty notes if it misses. Keep the sections in their canonical order
       (Added, Changed, Deprecated, Removed, Fixed, Security), and refresh the compare links, `[Unreleased]`
       included.
+- [ ] Want the release to announce itself? Write GitHub alert blocks right under its heading, before the first
+      `###`: `> [!IMPORTANT]` is the release's headline and opens the What's new dialog (one per release — a
+      second one is demoted to a callout, which is the signal to fold it into the groups); `> [!WARNING]` is
+      something the reader must do or avoid; `> [!NOTE]` is a detail worth a line. One or two sentences each,
+      opening with a bold sentence that names its audience. The same blocks render as callouts on the release
+      page. Most releases carry none.
 - [ ] Push the `vX.Y.Z` tag — `.github/workflows/release.yml` does the rest, and reads the notes from that section.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -126,7 +126,10 @@ tasks:
           # go run leaves the binary in a temp dir, where the bundled-window
           # lookup finds nothing; the pin names the window build:shell made.
           # Empty off Linux, where the system browser still answers.
-          LICH_DEV=1 LICH_DEV_URL="http://127.0.0.1:{{.VITE_PORT}}" LICH_LISTEN_PORT=47822 LICH_BROWSER="{{if eq OS "linux"}}{{.ROOT_DIR}}/{{.BIN_DIR}}/shell/lich-shell{{end}}" go run .
+          # The build reports "dev" unless VERSION is set: `VERSION=Unreleased
+          # task dev` is how the What's new dialog is smoked against the
+          # [Unreleased] changelog section, `VERSION=v0.44.0` against a release.
+          LICH_DEV=1 LICH_DEV_URL="http://127.0.0.1:{{.VITE_PORT}}" LICH_LISTEN_PORT=47822 LICH_BROWSER="{{if eq OS "linux"}}{{.ROOT_DIR}}/{{.BIN_DIR}}/shell/lich-shell{{end}}" go run {{if env "VERSION"}}-ldflags "-X main.version={{.VERSION}}" {{end}}.
 
   test:shell:
     desc: Run the window crate's suite (Linux)

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -835,6 +835,13 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   than being forgotten — but it also means a pane removed from the app for good leaves a pref that resolves
   silently, forever, and nothing rewrites it. Deleting a section means the users who were on it open on
   Appearance with no explanation.
+- **A release's highlight is read from the binary, so fixing it after the tag fixes nothing a user sees**
+  (`internal/patchnotes`): the What's new dialog parses the `CHANGELOG.md` embedded at build time — the alert
+  blocks under the version heading included. Editing that release on GitHub, or the changelog on `main`,
+  changes the release page and no dialog anywhere; the users who already updated have recorded the version as
+  seen, and the ones who have not will read the binary they install. A wrong headline is a patch release. The
+  update toast reads nothing from the release but its tag, on purpose: the toast says a release exists, and
+  the dialog is where it speaks.
 - **`agentplugin.Status` is the one settings read that is not remembered** (`UpdatesSettings.tsx`): it costs
   ~180 ms and its rows blank on every visit to Updates, while every other read on the screen paints from the
   last answer. It is not an oversight — `PluginSetting` awaits that read for its *outcome*, telling "Checked."

--- a/frontend/src/components/PatchNotesDialog.tsx
+++ b/frontend/src/components/PatchNotesDialog.tsx
@@ -1,16 +1,10 @@
 import type { ReactNode } from "react"
-import { ArrowUpRight, Sparkles } from "lucide-react"
+import { ArrowUpRight, ChevronRight, Info, TriangleAlert } from "lucide-react"
 import { Button } from "@/components/ui/button"
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog"
+import { Dialog, DialogContent, DialogFooter, DialogTitle } from "@/components/ui/dialog"
 import { System } from "@/lib/rpc"
-import type { PatchNotes } from "@/lib/api-types"
+import type { PatchNotes, PatchNotesHighlight } from "@/lib/api-types"
+import { layoutHighlights, splitLeadIn } from "@/lib/update/patch-notes-layout"
 import { cn } from "@/lib/utils"
 
 const RELEASE_TAG_BASE = "https://github.com/omartelo/lich/releases/tag/v"
@@ -54,6 +48,79 @@ function renderInline(text: string): ReactNode[] {
   })
 }
 
+// The release's headline: the first IMPORTANT block, set as the largest type
+// the app uses and nothing else — no fill, no badge. Size and space carry it.
+function Lead({ highlight }: { highlight: PatchNotesHighlight }) {
+  const { headline, body } = splitLeadIn(highlight.text)
+  return (
+    <div className="border-b px-6 pt-5 pb-6">
+      <p className="max-w-[22ch] text-2xl leading-tight font-semibold tracking-tight text-balance">
+        {renderInline(headline)}
+      </p>
+      {body !== "" && (
+        <p className="mt-2.5 max-w-[56ch] text-sm leading-relaxed text-muted-foreground">
+          {renderInline(body)}
+        </p>
+      )}
+    </div>
+  )
+}
+
+// Every other block: a compact callout. A warning is the one that paints —
+// the destructive tint says "do this or avoid this"; a note sits on the accent
+// fill like a row.
+function Callout({ highlight }: { highlight: PatchNotesHighlight }) {
+  const warning = highlight.kind === "warning"
+  const Icon = warning ? TriangleAlert : Info
+  return (
+    <div
+      className={cn(
+        "flex gap-2.5 rounded-md px-3 py-2.5 text-[0.8125rem] leading-relaxed text-muted-foreground",
+        warning ? "bg-destructive/10 ring-1 ring-destructive/30" : "bg-accent/60",
+      )}
+    >
+      <Icon
+        className={cn(
+          "mt-0.5 size-4 flex-none",
+          warning ? "text-destructive" : "text-muted-foreground",
+        )}
+      />
+      <div>{renderInline(highlight.text)}</div>
+    </div>
+  )
+}
+
+// One changelog item as a row: its bold lead-in, with the paragraph behind it
+// opening on click. A native <details> — the row needs no state of its own.
+function Item({ item }: { item: string }) {
+  const { headline, body } = splitLeadIn(item)
+  const row = "-mx-2 flex items-start gap-2 rounded-md px-2 py-1.5 text-[0.8125rem] leading-snug"
+  if (body === "") {
+    return (
+      <div className={row}>
+        <span className="mt-0.5 size-3.5 flex-none" />
+        <span className="font-medium">{renderInline(headline)}</span>
+      </div>
+    )
+  }
+  return (
+    <details className="group">
+      <summary
+        className={cn(
+          row,
+          "cursor-pointer list-none hover:bg-accent/50 [&::-webkit-details-marker]:hidden",
+        )}
+      >
+        <ChevronRight className="mt-0.5 size-3.5 flex-none text-muted-foreground transition-transform group-open:rotate-90" />
+        <span className="font-medium">{renderInline(headline)}</span>
+      </summary>
+      <p className="max-w-[60ch] pb-2 pl-5.5 text-[0.8125rem] leading-relaxed text-muted-foreground">
+        {renderInline(body)}
+      </p>
+    </details>
+  )
+}
+
 interface PatchNotesDialogProps {
   notes: PatchNotes
   /** Dismiss — also fired on Escape/backdrop; the gate records the version. */
@@ -62,44 +129,45 @@ interface PatchNotesDialogProps {
 
 export function PatchNotesDialog({ notes, onClose }: PatchNotesDialogProps) {
   const groups = notes.groups ?? []
+  const { lead, callouts } = layoutHighlights(notes.highlights)
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-lg">
-        <DialogHeader className="flex-row items-start gap-3 p-6 pr-12 pb-4">
-          <span className="grid size-10 flex-none place-items-center rounded-lg bg-emerald-500/15 text-emerald-500 ring-1 ring-emerald-500/30">
-            <Sparkles className="size-5" />
-          </span>
-          <div className="min-w-0 flex-1 pt-0.5">
-            <div className="flex flex-wrap items-center gap-2">
-              <DialogTitle className="text-[1.0625rem]">What's new in lich</DialogTitle>
-              <span className="flex-none rounded-full border bg-accent px-2 py-0.5 text-xs font-medium tabular-nums">
-                v{notes.version}
+      <DialogContent className="gap-0 overflow-hidden p-0 sm:max-w-xl" showCloseButton={false}>
+        <div className="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1 px-6 pt-5 text-[0.8125rem] text-muted-foreground">
+          <DialogTitle className="text-[0.8125rem] font-medium text-foreground">
+            What's new in lich <span className="font-normal tabular-nums">v{notes.version}</span>
+          </DialogTitle>
+          <div className="flex gap-3 tabular-nums">
+            {groups.map((group) => (
+              <span key={group.label} className="inline-flex items-center gap-1.5">
+                <span className={cn("size-1.5 rounded-full", dotColor(group.label))} />
+                {group.items.length} {group.label.toLowerCase()}
               </span>
-            </div>
-            <DialogDescription className="mt-1">
-              You updated to a new version — here's what changed.
-            </DialogDescription>
+            ))}
           </div>
-        </DialogHeader>
+        </div>
 
-        <div className="max-h-[55vh] overflow-y-auto px-6">
+        {lead && <Lead highlight={lead} />}
+
+        <div className="max-h-[60vh] overflow-y-auto px-6 pb-2">
+          {callouts.length > 0 && (
+            <div className="flex flex-col gap-2 pt-4">
+              {callouts.map((h, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: a release's blocks are read-only and never reordered.
+                <Callout key={i} highlight={h} />
+              ))}
+            </div>
+          )}
           {groups.map((group) => (
-            <div key={group.label} className="border-t py-3.5 first:border-t-0 first:pt-1">
-              <div className="mb-2.5 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <div key={group.label} className="border-t pt-3.5 pb-1.5 first:border-t-0">
+              <div className="mb-1.5 flex items-center gap-1.5 text-xs font-semibold tracking-wide text-muted-foreground uppercase">
                 <span className={cn("size-2 rounded-full", dotColor(group.label))} />
                 {group.label}
               </div>
-              <ul className="flex flex-col gap-2.5">
-                {group.items.map((item, i) => (
-                  <li
-                    // biome-ignore lint/suspicious/noArrayIndexKey: a release's notes are read-only and never reordered.
-                    key={i}
-                    className="relative pl-3.5 text-[0.8125rem] leading-relaxed text-muted-foreground before:absolute before:top-2 before:left-0 before:size-1 before:rounded-full before:bg-border"
-                  >
-                    {renderInline(item)}
-                  </li>
-                ))}
-              </ul>
+              {group.items.map((item, i) => (
+                // biome-ignore lint/suspicious/noArrayIndexKey: a release's notes are read-only and never reordered.
+                <Item key={i} item={item} />
+              ))}
             </div>
           ))}
         </div>

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -461,9 +461,19 @@ export interface PatchNotesGroup {
   items: string[]
 }
 
+/** internal/patchnotes.Highlight — one GitHub alert block under the version heading. */
+export interface PatchNotesHighlight {
+  /** The alert type lowercased: "important", "warning", "note". */
+  kind: string
+  /** Text with markdown bold/code markers intact, rendered by the dialog. */
+  text: string
+}
+
 /** internal/patchnotes.Notes — the running build's changelog section. */
 export interface PatchNotes {
   version: string
+  /** null when the section carries no alert blocks. */
+  highlights: PatchNotesHighlight[] | null
   /** null when no section matches (a dev build, or a version not in the changelog). */
   groups: PatchNotesGroup[] | null
 }

--- a/frontend/src/lib/update/patch-notes-gate.test.ts
+++ b/frontend/src/lib/update/patch-notes-gate.test.ts
@@ -4,6 +4,7 @@ import type { PatchNotes } from "@/lib/api-types"
 
 const notes: PatchNotes = {
   version: "0.11.0",
+  highlights: null,
   groups: [{ label: "Added", items: ["**A thing.** It does stuff."] }],
 }
 
@@ -25,8 +26,14 @@ describe("decidePatchNotes", () => {
   })
 
   it("does nothing without a section — a dev build or unreleased version", () => {
-    expect(decidePatchNotes({ version: "dev", groups: null }, "0.10.0")).toEqual({ kind: "none" })
-    expect(decidePatchNotes({ version: "0.11.0", groups: [] }, "0.10.0")).toEqual({ kind: "none" })
-    expect(decidePatchNotes({ version: "", groups: null }, null)).toEqual({ kind: "none" })
+    expect(decidePatchNotes({ version: "dev", highlights: null, groups: null }, "0.10.0")).toEqual({
+      kind: "none",
+    })
+    expect(decidePatchNotes({ version: "0.11.0", highlights: null, groups: [] }, "0.10.0")).toEqual(
+      { kind: "none" },
+    )
+    expect(decidePatchNotes({ version: "", highlights: null, groups: null }, null)).toEqual({
+      kind: "none",
+    })
   })
 })

--- a/frontend/src/lib/update/patch-notes-layout.test.ts
+++ b/frontend/src/lib/update/patch-notes-layout.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { layoutHighlights, splitLeadIn } from "./patch-notes-layout"
+
+describe("splitLeadIn", () => {
+  it("splits the bold lead-in from the paragraph behind it", () => {
+    expect(splitLeadIn("**A thing.** It does `stuff` now.")).toEqual({
+      headline: "A thing.",
+      body: "It does `stuff` now.",
+    })
+  })
+
+  it("keeps an item that is only its lead-in as a headline with no body", () => {
+    expect(splitLeadIn("**A thing.**")).toEqual({ headline: "A thing.", body: "" })
+  })
+
+  it("keeps an item without a lead-in whole", () => {
+    expect(splitLeadIn("Plain item.")).toEqual({ headline: "Plain item.", body: "" })
+    expect(splitLeadIn("**Unclosed bold")).toEqual({ headline: "**Unclosed bold", body: "" })
+  })
+})
+
+describe("layoutHighlights", () => {
+  const important = { kind: "important", text: "The headline." }
+  const note = { kind: "note", text: "A detail." }
+  const warning = { kind: "warning", text: "Do this." }
+
+  it("leads with the first important block and keeps the rest in order", () => {
+    expect(layoutHighlights([note, important, warning])).toEqual({
+      lead: important,
+      callouts: [note, warning],
+    })
+  })
+
+  it("demotes a second important block to a callout", () => {
+    const second = { kind: "important", text: "Another headline." }
+    expect(layoutHighlights([important, second])).toEqual({ lead: important, callouts: [second] })
+  })
+
+  it("has no lead without an important block", () => {
+    expect(layoutHighlights([note])).toEqual({ lead: null, callouts: [note] })
+    expect(layoutHighlights(null)).toEqual({ lead: null, callouts: [] })
+  })
+})

--- a/frontend/src/lib/update/patch-notes-layout.ts
+++ b/frontend/src/lib/update/patch-notes-layout.ts
@@ -1,0 +1,41 @@
+// How the What's new dialog lays a release out. Kept pure (no React) so the
+// splits are testable; PatchNotesDialog renders what these return.
+
+import type { PatchNotesHighlight } from "@/lib/api-types"
+
+// A changelog item split into the bold lead-in it opens with and the paragraph
+// behind it. Every entry since 0.40 opens with a bold sentence, so the lead-in
+// is the row and the body opens on click; an item without one is its own row.
+export interface ItemParts {
+  headline: string
+  body: string
+}
+
+export function splitLeadIn(item: string): ItemParts {
+  if (!item.startsWith("**")) return { headline: item, body: "" }
+  const close = item.indexOf("**", 2)
+  if (close === -1) return { headline: item, body: "" }
+  return {
+    headline: item.slice(2, close).trim(),
+    body: item.slice(close + 2).trim(),
+  }
+}
+
+// The dialog's opening: the first "important" block is the headline region,
+// everything else (a second important included) is a callout under it. Two
+// headlines would fight; the second demoting to a callout is the author's
+// signal to fold it into the groups.
+export interface HighlightLayout {
+  lead: PatchNotesHighlight | null
+  callouts: PatchNotesHighlight[]
+}
+
+export function layoutHighlights(highlights: PatchNotesHighlight[] | null): HighlightLayout {
+  const all = highlights ?? []
+  const leadIndex = all.findIndex((h) => h.kind === "important")
+  if (leadIndex === -1) return { lead: null, callouts: all }
+  return {
+    lead: all[leadIndex],
+    callouts: all.filter((_, i) => i !== leadIndex),
+  }
+}

--- a/internal/patchnotes/patchnotes.go
+++ b/internal/patchnotes/patchnotes.go
@@ -1,7 +1,24 @@
 // Package patchnotes serves the changelog section for the running build so the
 // app can show a "what's new" popup after an update. CHANGELOG.md is embedded
-// at the module root (see main.go) and parsed into groups here — the frontend
-// stays a dumb renderer.
+// at the module root (see main.go) and parsed here — the frontend stays a dumb
+// renderer.
+//
+// A section is the groups ("### Added / Changed / Fixed") plus, optionally,
+// GitHub alert blocks written between the version heading and the first group:
+//
+//	## [0.45.0] - 2026-09-06
+//
+//	> [!IMPORTANT]
+//	> **Linux users: lich now opens in its own window.** No browser needs
+//	> to be installed.
+//
+//	### Added
+//
+// Each block is a Highlight. GitHub renders the same blocks as callouts on the
+// release page, so a release announces itself in one place. The kind is the
+// volume: "important" is the release's headline and opens the popup as its
+// title, "warning" is something the reader must do or avoid, "note" a detail
+// worth a line. The frontend decides how each kind looks.
 package patchnotes
 
 import "strings"
@@ -13,10 +30,19 @@ type Group struct {
 	Items []string `json:"items"`
 }
 
+// Highlight is one GitHub alert block ("> [!IMPORTANT]") written between a
+// release's heading and its first group. Kind is the alert type, lowercased.
+type Highlight struct {
+	Kind string `json:"kind"`
+	// Text keeps its markdown bold/code markers; the frontend renders them.
+	Text string `json:"text"`
+}
+
 // Notes is a release's changelog section, ready for the frontend to render.
 type Notes struct {
-	Version string  `json:"version"`
-	Groups  []Group `json:"groups"`
+	Version    string      `json:"version"`
+	Highlights []Highlight `json:"highlights"`
+	Groups     []Group     `json:"groups"`
 }
 
 // Service serves the notes for one fixed version — the running build.
@@ -34,7 +60,21 @@ func New(version, changelog string) *Service {
 // no section matches (a dev build, or a version not yet in the changelog), and
 // the frontend then shows nothing.
 func (s *Service) Current() Notes {
-	return Notes{Version: normalize(s.version), Groups: Section(s.changelog, s.version)}
+	return Notes{
+		Version:    normalize(s.version),
+		Highlights: Highlights(s.changelog, s.version),
+		Groups:     Section(s.changelog, s.version),
+	}
+}
+
+// Highlights returns the alert blocks under the "## [<version>]" heading, in
+// the order written, or nil when the heading is absent or carries none.
+func Highlights(changelog, version string) []Highlight {
+	body, ok := sliceSection(changelog, normalize(version))
+	if !ok {
+		return nil
+	}
+	return parseHighlights(body)
 }
 
 // normalize drops a leading "v" so "v0.11.0" and "0.11.0" compare equal.
@@ -117,4 +157,52 @@ func parseGroups(lines []string) []Group {
 		}
 	}
 	return out
+}
+
+// parseHighlights collects the alert blocks written before the first group. A
+// block opens with "> [!KIND]" and runs through the "> " lines after it; a line
+// that is not quoted ends it, and the first "### " ends the search. A plain
+// blockquote (no [!KIND] opener) is prose, not a highlight, and is skipped —
+// as is an opener with no text under it.
+func parseHighlights(lines []string) []Highlight {
+	var out []Highlight
+	var cur *Highlight
+	var text []string
+	flush := func() {
+		if cur != nil && len(text) > 0 {
+			cur.Text = strings.Join(text, " ")
+			out = append(out, *cur)
+		}
+		cur, text = nil, nil
+	}
+	for _, line := range lines {
+		if strings.HasPrefix(line, "### ") {
+			break
+		}
+		if !strings.HasPrefix(line, ">") {
+			flush()
+			continue
+		}
+		body := strings.TrimSpace(strings.TrimPrefix(line, ">"))
+		if kind, ok := alertKind(body); ok {
+			flush()
+			cur = &Highlight{Kind: kind}
+			continue
+		}
+		if cur != nil && body != "" {
+			text = append(text, body)
+		}
+	}
+	flush()
+	return out
+}
+
+// alertKind reads a GitHub alert opener such as "[!IMPORTANT]" and returns its
+// type lowercased; ok is false for any other quoted line.
+func alertKind(line string) (kind string, ok bool) {
+	if !strings.HasPrefix(line, "[!") || !strings.HasSuffix(line, "]") {
+		return "", false
+	}
+	kind = strings.ToLower(line[2 : len(line)-1])
+	return kind, kind != ""
 }

--- a/internal/patchnotes/patchnotes_test.go
+++ b/internal/patchnotes/patchnotes_test.go
@@ -125,3 +125,66 @@ func TestSectionDropsEmptyGroups(t *testing.T) {
 		t.Fatalf("empty group not dropped:\n got %#v\nwant %#v", got, want)
 	}
 }
+
+const withHighlights = `## [0.45.0] - 2026-09-06
+
+> [!IMPORTANT]
+> **Linux users: lich now opens in its own window.** No browser needs to be
+> installed.
+
+> A plain quote is prose, not a highlight.
+
+> [!NOTE]
+> **NVIDIA under Wayland opens on XWayland by default.**
+
+> [!WARNING]
+
+### Added
+
+- **On Linux, lich now brings its own window.**
+
+> [!IMPORTANT]
+> Written under a group, so not a highlight.
+
+## [0.44.0] - 2026-08-30
+
+> [!IMPORTANT]
+> The previous release's headline.
+`
+
+func TestHighlightsReadsAlertBlocksBeforeTheFirstGroup(t *testing.T) {
+	got := Highlights(withHighlights, "v0.45.0")
+	want := []Highlight{
+		{Kind: "important", Text: "**Linux users: lich now opens in its own window.** No browser needs to be installed."},
+		{Kind: "note", Text: "**NVIDIA under Wayland opens on XWayland by default.**"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Highlights mismatch:\n got %#v\nwant %#v", got, want)
+	}
+}
+
+// The blocks are prose to the group parser: the "### Added" group must come
+// through exactly as it would without them.
+func TestHighlightsLeaveGroupsUntouched(t *testing.T) {
+	got := Section(withHighlights, "0.45.0")
+	want := []Group{{Label: "Added", Items: []string{"**On Linux, lich now brings its own window.**"}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("groups changed by highlights:\n got %#v\nwant %#v", got, want)
+	}
+}
+
+func TestHighlightsAreNilWithoutBlocksOrSection(t *testing.T) {
+	if got := Highlights(sample, "0.11.0"); got != nil {
+		t.Fatalf("want nil for a section without blocks, got %#v", got)
+	}
+	if got := Highlights(withHighlights, "9.9.9"); got != nil {
+		t.Fatalf("want nil for an absent version, got %#v", got)
+	}
+}
+
+func TestCurrentCarriesHighlights(t *testing.T) {
+	got := New("v0.45.0", withHighlights).Current()
+	if len(got.Highlights) != 2 || got.Highlights[0].Kind != "important" {
+		t.Fatalf("Highlights = %#v, want the two blocks of 0.45.0", got.Highlights)
+	}
+}


### PR DESCRIPTION
## Summary

A release can now announce itself without a code change. GitHub alert blocks written under the version heading in `CHANGELOG.md` become the opening of the What's new dialog, and the dialog is redesigned to be scanned rather than read.

```markdown
## [0.45.0] - 2026-09-06

> [!IMPORTANT]
> **Linux users: lich now opens in its own window.** No browser needs to be installed.

> [!NOTE]
> **NVIDIA under Wayland opens on XWayland by default.** `lich -- --ozone-platform=wayland` opens it native.

### Added
```

- **`internal/patchnotes`** parses every `> [!KIND]` block between the heading and the first `###` into `Notes.Highlights` (`{kind, text}`, order preserved). Plain blockquotes and blocks under a group are not highlights. The group parser is untouched.
- **`PatchNotesDialog`**: the first `important` block is the headline region (24px, one seam under it, nothing painted); `warning` and `note` follow as compact callouts. Every entry is a row of its bold lead-in with the paragraph opening on click (native `<details>`). The header is one line: name, version, and the per-group counts. Width goes from `max-w-lg` to `max-w-xl`.
- **`lib/update/patch-notes-layout.ts`** holds the pure splits (lead-in / body, lead / callouts) with tests; the component only renders them.
- **The update toast, `appupdate` and `ghrelease` are unchanged on purpose.** The toast says a release exists; the dialog is where the release speaks. No network call is added.
- **Docs**: the writing rule is a line in the `CLAUDE.md` release checklist; the trap (the dialog reads the changelog embedded in the binary, so a highlight fixed after the tag reaches nobody — a wrong headline is a patch release) is in `docs/ceilings.md`. The 0.45.0 blocks are in `[Unreleased]` and move with the section on cut; `release.yml` already copies the section verbatim, so the same blocks render as callouts on the release page.

Design and the accepted mockup: https://claude.ai/code/artifact/bdd69e63-d052-41b5-a884-c8340c57f61a

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` green
- [x] `biome check`, `tsc -b`, `vite build`, `vitest run` (1425 tests) green
- [x] New tests: highlights parsed before the first group and not after it, plain quotes skipped, opener without text dropped, nil without blocks or section, `Current` carries them; `splitLeadIn` and `layoutHighlights` branches
- [ ] Smoke: `VERSION=v0.44.0 task dev` (the Taskfile now injects `VERSION` into the binary when set) → Settings › Updates › *View patch notes* shows the rows collapsed and opening on click; `VERSION=Unreleased task dev` shows the headline and the note callout