### PR TITLE
fix: keep the window's feature lists out of kurogane's switch overwrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   all work. `--browser` / `LICH_BROWSER` still pin a browser of your choice
   above it, and `lich -- <flags>` still reaches the window — on NVIDIA under
   Wayland, `lich -- --ozone-platform=wayland` opens it native (the default
-  there is XWayland). If the bundled window is missing or dies within ten
-  seconds of launch — an update this machine cannot run — lich opens in a
+  there is XWayland). If the bundled window is missing or dies within half a
+  minute of launch — an update this machine cannot run — lich opens in a
   Chromium-family browser on the machine instead and says so in a
   notification. macOS and Windows keep opening the system browser for now; the
   shipped window is Linux-only.

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -884,13 +884,15 @@ work when nobody knows it and that the call site never shows. The mechanism and 
 - **A Linux install whose window is missing or dies at startup opens a system browser instead**
   (`internal/chromium.Run`): `go run`, a bare binary copied out of the tarball, a package missing
   `lib/lich/shell` — each falls through to the ladder below with one `Warn` line; a window that exits with
-  an error inside `startupGrace` (10 s: a segfault on first paint, a system library `libcef.so` cannot find
+  an error inside `startupGrace` (30 s: a segfault on first paint, a system library `libcef.so` cannot find
   on this distribution — the packages declare Chromium's own list, so that is a bare binary on a slim
   install, or a glibc older than 2.34, Debian 11 and RHEL 8, which `lich-shell` will not load on) is
   relaunched the same way, with a desktop notification naming the browser. Refusing
   to open would turn a packaging slip or a bad update into a lich that does nothing. The grace is the trap:
-  a crash at 10.1 s is the window's lifecycle ending, as it always was, and a window closed by hand inside
-  it exits 0 and never falls back. A pinned browser never falls back either — it is the user's word — and
+  a crash at 30.1 s is the window's lifecycle ending, as it always was, and a window closed by hand inside
+  it exits 0 and never falls back. Thirty seconds and not ten because a segfault is reported only after
+  its core dump is written, and systemd-coredump takes ~18 s over the window's process tree (measured): a
+  crash one second in reaches `Wait` at nineteen. A pinned browser never falls back either — it is the user's word — and
   with no browser at all the crash lands on the tab path, where the log has the story and the
   notification does not. `lich doctor` names the rung that answered; `task dev` pins the window it built
   (`LICH_BROWSER`), since `go run` never has one beside it.

--- a/internal/chromium/chromium.go
+++ b/internal/chromium/chromium.go
@@ -105,8 +105,11 @@ func Args(url, dataDir, class string, extra []string) []string {
 // as failing to open — a segfault on first paint, a system library libcef.so
 // cannot find on this distribution — rather than as the window's lifecycle
 // ending. The user closing it exits 0 and never trips this; a crash an hour in
-// is the exit it always was.
-const startupGrace = 10 * time.Second
+// is the exit it always was. Half a minute rather than the ten seconds a crash
+// itself takes: a segfault is only reported once its core dump is written, and
+// systemd-coredump took 18 s over the window's 1.3 GB tree (measured), so a
+// crash one second in reached Wait at nineteen and was read as a closed window.
+const startupGrace = 30 * time.Second
 
 // Run opens the window and blocks until the user closes it — the browser
 // process exiting is the app lifecycle. The browser is whatever Resolve found;

--- a/internal/chromium/shell_test.go
+++ b/internal/chromium/shell_test.go
@@ -73,7 +73,7 @@ func TestFindShellSkipsDirectoriesAndMissing(t *testing.T) {
 // exit, only inside the startup grace, and only once the window ran. A close
 // (nil error) never falls back, a pinned browser never does, a crash after the
 // grace is the window lifecycle ending, and a profile directory that could not
-// be made is the next rung's failure too. The grace is the literal ten seconds
+// be made is the next rung's failure too. The grace is the literal half-minute
 // the CHANGELOG promises, not the constant: a change to one must fail here.
 func TestFallsBack(t *testing.T) {
 	crashed := errors.New("signal: segmentation fault")
@@ -86,9 +86,10 @@ func TestFallsBack(t *testing.T) {
 		want    bool
 	}{
 		{"shell crashes at startup", stepShell, crashed, 2 * time.Second, true},
-		{"shell crashes just inside the grace", stepShell, crashed, 10*time.Second - time.Millisecond, true},
+		{"shell crashes at startup, core dump written", stepShell, crashed, 19 * time.Second, true},
+		{"shell crashes just inside the grace", stepShell, crashed, 30*time.Second - time.Millisecond, true},
 		{"shell closed by the user", stepShell, nil, 2 * time.Second, false},
-		{"shell crashes after the grace", stepShell, crashed, 10 * time.Second, false},
+		{"shell crashes after the grace", stepShell, crashed, 30 * time.Second, false},
 		{"shell profile dir cannot be made", stepShell, noDir, time.Second, false},
 		{"pinned browser crashes", stepPinned, crashed, time.Second, false},
 		{"system browser crashes", stepDefault, crashed, time.Second, false},

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -33,6 +33,13 @@ fn parse<I: IntoIterator<Item = String>>(args: I) -> Launch {
             "app" => launch.url = value,
             "class" => launch.class = value,
             "user-data-dir" => launch.profile_dir = value,
+            // Feature lists stay in argv, where CEF reads them and unions them
+            // with the features it disables itself. Pushed through kurogane
+            // they would land as a plain switch write after that union and
+            // replace it — with `--disable-features=Translate` alone, the
+            // window came up with Chrome's Glic actor UI enabled and
+            // segfaulted attaching its first tab (measured, CEF 150).
+            "disable-features" | "enable-features" => {}
             _ => launch.switches.push((name.to_owned(), value)),
         }
     }
@@ -103,9 +110,21 @@ mod tests {
                 switches: vec![
                     ("profile-directory".into(), Some("Default".into())),
                     ("no-first-run".into(), None),
-                    ("disable-features".into(), Some("Translate".into())),
                 ],
             }
+        );
+    }
+
+    #[test]
+    fn leaves_feature_lists_to_cef() {
+        let launch = parse(args(&[
+            "--disable-features=Translate",
+            "--enable-features=Vulkan",
+            "--ozone-platform=wayland",
+        ]));
+        assert_eq!(
+            launch.switches,
+            vec![("ozone-platform".into(), Some("wayland".into()))]
         );
     }
 


### PR DESCRIPTION
## What

`task dev` (and any Linux launch) of the bundled window died with `signal: segmentation fault` about a second after start, and lich showed the "could not open its window" dialog instead of falling back to a browser.

## Why

- `ChromeMainDelegateCef::BasicStartupComplete` builds CEF's own `--disable-features` list (Chrome's Glic actor UI is on it), unions it with whatever is already on argv, and only then calls `OnBeforeCommandLineProcessing`. In that hook kurogane re-applies the app's switches last-write-wins, so lich's `--disable-features=Translate` replaced the union. The actor UI then came up and crashed in `TabInterface::GetFromContents` while attaching the first tab. Deterministic: 3/3 today, same stack.
- The fallback missed it because a segfault is only reported once its core dump is written: systemd-coredump took ~18 s over the window's process tree, so a crash at 1 s reached `Wait` at 19 s, past the 10 s grace.

## Fix

- `shell/src/main.rs`: `disable-features` / `enable-features` stay on argv, where CEF unions them itself, instead of going through `App::chromium_flag_with_value`. Unit test added.
- `startupGrace` 10 s → 30 s, with the measurement in the comment; `TestFallsBack` pins 19 s (inside) and 30 s (outside). `docs/ceilings.md` and the Unreleased CHANGELOG entry follow.

## Verified

- Window with lich's full argv (`--disable-features=Translate` included): mapped by 5 s, alive at 40 s, no new core (`coredumpctl`). Same binary before the fix: SIGSEGV, exit 139.
- `bin/lich` end to end on an isolated config: `lichdev` window matched to the shell's pid, alive at 30 s, no error in the log.
- cargo fmt/clippy/test, gofmt, go vet, `go test ./...` green.
