### PR TITLE
fix: a scheduled prompt follows its session through a park and resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   confines itself; installing the release over the previous one is enough.
   Installs from the bare tarball are unchanged: a file unpacked as you cannot
   be owned by root, so those keep the unsandboxed window.
+- **A scheduled prompt survives parking its session.** Keeping a worktree, or
+  closing a card and resuming it later, re-inserted the session under a fresh id
+  and left the prompt parked on it behind, so it never fired and never came back
+  with the card, with nothing anywhere saying it had been forfeited. The resume
+  now carries the schedule over, alongside the rename, model, entrypoint and
+  cost ledgers it already carried: the card comes back with its countdown, and a
+  prompt that came due while the session was parked is typed at its first free
+  prompt, like one that came due while lich was closed. Deleting a session for
+  good still drops its prompt (the row is the only copy), but now logs which
+  session lost what.
 - **Scoop installs the current release.** The manifest 0.46.0 introduced pinned
   0.45.0 with no checksums, and nothing bumped it on a tag, so `scoop install`
   and `scoop update lich` handed out the previous release. Every release now

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -433,13 +433,12 @@ work when nobody knows it and that the call site never shows. The mechanism and 
 
 - **A scheduled prompt is late or gone, never on time** (`internal/relay/later.go`, `deliverDue`): due prompts
   are looked for every `scheduleTick`, and one whose session is not at a prompt — mid-setup, a draft on the
-  line, no terminal opened — is left parked for the next pass, so it lands whenever that session next has
-  somewhere to type, hours later if that is when. That covers lich having been closed at the time: the first
-  pass after launch types a prompt that came due days ago, unannounced. The other end of it is a session that
-  is closed rather than busy — a parked worktree card, a card closed for good. Its row leaves the roster
-  (`LoadState` reads open sessions only) and the resume reinserts it under a fresh id without the schedule, so
-  the prompt never fires and never comes back with the card, with nothing on screen having said it was
-  forfeited.
+  line, no terminal opened, a card parked and not yet resumed, is left for the next pass, so it lands
+  whenever that session next has somewhere to type, hours later if that is when. That covers lich having been
+  closed at the time: the first pass after launch types a prompt that came due days ago, unannounced. Gone is
+  the session removed for good rather than parked (deleted, forgotten, purged with its worktree, or taken by
+  a deleted project): the row is the only copy of the prompt, so it goes with the row, and all that says so is
+  one Warn in a log nobody is watching (`internal/store`, `noteForfeitedSchedules`).
 
 - **An answer that names no ticket is matched by delivery order** (`internal/relay/answer.go`,
   `errandOfLocked`): `lich reply "<answer>"` and `reply_to_session` without a ticket close the oldest message

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -94,6 +94,9 @@ const cardFromStored = (restored: StoredSession): Session => ({
   ...(restored.originSessionId
     ? { originSessionId: restored.originSessionId, originLabel: restored.originLabel }
     : {}),
+  ...(restored.scheduledAt
+    ? { scheduledAt: restored.scheduledAt, scheduledPrompt: restored.scheduledPrompt }
+    : {}),
 })
 
 // The first session of any project is always "Session 1"; the counter then

--- a/internal/relay/later_test.go
+++ b/internal/relay/later_test.go
@@ -180,3 +180,30 @@ func TestDeliverDueSurvivesAnUnreadableWorkspace(t *testing.T) {
 	svc := newRelay(fakeSessions{err: errors.New("no database")}, newFakeTerminal("s1"), nil)
 	svc.deliverDue()
 }
