### PR TITLE
chore: make the radius token and the label scale tell the truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Footer tooltips have a theme-colored border to separate them from the footer.
 - **Settings use the available window width** instead of a narrow centered
   column. Descriptions retain a readable line length.
+- **Uppercase section labels are all one size.** The small label that heads a
+  group of rows had drifted to four sizes across the session sidebar, the
+  command palette and picker, the worktree dialog, the review panel, the
+  shortcuts overlay and the file preview's read-only tag. They now render at the
+  single size the palette and the shortcuts overlay already used. The diff
+  file's language badge keeps its own smaller size, which is what fits two or
+  three letters into its box.
 
 ### Fixed
 
@@ -158,8 +165,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   were sized in absolute pixels rather than in the units the zoom control
   moves, so they stayed put while the chrome around them grew: the sandbox
   explanation lines, the plan usage numbers and quota path, the settings
-  search-result headings, and the inset of the segmented controls. At 150 per
-  cent they rendered at their original size beside text half again as large.
+  search-result headings, the theme card captions and previews, and the inset of
+  the segmented controls. At 150 per cent they rendered at their original size
+  beside text half again as large.
 
 - **Ctrl+Shift+T starts a session again in lich's own window.** Chromium runs
   its tab accelerators before the page is given the key, so in the bundled

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -127,8 +127,8 @@ Bring it into the idiom:
    Chromatic color only if it is semantic (state / language).
 4. **Buttons.** Default to `ghost` in chrome; reserve one `primary` per surface. Keep the `Button` variant
    scale (primary / secondary / outline / ghost / destructive) — don't invent new ones.
-5. **Radius from the token.** Lean on `--radius`; small controls `rounded-md`. Don't paper `rounded-lg` over
-   everything.
+5. **Radius from Tailwind's scale.** `rounded-sm`/`md`/`lg`/`xl` are the whole ladder and lich adds no token
+   of its own; small controls `rounded-md`. Don't paper `rounded-lg` over everything.
 6. **Tokens only.** No raw hex/oklch; route through the `--*` variables and Tailwind opacity steps.
 
 ### base-ui gotchas

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -72,13 +72,24 @@ finished turn is still unread, `emerald-500/30` once the user has watched that c
 - **FiraCode Nerd Font Mono** — the terminal, and every monospace context: file paths, code/diff, palette
   subtitles, dense meta. Bundled woff2; the terminal awaits `document.fonts` before opening.
 - Scale is small and tight. Titles `text-sm`/`text-2xl` for screen headers; body `text-sm`; meta/paths
-  `text-xs`. Section labels are uppercase with `tracking-wide` and `text-muted-foreground`.
+  `text-xs`. Exactly one rung sits below `text-xs`: `text-[0.65625rem]`, the uppercase section label
+  (`tracking-wide`, `text-muted-foreground`) that heads a group of rows. Sidebar groups, palette and picker
+  groups, dialog groups, the shortcuts overlay, the settings search count, the review panel's Said band and
+  the file preview's read-only tag all wear it, and nothing invents a size between the two.
+- Two sizes stay off that rung deliberately: `text-[0.5625rem]`, the diff language badge, which crams two or
+  three letters into a 20px box, and `text-[0.8125rem]`, a compact body size rather than a label.
+- **Every size is written in rem, never px.** The zoom control moves the root font size, so a rem-based
+  utility follows it while a `px` arbitrary value stays frozen. xterm and CodeMirror size their own text and
+  are the measured exceptions. `frontend/lint/no-px-sizes.grit` fails the biome gate on the arbitrary-value
+  form (`text-[11px]`, `h-[88px]`, `p-[3px]`).
 - Line up digits with `tabular-nums` wherever they change (zoom %, diff counts, clock).
 
 ### Radius, spacing, icons
 
-- `--radius: 0.45rem`. Use the Tailwind `rounded-*` scale that derives from it; don't sprinkle `rounded-lg`
-  everywhere. Small controls (list rows, menu items, ghost buttons) sit around `rounded-md`.
+- Radius is Tailwind's own scale and nothing else: `rounded-sm` 4px, `rounded-md` 6px, `rounded-lg` 8px,
+  `rounded-xl` 12px. lich has no radius token of its own, and the one place that reaches for a variable
+  (`ui/button.tsx`) reads Tailwind's `--radius-md`. Small controls (list rows, menu items, ghost buttons)
+  sit at `rounded-md`; don't sprinkle `rounded-lg` everywhere.
 - Density is high but breathing: list rows `~9px` vertical padding, `gap-1`–`gap-1.5` between them.
 - Icons are **lucide** at `size-3.5`/`size-4`; `size-3` inside dense meta. Provider marks come from
   `ProviderIcon.tsx`, file-type logos from `devicons-react` (`FileIcon.tsx`).
