### PR TITLE
docs: credit the macOS bundle layout to upstream's branch, not to closed PRs

### DIFF
--- a/build/linux/shell/README.md
+++ b/build/linux/shell/README.md
@@ -12,14 +12,18 @@ and a title) or place its Chromium profile where lich keeps one. Three builder
 methods fix that — `App::window_class`, `App::window_title`, `App::cache_dir` —
 submitted upstream as
 [0x48piraj/kurogane#11](https://github.com/0x48piraj/kurogane/pull/11), with
-the app-bundle framework lookup macOS needs as
-[0x48piraj/kurogane#13](https://github.com/0x48piraj/kurogane/pull/13), the
+the client handlers a browser delegate supplies (the keyboard handler that
+hands the page Chromium's reserved chords) as
+[0x48piraj/kurogane#12](https://github.com/0x48piraj/kurogane/pull/12), the
 `NSApplication` kept to the browser process as
-[0x48piraj/kurogane#14](https://github.com/0x48piraj/kurogane/pull/14), the
-subprocesses run as the bundle's helper app as
-[0x48piraj/kurogane#15](https://github.com/0x48piraj/kurogane/pull/15), and
-carried meanwhile on the fork `shell/Cargo.toml` pins: `omartelo/kurogane`,
-branch `lich`, on top of upstream `eedaedc`.
+[0x48piraj/kurogane#14](https://github.com/0x48piraj/kurogane/pull/14), and
+the macOS bundle layout (the framework resolved from `Contents/Frameworks`,
+the subprocesses run as the bundle's helper app), which upstream carries on
+its `seal-of-approval/distribution` branch
+([53d51ba](https://github.com/0x48piraj/kurogane/commit/53d51ba7d234161f8709109dcb8d6395f38c7bb4));
+lich's own PRs for that layout, #13 and #15, were closed as covered. All of
+it is carried meanwhile on the fork `shell/Cargo.toml` pins:
+`omartelo/kurogane`, branch `lich`, on top of upstream `eedaedc`.
 One wrinkle the patch works around: cef-rs hands CEF a *borrowed* string when
 it writes an out-parameter struct back, so a `wm_class_class` built from `&str`
 arrives empty — the fork allocates those through CEF's own

--- a/docs/chromium-shell.md
+++ b/docs/chromium-shell.md
@@ -181,13 +181,15 @@ bundle keeps opening a system browser. `lich-shell` sits beside `lich` in
 `Contents/MacOS`, because macOS reads a process's bundle off its executable's
 path and only a process inside the bundle is `Lich.app` to the Dock, to
 Cmd-Tab and to the menu bar; the framework goes to `Contents/Frameworks`,
-where kurogane looks for it since
-[kurogane#13](https://github.com/0x48piraj/kurogane/pull/13). CEF's
+where kurogane looks for it (upstream's `seal-of-approval/distribution`
+branch, commit
+[53d51ba](https://github.com/0x48piraj/kurogane/commit/53d51ba7d234161f8709109dcb8d6395f38c7bb4),
+carried on the fork meanwhile; lich's #13 was closed as covered). CEF's
 subprocesses run as the five helper apps beside the framework (`Lich
 Helper` and the Renderer, GPU, Plugin and Alerts variants, each a copy of
 the binary under an `LSUIElement` plist), the way CEF's own samples lay
-them out, and kurogane points `browser_subprocess_path` at the base one
-since [kurogane#15](https://github.com/0x48piraj/kurogane/pull/15). Both
+them out, and kurogane points `browser_subprocess_path` at the base one (the same
+upstream commit; lich's #15 was closed as covered). Both
 halves were measured on the runner before they were written: re-executing
 the window binary itself gave every subprocess a Dock tile of its own
 (four tiles for one window, until

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -8,12 +8,12 @@ license = "AGPL-3.0-only"
 
 [dependencies]
 # The fork's `lich` branch: upstream eedaedc plus window_class / window_title /
-# window_icon / cache_dir (kurogane#11) and the macOS bundle's Contents/Frameworks
-# lookup (kurogane#13), the NSApplication kept to the browser process
-# (kurogane#14), the subprocesses run as the bundle's helper app (kurogane#15)
-# and the client handlers a browser delegate supplies (kurogane#12); move back
-# to 0x48piraj/kurogane once they land
-# (build/linux/shell/README.md).
+# window_icon / cache_dir (kurogane#11), the client handlers a browser delegate
+# supplies (kurogane#12), the NSApplication kept to the browser process
+# (kurogane#14), and the macOS bundle layout (framework in Contents/Frameworks,
+# subprocesses as the bundle's helper app) that upstream carries on its
+# seal-of-approval/distribution branch (53d51ba); move back to
+# 0x48piraj/kurogane once they land (build/linux/shell/README.md).
 kurogane = { git = "https://github.com/omartelo/kurogane", rev = "12be327b0a47b9f16474ffcd7fa6700d7cf2af7f" }
 
 # The CEF handler types a delegate returns (main.rs). Pinned to the revision


### PR DESCRIPTION
Docs only. kurogane#13 and #15 were closed on 2026-09-07 after the maintainer pointed at his `seal-of-approval/distribution` branch, which carries the same bundle layout (framework in `Contents/Frameworks`, subprocesses as the bundle's helper app, commit 53d51ba). The three places that credited those PRs now name what the fork's `lich` branch actually stacks: #11 (window identity), #12 (client handlers, in since #478), #14 (`NSApplication` kept to the browser process) and that layout.

- `shell/Cargo.toml` pin comment
- `build/linux/shell/README.md`, the fork section
- `docs/chromium-shell.md`, the macOS paragraph

No code, no pin change: the rev stays at 12be327.