+
+// A resume re-keys the session under a fresh id and carries the parked prompt
+// with it (internal/store, reopen). What that leaves for this end is a prompt
+// that came due while nobody could type it: it lands on the resumed card's
+// first free prompt, and the row cleared is the resumed one: the id it was
+// scheduled under is gone.
+func TestDeliverDueTypesAPromptParkedThroughAResume(t *testing.T) {
+	writer := &scheduleWriter{}
+	sessions := fakeSessions{
+		projects: []store.Project{{ID: "p1", Name: "lich", Sessions: []store.Session{
+			{ID: "s2", Label: "worker", Kind: "claude", ScheduledAt: 1000, ScheduledPrompt: "pick it back up"},
+		}}},
+		schedule: writer.set,
+	}
+	term := newFakeTerminal("s2")
+	svc := newRelay(sessions, term, nil)
+	svc.now = at(1000 + 2*60*60)
+
+	svc.deliverDue()
+
+	if got := term.written("s2"); !strings.Contains(got, "pick it back up") {
+		t.Fatalf("typed at s2 = %q, want the prompt parked before the resume", got)
+	}
+	if got := writer.clearedRows(); len(got) != 1 || got[0] != "s2" {
+		t.Fatalf("cleared = %v, want the resumed row [s2]", got)
+	}
+}

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -89,6 +89,7 @@ func (s *Service) DeleteProject(id string) error {
 	if id == globalScope {
 		return fmt.Errorf("delete project: empty id")
 	}
+	s.noteForfeitedSchedules(`project_id = ?`, id)
 	return s.tx(func(tx *sql.Tx) error {
 		if _, err := tx.Exec(`DELETE FROM settings WHERE project_id = ?`, id); err != nil {
 			return fmt.Errorf("delete project settings %q: %w", id, err)
@@ -166,9 +167,42 @@ func (s *Service) addSession(
 	})
 }
 
+// noteForfeitedSchedules logs every prompt still parked on a session about to be
+// deleted for good. A close parks the row and the schedule comes back with the
+// card (see reopen); a delete is the one exit where the prompt is lost rather
+// than delayed, and the row is the only copy of what the user wrote, so this
+// line is the last place it exists. Read before the delete, because after it
+// there is nothing left to read.
+//
+// A failed read costs the log, never the delete: nothing here is allowed to
+// stand between the user and removing a session.
+func (s *Service) noteForfeitedSchedules(where string, args ...any) {
+	rows, err := s.db.Query(
+		`SELECT label, scheduled_at, scheduled_prompt
+		   FROM sessions WHERE scheduled_at != 0 AND `+where,
+		args...,
+	)
+	if err != nil {
+		slog.Warn("read schedules of deleted sessions", "err", err)
+		return
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var label, prompt string
+		var at int64
+		if err := rows.Scan(&label, &at, &prompt); err != nil {
+			slog.Warn("scan schedule of deleted session", "err", err)
+			return
+		}
+		slog.Warn("scheduled prompt forfeited with deleted session",
+			"session", label, "due", time.Unix(at, 0).Format(time.RFC3339), "prompt", prompt)
+	}
+}
+
 // DeleteSession removes a session for good and sets the project's active session
 // to activeID (the neighbor the frontend picked, or "" when none remain).
 func (s *Service) DeleteSession(projectID, sessionID, activeID string) error {
+	s.noteForfeitedSchedules(`id = ?`, sessionID)
 	if err := s.tx(func(tx *sql.Tx) error {
 		if _, err := tx.Exec(`DELETE FROM sessions WHERE id = ?`, sessionID); err != nil {
 			return fmt.Errorf("delete session %q: %w", sessionID, err)
@@ -214,6 +248,7 @@ func (s *Service) CloseSession(projectID, sessionID, activeID string) error {
 // was already gone is not an error, and only a delete that actually removed one
 // reports the session gone.
 func (s *Service) ForgetSession(sessionID string) error {
+	s.noteForfeitedSchedules(`id = ? AND is_open = 0`, sessionID)
 	res, err := s.db.Exec(`DELETE FROM sessions WHERE id = ? AND is_open = 0`, sessionID)
 	if err != nil {
 		return fmt.Errorf("forget session %q: %w", sessionID, err)
@@ -260,10 +295,10 @@ func (s *Service) ReopenSession(sessionID, newSessionID string) (*Session, error
 // reopen is the resume behind both doors: it finds one parked session with the
 // given WHERE clause and re-adds it to the workspace under a fresh id
 // (newSessionID), carrying over the old label, kind, path, provider session id,
-// label_auto flag, model, entrypoint, sandbox, pin and origin. The fresh id is
-// deliberate: it makes the frontend treat the card as never-spawned, so its
-// resume prompt fires and the provider conversation continues instead of
-// starting cold.
+// label_auto flag, model, entrypoint, sandbox, pin, origin and scheduled prompt.
+// The fresh id is deliberate: it makes the frontend treat the card as
+// never-spawned, so its resume prompt fires and the provider conversation
+// continues instead of starting cold.
 func (s *Service) reopen(newSessionID, where string, args ...any) (*Session, error) {
 	var restored *Session
 	err := s.tx(func(tx *sql.Tx) error {
@@ -279,19 +314,28 @@ func (s *Service) reopen(newSessionID, where string, args ...any) (*Session, err
 		// shell — silently, on the one path where the card keeps its identity but
 		// not its id.
 		//
+		// The scheduled prompt rides along because the row is the only copy of
+		// what the user parked there: parking a session is not cancelling its
+		// reminder, and a resume that dropped it forfeited the prompt with
+		// nothing anywhere saying so. One that came due while the session was
+		// parked is typed on the resumed card's first free prompt, exactly like
+		// one that came due while lich was closed (internal/relay, deliverDue).
+		//
 		// project_id is read rather than passed: reopening by id knows only the
 		// session, and the row is what says where it belongs.
 		var labelAuto int
 		var projectID, model, entrypoint, sandbox string
 		row := tx.QueryRow(
 			`SELECT id, project_id, label, kind, path, provider_session_id, label_auto,
-			        model, entrypoint, sandbox, pinned, origin_session_id, origin_label
+			        model, entrypoint, sandbox, pinned, origin_session_id, origin_label,
+			        scheduled_at, scheduled_prompt
 			   FROM sessions `+where,
 			args...,
 		)
 		if err := row.Scan(
 			&old.ID, &projectID, &old.Label, &old.Kind, &old.Path, &old.ProviderSessionID,
 			&labelAuto, &model, &entrypoint, &sandbox, &old.Pinned, &old.OriginSessionID, &old.OriginLabel,
+			&old.ScheduledAt, &old.ScheduledPrompt,
 		); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return nil // nothing parked; caller creates a new session
@@ -325,10 +369,12 @@ func (s *Service) reopen(newSessionID, where string, args ...any) (*Session, err
 		if _, err := tx.Exec(
 			`INSERT INTO sessions
 			   (id, project_id, label, kind, path, provider_session_id, label_auto,
-			    model, entrypoint, sandbox, pinned, origin_session_id, origin_label, position)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
+			    model, entrypoint, sandbox, pinned, origin_session_id, origin_label,
+			    scheduled_at, scheduled_prompt, position)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
 			newSessionID, projectID, old.Label, old.Kind, old.Path, old.ProviderSessionID, labelAuto,
-			model, entrypoint, sandbox, old.Pinned, old.OriginSessionID, old.OriginLabel, projectID,
+			model, entrypoint, sandbox, old.Pinned, old.OriginSessionID, old.OriginLabel,
+			old.ScheduledAt, old.ScheduledPrompt, projectID,
 		); err != nil {
 			return fmt.Errorf("reinsert session %q: %w", newSessionID, err)
 		}
@@ -352,6 +398,8 @@ func (s *Service) reopen(newSessionID, where string, args ...any) (*Session, err
 			Pinned:            old.Pinned,
 			OriginSessionID:   old.OriginSessionID,
 			OriginLabel:       old.OriginLabel,
+			ScheduledAt:       old.ScheduledAt,
+			ScheduledPrompt:   old.ScheduledPrompt,
 		}
 		return nil
 	})
@@ -371,6 +419,7 @@ func (s *Service) PurgeWorktreeSessions(projectID, path string) error {
 	if path == "" {
 		return nil
 	}
+	s.noteForfeitedSchedules(`project_id = ? AND path = ?`, projectID, path)
 	// Read before the delete, because what hangs off a session outside the
 	// database is keyed by id and the rows are about to be gone.
 	gone := s.sessionIDsAt(projectID, path)

--- a/internal/store/schedule_test.go
+++ b/internal/store/schedule_test.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"bytes"
+	"log/slog"
 	"strings"
 	"testing"
 )
@@ -86,4 +88,106 @@ func onlySession(t *testing.T, svc *Service) Session {
 		t.Fatalf("LoadState = %+v, want one project with one session", projects)
 	}
 	return projects[0].Sessions[0]
+}
+
+// A park is not a cancellation: the row is the only copy of the prompt, so the
+// resume that re-keys the session under a fresh id has to carry it over — both
+// into the database the relay reads and into the row the window redraws the
+// card from.
+func TestReopenSessionCarriesTheSchedule(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2, "")
+	_ = svc.AddSession("p1", "wt1", "worker", "claude", "/wt/foo", 3, "")
+	_ = svc.SetSessionSchedule("wt1", 1700000000, "run the release checklist")
+	_ = svc.CloseSession("p1", "wt1", "base")
+
+	restored, err := svc.ReopenWorktreeSession("p1", "/wt/foo", "wt2")
+	if err != nil {
+		t.Fatalf("ReopenWorktreeSession: %v", err)
+	}
+	if restored == nil || restored.ScheduledAt != 1700000000 ||
+		restored.ScheduledPrompt != "run the release checklist" {
+		t.Fatalf("restored = %+v, want the schedule reported to the window", restored)
+	}
+	if got := sessionByID(t, svc, "wt2"); got.ScheduledAt != 1700000000 ||
+		got.ScheduledPrompt != "run the release checklist" {
+		t.Fatalf("resumed row = %d %q, want the prompt still parked on it",
+			got.ScheduledAt, got.ScheduledPrompt)
+	}
+}
+
+// Deleting a session for good is the one exit where the prompt is forfeited
+// rather than delayed, and the log line is all that is left of what the user
+// wrote — every door that removes a row has to leave one.
+func TestDeletingASessionLogsTheForfeitedSchedule(t *testing.T) {
+	for name, remove := range map[string]func(*Service) error{
+		"delete":  func(svc *Service) error { return svc.DeleteSession("p1", "wt1", "base") },
+		"forget":  func(svc *Service) error { _ = svc.CloseSession("p1", "wt1", "base"); return svc.ForgetSession("wt1") },
+		"purge":   func(svc *Service) error { return svc.PurgeWorktreeSessions("p1", "/wt/foo") },
+		"project": func(svc *Service) error { return svc.DeleteProject("p1") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			svc := newTestStore(t)
+			_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+			_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2, "")
+			_ = svc.AddSession("p1", "wt1", "worker", "claude", "/wt/foo", 3, "")
+			_ = svc.SetSessionSchedule("wt1", 1700000000, "run the release checklist")
+			logged := captureLogs(t)
+
+			if err := remove(svc); err != nil {
+				t.Fatalf("remove: %v", err)
+			}
+			got := logged.String()
+			if !strings.Contains(got, "forfeited") || !strings.Contains(got, "worker") ||
+				!strings.Contains(got, "run the release checklist") {
+				t.Fatalf("log = %q, want the forfeited prompt named with its session", got)
+			}
+		})
+	}
+}
+
+// A session with nothing parked on it is removed in silence: a warning per
+// deleted card would bury the one that means something.
+func TestDeletingAnUnscheduledSessionLogsNothing(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2, "")
+	_ = svc.AddSession("p1", "wt1", "worker", "claude", "/wt/foo", 3, "")
+	logged := captureLogs(t)
+
+	if err := svc.DeleteSession("p1", "wt1", "base"); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	if got := logged.String(); strings.Contains(got, "forfeited") {
+		t.Fatalf("log = %q, want nothing said about a session with no schedule", got)
+	}
+}
+
+// captureLogs redirects the default logger for one test and hands back what it
+// collected.
+func captureLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(previous) })
+	return &buf
+}
+
+func sessionByID(t *testing.T, svc *Service, id string) Session {
+	t.Helper()
+	projects, err := svc.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	for _, p := range projects {
+		for _, sess := range p.Sessions {
+			if sess.ID == id {
+				return sess
+			}
+		}
+	}
+	t.Fatalf("LoadState = %+v, want a session %q", projects, id)
+	return Session{}
 }


### PR DESCRIPTION
Closes the second half of the "A scheduled prompt is late or gone, never on
time" ceiling: a prompt parked on a session that is then parked itself.

## The trap

A schedule lives on the session row (`sessions.scheduled_at`,
`scheduled_prompt`). Parking a session (keep the worktree, close the card,
`lich close`) leaves the row alone, but the resume deletes it and re-inserts it
under a fresh id, carrying over a hand-listed set of columns that did not
include the schedule. So the prompt never fired, never came back with the card,
and nothing on screen or in the log said it had been forfeited.

## The fix

`internal/store`, `reopen`: `scheduled_at` and `scheduled_prompt` ride the
delete/reinsert alongside the rename, model, entrypoint, sandbox, pin, origin
and cost ledgers that already did, and land on the `Session` handed back to the
window, so `cardFromStored` redraws the resumed card with its countdown.

Delivery needed nothing new. The resumed row is open again with the schedule
intact, so `deliverDue` sees it on its next `scheduleTick` pass and types a
prompt that came due while the session was parked at that session's first free
prompt, exactly like one that came due while lich was closed.

`internal/store`, `noteForfeitedSchedules`: a session removed for good still
loses its prompt, because the row is the only copy of it. What changes is that
it now says so, with one Warn naming the session, the time it was due and the
prompt itself, on every door that deletes a row: `DeleteSession`,
`ForgetSession`, `PurgeWorktreeSessions` and `DeleteProject`.

`docs/ceilings.md` keeps the "late, never on time" half and now names only the
trap that is left: the delete forfeits the prompt and the log is all that says
so.

## Test plan

- [x] `internal/store`: the resume carries the schedule into the new row and
      back to the window; each of the four delete doors logs the forfeited
      prompt with its session; a session with nothing scheduled is deleted in
      silence. All confirmed red before the fix.
- [x] `internal/relay`: a prompt parked through a resume is typed at the
      resumed id, and the row cleared is the resumed one.
- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green
      (33 packages), `go test -race -count=5 ./internal/store/ ./internal/relay/`
      green.
- [x] `pnpm exec biome ci .` exit 0, `pnpm build` and `pnpm test` green
      (129 files, 1514 tests).
