### PR TITLE
Search every setting by name, not just the eight pane titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of the pane and named no session, so with split panes nothing said which one
   would take the file.
 
+- **The Settings search finds the setting, not just the section.**
+  The box read the eight names in the sidebar and nothing else, so looking for
+  "theme", "font", "ssh" or "cost" answered that nothing matched, with all four
+  sitting one pane away. It now searches every control by name: results replace
+  the nav while you type, each showing the path that tells two settings apart
+  ("Appearance > Terminal" against "Appearance > Interface"), and choosing one
+  opens its pane and briefly highlights the control. Keyboard shortcuts are in
+  there too, and a provider's own settings list once per provider you have
+  enabled. Arrows move, Enter opens, Esc clears. The search reads names, never
+  values: a theme's name or a port number still finds nothing, and the empty
+  state now says so.
+
 - **Settings is one list of six, and every provider lives on its own screen.**
   The sidebar grew a line for every provider you turned on, under three
   headings, with two entries both called "Providers": twelve rows of plain

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -837,6 +837,17 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   workspace database under the project's own id. The trap is for whoever adds a pane that is genuinely about
   one repository's content. Its remembered state belongs on the per-project side, which means a new key with
   the project id in it, not another global one beside these two.
+- **The settings search reads names, and its index is written by hand** (`frontend/src/lib/settings-index.ts`):
+  every control is listed there with the section and group it lives in, because the panes are React components
+  whose blocks exist only once rendered and the suite runs in node. Two things follow. A block added without
+  an entry is a control the search cannot find, which is why `settings-index.test.ts` reads the
+  `SettingBlock` literals back out of the source and fails on one nobody indexed; that guard is the only
+  thing standing between this file and silent rot, so deleting it costs more than it looks. And the search
+  matches titles plus a few hand-picked keywords, never a description, a stored value or a theme's name: a
+  user hunting for `emerald` or a port number finds nothing, and the empty state says as much rather than
+  pretending the setting is absent. Shortcuts and the panes themselves are indexed off `HOTKEY_ACTIONS` and
+  `SETTING_SECTIONS`, so those two never fall behind.
+
 - **A remembered section id is never validated, and a dead one resolves to Providers** (`Settings.tsx`):
   the pref is stored raw rather than parsed against a list, because the sections belong to the screen and
   `settings-prefs` is not where they live. An id this build cannot place (one of the `provider-<id>` panes

--- a/frontend/src/components/settings/HotkeysSettings.tsx
+++ b/frontend/src/components/settings/HotkeysSettings.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button"
 import { ShortcutLine } from "@/components/common/ShortcutLine"
 import { isMac, isWindows } from "@/lib/platform"
 import { cn } from "@/lib/utils"
+import { GroupProvider, useHighlight } from "./setting-highlight"
 
 // A dense list rather than one setting block per action: the bindings read as a
 // table of rows, and a block each would be a column of near-empty cards.
@@ -28,7 +29,7 @@ function Group({ label, children }: { label: string; children: React.ReactNode }
       <h2 className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
         {label}
       </h2>
-      {children}
+      <GroupProvider value={label}>{children}</GroupProvider>
     </section>
   )
 }