@@ -117,7 +128,7 @@ Short specs; the code is the detail. All follow the idiom above.
   primary + ghost cancel.
 - **Segmented control** — a bordered track holding ghost options; the chosen option is an `bg-accent` fill.
 - **Stepper / numeric field** — icon buttons flanking a bordered value box (`tabular-nums`).
-- **Switch** — off `bg-accent`, on `bg-primary`.
+- **Switch** — off `bg-input` (`bg-input/80` in dark), on `bg-primary`.
 - **Toast** (sonner) — popover surface, hairline, semantic glyph.
 - **Footer** — two independently ordered sides, configured globally in Appearance › Footer. Actions default
   left; checkout, model, context, plan usage and hands-on time default right. Cost stays opt-in. The editor

--- a/frontend/biome.jsonc
+++ b/frontend/biome.jsonc
@@ -3,6 +3,9 @@
   "files": {
     "includes": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts", "vitest.config.ts"]
   },
+  // One GritQL rule, because no built-in one reads class strings: a px
+  // arbitrary value is frozen against the zoom control (DESIGN.md).
+  "plugins": ["./lint/no-px-sizes.grit"],
   // The style the codebase already mostly held, so adopting the tool is a
   // reflow, not a restyle: 2-space indent, double quotes, no semicolons.
   // lineWidth 100 measured as the least-churn width over the existing source.

--- a/frontend/lint/no-px-sizes.grit
+++ b/frontend/lint/no-px-sizes.grit
@@ -1,0 +1,19 @@
+// The zoom control moves the root font size, so a size written in rem follows
+// it and one written in px does not. Catches the Tailwind arbitrary-value form
+// (text-[11px], h-[88px], p-[3px]) in any string literal, which is where every
+// regression has landed so far. Suppress with `// biome-ignore lint/plugin:`
+// when a value really is device pixels rather than type.
+//
+// Matching whole string literals is what keeps one violation from reporting
+// once per enclosing node; it also means the rule sees strings that are not
+// class lists, which so far has cost nothing.
+language js
+
+`$literal` where {
+  $literal <: r"\"[^\"]*\[[0-9.]+px\][^\"]*\"",
+  register_diagnostic(
+    span = $literal,
+    message = "px is frozen against the zoom control, which moves the root font size. Write the size in rem.",
+    severity = "error"
+  )
+}

