### PR TITLE
fix: the selection ring stays inside the theme card, and the strip stays open

### DIFF
--- a/frontend/src/components/settings/ThemePicker.tsx
+++ b/frontend/src/components/settings/ThemePicker.tsx
@@ -108,12 +108,6 @@ export function ThemePicker({
 }: ThemePickerProps) {
   const [open, setOpen] = useState(false)
   const system = value === SYSTEM_THEME
-  const choose = (id: Theme) => {
-    onSelect(id)
-    // The trigger repaints with the theme just picked, which is the receipt for
-    // the click; leaving the strip open would hide it behind the list.
-    setOpen(false)
-  }
 
   return (
     <div className="min-w-0">
@@ -155,7 +149,7 @@ export function ThemePicker({
               name="System"
               caption="follows the OS"
               selected={system}
-              onSelect={() => choose(SYSTEM_THEME)}
+              onSelect={() => onSelect(SYSTEM_THEME)}
               preview={<SystemMiniature themes={themes} className="h-[88px] w-full" />}
             />
             {themes.map((theme) => (
@@ -170,7 +164,7 @@ export function ThemePicker({
                       : "bundled"
                 }
                 selected={value === theme.id}
-                onSelect={() => choose(theme.id)}
+                onSelect={() => onSelect(theme.id)}
                 preview={<ThemeMiniature theme={theme} className="h-[88px] w-full" />}
                 actions={
                   theme.origin === "custom" && (
@@ -253,10 +247,13 @@ function ThemeCard({ name, caption, selected, preview, onSelect, actions }: Them
           "focus-visible:ring-2 focus-visible:ring-ring",
         )}
       >
+        {/* The ring sits inside the card: ring-offset draws outside the
+            element, and the strip scrolls, so the offset was clipped off
+            whichever card sat against an edge. */}
         <span
           className={cn(
             "block overflow-hidden rounded-md",
-            selected && "ring-2 ring-ring ring-offset-2 ring-offset-background",
+            selected && "ring-2 ring-inset ring-ring",
           )}
         >
           {preview}


### PR DESCRIPTION
Two defects in the theme strip from #483, both reported against the running app.

**The ring around the selected card was cut.** It was `ring-offset-2 ring-offset-background`, and `ring-offset` paints outside the element. The strip is a horizontal scroller (`overflow-x: auto`), so the offset was clipped off whichever card sat against an edge, and the selected card read as a broken frame. It is `ring-2 ring-inset ring-ring` now, drawn inside the card's own bounds, which a scroller cannot clip.

**Picking a theme closed the strip.** Trying three themes in a row meant reopening it twice. It stays open until the trigger closes it, which is also what the trigger's chevron has been saying all along.

No CHANGELOG entry: this fixes code from #483, which has not shipped in a release yet.

## Test plan

- [x] `go test ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `pnpm test` green: 1514 tests
- [x] `tsc --noEmit` and `biome check .` clean (17 pre-existing a11y warnings)
- [x] Headless smoke in a 980px window, narrow enough that the strip scrolls with only the bundled themes, which is where the clipping showed: the selected card's frame sits inside the strip's own bounds, and its computed shadow is `0 0 0 2px inset`
- [x] Two picks in a row, `aria-expanded` still `true` after each