### PR TITLE
fix: search every parked session, not the newest hundred

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   underline came back with lich's block. The shape is now carried across the
   cycle beside the mouse encoding and cursor visibility, and follows the
   program's own reset back to the default.
+- **The command palette's History tab finds every session you ever closed.** It
+  was handed the hundred most recently parked sessions and filtered those in the
+  window, so anything closed further back could not be reached by typing its
+  name. The term now goes to the store, which searches every parked session by
+  its name, its project's name and its path, and answers with the hundred most
+  recently closed matches. The branch shown on a row is still read from git
+  afterwards, so it narrows the results but cannot be searched for on its own.
 - **Scoop installs the current release.** The manifest 0.46.0 introduced pinned
   0.45.0 with no checksums, and nothing bumped it on a tag, so `scoop install`
   and `scoop update lich` handed out the previous release. Every release now

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -734,18 +734,18 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   cask's `depends_on` and the bundle's `LSMinimumSystemVersion` say 13.0 because the compiler does —
   both move with the next Go bump, and a machine below the floor is refused by Homebrew rather than
   by a crash.
-- **A closed session's history reaches back a hundred rows, and the search never goes deeper**
-  (`internal/store/store.go`, `frontend/src/lib/session/command-palette.ts`): the History tab is handed the
-  hundred most recently closed sessions when it opens and filters those in the window, the bargain the closed
-  projects list already makes. So a session closed further back than that is in the database, counts against
-  nothing, and cannot be found — typing its name narrows a list it was never in. The fix when it bites is a
-  `LIKE` in the query, not a bigger number; nothing warns that the list was cut, because a cut that is always
-  in force is not news.
+- **The History tab searches names, and the branch on every row is not one** (`internal/store/store.go`,
+  `frontend/src/lib/session/use-history-search.ts`): the search runs in the store, which holds a parked
+  session's name, its project's and its path — the branch is read out of git afterwards, for the rows the
+  search already kept. So a row that shows `feat/relay-inbox` cannot be found by typing that, and the tab
+  answers a branch the user is reading off the screen with nothing at all. A term that matches more than a
+  hundred parked sessions is cut to the hundred closed most recently, and nothing says the list was cut.
 - **The history's branch is read live, so a row whose checkout is gone has none** (`internal/project.BranchesOf`):
   the branch is not stored — a worktree keeps the name it was created with while an agent moves the branch
