### PR TITLE
fix: delete the Pulls screen's scratch refs once the merge has been read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Pulls screen no longer leaves refs in your repository.** Naming a
+  conflicting pull request's files fetched its head and its base branch into
+  `refs/lich/pr/<n>/head` and `refs/lich/pr/<n>/base` and left them there, so
+  lich's bookkeeping piled up per pull request opened and a `git push --mirror`
+  would publish it. Both refs are now deleted once the merge has been read.
 - **Scoop installs the current release.** The manifest 0.46.0 introduced pinned
   0.45.0 with no checksums, and nothing bumped it on a tag, so `scoop install`
   and `scoop update lich` handed out the previous release. Every release now

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -340,11 +340,9 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   git writes lich makes outside the worktree flows: the base-branch readout moves remote refs in the user's own
   repository, unannounced, for as long as a card is on screen. Naming a conflicting pull request's files is the
   second, made when that pull request is opened on the Pulls screen: it fetches GitHub's `refs/pull/<n>/head`
-  and the base branch into `refs/lich/pr/<n>/head` and `refs/lich/pr/<n>/base`, and never deletes them — they
-  outlive the answer, and a `git push --mirror` carries them to the remote. The remote fetched from is the one
-  whose URL matches the pull request's own, origin when none does — lich reads gh's base repository off that URL
-  rather than asking gh again, so a clone whose remotes all name a different repository than the pull request
-  lives on falls back to origin and fails there.
+  and the base branch. The remote fetched from is the one whose URL matches the pull request's own, origin when
+  none does — lich reads gh's base repository off that URL rather than asking gh again, so a clone whose remotes
+  all name a different repository than the pull request lives on falls back to origin and fails there.
 - **Persistence is hybrid**: UI prefs in the page's localStorage (`lich.*` keys — the reason the listener port is
   pinned at 47821; `LICH_LISTEN_PORT` overrides it, `LICH_PORT` is the distinct per-session hook variable), the
   workspace in SQLite (`<config-dir>/lich/lich.db`, `internal/store`). Closing a session deletes its row; keeping a

--- a/internal/project/prconflicts.go
+++ b/internal/project/prconflicts.go
@@ -20,7 +20,7 @@ const prConflictBudget = 60 * time.Second
 // opening github.com or a session to find out which files it meant. This
 // computes it instead — both commits are fetched into refs lich owns and merged
 // in the object database alone (mergeConflicts), never in a worktree, an index
-// or HEAD.
+// or HEAD. The refs live no longer than the answer (dropPRRefs).
 //
 // nil means the merge is clean, so this is asked only once GitHub has said it
 // is not: the fetch is a network round trip, not something to poll.
@@ -34,6 +34,9 @@ func (s *Service) PullRequestConflicts(path string, number int, base, prURL stri
 	}
 	head := fmt.Sprintf("refs/lich/pr/%d/head", number)
 	baseRef := fmt.Sprintf("refs/lich/pr/%d/base", number)
+	// Deferred past the fetch's own failure too: two refspecs update
+	// independently, so a fetch that fails may still have written one of them.
+	defer dropPRRefs(path, head, baseRef)
 	if err := fetchPRPair(path, number, base, head, baseRef, prRemote(path, prURL)); err != nil {
 		return nil, err
 	}
@@ -115,8 +118,8 @@ func remoteRepo(remoteURL string) string {
 // Named destinations rather than FETCH_HEAD: that file is shared by every
 // worktree of the repository and the base-status fetch (basestatus.go) writes it
 // from a background goroutine, so two answers would mix into one. They are
-// forced because the refs are scratch space holding the previous answer, which
-// the new tip is routinely not a fast-forward of.
+// forced because a ref left over by a run killed before its cleanup is
+// routinely not an ancestor of the tip now being fetched.
 func fetchPRPair(path string, number int, base, head, baseRef, remote string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), prConflictBudget)
 	defer cancel()
@@ -135,4 +138,16 @@ func fetchPRPair(path string, number int, base, head, baseRef, remote string) er
 		return errors.New(gitMessage(stderr.String(), err))
 	}
 	return nil
+}
+
+// dropPRRefs deletes the scratch refs the fetch wrote. They exist to hold the
+// two commits for as long as merge-tree reads them and no longer: left behind
+// they outlive the answer, and a `git push --mirror` would carry lich's
+// bookkeeping to the remote. Deleting a ref that was never written is a silent
+// no-op, and a delete that fails is nothing to report — the next fetch forces
+// the ref over anyway.
+func dropPRRefs(path string, refs ...string) {
+	for _, ref := range refs {
+		gitQuiet(path, "update-ref", "-d", ref)
+	}
 }

--- a/internal/project/prconflicts_test.go
+++ b/internal/project/prconflicts_test.go
@@ -133,3 +133,28 @@ func TestRepoFromPRURLRefusesWhatItCannotRead(t *testing.T) {
 		}
 	}
 }
+
+// The scratch refs are lich's own bookkeeping, not something the user asked
+// their repository to carry: left behind they outlive the answer, and a
+// `git push --mirror` would publish them.
+func TestPullRequestConflictsLeavesNoRefsBehind(t *testing.T) {
+	clone, origin, originGit := pullRequestOrigin(t, 7)
+	commitFile(t, origin, originGit, "a.txt", "the base branch's line\n", "base edits a")
+	lichRefs := func() string {
+		return gitIn(t, clone)("for-each-ref", "--format=%(refname)", "refs/lich/")
+	}
+
+	if _, err := New(nil).PullRequestConflicts(clone, 7, "main", ""); err != nil {
+		t.Fatalf("PullRequestConflicts: %v", err)
+	}
+	if got := lichRefs(); got != "" {
+		t.Errorf("refs left behind by the answer: %q", got)
+	}
+
+	if _, err := New(nil).PullRequestConflicts(clone, 404, "main", ""); err == nil {
+		t.Fatal("want an error for a pull request origin does not have")
+	}
+	if got := lichRefs(); got != "" {
+		t.Errorf("refs left behind by a fetch that failed: %q", got)
+	}
+}


### PR DESCRIPTION
Closes the `docs/ceilings.md` trap under **lich fetches on its own**: naming a conflicting pull request's files fetched GitHub's `refs/pull/<n>/head` and the tip of the base branch into `refs/lich/pr/<n>/head` and `refs/lich/pr/<n>/base` and never deleted them. One pair of refs accumulated per pull request opened on the Pulls screen, and a `git push --mirror` would carry lich's bookkeeping to the remote.

## What changed

- `internal/project/prconflicts.go`: `dropPRRefs` deletes both refs with `git update-ref -d`, deferred right after the ref names are built — past the fetch's own failure too, since two refspecs update independently and a fetch that fails may still have written one of them. The conflict answer is unchanged: the delete runs after `mergeConflicts` has read the merge.
- The `--force` on the fetch stays, with its reason rewritten: the ref it now overwrites is one left by a run killed before its cleanup, not last answer's scratch space.
- `docs/ceilings.md`: the bullet no longer claims the refs outlive the answer; the rest of it (the remote-resolution ceiling) is untouched.
- `CHANGELOG.md`: `[Unreleased]` → Fixed.

## Test plan

- [x] `TestPullRequestConflictsLeavesNoRefsBehind` asserts `refs/lich/` is empty after a conflicting answer and after a fetch that failed. Verified RED without the fix — it reports both refs left behind on each path.
- [x] The existing conflict tests still pass unchanged, so the answer itself did not move.
- [x] Local gate: `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green. No frontend touched.