### PR TITLE
feat: install lich on Windows with scoop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unzipped beside it. An installed lich now updates by running the next
   installer rather than through the update button, which opens the release
   page instead.
+- **`scoop install` reaches lich on Windows.** The repository now carries a
+  Scoop manifest, so a Windows machine can install lich from the command line
+  with no bucket to add:
+  `scoop install https://raw.githubusercontent.com/omartelo/lich/main/build/windows/scoop/lich.json`.
+  It lays out the portable exe and its window the way the installer does, keeps
+  `lich` on PATH, adds a Start Menu entry, and leaves your workspace in
+  `%AppData%\lich` when you uninstall. `scoop update lich` re-reads the
+  manifest and picks up the next release.
 - **On Apple Silicon, `Lich.app` brings its own window.** The same embedded
   Chromium sits inside the app, and lich opens in it instead of looking for
   Chrome, Chromium, Brave, Vivaldi or Edge in `/Applications`; the Dock,

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -202,6 +202,18 @@ The installer is not code-signed, so SmartScreen will warn on first run —
 
 lich runs windowless on Windows; diagnostics live in `%AppData%\lich\lich.log`.
 
+Scoop installs the same two assets straight from the manifest in this
+repository, no bucket to add:
+
+```powershell
+scoop install https://raw.githubusercontent.com/omartelo/lich/main/build/windows/scoop/lich.json
+```
+
+It puts `lich.exe` in the app directory with the window beside it as `shell\`,
+keeps `lich` on PATH and adds a Start Menu entry; `scoop update lich` re-reads
+the manifest from that URL. The workspace stays in `%AppData%\lich`, so
+`scoop uninstall lich` leaves your projects and sessions alone.
+
 The bare `lich-*-windows-amd64.exe` is also published for a portable,
 no-install run — same binary the installer ships. Unzip
 `lich-*-windows-amd64-shell.zip` beside it to get the window as `shell\`;

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ curl -fsSL https://raw.githubusercontent.com/omartelo/lich/main/install.sh | sh
 | --- | --- | --- |
 | **Linux** | `install.sh` above, or AUR [`lich-bin`](https://aur.archlinux.org/packages/lich-bin) (`yay -S lich-bin`) | `zenity` — the window ships in the package |
 | **macOS** *(experimental)* | `brew install --cask omartelo/tap/lich` | nothing on Apple Silicon — the window ships in the app; a Chromium-family browser in `/Applications` on Intel |
-| **Windows** *(experimental)* | installer from [Releases](https://github.com/omartelo/lich/releases) | nothing — the window ships in the installer |
+| **Windows** *(experimental)* | installer from [Releases](https://github.com/omartelo/lich/releases), or Scoop: `scoop install https://raw.githubusercontent.com/omartelo/lich/main/build/windows/scoop/lich.json` | nothing — the window ships with both |
 
 On an Intel Mac, Chrome, Chromium, Brave, Vivaldi and Edge all qualify;
 `--browser` or `LICH_BROWSER` pins one outright, on every platform. With none

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -86,7 +86,7 @@ curl -fsSL https://raw.githubusercontent.com/omartelo/lich/main/install.sh | sh
 | --- | --- | --- |
 | **Linux** | 上面的 `install.sh`，或 AUR 的 [`lich-bin`](https://aur.archlinux.org/packages/lich-bin)（`yay -S lich-bin`） | `zenity` —— 窗口随软件包一起附带 |
 | **macOS** *(实验性)* | `brew install --cask omartelo/tap/lich` | Apple Silicon 上无需任何东西 —— 窗口随应用一起附带；Intel 上需要 `/Applications` 里有一个 Chromium 系浏览器 |
-| **Windows** *(实验性)* | 从 [Releases](https://github.com/omartelo/lich/releases) 下载安装程序 | 无需任何东西 —— 窗口随安装程序一起附带 |
+| **Windows** *(实验性)* | 从 [Releases](https://github.com/omartelo/lich/releases) 下载安装程序，或使用 Scoop：`scoop install https://raw.githubusercontent.com/omartelo/lich/main/build/windows/scoop/lich.json` | 无需任何东西 —— 两种方式都自带窗口 |
 
 在 Intel Mac 上，Chromium、Chrome、Brave、Vivaldi 和 Edge 都算数；`--browser`
 或 `LICH_BROWSER` 可以直接指定一个，任何平台上都可以。这些一个都没有时，lich 会开在你确实

--- a/build/windows/scoop/lich.json
+++ b/build/windows/scoop/lich.json
@@ -1,0 +1,50 @@
+{
+    "##": [
+        "Scoop manifest for lich, installed straight from its raw URL on main:",
+        "  scoop install https://raw.githubusercontent.com/omartelo/lich/main/build/windows/scoop/lich.json",
+        "There is no bucket repository. `version` and `hash` are per-release bookkeeping: `scoop checkver -u`",
+        "(Scoop's bin/checkver.ps1) reads the checkver and autoupdate blocks below, resolves the tag from the",
+        "releases API, downloads the assets' checksums and writes both fields back into this file. Nothing in",
+        ".github/workflows/release.yml touches it.",
+        "Two assets, because the window is a separate binary: lich.exe alone is a backend that has to fall back",
+        "to a system browser. internal/chromium/shell.go looks for shell/lich-shell.exe beside the executable",
+        "first, and lich-<tag>-windows-amd64-shell.zip already carries shell/ at its root, so Scoop's default",
+        "extraction lands it exactly there. That is the layout build/windows/lich.iss installs too."
+    ],
+    "version": "0.45.0",
+    "description": "A personal harness for AI-assisted development",
+    "homepage": "https://github.com/omartelo/lich",
+    "license": "AGPL-3.0-only",
+    "url": [
+        "https://github.com/omartelo/lich/releases/download/v0.45.0/lich-v0.45.0-windows-amd64.exe#/lich.exe",
+        "https://github.com/omartelo/lich/releases/download/v0.45.0/lich-v0.45.0-windows-amd64-shell.zip"
+    ],
+    "bin": "lich.exe",
+    "shortcuts": [
+        [
+            "lich.exe",
+            "lich"
+        ]
+    ],
+    "notes": [
+        "lich keeps its workspace in %APPDATA%\\lich, so it survives an uninstall; `scoop uninstall lich` leaves it.",
+        "The binaries are unsigned, so SmartScreen warns on first launch. Update with `scoop update lich`."
+    ],
+    "checkver": {
+        "url": "https://api.github.com/repos/omartelo/lich/releases/latest",
+        "jsonpath": "$.tag_name",
+        "regex": "^v([\\d.]+)$"
+    },
+    "autoupdate": {
+        "url": [
+            "https://github.com/omartelo/lich/releases/download/v$version/lich-v$version-windows-amd64.exe#/lich.exe",
+            "https://github.com/omartelo/lich/releases/download/v$version/lich-v$version-windows-amd64-shell.zip"
+        ],
+        "hash": [
+            {
+                "url": "$baseurl/checksums.txt",
+                "regex": "$sha256\\s+$basename"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Windows was the one platform with no package manager path. Linux has the AUR and nfpm, macOS has the homebrew cask; Windows had a download link and nothing else. This adds a Scoop manifest under `build/windows/scoop/`, mirroring how `build/linux/aur/` and `build/darwin/homebrew/` are laid out.

```powershell
scoop install https://raw.githubusercontent.com/omartelo/lich/main/build/windows/scoop/lich.json
```

## The shape, and why

The window is a separate binary, so `lich.exe` alone is a backend that falls back to whatever Chromium-family browser is on the machine. The manifest therefore takes two assets and reproduces the installer's layout:

| asset | where it lands |
| --- | --- |
| `lich-<tag>-windows-amd64.exe` | `$dir\lich.exe`, renamed through Scoop's `#/` URL fragment |
| `lich-<tag>-windows-amd64-shell.zip` | `$dir\shell\...`, Scoop's default extraction |

The zip is built by `7z a "lich-${tag}-windows-amd64-shell.zip" shell` in the release job, so it already carries `shell/` at its root. With no `extract_dir`, Scoop preserves that directory, which puts `shell\lich-shell.exe` beside `lich.exe`: the first entry `shellPaths()` returns in `internal/chromium/shell.go`, and the same layout `[Files]` in `build/windows/lich.iss` installs. No `extract_dir` or `extract_to` is needed, and a plain `.exe` is left unextracted because the manifest has no `innosetup` property.

`bin` keeps `lich` on PATH; `shortcuts` adds the Start Menu entry. The workspace lives in `%AppData%\lich`, outside the app directory, so nothing needs `persist` and an uninstall leaves projects and sessions alone.

`checkver` reads `$.tag_name` off `https://api.github.com/repos/omartelo/lich/releases/latest` and strips the `v`. `autoupdate` resolves both hashes out of the release's own `checksums.txt` with `{"url": "$baseurl/checksums.txt", "regex": "$sha256\\s+$basename"}`, one entry reused for both URLs, which is Scoop's documented behaviour when there are fewer hash templates than URLs.

## What I verified, from Linux

- The manifest parses, and validates clean against Scoop's own `schema.json` (0 errors, `jsonschema` Draft 7). `hash` is not a required property.
- Every URL shape was checked against the names the `windows` and `release` jobs in `.github/workflows/release.yml` actually produce, read from the workflow rather than assumed.
- The `autoupdate` hash regex was run against the real published `checksums.txt` from v0.45.0, with Scoop's substitutions applied the way `lib/autoupdate.ps1` applies them (`$sha256` template expanded, `$basename` regex-escaped). It resolves `lich-v0.45.0-windows-amd64.exe` to `8ea956f8...`, matching the published line, and does not cross-match the `-setup.exe` line.
- The `checkver` regex resolves `v0.45.0` to `0.45.0`.
- The zip layout claim was reproduced locally: `7z a t.zip shell` stores entries as `shell/lich-shell.exe`, not flattened.
- `go build ./...` and `gofmt -l .` clean. No Go, frontend or workflow file is touched, so the rest of the gate has nothing to say about this change.

## What is unproven

**No Windows machine ran `scoop install` here.** There is no Windows hardware on this box, so the end-to-end install, the shim on PATH, the Start Menu shortcut and the window actually opening from a Scoop-installed tree are all unverified in practice. What is verified is the layout the manifest produces and that it matches what the binary looks for.

Two more, both worth knowing before merging:

1. **No published release carries `lich-<tag>-windows-amd64-shell.zip` yet.** The Windows window is in `CHANGELOG.md`'s `[Unreleased]` section: v0.45.0's installer ships no `shell\` and the release has no shell zip. The manifest is seeded at `0.45.0` for structure only and its second URL 404s until the next tag. It goes live with the same release as the CHANGELOG entry it ships beside.
2. **Version and hash are per-release bookkeeping, and this PR does not automate them.** `scoop checkver -u` reads the `checkver` and `autoupdate` blocks and writes both fields back in one command, and I left the seed hashless rather than commit a hash I could not compute. **A release job should render this file** the way the AUR and homebrew jobs render their templates, after `release` publishes `checksums.txt`. It is a commit back to `main` rather than a push to a bucket, so I left it out of this PR on purpose; without it the manifest stays at whatever version was last bumped by hand.

Also deliberately out: the Start Menu shortcut carries no AppUserModelID, which Scoop's `shortcuts` cannot set, so a Scoop install does not get the taskbar grouping the installer's shortcut gets.

## The non-feature: winget

winget is out of scope on purpose. It is not a file in this repository: every release needs a pull request into `microsoft/winget-pkgs`, which is a maintenance promise rather than a manifest. Scoop was the cheap half of the same goal.
