### PR TITLE
fix: the selected theme's ring is drawn in the interface's own color

### DIFF
--- a/frontend/src/components/settings/ThemePicker.tsx
+++ b/frontend/src/components/settings/ThemePicker.tsx
@@ -247,16 +247,19 @@ function ThemeCard({ name, caption, selected, preview, onSelect, actions }: Them
           "focus-visible:ring-2 focus-visible:ring-ring",
         )}
       >
-        {/* The ring sits inside the card: ring-offset draws outside the
-            element, and the strip scrolls, so the offset was clipped off
-            whichever card sat against an edge. */}
+        {/* The ring belongs to the interface, not to the theme being previewed,
+            so it is drawn on the padding around the miniature and in the
+            interface's own foreground. Over the miniature and in --ring it
+            vanished on any theme whose ring is close to its own background,
+            which is most of them. The padding is always there, so selecting a
+            card never resizes it. */}
         <span
           className={cn(
-            "block overflow-hidden rounded-md",
-            selected && "ring-2 ring-inset ring-ring",
+            "block rounded-lg p-1",
+            selected && "ring-2 ring-inset ring-foreground/70",
           )}
         >
-          {preview}
+          <span className="block overflow-hidden rounded-md">{preview}</span>
         </span>
         <span className="mt-1.5 flex items-baseline gap-1.5">
           <span className="truncate text-xs font-medium text-foreground">{name}</span>


### PR DESCRIPTION
Follow-up to #487, reported against the running app: with Rosé Pine Moon applied, the card marked `in use` had no visible ring at all.

The ring was `ring-2 ring-inset ring-ring`, drawn on top of the miniature. `--ring` is the *previewed* theme's ring color, and a theme picks that color to sit on its own background: on Rosé Pine Moon it was the card's purple over the card's purple. Most dark themes have the same problem.

The ring belongs to the interface, not to the theme being previewed. It now surrounds the miniature instead of covering it, on padding the card carries whether or not it is selected (so selecting one never resizes it), and it is drawn in `foreground/70`, the color the rest of the pane is written in, which contrasts with the pane by definition.

Verified against the reported case rather than a guess: the rig installed `omartelo/rose-pine-lich` through the Import dialog, giving the same six themes as the report, applied Rosé Pine Moon, and the ring reads clearly around its card.

No CHANGELOG entry: this is code from #483, which has not shipped in a release yet.

## Test plan

- [x] `go test ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `pnpm test` green: 1514 tests
- [x] `tsc --noEmit` and `biome check .` clean (17 pre-existing a11y warnings)
- [x] Headless smoke with the reporter's own set: six themes, Rosé Pine Moon applied, ring visible on the selected card