### PR TITLE
fix: the window raises itself on a second launch instead of growing a browser

### DIFF
--- a/.github/scripts/mac-e2e.sh
+++ b/.github/scripts/mac-e2e.sh
@@ -5,8 +5,9 @@
 # is not proof), macOS counts exactly one application in Lich.app (lsappinfo,
 # which is what the Dock reads: a second entry is a subprocess with an
 # NSApplication of its own, and a Dock tile of its own with it, four of them
-# before kurogane#14), the window closes on SIGTERM, which is what the restart
-# flow sends, and lich exits with it. Its config lives under a HOME of its own.
+# before kurogane#14), a second launch is forwarded to the window without
+# opening a second browser in it (#470), the window closes on SIGTERM, which
+# is what the restart flow sends, and lich exits with it. Its config lives under a HOME of its own.
 # What a failure leaves behind goes to $RUNNER_TEMP/diag for the artifact the
 # workflow uploads.
 #
@@ -70,6 +71,16 @@ sleep 10
 # The browser process runs as lich-shell; the subprocesses are the helper apps.
 browser=$(pgrep -x lich-shell || true)
 test -n "$browser" || fail "the window died"
+
+# A second launch: lich finds the first on its port and hands the window its
+# URL, which CEF forwards to the running browser. The forward used to open a
+# second browser in it, a page more on CDP and a process that outlived the
+# window's close (#470); the window now raises itself and the count stays one.
+"$app/Contents/MacOS/lich" || fail "the duplicate launch exited $?"
+sleep 5
+curl -sf http://127.0.0.1:9334/json > "$pages"
+count=$(grep -c '"type": *"page"' "$pages" || true)
+[ "$count" = 1 ] || fail "the forwarded launch left $count pages in the window, expected one"
 
 lsappinfo list > "$RUNNER_TEMP/apps.txt"
 apps=$(grep -c 'bundle path=.*Lich.app' "$RUNNER_TEMP/apps.txt" || true)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,16 @@ jobs:
           grep -q '"title": *"lich"' "$RUNNER_TEMP/pages.json" || { echo "::error::the window never loaded lich's page"; cat "$APPDATA/lich/lich.log"; exit 1; }
           sleep 10
           tasklist | grep -q lich-shell.exe || { echo "::error::the window died"; cat "$APPDATA/lich/lich.log"; exit 1; }
+          # A second launch: lich finds the first on its port and hands the
+          # window its URL, which CEF forwards to the running browser. The
+          # forward used to open a second browser in it, a page more on CDP
+          # and a process that outlived the window's close (#470); the window
+          # now raises itself and the page count stays at one.
+          "$app/lich.exe" || { echo "::error::the duplicate launch exited $?"; cat "$APPDATA/lich/lich.log"; exit 1; }
+          sleep 5
+          curl -sf http://127.0.0.1:9334/json > "$RUNNER_TEMP/pages.json"
+          pages=$(grep -c '"type": *"page"' "$RUNNER_TEMP/pages.json")
+          [ "$pages" = 1 ] || { echo "::error::the forwarded launch left $pages pages in the window, expected one"; cat "$RUNNER_TEMP/pages.json"; cat "$APPDATA/lich/lich.log"; exit 1; }
           # A close request, not a kill: the same WM_CLOSE the restart flow posts.
           taskkill /IM lich-shell.exe > /dev/null
           for _ in $(seq 1 15); do sleep 1; tasklist | grep -q '^lich.exe' || break; done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Closing the window ends lich even after a second launch.** Starting lich
+  while it was already running raised its window, as it should, but the window
+  had been handed a whole second browser to do it, one with no window of its
+  own; closing the window you could see then left lich running with its port
+  held and no way back in, until it was killed. The window now raises itself on
+  that second launch and opens nothing else, so it closes the way it did before,
+  on Linux, Windows and macOS alike.
+
 - **Zooming the app now grows every label with it.** A handful of small labels
   were sized in absolute pixels rather than in the units the zoom control
   moves, so they stayed put while the chrome around them grew: the sandbox

