### PR TITLE
docs: say the window is lich's own on macOS everywhere the README still said --app

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,15 +27,17 @@ lich's own class and title, so the launcher icon, window rules by class and
 `StartupWMClass` all match it. `--browser` or `LICH_BROWSER` still pins a
 browser of your choice above it ([docs/chromium-shell.md](docs/chromium-shell.md)).
 
-On macOS, lich opens its window in a Chromium-family browser on the machine;
-none is bundled there yet. It looks for one in this order: the browser you
-pinned with `--browser` or `LICH_BROWSER`, your desktop's default browser when
-it is Chromium-family, the browsers installed on the machine. Chrome, Chromium,
-Edge, Brave and Vivaldi are looked up as `.app` bundles under `/Applications`
-(and `~/Applications`), and the folder picker is native. A browser installed
-somewhere else entirely is what `--browser` is for. The same ladder is what a
-Windows install falls back to when its own window fails: Chrome, Edge, Brave
-and Vivaldi via their conventional install paths (Edge ships with Windows).
+On macOS, `Lich.app` on Apple Silicon carries the same window; an Intel Mac
+opens it in a Chromium-family browser on the machine, looked for in this
+order: the browser you pinned with `--browser` or `LICH_BROWSER`, your
+desktop's default browser when it is Chromium-family, the browsers installed
+on the machine. Chrome, Chromium, Edge, Brave and Vivaldi are looked up as
+`.app` bundles under `/Applications` (and `~/Applications`), and the folder
+picker is native. A browser installed somewhere else entirely is what
+`--browser` is for. The same ladder is what an Apple Silicon or Windows
+install falls back to when its own window fails: on Windows, Chrome, Edge,
+Brave and Vivaldi via their conventional install paths (Edge ships with
+Windows).
 
 With **no** Chromium-family browser there, lich does not fail: it opens
 a plain tab in whatever browser you do have, tells you so in a desktop

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@
   <p>
     Open your projects, run agents like Claude Code, Codex and opencode in real
     terminals, and keep git — worktrees, diffs and pull requests — in view
-    without leaving the window. One static Go binary, no Electron: on Linux and
-    Windows the UI opens in lich's own embedded Chromium; on macOS in your
-    system's Chromium-family browser, in <code>--app</code> mode.
+    without leaving the window. One static Go binary, no Electron: on Linux,
+    Windows and Apple Silicon the UI opens in lich's own embedded Chromium; on
+    an Intel Mac in your system's Chromium-family browser.
   </p>
   <p><a href="https://omartelo.github.io/lich/"><strong>omartelo.github.io/lich</strong></a></p>
   <p>
     <a href="https://github.com/omartelo/lich/releases"><img alt="Release" src="https://img.shields.io/github/v/release/omartelo/lich?color=4285F4&label=release" /></a>
     <img alt="Go" src="https://img.shields.io/badge/Go-1.27-00ADD8?logo=go&logoColor=white" />
-    <img alt="Shell" src="https://img.shields.io/badge/shell-Chromium%20--app-4285F4?logo=googlechrome&logoColor=white" />
+    <img alt="Shell" src="https://img.shields.io/badge/shell-embedded%20Chromium%20(CEF)-4285F4?logo=googlechrome&logoColor=white" />
     <img alt="Platform" src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-333" />
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-AGPL--3.0-blue" /></a>
     <a href="https://github.com/sponsors/omartelo"><img alt="Sponsor" src="https://img.shields.io/github/sponsors/omartelo?color=ea4aaa&logo=githubsponsors&label=sponsors" /></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,14 +10,14 @@
   <p>
     打开你的项目，在真实终端里运行 Claude Code、Codex、opencode 这样的智能体，
     并把 git —— worktree、diff 和 Pull Request —— 一并留在视野里，无需离开窗口。
-    单个静态 Go 二进制文件，没有 Electron：在 Linux 上，界面在 lich 自带的内嵌
-    Chromium 里打开；在 macOS 和 Windows 上，则在你系统的 Chromium 系浏览器中以
-    <code>--app</code> 模式打开。
+    单个静态 Go 二进制文件，没有 Electron：在 Linux、Windows 和 Apple Silicon 上，
+    界面在 lich 自带的内嵌 Chromium 里打开；在 Intel Mac 上，则在你系统的
+    Chromium 系浏览器中打开。
   </p>
   <p>
     <a href="https://github.com/omartelo/lich/releases"><img alt="Release" src="https://img.shields.io/github/v/release/omartelo/lich?color=4285F4&label=release" /></a>
     <img alt="Go" src="https://img.shields.io/badge/Go-1.27-00ADD8?logo=go&logoColor=white" />
-    <img alt="Shell" src="https://img.shields.io/badge/shell-Chromium%20--app-4285F4?logo=googlechrome&logoColor=white" />
+    <img alt="Shell" src="https://img.shields.io/badge/shell-embedded%20Chromium%20(CEF)-4285F4?logo=googlechrome&logoColor=white" />
     <img alt="Platform" src="https://img.shields.io/badge/platform-Linux%20%7C%20macOS%20%7C%20Windows-333" />
     <a href="LICENSE"><img alt="License" src="https://img.shields.io/badge/license-AGPL--3.0-blue" /></a>
     <a href="https://github.com/sponsors/omartelo"><img alt="Sponsor" src="https://img.shields.io/github/sponsors/omartelo?color=ea4aaa&logo=githubsponsors&label=sponsors" /></a>
