### PR TITLE
fix: a card that cannot be forked says why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **A session card now says why it cannot be forked.** "Fork to worktree…" used
+  to be missing altogether on Antigravity, oh-my-pi, Crush, Cursor CLI and Kiro
+  CLI cards, so the offer looked lost rather than withheld. The item is there
+  now, disabled, under one line naming the provider — their CLIs keep no fork,
+  only resume.
+
 ### Fixed
 
 - **The Pulls screen no longer leaves refs in your repository.** Naming a

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -274,16 +274,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   at. And `.lich/setup-worktree.sh` is one file, versioned and shared by every checkout, holding sh — so a
   Windows session skips it rather than feeding it to PowerShell, which would run the leading words of every line
   as commands. A worktree opens there with its setup silently not done.
-- **A fork is offered by three providers of eight, and the other five never grow one**
-  (`internal/providers.SupportsFork`, `internal/terminal/command.go`, `resumeArgs`): Claude Code, Codex and
-  opencode branch a conversation themselves, so lich asks them to. The other five keep resume and no fork, and
-  lich will not forge one: a copy would mean writing into that harness's own private store — two SQLite
-  schemas with triggers (Crush's per-checkout `.crush/crush.db`, Antigravity's one database per conversation),
-  a blob store keyed on the md5 of the checkout (Cursor), and two JSONL formats with the id and cwd written
-  inside them (oh-my-pi, Kiro CLI) — none of them documented, each versioned by its own CLI, and the blast
-  radius of getting one wrong is the user's real history. The trap is that the menu item is simply absent
-  there, with nothing saying why, so a user who forks a Claude Code card and then looks for the same thing on
-  their Crush card finds no answer on screen.
 - **opencode files a fork under the parent's directory, not the new checkout's** (measured on 1.18.23): the
   copied session's `directory` column is the one the original ran in, and its `parent_id` is left empty, so
   opencode's own session list places a fork in the checkout it came from and records no lineage. lich's own

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -11,7 +11,6 @@ import {
   FolderCode,
   FolderOpen,
   GitBranch,
-  GitFork,
   GitPullRequestArrow,
   Inbox,
   Pencil,
@@ -29,7 +28,7 @@ import { toast } from "sonner"
 import { cn, errorText } from "@/lib/utils"
 import { dragStyle } from "@/lib/use-sortable-list"
 import { displayPath } from "@/lib/paths"
-import { forkableSession, type Session } from "@/lib/session/sessions"
+import type { Session } from "@/lib/session/sessions"
 import {
   useSessionStatus,
   useSessionStatusAge,
@@ -48,6 +47,7 @@ import { baseReadout } from "@/lib/git/base-status"
 import { usePullRequest } from "@/lib/pulls/use-pull-request"
 import { CloseButton } from "@/components/common/CloseButton"
 import { DiffStat } from "@/components/DiffStat"
+import { SessionForkItem } from "./SessionForkItem"
 import { SessionStatusIcon } from "./SessionStatusIcon"
 import { SessionTooltip } from "./SessionTooltip"
 import { Tooltip, TooltipTrigger } from "@/components/ui/tooltip"
@@ -290,7 +290,6 @@ export function SessionCard({
   // as an agent is started and quit by hand offers no action the user can rely
   // on being there.
   const canDelegate = active && session.kind !== "shell"
-  const canFork = forkableSession(session) !== null
 
   // The picker is only rendered while the card can delegate, so losing that
   // unmounts it — and an open flag left behind would spring the dialog back up
@@ -684,12 +683,7 @@ export function SessionCard({
             <Clock />
             {scheduleItem}
           </ContextMenuItem>
-          {canFork && (
-            <ContextMenuItem onClick={onFork}>
-              <GitFork />
-              Fork to worktree…
-            </ContextMenuItem>
-          )}
+          <SessionForkItem session={session} onFork={onFork} />
           <ContextMenuItem onClick={copySendCommand}>
             <Copy />
             Copy send command

--- a/frontend/src/components/sidebar/SessionForkItem.tsx
+++ b/frontend/src/components/sidebar/SessionForkItem.tsx
@@ -1,0 +1,40 @@
+import { GitFork } from "lucide-react"
+import { ContextMenuItem } from "@/components/ui/context-menu"
+import { forkUnavailableReason, forkableSession, type Session } from "@/lib/session/sessions"
+
+interface SessionForkItemProps {
+  session: Session
+  onFork: () => void
+}
+
+// "Fork to worktree…" on a session card: live where the provider's own CLI
+// branches a conversation, dead under the sentence naming why on the five that
+// only resume (providers.SupportsFork). The row stays either way, because a
+// user who forks a Claude Code card and finds nothing on their Crush card has
+// no way to learn that the offer was withheld rather than missing.
+//
+// Off the card entirely only where the answer is neither: a shell, and a
+// forkable session that has yet to report a conversation to branch.
+export function SessionForkItem({ session, onFork }: SessionForkItemProps) {
+  const reason = forkUnavailableReason(session)
+  if (reason !== null) {
+    return (
+      <ContextMenuItem disabled>
+        <GitFork />
+        <span className="flex flex-col items-start">
+          Fork to worktree…
+          <span className="text-xs">{reason}</span>
+        </span>
+      </ContextMenuItem>
+    )
+  }
+  if (forkableSession(session) === null) {
+    return null
+  }
+  return (
+    <ContextMenuItem onClick={onFork}>
+      <GitFork />
+      Fork to worktree…
+    </ContextMenuItem>
+  )
+}

--- a/frontend/src/components/sidebar/session-fork-item.test.tsx
+++ b/frontend/src/components/sidebar/session-fork-item.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment jsdom
+//
+// The Fork row of a session card, mounted for real: the node-only gate cannot
+// tell a disabled item carrying its reason from an item that never rendered,
+// and the reason is the whole point of the row.
+//
+// The harness is imported first for the reason render-budget.test.tsx names: it
+// has to hook react-dom before anything else reaches it.
+import { mountBudget } from "@/test/render-budget"
+import { createElement } from "react"
+import { expect, test } from "vitest"
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu"
+import type { Session } from "@/lib/session/sessions"
+import { SessionForkItem } from "./SessionForkItem"
+
+function menu(session: Session, onFork: () => void = () => {}) {
+  return createElement(
+    ContextMenu,
+    { open: true },
+    createElement(ContextMenuTrigger, null, "card"),
+    createElement(ContextMenuContent, null, createElement(SessionForkItem, { session, onFork })),
+  )
+}
+
+const item = () =>
+  [...document.querySelectorAll('[role="menuitem"]')].find((element) =>
+    element.textContent?.startsWith("Fork to worktree"),
+  )
+
+test("a provider that cannot fork gets the row disabled, naming why", async () => {
+  const session: Session = {
+    id: "s1",
+    label: "crush",
+    kind: "crush",
+    providerSessionId: "conv-1",
+  }
+  const mounted = await mountBudget(menu(session))
+
+  const row = item()
+  if (!row) {
+    throw new Error("Fork row not rendered")
+  }
+  expect(row.getAttribute("data-disabled")).not.toBeNull()
+  expect(row.textContent).toContain("Crush keeps no fork; resume only.")
+  await mounted.unmount()
+})
+
+test("a provider that forks gets the row live, with no reason to give", async () => {
+  const session: Session = {
+    id: "s1",
+    label: "claude",
+    kind: "claude",
+    providerSessionId: "conv-1",
+  }
+  const forks: number[] = []
+  const mounted = await mountBudget(menu(session, () => forks.push(1)))
+
+  const row = item()
+  if (!row) {
+    throw new Error("Fork row not rendered")
+  }
+  expect(row.getAttribute("data-disabled")).toBeNull()
+  expect(row.textContent).toBe("Fork to worktree…")
+
+  await mounted.act(() => {
+    ;(row as HTMLElement).click()
+  })
+  expect(forks).toEqual([1])
+  await mounted.unmount()
+})
+
+// Nothing to branch yet: the offer would fail, and no provider limit explains
+// it, so the row stays off the card as it always has.
+test("a forkable session with no conversation gets no row at all", async () => {
+  const mounted = await mountBudget(menu({ id: "s1", label: "claude", kind: "claude" }))
+  expect(item()).toBeUndefined()
+  await mounted.unmount()
+})

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   forkableSession,
+  forkUnavailableReason,
   activeSessionId,
   dragOrder,
   activeTarget,
@@ -624,6 +625,31 @@ describe("forkableSession", () => {
   it("returns null without a provider session id", () => {
     expect(forkableSession(buildState(2)[P].sessions[0])).toBeNull()
   })
+})
+
+describe("forkUnavailableReason", () => {
+  // Spelled out rather than looped: the sentence is read at the menu item, so a
+  // provider renamed here is a provider misnamed on screen.
+  it.each([
+    ["antigravity", "Antigravity keeps no fork; resume only."],
+    ["omp", "oh-my-pi keeps no fork; resume only."],
+    ["crush", "Crush keeps no fork; resume only."],
+    ["cursor", "Cursor CLI keeps no fork; resume only."],
+    ["kiro", "Kiro CLI keeps no fork; resume only."],
+  ] as const)("names %s at the item", (kind, reason) => {
+    const state = withClaudeSession(buildState(2), "s1", "conv-1", kind)
+    expect(forkUnavailableReason(state[P].sessions[0])).toBe(reason)
+  })
+
+  // The three that fork have a working item, and a shell has no conversation of
+  // any kind — neither has a limit to explain.
+  it.each(["claude", "codex", "opencode", "shell"] as const)(
+    "has nothing to say about %s",
+    (kind) => {
+      const state = withClaudeSession(buildState(2), "s1", "conv-1", kind)
+      expect(forkUnavailableReason(state[P].sessions[0])).toBeNull()
+    },
+  )
 })
 
 describe("resumableSession", () => {

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -594,6 +594,28 @@ const RESUMABLE_KINDS: readonly SessionKind[] = [
 // is withheld where the CLI has no verb for it.
 const FORKABLE_KINDS: readonly SessionKind[] = ["claude", "codex", "opencode"]
 
+// The five whose CLI resumes but never forks, under the name a user reads in
+// Settings. Written out one by one rather than derived from the kind union, so
+// a provider added to lich has to answer this question on purpose instead of
+// inheriting a sentence about a limit nobody measured.
+const NO_FORK_PROVIDERS: Partial<Record<SessionKind, string>> = {
+  antigravity: "Antigravity",
+  omp: "oh-my-pi",
+  crush: "Crush",
+  cursor: "Cursor CLI",
+  kiro: "Kiro CLI",
+}
+
+// forkUnavailableReason is the sentence the Fork item wears on a card whose
+// provider cannot branch a conversation, and null wherever the item carries no
+// explanation: the three that fork, and a shell, which has no conversation to
+// begin with. A missing row answers nothing — a user who forks a Claude Code
+// card and looks for the same thing on a Crush one has to read why it is dead.
+export function forkUnavailableReason(session: Session): string | null {
+  const name = NO_FORK_PROVIDERS[session.kind]
+  return name === undefined ? null : `${name} keeps no fork; resume only.`
+}
+
 // forkableSession returns the session a "Fork to worktree" offer can be made
 // for: one running a provider that forks, carrying the conversation to branch.
 // Null for every other card, which is what keeps the menu item off it — a row

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -119,9 +119,12 @@ func AcceptsMCPServer(id string) bool {
 // subcommand for `fork`, and opencode's `--fork` rides its `--session`
 // (measured on 2.1.261, 0.151.0 and 1.18.23). The other five keep no such verb
 // — oh-my-pi, Crush, Cursor CLI, Kiro CLI and Antigravity offer resume alone —
-// and forging a fork for them would mean writing a copy of the conversation
-// into that harness's own private store, which docs/ceilings.md names along
-// with what it would cost.
+// and lich will not forge one: the copy would have to be written into that
+// harness's own private store (two SQLite schemas with triggers, a blob store
+// keyed on the md5 of the checkout, two JSONL formats carrying the id and cwd
+// inside them), none documented, each versioned by its own CLI, and the blast
+// radius of getting one wrong is the user's real history. The card says so at
+// the dead menu item rather than dropping it (SessionForkItem).
 func SupportsFork(id string) bool {
 	return id == Claude || id == Codex || id == OpenCode
 }


### PR DESCRIPTION
Closes the `docs/ceilings.md` trap that the Fork item is simply absent on the five providers that cannot fork, with nothing on screen saying why. The bullet is deleted rather than reworded — the trap is closed in the UI.

## What changed

- `SessionForkItem` (new, `frontend/src/components/sidebar/`) owns the "Fork to worktree…" row: live where the provider's CLI branches a conversation, **disabled** on Antigravity, oh-my-pi, Crush, Cursor CLI and Kiro CLI under one line naming the provider — "Crush keeps no fork; resume only." Off the card only where neither answer applies: a shell, and a forkable session that has yet to report a conversation.
- `forkUnavailableReason` in `lib/session/sessions.ts`, beside the `FORKABLE_KINDS` mirror of `providers.SupportsFork`. The five names are spelled out one by one, matching the registry's own display names, so a provider added to lich answers this question on purpose.
- The enabled path is untouched: same item, same handler, same conditions.
- The *why* of the decision moved from `docs/ceilings.md` into the comment at `providers.SupportsFork`, where the answer is made. lich still refuses to forge a fork by writing into a harness's private store.
- The two fork bullets that followed it (opencode's directory, the billing) are unrelated and stay.

## Tests

`frontend/src/components/sidebar/session-fork-item.test.tsx` mounts the real base-ui context menu in jsdom and pins all three states: disabled with the sentence for a Crush card, live and clickable for a Claude Code one, absent with no conversation. `sessions.test.ts` pins the sentence for each of the five and its absence for the three that fork and for a shell.

## Gate

- `biome ci .` exit 0, `pnpm test` 1558 passed, `pnpm build` clean.
- `gofmt -l .` clean, `go vet ./...` clean, `go test ./internal/providers/ ./internal/terminal/` green (Go change is a comment).
- Render budgets unchanged — the menu content only mounts when the menu opens.