### PR TITLE
docs: headline the release with the window and the locked screen together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 > [!IMPORTANT]
-> **Lock your screen and walk away: the agents keep working.** While any
-> session has a turn open, lich holds the machine out of idle sleep the way a
-> playing media player does, on Windows, macOS and Linux alike. An idle prompt
-> lets it sleep again.
+> **Your own window on Windows and Apple Silicon, and agents that keep working
+> behind a locked screen.** The embedded Chromium the Linux packages ship now
+> sits inside the Windows installer and inside `Lich.app`, with lich's icon on
+> the taskbar and in the Dock. And while any session has a turn open, lich
+> holds the machine out of idle sleep the way a playing media player does.
 
 ### Added
 


### PR DESCRIPTION
Docs only, the `[Unreleased]` headline. The What's new dialog renders the first `[!IMPORTANT]` as the headline and demotes any second one to a callout (`patch-notes-layout.ts`, tested), so the window on Windows and Apple Silicon and the locked-screen behaviour share the one block: both in the title, one sentence each in the body. Option 1 of the mockup, sized to what the dialog holds (headline under 22 characters a line, body under 56).