### PR TITLE
fix: validate the remembered settings pane against the nav

### DIFF
--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -855,14 +855,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   pretending the setting is absent. Shortcuts and the panes themselves are indexed off `HOTKEY_ACTIONS` and
   `SETTING_SECTIONS`, so those two never fall behind.
 
-- **A remembered section id is never validated, and a dead one resolves to Providers** (`Settings.tsx`):
-  the pref is stored raw rather than parsed against a list, because the sections belong to the screen and
-  `settings-prefs` is not where they live. An id this build cannot place (one of the `provider-<id>` panes
-  that existed before Providers became a single section, say) resolves to `DEFAULT_SECTION` and is never
-  rewritten. That is a landing, not a fix: the stale pref stays in storage forever, and the user is never told
-  the pane they were on is gone. The same holds for the provider a Providers pane had open
-  (`lich.settings.provider`), which is genuinely unknowable at build time: it resolves back to the list while
-  that provider is disabled, and comes back when it is turned on again.
 - **The old terminal-theme selection is left where it was written** (`appearance.terminalTheme` in the
   workspace database, `lich.appearance.terminalTheme` in localStorage): one theme now colors both surfaces,
   and nothing reads either key any more. They are not deleted on upgrade, because a migration that runs on

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -22,7 +22,6 @@ import { UpdatesSettings } from "./UpdatesSettings"
 import { HelpSettings } from "./HelpSettings"
 import { SearchInput } from "@/components/common/SearchInput"
 import {
-  DEFAULT_SECTION,
   readSettingsProvider,
   readSettingsQuery,
   readSettingsSection,
@@ -102,6 +101,11 @@ const FOOTER_SECTIONS: Section[] = [
 
 const ALL_SECTIONS = [...SECTIONS, ...FOOTER_SECTIONS]
 
+// What the remembered pane is parsed against: the ids belong to this list, and
+// a stored one that is not in it is from a build whose nav was shaped
+// differently (settings-prefs).
+const SECTION_IDS = ALL_SECTIONS.map((section) => section.id)
+
 // Settings is the per-project settings screen (not a modal): it fills the main
 // area and sits on top of the persistent terminals, with the session sidebar
 // kept beside it. The route carries the project id, which the provider and
@@ -112,7 +116,7 @@ export function Settings() {
   // Seeded from the store and written through, so leaving the screen — a
   // session next door, another project — brings back the pane that was open
   // rather than the default one (settings-prefs).
-  const [active, setActive] = useState(readSettingsSection)
+  const [active, setActive] = useState(() => readSettingsSection(SECTION_IDS))
   const [query, setQuery] = useState(readSettingsQuery)
   const [openProvider, setOpenProvider] = useState(readSettingsProvider)
   // The result the arrow keys are on, and the control a chosen result lit up.
@@ -195,14 +199,10 @@ export function Settings() {
   const searching = query.trim() !== ""
   const sections = SECTIONS
   const footerSections = FOOTER_SECTIONS
-  // A section id this build cannot place resolves to the default pane, not to
-  // the first one: the ids a provider used to get its own section are still in
-  // people's storage, and landing them on Appearance forever is the trap
-  // docs/ceilings.md names.
-  const current =
-    ALL_SECTIONS.find((section) => section.id === active) ??
-    ALL_SECTIONS.find((section) => section.id === DEFAULT_SECTION) ??
-    ALL_SECTIONS[0]
+  // The remembered id was parsed against this list on the way in, and every
+  // other way `active` is set names a row of it, so this fallback answers the
+  // type rather than a pane anyone can land on.
+  const current = ALL_SECTIONS.find((section) => section.id === active) ?? ALL_SECTIONS[0]
   const providerName = providers.find((provider) => provider.id === openProvider)?.name ?? ""
 
   const navButton = (section: Section) => (

--- a/frontend/src/lib/settings-prefs.test.ts
+++ b/frontend/src/lib/settings-prefs.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
+import { enabledProviders, type ProviderState } from "./providers-store"
 import {
   readSettingsProvider,
   readSettingsQuery,
@@ -27,26 +28,43 @@ beforeEach(() => {
   stored.clear()
 })
 
+// The screen's own nav, which is what the section is parsed against.
+const SECTIONS = ["appearance", "hotkeys", "providers", "sandbox"]
+
 describe("the stored section", () => {
   it("opens on the providers pane with nothing stored", () => {
-    expect(readSettingsSection()).toBe("providers")
+    expect(readSettingsSection(SECTIONS)).toBe("providers")
   })
 
   it("round-trips the pane that was open", () => {
     writeSettingsSection("sandbox")
 
-    expect(readSettingsSection()).toBe("sandbox")
+    expect(readSettingsSection(SECTIONS)).toBe("sandbox")
   })
 
-  // The opposite of the sort pref, and the reason this one is not parsed
-  // against a known set: a provider's section id only exists while that
-  // provider is enabled, so an id this build cannot place has to come back
-  // whole. The screen resolves it to its first section for as long as the
-  // provider is off, and the pane is there again when it is turned back on.
-  it("keeps a section id it cannot place, for the screen to resolve", () => {
+  // The `provider-<id>` panes are still in the storage of anyone who used a
+  // build from before Providers became one section, and a pane this one cannot
+  // draw must not be where the screen tries to land.
+  it("opens the default pane for a section id it cannot place", () => {
     writeSettingsSection("provider-crush")
 
-    expect(readSettingsSection()).toBe("provider-crush")
+    expect(readSettingsSection(SECTIONS)).toBe("providers")
+  })
+
+  // And the value goes with it: resolving the same dead id at every launch for
+  // the life of the install is a landing, not a fix.
+  it("rewrites the stored id it could not place", () => {
+    writeSettingsSection("provider-crush")
+    readSettingsSection(SECTIONS)
+
+    expect(stored.get("lich.settings.section")).toBe("providers")
+  })
+
+  it("leaves a section it can place in storage untouched", () => {
+    writeSettingsSection("hotkeys")
+    readSettingsSection(SECTIONS)
+
+    expect(stored.get("lich.settings.section")).toBe("hotkeys")
   })
 })
 
@@ -71,6 +89,20 @@ describe("the stored search box", () => {
   })
 })
 
+const provider = (id: string, enabled: boolean): ProviderState => ({
+  id: id as ProviderState["id"],
+  name: id,
+  binary: id,
+  installed: true,
+  enabled,
+  docs: `https://example.test/${id}`,
+})
+
+// What ProvidersPane does with the stored id: the enabled roster decides
+// whether the screen it names is still reachable.
+const open = (list: ProviderState[]) =>
+  enabledProviders(list).find((p) => p.id === readSettingsProvider())
+
 describe("the stored provider screen", () => {
   it("reads as the list with nothing stored", () => {
     expect(readSettingsProvider()).toBe("")
@@ -82,12 +114,17 @@ describe("the stored provider screen", () => {
     expect(readSettingsProvider()).toBe("codex")
   })
 
-  // Same reason the section is not parsed against a known set: the id is only
-  // meaningful while that provider is enabled, and the pane resolves one it
-  // cannot place back to the list rather than forgetting it was open.
-  it("keeps a provider id it cannot place, for the pane to resolve", () => {
+  // Unlike the section, this one is not parsed on the way out: the roster is
+  // the backend's answer, and the id is only meaningful while that provider is
+  // enabled. So a disabled provider's screen resolves to the list — the pane's
+  // own rule, composed here out of the two pieces it composes — and the stored
+  // id is kept, which is what puts the screen back when it is turned on again.
+  it("resolves a disabled provider to the list, and back to its screen when it returns", () => {
     writeSettingsProvider("crush")
+    const off = [provider("claude", true), provider("crush", false)]
 
+    expect(open(off)).toBeUndefined()
+    expect(open([provider("claude", true), provider("crush", true)])?.id).toBe("crush")
     expect(readSettingsProvider()).toBe("crush")
   })
 

--- a/frontend/src/lib/settings-prefs.ts
+++ b/frontend/src/lib/settings-prefs.ts
@@ -1,4 +1,4 @@
-import { readPref, writePref } from "@/lib/prefs"
+import { parseEnumPref, readPref, writePref } from "@/lib/prefs"
 
 // Everything the settings screen remembers about how it was left. Like the pull
 // request screen it is an `<Outlet>` route, so stepping into a session or
@@ -23,19 +23,25 @@ const QUERY_KEY = "lich.settings.query"
 const PROVIDER_KEY = "lich.settings.provider"
 
 // The pane a screen with nothing remembered opens on: the one almost every
-// visit is for. Exported because it is also where a section id from another
-// build lands, and a pane that no longer exists must not strand its readers.
+// visit is for. Also where a section id this build cannot place lands, and a
+// pane that no longer exists must not strand its readers.
 export const DEFAULT_SECTION = "providers"
 
-/** The pane the nav had open.
+/** The pane the nav had open, parsed against the sections the screen has.
  *
- * Not checked against a known set the way a sort is. A provider's section id
- * only exists while that provider is enabled, so the set is not knowable here —
- * and the screen already resolves an id it cannot find to its first section,
- * which means a pane belonging to a provider turned off for now is waited out
- * rather than forgotten. */
-export function readSettingsSection(): string {
-  return readPref(SECTION_KEY) ?? DEFAULT_SECTION
+ * The panes belong to the screen, so it passes its own ids in — but they are a
+ * known set at the moment of the read, which is what makes this a parse like
+ * any other sort or theme. An id from a build that shaped the nav differently
+ * (a `provider-<id>` pane, from before Providers became one section) opens the
+ * default and is rewritten, rather than being resolved again on every launch
+ * for the life of the install. */
+export function readSettingsSection(sections: readonly string[]): string {
+  const stored = readPref(SECTION_KEY)
+  const section = parseEnumPref(stored, sections, DEFAULT_SECTION)
+  if (stored !== null && stored !== section) {
+    writePref(SECTION_KEY, section)
+  }
+  return section
 }
 
 export function writeSettingsSection(section: string): void {
@@ -54,9 +60,11 @@ export function writeSettingsQuery(query: string): void {
 }
 
 /** The provider whose own screen was open inside the Providers pane, "" for the
- * list. Unparsed for the same reason the section is: the id is only meaningful
- * while that provider is enabled, and the pane resolves one it cannot place
- * back to the list rather than forgetting it. */
+ * list. Unparsed, unlike the section: the roster is the backend's answer and is
+ * not in yet when this is read, and an id is only meaningful while that
+ * provider is enabled anyway. So the pane resolves it — back to the list while
+ * the provider is off, to its screen again when it is turned on — and the
+ * stored id is kept on purpose, which is what makes it come back. */
 export function readSettingsProvider(): string {
   return readPref(PROVIDER_KEY) ?? ""
 }


### PR DESCRIPTION
Closes the `docs/ceilings.md` bullet on the remembered settings section, and deletes it.

## The trap

`lich.settings.section` was written raw and resolved only at render time. A `provider-<id>` id — one of the sections a provider used to get before Providers became a single pane — landed on Providers on every launch and was never rewritten, so the dead value stayed in storage for the life of the install.

## The change

`readSettingsSection` now takes the ids the screen has and parses the stored value against them (`parseEnumPref`, the same helper the sorts and themes use). An id this build cannot place reads as `DEFAULT_SECTION` **and** is written back, so it resolves once instead of at every launch. `Settings.tsx` passes its own `ALL_SECTIONS` ids in and drops its second resolution — the fallback that remains answers the type, not a pane anyone lands on.

The provider a Providers pane had open (`lich.settings.provider`) keeps its behaviour deliberately: the roster is the backend's answer and is not in when the pref is read, so the id stays whole, the pane resolves a disabled provider back to the list, and the screen comes back when that provider is enabled again. That is the feature, not a trap, so the bullet goes entirely rather than shrinking to its provider half.

## Tests

`settings-prefs.test.ts`: a stale id resolves to the default pane; the stored value is rewritten; an id the screen can place is left untouched; a disabled provider resolves to the list and its screen returns when it is enabled.

No `CHANGELOG.md` entry: the landing a user sees is unchanged — a dead id already resolved to Providers through the screen's fallback. What the fix adds is that the stale value no longer sits in storage, which nothing on screen says.

## Gate

`./node_modules/.bin/biome ci .` exit 0 · `vitest run` 131 files / 1548 tests green · `tsc` + `vite build --mode production` clean. Frontend only.