### PR TITLE
chore: cut 0.46.0 in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.46.0] - 2026-09-07
+
 > [!IMPORTANT]
 > **Your own window on Windows and Apple Silicon, and agents that keep working
 > behind a locked screen.** The embedded Chromium the Linux packages ship now
@@ -4192,7 +4194,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.45.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.46.0...HEAD
+[0.46.0]: https://github.com/omartelo/lich/compare/v0.45.0...v0.46.0
 [0.45.0]: https://github.com/omartelo/lich/compare/v0.44.0...v0.45.0
 [0.44.0]: https://github.com/omartelo/lich/compare/v0.43.1...v0.44.0
 [0.43.1]: https://github.com/omartelo/lich/compare/v0.43.0...v0.43.1


### PR DESCRIPTION
`[Unreleased]` moves under `## [0.46.0] - 2026-09-07`; sections stay Added, Changed, Fixed; compare links refreshed. One `[!IMPORTANT]` block heads the release. The tag is not in this PR.