@@ -43,6 +44,9 @@ function Group({ label, children }: { label: string; children: React.ReactNode }
 function HotkeyRow({ action, conflicts }: { action: HotkeyAction; conflicts?: HotkeyId[] }) {
   const { hotkeys, setHotkey, resetHotkey } = useSettings()
   const [recording, setRecording] = useState(false)
+  // A shortcut is a searchable setting like any block, so it lights up the same
+  // way when the search sends someone to it.
+  const { lit, ref } = useHighlight<HTMLDivElement>(action.label)
   const combo = hotkeys[action.id]
   const isDefault = sameCombo(combo, DEFAULT_HOTKEYS[action.id])
   const isUnassigned = !combo.key
@@ -63,7 +67,13 @@ function HotkeyRow({ action, conflicts }: { action: HotkeyAction; conflicts?: Ho
   }
 
   return (
-    <div className="flex items-center gap-4 rounded-md px-2 py-1.5 hover:bg-accent/50">
+    <div
+      ref={ref}
+      className={cn(
+        "flex items-center gap-4 rounded-md px-2 py-1.5 transition-colors duration-700 hover:bg-accent/50",
+        lit && "bg-accent/60",
+      )}
+    >
       <div className="flex min-w-0 flex-1 flex-col">
         <span className="truncate text-sm text-foreground">{action.label}</span>
         {conflicts && (

--- a/frontend/src/components/settings/SettingBlock.tsx
+++ b/frontend/src/components/settings/SettingBlock.tsx
@@ -1,4 +1,6 @@
 import type { ReactNode } from "react"
+import { cn } from "@/lib/utils"
+import { GroupProvider, useHighlight } from "./setting-highlight"
 
 // A labelled cluster of setting rows within one section, so a long section
 // (Appearance holds both interface and terminal controls) reads as groups
@@ -10,7 +12,11 @@ export function SettingGroup({ label, children }: { label: string; children: Rea
       <h2 className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
         {label}
       </h2>
-      <div className="divide-y divide-border">{children}</div>
+      {/* The group is what tells two blocks with the same title apart, so the
+          search's highlight needs to know which one it is standing in. */}
+      <GroupProvider value={label}>
+        <div className="divide-y divide-border">{children}</div>
+      </GroupProvider>
     </section>
   )
 }
@@ -27,8 +33,18 @@ export function SettingBlock({
   description?: string
   children: ReactNode
 }) {
+  // Lit when the search sent the user here: a fill that fades out on its own,
+  // in the same accent every selection in the app uses.
+  const { lit, ref } = useHighlight<HTMLElement>(title)
+
   return (
-    <section className="py-5">
+    <section
+      ref={ref}
+      className={cn(
+        "py-5 transition-colors duration-700",
+        lit && "-mx-3 rounded-lg bg-accent/60 px-3",
+      )}
+    >
       <div className="mb-3">
         <div className="flex items-center gap-2 text-sm font-medium text-foreground">
           {icon}

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react"
-import type { ComponentType, ReactNode } from "react"
+import { useEffect, useMemo, useState } from "react"
+import type { ComponentType, KeyboardEvent, ReactNode } from "react"
 import { useParams } from "react-router-dom"
 import {
   Bell,
@@ -30,15 +30,24 @@ import {
   writeSettingsQuery,
   writeSettingsSection,
 } from "@/lib/settings-prefs"
-import { useProviders } from "@/lib/providers-store"
+import { enabledProviders, useProviders } from "@/lib/providers-store"
+import {
+  expandEntries,
+  hitPath,
+  searchSettings,
+  sectionLabel,
+  type SettingHit,
+} from "@/lib/settings-index"
+import { HighlightProvider, type HighlightTarget } from "./setting-highlight"
 import { cn } from "@/lib/utils"
 
 // A settings category: a nav entry plus the pane it renders. The glyph is what
 // makes the list scannable: every other list in the app is mark plus label,
 // and this one was twelve identical strings.
 interface Section {
+  /** Matches an entry in SETTING_SECTIONS, which is where the label lives: the
+   * search names sections too, and one of the two would have gone stale. */
   id: string
-  label: string
   icon: ComponentType<{ className?: string }>
   /** Drawn with a hairline above it: what belongs to the open project rather
    * than to the machine starts here. Two rows do not need a heading each. */
@@ -52,27 +61,24 @@ interface Section {
 // agent plus one for the project: the sidebar used to grow a line for every
 // provider turned on, and the group that grew was the one nobody visits.
 const SECTIONS: Section[] = [
-  { id: "appearance", label: "Appearance", icon: Palette, render: () => <AppearanceSettings /> },
+  { id: "appearance", icon: Palette, render: () => <AppearanceSettings /> },
   {
     id: "notifications",
-    label: "Notifications",
     icon: Bell,
     render: () => <NotificationsSettings />,
   },
-  { id: "hotkeys", label: "Hotkeys", icon: Keyboard, render: () => <HotkeysSettings /> },
-  { id: "providers", label: "Providers", icon: Blocks },
+  { id: "hotkeys", icon: Keyboard, render: () => <HotkeysSettings /> },
+  { id: "providers", icon: Blocks },
   {
     // Global rather than project: most of what it says is about the machine —
     // whether there is a backend at all, what is in your ssh agent — and the
     // values are project-scoped the same way the provider settings are.
     id: "sandbox",
-    label: "Sandbox",
     icon: ShieldCheck,
     render: (id) => <SandboxSettings projectId={id} />,
   },
   {
     id: "version-control",
-    label: "Version Control",
     icon: GitBranch,
     seam: true,
     // The tools are the machine's, not the project's, so they render above the
@@ -90,8 +96,8 @@ const SECTIONS: Section[] = [
 // The two sections that configure nothing: they are about the app itself, and
 // are reached once in a while rather than while setting a project up.
 const FOOTER_SECTIONS: Section[] = [
-  { id: "updates", label: "Updates", icon: Download, render: () => <UpdatesSettings /> },
-  { id: "help", label: "Help", icon: CircleHelp, render: () => <HelpSettings /> },
+  { id: "updates", icon: Download, render: () => <UpdatesSettings /> },
+  { id: "help", icon: CircleHelp, render: () => <HelpSettings /> },
 ]
 
 const ALL_SECTIONS = [...SECTIONS, ...FOOTER_SECTIONS]
@@ -109,6 +115,24 @@ export function Settings() {
   const [active, setActive] = useState(readSettingsSection)
   const [query, setQuery] = useState(readSettingsQuery)
   const [openProvider, setOpenProvider] = useState(readSettingsProvider)
+  // The result the arrow keys are on, and the control a chosen result lit up.
+  const [cursor, setCursor] = useState(0)
+  const [lit, setLit] = useState<HighlightTarget>({ title: "", group: "" })
+
+  const hits = useMemo(
+    () => searchSettings(query, expandEntries(enabledProviders(providers))),
+    [query, providers],
+  )
+
+  // The highlight is a pointer, not a state to live in: it says "you were just
+  // sent here", and a fill that stayed would read as a selection nobody made.
+  useEffect(() => {
+    if (lit.title === "") {
+      return
+    }
+    const timer = setTimeout(() => setLit({ title: "", group: "" }), 2000)
+    return () => clearTimeout(timer)
+  }, [lit])
 
   const openProviderScreen = (id: string) => {
     setOpenProvider(id)
@@ -129,12 +153,48 @@ export function Settings() {
   const search = (next: string) => {
     setQuery(next)
     writeSettingsQuery(next)
+    setCursor(0)
   }
 
-  const needle = query.trim().toLowerCase()
-  const matches = (section: Section) => section.label.toLowerCase().includes(needle)
-  const sections = SECTIONS.filter(matches)
-  const footerSections = FOOTER_SECTIONS.filter(matches)
+  // Open the pane the result lives in, walk into the provider when it has one,
+  // and tell the pane which control to light up. The box keeps its text: a
+  // search is often two or three results deep before it is the right one.
+  const choose = (hit: SettingHit) => {
+    setActive(hit.section)
+    writeSettingsSection(hit.section)
+    openProviderScreen(hit.providerId ?? "")
+    // A per-provider block carries the provider's name as its group, and that
+    // is not a group inside the pane: walking into that provider's screen is
+    // what already told the two apart.
+    setLit({ title: hit.title, group: hit.providerId ? "" : (hit.group ?? "") })
+  }
+
+  const onSearchKey = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Escape") {
+      search("")
+      return
+    }
+    if (hits.length === 0) {
+      return
+    }
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault()
+      const step = event.key === "ArrowDown" ? 1 : hits.length - 1
+      setCursor((at) => (at + step) % hits.length)
+      return
+    }
+    if (event.key === "Enter") {
+      event.preventDefault()
+      const hit = hits[cursor]
+      if (hit) {
+        choose(hit)
+      }
+    }
+  }
+
+  const searching = query.trim() !== ""
+  const sections = SECTIONS
+  const footerSections = FOOTER_SECTIONS
   // A section id this build cannot place resolves to the default pane, not to
   // the first one: the ids a provider used to get its own section are still in
   // people's storage, and landing them on Appearance forever is the trap
@@ -157,7 +217,7 @@ export function Settings() {
       )}
     >
       <section.icon className="size-4 shrink-0" />
-      {section.label}
+      {sectionLabel(section.id)}
       {/* Where you are, when the pane goes a level deeper than the nav does. */}
       {section.id === "providers" && current.id === "providers" && providerName && (
         <span className="ml-auto truncate text-xs opacity-70">{providerName}</span>
@@ -172,46 +232,95 @@ export function Settings() {
           <SearchInput
             value={query}
             onChange={(event) => search(event.target.value)}
-            placeholder="Search"
+            onKeyDown={onSearchKey}
+            placeholder="Search settings"
             aria-label="Search settings"
           />
         </div>
-        {/* Scrolls on its own so a short window shrinks this list instead of
-            pushing the footer out of view. */}
-        <nav className="flex min-h-0 flex-col gap-0.5 overflow-y-auto px-2 pb-3">
-          {sections.map(navButton)}
-        </nav>
 
-        {/* A search that matches nothing has to say so: an empty nav beside a
-            pane that stayed put reads as a screen that broke. */}
-        {sections.length === 0 && footerSections.length === 0 && (
-          <p className="px-5 text-xs leading-relaxed text-muted-foreground">
-            Nothing matches <span className="text-foreground">{query.trim()}</span>. Clear the
-            search to see every section.
-          </p>
-        )}
-
-        {footerSections.length > 0 && (
-          <nav className="mt-auto flex flex-col gap-0.5 border-t border-border px-2 py-2">
-            {footerSections.map(navButton)}
+        {/* While there is something typed, the nav is the results: the sections
+            are eight labels, and what people look for are the controls under
+            them. Esc puts the nav back. */}
+        {searching ? (
+          <>
+            {hits.length > 0 && (
+              <p className="px-5 pb-1.5 font-mono text-[10.5px] uppercase tracking-wider text-muted-foreground">
+                {hits.length} {hits.length === 1 ? "setting" : "settings"}
+              </p>
+            )}
+            <nav className="flex min-h-0 flex-col gap-0.5 overflow-y-auto px-2 pb-3">
+              {hits.map((hit, index) => (
+                <button
+                  key={`${hit.section}-${hit.providerId ?? ""}-${hit.group ?? ""}-${hit.title}`}
+                  type="button"
+                  onClick={() => choose(hit)}
+                  onMouseEnter={() => setCursor(index)}
+                  className={cn(
+                    "flex flex-col rounded-md px-3 py-1.5 text-left transition-colors hover:bg-accent/50",
+                    index === cursor && "bg-accent",
+                  )}
+                >
+                  {/* A section is its own result, and "Updates / Updates" would
+                      be the path saying the name twice. */}
+                  {hitPath(hit, sectionLabel(hit.section)) !== hit.title && (
+                    <span
+                      className={cn(
+                        "font-mono text-[10.5px] tracking-wide text-muted-foreground",
+                        index === cursor && "text-accent-foreground/75",
+                      )}
+                    >
+                      {hitPath(hit, sectionLabel(hit.section))}
+                    </span>
+                  )}
+                  <span
+                    className={cn(
+                      "text-sm leading-snug text-foreground",
+                      index === cursor && "text-accent-foreground",
+                    )}
+                  >
+                    {hit.title}
+                  </span>
+                </button>
+              ))}
+            </nav>
+            {hits.length === 0 && (
+              <p className="px-5 text-xs leading-relaxed text-muted-foreground">
+                Nothing matches <span className="text-foreground">{query.trim()}</span>. The search
+                reads the name of every setting, not their values.
+              </p>
+            )}
+          </>
+        ) : (
+          /* Scrolls on its own so a short window shrinks this list instead of
+             pushing the footer out of view. */
+          <nav className="flex min-h-0 flex-col gap-0.5 overflow-y-auto px-2 pb-3">
+            {sections.map(navButton)}
           </nav>
         )}
+
+        <nav className="mt-auto flex flex-col gap-0.5 border-t border-border px-2 py-2">
+          {footerSections.map(navButton)}
+        </nav>
       </aside>
 
       <div className="flex-1 overflow-auto">
         <div className="w-full px-6 py-8 lg:px-10">
-          {current.id === "providers" ? (
-            <ProvidersPane
-              projectId={projectId}
-              openProvider={openProvider}
-              onOpenProvider={openProviderScreen}
-            />
-          ) : (
-            <>
-              <h1 className="mb-4 text-2xl font-semibold text-foreground">{current.label}</h1>
-              <div className="divide-y divide-border">{current.render?.(projectId)}</div>
-            </>
-          )}
+          <HighlightProvider value={lit}>
+            {current.id === "providers" ? (
+              <ProvidersPane
+                projectId={projectId}
+                openProvider={openProvider}
+                onOpenProvider={openProviderScreen}
+              />
+            ) : (
+              <>
+                <h1 className="mb-4 text-2xl font-semibold text-foreground">
+                  {sectionLabel(current.id)}
+                </h1>
+                <div className="divide-y divide-border">{current.render?.(projectId)}</div>
+              </>
+            )}
+          </HighlightProvider>
         </div>
       </div>
     </div>

--- a/frontend/src/components/settings/setting-highlight.ts
+++ b/frontend/src/components/settings/setting-highlight.ts
@@ -1,0 +1,47 @@
+import { createContext, useContext, useEffect, useRef } from "react"
+
+/** The control the settings search just sent the user to. The group is part of
+ * it because titles repeat: Appearance holds two blocks called Theme, and
+ * lighting both up answers the question the path in the result had just
+ * settled. Empty group means "wherever it is", which is what a result that
+ * walked into a provider's own screen needs. */
+export interface HighlightTarget {
+  title: string
+  group: string
+}
+
+const NOTHING: HighlightTarget = { title: "", group: "" }
+
+// A context rather than a prop: the blocks sit three or four components below
+// the screen, in panes that know nothing about searching, and threading a
+// target through all of them would put the search in every signature.
+const HighlightContext = createContext<HighlightTarget>(NOTHING)
+
+// The group a block is rendered inside, provided by SettingGroup and by the
+// hotkey pane's own grouping.
+const GroupContext = createContext("")
+
+export const HighlightProvider = HighlightContext.Provider
+export const GroupProvider = GroupContext.Provider
+
+/** Whether this control is the one that was searched for, plus the ref to hang
+ * on it so it can be scrolled into view.
+ *
+ * Matched by prefix because one block titles itself after the open project
+ * ("GitHub account for lich"), and the index holds the part that does not
+ * change. */
+export function useHighlight<T extends HTMLElement>(title: string) {
+  const target = useContext(HighlightContext)
+  const group = useContext(GroupContext)
+  const named = target.title !== "" && title.toLowerCase().startsWith(target.title.toLowerCase())
+  const lit = named && (target.group === "" || target.group === group)
+  const ref = useRef<T>(null)
+
+  useEffect(() => {
+    if (lit) {
+      ref.current?.scrollIntoView({ block: "center", behavior: "smooth" })
+    }
+  }, [lit])
+
+  return { lit, ref }
+}

--- a/frontend/src/lib/settings-index.test.ts
+++ b/frontend/src/lib/settings-index.test.ts
@@ -1,0 +1,216 @@
+import { readdirSync, readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+import { HOTKEY_ACTIONS } from "./hotkeys"
+import {
+  SETTING_ENTRIES,
+  SETTING_SECTIONS,
+  allEntries,
+  expandEntries,
+  hitPath,
+  hotkeyEntries,
+  searchSettings,
+  sectionLabel,
+} from "./settings-index"
+
+const find = (query: string) => searchSettings(query, allEntries())
+
+describe("searching the settings", () => {
+  it("finds a control by a word the nav never says", () => {
+    const titles = find("ssh").map((entry) => entry.title)
+
+    expect(titles).toContain("SSH agent")
+  })
+
+  it("finds both Themes, and the path is what tells them apart", () => {
+    const groups = find("theme")
+      .filter((entry) => entry.title === "Theme")
+      .map((entry) => entry.group)
+
+    expect(groups).toEqual(["Interface", "Terminal"])
+  })
+
+  // The words nobody would guess from the title are the point of `also`: the
+  // block is called "Spend ceiling" and the thing it caps is a cost.
+  it("finds a block by a word only its keywords carry", () => {
+    expect(find("cost").map((entry) => entry.title)).toContain("Spend ceiling")
+  })
+
+  // Ranking, not filtering: a stray substring must not outrank the block the
+  // query names.
+  it("puts a title that starts with the query first", () => {
+    const [first] = find("bin")
+
+    expect(first?.title).toBe("Binary")
+  })
+
+  it("ranks a keyword-only match below every title match", () => {
+    const ranked = find("session").map((entry) => entry.title)
+    const keywordOnly = ranked.indexOf("Default provider")
+    const titleMatch = ranked.indexOf("Notify me when a session needs input")
+
+    expect(titleMatch).toBeGreaterThanOrEqual(0)
+    expect(keywordOnly).toBeGreaterThan(titleMatch)
+  })
+
+  it("answers nothing for an empty box, and for a word that is nowhere", () => {
+    expect(find("")).toEqual([])
+    expect(find("   ")).toEqual([])
+    expect(find("zzz")).toEqual([])
+  })
+
+  // A pane is a result of its own: nothing inside Updates is called "updates",
+  // and the row for it is right there in the nav.
+  it("finds a section by its own name", () => {
+    const hit = find("updates")[0]
+
+    expect(hit?.title).toBe("Updates")
+    expect(hit?.section).toBe("updates")
+  })
+
+  it("ranks a block above the pane it sits in", () => {
+    const titles = find("plan").map((entry) => entry.title)
+
+    expect(titles[0]).toBe("Plan usage")
+  })
+
+  it("searches the keyboard shortcuts too, which are not blocks", () => {
+    const titles = find("worktree").map((entry) => entry.title)
+
+    expect(titles).toContain("New worktree session")
+  })
+
+  it("carries every shortcut into the index without writing any of them out", () => {
+    expect(hotkeyEntries()).toHaveLength(HOTKEY_ACTIONS.length)
+    expect(allEntries()).toHaveLength(
+      SETTING_ENTRIES.length + HOTKEY_ACTIONS.length + SETTING_SECTIONS.length,
+    )
+  })
+})
+
+const PROVIDERS = [
+  { id: "claude", name: "Claude Code" },
+  { id: "codex", name: "Codex" },
+]
+
+describe("the blocks that exist once per provider", () => {
+  it("becomes one hit per enabled provider, named after it", () => {
+    const hits = expandEntries(PROVIDERS).filter((hit) => hit.title === "Binary")
+
+    expect(hits.map((hit) => hit.group)).toEqual(["Claude Code", "Codex"])
+    expect(hits.map((hit) => hit.providerId)).toEqual(["claude", "codex"])
+  })
+
+  // Not a stranded result: the block genuinely has nowhere to live when no
+  // provider is on, and the pane it would open shows the roster instead.
+  it("disappears when no provider is enabled", () => {
+    const titles = expandEntries([]).map((hit) => hit.title)
+
+    expect(titles).not.toContain("Binary")
+    expect(titles).toContain("Default provider")
+  })
+
+  it("leaves every other entry alone", () => {
+    expect(expandEntries(PROVIDERS).filter((hit) => hit.title === "Zoom")).toHaveLength(1)
+  })
+
+  it("searches the expanded hits, so one query answers for each provider", () => {
+    const hits = searchSettings("binary", expandEntries(PROVIDERS))
+
+    expect(hits.map((hit) => hit.providerId)).toEqual(["claude", "codex"])
+  })
+})
+
+describe("the path over a result", () => {
+  it("names a section by the label the nav shows", () => {
+    expect(sectionLabel("version-control")).toBe("Version Control")
+    expect(sectionLabel("nothing-like-it")).toBe("nothing-like-it")
+  })
+
+  it("names the section and the group", () => {
+    expect(hitPath({ section: "appearance", group: "Terminal", title: "Font" }, "Appearance")).toBe(
+      "Appearance \u203a Terminal",
+    )
+  })
+
+  it("is the section alone when the pane has no groups", () => {
+    expect(hitPath({ section: "help", title: "About" }, "Help")).toBe("Help")
+  })
+})
+
+// The index is written by hand, so it can fall behind the panes silently: a
+// block added without an entry here is a control the search cannot find, and
+// nothing else in the app would ever say so. This reads the same literals out
+// of the source the panes are written in.
+describe("the index against the panes it indexes", () => {
+  const paneDir = fileURLToPath(new URL("../components/settings", import.meta.url))
+
+  // Every `<SettingBlock ... title=...>` in the settings components, whether the
+  // title is a plain string or a template with the project's name in it. Split
+  // rather than one regex: a block's other props hold JSX and arrow functions,
+  // so "everything up to the closing angle bracket" is not a thing to match.
+  function renderedTitles(): string[] {
+    const titles: string[] = []
+    for (const file of readdirSync(paneDir).filter((name) => name.endsWith(".tsx"))) {
+      const source = readFileSync(`${paneDir}/${file}`, "utf8")
+      for (const block of source.split("<SettingBlock").slice(1)) {
+        const quoted = block.match(/^[\s\S]{0,400}?title="([^"]+)"/)
+        const templated = block.match(/^[\s\S]{0,400}?title=\{`([^`$]+)/)
+        const title = quoted?.[1] ?? templated?.[1]
+        if (title) {
+          titles.push(title.trim())
+        }
+      }
+    }
+    return titles
+  }
+
+  // Every title prop in the same files, block or not: what the entries are
+  // allowed to point at.
+  function allTitles(): string[] {
+    const titles: string[] = []
+    for (const file of readdirSync(paneDir).filter((name) => name.endsWith(".tsx"))) {
+      const source = readFileSync(`${paneDir}/${file}`, "utf8")
+      for (const match of source.matchAll(/title=(?:"([^"]+)"|\{`([^`$]+))/g)) {
+        titles.push((match[1] ?? match[2]).trim())
+      }
+    }
+    return titles
+  }
+
+  it("has an entry for every block the panes render", () => {
+    const indexed = SETTING_ENTRIES.map((entry) => entry.title.toLowerCase())
+    const missing = renderedTitles().filter(
+      (title) => !indexed.some((known) => title.toLowerCase().startsWith(known)),
+    )
+
+    expect(missing).toEqual([])
+  })
+
+  // The other direction, against every title in the panes rather than the block
+  // ones: an entry may point at a control nested inside a block (the sandbox
+  // grants are two switches under one title), but not at one that is gone.
+  it("indexes no control that no longer exists", () => {
+    const rendered = allTitles().map((title) => title.toLowerCase())
+    const stale = SETTING_ENTRIES.filter(
+      (entry) => !rendered.some((title) => title.startsWith(entry.title.toLowerCase())),
+    ).map((entry) => entry.title)
+
+    expect(stale).toEqual([])
+  })
+
+  it("points every entry at a section the nav actually has", () => {
+    const ids = SETTING_SECTIONS.map((section) => section.id)
+    const orphans = SETTING_ENTRIES.filter((entry) => !ids.includes(entry.section)).map(
+      (entry) => entry.title,
+    )
+
+    expect(orphans).toEqual([])
+  })
+
+  // Guards the guard: a broken extractor that finds nothing would let both
+  // checks above pass against an empty list.
+  it("reads the blocks out of the source at all", () => {
+    expect(renderedTitles().length).toBeGreaterThan(20)
+  })
+})

--- a/frontend/src/lib/settings-index.ts
+++ b/frontend/src/lib/settings-index.ts
@@ -1,0 +1,169 @@
+// What the settings search looks through. The nav has eight labels; the things
+// people actually look for are the twenty-five controls under them, and until
+// this existed a search for "theme" or "ssh" answered that nothing matched.
+//
+// The index is written out rather than derived from the rendered tree: the
+// panes are React components whose blocks only exist once rendered, and the
+// suite runs in node. settings-index.test.ts is what keeps the two in step, by
+// reading the same literals out of the source and failing on a block that
+// nobody added here.
+import { HOTKEY_ACTIONS, HOTKEY_GROUPS } from "@/lib/hotkeys"
+
+export interface SettingEntry {
+  /** The nav section that opens it, by the id Settings.tsx gives it. */
+  section: string
+  /** The group inside the pane, where the pane has groups. Part of the path a
+   * result shows, and the only thing that tells the two Themes apart. */
+  group?: string
+  /** The block's own title, verbatim from its SettingBlock. */
+  title: string
+  /** Words someone would type that the title does not contain. The reason a
+   * search for "cost" finds a block called "Spend ceiling". */
+  also?: string
+  /** Lives on a provider's own screen, so it exists once per enabled provider
+   * and reaching it is two steps rather than one. */
+  perProvider?: boolean
+}
+
+// Every SettingBlock in the app, in the order its pane renders it.
+export const SETTING_ENTRIES: readonly SettingEntry[] = [
+  { section: "appearance", group: "Interface", title: "Theme", also: "colors dark light" },
+  { section: "appearance", group: "Interface", title: "Zoom" },
+  { section: "appearance", group: "Terminal", title: "Theme", also: "colors palette" },
+  { section: "appearance", group: "Terminal", title: "Text size" },
+  { section: "appearance", group: "Terminal", title: "Font", also: "typeface monospace" },
+  { section: "appearance", group: "Footer", title: "Footer layout", also: "status bar arrange" },
+  { section: "appearance", group: "Footer", title: "Spend ceiling", also: "cost budget usd" },
+  { section: "notifications", title: "Notify me when a session needs input" },
+  { section: "notifications", title: "Notify me when a session finishes working" },
+  { section: "providers", title: "Default provider", also: "agent new session" },
+  {
+    section: "providers",
+    title: "Plan usage",
+    also: "quota subscription limit",
+    perProvider: true,
+  },
+  { section: "providers", title: "Binary", also: "path executable command", perProvider: true },
+  {
+    section: "providers",
+    title: "Skip permission prompts",
+    also: "yolo dangerous approvals",
+    perProvider: true,
+  },
+  { section: "providers", title: "Right now", also: "open sessions docs", perProvider: true },
+  { section: "sandbox", title: "Which sessions run confined", also: "isolate bwrap seatbelt" },
+  { section: "sandbox", title: "What a confined session may carry in" },
+  { section: "sandbox", title: "SSH agent", also: "push keys" },
+  { section: "sandbox", title: "GitHub token", also: "gh credentials" },
+  { section: "version-control", title: "Command-line tools", also: "git gh install" },
+  { section: "version-control", title: "GitHub account", also: "login gh switch" },
+  { section: "updates", title: "Application", also: "version upgrade" },
+  { section: "updates", title: "What's new", also: "changelog release notes" },
+  { section: "updates", title: "lich plugin", also: "hooks install" },
+  { section: "help", title: "Report a bug", also: "issue github" },
+  { section: "help", title: "Log file", also: "debug logs" },
+  { section: "help", title: "About", also: "version license" },
+]
+
+// The keyboard shortcuts are not blocks, so they are not written out twice:
+// HOTKEY_ACTIONS already carries a label per action, and it is the list the
+// pane itself renders. A shortcut added to the app is searchable the day it
+// lands, with no entry to forget.
+export function hotkeyEntries(): SettingEntry[] {
+  return HOTKEY_ACTIONS.map((action) => ({
+    section: "hotkeys",
+    group: HOTKEY_GROUPS.find((group) => group.id === action.group)?.label,
+    title: action.label,
+  }))
+}
+
+// The nav's own rows, by the id the entries above point at. Owned here rather
+// than in the screen because a result has to be able to name the section it
+// opens, and because the sections are searchable themselves: typing "updates"
+// has to reach the pane called Updates even though no block is called that.
+export const SETTING_SECTIONS: readonly { id: string; label: string }[] = [
+  { id: "appearance", label: "Appearance" },
+  { id: "notifications", label: "Notifications" },
+  { id: "hotkeys", label: "Hotkeys" },
+  { id: "providers", label: "Providers" },
+  { id: "sandbox", label: "Sandbox" },
+  { id: "version-control", label: "Version Control" },
+  { id: "updates", label: "Updates" },
+  { id: "help", label: "Help" },
+]
+
+/** The nav label of a section, by id. */
+export function sectionLabel(id: string): string {
+  return SETTING_SECTIONS.find((section) => section.id === id)?.label ?? id
+}
+
+// A section is its own coarsest result. Last in the index, so a block named
+// after what was typed outranks the pane it sits in.
+function sectionEntries(): SettingEntry[] {
+  return SETTING_SECTIONS.map((section) => ({ section: section.id, title: section.label }))
+}
+
+/** Every searchable entry: the written-out blocks, the shortcuts, the panes. */
+export function allEntries(): SettingEntry[] {
+  return [...SETTING_ENTRIES, ...hotkeyEntries(), ...sectionEntries()]
+}
+
+/** The entries a query matches, best first.
+ *
+ * Ranked, not just filtered: a search for "theme" should reach the Theme blocks
+ * before "Which sessions run confined" wins on a stray substring. A title that
+ * starts with the query beats one that merely contains it, and both beat a
+ * match that only came from the `also` words, which the result never shows.
+ * Ties keep the order above, which is the order the panes render. */
+export function searchSettings<T extends SettingEntry>(query: string, entries: readonly T[]): T[] {
+  const needle = query.trim().toLowerCase()
+  if (needle === "") {
+    return []
+  }
+  const scored: { entry: T; rank: number }[] = []
+  for (const entry of entries) {
+    const title = entry.title.toLowerCase()
+    if (title.startsWith(needle)) {
+      scored.push({ entry, rank: 0 })
+    } else if (title.includes(needle)) {
+      scored.push({ entry, rank: 1 })
+    } else if (entry.also?.includes(needle)) {
+      scored.push({ entry, rank: 2 })
+    }
+  }
+  return scored.sort((a, b) => a.rank - b.rank).map((hit) => hit.entry)
+}
+
+/** One result, after the per-provider entries have been spread over the
+ * providers that are actually enabled. */
+export interface SettingHit extends SettingEntry {
+  /** Set for a block that lives on a provider's own screen: reaching it means
+   * opening the Providers pane and then that provider. */
+  providerId?: string
+}
+
+/** The index as it applies to this machine: a block that exists once per
+ * provider becomes one hit per enabled provider, named after it, and vanishes
+ * entirely when none are on. Everything else passes through. */
+export function expandEntries(
+  providers: readonly { id: string; name: string }[],
+  entries: readonly SettingEntry[] = allEntries(),
+): SettingHit[] {
+  const hits: SettingHit[] = []
+  for (const entry of entries) {
+    if (!entry.perProvider) {
+      hits.push(entry)
+      continue
+    }
+    for (const provider of providers) {
+      hits.push({ ...entry, group: provider.name, providerId: provider.id })
+    }
+  }
+  return hits
+}
+
+/** The path a result shows above its name, which is what tells two blocks with
+ * the same title apart. */
+export function hitPath(hit: SettingHit, sectionLabel: string): string {
+  return hit.group ? `${sectionLabel} \u203a ${hit.group}` : sectionLabel
+}


### PR DESCRIPTION
The search box read the eight labels in the sidebar and nothing else, so `theme`, `font`, `zoom`, `ssh` and `cost` all answered that nothing matched, with every one of them sitting a pane away. This is the last part of the Settings pass, after #476.

## What it searches

25 blocks, written out in `lib/settings-index.ts` with the section and group each lives in, plus two lists that are derived rather than copied: every keyboard shortcut (from `HOTKEY_ACTIONS`) and the panes themselves (from `SETTING_SECTIONS`, so typing "updates" reaches the Updates pane even though nothing inside it is called that).

Matching is ranked, not filtered: a title that starts with the query beats one that merely contains it, and both beat a match that only came from an entry's keywords. The keywords are the few words nobody would guess from the title, `cost` for Spend ceiling, `yolo` for Skip permission prompts, `path` for Binary.

## What a result does

Results replace the nav while there is text in the box, showing the path above the name because titles repeat: `Appearance > Interface` against `Appearance > Terminal` is the only thing separating the two blocks called Theme. Choosing one opens its pane, walks into the provider when the block lives on a provider's own screen (`Binary` exists once per enabled provider), and lights the control for two seconds so nobody has to scan for what they just typed. Arrows move, Enter opens, Esc clears.

The highlight travels by context, keyed on title plus group, so the two Themes never light up together. `SettingGroup` and the hotkeys pane's own grouping provide that group.

## Keeping the index honest

`settings-index.test.ts` reads the `SettingBlock` literals back out of `components/settings/*.tsx` and fails on a block that nobody indexed, on an entry pointing at a control that no longer exists, and on an entry naming a section the nav does not have. Without that, a block added next month is a control the search cannot find and nothing says so. `docs/ceilings.md` records both that and the deliberate limit: the search reads names, never values, so a theme's name or a port number still finds nothing, which is what the empty state now says.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...`
- [x] `pnpm check`, `pnpm test` (1513), `tsc --noEmit`, `pnpm build`
- [x] Headless smoke over CDP: `the` (12 hits, arrow + Enter lands on Appearance with one Theme lit, not both), `binary` (one hit per enabled provider, opens that provider's screen with Binary lit), `worktree` (the shortcut row lit in Hotkeys), `zzz` (the empty state)
