### PR TITLE
fix: keep a session's last turn across a restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bracketing a session's last finished turn lived in memory alone, so relaunching
   lich emptied it and every restored session read "No last turn recorded" until
   its next turn ended. The record now rides the workspace database, keyed to the
-  session, and is read back when the card is restored. A turn still running is
-  never written, and a turn that loses a snapshot clears what was there instead
-  of leaving the turn before it standing.
+  session, and is read back when the card is restored. The card says so on its
+  hydration too, so the panel offers the "Last turn" switch to a session that has
+  been quiet since the launch instead of withholding it until that session next
+  reports. A turn still running is never written, and a turn that loses a
+  snapshot clears what was there instead of leaving the turn before it standing.
 - **Scoop installs the current release.** The manifest 0.46.0 introduced pinned
   0.45.0 with no checksums, and nothing bumped it on a tag, so `scoop install`
   and `scoop update lich` handed out the previous release. Every release now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   underline came back with lich's block. The shape is now carried across the
   cycle beside the mouse encoding and cursor visibility, and follows the
   program's own reset back to the default.
+- **The Review panel's "Last turn" survives a restart.** The pair of snapshots
+  bracketing a session's last finished turn lived in memory alone, so relaunching
+  lich emptied it and every restored session read "No last turn recorded" until
+  its next turn ended. The record now rides the workspace database, keyed to the
+  session, and is read back when the card is restored. A turn still running is
+  never written, and a turn that loses a snapshot clears what was there instead
+  of leaving the turn before it standing.
 - **Scoop installs the current release.** The manifest 0.46.0 introduced pinned
   0.45.0 with no checksums, and nothing bumped it on a tag, so `scoop install`
   and `scoop update lich` handed out the previous release. Every release now

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -198,24 +198,25 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   whose detail carries no commits. And there is no expanding *past the last hunk*: a unified diff carries
   no file length, so nothing here knows whether anything follows it, and an affordance drawn there would
   be a no-op on every file whose change reaches the end.
-- **The Review panel's "Last turn" is a window of wall-clock time, and it lives in memory**
+- **The Review panel's "Last turn" is a window of wall-clock time**
   (`internal/terminal/turnsnap.go`, `internal/project/turnsnap.go`): the panel brackets a turn with two
   `git write-tree` snapshots taken against an index of lich's own, so what it shows is everything that
   touched the checkout between the `busy` and the `done` — a formatter, an editor open beside lich, the
   user's own hands. Nothing in it can attribute a line, which is why the copy names the window and never
-  the agent. Four traps follow. The pair is held in Go memory alone: a lich restart empties it, so every
-  live session reads "No last turn recorded" until its next turn ends, and that wording is the same one a
-  session whose first turn is still running gets — the panel cannot say which. `add -A` obeys `.gitignore`
-  (deliberately, so this and `DiffText` never disagree about which files exist), so a turn that only
-  touched ignored files reports itself as having changed nothing. Every snapshot in the app runs on one
-  FIFO worker, because git refuses a second `add` against an index another holds — so one session's first
-  snapshot of a large checkout delays the next session's, and a queue past `snapQueueDepth` drops a job,
-  costing that turn its record with only the log saying so. A checkout whose *first* snapshot fails is
-  dropped outright and never asked again — the ordinary reason is a session opened outside a repository,
-  but a transient failure at spawn reads the same and leaves that card with no last turn until it respawns. And the boundary is the session-state contract,
-  so **Crush and Cursor CLI have no last turn at all**: neither reports a state (`docs/hooks/session-state.md`),
-  so nothing ever opens or closes a window there and the switch is never drawn — a rule read off the
-  session's own reports, not a list of providers, so it corrects itself the day either one starts reporting.
+  the agent. Four traps follow. `add -A` obeys `.gitignore` (deliberately, so this and `DiffText` never
+  disagree about which files exist), so a turn that only touched ignored files reports itself as having
+  changed nothing. Every snapshot in the app runs on one FIFO worker, because git refuses a second `add`
+  against an index another holds — so one session's first snapshot of a large checkout delays the next
+  session's, and a queue past `snapQueueDepth` drops a job, costing that turn its record with only the log
+  saying so. A checkout whose *first* snapshot fails is dropped outright and never asked again — the
+  ordinary reason is a session opened outside a repository, but a transient failure at spawn reads the same
+  and leaves that card with no last turn until it respawns. A pair read back at launch names loose objects
+  no ref reaches, so a `git gc --prune` in that checkout between one run and the next leaves the panel
+  reporting a failure rather than an absent turn. And the boundary is the session-state contract, so
+  **Crush and Cursor CLI have no last turn at all**: neither reports a state
+  (`docs/hooks/session-state.md`), so nothing ever opens or closes a window there and the switch is never
+  drawn — a rule read off the session's own reports, not a list of providers, so it corrects itself the day
+  either one starts reporting.
 - **The recap beside that diff answers to a different clock, and to a different set of providers**
   (`internal/terminal/said.go`): the band reads the last thing the agent *said* out of the provider's own
   transcript, where the diff beside it brackets the window a turn ran in. The two agree once a turn has

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -826,13 +826,14 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   back to them.
 - **The Review tab's remembered source is a wish, not what is on screen** (`ReviewPanel`,
   `frontend/src/lib/dock-prefs.ts`): the pref is global and holds what the user picked, while what the