-  inside it, so the directory cannot answer and only git can. The batch runs once per opening, which also means
-  a branch that moved while the palette is up is stale until it is reopened. A checkout removed behind lich's
-  back has no branch to read and no session to resume: that row says `checkout gone` and offers to forget
+  inside it, so the directory cannot answer and only git can. The batch runs once per settled search, which
+  also means a branch that moved while the palette is up is stale until the query changes or the palette is
+  reopened. A checkout removed behind lich's back has no branch to read and no session to resume: that row
+  says `checkout gone` and offers to forget
   itself, which is the only way such a row is ever collected — `PurgeWorktreeSessions` never ran for it,
   because the removal never went through the app.
 - **A worktree lich did not create can never be removed through lich** (`internal/project.WorktreeAdopted`):

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -13,7 +13,6 @@ import { SessionStatusIcon } from "@/components/sidebar/SessionStatusIcon"
 import {
   filterPalette,
   historyAction,
-  historyRows,
   nextTab,
   paletteGroups,
   paletteSessions,
@@ -27,13 +26,14 @@ import {
   type PaletteSession,
   type PaletteTab,
 } from "@/lib/session/command-palette"
+import { useHistorySearch } from "@/lib/session/use-history-search"
 import { useTranscriptSearch } from "@/lib/session/use-transcript-search"
 import { toast } from "sonner"
 import { PickerDialog, PickerEmpty, PickerGroup, PickerRow } from "@/components/common/PickerDialog"
 import { agoLabel } from "@/lib/ago"
 import { displayPath } from "@/lib/paths"
 import { isSessionKind } from "@/lib/session/sessions"
-import type { ClosedSession, Project, RecentProject } from "@/lib/api-types"
+import type { Project, RecentProject } from "@/lib/api-types"
 import { ProjectService, Store } from "@/lib/rpc"
 import { cn, errorText } from "@/lib/utils"
 
@@ -55,8 +55,6 @@ export function CommandPalette() {
   const [tab, setTab] = useState<PaletteTab>("All")
   const [selected, setSelected] = useState(0)
   const [closed, setClosed] = useState<RecentProject[]>([])
-  const [parked, setParked] = useState<ClosedSession[]>([])
-  const [branches, setBranches] = useState<Readonly<Record<string, string>>>({})
   const [running, setRunning] = useState<ReadonlySet<string>>(new Set())
   const [missing, setMissing] = useState<ReadonlySet<string>>(new Set())
 
@@ -67,55 +65,41 @@ export function CommandPalette() {
     setSelected(0)
   })
 
-  // The closed projects and the parked sessions both live in the store, not in
-  // the workspace state, so they are fetched per opening — anything closed or
-  // reopened since the last one moves in or out of these lists. Their
-  // directories are read with them: a project whose folder moved is relocated
-  // rather than reopened, and a session whose checkout is gone says so.
-  //
-  // The branches are asked for in one batch rather than by subscribing each row
-  // to the git poller a live card uses: that poll is three calls per path per
-  // second, and this list is long and on screen for as long as it takes to type.
+  // The closed projects live in the store, not in the workspace state, so they
+  // are fetched per opening — anything closed or reopened since the last one
+  // moves in or out of the list. Their directories are read with them: a project
+  // whose folder moved is relocated rather than reopened.
   useEffect(() => {
     if (!open) {
       return
     }
     let live = true
-    void Promise.all([Store.RecentProjects(), Store.ClosedSessions()]).then(
-      ([recentRows, parkedRows]) => {
-        const recents = recentRows ?? []
-        const history = parkedRows ?? []
-        if (!live) {
-          return
+    void Store.RecentProjects().then((recentRows) => {
+      const recents = recentRows ?? []
+      if (!live) {
+        return
+      }
+      setClosed(recents)
+      void ProjectService.Missing(recents.map((row) => row.path)).then((gone) => {
+        if (live) {
+          setMissing(new Set(gone ?? []))
         }
-        setClosed(recents)
-        setParked(history)
-        // Asked for after the rows are up: what git and the filesystem say is
-        // what a row says about itself, and a failed check must not cost the
-        // palette its entries.
-        const paths = history.map((row) => row.path).filter(Boolean)
-        void ProjectService.Missing([...recents.map((row) => row.path), ...paths]).then((gone) => {
-          if (live) {
-            setMissing(new Set(gone ?? []))
-          }
-        })
-        void ProjectService.BranchesOf(paths).then((named) => {
-          if (live) {
-            setBranches(named ?? {})
-          }
-        })
-      },
-    )
+      })
+    })
     return () => {
       live = false
     }
   }, [open])
 
+  // The parked sessions are searched in the store rather than filtered here, so
+  // the History tab reaches a session parked further back than one page of it.
+  const { rows: history, forget: dropParked } = useHistorySearch(query, open)
+
   // Forgetting drops the row from the list in place rather than closing the
   // palette: the whole point of the action is that there are usually several of
   // them, left by worktrees removed outside lich.
   const forget = (session: PaletteHistory) => {
-    setParked((rows) => rows.filter((row) => row.id !== session.id))
+    dropParked(session.id)
     void Store.ForgetSession(session.id).catch((error: unknown) => {
       toast.error(`Could not forget ${session.label}: ${errorText(error)}`)
     })
@@ -134,7 +118,6 @@ export function CommandPalette() {
     }
   }, [open])
   const all = useMemo(() => rankSessions(flat, running), [flat, running])
-  const history = useMemo(() => historyRows(parked, branches, missing), [parked, branches, missing])
   const results = useMemo(
     () => filterPalette(query, all, projects, closed, history),
     [query, all, projects, closed, history],
@@ -266,7 +249,11 @@ export function CommandPalette() {
         // the query found nothing, the other says nothing has ever been closed.
         // The second is the only place the retention rule is stated, which is
         // where it belongs — the moment somebody wonders what this remembers.
-        tab === "History" && parked.length === 0 ? (
+        //
+        // Only an empty query can tell the two apart: the history is searched in
+        // the store, so once a term is typed an empty list is a search that
+        // missed, never an empty workspace.
+        tab === "History" && query.trim() === "" && history.length === 0 ? (
           <PickerEmpty>
             <span className="block text-foreground">Nothing closed yet</span>
             <span className="mx-auto mt-2 block max-w-[44ch] leading-relaxed">

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -396,9 +396,11 @@ export const Store = {
   /** Resume a parked worktree session under a fresh id, or null when none. */
   ReopenWorktreeSession: (projectID: string, path: string, newSessionID: string) =>
     call<StoredSession | null>("store.ReopenWorktreeSession", [projectID, path, newSessionID]),
-  /** The parked sessions, last closed first — the history the palette browses.
-   * Capped store-side, so this is also how far back a search can reach. */
-  ClosedSessions: () => call<ClosedSession[] | null>("store.ClosedSessions", []),
+  /** The parked sessions matching `term`, last closed first — the history the
+   * palette browses. Every word of the term must appear in the session's name,
+   * its project's name or its path; an empty term is the plain history. The
+   * search runs in the query, so it reaches past the page this answers with. */
+  ClosedSessions: (term: string) => call<ClosedSession[] | null>("store.ClosedSessions", [term]),
   /** Resume one parked session by its own id, or null when it is no longer
    * parked — another window resumed it, or its worktree was removed. */
   ReopenSession: (sessionID: string, newSessionID: string) =>

--- a/frontend/src/lib/session/use-history-search.test.tsx
+++ b/frontend/src/lib/session/use-history-search.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+//
+// The wiring the History tab's search is: the typed term has to reach the store,
+// because the store is the only place that can see past the page it answers
+// with. A test that filters rows in the window would pass against the bug this
+// hook exists to close.
+//
+// The harness has to be imported before anything that reaches react-dom, which
+// is why it is first here (see @/test/render-budget).
+import { mountBudget } from "@/test/render-budget"
+import { StrictMode, createElement, useLayoutEffect, useState } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { ClosedSession } from "@/lib/api-types"
+import { useHistorySearch } from "@/lib/session/use-history-search"
+import type { PaletteHistory } from "@/lib/session/command-palette"
+
+const terms: string[] = []
+const branchPaths: string[][] = []
+
+function row(id: string, label: string): ClosedSession {
+  return {
+    id,
+    projectId: "p1",
+    projectName: "alpha",
+    projectPath: "/repo",
+    label,
+    kind: "claude",
+    path: `/wt/${id}`,
+    closedAt: 1_700_000_000,
+  }
+}
+
+// The fake store searches by name so the test can tell a backend search from a
+// window filter: only "old" is answered for a term, and it is never in the list
+// the empty term returns.
+vi.mock("@/lib/rpc", () => ({
+  Store: {
+    ClosedSessions: (term: string) => {
+      terms.push(term)
+      if (term === "") {
+        return Promise.resolve([row("s1", "recent work")])
+      }
+      return Promise.resolve(term.includes("old") ? [row("old", "the oldest work")] : [])
+    },
+  },
+  ProjectService: {
+    Missing: (paths: string[]) => Promise.resolve(paths.filter((p) => p === "/wt/old")),
+    BranchesOf: (paths: string[]) => {
+      branchPaths.push(paths)
+      return Promise.resolve(Object.fromEntries(paths.map((p) => [p, `branch${p}`])))
+    },
+  },
+}))
+
+// The debounce is real, so the test waits it out rather than mocking the clock:
+// act() and fake timers fight over the same queue, and what is being asserted is
+// that a burst of keystrokes costs one call.
+const DEBOUNCE_MS = 200
+
+const settled = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, DEBOUNCE_MS + 60))
+
+// The newest frame, which is the one the palette would be painting.
+function last<T>(frames: T[]): T | undefined {
+  return frames[frames.length - 1]
+}
+
+function probe(frames: PaletteHistory[][], forgets: ((id: string) => void)[]) {
+  return function Probe({ query, enabled }: { query: string; enabled: boolean }) {
+    const { rows, forget } = useHistorySearch(query, enabled)
+    useLayoutEffect(() => {
+      frames.push(rows)
+      forgets.push(forget)
+    })
+    return null
+  }
+}
+
+function typing(frames: PaletteHistory[][], typers: ((q: string) => void)[]) {
+  return function Typing() {
+    const [query, setQuery] = useState("")
+    const { rows } = useHistorySearch(query, true)
+    useLayoutEffect(() => {
+      frames.push(rows)
+      typers.push(setQuery)
+    })
+    return null
+  }
+}
+
+beforeEach(() => {
+  terms.length = 0
+  branchPaths.length = 0
+})
+
+describe("useHistorySearch", () => {
+  it("asks the store for the plain history when nothing is typed", async () => {
+    const frames: PaletteHistory[][] = []
+    const Probe = probe(frames, [])
+    const budget = await mountBudget(
+      createElement(StrictMode, null, createElement(Probe, { query: "", enabled: true })),
+    )
+    await budget.act(settled)
+
+    expect(terms).toEqual([""])
+    const rows = last(frames) ?? []
+    expect(rows.map((r) => r.id)).toEqual(["s1"])
+    // The branch is joined on from git, not from the row: the store has none.
+    expect(rows[0].branch).toBe("branch/wt/s1")
+    expect(rows[0].gone).toBe(false)
+    expect(last(branchPaths)).toEqual(["/wt/s1"])
+    await budget.unmount()
+  })
+
+  it("sends the typed term to the store, once for a burst of keystrokes", async () => {
+    const frames: PaletteHistory[][] = []
+    const typers: ((q: string) => void)[] = []
+    const Probe = typing(frames, typers)
+    const budget = await mountBudget(createElement(StrictMode, null, createElement(Probe)))
+    await budget.act(settled)
+    expect(terms).toEqual([""])
+
+    // Three keystrokes inside one debounce window buy one search, not three.
+    await budget.act(async () => {
+      for (const q of ["o", "ol", "old"]) {
+        last(typers)?.(q)
+        await Promise.resolve()
+      }
+    })
+    await budget.act(settled)
+
+    expect(terms).toEqual(["", "old"])
+    // The row the term returns was never in the empty-term list, so no filter
+    // over what the window already held could have produced it.
+    const rows = last(frames) ?? []
+    expect(rows.map((r) => r.id)).toEqual(["old"])
+    // Its checkout is gone, which is the row that forgets rather than resumes.
+    expect(rows[0].gone).toBe(true)
+    await budget.unmount()
+  })
+
+  it("stays idle while the palette is closed", async () => {
+    const frames: PaletteHistory[][] = []
+    const Probe = probe(frames, [])
+    const budget = await mountBudget(
+      createElement(StrictMode, null, createElement(Probe, { query: "old", enabled: false })),
+    )
+    await budget.act(settled)
+
+    expect(terms).toEqual([])
+    expect(last(frames)).toEqual([])
+    await budget.unmount()
+  })
+
+  it("drops a forgotten row without asking the store again", async () => {
+    const frames: PaletteHistory[][] = []
+    const forgets: ((id: string) => void)[] = []
+    const Probe = probe(frames, forgets)
+    const budget = await mountBudget(
+      createElement(StrictMode, null, createElement(Probe, { query: "", enabled: true })),
+    )
+    await budget.act(settled)
+
+    await budget.act(() => {
+      last(forgets)?.("s1")
+    })
+    expect(last(frames)).toEqual([])
+    expect(terms).toEqual([""])
+    await budget.unmount()
+  })
+})

--- a/frontend/src/lib/session/use-history-search.ts
+++ b/frontend/src/lib/session/use-history-search.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import type { ClosedSession } from "@/lib/api-types"
+import { ProjectService, Store } from "@/lib/rpc"
+import { historyRows, type PaletteHistory } from "./command-palette"
+
+// A history search runs a query over every session ever parked and then reads
+// git for the rows it returns, so it waits for the typing to settle rather than
+// firing on the keystroke — the same bargain the transcript search makes.
+const DEBOUNCE_MS = 200
+
+// useHistorySearch asks the store for the parked sessions matching `query` and
+// joins them to what git and the filesystem say about their checkouts. Idle —
+// no rows, no calls — while the palette is closed.
+//
+// The term goes to the backend rather than filtering rows already in hand: the
+// store answers with one page, so a session parked further back than that page
+// is only reachable if the match happens in the query. The palette's own filter
+// still runs over what comes back, which is what narrows by branch — the one
+// part of a row that is not in the database.
+//
+// An empty query skips the debounce: it is the list the palette opens with, and
+// nothing was typed to wait out. Every effect run supersedes the one before it,
+// so a reply that lands after the query moved on is dropped rather than painted
+// over newer rows.
+export function useHistorySearch(
+  query: string,
+  enabled: boolean,
+): { rows: PaletteHistory[]; forget: (sessionID: string) => void } {
+  const [parked, setParked] = useState<readonly ClosedSession[]>([])
+  const [branches, setBranches] = useState<Readonly<Record<string, string>>>({})
+  const [missing, setMissing] = useState<ReadonlySet<string>>(new Set())
+
+  useEffect(() => {
+    if (!enabled) {
+      setParked([])
+      return
+    }
+    let live = true
+    const timer = window.setTimeout(
+      () => {
+        void Store.ClosedSessions(query).then((parkedRows) => {
+          const history = parkedRows ?? []
+          if (!live) {
+            return
+          }
+          setParked(history)
+          // Asked for after the rows are up: what git and the filesystem say is
+          // what a row says about itself, and a failed check must not cost the
+          // palette its entries.
+          //
+          // The branches come in one batch rather than by subscribing each row
+          // to the git poller a live card uses: that poll is three calls per
+          // path per second, and this list is long and on screen for as long as
+          // it takes to type.
+          const paths = history.map((row) => row.path).filter(Boolean)
+          void ProjectService.Missing(paths).then((gone) => {
+            if (live) {
+              setMissing(new Set(gone ?? []))
+            }
+          })
+          void ProjectService.BranchesOf(paths).then((named) => {
+            if (live) {
+              setBranches(named ?? {})
+            }
+          })
+        })
+      },
+      query.trim() === "" ? 0 : DEBOUNCE_MS,
+    )
+    return () => {
+      live = false
+      window.clearTimeout(timer)
+    }
+  }, [query, enabled])
+
+  // Forgetting drops the row in place rather than refetching: the list stays up
+  // while several stale rows are cleared, which is how they are usually left.
+  const forget = useCallback((sessionID: string) => {
+    setParked((rows) => rows.filter((row) => row.id !== sessionID))
+  }, [])
+
+  // Memoised because the rows are a dependency of the palette's own filter:
+  // a fresh array every render would re-filter every group on every keystroke.
+  const rows = useMemo(() => historyRows(parked, branches, missing), [parked, branches, missing])
+  return { rows, forget }
+}

--- a/internal/spawn/park_test.go
+++ b/internal/spawn/park_test.go
@@ -82,7 +82,7 @@ func listed(t *testing.T, rows *store.Service, id string) (open, history bool) {
 			}
 		}
 	}
-	closed, err := rows.ClosedSessions()
+	closed, err := rows.ClosedSessions("")
 	if err != nil {
 		t.Fatalf("ClosedSessions: %v", err)
 	}
@@ -171,7 +171,7 @@ func TestAParkedSessionIsFoundInTheHistoryWithItsName(t *testing.T) {
 		t.Fatalf("Close alone: %v", err)
 	}
 
-	closed, err := rows.ClosedSessions()
+	closed, err := rows.ClosedSessions("")
 	if err != nil {
 		t.Fatalf("ClosedSessions: %v", err)
 	}

--- a/internal/store/history_test.go
+++ b/internal/store/history_test.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"fmt"
+	"slices"
 	"testing"
 	"time"
 )
@@ -30,7 +32,7 @@ func TestClosedSessionsOrdersByCloseNotByInsert(t *testing.T) {
 	atClock(t, time.Unix(1_700_000_100, 0), func() { _ = svc.CloseSession("p1", "second", "keep") })
 	atClock(t, time.Unix(1_700_000_200, 0), func() { _ = svc.CloseSession("p1", "first", "keep") })
 
-	closed, err := svc.ClosedSessions()
+	closed, err := svc.ClosedSessions("")
 	if err != nil {
 		t.Fatalf("ClosedSessions: %v", err)
 	}
@@ -55,7 +57,7 @@ func TestClosedSessionsIdentifiesEachRow(t *testing.T) {
 	_ = svc.AddSession("p1", "gone", "Wire the relay inbox", "shell", "/wt/relay", 3, "")
 	atClock(t, time.Unix(1_700_000_000, 0), func() { _ = svc.CloseSession("p1", "gone", "keep") })
 
-	closed, _ := svc.ClosedSessions()
+	closed, _ := svc.ClosedSessions("")
 	if len(closed) != 1 {
 		t.Fatalf("got %d closed sessions, want 1", len(closed))
 	}
@@ -78,7 +80,7 @@ func TestClosedSessionsSkipsOpenOnes(t *testing.T) {
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
 	_ = svc.AddSession("p1", "live", "Session 1", "claude", "", 2, "")
 
-	closed, err := svc.ClosedSessions()
+	closed, err := svc.ClosedSessions("")
 	if err != nil {
 		t.Fatalf("ClosedSessions: %v", err)
 	}
@@ -98,15 +100,15 @@ func TestClosedSessionsIncludesClosedProjects(t *testing.T) {
 	_ = svc.CloseSession("p1", "old", "keep")
 	_ = svc.CloseProject("p1")
 
-	closed, _ := svc.ClosedSessions()
+	closed, _ := svc.ClosedSessions("")
 	if len(closed) != 1 || closed[0].ProjectName != "alpha" {
 		t.Errorf("closed = %+v, want the session of the closed project, named", closed)
 	}
 }
 
 // TestClosedSessionsCapsTheList pins the bound rather than deriving it from the
-// constant: the cap is how far back a search can reach, so a change to it has to
-// be a deliberate edit here too.
+// constant: the cap is how many rows one call answers with, so a change to it
+// has to be a deliberate edit here too.
 func TestClosedSessionsCapsTheList(t *testing.T) {
 	svc := newTestStore(t)
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
@@ -119,7 +121,7 @@ func TestClosedSessionsCapsTheList(t *testing.T) {
 		})
 	}
 
-	closed, _ := svc.ClosedSessions()
+	closed, _ := svc.ClosedSessions("")
 	if len(closed) != 100 {
 		t.Errorf("got %d closed sessions, want the list capped at 100", len(closed))
 	}
@@ -160,7 +162,7 @@ func TestReopenSessionRestoresByID(t *testing.T) {
 	if len(projects) != 1 || len(projects[0].Sessions) != 2 {
 		t.Fatalf("sessions after resume = %+v, want the kept one and the resumed one", projects)
 	}
-	closed, _ := svc.ClosedSessions()
+	closed, _ := svc.ClosedSessions("")
 	if len(closed) != 0 {
 		t.Errorf("closed = %+v, want the resumed row out of the history", closed)
 	}
@@ -253,7 +255,7 @@ func TestReopenWorktreeSessionRefusesTheEmptyPath(t *testing.T) {
 		t.Errorf("ReopenWorktreeSession(path: \"\") = %+v, want nil", restored)
 	}
 	// And the parked root session is still there for its own door.
-	closed, _ := svc.ClosedSessions()
+	closed, _ := svc.ClosedSessions("")
 	if len(closed) != 1 || closed[0].ID != "root" {
 		t.Errorf("closed = %+v, want the root session still parked", closed)
 	}
@@ -273,7 +275,7 @@ func TestForgetSessionRemovesOneParkedRow(t *testing.T) {
 	if err := svc.ForgetSession("dead"); err != nil {
 		t.Fatalf("ForgetSession: %v", err)
 	}
-	closed, _ := svc.ClosedSessions()
+	closed, _ := svc.ClosedSessions("")
 	if len(closed) != 0 {
 		t.Errorf("closed = %+v, want the forgotten row gone", closed)
 	}
@@ -311,4 +313,168 @@ func TestForgetSessionOnAMissingRowIsNotAnError(t *testing.T) {
 	if err := svc.ForgetSession("never-existed"); err != nil {
 		t.Errorf("ForgetSession on a missing row = %v, want nil", err)
 	}
+}
+
+// park closes one session of project p1 at a fixed clock, so a search test can
+// name what it is looking for and when it was parked in one line.
+func park(t *testing.T, svc *Service, id, label string, at int64) {
+	t.Helper()
+	_ = svc.AddSession("p1", id, label, "claude", "/wt/"+id, 0, "")
+	atClock(t, time.Unix(at, 0), func() { _ = svc.CloseSession("p1", id, "keep") })
+}
+
+// searchStore is a store with a keep-open session and three parked ones, closed
+// oldest first.
+func searchStore(t *testing.T) *Service {
+	t.Helper()
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 1, "")
+	park(t, svc, "s1", "Wire the relay inbox", 1_700_000_100)
+	park(t, svc, "s2", "relay ticket lifecycle", 1_700_000_200)
+	park(t, svc, "s3", "Split groups design", 1_700_000_300)
+	return svc
+}
+
+func ids(closed []ClosedSession) []string {
+	got := make([]string, len(closed))
+	for i, c := range closed {
+		got[i] = c.ID
+	}
+	return got
+}
+
+// TestClosedSessionsSearchesByName is the search itself: a term narrows the list
+// to the rows whose name contains it, whatever their case.
+func TestClosedSessionsSearchesByName(t *testing.T) {
+	svc := searchStore(t)
+
+	for _, term := range []string{"relay", "RELAY", "ReLaY"} {
+		closed, err := svc.ClosedSessions(term)
+		if err != nil {
+			t.Fatalf("ClosedSessions(%q): %v", term, err)
+		}
+		// Newest first, the same order the unfiltered list is in.
+		if got := ids(closed); len(got) != 2 || got[0] != "s2" || got[1] != "s1" {
+			t.Errorf("ClosedSessions(%q) = %v, want [s2 s1]", term, got)
+		}
+	}
+}
+
+// TestClosedSessionsSearchesEveryWord pins the term's reading against the
+// palette's own filter, which requires every word and not the phrase.
+func TestClosedSessionsSearchesEveryWord(t *testing.T) {
+	svc := searchStore(t)
+
+	if got := ids(mustClosed(t, svc, "inbox relay")); len(got) != 1 || got[0] != "s1" {
+		t.Errorf(`ClosedSessions("inbox relay") = %v, want [s1] whatever the word order`, got)
+	}
+	if got := ids(mustClosed(t, svc, "relay split")); len(got) != 0 {
+		t.Errorf(`ClosedSessions("relay split") = %v, want none: no row carries both`, got)
+	}
+	// The project's name and the checkout path are part of the haystack, so a
+	// term the window would have matched is not dropped before it gets there.
+	if got := ids(mustClosed(t, svc, "alpha s3")); len(got) != 1 || got[0] != "s3" {
+		t.Errorf(`ClosedSessions("alpha s3") = %v, want [s3] by project and path`, got)
+	}
+}
+
+// TestClosedSessionsSearchEscapesWildcards is why the term is escaped: LIKE
+// reads % and _ as patterns, so an unescaped name containing either would match
+// rows that have nothing to do with it.
+func TestClosedSessionsSearchEscapesWildcards(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 1, "")
+	park(t, svc, "pct", "100% done", 1_700_000_100)
+	park(t, svc, "und", "hand_off", 1_700_000_200)
+	park(t, svc, "esc", `back\slash`, 1_700_000_300)
+	// The decoys are what an unescaped term matches: % swallows the trailing
+	// zero, _ stands in for the X, and a bare backslash is an escape sequence
+	// SQLite refuses outright.
+	park(t, svc, "wide", "1000 lines", 1_700_000_400)
+	park(t, svc, "any", "handXoff", 1_700_000_500)
+
+	cases := []struct {
+		term string
+		want string
+	}{
+		{"100%", "pct"},
+		{"hand_off", "und"},
+		{`back\slash`, "esc"},
+	}
+	for _, tc := range cases {
+		got := ids(mustClosed(t, svc, tc.term))
+		if len(got) != 1 || got[0] != tc.want {
+			t.Errorf("ClosedSessions(%q) = %v, want [%s] only", tc.term, got, tc.want)
+		}
+	}
+}
+
+// TestClosedSessionsSearchReachesPastTheCap is the ceiling this search closed: a
+// session parked further back than one page of history is still findable by
+// name, which is the whole point of matching in the query.
+func TestClosedSessionsSearchReachesPastTheCap(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 1, "")
+	park(t, svc, "needle", "the oldest work", 1_700_000_000)
+	for i := range closedSessionLimit + 5 {
+		park(t, svc, fmt.Sprintf("s%d", i), "newer work", int64(1_700_001_000+i))
+	}
+
+	if got := ids(mustClosed(t, svc, "")); len(got) != closedSessionLimit {
+		t.Fatalf("unfiltered list = %d rows, want %d", len(got), closedSessionLimit)
+	} else if slices.Contains(got, "needle") {
+		t.Fatal("the oldest row is inside the unfiltered page; the test proves nothing")
+	}
+	if got := ids(mustClosed(t, svc, "oldest")); len(got) != 1 || got[0] != "needle" {
+		t.Errorf(`ClosedSessions("oldest") = %v, want [needle] from past the cap`, got)
+	}
+}
+
+// TestClosedSessionsSearchCapsMatches pins that the cap outlives the search: a
+// term matching everything is still one page of rows.
+func TestClosedSessionsSearchCapsMatches(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 1, "")
+	for i := range closedSessionLimit + 5 {
+		park(t, svc, fmt.Sprintf("s%d", i), "work", int64(1_700_000_000+i))
+	}
+
+	closed := mustClosed(t, svc, "work")
+	if len(closed) != closedSessionLimit {
+		t.Fatalf("got %d matches, want the list capped at %d", len(closed), closedSessionLimit)
+	}
+	if closed[0].ClosedAt != int64(1_700_000_000+closedSessionLimit+4) {
+		t.Errorf("newest match = %d, want the last close of the run", closed[0].ClosedAt)
+	}
+}
+
+// TestEscapeLike covers the escape on its own, since the backslash has to be
+// doubled before the wildcards are escaped with it.
+func TestEscapeLike(t *testing.T) {
+	cases := map[string]string{
+		"plain": "plain",
+		"50%":   `50\%`,
+		"a_b":   `a\_b`,
+		`c\d`:   `c\\d`,
+		`\%_`:   `\\\%\_`,
+		"":      "",
+	}
+	for in, want := range cases {
+		if got := escapeLike(in); got != want {
+			t.Errorf("escapeLike(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func mustClosed(t *testing.T, svc *Service, term string) []ClosedSession {
+	t.Helper()
+	closed, err := svc.ClosedSessions(term)
+	if err != nil {
+		t.Fatalf("ClosedSessions(%q): %v", term, err)
+	}
+	return closed
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -448,30 +448,58 @@ type ClosedSession struct {
 	ClosedAt int64 `json:"closedAt"`
 }
 
-// closedSessionLimit caps the history handed to the window. The palette filters
-// what it was given rather than asking again per keystroke (the same bargain
-// RecentProjects makes), so this number is how far back a search can reach:
-// deep enough to cover the sessions a workspace churns through in months, and
-// still a bound — the alternative is reading every session ever closed to draw
-// a list nobody scrolls to the end of.
+// closedSessionLimit caps the history handed to the window — how many rows one
+// call answers with, not how far back it looks: the search runs in the query,
+// so a match older than the newest hundred is still found. The alternative is
+// handing over every session ever closed to draw a list nobody scrolls to the
+// end of.
 const closedSessionLimit = 100
 
-// ClosedSessions returns the parked sessions (is_open = 0), the last one closed
-// first, up to closedSessionLimit of them. Sessions of closed projects answer
-// too: a project hidden from the tab strip still owns the work done in it, and
-// resuming one of its sessions is what reopens it.
+// likeEscape is the ESCAPE character the history search declares, so a name
+// containing % or _ searches for those characters instead of matching anything.
+const likeEscape = `\`
+
+// escapeLike neutralises the LIKE wildcards in a user's search term. The escape
+// character goes first, or escaping the wildcards would re-escape it.
+func escapeLike(term string) string {
+	term = strings.ReplaceAll(term, likeEscape, likeEscape+likeEscape)
+	term = strings.ReplaceAll(term, "%", likeEscape+"%")
+	return strings.ReplaceAll(term, "_", likeEscape+"_")
+}
+
+// ClosedSessions returns the parked sessions (is_open = 0) matching term, the
+// last one closed first, up to closedSessionLimit of them. An empty term is the
+// plain history: the most recently closed, whatever they are named. Sessions of
+// closed projects answer too: a project hidden from the tab strip still owns the
+// work done in it, and resuming one of its sessions is what reopens it.
+//
+// The term is matched here rather than in the window because the window only
+// ever sees one page of rows, and a session parked further back than that page
+// would be unfindable by name. Every whitespace-separated word must appear
+// somewhere in the name, the project's name or the path — the same reading the
+// palette's own filter gives a query, so narrowing here never drops a row that
+// filter would have kept. LIKE is case-insensitive for ASCII in SQLite, which
+// is what makes this a search and not a prefix test.
 //
 // rowid is the tiebreak, not the order, for RecentProjects' reason twice over:
 // it dates the insert, and a resumed session is reinserted — so rows parked
 // before closed_at existed all carry 0 and fall back to it together.
-func (s *Service) ClosedSessions() ([]ClosedSession, error) {
+func (s *Service) ClosedSessions(term string) ([]ClosedSession, error) {
+	where := "WHERE s.is_open = 0"
+	args := []any{}
+	for _, word := range strings.Fields(term) {
+		where += " AND (s.label || ' ' || p.name || ' ' || s.path) LIKE ? ESCAPE '" + likeEscape + "'"
+		args = append(args, "%"+escapeLike(word)+"%")
+	}
+	args = append(args, closedSessionLimit)
+
 	rows, err := s.db.Query(
 		`SELECT s.id, s.project_id, p.name, p.path, s.label, s.kind, s.path, s.closed_at
 		   FROM sessions s JOIN projects p ON p.id = s.project_id
-		  WHERE s.is_open = 0
+		   `+where+`
 		  ORDER BY s.closed_at DESC, s.rowid DESC
 		  LIMIT ?`,
-		closedSessionLimit,
+		args...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("query closed sessions: %w", err)


### PR DESCRIPTION
## What

The command palette's History tab was handed the hundred most recently closed
sessions and filtered them in the window. A session parked further back than
that was in the database, counted against nothing, and could not be found:
typing its name narrowed a list it was never in.

`store.ClosedSessions` now takes a search term and matches it in the query.
Every whitespace-separated word must appear in the session's name, its
project's name or its path — the same reading the palette's own filter gives a
query, so narrowing in the store never drops a row the window would have kept.
LIKE's wildcards are escaped, so a name carrying `%` or `_` searches for those
characters instead of matching anything. An empty term is unchanged: the
hundred most recently closed.

The palette sends the typed term behind the same 200ms debounce the Messages
tab uses. `useHistorySearch` now owns the parked rows, their branches and their
missing checkouts, which is what let `CommandPalette` shrink.

## Ceilings

The closed trap is deleted from `docs/ceilings.md`. What still traps is
written there instead: the branch shown on every history row is read from git
after the search, so it narrows the results but cannot be searched for on its
own, and a term matching more than a hundred parked sessions is cut to the
hundred closed most recently with nothing saying so.

## Test plan

- [x] `go test ./...` — new store tests cover the LIKE (case-insensitivity,
      per-word matching, `%`/`_`/`\` escaping, ordering, the cap, and a match
      found past the cap). Both the escape and the reach tests were mutated to
      confirm they fail without the fix. Store coverage 86.4%.
- [x] `frontend/src/lib/session/use-history-search.test.tsx` mounts the hook
      and asserts the typed term reaches the store (the row it returns is never
      in the empty-term list), that a burst of keystrokes costs one call, that a
      closed palette is idle, and that forgetting drops a row without a refetch.
      Both assertions were mutation-checked.
- [x] `gofmt -l .` clean, `go vet ./...` clean, `biome ci .` exit 0,
      `vitest run` (1518 passing), `tsc && vite build` clean — rerun after the
      rebase onto `9bcf1ce`.