### PR TITLE
fix: keep a session's read mark across a page reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its name, its project's name and its path, and answers with the hundred most
   recently closed matches. The branch shown on a row is still read from git
   afterwards, so it narrows the results but cannot be searched for on its own.
+- **A finished turn stays read across a reload.** The mark behind a session's
+  solid emerald ring lived in the page, so reloading the window handed back
+  every finished turn as news, including the ones read twenty minutes ago. It is
+  workspace state now, written where the turn actually ends: a turn that
+  finishes while the page is gone is waiting to be found when it comes back, and
+  one already read comes back read.
 - **Scoop installs the current release.** The manifest 0.46.0 introduced pinned
   0.45.0 with no checksums, and nothing bumped it on a tag, so `scoop install`
   and `scoop update lich` handed out the previous release. Every release now

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -235,11 +235,9 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   blobs ordered by a protobuf index, with a `blobEncryptionKey` sitting in its own metadata.
 - **A finished turn is unread until its own card is watched** (`frontend/src/lib/session/session-status-store.ts`,
   `frontend/src/providers/projects.tsx`): the solid emerald ring means "back from the agent, not read yet", and it
-  fades only for the session whose terminal is on screen **while the window has focus**. Two things follow. A card
-  left focused in a background window keeps its ring solid until the window is touched again, which is the point
-  — but it also means a browser that reports focus oddly never fades one. And the mark lives in the page like the
-  rest of the session state, so a reload starts every session unread again: a turn read twenty minutes ago comes
-  back looking like news, and nothing on screen says the page forgot.
+  fades only for the session whose terminal is on screen **while the window has focus**. A card left focused in a
+  background window keeps its ring solid until the window is touched again, which is the point, but it also means
+  a browser that reports focus oddly never fades one.
 - **A session close is a hang-up on Unix and a kill on Windows** (`internal/terminal/pty_unix.go`,
   `pty_windows.go`): closing a card signals the agent and gives it `closeGrace` to leave, so its exit path runs —
   hooks, transcripts, whatever it writes on the way out. A ConPTY has no signal to deliver, so the same close on

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -333,6 +333,9 @@ export interface StoredSession {
    * restored card, instead of withholding the switch until that session
    * next reports (internal/store.SaveTurnRecord). */
   hasLastTurn: boolean
+  /** Whether this session's last finished turn is still waiting to be read: the
+   * card's solid ring, restored from here after a reload. */
+  unread: boolean
 }
 
 /** internal/store.ClosedSession — one parked session offered for resuming. What

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -437,6 +437,11 @@ export const Store = {
   /** Re-attach a provider conversation id to a session row. */
   SetProviderSession: (sessionID: string, providerSessionID: string) =>
     call<null>("store.SetProviderSession", [sessionID, providerSessionID]),
+  /** Record whether a session's last finished turn is still waiting to be read.
+   * The window only ever clears it: the backend sets it at the turn's own end,
+   * where a session with no window attached can still earn one. */
+  SetSessionUnread: (sessionID: string, unread: boolean) =>
+    call<null>("store.SetSessionUnread", [sessionID, unread]),
   /** Pin (or unpin) a session: it sorts to the head of its project's list and
    * refuses to close until unpinned. */
   SetSessionPinned: (sessionID: string, pinned: boolean) =>

--- a/frontend/src/lib/session/session-status-store.test.ts
+++ b/frontend/src/lib/session/session-status-store.test.ts
@@ -243,6 +243,115 @@ describe("unread", () => {
   })
 })
 
