### PR TITLE
fix: restore the CEF runtime cargo's cache had lost before assembling the window

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,6 +48,14 @@ tasks:
       # binary on CEF, found beside it at run time (internal/chromium/shell.go).
       # assemble.sh strips libcef.so and keeps only the runtime files lich
       # needs — the 1.3 GB cargo leaves in target/ becomes ~300 MB.
+      #
+      # cef-dll-sys's build script is what copies libcef.so and the rest of the
+      # runtime into target/release, and it only runs when cargo decides the
+      # crate is stale. A target/ restored from CI's cache is not stale, but
+      # rust-cache drops every loose file in target/release when it saves — so
+      # the crate is fresh and the runtime is gone. Cleaning the crate is the
+      # one way to make its build script run again; a no-op everywhere else.
+      - cmd: test -f shell/target/release/libcef.so || (cd shell && cargo clean --release -p cef-dll-sys)
       - cmd: cd shell && cargo build --release
       - cmd: build/linux/shell/assemble.sh shell/target/release {{.BIN_DIR}}/shell
 


### PR DESCRIPTION
The v0.45.0 release run failed in the linux job at `strip: 'shell/target/release/libcef.so': No such file` (https://github.com/omartelo/lich/actions/runs/34006166164).

**Cause.** `cef-dll-sys`'s build script is what copies `libcef.so` and the rest of the CEF runtime into `target/release`, and it runs only when cargo finds the crate stale. `Swatinem/rust-cache` deletes every loose file in `target/release` when it saves, and since #454 the release job restores that cache from `main` (shared-key `shell`). So the release job got a target where the crate was fresh and the runtime was gone: `cargo build` finished in 1.2 s and `assemble.sh` had nothing to strip. ci.yml's `shell` job never runs `assemble.sh`, which is why nothing turned red before the tag.

**Fix.** One guard before `cargo build` in `build:shell`: if `target/release/libcef.so` is missing, `cargo clean --release -p cef-dll-sys` — the only way to make that build script run again. A no-op on a machine that built the window before.

**Measured.** Reproduced locally by deleting the loose files in `target/release` the way rust-cache does: the guard fired, cargo rebuilt `cef-dll-sys` → `cef` → `kurogane` → `lich-shell` in 2m38s, and `assemble.sh` produced the 261 MB `libcef.so`. CI's cold `shell` job is 3m36s against 57s warm, so the release job pays about that once per tag.

No CHANGELOG entry: the broken tag never shipped. The `v0.45.0` tag is moved onto main after this merges.