### PR TITLE
feat: make footer layout configurable in global appearance settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of the pane and named no session, so with split panes nothing said which one
   would take the file.
 
+- **Arrange the footer in Settings › Appearance › Footer.**
+  Drag actions and readings between Available items, Left side and Right side,
+  reorder them, or use each item's menu from the keyboard. A preview follows
+  the layout, which persists across projects and restarts; Restore default
+  returns the original arrangement. Model, context, plan usage, cost, hands-on
+  time, date/time, branch, path, PR, files, changes and attachment can
+  each be placed independently. Session readings stay inline and wrap when
+  needed. These global controls replace the duplicated provider-page controls
+  and preserve existing visibility/cost choices. The editor uses compact
+  controls in full-width rows that wrap without horizontal scrolling; its
+  preview stays on one line. Branch and path are plain text without a checkout
+  popover. Plan usage retains its compact provider/plan heading and wide gauges,
+  without redundant labels, with more vertical space inside the tooltip.
+  Footer tooltips have a theme-colored border to separate them from the footer.
+- **Settings use the available window width** instead of a narrow centered
+  column. Descriptions retain a readable line length.
+
 ### Fixed
 
 - **Dropping a file on a session works again under Wayland.** The 0.45.0

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -62,7 +62,7 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   CLI's own footer is the only place that credit figure can be read.
 
   The cost-only rung's footer shows the figure and nothing else: its usage event carries a zero window, and a
-  zero window is what tells `FooterBar` to drop the ring and `SessionModel` to render nothing rather than a
+  zero window is what tells `FooterSession` to drop the ring and `SessionModel` to render nothing rather than a
   provider glyph beside a model nobody reported. **Those three figures are the providers' own arithmetic, never
   re-priced here** — they bill models `internal/pricing` has never heard of, so a second opinion would only be a
   second, disagreeing number — and each therefore inherits what its own accounting leaves out. oh-my-pi's total
@@ -94,6 +94,15 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   release froze reads as an ordinary figure with nothing beside it. The marker also names the reason and
   never the model or the turn, so a session whose sub-agent alone is unpriced looks like one whose every
   turn is.
+- **Footer choices cannot add readings a provider never reports** (`frontend/src/components/FooterSession.tsx`):
+  Appearance's global toggles preserve the gaps above — Claude Code and Codex full usage,
+  oh-my-pi/opencode/Crush cost only, Kiro context only, and Antigravity/Cursor no transcript usage.
+  Selecting a missing reading renders nothing, never a zero. The two ordered sides live in localStorage and
+  disappear with a cleared browser profile. Cost still uses the backend setting because it controls whether
+  transcripts are priced: when another profile disables it, an old layout cannot enable pricing just by
+  moving an unrelated item. The editor waits for that setting before migrating old visibility choices.
+  Hiding a reading hides its warning too. An item without data can occupy an editor slot while drawing
+  nothing in the live footer — a PR on a branch without one, or an unsupported provider reading.
 - **`lich cost --since` windows on sessions, never on days** (`store.CostTotals`): the ledger is a running
   total per `(session, transcript)` with no per-turn history behind it, so the only date a session's spend
   carries is when it was last counted. A window therefore selects *sessions active in it* and counts each one

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -119,6 +119,13 @@ Short specs; the code is the detail. All follow the idiom above.
 - **Stepper / numeric field** — icon buttons flanking a bordered value box (`tabular-nums`).
 - **Switch** — off `bg-accent`, on `bg-primary`.
 - **Toast** (sonner) — popover surface, hairline, semantic glyph.
+- **Footer** — two independently ordered sides, configured globally in Appearance › Footer. Actions default
+  left; checkout, model, context, plan usage and hands-on time default right. Cost stays opt-in. The editor
+  offers full-width Available/Left/Right drop areas, compact items, menus for keyboard moves, and a
+  single-line preview. Editor items wrap when needed so none require horizontal scrolling to reach. Use
+  spacing and hairline seams to define drop areas; selected items use a subtle fill. Readings remain inline
+  and wrap when needed, never into an overflow menu. Branch and path are plain selectable text, with full
+  values on hover, not popover triggers. Plan usage keeps its provider/plan heading and wide window gauges.
 
 ## Fixed by decision — do not "fix" these
 

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -1,42 +1,24 @@
-import type { ReactNode } from "react"
+import { Fragment, type ReactNode } from "react"
 import { useNavigate } from "react-router-dom"
 import { openPulls } from "@/lib/pulls-card-store"
 import { toast } from "sonner"
-import {
-  Code,
-  FileText,
-  GitBranch,
-  Folder,
-  Paperclip,
-  Diff,
-  GitPullRequestArrow,
-  Timer,
-} from "lucide-react"
+import { Code, FileText, Paperclip, Diff, GitPullRequestArrow } from "lucide-react"
 import { DropService, Terminal as TerminalService } from "@/lib/rpc"
 import type { DockTab } from "@/components/dock/RightDock"
 import { useActiveSession } from "@/lib/session/use-active-session"
-import { useSessionUsage } from "@/lib/session/use-session-usage"
-import { useSessionAgent } from "@/lib/session/use-session-agent"
-import { useCostReadout } from "@/lib/use-cost-readout"
-import { COST_MISS_REASON, budgetShare, formatCost } from "@/lib/session/session-cost"
-import { formatHandsOn, handsOnDetail, spellHandsOn } from "@/lib/session/hands-on"
-import { useRemoteResource } from "@/lib/use-remote-resource"
-import { baseName, displayPath } from "@/lib/paths"
+import { baseName } from "@/lib/paths"
 import { isWindows } from "@/lib/platform"
 import { composeDroppedPaths } from "@/lib/terminal/drop-files"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { usePullRequest } from "@/lib/pulls/use-pull-request"
-import { useSettings } from "@/providers/settings"
-import { useNow } from "@/lib/use-now"
 import { cn } from "@/lib/utils"
+import { useSettings } from "@/providers/settings"
+import { useCostReadout } from "@/lib/use-cost-readout"
+import { resolveFooterLayout, type FooterItem } from "@/lib/footer-layout"
 import { DiffStat } from "./DiffStat"
