### PR TITLE
chore: name the label rung, and let the release e2e report a lost window

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
           "$app/lich.exe" || { echo "::error::the duplicate launch exited $?"; cat "$APPDATA/lich/lich.log"; exit 1; }
           sleep 5
           curl -sf http://127.0.0.1:9334/json > "$RUNNER_TEMP/pages.json"
-          pages=$(grep -c '"type": *"page"' "$RUNNER_TEMP/pages.json")
+          pages=$(grep -c '"type": *"page"' "$RUNNER_TEMP/pages.json" || true)
           [ "$pages" = 1 ] || { echo "::error::the forwarded launch left $pages pages in the window, expected one"; cat "$RUNNER_TEMP/pages.json"; cat "$APPDATA/lich/lich.log"; exit 1; }
           # A close request, not a kill: the same WM_CLOSE the restart flow posts.
           taskkill /IM lich-shell.exe > /dev/null

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,10 +154,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Uppercase section labels are all one size.** The small label that heads a
   group of rows had drifted to four sizes across the session sidebar, the
   command palette and picker, the worktree dialog, the review panel, the
-  shortcuts overlay and the file preview's read-only tag. They now render at the
-  single size the palette and the shortcuts overlay already used. The diff
-  file's language badge keeps its own smaller size, which is what fits two or
-  three letters into its box.
+  shortcuts overlay, the plan usage table's header and the file preview's
+  read-only tag. They now render at the single size the palette and the
+  shortcuts overlay already used. The diff file's language badge keeps its own
+  smaller size, which is what fits two or three letters into its box.
 
 ### Fixed
 

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -971,7 +971,8 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   `no_sandbox`): Chromium confines the window's subprocesses in a user namespace, or through the setuid
   helper beside `lich-shell`, and needs nothing of the binary for either. Where it has neither, the browser
   process would abort at its zygote, so the shell asks first, the way Chromium does (a fork trying
-  `CLONE_NEWUSER`, the helper checked for root and 4755, never as root) and opens with `--no-sandbox`: that
+  `CLONE_NEWUSER`, the helper checked for root and 4755, never as root; the `CHROME_DEVEL_SANDBOX` helper
+  Chromium also accepts for a binary the user owns is not asked) and opens with `--no-sandbox`: that
   is Ubuntu's desktop, whose AppArmor policy denies unprivileged user namespaces to unconfined binaries, and
   the packages do not ship the helper setuid (`cef/chrome-sandbox`, mode 755, not beside the executable),
   so every Ubuntu window runs unsandboxed and carries Chrome's "stability and security will suffer" bar,

--- a/frontend/DESIGN.md
+++ b/frontend/DESIGN.md
@@ -72,12 +72,16 @@ finished turn is still unread, `emerald-500/30` once the user has watched that c
 - **FiraCode Nerd Font Mono** — the terminal, and every monospace context: file paths, code/diff, palette
   subtitles, dense meta. Bundled woff2; the terminal awaits `document.fonts` before opening.
 - Scale is small and tight. Titles `text-sm`/`text-2xl` for screen headers; body `text-sm`; meta/paths
