### PR TITLE
fix: the window runs sandboxed on Linux, and loses Chrome's bad-flag bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The window no longer opens with Chrome's "unsupported command-line flag"
+  bar across its top.** Every launch on Linux, Windows and macOS drew the
+  "--disable-setuid-sandbox. Stability and security will suffer" warning under
+  the title bar, because the window ran with Chromium's sandbox switched off
+  everywhere. On Linux the sandbox is now on: Chromium confines the window's
+  subprocesses in a user namespace, as it does in any Chromium you install, and
+  the bar is gone. A machine that denies user namespaces to unconfined programs
+  (Ubuntu's AppArmor policy) or a lich run as root cannot have it, and the window
+  says so in the log and opens unsandboxed with the bar, as before. Windows and
+  macOS still run unsandboxed and keep the bar for now.
+
 - **Closing the window ends lich even after a second launch.** Starting lich
   while it was already running raised its window, as it should, but the window
   had been handed a whole second browser to do it, one with no window of its

--- a/build/linux/shell/README.md
+++ b/build/linux/shell/README.md
@@ -26,7 +26,12 @@ fix is the fork's alone so far: a second launch on the profile makes CEF
 ask the running browser what to do with it, and kurogane answered nothing,
 so CEF opened a Chrome-style browser no window of ours owned and the app
 outlived its last window (lich#470); the fork raises the window it already
-has. All of it is carried meanwhile on the fork `shell/Cargo.toml` pins:
+has. And kurogane disabled the sandbox on every platform, which put Chrome's
+"unsupported command-line flag" bar on every window; the fork leaves it on
+for Linux, where Chromium needs nothing of the binary to confine its
+subprocesses, and `shell/src/main.rs` passes `--no-sandbox` on the machines
+that cannot (Ubuntu's AppArmor policy, root). All of it is carried meanwhile
+on the fork `shell/Cargo.toml` pins:
 `omartelo/kurogane`, branch `lich`, on top of upstream `eedaedc`.
 One wrinkle the patch works around: cef-rs hands CEF a *borrowed* string when
 it writes an out-parameter struct back, so a `wm_class_class` built from `&str`

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -967,6 +967,18 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   with no browser at all the crash lands on the tab path, where the log has the story and the
   notification does not. `lich doctor` names the rung that answered; `task dev` pins the window it built
   (`LICH_BROWSER`), since `go run` never has one beside it.
+- **The window's own sandbox is on for Linux alone** (`shell/src/main.rs`, the kurogane fork's
+  `no_sandbox`): Chromium confines the window's subprocesses in a user namespace, or through the setuid
+  helper beside `lich-shell`, and needs nothing of the binary for either. Where it has neither, the browser
+  process would abort at its zygote, so the shell asks first, the way Chromium does (a fork trying
+  `CLONE_NEWUSER`, the helper checked for root and 4755, never as root) and opens with `--no-sandbox`: that
+  is Ubuntu's desktop, whose AppArmor policy denies unprivileged user namespaces to unconfined binaries, and
+  the packages do not ship the helper setuid (`cef/chrome-sandbox`, mode 755, not beside the executable),
+  so every Ubuntu window runs unsandboxed and carries Chrome's "stability and security will suffer" bar,
+  which is the truth about it. The upgrade is the deb, rpm and AUR installing `chrome-sandbox` root-owned
+  4755 beside `lich-shell`; the AppImage never can, its squashfs mounts nosuid. Windows and macOS run with
+  `no_sandbox` and the same bar: the Windows sandbox needs `cef_sandbox` linked into the executable and the
+  macOS one a helper app initialising it, and neither is wired.
 - **The bundled window and a pinned browser share one profile directory** (`shell/src/main.rs`,
   `internal/chromium.Run`): the shell is told `cache_dir` = the `--user-data-dir` lich hands every browser,
   so CEF writes `<config>/lich/chromium-profile` as its own Chromium profile. Pin a browser with `--browser`

--- a/docs/chromium-shell.md
+++ b/docs/chromium-shell.md
@@ -172,8 +172,9 @@ its WM_CLASS come from elsewhere on Windows: the executable carries lich's
 icon and manifest as resources (`shell/build.rs`), and the process claims the
 AppUserModelID the Start Menu shortcut declares, which is what makes the
 taskbar group the running window under the pinned icon. The sandbox stays
-off, as kurogane runs it, so the binary is a plain exe rather than CEF's
-`bootstrap.exe` loading a DLL. Built and smoke-tested on the CI runner only.
+off there, as kurogane runs it, so the binary is a plain exe rather than CEF's
+`bootstrap.exe` loading a DLL; Linux is the one platform whose window runs
+sandboxed (`docs/ceilings.md`). Built and smoke-tested on the CI runner only.
 
 macOS ships the same window inside `Lich.app`, Apple Silicon only: the
 release runner is arm64 and builds the window for itself, and the Intel

--- a/shell/Cargo.lock
+++ b/shell/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "kurogane"
 version = "0.0.4"
-source = "git+https://github.com/omartelo/kurogane?rev=451bd7c90ceb66447fa222f45402b7d1d794c74f#451bd7c90ceb66447fa222f45402b7d1d794c74f"
+source = "git+https://github.com/omartelo/kurogane?rev=bb274847fc3bd517358f1bd41cc56ab69bfd7dd9#bb274847fc3bd517358f1bd41cc56ab69bfd7dd9"
 dependencies = [
  "cef",
  "ctrlc",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "kurogane-layout"
 version = "0.0.4"
-source = "git+https://github.com/omartelo/kurogane?rev=451bd7c90ceb66447fa222f45402b7d1d794c74f#451bd7c90ceb66447fa222f45402b7d1d794c74f"
+source = "git+https://github.com/omartelo/kurogane?rev=bb274847fc3bd517358f1bd41cc56ab69bfd7dd9#bb274847fc3bd517358f1bd41cc56ab69bfd7dd9"
 dependencies = [
  "dirs",
  "serde",
@@ -758,6 +758,7 @@ version = "0.0.0"
 dependencies = [
  "cef",
  "kurogane",
+ "libc",
  "windows-sys 0.61.2",
  "winresource",
 ]

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -13,14 +13,20 @@ license = "AGPL-3.0-only"
 # (kurogane#14), and the macOS bundle layout (framework in Contents/Frameworks,
 # subprocesses as the bundle's helper app) that upstream carries on its
 # seal-of-approval/distribution branch (53d51ba), and a relaunch on the
-# profile raising the window it already has (451bd7c); move back to
-# 0x48piraj/kurogane once they land (build/linux/shell/README.md).
-kurogane = { git = "https://github.com/omartelo/kurogane", rev = "451bd7c90ceb66447fa222f45402b7d1d794c74f" }
+# profile raising the window it already has (451bd7c) and the Linux sandbox
+# left on (bb27484); move back to 0x48piraj/kurogane once they land
+# (build/linux/shell/README.md).
+kurogane = { git = "https://github.com/omartelo/kurogane", rev = "bb274847fc3bd517358f1bd41cc56ab69bfd7dd9" }
 
 # The CEF handler types a delegate returns (main.rs). Pinned to the revision
 # kurogane's own workspace pins: two cef crates in one binary are two different
 # KeyboardHandler types, and the delegate would not compile against ours.
 cef = { git = "https://github.com/tauri-apps/cef-rs", rev = "c73f792f245d71ac1716448cdb7c165c8009e20c" }
+
+# Whether this machine can confine Chromium's subprocesses is asked the way
+# Chromium asks it (main.rs): a fork that tries a user namespace.
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
 
 # The taskbar groups windows by AppUserModelID (main.rs); nothing else of the
 # Win32 API is used.

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -36,6 +36,15 @@ struct Launch {
     switches: Vec<(String, Option<String>)>,
 }
 
+impl Launch {
+    /// CEF re-executes the binary for its renderer, GPU and utility roles,
+    /// each with a --type of its own; the browser process has none.
+    #[cfg(target_os = "linux")]
+    fn is_subprocess(&self) -> bool {
+        self.switches.iter().any(|(name, _)| name == "type")
+    }
+}
+
 fn parse<I: IntoIterator<Item = String>>(args: I) -> Launch {
     let mut launch = Launch::default();
     for arg in args {
@@ -157,6 +166,10 @@ fn main() {
     if let Some(class) = &launch.class {
         claim_taskbar_identity(class);
     }
+    // Only the browser process decides; CEF's subprocesses carry --type and
+    // inherit the switch from it.
+    #[cfg(target_os = "linux")]
+    let unsandboxed = !launch.is_subprocess() && !sandbox_available();
     let mut app = App::url(launch.url.unwrap_or_else(|| "about:blank".into()))
         // Only reached without --user-data-dir, which lich always passes: a
         // shell launched by hand gets a profile under its own name rather than
@@ -193,6 +206,13 @@ fn main() {
     if let Some((name, value)) = display_switch(wayland.as_deref()) {
         app = app.chromium_flag_with_value(name, value);
     }
+    #[cfg(target_os = "linux")]
+    if unsandboxed {
+        eprintln!(
+            "lich-shell: this machine cannot confine Chromium's subprocesses; opening the window unsandboxed"
+        );
+        app = app.chromium_flag("no-sandbox");
+    }
     // The user's switches go through kurogane rather than staying in argv, so
     // they land after its own policy and win: --ozone-platform=x11 beats the
     // Wayland chosen above.
@@ -203,6 +223,64 @@ fn main() {
         };
     }
     app.run_or_exit();
+}
+
+/// Whether Chromium can confine its subprocesses here, decided the way
+/// Chromium decides it at its zygote (content/browser/zygote_host): never as
+/// root; otherwise a user namespace, or the setuid helper beside the executable.
+/// With neither the browser process aborts at startup, and Chromium's own
+/// advice is --no-sandbox; Ubuntu denies unprivileged user namespaces through
+/// AppArmor, and the packages do not ship the helper setuid, so that is every
+/// Ubuntu desktop. The "stability and security will suffer" bar Chrome draws
+/// over the switch is then the truth about that machine.
+#[cfg(target_os = "linux")]
+fn sandbox_available() -> bool {
+    // SAFETY: geteuid has no preconditions.
+    if unsafe { libc::geteuid() } == 0 {
+        return false;
+    }
+    if can_create_user_namespace() {
+        return true;
+    }
+    std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.with_file_name("chrome-sandbox").metadata().ok())
+        .is_some_and(|meta| {
+            use std::os::unix::fs::MetadataExt;
+            helper_usable(meta.uid(), meta.mode())
+        })
+}
+
+/// What Chromium requires of the setuid helper: owned by root, setuid, and
+/// executable by everyone (sandbox/linux/suid/client/setuid_sandbox_host.cc).
+#[cfg(target_os = "linux")]
+fn helper_usable(uid: u32, mode: u32) -> bool {
+    uid == 0 && mode & libc::S_ISUID != 0 && mode & libc::S_IXOTH != 0
+}
+
+/// Chromium's own probe (sandbox::Credentials::CanCreateProcessInNewUserNS):
+/// a child tries to enter a new user namespace, and its exit status is the
+/// answer. Asked from a process, not read from a sysctl, because what denies
+/// the namespace on Ubuntu is an AppArmor policy on unconfined processes, which
+/// is what lich-shell is and a probe binary with a profile of its own is not.
+#[cfg(target_os = "linux")]
+fn can_create_user_namespace() -> bool {
+    // SAFETY: called before CEF starts, while this is the only thread, so the
+    // child is a clean copy; it calls nothing but unshare and _exit.
+    unsafe {
+        let pid = libc::fork();
+        if pid < 0 {
+            return false;
+        }
+        if pid == 0 {
+            let entered = libc::unshare(libc::CLONE_NEWUSER) == 0;
+            libc::_exit(if entered { 0 } else { 1 });
+        }
+        let mut status = 0;
+        libc::waitpid(pid, &mut status, 0) == pid
+            && libc::WIFEXITED(status)
+            && libc::WEXITSTATUS(status) == 0
+    }
 }
 
 /// The AppUserModelID is Windows's WM_CLASS: the taskbar groups a process's
@@ -297,6 +375,22 @@ mod tests {
         );
         assert_eq!(display_switch(Some("")), None);
         assert_eq!(display_switch(None), None);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn tells_the_browser_process_from_its_subprocesses() {
+        assert!(!parse(args(&["--app=http://h/", "--class=lich"])).is_subprocess());
+        assert!(parse(args(&["--type=zygote", "--no-zygote-sandbox"])).is_subprocess());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn requires_the_helper_root_owned_setuid_and_world_executable() {
+        assert!(helper_usable(0, 0o104755), "root, 4755");
+        assert!(!helper_usable(1000, 0o104755), "not root");
+        assert!(!helper_usable(0, 0o100755), "no setuid bit");
+        assert!(!helper_usable(0, 0o104750), "not executable by others");
     }
 
     #[test]


### PR DESCRIPTION
Closes #493.

## What was wrong

Every launch of the window drew Chrome's "You are using an unsupported command-line flag: --disable-setuid-sandbox. Stability and security will suffer" bar under the title bar. kurogane set `CefSettings.no_sandbox` on every platform and added that switch on Linux; both are on Chrome's bad-flags list (`bad_flags_prompt.cc`), and nothing suppresses the prompt any more (`--test-type` is gone from Chromium). Nothing needed the sandbox off on Linux: Chromium confines its subprocesses in a user namespace, or through the setuid helper beside the executable, with no work from the binary.

## The fix

- The kurogane fork (`lich` bb27484, cherry-picked to `lich-next`) leaves the sandbox on for Linux and drops the switch. Windows and macOS keep `no_sandbox`, and the bar: the Windows sandbox needs `cef_sandbox` linked into the exe, the macOS one a helper app initialising it. Both are real work, written down in `docs/ceilings.md`.
- `shell/src/main.rs` asks first whether the machine can have the sandbox, the way Chromium's zygote decides it: never as root; else a fork trying `CLONE_NEWUSER`; else `chrome-sandbox` beside the executable, root-owned and 4755. With neither it opens with `--no-sandbox`, which is Ubuntu's desktop under its AppArmor policy: that window keeps the bar, and stderr says why. Probed by fork rather than by sysctl or `unshare -U true`: Ubuntu's `unshare` binary has an AppArmor profile granting namespaces, `lich-shell` has none.
- The packages do not ship the helper setuid (it sits in `cef/` at 755), so every Ubuntu window runs unsandboxed for now; the upgrade path (deb, rpm and AUR installing it root 4755 beside `lich-shell`) is in the ceilings bullet.

## Measured

Linux, isolated config: the browser process's command line read over CDP from `chrome://version`, which is exactly what the bad-flags prompt reads, carries no sandbox switch; the zygote's `uid_map` is `1000 1000 1` (a user namespace); the page loads and the window closes in a second. `lich -- --no-sandbox` still reaches Chromium.

## Gate

Shell fmt, clippy and tests clean, two tests added for the pure decisions (subprocess detection, helper permissions). Go and frontend untouched. The shell CI matrix is the check that the `cfg(target_os = "linux")` gating builds on Windows and macOS.