### PR TITLE
fix: keep rebound hotkeys in the workspace database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   confines itself; installing the release over the previous one is enough.
   Installs from the bare tarball are unchanged: a file unpacked as you cannot
   be owned by root, so those keep the unsandboxed window.
+- **Rebound keyboard shortcuts survive a recreated browser profile.** The
+  bindings lived in the page's own storage, which sits in the Chromium profile
+  lich recreates when its storage comes back damaged: every rebind was lost, and
+  Settings and the shortcuts overlay went on showing the defaults as though
+  nothing had been changed. They are stored in the workspace database now, beside
+  the theme, and an existing set is moved there once on the next launch.
 - **Scoop installs the current release.** The manifest 0.46.0 introduced pinned
   0.45.0 with no checksums, and nothing bumped it on a tag, so `scoop install`
   and `scoop update lich` handed out the previous release. Every release now

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -365,13 +365,10 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   no confirmation on the way. It is not a new privilege — the agent already runs as you, in a shell that can read
   the same disk — but it is new visibility, and a card it opens there is a card with a PTY in it.
 
-- **A hotkey is taken from the agent, and its rebind lives only in the page** (`frontend/src/lib/use-hotkey.ts`,
+- **A hotkey is taken from the agent, and a rebind is checked against nothing** (`frontend/src/lib/use-hotkey.ts`,
   `hotkeys.ts`): every bound combo is caught in the window capture phase and stopped there, so the chord never
-  reaches the PTY — the defaults spend chords no TUI can bind, but a rebind is checked against nothing, and
-  recording `Ctrl+R` silently costs the shell its history search with nothing on screen connecting the two. The
-  bindings are a `lich.hotkeys` entry in localStorage, which the theme left for the workspace database precisely
-  because a recreated Chromium profile drops it: the combos revert to the defaults, and both the overlay and
-  Settings then show those defaults as if nothing had ever been rebound.
+  reaches the PTY. The defaults spend chords no TUI can bind, but nothing holds a rebind to that, and recording
+  `Ctrl+R` silently costs the shell its history search with nothing on screen connecting the two.
 - **lich's own window offers the page every primary-modifier chord before Chromium runs it**
   (`shell/src/main.rs`): a CEF keyboard handler marks each Ctrl chord (Cmd on macOS) a keyboard shortcut, which
   is the only way a page can claim one of Chromium's *reserved* accelerators. Ctrl+T, Ctrl+W, Ctrl+Shift+T and

--- a/frontend/src/lib/hotkeys.test.ts
+++ b/frontend/src/lib/hotkeys.test.ts
@@ -1,35 +1,20 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { describe, expect, it } from "vitest"
 import {
   comboFromEvent,
   DEFAULT_HOTKEYS,
   formatCombo,
   hotkeyConflicts,
+  adoptStoredHotkeys,
   hotkeyLabel,
-  loadHotkeys,
   matchesCombo,
   mergeHotkeys,
+  parseHotkeys,
   sameCombo,
-  saveHotkeys,
   UNASSIGNED,
   UNASSIGNED_LABEL,
   type Combo,
   type KeyState,
 } from "./hotkeys"
-
-// The suite runs in node, which has no localStorage; the stored half of the
-// hotkeys is the point of the two functions below, so the storage is stubbed and
-// the round-trip through it is what is checked.
-const stored = new Map<string, string>()
-
-vi.stubGlobal("localStorage", {
-  getItem: (key: string) => stored.get(key) ?? null,
-  setItem: (key: string, value: string) => {
-    stored.set(key, value)
-  },
-  removeItem: (key: string) => {
-    stored.delete(key)
-  },
-})
 
 const key = (over: Partial<KeyState>): KeyState => ({
   ctrlKey: false,
@@ -234,63 +219,97 @@ describe("sameCombo", () => {
   })
 })
 
-describe("loadHotkeys", () => {
-  beforeEach(() => {
-    stored.clear()
+describe("parseHotkeys", () => {
+  it("answers the defaults for a value nobody has set", () => {
+    expect(parseHotkeys("")).toEqual(DEFAULT_HOTKEYS)
   })
 
-  it("answers the defaults with nothing stored", () => {
-    expect(loadHotkeys()).toEqual(DEFAULT_HOTKEYS)
-  })
-
-  it("round-trips what saveHotkeys wrote", () => {
+  it("round-trips what the provider stores", () => {
     const mine: Combo = { mod: true, shift: true, alt: false, key: "j" }
-    saveHotkeys({ ...DEFAULT_HOTKEYS, newSession: mine })
+    const raw = JSON.stringify({ ...DEFAULT_HOTKEYS, newSession: mine })
 
-    expect(loadHotkeys().newSession).toEqual(mine)
+    expect(parseHotkeys(raw).newSession).toEqual(mine)
   })
 
   it("round-trips an unassigned action, and takes its default back on reset", () => {
-    saveHotkeys({ ...DEFAULT_HOTKEYS, newSession: UNASSIGNED })
-    const cleared = loadHotkeys()
+    const cleared = parseHotkeys(JSON.stringify({ ...DEFAULT_HOTKEYS, newSession: UNASSIGNED }))
     expect(cleared.newSession).toEqual(UNASSIGNED)
     expect(matchesCombo(key({ ctrlKey: true, shiftKey: true, key: "T" }), cleared.newSession)).toBe(
       false,
     )
 
     // What resetHotkey writes back (settings.tsx): the default for that id.
-    saveHotkeys({ ...cleared, newSession: DEFAULT_HOTKEYS.newSession })
-    expect(loadHotkeys()).toEqual(DEFAULT_HOTKEYS)
+    const reset = { ...cleared, newSession: DEFAULT_HOTKEYS.newSession }
+    expect(parseHotkeys(JSON.stringify(reset))).toEqual(DEFAULT_HOTKEYS)
   })
 
-  // A pref must never be able to break a launch: the value is a string somebody
-  // can hand-edit, and half of one is what an interrupted write leaves.
+  // A stored setting must never be able to break a launch: the value is a string
+  // somebody can hand-edit, and half of one is what an interrupted write leaves.
   it("falls back to the defaults for a value that is not JSON", () => {
-    stored.set("lich.hotkeys", '{"newSession":')
-
-    expect(loadHotkeys()).toEqual(DEFAULT_HOTKEYS)
+    expect(parseHotkeys('{"newSession":')).toEqual(DEFAULT_HOTKEYS)
   })
 
   it("falls back for JSON that is not an object at all", () => {
-    stored.set("lich.hotkeys", '"ctrl+shift+t"')
-
-    expect(loadHotkeys()).toEqual(DEFAULT_HOTKEYS)
+    expect(parseHotkeys('"ctrl+shift+t"')).toEqual(DEFAULT_HOTKEYS)
   })
 
   // Stored under a key the build no longer has, beside one it does: the known
   // override stands and the stranger is dropped.
   it("keeps a valid override and ignores what is not an action", () => {
-    stored.set(
-      "lich.hotkeys",
+    const parsed = parseHotkeys(
       JSON.stringify({
         newSession: { mod: true, shift: true, alt: false, key: "J" },
         zoomIn: { mod: true, shift: false, alt: false, key: "+" },
       }),
     )
 
-    const loaded = loadHotkeys()
-    expect(loaded.newSession.key).toBe("j")
-    expect(loaded).not.toHaveProperty("zoomIn")
+    expect(parsed.newSession.key).toBe("j")
+    expect(parsed).not.toHaveProperty("zoomIn")
+  })
+})
+
+describe("adoptStoredHotkeys", () => {
+  const mine: Combo = { mod: true, shift: true, alt: false, key: "j" }
+  const raw = (combo: Combo) => JSON.stringify({ ...DEFAULT_HOTKEYS, newSession: combo })
+
+  it("reads the workspace copy, and asks for no migration", () => {
+    const { hotkeys, migrate } = adoptStoredHotkeys(raw(mine), null)
+
+    expect(hotkeys.newSession).toEqual(mine)
+    expect(migrate).toBe(false)
+  })
+
+  // The install that predates the move: the page's entry is the only record, so
+  // it is adopted and handed to the caller to write back once.
+  it("adopts the page copy and asks to migrate it", () => {
+    const { hotkeys, migrate } = adoptStoredHotkeys("", raw(mine))
+
+    expect(hotkeys.newSession).toEqual(mine)
+    expect(migrate).toBe(true)
+  })
+
+  // Both stores answering is the launch after the migration wrote but before the
+  // page entry was dropped, and a stale page copy must never win.
+  it("lets the workspace copy beat the page copy", () => {
+    const theirs: Combo = { mod: true, shift: true, alt: false, key: "y" }
+    const { hotkeys, migrate } = adoptStoredHotkeys(raw(theirs), raw(mine))
+
+    expect(hotkeys.newSession).toEqual(theirs)
+    expect(migrate).toBe(false)
+  })
+
+  it("answers the defaults, and no migration, for an install with neither", () => {
+    const { hotkeys, migrate } = adoptStoredHotkeys("", null)
+
+    expect(hotkeys).toEqual(DEFAULT_HOTKEYS)
+    expect(migrate).toBe(false)
+  })
+
+  // A page entry nobody ever rebound still migrates: writing the defaults is
+  // what makes the database the record, and re-reading the entry after this
+  // would take the migration for one still pending.
+  it("migrates an empty page entry rather than leaving it behind", () => {
+    expect(adoptStoredHotkeys("", "{}")).toEqual({ hotkeys: DEFAULT_HOTKEYS, migrate: true })
   })
 })
 

--- a/frontend/src/lib/hotkeys.ts
+++ b/frontend/src/lib/hotkeys.ts
@@ -1,9 +1,7 @@
-import { readPref, writePref } from "@/lib/prefs"
-
-// Global keyboard shortcuts. Combos are user-configurable and persisted to
-// localStorage, matching every other setting (see settings.tsx). `mod` is the
-// platform primary modifier — Ctrl on Windows/Linux, Cmd on macOS — so a single
-// stored combo works on both.
+// Global keyboard shortcuts. Combos are user-configurable and persisted to the
+// workspace database, the way the theme selection is (see settings.tsx). `mod`
+// is the platform primary modifier — Ctrl on Windows/Linux, Cmd on macOS — so a
+// single stored combo works on both.
 
 // Zoom is deliberately absent: those chords shadow Chromium's own accelerators,
 // which are bound to physical keys, so they are matched on event.code in
@@ -238,7 +236,16 @@ export type KeyState = Pick<
 >
 
 const MODIFIER_KEYS = new Set(["Control", "Meta", "Shift", "Alt", "AltGraph"])
-const STORAGE_KEY = "lich.hotkeys"
+
+// The workspace key the bindings live under, global scope: a rebind answers for
+// this install rather than for one project, exactly like the theme selection.
+export const HOTKEYS_SETTING_KEY = "hotkeys.bindings"
+
+// Where the bindings lived before that: an entry in the page's own storage,
+// which sits in the Chromium profile. A profile Chromium recreates from scratch
+// (#209) comes back without it, and every rebind was gone with no sign on screen
+// that anything had been lost. Read once, migrated, and dropped.
+export const LEGACY_HOTKEYS_KEY = "lich.hotkeys"
 
 // normalizeKey folds "=" into "+" (same physical key) and lowercases single
 // characters so casing from Shift does not change the identity of the combo.
@@ -380,15 +387,32 @@ export function mergeHotkeys(overrides: unknown): Hotkeys {
   return result
 }
 
-export function loadHotkeys(): Hotkeys {
+// parseHotkeys reads one stored value, from either store. A persisted binding
+// must never be able to break a launch: the value is a string somebody can
+// hand-edit, and half of one is what an interrupted write leaves, so anything
+// that does not parse reads as the defaults.
+export function parseHotkeys(raw: string): Hotkeys {
   try {
-    const raw = readPref(STORAGE_KEY)
     return raw ? mergeHotkeys(JSON.parse(raw)) : DEFAULT_HOTKEYS
   } catch {
     return DEFAULT_HOTKEYS
   }
 }
 
-export function saveHotkeys(hotkeys: Hotkeys): void {
-  writePref(STORAGE_KEY, JSON.stringify(hotkeys))
+// adoptStoredHotkeys resolves the bindings a launch starts from against the two
+// stores, mirroring adoptStoredTheme: the workspace copy is the durable one and
+// wins, and the page copy is what an install that predates the move still has.
+// `migrate` reports that copy still being the only record — it is written to the
+// database once and then removed, so the profile no longer owns the answer.
+export function adoptStoredHotkeys(
+  stored: string,
+  legacy: string | null,
+): { hotkeys: Hotkeys; migrate: boolean } {
+  if (stored) {
+    return { hotkeys: parseHotkeys(stored), migrate: false }
+  }
+  if (legacy === null) {
+    return { hotkeys: DEFAULT_HOTKEYS, migrate: false }
+  }
+  return { hotkeys: parseHotkeys(legacy), migrate: true }
 }

--- a/frontend/src/providers/settings.test.tsx
+++ b/frontend/src/providers/settings.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+//
+// Where the hotkey bindings come from, and the one migration off the page's own
+// storage. This is rendered rather than left to the pure half (hotkeys.test.ts)
+// because the migration runs exactly once per install: it writes the workspace
+// copy and drops the page entry, and a launch that gets that order wrong takes
+// every rebind with it, with nothing left to read it back from.
+//
+// The harness has to be imported before anything that reaches react-dom, which
+// is why it is first here (see @/test/render-budget).
+import { mountBudget } from "@/test/render-budget"
+import { createElement } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_HOTKEYS, HOTKEYS_SETTING_KEY, LEGACY_HOTKEYS_KEY } from "@/lib/hotkeys"
+import type { Combo, Hotkeys } from "@/lib/hotkeys"
+import { SettingsProvider, useSettings } from "@/providers/settings"
+
+const settings = new Map<string, string>()
+const writes: string[] = []
+
+vi.mock("@/lib/rpc", () => ({
+  Store: {
+    GetSetting: (key: string, scope: string) =>
+      Promise.resolve(settings.get(`${key}@${scope}`) ?? ""),
+    SetSetting: (key: string, scope: string, value: string) => {
+      if (key === HOTKEYS_SETTING_KEY) {
+        writes.push(`${key}@${scope}`)
+      }
+      settings.set(`${key}@${scope}`, value)
+      return Promise.resolve(null)
+    },
+  },
+  // The theme list is the provider's other boot call; it hangs, which leaves the
+  // bundled themes standing and keeps this file about the bindings.
+  Themes: new Proxy({}, { get: () => () => new Promise<never>(() => {}) }),
+}))
+
+const MINE: Combo = { mod: true, shift: true, alt: false, key: "j" }
+const rebound = (combo: Combo) => JSON.stringify({ ...DEFAULT_HOTKEYS, newSession: combo })
+
+/** The bindings as a consumer sees them, once every boot read has settled. */
+async function mountSettings(): Promise<Hotkeys> {
+  let seen: Hotkeys = DEFAULT_HOTKEYS
+  function Probe() {
+    seen = useSettings().hotkeys
+    return null
+  }
+  const mounted = await mountBudget(createElement(SettingsProvider, null, createElement(Probe)))
+  await mounted.act(() => {})
+  await mounted.unmount()
+  return seen
+}
+
+beforeEach(() => {
+  settings.clear()
+  writes.length = 0
+  localStorage.clear()
+})
+
+describe("the hotkey bindings", () => {
+  it("reads them from the workspace, without writing anything back", async () => {
+    settings.set(`${HOTKEYS_SETTING_KEY}@`, rebound(MINE))
+
+    expect((await mountSettings()).newSession).toEqual(MINE)
+    expect(writes).toEqual([])
+  })
+
+  it("migrates the page's copy into the workspace and drops it", async () => {
+    localStorage.setItem(LEGACY_HOTKEYS_KEY, rebound(MINE))
+
+    expect((await mountSettings()).newSession).toEqual(MINE)
+    expect(writes).toEqual([`${HOTKEYS_SETTING_KEY}@`])
+    expect(localStorage.getItem(LEGACY_HOTKEYS_KEY)).toBeNull()
+
+    // And the launch after it reads the workspace, with nothing left to migrate.
+    writes.length = 0
+    expect((await mountSettings()).newSession).toEqual(MINE)
+    expect(writes).toEqual([])
+  })
+
+  it("leaves a stale page copy standing under the workspace one", async () => {
+    const theirs: Combo = { mod: true, shift: true, alt: false, key: "y" }
+    settings.set(`${HOTKEYS_SETTING_KEY}@`, rebound(theirs))
+    localStorage.setItem(LEGACY_HOTKEYS_KEY, rebound(MINE))
+
+    expect((await mountSettings()).newSession).toEqual(theirs)
+    expect(writes).toEqual([])
+  })
+
+  it("answers the defaults for an install that has neither", async () => {
+    expect(await mountSettings()).toEqual(DEFAULT_HOTKEYS)
+    expect(writes).toEqual([])
+  })
+
+  it("writes a rebind through to the workspace", async () => {
+    let rebind: (() => void) | undefined
+    function Probe() {
+      const { setHotkey } = useSettings()
+      rebind = () => setHotkey("newSession", MINE)
+      return null
+    }
+    const mounted = await mountBudget(createElement(SettingsProvider, null, createElement(Probe)))
+    await mounted.act(() => {})
+    await mounted.act(() => rebind?.())
+
+    expect(settings.get(`${HOTKEYS_SETTING_KEY}@`)).toContain('"key":"j"')
+    await mounted.unmount()
+  })
+})

--- a/frontend/src/providers/settings.tsx
+++ b/frontend/src/providers/settings.tsx
@@ -1,10 +1,11 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react"
 import type { ReactNode } from "react"
 import {
+  adoptStoredHotkeys,
   DEFAULT_HOTKEYS,
+  HOTKEYS_SETTING_KEY,
   isRecordingTarget,
-  loadHotkeys,
-  saveHotkeys,
+  LEGACY_HOTKEYS_KEY,
   type Combo,
   type HotkeyId,
   type Hotkeys,
@@ -15,6 +16,7 @@ import {
   parseNumberPref,
   parseOptionalBoolPref,
   readPref,
+  removePref,
   writePref,
 } from "@/lib/prefs"
 import { Store, Themes as ThemeRPC } from "@/lib/rpc"
@@ -194,7 +196,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   const [theme, setThemeState] = useState<Theme>(readTheme)
   const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(BUNDLED_THEMES[0])
   const [zoom, setZoomState] = useState<number>(readZoom)
-  const [hotkeys, setHotkeys] = useState<Hotkeys>(loadHotkeys)
+  // The defaults until the stored bindings land: unlike the theme there is no
+  // page-side cache to paint from, and a chord pressed in that first moment is
+  // one the window has not claimed yet — it reaches the terminal, which is the
+  // harmless way round.
+  const [hotkeys, setHotkeys] = useState<Hotkeys>(DEFAULT_HOTKEYS)
   const [showContextUsage] = useState<boolean>(readContextUsage)
   const [footerLayout, setFooterLayoutState] = useState(readFooterLayout)
   const [footerVisibility] = useState(() => readFooterVisibility(readContextUsage()))
@@ -210,6 +216,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   // overwritten by the stored one still in flight, so the load below stands down
   // once anything has been persisted.
   const selectionTouched = useRef(false)
+
+  // The same guard for the bindings: a rebind made before the stored ones land
+  // must not be overwritten by the read still in flight.
+  const hotkeysTouched = useRef(false)
 
   const persistTheme = useCallback((next: Theme) => {
     selectionTouched.current = true
@@ -244,6 +254,44 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       cancelled = true
     }
   }, [persistTheme])
+
+  const persistHotkeys = useCallback((next: Hotkeys) => {
+    hotkeysTouched.current = true
+    // Loud, unlike the theme's write: there is no page-side copy standing behind
+    // this one, so a write that fails is a rebind the next launch will not have.
+    void Store.SetSetting(HOTKEYS_SETTING_KEY, GLOBAL_SCOPE, JSON.stringify(next)).catch(
+      (error) => {
+        console.warn("[settings] failed to persist the hotkey bindings", error)
+      },
+    )
+  }, [])
+
+  // The stored bindings, and the one migration off the page's own storage. The
+  // state is only replaced when the answer differs from what is already on
+  // screen — the common case is an install with no rebinds, and handing every
+  // consumer a fresh (identical) map would repaint the window for nothing.
+  useEffect(() => {
+    let cancelled = false
+    Store.GetSetting(HOTKEYS_SETTING_KEY, GLOBAL_SCOPE)
+      .then((stored) => {
+        if (cancelled || hotkeysTouched.current) return
+        const { hotkeys: adopted, migrate } = adoptStoredHotkeys(
+          stored,
+          readPref(LEGACY_HOTKEYS_KEY),
+        )
+        setHotkeys((prev) => (adopted === prev ? prev : adopted))
+        if (migrate) {
+          persistHotkeys(adopted)
+          removePref(LEGACY_HOTKEYS_KEY)
+        }
+      })
+      .catch((error) => {
+        console.warn("[settings] failed to load the stored hotkey bindings", error)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [persistHotkeys])
 
   useEffect(() => {
     let cancelled = false
@@ -361,21 +409,27 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     [theme, persistTheme],
   )
 
-  const setHotkey = useCallback((id: HotkeyId, combo: Combo) => {
-    setHotkeys((prev) => {
-      const next = { ...prev, [id]: combo }
-      saveHotkeys(next)
-      return next
-    })
-  }, [])
+  const setHotkey = useCallback(
+    (id: HotkeyId, combo: Combo) => {
+      setHotkeys((prev) => {
+        const next = { ...prev, [id]: combo }
+        persistHotkeys(next)
+        return next
+      })
+    },
+    [persistHotkeys],
+  )
 
-  const resetHotkey = useCallback((id: HotkeyId) => {
-    setHotkeys((prev) => {
-      const next = { ...prev, [id]: DEFAULT_HOTKEYS[id] }
-      saveHotkeys(next)
-      return next
-    })
-  }, [])
+  const resetHotkey = useCallback(
+    (id: HotkeyId) => {
+      setHotkeys((prev) => {
+        const next = { ...prev, [id]: DEFAULT_HOTKEYS[id] }
+        persistHotkeys(next)
+        return next
+      })
+    },
+    [persistHotkeys],
+  )
 
   const setCostBudget = useCallback((next: number) => {
     const clamped = clampCostBudget(next)

--- a/internal/store/settings_test.go
+++ b/internal/store/settings_test.go
@@ -37,6 +37,39 @@ func TestSettingGlobalAndProjectScope(t *testing.T) {
 	}
 }
 
+// The hotkey bindings are a JSON document rather than the flag or path every
+// other setting holds (frontend/src/lib/hotkeys.ts), and they are what a
+// recreated Chromium profile used to take with it. Nothing may reshape the value
+// on the way through: a binding that comes back re-quoted or trimmed is a
+// shortcut that no longer fires, with nothing on screen saying why.
+func TestSettingRoundTripsAJSONDocument(t *testing.T) {
+	svc := newTestStore(t)
+
+	const key = "hotkeys.bindings"
+	const bindings = `{"newSession":{"mod":true,"shift":true,"alt":false,"key":"j"},` +
+		`"closeSession":{"mod":false,"shift":false,"alt":false,"key":""}}`
+
+	if err := svc.SetSetting(key, globalScope, bindings); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	got, err := svc.GetSetting(key, globalScope)
+	if err != nil {
+		t.Fatalf("GetSetting: %v", err)
+	}
+	if got != bindings {
+		t.Errorf("round-tripped = %q, want %q", got, bindings)
+	}
+
+	// A rebind replaces the whole document; nothing of the old one survives.
+	const rebound = `{"newSession":{"mod":true,"shift":true,"alt":false,"key":"y"}}`
+	if err := svc.SetSetting(key, globalScope, rebound); err != nil {
+		t.Fatalf("SetSetting rebind: %v", err)
+	}
+	if got, _ := svc.GetSetting(key, globalScope); got != rebound {
+		t.Errorf("rebound = %q, want %q", got, rebound)
+	}
+}
+
 func TestClaudeProviderBinResolution(t *testing.T) {
 	svc := newTestStore(t)
 


### PR DESCRIPTION
Closes half of the "A hotkey is taken from the agent, and its rebind lives only in the page" ceiling: the
localStorage half.

The bindings were a `lich.hotkeys` entry in the page's own storage, which sits in the Chromium profile lich
recreates when its storage comes back damaged (#209). Every rebind went with it, and both Settings and the
shortcuts overlay then showed the defaults as though nothing had ever been changed — which is exactly why the
theme selection had already moved to the workspace database.

## What changed

- **One global `hotkeys.bindings` setting**, read on boot and written through on every rebind, the same route
  `appearance.theme` takes (`store.GetSetting` / `store.SetSetting`, global scope). No new Go code and no new
  RPC: the settings table already holds arbitrary strings.
- **`mergeHotkeys` still owns the validation** — an unparseable or hand-edited value reads as the defaults,
  wherever it came from. `loadHotkeys`/`saveHotkeys` split into `parseHotkeys` (one stored value) and
  `adoptStoredHotkeys` (which of the two stores answers), mirroring `adoptStoredTheme`.
- **One migration, once.** An install that still has the page entry adopts it, writes it to the database and
  removes it. The database wins from then on, and a stale page entry can never beat it.
- Unlike the theme there is no page-side cache to paint the first frame from: the defaults stand until the
  read lands, and a chord pressed in that moment is one the window has not claimed yet, so it reaches the
  terminal.

The other half of the ceiling — a rebind is checked against nothing, and `Ctrl+R` silently costs the shell its
history search — is untouched, and is what the bullet in `docs/ceilings.md` now names.

## Tests

- `internal/store/settings_test.go`: the bindings are a JSON document rather than the flag or path every other
  setting holds, so the round-trip pins that nothing reshapes it, and that a rebind replaces the whole value.
- `frontend/src/lib/hotkeys.test.ts`: `parseHotkeys` (defaults, round-trip, unassigned, corrupt JSON, unknown
  action) and `adoptStoredHotkeys` (each of the four store combinations).
- `frontend/src/providers/settings.test.tsx` (new, jsdom): the provider actually reading the workspace copy,
  the migration writing then removing the page entry, the launch after it having nothing left to migrate, a
  stale page copy losing, and a rebind reaching the store. Rendered rather than left pure because the
  migration runs exactly once per install — an order it gets wrong takes every rebind with it.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...`
- [x] `pnpm exec biome ci .` exit 0, `pnpm test` (1524), `pnpm build`
- [ ] Rebind a shortcut in Settings, relaunch, and confirm it is still bound with `lich.hotkeys` gone from
      localStorage