--- a/frontend/src/components/diff/ReviewPanel.tsx
+++ b/frontend/src/components/diff/ReviewPanel.tsx
@@ -243,7 +243,7 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
 function SaidBand({ text }: { text: string }) {
   return (
     <div className="flex shrink-0 flex-col gap-1 border-b border-border bg-muted px-2.5 pt-2 pb-2.5">
-      <span className="text-[0.625rem] font-medium tracking-wider text-muted-foreground uppercase">
+      <span className="text-[0.65625rem] font-medium tracking-wider text-muted-foreground uppercase">
         Said
       </span>
       <p className="max-h-32 overflow-y-auto whitespace-pre-wrap text-xs">{text}</p>

--- a/frontend/src/components/dock/FilesPanel.tsx
+++ b/frontend/src/components/dock/FilesPanel.tsx
@@ -262,7 +262,7 @@ function FilePreview({ path, rel, onBack, onInject, onComment }: FilePreviewProp
         <span className="truncate font-mono" title={rel}>
           {rel}
         </span>
-        <span className="ml-auto shrink-0 text-[0.5625rem] uppercase tracking-wide text-muted-foreground">
+        <span className="ml-auto shrink-0 text-[0.65625rem] uppercase tracking-wide text-muted-foreground">
           read-only
         </span>
       </div>

--- a/frontend/src/components/settings/ThemePicker.tsx
+++ b/frontend/src/components/settings/ThemePicker.tsx
@@ -150,7 +150,7 @@ export function ThemePicker({
               caption="follows the OS"
               selected={system}
               onSelect={() => onSelect(SYSTEM_THEME)}
-              preview={<SystemMiniature themes={themes} className="h-[88px] w-full" />}
+              preview={<SystemMiniature themes={themes} className="h-22 w-full" />}
             />
             {themes.map((theme) => (
               <ThemeCard
@@ -165,7 +165,7 @@ export function ThemePicker({
                 }
                 selected={value === theme.id}
                 onSelect={() => onSelect(theme.id)}
-                preview={<ThemeMiniature theme={theme} className="h-[88px] w-full" />}
+                preview={<ThemeMiniature theme={theme} className="h-22 w-full" />}
                 actions={
                   theme.origin === "custom" && (
                     <>
@@ -260,7 +260,7 @@ function ThemeCard({ name, caption, selected, preview, onSelect, actions }: Them
         </span>
         <span className="mt-1.5 flex items-baseline gap-1.5">
           <span className="truncate text-xs font-medium text-foreground">{name}</span>
-          <span className="truncate text-[11px] text-muted-foreground">{caption}</span>
+          <span className="truncate text-[0.6875rem] text-muted-foreground">{caption}</span>
         </span>
       </button>
       {/* Update and remove ride the card rather than a row of their own: they

--- a/frontend/src/components/sidebar/SessionGroupHeader.tsx
+++ b/frontend/src/components/sidebar/SessionGroupHeader.tsx
@@ -72,7 +72,7 @@ function SessionGroupTitleButton({
           !collapsed && "rotate-90",
         )}
       />
-      <span className="min-w-0 truncate text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground/70 transition-colors group-hover/collapse:text-muted-foreground">
+      <span className="min-w-0 truncate text-[0.65625rem] font-semibold uppercase tracking-wider text-muted-foreground/70 transition-colors group-hover/collapse:text-muted-foreground">
         {name}
       </span>
       <span className="h-px flex-1 bg-border" />
@@ -130,7 +130,7 @@ export function SessionGroupHeader({
           onFocus={(event) => event.currentTarget.select()}
           onKeyDown={onEditKeyDown}
           onBlur={(event) => commit(event.currentTarget.value)}
-          className="min-w-0 flex-1 rounded-sm bg-transparent px-1 py-0.5 text-[0.65rem] font-semibold uppercase tracking-wider text-foreground outline-none ring-1 ring-accent-foreground/30"
+          className="min-w-0 flex-1 rounded-sm bg-transparent px-1 py-0.5 text-[0.65625rem] font-semibold uppercase tracking-wider text-foreground outline-none ring-1 ring-accent-foreground/30"
         />
       ) : (
         <SessionGroupTitleButton

--- a/frontend/src/components/sidebar/WorktreeDialog.tsx
+++ b/frontend/src/components/sidebar/WorktreeDialog.tsx
@@ -103,7 +103,7 @@ function Group({ title, items, base, onSelect }: GroupProps) {
   }
   return (
     <div>
-      <div className="px-2 pb-1 pt-2 text-[0.625rem] font-semibold tracking-wider text-muted-foreground uppercase">
+      <div className="px-2 pb-1 pt-2 text-[0.65625rem] font-semibold tracking-wider text-muted-foreground uppercase">
         {title} <span className="font-normal">({items.length})</span>
       </div>
       {items.map((item) => (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -86,7 +86,6 @@
     --chart-3: oklch(0.442 0.017 285.786);
     --chart-4: oklch(0.37 0.013 285.805);
     --chart-5: oklch(0.274 0.006 286.033);
-    --radius: 0.45rem;
     --sidebar: oklch(0.98 0.002 286.32);
     --sidebar-foreground: oklch(0.21 0.006 285.885);
     --sidebar-primary: oklch(0.21 0.006 285.885);

--- a/internal/themes/themes_test.go
+++ b/internal/themes/themes_test.go
@@ -539,7 +539,6 @@ func TestBootCSSMatchesBundledThemes(t *testing.T) {
 	for i, theme := range bundledThemes {
 		t.Run(theme.ID, func(t *testing.T) {
 			got := cssVariables(t, css, selectors[i])
-			delete(got, "radius")
 			if !reflect.DeepEqual(got, theme.App) {
 				t.Fatalf("%s boot variables differ from bundled JSON\nCSS: %#v\nJSON: %#v", selectors[i], got, theme.App)
 			}


### PR DESCRIPTION
## What moved on screen

Only the uppercase section label, which had drifted to four sizes for one role
and is now one:

| Site | Before | After |
| --- | --- | --- |
| `FilesPanel` read-only tag | 9px | 10.5px |
| `ReviewPanel` Said band | 10px | 10.5px |
| `WorktreeDialog` group heading | 10px | 10.5px |
| `SessionGroupHeader` (label and its inline edit) | 10.4px | 10.5px |
| `ShortcutsOverlay`, `PickerDialog`, `Settings` search count | 10.5px | unchanged |

10.5px is the spelling three of the seven sites already used, so it is the
choice that moves the fewest pixels. Two things stay off the rung on purpose
and are documented as such: the diff language badge at 9px, which is one micro
size cramming two or three letters into a 20px box (`lang-badge.ts` falls back
to the uppercased file extension, so the badge and the extension suffix are the
same site), and 13px, which is a compact body size and a different role.

Nothing else moves. The radius deletion is a no-op at render time, and the
ThemePicker px conversions are the same values written in rem.

## What was verified before deleting `--radius`

- `@theme inline` in `index.css` maps colors only. `shadcn/tailwind.css` (the
  imported one, `shadcn@4.13.0`) contains no `radius` at all, so nothing maps
  `--radius-*` off `--radius` the way stock shadcn v4 does.
- Tailwind's own `theme.css` defines the rungs as literals: `--radius-sm`
  0.25rem, `--radius-md` 0.375rem, `--radius-lg` 0.5rem, `--radius-xl` 0.75rem.
  Its `--radius: 0.25rem` sits in a `@theme default inline reference` block,
  which emits nothing.
- In the built stylesheet: `var(--radius)` appears **0 times**;
  `var(--radius-md)` 13 times, `--radius-sm` twice, `--radius-lg` and
  `--radius-xl` once each. After the deletion the four rungs are emitted
  unchanged and `--radius` is gone.
- Grepped the whole frontend, `internal/themes`, `themes/` and
  `docs/themes.md`. The only other hit repo-wide is
  `internal/themes/themes_test.go`, which dropped `"radius"` from the parsed
  `:root` block precisely because the theme JSON has no such token. That line
  is dead now and is removed, which makes the test stricter: a future non-color
  variable in the boot block fails it instead of being silently tolerated. It
  is the one backend line this PR touches; `go test ./internal/themes/` is
  green.

**Alternative not taken.** Wiring `--radius` the shadcn way (`--radius-md:
calc(var(--radius) - 2px)` and friends inside `@theme inline`) is a visible
restyle of every corner in the app: md 6px to 5.2px, lg 8px to 7.2px. That
deserves its own mockup and its own PR, not a silent ride-along on a
truth-telling change.

## Can biome express the px rule?

Yes, so it is built rather than left to the doc. No built-in rule reads class
strings, but biome 2.5.5 ships GritQL plugins (`plugins` in `biome.jsonc`), and
`frontend/lint/no-px-sizes.grit` matches any string literal containing the
Tailwind arbitrary-value form and reports it as an error. Measured on a
scratch file:

- one diagnostic per string literal, not one per enclosing node (anchoring the
  regex on the quotes is what does that);
- it fires inside `className="..."`, inside `cn("...")` arguments and on a
  hoisted `const row = "..."` class string alike;
- `"600px 0px"` (an IntersectionObserver rootMargin) and `fontSize: "12px"`
  (the CodeMirror theme) are not matched, since neither is the bracket form;
- `// biome-ignore lint/plugin: reason` suppresses it. `biome-ignore plugin:`
  and `biome-ignore plugin/<name>:` do not, so the working spelling is in the
  file's header comment.

The rule already earns its place: three px declarations landed in
`ThemePicker.tsx` after #486 fixed the previous eleven (`h-[88px]` twice,
`text-[11px]` once). They are converted here, so the tree is clean under the
new rule, and `biome check` reports zero errors.

## Note on the gate

`src/components/render-budget.test.tsx` is a pre-existing flake
under full-suite load: its first test times out at `mountSidebar()` and the
five that follow then measure an empty tree and fail on `expected {} to deeply
equal ...`. Measured on this branch's base with the working tree stashed, it
fails **2 of 12** full-suite runs; with the branch applied, 4 of 12, which at
that sample size is the same rate. It reproduces with nothing of this PR in the
tree, so it is not this change, but it is worth its own fix.

## Gate

- `biome ci .` exit 0 (17 warnings and 1 info are the standing backlog).
- `vitest run`: 129 files, 1514 tests green.
- `tsc -b` clean, `vite build` succeeds.
- `gofmt -l .` clean, `go vet ./...` clean, `go test ./internal/themes/` green.
