### PR TITLE
fix: format the theme card, and make the gate read biome's exit code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,10 @@ lives in the code, `docs/` and `CHANGELOG.md` — never restate any of it here.
 ## Local Gate (before every commit / PR)
 
 - `gofmt -l .` clean (fix with `gofmt -w .`) and `go vet ./...` clean.
-- `cd frontend && pnpm check` clean — biome is the frontend's gofmt + vet (fix with `pnpm format`).
+- `cd frontend && pnpm exec biome ci .` **exit 0** — biome is the frontend's gofmt + vet (fix with
+  `pnpm format`). Read the exit code, never the last lines: `pnpm check` ends on the same
+  "Some errors were emitted" banner whether the count is one error or none, and the standing 17 a11y
+  warnings sit right above it. A single unformatted file has reached `main` this way.
 - `go test ./...` (backend) and `cd frontend && pnpm test` (frontend) green — or `task test` for both.
 - Touched `shell/`? `cd shell && cargo fmt --check && cargo clippy --release --all-targets -- -D warnings &&
   cargo test --release` clean (`--release` shares the CEF build with `task build:shell`).

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -52,7 +52,8 @@ components, which are PascalCase after their export. Tests sit next to what they
 ```bash
 pnpm build        # tsc typecheck + vite build (the real gate)
 pnpm test         # vitest run
-pnpm check        # biome format + lint check (CI runs this; errors fail)
+pnpm check        # biome format + lint, human-readable
+pnpm exec biome ci .   # the gate: read its exit code, not its last lines
 pnpm format       # biome, writing the fixes
 ```
 
@@ -70,6 +71,9 @@ run the binaries directly: `./node_modules/.bin/vitest run` or `pnpm exec vitest
   one back on. Import order is deliberately not enforced.
 - Warnings do not fail the gate; errors do. The standing warning backlog is the a11y one: `role="button"`
   spans that take a click but no key, and the `role="separator"` resize handles.
+- **Check the exit code.** `pnpm check` prints the same "Some errors were emitted" banner with one error or
+  none, directly under the 17 standing warnings, so reading the tail says nothing. `pnpm exec biome ci .`
+  answers 0 or 1, and that is what CI is asking. One unformatted file has reached `main` behind that banner.
 
 ## State — no state library
 

--- a/frontend/src/components/settings/ThemePicker.tsx
+++ b/frontend/src/components/settings/ThemePicker.tsx
@@ -254,10 +254,7 @@ function ThemeCard({ name, caption, selected, preview, onSelect, actions }: Them
             which is most of them. The padding is always there, so selecting a
             card never resizes it. */}
         <span
-          className={cn(
-            "block rounded-lg p-1",
-            selected && "ring-2 ring-inset ring-foreground/70",
-          )}
+          className={cn("block rounded-lg p-1", selected && "ring-2 ring-inset ring-foreground/70")}
         >
           <span className="block overflow-hidden rounded-md">{preview}</span>
         </span>


### PR DESCRIPTION
`main` is currently failing `biome ci`: one unformatted line in `ThemePicker.tsx`, from #488. Every PR opened against it fails its `test` job on the lint step for a reason that is not the PR's.

## Why it got through

`pnpm check` ends on "Some errors were emitted while running checks" whether it found one error or none, and that banner sits directly under the 17 standing a11y warnings. Reading the tail of that output says nothing about whether the gate passed. `pnpm exec biome ci .` answers with an exit code, which is what CI is actually asking.

Both `CLAUDE.md` files now name that command and the exit code as the gate, with the reason next to it, so the next person is not told to read a banner that cannot answer.

## Test plan

- [x] `pnpm exec biome ci .` exit 0 (it is 1 on `main` right now)
- [x] `pnpm test` green: 1514 tests, three consecutive runs
- [x] `tsc --noEmit` clean
- [x] `go test ./...`, `go vet ./...`, `gofmt -l .` clean

No CHANGELOG entry: formatting plus repo instructions, nothing a user of a released version can see.