### PR TITLE
fix: open the Linux window on native Wayland so file drops arrive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Dragging a file over a session now says where it will land.** The pane
+  under the cursor fills and reads "Attach to <session>", with the line under
+  it saying that the path is pasted at the prompt (or, for a sandboxed
+  session, that a file outside the checkout arrives as a copy). Before, a small "Drop to paste at the prompt" tag sat at the foot
+  of the pane and named no session, so with split panes nothing said which one
+  would take the file.
+
+### Fixed
+
+- **Dropping a file on a session works again under Wayland.** The 0.45.0
+  window opened on XWayland when the GPU is NVIDIA, and a file dragged from a
+  Wayland file manager onto an XWayland window never arrives on Hyprland: the
+  drop was silently lost. The window now opens native Wayland whenever a
+  Wayland display is present, as the system Chromium it replaced did;
+  `lich -- --ozone-platform=x11` brings the old behaviour back.
+
 ## [0.45.0] - 2026-09-05
 
 > [!IMPORTANT]

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -909,11 +909,15 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   and that profile is handed to a different Chromium — the bullet above, now with the window on one side
   of it. The prefs write is skipped for the window: it has no account chooser or translate bubble to hold
   down, and the file would be dead weight in a profile CEF owns.
-- **On NVIDIA under Wayland the window is XWayland unless asked otherwise** (`shell/src/main.rs`): kurogane
-  forces `--ozone-platform=x11` there, on its own reading of NVIDIA's EGL. The user's switches go through
-  kurogane so they win, and `lich -- --ozone-platform=wayland` opens native Wayland (measured on the
-  reference machine, RTX 3050 + Hyprland: it works). A compositor with no XWayland — niri — needs that
-  switch on NVIDIA; on any other GPU kurogane leaves the choice to Chromium's own hint, which picks Wayland.
+- **Under Wayland the window is native Wayland, whatever the GPU** (`shell/src/main.rs`): kurogane forces
+  `--ozone-platform=x11` on NVIDIA, on its own reading of NVIDIA's EGL, and 0.45.0 shipped that default.
+  It cost file drops: a Wayland file manager dropping on an XWayland window goes through the compositor's
+  DnD bridge, and Hyprland's does not deliver (its issue #7800): the drop that worked in the system
+  Chromium, which opens native Wayland on its own, silently did nothing. The shell now asks for Wayland
+  whenever `WAYLAND_DISPLAY` is set, the way Chromium's own `auto` hint does, and the user's switches still
+  go through kurogane after it, so `lich -- --ozone-platform=x11` is the way back if NVIDIA's Wayland path
+  misbehaves on a machine (the reference one, RTX 3050 + Hyprland, ran the system Chromium on it for
+  months). A compositor with no XWayland (niri) gets the native window by default now.
 - **The window opens at CEF's default size** (`shell/src/main.rs`): a system browser remembered the
   window's last size and position in its profile; the CEF Views window does not, so each launch is the
   default rectangle until the window manager places it. Tiling compositors never notice.