-import { ContextRing, usageColor } from "./ContextRing"
-import { PlanQuota } from "./PlanQuota"
-import { SessionModel } from "./SessionModel"
-import { Separator } from "@/components/ui/separator"
+import { FooterCheckout } from "./FooterCheckout"
+import { FooterSession } from "./FooterSession"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
-
-const two = (n: number): string => String(n).padStart(2, "0")
 
 interface FooterButtonProps {
   /** Both the tooltip and the accessible name — one string, one meaning. */
@@ -66,7 +48,7 @@ function FooterButton({ label, onClick, pressed, disabled, wide, children }: Foo
             aria-pressed={pressed}
             aria-label={label}
             className={cn(
-              "flex items-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-40",
+              "flex shrink-0 items-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground disabled:pointer-events-none disabled:opacity-40",
               wide ? "gap-1.5 px-1.5 py-1" : "justify-center p-1",
               pressed && "bg-accent text-accent-foreground",
             )}
@@ -90,32 +72,12 @@ interface FooterBarProps {
 // shows its checkout's path, branch and diff.
 export function FooterBar({ dock, onDock }: FooterBarProps) {
   const navigate = useNavigate()
-  const { projectId, sessionId, path, checkout, kind, sandboxed } = useActiveSession()
-  // Context-window occupancy of the active session, read off its transcript at
-  // each turn's end (null until the first turn of a supported session lands).
-  const usage = useSessionUsage(sessionId)
-  // Which provider the clock is listening to, resolved the way the card and
-  // SessionModel resolve it: a CLI started by hand inside a shell wins over the
-  // session's persisted kind. It is what the hands-on tooltip reads its rung off.
-  const provider = useSessionAgent(sessionId) ?? kind
-  // The footer context readout is opt-out (Settings › Providers); the cost
-  // beside it is opt-in, and off for everyone not billed per token.
-  const { showContextUsage, costBudget } = useSettings()
+  const { footerLayout, footerVisibility, showContextUsage } = useSettings()
   const showCost = useCostReadout()
+  const layout = resolveFooterLayout(footerLayout, footerVisibility, showContextUsage, showCost)
+  const { projectId, sessionId, path, checkout, kind, sandboxed } = useActiveSession()
   const status = useGitStatus(path)
   const pr = usePullRequest(path, status?.branch ?? "", status?.head ?? "")
-  const now = useNow()
-  // How long the active session has been worked on. Re-read off the footer's
-  // own clock rather than pushed: the figure is minutes, `now` already ticks on
-  // the minute, and keying the lookup by it is the whole refresh loop — no
-  // event, no store, and a reload paints the number on its first render instead
-  // of waiting out a flush.
-  const handsOn = useRemoteResource(
-    sessionId ? `${sessionId}:${now.getTime()}` : "",
-    () => TerminalService.HandsOn(sessionId),
-    { empty: 0, resetOn: sessionId },
-  )
-
   // The picker runs on the backend (DropService.Attach), not through
   // ProjectService: a confined session cannot open a file outside its checkout,
   // so the same call that chooses the file also copies it where that session can
@@ -146,210 +108,76 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
     }
   }
 
-  // What the session has cost, beside the ring. Rendered only when the backend
-  // sent a number: on a subscription there is nothing here at all, which is the
-  // point of the setting. With a spend ceiling set it takes the same colour ramp
-  // as the context ring, so a session running long shows it in the corner of the
-  // eye rather than only to whoever reads the figure.
-  const costReadout =
-    usage && showCost && usage.costUsd !== null ? (
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <span
-              className={cn("tabular-nums", usageColor(budgetShare(usage.costUsd, costBudget)))}
-            />
-          }
-        >
-          {formatCost(usage.costUsd)}
-        </TooltipTrigger>
-        <TooltipContent side="top" className="border border-border bg-card text-foreground">
-          <div className="flex flex-col gap-1">
-            <span className="font-medium">Session cost</span>
-            {costBudget > 0 && (
-              <span className="font-mono text-xs text-muted-foreground">
-                {formatCost(usage.costUsd)} of {formatCost(costBudget)} budget
-              </span>
-            )}
-            <span className="text-xs text-muted-foreground">
-              API pricing for every turn this session has run, this conversation and the ones it
-              cleared.
-            </span>
-          </div>
-        </TooltipContent>
-      </Tooltip>
-    ) : null
-
-  // The same slot when there is a number lich cannot produce rather than none to
-  // show. An empty corner reads as zero spend, so the absence gets a mark of its
-  // own and the tooltip names which of the two standing reasons it is. Muted and
-  // never on the budget ramp: nothing is known to be near a ceiling.
-  const costMissReadout =
-    usage && showCost && usage.costUsd === null && usage.costMiss ? (
-      <Tooltip>
-        <TooltipTrigger render={<span className="tabular-nums text-muted-foreground" />}>
-          $&mdash;
-        </TooltipTrigger>
-        <TooltipContent side="top" className="border border-border bg-card text-foreground">
-          <div className="flex max-w-64 flex-col gap-1">
-            <span className="font-medium">Cost unavailable</span>
-            <span className="text-xs text-muted-foreground">
-              {COST_MISS_REASON[usage.costMiss]}
-            </span>
-          </div>
-        </TooltipContent>
-      </Tooltip>
-    ) : null
-
-  // How long this session has been worked on, in the same group as the cost so
-  // the two read as one fact about the session. Unlike the cost it has no
-  // ceiling to be near, so it never takes the amber/red ramp: colouring it
-  // would be an opinion about how long is too long, and lich does not have one.
-  //
-  // The glyph is not decoration. The cost figure is opt-in and Claude-only
-  // while this is measured for every session, so the number usually stands
-  // alone — and a bare "1h12m" in this strip reads as a quota window, which is
-  // drawn two segments to the left.
-  const handsOnReadout = formatHandsOn(handsOn.data) ? (
-    <Tooltip>
-      <TooltipTrigger render={<span className="flex items-center gap-1.5 tabular-nums" />}>
-        <Timer className="size-3.5 shrink-0" aria-hidden="true" />
-        {formatHandsOn(handsOn.data)}
-      </TooltipTrigger>
-      <TooltipContent side="top" className="border border-border bg-card text-foreground">
-        <div className="flex max-w-64 flex-col gap-1">
-          <span className="font-medium">Hands-on time</span>
-          <span className="font-mono text-xs text-muted-foreground">
-            {spellHandsOn(handsOn.data)}
-          </span>
-          <span className="text-xs text-muted-foreground">{handsOnDetail(provider)}</span>
-        </div>
-      </TooltipContent>
-    </Tooltip>
-  ) : null
-
-  // The context-window readout — the ring plus percent, with a detailed
-  // tooltip. Null when the user turned it off (Settings › Providers), and null
-  // for a provider that reports no window at all: oh-my-pi, opencode and Crush
-  // record what a turn spent but not what it spent it against, so the footer
-  // degrades to the cost beside it rather than drawing a 0% ring around
-  // "0 / 0 tokens" (docs/ceilings.md).
-  const contextReadout =
-    usage && showContextUsage && usage.window > 0 ? (
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <span
-              className={cn("flex items-center gap-1.5 tabular-nums", usageColor(usage.percent))}
-            />
-          }
-        >
-          <ContextRing percent={usage.percent} />
-          {usage.percent}%
-        </TooltipTrigger>
-        <TooltipContent side="top" className="border border-border bg-card text-foreground">
-          <div className="flex flex-col gap-1.5">
-            <span className="font-medium">Context window</span>
-            <div className={cn("flex items-center gap-2", usageColor(usage.percent))}>
-              <span className="h-1.5 w-24 overflow-hidden rounded-full bg-muted">
-                <span
-                  className="block h-full rounded-full bg-current"
-                  style={{ width: `${usage.percent}%` }}
-                />
-              </span>
-              <span className="tabular-nums">{usage.percent}%</span>
-            </div>
-            <span className="font-mono text-xs text-muted-foreground">
-              {usage.tokens.toLocaleString()} / {usage.window.toLocaleString()} tokens
-            </span>
-          </div>
-        </TooltipContent>
-      </Tooltip>
-    ) : null
-
-  return (
-    <footer className="flex h-9 shrink-0 items-center gap-2 border-t border-border bg-sidebar px-3 text-xs text-muted-foreground">
+  const controls: Partial<Record<FooterItem, ReactNode>> = {
+    attach: (
       <FooterButton label="Attach file" onClick={() => void attachFile()} disabled={!sessionId}>
         <Paperclip className="size-4" />
       </FooterButton>
-      {path && (
-        <FooterButton
-          label="Browse code"
-          onClick={() => onDock("files")}
-          pressed={dock === "files"}
-        >
-          <Code className="size-4" />
-        </FooterButton>
-      )}
-      {status && (
-        <FooterButton
-          label="Review changes"
-          onClick={() => onDock("review")}
-          pressed={dock === "review"}
-          wide
-        >
-          {status.files === 0 ? (
-            <>
-              <Diff className="size-3.5" /> 0
-            </>
-          ) : (
-            <>
-              <FileText className="size-3.5" />
-              {status.files}
-              <span className="opacity-50">·</span>
-              <DiffStat added={status.added} deleted={status.deleted} />
-            </>
+    ),
+    files: path && (
+      <FooterButton label="Browse code" onClick={() => onDock("files")} pressed={dock === "files"}>
+        <Code className="size-4" />
+      </FooterButton>
+    ),
+    changes: status && (
+      <FooterButton
+        label="Review changes"
+        onClick={() => onDock("review")}
+        pressed={dock === "review"}
+        wide
+      >
+        {status.files === 0 ? (
+          <>
+            <Diff className="size-3.5" /> 0
+          </>
+        ) : (
+          <>
+            <FileText className="size-3.5" />
+            {status.files}
+            <span className="opacity-50">·</span>
+            <DiffStat added={status.added} deleted={status.deleted} />
+          </>
+        )}
+      </FooterButton>
+    ),
+    pr: pr && projectId && (
+      <FooterButton
+        label="View pull request"
+        onClick={() => {
+          openPulls(checkout)
+          navigate(`/projects/${projectId}/pulls`)
+        }}
+        wide
+      >
+        <GitPullRequestArrow className="size-3.5" /> PR #{pr.number}
+      </FooterButton>
+    ),
+    checkout: path && <FooterCheckout path={path} branch={status?.branch ?? ""} />,
+    path: path && <FooterCheckout path={path} branch={status?.branch ?? ""} display="path" />,
+  }
+  return (
+    <footer className="flex min-h-9 min-w-0 shrink-0 flex-wrap items-center justify-between gap-x-4 gap-y-1 border-t border-border bg-sidebar px-3 py-1 text-xs text-muted-foreground">
+      {(["left", "right"] as const).map((side) => (
+        <section
+          key={side}
+          aria-label={side === "left" ? "Left footer" : "Right footer"}
+          data-footer-side={side}
+          className={cn(
+            "flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1",
+            side === "right" && "ml-auto justify-end",
           )}
-        </FooterButton>
-      )}
-
-      {pr && projectId && (
-        <FooterButton
-          label="View pull request"
-          onClick={() => {
-            openPulls(checkout)
-            navigate(`/projects/${projectId}/pulls`)
-          }}
-          wide
         >
-          <GitPullRequestArrow className="size-3.5" /> PR #{pr.number}
-        </FooterButton>
-      )}
-
-      <span className="ml-auto flex items-center gap-4">
-        {showContextUsage && <SessionModel sessionId={sessionId} kind={kind} />}
-        <PlanQuota kind={kind} sessionId={sessionId} />
-        {(costReadout || costMissReadout || handsOnReadout) && (
-          <span className="flex items-center gap-1.5">
-            {costReadout ?? costMissReadout}
-            {(costReadout || costMissReadout) && handsOnReadout && (
-              <span className="opacity-50">·</span>
-            )}
-            {handsOnReadout}
-          </span>
-        )}
-        {contextReadout}
-        {(contextReadout || costReadout || costMissReadout || handsOnReadout) &&
-          (status?.branch || path) && <Separator orientation="vertical" className="h-4" />}
-        {status?.branch && (
-          <span className="flex items-center gap-1">
-            <GitBranch className="size-3.5" />
-            {status.branch}
-          </span>
-        )}
-        {path && (
-          <Tooltip>
-            <TooltipTrigger render={<span className="flex items-center gap-1" />}>
-              <Folder className="size-3.5" />
-              {displayPath(path)}
-            </TooltipTrigger>
-            <TooltipContent>{path}</TooltipContent>
-          </Tooltip>
-        )}
-        {(status?.branch || path) && <Separator orientation="vertical" className="h-4" />}
-        <span>{now.toDateString()}</span>
-        <span>{`${two(now.getHours())}:${two(now.getMinutes())}`}</span>
-      </span>
+          {layout[side].map((id) => (
+            <Fragment key={id}>
+              {id in controls ? (
+                controls[id]
+              ) : (
+                <FooterSession sessionId={sessionId} kind={kind} item={id} />
+              )}
+            </Fragment>
+          ))}
+        </section>
+      ))}
     </footer>
   )
 }

--- a/frontend/src/components/FooterCheckout.tsx
+++ b/frontend/src/components/FooterCheckout.tsx
@@ -1,0 +1,24 @@
+import { Folder, GitBranch } from "lucide-react"
+import { baseName, displayPath } from "@/lib/paths"
+
+interface FooterCheckoutProps {
+  path: string
+  branch: string
+  display?: "branch" | "path"
+}
+
+export function FooterCheckout({ path, branch, display = "branch" }: FooterCheckoutProps) {
+  const showBranch = display === "branch" && branch
+  const label =
+    display === "path" ? displayPath(path) : branch || baseName(path) || displayPath(path)
+  const Icon = showBranch ? GitBranch : Folder
+  return (
+    <span
+      title={display === "path" ? path : label}
+      className="flex min-w-0 max-w-56 items-center gap-1.5 select-text"
+    >
+      <Icon className="size-3.5 shrink-0" aria-hidden="true" />
+      <span className="truncate">{label}</span>
+    </span>
+  )
+}

--- a/frontend/src/components/FooterReadout.tsx
+++ b/frontend/src/components/FooterReadout.tsx
@@ -1,0 +1,56 @@
+import { useId, type ReactNode } from "react"
+import { cn } from "@/lib/utils"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+
+interface FooterReadoutProps {
+  label: string
+  title?: string
+  detail: ReactNode
+  children: ReactNode
+  className?: string
+  tooltipClassName?: string
+}
+
+export function FooterReadout({
+  label,
+  title = label,
+  detail,
+  children,
+  className,
+  tooltipClassName,
+}: FooterReadoutProps) {
+  const descriptionId = useId()
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        aria-describedby={descriptionId}
+        render={
+          <button
+            type="button"
+            className={cn(
+              "flex min-w-0 shrink-0 items-center gap-1.5 whitespace-nowrap rounded-sm py-0.5 tabular-nums outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              className,
+            )}
+          />
+        }
+      >
+        <span className="sr-only">{label}: </span>
+        {children}
+      </TooltipTrigger>
+      <TooltipContent
+        id={descriptionId}
+        role="tooltip"
+        side="top"
+        className={cn(
+          "max-w-80 border border-border bg-popover text-popover-foreground",
+          tooltipClassName,
+        )}
+      >
+        <div className="flex flex-col gap-1.5">
+          <span className="font-medium">{title}</span>
+          <div className="text-xs text-muted-foreground">{detail}</div>
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/frontend/src/components/FooterSession.test.tsx
+++ b/frontend/src/components/FooterSession.test.tsx
@@ -1,0 +1,316 @@
+// @vitest-environment jsdom
+// Contract changed: selected readings are visible without opening a menu.
+import { act, createElement, Fragment } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, expect, test, vi } from "vitest"
+import type { QuotaPlan } from "@/lib/api-types"
+import type { SessionUsage } from "@/lib/session/session-events"
+import type { SessionKind } from "@/lib/session/sessions"
+import { DEFAULT_FOOTER_LAYOUT, resolveFooterLayout, type FooterLayout } from "@/lib/footer-layout"
+import { FooterSession } from "./FooterSession"
+import { FooterCheckout } from "./FooterCheckout"
+import { FooterSettings } from "./settings/FooterSettings"
+
+const state = vi.hoisted(() => ({
+  usage: null as SessionUsage | null,
+  plan: null as QuotaPlan | null,
+  context: true,
+  cost: true,
+  budget: 10,
+  agent: null as SessionKind | null,
+  visibility: { model: true, plan: true, handsOn: true, clock: false },
+  layout: null as FooterLayout | null,
+  ready: true,
+}))
+vi.mock("@/lib/session/use-session-usage", () => ({ useSessionUsage: () => state.usage }))
+vi.mock("@/lib/session/use-session-agent", () => ({ useSessionAgent: () => state.agent }))
+vi.mock("@/lib/quota/use-plan-quota", () => ({ usePlanQuotaFor: vi.fn(() => state.plan) }))
+vi.mock("@/providers/settings", () => ({
+  useSettings: () => ({
+    showContextUsage: state.context,
+    costBudget: state.budget,
+    footerVisibility: state.visibility,
+    footerLayout: state.layout,
+    setFooterLayout: (value: FooterLayout) => {
+      state.layout = value
+    },
+    setCostBudget: (value: number) => {
+      state.budget = value
+    },
+  }),
+}))
+vi.mock("@/lib/use-cost-readout", () => ({
+  useCostReadout: () => state.cost,
+  useCostReadoutReady: () => state.ready,
+}))
+vi.mock("@/lib/cost-readout-store", () => ({
+  setCostReadout: vi.fn(async (value: boolean) => {
+    state.cost = value
+  }),
+}))
+vi.mock("@/lib/rpc", () => ({ Terminal: { HandsOn: vi.fn(async () => 120) } }))
+vi.mock("@/lib/use-now", () => ({ useNow: () => new Date("2026-09-06T12:00:00Z") }))
+
+let root: Root
+let container: HTMLDivElement
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true)
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  )
+  Object.assign(state, {
+    usage: null,
+    plan: null,
+    context: true,
+    cost: true,
+    budget: 10,
+    agent: null,
+    visibility: { model: true, plan: true, handsOn: true, clock: false },
+    layout: null,
+    ready: true,
+  })
+  container = document.createElement("div")
+  document.body.append(container)
+  root = createRoot(container)
+})
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+const reading = (window: number, costUsd: number | null): SessionUsage => ({
+  window,
+  costUsd,
+  tokens: window / 2,
+  percent: 50,
+  model: window ? "test-model" : "",
+  effort: "",
+  costMiss: null,
+})
+async function render(kind: SessionKind = "codex") {
+  const layout = resolveFooterLayout(state.layout, state.visibility, state.context, state.cost)
+  await act(async () =>
+    root.render(
+      createElement(
+        Fragment,
+        null,
+        [...layout.left, ...layout.right].map((item) =>
+          createElement(FooterSession, { key: item, sessionId: "active", kind, item }),
+        ),
+      ),
+    ),
+  )
+}
+function button(label: string) {
+  const found = Array.from(container.querySelectorAll("button")).find((element) =>
+    element.textContent?.startsWith(label),
+  )
+  if (!found) throw new Error(`Missing button: ${label}`)
+  return found
+}
+async function tooltip(label: string) {
+  await act(async () => button(label).focus())
+  await vi.waitFor(() => expect(document.querySelector('[role="tooltip"]')).not.toBeNull())
+  return document.querySelector('[role="tooltip"]')?.textContent
+}
+
+test.each<[SessionKind, number, number | null]>([
+  ["claude", 200000, 2],
+  ["codex", 200000, 2],
+  ["omp", 0, 2],
+  ["opencode", 0, 2],
+  ["crush", 0, 2],
+  ["kiro", 200000, null],
+  ["antigravity", 0, null],
+  ["cursor", 0, null],
+])("%s shows available readings without opening a menu", async (kind, window, cost) => {
+  state.usage = window || cost !== null ? reading(window, cost) : null
+  await render(kind)
+  expect(document.querySelector('[role="dialog"]')).toBeNull()
+  expect(container.textContent?.includes("Context window")).toBe(window > 0)
+  expect(container.textContent?.includes("Session cost")).toBe(cost !== null)
+  expect(container.querySelector('[aria-label^="Context window"]') !== null).toBe(window > 0)
+  expect(container.textContent).toContain("Hands-on time")
+  expect(container.textContent).toContain("2m")
+  expect(container.querySelector("time")).toBeNull()
+})
+
+test("model and context visibility are independent", async () => {
+  state.usage = reading(200000, null)
+  state.context = false
+  await render()
+  expect(container.textContent).toContain("test-model")
+  expect(container.textContent).not.toContain("Context window")
+  state.context = true
+  state.visibility.model = false
+  await render()
+  expect(container.textContent).not.toContain("test-model")
+  expect(container.textContent).toContain("50%")
+})
+
+test("context and budget warnings stay attached to their visible readings", async () => {
+  state.usage = { ...reading(200000, 9), percent: 80 }
+  await render()
+  expect(button("Context window").classList.contains("text-amber-500")).toBe(true)
+  expect(button("Session cost").classList.contains("text-amber-500")).toBe(true)
+  state.context = false
+  state.cost = false
+  await render()
+  expect(container.textContent).not.toContain("Session cost")
+  expect(container.textContent).not.toContain("Context window")
+})
+
+test("a locked window stays visible even when another window is fuller", async () => {
+  state.plan = {
+    provider: "codex",
+    name: "Codex",
+    status: "ok",
+    account: "session account",
+    windows: [
+      { label: "Session", seconds: 18000, percent: 10, lockedReason: "Limit reached" },
+      { label: "Weekly", seconds: 604800, percent: 20 },
+    ],
+  }
+  await render()
+  expect(button("Plan usage").textContent).toContain("Locked")
+  expect(button("Plan usage").classList.contains("text-destructive")).toBe(true)
+  const details = await tooltip("Plan usage")
+  expect(details).toContain("Weekly")
+  expect(details).toContain("session account")
+})
+
+test("plan details retain the provider heading without redundant usage labels", async () => {
+  state.plan = {
+    provider: "codex",
+    name: "Codex",
+    plan: "Plus",
+    status: "ok",
+    windows: [{ label: "Session", seconds: 18000, percent: 50 }],
+  }
+  await render()
+  const details = await tooltip("Plan usage")
+  expect(details).toContain("Codex · Plus")
+  expect(details).toContain("Session")
+  expect(details).not.toContain("Plan usage")
+  expect(details).not.toContain("resets in")
+})
+
+test.each(["path", "branch"] as const)(
+  "checkout %s is text, not a popover trigger",
+  async (display) => {
+    await act(async () =>
+      root.render(
+        createElement(FooterCheckout, {
+          path: "/project/.worktrees/a-long-worktree",
+          branch: "feature/footer",
+          display,
+        }),
+      ),
+    )
+    expect(container.querySelector("button, [aria-haspopup]")).toBeNull()
+    expect(container.querySelector("[title]")?.getAttribute("title")).toBe(
+      display === "path" ? "/project/.worktrees/a-long-worktree" : "feature/footer",
+    )
+  },
+)
+
+test.each(["signed-out", "error", "unknown"] as const)(
+  "%s never shows quota as zero",
+  async (status) => {
+    state.plan = { provider: "codex", name: "Codex", status }
+    await render()
+    expect(container.textContent).not.toContain("Plan usage")
+    expect(container.textContent).not.toContain("0%")
+  },
+)
+
+test("unavailable cost keeps its mark and an explanation reachable by keyboard", async () => {
+  state.usage = { ...reading(0, null), costMiss: "mixed-models" }
+  await render()
+  expect(container.textContent).toContain("$—")
+  expect(await tooltip("Cost unavailable")).toContain("switched models")
+})
+
+test("a provider started in a shell determines whose plan is shown", async () => {
+  state.agent = "claude"
+  await render("shell")
+  const { usePlanQuotaFor } = await import("@/lib/quota/use-plan-quota")
+  expect(usePlanQuotaFor).toHaveBeenCalledWith("claude", "active")
+})
+
+test("clock and hands-on time follow independent display choices", async () => {
+  state.visibility.clock = true
+  state.visibility.handsOn = false
+  await render()
+  expect(container.querySelector("time")).not.toBeNull()
+  expect(container.textContent).not.toContain("Hands-on time")
+  const { Terminal } = await import("@/lib/rpc")
+  expect(Terminal.HandsOn).not.toHaveBeenCalled()
+})
+
+test("zero cost remains a real reading", async () => {
+  state.usage = reading(0, 0)
+  await render("omp")
+  expect(button("Session cost").textContent).toContain("$0")
+})
+
+test("the editor removes items independently and restores the full default layout", async () => {
+  await act(async () => root.render(createElement(FooterSettings)))
+  await act(async () =>
+    container.querySelector<HTMLButtonElement>('[aria-label="Remove Model"]')?.click(),
+  )
+  expect(state.layout?.right).not.toContain("model")
+  expect(state.layout?.right).toContain("context")
+  await act(async () => root.render(createElement(FooterSettings)))
+  await act(async () =>
+    container.querySelector<HTMLButtonElement>('[aria-label="Remove Cost"]')?.click(),
+  )
+  const { setCostReadout } = await import("@/lib/cost-readout-store")
+  expect(setCostReadout).toHaveBeenCalledWith(false)
+  expect(state.context).toBe(true)
+  await act(async () => root.render(createElement(FooterSettings)))
+  await act(async () => button("Restore default").click())
+  expect(state.layout).toEqual(DEFAULT_FOOTER_LAYOUT)
+  expect(state.cost).toBe(false)
+})
+
+test("the editor waits for the old cost setting before allowing a layout migration", async () => {
+  state.ready = false
+  await act(async () => root.render(createElement(FooterSettings)))
+  expect(container.querySelector<HTMLButtonElement>('[aria-label="Move Model"]')?.disabled).toBe(
+    true,
+  )
+  expect(button("Restore default").disabled).toBe(true)
+  expect(state.layout).toBeNull()
+})
+
+test("a saved layout controls the order and visibility of readings", async () => {
+  state.usage = reading(200000, 2)
+  state.layout = { left: ["cost", "context", "model"], right: [] }
+  await render()
+  // Glyph spacing is presentational; this contract is the order of the readings.
+  expect(
+    Array.from(container.querySelectorAll("button")).map((item) =>
+      item.textContent?.replace(/\s+/g, " "),
+    ),
+  ).toEqual(["Session cost: $2.00", "Context window: 50%"])
+  expect(container.textContent).not.toContain("Hands-on time")
+})
+
+test("a failed pricing-setting write leaves the previous layout in place", async () => {
+  const { setCostReadout } = await import("@/lib/cost-readout-store")
+  vi.mocked(setCostReadout).mockRejectedValueOnce(new Error("offline"))
+  await act(async () => root.render(createElement(FooterSettings)))
+  await act(async () =>
+    container.querySelector<HTMLButtonElement>('[aria-label="Remove Cost"]')?.click(),
+  )
+  expect(state.layout).toBeNull()
+  expect(container.querySelector('[aria-label="Remove Cost"]')).not.toBeNull()
+})

