### PR TITLE
fix: the packages install Chromium's setuid sandbox helper beside the window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `refs/lich/pr/<n>/head` and `refs/lich/pr/<n>/base` and left them there, so
   lich's bookkeeping piled up per pull request opened and a `git push --mirror`
   would publish it. Both refs are now deleted once the merge has been read.
+- **The window is sandboxed on Ubuntu again.** Chromium confines the window's
+  subprocesses through a user namespace, and Ubuntu's AppArmor policy denies
+  those to unconfined binaries, so the window opened with `--no-sandbox` and
+  Chrome drew its "stability and security will suffer" bar over it. The deb,
+  rpm and AUR packages now install Chromium's setuid helper root-owned and
+  mode 4755 beside the window's binary, which is the other way Chromium
+  confines itself; installing the release over the previous one is enough.
+  Installs from the bare tarball are unchanged: a file unpacked as you cannot
+  be owned by root, so those keep the unsandboxed window.
 - **Scoop installs the current release.** The manifest 0.46.0 introduced pinned
   0.45.0 with no checksums, and nothing bumped it on a tag, so `scoop install`
   and `scoop update lich` handed out the previous release. Every release now

--- a/build/linux/aur/PKGBUILD.tpl
+++ b/build/linux/aur/PKGBUILD.tpl
@@ -33,6 +33,11 @@ package() {
   # /usr/bin/lich looks for it: /usr/lib/lich/shell.
   install -d "${pkgdir}/usr/lib/lich"
   cp -a shell "${pkgdir}/usr/lib/lich/shell"
+  # Chromium's setuid sandbox helper, at the only path its zygote reads:
+  # beside lich-shell, root-owned (install under fakeroot) and 4755. Without
+  # it a desktop that denies unprivileged user namespaces opens the window
+  # with --no-sandbox. The tarball's own copy under cef/ is read by nothing.
+  install -m4755 shell/cef/chrome-sandbox "${pkgdir}/usr/lib/lich/shell/chrome-sandbox"
   install -Dm644 "lich-${pkgver}.desktop" "${pkgdir}/usr/share/applications/lich.desktop"
   install -Dm644 "lich-${pkgver}.png" "${pkgdir}/usr/share/icons/hicolor/128x128/apps/lich.png"
 }

--- a/build/linux/nfpm/nfpm.yaml
+++ b/build/linux/nfpm/nfpm.yaml
@@ -25,6 +25,18 @@ contents:
   - src: "./bin/shell"
     dst: "/usr/local/lib/lich/shell"
     type: tree
+  # Chromium's setuid sandbox helper, at the only path its zygote reads —
+  # beside the executable, root-owned and 4755 (shell/src/main.rs). Without it
+  # a desktop that denies unprivileged user namespaces, which is Ubuntu's
+  # AppArmor policy, opens the window with --no-sandbox. Copied rather than
+  # moved: the tree above carries the same binary under cef/, where the
+  # tarball keeps it and nothing reads it.
+  - src: "./bin/shell/cef/chrome-sandbox"
+    dst: "/usr/local/lib/lich/shell/chrome-sandbox"
+    file_info:
+      mode: 0o4755
+      owner: root
+      group: root
   - src: "./build/appicon.png"
     dst: "/usr/share/icons/hicolor/128x128/apps/lich.png"
   - src: "./build/linux/lich.desktop"

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -965,19 +965,18 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   with no browser at all the crash lands on the tab path, where the log has the story and the
   notification does not. `lich doctor` names the rung that answered; `task dev` pins the window it built
   (`LICH_BROWSER`), since `go run` never has one beside it.
-- **The window's own sandbox is on for Linux alone** (`shell/src/main.rs`, the kurogane fork's
-  `no_sandbox`): Chromium confines the window's subprocesses in a user namespace, or through the setuid
-  helper beside `lich-shell`, and needs nothing of the binary for either. Where it has neither, the browser
-  process would abort at its zygote, so the shell asks first, the way Chromium does (a fork trying
-  `CLONE_NEWUSER`, the helper checked for root and 4755, never as root; the `CHROME_DEVEL_SANDBOX` helper
-  Chromium also accepts for a binary the user owns is not asked) and opens with `--no-sandbox`: that
-  is Ubuntu's desktop, whose AppArmor policy denies unprivileged user namespaces to unconfined binaries, and
-  the packages do not ship the helper setuid (`cef/chrome-sandbox`, mode 755, not beside the executable),
-  so every Ubuntu window runs unsandboxed and carries Chrome's "stability and security will suffer" bar,
-  which is the truth about it. The upgrade is the deb, rpm and AUR installing `chrome-sandbox` root-owned
-  4755 beside `lich-shell`; the AppImage never can, its squashfs mounts nosuid. Windows and macOS run with
-  `no_sandbox` and the same bar: the Windows sandbox needs `cef_sandbox` linked into the executable and the
-  macOS one a helper app initialising it, and neither is wired.
+- **The window's own sandbox needs an install a package manager made** (`shell/src/main.rs`, the kurogane
+  fork's `no_sandbox`): Chromium confines the window's subprocesses in a user namespace, or through the
+  setuid helper beside `lich-shell`. Where it has neither, the browser process would abort at its zygote, so
+  the shell asks first, the way Chromium does (a fork trying `CLONE_NEWUSER`, the helper checked for root and
+  4755, never as root; the `CHROME_DEVEL_SANDBOX` helper Chromium also accepts for a binary the user owns is
+  not asked) and opens with `--no-sandbox`. Only a package can own that helper root: a tarball unpacked as
+  the user cannot, and an AppImage's squashfs mounts nosuid. On a desktop that denies unprivileged user
+  namespaces — Ubuntu's AppArmor policy, over every unconfined binary — either install therefore runs
+  unsandboxed and carries Chrome's "stability and security will suffer" bar, which is the truth about it.
+  Windows and macOS run with `no_sandbox` and the same bar everywhere: the Windows sandbox needs
+  `cef_sandbox` linked into the executable and the macOS one a helper app initialising it, and neither is
+  wired.
 - **The bundled window and a pinned browser share one profile directory** (`shell/src/main.rs`,
   `internal/chromium.Run`): the shell is told `cache_dir` = the `--user-data-dir` lich hands every browser,
   so CEF writes `<config>/lich/chromium-profile` as its own Chromium profile. Pin a browser with `--browser`

