### PR TITLE
feat: prove the sandbox in `lich doctor` instead of trusting a lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`lich doctor` now proves the sandbox instead of assuming it.** A new
+  `sandbox` line opens one confined child and reads two files through it: one in
+  the checkout, which has to come back, and one in the private home the sandbox
+  replaces, which must not. Both halves are checked, so a backend that starts
+  and confines nothing is caught alongside one the kernel refuses. On Ubuntu and
+  Debian, where an AppArmor policy denies unprivileged user namespaces,
+  bubblewrap is installed and every confined session dies on its error; that now
+  shows up as a warning naming bubblewrap's own reason instead of as a card with
+  no session in it. The check is bounded at two seconds, warns rather than fails
+  (lich starts either way), and is skipped on Windows, which has no sandbox
+  backend. `lich rage` reports the same line.
 - **Sessions no longer pause behind a locked screen.** While an agent is
   working, lich holds the same idle-sleep assertion a media player holds
   while it plays, so a machine left locked keeps running its sessions and

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -662,7 +662,11 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   loopback: a method that reads a host path it was *handed* would copy anything into reach of the sandbox,
   which is why the attach flow opens the picker inside the backend (`drop.Attach`) instead of taking a path. The private home is writable and vanishes with the session, so a dotfile an agent writes is gone
   next spawn with nothing saying so. On Ubuntu and Debian the kernel may refuse the user namespace outright
-  (an AppArmor policy), which surfaces as bubblewrap's own error in the card and no session. `~/.ssh` is not
+  (an AppArmor policy), which surfaces as bubblewrap's own error in the card and no session: `Available` is
+  `exec.LookPath` and stays that way, because only a spawn can ask the kernel, so nothing before the card
+  can refuse the rung. What answers ahead of time is `lich doctor`, whose `sandbox` check opens one confined
+  child and reads a file in the checkout and a file in the home the backend replaces: it is a diagnosis, not
+  a gate, and a machine where the probe fails still lets the user turn the sandbox on and watch it fail. `~/.ssh` is not
   mounted at all: a push over ssh from inside a confined session fails unless the project hands over the ssh
   agent (below), and lich's own PR flows run outside the sandbox and are unaffected either way. The distribution's `/etc/ssh/ssh_config.d` drop-ins are replaced by an empty
   directory, because inside the namespace they belong to nobody and ssh refuses to read a config file it

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -551,7 +551,7 @@ collects say where the process is stuck.
 
 | Entry | What it holds |
 |-------|---------------|
-| `report.md` | Version and build, platform, instance state, browser, providers on PATH, plugin state per provider, and the config directory one level deep. |
+| `report.md` | Version and build, platform, instance state, browser, whether a confined session would actually be confined here, providers on PATH, plugin state per provider, and the config directory one level deep. |
 | `env.txt` | Every `LICH_*` variable plus a fixed allowlist (`SHELL`, `PATH`, `EDITOR`, the desktop ones). Anything named like a token, key, secret or password is `<SET>` / `<UNSET>`, never a value. |
 | `logs/` | `lich.log` and the rotated `lich.log.old`, each carrying at most its last 4 MiB. |
 | `goroutines.txt` | Every stack in the running instance, blocked ones included — only when one is running. A lich that holds its port but will not answer within 5s leaves that sentence here instead, which is the finding. |
@@ -575,7 +575,8 @@ lich v0.25.0 — linux/amd64
   skip  store        <1ms  held by the running lich (pid 4242)
   ok    browser       2ms  /usr/bin/chromium
   ok    providers     3ms  4 of 8 on PATH: claude, codex, opencode, crush
