### PR TITLE
feat: keep the machine awake while a session is working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+> [!IMPORTANT]
+> **Lock your screen and walk away: the agents keep working.** While any
+> session has a turn open, lich holds the machine out of idle sleep the way a
+> playing media player does, on Windows, macOS and Linux alike. An idle prompt
+> lets it sleep again.
+
 ### Added
 
+- **Sessions no longer pause behind a locked screen.** While an agent is
+  working, lich holds the same idle-sleep assertion a media player holds
+  while it plays, so a machine left locked keeps running its sessions and
+  only sleeps once every session is back at its prompt. On Windows that also
+  covers Modern Standby laptops, whose "screen off" used to freeze every
+  desktop app, lich included; `powercfg /requests` names lich as the holder.
+  On macOS it is `caffeinate` (`pmset -g assertions`), on Linux a logind idle
+  inhibitor (`systemd-inhibit --list`). The screen still turns off, and a
+  closed lid or a Sleep you choose still sleeps.
 - **On Windows, lich now brings its own window too.** The installer ships the
   same embedded Chromium (CEF) the Linux packages do, beside `lich.exe` as
   `shell\`, and lich opens in it instead of looking for Chrome, Edge, Brave or

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -956,3 +956,11 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   hand off to. A desktop with a URL handler installed but no browser behind it therefore looks like success:
   lich stays up with a notification and nothing on screen. Only a machine missing the opener itself reaches
   the dialog that carries the URL.
+- **Keep-awake follows the session-state report, and only that** (`internal/awake`, `turnLog.onOpen`): the
+  machine is held out of idle sleep while a hook says a turn is open. Crush reports no state at all, so a
+  Crush session left working behind a locked screen sleeps as it always did, and no card says so. Kiro's
+  permission prompt reads as `busy` (docs/hooks/session-state.md), so a Kiro session blocked on a human keeps
+  the machine awake until someone answers. Linux holds it through `systemd-inhibit --what=idle`: a distro
+  without systemd logs one warning per burst of work and sleeps, and a desktop that ignores logind idle
+  inhibitors sleeps silently. The hold was measured on Linux only; on Windows and macOS CI proves the request
+  is registered (`powercfg /requests`, `pmset -g assertions`), not that the machine stays up.

--- a/internal/awake/argv_darwin.go
+++ b/internal/awake/argv_darwin.go
@@ -1,0 +1,8 @@
+package awake
+
+// holdArgv is caffeinate's idle-sleep assertion (-i: PreventUserIdleSystemSleep)
+// held for as long as cat runs. The display still sleeps: that is -d, and a
+// working agent has no use for a lit screen.
+func holdArgv() []string {
+	return []string{"caffeinate", "-i", "cat"}
+}

--- a/internal/awake/argv_linux.go
+++ b/internal/awake/argv_linux.go
@@ -1,0 +1,12 @@
+package awake
+
+// holdArgv is a logind idle inhibitor held for as long as cat runs. `idle` is
+// the one class that means "do not sleep for lack of activity" and nothing
+// more, `sleep` would block a suspend the user chose, and it is the class
+// GNOME, KDE and hypridle all read before acting on their idle timeout.
+func holdArgv() []string {
+	return []string{
+		"systemd-inhibit", "--what=idle", "--who=lich",
+		"--why=a session is working", "--mode=block", "cat",
+	}
+}

--- a/internal/awake/awake.go
+++ b/internal/awake/awake.go
@@ -1,0 +1,52 @@
+// Package awake keeps the machine from idling into sleep while a session is
+// working, the way a media player does while it plays. Lock the screen and
+// the agents go on; leave the machine at an idle prompt and it sleeps as it
+// always did. What is held is the OS's own idle-sleep assertion, so `powercfg
+// /requests`, `pmset -g assertions` and `systemd-inhibit --list` all name lich
+// as the holder, and the user's own sleep policy is what decides the rest: a
+// closed lid, a chosen Sleep and a critical battery all still sleep.
+package awake
+
+import (
+	"log/slog"
+	"sync"
+)
+
+// Keeper turns a count of working sessions into one held assertion.
+type Keeper struct {
+	mu      sync.Mutex
+	release func()
+	// hold takes the assertion and returns what lets go of it. Set per OS.
+	hold func() (release func(), err error)
+}
+
+// New returns a Keeper backed by this OS's idle-sleep assertion.
+func New() *Keeper {
+	return &Keeper{hold: hold}
+}
+
+// Set reports how many sessions are working right now. The assertion is
+// taken on the first and let go on the last; the numbers in between change
+// nothing. A hold that fails is logged and tried again on the next rise from
+// zero, so a machine without the tool (a Linux without systemd) costs one log
+// line per burst of work, never a stuck session.
+//
+// The lock is held across the hold itself, which spawns a process on macOS and
+// Linux. That costs milliseconds and buys the ordering: a release can never
+// overtake the hold it undoes.
+func (k *Keeper) Set(working int) {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	switch {
+	case working > 0 && k.release == nil:
+		release, err := k.hold()
+		if err != nil {
+			slog.Warn("keep awake", "err", err)
+			return
+		}
+		k.release = release
+	case working == 0 && k.release != nil:
+		k.release()
+		k.release = nil
+	}
+}

