### PR TITLE
feat: one theme for the app and the terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **One theme now colors the app and the terminal.** Settings > Appearance had
+  a second picker for the terminal, defaulting to "Match app", and every theme
+  lich can install already carries both palettes: the interface tokens and the
+  terminal's sixteen colors. The terminal now always paints the palette of the
+  theme you picked, and the extra picker is gone. A terminal you had pointed at
+  a different theme follows the app one from this version on.
+
 - **The app icon sits on a dark plate.** The launcher, dock, taskbar and Start
   Menu icon was the bare white mark on a transparent background, invisible on
   a light taskbar or launcher, and no desktop swaps an app icon with its

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -865,6 +865,13 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   the pane they were on is gone. The same holds for the provider a Providers pane had open
   (`lich.settings.provider`), which is genuinely unknowable at build time: it resolves back to the list while
   that provider is disabled, and comes back when it is turned on again.
+- **The old terminal-theme selection is left where it was written** (`appearance.terminalTheme` in the
+  workspace database, `lich.appearance.terminalTheme` in localStorage): one theme now colors both surfaces,
+  and nothing reads either key any more. They are not deleted on upgrade, because a migration that runs on
+  every launch to clear a value nobody reads costs more than the row it removes. The trap is for whoever
+  gives the terminal its own theme again: an install that used one before this version still holds the id it
+  had, so that feature must write a fresh key rather than adopting this one, which would silently restore a
+  choice the user made under different rules.
 - **A release's highlight is read from the binary, so fixing it after the tag fixes nothing a user sees**
   (`internal/patchnotes`): the What's new dialog parses the `CHANGELOG.md` embedded at build time — the alert
   blocks under the version heading included. Editing that release on GitHub, or the changelog on `main`,

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -147,8 +147,8 @@ export function TerminalView({
   onClose,
   stillInWorkspace,
 }: TerminalViewProps) {
-  const { font, terminalFontSize, resolvedTerminalTheme } = useSettings()
-  const terminalColors = resolvedTerminalTheme.terminal
+  const { font, terminalFontSize, resolvedTheme } = useSettings()
+  const terminalColors = resolvedTheme.terminal
   const { activateSession } = useProjects()
   const navigate = useNavigate()
   const containerRef = useRef<HTMLDivElement | null>(null)
@@ -742,9 +742,9 @@ export function TerminalView({
   useEffect(() => {
     const live = liveRef.current
     if (live) {
-      live.term.options.theme = resolvedTerminalTheme.terminal
+      live.term.options.theme = resolvedTheme.terminal
     }
-  }, [resolvedTerminalTheme])
+  }, [resolvedTheme])
 
   // The container carries the terminal's own background: the sub-cell
   // remainder of the grid fit and the ruler gutter then blend into the

--- a/frontend/src/components/settings/AppearanceSettings.tsx
+++ b/frontend/src/components/settings/AppearanceSettings.tsx
@@ -6,7 +6,6 @@ import {
   Minus,
   Plus,
   RefreshCw,
-  SquareTerminal,
   Trash2,
   Upload,
   ZoomIn,
@@ -25,7 +24,7 @@ import {
   ZOOM_STEP,
   useSettings,
 } from "@/providers/settings"
-import type { TerminalTheme, Theme } from "@/providers/settings"
+import type { Theme } from "@/providers/settings"
 import type { ThemeDefinition } from "@/lib/api-types"
 import { ProjectService, Themes } from "@/lib/rpc"
 import { ConfirmDialog } from "@/components/ConfirmDialog"
@@ -48,7 +47,6 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import {
   bundledThemes,
   customThemes,
-  MATCH_TERMINAL_THEME,
   repoLabel,
   SYSTEM_THEME,
   THEME_TEMPLATE_FILENAME,
@@ -57,9 +55,9 @@ import {
 import { errorText } from "@/lib/utils"
 
 // Appearance holds every look-and-feel control, split into an Interface group
-// (theme, zoom) and a Terminal group (background, text size, font) so the two
-// concerns read apart instead of as one flat list. The group label supplies the
-// context, so the block titles drop their "Interface"/"Terminal" prefix.
+// (theme, zoom) and a Terminal group (text size, font) so the two concerns read
+// apart instead of as one flat list. The group label supplies the context, so
+// the block titles drop their "Interface"/"Terminal" prefix.
 export function AppearanceSettings() {
   const [themePendingRemoval, setThemePendingRemoval] = useState<ThemeDefinition | null>(null)
   const [themePendingOverwrite, setThemePendingOverwrite] = useState<{
@@ -86,8 +84,6 @@ export function AppearanceSettings() {
     setZoom,
     terminalFontSize,
     setTerminalFontSize,
-    terminalTheme,
-    setTerminalTheme,
   } = useSettings()
   const importedThemes = customThemes(themes)
   const hasCustomThemes = importedThemes.length > 0
@@ -188,7 +184,7 @@ export function AppearanceSettings() {
       <SettingGroup label="Interface">
         <SettingBlock
           title="Theme"
-          description="Controls the app color tokens. System follows your OS and uses the bundled light or dark theme."
+          description="Colors the interface and the terminal. System follows your OS and uses the bundled light or dark theme."
         >
           <div className="flex flex-wrap items-center gap-2">
             <Select
@@ -399,29 +395,6 @@ export function AppearanceSettings() {
       </SettingGroup>
 
       <SettingGroup label="Terminal">
-        <SettingBlock
-          icon={<SquareTerminal className="size-4" />}
-          title="Theme"
-          description="Match app keeps the terminal in sync with the interface theme so text stays legible."
-        >
-          <Select
-            value={terminalTheme}
-            items={themeSelectItems(themes, MATCH_TERMINAL_THEME, "Match app")}
-            onValueChange={(value) => value && setTerminalTheme(value as TerminalTheme)}
-          >
-            <SelectTrigger className="w-64">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectGroup>
-                <SelectLabel>Automatic</SelectLabel>
-                <SelectItem value={MATCH_TERMINAL_THEME}>Match app</SelectItem>
-              </SelectGroup>
-              <ThemeOptions themes={themes} />
-            </SelectContent>
-          </Select>
-        </SettingBlock>
-
         <SettingBlock
           icon={<CaseSensitive className="size-4" />}
           title="Text size"

--- a/frontend/src/lib/settings-index.test.ts
+++ b/frontend/src/lib/settings-index.test.ts
@@ -22,12 +22,13 @@ describe("searching the settings", () => {
     expect(titles).toContain("SSH agent")
   })
 
-  it("finds both Themes, and the path is what tells them apart", () => {
-    const groups = find("theme")
-      .filter((entry) => entry.title === "Theme")
-      .map((entry) => entry.group)
+  // One theme colors both surfaces, so there is one entry, and searching for
+  // the terminal's colors has to reach it.
+  it("answers the terminal's colors with the one Theme there is", () => {
+    const hits = find("theme").filter((entry) => entry.title === "Theme")
 
-    expect(groups).toEqual(["Interface", "Terminal"])
+    expect(hits.map((entry) => entry.group)).toEqual(["Interface"])
+    expect(find("palette").map((entry) => entry.title)).toContain("Theme")
   })
 
   // The words nobody would guess from the title are the point of `also`: the

--- a/frontend/src/lib/settings-index.ts
+++ b/frontend/src/lib/settings-index.ts
@@ -1,5 +1,5 @@
 // What the settings search looks through. The nav has eight labels; the things
-// people actually look for are the twenty-five controls under them, and until
+// people actually look for are the two dozen controls under them, and until
 // this existed a search for "theme" or "ssh" answered that nothing matched.
 //
 // The index is written out rather than derived from the rendered tree: the
@@ -13,7 +13,7 @@ export interface SettingEntry {
   /** The nav section that opens it, by the id Settings.tsx gives it. */
   section: string
   /** The group inside the pane, where the pane has groups. Part of the path a
-   * result shows, and the only thing that tells the two Themes apart. */
+   * result shows. */
   group?: string
   /** The block's own title, verbatim from its SettingBlock. */
   title: string
@@ -27,9 +27,13 @@ export interface SettingEntry {
 
 // Every SettingBlock in the app, in the order its pane renders it.
 export const SETTING_ENTRIES: readonly SettingEntry[] = [
-  { section: "appearance", group: "Interface", title: "Theme", also: "colors dark light" },
+  {
+    section: "appearance",
+    group: "Interface",
+    title: "Theme",
+    also: "colors dark light terminal palette",
+  },
   { section: "appearance", group: "Interface", title: "Zoom" },
-  { section: "appearance", group: "Terminal", title: "Theme", also: "colors palette" },
   { section: "appearance", group: "Terminal", title: "Text size" },
   { section: "appearance", group: "Terminal", title: "Font", also: "typeface monospace" },
   { section: "appearance", group: "Footer", title: "Footer layout", also: "status bar arrange" },

--- a/frontend/src/lib/themes.test.ts
+++ b/frontend/src/lib/themes.test.ts
@@ -1,21 +1,19 @@
 import { describe, expect, it } from "vitest"
 import type { ThemeDefinition } from "./api-types"
 import {
-  adoptStoredSelections,
+  adoptStoredTheme,
   APP_COLOR_TOKENS,
   applyAppTheme,
   BUNDLED_THEMES,
   bundledThemes,
   customThemes,
-  DEFAULT_TERMINAL_THEME,
   DEFAULT_THEME,
   mergeImportedThemes,
   mergeThemes,
-  reconcileThemeSelections,
+  reconcileTheme,
   repoLabel,
-  resolveTerminalTheme,
   resolveTheme,
-  selectionsAfterThemeRemoval,
+  themeAfterRemoval,
   SYSTEM_THEME,
   THEME_TEMPLATE_FILENAME,
   themeSelectItems,
@@ -104,73 +102,33 @@ describe("themes", () => {
     expect(resolveTheme("missing", BUNDLED_THEMES, true).id).toBe("dark")
   })
 
-  it("resolves terminal match to the app theme", () => {
-    const appTheme = customTheme("custom")
-    expect(resolveTerminalTheme("match", appTheme, BUNDLED_THEMES)).toBe(appTheme)
-    expect(resolveTerminalTheme("dark", appTheme, BUNDLED_THEMES).id).toBe("dark")
-    expect(resolveTerminalTheme("missing", appTheme, BUNDLED_THEMES)).toBe(appTheme)
+  // One selection colors both surfaces, so the palette the terminal paints is
+  // the resolved theme's own, with nothing left to resolve separately.
+  it("carries a terminal palette on the theme the app resolved to", () => {
+    expect(resolveTheme("dark", BUNDLED_THEMES, false).terminal.background).toBeTruthy()
+    expect(resolveTheme(SYSTEM_THEME, BUNDLED_THEMES, true).terminal.foreground).toBeTruthy()
   })
 
-  it("reconciles missing stored selections after themes load", () => {
-    expect(
-      reconcileThemeSelections(
-        { theme: "missing-app", terminalTheme: "missing-terminal" },
-        BUNDLED_THEMES,
-      ),
-    ).toEqual({ theme: DEFAULT_THEME, terminalTheme: DEFAULT_TERMINAL_THEME })
-    expect(
-      reconcileThemeSelections({ theme: "dark", terminalTheme: "light" }, BUNDLED_THEMES),
-    ).toEqual({ theme: "dark", terminalTheme: "light" })
+  it("reconciles a missing stored selection after themes load", () => {
+    expect(reconcileTheme("missing-theme", BUNDLED_THEMES)).toBe(DEFAULT_THEME)
+    expect(reconcileTheme("dark", BUNDLED_THEMES)).toBe("dark")
+    expect(reconcileTheme(SYSTEM_THEME, BUNDLED_THEMES)).toBe(SYSTEM_THEME)
   })
 
-  it("prefers the stored selections over the boot cache", () => {
-    expect(
-      adoptStoredSelections(
-        { theme: "dracula", terminalTheme: "dark" },
-        { theme: SYSTEM_THEME, terminalTheme: DEFAULT_TERMINAL_THEME },
-      ),
-    ).toEqual({
-      selections: { theme: "dracula", terminalTheme: "dark" },
+  it("prefers the stored selection over the boot cache", () => {
+    expect(adoptStoredTheme("dracula", SYSTEM_THEME)).toEqual({
+      theme: "dracula",
       persist: false,
     })
   })
 
   it("adopts the boot cache and asks for a write-back when nothing is stored", () => {
-    expect(
-      adoptStoredSelections(
-        { theme: "", terminalTheme: "" },
-        { theme: "dracula", terminalTheme: "light" },
-      ),
-    ).toEqual({
-      selections: { theme: "dracula", terminalTheme: "light" },
-      persist: true,
-    })
+    expect(adoptStoredTheme("", "dracula")).toEqual({ theme: "dracula", persist: true })
   })
 
-  // The two keys are written together but read apart: an install that stored one
-  // selection before the other must not have the missing one left unwritten.
-  it("writes back when only one selection is stored", () => {
-    expect(
-      adoptStoredSelections(
-        { theme: "dracula", terminalTheme: "" },
-        { theme: SYSTEM_THEME, terminalTheme: "light" },
-      ),
-    ).toEqual({
-      selections: { theme: "dracula", terminalTheme: "light" },
-      persist: true,
-    })
-  })
-
-  it("resets only selections that use a removed theme", () => {
-    expect(
-      selectionsAfterThemeRemoval("custom", {
-        theme: "custom",
-        terminalTheme: "custom",
-      }),
-    ).toEqual({ theme: DEFAULT_THEME, terminalTheme: DEFAULT_TERMINAL_THEME })
-    expect(
-      selectionsAfterThemeRemoval("other", { theme: "custom", terminalTheme: "dark" }),
-    ).toEqual({ theme: "custom", terminalTheme: "dark" })
+  it("resets the selection only when the removed theme is the one in use", () => {
+    expect(themeAfterRemoval("custom", "custom")).toBe(DEFAULT_THEME)
+    expect(themeAfterRemoval("other", "custom")).toBe("custom")
   })
 
   it("applies every app token as a CSS variable", () => {

--- a/frontend/src/lib/themes.ts
+++ b/frontend/src/lib/themes.ts
@@ -3,9 +3,7 @@ import darkTheme from "../../../themes/dark.json"
 import lightTheme from "../../../themes/light.json"
 
 export const SYSTEM_THEME = "system"
-export const MATCH_TERMINAL_THEME = "match"
 export const DEFAULT_THEME = SYSTEM_THEME
-export const DEFAULT_TERMINAL_THEME = MATCH_TERMINAL_THEME
 const LIGHT_THEME_ID = "light"
 const DARK_THEME_ID = "dark"
 const BUNDLED_THEME_ORIGIN = "bundled"
@@ -14,7 +12,6 @@ export const DARK_THEME_SCHEME = "dark"
 export const THEME_TEMPLATE_FILENAME = "lich-theme-template.json"
 
 export type Theme = typeof SYSTEM_THEME | string
-export type TerminalTheme = typeof MATCH_TERMINAL_THEME | string
 export type ResolvedTheme = ThemeDefinition
 
 const BUNDLED = [lightTheme, darkTheme].map((theme) =>
@@ -60,17 +57,6 @@ export function resolveTheme(
     return systemTheme
   }
   return themes.find((theme) => theme.id === selected) ?? systemTheme
-}
-
-export function resolveTerminalTheme(
-  selected: TerminalTheme,
-  appTheme: ThemeDefinition,
-  themes: readonly ThemeDefinition[],
-): ThemeDefinition {
-  if (selected === MATCH_TERMINAL_THEME) {
-    return appTheme
-  }
-  return themes.find((theme) => theme.id === selected) ?? appTheme
 }
 
 export function applyAppTheme(theme: ThemeDefinition, root: HTMLElement): void {
@@ -120,56 +106,23 @@ export function repoLabel(url: string): string {
   return segments.slice(-2).join("/") || trimmed
 }
 
-export interface ThemeSelections {
-  theme: Theme
-  terminalTheme: TerminalTheme
-}
-
-export function reconcileThemeSelections(
-  selections: ThemeSelections,
-  themes: readonly ThemeDefinition[],
-): ThemeSelections {
+export function reconcileTheme(selected: Theme, themes: readonly ThemeDefinition[]): Theme {
   const ids = new Set(themes.map((item) => item.id))
-  return {
-    theme:
-      selections.theme === SYSTEM_THEME || ids.has(selections.theme)
-        ? selections.theme
-        : DEFAULT_THEME,
-    terminalTheme:
-      selections.terminalTheme === MATCH_TERMINAL_THEME || ids.has(selections.terminalTheme)
-        ? selections.terminalTheme
-        : DEFAULT_TERMINAL_THEME,
-  }
+  return selected === SYSTEM_THEME || ids.has(selected) ? selected : DEFAULT_THEME
 }
 
-// adoptStoredSelections resolves the selections a launch starts from against
-// the workspace copy, which is the durable one: the boot cache lives in the
+// adoptStoredTheme resolves the selection a launch starts from against the
+// workspace copy, which is the durable one: the boot cache lives in the
 // Chromium profile, and a profile Chromium recreates comes back empty while the
 // workspace database survives. A setting that was never written reads as "" —
 // an install whose cache is still the only record — so the cache is adopted and
 // written back once, which is what `persist` reports.
-export function adoptStoredSelections(
-  stored: ThemeSelections,
-  cached: ThemeSelections,
-): { selections: ThemeSelections; persist: boolean } {
-  return {
-    selections: {
-      theme: stored.theme || cached.theme,
-      terminalTheme: stored.terminalTheme || cached.terminalTheme,
-    },
-    persist: !stored.theme || !stored.terminalTheme,
-  }
+export function adoptStoredTheme(stored: Theme, cached: Theme): { theme: Theme; persist: boolean } {
+  return { theme: stored || cached, persist: !stored }
 }
 
-export function selectionsAfterThemeRemoval(
-  removedID: string,
-  selections: ThemeSelections,
-): ThemeSelections {
-  return {
-    theme: selections.theme === removedID ? DEFAULT_THEME : selections.theme,
-    terminalTheme:
-      selections.terminalTheme === removedID ? DEFAULT_TERMINAL_THEME : selections.terminalTheme,
-  }
+export function themeAfterRemoval(removedID: string, selected: Theme): Theme {
+  return selected === removedID ? DEFAULT_THEME : selected
 }
 
 function normalizeTheme(theme: ThemeDefinition): ThemeDefinition {

--- a/frontend/src/providers/settings.tsx
+++ b/frontend/src/providers/settings.tsx
@@ -21,46 +21,42 @@ import { Store, Themes as ThemeRPC } from "@/lib/rpc"
 import { readFooterLayout, writeFooterLayout, type FooterLayout } from "@/lib/footer-layout"
 import { readFooterVisibility, type FooterVisibility } from "@/lib/footer-prefs"
 import {
-  adoptStoredSelections,
+  adoptStoredTheme,
   applyAppTheme,
   BUNDLED_THEMES,
   DARK_THEME_SCHEME,
-  DEFAULT_TERMINAL_THEME,
   DEFAULT_THEME,
   mergeImportedThemes,
   mergeThemes,
-  reconcileThemeSelections,
-  resolveTerminalTheme,
+  reconcileTheme,
   resolveTheme,
-  selectionsAfterThemeRemoval,
+  themeAfterRemoval,
   SYSTEM_THEME,
 } from "@/lib/themes"
-import type { TerminalTheme, Theme, ResolvedTheme } from "@/lib/themes"
+import type { Theme, ResolvedTheme } from "@/lib/themes"
 import type { ThemeDefinition, ThemeGitInstallResult, ThemeImportResult } from "@/lib/api-types"
 
-export type { TerminalTheme, Theme, ResolvedTheme } from "@/lib/themes"
-export { DEFAULT_TERMINAL_THEME, DEFAULT_THEME } from "@/lib/themes"
+export type { Theme, ResolvedTheme } from "@/lib/themes"
+export { DEFAULT_THEME } from "@/lib/themes"
 
 const FONT_STORAGE_KEY = "lich.terminal.font"
 const TERMINAL_FONT_SIZE_STORAGE_KEY = "lich.terminal.fontSize"
 const THEME_STORAGE_KEY = "lich.appearance.theme"
 const ZOOM_STORAGE_KEY = "lich.appearance.zoom"
-const TERMINAL_THEME_STORAGE_KEY = "lich.appearance.terminalTheme"
 const CONTEXT_USAGE_STORAGE_KEY = "lich.footer.contextUsage"
 const COST_BUDGET_STORAGE_KEY = "lich.footer.costBudget"
 const DESKTOP_NOTIFICATIONS_STORAGE_KEY = "lich.notifications.desktop"
 const FINISHED_TURN_NOTIFICATIONS_STORAGE_KEY = "lich.notifications.finishedTurn"
 
-// The workspace keys the two theme selections actually live under. The
-// localStorage pair above keeps them too, but only as the cache the first frame
-// paints from: it sits in the Chromium profile, which Chromium recreates from
-// scratch when its storage comes back damaged — a window killed rather than
-// closed (#209) is how that happened — taking every `lich.*` pref with it
-// (#236). The database is the same store the sessions survive in, and it is
-// where the "what's new" flag went for the same reason (#199).
+// The workspace key the theme selection actually lives under. The localStorage
+// pref above keeps it too, but only as the cache the first frame paints from:
+// it sits in the Chromium profile, which Chromium recreates from scratch when
+// its storage comes back damaged (a window killed rather than closed, #209, is
+// how that happened), taking every `lich.*` pref with it (#236). The database is
+// the same store the sessions survive in, and it is where the "what's new" flag
+// went for the same reason (#199).
 const THEME_SETTING_KEY = "appearance.theme"
-const TERMINAL_THEME_SETTING_KEY = "appearance.terminalTheme"
-// The selections answer for this install, not for a project.
+// The selection answers for this install, not for a project.
 const GLOBAL_SCOPE = ""
 
 // DEFAULT_FONT is the bundled FiraCode Nerd Font Mono. It is not installed via
@@ -102,13 +98,10 @@ const readTerminalFontSize = (): number =>
     clampTerminalFontSize,
   )
 
-// Both preferences are read raw: the stored id is an open value, and the only
-// check worth making is membership, which reconcileThemeSelections applies once
-// the theme list lands. Until then an unknown id resolves to the system theme.
+// Read raw: the stored id is an open value, and the only check worth making is
+// membership, which reconcileTheme applies once the theme list lands. Until then
+// an unknown id resolves to the system theme.
 const readTheme = (): Theme => readPref(THEME_STORAGE_KEY) ?? DEFAULT_THEME
-
-const readTerminalTheme = (): TerminalTheme =>
-  readPref(TERMINAL_THEME_STORAGE_KEY) ?? DEFAULT_TERMINAL_THEME
 
 const readZoom = (): number => parseNumberPref(readPref(ZOOM_STORAGE_KEY), DEFAULT_ZOOM, clampZoom)
 
@@ -168,11 +161,6 @@ interface SettingsValue {
   /** UI zoom factor applied to the whole app (1 = 100%). */
   zoom: number
   setZoom: (zoom: number) => void
-  /** Terminal background theme selection. */
-  terminalTheme: TerminalTheme
-  setTerminalTheme: (theme: TerminalTheme) => void
-  /** Terminal theme resolved to a concrete scheme (match already mapped). */
-  resolvedTerminalTheme: ResolvedTheme
   /** Configurable global keyboard shortcuts, keyed by action. */
   hotkeys: Hotkeys
   setHotkey: (id: HotkeyId, combo: Combo) => void
@@ -206,7 +194,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [theme, setThemeState] = useState<Theme>(readTheme)
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(BUNDLED_THEMES[0])
   const [zoom, setZoomState] = useState<number>(readZoom)
-  const [terminalTheme, setTerminalThemeState] = useState<TerminalTheme>(readTerminalTheme)
   const [hotkeys, setHotkeys] = useState<Hotkeys>(loadHotkeys)
   const [showContextUsage] = useState<boolean>(readContextUsage)
   const [footerLayout, setFooterLayoutState] = useState(readFooterLayout)
@@ -222,58 +209,41 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   // A selection the user (or a reconcile) has already written must not be
   // overwritten by the stored one still in flight, so the load below stands down
   // once anything has been persisted.
-  const selectionsTouched = useRef(false)
+  const selectionTouched = useRef(false)
 
   const persistTheme = useCallback((next: Theme) => {
-    selectionsTouched.current = true
+    selectionTouched.current = true
     writePref(THEME_STORAGE_KEY, next)
     // A failed write costs the selection only if the profile is later recreated
     // — the cache answers every ordinary launch — so it stays quiet.
     void Store.SetSetting(THEME_SETTING_KEY, GLOBAL_SCOPE, next).catch(() => {})
   }, [])
 
-  const persistTerminalTheme = useCallback((next: TerminalTheme) => {
-    selectionsTouched.current = true
-    writePref(TERMINAL_THEME_STORAGE_KEY, next)
-    void Store.SetSetting(TERMINAL_THEME_SETTING_KEY, GLOBAL_SCOPE, next).catch(() => {})
-  }, [])
-
-  // The stored selections land after the first paint, which the cache has
+  // The stored selection lands after the first paint, which the cache has
   // already answered for: a theme that is only in the database repaints once,
   // and a custom one waits for the theme list either way.
   useEffect(() => {
     let cancelled = false
-    const cached = { theme: readTheme(), terminalTheme: readTerminalTheme() }
-    Promise.all([
-      Store.GetSetting(THEME_SETTING_KEY, GLOBAL_SCOPE),
-      Store.GetSetting(TERMINAL_THEME_SETTING_KEY, GLOBAL_SCOPE),
-    ])
-      .then(([storedTheme, storedTerminalTheme]) => {
-        if (cancelled || selectionsTouched.current) return
-        const { selections, persist } = adoptStoredSelections(
-          { theme: storedTheme, terminalTheme: storedTerminalTheme },
-          cached,
-        )
-        if (selections.theme !== cached.theme) {
-          setThemeState(selections.theme)
-          writePref(THEME_STORAGE_KEY, selections.theme)
-        }
-        if (selections.terminalTheme !== cached.terminalTheme) {
-          setTerminalThemeState(selections.terminalTheme)
-          writePref(TERMINAL_THEME_STORAGE_KEY, selections.terminalTheme)
+    const cached = readTheme()
+    Store.GetSetting(THEME_SETTING_KEY, GLOBAL_SCOPE)
+      .then((stored) => {
+        if (cancelled || selectionTouched.current) return
+        const { theme: adopted, persist } = adoptStoredTheme(stored, cached)
+        if (adopted !== cached) {
+          setThemeState(adopted)
+          writePref(THEME_STORAGE_KEY, adopted)
         }
         if (persist) {
-          persistTheme(selections.theme)
-          persistTerminalTheme(selections.terminalTheme)
+          persistTheme(adopted)
         }
       })
       .catch((error) => {
-        console.warn("[settings] failed to load the stored theme selections", error)
+        console.warn("[settings] failed to load the stored theme selection", error)
       })
     return () => {
       cancelled = true
     }
-  }, [persistTheme, persistTerminalTheme])
+  }, [persistTheme])
 
   useEffect(() => {
     let cancelled = false
@@ -294,16 +264,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     if (!themesLoaded) return
-    const reconciled = reconcileThemeSelections({ theme, terminalTheme }, themes)
-    if (reconciled.theme !== theme) {
-      setThemeState(reconciled.theme)
-      persistTheme(reconciled.theme)
+    const reconciled = reconcileTheme(theme, themes)
+    if (reconciled !== theme) {
+      setThemeState(reconciled)
+      persistTheme(reconciled)
     }
-    if (reconciled.terminalTheme !== terminalTheme) {
-      setTerminalThemeState(reconciled.terminalTheme)
-      persistTerminalTheme(reconciled.terminalTheme)
-    }
-  }, [theme, terminalTheme, themes, themesLoaded, persistTheme, persistTerminalTheme])
+  }, [theme, themes, themesLoaded, persistTheme])
 
   const setFont = useCallback((next: string) => {
     setFontState(next)
@@ -336,14 +302,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const zoomBy = useCallback((delta: number) => {
     setZoomState((prev) => clampZoom(prev + delta))
   }, [])
-
-  const setTerminalTheme = useCallback(
-    (next: TerminalTheme) => {
-      setTerminalThemeState(next)
-      persistTerminalTheme(next)
-    },
-    [persistTerminalTheme],
-  )
 
   const importTheme = useCallback(
     async (path: string, overwrite: boolean) => {
@@ -394,17 +352,13 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     async (id: string) => {
       await ThemeRPC.Remove(id)
       setThemes((prev) => mergeThemes(prev.filter((item) => item.id !== id)))
-      const next = selectionsAfterThemeRemoval(id, { theme, terminalTheme })
-      if (next.theme !== theme) {
-        setThemeState(next.theme)
-        persistTheme(next.theme)
-      }
-      if (next.terminalTheme !== terminalTheme) {
-        setTerminalThemeState(next.terminalTheme)
-        persistTerminalTheme(next.terminalTheme)
+      const next = themeAfterRemoval(id, theme)
+      if (next !== theme) {
+        setThemeState(next)
+        persistTheme(next)
       }
     },
-    [theme, terminalTheme, persistTheme, persistTerminalTheme],
+    [theme, persistTheme],
   )
 
   const setHotkey = useCallback((id: HotkeyId, combo: Combo) => {
@@ -524,8 +478,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     }
   }, [zoomBy, setZoom])
 
-  const resolvedTerminalTheme = resolveTerminalTheme(terminalTheme, resolvedTheme, themes)
-
   // Memoised for the same reason ProjectsProvider is: a literal here hands every
   // consumer a new object on every render of this provider, and one of those
   // consumers is TerminalView — one per spawned session. A Ctrl+wheel zoom is a
@@ -547,9 +499,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       resolvedTheme,
       zoom,
       setZoom,
-      terminalTheme,
-      setTerminalTheme,
-      resolvedTerminalTheme,
       hotkeys,
       setHotkey,
       resetHotkey,
@@ -579,9 +528,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       resolvedTheme,
       zoom,
       setZoom,
-      terminalTheme,
-      setTerminalTheme,
-      resolvedTerminalTheme,
       hotkeys,
       setHotkey,
       resetHotkey,


### PR DESCRIPTION
Appearance asked for the theme twice: once for the interface, once for the terminal, the second defaulting to "Match app". The second question never had to exist.

Every theme lich can install already carries both palettes, and the schema enforces it: `internal/themes/schema.go` requires `app` and `terminal`, and every terminal color inside it. So the extra picker only ever served someone who wanted the two surfaces to disagree on purpose. Warp, which is where the comparison started, has one picker.

## What changed

- The terminal paints `resolvedTheme.terminal`, the palette of the theme in use. Picking a theme now recolors both surfaces at once.
- The terminal theme block is gone from Settings > Appearance, and the remaining Theme block says what it does: "Colors the interface and the terminal."
- Gone from the code: `terminalTheme`, `MATCH_TERMINAL_THEME`, `DEFAULT_TERMINAL_THEME`, `resolveTerminalTheme`, the `ThemeSelections` pair and both of its storage keys.
- What was two selections reconciled together is now one, so `reconcileThemeSelections`, `adoptStoredSelections` and `selectionsAfterThemeRemoval` lose their plural and their object argument: `reconcileTheme`, `adoptStoredTheme`, `themeAfterRemoval`.
- The settings index keeps one Theme entry, and it answers for the terminal too: searching `palette` or `terminal` reaches it.

Net 165 lines removed.

## The stored value

`appearance.terminalTheme` in the workspace database, and `lich.appearance.terminalTheme` in localStorage, are left where they were written. Nothing reads them, and a migration running on every launch to clear a value nobody reads costs more than the row it removes. The trap that leaves for a future terminal theme (an install still holding the id it chose under the old rules) is written down in `docs/ceilings.md`.

A terminal that had been pointed at a different theme follows the app one from this version on, which the CHANGELOG entry says out loud.

## Test plan

- [x] `go test ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `pnpm test` green: 1512 tests, 129 files
- [x] `tsc --noEmit` and `biome check .` clean (17 pre-existing a11y warnings)
- [x] `pnpm build` succeeds
- [x] Headless smoke on the real app, which the node-only suite cannot do: Appearance renders Interface (Theme, Zoom) and Terminal (Text size, Font), one theme picker, zero console errors; searching `palette` still reaches the Theme block
- [x] CHANGELOG entry under `[Unreleased]`, ceilings bullet in the same PR