### PR TITLE
fix: the cursor keeps the shape a program chose across a card switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   confines itself; installing the release over the previous one is enough.
   Installs from the bare tarball are unchanged: a file unpacked as you cannot
   be owned by root, so those keep the unsandboxed window.
+- **The cursor keeps its shape across a card switch.** Hiding a session
+  serializes its terminal and destroys it, and the snapshot never carried the
+  cursor shape a program had chosen, so a shell or editor drawing a bar or an
+  underline came back with lich's block. The shape is now carried across the
+  cycle beside the mouse encoding and cursor visibility, and follows the
+  program's own reset back to the default.
 - **Scoop installs the current release.** The manifest 0.46.0 introduced pinned
   0.45.0 with no checksums, and nothing bumped it on a tag, so `scoop install`
   and `scoop update lich` handed out the previous release. Every release now

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -385,9 +385,7 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   (`frontend/src/lib/terminal/replay-buffer.ts` page-side, `internal/terminal/replay.go` backend-side — the latter
   survives a full page reload). Scrollback past the ring is gone, not paged. The snapshot carries only the modes
   xterm's SerializeAddon reads off `term.modes`; the ones an app relies on and it does not record are restored by
-  hand in `frontend/src/lib/terminal/term-modes.ts` — today the mouse encoding and cursor visibility. Cursor
-  *shape* (DECSCUSR) is not among them: a TUI that chose a bar or underline cursor gets lich's block back after a
-  card switch.
+  hand in `frontend/src/lib/terminal/term-modes.ts`.
 - **One socket carries every session's output** (`internal/terminal/writequeue.go`): the per-session outbox
   decouples the *producers*, never the wire. A window that stops reading stalls the connection's single writer,
   so after `wsWriteTimeout` (5s) every session's output switches to the `/events` bridge at once. That is a

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -23,6 +23,7 @@ import { copyToastMessage, COPY_TOAST_DURATION_MS } from "@/lib/terminal/copy-to
 import { decodeBase64 } from "@/lib/terminal/term-frame"
 import {
   cursorHidden,
+  cursorShape,
   ensureFontLoaded,
   fitTerminal,
   mouseEncoding,
@@ -34,6 +35,7 @@ import { TerminalDropHint } from "./TerminalDropHint"
 import { TerminalSearchBar, type SearchResults } from "./TerminalSearchBar"
 import { useTerminalDrop } from "./useTerminalDrop"
 import {
+  cursorShapeSequence,
   cursorVisibilitySequence,
   linkClickIsOurs,
   mouseEncodingSequence,
@@ -452,7 +454,8 @@ export function TerminalView({
     serializedRef.current = live.serialize.serialize()
     carriedModesRef.current =
       mouseEncodingSequence(mouseEncoding(live.term)) +
-      cursorVisibilitySequence(cursorHidden(live.term))
+      cursorVisibilitySequence(cursorHidden(live.term)) +
+      cursorShapeSequence(cursorShape(live.term))
     live.dispose()
     liveRef.current = null
   }

--- a/frontend/src/lib/terminal/term-modes.test.ts
+++ b/frontend/src/lib/terminal/term-modes.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { cursorVisibilitySequence, linkClickIsOurs, mouseEncodingSequence } from "./term-modes"
+import {
+  cursorShapeSequence,
+  cursorVisibilitySequence,
+  linkClickIsOurs,
+  mouseEncodingSequence,
+} from "./term-modes"
 
 describe("mouseEncodingSequence", () => {
   it("restores SGR, the encoding every modern TUI selects", () => {
@@ -30,6 +35,29 @@ describe("cursorVisibilitySequence", () => {
 
   it("writes nothing when it was visible, which a fresh terminal already is", () => {
     expect(cursorVisibilitySequence(false)).toBe("")
+  })
+})
+
+describe("cursorShapeSequence", () => {
+  it("carries a bar cursor across the serialize/restore cycle", () => {
+    expect(cursorShapeSequence({ style: "bar", blink: false })).toBe("\x1b[6 q")
+    expect(cursorShapeSequence({ style: "bar", blink: true })).toBe("\x1b[5 q")
+  })
+
+  it("restores the other shapes DECSCUSR can select", () => {
+    expect(cursorShapeSequence({ style: "block", blink: true })).toBe("\x1b[1 q")
+    expect(cursorShapeSequence({ style: "block", blink: false })).toBe("\x1b[2 q")
+    expect(cursorShapeSequence({ style: "underline", blink: true })).toBe("\x1b[3 q")
+    expect(cursorShapeSequence({ style: "underline", blink: false })).toBe("\x1b[4 q")
+  })
+
+  it("writes nothing once the app resets the cursor (Ps 0, or a full reset)", () => {
+    expect(cursorShapeSequence({})).toBe("")
+    expect(cursorShapeSequence({ style: undefined, blink: undefined })).toBe("")
+  })
+
+  it("writes nothing for a shape name xterm added since", () => {
+    expect(cursorShapeSequence({ style: "SOMETHING_NEW", blink: true })).toBe("")
   })
 })
 

--- a/frontend/src/lib/terminal/term-modes.ts
+++ b/frontend/src/lib/terminal/term-modes.ts
@@ -3,7 +3,7 @@
  *
  * Hiding a session serializes the terminal and destroys it; showing it writes
  * the snapshot into a fresh one. xterm's SerializeAddon replays the modes it
- * can read off `term.modes`, and two an app depends on are not among them:
+ * can read off `term.modes`, and three an app depends on are not among them:
  *
  * - The mouse *encoding*. The addon restores the mouse *protocol*
  *   (`?1000`/`?1002`/`?1003`) but never the encoding the app turned on with it,
@@ -14,6 +14,9 @@
  * - Cursor visibility (`?25`). A fresh terminal shows its cursor, so an app
  *   that hid it — every full-screen TUI does, drawing its own — gets lich's
  *   blinking block back, parked wherever the snapshot left the real cursor.
+ * - Cursor shape (DECSCUSR, `CSI Ps SP q`). xterm parses it into a private the
+ *   addon never reads, so a shell or editor that asked for a bar or an
+ *   underline gets lich's block back on the next card switch.
  */
 
 // Keyed by xterm's CoreMouseEncoding names; DEFAULT (X10) needs no sequence.
@@ -38,6 +41,24 @@ export function mouseEncodingSequence(encoding: string | undefined): string {
  */
 export function cursorVisibilitySequence(hidden: boolean): string {
   return hidden ? "\x1b[?25l" : ""
+}
+
+// Keyed by xterm's cursorStyle names; each pair is the DECSCUSR Ps for that
+// shape, blinking first. A style xterm never set means the app never chose one
+// (or reset it with Ps 0 / RIS), which is the fresh terminal's own default.
+const CURSOR_SHAPE_PS: Record<string, [blinking: number, steady: number]> = {
+  block: [1, 2],
+  underline: [3, 4],
+  bar: [5, 6],
+}
+
+/**
+ * The DECSCUSR sequence that re-selects the cursor shape the app asked for, or
+ * "" when it never asked, reset it, or picked a name xterm added since.
+ */
+export function cursorShapeSequence(shape: { style?: string; blink?: boolean }): string {
+  const ps = shape.style ? CURSOR_SHAPE_PS[shape.style] : undefined
+  return ps ? `\x1b[${shape.blink === false ? ps[1] : ps[0]} q` : ""
 }
 
 /**

--- a/frontend/src/lib/terminal/term-view.ts
+++ b/frontend/src/lib/terminal/term-view.ts
@@ -1,6 +1,6 @@
 // The xterm and document side of a live terminal: the cell metrics the grid fit
-// needs, the mouse encoding a snapshot cannot carry, and the font the renderer
-// measures against. Two of the four reach into xterm privates, and every one of
+// needs, the modes a snapshot cannot carry, and the font the renderer
+// measures against. Three of the five reach into xterm privates, and every one of
 // them needs a real Terminal or a real document — which is why this file is the
 // boundary invariant #1 exempts and is excluded from the coverage denominator
 // beside term-transport and term-perf. The arithmetic under the fit is
@@ -46,7 +46,7 @@ export function mouseEncoding(term: Terminal): string | undefined {
 }
 
 // cursorHidden reads whether the app turned the cursor off (DECRST 25) — a
-// third private, and the third mode a snapshot cannot carry (term-modes.ts).
+// third private, and the second mode a snapshot cannot carry (term-modes.ts).
 // False if xterm ever moves it, which restores nothing and matches a fresh
 // terminal's own default.
 export function cursorHidden(term: Terminal): boolean {
@@ -54,6 +54,22 @@ export function cursorHidden(term: Terminal): boolean {
     (term as unknown as { _core?: { coreService?: { isCursorHidden?: boolean } } })._core
       ?.coreService?.isCursorHidden === true
   )
+}
+
+// cursorShape reads the shape the app selected with DECSCUSR — the fourth
+// private, and the third mode a snapshot cannot carry (term-modes.ts). xterm
+// parses the sequence into decPrivateModes, which `term.modes` does not expose
+// and the renderer falls back from to the terminal's own options. Empty if
+// xterm ever moves it, which restores nothing and leaves lich's block.
+export function cursorShape(term: Terminal): { style?: string; blink?: boolean } {
+  const modes = (
+    term as unknown as {
+      _core?: {
+        coreService?: { decPrivateModes?: { cursorStyle?: string; cursorBlink?: boolean } }
+      }
+    }
+  )._core?.coreService?.decPrivateModes
+  return { style: modes?.cursorStyle, blink: modes?.cursorBlink }
 }
 
 // fitTerminal resizes the grid to fill the container edge to edge on the


### PR DESCRIPTION
Hiding a session serializes its terminal and destroys it; showing it writes the snapshot back. The snapshot carries only the modes xterm's `SerializeAddon` reads off `term.modes`, and DECSCUSR (`CSI Ps SP q`) is not one of them — xterm parses it into `coreService.decPrivateModes`, a private the addon never reads. A shell or editor that chose a bar or an underline cursor got lich's block back on the next card switch.

## What changed

- `term-view.ts`: `cursorShape` reads that private, beside the two readers already there for the mouse encoding and cursor visibility.
- `term-modes.ts`: `cursorShapeSequence` maps xterm's style + blink back to the DECSCUSR `Ps` (block 1/2, underline 3/4, bar 5/6), and writes nothing when the program never chose a shape — which is what `Ps 0` and a full reset leave behind, so a reset restores the terminal's own default.
- `TerminalView.tsx`: the sequence joins the carried modes at hide and is re-emitted after the snapshot replay, before the queued tail, so newer output still wins.
- `docs/ceilings.md`: the trap is closed, so its sentence goes. The bullet's list of restored modes went with it rather than growing a third entry that would be stale again on the next one; the code and the changelog say what is restored.

## Test plan

- [x] `frontend/src/lib/terminal/term-modes.test.ts`: a bar cursor survives the cycle (blinking and steady), the other four shapes, a reset carrying nothing, and an unknown style name.
- [x] `pnpm exec biome ci .` exit 0 (17 standing a11y warnings, no errors)
- [x] `vitest run` — 1518 tests, 129 files, green
- [x] `tsc` + `vite build`
- [ ] By hand in `task dev`: `printf '\e[6 q'` in a session, switch cards, and the bar comes back; `printf '\e[0 q'` then a switch leaves the block.