-  panel shows is that choice put through `useSessionEverReported` — a session whose provider never
-  reports has no turn to bracket, so it is shown the working tree and offered no switch. Nothing writes
-  the guard's answer back, and that is the whole design: `switchable` is false after every reload until
-  the session next reports, so a panel that reset the pref instead of overriding it would erase the
-  choice before the switch had a chance to appear. The visible cost is that "Last turn" cannot be
-  restored on a session that has been quiet since the reload — it comes back the moment that session
-  reports again.
+  panel shows is that choice put through `turnSwitchable` — a session whose provider never reports and
+  holds no last-turn record has no turn to bracket, so it is shown the working tree and offered no
+  switch. Nothing writes the guard's answer back, and that is the whole design: a session with neither is
+  unswitchable after a reload until it next reports, so a panel that reset the pref instead of overriding
+  it would erase the choice before the switch had a chance to appear. The two halves of that guard read
+  different sources — the record rides the session's hydration, the diff behind it is seeded when the
+  PTY is spawned — so a panel that reaches a restored card before its spawn has been tracked is offered
+  the switch and told nothing is recorded, until the next read.
 - **The pull request screen's remembered state is read once, at mount** (`frontend/src/lib/pulls/pulls-prefs.ts`):
   the filter box, the quick filter and the selected pull request are keyed per project but seeded from
   `useState`, which holds because every route into the screen carries its own project and leaving one unmounts

--- a/frontend/src/components/diff/ReviewPanel.tsx
+++ b/frontend/src/components/diff/ReviewPanel.tsx
@@ -6,7 +6,7 @@ import type { LastSaid, LastTurn } from "@/lib/api-types"
 import { onAppEvent } from "@/lib/app-events"
 import { readDiffSource, writeDiffSource, type DiffSource } from "@/lib/dock-prefs"
 import { discardTargets, parseDiff, type DiffFile } from "@/lib/git/diff"
-import { lastTurnNotice } from "@/lib/git/last-turn"
+import { lastTurnNotice, turnSwitchable } from "@/lib/git/last-turn"
 import { addReviewComment } from "@/lib/review-comments"
 import { ProjectService, Terminal } from "@/lib/rpc"
 import { useActiveSession } from "@/lib/session/use-active-session"
@@ -45,12 +45,14 @@ const LAST_TURN_HINT =
 // the project root. The dock (RightDock) owns the surrounding chrome: width,
 // full screen, the tab bar and the close button.
 export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
-  const { sessionId, path } = useActiveSession()
+  const { sessionId, path, hasLastTurn } = useActiveSession()
   const inject = useInject(sessionId)
   const status = useGitStatus(path)
   // The source switch is earned, not assumed: a provider that never reports its
-  // state has no turn to bracket, so it is offered the working tree alone.
-  const switchable = useSessionEverReported(sessionId)
+  // state and holds no record has no turn to bracket, so it is offered the
+  // working tree alone (turnSwitchable).
+  const reported = useSessionEverReported(sessionId)
+  const switchable = turnSwitchable(reported, hasLastTurn)
   // The source the reviewer picked, read back on every mount because the dock
   // has no shortage of them: it is a ternary between two component types, so
   // each flip to the Code tab unmounts this panel whole (dock-prefs).
@@ -58,9 +60,9 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
   // A source the session cannot answer for must never be the one on screen: it
   // would sit on an empty panel with no control anywhere to leave it by. So the
   // guard makes what is *shown*, and nothing writes "worktree" back over the
