### PR TITLE
chore: strip libcef.so fully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,9 +223,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   many entries were added, changed and fixed. The update toast is unchanged:
   it says a release exists, and the dialog is where the release speaks.
 
-- **The Linux packages are ~120 MB to download and ~480 MB installed, up from
-  ~10 MB.** That is the embedded Chromium: `libcef.so` stripped of its debug
-  info (its symbol table has to stay — CEF resolves it at runtime), the
+- **The Linux packages are ~100 MB to download and ~300 MB installed, up from
+  ~10 MB.** That is the embedded Chromium: `libcef.so` stripped, the
   resources, the ANGLE GL libraries and the one locale pack the UI uses. The
   `chromium` recommends is gone from the deb, rpm and Arch packages (which now
   compress with xz), and the AUR package now fetches the window as a second

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -47,7 +47,7 @@ tasks:
       # The Go binary stays pure and static; the window is a separate Rust
       # binary on CEF, found beside it at run time (internal/chromium/shell.go).
       # assemble.sh strips libcef.so and keeps only the runtime files lich
-      # needs — the 1.3 GB cargo leaves in target/ becomes ~480 MB.
+      # needs — the 1.3 GB cargo leaves in target/ becomes ~300 MB.
       - cmd: cd shell && cargo build --release
       - cmd: build/linux/shell/assemble.sh shell/target/release {{.BIN_DIR}}/shell
 

--- a/build/linux/shell/README.md
+++ b/build/linux/shell/README.md
@@ -27,16 +27,17 @@ rev that includes it. Nothing else changes.
 `task build:shell` compiles the crate and runs `assemble.sh`, which reduces the
 1.3 GB cargo output to what ships:
 
-- `libcef.so` **`--strip-debug` only** — a full `strip` removes the symbol table
-  CEF resolves at runtime and the window segfaults on first paint (measured).
-  Debug info is ~1 GB; the symbols are another ~180 MB and stay. Result ~430 MB.
+- `libcef.so` fully stripped: debug info and symbol table are ~1.1 GB of the
+  1.3 GB, and what is left is ~260 MB. (A segfault was once blamed on the
+  symbol table going; it was the feature-list overwrite `shell/src/main.rs`
+  guards against, and a full strip was measured clean after that fix.)
 - resources (`.pak`, `icudtl.dat`, the V8 snapshot), the ANGLE GL libs, and only
   `locales/en-US.pak` — the UI is English and the other 219 packs only translate
   Chromium's own dialogs.
 - SwiftShader and the Vulkan loader are left out: software WebGL for a GPU-less
   machine, where xterm.js falls back to its canvas renderer anyway. 16 MB saved.
 
-On disk ~480 MB; ~120 MB compressed into the package. The first build downloads
+On disk ~300 MB; ~100 MB compressed into the package. The first build downloads
 the CEF distribution (~200 MB) and compiles its C++ wrapper — CMake and Ninja
 required, a few minutes once.
 

--- a/build/linux/shell/assemble.sh
+++ b/build/linux/shell/assemble.sh
@@ -13,11 +13,11 @@ rm -rf "$out"
 mkdir -p "$out/cef/locales"
 cp "$src/lich-shell" "$out/lich-shell"
 
-# Debug info is ~1 GB of the 1.3 GB libcef.so; dropping it leaves ~430 MB.
-# --strip-debug only: a full strip removes the symbol table CEF resolves at
-# runtime and the window segfaults on first paint (measured), so the symbols
-# stay even though they are another ~180 MB.
-strip --strip-debug -o "$out/cef/libcef.so" "$src/libcef.so"
+# Debug info and the symbol table are ~1.1 GB of the 1.3 GB libcef.so; the
+# stripped library is ~260 MB. CEF resolves nothing through the symbol table
+# at run time: the segfault once blamed on stripping it was the feature-list
+# overwrite (shell/src/main.rs), measured again after that fix.
+strip -o "$out/cef/libcef.so" "$src/libcef.so"
 for f in libEGL.so libGLESv2.so chrome_100_percent.pak chrome_200_percent.pak \
   resources.pak icudtl.dat v8_context_snapshot.bin chrome-sandbox; do
   cp "$src/$f" "$out/cef/$f"


### PR DESCRIPTION
## What

`assemble.sh` strips `libcef.so` fully instead of `--strip-debug` only.

## Why

The symbol table was kept because a full strip appeared to segfault the window on first paint. That crash was the feature-list overwrite fixed in #464, not the strip: after that fix a fully stripped `libcef.so` was measured clean.

## Measured

| | `--strip-debug` | full strip |
|---|---|---|
| `libcef.so` | 447 MB | 261 MB |
| `shell/` on disk | 477 MB | 300 MB |
| tar.zst -19 | ~122 MB | 100 MB |

- Window alone with lich's full argv: mapped by 5 s, alive at 40 s, no core.
- `bin/lich` end to end on an isolated config, page loaded (checked over CDP), window alive at 30 s, no error in the log.
- `task build:shell` with the new `assemble.sh`, then the same run again: clean.

The comments that explained the old decision (`assemble.sh`, `build/linux/shell/README.md`, `Taskfile.yml`) and the Unreleased CHANGELOG sizes now say this.