--- a/internal/awake/awake_test.go
+++ b/internal/awake/awake_test.go
@@ -1,0 +1,61 @@
+package awake
+
+import (
+	"errors"
+	"testing"
+)
+
+// The count is a level, not an edge stream: only the crossings of zero touch
+// the assertion, and each crossing touches it exactly once.
+func TestKeeperHoldsAcrossCountAndReleasesAtZero(t *testing.T) {
+	holds, releases := 0, 0
+	k := &Keeper{hold: func() (func(), error) {
+		holds++
+		return func() { releases++ }, nil
+	}}
+	for _, n := range []int{1, 2, 3, 2, 1} {
+		k.Set(n)
+	}
+	if holds != 1 || releases != 0 {
+		t.Fatalf("after rising: holds=%d releases=%d, want 1/0", holds, releases)
+	}
+	k.Set(0)
+	k.Set(0)
+	if holds != 1 || releases != 1 {
+		t.Fatalf("after zero twice: holds=%d releases=%d, want 1/1", holds, releases)
+	}
+	k.Set(1)
+	if holds != 2 {
+		t.Fatalf("a second burst of work must hold again, holds=%d", holds)
+	}
+}
+
+// A hold that fails is not remembered as held: the next rise from zero tries
+// again, and a zero in between releases nothing.
+func TestKeeperRetriesAfterFailedHold(t *testing.T) {
+	calls, releases := 0, 0
+	k := &Keeper{hold: func() (func(), error) {
+		calls++
+		if calls == 1 {
+			return nil, errors.New("no inhibitor here")
+		}
+		return func() { releases++ }, nil
+	}}
+	k.Set(1)
+	k.Set(0)
+	if releases != 0 {
+		t.Fatalf("released a hold that never happened")
+	}
+	k.Set(1)
+	if calls != 2 {
+		t.Fatalf("hold calls=%d, want a retry", calls)
+	}
+}
+
+// The real seam builds and hands out a hold on this OS; whether the OS honours
+// it is measured outside the suite (`pmset -g assertions`, `powercfg /requests`).
+func TestNewUsesThisOSHold(t *testing.T) {
+	if New().hold == nil {
+		t.Fatal("New wired no hold")
+	}
+}

--- a/internal/awake/hold_unix.go
+++ b/internal/awake/hold_unix.go
@@ -1,0 +1,30 @@
+//go:build darwin || linux
+
+package awake
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// hold runs the OS's own inhibitor around a `cat` reading a pipe lich holds.
+// Closing that pipe is the release: cat sees EOF and exits, the inhibitor
+// exits behind it and the OS drops the assertion, and the same thing happens
+// on its own when lich dies, however it dies, so a crash never leaves a
+// machine that cannot sleep. Killing the inhibitor directly would not do:
+// neither tool forwards a signal to the child it is waiting on.
+func hold() (func(), error) {
+	argv := holdArgv()
+	cmd := exec.Command(argv[0], argv[1:]...)
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("%s: %w", argv[0], err)
+	}
+	return func() {
+		_ = stdin.Close()
+		_ = cmd.Wait()
+	}, nil
+}

