### PR TITLE
feat: Appearance reads as a list, and a theme shows its colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   text size lost their permanent greyed-out Reset button: clicking the value
   returns it to the default. The footer editor is always open at the foot of the
   pane, its items carrying the reading they will show ("3 · +10 −2", "42%")
-  rather than their setting name, and nothing else: the per-item menu and remove
+  rather than their setting name, and the model item showing the model the
+  active session is actually running, provider mark included, the way the footer
+  draws it. Nothing else rides the item: the per-item menu and remove
   button are gone, since dragging an item out to Available is what hides it. The
   theme template moved into the
   Import dialog, where writing a theme starts, and the "Imported themes" list is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   text size lost their permanent greyed-out Reset button: clicking the value
   returns it to the default. The footer editor is always open at the foot of the
   pane, its items carrying the reading they will show ("3 · +10 −2", "42%")
-  rather than their setting name, with the remove and the item menu appearing on
-  hover instead of sitting on every chip. The theme template moved into the
+  rather than their setting name, and nothing else: the per-item menu and remove
+  button are gone, since dragging an item out to Available is what hides it. The
+  theme template moved into the
   Import dialog, where writing a theme starts, and the "Imported themes" list is
   gone: each theme's own card carries its repository, its version, and the
   update and remove buttons.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Appearance is a list now, and the theme shows its colors.** The pane put
+  every control under its own paragraph, so five settings filled a screen and a
+  256px dropdown sat in 600px of empty space. Each setting is one row: name on
+  the left, control on the right, the way Sandbox and Hotkeys already read.
+  Picking a theme opens a strip of previews under the row, two rows of
+  miniatures of the lich window in that theme, and choosing one closes it. The
+  terminal font row renders its sample in the font itself. Zoom and terminal
+  text size lost their permanent greyed-out Reset button: clicking the value
+  returns it to the default. The footer editor is always open at the foot of the
+  pane, its items carrying the reading they will show ("3 · +10 −2", "42%")
+  rather than their setting name, with the remove and the item menu appearing on
+  hover instead of sitting on every chip. The theme template moved into the
+  Import dialog, where writing a theme starts, and the "Imported themes" list is
+  gone: each theme's own card carries its repository, its version, and the
+  update and remove buttons.
+
 - **One theme now colors the app and the terminal.** Settings > Appearance had
   a second picker for the terminal, defaulting to "Match app", and every theme
   lich can install already carries both palettes: the interface tokens and the

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -850,7 +850,7 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   every control is listed there with the section and group it lives in, because the panes are React components
   whose blocks exist only once rendered and the suite runs in node. Two things follow. A block added without
   an entry is a control the search cannot find, which is why `settings-index.test.ts` reads the
-  `SettingBlock` literals back out of the source and fails on one nobody indexed; that guard is the only
+  `SettingBlock` and `SettingRow` literals back out of the source and fails on one nobody indexed; that guard is the only
   thing standing between this file and silent rot, so deleting it costs more than it looks. And the search
   matches titles plus a few hand-picked keywords, never a description, a stored value or a theme's name: a
   user hunting for `emerald` or a port number finds nothing, and the empty state says as much rather than
@@ -872,6 +872,13 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   gives the terminal its own theme again: an install that used one before this version still holds the id it
   had, so that feature must write a fresh key rather than adopting this one, which would silently restore a
   choice the user made under different rules.
+- **The footer editor's sides wrap, and stop lining up when they do**
+  (`FooterLayoutEditor.tsx`): each side is a tray of chips laid out with `flex-wrap`, so a user who turns on
+  most of the twelve items gets two rows in one column and one in the other, and the two stop reading as the
+  two ends of the footer. Chosen with the drag: the alternatives that never wrap are lists, one item per
+  line, and moving an item then stops being a drag between the sides. Both sides stretch to the taller of the
+  two so the block still reads as one thing. Whoever adds a thirteenth footer item is making that worse, and
+  the answer is not a narrower chip: it is deciding the drag is worth less than the alignment.
 - **A release's highlight is read from the binary, so fixing it after the tag fixes nothing a user sees**
   (`internal/patchnotes`): the What's new dialog parses the `CHANGELOG.md` embedded at build time — the alert
   blocks under the version heading included. Editing that release on GitHub, or the changelog on `main`,

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -878,7 +878,11 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   two ends of the footer. Chosen with the drag: the alternatives that never wrap are lists, one item per
   line, and moving an item then stops being a drag between the sides. Both sides stretch to the taller of the
   two so the block still reads as one thing. Whoever adds a thirteenth footer item is making that worse, and
-  the answer is not a narrower chip: it is deciding the drag is worth less than the alignment.
+  the answer is not a narrower chip: it is deciding the drag is worth less than the alignment. The chip also
+  carries nothing but its own reading: a menu and a remove button that appeared on hover were tried and taken
+  back out, because a control that grows under the pointer shifts the chips beside it at the exact moment a
+  drag is being aimed. Moving an item without a pointer is the dnd-kit keyboard sensor (focus the chip, Space,
+  arrows), which is why removing the menu costs no keyboard path.
 - **A release's highlight is read from the binary, so fixing it after the tag fixes nothing a user sees**
   (`internal/patchnotes`): the What's new dialog parses the `CHANGELOG.md` embedded at build time — the alert
   blocks under the version heading included. Editing that release on GitHub, or the changelog on `main`,

--- a/frontend/src/components/FooterSession.test.tsx
+++ b/frontend/src/components/FooterSession.test.tsx
@@ -261,24 +261,19 @@ test("zero cost remains a real reading", async () => {
   expect(button("Session cost").textContent).toContain("$0")
 })
 
