### PR TITLE
fix: let the page claim the chords Chromium reserves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Ctrl+Shift+T starts a session again in lich's own window.** Chromium runs
+  its tab accelerators before the page is given the key, so in the bundled
+  window the chord reopened a closed tab instead of opening a session, and
+  Ctrl+T at a prompt opened a browser tab rather than reaching the shell. The
+  window now offers every Ctrl chord (Cmd on macOS) to the page first: a chord
+  lich binds runs its own action, and one it does not still falls through to
+  Chromium. Opened in a system browser (`--no-window`), the browser keeps its
+  own shortcuts as before.
+
 - **Dropping a file on a session works again under Wayland.** The 0.45.0
   window opened on XWayland when the GPU is NVIDIA, and a file dragged from a
   Wayland file manager onto an XWayland window never arrives on Hyprland: the

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -374,6 +374,15 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   bindings are a `lich.hotkeys` entry in localStorage, which the theme left for the workspace database precisely
   because a recreated Chromium profile drops it: the combos revert to the defaults, and both the overlay and
   Settings then show those defaults as if nothing had ever been rebound.
+- **lich's own window offers the page every primary-modifier chord before Chromium runs it**
+  (`shell/src/main.rs`): a CEF keyboard handler marks each Ctrl chord (Cmd on macOS) a keyboard shortcut, which
+  is the only way a page can claim one of Chromium's *reserved* accelerators. Ctrl+T, Ctrl+W, Ctrl+Shift+T and
+  the tab selectors otherwise run in the browser before the renderer is given the key, and no command handler
+  sees them either: that is how Ctrl+Shift+T came to reopen a closed tab in a window with no tabs. What the page
+  consumes is now gone from the browser, and a focused session consumes a lot, since xterm.js claims every
+  Ctrl+letter: while you type in a session, Ctrl+W no longer closes the window and Ctrl+T no longer opens a tab.
+  It also holds in the bundled window alone. Opened in a system browser (`--no-window`, or the fallback when the
+  window fails), the browser keeps its accelerators and a chord it reserves never reaches lich at all.
 - **Hidden sessions are serialized and destroyed**: 2MB replay rings on both sides
   (`frontend/src/lib/terminal/replay-buffer.ts` page-side, `internal/terminal/replay.go` backend-side — the latter
   survives a full page reload). Scrollback past the ring is gone, not paged. The snapshot carries only the modes