-  // choice — `switchable` starts false after a reload and turns true only when
-  // the session next reports, so a reset would fire first and throw the
-  // remembered choice away before the switch ever appeared.
+  // choice — a session that holds no record starts unswitchable after a reload
+  // and turns true only when it next reports, so a reset would fire first and
+  // throw the remembered choice away before the switch ever appeared.
   const source: DiffSource = switchable ? wanted : "worktree"
   const changeSource = (next: DiffSource) => {
     writeDiffSource(next)

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -328,6 +328,11 @@ export interface StoredSession {
   /** The prompt to type at this session when that time comes, as the user
    * wrote it. Empty when nothing is scheduled. */
   scheduledPrompt: string
+  /** Whether a last-turn record survives for this session. It rides the
+   * hydration so the Review panel can offer the "Last turn" source to a
+   * restored card, instead of withholding the switch until that session
+   * next reports (internal/store.SaveTurnRecord). */
+  hasLastTurn: boolean
 }
 
 /** internal/store.ClosedSession — one parked session offered for resuming. What

--- a/frontend/src/lib/git/last-turn.test.ts
+++ b/frontend/src/lib/git/last-turn.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { lastTurnNotice } from "./last-turn"
+import { lastTurnNotice, turnSwitchable } from "./last-turn"
 
 describe("lastTurnNotice", () => {
   it("draws the diff only when there is one to draw", () => {
@@ -24,5 +24,26 @@ describe("lastTurnNotice", () => {
   // the backend never made.
   it("does not promote an unrenderable diff to an empty turn", () => {
     expect(lastTurnNotice("ok", 0)).toBe("unrecorded")
+  })
+})
+
+describe("turnSwitchable", () => {
+  // The state a card is restored in: quiet since the launch, with a turn the
+  // backend read back off the workspace database. Withholding the switch here
+  // is what used to hide it.
+  it("offers the switch to a restored session that has not reported yet", () => {
+    expect(turnSwitchable(false, true)).toBe(true)
+  })
+
+  // The other half, unchanged: a session that has reported has a turn boundary,
+  // so the switch is earned before its first turn has finished.
+  it("offers the switch to a session that has reported", () => {
+    expect(turnSwitchable(true, false)).toBe(true)
+  })
+
+  // A provider that reports no state has no turn to bracket, and with nothing
+  // on record there is none to show: the working tree alone.
+  it("withholds the switch from a session with neither", () => {
+    expect(turnSwitchable(false, false)).toBe(false)
   })
 })

--- a/frontend/src/lib/git/last-turn.ts
+++ b/frontend/src/lib/git/last-turn.ts
@@ -20,3 +20,16 @@ export function lastTurnNotice(state: LastTurn["state"] | null, fileCount: numbe
   }
   return "unrecorded"
 }
+
+// turnSwitchable is whether the Review panel offers the "Last turn" source at
+// all. Either half is enough. A session that has reported its state has a turn
+// boundary, so the switch is earned even before the first turn closes; a
+// session holding a record has one on file already, which is the case a
+// restored card lands in — it may not report again for hours, and withholding
+// the switch until it does would hide a turn the backend is already holding.
+//
+// A provider that reports nothing and has never recorded a turn is still
+// offered the working tree alone, which is the whole point of the gate.
+export function turnSwitchable(everReported: boolean, hasLastTurn: boolean): boolean {
+  return everReported || hasLastTurn
+}

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -764,6 +764,7 @@ describe("activeTarget", () => {
       path: root,
       kind: "claude",
       sandboxed: false,
+      hasLastTurn: false,
     })
   })
 
@@ -779,6 +780,7 @@ describe("activeTarget", () => {
       path: "/repo/.worktrees/swift-rabbit",
       kind: "shell",
       sandboxed: false,
+      hasLastTurn: false,
     })
   })
 
@@ -796,12 +798,26 @@ describe("activeTarget", () => {
     expect(activeTarget(state, P, root).sandboxed).toBe(true)
   })
 
+  // What the Review panel's source switch is seeded from: the record travels
+  // with the session, so a card restored quiet is offered its last turn instead
+  // of the working tree alone.
+  it("reports a session that holds a last turn", () => {
+    const state = restoreSession(buildState(1), P, {
+      id: "wt1",
+      label: "swift-rabbit",
+      kind: "claude",
+      hasLastTurn: true,
+    })
+    expect(activeTarget(state, P, root).hasLastTurn).toBe(true)
+  })
+
   it("keeps the project root when there is no session at all", () => {
     expect(activeTarget({}, P, root)).toEqual({
       sessionId: "",
       path: root,
       kind: "",
       sandboxed: false,
+      hasLastTurn: false,
     })
   })
 
@@ -811,6 +827,7 @@ describe("activeTarget", () => {
       path: "",
       kind: "",
       sandboxed: false,
+      hasLastTurn: false,
     })
   })
 })

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -70,6 +70,12 @@ export interface Session {
   // card as SCHEDULE_EVENT.
   scheduledAt?: number
   scheduledPrompt?: string
+  // Whether the backend holds a record of this session's last finished turn.
+  // Absent means none — a session that has never finished a turn, or one whose
+  // record was retracted. Only ever set on hydration: a turn closing in this
+  // run reaches the panel through the session's own state reports, which is the
+  // other half of what draws the switch (ReviewPanel).
+  hasLastTurn?: boolean
 }
 
 export interface ProjectSessions {
@@ -638,9 +644,15 @@ export function activeTarget(
   state: SessionState,
   projectId: string | null,
   projectPath: string,
-): { sessionId: string; path: string; kind: SessionKind | ""; sandboxed: boolean } {
+): {
+  sessionId: string
+  path: string
+  kind: SessionKind | ""
+  sandboxed: boolean
+  hasLastTurn: boolean
+} {
   if (!projectId) {
-    return { sessionId: "", path: projectPath, kind: "", sandboxed: false }
+    return { sessionId: "", path: projectPath, kind: "", sandboxed: false, hasLastTurn: false }
   }
   const sessionId = activeSessionId(state, projectId)
   const session = sessionsOf(state, projectId).find((s) => s.id === sessionId)
@@ -649,6 +661,7 @@ export function activeTarget(
     path: session?.path || projectPath,
     kind: session?.kind ?? "",
     sandboxed: session?.sandboxed ?? false,
+    hasLastTurn: session?.hasLastTurn ?? false,
   }
 }
 

--- a/frontend/src/lib/session/use-active-session.ts
+++ b/frontend/src/lib/session/use-active-session.ts
@@ -30,6 +30,9 @@ export function useActiveSession(): {
   kind: SessionKind | ""
   /** Whether the active session's PTY runs confined (internal/sandbox). */
   sandboxed: boolean
+  /** Whether the backend holds a record of this session's last finished turn,
+   * read off the hydration so a restored card can be offered it. */
+  hasLastTurn: boolean
 } {
   const { projects, sessions } = useProjects()
   const match = useMatch({ path: "/projects/:projectId", end: false })
@@ -44,5 +47,6 @@ export function useActiveSession(): {
     checkout: target.path,
     kind: target.kind,
     sandboxed: target.sandboxed,
+    hasLastTurn: target.hasLastTurn,
   }
 }

--- a/frontend/src/providers/project-workspace.test.ts
+++ b/frontend/src/providers/project-workspace.test.ts
@@ -17,6 +17,7 @@ const storedSession = (overrides: Partial<StoredSession> = {}): StoredSession =>
   pinned: false,
   originSessionId: "",
   originLabel: "",
+  hasLastTurn: false,
   ...overrides,
 })
 