--- a/frontend/src/components/TerminalDropHint.tsx
+++ b/frontend/src/components/TerminalDropHint.tsx
@@ -1,0 +1,28 @@
+import { Paperclip } from "lucide-react"
+import { dropHintDetail } from "@/lib/terminal/drop-hint"
+
+interface TerminalDropHintProps {
+  label: string
+  confined: boolean
+}
+
+// TerminalDropHint covers a terminal while a file drag is over it and says
+// which session the file lands in. The fill is the "where": one pane of a
+// split lights, its neighbour does not. The name is set at reading size
+// because the eye is on the cursor, mid-pane, not on a footer. What the drop
+// does is the muted line under it, dropped on a pane too short to hold both.
+export function TerminalDropHint({ label, confined }: TerminalDropHintProps) {
+  return (
+    <div className="pointer-events-none absolute inset-0 z-10 grid place-items-center bg-accent/45 [container-type:size]">
+      <div className="grid justify-items-center gap-1.5 px-4 text-center">
+        <Paperclip className="size-5 text-foreground" />
+        <span className="text-sm text-foreground">
+          Attach to <span className="font-semibold">{label}</span>
+        </span>
+        <span className="text-xs text-muted-foreground [@container(max-height:120px)]:hidden">
+          {dropHintDetail(confined)}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/TerminalHost.tsx
+++ b/frontend/src/components/TerminalHost.tsx
@@ -336,6 +336,7 @@ export function TerminalHost() {
                   visible={visible}
                   focused={focused}
                   sandboxed={session.sandboxed ?? false}
+                  label={session.label}
                   onClose={() => worktreeClose.requestClose(session)}
                   stillInWorkspace={() => hasSession(sessionsRef.current, session.id)}
                 />

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/lib/terminal/term-view"
 import { exitMarker, readSessionExit, type SessionExit } from "@/lib/terminal/session-exit"
 import { TerminalExitBanner } from "./TerminalExitBanner"
+import { TerminalDropHint } from "./TerminalDropHint"
 import { TerminalSearchBar, type SearchResults } from "./TerminalSearchBar"
 import { useTerminalDrop } from "./useTerminalDrop"
 import {
@@ -106,6 +107,8 @@ export interface TerminalViewProps {
    * dragged in from outside its checkout has to arrive as a copy.
    */
   sandboxed: boolean
+  /** The card's title, so the drop hint can say which session the file lands in. */
+  label: string
   /**
    * Close this session's card, through the same flow the sidebar's × runs —
    * raised by the exit banner, which is the only affordance here that ends a
@@ -140,6 +143,7 @@ export function TerminalView({
   visible,
   focused,
   sandboxed,
+  label,
   onClose,
   stillInWorkspace,
 }: TerminalViewProps) {
@@ -764,13 +768,7 @@ export function TerminalView({
           paddingLeft: TERMINAL_PADDING_LEFT,
         }}
       />
-      {dropping && (
-        <div className="pointer-events-none absolute inset-0 z-10 flex items-end justify-center bg-accent/10 pb-6 ring-2 ring-inset ring-ring">
-          <span className="rounded-md bg-popover px-2 py-1 text-xs text-muted-foreground shadow-lg">
-            Drop to paste at the prompt
-          </span>
-        </div>
-      )}
+      {dropping && <TerminalDropHint label={label} confined={sandboxed} />}
       {exited && <TerminalExitBanner exit={exited} onRestart={restart} onClose={onClose} />}
       {searchOpen && (
         <TerminalSearchBar

--- a/frontend/src/lib/terminal/drop-hint.test.ts
+++ b/frontend/src/lib/terminal/drop-hint.test.ts
@@ -1,0 +1,7 @@
+import { expect, it } from "vitest"
+import { dropHintDetail } from "./drop-hint"
+
+it("says what the drop does, and the copy for a confined session", () => {
+  expect(dropHintDetail(false)).toBe("Its path is pasted at the prompt")
+  expect(dropHintDetail(true)).toBe("Outside the checkout it arrives as a copy")
+})

--- a/frontend/src/lib/terminal/drop-hint.ts
+++ b/frontend/src/lib/terminal/drop-hint.ts
@@ -2,7 +2,5 @@
 // what the drop does. A confined session (internal/sandbox) cannot see the
 // user's file, so for it the honest line is the copy.
 export function dropHintDetail(confined: boolean): string {
-  return confined
-    ? "Outside the checkout it arrives as a copy"
-    : "Its path is pasted at the prompt"
+  return confined ? "Outside the checkout it arrives as a copy" : "Its path is pasted at the prompt"
 }

--- a/frontend/src/lib/terminal/drop-hint.ts
+++ b/frontend/src/lib/terminal/drop-hint.ts
@@ -1,0 +1,8 @@
+// The line under "Attach to <session>" while a file drag is over a terminal:
+// what the drop does. A confined session (internal/sandbox) cannot see the
+// user's file, so for it the honest line is the copy.
+export function dropHintDetail(confined: boolean): string {
+  return confined
+    ? "Outside the checkout it arrives as a copy"
+    : "Its path is pasted at the prompt"
+}

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -46,6 +46,19 @@ fn parse<I: IntoIterator<Item = String>>(args: I) -> Launch {
     launch
 }
 
+/// The display the window opens on. Chromium's own default is the hint `auto`,
+/// Wayland whenever WAYLAND_DISPLAY is set, and the system browser lich
+/// launched before the window followed it. kurogane instead forces X11 on
+/// NVIDIA, and an XWayland window under a Wayland file manager loses every
+/// file drop to the compositor's DnD bridge (Hyprland, measured; its issue
+/// #7800). Set before the user's switches, so `lich -- --ozone-platform=x11`
+/// still wins.
+fn display_switch(wayland_display: Option<&str>) -> Option<(&'static str, &'static str)> {
+    wayland_display
+        .filter(|display| !display.is_empty())
+        .map(|_| ("ozone-platform", "wayland"))
+}
+
 fn main() {
     // CEF re-executes this binary for the renderer, GPU and utility roles with
     // an argv of its own. Those roles exit inside run_or_exit before any window
@@ -71,9 +84,13 @@ fn main() {
     if let Some(dir) = launch.profile_dir {
         app = app.cache_dir(dir);
     }
+    let wayland = std::env::var("WAYLAND_DISPLAY").ok();
+    if let Some((name, value)) = display_switch(wayland.as_deref()) {
+        app = app.chromium_flag_with_value(name, value);
+    }
     // The user's switches go through kurogane rather than staying in argv, so
-    // they land after its own policy and win: --ozone-platform=wayland beats
-    // the x11 it forces on NVIDIA.
+    // they land after its own policy and win: --ozone-platform=x11 beats the
+    // Wayland chosen above.
     for (name, value) in launch.switches {
         app = match value {
             Some(value) => app.chromium_flag_with_value(name, value),
@@ -132,6 +149,16 @@ mod tests {
     fn keeps_the_first_equals_inside_a_value() {
         let launch = parse(args(&["--app=http://h/?a=1&b=2"]));
         assert_eq!(launch.url.as_deref(), Some("http://h/?a=1&b=2"));
+    }
+
+    #[test]
+    fn opens_native_wayland_when_a_wayland_display_exists() {
+        assert_eq!(
+            display_switch(Some("wayland-1")),
+            Some(("ozone-platform", "wayland"))
+        );
+        assert_eq!(display_switch(Some("")), None);
+        assert_eq!(display_switch(None), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Regression from 0.45.0: dragging a file from the file manager onto a session did nothing on Linux.

**Cause.** The frontend and `internal/drop` are untouched and innocent. kurogane forces `--ozone-platform=x11` on NVIDIA, so the bundled window was an XWayland client. A file dragged from a Wayland file manager (Nautilus) onto an XWayland window goes through the compositor's DnD bridge, and Hyprland's does not deliver it (hyprwm/Hyprland#7800, #1083). The system Chromium 151 the window replaced opens native Wayland on its own, which is why the drop worked before.

Measured with an A/B probe (same shell build, a page logging `dragenter`/`drop` over HTTP):

| Window | Backend | `dragenter` types | `drop` |
| --- | --- | --- | --- |
| 0.45.0 default | XWayland | empty | 0 files |
| this branch | Wayland | `Files` | the file, name and size |

With no `Files` type the terminal's `onDragOver` never calls `preventDefault`, so the drop is lost silently, with nothing in any log.

**Fix.** `shell/src/main.rs` asks for `ozone-platform=wayland` whenever `WAYLAND_DISPLAY` is set, the way Chromium's own `auto` hint does, before the user's switches: `lich -- --ozone-platform=x11` is the way back. The ceilings bullet is rewritten around the trap.

**Hint.** While a file drag is over a terminal, the pane now fills and reads "Attach to <session>", with a muted line saying the path is pasted at the prompt (or, for a sandboxed session, that a file outside the checkout arrives as a copy). The old tag at the foot of the pane named no session, so with split panes nothing said which one would take the file. Mockup with the three treatments considered: the one implemented is C, no ring, fill as state.

## Test plan

- [x] Shell gate: `cargo fmt --check`, `cargo clippy --release --all-targets -D warnings`, `cargo test --release` (5 tests)
- [x] Frontend gate: biome clean on touched files, `tsc -b`, `vite build`, vitest 1426 tests
- [x] `gofmt -l .` and `go vet ./...` clean (no Go touched)
- [x] A/B probe above: drop lost on XWayland, delivered on Wayland, same build
- [x] `task dev` on this branch: file dropped on a session lands at the prompt, hint shows the session name
- [ ] NVIDIA + Wayland on a machine other than the reference one: if the window misbehaves, `lich -- --ozone-platform=x11`