-test("the editor removes items independently and restores the full default layout", async () => {
-  await act(async () => root.render(createElement(FooterSettings)))
-  await act(async () =>
-    container.querySelector<HTMLButtonElement>('[aria-label="Remove Model"]')?.click(),
-  )
-  expect(state.layout?.right).not.toContain("model")
-  expect(state.layout?.right).toContain("context")
-  await act(async () => root.render(createElement(FooterSettings)))
-  await act(async () =>
-    container.querySelector<HTMLButtonElement>('[aria-label="Remove Cost"]')?.click(),
-  )
-  const { setCostReadout } = await import("@/lib/cost-readout-store")
-  expect(setCostReadout).toHaveBeenCalledWith(false)
-  expect(state.context).toBe(true)
+// Contract changed: an item is moved and hidden by dragging it, so the chip has
+// no remove button to click. Restore default is the layout change jsdom can
+// still make, and it drops the cost item, which is the one that has to carry a
+// second write with it.
+test("restoring the default writes the layout and turns off the reading it drops", async () => {
+  state.layout = { left: ["attach"], right: ["cost", "context"] }
   await act(async () => root.render(createElement(FooterSettings)))
   await act(async () => button("Restore default").click())
+  const { setCostReadout } = await import("@/lib/cost-readout-store")
   expect(state.layout).toEqual(DEFAULT_FOOTER_LAYOUT)
+  expect(setCostReadout).toHaveBeenCalledWith(false)
   expect(state.cost).toBe(false)
+  expect(state.context).toBe(true)
 })
 
 test("the editor waits for the old cost setting before allowing a layout migration", async () => {
@@ -307,10 +302,9 @@ test("a saved layout controls the order and visibility of readings", async () =>
 test("a failed pricing-setting write leaves the previous layout in place", async () => {
   const { setCostReadout } = await import("@/lib/cost-readout-store")
   vi.mocked(setCostReadout).mockRejectedValueOnce(new Error("offline"))
+  state.layout = { left: ["attach"], right: ["cost"] }
   await act(async () => root.render(createElement(FooterSettings)))
-  await act(async () =>
-    container.querySelector<HTMLButtonElement>('[aria-label="Remove Cost"]')?.click(),
-  )
-  expect(state.layout).toBeNull()
-  expect(container.querySelector('[aria-label="Remove Cost"]')).not.toBeNull()
+  await act(async () => button("Restore default").click())
+  expect(state.layout).toEqual({ left: ["attach"], right: ["cost"] })
+  expect(container.querySelector('[data-footer-item="cost"]')).not.toBeNull()
 })

--- a/frontend/src/components/FooterSession.test.tsx
+++ b/frontend/src/components/FooterSession.test.tsx
@@ -23,6 +23,19 @@ const state = vi.hoisted(() => ({
   ready: true,
 }))
 vi.mock("@/lib/session/use-session-usage", () => ({ useSessionUsage: () => state.usage }))
+// The footer editor reads the active session to show the model that session is
+// actually running, which needs the project context and the router the footer
+// itself already has.
+vi.mock("@/lib/session/use-active-session", () => ({
+  useActiveSession: () => ({
+    projectId: "p1",
+    sessionId: "s1",
+    path: "/repo",
+    checkout: "/repo",
+    kind: state.agent ?? "",
+    sandboxed: false,
+  }),
+}))
 vi.mock("@/lib/session/use-session-agent", () => ({ useSessionAgent: () => state.agent }))
 vi.mock("@/lib/quota/use-plan-quota", () => ({ usePlanQuotaFor: vi.fn(() => state.plan) }))
 vi.mock("@/providers/settings", () => ({
@@ -274,6 +287,23 @@ test("restoring the default writes the layout and turns off the reading it drops
   expect(setCostReadout).toHaveBeenCalledWith(false)
   expect(state.cost).toBe(false)
   expect(state.context).toBe(true)
+})
+
+// The model chip is the one whose reading is a fact rather than a shape: an
+// invented "Codex · GPT-6" named a provider the footer never writes.
+test("the editor shows the model the active session is running", async () => {
+  state.agent = "claude"
+  state.usage = { ...reading(1000, 1), model: "claude-opus-5", effort: "xhigh" }
+  await act(async () => root.render(createElement(FooterSettings)))
+  expect(container.querySelector('[data-footer-item="model"]')?.textContent).toContain(
+    "opus 5 · xhigh",
+  )
+})
+
+test("the model chip falls back to its name when no session has reported one", async () => {
+  state.usage = null
+  await act(async () => root.render(createElement(FooterSettings)))
+  expect(container.querySelector('[data-footer-item="model"]')?.textContent).toBe("Model")
 })
 
 test("the editor waits for the old cost setting before allowing a layout migration", async () => {

--- a/frontend/src/components/common/Stepper.tsx
+++ b/frontend/src/components/common/Stepper.tsx
@@ -58,11 +58,14 @@ export function Stepper({
             <Button
               variant="outline"
               // Not an icon button: the box is as wide as its longest reading,
-              // so stepping never shifts the controls around it.
+              // so stepping never shifts the controls around it. Never
+              // disabled either — the reading is what this box is for, and a
+              // disabled button greys the number out for as long as the value
+              // is the default, which is most of the time. At the default the
+              // click is simply a no-op.
               className="min-w-16 tabular-nums"
-              disabled={!custom}
-              aria-label={`Reset ${name}`}
-              onClick={() => onChange(fallback)}
+              aria-label={custom ? `Reset ${name}` : display}
+              onClick={() => custom && onChange(fallback)}
             />
           }
         >

--- a/frontend/src/components/common/Stepper.tsx
+++ b/frontend/src/components/common/Stepper.tsx
@@ -1,6 +1,6 @@
-import { RotateCcw } from "lucide-react"
 import type { ReactNode } from "react"
 import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 
 interface StepperProps {
   value: number
@@ -9,8 +9,10 @@ interface StepperProps {
   min: number
   max: number
   step: number
-  /** What Reset returns to; the button greys out once value is already there. */
+  /** What clicking the value returns to. */
   fallback: number
+  /** The setting's name, for the reset control's label ("Reset the zoom"). */
+  name: string
   onChange: (next: number) => void
   /** Glyphs for decrement and increment — zoom uses magnifiers, size ∓. */
   decrementIcon: ReactNode
@@ -19,9 +21,11 @@ interface StepperProps {
   incrementLabel: string
 }
 
-// The numeric setting control: two icon buttons flanking a bordered value box,
-// with a Reset that disappears into disabled once the value is the default.
-// Both Appearance controls (interface zoom, terminal text size) are this.
+// The numeric setting control: two icon buttons flanking the value, which is
+// itself the reset. A Reset button beside it spent a permanent third control on
+// the rarest action, greyed out for as long as the value was the default, which
+// is most of the time. Both Appearance controls (interface zoom, terminal text
+// size) are this.
 export function Stepper({
   value,
   display,
@@ -29,12 +33,14 @@ export function Stepper({
   max,
   step,
   fallback,
+  name,
   onChange,
   decrementIcon,
   incrementIcon,
   decrementLabel,
   incrementLabel,
 }: StepperProps) {
+  const custom = value !== fallback
   return (
     <div className="flex items-center gap-2">
       <Button
@@ -46,9 +52,24 @@ export function Stepper({
       >
         {decrementIcon}
       </Button>
-      <div className="flex h-9 min-w-16 items-center justify-center rounded-lg border border-border px-3 text-sm tabular-nums text-foreground">
-        {display}
-      </div>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              variant="outline"
+              // Not an icon button: the box is as wide as its longest reading,
+              // so stepping never shifts the controls around it.
+              className="min-w-16 tabular-nums"
+              disabled={!custom}
+              aria-label={`Reset ${name}`}
+              onClick={() => onChange(fallback)}
+            />
+          }
+        >
+          {display}
+        </TooltipTrigger>
+        <TooltipContent>{custom ? `Reset ${name}` : "Default"}</TooltipContent>
+      </Tooltip>
       <Button
         variant="outline"
         size="icon"
@@ -57,10 +78,6 @@ export function Stepper({
         onClick={() => onChange(value + step)}
       >
         {incrementIcon}
-      </Button>
-      <Button variant="ghost" disabled={value === fallback} onClick={() => onChange(fallback)}>
-        <RotateCcw />
-        Reset
       </Button>
     </div>
   )

--- a/frontend/src/components/settings/AppearanceSettings.tsx
+++ b/frontend/src/components/settings/AppearanceSettings.tsx
@@ -1,16 +1,4 @@
-import {
-  CaseSensitive,
-  ChevronDown,
-  Download,
-  GitBranch,
-  Minus,
-  Plus,
-  RefreshCw,
-  Trash2,
-  Upload,
-  ZoomIn,
-  ZoomOut,
-} from "lucide-react"
+import { Minus, Plus, ZoomIn, ZoomOut } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
 import {
@@ -29,35 +17,19 @@ import type { ThemeDefinition } from "@/lib/api-types"
 import { ProjectService, Themes } from "@/lib/rpc"
 import { ConfirmDialog } from "@/components/ConfirmDialog"
 import { Stepper } from "@/components/common/Stepper"
-import { SettingBlock, SettingGroup } from "./SettingBlock"
+import { SettingRow } from "./SettingBlock"
 import { FontSetting } from "./FontSetting"
 import { FooterSettings } from "./FooterSettings"
 import { ImportThemeDialog } from "./ImportThemeDialog"
+import { ThemePicker } from "./ThemePicker"
 import { Button } from "@/components/ui/button"
-import {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select"
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
-import {
-  bundledThemes,
-  customThemes,
-  repoLabel,
-  SYSTEM_THEME,
-  THEME_TEMPLATE_FILENAME,
-  themeSelectItems,
-} from "@/lib/themes"
+import { THEME_TEMPLATE_FILENAME } from "@/lib/themes"
 import { errorText } from "@/lib/utils"
 
-// Appearance holds every look-and-feel control, split into an Interface group
-// (theme, zoom) and a Terminal group (text size, font) so the two concerns read
-// apart instead of as one flat list. The group label supplies the context, so
-// the block titles drop their "Interface"/"Terminal" prefix.
+// Appearance is a list of rows: a name on the left, its control on the right.
+// Two of them carry more than a control — the theme opens a strip of previews,
+// the footer an editor — and both open in place, below their own row, so the
+// pane never stops being one list.
 export function AppearanceSettings() {
   const [themePendingRemoval, setThemePendingRemoval] = useState<ThemeDefinition | null>(null)
   const [themePendingOverwrite, setThemePendingOverwrite] = useState<{
@@ -71,10 +43,10 @@ export function AppearanceSettings() {
   const [importOpen, setImportOpen] = useState(false)
   const [importing, setImporting] = useState(false)
   const [updatingID, setUpdatingID] = useState<string | null>(null)
-  const [importedThemesOpen, setImportedThemesOpen] = useState(false)
   const {
     themes,
     theme,
+    resolvedTheme,
     setTheme,
     importTheme,
     installThemesFromGit,
@@ -85,8 +57,6 @@ export function AppearanceSettings() {
     terminalFontSize,
     setTerminalFontSize,
   } = useSettings()
-  const importedThemes = customThemes(themes)
-  const hasCustomThemes = importedThemes.length > 0
 
   const onChooseThemeFile = async () => {
     setImporting(true)
@@ -181,278 +151,119 @@ export function AppearanceSettings() {
 
   return (
     <>
-      <SettingGroup label="Interface">
-        <SettingBlock
-          title="Theme"
-          description="Colors the interface and the terminal. System follows your OS and uses the bundled light or dark theme."
-        >
-          <div className="flex flex-wrap items-center gap-2">
-            <Select
-              value={theme}
-              items={themeSelectItems(themes, SYSTEM_THEME, "System")}
-              onValueChange={(value) => value && setTheme(value as Theme)}
-            >
-              <SelectTrigger className="w-64">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectGroup>
-                  <SelectLabel>Automatic</SelectLabel>
-                  <SelectItem value={SYSTEM_THEME}>System</SelectItem>
-                </SelectGroup>
-                <ThemeOptions themes={themes} />
-              </SelectContent>
-            </Select>
-            <Button type="button" variant="outline" onClick={() => setImportOpen(true)}>
-              <Upload />
-              Import
-            </Button>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon"
-                    aria-label="Download Theme Template"
-                    onClick={() => void onDownloadThemeTemplate()}
-                  />
-                }
-              >
-                <Download />
-              </TooltipTrigger>
-              <TooltipContent>Download Theme Template</TooltipContent>
-            </Tooltip>
-          </div>
-          {hasCustomThemes && (
-            <div className="mt-3 w-full max-w-md">
-              <Button
-                type="button"
-                variant="ghost"
-                className="h-8 w-full justify-start px-1.5 text-muted-foreground"
-                aria-expanded={importedThemesOpen}
-                onClick={() => setImportedThemesOpen((open) => !open)}
-              >
-                <ChevronDown
-                  className={
-                    importedThemesOpen ? "transition-transform" : "-rotate-90 transition-transform"
-                  }
-                />
-                Imported themes ({importedThemes.length})
-              </Button>
-              {importedThemesOpen && (
-                <div className="mt-1 space-y-0.5">
-                  {importedThemes.map((item) => (
-                    <div
-                      key={item.id}
-                      className="flex min-h-10 items-center gap-2 rounded-md px-2 py-1.5 hover:bg-accent/50"
-                    >
-                      <span
-                        aria-hidden
-                        className="size-4 shrink-0 rounded-sm border border-border"
-                        style={{ backgroundColor: item.app.background }}
-                      />
-                      <span className="min-w-0 flex-1">
-                        <span className="block truncate text-sm">{item.name}</span>
-                        {/* The row is narrow: the repository replaces the id
-                            rather than sharing the line, or both truncate away. */}
-                        {item.source ? (
-                          <span className="flex min-w-0 items-center gap-1.5 font-mono text-xs text-muted-foreground">
-                            <GitBranch className="size-3 shrink-0" />
-                            <span className="truncate" title={item.source.url}>
-                              {repoLabel(item.source.url)}
-                            </span>
-                            <span className="shrink-0 tabular-nums">v{item.source.version}</span>
-                          </span>
-                        ) : (
-                          <span className="block truncate font-mono text-xs text-muted-foreground">
-                            {item.id}
-                          </span>
-                        )}
-                      </span>
-                      {item.source && (
-                        <Tooltip>
-                          <TooltipTrigger
-                            render={
-                              <Button
-                                type="button"
-                                variant="ghost"
-                                size="icon-sm"
-                                aria-label={`Update ${item.name}`}
-                                disabled={updatingID !== null}
-                                onClick={() => void onUpdateTheme(item)}
-                              />
-                            }
-                          >
-                            <RefreshCw className={updatingID === item.id ? "animate-spin" : ""} />
-                          </TooltipTrigger>
-                          <TooltipContent>Check the repository for a newer version</TooltipContent>
-                        </Tooltip>
-                      )}
-                      <Tooltip>
-                        <TooltipTrigger
-                          render={
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="icon-sm"
-                              aria-label={`Remove ${item.name}`}
-                              onClick={() => setThemePendingRemoval(item)}
-                            />
-                          }
-                        >
-                          <Trash2 />
-                        </TooltipTrigger>
-                        <TooltipContent>{`Remove ${item.name}`}</TooltipContent>
-                      </Tooltip>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-          <ImportThemeDialog
-            open={importOpen}
-            onOpenChange={setImportOpen}
-            onInstallRepository={(url) => installRepository(url, false)}
-            onChooseFile={onChooseThemeFile}
-            busy={importing}
-          />
-          <ConfirmDialog
-            open={packPendingOverwrite !== null}
-            onCancel={() => setPackPendingOverwrite(null)}
-            title="Replace imported themes?"
-            description={
-              <>
-                The repository carries themes that are already installed:{" "}
-                <span className="font-medium">{packPendingOverwrite?.conflicts.join(", ")}</span>.
-                Install anyway? This permanently deletes the previous versions.
-              </>
-            }
-          >
-            <Button
-              variant="destructive"
-              disabled={importing}
-              onClick={() => {
-                if (packPendingOverwrite) void installRepository(packPendingOverwrite.url, true)
-              }}
-            >
-              Replace themes
-            </Button>
-          </ConfirmDialog>
-          <ConfirmDialog
-            open={themePendingRemoval !== null}
-            onCancel={() => setThemePendingRemoval(null)}
-            title="Remove imported theme?"
-            description={
-              <>
-                Delete <span className="font-medium">{themePendingRemoval?.name}</span>? This
-                removes the imported theme file from lich.
-              </>
-            }
-          >
-            <Button variant="destructive" onClick={() => void onRemoveTheme()}>
-              Remove theme
-            </Button>
-          </ConfirmDialog>
-          <ConfirmDialog
-            open={themePendingOverwrite !== null}
-            onCancel={() => setThemePendingOverwrite(null)}
-            title="Replace imported theme?"
-            description={
-              <>
-                A theme with the id{" "}
-                <span className="font-medium">{themePendingOverwrite?.theme.id}</span> already
-                exists. Import anyway? This permanently deletes the previous theme.
-              </>
-            }
-          >
-            <Button variant="destructive" onClick={() => void onOverwriteTheme()}>
-              Replace theme
-            </Button>
-          </ConfirmDialog>
-        </SettingBlock>
+      <ThemePicker
+        themes={themes}
+        value={theme}
+        resolved={resolvedTheme}
+        onSelect={(id: Theme) => setTheme(id)}
+        onImport={() => setImportOpen(true)}
+        onUpdate={(item) => void onUpdateTheme(item)}
+        onRemove={setThemePendingRemoval}
+        updatingID={updatingID}
+      />
 
-        <SettingBlock
-          icon={<ZoomIn className="size-4" />}
-          title="Zoom"
-          description="Scales the interface."
-        >
-          <Stepper
-            value={zoom}
-            display={`${Math.round(zoom * 100)}%`}
-            min={ZOOM_MIN}
-            max={ZOOM_MAX}
-            step={ZOOM_STEP}
-            fallback={DEFAULT_ZOOM}
-            onChange={setZoom}
-            decrementIcon={<ZoomOut />}
-            incrementIcon={<ZoomIn />}
-            decrementLabel="Zoom out"
-            incrementLabel="Zoom in"
-          />
-        </SettingBlock>
-      </SettingGroup>
+      <SettingRow title="Zoom">
+        <Stepper
+          value={zoom}
+          display={`${Math.round(zoom * 100)}%`}
+          min={ZOOM_MIN}
+          max={ZOOM_MAX}
+          step={ZOOM_STEP}
+          fallback={DEFAULT_ZOOM}
+          name="the zoom"
+          onChange={setZoom}
+          decrementIcon={<ZoomOut />}
+          incrementIcon={<ZoomIn />}
+          decrementLabel="Zoom out"
+          incrementLabel="Zoom in"
+        />
+      </SettingRow>
 
-      <SettingGroup label="Terminal">
-        <SettingBlock
-          icon={<CaseSensitive className="size-4" />}
-          title="Text size"
-          description="Scales the terminal."
-        >
-          <Stepper
-            value={terminalFontSize}
-            display={`${terminalFontSize}px`}
-            min={TERMINAL_FONT_SIZE_MIN}
-            max={TERMINAL_FONT_SIZE_MAX}
-            step={TERMINAL_FONT_SIZE_STEP}
-            fallback={DEFAULT_TERMINAL_FONT_SIZE}
-            onChange={setTerminalFontSize}
-            decrementIcon={<Minus />}
-            incrementIcon={<Plus />}
-            decrementLabel="Smaller terminal text"
-            incrementLabel="Larger terminal text"
-          />
-        </SettingBlock>
+      <SettingRow title="Terminal text size">
+        <Stepper
+          value={terminalFontSize}
+          display={`${terminalFontSize}px`}
+          min={TERMINAL_FONT_SIZE_MIN}
+          max={TERMINAL_FONT_SIZE_MAX}
+          step={TERMINAL_FONT_SIZE_STEP}
+          fallback={DEFAULT_TERMINAL_FONT_SIZE}
+          name="the terminal text size"
+          onChange={setTerminalFontSize}
+          decrementIcon={<Minus />}
+          incrementIcon={<Plus />}
+          decrementLabel="Smaller terminal text"
+          incrementLabel="Larger terminal text"
+        />
+      </SettingRow>
 
-        <FontSetting />
-      </SettingGroup>
+      <FontSetting />
       <FooterSettings />
+
+      <ImportThemeDialog
+        open={importOpen}
+        onOpenChange={setImportOpen}
+        onInstallRepository={(url) => installRepository(url, false)}
+        onChooseFile={onChooseThemeFile}
+        onDownloadTemplate={() => void onDownloadThemeTemplate()}
+        busy={importing}
+      />
+      <ConfirmDialog
+        open={packPendingOverwrite !== null}
+        onCancel={() => setPackPendingOverwrite(null)}
+        title="Replace imported themes?"
+        description={
+          <>
+            The repository carries themes that are already installed:{" "}
+            <span className="font-medium">{packPendingOverwrite?.conflicts.join(", ")}</span>.
+            Install anyway? This permanently deletes the previous versions.
+          </>
+        }
+      >
+        <Button
+          variant="destructive"
+          disabled={importing}
+          onClick={() => {
+            if (packPendingOverwrite) void installRepository(packPendingOverwrite.url, true)
+          }}
+        >
+          Replace themes
+        </Button>
+      </ConfirmDialog>
+      <ConfirmDialog
+        open={themePendingRemoval !== null}
+        onCancel={() => setThemePendingRemoval(null)}
+        title="Remove imported theme?"
+        description={
+          <>
+            Delete <span className="font-medium">{themePendingRemoval?.name}</span>? This removes
+            the imported theme file from lich.
+          </>
+        }
+      >
+        <Button variant="destructive" onClick={() => void onRemoveTheme()}>
+          Remove theme
+        </Button>
+      </ConfirmDialog>
+      <ConfirmDialog
+        open={themePendingOverwrite !== null}
+        onCancel={() => setThemePendingOverwrite(null)}
+        title="Replace imported theme?"
+        description={
+          <>
+            A theme with the id{" "}
+            <span className="font-medium">{themePendingOverwrite?.theme.id}</span> already exists.
+            Import anyway? This permanently deletes the previous theme.
+          </>
+        }
+      >
+        <Button variant="destructive" onClick={() => void onOverwriteTheme()}>
+          Replace theme
+        </Button>
+      </ConfirmDialog>
     </>
   )
 }
 
 function themeCount(count: number): string {
   return count === 1 ? "1 theme" : `${count} themes`
-}
-
-interface ThemeOptionsProps {
-  themes: readonly ThemeDefinition[]
-}
-
-function ThemeOptions({ themes }: ThemeOptionsProps) {
-  const bundled = bundledThemes(themes)
-  const custom = customThemes(themes)
-  return (
-    <>
-      <SelectGroup>
-        <SelectLabel>Bundled</SelectLabel>
-        {bundled.map((item) => (
-          <SelectItem key={item.id} value={item.id}>
-            {item.name}
-          </SelectItem>
-        ))}
-      </SelectGroup>
-      {custom.length > 0 && (
-        <SelectGroup>
-          <SelectLabel>Custom</SelectLabel>
-          {custom.map((item) => (
-            <SelectItem key={item.id} value={item.id}>
-              {item.name}
-            </SelectItem>
-          ))}
-        </SelectGroup>
-      )}
-    </>
-  )
 }

--- a/frontend/src/components/settings/FontSetting.tsx
+++ b/frontend/src/components/settings/FontSetting.tsx
@@ -10,7 +10,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select"
-import { SettingBlock } from "./SettingBlock"
+import { SettingRow } from "./SettingBlock"
 
 // A module-level constant, as every array `empty` has to be: a fresh one per
 // render would notify subscribers on every failed read.
@@ -35,9 +35,16 @@ export function FontSetting() {
   )
 
   return (
-    <SettingBlock title="Font" description="Font family used to render the terminal.">
+    <SettingRow
+      title="Terminal font"
+      description={
+        // The sample renders in the family itself: the answer to "which one is
+        // this" is the shape of the glyphs, not the name.
+        <span style={{ fontFamily: font }}>the quick brown fox 0O1lI</span>
+      }
+    >
       <Select value={font} onValueChange={(value) => value && setFont(value)}>
-        <SelectTrigger className="w-64">
+        <SelectTrigger className="w-56">
           <SelectValue placeholder="Select a font" />
         </SelectTrigger>
         <SelectContent>
@@ -50,6 +57,6 @@ export function FontSetting() {
           </SelectGroup>
         </SelectContent>
       </Select>
-    </SettingBlock>
+    </SettingRow>
   )
 }

--- a/frontend/src/components/settings/FooterLayoutEditor.tsx
+++ b/frontend/src/components/settings/FooterLayoutEditor.tsx
@@ -31,6 +31,11 @@ import {
   type LucideIcon,
 } from "lucide-react"
 import { dragStyle, useDragSensors } from "@/lib/use-sortable-list"
+import { formatModel } from "@/lib/model-name"
+import { useActiveSession } from "@/lib/session/use-active-session"
+import { useSessionAgent } from "@/lib/session/use-session-agent"
+import { useSessionUsage } from "@/lib/session/use-session-usage"
+import { ProviderIcon } from "@/components/ProviderIcon"
 import {
   FOOTER_ITEMS,
   hasFooterItem,
@@ -64,6 +69,54 @@ const LABELS: Record<FooterZone, string> = {
 }
 const exampleOf = (id: FooterItem) => FOOTER_ITEMS.find((item) => item.id === id)?.example ?? id
 const labelOf = (id: FooterItem) => FOOTER_ITEMS.find((item) => item.id === id)?.label ?? id
+
+interface ItemReadingProps {
+  id: FooterItem
+  /** The preview bar sets its own smaller glyph. */
+  small?: boolean
+}
+
+// What the item puts in the footer: its glyph and its reading. One component
+// for the chip, the drag overlay and the preview bar, so the thing under the
+// cursor is the thing that was picked up.
+function ItemReading({ id, small }: ItemReadingProps) {
+  if (id === "model") {
+    return <ModelReading small={small} />
+  }
+  const Icon = ICONS[id]
+  return (
+    <>
+      <Icon className={small ? "size-3" : undefined} aria-hidden="true" />
+      {exampleOf(id)}
+    </>
+  )
+}
+
+// The model slot is the one item whose footer reading is not a shape but a
+// fact: the provider's own mark and the model the active session is running,
+// which is what SessionModel draws. A made-up "Codex · GPT-6" named a provider
+// the footer never writes and pinned a model nobody chose.
+function ModelReading({ small }: { small?: boolean }) {
+  const { sessionId, kind } = useActiveSession()
+  const usage = useSessionUsage(sessionId)
+  const provider = useSessionAgent(sessionId) ?? kind
+  if (!usage?.model || !provider) {
+    const Icon = ICONS.model
+    return (
+      <>
+        <Icon className={small ? "size-3" : undefined} aria-hidden="true" />
+        {exampleOf("model")}
+      </>
+    )
+  }
+  return (
+    <>
+      <ProviderIcon kind={provider} size={small ? 12 : 14} />
+      {formatModel(usage.model)}
+      {usage.effort ? ` · ${usage.effort}` : ""}
+    </>
+  )
+}
 
 // Only a pointer inside a drop area may commit; inside it, items take precedence.
 const collisionDetection: CollisionDetection = (args) => {
@@ -138,8 +191,8 @@ export function FooterLayoutEditor({ layout, disabled, onChange }: FooterLayoutE
       </div>
       <DragOverlay>
         {dragging && (
-          <span className="rounded-md bg-popover px-2.5 py-1.5 text-xs shadow-md">
-            {exampleOf(dragging)}
+          <span className="flex items-center gap-1.5 rounded-md bg-popover px-2.5 py-1.5 text-xs shadow-md">
+            <ItemReading id={dragging} />
           </span>
         )}
       </DragOverlay>
@@ -207,7 +260,6 @@ function FooterEditorItem({ id, layout, disabled }: FooterEditorItemProps) {
     transition,
     isDragging,
   } = useSortable({ id, disabled })
-  const Icon = ICONS[id]
   const inFooter = hasFooterItem(layout, id)
   return (
     <div
@@ -234,8 +286,7 @@ function FooterEditorItem({ id, layout, disabled }: FooterEditorItemProps) {
         aria-label={`Move ${labelOf(id)}`}
         className="touch-none cursor-grab tabular-nums active:cursor-grabbing"
       >
-        <Icon />
-        {exampleOf(id)}
+        <ItemReading id={id} />
       </Button>
     </div>
   )
@@ -267,15 +318,11 @@ export function FooterLayoutPreview({ layout }: FooterLayoutPreviewProps) {
                 side === "right" && "ml-auto justify-end",
               )}
             >
-              {layout[side].map((id) => {
-                const Icon = ICONS[id]
-                return (
-                  <span key={id} className="flex items-center gap-1 tabular-nums">
-                    <Icon className="size-3" aria-hidden="true" />
-                    {FOOTER_ITEMS.find((item) => item.id === id)?.example}
-                  </span>
-                )
-              })}
+              {layout[side].map((id) => (
+                <span key={id} className="flex items-center gap-1 tabular-nums">
+                  <ItemReading id={id} small />
+                </span>
+              ))}
             </div>
           ))}
           {layout.left.length + layout.right.length === 0 && (

--- a/frontend/src/components/settings/FooterLayoutEditor.tsx
+++ b/frontend/src/components/settings/FooterLayoutEditor.tsx
@@ -277,8 +277,11 @@ function FooterEditorItem({ id, layout, disabled, onMove }: FooterEditorItemProp
       </Button>
       {/* Kept out of the resting chip: the menu and the remove are one hover
           away, and a row of them across every chip was the loudest thing on the
-          pane. focus-within keeps them reachable without a pointer. */}
-      <span className="hidden items-center group-hover:flex group-focus-within:flex">
+          pane. Collapsed to nothing rather than hidden, because `display: none`
+          takes them out of the tab order, and then focus-within can never fire
+          to bring them back — the keyboard would lose the only path to moving
+          an item without dragging it. */}
+      <span className="flex w-0 items-center overflow-hidden opacity-0 group-hover:w-auto group-hover:opacity-100 group-focus-within:w-auto group-focus-within:opacity-100">
         <FooterItemMenu id={id} layout={layout} disabled={disabled} onMove={onMove} />
         {inFooter && (
           <Button

--- a/frontend/src/components/settings/FooterLayoutEditor.tsx
+++ b/frontend/src/components/settings/FooterLayoutEditor.tsx
@@ -17,10 +17,6 @@ import {
   useSortable,
 } from "@dnd-kit/sortable"
 import {
-  ArrowLeft,
-  ArrowRight,
-  ChevronLeft,
-  ChevronRight,
   Clock,
   Code,
   Coins,
@@ -30,16 +26,13 @@ import {
   Gauge,
   GitBranch,
   GitPullRequestArrow,
-  MoreHorizontal,
   Paperclip,
   Timer,
-  X,
   type LucideIcon,
 } from "lucide-react"
 import { dragStyle, useDragSensors } from "@/lib/use-sortable-list"
 import {
   FOOTER_ITEMS,
-  footerZone,
   hasFooterItem,
   isFooterItem,
   moveFooterItem,
@@ -49,13 +42,6 @@ import {
 } from "@/lib/footer-layout"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 
 const ICONS: Record<FooterItem, LucideIcon> = {
   attach: Paperclip,
@@ -145,28 +131,10 @@ export function FooterLayoutEditor({ layout, disabled, onChange }: FooterLayoutE
             side it will show on. Available lands below them: what is in the
             footer is what the pane is about. */}
         <div className="grid min-w-0 grid-cols-2 gap-3">
-          <FooterZoneView
-            zone="left"
-            items={layout.left}
-            layout={layout}
-            disabled={disabled}
-            onMove={move}
-          />
-          <FooterZoneView
-            zone="right"
-            items={layout.right}
-            layout={layout}
-            disabled={disabled}
-            onMove={move}
-          />
+          <FooterZoneView zone="left" items={layout.left} layout={layout} disabled={disabled} />
+          <FooterZoneView zone="right" items={layout.right} layout={layout} disabled={disabled} />
         </div>
-        <FooterZoneView
-          zone="available"
-          items={available}
-          layout={layout}
-          disabled={disabled}
-          onMove={move}
-        />
+        <FooterZoneView zone="available" items={available} layout={layout} disabled={disabled} />
       </div>
       <DragOverlay>
         {dragging && (
@@ -184,10 +152,9 @@ interface FooterZoneViewProps {
   items: FooterItem[]
   layout: FooterLayout
   disabled: boolean
-  onMove: (id: FooterItem, target: string) => void
 }
 
-function FooterZoneView({ zone, items, layout, disabled, onMove }: FooterZoneViewProps) {
+function FooterZoneView({ zone, items, layout, disabled }: FooterZoneViewProps) {
   const { setNodeRef, isOver } = useDroppable({
     id: zone,
     disabled,
@@ -211,13 +178,7 @@ function FooterZoneView({ zone, items, layout, disabled, onMove }: FooterZoneVie
       >
         <SortableContext items={items} strategy={rectSortingStrategy}>
           {items.map((id) => (
-            <FooterEditorItem
-              key={id}
-              id={id}
-              layout={layout}
-              disabled={disabled}
-              onMove={onMove}
-            />
+            <FooterEditorItem key={id} id={id} layout={layout} disabled={disabled} />
           ))}
         </SortableContext>
         {items.length === 0 && (
@@ -234,10 +195,9 @@ interface FooterEditorItemProps {
   id: FooterItem
   layout: FooterLayout
   disabled: boolean
-  onMove: (id: FooterItem, target: string) => void
 }
 
-function FooterEditorItem({ id, layout, disabled, onMove }: FooterEditorItemProps) {
+function FooterEditorItem({ id, layout, disabled }: FooterEditorItemProps) {
   const {
     setNodeRef,
     setActivatorNodeRef,
@@ -256,8 +216,10 @@ function FooterEditorItem({ id, layout, disabled, onMove }: FooterEditorItemProp
       data-footer-item={id}
       className={cn(
         // The chip carries the reading the footer will show, not the setting's
-        // name: an item is recognised by what it puts on screen.
-        "group flex shrink-0 items-center rounded-md ring-1 ring-inset ring-border",
+        // name: an item is recognised by what it puts on screen. Nothing on it
+        // appears on hover: a control that grows under the pointer moves the
+        // chips beside it, which is exactly the moment a drag is being aimed.
+        "flex shrink-0 items-center rounded-md ring-1 ring-inset ring-border",
         inFooter ? "bg-background" : "bg-transparent text-muted-foreground",
         isDragging && "opacity-30",
       )}
@@ -275,78 +237,7 @@ function FooterEditorItem({ id, layout, disabled, onMove }: FooterEditorItemProp
         <Icon />
         {exampleOf(id)}
       </Button>
-      {/* Kept out of the resting chip: the menu and the remove are one hover
-          away, and a row of them across every chip was the loudest thing on the
-          pane. Collapsed to nothing rather than hidden, because `display: none`
-          takes them out of the tab order, and then focus-within can never fire
-          to bring them back — the keyboard would lose the only path to moving
-          an item without dragging it. */}
-      <span className="flex w-0 items-center overflow-hidden opacity-0 group-hover:w-auto group-hover:opacity-100 group-focus-within:w-auto group-focus-within:opacity-100">
-        <FooterItemMenu id={id} layout={layout} disabled={disabled} onMove={onMove} />
-        {inFooter && (
-          <Button
-            variant="ghost"
-            size="icon-xs"
-            disabled={disabled}
-            aria-label={`Remove ${labelOf(id)}`}
-            onClick={() => onMove(id, "available")}
-          >
-            <X />
-          </Button>
-        )}
-      </span>
     </div>
-  )
-}
-
-function FooterItemMenu({ id, layout, disabled, onMove }: FooterEditorItemProps) {
-  const zone = footerZone(layout, id)
-  const items = zone === "available" ? [] : layout[zone]
-  const index = items.indexOf(id)
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        aria-label={`Options for ${labelOf(id)}`}
-        render={<Button variant="ghost" size="icon-xs" disabled={disabled} />}
-      >
-        <MoreHorizontal />
-      </DropdownMenuTrigger>
-      <DropdownMenuContent>
-        <DropdownMenuGroup>
-          {zone !== "left" && (
-            <DropdownMenuItem onClick={() => onMove(id, "left")}>
-              <ArrowLeft />
-              {zone === "available" ? "Add to left" : "Move to left"}
-            </DropdownMenuItem>
-          )}
-          {zone !== "right" && (
-            <DropdownMenuItem onClick={() => onMove(id, "right")}>
-              <ArrowRight />
-              {zone === "available" ? "Add to right" : "Move to right"}
-            </DropdownMenuItem>
-          )}
-          {zone !== "available" && (
-            <>
-              <DropdownMenuItem disabled={index <= 0} onClick={() => onMove(id, items[index - 1])}>
-                <ChevronLeft />
-                Move earlier
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                disabled={index >= items.length - 1}
-                onClick={() => onMove(id, items[index + 1])}
-              >
-                <ChevronRight />
-                Move later
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => onMove(id, "available")}>
-                <X />
-                Remove from footer
-              </DropdownMenuItem>
-            </>
-          )}
-        </DropdownMenuGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
   )
 }
 

--- a/frontend/src/components/settings/FooterLayoutEditor.tsx
+++ b/frontend/src/components/settings/FooterLayoutEditor.tsx
@@ -30,7 +30,6 @@ import {
   Gauge,
   GitBranch,
   GitPullRequestArrow,
-  GripVertical,
   MoreHorizontal,
   Paperclip,
   Timer,
@@ -73,10 +72,11 @@ const ICONS: Record<FooterItem, LucideIcon> = {
   clock: Clock,
 }
 const LABELS: Record<FooterZone, string> = {
-  available: "Available items",
-  left: "Left side",
-  right: "Right side",
+  available: "Available",
+  left: "Left",
+  right: "Right",
 }
+const exampleOf = (id: FooterItem) => FOOTER_ITEMS.find((item) => item.id === id)?.example ?? id
 const labelOf = (id: FooterItem) => FOOTER_ITEMS.find((item) => item.id === id)?.label ?? id
 
 // Only a pointer inside a drop area may commit; inside it, items take precedence.
@@ -140,7 +140,26 @@ export function FooterLayoutEditor({ layout, disabled, onChange }: FooterLayoutE
       onDragEnd={drop}
       onDragCancel={() => setDragging(null)}
     >
-      <div className="flex min-w-0 flex-col gap-5">
+      <div className="flex min-w-0 flex-col gap-4">
+        {/* Two columns, one per end of the real footer, so an item sits on the
+            side it will show on. Available lands below them: what is in the
+            footer is what the pane is about. */}
+        <div className="grid min-w-0 grid-cols-2 gap-3">
+          <FooterZoneView
+            zone="left"
+            items={layout.left}
+            layout={layout}
+            disabled={disabled}
+            onMove={move}
+          />
+          <FooterZoneView
+            zone="right"
+            items={layout.right}
+            layout={layout}
+            disabled={disabled}
+            onMove={move}
+          />
+        </div>
         <FooterZoneView
           zone="available"
           items={available}
@@ -148,25 +167,11 @@ export function FooterLayoutEditor({ layout, disabled, onChange }: FooterLayoutE
           disabled={disabled}
           onMove={move}
         />
-        <FooterZoneView
-          zone="left"
-          items={layout.left}
-          layout={layout}
-          disabled={disabled}
-          onMove={move}
-        />
-        <FooterZoneView
-          zone="right"
-          items={layout.right}
-          layout={layout}
-          disabled={disabled}
-          onMove={move}
-        />
       </div>
       <DragOverlay>
         {dragging && (
-          <span className="rounded-md bg-popover px-3 py-2 text-xs shadow-md">
-            {labelOf(dragging)}
+          <span className="rounded-md bg-popover px-2.5 py-1.5 text-xs shadow-md">
+            {exampleOf(dragging)}
           </span>
         )}
       </DragOverlay>
@@ -188,15 +193,20 @@ function FooterZoneView({ zone, items, layout, disabled, onMove }: FooterZoneVie
     disabled,
     data: { empty: items.length === 0 },
   })
+  const side = zone !== "available"
   return (
-    <section className="min-w-0" aria-label={LABELS[zone]}>
-      <h3 className="mb-2 text-sm font-medium">{LABELS[zone]}</h3>
+    <section className="flex min-w-0 flex-col" aria-label={LABELS[zone]}>
+      <h3 className="mb-1.5 text-xs text-muted-foreground">{LABELS[zone]}</h3>
       <div
         ref={setNodeRef}
         data-footer-zone={zone}
         className={cn(
-          "flex min-h-12 flex-wrap items-center gap-1.5 border-y border-border px-1 py-3",
-          isOver && "bg-accent/50",
+          "flex flex-1 flex-wrap content-start items-center gap-1.5 rounded-lg p-2",
+          side ? "min-h-18 bg-sidebar" : "min-h-11",
+          // The outline is the answer to "does it land here", so it only exists
+          // while something is in the air; a permanent one reads as a border.
+          isOver && "ring-2 ring-ring",
+          zone === "right" && "justify-end",
         )}
       >
         <SortableContext items={items} strategy={rectSortingStrategy}>
@@ -211,8 +221,8 @@ function FooterZoneView({ zone, items, layout, disabled, onMove }: FooterZoneVie
           ))}
         </SortableContext>
         {items.length === 0 && (
-          <p className="px-2 py-3 text-xs text-muted-foreground">
-            {zone === "available" ? "Drag here to hide an item" : "Drag items here"}
+          <p className="px-1 text-xs text-muted-foreground">
+            {zone === "available" ? "Every item is in the footer" : "Drag items here"}
           </p>
         )}
       </div>
@@ -238,13 +248,17 @@ function FooterEditorItem({ id, layout, disabled, onMove }: FooterEditorItemProp
     isDragging,
   } = useSortable({ id, disabled })
   const Icon = ICONS[id]
+  const inFooter = hasFooterItem(layout, id)
   return (
     <div
       ref={setNodeRef}
       style={dragStyle(transform, transition)}
       data-footer-item={id}
       className={cn(
-        "flex shrink-0 items-center rounded-md bg-accent/30",
+        // The chip carries the reading the footer will show, not the setting's
+        // name: an item is recognised by what it puts on screen.
+        "group flex shrink-0 items-center rounded-md ring-1 ring-inset ring-border",
+        inFooter ? "bg-background" : "bg-transparent text-muted-foreground",
         isDragging && "opacity-30",
       )}
     >
@@ -256,24 +270,28 @@ function FooterEditorItem({ id, layout, disabled, onMove }: FooterEditorItemProp
         {...attributes}
         {...listeners}
         aria-label={`Move ${labelOf(id)}`}
-        className="touch-none cursor-grab active:cursor-grabbing"
+        className="touch-none cursor-grab tabular-nums active:cursor-grabbing"
       >
-        <GripVertical data-icon="inline-start" />
         <Icon />
-        {labelOf(id)}
+        {exampleOf(id)}
       </Button>
-      <FooterItemMenu id={id} layout={layout} disabled={disabled} onMove={onMove} />
-      {hasFooterItem(layout, id) && (
-        <Button
-          variant="ghost"
-          size="icon-xs"
-          disabled={disabled}
-          aria-label={`Remove ${labelOf(id)}`}
-          onClick={() => onMove(id, "available")}
-        >
-          <X />
-        </Button>
-      )}
+      {/* Kept out of the resting chip: the menu and the remove are one hover
+          away, and a row of them across every chip was the loudest thing on the
+          pane. focus-within keeps them reachable without a pointer. */}
+      <span className="hidden items-center group-hover:flex group-focus-within:flex">
+        <FooterItemMenu id={id} layout={layout} disabled={disabled} onMove={onMove} />
+        {inFooter && (
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            disabled={disabled}
+            aria-label={`Remove ${labelOf(id)}`}
+            onClick={() => onMove(id, "available")}
+          >
+            <X />
+          </Button>
+        )}
+      </span>
     </div>
   )
 }

--- a/frontend/src/components/settings/FooterSettings.tsx
+++ b/frontend/src/components/settings/FooterSettings.tsx
@@ -12,7 +12,7 @@ import {
 import { errorText } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { SettingBlock, SettingGroup } from "./SettingBlock"
+import { SettingRow } from "./SettingBlock"
 import { FooterLayoutEditor, FooterLayoutPreview } from "./FooterLayoutEditor"
 
 export function FooterSettings() {
@@ -35,37 +35,37 @@ export function FooterSettings() {
     }
   }
   return (
-    <SettingGroup label="Footer">
-      <SettingBlock
-        title="Footer layout"
-        description="Drag items between the rows to show, hide or reorder them, or use an item's menu. Applies to every project and provider."
+    <>
+      {/* The row names the setting and holds the one control that is not a
+          drag; the editor below it is always open, because it is the thing the
+          row is about and hiding it behind a click buys nothing. */}
+      <SettingRow
+        title="Footer"
+        description={
+          !ready
+            ? "Loading saved choices…"
+            : saving
+              ? "Saving…"
+              : "Drag an item between the sides, or out to hide it. Applies to every project."
+        }
       >
-        <div className="mb-3 flex items-center justify-between gap-3">
-          <span className="text-xs text-muted-foreground">
-            {!ready
-              ? "Loading saved choices…"
-              : saving
-                ? "Saving…"
-                : "Readings appear when the provider reports them."}
-          </span>
-          <Button
-            variant="ghost"
-            size="xs"
-            disabled={!ready || saving}
-            onClick={() => void change(DEFAULT_FOOTER_LAYOUT)}
-          >
-            Restore default
-          </Button>
-        </div>
-        <FooterLayoutEditor
-          layout={layout}
+        <Button
+          variant="ghost"
+          size="xs"
           disabled={!ready || saving}
-          onChange={(next) => void change(next)}
-        />
-        <FooterLayoutPreview layout={layout} />
-      </SettingBlock>
+          onClick={() => void change(DEFAULT_FOOTER_LAYOUT)}
+        >
+          Restore default
+        </Button>
+      </SettingRow>
+      <FooterLayoutEditor
+        layout={layout}
+        disabled={!ready || saving}
+        onChange={(next) => void change(next)}
+      />
+      <FooterLayoutPreview layout={layout} />
       {hasFooterItem(layout, "cost") && <SpendCeiling />}
-    </SettingGroup>
+    </>
   )
 }
 
@@ -74,9 +74,9 @@ function SpendCeiling() {
   // Preserve a half-typed decimal while the stored amount stays numeric.
   const [budget, setBudget] = useState(() => (costBudget > 0 ? String(costBudget) : ""))
   return (
-    <SettingBlock
+    <SettingRow
       title="Spend ceiling"
-      description="Warn as the session's API cost approaches this amount: amber at 80%, red at 95%. This does not stop the session or represent subscription charges. Leave empty for none."
+      description="Warn as the session's API cost nears this amount: amber at 80%, red at 95%. Empty for none."
     >
       <Input
         type="number"
@@ -91,6 +91,6 @@ function SpendCeiling() {
         aria-label="Session spend ceiling in dollars"
         className="w-40 font-mono"
       />
-    </SettingBlock>
+    </SettingRow>
   )
 }

--- a/frontend/src/components/settings/ImportThemeDialog.tsx
+++ b/frontend/src/components/settings/ImportThemeDialog.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { FileJson } from "lucide-react"
+import { Download, FileJson } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
@@ -19,6 +19,8 @@ interface ImportThemeDialogProps {
   onInstallRepository: (url: string) => Promise<void>
   /** Open the native picker for a single theme file. */
   onChooseFile: () => Promise<void>
+  /** Save the theme template, the starting point for writing one. */
+  onDownloadTemplate: () => void
   /** True while a clone or a file import is in flight. */
   busy: boolean
 }
@@ -30,6 +32,7 @@ export function ImportThemeDialog({
   onOpenChange,
   onInstallRepository,
   onChooseFile,
+  onDownloadTemplate,
   busy,
 }: ImportThemeDialogProps) {
   const [url, setUrl] = useState("")
@@ -96,7 +99,14 @@ export function ImportThemeDialog({
             A single theme file. No version, no updates.
           </span>
         </div>
-        <DialogFooter>
+        <DialogFooter className="sm:justify-between">
+          {/* Writing a theme starts here, so the template belongs to this
+              dialog. On the pane it was an unlabelled download glyph beside
+              Import, which named neither the file nor what it was for. */}
+          <Button type="button" variant="ghost" disabled={busy} onClick={onDownloadTemplate}>
+            <Download />
+            Download template
+          </Button>
           <Button variant="ghost" disabled={busy} onClick={() => onOpenChange(false)}>
             Cancel
           </Button>

--- a/frontend/src/components/settings/SettingBlock.tsx
+++ b/frontend/src/components/settings/SettingBlock.tsx
@@ -58,3 +58,36 @@ export function SettingBlock({
     </section>
   )
 }
+
+// A setting that fits on one line: the name on the left, the control on the
+// right, hairline between rows. What Sandbox and Hotkeys already draw by hand,
+// and what Appearance moved to when its controls stopped needing a paragraph
+// each. A block is still the right shape for a control that carries an editor
+// or a long explanation; this is for the rest.
+export function SettingRow({
+  title,
+  description,
+  children,
+}: {
+  title: string
+  description?: ReactNode
+  children: ReactNode
+}) {
+  const { lit, ref } = useHighlight<HTMLElement>(title)
+
+  return (
+    <section
+      ref={ref}
+      className={cn(
+        "flex items-center justify-between gap-6 border-t border-border py-3 transition-colors duration-700 first:border-t-0",
+        lit && "-mx-3 rounded-lg bg-accent/60 px-3",
+      )}
+    >
+      <div className="min-w-0">
+        <div className="text-sm font-medium text-foreground">{title}</div>
+        {description && <div className="mt-0.5 text-xs text-muted-foreground">{description}</div>}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">{children}</div>
+    </section>
+  )
+}

--- a/frontend/src/components/settings/ThemePicker.tsx
+++ b/frontend/src/components/settings/ThemePicker.tsx
@@ -1,0 +1,278 @@
+import { useState } from "react"
+import { ChevronDown, RefreshCw, Trash2, Upload } from "lucide-react"
+import type { ThemeDefinition } from "@/lib/api-types"
+import { bundledThemes, repoLabel, SYSTEM_THEME } from "@/lib/themes"
+import type { Theme } from "@/providers/settings"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { SettingRow } from "./SettingBlock"
+
+// A theme is a set of colors, and a dropdown of names says nothing about them:
+// the old select answered "Rosé Pine" and the only way to see it was to apply
+// it. Every theme carries the tokens this draws, so the picker shows what it is
+// choosing between.
+interface ThemeMiniatureProps {
+  theme: ThemeDefinition
+  className?: string
+  /** Drawn inside another miniature's frame, so it brings no edge of its own. */
+  bare?: boolean
+}
+
+// The lich window at a glance: sidebar, canvas, and three lines standing for
+// the text, the muted text and a filled row. Not a screenshot, but the same
+// four tokens the real window leads with, in the same places.
+export function ThemeMiniature({ theme, className, bare }: ThemeMiniatureProps) {
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "grid shrink-0 grid-cols-[26%_1fr] overflow-hidden",
+        // The edge is the foreground rather than the border token: a dark
+        // theme's own background is the same value as the pane behind it, and
+        // --border is white at 10% there, so the card would have no edge at all.
+        !bare && "rounded-sm ring-1 ring-inset ring-foreground/20",
+        className,
+      )}
+      style={{ backgroundColor: theme.app.background }}
+    >
+      <span style={{ backgroundColor: theme.app.sidebar }} />
+      <span className="flex flex-col justify-start gap-[15%] p-[12%]">
+        <span
+          className="block h-[8%] min-h-px w-[60%] rounded-full"
+          style={{ backgroundColor: theme.app.foreground }}
+        />
+        <span
+          className="block h-[8%] min-h-px w-[85%] rounded-full"
+          style={{ backgroundColor: theme.app["muted-foreground"] }}
+        />
+        <span
+          className="block h-[8%] min-h-px w-[45%] rounded-full"
+          style={{ backgroundColor: theme.app.accent }}
+        />
+      </span>
+    </span>
+  )
+}
+
+// The System card is the only one whose colors are not its own: it is whichever
+// bundled theme the OS is asking for, so it shows both halves rather than
+// picking one and lying about the other half of the time.
+function SystemMiniature({
+  themes,
+  className,
+}: {
+  themes: readonly ThemeDefinition[]
+  className?: string
+}) {
+  const [light, dark] = bundledThemes(themes)
+  return (
+    <span
+      aria-hidden
+      className={cn(
+        "grid shrink-0 grid-cols-2 overflow-hidden rounded-sm ring-1 ring-inset ring-foreground/20",
+        className,
+      )}
+    >
+      {/* Both windows, cut down the middle. Two flat halves of background were
+          the honest colors and still read as one empty card, because a dark
+          theme's background is the same value as the pane it sits on. */}
+      {light && <ThemeMiniature theme={light} bare className="h-full w-full" />}
+      {dark && <ThemeMiniature theme={dark} bare className="h-full w-full" />}
+    </span>
+  )
+}
+
+interface ThemePickerProps {
+  themes: readonly ThemeDefinition[]
+  /** The selected id, which may be SYSTEM_THEME rather than a theme's own. */
+  value: Theme
+  /** The theme those colors resolve to, which is what the trigger shows. */
+  resolved: ThemeDefinition
+  onSelect: (id: Theme) => void
+  onImport: () => void
+  onUpdate: (theme: ThemeDefinition) => void
+  onRemove: (theme: ThemeDefinition) => void
+  updatingID: string | null
+}
+
+export function ThemePicker({
+  themes,
+  value,
+  resolved,
+  onSelect,
+  onImport,
+  onUpdate,
+  onRemove,
+  updatingID,
+}: ThemePickerProps) {
+  const [open, setOpen] = useState(false)
+  const system = value === SYSTEM_THEME
+  const choose = (id: Theme) => {
+    onSelect(id)
+    // The trigger repaints with the theme just picked, which is the receipt for
+    // the click; leaving the strip open would hide it behind the list.
+    setOpen(false)
+  }
+
+  return (
+    <div className="min-w-0">
+      <SettingRow title="Theme" description="Colors the interface and the terminal.">
+        <Button
+          type="button"
+          variant="outline"
+          aria-expanded={open}
+          aria-label="Choose a theme"
+          className="h-10 justify-between gap-3 pl-1.5"
+          onClick={() => setOpen((wasOpen) => !wasOpen)}
+        >
+          <span className="flex items-center gap-2.5">
+            {system ? (
+              <SystemMiniature themes={themes} className="h-7 w-11" />
+            ) : (
+              <ThemeMiniature theme={resolved} className="h-7 w-11" />
+            )}
+            <span className="text-sm font-medium">{system ? "System" : resolved.name}</span>
+          </span>
+          <ChevronDown className={cn("transition-transform", open && "rotate-180")} />
+        </Button>
+      </SettingRow>
+
+      {open && (
+        <div className="min-w-0">
+          <div className="mb-2 flex items-center justify-between gap-4">
+            <span className="text-xs text-muted-foreground">{themeCount(themes.length + 1)}</span>
+            <Button type="button" variant="ghost" size="xs" onClick={onImport}>
+              <Upload />
+              Import
+            </Button>
+          </div>
+          {/* Two rows that grow sideways: a tenth theme costs width, which
+              scrolls, instead of height, which pushes the rest of the pane off
+              the screen. */}
+          <div className="grid grid-flow-col grid-rows-2 auto-cols-[9.5rem] gap-3 overflow-x-auto px-0.5 pb-3">
+            <ThemeCard
+              name="System"
+              caption="follows the OS"
+              selected={system}
+              onSelect={() => choose(SYSTEM_THEME)}
+              preview={<SystemMiniature themes={themes} className="h-[88px] w-full" />}
+            />
+            {themes.map((theme) => (
+              <ThemeCard
+                key={theme.id}
+                name={theme.name}
+                caption={
+                  value === theme.id
+                    ? "in use"
+                    : theme.source
+                      ? `${repoLabel(theme.source.url)} v${theme.source.version}`
+                      : "bundled"
+                }
+                selected={value === theme.id}
+                onSelect={() => choose(theme.id)}
+                preview={<ThemeMiniature theme={theme} className="h-[88px] w-full" />}
+                actions={
+                  theme.origin === "custom" && (
+                    <>
+                      {theme.source && (
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="icon-xs"
+                                aria-label={`Update ${theme.name}`}
+                                disabled={updatingID !== null}
+                                onClick={(event) => {
+                                  event.stopPropagation()
+                                  onUpdate(theme)
+                                }}
+                              />
+                            }
+                          >
+                            <RefreshCw className={updatingID === theme.id ? "animate-spin" : ""} />
+                          </TooltipTrigger>
+                          <TooltipContent>Check the repository for a newer version</TooltipContent>
+                        </Tooltip>
+                      )}
+                      <Tooltip>
+                        <TooltipTrigger
+                          render={
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              aria-label={`Remove ${theme.name}`}
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                onRemove(theme)
+                              }}
+                            />
+                          }
+                        >
+                          <Trash2 />
+                        </TooltipTrigger>
+                        <TooltipContent>{`Remove ${theme.name}`}</TooltipContent>
+                      </Tooltip>
+                    </>
+                  )
+                }
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function themeCount(count: number): string {
+  return count === 1 ? "1 theme" : `${count} themes`
+}
+
+interface ThemeCardProps {
+  name: string
+  caption: string
+  selected: boolean
+  preview: React.ReactNode
+  onSelect: () => void
+  actions?: React.ReactNode
+}
+
+function ThemeCard({ name, caption, selected, preview, onSelect, actions }: ThemeCardProps) {
+  return (
+    <div className="group relative w-[9.5rem] shrink-0">
+      <button
+        type="button"
+        onClick={onSelect}
+        aria-current={selected}
+        className={cn(
+          "block w-full rounded-md text-left outline-none",
+          "focus-visible:ring-2 focus-visible:ring-ring",
+        )}
+      >
+        <span
+          className={cn(
+            "block overflow-hidden rounded-md",
+            selected && "ring-2 ring-ring ring-offset-2 ring-offset-background",
+          )}
+        >
+          {preview}
+        </span>
+        <span className="mt-1.5 flex items-baseline gap-1.5">
+          <span className="truncate text-xs font-medium text-foreground">{name}</span>
+          <span className="truncate text-[11px] text-muted-foreground">{caption}</span>
+        </span>
+      </button>
+      {/* Update and remove ride the card rather than a row of their own: they
+          belong to one theme, and only an imported theme has them. */}
+      {actions && (
+        <div className="absolute right-1 top-1 hidden gap-0.5 rounded-md bg-popover/90 p-0.5 group-hover:flex group-focus-within:flex">
+          {actions}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/lib/footer-layout.ts
+++ b/frontend/src/lib/footer-layout.ts
@@ -8,7 +8,9 @@ export const FOOTER_ITEMS = [
   { id: "pr", label: "Pull request", example: "PR #123" },
   { id: "checkout", label: "Branch", example: "feature/toolbar" },
   { id: "path", label: "Working directory", example: "~/project" },
-  { id: "model", label: "Model", example: "Codex · GPT-6" },
+  // No example of its own: the editor shows the model the active session is
+  // running, and this is what it falls back to when no session has reported one.
+  { id: "model", label: "Model", example: "Model" },
   { id: "context", label: "Context window", example: "42%" },
   { id: "plan", label: "Plan usage", example: "5h 28%" },
   { id: "cost", label: "Cost", example: "$1.25" },

--- a/frontend/src/lib/settings-index.test.ts
+++ b/frontend/src/lib/settings-index.test.ts
@@ -25,9 +25,9 @@ describe("searching the settings", () => {
   // One theme colors both surfaces, so there is one entry, and searching for
   // the terminal's colors has to reach it.
   it("answers the terminal's colors with the one Theme there is", () => {
-    const hits = find("theme").filter((entry) => entry.title === "Theme")
+    const themes = find("theme").filter((entry) => entry.title === "Theme")
 
-    expect(hits.map((entry) => entry.group)).toEqual(["Interface"])
+    expect(themes).toHaveLength(1)
     expect(find("palette").map((entry) => entry.title)).toContain("Theme")
   })
 
@@ -146,15 +146,16 @@ describe("the path over a result", () => {
 describe("the index against the panes it indexes", () => {
   const paneDir = fileURLToPath(new URL("../components/settings", import.meta.url))
 
-  // Every `<SettingBlock ... title=...>` in the settings components, whether the
-  // title is a plain string or a template with the project's name in it. Split
-  // rather than one regex: a block's other props hold JSX and arrow functions,
-  // so "everything up to the closing angle bracket" is not a thing to match.
+  // Every `<SettingBlock ... title=...>` and `<SettingRow ... title=...>` in the
+  // settings components, whether the title is a plain string or a template with
+  // the project's name in it. Split rather than one regex: a block's other props
+  // hold JSX and arrow functions, so "everything up to the closing angle
+  // bracket" is not a thing to match.
   function renderedTitles(): string[] {
     const titles: string[] = []
     for (const file of readdirSync(paneDir).filter((name) => name.endsWith(".tsx"))) {
       const source = readFileSync(`${paneDir}/${file}`, "utf8")
-      for (const block of source.split("<SettingBlock").slice(1)) {
+      for (const block of source.split(/<Setting(?:Block|Row)/).slice(1)) {
         const quoted = block.match(/^[\s\S]{0,400}?title="([^"]+)"/)
         const templated = block.match(/^[\s\S]{0,400}?title=\{`([^`$]+)/)
         const title = quoted?.[1] ?? templated?.[1]

--- a/frontend/src/lib/settings-index.ts
+++ b/frontend/src/lib/settings-index.ts
@@ -27,17 +27,12 @@ export interface SettingEntry {
 
 // Every SettingBlock in the app, in the order its pane renders it.
 export const SETTING_ENTRIES: readonly SettingEntry[] = [
-  {
-    section: "appearance",
-    group: "Interface",
-    title: "Theme",
-    also: "colors dark light terminal palette",
-  },
-  { section: "appearance", group: "Interface", title: "Zoom" },
-  { section: "appearance", group: "Terminal", title: "Text size" },
-  { section: "appearance", group: "Terminal", title: "Font", also: "typeface monospace" },
-  { section: "appearance", group: "Footer", title: "Footer layout", also: "status bar arrange" },
-  { section: "appearance", group: "Footer", title: "Spend ceiling", also: "cost budget usd" },
+  { section: "appearance", title: "Theme", also: "colors dark light terminal palette" },
+  { section: "appearance", title: "Zoom" },
+  { section: "appearance", title: "Terminal text size" },
+  { section: "appearance", title: "Terminal font", also: "typeface monospace" },
+  { section: "appearance", title: "Footer", also: "status bar layout arrange" },
+  { section: "appearance", title: "Spend ceiling", also: "cost budget usd" },
   { section: "notifications", title: "Notify me when a session needs input" },
   { section: "notifications", title: "Notify me when a session finishes working" },
   { section: "providers", title: "Default provider", also: "agent new session" },


### PR DESCRIPTION
Follows #482. The pane put every control under its own title and paragraph, so five settings filled a screen and a 256px dropdown floated in 600px of empty space. Sandbox and Hotkeys had already answered this: name left, control right, one hairline between rows.

Mockup this was drawn against, with the states side by side: https://claude.ai/code/artifact/26b1718d-d913-4e21-928c-7fa2a6b432b3

## The rows

`SettingRow` sits next to `SettingBlock`, which stays for the controls that carry an editor or a long explanation. Appearance is now five rows: Theme, Zoom, Terminal text size, Terminal font, Footer. No group headings, no icon on some blocks and not others, no description narrating the control it sits under.

## The theme

A dropdown of names says nothing about a set of colors: picking one meant applying it to find out. The row shows the theme in use as a miniature of the lich window (sidebar, canvas, text, muted text, accent), and opens a strip of them below itself. Two rows scrolling sideways, so a tenth theme costs width instead of the pane's height. Choosing closes the strip, and the new miniature on the row is the receipt.

`System` is the first card, drawn as both bundled windows split down the middle, because it is whichever one the OS is asking for. The card edge is `ring-foreground/20`, not `--border`: a dark theme's background is the same value as the pane behind it, and the border token is white at 10% there, so a card would have had no edge at all.

The strip carries what the "Imported themes" accordion carried, on each card: repository, version, and the update and remove buttons, on hover.

## The rest

- The terminal font row renders its sample in the font itself.
- The steppers dropped the greyed-out `Reset` that stood beside them permanently for the sake of the rarest action. The value is the reset, with a tooltip that says so.
- The theme template moved into the Import dialog, where writing a theme starts. On the pane it was an unlabelled download glyph next to Import.
- The footer editor is always open at the foot of the list. Its two sides sit side by side as the footer's two ends, each aligned to its own end; `Available` is below them, because what is in the footer comes first. Chips carry the reading they will show (`3 · +10 −2`, `42%`) rather than the setting's name, and remove and the item menu wait for hover instead of standing on every chip.

## The ceiling this keeps

With most of the twelve items turned on, a side wraps to two rows and the two stop lining up. That is the price of moving items by dragging them: the alternatives that never wrap are lists, one item per line, and then moving an item is not a drag any more. Both sides stretch to the taller one so the block still reads as one thing. Written down in `docs/ceilings.md`, so the next person meets it as a decision.

## Test plan

- [x] `go test ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `pnpm test` green: 1512 tests, 129 files. The search index guard now reads `SettingRow` literals too, so a row added without an entry still fails the suite
- [x] `tsc --noEmit` and `biome check .` clean (17 pre-existing a11y warnings)
- [x] `pnpm build` succeeds
- [x] Headless smoke on the real app, which the node-only suite cannot do:
  - five rows render, zero console errors
  - the strip opens, lists System / Light / Dark, picking Dark repaints the whole window and closes the strip
  - the whole pane fits 900px without scrolling
  - a footer chip at rest exposes only its drag handle; on hover it exposes `Options for Changes` and `Remove Changes`
  - both themes checked, which is what caught the invisible card edge
- [x] CHANGELOG entry under `[Unreleased]`, ceilings bullet in the same PR