### PR TITLE
fix: size the small labels in the units the zoom control moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Zooming the app now grows every label with it.** A handful of small labels
+  were sized in absolute pixels rather than in the units the zoom control
+  moves, so they stayed put while the chrome around them grew: the sandbox
+  explanation lines, the plan usage numbers and quota path, the settings
+  search-result headings, and the inset of the segmented controls. At 150 per
+  cent they rendered at their original size beside text half again as large.
+
 - **Ctrl+Shift+T starts a session again in lich's own window.** Chromium runs
   its tab accelerators before the page is given the key, so in the bundled
   window the chord reopened a closed tab instead of opening a session, and

--- a/frontend/src/components/PlanQuota.tsx
+++ b/frontend/src/components/PlanQuota.tsx
@@ -44,7 +44,7 @@ function PlanDetails({ plan }: PlanQuotaProps) {
         </div>
       ))}
       {plan.account && (
-        <span className="break-all border-t border-border pt-2 font-mono text-[11px] text-muted-foreground">
+        <span className="break-all border-t border-border pt-2 font-mono text-[0.6875rem] text-muted-foreground">
           {plan.account}
         </span>
       )}

--- a/frontend/src/components/diff/ReviewPanel.tsx
+++ b/frontend/src/components/diff/ReviewPanel.tsx
@@ -270,7 +270,7 @@ function SourceRow({ source, onSource, endedAt }: SourceRowProps) {
         onValueChange={(next) => next[0] && onSource(next[0] as DiffSource)}
         spacing={1}
         aria-label="Which changes to show"
-        className="border border-border p-[3px]"
+        className="border border-border p-[0.1875rem]"
       >
         <ToggleGroupItem value="worktree" size="sm" className="h-6 px-2.5 text-xs">
           Working tree

--- a/frontend/src/components/settings/PlanUsageSetting.tsx
+++ b/frontend/src/components/settings/PlanUsageSetting.tsx
@@ -65,7 +65,10 @@ function PlanBody({ plan, now }: { plan: QuotaPlan; now: Date }) {
       {/* The plan doubles as the table's left header, which is what keeps it from
           floating above the rows as a line of its own. */}
       <div
-        className={cn(gaugeGrid, "text-[11px] uppercase tracking-wide text-muted-foreground/80")}
+        className={cn(
+          gaugeGrid,
+          "text-[0.6875rem] uppercase tracking-wide text-muted-foreground/80",
+        )}
       >
         <span className="truncate normal-case tracking-normal text-muted-foreground">
           {plan.plan}
@@ -80,7 +83,7 @@ function PlanBody({ plan, now }: { plan: QuotaPlan; now: Date }) {
       {/* The login this reading was taken against. Settings asks the machine-wide
           question, so this is lich's own — never a session's wrapper binary. */}
       {plan.account && (
-        <span className="break-all font-mono text-[11px] text-muted-foreground">
+        <span className="break-all font-mono text-[0.6875rem] text-muted-foreground">
           {plan.account}
         </span>
       )}

--- a/frontend/src/components/settings/ProviderBinSettings.tsx
+++ b/frontend/src/components/settings/ProviderBinSettings.tsx
@@ -117,7 +117,7 @@ export function ProviderBinSettings({
             onValueChange={(next) => next[0] && chooseLevel(next[0] as SkipLevel)}
             spacing={1}
             aria-label={`How far ${providerName} runs without asking`}
-            className="border border-border p-[3px]"
+            className="border border-border p-[0.1875rem]"
           >
             {SKIP_LEVELS.map((rung) => (
               <ToggleGroupItem key={rung.level} value={rung.level} size="sm">

--- a/frontend/src/components/settings/SandboxSettings.tsx
+++ b/frontend/src/components/settings/SandboxSettings.tsx
@@ -215,7 +215,7 @@ function Rung({
         onValueChange={(next) => next[0] && choose(next[0] as SandboxLevel)}
         spacing={1}
         aria-label={`Which ${providerName} sessions run confined`}
-        className="shrink-0 border border-border p-[3px]"
+        className="shrink-0 border border-border p-[0.1875rem]"
       >
         {RUNGS.map((rung) => (
           <ToggleGroupItem key={rung.level} value={rung.level} size="sm">
@@ -254,7 +254,7 @@ function StatusStrip({ backend }: { backend: string }) {
     <div className="flex items-center gap-2.5 rounded-md border border-border px-3 py-2.5 text-xs">
       <span
         aria-hidden
-        className={`size-[7px] shrink-0 rounded-full ${
+        className={`size-[0.4375rem] shrink-0 rounded-full ${
           backend ? "bg-emerald-600 dark:bg-emerald-400" : "bg-muted-foreground"
         }`}
       />
@@ -288,7 +288,9 @@ function Grant({
       <div className="min-w-0 flex-1">
         <div className="text-sm font-medium text-foreground">{title}</div>
         <p className="mt-0.5 max-w-prose text-xs text-muted-foreground">{description}</p>
-        <p className="mt-1 font-mono text-[11px] leading-relaxed text-muted-foreground">{detail}</p>
+        <p className="mt-1 font-mono text-[0.6875rem] leading-relaxed text-muted-foreground">
+          {detail}
+        </p>
       </div>
       <Switch checked={checked} onCheckedChange={onChange} aria-label={title} />
     </div>

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -244,7 +244,7 @@ export function Settings() {
         {searching ? (
           <>
             {hits.length > 0 && (
-              <p className="px-5 pb-1.5 font-mono text-[10.5px] uppercase tracking-wider text-muted-foreground">
+              <p className="px-5 pb-1.5 font-mono text-[0.65625rem] uppercase tracking-wider text-muted-foreground">
                 {hits.length} {hits.length === 1 ? "setting" : "settings"}
               </p>
             )}
@@ -265,7 +265,7 @@ export function Settings() {
                   {hitPath(hit, sectionLabel(hit.section)) !== hit.title && (
                     <span
                       className={cn(
-                        "font-mono text-[10.5px] tracking-wide text-muted-foreground",
+                        "font-mono text-[0.65625rem] tracking-wide text-muted-foreground",
                         index === cursor && "text-accent-foreground/75",
                       )}
                     >

--- a/frontend/src/components/ui/toggle.tsx
+++ b/frontend/src/components/ui/toggle.tsx
@@ -7,7 +7,7 @@ import { cn } from "@/lib/utils"
 // selection is a flat accent fill — no shadow, no ring, no border of its own.
 // The enclosure belongs to the track around the group, not to the options.
 const toggleVariants = cva(
-  "group/toggle inline-flex items-center justify-center gap-1 rounded-md text-sm font-medium whitespace-nowrap text-muted-foreground transition-[color,box-shadow] outline-none hover:bg-accent/50 hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-accent aria-pressed:text-accent-foreground dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+  "group/toggle inline-flex items-center justify-center gap-1 rounded-md text-sm font-medium whitespace-nowrap text-muted-foreground transition-[color,box-shadow] outline-none hover:bg-accent/50 hover:text-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 aria-pressed:bg-accent aria-pressed:text-accent-foreground dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {


### PR DESCRIPTION
## What

A token census of the rendered UI, driven over CDP against the real app in both
themes, turned up one defect worth a diff: eleven declarations sized in absolute
pixels in a chrome that zooms by moving the root font size.

`SettingsProvider` scales the app with `document.documentElement.style.fontSize`,
and its own comment says why that works: "every Tailwind spacing and type utility
resolves in rem". These eleven did not, so they stayed frozen while everything
around them grew.

| Where | Was | Now |
| --- | --- | --- |
| `SandboxSettings` detail lines, `PlanQuota` path, `PlanUsageSetting` numbers | `text-[11px]` | `text-[0.6875rem]` |
| `Settings` search-result headings | `text-[10.5px]` | `text-[0.65625rem]` |
| `ReviewPanel`, `ProviderBinSettings`, `SandboxSettings` segmented tracks | `p-[3px]` | `p-[0.1875rem]` |
| `SandboxSettings` backend dot | `size-[7px]` | `size-[0.4375rem]` |
| `ui/toggle` focus ring | `ring-[3px]` | `ring-3` |

Every replacement is the same size written in rem, and each spelling already
existed in the codebase for that value: `ReviewPanel` for 11px,
`ShortcutsOverlay` and `PickerDialog` for 10.5px, `ui/tabs` for the 3px inset.
`ring-3` is the rung `button`, `input`, `select` and `switch` already use, and is
the same 3px.

## Measured

Driven headless over CDP against a `go run` backend on its own port, DB and
profile, with the rig proved on a control of known geometry first.

Before, in Settings › Sandbox:

| root font size | `text-xs` | `text-[11px]` |
| --- | --- | --- |
| 100% (16px) | 12px | 11px |
| 150% (24px) | 18px | **11px** |

After: 11px at 100%, 16.5px at 150%.

Nothing moves at 100%. A census of every element on 27 surfaces in both themes
(session cards, sidebar, footer, all eight Settings panes, command palette,
shortcuts overlay, both Pulls screens, the file and review docks, the session and
new-session menus, the notifications and project popovers) reports the identical
set of computed heights, font sizes, radii and paddings before and after this
change.

## Test plan

- [x] `pnpm check` clean
- [x] `pnpm test` green (129 files, 1512 tests)
- [x] `pnpm build` succeeds
- [x] Zoom verified in the running app at 100% and 150%
- [x] Full census re-run in both themes, no pixel moved
- Backend untouched.