--- a/internal/awake/hold_unix.go
+++ b/internal/awake/hold_unix.go
@@ -4,6 +4,7 @@ package awake
 
 import (
 	"fmt"
+	"log/slog"
 	"os/exec"
 )
 
@@ -25,6 +26,11 @@ func hold() (func(), error) {
 	}
 	return func() {
 		_ = stdin.Close()
-		_ = cmd.Wait()
+		// The one place an inhibitor that never took its lock shows: it exits
+		// non-zero at once without running cat (systemd-inhibit with no logind
+		// does), Start still succeeds, and only Wait carries the verdict.
+		if err := cmd.Wait(); err != nil {
+			slog.Warn("keep awake ended", "cmd", argv[0], "err", err)
+		}
 	}, nil
 }

--- a/internal/awake/hold_unix_test.go
+++ b/internal/awake/hold_unix_test.go
@@ -1,0 +1,30 @@
+//go:build darwin || linux
+
+package awake
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+	"time"
+)
+
+// The pipe is the release: closing it has to bring the inhibitor down on its
+// own, with nothing signalled. A release that hangs here is one that would
+// hang a session-state report.
+func TestHoldReleasesByClosingThePipe(t *testing.T) {
+	release, err := hold()
+	if errors.Is(err, exec.ErrNotFound) {
+		t.Skipf("no inhibitor on this machine: %v", err)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() { release(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("release did not return: the inhibitor outlived its pipe")
+	}
+}

--- a/internal/awake/hold_windows.go
+++ b/internal/awake/hold_windows.go
@@ -30,6 +30,9 @@ type reasonContext struct {
 	reason  *uint16
 }
 
+// powerRequestKinds is every request type set on the handle, and cleared from it.
+var powerRequestKinds = []uintptr{powerRequestSystemRequired, powerRequestExecutionRequired}
+
 var (
 	kernel32          = windows.NewLazySystemDLL("kernel32.dll")
 	powerCreateReq    = kernel32.NewProc("PowerCreateRequest")
@@ -48,14 +51,14 @@ func hold() (func(), error) {
 		return nil, fmt.Errorf("PowerCreateRequest: %w", callErr)
 	}
 	handle := windows.Handle(h)
-	for _, kind := range []uintptr{powerRequestSystemRequired, powerRequestExecutionRequired} {
+	for _, kind := range powerRequestKinds {
 		if ok, _, callErr := powerSetRequest.Call(uintptr(handle), kind); ok == 0 {
 			_ = windows.CloseHandle(handle)
 			return nil, fmt.Errorf("PowerSetRequest(%d): %w", kind, callErr)
 		}
 	}
 	return func() {
-		for _, kind := range []uintptr{powerRequestSystemRequired, powerRequestExecutionRequired} {
+		for _, kind := range powerRequestKinds {
 			_, _, _ = powerClearRequest.Call(uintptr(handle), kind)
 		}
 		_ = windows.CloseHandle(handle)

--- a/internal/awake/hold_windows.go
+++ b/internal/awake/hold_windows.go
@@ -1,0 +1,63 @@
+package awake
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// The power request API (PowerCreateRequest and friends) is not in x/sys, so
+// it is bound here by hand. Two request types are set on the one handle:
+// SystemRequired resets the idle timer that leads to S3 sleep, the assertion
+// every media player holds; ExecutionRequired is the one Modern Standby
+// laptops answer to, there the screen going off is the entry into standby,
+// and the Desktop Activity Moderator then freezes every desktop process that
+// does not hold it. Without the second, a locked laptop pauses the agents
+// exactly as before.
+const (
+	powerRequestContextVersion      = 0
+	powerRequestContextSimpleString = 1
+	powerRequestSystemRequired      = 1
+	powerRequestExecutionRequired   = 3
+)
+
+// reasonContext mirrors REASON_CONTEXT with a simple string, which is what
+// `powercfg /requests` prints beside lich.exe.
+type reasonContext struct {
+	version uint32
+	flags   uint32
+	reason  *uint16
+}
+
+var (
+	kernel32          = windows.NewLazySystemDLL("kernel32.dll")
+	powerCreateReq    = kernel32.NewProc("PowerCreateRequest")
+	powerSetRequest   = kernel32.NewProc("PowerSetRequest")
+	powerClearRequest = kernel32.NewProc("PowerClearRequest")
+)
+
+func hold() (func(), error) {
+	reason, err := windows.UTF16PtrFromString("A lich session is working")
+	if err != nil {
+		return nil, err
+	}
+	ctx := reasonContext{version: powerRequestContextVersion, flags: powerRequestContextSimpleString, reason: reason}
+	h, _, callErr := powerCreateReq.Call(uintptr(unsafe.Pointer(&ctx)))
+	if windows.Handle(h) == windows.InvalidHandle {
+		return nil, fmt.Errorf("PowerCreateRequest: %w", callErr)
+	}
+	handle := windows.Handle(h)
+	for _, kind := range []uintptr{powerRequestSystemRequired, powerRequestExecutionRequired} {
+		if ok, _, callErr := powerSetRequest.Call(uintptr(handle), kind); ok == 0 {
+			_ = windows.CloseHandle(handle)
+			return nil, fmt.Errorf("PowerSetRequest(%d): %w", kind, callErr)
+		}
+	}
+	return func() {
+		for _, kind := range []uintptr{powerRequestSystemRequired, powerRequestExecutionRequired} {
+			_, _, _ = powerClearRequest.Call(uintptr(handle), kind)
+		}
+		_ = windows.CloseHandle(handle)
+	}, nil
+}

--- a/internal/terminal/hookstate.go
+++ b/internal/terminal/hookstate.go
@@ -21,6 +21,10 @@ import "sync"
 type turnLog struct {
 	mu   sync.Mutex
 	open map[string]bool
+	// onOpen, when set, hears how many turns are open after every change —
+	// the count that keeps the machine awake (internal/awake). Called outside
+	// the lock, so what it does (spawn an inhibitor) never holds a report up.
+	onOpen func(n int)
 }
 
 // report takes one session-state report and answers whether the window should
@@ -30,13 +34,14 @@ type turnLog struct {
 // session nobody is blocked on should show.
 func (l *turnLog) report(id, state string) bool {
 	l.mu.Lock()
-	defer l.mu.Unlock()
+	open := l.open[id]
 	switch state {
 	case statusWaiting:
 		// Recorded neither way: `waiting` interrupts a turn rather than replacing
 		// it, so the report after it still has to be read against the turn it
 		// interrupted. Two permission prompts in one turn are two blocks.
-		return l.open[id]
+		l.mu.Unlock()
+		return open
 	case statusBusy:
 		if l.open == nil {
 			l.open = make(map[string]bool)
@@ -48,7 +53,18 @@ func (l *turnLog) report(id, state string) bool {
 		// as "no turn open", which is what both of them mean here.
 		delete(l.open, id)
 	}
+	l.changed()
 	return true
+}
+
+// changed hands the open count to onOpen. Called with the lock held; it is
+// the one that releases it, so the callback runs outside.
+func (l *turnLog) changed() {
+	n, cb := len(l.open), l.onOpen
+	l.mu.Unlock()
+	if cb != nil {
+		cb(n)
+	}
 }
 
 // busy reports whether a turn is open in this session right now — the provider's
@@ -64,8 +80,8 @@ func (l *turnLog) busy(id string) bool {
 // against its own reports rather than against those of the provider that left.
 func (l *turnLog) forget(id string) {
 	l.mu.Lock()
-	defer l.mu.Unlock()
 	delete(l.open, id)
+	l.changed()
 }
 
 // interrupt closes an open turn the user ended themselves at the PTY, and
@@ -75,10 +91,11 @@ func (l *turnLog) forget(id string) {
 // changes nothing.
 func (l *turnLog) interrupt(id string) bool {
 	l.mu.Lock()
-	defer l.mu.Unlock()
 	if !l.open[id] {
+		l.mu.Unlock()
 		return false
 	}
 	delete(l.open, id)
+	l.changed()
 	return true
 }

--- a/internal/terminal/hookstate.go
+++ b/internal/terminal/hookstate.go
@@ -21,9 +21,10 @@ import "sync"
 type turnLog struct {
 	mu   sync.Mutex
 	open map[string]bool
-	// onOpen, when set, hears how many turns are open after every change —
-	// the count that keeps the machine awake (internal/awake). Called outside
-	// the lock, so what it does (spawn an inhibitor) never holds a report up.
+	// onOpen, when set, hears how many turns are open after every report, the
+	// count that keeps the machine awake (internal/awake). Called outside the
+	// lock, so what it does (spawn an inhibitor) never holds a report up. It
+	// may hear the same count twice: the consumer is a level, not an edge.
 	onOpen func(n int)
 }
 
@@ -34,14 +35,13 @@ type turnLog struct {
 // session nobody is blocked on should show.
 func (l *turnLog) report(id, state string) bool {
 	l.mu.Lock()
-	open := l.open[id]
+	defer l.changed()
 	switch state {
 	case statusWaiting:
 		// Recorded neither way: `waiting` interrupts a turn rather than replacing
 		// it, so the report after it still has to be read against the turn it
 		// interrupted. Two permission prompts in one turn are two blocks.
-		l.mu.Unlock()
-		return open
+		return l.open[id]
 	case statusBusy:
 		if l.open == nil {
 			l.open = make(map[string]bool)
@@ -53,12 +53,12 @@ func (l *turnLog) report(id, state string) bool {
 		// as "no turn open", which is what both of them mean here.
 		delete(l.open, id)
 	}
-	l.changed()
 	return true
 }
 
-// changed hands the open count to onOpen. Called with the lock held; it is
-// the one that releases it, so the callback runs outside.
+// changed releases the lock and hands the open count to onOpen. Deferred
+// right after the Lock by every method that may change the count, so the
+// unlock and the callback cannot drift apart.
 func (l *turnLog) changed() {
 	n, cb := len(l.open), l.onOpen
 	l.mu.Unlock()
@@ -80,8 +80,8 @@ func (l *turnLog) busy(id string) bool {
 // against its own reports rather than against those of the provider that left.
 func (l *turnLog) forget(id string) {
 	l.mu.Lock()
+	defer l.changed()
 	delete(l.open, id)
-	l.changed()
 }
 
 // interrupt closes an open turn the user ended themselves at the PTY, and
@@ -91,11 +91,10 @@ func (l *turnLog) forget(id string) {
 // changes nothing.
 func (l *turnLog) interrupt(id string) bool {
 	l.mu.Lock()
+	defer l.changed()
 	if !l.open[id] {
-		l.mu.Unlock()
 		return false
 	}
 	delete(l.open, id)
-	l.changed()
 	return true
 }

--- a/internal/terminal/hookstate_test.go
+++ b/internal/terminal/hookstate_test.go
@@ -263,3 +263,41 @@ func sendInput(t *testing.T, svc *Service, id string, data []byte) {
 	waitFor(t, func() bool { return !svc.turns.report(id, statusWaiting) },
 		"the keystroke to end the turn")
 }
+
+// onOpen hears the open count after every change, from every path that
+// changes it — a report, an interrupt, a forget — and never from a `waiting`,
+// which changes nothing.
+func TestTurnLogReportsOpenCount(t *testing.T) {
+	var got []int
+	l := &turnLog{onOpen: func(n int) { got = append(got, n) }}
+	l.report("a", statusBusy)
+	l.report("b", statusBusy)
+	l.report("a", statusWaiting)
+	l.report("a", statusDone)
+	l.interrupt("b")
+	l.interrupt("b")
+	l.report("c", statusBusy)
+	l.forget("c")
+	want := []int{1, 2, 1, 0, 1, 0}
+	if !slices.Equal(got, want) {
+		t.Fatalf("open counts %v, want %v", got, want)
+	}
+}
+
+// A closed card takes its turn with it: the count that keeps the machine
+// awake must not remember a session that no longer exists.
+func TestCloseForgetsOpenTurn(t *testing.T) {
+	s := &Service{sessions: map[string]*session{}, hub: events.New()}
+	var last int
+	s.turns.onOpen = func(n int) { last = n }
+	s.turns.report("gone", statusBusy)
+	if last != 1 {
+		t.Fatalf("open=%d before close, want 1", last)
+	}
+	if err := s.Close("gone"); err != nil {
+		t.Fatal(err)
+	}
+	if last != 0 {
+		t.Fatalf("open=%d after close, want 0", last)
+	}
+}

--- a/internal/terminal/hookstate_test.go
+++ b/internal/terminal/hookstate_test.go
@@ -264,9 +264,9 @@ func sendInput(t *testing.T, svc *Service, id string, data []byte) {
 		"the keystroke to end the turn")
 }
 
-// onOpen hears the open count after every change, from every path that
-// changes it — a report, an interrupt, a forget — and never from a `waiting`,
-// which changes nothing.
+// onOpen hears the open count after every report, interrupt and forget,
+// whether or not it changed: the consumer reads a level, and a `waiting` or
+// a repeated interrupt repeats the count rather than going silent.
 func TestTurnLogReportsOpenCount(t *testing.T) {
 	var got []int
 	l := &turnLog{onOpen: func(n int) { got = append(got, n) }}
@@ -278,7 +278,7 @@ func TestTurnLogReportsOpenCount(t *testing.T) {
 	l.interrupt("b")
 	l.report("c", statusBusy)
 	l.forget("c")
-	want := []int{1, 2, 1, 0, 1, 0}
+	want := []int{1, 2, 2, 1, 0, 0, 1, 0}
 	if !slices.Equal(got, want) {
 		t.Fatalf("open counts %v, want %v", got, want)
 	}

--- a/internal/terminal/io.go
+++ b/internal/terminal/io.go
@@ -60,6 +60,11 @@ func (s *Service) stream(id string, sess *session) {
 		s.spawns.Delete(id)
 	}
 	s.mu.Unlock()
+	// Outside mu: closing the turn may spawn the awake inhibitor's release, and
+	// nothing that runs a process belongs under the spawn lock.
+	if reaped {
+		s.turns.forget(id)
+	}
 
 	// Only the goroutine that actually evicted its own PTY owes an exit event:
 	// a reap that lost the race to a respawn under the same id would otherwise

--- a/internal/terminal/io.go
+++ b/internal/terminal/io.go
@@ -58,13 +58,14 @@ func (s *Service) stream(id string, sess *session) {
 	// registered with.
 	if reaped {
 		s.spawns.Delete(id)
-	}
-	s.mu.Unlock()
-	// Outside mu: closing the turn may spawn the awake inhibitor's release, and
-	// nothing that runs a process belongs under the spawn lock.
-	if reaped {
+		// Under mu for the same reason: a respawn that lands after the unlock
+		// forgets the turn itself before it spawns (spawnSession), and a reap
+		// running behind it would otherwise delete the new session's own turn.
+		// The awake release this may run waits milliseconds for a child to
+		// exit, well under what the spawn itself holds mu for.
 		s.turns.forget(id)
 	}
+	s.mu.Unlock()
 
 	// Only the goroutine that actually evicted its own PTY owes an exit event:
 	// a reap that lost the race to a respawn under the same id would otherwise

--- a/internal/terminal/respawn_test.go
+++ b/internal/terminal/respawn_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -184,4 +185,28 @@ func replayOf(t *testing.T, svc *Service, id string) string {
 		t.Fatalf("decode replay: %v", err)
 	}
 	return string(raw)
+}
+
+// A PTY that dies with its turn open, the agent crashing or the shell exiting
+// under it, takes the turn with it: the count that keeps the machine awake
+// must fall on the reap, not wait for someone to close the card.
+func TestReapForgetsOpenTurn(t *testing.T) {
+	svc := New(stubBins{bin: echoBin(t)}, nil, events.New())
+	var open atomic.Int64
+	svc.turns.onOpen = func(n int) { open.Store(int64(n)) }
+	id := "reaped"
+	if err := svc.Start(id, "p1", t.TempDir(), "claude", "", "", false, false, 80, 24); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	svc.turns.report(id, statusBusy)
+	if open.Load() != 1 {
+		t.Fatalf("open=%d with a turn reported, want 1", open.Load())
+	}
+	svc.mu.Lock()
+	sess := svc.sessions[id]
+	svc.mu.Unlock()
+	if err := sess.pty.Close(); err != nil {
+		t.Fatalf("kill pty: %v", err)
+	}
+	waitFor(t, func() bool { return open.Load() == 0 }, "the reap to close the turn")
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/omartelo/lich/internal/awake"
 	"github.com/omartelo/lich/internal/events"
 	"github.com/omartelo/lich/internal/pricing"
 )
@@ -346,6 +347,10 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 	s.snaps.filed = func(id string) {
 		hub.Emit(turnEventName, turnEvent{ID: id})
 	}
+	// While any turn is open the machine is kept from idling into sleep, the
+	// way a playing media player keeps it: a locked screen no longer pauses
+	// the agents (internal/awake).
+	s.turns.onOpen = awake.New().Set
 	ws, err := newTransport(s.onInput, s.onHookState, s.onSessionStart, s.onTitle, s.onTouched)
 	s.ws, s.wsErr = ws, err
 	if ws != nil {
@@ -612,6 +617,9 @@ func (s *Service) Close(id string) error {
 	}
 	s.mu.Unlock()
 	s.spawns.Delete(id)
+	// A turn dies with its session, and an open one left behind would keep the
+	// machine awake for a card that no longer exists.
+	s.turns.forget(id)
 
 	// Before the bail below, because a card is closed far more often than it is
 	// running: its row is deleted either way, so nothing will ever ask what its


### PR DESCRIPTION
## Summary

Users on Windows report that locking the screen pauses their sessions: the PTYs stop until they unlock. The lock itself does nothing; what follows it does. On a Modern Standby laptop the screen going off is the entry into standby, and the Desktop Activity Moderator freezes every desktop process; on a classic machine it is the idle timer running out into S3, and on macOS the idle sleep. Hyprland shows none of it only because nothing there suspends the machine on idle.

This PR does what a media player does while it plays: while any session has a turn open, lich holds the OS's own idle-sleep assertion, and lets go once every session is back at its prompt.

- **Windows**: one power request carrying `SystemRequired` and `ExecutionRequired`. The second is the one Modern Standby answers to; `SetThreadExecutionState` alone does not cover it. Bound by hand on `kernel32` (not in `x/sys`), pure Go. `powercfg /requests` names `lich.exe` as the holder.
- **macOS**: `caffeinate -i cat` (`pmset -g assertions`).
- **Linux**: `systemd-inhibit --what=idle --mode=block cat` (`systemd-inhibit --list`). GNOME, KDE and hypridle read logind idle inhibitors.

On unix the hold is a child reading a pipe lich owns: closing the pipe is the release, and it happens on its own if lich dies, however it dies, so a crash never leaves a machine that cannot sleep. Neither tool forwards a signal to its child, which is why the pipe rather than a kill.

The count is `turnLog`'s own: it now reports how many turns are open after every change, and a turn is forgotten when its session is closed or reaped (before, only on a respawn under the same id), so a dead card never keeps a machine up. The callback runs outside every lock the terminal service holds, since it spawns a process.

The screen still turns off (no `DisplayRequired`, no `-d`), and a closed lid or a Sleep the user chooses still sleeps.

## Provider trace

Rides on the session-state report (`docs/hooks/session-state.md`), so seven of eight providers hold the machine while they work. **Crush reports no state at all and stays out**; the Kiro permission prompt reads as `busy` and keeps the machine awake while a human is blocking. Both written down in `docs/ceilings.md`, together with the Linux dependence on systemd and a desktop that honours logind idle inhibitors.

## Test plan

- [x] `internal/awake`: the count is a level, only the crossings of zero touch the assertion; a failed hold is retried on the next rise; the unix release returns when the pipe closes.
- [x] `turnLog` reports the open count from every path that changes it and never from a `waiting`; `Service.Close` drops an open turn.
- [x] Measured on Linux: with a hold taken, `systemd-inhibit --list` shows `lich … idle … a session is working … block`, and the row is gone after the release.
- [x] `gofmt`, `go vet`, `go test ./...`, cross-compile loop for linux/darwin/windows.
- [ ] Windows and macOS: no hardware here. CI's runners can prove the request is registered (`powercfg /requests` on a Windows runner runs as admin, `pmset -g assertions` on macOS); whether the machine then stays out of standby is for a user with a laptop to measure. Windows users who asked for this are the first check.

## Changelog

Carries the `> [!IMPORTANT]` headline for the release, under `[Unreleased]`.