@@ -85,19 +85,20 @@ curl -fsSL https://raw.githubusercontent.com/omartelo/lich/main/install.sh | sh
 | 平台 | 安装方式 | 运行时依赖 |
 | --- | --- | --- |
 | **Linux** | 上面的 `install.sh`，或 AUR 的 [`lich-bin`](https://aur.archlinux.org/packages/lich-bin)（`yay -S lich-bin`） | `zenity` —— 窗口随软件包一起附带 |
-| **macOS** *(实验性)* | `brew install --cask omartelo/tap/lich` | `/Applications` 里有一个 Chromium 系浏览器 |
-| **Windows** *(实验性)* | 从 [Releases](https://github.com/omartelo/lich/releases) 下载安装程序 | 一个 Chromium 系浏览器 |
+| **macOS** *(实验性)* | `brew install --cask omartelo/tap/lich` | Apple Silicon 上无需任何东西 —— 窗口随应用一起附带；Intel 上需要 `/Applications` 里有一个 Chromium 系浏览器 |
+| **Windows** *(实验性)* | 从 [Releases](https://github.com/omartelo/lich/releases) 下载安装程序 | 无需任何东西 —— 窗口随安装程序一起附带 |
 
-在 macOS 和 Windows 上，Chromium、Chrome、Brave、Vivaldi 和 Edge 都算数；`--browser`
-或 `LICH_BROWSER` 可以直接指定一个，Linux 上也可以。这些一个都没有时，lich 会开在你确实
+在 Intel Mac 上，Chromium、Chrome、Brave、Vivaldi 和 Edge 都算数；`--browser`
+或 `LICH_BROWSER` 可以直接指定一个，任何平台上都可以。这些一个都没有时，lich 会开在你确实
 装了的那个浏览器里 —— 丢掉的是它自己那扇窗，而不是这个应用。
 
 手动的分发版软件包和静态二进制文件见 [INSTALL.md](INSTALL.md)。macOS 和 Windows 的
 二进制文件未签名 —— 在公证/签名做好之前，Gatekeeper 和 SmartScreen 会发出警告。用
 Homebrew 安装可以绕开 Gatekeeper 的提示；从 Releases 页面下载的二进制文件则需要手动
 清除隔离标记。在 macOS 上，cask 会把 `Lich.app` 装进 `/Applications`，lich 因此有了
-自己的图标；而它运行期间，Dock 里显示的仍是持有那个窗口的浏览器。从旧的 formula 升级
-需要先 `brew uninstall lich`，[INSTALL.md](INSTALL.md) 里写了这一点。
+自己的图标；在 Apple Silicon 上，运行期间 Dock 里显示的也是它；在 Intel 上，Dock 里
+显示的是持有那个窗口的浏览器。从旧的 formula 升级需要先 `brew uninstall lich`，
+[INSTALL.md](INSTALL.md) 里写了这一点。
 
 ## 快速上手
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -59,8 +59,8 @@
   <section id="features">
     <h2>Why lich</h2>
     <p class="section-lede">
-      A single static Go binary that opens its UI in your system's Chromium-family browser
-      in <code>--app</code> mode. No Electron, no bundled webview.
+      A single static Go binary that opens its UI in its own embedded Chromium (CEF)
+      on Linux, Windows and Apple Silicon. No Electron, no webview toolkit.
     </p>
 
     <div class="features">

--- a/docs/index.zh-CN.html
+++ b/docs/index.zh-CN.html
@@ -58,8 +58,8 @@
   <section id="features">
     <h2>为什么选 lich</h2>
     <p class="section-lede">
-      单个静态 Go 二进制文件，界面在你系统自带的 Chromium 系浏览器中以 <code>--app</code> 模式打开。
-      没有 Electron，也不捆绑 webview。
+      单个静态 Go 二进制文件，在 Linux、Windows 和 Apple Silicon 上，界面在 lich 自带的内嵌 Chromium（CEF）里打开。
+      没有 Electron，也没有 webview 工具包。
     </p>
 
     <div class="features">


### PR DESCRIPTION
Docs only. After #474 the README header still said the UI opens on macOS in the system's Chromium-family browser in `--app` mode, and the shell badge still read `Chromium --app`. The same claim lived in the landing page (`docs/index.html`, `docs/index.zh-CN.html`), in `README.zh-CN.md` (which also still listed a browser as what Windows needs, a leftover from before #469) and in INSTALL's browser ladder.

All of them now say what ships: an embedded Chromium (CEF) on Linux, Windows and Apple Silicon, a Chromium-family browser on an Intel Mac. The ladder paragraph in INSTALL names the Intel Mac as the one that walks it by default and the Apple Silicon and Windows installs as the ones that fall back to it.

Left alone on purpose: `docs/chromium-shell.md` (a decision record, its option 1 section is history) and `docs/lich-architecture.json`'s "Chromium · --app window" label, which is the argv the Go side still speaks and the diagram is generated from it.