-        total         6ms
+  ok    sandbox      11ms  bubblewrap confines a session here
+        total        17ms
 
 lich starts here — nothing is in the way.
 ```
@@ -590,6 +591,7 @@ The checks are in boot order, and each carries its own verdict:
 | `store` | The workspace database will not open or migrate. Skipped while an instance is running — a second process migrating the store is not a price a diagnosis may charge. | It will not close cleanly. |
 | `browser` | No Chromium-family browser resolves. lich would run and show nothing. | — |
 | `providers` | — | None on PATH: the window opens, but no session can spawn. |
+| `sandbox` | — | The backend will not start (an AppArmor policy denying user namespaces, say), so a session opened with the sandbox on will not start either; or it starts and confines nothing, so a session marked confined runs on the machine. Skipped where the platform has no backend at all. |
 
 A `fail` exits 1 and a clean run exits 0, which is the automation surface here —
 there is no `--json`. It needs no TTY, no running instance and no network.
@@ -598,6 +600,17 @@ Two things it does on purpose, because a launch does them too: it creates
 `<config-dir>/lich` and an empty log file if they are missing, and — only when
 no instance is running — it opens the workspace database, creating it on a
 first run.
+
+The `sandbox` check is the one that cannot be answered by a lookup, so it opens
+a confined child and reads two files through it: one in the checkout, which
+must come back, and one in the private home the backend replaces, which must
+not. Both halves are needed. A backend whose ruleset silently applied nothing
+would start perfectly and confine nothing, and on Ubuntu and Debian an AppArmor
+policy denies unprivileged user namespaces, so bubblewrap is installed, resolves
+on `PATH`, and every confined session dies on its error. The spawn is bounded at
+two seconds and killed, so a kernel that blocks the request cannot hang the
+report. It never turns a session confined or unconfined: `internal/sandbox`
+answers that at spawn time, and this only says what the answer would be worth.
 
 ## Registration
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -22,6 +22,7 @@ import (
 	"github.com/omartelo/lich/internal/chromium"
 	"github.com/omartelo/lich/internal/logging"
 	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/sandbox"
 	"github.com/omartelo/lich/internal/singleton"
 	"github.com/omartelo/lich/internal/store"
 )
@@ -71,6 +72,7 @@ type Doctor struct {
 	browser  func() (string, error)
 	detect   func() []providers.Detected
 	store    func() (io.Closer, error)
+	sandbox  func() (string, error)
 	lookPath func(string) (string, error)
 	getenv   func(string) string
 }
@@ -86,6 +88,7 @@ func New(configDir string, getenv func(string) string) *Doctor {
 		browser:   Browser,
 		detect:    Providers,
 		store:     func() (io.Closer, error) { return store.New() },
+		sandbox:   sandbox.Probe,
 		lookPath:  exec.LookPath,
 		getenv:    getenv,
 	}
@@ -108,6 +111,7 @@ func (d *Doctor) Run() []Check {
 		{"store", func() (Status, string) { return d.checkStore(info, running) }},
 		{"browser", d.checkBrowser},
 		{"providers", d.checkProviders},
+		{"sandbox", d.checkSandbox},
 		{"git", func() (Status, string) { return d.checkTool("git", gitWithout) }},
 		{"gh", func() (Status, string) { return d.checkTool("gh", ghWithout) }},
 	}
@@ -217,6 +221,29 @@ func (d *Doctor) checkProviders() (Status, string) {
 	}
 	return OK, fmt.Sprintf("%d of %d on PATH: %s",
 		len(installed), len(found), strings.Join(installed, ", "))
+}
+
+// checkSandbox proves the sandbox instead of trusting the launcher being on
+// PATH, which is all a spawn-time Available can afford to ask. It opens one
+// confined child and reads two files through it: one in the checkout, which
+// proves the child ran, and one in the home the backend replaces, which must
+// not come back.
+//
+// Never a Fail: lich starts and every unconfined session spawns. What breaks is
+// a project with the sandbox turned on, where the backend's own error arrives
+// in a card that then has no session in it, which is the failure worth naming
+// before it happens rather than after.
+func (d *Doctor) checkSandbox() (Status, string) {
+	backend, err := d.sandbox()
+	switch {
+	case backend == "":
+		return Skip, "no sandbox backend on this platform, so sessions run unconfined"
+	case err != nil:
+		// The probe's own sentence, whole: the two ways to fail cost different
+		// things, and only it knows which one this was.
+		return Warn, err.Error()
+	}
+	return OK, backend + " confines a session here"
 }
 
 // What a machine loses with each version control tool missing. The same two

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -32,6 +32,7 @@ func healthy(t *testing.T) *Doctor {
 		}
 	}
 	d.store = func() (io.Closer, error) { return io.NopCloser(nil), nil }
+	d.sandbox = func() (string, error) { return "bubblewrap", nil }
 	d.lookPath = func(name string) (string, error) { return "/usr/bin/" + name, nil }
 	return d
 }
@@ -51,7 +52,7 @@ func TestAHealthyMachineWalksTheWholeBoot(t *testing.T) {
 	for _, c := range checks {
 		names = append(names, c.Name)
 	}
-	want := []string{"home", "log", "listener", "store", "browser", "providers", "git", "gh"}
+	want := []string{"home", "log", "listener", "store", "browser", "providers", "sandbox", "git", "gh"}
 	if strings.Join(names, ",") != strings.Join(want, ",") {
 		t.Errorf("checks ran as %v, want the boot order %v", names, want)
 	}
@@ -327,5 +328,65 @@ func TestThePortComesFromTheEnvironmentTheLaunchWouldRead(t *testing.T) {
 	}
 	if nonsense := New(t.TempDir(), func(string) string { return "not-a-port" }); nonsense.port != singleton.DefaultPort {
 		t.Errorf("port = %d, want the default when the override is not a number", nonsense.port)
+	}
+}
+
+// The sandbox check is the one that cannot be answered by a lookup: bubblewrap
+// is installed on every Ubuntu and Debian machine whose kernel then refuses the
+// namespace, and a session opened with the sandbox on dies on that error. It
+// warns rather than fails, because lich itself starts and every unconfined
+// session spawns.
+func TestASandboxThatConfinesNothingWarnsWithoutStoppingTheLaunch(t *testing.T) {
+	// The probe's own sentence, whole: a backend that will not start and one
+	// that starts and confines nothing cost different things, and the check may
+	// not flatten them into one consequence of its own.
+	const reason = "bwrap: Creating new namespace failed: Operation not permitted, " +
+		"so a session opened with the sandbox on will not start"
+	d := healthy(t)
+	d.sandbox = func() (string, error) { return "bubblewrap", errors.New(reason) }
+
+	checks := d.Run()
+	got := statuses(checks)["sandbox"]
+
+	if got.Status != Warn {
+		t.Errorf("sandbox = %s (%s), want warn", got.Status, got.Detail)
+	}
+	if got.Detail != reason {
+		t.Errorf("detail = %q, want the probe's reason unchanged", got.Detail)
+	}
+	if Failed(checks) {
+		t.Error("a sandbox that will not start is reported as launch-stopping")
+	}
+}
+
+// Windows has no backend to probe, and a platform that never offered the
+// feature has not failed at it: the check is skipped and says so, the way the
+// store is when a running instance holds it.
+func TestAPlatformWithNoBackendSkipsTheSandboxCheck(t *testing.T) {
+	d := healthy(t)
+	d.sandbox = func() (string, error) { return "", nil }
+
+	checks := d.Run()
+	got := statuses(checks)["sandbox"]
+
+	if got.Status != Skip {
+		t.Errorf("sandbox = %s (%s), want skip", got.Status, got.Detail)
+	}
+	if !strings.Contains(got.Detail, "unconfined") {
+		t.Errorf("detail does not say what a session gets instead: %q", got.Detail)
+	}
+	if Failed(checks) {
+		t.Error("a platform with no sandbox backend is reported as launch-stopping")
+	}
+}
+
+// A machine that confines names the backend it confined with: a confined
+// session behaves differently on each, and "yes" alone sends the reader to read
+// the source to find out which.
+func TestAWorkingSandboxNamesItsBackend(t *testing.T) {
+	got := statuses(healthy(t).Run())["sandbox"]
+
+	if got.Status != OK || !strings.Contains(got.Detail, "bubblewrap") {
+		t.Errorf("sandbox = %s (%s), want ok naming the backend", got.Status, got.Detail)
 	}
 }

--- a/internal/rage/rage.go
+++ b/internal/rage/rage.go
@@ -25,6 +25,7 @@ import (
 	"github.com/omartelo/lich/internal/doctor"
 	"github.com/omartelo/lich/internal/logging"
 	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/sandbox"
 	"github.com/omartelo/lich/internal/singleton"
 )
 
@@ -49,6 +50,11 @@ type Report struct {
 	ConfigDir string
 	LogPath   string
 	Browser   string
+	// Sandbox is what a confined session would actually get on this machine,
+	// proved rather than looked up: a backend installed and refused by the
+	// kernel is a whole class of report where the session never opened and the
+	// log holds only the launcher's error.
+	Sandbox   string
 	Providers []providers.Detected
 	Plugin    []agentplugin.Status
 	Entries   []Entry
@@ -63,9 +69,9 @@ type Entry struct {
 	Dir  bool
 }
 
-// Collector gathers a Report. The five probes are fields because each one
-// reaches the machine — PATH, the provider CLIs, the network, the running
-// instance — and a test must answer for all of them.
+// Collector gathers a Report. The six probes are fields because each one
+// reaches the machine (PATH, the provider CLIs, a confined spawn, the network,
+// the running instance), and a test must answer for all of them.
 type Collector struct {
 	configDir string
 	version   string
@@ -73,6 +79,7 @@ type Collector struct {
 
 	browser func() (string, error)
 	detect  func() []providers.Detected
+	confine func() (string, error)
 	plugin  func() []agentplugin.Status
 	probe   func() (*singleton.Info, bool)
 	dump    func(port int, token string) ([]byte, error)
@@ -88,10 +95,25 @@ func New(configDir, version string, environ []string) *Collector {
 		environ:   environ,
 		browser:   doctor.Browser,
 		detect:    doctor.Providers,
+		confine:   sandbox.Probe,
 		plugin:    func() []agentplugin.Status { return agentplugin.New(pathBins{}).Status() },
 		probe:     func() (*singleton.Info, bool) { return doctor.Instance(configDir) },
 		dump:      fetchGoroutines,
 	}
+}
+
+// sandboxLine renders the probe's answer as the one line report.md carries. The
+// failure is the fact worth reporting: a backend that starts and confines
+// nothing, or one the kernel refuses, is why a session in that report has no
+// card behind it.
+func sandboxLine(backend string, err error) string {
+	switch {
+	case backend == "":
+		return "no backend on this platform"
+	case err != nil:
+		return err.Error()
+	}
+	return backend + " (confined)"
 }
 
 // dumpTimeout bounds the goroutine fetch. A lich that stopped answering is the
@@ -231,6 +253,7 @@ func (c *Collector) collect() (Report, *singleton.Info) {
 	if err != nil {
 		report.Browser = err.Error()
 	}
+	report.Sandbox = sandboxLine(c.confine())
 
 	info, alive := c.probe()
 	switch {

--- a/internal/rage/rage_test.go
+++ b/internal/rage/rage_test.go
@@ -32,6 +32,7 @@ func collector(t *testing.T, configDir string, info *singleton.Info, alive bool)
 	c.detect = func() []providers.Detected {
 		return []providers.Detected{{ID: "claude", Name: "Claude Code", Installed: true, Path: "/usr/bin/claude"}}
 	}
+	c.confine = func() (string, error) { return "bubblewrap", nil }
 	c.plugin = func() []agentplugin.Status {
 		return []agentplugin.Status{{Provider: "claude", Name: "Claude Code", Available: true, Installed: true, InstalledVersion: "0.2.0"}}
 	}

--- a/internal/rage/report.go
+++ b/internal/rage/report.go
@@ -50,6 +50,7 @@ func render(r Report) string {
 	row(&b, "config dir", r.ConfigDir)
 	row(&b, "log", logLine(r.LogPath))
 	row(&b, "browser", r.Browser)
+	row(&b, "sandbox", r.Sandbox)
 
 	b.WriteString("\n## Providers\n\n")
 	b.WriteString("| Provider | On PATH | Resolved to |\n|---|---|---|\n")

--- a/internal/rage/report_test.go
+++ b/internal/rage/report_test.go
@@ -2,6 +2,7 @@ package rage
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -142,5 +143,32 @@ func TestNewProbesTheConfigDirItWasGiven(t *testing.T) {
 	}
 	if len(c.detect()) == 0 {
 		t.Error("provider detection returned no rows at all — every known provider should be listed")
+	}
+}
+
+// The sandbox row carries the failure, not a yes or no: a bug report where the
+// session never opened is answered by the backend's own sentence, and a report
+// saying only "no" sends the maintainer asking for it.
+func TestTheSandboxRowCarriesWhyItDoesNotConfine(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		backend string
+		err     error
+		want    string
+	}{
+		{"confined", "bubblewrap", nil, "bubblewrap (confined)"},
+		{"no backend", "", nil, "no backend on this platform"},
+		{
+			"the kernel refused",
+			"bubblewrap",
+			errors.New("bwrap: Creating new namespace failed: Operation not permitted"),
+			"bwrap: Creating new namespace failed: Operation not permitted",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sandboxLine(tc.backend, tc.err); got != tc.want {
+				t.Errorf("sandboxLine = %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/sandbox/probe.go
+++ b/internal/sandbox/probe.go
@@ -1,0 +1,179 @@
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// probeTimeout bounds the confined spawn. A kernel that refuses the namespace
+// answers at once, but a machine where the request blocks must not take the
+// diagnosis with it: `lich doctor` prints how long every check took, so no
+// check of its own may be the one that never returns.
+const probeTimeout = 2 * time.Second
+
+// The markers the probe reads back from inside the sandbox. They are written to
+// two files the backend is supposed to treat differently, and the answer is
+// which of them came out:
+//
+//   - probeReachable sits in the checkout, which every backend keeps readable.
+//     It coming back proves the confined child ran at all.
+//   - probeUnreachable sits in the home, which every backend takes away. It
+//     coming back proves the backend started and confined nothing.
+//
+// Asking for both is what makes the answer honest. A probe that only checked
+// whether the launcher starts would pass on a machine whose ruleset silently
+// applies nothing, which is a session running unconfined under a shield saying
+// otherwise.
+const (
+	probeReachable   = "lich-probe-checkout"
+	probeUnreachable = "lich-probe-home"
+)
+
+// Probe answers whether a confined session on this machine would actually be
+// confined, by opening one and looking. It returns the backend's name and why
+// it confines nothing, or a nil error when it does; an empty name means this
+// platform has no backend at all and there is nothing to report.
+//
+// Available cannot answer this and does not try: it resolves the launcher and
+// stops, because only a spawn can ask the kernel. On Ubuntu and Debian an
+// AppArmor policy denies unprivileged user namespaces, so bubblewrap is
+// installed, Available says yes, and every confined session dies on bwrap's own
+// error. This is the diagnosis of that machine, not a second gate in front of
+// it: nothing here decides whether a session is confined.
+func Probe() (string, error) {
+	if !Available() {
+		return "", nil
+	}
+	// cat is what reads the two markers, one process and no shell. It comes
+	// from the host's PATH and is bound at the same path inside, which is how
+	// the session's own binaries get there at all.
+	reader, err := exec.LookPath("cat")
+	if err != nil {
+		return backendName, fmt.Errorf("cat is not on PATH, so nothing can be read from inside a sandbox: %w", err)
+	}
+	layout, err := layOutProbe()
+	if err != nil {
+		return backendName, err
+	}
+	defer func() { _ = os.RemoveAll(layout.dir) }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), probeTimeout)
+	defer cancel()
+	// The spec is a real one, so what is probed is the sandbox a session gets
+	// rather than a second ruleset written to pass.
+	bin, args := Wrap(layout.spec, reader, []string{layout.reachable, layout.unreachable})
+	cmd := exec.CommandContext(ctx, bin, args...)
+	// The deadline kills the launcher, and WaitDelay bounds the wait for what it
+	// left behind: a namespace request that hangs must not outlive the check.
+	cmd.WaitDelay = probeTimeout
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &stdout, &stderr
+	runErr := cmd.Run()
+	return backendName, verdict(stdout.String(), stderr.String(), ctx.Err(), runErr)
+}
+
+// probeLayout is one probe run laid out on disk: the spec that decides what the
+// sandbox may see, and the two files read through it.
+type probeLayout struct {
+	spec        Spec
+	reachable   string
+	unreachable string
+	// dir holds both and is the caller's to remove.
+	dir string
+}
+
+// layOutProbe writes the markers and the spec that separates them. Split from
+// Probe because the whole answer rests on which file lands where, and that half
+// has a test on any machine: a layout with both markers on the same side of the
+// sandbox would report every machine broken, or every machine fine, and the
+// spawn would not notice either way.
+func layOutProbe() (probeLayout, error) {
+	dir, err := os.MkdirTemp("", "lich-sandbox-probe")
+	if err != nil {
+		return probeLayout{}, fmt.Errorf("the probe has nowhere to write its files: %w", err)
+	}
+	// macOS hands out a temporary directory behind /var, a symlink to
+	// /private/var, and the seatbelt profile matches the resolved path: an
+	// unresolved one is denied by no rule and read straight back, which would
+	// read as a backend confining nothing.
+	if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+		dir = resolved
+	}
+
+	layout := probeLayout{
+		spec:        Spec{Home: filepath.Join(dir, "home"), Cwd: filepath.Join(dir, "cwd")},
+		reachable:   filepath.Join(dir, "cwd", "checkout-file"),
+		unreachable: filepath.Join(dir, "home", "home-file"),
+		dir:         dir,
+	}
+	for path, marker := range map[string]string{
+		layout.reachable:   probeReachable,
+		layout.unreachable: probeUnreachable,
+	} {
+		if err := plant(path, marker); err != nil {
+			_ = os.RemoveAll(dir)
+			return probeLayout{}, fmt.Errorf("the probe could not be laid out: %w", err)
+		}
+	}
+	return layout, nil
+}
+
+// plant writes one marker file and the directory holding it.
+func plant(path, marker string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(marker), 0o600)
+}
+
+// verdict reads what came back, and carries its own consequence: the two ways
+// to fail cost different things, and a caller appending one sentence to both
+// would tell half of them the wrong thing. It is a pure function so the
+// decision has a test on any machine, including one with no backend to run the
+// spawn half on.
+//
+// Order is the contract: a sandbox that leaked the home also handed over the
+// checkout, so the leak is answered first and a probe is only believed confined
+// when it proved it ran.
+func verdict(stdout, stderr string, timeout, runErr error) error {
+	if strings.Contains(stdout, probeUnreachable) {
+		// This one still opens a session. It is the worse failure of the two:
+		// the card draws its shield and the agent is on the machine.
+		return fmt.Errorf("%s starts and confines nothing: a file under the home it replaces was read from inside the sandbox, so a session marked confined would run on the machine itself", backendName)
+	}
+	if strings.Contains(stdout, probeReachable) {
+		return nil
+	}
+	return fmt.Errorf("%s, so a session opened with the sandbox on will not start", refusal(stderr, timeout, runErr))
+}
+
+// refusal is why the confined child never ran, in the order the answers are
+// worth having: the deadline first, because a killed spawn leaves whatever it
+// had written, then the backend's own complaint, which is the sentence the
+// reader can act on. bubblewrap names the namespace the kernel refused, and a
+// distribution denying them is the whole reason this check exists.
+func refusal(stderr string, timeout, runErr error) string {
+	switch {
+	case timeout != nil:
+		return fmt.Sprintf("%s did not answer within %s", backendName, probeTimeout)
+	case firstLine(stderr) != "":
+		return firstLine(stderr)
+	case runErr != nil:
+		return fmt.Sprintf("%s could not open a confined session: %v", backendName, runErr)
+	}
+	return backendName + " opened a session that read nothing back"
+}
+
+// firstLine is the head of a backend's stderr, trimmed. What follows it is a
+// second failure caused by the first, and a diagnosis reads better ending at
+// the cause.
+func firstLine(s string) string {
+	line, _, _ := strings.Cut(strings.TrimSpace(s), "\n")
+	return strings.TrimSpace(line)
+}

--- a/internal/sandbox/sandbox_test.go
+++ b/internal/sandbox/sandbox_test.go
@@ -1,10 +1,14 @@
 package sandbox
 
 import (
+	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/omartelo/lich/internal/providers"
 )
@@ -229,5 +233,177 @@ func TestBackendAgreesWithAvailable(t *testing.T) {
 	}
 	if !Available() && name != "" {
 		t.Errorf("a machine that cannot confine named %q", name)
+	}
+}
+
+// The probe answers the question Available cannot, so the one thing it may
+// never do is call a machine confined without proof from inside it. Each case
+// below is one shape a spawn comes back in.
+func TestTheProbeBelievesConfinementOnlyWhenItWasProved(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		stdout, stderr string
+		timeout        error
+		runErr         error
+		want           string
+	}{
+		{
+			name:   "the checkout was read and the home was not",
+			stdout: probeReachable,
+			want:   "",
+		},
+		{
+			// The dangerous machine: the launcher runs, the ruleset applies
+			// nothing, and every session it opens is unconfined behind a shield.
+			name:   "the home was read from inside",
+			stdout: probeReachable + "\n" + probeUnreachable,
+			want:   "confines nothing",
+		},
+		{
+			name:   "the backend refused to start",
+			stderr: "bwrap: Creating new namespace failed: Operation not permitted\nbwrap: gave up",
+			runErr: errors.New("exit status 1"),
+			want:   "Creating new namespace failed: Operation not permitted, so a session opened with the sandbox on will not start",
+		},
+		{
+			name:    "the namespace request never came back",
+			timeout: context.DeadlineExceeded,
+			runErr:  errors.New("signal: killed"),
+			want:    "did not answer within",
+		},
+		{
+			// No markers, no complaint and no error: nothing was proved, so
+			// nothing is claimed.
+			name: "the spawn said nothing at all",
+			want: "read nothing back",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := verdict(tc.stdout, tc.stderr, tc.timeout, tc.runErr)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("verdict = %v, want a confined machine", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("verdict called the machine confined, want %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("verdict = %q, want it to carry %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// A backend that leaked the home also handed over the checkout, so the two
+// markers arrive together and the leak has to win: reporting "confined"
+// because the proof marker was there is exactly the false pass this exists to
+// catch.
+func TestALeakedHomeBeatsTheProofItRan(t *testing.T) {
+	err := verdict(probeUnreachable, "", nil, nil)
+	if err == nil || !strings.Contains(err.Error(), "confines nothing") {
+		t.Errorf("verdict = %v, want the leak reported", err)
+	}
+}
+
+// firstLine is what a reader is handed, so it ends at the cause: bubblewrap
+// follows its complaint with the consequences of it.
+func TestOnlyTheFirstStderrLineIsReported(t *testing.T) {
+	if got := firstLine("  bwrap: no permitted namespace \n and then this\n"); got != "bwrap: no permitted namespace" {
+		t.Errorf("firstLine = %q", got)
+	}
+	if got := firstLine("  \n\n"); got != "" {
+		t.Errorf("firstLine = %q, want empty for a backend that said nothing", got)
+	}
+}
+
+// Probe never claims a backend this platform does not have: unsupported.go
+// answers Available false, and an empty name is what the caller reports as a
+// skip rather than as a machine that cannot confine.
+func TestProbeNamesNoBackendWhereThereIsNone(t *testing.T) {
+	if Available() {
+		t.Skip("this machine has a backend, so the empty answer cannot be reached")
+	}
+	name, err := Probe()
+	if name != "" || err != nil {
+		t.Errorf("Probe = %q, %v; want no backend and nothing to report", name, err)
+	}
+}
+
+// The layout is the half of the probe that decides what its answer means: the
+// marker that must come back has to sit where every backend keeps a session
+// readable, and the marker that must not has to sit under the home every
+// backend takes away. Both on the same side and the probe answers the same
+// thing for every machine.
+func TestTheProbeLaysOneMarkerOnEachSideOfTheSandbox(t *testing.T) {
+	layout, err := layOutProbe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(layout.dir) })
+
+	if !strings.HasPrefix(layout.reachable, layout.spec.Cwd+string(filepath.Separator)) {
+		t.Errorf("the marker that proves the child ran is not in the checkout: %q", layout.reachable)
+	}
+	if !strings.HasPrefix(layout.unreachable, layout.spec.Home+string(filepath.Separator)) {
+		t.Errorf("the marker that must be hidden is not under the home: %q", layout.unreachable)
+	}
+	if layout.spec.Home == layout.spec.Cwd {
+		t.Error("the home and the checkout are the same directory, so no backend can tell them apart")
+	}
+	for path, want := range map[string]string{
+		layout.reachable:   probeReachable,
+		layout.unreachable: probeUnreachable,
+	} {
+		got, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("%s was not written: %v", path, err)
+		}
+		if string(got) != want {
+			t.Errorf("%s holds %q, want %q", path, got, want)
+		}
+	}
+	// Two markers, never one: a probe reading the same string on both sides
+	// cannot tell which of them came back.
+	if probeReachable == probeUnreachable {
+		t.Error("the two markers are the same string")
+	}
+}
+
+// The probe cleans up after itself. It runs on every `lich doctor`, and a
+// diagnosis that leaves a directory behind each time is a machine it made
+// slightly worse.
+func TestTheProbeLeavesNothingBehind(t *testing.T) {
+	layout, err := layOutProbe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(layout.dir); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(layout.dir); !os.IsNotExist(err) {
+		t.Errorf("the probe directory survived its own removal: %v", err)
+	}
+}
+
+// Probe reaches the machine, so what a test can pin is the shape of its answer
+// rather than this kernel's verdict on it: the backend it names is the one that
+// would confine a session, and the answer comes back inside its own bound.
+// Whether this machine confines is the machine's finding and the caller's to
+// report, never a reason to skip.
+func TestTheProbeAnswersForTheBackendItNamesWithinItsBound(t *testing.T) {
+	started := time.Now()
+	name, err := Probe()
+	took := time.Since(started)
+
+	if took > 2*probeTimeout {
+		t.Errorf("the probe took %s, past the %s it bounds itself to", took, probeTimeout)
+	}
+	if name != Backend() {
+		t.Errorf("the probe named %q, and the backend a session gets is %q", name, Backend())
+	}
+	if name == "" && err != nil {
+		t.Errorf("a platform with no backend reported a failure to confine: %v", err)
 	}
 }

--- a/internal/terminal/hookstate_test.go
+++ b/internal/terminal/hookstate_test.go
@@ -207,6 +207,14 @@ func TestInterruptedTurnReachesTheWindow(t *testing.T) {
 
 	postHook(t, svc, "s1", statusBusy)
 	sendInput(t, svc, "s1", []byte{esc})
+	// The keystroke is handled on the transport's own goroutine, so the write
+	// returning says only that the frame was sent. The hook below travels a
+	// second connection and is answered by a third goroutine: posting it here
+	// without waiting is a race the test would lose on a slow enough machine,
+	// and the contract is that the provider's report outranks the guess, never
+	// that the two cannot arrive at once.
+	waitFor(t, func() bool { return slices.Contains(rec.statesOf("s1"), statusInterrupted) },
+		"the interrupt raised at the PTY to reach the window")
 	postHook(t, svc, "s1", statusDone)
 
 	hub.Emit(probeReadyEvent, nil)


### PR DESCRIPTION
`internal/sandbox.Available()` is `exec.LookPath("bwrap")` and nothing else, deliberately: only a spawn can ask the kernel. On Ubuntu and Debian an AppArmor policy denies unprivileged user namespaces, so bubblewrap is installed, `Available` says yes, and a project with the sandbox on gets bwrap's own error and no session, with nothing before that saying so. `lich doctor` exists to answer "would lich start on this machine, and why not" and checked no sandbox at all.

Borrowed from the refact engine (`JegernOUTT/refact`, `crates/refact-sandbox`), which probes by running something the sandbox must deny and only believes the backend when it actually failed.

## What the probe does

`sandbox.Probe()` opens one confined child through the real `Wrap`, with a real `Spec`, and reads two marker files through it with a single `cat`:

- one under the checkout (`Spec.Cwd`), which every backend keeps readable. It coming back proves the child ran, so the kernel granted the namespace.
- one under the private home (`Spec.Home`), which every backend replaces or denies. It coming back proves the backend started and confined nothing.

Both halves are checked, and the leak wins over the proof: a sandbox that handed over the home also handed over the checkout, so reading "the proof marker was there" as a pass is exactly the false green this exists to catch. A probe that only checked whether the launcher starts would pass on a machine whose ruleset silently applied nothing, which is the worse of the two failures: the session opens, the card draws its shield, and the agent is on the machine.

The spawn is bounded at 2s with `exec.CommandContext` plus `WaitDelay`, so a kernel that blocks the namespace request cannot hang the report. The temp directory is removed on every path.

`Available()` is untouched. The probe is the diagnosis, never a gate: nothing here decides whether a session is confined, and a machine where it fails still lets the user turn the sandbox on and watch it fail.

## No new build tag

The probe is written against `Available` and `Wrap`, which is the seam that already selects bubblewrap on Linux, the seatbelt profile on macOS and nothing at all elsewhere. So Linux probes bwrap, darwin probes the profile it would really build, and `unsupported.go` answers `Available() == false`, which `Probe` turns into an empty backend name and the doctor reports as `skip`, not a failure. One wrinkle handled for macOS: the temp dir comes back behind `/var -> /private/var`, and the seatbelt profile matches the resolved path, so the layout runs `filepath.EvalSymlinks` first. Without it, macOS would report every machine as confining nothing.

## Measured on this machine (Linux, bwrap 0.11, CachyOS)

```
  ok    providers     <1ms  8 of 8 on PATH: claude, codex, antigravity, opencode, omp, crush, cursor, kiro
  ok    sandbox        8ms  bubblewrap confines a session here