--- a/docs/chromium-shell.md
+++ b/docs/chromium-shell.md
@@ -174,7 +174,10 @@ AppUserModelID the Start Menu shortcut declares, which is what makes the
 taskbar group the running window under the pinned icon. The sandbox stays
 off there, as kurogane runs it, so the binary is a plain exe rather than CEF's
 `bootstrap.exe` loading a DLL; Linux is the one platform whose window runs
-sandboxed (`docs/ceilings.md`). Built and smoke-tested on the CI runner only.
+sandboxed — from a package, where the deb, rpm and AUR install Chromium's
+setuid helper root-owned 4755 beside `lich-shell` for the desktops that deny
+unprivileged user namespaces (`docs/ceilings.md`). Built and smoke-tested on
+the CI runner only.
 
 macOS ships the same window inside `Lich.app`, Apple Silicon only: the
 release runner is arm64 and builds the window for itself, and the Intel


### PR DESCRIPTION
Closes the `docs/ceilings.md` trap that said every Ubuntu desktop runs the window unsandboxed.

Chromium confines the window's subprocesses in a user namespace **or** through the setuid helper beside the executable (`shell/src/main.rs` probes for exactly that: `chrome-sandbox` next to `lich-shell`, owned by root, mode 4755). Ubuntu's AppArmor policy denies unprivileged user namespaces to unconfined binaries, and the packages shipped the helper only as `cef/chrome-sandbox`, mode 755, at a path Chromium's zygote never reads — so the window opened with `--no-sandbox` and Chrome drew its "stability and security will suffer" bar over it.

## What changed

- `build/linux/nfpm/nfpm.yaml` (deb, rpm, archlinux): one extra content entry installing `bin/shell/cef/chrome-sandbox` to `/usr/local/lib/lich/shell/chrome-sandbox` with `file_info: {mode: 0o4755, owner: root, group: root}`.
- `build/linux/aur/PKGBUILD.tpl`: `install -m4755 shell/cef/chrome-sandbox` into `/usr/lib/lich/shell/`, which under `makepkg`'s fakeroot lands root:root.
- `docs/ceilings.md`: the closed half of the bullet is gone; what still traps stays (no package manager, no root-owned helper — the tarball and an AppImage's nosuid squashfs — plus Windows and macOS).
- `docs/chromium-shell.md` and a `CHANGELOG.md` `[Unreleased]` entry under Fixed.

**No postinstall script.** nfpm sets the setuid bit and the ownership itself through `file_info`, verified in all three formats below.

`build/linux/shell/assemble.sh` is deliberately untouched, so the shell tarball keeps its layout: the helper is copied, not moved, and the unread `cef/` copy stays. Moving it there instead would leave one copy at the right path — a one-line follow-up if that layout change is wanted.

## Verified locally

`nfpm` run against this `nfpm.yaml` over a stub `bin/` tree (the real one needs a full CEF build), then the archives read back:

| format | entry |
|---|---|
| deb | `-rwsr-xr-x root/root ./usr/local/lib/lich/shell/chrome-sandbox` |
| rpm | `-rwsr-xr-x 1 0 0 /usr/local/lib/lich/shell/chrome-sandbox` |
| archlinux | `-rwsr-xr-x 0/0 usr/local/lib/lich/shell/chrome-sandbox` |

The AUR `package()` body was run under `fakeroot` against a stub tree: `-rwsr-xr-x 1 root root chrome-sandbox` beside `lich-shell`.

No Go, frontend or Rust source is touched, so the code gates are unaffected.

## What only CI or a real install can prove

- That the released packages carry the bit end to end (a real `task package` over a real `bin/shell`, and `dpkg-deb -c` / `rpm -qlvp` on the release assets — this machine has neither `dpkg` nor a CEF build).
- That `dpkg` and `rpm` preserve setuid on install, and that `makepkg`/namcap do not object to a setuid file in `lich-bin`.
- The payoff itself: an Ubuntu desktop installing the deb and getting a window with no "stability and security will suffer" bar — `chrome://version` on the window's CDP shows the sandbox state.

## Test plan

- [ ] Release build: `dpkg-deb -c lich-*.deb | grep chrome-sandbox` shows `rwsr-xr-x root/root` at `usr/local/lib/lich/shell/`.
- [ ] Same for `rpm -qlvp` and the `.pkg.tar.zst`.
- [ ] Install the deb on an Ubuntu desktop, open lich, confirm no bad-flags bar and a sandboxed `chrome://version`.
- [ ] Tarball install still opens (unsandboxed, unchanged).