--- a/frontend/src/lib/hotkeys.ts
+++ b/frontend/src/lib/hotkeys.ts
@@ -69,7 +69,10 @@ export interface HotkeyAction {
 //   (Ctrl+R search, Ctrl+U kill, Ctrl+W erase word) — never take one.
 // - Ctrl+Shift+letter reaches the PTY as *nothing at all*: xterm's control-code
 //   mapping requires Shift to be up, so no TUI can bind it and the chord is free.
-//   It is the family to reach for, minus the letters Chromium keeps for itself.
+//   It is the family to reach for, minus the letters Chromium keeps for itself:
+//   lich's own window hands the page every Ctrl chord before Chromium acts on
+//   it (shell/src/main.rs), but a system browser, which is what `--no-window`
+//   and the fallback open, never does.
 // - Ctrl+Shift+arrow arrives as a real sequence (CSI 1;6A…D), so it does cost
 //   the TUI something. It is spent only where the direction *is* the meaning.
 // - Ctrl+Alt+arrow is the desktop's workspace switch on Linux and would never
@@ -86,7 +89,7 @@ export const HOTKEY_ACTIONS: readonly HotkeyAction[] = [
   },
   // B for branch: the dialog's whole subject is which branch the checkout is
   // cut from. Ctrl+Shift+W would have read better and is Chromium's close
-  // window, which a page cannot take back.
+  // window, which a page opened in a browser cannot take back.
   {
     id: "newWorktree",
     label: "New worktree session",

--- a/shell/Cargo.lock
+++ b/shell/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "kurogane"
 version = "0.0.4"
-source = "git+https://github.com/omartelo/kurogane?rev=acc12a2f3ff4e8f06aab2da03532dbc50890e676#acc12a2f3ff4e8f06aab2da03532dbc50890e676"
+source = "git+https://github.com/omartelo/kurogane?rev=12be327b0a47b9f16474ffcd7fa6700d7cf2af7f#12be327b0a47b9f16474ffcd7fa6700d7cf2af7f"
 dependencies = [
  "cef",
  "ctrlc",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "kurogane-layout"
 version = "0.0.4"
-source = "git+https://github.com/omartelo/kurogane?rev=acc12a2f3ff4e8f06aab2da03532dbc50890e676#acc12a2f3ff4e8f06aab2da03532dbc50890e676"
+source = "git+https://github.com/omartelo/kurogane?rev=12be327b0a47b9f16474ffcd7fa6700d7cf2af7f#12be327b0a47b9f16474ffcd7fa6700d7cf2af7f"
 dependencies = [
  "dirs",
  "serde",
@@ -756,6 +756,7 @@ dependencies = [
 name = "lich-shell"
 version = "0.0.0"
 dependencies = [
+ "cef",
  "kurogane",
  "windows-sys 0.61.2",
  "winresource",

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -10,10 +10,16 @@ license = "AGPL-3.0-only"
 # The fork's `lich` branch: upstream eedaedc plus window_class / window_title /
 # window_icon / cache_dir (kurogane#11) and the macOS bundle's Contents/Frameworks
 # lookup (kurogane#13), the NSApplication kept to the browser process
-# (kurogane#14) and the subprocesses run as the bundle's helper app
-# (kurogane#15); move back to 0x48piraj/kurogane once they land
+# (kurogane#14), the subprocesses run as the bundle's helper app (kurogane#15)
+# and the client handlers a browser delegate supplies (kurogane#12); move back
+# to 0x48piraj/kurogane once they land
 # (build/linux/shell/README.md).
-kurogane = { git = "https://github.com/omartelo/kurogane", rev = "acc12a2f3ff4e8f06aab2da03532dbc50890e676" }
+kurogane = { git = "https://github.com/omartelo/kurogane", rev = "12be327b0a47b9f16474ffcd7fa6700d7cf2af7f" }
+
+# The CEF handler types a delegate returns (main.rs). Pinned to the revision
+# kurogane's own workspace pins: two cef crates in one binary are two different
+# KeyboardHandler types, and the delegate would not compile against ours.
+cef = { git = "https://github.com/tauri-apps/cef-rs", rev = "c73f792f245d71ac1716448cdb7c165c8009e20c" }
 
 # The taskbar groups windows by AppUserModelID (main.rs); nothing else of the
 # Win32 API is used.

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -4,7 +4,14 @@
 //! `--class=<name>` names the window for the window manager,
 //! `--user-data-dir=<dir>` is where the profile lives, and every other
 //! `--switch[=value]` is a Chromium switch to honour (`lich -- --ozone-platform=wayland`).
-use kurogane::App;
+use cef::rc::Rc as _;
+use cef::sys::cef_event_flags_t;
+use cef::{
+    Browser, ImplKeyboardHandler, KeyEvent, KeyboardHandler, WrapKeyboardHandler,
+    wrap_keyboard_handler,
+};
+use kurogane::{App, ClientAppBrowserDelegate};
+use std::os::raw::c_int;
 
 /// The title the window carries. The page title is never used for it.
 const TITLE: &str = "lich";
@@ -71,6 +78,65 @@ fn display_switch(wayland_display: Option<&str>) -> Option<(&'static str, &'stat
         .map(|_| ("ozone-platform", "wayland"))
 }
 
+/// CEF's native event for a key press, never read: what the window decides, it
+/// decides from the CefKeyEvent. Its type is the platform's own, so the
+/// signature CEF asks for differs on each.
+#[cfg(target_os = "linux")]
+type OsEvent<'a> = Option<&'a mut cef::sys::XEvent>;
+#[cfg(target_os = "windows")]
+type OsEvent<'a> = Option<&'a mut cef::sys::MSG>;
+#[cfg(target_os = "macos")]
+type OsEvent<'a> = *mut u8;
+
+/// Whether the page is given first refusal on a chord: every one carrying the
+/// primary modifier: Ctrl on Linux and Windows, Cmd on macOS.
+fn page_first(modifiers: u32) -> bool {
+    const PRIMARY: u32 =
+        cef_event_flags_t::EVENTFLAG_CONTROL_DOWN.0 | cef_event_flags_t::EVENTFLAG_COMMAND_DOWN.0;
+    modifiers & PRIMARY != 0
+}
+
+// Chromium reserves its tab accelerators: Ctrl+T, Ctrl+W, Ctrl+Shift+T and the
+// rest run in the browser *before* the key is sent to the renderer, so a page
+// binding one never sees it: lich's Ctrl+Shift+T reopened a closed tab rather
+// than starting a session, in a window that has no tabs to reopen into. Marking a
+// chord a keyboard shortcut is how CEF inverts that order: the renderer gets the
+// key first, and Chromium runs the accelerator only if the page let it through
+// (measured on CEF 150; a vetoed CefCommandHandler command cannot do it, the
+// reserved ones never reach it).
+wrap_keyboard_handler! {
+    struct PageFirstKeys;
+
+    impl KeyboardHandler {
+        fn on_pre_key_event(
+            &self,
+            _browser: Option<&mut Browser>,
+            event: Option<&KeyEvent>,
+            _os_event: OsEvent<'_>,
+            is_keyboard_shortcut: Option<&mut c_int>,
+        ) -> c_int {
+            if let (Some(event), Some(shortcut)) = (event, is_keyboard_shortcut)
+                && page_first(event.modifiers)
+            {
+                *shortcut = 1;
+            }
+            0
+        }
+    }
+}
+
+/// CEF asks for a handler on every key event, so the window holds one and hands
+/// out clones rather than building it in the getter.
+struct Window {
+    keys: KeyboardHandler,
+}
+
+impl ClientAppBrowserDelegate for Window {
+    fn keyboard_handler(&self) -> Option<KeyboardHandler> {
+        Some(self.keys.clone())
+    }
+}
+
 fn main() {
     // CEF re-executes this binary for the renderer, GPU and utility roles with
     // an argv of its own. Those roles exit inside run_or_exit before any window
@@ -97,7 +163,10 @@ fn main() {
         // CEF's Chrome runtime loads the extensions a distribution installs
         // system-wide (plasma-browser-integration on KDE). A window that is
         // not a browser has no use for them.
-        .chromium_flag("disable-extensions");
+        .chromium_flag("disable-extensions")
+        .delegate(Window {
+            keys: PageFirstKeys::new(),
+        });
     // Chromium keeps the key for its cookie store in the Keychain, granted to
     // one code identity; an ad-hoc signed binary gets a new one every build,
     // and every start would ask the user for the Keychain again. The only
@@ -153,6 +222,24 @@ mod tests {
 
     fn args(list: &[&str]) -> Vec<String> {
         list.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn hands_the_page_every_primary_modifier_chord() {
+        // Flag values are CEF's own (cef_event_flags_t): shift 2, control 4,
+        // alt 8, command 128.
+        assert!(page_first(4), "Ctrl");
+        assert!(page_first(4 | 2), "Ctrl+Shift");
+        assert!(page_first(128), "Cmd");
+        assert!(page_first(128 | 2), "Cmd+Shift");
+    }
+
+    #[test]
+    fn leaves_the_rest_to_chromium() {
+        assert!(!page_first(0), "no modifier");
+        assert!(!page_first(2), "Shift");
+        assert!(!page_first(8), "Alt");
+        assert!(!page_first(2 | 8), "Shift+Alt");
     }
 
     #[test]

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -90,9 +90,13 @@ type OsEvent<'a> = *mut u8;
 
 /// Whether the page is given first refusal on a chord: every one carrying the
 /// primary modifier: Ctrl on Linux and Windows, Cmd on macOS.
+// The cast is required on Windows, where the flag's C int is signed, and
+// redundant on Linux and macOS, where it is not: the lint has to go, because
+// neither spelling alone builds on all three.
+#[allow(clippy::unnecessary_cast)]
 fn page_first(modifiers: u32) -> bool {
-    const PRIMARY: u32 =
-        cef_event_flags_t::EVENTFLAG_CONTROL_DOWN.0 | cef_event_flags_t::EVENTFLAG_COMMAND_DOWN.0;
+    const PRIMARY: u32 = cef_event_flags_t::EVENTFLAG_CONTROL_DOWN.0 as u32
+        | cef_event_flags_t::EVENTFLAG_COMMAND_DOWN.0 as u32;
     modifiers & PRIMARY != 0
 }
 


### PR DESCRIPTION
`Ctrl+Shift+T` opened a Chromium tab instead of a new session, on Linux, in lich's own window.

## The cause

Chromium keeps a set of *reserved* accelerators (`Ctrl+T`, `Ctrl+W`, `Ctrl+Shift+T`, the tab selectors, `Ctrl+Shift+Q`). `BrowserView::PreHandleKeyboardEvent` runs those in the browser **before** the key is sent to the renderer, so the page never sees them and `use-hotkey.ts` never gets to `preventDefault` one. A window with no tab strip still has the commands: `Ctrl+Shift+T` restored the last closed tab, in a browser window of its own. The system Chromium lich launched before ran the page in an app window, where this did not happen.

Measured on the shipped v0.45.0 window (CEF 150), with a page that reports every key it receives and a probe on both CEF hooks:

| chord | page sees it | Chromium command |
|---|---|---|
| `Ctrl+T` | no | `34014` (`IDC_NEW_TAB`) |
| `Ctrl+Shift+T`, closed tab on the stack | no | restores the tab, no `OnChromeCommand` |
| `Ctrl+Shift+T`, nothing to restore | yes | none (the command is disabled, so the key falls through) |

That last row is why the bug looks intermittent: the chord works until something lands on the tab-restore stack, and from then on it never reaches lich again.

A `CefCommandHandler` veto cannot fix it. The reserved commands do not reach `OnChromeCommand` at all (second row above).

## The fix

`shell/src/main.rs` registers a browser delegate whose keyboard handler marks every chord carrying the primary modifier (Ctrl, Cmd on macOS) as a keyboard shortcut. That is the CEF contract for "the page will decide": the renderer is given the key first, and Chromium runs the accelerator only for what the page declined.

Measured again on the patched window:

| case | result |
|---|---|
| page calls `preventDefault` on `Ctrl+T` | page receives it, no Chromium command |
| page declines `Ctrl+T` | page receives it, tab opens, page blurs |

The handler API comes from kurogane#12, cherry-picked onto the fork's `lich` branch (`acc12a2` to `12be327`); `cef` joins the crate's dependencies for the handler types, pinned to the revision kurogane itself pins.

## Cost, named in `docs/ceilings.md`

What the page consumes is now gone from the browser, and a focused session consumes a lot: xterm.js claims every `Ctrl+letter`, so while you type in a session `Ctrl+W` no longer closes the window and `Ctrl+T` no longer opens a tab. Both reach the shell instead, which is what `hotkeys.ts` always assumed. It holds in the bundled window alone: opened in a system browser (`--no-window`, or the fallback), the browser keeps its accelerators.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --release --all-targets -- -D warnings`, `cargo test --release` in `shell/`
- [x] Unit tests for the modifier decision (`page_first`)
- [x] Manual: the tables above, driven by real X11 key events against the assembled window under Xvfb
- [x] Windows and macOS: `shell` green on both runners, which is what the second commit is about. The event flag is a signed C int on Windows alone, so the mask needs a cast that clippy rejects as redundant on the other two
- [ ] Behaviour on Windows and macOS: the same code path, never pressed on that hardware
