### PR TITLE
fix: split an MCP tool name against the servers a session can reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **oh-my-pi and opencode cards name the MCP tool, not the server that carries
+  it.** Both harnesses spell an MCP tool with a single underscore between the
+  server and the tool, which a card could not divide, so it spent its width on
+  `lich_open_session` where a Claude Code card already read `lich ·
+  open_session`. Every session now records the servers its harness could reach
+  when it was spawned — opencode's project config included — and those cards
+  divide the name the same way.
 - **The Pulls screen no longer leaves refs in your repository.** Naming a
   conflicting pull request's files fetched its head and its base branch into
   `refs/lich/pr/<n>/head` and `refs/lich/pr/<n>/base` and left them there, so

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -544,15 +544,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   Claude Code card draws `lich · open_session`. The trap is reaching for `tool-label.ts` when that line looks
   wrong: the tool's identity arrives in a different field on this provider, and a plugin older than the release
   that added it sends `call_mcp_tool` with no detail at all.
-- **Only two of the five harnesses that report a tool spell an MCP one splittably** (`frontend/src/lib/session/tool-label.ts`,
-  table in `docs/hooks/session-state.md`): Claude Code and Codex send `mcp__<server>__<tool>`, which the card draws
-  as `<server> · <tool>`. omp's `mcp__<server>_<tool>` has one underscore doing two jobs — `mcp__lich_list_sessions`
-  splits into `lich` + `list_sessions` or `lich_list` + `sessions` and the string cannot say which — so only its
-  prefix comes off, and opencode's `<server>_<tool>` carries no marker at all and is shown whole. Nothing overflows
-  anywhere (the line truncates), but on those two the card spends its width on a server name nobody asked for.
-  Splitting them needs the list of registered server names, which the card does not have. Antigravity is the fifth
-  and nothing here reaches it: its name is not a tool name at all, so the split never applies and the bullet above
-  is where that one is answered. Crush is on no version of this list: it reports no tool.
 - **Only Claude Code says what a session is waiting for; the others say less or nothing**
   (`frontend/src/components/sidebar/SessionCard.tsx`, table in `docs/hooks/session-state.md`): its
   `Notification` carries a `message` written for a human, so the card reads "Claude needs your permission to

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -166,8 +166,8 @@ part worth reading starts:
 | Claude Code       | `mcp__lich__open_session` | `lich · open_session`             |
 | Codex             | `mcp__srv__tool`          | `srv · tool`                      |
 | Antigravity       | `call_mcp_tool`           | `call_mcp_tool · lich/open_session` |
-| oh-my-pi          | `mcp__lich_list_sessions` | `lich_list_sessions`              |
-| opencode          | `lichprobe_list_sessions` | unchanged                         |
+| oh-my-pi          | `mcp__lich_list_sessions` | `lich · list_sessions`            |
+| opencode          | `lichprobe_list_sessions` | `lichprobe · list_sessions`       |
 
 Measured against opencode 1.18.18, omp 17.3.7 and Antigravity 1.1.19 by running
 each CLI against a `lich mcp` server and reading the name off the handler the
@@ -180,11 +180,15 @@ are two of its arguments (`args.ServerName`, `args.ToolName`) — so the client
 reads them and sends them as `detail`, which is why that row is the only one
 whose card line is made of both fields.
 