@@ -49,6 +50,22 @@ describe("buildSessionState", () => {
   it("reads a null session list as a project with no sessions", () => {
     const state = buildSessionState([storedProject({ sessions: null })])
     expect(state.p1).toEqual({ sessions: [], activeId: "", nextSeq: 2 })
+  })
+
+  // The seed the Review panel's source switch is drawn from: without it a card
+  // restored quiet is offered the working tree alone, and the turn the backend
+  // read back has no control to reach it by.
+  it("carries which sessions hold a last turn, and leaves the field off the rest", () => {
+    const state = buildSessionState([
+      storedProject({
+        sessions: [
+          storedSession({ id: "s1", hasLastTurn: true }),
+          storedSession({ id: "s2", hasLastTurn: false }),
+        ],
+      }),
+    ])
+    expect(state.p1.sessions[0].hasLastTurn).toBe(true)
+    expect(state.p1.sessions[1]).not.toHaveProperty("hasLastTurn")
   })
 
   it("restores a terminal's entrypoint, and leaves the field off a plain shell", () => {

--- a/frontend/src/providers/project-workspace.ts
+++ b/frontend/src/providers/project-workspace.ts
@@ -23,6 +23,7 @@ export function buildSessionState(loaded: StoredProject[]): SessionState {
       ...(session.scheduledAt
         ? { scheduledAt: session.scheduledAt, scheduledPrompt: session.scheduledPrompt }
         : {}),
+      ...(session.hasLastTurn ? { hasLastTurn: true } : {}),
     }))
     state[project.id] = {
       sessions,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -204,6 +204,12 @@ type Session struct {
 	// call, and neither needs a channel of its own.
 	ScheduledAt     int64  `json:"scheduledAt"`
 	ScheduledPrompt string `json:"scheduledPrompt"`
+	// HasLastTurn is whether a last-turn record survives for this session
+	// (SaveTurnRecord). It rides the hydration because the Review panel's
+	// source switch is drawn before anything has asked what the turn changed:
+	// without it the panel would have to wait for the session to report before
+	// it could offer a record it is already holding.
+	HasLastTurn bool `json:"hasLastTurn"`
 }
 
 // Project is a persisted project together with its restorable session state.
@@ -541,7 +547,8 @@ func (s *Service) ProjectAt(path string) (string, string) {
 func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	rows, err := s.db.Query(
 		`SELECT id, label, kind, path, provider_session_id, entrypoint, sandbox, pinned,
-		        origin_session_id, origin_label, scheduled_at, scheduled_prompt
+		        origin_session_id, origin_label, scheduled_at, scheduled_prompt,
+		        EXISTS (SELECT 1 FROM session_last_turn WHERE session_id = sessions.id)
 		   FROM sessions WHERE project_id = ? AND is_open = 1 ORDER BY position, rowid`,
 		projectID,
 	)
@@ -556,7 +563,7 @@ func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 		if err := rows.Scan(
 			&sess.ID, &sess.Label, &sess.Kind, &sess.Path, &sess.ProviderSessionID,
 			&sess.Entrypoint, &sess.Sandbox, &sess.Pinned, &sess.OriginSessionID, &sess.OriginLabel,
-			&sess.ScheduledAt, &sess.ScheduledPrompt,
+			&sess.ScheduledAt, &sess.ScheduledPrompt, &sess.HasLastTurn,
 		); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -120,6 +120,16 @@ CREATE TABLE IF NOT EXISTS session_hands_on (
     -- only ever hands whole seconds down (internal/terminal.handsOn).
     seconds    INTEGER NOT NULL DEFAULT 0
 );
+
+CREATE TABLE IF NOT EXISTS session_last_turn (
+    session_id  TEXT NOT NULL PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
+    -- The trees a session's last finished turn ran between, and when its window
+    -- shut in unix milliseconds. One row per session, replaced by each turn:
+    -- the panel answers for the LAST turn and there is no history behind it.
+    before_tree TEXT    NOT NULL,
+    after_tree  TEXT    NOT NULL,
+    ended_at    INTEGER NOT NULL DEFAULT 0
+);
 `
 
 // busyTimeoutMS is how long a write waits on SQLite's lock before failing.

--- a/internal/store/turnrecord.go
+++ b/internal/store/turnrecord.go
@@ -1,0 +1,71 @@
+package store
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+)
+
+// TurnRecord is one session's last finished turn: the two snapshot trees the
+// turn ran between and when its window shut, in unix milliseconds — the unit
+// the panel reads (internal/terminal.LastTurn).
+//
+// The trees are loose git objects in the session's own checkout, written by
+// `git write-tree` against an index of lich's own and reachable from no ref. The
+// row outlives the process that took them; it does not outlive a prune of the
+// objects they name.
+type TurnRecord struct {
+	Before  string
+	After   string
+	EndedAt int64
+}
+
+// SaveTurnRecord files a session's last finished turn, replacing whatever was
+// there. A record missing either tree deletes the row instead: a turn that lost
+// a snapshot has no record, and leaving the previous one on disk would let a
+// later launch answer with a turn this lich had already retracted.
+//
+// The SELECT ... WHERE EXISTS writes nothing for a session whose row is already
+// gone — closed while its closing snapshot was still on the worker — for the
+// same reason AddHandsOn does it: that is a race, not a failure.
+func (s *Service) SaveTurnRecord(sessionID string, rec TurnRecord) error {
+	if rec.Before == "" || rec.After == "" {
+		if _, err := s.db.Exec(
+			`DELETE FROM session_last_turn WHERE session_id = ?`, sessionID,
+		); err != nil {
+			return fmt.Errorf("clear last turn for %q: %w", sessionID, err)
+		}
+		return nil
+	}
+	_, err := s.db.Exec(
+		`INSERT INTO session_last_turn (session_id, before_tree, after_tree, ended_at)
+		 SELECT ?, ?, ?, ? WHERE EXISTS (SELECT 1 FROM sessions WHERE id = ?)
+		 ON CONFLICT(session_id) DO UPDATE SET
+		     before_tree = excluded.before_tree,
+		     after_tree  = excluded.after_tree,
+		     ended_at    = excluded.ended_at`,
+		sessionID, rec.Before, rec.After, rec.EndedAt, sessionID,
+	)
+	if err != nil {
+		return fmt.Errorf("save last turn for %q: %w", sessionID, err)
+	}
+	return nil
+}
+
+// TurnRecord reads back a session's last finished turn. A session with no turn
+// on record answers false rather than an error: nothing has finished there yet,
+// which is an answer the panel already knows how to draw.
+func (s *Service) TurnRecord(sessionID string) (TurnRecord, bool, error) {
+	var rec TurnRecord
+	err := s.db.QueryRow(
+		`SELECT before_tree, after_tree, ended_at FROM session_last_turn WHERE session_id = ?`,
+		sessionID,
+	).Scan(&rec.Before, &rec.After, &rec.EndedAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return TurnRecord{}, false, nil
+	}
+	if err != nil {
+		return TurnRecord{}, false, fmt.Errorf("read last turn for %q: %w", sessionID, err)
+	}
+	return rec, true, nil
+}

--- a/internal/store/turnrecord_test.go
+++ b/internal/store/turnrecord_test.go
@@ -115,3 +115,32 @@ func TestDeletingTheSessionDropsItsTurn(t *testing.T) {
 		t.Errorf("the turn outlived its session (ok=%v, err=%v)", ok, err)
 	}
 }
+
+// The Review panel draws its source switch off the hydration, long before
+// anything asks what the turn changed: a restored session has to say it holds a
+// record, or the switch that reaches it is withheld until it next reports.
+func TestHydrationSaysWhichSessionsHoldATurn(t *testing.T) {
+	svc := newCostSession(t)
+	if err := svc.AddSession("p1", "s2", "Session 2", "", "", 2, ""); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+	if err := svc.SaveTurnRecord("s1", TurnRecord{Before: "aaa", After: "bbb", EndedAt: 1}); err != nil {
+		t.Fatalf("SaveTurnRecord: %v", err)
+	}
+
+	sessions, err := svc.sessionsOf("p1")
+	if err != nil {
+		t.Fatalf("sessionsOf: %v", err)
+	}
+
+	held := map[string]bool{}
+	for _, sess := range sessions {
+		held[sess.ID] = sess.HasLastTurn
+	}
+	if !held["s1"] {
+		t.Error("the session holding a turn hydrated without it")
+	}
+	if held["s2"] {
+		t.Error("a session with no turn on record claimed one")
+	}
+}

--- a/internal/store/turnrecord_test.go
+++ b/internal/store/turnrecord_test.go
@@ -1,0 +1,117 @@
+package store
+
+import "testing"
+
+// The reason the table exists: what a turn recorded has to come back out of a
+// database opened by a different run of lich, tree for tree and to the
+// millisecond.
+func TestTurnRecordRoundTrips(t *testing.T) {
+	svc := newCostSession(t)
+	want := TurnRecord{Before: "aaa111", After: "bbb222", EndedAt: 1_725_000_000_123}
+
+	if err := svc.SaveTurnRecord("s1", want); err != nil {
+		t.Fatalf("SaveTurnRecord: %v", err)
+	}
+	got, ok, err := svc.TurnRecord("s1")
+
+	if err != nil {
+		t.Fatalf("TurnRecord: %v", err)
+	}
+	if !ok {
+		t.Fatal("the saved turn read back as absent")
+	}
+	if got != want {
+		t.Errorf("TurnRecord = %+v, want %+v", got, want)
+	}
+}
+
+// A session with nothing on record is where every session starts, and the panel
+// already has words for it — so it is an absence, never an error.
+func TestASessionWithNoTurnReadsAbsent(t *testing.T) {
+	svc := newCostSession(t)
+
+	got, ok, err := svc.TurnRecord("s1")
+
+	if err != nil {
+		t.Fatalf("TurnRecord: %v", err)
+	}
+	if ok {
+		t.Errorf("an unrecorded session answered %+v", got)
+	}
+}
+
+// One row per session, replaced by each turn: the panel answers for the LAST
+// turn, and a second row would let a later launch pick the wrong one.
+func TestSavingAgainReplacesTheTurn(t *testing.T) {
+	svc := newCostSession(t)
+	if err := svc.SaveTurnRecord("s1", TurnRecord{Before: "old1", After: "old2", EndedAt: 1}); err != nil {
+		t.Fatalf("SaveTurnRecord: %v", err)
+	}
+	want := TurnRecord{Before: "new1", After: "new2", EndedAt: 2}
+
+	if err := svc.SaveTurnRecord("s1", want); err != nil {
+		t.Fatalf("SaveTurnRecord: %v", err)
+	}
+
+	got, _, err := svc.TurnRecord("s1")
+	if err != nil {
+		t.Fatalf("TurnRecord: %v", err)
+	}
+	if got != want {
+		t.Errorf("TurnRecord = %+v, want %+v", got, want)
+	}
+}
+
+// A turn that lost a snapshot has no record. Saving one without both trees
+// clears the row rather than leaving the turn before it standing, which is the
+// same rule the in-memory accounting follows (internal/terminal.closeTurn).
+func TestATurnWithoutBothTreesClearsTheRow(t *testing.T) {
+	svc := newCostSession(t)
+	if err := svc.SaveTurnRecord("s1", TurnRecord{Before: "aaa", After: "bbb", EndedAt: 1}); err != nil {
+		t.Fatalf("SaveTurnRecord: %v", err)
+	}
+
+	if err := svc.SaveTurnRecord("s1", TurnRecord{}); err != nil {
+		t.Fatalf("SaveTurnRecord: %v", err)
+	}
+
+	got, ok, err := svc.TurnRecord("s1")
+	if err != nil {
+		t.Fatalf("TurnRecord: %v", err)
+	}
+	if ok {
+		t.Errorf("the retracted turn survived as %+v", got)
+	}
+}
+
+// The closing snapshot lands on the worker long after the `done` that asked for
+// it, so the card can be gone by then. That is a race, not a failure — and the
+// foreign key would otherwise turn it into one.
+func TestSavingForAGoneSessionIsNotAnError(t *testing.T) {
+	svc := newCostSession(t)
+
+	if err := svc.SaveTurnRecord("never-existed", TurnRecord{Before: "a", After: "b"}); err != nil {
+		t.Fatalf("SaveTurnRecord: %v", err)
+	}
+
+	if _, ok, _ := svc.TurnRecord("never-existed"); ok {
+		t.Error("a turn was filed for a session with no row")
+	}
+}
+
+// The record belongs to the card: deleting the session takes it with it, so a
+// later session reusing the id can never inherit it.
+func TestDeletingTheSessionDropsItsTurn(t *testing.T) {
+	svc := newCostSession(t)
+	if err := svc.SaveTurnRecord("s1", TurnRecord{Before: "aaa", After: "bbb", EndedAt: 1}); err != nil {
+		t.Fatalf("SaveTurnRecord: %v", err)
+	}
+
+	if err := svc.DeleteSession("p1", "s1", ""); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+
+	if _, ok, err := svc.TurnRecord("s1"); err != nil || ok {
+		t.Errorf("the turn outlived its session (ok=%v, err=%v)", ok, err)
+	}
+}

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -18,6 +18,7 @@ import (
 	"github.com/omartelo/lich/internal/awake"
 	"github.com/omartelo/lich/internal/events"
 	"github.com/omartelo/lich/internal/pricing"
+	"github.com/omartelo/lich/internal/store"
 )
 
 // Event names. A terminal I/O event carries the session ID as a suffix (e.g.
@@ -206,6 +207,8 @@ type Store interface {
 	SessionCost(sessionID string) (float64, error)
 	AddHandsOn(sessionID string, seconds int64) error
 	HandsOn(sessionID string) (int64, error)
+	SaveTurnRecord(sessionID string, rec store.TurnRecord) error
+	TurnRecord(sessionID string) (store.TurnRecord, bool, error)
 }
 
 // Service manages PTY-backed shell sessions keyed by session ID.
@@ -347,6 +350,10 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 	s.snaps.filed = func(id string) {
 		hub.Emit(turnEventName, turnEvent{ID: id})
 	}
+	// What a turn recorded outlives the process that recorded it: a session
+	// restored at launch answers for its last turn straight away, instead of
+	// reading as unrecorded until its next one ends.
+	s.snaps.store = store
 	// While any turn is open the machine is kept from idling into sleep, the
 	// way a playing media player keeps it: a locked screen no longer pauses
 	// the agents (internal/awake).

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/omartelo/lich/internal/events"
 	"github.com/omartelo/lich/internal/providers"
 	"github.com/omartelo/lich/internal/shquote"
+	"github.com/omartelo/lich/internal/store"
 )
 
 // stubBins is a Store returning a fixed binary path and project directory,
@@ -53,6 +54,10 @@ type stubBins struct {
 	// Nil until a test cares: the flush only ever writes for a session the
 	// accumulator actually counted something for.
 	handsOn map[string]int64
+	// The last finished turn per session, the shape store.SaveTurnRecord files.
+	// Nil until a test cares, and then it stands in for the workspace database
+	// across a restart.
+	turns map[string]store.TurnRecord
 	// One field per cost method, because the three failures are three different
 	// stories: a ledger that cannot be read, one that cannot be written, and a
 	// total that cannot be summed. A single error field would let a test claim
@@ -165,6 +170,18 @@ func (s stubBins) AddHandsOn(sessionID string, seconds int64) error {
 }
 
 func (s stubBins) HandsOn(sessionID string) (int64, error) { return s.handsOn[sessionID], nil }
+
+func (s stubBins) SaveTurnRecord(sessionID string, rec store.TurnRecord) error {
+	if s.turns != nil {
+		s.turns[sessionID] = rec
+	}
+	return nil
+}
+
+func (s stubBins) TurnRecord(sessionID string) (store.TurnRecord, bool, error) {
+	rec, ok := s.turns[sessionID]
+	return rec, ok, nil
+}
 
 // TestChildEnvStripsAppImageVars proves the AppImage runtime variables that break
 // mise/asdf shims are dropped while the real user environment is passed through.

--- a/internal/terminal/turnsnap.go
+++ b/internal/terminal/turnsnap.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/omartelo/lich/internal/project"
+	"github.com/omartelo/lich/internal/store"
 )
 
 // snapQueueDepth bounds the work waiting on the snapshot worker. A full queue
@@ -85,6 +86,17 @@ type turnSnaps struct {
 	// the only moment the panel can act on: a turn is filed on the worker, well
 	// after the `done` that closed it. Nil in a test that does not care.
 	filed func(id string)
+	// store keeps the filed pair across runs of lich, so a session restored at
+	// launch can answer for its last turn without waiting for its next one to
+	// end. Nil in a test that does not care, and then a record lives only as
+	// long as the process.
+	store turnStore
+}
+
+// turnStore is the workspace database as this file uses it.
+type turnStore interface {
+	SaveTurnRecord(sessionID string, rec store.TurnRecord) error
+	TurnRecord(sessionID string) (store.TurnRecord, bool, error)
 }
 
 // track binds a session to the checkout its PTY was spawned at and warms the
@@ -92,6 +104,11 @@ type turnSnaps struct {
 // the whole worktree. Any previous accounting under this id belongs to the
 // provider that left: a respawn is a new session's turns, and the last one it
 // recorded is not this one's.
+//
+// The exception is the spawn of a session this run has not tracked at all —
+// the card being restored at launch — which reads its last turn back from the
+// workspace database. That is the only reload: a session already tracked keeps
+// what this run gave it, so the rule above still holds for every respawn.
 func (t *turnSnaps) track(id, dir string) {
 	if id == "" || dir == "" {
 		return
@@ -101,11 +118,12 @@ func (t *turnSnaps) track(id, dir string) {
 		slog.Warn("turnsnap: no place to keep the index", "session", id, "err", err)
 		return
 	}
+	last := t.reload(id)
 	t.mu.Lock()
 	if t.sessions == nil {
 		t.sessions = make(map[string]*snapState)
 	}
-	t.sessions[id] = &snapState{dir: dir, index: index}
+	t.sessions[id] = &snapState{dir: dir, index: index, last: last}
 	t.mu.Unlock()
 	// Warming discards the tree it computes: what is being bought is git's stat
 	// cache in the index file, not the oid.
@@ -120,6 +138,30 @@ func (t *turnSnaps) track(id, dir string) {
 			t.forget(id)
 		}
 	})
+}
+
+// reload reads a session's last finished turn back out of the workspace
+// database, and answers nil for every session that is not being restored: one
+// this run is already tracking, or one nothing has ever filed a turn for. A
+// read that fails is a session without a last turn, which the panel already has
+// words for — never a spawn that refuses to happen.
+func (t *turnSnaps) reload(id string) *turnPair {
+	t.mu.Lock()
+	_, tracked := t.sessions[id]
+	db := t.store
+	t.mu.Unlock()
+	if tracked || db == nil {
+		return nil
+	}
+	rec, ok, err := db.TurnRecord(id)
+	if err != nil {
+		slog.Warn("turnsnap: reading back the last turn failed", "session", id, "err", err)
+		return nil
+	}
+	if !ok {
+		return nil
+	}
+	return &turnPair{before: rec.Before, after: rec.After, endedAt: time.UnixMilli(rec.EndedAt)}
 }
 
 // note reads one session-state report as a turn boundary. Repeat `busy` reports
@@ -196,8 +238,29 @@ func (t *turnSnaps) closeTurn(id string) {
 		if ok && state.seq == seq && err == nil && state.before != "" {
 			state.last = &turnPair{before: state.before, after: oid, endedAt: time.Now()}
 		}
-		filed := t.filed
+		// The same seq guard the record itself answers to: a session re-tracked
+		// while this job was queued is no longer the one that asked for it, and
+		// writing here would file its turn — or, worse, clear it.
+		mine := ok && state.seq == seq
+		var rec store.TurnRecord
+		if mine && state.last != nil {
+			rec = store.TurnRecord{
+				Before:  state.last.before,
+				After:   state.last.after,
+				EndedAt: state.last.endedAt.UnixMilli(),
+			}
+		}
+		filed, db := t.filed, t.store
 		t.mu.Unlock()
+		// Written whatever the outcome, and off the lock: a turn that lost its
+		// snapshot clears the row too, or the next launch would answer with a
+		// turn this lich has already retracted. Only a closed turn reaches
+		// here — an open one has no pair to write.
+		if db != nil && mine {
+			if err := db.SaveTurnRecord(id, rec); err != nil {
+				slog.Warn("turnsnap: saving the last turn failed", "session", id, "err", err)
+			}
+		}
 		// Outside the lock, and whatever the outcome: a turn that lost its
 		// snapshot changed the answer too, from "the turn before" to "none".
 		if filed != nil {

--- a/internal/terminal/turnsnap_test.go
+++ b/internal/terminal/turnsnap_test.go
@@ -5,8 +5,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/omartelo/lich/internal/store"
 )
 
 // snapRepo creates a git repository with one commit and a Service wired to keep
@@ -319,6 +322,7 @@ func TestRespawnDropsThePreviousProvidersTurn(t *testing.T) {
 	openAndWait(t, svc, "s1")
 	writeIn(t, repo, "a.txt", "the last provider's work\n")
 	closeAndWait(t, svc, "s1", turnDiffOK)
+	drainSnaps(t, svc)
 
 	svc.snaps.track("s1", repo)
 	turn, err := svc.LastTurnDiff("s1")
@@ -463,5 +467,143 @@ func TestACheckoutGitCannotSnapshotIsDropped(t *testing.T) {
 	if turn.State != turnDiffUnavailable {
 		t.Errorf("a directory outside a repository reads as %q, want %q",
 			turn.State, turnDiffUnavailable)
+	}
+}
+
+// memTurns is the workspace database as turnSnaps uses it, held in memory so a
+// test can hand the same one to two services and read the second as the lich
+// that launched after the first was closed.
+type memTurns struct {
+	mu      sync.Mutex
+	records map[string]store.TurnRecord
+}
+
+func (m *memTurns) SaveTurnRecord(sessionID string, rec store.TurnRecord) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if rec.Before == "" || rec.After == "" {
+		delete(m.records, sessionID)
+		return nil
+	}
+	m.records[sessionID] = rec
+	return nil
+}
+
+func (m *memTurns) TurnRecord(sessionID string) (store.TurnRecord, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	rec, ok := m.records[sessionID]
+	return rec, ok, nil
+}
+
+// relaunch is the lich that starts after the one holding svc has exited: a new
+// service over the same workspace database and the same checkout, with indexes
+// of its own the way a fresh process finds them.
+func relaunch(t *testing.T, db *memTurns) *Service {
+	t.Helper()
+	svc := &Service{}
+	svc.snaps.root = t.TempDir()
+	svc.snaps.store = db
+	t.Cleanup(func() { drainSnaps(t, svc) })
+	return svc
+}
+
+// The trap this closes: the pair lived in Go memory alone, so every restored
+// session read as unrecorded until its next turn ended — which, for a session
+// nobody is typing at, is never.
+func TestARestoredSessionAnswersItsLastTurn(t *testing.T) {
+	svc, repo := snapRepo(t)
+	db := &memTurns{records: map[string]store.TurnRecord{}}
+	svc.snaps.store = db
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "a.txt", "one\ntwo\n")
+	filed := closeAndWait(t, svc, "s1", turnDiffOK)
+	// The panel can read the record before the worker has written it: the save
+	// runs in the same job, after the lock the answer came from is released.
+	drainSnaps(t, svc)
+
+	// The spawn that restores the card, in a lich that recorded nothing itself.
+	next := relaunch(t, db)
+	next.snaps.track("s1", repo)
+	turn, err := next.LastTurnDiff("s1")
+
+	if err != nil {
+		t.Fatalf("LastTurnDiff: %v", err)
+	}
+	if turn.State != turnDiffOK {
+		t.Fatalf("a restored session reads as %q, want %q", turn.State, turnDiffOK)
+	}
+	if !strings.Contains(turn.Diff, "+two") {
+		t.Errorf("the restored turn lost its diff:\n%s", turn.Diff)
+	}
+	if turn.After != filed.After {
+		t.Errorf("the restored turn stands at %q, want %q", turn.After, filed.After)
+	}
+	if turn.EndedAt != filed.EndedAt {
+		t.Errorf("the restored turn is dated %d, want %d", turn.EndedAt, filed.EndedAt)
+	}
+}
+
+// A turn that lost its closing snapshot retracts the record, and the retraction
+// has to reach the database too — otherwise the next launch would answer with a
+// turn this lich had already taken back.
+func TestARetractedTurnIsNotRestored(t *testing.T) {
+	svc, repo := snapRepo(t)
+	db := &memTurns{records: map[string]store.TurnRecord{}}
+	svc.snaps.store = db
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "a.txt", "recorded\n")
+	closeAndWait(t, svc, "s1", turnDiffOK)
+
+	// The state a dropped opening snapshot leaves behind: a turn is open and
+	// nothing recorded where it started.
+	svc.snaps.mu.Lock()
+	svc.snaps.sessions["s1"].open = true
+	svc.snaps.sessions["s1"].seq++
+	svc.snaps.sessions["s1"].before = ""
+	svc.snaps.mu.Unlock()
+	closeAndWait(t, svc, "s1", turnDiffUnavailable)
+	drainSnaps(t, svc)
+
+	next := relaunch(t, db)
+	next.snaps.track("s1", repo)
+	turn, err := next.LastTurnDiff("s1")
+
+	if err != nil {
+		t.Fatalf("LastTurnDiff: %v", err)
+	}
+	if turn.State != turnDiffUnavailable {
+		t.Errorf("a retracted turn came back as %q, want %q", turn.State, turnDiffUnavailable)
+	}
+}
+
+// The read-back is for the card being restored, and only for it. A respawn
+// under an id this run is already tracking is a new session's turns, so the one
+// the provider that left recorded stays where it is: on disk, not on screen.
+func TestARespawnDoesNotReadTheStoredTurnBack(t *testing.T) {
+	svc, repo := snapRepo(t)
+	db := &memTurns{records: map[string]store.TurnRecord{}}
+	svc.snaps.store = db
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "a.txt", "the last provider's work\n")
+	closeAndWait(t, svc, "s1", turnDiffOK)
+
+	svc.snaps.track("s1", repo)
+	turn, err := svc.LastTurnDiff("s1")
+
+	if err != nil {
+		t.Fatalf("LastTurnDiff: %v", err)
+	}
+	if turn.State != turnDiffUnavailable {
+		t.Errorf("a respawned session inherited a turn: %q", turn.State)
+	}
+	if _, ok, _ := db.TurnRecord("s1"); !ok {
+		t.Error("the respawn dropped the record the next launch restores from")
 	}
 }


### PR DESCRIPTION
Closes the first trap in the "Last turn" ceiling: the before/after `git write-tree` pair was held in Go memory alone, so a lich restart emptied it and every restored session read "No last turn recorded" until its next turn ended — which, for a session nobody is typing at, is never.

## What changed

**The record survives the process.**

- `internal/store/turnrecord.go`: a `session_last_turn` row per session — the two trees and the window's close in unix ms — with `SaveTurnRecord` / `TurnRecord`. The table is created by the schema the way `session_hands_on` is, so there is no `ALTER` to migrate. `ON DELETE CASCADE` ties the record to the card, and the `WHERE EXISTS` guard makes a session closed while its closing snapshot was still on the worker a race rather than a foreign-key failure.
- `internal/terminal/turnsnap.go`: `closeTurn` files the pair to the store from the same job that fills the in-memory record, under the same `seq` guard. A turn that lost a snapshot writes a record with no trees, which clears the row — otherwise a later launch would answer with a turn this lich had already retracted. Nothing is written for a turn that is still open.
- `track` reads the record back, but only for a session this run has not tracked at all — the spawn that restores a card. A respawn under an id already tracked still drops the record: that is a new session's turns, and the rule is now covered by a test with a store wired.

**And the panel can reach it.** The switch was gated on `useSessionEverReported`, so a restored card was shown the working tree and no way to reach the turn the backend was holding.

- `store.Session` gains `hasLastTurn`, read off an `EXISTS` in the sessions query and mirrored in `api-types.ts`; it rides the hydration through `buildSessionState`, `activeTarget` and `useActiveSession`.
- `turnSwitchable(everReported, hasLastTurn)` (`lib/git/last-turn.ts`) is what `ReviewPanel` draws the switch from. A provider that reports nothing and has never recorded a turn is still offered the working tree alone, which is what the guard is for.

## Tests

- `internal/store/turnrecord_test.go`: round-trip, absence, replacement, the clear, the gone-session race, the cascade on `DeleteSession`, and the hydration flag.
- `internal/terminal/turnsnap_test.go`: a second service over the same database — the lich that launched after the first exited — answers the restored session's last turn with its diff, `after` and `endedAt`, without a new turn; a retracted turn is not restored; a respawn does not read the record back.
- Frontend: `turnSwitchable` over its three cases, the hydration carrying the flag (`project-workspace.test.ts`), and `activeTarget` surfacing it (`sessions.test.ts`).

## Docs

`docs/ceilings.md` loses the restart trap and its title; the three remaining traps stand. Its "remembered source is a wish" bullet loses the "cannot be restored on a session quiet since the reload" cost, which this closes. Two traps take their place, both set by this change: a pair read back at launch names loose objects no ref reaches, so a `git gc --prune` between runs leaves the panel reporting a failure; and the switch's two halves read different sources, so a panel reaching a restored card before its spawn is tracked is offered the switch and told nothing is recorded.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` green; `go test -race` green on `internal/terminal` and `internal/store`
- [x] Cross-compile loop (`linux`, `darwin`, `windows`) builds and vets
- [x] `pnpm test` (1533), `tsc --noEmit`, `pnpm build` green
- [x] `biome ci .` — no errors in any touched file; the standing 17 a11y warnings and the deprecated-config info are unchanged from `main`
- [x] Coverage: store 85.9%, terminal 94.2%