--- a/build/linux/shell/README.md
+++ b/build/linux/shell/README.md
@@ -21,8 +21,12 @@ the macOS bundle layout (the framework resolved from `Contents/Frameworks`,
 the subprocesses run as the bundle's helper app), which upstream carries on
 its `seal-of-approval/distribution` branch
 ([53d51ba](https://github.com/0x48piraj/kurogane/commit/53d51ba7d234161f8709109dcb8d6395f38c7bb4));
-lich's own PRs for that layout, #13 and #15, were closed as covered. All of
-it is carried meanwhile on the fork `shell/Cargo.toml` pins:
+lich's own PRs for that layout, #13 and #15, were closed as covered. One more
+fix is the fork's alone so far: a second launch on the profile makes CEF
+ask the running browser what to do with it, and kurogane answered nothing,
+so CEF opened a Chrome-style browser no window of ours owned and the app
+outlived its last window (lich#470); the fork raises the window it already
+has. All of it is carried meanwhile on the fork `shell/Cargo.toml` pins:
 `omartelo/kurogane`, branch `lich`, on top of upstream `eedaedc`.
 One wrinkle the patch works around: cef-rs hands CEF a *borrowed* string when
 it writes an out-parameter struct back, so a `wm_class_class` built from `&str`

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -399,13 +399,15 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   it across sessions: a push that finds it full, and the flush a session runs before its exit banner so the banner
   cannot overtake its own last bytes.
 - **Single instance via the pinned port**: the bind is the lock (`internal/singleton`); a duplicate launch hands
-  its URL to the running window through Chromium's profile lock (`chromium.Focus`, best-effort, untested
-  against a real window) and exits 0. With the bundled window the hand-off is a second `lich-shell` on the same
-  profile: CEF reports the forward as a failed initialise, the duplicate exits 1, and `focusRunning` logs one
-  Warn per duplicate launch. Focus never climbs the ladder — a fallback there would open lich a second time, in
-  a system browser, on the profile the window owns — so a lich already running in the fallback browser is not
-  focused by it either. What the running window does with the forwarded command line, focus or a second
-  window, is unmeasured for the shell.
+  its URL to the running window through Chromium's profile lock (`chromium.Focus`) and exits 0. With the
+  bundled window the hand-off is a second `lich-shell` on the same profile: CEF forwards the command line to
+  the running one, which raises the window it has (the kurogane fork's relaunch hook; without it CEF opened a
+  second browser that kept lich alive after the window closed, #470), reports the forward as a failed
+  initialise, the duplicate exits 1, and `focusRunning` logs one Warn per duplicate launch. Raising is
+  best-effort: a Wayland compositor may only mark the window urgent. Focus never climbs the ladder — a
+  fallback there would open lich a second time, in a system browser, on the profile the window owns — so a
+  lich already running in the fallback browser is not focused by it either, and what a system browser does
+  with the forwarded command line is its own.
 - **lich appends to the agent's system prompt, for two providers only**
   (`internal/terminal/command.go`, `briefingFlags` → `relay.SpawnBriefing`): Claude Code and oh-my-pi are spawned
   with `--append-system-prompt` carrying lich's own briefing, so text the user never wrote is in every session's

--- a/main.go
+++ b/main.go
@@ -449,10 +449,11 @@ func handleBindFailure(configDir string, cause error) {
 // window spawning its own process — see chromium.Args) instead of opening a new
 // one. Best effort — a failure only means the user raises the window by hand.
 //
-// Skipped for the dev shell (its own profile/port). On some Chromium builds a
-// forwarded --app may open a second app window rather than focus; the dup-free
-// fix is a per-platform window raise, which Wayland forbids for an external
-// process, so Chromium's IPC is the portable lever we have.
+// Skipped for the dev shell (its own profile/port). The bundled window raises
+// itself on the forward (the kurogane fork's relaunch hook); a system browser
+// does what it does with a forwarded --app. A per-platform raise from here is
+// no alternative: Wayland forbids it for an external process, so Chromium's
+// IPC is the portable lever we have.
 func focusRunning(configDir string, running *singleton.Info) {
 	if os.Getenv("LICH_DEV_URL") != "" {
 		return

--- a/shell/Cargo.lock
+++ b/shell/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "kurogane"
 version = "0.0.4"
-source = "git+https://github.com/omartelo/kurogane?rev=12be327b0a47b9f16474ffcd7fa6700d7cf2af7f#12be327b0a47b9f16474ffcd7fa6700d7cf2af7f"
+source = "git+https://github.com/omartelo/kurogane?rev=451bd7c90ceb66447fa222f45402b7d1d794c74f#451bd7c90ceb66447fa222f45402b7d1d794c74f"
 dependencies = [
  "cef",
  "ctrlc",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "kurogane-layout"
 version = "0.0.4"
-source = "git+https://github.com/omartelo/kurogane?rev=12be327b0a47b9f16474ffcd7fa6700d7cf2af7f#12be327b0a47b9f16474ffcd7fa6700d7cf2af7f"
+source = "git+https://github.com/omartelo/kurogane?rev=451bd7c90ceb66447fa222f45402b7d1d794c74f#451bd7c90ceb66447fa222f45402b7d1d794c74f"
 dependencies = [
  "dirs",
  "serde",

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -12,9 +12,10 @@ license = "AGPL-3.0-only"
 # supplies (kurogane#12), the NSApplication kept to the browser process
 # (kurogane#14), and the macOS bundle layout (framework in Contents/Frameworks,
 # subprocesses as the bundle's helper app) that upstream carries on its
-# seal-of-approval/distribution branch (53d51ba); move back to
+# seal-of-approval/distribution branch (53d51ba), and a relaunch on the
+# profile raising the window it already has (451bd7c); move back to
 # 0x48piraj/kurogane once they land (build/linux/shell/README.md).
-kurogane = { git = "https://github.com/omartelo/kurogane", rev = "12be327b0a47b9f16474ffcd7fa6700d7cf2af7f" }
+kurogane = { git = "https://github.com/omartelo/kurogane", rev = "451bd7c90ceb66447fa222f45402b7d1d794c74f" }
 
 # The CEF handler types a delegate returns (main.rs). Pinned to the revision
 # kurogane's own workspace pins: two cef crates in one binary are two different


### PR DESCRIPTION
Closes #470.

## What was wrong

Launching lich while it runs finds the first instance on its port and hands the window its URL. CEF forwards that command line to the running browser and asks `OnAlreadyRunningAppRelaunch` what to do with it. kurogane did not implement the hook, so CEF took its default and opened a Chrome-style browser for the forwarded `--app`: a page more on CDP, a second window for the shell's pid, and a browser no window delegate of ours owned. Closing the window you could see left that browser alive, and lich with it, port held, until SIGTERM. Shipped in 0.45.0; Windows and macOS take the same path.

## The fix

The kurogane fork (`lich` branch, 451bd7c, cherry-picked to `lich-next` too) implements the hook: restore, show and activate every registered window, and report the relaunch handled. The shell pins that revision. No change to the Go side beyond the comment on `focusRunning`.

## Measured

Linux, isolated config on port 47899, three runs each of the installed 0.45.0 and this branch: launch, second launch, close the window through the compositor.

| | pages on CDP after the dup | windows for the shell pid | lich after the close |
|---|---|---|---|
| 0.45.0 | 2 | 2 | still up at 20 s |
| this branch | 1 | 1 | gone in 1 s, focused |

The page count is what told the two apart, so the release job's Windows and macOS benches now run the second launch and assert one page before closing the window.

## Gate

gofmt, go vet, go test, and the shell's fmt, clippy and tests are clean. The frontend is untouched.