-  `text-xs`. Exactly one rung sits below `text-xs`: `text-[0.65625rem]`, the uppercase section label
-  (`tracking-wide`, `text-muted-foreground`) that heads a group of rows. Sidebar groups, palette and picker
-  groups, dialog groups, the shortcuts overlay, the settings search count, the review panel's Said band and
-  the file preview's read-only tag all wear it, and nothing invents a size between the two.
-- Two sizes stay off that rung deliberately: `text-[0.5625rem]`, the diff language badge, which crams two or
-  three letters into a 20px box, and `text-[0.8125rem]`, a compact body size rather than a label.
+  `text-xs`. One named rung sits below `text-xs`: `text-2xs` (`--text-2xs` in `index.css`, 0.65625rem), the
+  uppercase section label (`tracking-wide`, `text-muted-foreground`) that heads a group of rows. Sidebar
+  groups, palette and picker groups, dialog groups, the shortcuts overlay, the settings search count, the
+  plan usage table's header, the review panel's Said band and the file preview's read-only tag all wear it.
+  A label never invents a size of its own.
+- Four sizes stay off that rung deliberately, none of them a label: `text-[0.625rem]` for monospace meta
+  (`<kbd>`, palette counts, the tab's "relocate" tag), `text-[0.6875rem]` for a compact detail line
+  (the account under the plan gauges, "ended … ago", a sandbox probe's detail, a theme card's caption),
+  `text-[0.5625rem]` for the diff language badge, which crams two or three letters into a 20px box, and
+  `text-[0.8125rem]`, a compact body size rather than a label.
 - **Every size is written in rem, never px.** The zoom control moves the root font size, so a rem-based
   utility follows it while a `px` arbitrary value stays frozen. xterm and CodeMirror size their own text and
   are the measured exceptions. `frontend/lint/no-px-sizes.grit` fails the biome gate on the arbitrary-value

--- a/frontend/lint/no-px-sizes.grit
+++ b/frontend/lint/no-px-sizes.grit
@@ -1,8 +1,9 @@
 // The zoom control moves the root font size, so a size written in rem follows
 // it and one written in px does not. Catches the Tailwind arbitrary-value form
-// (text-[11px], h-[88px], p-[3px]) in any string literal, which is where every
-// regression has landed so far. Suppress with `// biome-ignore lint/plugin:`
-// when a value really is device pixels rather than type.
+// (text-[11px], h-[88px], p-[3px]) in any string or template literal, which is
+// where every regression has landed so far. Suppress with
+// `// biome-ignore lint/plugin:` when a value really is device pixels rather
+// than type.
 //
 // Matching whole string literals is what keeps one violation from reporting
 // once per enclosing node; it also means the rule sees strings that are not
@@ -10,7 +11,10 @@
 language js
 
 `$literal` where {
-  $literal <: r"\"[^\"]*\[[0-9.]+px\][^\"]*\"",
+  $literal <: or {
+    r"\"[^\"]*\[[0-9.]+px\][^\"]*\"",
+    r"`[^`]*\[[0-9.]+px\][^`]*`"
+  },
   register_diagnostic(
     span = $literal,
     message = "px is frozen against the zoom control, which moves the root font size. Write the size in rem.",

--- a/frontend/src/components/ShortcutsOverlay.tsx
+++ b/frontend/src/components/ShortcutsOverlay.tsx
@@ -35,7 +35,7 @@ export function ShortcutsOverlay() {
           <div className="flex-1 overflow-y-auto p-1.5">
             {groups.map((group) => (
               <div key={group.title}>
-                <div className="px-3 pb-1 pt-3 text-[0.65625rem] font-semibold uppercase tracking-wider text-muted-foreground">
+                <div className="px-3 pb-1 pt-3 text-2xs font-semibold uppercase tracking-wider text-muted-foreground">
                   {group.title}
                 </div>
                 {group.rows.map((row) => (

--- a/frontend/src/components/common/PickerDialog.tsx
+++ b/frontend/src/components/common/PickerDialog.tsx
@@ -118,7 +118,7 @@ export function PickerGroup({
     // biome-ignore lint/a11y/useSemanticElements: the rule offers <fieldset>, which groups form controls and is not a valid child of a listbox.
     <div role="group" aria-label={label}>
       {showLabel && (
-        <div className="flex items-baseline justify-between gap-2 px-3 pb-1 pt-3 text-[0.65625rem] font-semibold uppercase tracking-wider text-muted-foreground">
+        <div className="flex items-baseline justify-between gap-2 px-3 pb-1 pt-3 text-2xs font-semibold uppercase tracking-wider text-muted-foreground">
           <span>{label}</span>
           {trailing && (
             <span className="font-mono font-normal normal-case tracking-normal">{trailing}</span>

--- a/frontend/src/components/diff/ReviewPanel.tsx
+++ b/frontend/src/components/diff/ReviewPanel.tsx
@@ -243,7 +243,7 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
 function SaidBand({ text }: { text: string }) {
   return (
     <div className="flex shrink-0 flex-col gap-1 border-b border-border bg-muted px-2.5 pt-2 pb-2.5">
-      <span className="text-[0.65625rem] font-medium tracking-wider text-muted-foreground uppercase">
+      <span className="text-2xs font-medium tracking-wider text-muted-foreground uppercase">
         Said
       </span>
       <p className="max-h-32 overflow-y-auto whitespace-pre-wrap text-xs">{text}</p>

--- a/frontend/src/components/dock/FilesPanel.tsx
+++ b/frontend/src/components/dock/FilesPanel.tsx
@@ -262,7 +262,7 @@ function FilePreview({ path, rel, onBack, onInject, onComment }: FilePreviewProp
         <span className="truncate font-mono" title={rel}>
           {rel}
         </span>
-        <span className="ml-auto shrink-0 text-[0.65625rem] uppercase tracking-wide text-muted-foreground">
+        <span className="ml-auto shrink-0 text-2xs uppercase tracking-wide text-muted-foreground">
           read-only
         </span>
       </div>

--- a/frontend/src/components/settings/PlanUsageSetting.tsx
+++ b/frontend/src/components/settings/PlanUsageSetting.tsx
@@ -64,12 +64,7 @@ function PlanBody({ plan, now }: { plan: QuotaPlan; now: Date }) {
     <div className="flex max-w-prose flex-col gap-2">
       {/* The plan doubles as the table's left header, which is what keeps it from
           floating above the rows as a line of its own. */}
-      <div
-        className={cn(
-          gaugeGrid,
-          "text-[0.6875rem] uppercase tracking-wide text-muted-foreground/80",
-        )}
-      >
+      <div className={cn(gaugeGrid, "text-2xs uppercase tracking-wide text-muted-foreground/80")}>
         <span className="truncate normal-case tracking-normal text-muted-foreground">
           {plan.plan}
         </span>

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -244,7 +244,7 @@ export function Settings() {
         {searching ? (
           <>
             {hits.length > 0 && (
-              <p className="px-5 pb-1.5 font-mono text-[0.65625rem] uppercase tracking-wider text-muted-foreground">
+              <p className="px-5 pb-1.5 font-mono text-2xs uppercase tracking-wider text-muted-foreground">
                 {hits.length} {hits.length === 1 ? "setting" : "settings"}
               </p>
             )}
@@ -265,7 +265,7 @@ export function Settings() {
                   {hitPath(hit, sectionLabel(hit.section)) !== hit.title && (
                     <span
                       className={cn(
-                        "font-mono text-[0.65625rem] tracking-wide text-muted-foreground",
+                        "font-mono text-2xs tracking-wide text-muted-foreground",
                         index === cursor && "text-accent-foreground/75",
                       )}
                     >

--- a/frontend/src/components/sidebar/SessionGroupHeader.tsx
+++ b/frontend/src/components/sidebar/SessionGroupHeader.tsx
@@ -72,7 +72,7 @@ function SessionGroupTitleButton({
           !collapsed && "rotate-90",
         )}
       />
-      <span className="min-w-0 truncate text-[0.65625rem] font-semibold uppercase tracking-wider text-muted-foreground/70 transition-colors group-hover/collapse:text-muted-foreground">
+      <span className="min-w-0 truncate text-2xs font-semibold uppercase tracking-wider text-muted-foreground/70 transition-colors group-hover/collapse:text-muted-foreground">
         {name}
       </span>
       <span className="h-px flex-1 bg-border" />
@@ -130,7 +130,7 @@ export function SessionGroupHeader({
           onFocus={(event) => event.currentTarget.select()}
           onKeyDown={onEditKeyDown}
           onBlur={(event) => commit(event.currentTarget.value)}
-          className="min-w-0 flex-1 rounded-sm bg-transparent px-1 py-0.5 text-[0.65625rem] font-semibold uppercase tracking-wider text-foreground outline-none ring-1 ring-accent-foreground/30"
+          className="min-w-0 flex-1 rounded-sm bg-transparent px-1 py-0.5 text-2xs font-semibold uppercase tracking-wider text-foreground outline-none ring-1 ring-accent-foreground/30"
         />
       ) : (
         <SessionGroupTitleButton

--- a/frontend/src/components/sidebar/WorktreeDialog.tsx
+++ b/frontend/src/components/sidebar/WorktreeDialog.tsx
@@ -103,7 +103,7 @@ function Group({ title, items, base, onSelect }: GroupProps) {
   }
   return (
     <div>
-      <div className="px-2 pb-1 pt-2 text-[0.65625rem] font-semibold tracking-wider text-muted-foreground uppercase">
+      <div className="px-2 pb-1 pt-2 text-2xs font-semibold tracking-wider text-muted-foreground uppercase">
         {title} <span className="font-normal">({items.length})</span>
       </div>
       {items.map((item) => (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -24,6 +24,9 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme inline {
+    /* The one text rung below text-xs: the uppercase label that heads a group
+       of rows (DESIGN.md). Font size only, as the arbitrary value it replaced. */
+    --text-2xs: 0.65625rem;
     --font-heading: var(--font-sans);
     --font-sans: 'Geist Variable', sans-serif;
     --color-sidebar-ring: var(--sidebar-ring);


### PR DESCRIPTION
## Summary

Follow-ups from a code-quality audit of #489–#494.

- **`text-2xs`.** The uppercase section label that #489 promoted to "the" rung below `text-xs` lived as nine copies of `text-[0.65625rem]`. It is now a `--text-2xs` token in `index.css`, and the plan usage table's header, the one uppercase label still at `0.6875rem`, joins the rung. `DESIGN.md` names the utility and lists the four sizes that deliberately stay off it (`0.625rem` mono meta, `0.6875rem` compact detail, `0.5625rem` language badge, `0.8125rem` compact body) instead of claiming no size sits between the two.
- **px lint reads template literals.** `no-px-sizes.grit` only matched double-quoted strings, so `` `text-[11px]` `` in a template literal passed the gate. Verified with a fixture before and after; `style={{ height: "88px" }}` still passes, by design.
- **Windows release e2e reports a lost window.** The page count after the duplicate launch was a bare `grep -c` under `bash -e`; a count of zero ended the step before its `::error` and the log dump. `|| true`, as the macOS script already had.
- **ceilings**: the sandbox probe does not consult `CHROME_DEVEL_SANDBOX`, which Chromium accepts for a binary the user owns.

## Test plan

- [x] `pnpm exec biome ci .` exit 0
- [x] `pnpm test` (1514 passing)
- [x] `pnpm build` exit 0
- [x] grit rule proven on a fixture: double-quoted and template-literal `[Npx]` both fail, `style` px passes
- [ ] Windows release job: only observable on a run where the window dies after the forward
