### PR TITLE
fix: stop the render budgets timing out, and lying when they do

### DIFF
--- a/frontend/src/components/render-budget.test.tsx
+++ b/frontend/src/components/render-budget.test.tsx
@@ -20,6 +20,16 @@
 // The harness has to be imported before anything that reaches react-dom, which
 // is why it is first here (see @/test/render-budget).
 import { mountBudget } from "@/test/render-budget"
+// Loading these pulls in most of the app's module graph. Left to a dynamic
+// import inside the first test, that load was billed to that test: it cost 4.4s
+// of the 5s a test is given on a busy machine and timed out, while every test
+// after it, handed a warm registry, mounted in 40ms. Imported here the cost is
+// the file's, which is whose it always was.
+import { SessionSidebar } from "./sidebar/SessionSidebar"
+import { FooterBar } from "./FooterBar"
+import { TerminalHost } from "./TerminalHost"
+import { SettingsProvider } from "@/providers/settings"
+import { writeGroups } from "@/lib/session/panes-store"
 import { createElement, useEffect } from "react"
 import { HashRouter } from "react-router-dom"
 import { afterEach, beforeEach, expect, test, vi } from "vitest"
@@ -204,9 +214,6 @@ afterEach(() => {
 
 async function mountSidebar() {
   window.location.hash = "#/projects/p1"
-  const { SessionSidebar } = await import("./sidebar/SessionSidebar")
-  const { FooterBar } = await import("./FooterBar")
-  const { SettingsProvider } = await import("@/providers/settings")
   const budget = await mountBudget(
     createElement(
       HashRouter,
@@ -308,7 +315,6 @@ test("a usage event with no context window draws no ring", async () => {
 
 test("switching project re-renders the mounted terminals but never remounts one", async () => {
   window.location.hash = "#/projects/p1"
-  const { TerminalHost } = await import("./TerminalHost")
   const budget = await mountBudget(
     createElement(
       HashRouter,
@@ -372,8 +378,6 @@ test("switching project re-renders the mounted terminals but never remounts one"
 
 test("adding a pane mounts its terminal and never remounts the ones already up", async () => {
   window.location.hash = "#/projects/p1"
-  const { TerminalHost } = await import("./TerminalHost")
-  const { writeGroups } = await import("@/lib/session/panes-store")
   const budget = await mountBudget(
     createElement(
       HashRouter,

--- a/frontend/src/test/render-budget.ts
+++ b/frontend/src/test/render-budget.ts
@@ -1,4 +1,5 @@
 import type { ReactElement } from "react"
+import { afterEach } from "vitest"
 
 // A render budget: how many times each component's body ran for one action.
 //
@@ -124,6 +125,22 @@ export interface RenderBudget {
   unmount(): Promise<void>
 }
 
+// Every root still standing. A test that fails, or that vitest abandons on a
+// timeout, never reaches its own unmount(), and both halves of what it leaves
+// behind are shared: the container stays in the document, and the abandoned body
+// goes on holding React's act scope, which is global. Every later act() is then
+// taken for a nested one and flushes nothing, so the tests after it measure an
+// empty tree and report it as a budget. That is how one timeout used to print as
+// five budget regressions, which is the failure a real one prints too.
+const live = new Set<() => Promise<void>>()
+
+afterEach(async () => {
+  for (const teardown of [...live]) {
+    // One root that cannot come down must not strand the roots behind it.
+    await teardown().catch(() => {})
+  }
+})
+
 export async function mountBudget(element: ReactElement): Promise<RenderBudget> {
   const { act } = await import("react")
   const { createRoot } = await import("react-dom/client")
@@ -175,18 +192,30 @@ export async function mountBudget(element: ReactElement): Promise<RenderBudget> 
     await act(async () => {})
   }
 
+  const before = commits.length
   await settle(() => {
     root.render(element)
   })
+  // A render always commits, so no growth here means act() flushed nothing at
+  // all: there is no tree, and every budget read against it would be {}. Saying
+  // that outright beats reporting it as a component that stopped repainting.
+  if (commits.length === before) {
+    throw new Error(
+      "render-budget: the tree never committed. An earlier test in this file was most likely abandoned on a timeout and still holds React's act scope open.",
+    )
+  }
 
-  return {
-    take,
-    act: settle,
-    unmount: async () => {
+  const unmount = async (): Promise<void> => {
+    live.delete(unmount)
+    try {
       await act(async () => {
         root.unmount()
       })
+    } finally {
       container.remove()
-    },
+    }
   }
+  live.add(unmount)
+
+  return { take, act: settle, unmount }
 }


### PR DESCRIPTION
## The flake

`frontend/src/components/render-budget.test.tsx` failed under full-suite load and never alone. It failed as five budget assertions reporting `expected {} to deeply equal { ... }`, which reads as a regression that stopped a component repainting. It was not one.

Measured on this base, full suite, `vitest run` in a loop: **7 failures in 30 runs**, all seven the identical signature (test 1 `Error: Test timed out in 5000ms`, then four `{}` diffs).

## Two defects

**1. The first test spent its budget loading the app.** `mountSidebar()` reached the app through three `await import()` calls inside the test body. Instrumented in a full-suite run, that split as `import=4365ms mount=198ms`, against the 5000ms a test is given. Every test after it was handed a warm registry and mounted in 40ms, which is why only the first one ever failed and why the file is green when it runs alone.

The imports are static now. The graph is loaded when the file is loaded, and the file's own `tests` time fell from 2410ms to 444ms with the same work done.

**2. One timeout poisoned the five tests after it.** A timed-out test body is abandoned, not cancelled, so it keeps running. React's act scope is global, and the abandoned body goes on holding it open, so every later `act()` was taken for a nested one and flushed nothing. Instrumenting the harness showed it directly: on the tests after the timeout the commit counter did not move across the initial render (`commitsBefore=10 commitsAfter=10`), so nothing was ever committed and `take()` had an empty tree to walk. Meanwhile `document.body` grew a container per test, since `unmount()` only ran on the success path.

`mountBudget` now registers each root and tears it down in an `afterEach`, and refuses to return a budget for a tree that never committed. A render always commits, so that check cannot fire on a healthy mount.

## Rate

| | before | after |
|---|---|---|
| full suite, 30 runs | 7 failures | 0 failures |
| full suite, 20 further runs on the final code | | 0 failures |
| one test forced to time out (`--testTimeout=130`) | 5 failed, 1 passed | 1 failed, 5 passed |

The forced-timeout row is the isolation fix on its own: the timeout is still a timeout, but it is now one honest failure instead of five that read as budget regressions.

No test was weakened. No timeout was raised, no budget number was loosened, nothing was skipped. The four budget objects are byte for byte what they were.

## What I found and left alone

- **`a usage event for a background session repaints nothing` passed vacuously during the flake.** It asserts `toEqual({})`, so a poisoned run gave it the answer it wanted. That is why the failure was five and not six. It is a genuine gap in that assertion, but the contract it states is right and the new commit check now fails it honestly, so I did not touch the test.
- **Under a deliberately oversubscribed machine (20 busy loops on 20 cores, on top of the 20 vitest workers) jsdom mounts across the suite can still exceed 5000ms.** In 8 such runs one failed, with independent timeouts in `FooterSession.test.tsx`, `worktree-run.test.tsx` and this file. That is starvation hitting every jsdom test equally, not this harness, and `render-budget.test.tsx` contributed exactly one failure rather than six, which is the isolation fix holding at the worst case. Raising the default timeout to cover a pathological load is the trade CLAUDE.md forbids without a contract argument, and I do not have one.
- **`docs/ceilings.md` unchanged.** This closes a trap rather than setting one, and the trap it closed is documented where it lives, in the harness.

No `CHANGELOG.md` entry: nothing here is visible to a user of a published version.

## Gate

`biome ci .` exit 0 (the standing 17 warnings and 1 info, identical to pristine `main`, verified by running the same binary against an `origin/main` worktree), `vitest run` 1514 passed in 129 files, `tsc` and `vite build` clean. Backend untouched.