--- a/frontend/src/components/FooterSession.tsx
+++ b/frontend/src/components/FooterSession.tsx
@@ -1,0 +1,149 @@
+import { Timer } from "lucide-react"
+import { Terminal } from "@/lib/rpc"
+import type { SessionKind } from "@/lib/session/sessions"
+import type { FooterItem } from "@/lib/footer-layout"
+import type { SessionUsage } from "@/lib/session/session-events"
+import { useSessionUsage } from "@/lib/session/use-session-usage"
+import { useSessionAgent } from "@/lib/session/use-session-agent"
+import { usePlanQuotaFor } from "@/lib/quota/use-plan-quota"
+import { useSettings } from "@/providers/settings"
+import { useCostReadout } from "@/lib/use-cost-readout"
+import { budgetShare, COST_MISS_REASON, formatCost } from "@/lib/session/session-cost"
+import { formatHandsOn, handsOnDetail, spellHandsOn } from "@/lib/session/hands-on"
+import { useRemoteResource } from "@/lib/use-remote-resource"
+import { useNow } from "@/lib/use-now"
+import { ContextRing, usageColor } from "./ContextRing"
+import { SessionModel } from "./SessionModel"
+import { PlanQuota } from "./PlanQuota"
+import { FooterReadout } from "./FooterReadout"
+
+interface FooterSessionProps {
+  sessionId: string
+  kind: SessionKind | ""
+}
+
+interface FooterSessionItemProps extends FooterSessionProps {
+  item: FooterItem
+}
+
+// Each selected reading subscribes on its own, so layout changes never add a
+// second usage reader to unrelated controls or to the opposite side.
+export function FooterSession({ sessionId, kind, item }: FooterSessionItemProps) {
+  switch (item) {
+    case "model":
+      return <SessionModel sessionId={sessionId} kind={kind} />
+    case "context":
+      return <SessionContext sessionId={sessionId} />
+    case "plan":
+      return <SessionPlan sessionId={sessionId} kind={kind} />
+    case "cost":
+      return <SessionCost sessionId={sessionId} />
+    case "handsOn":
+      return <HandsOnReadout sessionId={sessionId} kind={kind} />
+    case "clock":
+      return <FooterClock />
+    default:
+      return null
+  }
+}
+
+function SessionContext({ sessionId }: { sessionId: string }) {
+  const usage = useSessionUsage(sessionId)
+  return usage && usage.window > 0 ? <ContextReadout usage={usage} /> : null
+}
+
+function SessionPlan({ sessionId, kind }: FooterSessionProps) {
+  const provider = useSessionAgent(sessionId) ?? kind
+  const plan = usePlanQuotaFor(provider || undefined, sessionId)
+  return plan ? <PlanQuota plan={plan} /> : null
+}
+
+function SessionCost({ sessionId }: { sessionId: string }) {
+  const usage = useSessionUsage(sessionId)
+  const showCost = useCostReadout()
+  const { costBudget } = useSettings()
+  return showCost && usage ? <CostReadout usage={usage} budget={costBudget} /> : null
+}
+
+function ContextReadout({ usage }: { usage: SessionUsage }) {
+  return (
+    <FooterReadout
+      label="Context window"
+      className={usageColor(usage.percent)}
+      detail={
+        <span className="font-mono">
+          {usage.tokens.toLocaleString()} / {usage.window.toLocaleString()} tokens
+        </span>
+      }
+    >
+      <ContextRing percent={usage.percent} /> {usage.percent}%
+    </FooterReadout>
+  )
+}
+
+function CostReadout({ usage, budget }: { usage: SessionUsage; budget: number }) {
+  if (usage.costUsd === null && !usage.costMiss) return null
+  return (
+    <FooterReadout
+      label={usage.costUsd === null ? "Cost unavailable" : "Session cost"}
+      className={usageColor(budgetShare(usage.costUsd ?? 0, budget))}
+      detail={
+        usage.costUsd === null && usage.costMiss ? (
+          COST_MISS_REASON[usage.costMiss]
+        ) : (
+          <div className="flex flex-col gap-1">
+            {budget > 0 && (
+              <span>
+                {formatCost(usage.costUsd ?? 0)} of {formatCost(budget)} budget
+              </span>
+            )}
+            <span>
+              API cost across this session's conversations. Subscription charges may differ.
+            </span>
+          </div>
+        )
+      }
+    >
+      {usage.costUsd === null ? "$—" : formatCost(usage.costUsd)}
+    </FooterReadout>
+  )
+}
+
+function HandsOnReadout({ sessionId, kind }: FooterSessionProps) {
+  const provider = useSessionAgent(sessionId) ?? kind
+  const now = useNow()
+  const handsOn = useRemoteResource(
+    sessionId ? `${sessionId}:${now.getTime()}` : "",
+    () => Terminal.HandsOn(sessionId),
+    { empty: 0, resetOn: sessionId },
+  )
+  if (handsOn.error)
+    return (
+      <FooterReadout label="Hands-on time" detail="Could not read hands-on time.">
+        —
+      </FooterReadout>
+    )
+  if (!formatHandsOn(handsOn.data)) return null
+  return (
+    <FooterReadout
+      label="Hands-on time"
+      detail={
+        <div className="flex flex-col gap-1">
+          <span>{spellHandsOn(handsOn.data)}</span>
+          <span>{handsOnDetail(provider)}</span>
+        </div>
+      }
+    >
+      <Timer className="size-3.5" aria-hidden="true" /> {formatHandsOn(handsOn.data)}
+    </FooterReadout>
+  )
+}
+
+function FooterClock() {
+  const now = useNow()
+  return (
+    <time dateTime={now.toISOString()} className="whitespace-nowrap tabular-nums">
+      {now.toDateString()} · {now.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+    </time>
+  )
+}

--- a/frontend/src/components/PlanQuota.tsx
+++ b/frontend/src/components/PlanQuota.tsx
@@ -1,75 +1,53 @@
+import type { QuotaPlan } from "@/lib/api-types"
 import { Gauge } from "lucide-react"
 import { hottestWindow, shortWindow } from "@/lib/quota/quota-format"
-import { usePlanQuotaFor } from "@/lib/quota/use-plan-quota"
-import type { SessionKind } from "@/lib/session/sessions"
 import { useNow } from "@/lib/use-now"
-import { cn } from "@/lib/utils"
-import { usageColor } from "./ContextRing"
 import { QuotaGauge } from "./QuotaGauge"
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { usageColor } from "./ContextRing"
+import { FooterReadout } from "./FooterReadout"
 
 interface PlanQuotaProps {
-  /** Which provider the active session runs; "" when none is active. */
-  kind: SessionKind | ""
-  /** Whose plan to read: the active session, which may spend an account of its
-   * own when it runs a binary the user configured. */
-  sessionId: string
+  plan: QuotaPlan
 }
 
-// PlanQuota is the footer's plan-usage slot: how much of the active session's
-// subscription is spent, with every window behind a tooltip. Self-contained like
-// SessionModel — it resolves its own reading from the provider id.
-//
-// The account the reading was taken against sits at the foot, under a seam:
-// a session spawned from a wrapper binary spends a login lich's own environment
-// does not name, which is the whole reason it is said at all. It is provenance
-// rather than part of the plan's name, so it reads last and in the mono the app
-// gives every other identifier. Absent for a provider that names nobody, which
-// is what the gauge has always looked like.
-//
-// One window is shown, and it is the fullest one: a weekly cap about to run out
-// must not hide behind a session window that reset an hour ago. Nothing renders
-// at all for a provider that meters no subscription, while the reading is
-// signed out or failed — the Settings screen is where a login is fixed, and a
-// status strip is the wrong place to be told to run a command — or for a
-// session whose account lich could not identify, where any number would be
-// somebody else's.
-export function PlanQuota({ kind, sessionId }: PlanQuotaProps) {
-  const plan = usePlanQuotaFor(kind || undefined, sessionId)
-  const now = useNow()
-  const hottest = plan && plan.status === "ok" ? hottestWindow(plan) : null
-  if (!plan || !hottest) {
-    return null
-  }
-  const length = shortWindow(hottest.seconds)
+// A session can spend a different login from lich's own. Keep the account
+// beside its windows, and omit the name when the provider cannot identify it.
+export function PlanQuota({ plan }: PlanQuotaProps) {
+  // A locked window must remain visible even when another window is fuller.
+  const hottest =
+    plan.status === "ok"
+      ? (plan.windows?.find((window) => window.lockedReason) ?? hottestWindow(plan))
+      : null
+  if (!hottest) return null
   return (
-    <Tooltip>
-      <TooltipTrigger
-        render={
-          <span
-            className={cn("flex items-center gap-1.5 tabular-nums", usageColor(hottest.percent))}
-          />
-        }
-      >
-        <Gauge className="size-3.5 shrink-0" aria-hidden="true" />
-        {length && <span className="opacity-70">{length}</span>}
-        {hottest.percent}%
-      </TooltipTrigger>
-      <TooltipContent side="top" className="border border-border bg-card text-foreground">
-        <div className="flex min-w-52 flex-col gap-2.5">
-          <span className="font-medium">
-            {plan.plan ? `${plan.name} · ${plan.plan}` : plan.name}
-          </span>
-          {(plan.windows ?? []).map((w) => (
-            <QuotaGauge key={w.label} window={w} now={now} stacked />
-          ))}
-          {plan.account && (
-            <span className="break-all border-border border-t pt-2 font-mono text-[11px] text-muted-foreground">
-              {plan.account}
-            </span>
-          )}
+    <FooterReadout
+      label="Plan usage"
+      title={plan.plan ? `${plan.name} · ${plan.plan}` : plan.name}
+      tooltipClassName="py-3"
+      className={hottest.lockedReason ? "text-destructive" : usageColor(hottest.percent)}
+      detail={<PlanDetails plan={plan} />}
+    >
+      <Gauge className="size-3.5" aria-hidden="true" />
+      {shortWindow(hottest.seconds)} {hottest.lockedReason ? "Locked" : `${hottest.percent}%`}
+    </FooterReadout>
+  )
+}
+
+function PlanDetails({ plan }: PlanQuotaProps) {
+  const now = useNow()
+  return (
+    <div className="flex min-w-52 flex-col gap-2.5">
+      {(plan.windows ?? []).map((window) => (
+        <div key={window.label} className="flex flex-col gap-1">
+          <QuotaGauge window={window} now={now} stacked />
+          {window.lockedReason && <p className="text-xs text-destructive">{window.lockedReason}</p>}
         </div>
-      </TooltipContent>
-    </Tooltip>
+      ))}
+      {plan.account && (
+        <span className="break-all border-t border-border pt-2 font-mono text-[11px] text-muted-foreground">
+          {plan.account}
+        </span>
+      )}
+    </div>
   )
 }

--- a/frontend/src/components/SessionModel.tsx
+++ b/frontend/src/components/SessionModel.tsx
@@ -26,10 +26,15 @@ export function SessionModel({ sessionId, kind }: SessionModelProps) {
     return null
   }
   return (
-    <span className="flex items-center gap-1.5">
+    <span
+      className="flex min-w-0 max-w-64 items-center gap-1.5"
+      title={`${usage.model}${usage.effort ? ` · ${usage.effort}` : ""}`}
+    >
       <ProviderIcon kind={provider} size={14} />
-      {formatModel(usage.model)}
-      {usage.effort ? ` · ${usage.effort}` : ""}
+      <span className="truncate">
+        {formatModel(usage.model)}
+        {usage.effort ? ` · ${usage.effort}` : ""}
+      </span>
     </span>
   )
 }

--- a/frontend/src/components/render-budget.test.tsx
+++ b/frontend/src/components/render-budget.test.tsx
@@ -275,27 +275,21 @@ test("a usage event for a background session repaints nothing", async () => {
 test("a usage event for the active session repaints the footer, not the sidebar", async () => {
   const budget = await mountSidebar()
   await budget.act(() => bus.emit(USAGE_EVENT, usageEvent("s1")))
-  // The whole footer re-renders for a token count, segments that know nothing
-  // about usage included — that is the measured cost, not an endorsement of it.
-  // No SessionCard appears, which is what this pins.
+  // Contract changed: readings can be placed independently on either side.
+  // Only the model/context readers repaint; actions, time and cards stay absent.
   expect(budget.take()).toEqual({
-    FooterBar: 1,
-    FooterButton: 2,
-    ContextRing: 1,
+    SessionContext: 1,
     SessionModel: 1,
-    PlanQuota: 1,
     ProviderIcon: 1,
     BrandIcon: 1,
-    Separator: 4,
-    Tooltip: 4,
-    TooltipRoot: 4,
-    TooltipTrigger: 8,
-    TooltipContent: 4,
-    TooltipPortal: 4,
-    Paperclip: 1,
-    Folder: 1,
-    Code: 1,
-    Anonymous: 3,
+    ContextReadout: 1,
+    ContextRing: 1,
+    FooterReadout: 1,
+    Tooltip: 1,
+    TooltipRoot: 1,
+    TooltipTrigger: 2,
+    TooltipContent: 1,
+    TooltipPortal: 1,
   })
   await budget.unmount()
 })
@@ -303,27 +297,11 @@ test("a usage event for the active session repaints the footer, not the sidebar"
 test("a usage event with no context window draws no ring", async () => {
   const budget = await mountSidebar()
   await budget.act(() => bus.emit(USAGE_EVENT, costOnlyUsageEvent("s1")))
-  // The footer still repaints, but no ContextRing and no provider glyph: a
-  // report with no window has no percentage to draw a ring around, and the model
-  // slot renders nothing rather than naming zero of zero tokens. Against the
-  // budget above, the missing ContextRing, ProviderIcon, BrandIcon and one
-  // Separator are the whole degradation to the cost-only rung. (The cost figure
-  // itself is not here: its setting is an RPC, and every RPC hangs in this rig.)
+  // Cost-only readings keep their missing model and context absent. Cost is
+  // off in this rig because its stored setting has not answered.
   expect(budget.take()).toEqual({
-    FooterBar: 1,
-    FooterButton: 2,
+    SessionContext: 1,
     SessionModel: 1,
-    PlanQuota: 1,
-    Separator: 2,
-    Tooltip: 3,
-    TooltipRoot: 3,
-    TooltipTrigger: 6,
-    TooltipContent: 3,
-    TooltipPortal: 3,
-    Paperclip: 1,
-    Folder: 1,
-    Code: 1,
-    Anonymous: 3,
   })
   await budget.unmount()
 })

--- a/frontend/src/components/settings/AppearanceSettings.tsx
+++ b/frontend/src/components/settings/AppearanceSettings.tsx
@@ -32,6 +32,7 @@ import { ConfirmDialog } from "@/components/ConfirmDialog"
 import { Stepper } from "@/components/common/Stepper"
 import { SettingBlock, SettingGroup } from "./SettingBlock"
 import { FontSetting } from "./FontSetting"
+import { FooterSettings } from "./FooterSettings"
 import { ImportThemeDialog } from "./ImportThemeDialog"
 import { Button } from "@/components/ui/button"
 import {
@@ -443,6 +444,7 @@ export function AppearanceSettings() {
 
         <FontSetting />
       </SettingGroup>
+      <FooterSettings />
     </>
   )
 }

--- a/frontend/src/components/settings/FooterLayoutEditor.tsx
+++ b/frontend/src/components/settings/FooterLayoutEditor.tsx
@@ -1,0 +1,376 @@
+import { useState } from "react"
+import {
+  DndContext,
+  DragOverlay,
+  closestCenter,
+  pointerWithin,
+  rectIntersection,
+  useDroppable,
+  type CollisionDetection,
+  type DragEndEvent,
+  type KeyboardCoordinateGetter,
+} from "@dnd-kit/core"
+import {
+  SortableContext,
+  rectSortingStrategy,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from "@dnd-kit/sortable"
+import {
+  ArrowLeft,
+  ArrowRight,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  Code,
+  Coins,
+  Cpu,
+  FileDiff,
+  Folder,
+  Gauge,
+  GitBranch,
+  GitPullRequestArrow,
+  GripVertical,
+  MoreHorizontal,
+  Paperclip,
+  Timer,
+  X,
+  type LucideIcon,
+} from "lucide-react"
+import { dragStyle, useDragSensors } from "@/lib/use-sortable-list"
+import {
+  FOOTER_ITEMS,
+  footerZone,
+  hasFooterItem,
+  isFooterItem,
+  moveFooterItem,
+  type FooterItem,
+  type FooterLayout,
+  type FooterZone,
+} from "@/lib/footer-layout"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+
+const ICONS: Record<FooterItem, LucideIcon> = {
+  attach: Paperclip,
+  files: Code,
+  changes: FileDiff,
+  pr: GitPullRequestArrow,
+  checkout: GitBranch,
+  path: Folder,
+  model: Cpu,
+  context: Gauge,
+  plan: Gauge,
+  cost: Coins,
+  handsOn: Timer,
+  clock: Clock,
+}
+const LABELS: Record<FooterZone, string> = {
+  available: "Available items",
+  left: "Left side",
+  right: "Right side",
+}
+const labelOf = (id: FooterItem) => FOOTER_ITEMS.find((item) => item.id === id)?.label ?? id
+
+// Only a pointer inside a drop area may commit; inside it, items take precedence.
+const collisionDetection: CollisionDetection = (args) => {
+  const hits = args.pointerCoordinates ? pointerWithin(args) : rectIntersection(args)
+  if (
+    args.pointerCoordinates &&
+    !hits.some((hit) => ["available", "left", "right"].includes(String(hit.id)))
+  )
+    return []
+  const items = hits.filter((hit) => hit.id !== args.active.id && isFooterItem(String(hit.id)))
+  return items.length ? items : hits.length || args.pointerCoordinates ? hits : closestCenter(args)
+}
+
+// A populated zone's rectangle would steal arrow-key moves from its items.
+// Keep only empty zone rectangles; they are the targets with no item to aim at.
+const keyboardCoordinates: KeyboardCoordinateGetter = (event, args) => {
+  const droppableRects = new Map(args.context.droppableRects)
+  const current = args.context.collisionRect
+  const horizontal = event.code === "ArrowLeft" || event.code === "ArrowRight"
+  for (const [id, rect] of droppableRects) {
+    if (horizontal && current && (rect.bottom <= current.top || rect.top >= current.bottom))
+      droppableRects.delete(id)
+  }
+  for (const zone of ["available", "left", "right"]) {
+    if (!args.context.droppableContainers.get(zone)?.data.current?.empty)
+      droppableRects.delete(zone)
+  }
+  return sortableKeyboardCoordinates(event, {
+    ...args,
+    context: { ...args.context, droppableRects },
+  })
+}
+
+interface FooterLayoutEditorProps {
+  layout: FooterLayout
+  disabled: boolean
+  onChange: (layout: FooterLayout) => void
+}
+
+export function FooterLayoutEditor({ layout, disabled, onChange }: FooterLayoutEditorProps) {
+  const sensors = useDragSensors(keyboardCoordinates)
+  const [dragging, setDragging] = useState<FooterItem | null>(null)
+  const move = (id: FooterItem, target: string) => {
+    const next = moveFooterItem(layout, id, target)
+    if (next !== layout) onChange(next)
+  }
+  const drop = ({ active, over }: DragEndEvent) => {
+    setDragging(null)
+    if (!disabled && over && isFooterItem(String(active.id)))
+      move(String(active.id) as FooterItem, String(over.id))
+  }
+  const available = FOOTER_ITEMS.map((item) => item.id).filter((id) => !hasFooterItem(layout, id))
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={collisionDetection}
+      onDragStart={({ active }) =>
+        isFooterItem(String(active.id)) && setDragging(String(active.id) as FooterItem)
+      }
+      onDragEnd={drop}
+      onDragCancel={() => setDragging(null)}
+    >
+      <div className="flex min-w-0 flex-col gap-5">
+        <FooterZoneView
+          zone="available"
+          items={available}
+          layout={layout}
+          disabled={disabled}
+          onMove={move}
+        />
+        <FooterZoneView
+          zone="left"
+          items={layout.left}
+          layout={layout}
+          disabled={disabled}
+          onMove={move}
+        />
+        <FooterZoneView
+          zone="right"
+          items={layout.right}
+          layout={layout}
+          disabled={disabled}
+          onMove={move}
+        />
+      </div>
+      <DragOverlay>
+        {dragging && (
+          <span className="rounded-md bg-popover px-3 py-2 text-xs shadow-md">
+            {labelOf(dragging)}
+          </span>
+        )}
+      </DragOverlay>
+    </DndContext>
+  )
+}
+
+interface FooterZoneViewProps {
+  zone: FooterZone
+  items: FooterItem[]
+  layout: FooterLayout
+  disabled: boolean
+  onMove: (id: FooterItem, target: string) => void
+}
+
+function FooterZoneView({ zone, items, layout, disabled, onMove }: FooterZoneViewProps) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: zone,
+    disabled,
+    data: { empty: items.length === 0 },
+  })
+  return (
+    <section className="min-w-0" aria-label={LABELS[zone]}>
+      <h3 className="mb-2 text-sm font-medium">{LABELS[zone]}</h3>
+      <div
+        ref={setNodeRef}
+        data-footer-zone={zone}
+        className={cn(
+          "flex min-h-12 flex-wrap items-center gap-1.5 border-y border-border px-1 py-3",
+          isOver && "bg-accent/50",
+        )}
+      >
+        <SortableContext items={items} strategy={rectSortingStrategy}>
+          {items.map((id) => (
+            <FooterEditorItem
+              key={id}
+              id={id}
+              layout={layout}
+              disabled={disabled}
+              onMove={onMove}
+            />
+          ))}
+        </SortableContext>
+        {items.length === 0 && (
+          <p className="px-2 py-3 text-xs text-muted-foreground">
+            {zone === "available" ? "Drag here to hide an item" : "Drag items here"}
+          </p>
+        )}
+      </div>
+    </section>
+  )
+}
+
+interface FooterEditorItemProps {
+  id: FooterItem
+  layout: FooterLayout
+  disabled: boolean
+  onMove: (id: FooterItem, target: string) => void
+}
+
+function FooterEditorItem({ id, layout, disabled, onMove }: FooterEditorItemProps) {
+  const {
+    setNodeRef,
+    setActivatorNodeRef,
+    attributes,
+    listeners,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id, disabled })
+  const Icon = ICONS[id]
+  return (
+    <div
+      ref={setNodeRef}
+      style={dragStyle(transform, transition)}
+      data-footer-item={id}
+      className={cn(
+        "flex shrink-0 items-center rounded-md bg-accent/30",
+        isDragging && "opacity-30",
+      )}
+    >
+      <Button
+        ref={setActivatorNodeRef}
+        variant="ghost"
+        size="xs"
+        disabled={disabled}
+        {...attributes}
+        {...listeners}
+        aria-label={`Move ${labelOf(id)}`}
+        className="touch-none cursor-grab active:cursor-grabbing"
+      >
+        <GripVertical data-icon="inline-start" />
+        <Icon />
+        {labelOf(id)}
+      </Button>
+      <FooterItemMenu id={id} layout={layout} disabled={disabled} onMove={onMove} />
+      {hasFooterItem(layout, id) && (
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          disabled={disabled}
+          aria-label={`Remove ${labelOf(id)}`}
+          onClick={() => onMove(id, "available")}
+        >
+          <X />
+        </Button>
+      )}
+    </div>
+  )
+}
+
+function FooterItemMenu({ id, layout, disabled, onMove }: FooterEditorItemProps) {
+  const zone = footerZone(layout, id)
+  const items = zone === "available" ? [] : layout[zone]
+  const index = items.indexOf(id)
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        aria-label={`Options for ${labelOf(id)}`}
+        render={<Button variant="ghost" size="icon-xs" disabled={disabled} />}
+      >
+        <MoreHorizontal />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent>
+        <DropdownMenuGroup>
+          {zone !== "left" && (
+            <DropdownMenuItem onClick={() => onMove(id, "left")}>
+              <ArrowLeft />
+              {zone === "available" ? "Add to left" : "Move to left"}
+            </DropdownMenuItem>
+          )}
+          {zone !== "right" && (
+            <DropdownMenuItem onClick={() => onMove(id, "right")}>
+              <ArrowRight />
+              {zone === "available" ? "Add to right" : "Move to right"}
+            </DropdownMenuItem>
+          )}
+          {zone !== "available" && (
+            <>
+              <DropdownMenuItem disabled={index <= 0} onClick={() => onMove(id, items[index - 1])}>
+                <ChevronLeft />
+                Move earlier
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                disabled={index >= items.length - 1}
+                onClick={() => onMove(id, items[index + 1])}
+              >
+                <ChevronRight />
+                Move later
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={() => onMove(id, "available")}>
+                <X />
+                Remove from footer
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+interface FooterLayoutPreviewProps {
+  layout: FooterLayout
+}
+
+export function FooterLayoutPreview({ layout }: FooterLayoutPreviewProps) {
+  return (
+    <section className="mt-5 flex flex-col gap-2" aria-label="Footer preview">
+      <span className="text-xs text-muted-foreground">
+        Preview · example values · scroll to see all items
+      </span>
+      <section
+        className="overflow-x-auto bg-sidebar"
+        // biome-ignore lint/a11y/noNoninteractiveTabindex: scrollable region needs keyboard access
+        tabIndex={0}
+        aria-label="Scrollable footer preview"
+      >
+        <div className="flex min-h-12 w-max min-w-full items-center justify-between gap-8 px-3 py-2">
+          {(["left", "right"] as const).map((side) => (
+            <div
+              key={side}
+              data-preview-side={side}
+              className={cn(
+                "flex shrink-0 items-center gap-3 whitespace-nowrap text-xs text-muted-foreground",
+                side === "right" && "ml-auto justify-end",
+              )}
+            >
+              {layout[side].map((id) => {
+                const Icon = ICONS[id]
+                return (
+                  <span key={id} className="flex items-center gap-1 tabular-nums">
+                    <Icon className="size-3" aria-hidden="true" />
+                    {FOOTER_ITEMS.find((item) => item.id === id)?.example}
+                  </span>
+                )
+              })}
+            </div>
+          ))}
+          {layout.left.length + layout.right.length === 0 && (
+            <span className="text-xs text-muted-foreground">No footer items selected</span>
+          )}
+        </div>
+      </section>
+    </section>
+  )
+}

--- a/frontend/src/components/settings/FooterSettings.tsx
+++ b/frontend/src/components/settings/FooterSettings.tsx
@@ -1,0 +1,96 @@
+import { useState } from "react"
+import { toast } from "sonner"
+import { useSettings } from "@/providers/settings"
+import { useCostReadout, useCostReadoutReady } from "@/lib/use-cost-readout"
+import { setCostReadout } from "@/lib/cost-readout-store"
+import {
+  DEFAULT_FOOTER_LAYOUT,
+  hasFooterItem,
+  resolveFooterLayout,
+  type FooterLayout,
+} from "@/lib/footer-layout"
+import { errorText } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { SettingBlock, SettingGroup } from "./SettingBlock"
+import { FooterLayoutEditor, FooterLayoutPreview } from "./FooterLayoutEditor"
+
+export function FooterSettings() {
+  const { footerLayout, setFooterLayout, footerVisibility, showContextUsage } = useSettings()
+  const showCost = useCostReadout()
+  const ready = useCostReadoutReady()
+  const [saving, setSaving] = useState(false)
+  const layout = resolveFooterLayout(footerLayout, footerVisibility, showContextUsage, showCost)
+  const change = async (next: FooterLayout) => {
+    if (!ready || saving) return
+    setSaving(true)
+    try {
+      const cost = hasFooterItem(next, "cost")
+      if (showCost !== cost) await setCostReadout(cost)
+      setFooterLayout(next)
+    } catch (error) {
+      toast.error(`Could not save the footer: ${errorText(error)}`)
+    } finally {
+      setSaving(false)
+    }
+  }
+  return (
+    <SettingGroup label="Footer">
+      <SettingBlock
+        title="Footer layout"
+        description="Drag items between the rows to show, hide or reorder them, or use an item's menu. Applies to every project and provider."
+      >
+        <div className="mb-3 flex items-center justify-between gap-3">
+          <span className="text-xs text-muted-foreground">
+            {!ready
+              ? "Loading saved choices…"
+              : saving
+                ? "Saving…"
+                : "Readings appear when the provider reports them."}
+          </span>
+          <Button
+            variant="ghost"
+            size="xs"
+            disabled={!ready || saving}
+            onClick={() => void change(DEFAULT_FOOTER_LAYOUT)}
+          >
+            Restore default
+          </Button>
+        </div>
+        <FooterLayoutEditor
+          layout={layout}
+          disabled={!ready || saving}
+          onChange={(next) => void change(next)}
+        />
+        <FooterLayoutPreview layout={layout} />
+      </SettingBlock>
+      {hasFooterItem(layout, "cost") && <SpendCeiling />}
+    </SettingGroup>
+  )
+}
+
+function SpendCeiling() {
+  const { costBudget, setCostBudget } = useSettings()
+  // Preserve a half-typed decimal while the stored amount stays numeric.
+  const [budget, setBudget] = useState(() => (costBudget > 0 ? String(costBudget) : ""))
+  return (
+    <SettingBlock
+      title="Spend ceiling"
+      description="Warn as the session's API cost approaches this amount: amber at 80%, red at 95%. This does not stop the session or represent subscription charges. Leave empty for none."
+    >
+      <Input
+        type="number"
+        min={0}
+        step={1}
+        value={budget}
+        onChange={(event) => {
+          setBudget(event.target.value)
+          setCostBudget(Number(event.target.value))
+        }}
+        placeholder="No ceiling"
+        aria-label="Session spend ceiling in dollars"
+        className="w-40 font-mono"
+      />
+    </SettingBlock>
+  )
+}

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -1,22 +1,15 @@
 import { useState } from "react"
 import {
   climbsToRiskier,
-  footerReadout,
-  footerReadoutPair,
   skipLevel,
   skipLevelPair,
   skipPermissionFlags,
   skipPermissionsKey,
   SKIP_RISK_ORDER,
-  type FooterReadout,
   type SkipLevel,
 } from "@/lib/providers-store"
-import { useSettings } from "@/providers/settings"
-import { setCostReadout } from "@/lib/cost-readout-store"
-import { useCostReadout } from "@/lib/use-cost-readout"
 import { useStoredFlag } from "@/lib/use-stored-setting"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { ConfirmDialog } from "@/components/ConfirmDialog"
 import { PlanUsageSetting } from "./PlanUsageSetting"
@@ -25,29 +18,7 @@ import { SettingBlock } from "./SettingBlock"
 
 const GLOBAL_SCOPE = ""
 
-// Each rung says what lands in the footer, and the line under it says what that
-// means — the half of the answer the two switches made people assemble in their
-// heads.
-const FOOTER_READOUTS: { level: FooterReadout; label: string; consequence: string }[] = [
-  {
-    level: "off",
-    label: "Nothing",
-    consequence: "The footer keeps only the branch, the path and the clock.",
-  },
-  {
-    level: "context",
-    label: "Model & context",
-    consequence: "The model a session runs, and a ring showing how full its context window is.",
-  },
-  {
-    level: "cost",
-    label: "And cost",
-    consequence:
-      "Plus what the session has cost at API prices, summed from its transcript. That figure only means something when you are billed per token, not on a subscription.",
-  },
-]
-
-// The same shape for how far the provider runs without asking, ordered by risk.
+// How far the provider runs without asking, ordered by risk.
 const SKIP_LEVELS: { level: SkipLevel; label: string; consequence: string }[] = [
   {
     level: "never",
@@ -68,8 +39,7 @@ const SKIP_LEVELS: { level: SkipLevel; label: string; consequence: string }[] = 
 
 // ProviderBinSettings is the config section a provider gets when enabled: what
 // its plan has left, which binary its sessions spawn, and how far it runs
-// without asking. Claude Code and Codex add the footer readout because their
-// transcripts report the model and context-window usage.
+// without asking. Footer visibility is configured globally in Appearance.
 export function ProviderBinSettings({
   providerId,
   providerName,
@@ -81,11 +51,6 @@ export function ProviderBinSettings({
   providerBin: string
   projectId?: string
 }) {
-  const { showContextUsage, setShowContextUsage, costBudget, setCostBudget } = useSettings()
-  const showCost = useCostReadout()
-  // The field keeps the raw string so a half-typed "1." survives the keystroke;
-  // the stored budget is the parsed value, and an emptied field is no budget.
-  const [budget, setBudget] = useState(() => (costBudget > 0 ? String(costBudget) : ""))
   // Off until the store answers, and that direction is not a detail: this is
   // the switch that hands an agent the machine, so the unknown state can never
   // be drawn as the permissive one.
@@ -101,18 +66,6 @@ export function ProviderBinSettings({
   const level = skipLevel(skipHere, skipInWorktrees)
   const consequence = SKIP_LEVELS.find((rung) => rung.level === level)?.consequence ?? ""
   const pendingRung = SKIP_LEVELS.find((rung) => rung.level === pendingLevel)
-  const readout = footerReadout(showContextUsage, showCost)
-  const readoutConsequence =
-    FOOTER_READOUTS.find((rung) => rung.level === readout)?.consequence ?? ""
-
-  // One rung writes both settings, for the same reason the permission ladder
-  // does: the pair is the storage, the rung is the choice.
-  const setReadout = (next: FooterReadout) => {
-    const pair = footerReadoutPair(next)
-    setShowContextUsage(pair.context)
-    setCostReadout(pair.cost)
-  }
-
   // One rung writes both keys, always: the pair is the storage, the rung is the
   // choice. Writing only the one that changed would leave the other holding an
   // answer to a question the user is no longer being asked.
@@ -133,11 +86,6 @@ export function ProviderBinSettings({
     setLevel(next)
   }
 
-  const persistBudget = (value: string) => {
-    setBudget(value)
-    setCostBudget(Number(value))
-  }
-
   return (
     <>
       {/* What the plan has left comes first: it is the state of this provider,
@@ -151,52 +99,6 @@ export function ProviderBinSettings({
         providerBin={providerBin}
         projectId={projectId}
       />
-
-      {/* Only providers with a context-window transcript reader carry this
-          control; the underlying preference stays global. */}
-      {(providerId === "claude" || providerId === "codex") && (
-        <>
-          <SettingBlock
-            title="Session readout in the footer"
-            description="How much of what a session is spending the footer carries, read from its transcript."
-          >
-            <ToggleGroup
-              value={[readout]}
-              onValueChange={(next) => next[0] && setReadout(next[0] as FooterReadout)}
-              spacing={1}
-              aria-label="What the footer says about the session"
-              className="border border-border p-[3px]"
-            >
-              {FOOTER_READOUTS.map((rung) => (
-                <ToggleGroupItem key={rung.level} value={rung.level} size="sm">
-                  {rung.label}
-                </ToggleGroupItem>
-              ))}
-            </ToggleGroup>
-            <p className="mt-2 max-w-prose text-xs text-muted-foreground">{readoutConsequence}</p>
-          </SettingBlock>
-
-          {/* A ceiling is only ever seen through the readout, so it is offered
-              beside it and hidden with it. */}
-          {readout === "cost" && (
-            <SettingBlock
-              title="Spend ceiling"
-              description="Colour the cost in the footer as a session approaches this many dollars — amber at 80%, red at 95%. It is a warning, not a limit: nothing is stopped, and the figure it watches is API pricing from a table. Leave empty for none."
-            >
-              <Input
-                type="number"
-                min={0}
-                step={1}
-                value={budget}
-                onChange={(event) => persistBudget(event.target.value)}
-                placeholder="No ceiling"
-                aria-label="Session spend ceiling in dollars"
-                className="w-40 font-mono"
-              />
-            </SettingBlock>
-          )}
-        </>
-      )}
 
       {/* Never unless the user says otherwise. A worktree is its own rung
           because it is a checkout you can throw away, while the project

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -204,7 +204,7 @@ export function Settings() {
       </aside>
 
       <div className="flex-1 overflow-auto">
-        <div className="mx-auto max-w-3xl px-8 py-8">
+        <div className="w-full px-6 py-8 lg:px-10">
           <h1 className="mb-4 text-2xl font-semibold text-foreground">{current.label}</h1>
           <div className="divide-y divide-border">{current.render(projectId)}</div>
         </div>

--- a/frontend/src/lib/cost-readout-store.test.ts
+++ b/frontend/src/lib/cost-readout-store.test.ts
@@ -90,4 +90,39 @@ describe("costReadoutStore", () => {
 
     expect(notified).toBe(0)
   })
+
+  it("announces when the initial value settles without adding value notifications", async () => {
+    const ready = vi.fn()
+    const value = vi.fn()
+    const off = costReadoutStore.subscribeReady(ready)
+    costReadoutStore.subscribe(value)
+    expect(costReadoutStore.isReady()).toBe(false)
+    await flush()
+    expect(costReadoutStore.isReady()).toBe(true)
+    expect(ready).toHaveBeenCalledTimes(1)
+    expect(value).not.toHaveBeenCalled()
+    off()
+  })
+
+  it("rolls back a failed write and reports the error to the layout editor", async () => {
+    setSetting.mockRejectedValueOnce(new Error("offline"))
+    await expect(setCostReadout(true)).rejects.toThrow("offline")
+    expect(costReadoutStore.get()).toBe(false)
+  })
+
+  it("does not let a late initial read overwrite a user choice", async () => {
+    let finish: (value: string) => void = () => {}
+    getSetting.mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          finish = resolve
+        }),
+    )
+    costReadoutStore.subscribe(() => {})
+    await setCostReadout(true)
+    finish("false")
+    await flush()
+    expect(costReadoutStore.get()).toBe(true)
+    expect(costReadoutStore.isReady()).toBe(true)
+  })
 })

--- a/frontend/src/lib/cost-readout-store.ts
+++ b/frontend/src/lib/cost-readout-store.ts
@@ -17,6 +17,10 @@ const GLOBAL_SCOPE = ""
 
 let enabled = false
 let loaded = false
+let ready = false
+let revision = 0
+let generation = 0
+const readyListeners = new Set<() => void>()
 const listeners = new Set<() => void>()
 
 const notify = () => {
@@ -28,20 +32,37 @@ const notify = () => {
 // load reads the stored flag once per page. A failed read leaves it off, which
 // is what an unreachable backend should show for a number about money.
 const load = async () => {
+  const startedAt = revision
+  const loadGeneration = generation
   try {
     const value = await Store.GetSetting(SETTING_KEY, GLOBAL_SCOPE)
+    if (loadGeneration !== generation) return
     const next = value === "true"
-    if (next !== enabled) {
+    if (startedAt === revision && next !== enabled) {
       enabled = next
       notify()
     }
   } catch {
     // Keep the default; the toggle in Settings still works and will write.
+  } finally {
+    if (loadGeneration === generation) {
+      ready = true
+      for (const listener of readyListeners) listener()
+    }
   }
 }
 
 export const costReadoutStore = {
   get: (): boolean => enabled,
+  isReady: (): boolean => ready,
+  subscribeReady(listener: () => void): () => void {
+    readyListeners.add(listener)
+    const off = costReadoutStore.subscribe(() => {})
+    return () => {
+      readyListeners.delete(listener)
+      off()
+    }
+  },
   subscribe(listener: () => void): () => void {
     listeners.add(listener)
     if (!loaded) {
@@ -56,17 +77,32 @@ export const costReadoutStore = {
 
 // setCostReadout flips the flag for good: the page updates at once and the
 // backend stops (or starts) counting from its next turn.
-export function setCostReadout(on: boolean): void {
+export function setCostReadout(on: boolean): Promise<void> {
+  const previous = enabled
+  const writeRevision = ++revision
   if (on !== enabled) {
     enabled = on
     notify()
   }
-  void Store.SetSetting(SETTING_KEY, GLOBAL_SCOPE, String(on))
+  return Store.SetSetting(SETTING_KEY, GLOBAL_SCOPE, String(on)).then(
+    () => {},
+    (error) => {
+      if (revision === writeRevision && enabled !== previous) {
+        enabled = previous
+        notify()
+      }
+      throw error
+    },
+  )
 }
 
 // resetCostReadoutStore drops the module state between tests.
 export function resetCostReadoutStore(): void {
   enabled = false
   loaded = false
+  ready = false
+  revision++
+  generation++
+  readyListeners.clear()
   listeners.clear()
 }

--- a/frontend/src/lib/footer-layout.test.ts
+++ b/frontend/src/lib/footer-layout.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, expect, test, vi } from "vitest"
+import {
+  DEFAULT_FOOTER_LAYOUT,
+  FOOTER_ITEMS,
+  footerZone,
+  hasFooterItem,
+  moveFooterItem,
+  parseFooterLayout,
+  readFooterLayout,
+  resolveFooterLayout,
+  writeFooterLayout,
+  type FooterLayout,
+} from "./footer-layout"
+
+afterEach(() => vi.unstubAllGlobals())
+const layout: FooterLayout = {
+  left: ["attach", "files", "changes"],
+  right: ["model", "context", "plan"],
+}
+
+test.each([null, "{", "null", "[]", '{"left":[]}', '{"left":[],"right":false}'])(
+  "rejects malformed layout %s",
+  (raw) => {
+    expect(parseFooterLayout(raw)).toBeNull()
+  },
+)
+test("preserves empty sides, drops unknown items and deduplicates across sides", () => {
+  expect(parseFooterLayout('{"left":[],"right":[]}')).toEqual({ left: [], right: [] })
+  expect(
+    parseFooterLayout('{"left":["model","future",2,"model"],"right":["model","cost","files"]}'),
+  ).toEqual({ left: ["model"], right: ["cost", "files"] })
+})
+test("migrates old visibility, context and cost without restoring hidden indicators", () => {
+  expect(
+    resolveFooterLayout(
+      null,
+      { model: false, plan: true, handsOn: false, clock: true },
+      false,
+      true,
+    ),
+  ).toEqual({ left: DEFAULT_FOOTER_LAYOUT.left, right: ["checkout", "plan", "cost", "clock"] })
+  expect(
+    resolveFooterLayout(
+      layout,
+      { model: false, plan: false, handsOn: false, clock: true },
+      false,
+      false,
+    ),
+  ).toBe(layout)
+})
+test("removed Settings item is discarded from either saved side and cannot be added", () => {
+  expect(parseFooterLayout('{"left":["settings","attach"],"right":["model","settings"]}')).toEqual({
+    left: ["attach"],
+    right: ["model"],
+  })
+  expect(moveFooterItem(layout, "settings", "left")).toBe(layout)
+})
+test.each([
+  ["attach", "changes", { left: ["files", "changes", "attach"], right: layout.right }],
+  ["context", "model", { left: layout.left, right: ["context", "model", "plan"] }],
+  ["model", "files", { left: ["attach", "model", "files", "changes"], right: ["context", "plan"] }],
+  ["model", "left", { left: ["attach", "files", "changes", "model"], right: ["context", "plan"] }],
+  ["clock", "right", { left: layout.left, right: ["model", "context", "plan", "clock"] }],
+  ["model", "available", { left: layout.left, right: ["context", "plan"] }],
+  ["model", "clock", { left: layout.left, right: ["context", "plan"] }],
+])("moves %s onto %s without changing the source layout", (id, target, expected) => {
+  const before = JSON.stringify(layout)
+  expect(moveFooterItem(layout, id, target)).toEqual(expected)
+  expect(JSON.stringify(layout)).toBe(before)
+})
+test("empty sides accept a first item and invalid/cancelled moves preserve identity", () => {
+  expect(moveFooterItem({ left: [], right: [] }, "model", "left")).toEqual({
+    left: ["model"],
+    right: [],
+  })
+  expect(moveFooterItem(layout, "unknown", "left")).toBe(layout)
+  expect(moveFooterItem(layout, "model", "outside")).toBe(layout)
+  expect(moveFooterItem(layout, "model", "model")).toBe(layout)
+  expect(moveFooterItem(layout, "clock", "available")).toBe(layout)
+})
+test("each item can move between both sides and available without duplication", () => {
+  for (const item of FOOTER_ITEMS) {
+    let next = moveFooterItem(layout, item.id, "left")
+    expect(footerZone(next, item.id)).toBe("left")
+    next = moveFooterItem(next, item.id, "right")
+    expect(footerZone(next, item.id)).toBe("right")
+    expect([...next.left, ...next.right].filter((id) => id === item.id)).toHaveLength(1)
+    next = moveFooterItem(next, item.id, "available")
+    expect(hasFooterItem(next, item.id)).toBe(false)
+  }
+})
+test("persists both sides and their exact order", () => {
+  const stored = new Map<string, string>()
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => stored.get(key) ?? null,
+    setItem: (key: string, value: string) => stored.set(key, value),
+  })
+  expect(readFooterLayout()).toBeNull()
+  writeFooterLayout(layout)
+  expect(readFooterLayout()).toEqual(layout)
+})
+
+test("the backend cost choice wins over a layout saved by another browser profile", () => {
+  const visibility = { model: true, plan: true, handsOn: true, clock: false }
+  expect(
+    resolveFooterLayout({ left: ["cost", "model"], right: [] }, visibility, true, false),
+  ).toEqual({ left: ["model"], right: [] })
+  expect(resolveFooterLayout({ left: ["model"], right: [] }, visibility, true, true)).toEqual({
+    left: ["model"],
+    right: ["cost"],
+  })
+})

--- a/frontend/src/lib/footer-layout.ts
+++ b/frontend/src/lib/footer-layout.ts
@@ -1,0 +1,106 @@
+import type { FooterVisibility } from "./footer-prefs"
+import { readPref, writePref } from "./prefs"
+
+export const FOOTER_ITEMS = [
+  { id: "attach", label: "Attach file", example: "Attach file" },
+  { id: "files", label: "File explorer", example: "Files" },
+  { id: "changes", label: "Changes", example: "3 · +10 −2" },
+  { id: "pr", label: "Pull request", example: "PR #123" },
+  { id: "checkout", label: "Branch", example: "feature/toolbar" },
+  { id: "path", label: "Working directory", example: "~/project" },
+  { id: "model", label: "Model", example: "Codex · GPT-6" },
+  { id: "context", label: "Context window", example: "42%" },
+  { id: "plan", label: "Plan usage", example: "5h 28%" },
+  { id: "cost", label: "Cost", example: "$1.25" },
+  { id: "handsOn", label: "Hands-on time", example: "12m" },
+  { id: "clock", label: "Date & time", example: "Sep 6 · 14:30" },
+] as const
+
+export type FooterItem = (typeof FOOTER_ITEMS)[number]["id"]
+export type FooterSide = "left" | "right"
+export type FooterZone = FooterSide | "available"
+export interface FooterLayout {
+  left: FooterItem[]
+  right: FooterItem[]
+}
+
+export const DEFAULT_FOOTER_LAYOUT: FooterLayout = {
+  left: ["attach", "files", "changes", "pr"],
+  right: ["checkout", "model", "context", "plan", "handsOn"],
+}
+const KEY = "lich.footer.layout"
+
+export const isFooterItem = (id: string): id is FooterItem =>
+  FOOTER_ITEMS.some((item) => item.id === id)
+export const hasFooterItem = (layout: FooterLayout, id: FooterItem): boolean =>
+  layout.left.includes(id) || layout.right.includes(id)
+
+// Old visibility choices become an initial layout only. A saved empty side is
+// intentional; unknown or repeated items cannot clone a control on reload.
+export function parseFooterLayout(raw: string | null): FooterLayout | null {
+  try {
+    const value: unknown = JSON.parse(raw ?? "null")
+    if (!value || typeof value !== "object") return null
+    const { left, right } = value as Record<string, unknown>
+    if (!Array.isArray(left) || !Array.isArray(right)) return null
+    const seen = new Set<string>()
+    const clean = (items: unknown[]): FooterItem[] =>
+      items.filter((id): id is FooterItem => {
+        if (typeof id !== "string" || !isFooterItem(id) || seen.has(id)) return false
+        seen.add(id)
+        return true
+      })
+    return { left: clean(left), right: clean(right) }
+  } catch {
+    return null
+  }
+}
+
+export function resolveFooterLayout(
+  stored: FooterLayout | null,
+  visibility: FooterVisibility,
+  context: boolean,
+  cost: boolean,
+): FooterLayout {
+  // Cost's backend flag also controls pricing. A layout from another browser
+  // profile must not silently turn that work back on when an unrelated item moves.
+  if (stored)
+    return hasFooterItem(stored, "cost") === cost
+      ? stored
+      : moveFooterItem(stored, "cost", cost ? "right" : "available")
+  const flags = { ...visibility, context, cost }
+  const readings = ["model", "context", "plan", "cost", "handsOn", "clock"] as const
+  return {
+    left: [...DEFAULT_FOOTER_LAYOUT.left],
+    right: ["checkout", ...readings.filter((id) => flags[id])],
+  }
+}
+
+export function footerZone(layout: FooterLayout, id: string): FooterZone {
+  if (id === "left" || layout.left.includes(id as FooterItem)) return "left"
+  if (id === "right" || layout.right.includes(id as FooterItem)) return "right"
+  return "available"
+}
+
+// One move serves pointer drops and the keyboard/menu alternatives. Dropping
+// on a side appends; on an item it takes that item's position.
+export function moveFooterItem(layout: FooterLayout, id: string, over: string): FooterLayout {
+  if (
+    !isFooterItem(id) ||
+    id === over ||
+    (!isFooterItem(over) && !["left", "right", "available"].includes(over))
+  )
+    return layout
+  const side = footerZone(layout, over)
+  const index = side === "available" ? -1 : layout[side].indexOf(over as FooterItem)
+  const next = {
+    left: layout.left.filter((item) => item !== id),
+    right: layout.right.filter((item) => item !== id),
+  }
+  if (side !== "available") next[side].splice(index < 0 ? next[side].length : index, 0, id)
+  return JSON.stringify(next) === JSON.stringify(layout) ? layout : next
+}
+
+export const readFooterLayout = (): FooterLayout | null => parseFooterLayout(readPref(KEY))
+export const writeFooterLayout = (layout: FooterLayout): void =>
+  writePref(KEY, JSON.stringify(layout))

--- a/frontend/src/lib/footer-prefs.test.ts
+++ b/frontend/src/lib/footer-prefs.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, expect, test, vi } from "vitest"
+import { parseFooterVisibility, readFooterVisibility } from "./footer-prefs"
+
+afterEach(() => vi.unstubAllGlobals())
+
+test.each([true, false])("preserves the legacy model visibility %s", (context) => {
+  expect(parseFooterVisibility(null, context)).toEqual({
+    model: context,
+    plan: true,
+    handsOn: true,
+    clock: false,
+  })
+})
+
+test.each(["{", "null", "[]", "true", '"off"', '{"model":"false","plan":0}'])(
+  "invalid preferences %s retain safe defaults",
+  (raw) => {
+    expect(parseFooterVisibility(raw, false)).toEqual({
+      model: false,
+      plan: true,
+      handsOn: true,
+      clock: false,
+    })
+  },
+)
+
+test("valid choices override only their own defaults", () => {
+  expect(
+    parseFooterVisibility('{"model":true,"plan":false,"clock":true,"future":false}', false),
+  ).toEqual({ model: true, plan: false, handsOn: true, clock: true })
+})
+
+// Contract changed: layout owns new writes; these choices are read for migration.
+test("reads legacy display choices independently of context and provider", () => {
+  const stored = new Map<string, string>()
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => stored.get(key) ?? null,
+    setItem: (key: string, value: string) => stored.set(key, value),
+  })
+  const visibility = { model: false, plan: false, handsOn: false, clock: true }
+  stored.set("lich.footer.visibility", JSON.stringify(visibility))
+  expect(readFooterVisibility(true)).toEqual(visibility)
+  expect(readFooterVisibility(false)).toEqual(visibility)
+  expect(stored.size).toBe(1)
+})

--- a/frontend/src/lib/footer-prefs.ts
+++ b/frontend/src/lib/footer-prefs.ts
@@ -1,0 +1,40 @@
+import { readPref } from "./prefs"
+
+export interface FooterVisibility {
+  model: boolean
+  plan: boolean
+  handsOn: boolean
+  clock: boolean
+}
+
+export const DEFAULT_FOOTER_VISIBILITY: FooterVisibility = {
+  model: true,
+  plan: true,
+  handsOn: true,
+  clock: false,
+}
+
+const KEY = "lich.footer.visibility"
+
+// Model and context used to share a switch. Preserve that choice until the
+// user selects model visibility independently in Appearance.
+export function parseFooterVisibility(
+  raw: string | null,
+  legacyContext: boolean,
+): FooterVisibility {
+  const fallback = { ...DEFAULT_FOOTER_VISIBILITY, model: legacyContext }
+  try {
+    const value: unknown = JSON.parse(raw ?? "null")
+    if (!value || typeof value !== "object" || Array.isArray(value)) return fallback
+    const stored = value as Record<string, unknown>
+    for (const key of Object.keys(fallback) as (keyof FooterVisibility)[]) {
+      if (typeof stored[key] === "boolean") fallback[key] = stored[key]
+    }
+    return fallback
+  } catch {
+    return fallback
+  }
+}
+
+export const readFooterVisibility = (legacyContext: boolean): FooterVisibility =>
+  parseFooterVisibility(readPref(KEY), legacyContext)

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -7,8 +7,6 @@ import {
   createProvidersStore,
   enabledKey,
   enabledProviders,
-  footerReadout,
-  footerReadoutPair,
   readEnabled,
   noProviderInstalled,
   resolveDefaultProvider,
@@ -142,33 +140,8 @@ describe("the confirmation gate on a standing safety setting", () => {
   })
 })
 
-describe("the footer readout ladder", () => {
-  it("folds the stored pair into a rung", () => {
-    expect(footerReadout(false, false)).toBe("off")
-    expect(footerReadout(true, false)).toBe("context")
-    expect(footerReadout(true, true)).toBe("cost")
-  })
-
-  // The pair nothing offers any more: the cost on its own, with no model and no
-  // ring beside it. The cost was always the addition, so it reads as the rung
-  // that carries it.
-  it("reads the pair no rung writes as the cost rung", () => {
-    expect(footerReadout(false, true)).toBe("cost")
-  })
-
-  it("writes both settings for the chosen rung", () => {
-    expect(footerReadoutPair("off")).toEqual({ context: false, cost: false })
-    expect(footerReadoutPair("context")).toEqual({ context: true, cost: false })
-    expect(footerReadoutPair("cost")).toEqual({ context: true, cost: true })
-  })
-
-  it("round-trips every rung", () => {
-    for (const level of ["off", "context", "cost"] as const) {
-      const pair = footerReadoutPair(level)
-      expect(footerReadout(pair.context, pair.cost)).toBe(level)
-    }
-  })
-})
+// Contract changed: independent global footer choices replace the provider
+// ladder. Legacy visibility and persistence are covered in footer-prefs.test.ts.
 
 describe("readEnabled", () => {
   it("honors an explicit flag over the default", () => {

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -156,27 +156,6 @@ export function sandboxDefaultFor(level: SandboxLevel, worktree: boolean): boole
   return level === "worktrees" && worktree
 }
 
-// How much of a session's own accounting the footer carries, as one ladder
-// ordered by how much it says. The two settings keys stay exactly as they are —
-// this is the shape the user chooses in, not the shape lich stores.
-export type FooterReadout = "off" | "context" | "cost"
-
-// footerReadout folds the stored pair into a rung. The fourth combination — the
-// cost without the model and the ring — is a readout nobody chose: the cost
-// setting was always the extra one, offered beside a readout that was already
-// there. It reads as the top rung, and choosing that rung back turns both on.
-export function footerReadout(context: boolean, cost: boolean): FooterReadout {
-  if (cost) {
-    return "cost"
-  }
-  return context ? "context" : "off"
-}
-
-// footerReadoutPair is the inverse: the pair a chosen rung writes back.
-export function footerReadoutPair(level: FooterReadout): { context: boolean; cost: boolean } {
-  return { context: level !== "off", cost: level === "cost" }
-}
-
 // readEnabled interprets the stored flag: Claude is enabled by default (it was
 // always offered before the providers feature), every other provider is opt-in.
 // An explicit "1"/"0" overrides the default.

--- a/frontend/src/lib/use-cost-readout.ts
+++ b/frontend/src/lib/use-cost-readout.ts
@@ -7,3 +7,8 @@ import { costReadoutStore } from "./cost-readout-store"
 export function useCostReadout(): boolean {
   return useSyncExternalStore(costReadoutStore.subscribe, costReadoutStore.get)
 }
+
+// A layout edit must wait for the old cost choice before saving its migration.
+export function useCostReadoutReady(): boolean {
+  return useSyncExternalStore(costReadoutStore.subscribeReady, costReadoutStore.isReady)
+}

--- a/frontend/src/lib/use-sortable-list.ts
+++ b/frontend/src/lib/use-sortable-list.ts
@@ -5,6 +5,7 @@ import {
   useSensors,
   type DragEndEvent,
   type Modifier,
+  type KeyboardCoordinateGetter,
 } from "@dnd-kit/core"
 import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable"
 import { CSS, type Transform } from "@dnd-kit/utilities"
@@ -57,13 +58,19 @@ export function dragStyle(transform: Transform | null, transition?: string) {
 // dnd-kit rides pointer events instead of the HTML5 DnD API — and it animates
 // with CSS transforms rather than reordering the DOM, so no rearranged-list
 // state has to exist while a drag is in flight.
-export function useSortableList(ids: string[], onCommit: (ids: string[]) => void) {
-  const sensors = useSensors(
+export function useDragSensors(
+  coordinateGetter: KeyboardCoordinateGetter = sortableKeyboardCoordinates,
+) {
+  return useSensors(
     useSensor(PointerSensor, {
       activationConstraint: { distance: DRAG_THRESHOLD_PX },
     }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    useSensor(KeyboardSensor, { coordinateGetter }),
   )
+}
+
+export function useSortableList(ids: string[], onCommit: (ids: string[]) => void) {
+  const sensors = useDragSensors()
 
   const onDragEnd = ({ active, over }: DragEndEvent) => {
     if (!over || active.id === over.id) {

--- a/frontend/src/providers/settings.tsx
+++ b/frontend/src/providers/settings.tsx
@@ -18,6 +18,8 @@ import {
   writePref,
 } from "@/lib/prefs"
 import { Store, Themes as ThemeRPC } from "@/lib/rpc"
+import { readFooterLayout, writeFooterLayout, type FooterLayout } from "@/lib/footer-layout"
+import { readFooterVisibility, type FooterVisibility } from "@/lib/footer-prefs"
 import {
   adoptStoredSelections,
   applyAppTheme,
@@ -177,7 +179,9 @@ interface SettingsValue {
   resetHotkey: (id: HotkeyId) => void
   /** Whether the footer shows the active session's context-window usage. */
   showContextUsage: boolean
-  setShowContextUsage: (show: boolean) => void
+  footerVisibility: FooterVisibility
+  footerLayout: FooterLayout | null
+  setFooterLayout: (layout: FooterLayout) => void
   /** Spend ceiling in USD the footer cost readout colours against; 0 is none. */
   costBudget: number
   setCostBudget: (usd: number) => void
@@ -204,7 +208,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [zoom, setZoomState] = useState<number>(readZoom)
   const [terminalTheme, setTerminalThemeState] = useState<TerminalTheme>(readTerminalTheme)
   const [hotkeys, setHotkeys] = useState<Hotkeys>(loadHotkeys)
-  const [showContextUsage, setShowContextUsageState] = useState<boolean>(readContextUsage)
+  const [showContextUsage] = useState<boolean>(readContextUsage)
+  const [footerLayout, setFooterLayoutState] = useState(readFooterLayout)
+  const [footerVisibility] = useState(() => readFooterVisibility(readContextUsage()))
   const [costBudget, setCostBudgetState] = useState<number>(readCostBudget)
   const [desktopNotifications, setDesktopNotificationsState] = useState<boolean | null>(
     readDesktopNotifications,
@@ -417,15 +423,15 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     })
   }, [])
 
-  const setShowContextUsage = useCallback((next: boolean) => {
-    setShowContextUsageState(next)
-    writePref(CONTEXT_USAGE_STORAGE_KEY, next)
-  }, [])
-
   const setCostBudget = useCallback((next: number) => {
     const clamped = clampCostBudget(next)
     setCostBudgetState(clamped)
     writePref(COST_BUDGET_STORAGE_KEY, clamped)
+  }, [])
+
+  const setFooterLayout = useCallback((next: FooterLayout) => {
+    writeFooterLayout(next)
+    setFooterLayoutState(next)
   }, [])
 
   // Writing either answer settles the question for good: a refusal is stored,
@@ -548,7 +554,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setHotkey,
       resetHotkey,
       showContextUsage,
-      setShowContextUsage,
+      footerVisibility,
+      footerLayout,
+      setFooterLayout,
       costBudget,
       setCostBudget,
       desktopNotifications,
@@ -578,7 +586,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       setHotkey,
       resetHotkey,
       showContextUsage,
-      setShowContextUsage,
+      footerVisibility,
+      footerLayout,
+      setFooterLayout,
       costBudget,
       setCostBudget,
       desktopNotifications,


### PR DESCRIPTION
## Summary

- Move footer customization into Settings → Appearance, removing duplicate provider controls.
- Add compact Available / Left / Right layout areas with drag-and-drop, keyboard menus, persistence, defaults and a single-line preview. Editor items wrap without horizontal scrolling.
- Keep session readings inline and independently configurable; retain the provider/plan quota tooltip with more vertical padding and restore theme-colored borders on footer tooltips.
- Show branch and working directory as plain text, remove the redundant footer Settings action, and use the available Settings page width.
- Preserve legacy visibility and backend cost choices, handle failed saves, and document existing reading gaps across all eight providers.

## Validation

- [x] gofmt -l . — clean
- [x] go vet ./...
- [x] go test ./... — 85.5% statement coverage
- [x] pnpm check — no errors; existing warning backlog unchanged
- [x] Frontend test suite with coverage — 98.17% line coverage
- [x] pnpm build
- [x] Browser checks during iteration: pointer and keyboard moves, empty areas, persistence, restore, compact layout at narrow widths, inline readings and tooltip content
- [x] CHANGELOG, design guidance and provider ceilings updated

Rebased onto current main; changelog entries from both branches are preserved. No backend contracts, provider hooks or shell code are changed by this PR.