### PR TITLE
feat: group the session card menu and name its shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of the pane and named no session, so with split panes nothing said which one
   would take the file.
 
+- **A session card's right-click menu is grouped, and names its shortcuts.**
+  Every action sat in one flat list of up to fourteen items with no order to
+  it. They now fall in three blocks a hairline apart: what the session is
+  (rename, pin, show beside), who its work goes to (delegate, schedule, fork,
+  copy send command), and where its checkout opens, with Terminal, Editor
+  and File manager gathered under one "Open in". Rename, Pin, Delegate, Terminal
+  and Close session print their keyboard shortcut beside them on the active
+  session's card, which is the card those shortcuts act on.
+
 ### Fixed
 
 - **Dropping a file on a session works again under Wayland.** The 0.45.0

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -56,18 +56,24 @@ import {
   ContextMenuContent,
   ContextMenuItem,
   ContextMenuSeparator,
+  ContextMenuShortcut,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
 import { System, Terminal as TerminalService } from "@/lib/rpc"
 import { queuePaste } from "@/lib/terminal/paste-queue"
 import type { DelegateGroup } from "@/lib/session/delegate-targets"
 import { delegatePrompt, delegateWorktreePrompt } from "@/lib/session/delegate-prompt"
-import { isWindows } from "@/lib/platform"
+import { isMac, isWindows } from "@/lib/platform"
+import { formatCombo, type HotkeyId } from "@/lib/hotkeys"
 import { sendCommand } from "@/lib/session/send-command"
 import { bracketedPaste } from "@/lib/terminal/bracketed-paste"
 import { requestTerminalFocus } from "@/lib/terminal/focus-request"
 import { useSessionIntent } from "@/lib/use-sidebar-intent"
 import { useProjects } from "@/providers/projects"
+import { useSettings } from "@/providers/settings"
 import { timeUntil } from "@/lib/session/schedule"
 import { SessionTargetPicker } from "./SessionTargetPicker"
 import { EntrypointDialog } from "./EntrypointDialog"
@@ -148,6 +154,13 @@ export function SessionCard({
   // the project only when another session shares this card's label, and that is
   // a question about every open project — not about the one this card sits in.
   const { projects, sessions, scheduleSession } = useProjects()
+  const { hotkeys } = useSettings()
+  // The card chords act on whichever session is active (App.tsx cardAction), so
+  // they are true of this card only while it is that one. On any other card the
+  // menu says nothing: naming a chord that renames somewhere else is worse than
+  // naming none.
+  const chord = (id: HotkeyId) =>
+    active ? <ContextMenuShortcut>{formatCombo(hotkeys[id], isMac)}</ContextMenuShortcut> : null
   const pinned = !!session.pinned
   const pathRef = useRef<HTMLSpanElement>(null)
   const [pathOverflow, setPathOverflow] = useState(false)
@@ -620,17 +633,46 @@ export function SessionCard({
           </ContextMenuTrigger>
           <SessionTooltip session={session} path={path} />
         </Tooltip>
+        {/* Three blocks, hairline apart: what this card is, what its work is
+            handed to, and where its checkout opens. The chords ride the items
+            that have one, since the menu is where a user meets them. */}
         <ContextMenuContent>
-          {canFork && (
-            <ContextMenuItem onClick={onFork}>
-              <GitFork />
-              Fork to worktree…
+          <ContextMenuItem onClick={() => setEditing(true)}>
+            <Pencil />
+            Rename
+            {chord("renameSession")}
+          </ContextMenuItem>
+          <ContextMenuItem onClick={() => onPin(!pinned)}>
+            {pinned ? <PinOff /> : <Pin />}
+            {pinned ? "Unpin" : "Pin"}
+            {chord("togglePin")}
+          </ContextMenuItem>
+          {session.kind === "shell" && (
+            <ContextMenuItem onClick={() => setEntrypointOpen(true)}>
+              <Play />
+              Entrypoint…
             </ContextMenuItem>
           )}
+          {!active && (
+            <ContextMenuItem onClick={onStageToggle}>
+              <Columns2 />
+              {showing ? "Stop showing" : "Show beside"}
+            </ContextMenuItem>
+          )}
+          {delegateCount > 0 && (
+            <ContextMenuItem onClick={onGroupDelegates}>
+              <Columns2 />
+              {delegateCount === 1
+                ? "Show beside its 1 delegate"
+                : `Show beside its ${delegateCount} delegates`}
+            </ContextMenuItem>
+          )}
+          <ContextMenuSeparator />
           {canDelegate && (
             <ContextMenuItem onClick={() => setDelegatePickerOpen(true)}>
               <ArrowRight />
               Delegate to session…
+              {chord("delegate")}
             </ContextMenuItem>
           )}
           {/* Under delegation, because the two are the same move a beat apart:
@@ -642,52 +684,40 @@ export function SessionCard({
             <Clock />
             {scheduleItem}
           </ContextMenuItem>
+          {canFork && (
+            <ContextMenuItem onClick={onFork}>
+              <GitFork />
+              Fork to worktree…
+            </ContextMenuItem>
+          )}
           <ContextMenuItem onClick={copySendCommand}>
             <Copy />
             Copy send command
           </ContextMenuItem>
-          {delegateCount > 0 && (
-            <ContextMenuItem onClick={onGroupDelegates}>
-              <Columns2 />
-              {delegateCount === 1
-                ? "Show beside its 1 delegate"
-                : `Show beside its ${delegateCount} delegates`}
-            </ContextMenuItem>
-          )}
-          {!active && (
-            <ContextMenuItem onClick={onStageToggle}>
-              <Columns2 />
-              {showing ? "Stop showing" : "Show beside"}
-            </ContextMenuItem>
-          )}
-          <ContextMenuItem onClick={() => setEditing(true)}>
-            <Pencil />
-            Rename
-          </ContextMenuItem>
-          {session.kind === "shell" && (
-            <ContextMenuItem onClick={() => setEntrypointOpen(true)}>
-              <Play />
-              Entrypoint…
-            </ContextMenuItem>
-          )}
-          <ContextMenuItem onClick={() => onPin(!pinned)}>
-            {pinned ? <PinOff /> : <Pin />}
-            {pinned ? "Unpin" : "Pin"}
-          </ContextMenuItem>
-          {session.kind !== "shell" && (
-            <ContextMenuItem onClick={() => onOpenTerminal(shownPath)}>
-              <Terminal />
-              Open Terminal
-            </ContextMenuItem>
-          )}
-          <ContextMenuItem onClick={openFolderInEditor}>
-            <FolderCode />
-            Open in editor
-          </ContextMenuItem>
-          <ContextMenuItem onClick={openFolder}>
-            <FolderOpen />
-            Open folder
-          </ContextMenuItem>
+          <ContextMenuSeparator />
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>
+              <FolderOpen />
+              Open in
+            </ContextMenuSubTrigger>
+            <ContextMenuSubContent>
+              {session.kind !== "shell" && (
+                <ContextMenuItem onClick={() => onOpenTerminal(shownPath)}>
+                  <Terminal />
+                  Terminal
+                  {chord("openTerminal")}
+                </ContextMenuItem>
+              )}
+              <ContextMenuItem onClick={openFolderInEditor}>
+                <FolderCode />
+                Editor
+              </ContextMenuItem>
+              <ContextMenuItem onClick={openFolder}>
+                <FolderOpen />
+                File manager
+              </ContextMenuItem>
+            </ContextMenuSubContent>
+          </ContextMenuSub>
           <ContextMenuItem onClick={onPulls}>
             <GitPullRequestArrow />
             Pull request
@@ -698,6 +728,7 @@ export function SessionCard({
               <ContextMenuItem variant="destructive" onClick={onClose}>
                 <X />
                 Close session
+                {chord("closeSession")}
               </ContextMenuItem>
             </>
           )}

--- a/frontend/src/components/ui/context-menu.tsx
+++ b/frontend/src/components/ui/context-menu.tsx
@@ -218,7 +218,10 @@ function ContextMenuShortcut({ className, ...props }: React.ComponentProps<"span
     <span
       data-slot="context-menu-shortcut"
       className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/context-menu-item:text-accent-foreground",
+        // pl-5 on top of the item's gap-2: ml-auto alone parks the chord hard
+        // against a label that fills the row, and the widest label is what sets
+        // the menu's width, so the collision is the normal case and not an edge.
+        "ml-auto pl-5 text-xs tracking-widest text-muted-foreground group-focus/context-menu-item:text-accent-foreground",
         className,
       )}
       {...props}


### PR DESCRIPTION
Right-clicking a session card dropped up to fourteen items in one flat list with a single separator, no order anyone could name, and no sign that five of those actions already have a global chord.

Three blocks, a hairline apart:

- **the session itself**: Rename, Pin, Entrypoint (shell cards), Show beside, Show beside its N delegates
- **who its work goes to**: Delegate, Schedule a prompt, Fork to worktree, Copy send command
- **where its checkout opens**: `Open in` (Terminal, Editor, File manager), Pull request

then Close session, as before.

`Open Terminal`, `Open in editor` and `Open folder` were three top-level rows for one family, so they moved into an `Open in` submenu. That is the first use of the base-ui submenu parts in the app.

### Shortcuts

Rename, Pin, Delegate, Terminal and Close session now print their chord, read from the user's own bindings through `formatCombo`, so a rebind in Settings shows up here. `ContextMenuShortcut` already existed in `ui/context-menu.tsx` and had never been used.

They print **only on the active card**. Every card chord routes through `cardAction` in `App.tsx`, which acts on the active session, not on the card that received the right-click; on any other card the menu would be naming a chord that acts somewhere else.

`ContextMenuShortcut` also gained `pl-5`. With `ml-auto` alone, a label that fills the row parks against its chord, and since the widest label is what sets the menu's width, that collision is the normal case rather than an edge.

### Design

Three options were drawn against the real tokens and the real geometry before any TSX moved: labelled groups, hairline groups with the submenu, and a short list with a `More` bucket. The second shipped. The first spends four extra rows on group labels, which `DESIGN.md` asks to spend on seams instead; the third hides seven items behind a bucket with no criterion, which is the ordering defect one level down.

### Test plan

- [x] `pnpm check`, `tsc`, `vitest run` (124 files, 1426 tests), `vite build`
- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] Submenu composition exercised in a throwaway jsdom probe: the menu opens, the submenu content is absent before the sub-trigger is clicked and present after. The node-only gate cannot render, so a broken base-ui composition ships green.
- [x] Read in `task dev`, both the collision and the fix