-Of the names that *are* the tool, only the doubled underscore can be split:
-omp's single one divides `mcp__lich_list_sessions` into `lich` + `list_sessions`
-or `lich_list` + `sessions` with nothing in the string to say which, so only its
-prefix comes off, and opencode's form carries no marker at all. Crush is absent
-because it reports no tool (see above).
+Of the names that *are* the tool, only the doubled underscore divides on the
+string alone: `mcp__lich_list_sessions` reads as `lich` + `list_sessions` or
+`lich_list` + `sessions`, and opencode's form carries no marker at all. What says
+which is the list of servers that session's own spawn found registered with its
+provider — read from the harness's own config documents and the session's
+directory, recorded on its row (`store.Session`'s `mcpServers`) and announced as
+`session-mcp`. The card takes the longest server name the tool name spells, and
+leaves a name no server claims whole. Crush is absent because it reports no tool
+(see above).
 
 `detail` is whatever identifies the call at a glance — the command line, the
 file path, the pattern, and on Antigravity the MCP tool its step name does not

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -508,7 +508,7 @@ export function SessionCard({
                       The separator travels inside the detail so it leaves with it,
                       instead of dangling after a truncated name. */}
                   <span className="min-w-0 truncate font-medium text-foreground">
-                    {toolLabel(tool.name)}
+                    {toolLabel(tool.name, session.mcpServers)}
                   </span>
                   {tool.detail && (
                     <span className="min-w-0 shrink-[9999] truncate font-mono">

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -336,6 +336,10 @@ export interface StoredSession {
   /** Whether this session's last finished turn is still waiting to be read: the
    * card's solid ring, restored from here after a reload. */
   unread: boolean
+  /** The MCP servers this session's provider could reach when it was spawned —
+   * what the card divides a tool name carrying no separator of its own against.
+   * null for a row nothing has spawned yet. */
+  mcpServers: string[] | null
 }
 
 /** internal/store.ClosedSession — one parked session offered for resuming. What

--- a/frontend/src/lib/session/session-events.test.ts
+++ b/frontend/src/lib/session/session-events.test.ts
@@ -4,6 +4,7 @@ import {
   decideStatusNotice,
   isAgentEvent,
   isCwdEvent,
+  isMCPEvent,
   isIdEvent,
   isIdleEvent,
   isStatusEvent,
@@ -142,6 +143,23 @@ describe("isCwdEvent", () => {
     expect(isCwdEvent({ cwd: "/home/user" })).toBe(false)
     expect(isCwdEvent({ id: "s1", cwd: 2 })).toBe(false)
     expect(isCwdEvent(null)).toBe(false)
+  })
+})
+
+describe("isMCPEvent", () => {
+  it("accepts a payload carrying a string id and a list of names", () => {
+    expect(isMCPEvent({ id: "s1", servers: ["lich"] })).toBe(true)
+    // A session that reached nothing still reports, and the empty list is the
+    // report — the card has to clear whatever the last spawn left it.
+    expect(isMCPEvent({ id: "s1", servers: [] })).toBe(true)
+  })
+
+  it("rejects a payload that is not one", () => {
+    expect(isMCPEvent({ id: "s1" })).toBe(false)
+    expect(isMCPEvent({ servers: ["lich"] })).toBe(false)
+    expect(isMCPEvent({ id: "s1", servers: "lich" })).toBe(false)
+    expect(isMCPEvent({ id: "s1", servers: ["lich", 2] })).toBe(false)
+    expect(isMCPEvent(null)).toBe(false)
   })
 })
 

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -55,6 +55,13 @@ export const AGENT_EVENT = "session-agent"
 // a page reload hydrates from.
 export const SANDBOX_EVENT = "session-sandbox"
 
+// Global event the backend emits on every spawn with the MCP servers that
+// session's provider could reach (see terminal.mcpEventName). Payload:
+// { id, servers }. The spawn is what resolves them — from the harness's own
+// config documents and the session's directory — and they are persisted with the
+// row too, which is what a page reload hydrates from.
+export const MCP_EVENT = "session-mcp"
+
 // Global event the backend emits after a turn ends with the session's
 // context-window usage (see terminal.usageEventName). Payload: { id, percent,
 // tokens, window, model, effort } — percent is 0–100 of the window, tokens the
@@ -241,6 +248,14 @@ export function isScheduleEvent(data: unknown): data is { id: string; at: number
 
 export function isSandboxEvent(data: unknown): data is { id: string; confined: boolean } {
   return isIdEvent(data) && typeof (data as { confined?: unknown }).confined === "boolean"
+}
+
+export function isMCPEvent(data: unknown): data is { id: string; servers: string[] } {
+  if (!isIdEvent(data)) {
+    return false
+  }
+  const servers = (data as { servers?: unknown }).servers
+  return Array.isArray(servers) && servers.every((name) => typeof name === "string")
 }
 
 export function isStatusEvent(data: unknown): data is { id: string; state: string } {

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -28,6 +28,7 @@ import {
   setActiveSession,
   setSessionEntrypoint,
   setSessionPinned,
+  setSessionMCPServers,
   setSessionSandboxed,
   setSessionSchedule,
   delegatesOf,
@@ -1142,6 +1143,47 @@ describe("setSessionSandboxed", () => {
   it("ignores a session it does not know", () => {
     const current = state()
     expect(setSessionSandboxed(current, "gone", true)).toBe(current)
+  })
+})
+
+describe("setSessionMCPServers", () => {
+  const state = () => buildState(2)
+
+  it("records the servers the spawn reported, on that session alone", () => {
+    const next = setSessionMCPServers(state(), "s1", ["ai-memory", "lich"])
+    expect(next[P]?.sessions[0]?.mcpServers).toEqual(["ai-memory", "lich"])
+    expect(next[P]?.sessions[1]?.mcpServers).toBeUndefined()
+  })
+
+  it("clears them when a respawn reaches none", () => {
+    const listed = setSessionMCPServers(state(), "s1", ["lich"])
+    const next = setSessionMCPServers(listed, "s1", [])
+    expect(next[P]?.sessions[0]?.mcpServers).toBeUndefined()
+  })
+
+  // The event fires on every spawn, so an unchanged list has to return the same
+  // object: a new one re-renders every card in the project for nothing.
+  it("returns the same state when the list did not change", () => {
+    const current = state()
+    expect(setSessionMCPServers(current, "s1", [])).toBe(current)
+    const listed = setSessionMCPServers(current, "s1", ["lich"])
+    expect(setSessionMCPServers(listed, "s1", ["lich"])).toBe(listed)
+    // Same length, different names — a comparison on length alone would miss it.
+    expect(setSessionMCPServers(listed, "s1", ["other"])).not.toBe(listed)
+  })
+
+  it("ignores a session it does not know", () => {
+    const current = state()
+    expect(setSessionMCPServers(current, "gone", ["lich"])).toBe(current)
+  })
+
+  // Dropped rather than set to an empty array, for the reason the sandbox mark
+  // is: hydration omits the key entirely.
+  it("leaves no mcpServers key on a session that reached none", () => {
+    const listed = setSessionMCPServers(buildState(1), "s1", ["lich"])
+    const cleared = setSessionMCPServers(listed, "s1", [])
+    const session = cleared[P]?.sessions[0]
+    expect(session && "mcpServers" in session).toBe(false)
   })
 })
 

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -76,6 +76,11 @@ export interface Session {
   // run reaches the panel through the session's own state reports, which is the
   // other half of what draws the switch (ReviewPanel).
   hasLastTurn?: boolean
+  // The MCP servers this session's provider could reach when it was spawned,
+  // which is what toolLabel divides a tool name against. Absent means none were
+  // reported — the same answer as a name no server claims, so the card shows it
+  // whole. Written by the spawn (MCP_EVENT) and read back on hydration.
+  mcpServers?: string[]
 }
 
 export interface ProjectSessions {
@@ -299,6 +304,42 @@ export function setSessionSandboxed(
       }),
     },
   }
+}
+
+// setSessionMCPServers records the MCP servers a spawn reported for a session.
+// Unknown ids leave the state untouched, and a list that already matches returns
+// the same object — the event fires on every spawn, and a re-render per respawn
+// of an unchanged card is a card that flickers.
+export function setSessionMCPServers(
+  state: SessionState,
+  sessionId: string,
+  servers: string[],
+): SessionState {
+  const projectId = projectOfSession(state, sessionId)
+  const current = projectId ? state[projectId] : undefined
+  const session = current?.sessions.find((s) => s.id === sessionId)
+  if (!projectId || !current || !session || sameServers(session.mcpServers, servers)) {
+    return state
+  }
+  return {
+    ...state,
+    [projectId]: {
+      ...current,
+      sessions: current.sessions.map((s) => {
+        if (s.id !== sessionId) {
+          return s
+        }
+        // Dropped rather than set to an empty array, so a session that reached
+        // nothing carries no key at all — the shape hydration produces.
+        const { mcpServers: _was, ...rest } = s
+        return servers.length > 0 ? { ...rest, mcpServers: servers } : rest
+      }),
+    },
+  }
+}
+
+function sameServers(a: string[] | undefined, b: string[]): boolean {
+  return (a ?? []).length === b.length && (a ?? []).every((name, i) => name === b[i])
 }
 
 // setSessionSchedule parks a prompt on a session, or takes one off it: at 0

--- a/frontend/src/lib/session/tool-label.test.ts
+++ b/frontend/src/lib/session/tool-label.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 import { toolLabel } from "./tool-label"
 
+// The names a session's provider reports its servers under (providers.Detect).
+const SERVERS = ["lich", "ai-memory"]
+
 describe("toolLabel", () => {
   it("drops the mcp machinery and keeps the server and the tool", () => {
     expect(toolLabel("mcp__ai-memory__memory_write_page")).toBe("ai-memory · memory_write_page")
@@ -14,27 +17,46 @@ describe("toolLabel", () => {
   })
 
   // Measured against omp 17.3.7: a single underscore between the server and the
-  // tool, which nothing in the string can split — "lich" + "list_sessions" and
-  // "lich_list" + "sessions" are equally readable, so only the prefix comes off.
-  it("takes the prefix off omp's single-underscore form and splits no further", () => {
+  // tool, which only the list of registered servers can divide.
+  it("splits omp's single-underscore form against the servers", () => {
+    expect(toolLabel("mcp__lich_list_sessions", SERVERS)).toBe("lich · list_sessions")
+    expect(toolLabel("mcp__ai-memory_memory_query", SERVERS)).toBe("ai-memory · memory_query")
+  })
+
+  // Measured against opencode 1.18.18: no prefix at all, so the servers are the
+  // whole of what says where the name divides.
+  it("splits opencode's bare form against the servers", () => {
+    expect(toolLabel("lich_open_session", SERVERS)).toBe("lich · open_session")
+  })
+
+  // Two servers could claim the same name; the longer one is the one that read
+  // the whole prefix rather than stopping inside it.
+  it("takes the longest server that matches", () => {
+    expect(toolLabel("lich_relay_send", ["lich", "lich_relay"])).toBe("lich_relay · send")
+  })
+
+  // A server name is not a word boundary: `lichen_pick` is not lich's.
+  it("matches a whole server name, not a prefix of one", () => {
+    expect(toolLabel("lichen_pick", SERVERS)).toBe("lichen_pick")
+  })
+
+  it("leaves a name no server claims exactly as it arrived", () => {
+    expect(toolLabel("lichprobe_list_sessions", SERVERS)).toBe("lichprobe_list_sessions")
+    expect(toolLabel("mcp__other_list_sessions", SERVERS)).toBe("other_list_sessions")
     expect(toolLabel("mcp__lich_list_sessions")).toBe("lich_list_sessions")
   })
 
-  // Measured against opencode 1.18.18: no prefix at all, so there is no marker
-  // to key on and the name is shown whole.
-  it("leaves opencode's form alone", () => {
-    expect(toolLabel("lichprobe_list_sessions")).toBe("lichprobe_list_sessions")
-  })
-
   it("shows a name that is not an MCP tool's exactly as it arrived", () => {
-    expect(toolLabel("Bash")).toBe("Bash")
-    expect(toolLabel("apply_patch")).toBe("apply_patch")
-    expect(toolLabel("")).toBe("")
+    expect(toolLabel("Bash", SERVERS)).toBe("Bash")
+    expect(toolLabel("apply_patch", SERVERS)).toBe("apply_patch")
+    expect(toolLabel("", SERVERS)).toBe("")
   })
 
   // Half a prefix is not an MCP name, and neither half is a server or a tool.
   it("still strips the prefix off a name it cannot split", () => {
-    expect(toolLabel("mcp__lich")).toBe("lich")
-    expect(toolLabel("mcp____tool")).toBe("__tool")
+    expect(toolLabel("mcp__lich", SERVERS)).toBe("lich")
+    expect(toolLabel("mcp____tool", SERVERS)).toBe("__tool")
+    // A server with nothing after it draws no separator.
+    expect(toolLabel("lich_", SERVERS)).toBe("lich_")
   })
 })

--- a/frontend/src/lib/session/tool-label.ts
+++ b/frontend/src/lib/session/tool-label.ts
@@ -11,20 +11,39 @@
 const MCP_DOUBLE = /^mcp__(.+?)__(.+)$/
 const MCP_PREFIX = "mcp__"
 
-// toolLabel shortens what it can prove and leaves the rest alone.
+// toolLabel shortens what it can prove and leaves the rest alone, drawing an MCP
+// tool as "<server> · <tool>".
 //
-// The doubled form splits cleanly, so it draws as "<server> · <tool>" —
-// non-greedy on the server, so a tool whose own name contains `__` keeps it.
-// omp's single underscore cannot be split at all: `mcp__lich_list_sessions`
-// divides into "lich" + "list_sessions" or "lich_list" + "sessions" and nothing
-// in the string says which, so only the prefix comes off. opencode's form has no
-// marker to key on — a server name is not distinguishable from the first word of
-// a tool name — so it is shown as it arrived, which is also what any name that is
-// not an MCP tool's gets.
-export function toolLabel(name: string): string {
+// The doubled form splits on the string alone — non-greedy on the server, so a
+// tool whose own name contains `__` keeps it. The single-underscore forms cannot:
+// `mcp__lich_list_sessions` divides into "lich" + "list_sessions" or "lich_list"
+// + "sessions" and nothing in the string says which. What says which is servers,
+// the names that session's own spawn found registered with its provider —
+// matched longest first, so a `lich_relay` server wins over a `lich` one on a
+// name both could claim.
+//
+// A name matching no server keeps whatever survives the prefix, which is also
+// what any name that is not an MCP tool's gets, and what every name got before
+// a session had a list.
+export function toolLabel(name: string, servers: readonly string[] = []): string {
   const parts = MCP_DOUBLE.exec(name)
   if (parts) {
     return `${parts[1]} · ${parts[2]}`
   }
-  return name.startsWith(MCP_PREFIX) ? name.slice(MCP_PREFIX.length) : name
+  const rest = name.startsWith(MCP_PREFIX) ? name.slice(MCP_PREFIX.length) : name
+  const server = longestServer(rest, servers)
+  return server ? `${server} · ${rest.slice(server.length + 1)}` : rest
+}
+
+// longestServer is the longest name in servers that rest spells as `<name>_`,
+// or "" when none does — and never one with nothing after it, which would draw a
+// separator with an empty tool beside it.
+function longestServer(rest: string, servers: readonly string[]): string {
+  let found = ""
+  for (const server of servers) {
+    if (server.length > found.length && rest.length > server.length + 1) {
+      if (rest.startsWith(`${server}_`)) found = server
+    }
+  }
+  return found
 }

--- a/frontend/src/providers/project-workspace.test.ts
+++ b/frontend/src/providers/project-workspace.test.ts
@@ -19,6 +19,7 @@ const storedSession = (overrides: Partial<StoredSession> = {}): StoredSession =>
   originLabel: "",
   hasLastTurn: false,
   unread: false,
+  mcpServers: null,
   ...overrides,
 })
 
@@ -166,6 +167,29 @@ describe("confined sessions", () => {
         storedProject({ sessions: [storedSession({ id: "s1", sandbox })] }),
       ])
       expect(state.p1?.sessions[0]?.sandboxed).toBeUndefined()
+    }
+  })
+})
+
+// A page reload finds the PTY already running, so the row is the only route
+// these names take back to the card.
+describe("MCP servers on hydration", () => {
+  it("carries the servers the spawn recorded", () => {
+    const state = buildSessionState([
+      storedProject({ sessions: [storedSession({ id: "s1", mcpServers: ["lich", "srv"] })] }),
+    ])
+    expect(state.p1?.sessions[0]?.mcpServers).toEqual(["lich", "srv"])
+  })
+
+  // null is a row nothing has spawned yet, and [] a session that reached
+  // nothing. The card does the same thing with both, so both drop the key.
+  it("leaves no key for a row that names none", () => {
+    for (const mcpServers of [null, []]) {
+      const state = buildSessionState([
+        storedProject({ sessions: [storedSession({ id: "s1", mcpServers })] }),
+      ])
+      const session = state.p1?.sessions[0]
+      expect(session && "mcpServers" in session).toBe(false)
     }
   })
 })

--- a/frontend/src/providers/project-workspace.ts
+++ b/frontend/src/providers/project-workspace.ts
@@ -24,6 +24,7 @@ export function buildSessionState(loaded: StoredProject[]): SessionState {
         ? { scheduledAt: session.scheduledAt, scheduledPrompt: session.scheduledPrompt }
         : {}),
       ...(session.hasLastTurn ? { hasLastTurn: true } : {}),
+      ...(session.mcpServers?.length ? { mcpServers: session.mcpServers } : {}),
     }))
     state[project.id] = {
       sessions,

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -25,6 +25,7 @@ import {
   setActiveSession,
   setSessionEntrypoint as recordEntrypoint,
   setSessionPinned,
+  setSessionMCPServers,
   setSessionSandboxed,
   setSessionSchedule,
   type Session,
@@ -46,6 +47,7 @@ import {
   OPENED_EVENT,
   PROJECT_OPENED_EVENT,
   RELAY_STALLED_EVENT,
+  MCP_EVENT,
   SANDBOX_EVENT,
   SCHEDULE_EVENT,
   STATUS_EVENT,
@@ -54,6 +56,7 @@ import {
   decideStatusNotice,
   isIdEvent,
   isRelayStalledEvent,
+  isMCPEvent,
   isSandboxEvent,
   isScheduleEvent,
   isStatusEvent,
@@ -97,6 +100,7 @@ const cardFromStored = (restored: StoredSession): Session => ({
   ...(restored.scheduledAt
     ? { scheduledAt: restored.scheduledAt, scheduledPrompt: restored.scheduledPrompt }
     : {}),
+  ...(restored.mcpServers?.length ? { mcpServers: restored.mcpServers } : {}),
 })
 
 // The first session of any project is always "Session 1"; the counter then
@@ -232,6 +236,23 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
         return
       }
       const next = setSessionSandboxed(sessionsRef.current, data.id, data.confined)
+      if (next !== sessionsRef.current) {
+        commit(next)
+      }
+    })
+    return () => off()
+  }, [])
+
+  // Every spawn reports the MCP servers its provider could reach, so a card
+  // divides a tool name against the list that spawn resolved rather than one
+  // read when lich started. The row is already written, so this never writes
+  // back.
+  useEffect(() => {
+    const off = onAppEvent(MCP_EVENT, (data) => {
+      if (!isMCPEvent(data)) {
+        return
+      }
+      const next = setSessionMCPServers(sessionsRef.current, data.id, data.servers)
       if (next !== sessionsRef.current) {
         commit(next)
       }

--- a/internal/agentplugin/mcpservers.go
+++ b/internal/agentplugin/mcpservers.go
@@ -1,0 +1,218 @@
+package agentplugin
+
+import (
+	"bytes"
+	"encoding/json"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/relay"
+)
+
+// The MCP server names a card reads a tool report against. Two harnesses spell
+// an MCP tool with a single underscore between the server and the tool
+// (oh-my-pi's `mcp__<server>_<tool>`, opencode's `<server>_<tool>`), which
+// divides only against a list of the servers that exist — so lich reads the
+// documents those two take their servers from, at the spawn that will report the
+// tools, and hands the names to the card.
+//
+// Every other provider is answered with lich's own name alone: their tool names
+// either carry the doubled underscore the card splits without help, or are not a
+// tool name at all (Antigravity's, docs/ceilings.md).
+
+// opencodeMCPKey is the key opencode holds its servers under.
+const opencodeMCPKey = "mcp"
+
+// opencodeConfigFiles are the documents opencode reads a config from, in every
+// directory it looks in: its global config directory, then `.opencode/` and the
+// session's own directory on the way up from the cwd. `config.json` is the
+// global-only third name it also merges. Measured off opencode 1.18.18's own
+// `Config.loadInstanceState` and `ConfigPaths`.
+var (
+	opencodeConfigFiles       = []string{"opencode.json", "opencode.jsonc"}
+	opencodeGlobalConfigFiles = append([]string{"config.json"}, opencodeConfigFiles...)
+)
+
+// opencodeProjectDir is the directory name opencode also reads a config out of,
+// in the cwd and in every directory above it.
+const opencodeProjectDir = ".opencode"
+
+// MCPServers names the MCP servers whose tools a session of this provider,
+// started in cwd, can call — sorted, with lich's own always among them, since
+// lich is registered wherever it spawns a session.
+func MCPServers(provider, cwd string) []string {
+	names := map[string]bool{relay.MCPServerName: true}
+	for _, name := range registeredServers(provider, cwd) {
+		names[name] = true
+	}
+	return slices.Sorted(maps.Keys(names))
+}
+
+// registeredServers reads the provider's own documents, or answers nothing at
+// all — an absent file, one lich cannot parse and a provider that keeps none are
+// the same answer, and it is the one that leaves a tool name whole.
+func registeredServers(provider, cwd string) []string {
+	switch provider {
+	case providers.OMP:
+		dir, err := ompAgentDir()
+		if err != nil {
+			return nil
+		}
+		return serverKeys(filepath.Join(dir, ompMCPFile), mcpServersKey)
+	case providers.OpenCode:
+		return opencodeServers(cwd)
+	}
+	return nil
+}
+
+// opencodeServers reads every document opencode merges its config from: the
+// global directory, then — because a project may register a server of its own —
+// `opencode.json`, `opencode.jsonc` and `.opencode/`'s pair in cwd and in every
+// directory above it. opencode stops that walk at the project root and lich does
+// not, which makes this a superset: the cost of the extra names is a split lich
+// would not otherwise offer, and the cost of stopping short is a tool the card
+// cannot divide.
+func opencodeServers(cwd string) []string {
+	var out []string
+	if dir, err := opencodeConfigDir(); err == nil {
+		out = append(out, dirServers(dir, opencodeGlobalConfigFiles)...)
+	}
+	// $OPENCODE_CONFIG names one more document, merged on top of the rest rather
+	// than replacing them (measured on 1.18.18).
+	if extra := os.Getenv("OPENCODE_CONFIG"); extra != "" {
+		out = append(out, serverKeys(extra, opencodeMCPKey)...)
+	}
+	for _, dir := range ancestors(cwd) {
+		out = append(out, dirServers(dir, opencodeConfigFiles)...)
+		out = append(out, dirServers(filepath.Join(dir, opencodeProjectDir), opencodeConfigFiles)...)
+	}
+	return out
+}
+
+// dirServers is every server named by any of files in dir.
+func dirServers(dir string, files []string) []string {
+	var out []string
+	for _, file := range files {
+		out = append(out, serverKeys(filepath.Join(dir, file), opencodeMCPKey)...)
+	}
+	return out
+}
+
+// ancestors is dir and every directory above it, up to the filesystem root.
+// Empty for a relative or empty path: a walk from one would climb whatever the
+// process's own working directory happens to be, which is not the session's.
+func ancestors(dir string) []string {
+	if !filepath.IsAbs(dir) {
+		return nil
+	}
+	var out []string
+	for {
+		out = append(out, dir)
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return out
+		}
+		dir = parent
+	}
+}
+
+// serverKeys are the keys of the object under key in the JSON document at path.
+func serverKeys(path, key string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var doc map[string]json.RawMessage
+	if err := json.Unmarshal(jsonc(data), &doc); err != nil {
+		return nil
+	}
+	var servers map[string]json.RawMessage
+	if err := json.Unmarshal(doc[key], &servers); err != nil {
+		return nil
+	}
+	return slices.Collect(maps.Keys(servers))
+}
+
+// opencodeConfigDir is where opencode merges its global config from: the parent
+// of the plugin directory, resolved the same xdg way, with $OPENCODE_CONFIG_DIR
+// moving it outright (measured on 1.18.18).
+func opencodeConfigDir() (string, error) {
+	if dir := os.Getenv("OPENCODE_CONFIG_DIR"); dir != "" {
+		return dir, nil
+	}
+	dir, err := opencodePluginDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Dir(dir), nil
+}
+
+// jsonc strips what a JSON document may not carry and a `.jsonc` one may: `//`
+// and `/* */` comments, and a comma before a closing brace or bracket. opencode
+// parses its config with both allowed (measured on 1.18.18), so a lich that
+// refused them would miss servers the harness itself loads — and the extension
+// exists for exactly the comments encoding/json rejects.
+//
+// String literals are copied through untouched, which is what keeps a URL's
+// `//` and a prompt's `/*` intact.
+func jsonc(data []byte) []byte {
+	out := make([]byte, 0, len(data))
+	inString, escaped := false, false
+	for i := 0; i < len(data); i++ {
+		c := data[i]
+		if inString {
+			out = append(out, c)
+			switch {
+			case escaped:
+				escaped = false
+			case c == '\\':
+				escaped = true
+			case c == '"':
+				inString = false
+			}
+			continue
+		}
+		switch {
+		case c == '"':
+			inString = true
+			out = append(out, c)
+		case c == '/' && i+1 < len(data) && data[i+1] == '/':
+			for i < len(data) && data[i] != '\n' {
+				i++
+			}
+			// Back one, so the loop's own step lands on the newline and keeps it:
+			// dropping it would join this line to the next.
+			i--
+		case c == '/' && i+1 < len(data) && data[i+1] == '*':
+			end := bytes.Index(data[i+2:], []byte("*/"))
+			if end < 0 {
+				// Unterminated: everything after it is comment as far as any
+				// parser is concerned, and what is left may still parse.
+				return out
+			}
+			i += 2 + end + 1
+		case c == '}' || c == ']':
+			// The comma before a closer is trailing. Taken off what has already
+			// been written rather than looked for ahead: a comment can sit
+			// between the two, and by here it is gone.
+			out = append(dropTrailingComma(out), c)
+		default:
+			out = append(out, c)
+		}
+	}
+	return out
+}
+
+// dropTrailingComma removes the last comma in out when nothing but space
+// follows it, along with the space between. Called only where a closer is about
+// to be written, which is the one place such a comma is trailing.
+func dropTrailingComma(out []byte) []byte {
+	trimmed := bytes.TrimRight(out, " \t\r\n")
+	if len(trimmed) > 0 && trimmed[len(trimmed)-1] == ',' {
+		return trimmed[:len(trimmed)-1]
+	}
+	return out
+}

--- a/internal/agentplugin/mcpservers_test.go
+++ b/internal/agentplugin/mcpservers_test.go
@@ -1,0 +1,220 @@
+package agentplugin
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/omartelo/lich/internal/providers"
+	"github.com/omartelo/lich/internal/relay"
+)
+
+// writeMCPConfig drops one JSON document into dir.
+func writeMCPConfig(t *testing.T, dir, name, body string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create %s: %v", dir, err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// opencodeConfigHome isolates opencode's global config directory the way its own
+// resolver reads it — the xdg variable, on every OS, since opencode applies the
+// convention rather than the OS-native location.
+func opencodeConfigHome(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("OPENCODE_CONFIG_DIR", "")
+	t.Setenv("XDG_CONFIG_HOME", root)
+	return filepath.Join(root, "opencode")
+}
+
+// The names are what a card divides `mcp__<server>_<tool>` against, so omp's own
+// document is the list — lich's entry in it and every server beside it.
+func TestMCPServersReadsOMPDocument(t *testing.T) {
+	dir := ompHome(t)
+	writeMCPConfig(t, dir, ompMCPFile, `{"mcpServers":{
+		"lich":{"command":"/usr/bin/lich"},
+		"ai-memory":{"command":"memory"}
+	}}`)
+
+	got := MCPServers(providers.OMP, t.TempDir())
+
+	if want := []string{"ai-memory", "lich"}; !slices.Equal(got, want) {
+		t.Errorf("MCPServers = %v, want %v", got, want)
+	}
+}
+
+// opencode holds its servers under a different key, in the config document
+// beside the plugin directory.
+func TestMCPServersReadsOpenCodeGlobalConfig(t *testing.T) {
+	dir := opencodeConfigHome(t)
+	writeMCPConfig(t, dir, "opencode.jsonc", `{"mcp":{"ai-memory":{"type":"remote"}}}`)
+
+	got := MCPServers(providers.OpenCode, t.TempDir())
+
+	if want := []string{"ai-memory", "lich"}; !slices.Equal(got, want) {
+		t.Errorf("MCPServers = %v, want %v", got, want)
+	}
+}
+
+// opencode merges three documents into its global config, and a server declared
+// in any of them is a server whose tools reach the session.
+func TestMCPServersMergesEveryOpenCodeGlobalDocument(t *testing.T) {
+	dir := opencodeConfigHome(t)
+	writeMCPConfig(t, dir, "config.json", `{"mcp":{"first":{}}}`)
+	writeMCPConfig(t, dir, "opencode.json", `{"mcp":{"second":{}}}`)
+
+	got := MCPServers(providers.OpenCode, t.TempDir())
+
+	if want := []string{"first", "lich", "second"}; !slices.Equal(got, want) {
+		t.Errorf("MCPServers = %v, want %v", got, want)
+	}
+}
+
+// A project registers servers of its own, in the four documents opencode reads
+// out of every directory from the session's own up — which is why the answer is
+// per session rather than per provider.
+func TestMCPServersReadsOpenCodeProjectConfig(t *testing.T) {
+	opencodeConfigHome(t)
+	root := t.TempDir()
+	deep := filepath.Join(root, "packages", "web")
+	writeMCPConfig(t, root, "opencode.json", `{"mcp":{"repo-root":{}}}`)
+	writeMCPConfig(t, filepath.Join(root, opencodeProjectDir), "opencode.jsonc",
+		`{"mcp":{"repo-dot-dir":{}}}`)
+	writeMCPConfig(t, deep, "opencode.jsonc", `{"mcp":{"package":{}}}`)
+
+	got := MCPServers(providers.OpenCode, deep)
+
+	want := []string{"lich", "package", "repo-dot-dir", "repo-root"}
+	if !slices.Equal(got, want) {
+		t.Errorf("MCPServers = %v, want %v", got, want)
+	}
+}
+
+// A cwd that is not an absolute path is not a directory to walk up from: doing
+// it anyway would climb lich's own working directory and report servers this
+// session has no way to reach.
+func TestMCPServersIgnoresARelativeCwd(t *testing.T) {
+	opencodeConfigHome(t)
+
+	for _, cwd := range []string{"", "relative/path"} {
+		if got := MCPServers(providers.OpenCode, cwd); !slices.Equal(got, []string{relay.MCPServerName}) {
+			t.Errorf("MCPServers(%q) = %v, want just lich's own", cwd, got)
+		}
+	}
+}
+
+// Every absence answers the same way, because the card's fallback for all of
+// them is the same: show the tool name whole.
+func TestMCPServersAnswersLichAloneWithoutADocument(t *testing.T) {
+	ompHome(t)
+
+	for _, tc := range []struct {
+		name     string
+		provider string
+		setup    func() string
+	}{
+		{name: "no document at all", provider: providers.OMP},
+		{
+			name:     "a document lich cannot parse",
+			provider: providers.OpenCode,
+			setup: func() string {
+				cwd := t.TempDir()
+				writeMCPConfig(t, cwd, "opencode.json", `{"mcp": [not json`)
+				return cwd
+			},
+		},
+		{name: "a provider that keeps none", provider: providers.Claude},
+		{name: "a provider lich does not know", provider: "nonesuch"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cwd := opencodeConfigHome(t)
+			if tc.setup != nil {
+				cwd = tc.setup()
+			}
+			got := MCPServers(tc.provider, cwd)
+			if want := []string{relay.MCPServerName}; !slices.Equal(got, want) {
+				t.Errorf("MCPServers = %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+// $OPENCODE_CONFIG_DIR moves the whole global config directory, and a lich
+// reading the xdg one there would report servers no session has.
+func TestMCPServersFollowsOpenCodeConfigDirOverride(t *testing.T) {
+	opencodeConfigHome(t)
+	override := t.TempDir()
+	t.Setenv("OPENCODE_CONFIG_DIR", override)
+	writeMCPConfig(t, override, "opencode.json", `{"mcp":{"elsewhere":{}}}`)
+
+	got := MCPServers(providers.OpenCode, t.TempDir())
+
+	if want := []string{"elsewhere", "lich"}; !slices.Equal(got, want) {
+		t.Errorf("MCPServers = %v, want %v", got, want)
+	}
+}
+
+// The extension exists for the comments encoding/json rejects, and opencode's
+// own parser takes them — so a config lich refused would be a config the harness
+// loads and the card cannot see.
+func TestMCPServersReadsACommentedJSONC(t *testing.T) {
+	opencodeConfigHome(t)
+	cwd := t.TempDir()
+	writeMCPConfig(t, cwd, "opencode.jsonc", `{
+		// the one lich registers
+		"$schema": "https://opencode.ai/config.json",
+		"mcp": {
+			"documented": { "type": "remote", "url": "http://127.0.0.1:1/mcp" }, /* kept */
+		},
+	}`)
+
+	got := MCPServers(providers.OpenCode, cwd)
+
+	if want := []string{"documented", "lich"}; !slices.Equal(got, want) {
+		t.Errorf("MCPServers = %v, want %v", got, want)
+	}
+}
+
+// $OPENCODE_CONFIG names one more document on top of the rest.
+func TestMCPServersReadsTheOpenCodeConfigOverride(t *testing.T) {
+	opencodeConfigHome(t)
+	extra := filepath.Join(t.TempDir(), "extra.json")
+	if err := os.WriteFile(extra, []byte(`{"mcp":{"extra":{}}}`), 0o644); err != nil {
+		t.Fatalf("write %s: %v", extra, err)
+	}
+	t.Setenv("OPENCODE_CONFIG", extra)
+
+	got := MCPServers(providers.OpenCode, t.TempDir())
+
+	if want := []string{"extra", "lich"}; !slices.Equal(got, want) {
+		t.Errorf("MCPServers = %v, want %v", got, want)
+	}
+}
+
+// A `//` inside a string is not a comment, and neither is a `/*`. Asserted on
+// jsonc directly: the failure it guards against is a URL cut in half, which no
+// document-level assertion would name.
+func TestJSONCLeavesStringsAlone(t *testing.T) {
+	for _, tc := range []struct{ name, in, want string }{
+		{"a url survives", `{"url":"http://x/y"}`, `{"url":"http://x/y"}`},
+		{"a block opener in a string survives", `{"p":"/* not a comment"}`, `{"p":"/* not a comment"}`},
+		{"an escaped quote does not end the string", `{"p":"a \" // b"}`, `{"p":"a \" // b"}`},
+		{"a line comment goes, its newline stays", "{}// x\n{}", "{}\n{}"},
+		{"a block comment goes", "{/* x */}", "{}"},
+		{"an unterminated block takes the rest", "{}/* x", "{}"},
+		{"a trailing comma goes", `{"a":1,}`, `{"a":1}`},
+		{"one behind a comment goes too", "{\"a\":1, /* x */ }", `{"a":1}`},
+		{"a separating comma stays", `{"a":1,"b":2}`, `{"a":1,"b":2}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := string(jsonc([]byte(tc.in))); got != tc.want {
+				t.Errorf("jsonc(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/agentplugin/opencode.go
+++ b/internal/agentplugin/opencode.go
@@ -35,7 +35,7 @@ func (s *Service) opencodeInstall() error {
 	if err != nil {
 		return err
 	}
-	dir, err := s.opencodePluginDir()
+	dir, err := opencodePluginDir()
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func (s *Service) opencodeInstall() error {
 // — a hand-installed copy carries no marker, and reporting a version for it
 // would claim an install lich cannot update.
 func (s *Service) opencodeInstalledVersion() (string, bool) {
-	dir, err := s.opencodePluginDir()
+	dir, err := opencodePluginDir()
 	if err != nil {
 		return "", false
 	}
@@ -68,7 +68,7 @@ func (s *Service) opencodeInstalledVersion() (string, bool) {
 // which it applies on every platform rather than deferring to the OS-native
 // config location, so os.UserConfigDir would point elsewhere on macOS and
 // Windows and the module would land where nothing loads it.
-func (s *Service) opencodePluginDir() (string, error) {
+func opencodePluginDir() (string, error) {
 	base := os.Getenv("XDG_CONFIG_HOME")
 	if base == "" {
 		home, err := os.UserHomeDir()

--- a/internal/store/mcpservers_test.go
+++ b/internal/store/mcpservers_test.go
@@ -1,0 +1,75 @@
+package store
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// sessionOf reads one session back out of the hydration the window loads, which
+// is the only route these names take to the card.
+func sessionOf(t *testing.T, svc *Service, sessionID string) Session {
+	t.Helper()
+	projects, err := svc.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	for _, project := range projects {
+		for _, session := range project.Sessions {
+			if session.ID == sessionID {
+				return session
+			}
+		}
+	}
+	t.Fatalf("no session %q in the loaded state", sessionID)
+	return Session{}
+}
+
+// The spawn writes the names and the hydration reads them back: a page reload
+// finds the PTY already running, so there is no second spawn to report them.
+func TestSessionMCPServersRoundTrip(t *testing.T) {
+	svc := sandboxProject(t, "/work/alpha")
+	if err := svc.AddSession("p1", "s1", "one", providers.OMP, "", 0, ""); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+	if got := sessionOf(t, svc, "s1").MCPServers; got != nil {
+		t.Errorf("an unspawned session = %v, want none", got)
+	}
+
+	want := []string{"ai-memory", "lich"}
+	if err := svc.SetSessionMCPServers("s1", want); err != nil {
+		t.Fatalf("SetSessionMCPServers: %v", err)
+	}
+	if got := sessionOf(t, svc, "s1").MCPServers; !slices.Equal(got, want) {
+		t.Errorf("MCPServers = %v, want %v", got, want)
+	}
+}
+
+// A session that reached nothing and a session nobody spawned read the same
+// way, because the card does the same thing with both: shows the name whole.
+func TestSessionMCPServersClearsOnAnEmptyList(t *testing.T) {
+	svc := sandboxProject(t, "/work/alpha")
+	if err := svc.AddSession("p1", "s1", "one", providers.OMP, "", 0, ""); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+	if err := svc.SetSessionMCPServers("s1", []string{"lich"}); err != nil {
+		t.Fatalf("SetSessionMCPServers: %v", err)
+	}
+	if err := svc.SetSessionMCPServers("s1", nil); err != nil {
+		t.Fatalf("SetSessionMCPServers(nil): %v", err)
+	}
+	if got := sessionOf(t, svc, "s1").MCPServers; got != nil {
+		t.Errorf("MCPServers = %v, want none", got)
+	}
+}
+
+// A row written by a lich that spelled this column differently is not a crash
+// and not a guess: it reads as no servers, which is what an unspawned row says.
+func TestDecodeMCPServersRefusesWhatItCannotRead(t *testing.T) {
+	for _, encoded := range []string{"", "not json", `{"lich":true}`} {
+		if got := decodeMCPServers(encoded); got != nil {
+			t.Errorf("decodeMCPServers(%q) = %v, want none", encoded, got)
+		}
+	}
+}

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -761,4 +762,43 @@ func (s *Service) tx(fn func(*sql.Tx) error) error {
 		return fmt.Errorf("commit transaction: %w", err)
 	}
 	return nil
+}
+
+// SetSessionMCPServers records the MCP servers a session's provider could reach
+// at the spawn that just happened. The window divides a tool name against them
+// (frontend/src/lib/session/tool-label.ts), and the row is what a page reload
+// comes back to — the PTY is still running by then, so there is no second spawn
+// to report it again.
+//
+// An empty list clears the row rather than parking "[]": a session that reached
+// nothing and a session nobody has spawned read the same way, and both mean the
+// card shows a tool name whole.
+func (s *Service) SetSessionMCPServers(sessionID string, servers []string) error {
+	encoded := ""
+	if len(servers) > 0 {
+		body, err := json.Marshal(servers)
+		if err != nil {
+			return fmt.Errorf("encode MCP servers for %q: %w", sessionID, err)
+		}
+		encoded = string(body)
+	}
+	if _, err := s.db.Exec(
+		`UPDATE sessions SET mcp_servers = ? WHERE id = ?`, encoded, sessionID,
+	); err != nil {
+		return fmt.Errorf("set MCP servers on %q: %w", sessionID, err)
+	}
+	return nil
+}
+
+// decodeMCPServers reads back what SetSessionMCPServers wrote. A row lich cannot
+// parse answers nil, which is the same answer an unspawned row gives.
+func decodeMCPServers(encoded string) []string {
+	if encoded == "" {
+		return nil
+	}
+	var servers []string
+	if err := json.Unmarshal([]byte(encoded), &servers); err != nil {
+		return nil
+	}
+	return servers
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -89,7 +89,13 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- all, is still news when somebody comes back. Two writers own one edge each
     -- (SetSessionUnread): the terminal service, on the turn's own boundaries,
     -- and the window, when the card is read.
-    unread              INTEGER NOT NULL DEFAULT 0
+    unread              INTEGER NOT NULL DEFAULT 0,
+    -- The MCP servers this session's provider could reach when it was spawned,
+    -- as a JSON array. Written by the spawn because the answer took that
+    -- provider's own config documents and this session's directory to reach, and
+    -- the window needs it to divide a tool name two harnesses spell with a single
+    -- underscore. Empty for a row nothing has spawned yet.
+    mcp_servers         TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
 
@@ -223,6 +229,12 @@ type Session struct {
 	// reload: the window holds it while it is up, and this row is what it comes
 	// back to (see SetSessionUnread).
 	Unread bool `json:"unread"`
+	// MCPServers names the MCP servers this session's provider could reach when
+	// it was spawned. It rides the row for the reason Sandbox does: the spawn is
+	// what resolved it — from the provider's own config documents and this
+	// session's directory — and a page reload has to come back to the same
+	// answer without re-deriving it. Nil for a row nothing has spawned yet.
+	MCPServers []string `json:"mcpServers"`
 }
 
 // Project is a persisted project together with its restorable session state.
@@ -295,6 +307,7 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN scheduled_at INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN scheduled_prompt TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN unread INTEGER NOT NULL DEFAULT 0`,
+		`ALTER TABLE sessions ADD COLUMN mcp_servers TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN closed_seq INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE session_costs ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0`,
@@ -590,6 +603,7 @@ func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	rows, err := s.db.Query(
 		`SELECT id, label, kind, path, provider_session_id, entrypoint, sandbox, pinned,
 		        origin_session_id, origin_label, scheduled_at, scheduled_prompt, unread,
+		        mcp_servers,
 		        EXISTS (SELECT 1 FROM session_last_turn WHERE session_id = sessions.id)
 		   FROM sessions WHERE project_id = ? AND is_open = 1 ORDER BY position, rowid`,
 		projectID,
@@ -602,13 +616,15 @@ func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	sessions := []Session{}
 	for rows.Next() {
 		var sess Session
+		var servers string
 		if err := rows.Scan(
 			&sess.ID, &sess.Label, &sess.Kind, &sess.Path, &sess.ProviderSessionID,
 			&sess.Entrypoint, &sess.Sandbox, &sess.Pinned, &sess.OriginSessionID, &sess.OriginLabel,
-			&sess.ScheduledAt, &sess.ScheduledPrompt, &sess.Unread, &sess.HasLastTurn,
+			&sess.ScheduledAt, &sess.ScheduledPrompt, &sess.Unread, &servers, &sess.HasLastTurn,
 		); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}
+		sess.MCPServers = decodeMCPServers(servers)
 		sessions = append(sessions, sess)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/terminal/mcpservers_spawn_test.go
+++ b/internal/terminal/mcpservers_spawn_test.go
@@ -1,0 +1,41 @@
+// The suite spawns a real PTY and reuses stubBins from terminal_test.go, which
+// is Unix-tagged for the same reason; this file carries the tag so the package
+// still builds on Windows.
+//go:build !windows
+
+package terminal
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/omartelo/lich/internal/events"
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// The spawn is what resolves the list, so a server registered while lich was
+// already open reaches the next session started after it — which is the whole
+// reason this is not read once at startup.
+func TestSpawnRecordsTheMCPServersItCanReach(t *testing.T) {
+	t.Setenv("SHELL", "sh")
+	t.Setenv("OPENCODE_CONFIG_DIR", t.TempDir())
+	cwd := t.TempDir()
+	config := `{"mcp":{"registered-after-launch":{}}}`
+	if err := os.WriteFile(filepath.Join(cwd, "opencode.json"), []byte(config), 0o644); err != nil {
+		t.Fatalf("write opencode.json: %v", err)
+	}
+	recorded := map[string][]string{}
+	svc := New(stubBins{bin: "sh", mcpServers: recorded}, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1") })
+
+	if err := svc.Start("s1", "p1", cwd, providers.OpenCode, "", "", false, false, 80, 24); err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+
+	want := []string{"lich", "registered-after-launch"}
+	if got := recorded["s1"]; !slices.Equal(got, want) {
+		t.Errorf("recorded %v, want %v", got, want)
+	}
+}

--- a/internal/terminal/start.go
+++ b/internal/terminal/start.go
@@ -2,10 +2,12 @@ package terminal
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"runtime"
 	"time"
 
+	"github.com/omartelo/lich/internal/agentplugin"
 	"github.com/omartelo/lich/internal/project"
 	"github.com/omartelo/lich/internal/providers"
 )
@@ -65,6 +67,7 @@ func (s *Service) Start(
 	s.hub.Emit(cwdEventName, cwdEvent{ID: id, Cwd: cwd})
 	s.hub.Emit(agentEventName, agentEvent{ID: id, Agent: ""})
 	s.hub.Emit(sandboxEventName, sandboxEvent{ID: id, Confined: sess.confined})
+	s.reportMCPServers(id, kind, cwd)
 	// Bound to the effective cwd rather than the requested one, and outside
 	// s.mu: track queues a warm-up of this checkout's snapshot index, and the
 	// first one on a large repository is measured in seconds.
@@ -221,4 +224,21 @@ func closableState(kind, state string) bool {
 		return true
 	}
 	return state == statusIdle
+}
+
+// reportMCPServers records and announces the MCP servers this spawn's provider
+// could reach. Resolved here rather than once at startup because the answer
+// takes the harness's own config documents and this session's directory to
+// reach, and both move while lich is open: a server registered after launch is
+// divided on the next card to spawn.
+//
+// A failed write is logged and nothing else. It costs a card the split on the
+// next page reload — the event has already gone out — and refusing to spawn a
+// session over the way its tool names draw would be the worse trade.
+func (s *Service) reportMCPServers(id, kind, cwd string) {
+	servers := agentplugin.MCPServers(kind, cwd)
+	if err := s.store.SetSessionMCPServers(id, servers); err != nil {
+		slog.Warn("record MCP servers", "session", id, "error", err)
+	}
+	s.hub.Emit(mcpEventName, mcpEvent{ID: id, Servers: servers})
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -62,6 +62,14 @@ const (
 	// asked to work it out again. Persisted with the row too (store.Session's
 	// Sandbox), which is what a page reload hydrates from.
 	sandboxEventName = "session-sandbox"
+	// mcpEventName carries the MCP servers a session's provider could reach at
+	// its spawn ({id, servers}), emitted by every spawn. The card divides a tool
+	// name against them — two harnesses spell an MCP tool with a single
+	// underscore between the server and the tool, which nothing in the string
+	// divides (docs/hooks/session-state.md). Persisted with the row too
+	// (store.Session's MCPServers), which is what a page reload hydrates from:
+	// the PTY outlives the page, so there is no second spawn to report it again.
+	mcpEventName = "session-mcp"
 	// turnEventName carries the id of a session whose last finished turn has
 	// just been filed ({id}) — emitted when the closing snapshot lands, not when
 	// the turn's `done` is reported. The two are not the same moment: the
@@ -126,6 +134,13 @@ type agentEvent struct {
 type sandboxEvent struct {
 	ID       string `json:"id"`
 	Confined bool   `json:"confined"`
+}
+
+// mcpEvent is the payload of mcpEventName: the session and the MCP servers its
+// provider could reach when it was spawned.
+type mcpEvent struct {
+	ID      string   `json:"id"`
+	Servers []string `json:"servers"`
 }
 
 // turnEvent is the payload of turnEventName: the session whose last-turn record
@@ -196,6 +211,7 @@ type Store interface {
 	SessionEntrypoint(sessionID string) string
 	SessionSandbox(sessionID string) string
 	SetSessionSandbox(sessionID, sandbox string) error
+	SetSessionMCPServers(sessionID string, servers []string) error
 	SandboxDefault(providerID, projectID, cwd string) bool
 	SandboxSSHAgent(projectID string) bool
 	SandboxGHToken(projectID string) bool

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -58,6 +58,9 @@ type stubBins struct {
 	// Nil until a test cares, and then it stands in for the workspace database
 	// across a restart.
 	turns map[string]store.TurnRecord
+	// The MCP servers the spawn recorded per session, the shape
+	// store.SetSessionMCPServers writes. Nil until a test cares.
+	mcpServers map[string][]string
 	// One field per cost method, because the three failures are three different
 	// stories: a ledger that cannot be read, one that cannot be written, and a
 	// total that cannot be summed. A single error field would let a test claim
@@ -96,14 +99,22 @@ func newCostStore(providerSession string) stubBins {
 	}
 }
 
-func (s stubBins) ProviderBin(_, _ string) string       { return s.bin }
-func (s stubBins) SessionCustomBin(_ string) bool       { return s.bin != "" }
-func (s stubBins) SkipPermissions(_, _, _ string) bool  { return s.skipPerms }
-func (s stubBins) ProjectPath(_ string) string          { return s.projectPath }
-func (s stubBins) SessionModel(_ string) string         { return s.model }
-func (s stubBins) SessionEntrypoint(_ string) string    { return s.entrypoint }
-func (s stubBins) SessionSandbox(_ string) string       { return s.sandbox }
-func (s stubBins) SetSessionSandbox(_, _ string) error  { return nil }
+func (s stubBins) ProviderBin(_, _ string) string      { return s.bin }
+func (s stubBins) SessionCustomBin(_ string) bool      { return s.bin != "" }
+func (s stubBins) SkipPermissions(_, _, _ string) bool { return s.skipPerms }
+func (s stubBins) ProjectPath(_ string) string         { return s.projectPath }
+func (s stubBins) SessionModel(_ string) string        { return s.model }
+func (s stubBins) SessionEntrypoint(_ string) string   { return s.entrypoint }
+func (s stubBins) SessionSandbox(_ string) string      { return s.sandbox }
+func (s stubBins) SetSessionSandbox(_, _ string) error { return nil }
+
+func (s stubBins) SetSessionMCPServers(id string, servers []string) error {
+	if s.mcpServers != nil {
+		s.mcpServers[id] = servers
+	}
+	return nil
+}
+
 func (s stubBins) SandboxDefault(_, _, _ string) bool   { return s.sandboxOn }
 func (s stubBins) SandboxSSHAgent(_ string) bool        { return s.sshAgent }
 func (s stubBins) SandboxGHToken(_ string) bool         { return s.ghToken }


### PR DESCRIPTION
oh-my-pi spells an MCP tool `mcp__<server>_<tool>` and opencode `<server>_<tool>`, both with one underscore doing two jobs. A card could not tell `lich` + `list_sessions` from `lich_list` + `sessions`, so it drew the whole name and spent its width on a server nobody asked for — while a Claude Code card, whose doubled underscore divides on the string alone, already read `lich · list_sessions`.

## What says where the name divides

The list of servers that exist. **Every spawn resolves it** (`agentplugin.MCPServers(provider, cwd)`), reading the documents those two harnesses keep their servers in:

- oh-my-pi: `mcp.json` beside its extensions.
- opencode: its global config directory (`config.json`, `opencode.json`, `opencode.jsonc`, `$OPENCODE_CONFIG_DIR` honoured), the extra document `$OPENCODE_CONFIG` names, and — because a project registers servers of its own — `opencode.json`, `opencode.jsonc` and `.opencode/`'s pair in the session's own directory and every directory above it. `.jsonc` is parsed the way opencode parses it, comments and trailing commas included.

lich's own name is always among them, since lich is registered wherever it spawns a session. Every other provider gets that name alone: their tool names either carry the doubled underscore, or are not a tool name at all (Antigravity's, answered by its own ceiling).

Reading it **per spawn** rather than once at startup is what makes a server registered while lich is open reach the next session started after it, and what lets the opencode answer depend on the session's own directory.

## How it reaches the card

The way the sandbox verdict does: the spawn writes it on the session row (`store.Session.MCPServers`, new `mcp_servers` column) and emits `session-mcp`. The row is what a page reload hydrates from — the PTY outlives the page, so there is no second spawn to report it again. `toolLabel` takes the longest server name a tool name spells and leaves a name no server claims whole, which is what every name got before.

## Docs

- `docs/ceilings.md`: the "only two of the five harnesses spell an MCP one splittably" bullet is **deleted**, not replaced.
- `docs/hooks/session-state.md`: the oh-my-pi and opencode rows now show the split, and the paragraph under the table says what divides them.
- `CHANGELOG.md` `[Unreleased]` › Fixed.

## Test plan

- [x] `internal/agentplugin/mcpservers_test.go` — oh-my-pi's document; opencode's global directory, all three global names, `$OPENCODE_CONFIG_DIR`, `$OPENCODE_CONFIG`, and the project walk (repo root, `.opencode/`, a nested package dir); a commented `.jsonc`; a relative or empty cwd walking nothing; and the four absences (no file, a document lich cannot parse, a provider that keeps none, an unknown id) answering lich's name alone. Plus `jsonc` itself: a URL's `//` and a `/*` inside a string survive, an escaped quote does not end the string, a line comment keeps its newline, an unterminated block takes the rest, and a trailing comma goes — including one behind a comment.
- [x] `internal/store/mcpservers_test.go` — the spawn's write reaches the hydration, an empty list clears the row, and a value lich cannot decode reads as none.
- [x] `internal/terminal/mcpservers_spawn_test.go` — a real spawn records the servers reachable from its own cwd, including one registered after launch.
- [x] `frontend/src/lib/session/sessions.test.ts` — the setter records, clears, ignores unknown ids, returns the same object for an unchanged list (and a different one for a same-length different list), and leaves no key behind.
- [x] `frontend/src/providers/project-workspace.test.ts` — hydration carries the names; `null` and `[]` both leave no key.
- [x] `frontend/src/lib/session/session-events.test.ts` — the `session-mcp` guard, empty list accepted, non-string entries rejected.
- [x] `frontend/src/lib/session/tool-label.test.ts` — oh-my-pi and opencode split, longest server wins, a server name is not matched as a prefix of a longer word, and a name no server claims is unchanged.
- [x] Local gate: `gofmt -l`, `go vet ./...`, `go test ./...`, `biome ci .` exit 0, `pnpm test` (1558), `pnpm build`.
- [x] Cross-compile loop for linux, darwin and windows.