```

Both failure modes were exercised end to end through the built binary, with a stub `bwrap` earlier on `PATH`:

```
  warn  sandbox        3ms  bwrap: Creating new namespace failed: Operation not permitted, so a session
                            opened with the sandbox on will not start
  warn  sandbox        3ms  bubblewrap starts and confines nothing: a file under the home it replaces was
                            read from inside the sandbox, so a session marked confined would run on the
                            machine itself
```

`warn`, never `fail`: lich starts and every unconfined session spawns. The consequence sentence lives in the probe rather than in the check, because the two failures cost different things and a caller appending one sentence to both would tell half of them the wrong thing.

## rage reports it too

Yes, and it is wired. `probes.go` exists so `lich doctor` and `lich rage` describe the same machine, and a bug report where a confined session never opened is answered by exactly this line: the log holds only the launcher's error, and "bubblewrap (confined)" versus "bwrap: Creating new namespace failed" is the difference between an actionable report and a round trip. Both call `sandbox.Probe` directly rather than through a fourth wrapper in `probes.go`, because unlike `Browser`, `Providers` and `Instance` this one needs no adaptation to be shared: what differs is only how each renders it (a `Check` for doctor, a table row for `report.md`).

## Tests

Doctor is tested by injecting the probes as fields, so the new one is a field like the rest and every case runs on a machine with no bwrap:

- a backend that confines nothing warns, carries the probe's own sentence unchanged, and does not stop a launch
- a platform with no backend skips and says a session runs unconfined
- a working sandbox names its backend
- the boot order test covers the new step's position

In `internal/sandbox`, the decision was split from the spawn so both halves have a test anywhere: `verdict` is pure and table-tested over the five shapes a spawn comes back in, and `layOutProbe` is asserted to put one marker on each side of the sandbox. A layout with both markers on the same side would answer the same thing for every machine, and the spawn would not notice. `Probe` itself is pinned only on the shape of its answer (it names the backend a session would get, and returns inside its own bound), never skipped on a machine that refuses to confine: that is the machine's finding, not the test's.

Package coverage: `internal/sandbox` 92.6% to 91.1%, `internal/doctor` 86.1%, `internal/rage` 92.0%.

## Docs

- `docs/ceilings.md`: the sandbox bullet now says why `Available` stays a lookup and that doctor is what answers ahead of time, and that it is a diagnosis rather than a gate.
- `docs/cli.md`: sample output, the checks table, how the probe works, and the `report.md` row for rage.
- `CHANGELOG.md` `[Unreleased]`, since a user running `lich doctor` sees a new line.

## Considered and dropped

- **A new build tag for the probe.** It would have been three files reproducing a seam that already exists. `Available` and `Wrap` answer per platform already, and probing through them means what is probed is the sandbox a session actually gets rather than a second ruleset written to pass.
- **Failing rather than warning.** `Fail` is defined here as "a launch stops here" and exits non-zero. lich starts fine without a sandbox, so this is the same class as `providers`.
- **A shell inside the sandbox.** One `cat` with two paths reads both markers and needs no `/bin/sh`, no quoting, and no second process.
- **An end-to-end test that skips when the kernel refuses.** It would go green on a broken layout for the same reason it goes green on a hardened kernel, which is the flake-hiding shape the invariants forbid.

## Gate

`gofmt -l` clean, `go vet ./...` clean, `go test ./...` and `go test -race ./...` green, and the cross-compile loop (`for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done`) clean, which is what catches an untagged `_test.go`. The frontend is untouched. `go build`/`go vet` needed the usual throwaway `frontend/dist` placeholder in a clean worktree; it is gitignored and was removed before committing.


## One unrelated flake, root-caused rather than re-run

The first CI run failed in `internal/terminal`, which this PR does not touch: `TestInterruptedTurnReachesTheWindow`, with the window told `[busy done interrupted]` instead of `[busy interrupted done]`.

The test asserted an ordering it never established, and the contract never promised it. `sendInput` writes a websocket frame and returns, so the keystroke is handled on the transport's own goroutine; the hook posted on the next line travels a second connection and is answered by a third. Nothing orders them, and a slow enough runner lets the hook win. What `noteInterrupt` promises is that a provider's own report outranks the guess made from keystrokes, never that the two cannot arrive at once.

The second commit makes the test wait for the interrupt to reach the window before posting the hook that overrides it. Every assertion is unchanged. Proved rather than re-run: with a 20ms sleep injected before the interrupt's `Emit`, which is the CI timing, the old test fails 5 out of 5 and the fixed one passes 20 out of 20. Without the sleep both pass 200 out of 200 locally, which is why the runner found it first.