+// The ring outlives the page it was drawn in: what is on disk is the read mark,
+// and hydration is the only thing that puts a status back into an empty store.
+describe("restoreUnread", () => {
+  it("brings back a turn that finished while the page was away", () => {
+    const { source } = fakeSource()
+    const store = createSessionStatusStore(source)
+    store.restoreUnread(["s1"])
+    expect(store.get("s1")).toBe("done")
+    expect(store.unread("s1")).toBe(true)
+    expect(store.reported("s1")).toBe(true)
+    expect(store.pendingOf(["s1"])).toBe("done")
+  })
+
+  it("leaves a session it was not given alone", () => {
+    const { source } = fakeSource()
+    const store = createSessionStatusStore(source)
+    store.restoreUnread(["s1"])
+    expect(store.get("s2")).toBeNull()
+    expect(store.unread("s2")).toBe(false)
+  })
+
+  // A card focused before hydration landed is marked seen with nothing reported
+  // for it yet. The row says the turn was never read, and it outranks a mark
+  // taken against no status at all.
+  it("outranks a seen mark taken before anything was reported", () => {
+    const { source } = fakeSource()
+    const store = createSessionStatusStore(source)
+    store.subscribe("s1", () => {})
+    store.markSeen("s1")
+    store.restoreUnread(["s1"])
+    expect(store.unread("s1")).toBe(true)
+  })
+
+  // Hydration resolves after the events socket is open, so a report that landed
+  // in between is newer than the row it would overwrite.
+  it("never overwrites a status a report already gave", () => {
+    const { source, emit } = fakeSource()
+    const store = createSessionStatusStore(source)
+    emit(report("s1", "busy"))
+    store.restoreUnread(["s1"])
+    expect(store.get("s1")).toBe("busy")
+    expect(store.unread("s1")).toBe(false)
+  })
+
+  it("notifies the subscribers of the sessions it restored", () => {
+    const { source } = fakeSource()
+    const store = createSessionStatusStore(source)
+    const notify = vi.fn()
+    store.subscribe("s1", notify)
+    const other = vi.fn()
+    store.subscribe("s2", other)
+    store.restoreUnread(["s1"])
+    expect(notify).toHaveBeenCalledTimes(1)
+    expect(other).not.toHaveBeenCalled()
+  })
+
+  // The queue the bell reads is recomputed once for the whole batch, and a
+  // restored turn belongs in it: nobody has collected that result either.
+  it("puts what it restored in the notification queue", () => {
+    const { source } = fakeSource()
+    const store = createSessionStatusStore(source)
+    const notify = vi.fn()
+    store.subscribeAll(notify)
+    store.restoreUnread(["s1", "s2"])
+    expect(store.pendingAll()).toEqual([
+      { id: "s1", status: "done" },
+      { id: "s2", status: "done" },
+    ])
+    expect(notify).toHaveBeenCalledTimes(1)
+  })
+
+  // Reading a restored turn is what takes the mark off disk: without the write
+  // the next reload hands the same ring back as news.
+  it("persists the read of a turn it restored", () => {
+    const { source } = fakeSource()
+    const markRead = vi.fn()
+    const store = createSessionStatusStore(source, markRead)
+    store.restoreUnread(["s1"])
+    store.markSeen("s1")
+    expect(markRead).toHaveBeenCalledWith("s1")
+  })
+})
+
+// Persisting the read is the half of the mark only the window can see: the
+// backend writes the turn's own edges.
+describe("markRead", () => {
+  it("is called once for a finished turn that was read", () => {
+    const { source, emit } = fakeSource()
+    const markRead = vi.fn()
+    const store = createSessionStatusStore(source, markRead)
+    emit(report("s1", "done"))
+    store.markSeen("s1")
+    store.markSeen("s1")
+    expect(markRead).toHaveBeenCalledTimes(1)
+    expect(markRead).toHaveBeenCalledWith("s1")
+  })
+
+  it("is not called for a live state, which has no mark on disk", () => {
+    const { source, emit } = fakeSource()
+    const markRead = vi.fn()
+    const store = createSessionStatusStore(source, markRead)
+    emit(report("s1", "busy"))
+    store.markSeen("s1")
+    emit(report("s2", "waiting"))
+    store.markSeen("s2")
+    expect(markRead).not.toHaveBeenCalled()
+  })
+})
+
 describe("runningOf", () => {
   it("returns nothing when no session of the project is mid-turn", () => {
     const { source, emit } = fakeSource()

--- a/frontend/src/lib/session/session-status-store.ts
+++ b/frontend/src/lib/session/session-status-store.ts
@@ -71,7 +71,10 @@ const BADGE_PRIORITY = ["waiting", "busy", "done"] as const
 // back to the project showed no spinner for a session Claude was still working
 // on. Entries therefore outlive their listeners: unsubscribing on unmount drops
 // the listener, never the status.
-export function createSessionStatusStore(source: SessionEventSource) {
+export function createSessionStatusStore(
+  source: SessionEventSource,
+  markRead: (id: string) => void = () => {},
+) {
   const entries = new Map<string, Entry>()
 
   const entryOf = (id: string): Entry => {
@@ -177,6 +180,35 @@ export function createSessionStatusStore(source: SessionEventSource) {
     entry.seen = true
     if (entry.status === "done") {
       notify(entry)
+      // Only a finished turn has a mark on disk to take down: the backend writes
+      // one when a turn ends and clears it when the next one opens, and reading
+      // it is the one edge only the window can see (see restoreUnread).
+      markRead(id)
+    }
+    refreshPending()
+  }
+
+  // restoreUnread seeds the sessions the workspace database says came back
+  // holding a finished turn nobody has read (store.Session.Unread), which is how
+  // the ring outlives the page it was drawn in. The mark is enough to restore
+  // the status with it: what is unread is a turn that ended, and no other state
+  // is ever kept on disk.
+  //
+  // A session a report has already spoken for is left alone. Hydration lands
+  // after the events socket is open, so a turn that ended in between has already
+  // said something newer than the row.
+  const restoreUnread = (ids: readonly string[]): void => {
+    for (const id of ids) {
+      const entry = entryOf(id)
+      if (entry.status !== null) {
+        continue
+      }
+      entry.status = "done"
+      // A restored turn is proof the provider reports at all, which is what a
+      // turn-shaped control asks before drawing itself (see Entry.reported).
+      entry.reported = true
+      entry.seen = false
+      notify(entry)
     }
     refreshPending()
   }
@@ -266,6 +298,7 @@ export function createSessionStatusStore(source: SessionEventSource) {
     reason,
     since,
     markSeen,
+    restoreUnread,
     pendingOf,
     runningOf,
     subscribeAll,

--- a/frontend/src/lib/session/use-session-status.ts
+++ b/frontend/src/lib/session/use-session-status.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState, useSyncExternalStore } from "react"
 import { onAppEvent } from "@/lib/app-events"
+import { Store } from "@/lib/rpc"
 import { STATUS_EVENT, type SessionStatus } from "./session-events"
 import { createSessionStatusStore, type PendingStatus } from "./session-status-store"
 import { formatAge, subscribeAge } from "./session-age"
@@ -7,7 +8,14 @@ import { useKeyedStore } from "@/lib/use-keyed-store"
 
 // Subscribed at import rather than on first use: that opens the /events socket
 // at page load, so a status reported before any card mounts still lands.
-const store = createSessionStatusStore((handler) => onAppEvent(STATUS_EVENT, handler))
+const store = createSessionStatusStore(
+  (handler) => onAppEvent(STATUS_EVENT, handler),
+  // Reading a finished turn is persisted, so the ring does not come back as news
+  // after a reload. Fire and forget: the mark is already down in the page, and a
+  // write that fails costs one stale ring on the next launch, never a card that
+  // stops answering now.
+  (id) => void Store.SetSessionUnread(id, false).catch(() => undefined),
+)
 
 // useSessionStatus reads a session's last reported Claude Code processing state
 // from the shared store (see session-status-store), which retains it across the
@@ -93,6 +101,14 @@ export function useSessionStatusAge(sessionId: string): string {
 // lets its ring fade. Called from the provider, outside React's render.
 export function markSessionSeen(sessionId: string): void {
   store.markSeen(sessionId)
+}
+
+// restoreSessionUnread seeds the sessions the workspace came back with a finished
+// turn nobody has read, from the hydration call (store.Session.Unread). Called
+// from the provider with every session it just loaded, so a ring read before the
+// reload stays down and one earned while the page was gone is there to be found.
+export function restoreSessionUnread(sessionIds: readonly string[]): void {
+  store.restoreUnread(sessionIds)
 }
 
 // useProjectStatus reduces a project's sessions to the single status its tab

--- a/frontend/src/providers/project-workspace.test.ts
+++ b/frontend/src/providers/project-workspace.test.ts
@@ -18,6 +18,7 @@ const storedSession = (overrides: Partial<StoredSession> = {}): StoredSession =>
   originSessionId: "",
   originLabel: "",
   hasLastTurn: false,
+  unread: false,
   ...overrides,
 })
 

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -68,7 +68,7 @@ import {
 } from "@/lib/session/session-events"
 import { NotificationsOptIn } from "@/components/NotificationsOptIn"
 import { refreshGitStatus } from "@/lib/git/use-git-status"
-import { markSessionSeen } from "@/lib/session/use-session-status"
+import { markSessionSeen, restoreSessionUnread } from "@/lib/session/use-session-status"
 import { useHotkey } from "@/lib/use-hotkey"
 import { neighborProjectId } from "@/lib/project-order"
 import { requestTerminalFocus } from "@/lib/terminal/focus-request"
@@ -169,6 +169,12 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
   const applyLoaded = useCallback((loaded: StoreProject[]) => {
     setProjects(loaded.map(toProject))
     commit(buildSessionState(loaded))
+    // The rings the workspace was left with. Seeded before the effect below
+    // runs, so the card the user lands on is marked read from there and the
+    // sessions beside it keep the turn nobody has collected.
+    restoreSessionUnread(
+      loaded.flatMap((p) => (p.sessions ?? []).filter((s) => s.unread).map((s) => s.id)),
+    )
   }, [])
 
   // Restore the workspace once on launch, and seed the always-present Home tab:

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -486,6 +486,24 @@ func (s *Service) SetSessionPinned(sessionID string, pinned bool) error {
 	return nil
 }
 
+// SetSessionUnread records whether a session's last finished turn is still
+// waiting to be read: the mark behind the card's solid ring. Two writers, one
+// edge each. The terminal service sets it on a turn's own boundaries, so a turn
+// that ends with no window attached is still news when one opens; the window
+// clears it when the card is read, which is the only side that knows what the
+// user looked at.
+//
+// A session whose row is gone matches nothing, which is not an error: a card
+// closed between a turn ending and this write has no mark left to carry.
+func (s *Service) SetSessionUnread(sessionID string, unread bool) error {
+	if _, err := s.db.Exec(
+		`UPDATE sessions SET unread = ? WHERE id = ?`, unread, sessionID,
+	); err != nil {
+		return fmt.Errorf("set session %q unread: %w", sessionID, err)
+	}
+	return nil
+}
+
 // SetSessionTitle sets a session's label from the provider's ai-title reported
 // by the Stop hook, but only while the label is still automatic: a prior
 // RenameSession clears label_auto and makes this a no-op, so a user's own name

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -81,7 +81,15 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- is what keeps the card able to say the whole of it in a line and this
     -- feature a reminder rather than a job runner. 0 means nothing is waiting.
     scheduled_at        INTEGER NOT NULL DEFAULT 0,
-    scheduled_prompt    TEXT    NOT NULL DEFAULT ''
+    scheduled_prompt    TEXT    NOT NULL DEFAULT '',
+    -- Whether this session's last finished turn is still waiting to be read:
+    -- the mark behind the card's solid ring. It is workspace state rather than a
+    -- UI preference because the window is not always there to hold it. A turn
+    -- that ends while the page reloads, or with lich running without a window at
+    -- all, is still news when somebody comes back. Two writers own one edge each
+    -- (SetSessionUnread): the terminal service, on the turn's own boundaries,
+    -- and the window, when the card is read.
+    unread              INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
 
@@ -210,6 +218,11 @@ type Session struct {
 	// without it the panel would have to wait for the session to report before
 	// it could offer a record it is already holding.
 	HasLastTurn bool `json:"hasLastTurn"`
+	// Unread is whether this session's last finished turn is still waiting to be
+	// read. It rides the hydration call because the mark has to survive a page
+	// reload: the window holds it while it is up, and this row is what it comes
+	// back to (see SetSessionUnread).
+	Unread bool `json:"unread"`
 }
 
 // Project is a persisted project together with its restorable session state.
@@ -281,6 +294,7 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN closed_at INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN scheduled_at INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN scheduled_prompt TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN unread INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN closed_seq INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE session_costs ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0`,
@@ -575,7 +589,7 @@ func (s *Service) ProjectAt(path string) (string, string) {
 func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	rows, err := s.db.Query(
 		`SELECT id, label, kind, path, provider_session_id, entrypoint, sandbox, pinned,
-		        origin_session_id, origin_label, scheduled_at, scheduled_prompt,
+		        origin_session_id, origin_label, scheduled_at, scheduled_prompt, unread,
 		        EXISTS (SELECT 1 FROM session_last_turn WHERE session_id = sessions.id)
 		   FROM sessions WHERE project_id = ? AND is_open = 1 ORDER BY position, rowid`,
 		projectID,
@@ -591,7 +605,7 @@ func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 		if err := rows.Scan(
 			&sess.ID, &sess.Label, &sess.Kind, &sess.Path, &sess.ProviderSessionID,
 			&sess.Entrypoint, &sess.Sandbox, &sess.Pinned, &sess.OriginSessionID, &sess.OriginLabel,
-			&sess.ScheduledAt, &sess.ScheduledPrompt, &sess.HasLastTurn,
+			&sess.ScheduledAt, &sess.ScheduledPrompt, &sess.Unread, &sess.HasLastTurn,
 		); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1366,3 +1366,53 @@ func TestSessionGoneReportsEveryRowOfARemovedWorktree(t *testing.T) {
 		t.Fatalf("reported %v, want %v", gone, want)
 	}
 }
+
+// The mark behind a card's solid ring is workspace state: a finished turn
+// nobody has read has to come back unread after a page reload, and a turn the
+// user already read has to come back read.
+func TestSessionUnreadSurvivesHydration(t *testing.T) {
+	svc := newTestStore(t)
+	if err := svc.AddProject("p1", "alpha", "/tmp/alpha"); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+	if err := svc.AddSession("p1", "s1", "Session 1", "", "", 2, ""); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+
+	unreadOf := func(t *testing.T) bool {
+		t.Helper()
+		projects, err := svc.LoadState()
+		if err != nil {
+			t.Fatalf("LoadState: %v", err)
+		}
+		if len(projects) != 1 || len(projects[0].Sessions) != 1 {
+			t.Fatalf("LoadState = %+v, want one project with one session", projects)
+		}
+		return projects[0].Sessions[0].Unread
+	}
+
+	if unreadOf(t) {
+		t.Error("a session that has never finished a turn hydrated unread")
+	}
+	if err := svc.SetSessionUnread("s1", true); err != nil {
+		t.Fatalf("SetSessionUnread(true): %v", err)
+	}
+	if !unreadOf(t) {
+		t.Error("a finished turn nobody read hydrated read")
+	}
+	if err := svc.SetSessionUnread("s1", false); err != nil {
+		t.Fatalf("SetSessionUnread(false): %v", err)
+	}
+	if unreadOf(t) {
+		t.Error("a turn the user read hydrated unread")
+	}
+}
+
+// A card closed between its turn ending and the write has no mark left to
+// carry, and the writer must not turn that into an error the caller logs.
+func TestSetSessionUnreadIgnoresAMissingSession(t *testing.T) {
+	svc := newTestStore(t)
+	if err := svc.SetSessionUnread("ghost", true); err != nil {
+		t.Fatalf("SetSessionUnread on a missing session: %v", err)
+	}
+}

--- a/internal/terminal/hookstate_test.go
+++ b/internal/terminal/hookstate_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -112,14 +113,101 @@ func TestHookPublishesOnlyABlockingWait(t *testing.T) {
 	}
 }
 
-// hookStore answers the one question a status report asks of the store: every
+// The unread mark the card's ring is restored from after a page reload, written
+// at the turn's own edges: set when a turn ends, cleared when the next one
+// opens. The repeated `busy` is the point of the dedupe: a report per tool call
+// must not take the workspace database's write lock to change nothing.
+func TestHookRecordsTheUnreadMarkAtTurnEdges(t *testing.T) {
+	hub, _ := newProbeHub(t)
+	marks := &unreadStore{}
+	svc := New(marks, nil, hub)
+	if svc.wsErr != nil {
+		t.Fatalf("transport: %v", svc.wsErr)
+	}
+
+	for _, state := range []string{statusBusy, statusBusy, statusDone, statusBusy, statusDone} {
+		postHook(t, svc, "s1", state)
+	}
+
+	want := []bool{false, true, false, true}
+	if got := marks.written(); !slices.Equal(got, want) {
+		t.Fatalf("marks written = %v, want %v", got, want)
+	}
+}
+
+// The window clears the same column when the card is read, out of this process's
+// sight, so a finished turn is written every time it happens: a memo of the mark
+// would hand back a card with no ring for the turn after the one that was read.
+func TestHookWritesEveryFinishedTurn(t *testing.T) {
+	hub, _ := newProbeHub(t)
+	marks := &unreadStore{}
+	svc := New(marks, nil, hub)
+	if svc.wsErr != nil {
+		t.Fatalf("transport: %v", svc.wsErr)
+	}
+
+	for _, state := range []string{statusBusy, statusDone, statusDone} {
+		postHook(t, svc, "s1", state)
+	}
+
+	want := []bool{false, true, true}
+	if got := marks.written(); !slices.Equal(got, want) {
+		t.Fatalf("marks written = %v, want %v", got, want)
+	}
+}
+
+// A session end clears the mark, the way it clears the ring: a card with no
+// provider left in it has nothing to come back to.
+func TestHookClearsTheUnreadMarkOnSessionEnd(t *testing.T) {
+	hub, _ := newProbeHub(t)
+	marks := &unreadStore{}
+	svc := New(marks, nil, hub)
+	if svc.wsErr != nil {
+		t.Fatalf("transport: %v", svc.wsErr)
+	}
+
+	for _, state := range []string{statusBusy, statusDone, statusIdle} {
+		postHook(t, svc, "s1", state)
+	}
+
+	want := []bool{false, true, false}
+	if got := marks.written(); !slices.Equal(got, want) {
+		t.Fatalf("marks written = %v, want %v", got, want)
+	}
+}
+
+// unreadStore is hookStore that also records every unread mark written, in
+// order: the dedupe is half of what the writer promises, so the sequence is the
+// assertion and not the last value.
+type unreadStore struct {
+	hookStore
+	mu    sync.Mutex
+	marks []bool
+}
+
+func (s *unreadStore) SetSessionUnread(_ string, unread bool) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.marks = append(s.marks, unread)
+	return nil
+}
+
+func (s *unreadStore) written() []bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return slices.Clone(s.marks)
+}
+
+// hookStore answers the two questions a status report asks of the store. Every
 // non-idle report refreshes the context readout, which looks up the session's
-// provider conversation. An empty one ends that lookup there. The rest of the
-// interface is embedded and nil, so a path that starts using it panics loudly
-// rather than being quietly stubbed out here.
+// provider conversation, and an empty one ends that lookup there; every
+// published report records whether the card is holding an unread turn. The rest
+// of the interface is embedded and nil, so a path that starts using it panics
+// loudly rather than being quietly stubbed out here.
 type hookStore struct{ Store }
 
 func (hookStore) ProviderSession(string) (string, error) { return "", nil }
+func (hookStore) SetSessionUnread(string, bool) error    { return nil }
 
 // postHook reports one state the way the companion plugin does, and fails the
 // test unless lich accepted it (docs/hooks/session-state.md).

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -180,9 +180,9 @@ type session struct {
 // whether that spawn drops the provider's permission prompts and whether it runs
 // confined, that project's own directory, the dev-server port reserved for each
 // checkout, where to record the provider session id a PTY reports through its
-// session-start hook, and the running cost accounting behind the footer readout
-// (CostReadout gates it — off, none of the rest is called). The store implements
-// them all.
+// session-start hook, where to record a finished turn nobody has read yet, and
+// the running cost accounting behind the footer readout (CostReadout gates it —
+// off, none of the rest is called). The store implements them all.
 type Store interface {
 	ProviderBin(providerID, projectID string) string
 	SessionCustomBin(sessionID string) bool
@@ -201,6 +201,7 @@ type Store interface {
 	SandboxGHToken(projectID string) bool
 	GHAccountForPath(path string) string
 	SetSessionTitle(sessionID, title string) (bool, error)
+	SetSessionUnread(sessionID string, unread bool) error
 	CostReadout() bool
 	CostLedger(sessionID, transcriptID string) (int64, string, float64, error)
 	SaveCostLedger(sessionID, transcriptID string, offset int64, lastMessage string, cost float64) error
@@ -257,6 +258,11 @@ type Service struct {
 	// nothing else about a report needs mu, and a hook must never queue behind a
 	// PTY spawn.
 	turns turnLog
+	// unread is the last unread mark written for each session, so the `busy`
+	// reported per tool call never reaches the database (see noteUnread). Not
+	// under mu for the reason spawns is not: it is read on every hook report,
+	// which must never queue behind a PTY spawn.
+	unread sync.Map
 	// hands is how long each session has been worked on, measured off the same
 	// three signals the card is already drawing — a state report, a keystroke,
 	// output while the agent is busy (see handsOn). It carries its own lock for
@@ -404,6 +410,7 @@ func (s *Service) onHookState(req hookRequest) {
 	// `waiting` outside a turn is a session idle at its prompt, and the
 	// card would draw it as a human being blocked (see turnLog).
 	if s.turns.report(req.SessionID, req.State) {
+		s.noteUnread(req.SessionID, req.State == statusDone)
 		s.hub.Emit(statusEventName, statusEvent{
 			ID:     req.SessionID,
 			State:  req.State,
@@ -429,6 +436,28 @@ func (s *Service) onHookState(req hookRequest) {
 	// idle (SessionEnd): the session is ending, nothing new to read.
 	if req.State != statusIdle {
 		go s.emitUsage(req.SessionID)
+	}
+}
+
+// noteUnread persists whether this session's card is holding a finished turn
+// nobody has read, so the mark survives a page reload (docs/ceilings.md). It is
+// written from here rather than from the window because a turn can end with no
+// window attached at all: during a reload, or under --no-window.
+//
+// Only the clear is deduped, and it is the whole hot path: `busy` is reported
+// once per tool call, and without this every one of them would take the
+// workspace database's write lock to change nothing. The mark itself is written
+// on every finished turn, because the window clears that same column when the
+// card is read and this process never sees it: a memo of the mark would swallow
+// the next turn to end.
+func (s *Service) noteUnread(id string, unread bool) {
+	last, written := s.unread.Load(id)
+	if !unread && written && last == unread {
+		return
+	}
+	s.unread.Store(id, unread)
+	if err := s.store.SetSessionUnread(id, unread); err != nil {
+		slog.Warn("terminal: record unread", "session", id, "err", err)
 	}
 }
 

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -128,6 +128,7 @@ func (s stubBins) ProviderSession(_ string) (string, error) {
 	return s.providerSession, s.providerErr
 }
 func (s stubBins) SetSessionTitle(_, _ string) (bool, error) { return false, nil }
+func (s stubBins) SetSessionUnread(_ string, _ bool) error   { return nil }
 
 func (s stubBins) CostReadout() bool { return s.costOn }
 


### PR DESCRIPTION
## What

Closes the reload half of the "a finished turn is unread until its own card is watched" ceiling. The solid emerald ring means "back from the agent, not read yet", and the mark behind it lived only in the page: a reload started every session unread again, so a turn read twenty minutes ago came back looking like news.

The mark is workspace state now (`sessions.unread`), with each writer owning the edge it can actually see:

- **The terminal service** writes it on the turn's own boundaries (`noteUnread`, off the published state report): set on `done`, cleared when the next turn opens and on `idle`. A turn that ends while the page is reloading, or with lich running under `--no-window`, is still news when a window comes back. Only the clear is deduped in memory, because `busy` is reported once per tool call, while a finished turn has to be written every time it happens: the window clears the same column out of this process's sight, so a memo of the mark would swallow the next turn to end.
- **The window** writes the read, through `store.SetSessionUnread(id, false)` when a card whose status is `done` is marked seen. That is the one edge only the page can see, and it fires at most once per finished turn.
- **Hydration** seeds the ring back: `restoreSessionUnread` puts the `done` status and the unread mark into the status store for every session `LoadState` came back unread for, leaving alone any session a live report has already spoken for.

The focus half of the ceiling is untouched: a card focused in a background window keeps its ring solid until the window is touched again.

No round trip is on the render path, so the ring does not flicker: the mark is restored from the same hydration call the cards are drawn from, and the read is written after the ring is already down in the page.

## Where

- `internal/store`: `sessions.unread` column plus its migration, `Session.Unread` on the hydration call, `SetSessionUnread`.
- `internal/terminal`: `Store.SetSessionUnread`, `noteUnread`, wired into the published state report.
- `frontend/src/lib/session`: `restoreUnread` and the injected `markRead` on the status store, `restoreSessionUnread` and the RPC wiring in `use-session-status`.
- `frontend/src/providers/projects.tsx`: seeds the restored rings from `applyLoaded`.
- `frontend/src/lib/api-types.ts` mirrors the new JSON tag; `docs/ceilings.md` drops the reload trap; `CHANGELOG.md` gets its `[Unreleased]` entry.

## Test plan

- [x] `go test ./...`, backend suite green, including three new hook tests (the mark at a turn's edges, every finished turn written, the mark cleared on session end) and two store tests (the mark survives hydration, a missing session is not an error).
- [x] `cd frontend && pnpm exec vitest run`: 1523 tests green, including the new `restoreUnread` and `markRead` suites.
- [x] `gofmt -l .` clean, `go vet ./...` clean, cross-compile loop (linux/darwin/windows) clean.
- [x] `pnpm exec biome ci .` exit 0.
- [x] `pnpm build` (tsc + vite) succeeds.

### Flake check

An early run of the frontend suite, taken while the Go suite ran beside it, reported 2 failures in 1 file and its output scrolled before the file could be named. The conditions were reproduced deliberately, five times:

```
for i in 1 2 3 4 5; do
  (go test ./... > go-$i.log 2>&1 &)
  (cd frontend && ./node_modules/.bin/vitest run --reporter=verbose > vitest-$i.log 2>&1)
  wait
done
```

All five loaded runs are green on both suites (5x1523 frontend tests, `go test ./...` clean; no `FAIL` and no failing case in any of the ten logs), so nothing was reproduced and there is no failing file to name. Rerun on this branch if it appears in CI, where the log survives.
