### PR TITLE
fix: a card says when the sandbox setting moved past it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A session card now says when the sandbox setting moved past it.** A session
+  is confined by the answer it opened with, so changing the rung in Settings
+  never reaches a card already open, and the card's shield said confined or not
+  without ever saying why. A session the rung would confine today now carries a
+  crossed shield, and the tooltip on either side of the disagreement says to
+  reopen the session to apply the setting.
 - **A session card now says why it cannot be forked.** "Fork to worktree…" used
   to be missing altogether on Antigravity, oh-my-pi, Crush, Cursor CLI and Kiro
   CLI cards, so the offer looked lost rather than withheld. The item is there

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -698,11 +698,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   has one place to put the question, so a session opened from the New Session menu, by a delegation, or
   through the MCP tool is not confined on that rung — it takes the answer closing the dialog would give.
   `Worktrees only` and `Everywhere` reach every caller; `Ask` reaches one.
-- **A confined session is frozen at the answer it opened with** (`internal/terminal/sandbox.go`): the row
-  wins over the rung in both directions, so moving the ladder afterwards changes nothing for the cards
-  already on screen — including a parked worktree session resumed months later. The card's shield is the only
-  thing that says so, and it says confined or not, never why: a card with no shield beside a rung set to
-  Everywhere is a session that opened before the rung moved, and reopening it is the only way to change it.
 - **A terminal session is never confined by a rung** (`internal/store/settings.go`): the rung is keyed by
   provider, and `shell` is not one — the sandbox exists to confine an agent working unattended, not the
   user's own prompt. A terminal opened in a project whose provider is on `Everywhere` still runs on the

--- a/frontend/src/components/settings/SandboxSettings.tsx
+++ b/frontend/src/components/settings/SandboxSettings.tsx
@@ -16,6 +16,7 @@ import { isMac, isWindows } from "@/lib/platform"
 import { cannotConfineCopy } from "@/lib/sandbox-copy"
 import { splitAccount } from "@/lib/gh-account"
 import { useRemoteResource } from "@/lib/use-remote-resource"
+import { refreshSandboxRungs } from "@/lib/use-sandbox-rung"
 import { useStoredSetting } from "@/lib/use-stored-setting"
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group"
 import { Button } from "@/components/ui/button"
@@ -196,6 +197,11 @@ function Rung({
   const [pending, setPending] = useState<SandboxLevel | null>(null)
   const level = sandboxLevel(stored)
 
+  // The cards are the other reader of this setting, and they are on screen
+  // behind this pane: a session whose frozen answer this write disagrees with
+  // says so on its card, and only a re-read tells it the ladder moved.
+  const write = (next: SandboxLevel) => void setStored(next).then(refreshSandboxRungs)
+
   // Loosening confinement is confirmed once; tightening it is written straight
   // through, because putting a session back inside the sandbox must never be
   // the harder direction.
@@ -204,7 +210,7 @@ function Rung({
       setPending(next)
       return
     }
-    setStored(next)
+    write(next)
   }
 
   return (
@@ -234,7 +240,7 @@ function Rung({
           variant="destructive"
           onClick={() => {
             if (pending) {
-              setStored(pending)
+              write(pending)
             }
             setPending(null)
           }}

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -19,6 +19,7 @@ import {
   PinOff,
   Play,
   Shield,
+  ShieldOff,
   Terminal,
   TriangleAlert,
   X,
@@ -72,6 +73,8 @@ import { sendCommand } from "@/lib/session/send-command"
 import { bracketedPaste } from "@/lib/terminal/bracketed-paste"
 import { requestTerminalFocus } from "@/lib/terminal/focus-request"
 import { useSessionIntent } from "@/lib/use-sidebar-intent"
+import { sandboxDrift } from "@/lib/providers-store"
+import { useSandboxRung } from "@/lib/use-sandbox-rung"
 import { useProjects } from "@/providers/projects"
 import { useSettings } from "@/providers/settings"
 import { timeUntil } from "@/lib/session/schedule"
@@ -82,6 +85,9 @@ import { SchedulePromptDialog } from "./SchedulePromptDialog"
 interface SessionCardProps {
   session: Session
   path: string
+  // The project this card sits in, which is the scope its provider's sandbox
+  // rung is read in — a project override wins over the global ladder.
+  projectId: string
   // The session this one was opened from, named as it is called now; "" for a
   // session nobody delegated, which is most of them (sessionOrigin).
   origin: string
@@ -133,6 +139,7 @@ interface SessionCardProps {
 export function SessionCard({
   session,
   path,
+  projectId,
   origin,
   active,
   showing,
@@ -190,6 +197,12 @@ export function SessionCard({
   // `codex` in a shell session puts that provider's mark on the card while it
   // runs; null falls back to the session's own kind.
   const agent = useSessionAgent(session.id)
+  // Whether the sandbox answer frozen on this row still matches the rung the
+  // project is on. The kind, not the live agent: what confined this PTY was
+  // decided against the provider it was spawned as.
+  const rung = useSandboxRung(session.kind, projectId)
+  const confined = session.sandboxed ?? false
+  const drift = rung === null ? "" : sandboxDrift(rung, !!session.path, confined)
   // The tool the turn is running right now, reported by the provider's pre-tool
   // hook: null outside a tool call, which is what keeps the card its usual size
   // whenever nothing is happening in it.
@@ -427,12 +440,25 @@ export function SessionCard({
                   {/* Permanent state, so it sits with the status and the age
                       rather than on the line below, which is a ladder where one
                       rung draws at a time and every rung is news. Muted and
-                      wordless: the tooltip carries what it means. */}
-                  {session.sandboxed && (
+                      wordless: the tooltip carries what it means.
+
+                      The crossed shield is the case that used to have no mark at
+                      all: a session the rung would confine today, opened before
+                      it moved. It is drawn dimmer than the shield and negated,
+                      because the one thing it must never be read as is a
+                      confined session. */}
+                  {confined ? (
                     <Shield
-                      aria-label="Sandboxed"
+                      aria-label={drift ? "Sandboxed, setting has moved" : "Sandboxed"}
                       className="size-3 shrink-0 text-muted-foreground"
                     />
+                  ) : (
+                    drift === "would-confine" && (
+                      <ShieldOff
+                        aria-label="Not sandboxed, setting has moved"
+                        className="size-3 shrink-0 text-muted-foreground/60"
+                      />
+                    )
                   )}
                   <span className="truncate text-sm font-medium text-foreground">
                     {session.label}
@@ -630,7 +656,7 @@ export function SessionCard({
               )}
             </span>
           </ContextMenuTrigger>
-          <SessionTooltip session={session} path={path} />
+          <SessionTooltip session={session} path={path} projectId={projectId} />
         </Tooltip>
         {/* Three blocks, hairline apart: what this card is, what its work is
             handed to, and where its checkout opens. The chords ride the items

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -222,6 +222,7 @@ export function SessionGroup({
                       key={session.id}
                       session={session}
                       path={projectPath}
+                      projectId={projectId}
                       // Resolved here rather than in the card: the parent can be a
                       // session in another project, which only the workspace-wide
                       // state knows about.

--- a/frontend/src/components/sidebar/SessionTooltip.tsx
+++ b/frontend/src/components/sidebar/SessionTooltip.tsx
@@ -6,9 +6,12 @@ import {
   GitPullRequestArrow,
   Play,
   Shield,
+  ShieldOff,
   TriangleAlert,
 } from "lucide-react"
+import { sandboxDrift } from "@/lib/providers-store"
 import type { Session } from "@/lib/session/sessions"
+import { useSandboxRung } from "@/lib/use-sandbox-rung"
 import { useSessionCwd } from "@/lib/session/use-session-cwd"
 import { useSessionRelay } from "@/lib/session/use-session-relay"
 import { scheduledFor } from "@/lib/session/schedule"
@@ -23,6 +26,10 @@ interface SessionTooltipProps {
   // The project's own directory: the fallback for a session with neither a
   // checkout of its own nor a reported cwd.
   path: string
+  // The project this session sits in — the scope its provider's sandbox rung is
+  // read in. The rail is the reason it is a prop: collapsed, this tooltip is the
+  // only text a session has, so it cannot be the half that stops explaining.
+  projectId: string
 }
 
 // Everything a session card knows, in words — its directory, its branch and how
@@ -38,13 +45,16 @@ interface SessionTooltipProps {
 // It resolves its own readouts instead of taking them as props. The stores
 // behind them are keyed by path and shared (one git poller per repository), so
 // the second reader costs a subscription, not a second poll.
-export function SessionTooltip({ session, path }: SessionTooltipProps) {
+export function SessionTooltip({ session, path, projectId }: SessionTooltipProps) {
   const liveCwd = useSessionCwd(session.id)
   const relay = useSessionRelay(session.id)
   const shownPath = liveCwd || session.path || path
   const git = useGitStatus(shownPath)
   const pr = usePullRequest(shownPath, git?.branch ?? "", git?.head ?? "")
   const base = baseReadout(git?.base ?? null)
+  const rung = useSandboxRung(session.kind, projectId)
+  const confined = session.sandboxed ?? false
+  const drift = rung === null ? "" : sandboxDrift(rung, !!session.path, confined)
   return (
     <TooltipContent side="right" className="max-w-xs border border-border bg-card text-foreground">
       <div className="flex flex-col gap-1.5">
@@ -116,16 +126,27 @@ export function SessionTooltip({ session, path }: SessionTooltipProps) {
             between a session that can write anywhere and one that can write
             here. The last line is the part nothing else says — the answer was
             taken when the session opened, and moving the rung in Settings will
-            not move this card. */}
-        {session.sandboxed && (
+            not move this card.
+
+            An unconfined session is silent here unless the rung has since moved
+            past it, which is the one time its lack of a shield is news. */}
+        {(confined || drift) && (
           <span className="flex flex-col gap-0.5">
             <span className="flex items-center gap-1.5">
-              <Shield className="size-3 shrink-0" />
-              Sandboxed
+              {confined ? (
+                <Shield className="size-3 shrink-0" />
+              ) : (
+                <ShieldOff className="size-3 shrink-0" />
+              )}
+              {confined ? "Sandboxed" : "Not sandboxed"}
             </span>
             <span className="text-muted-foreground">
-              Empty home, machine read-only, writes only in this checkout. Set when the session
-              opened; reopen it to change.
+              {confined
+                ? "Empty home, machine read-only, writes only in this checkout. "
+                : "This session runs on the machine. "}
+              {drift
+                ? "Opened before the sandbox setting changed; reopen the session to apply it."
+                : "Set when the session opened; reopen it to change."}
             </span>
           </span>
         )}

--- a/frontend/src/components/sidebar/SidebarRail.tsx
+++ b/frontend/src/components/sidebar/SidebarRail.tsx
@@ -16,6 +16,8 @@ interface RailSessionProps {
   // The project's own directory, the fallback for a session with no path of its
   // own and no cwd reported yet.
   projectPath: string
+  // The project this session sits in, the scope its sandbox rung is read in.
+  projectId: string
   active: boolean
   onSelect: () => void
 }
@@ -26,7 +28,7 @@ interface RailSessionProps {
 // drawn from the same component the card uses, not a second implementation.
 // Same for the tooltip: at this width it is the only place the card's words can
 // go, so it is the card's own tooltip, not a shortened one.
-function RailSession({ session, projectPath, active, onSelect }: RailSessionProps) {
+function RailSession({ session, projectPath, projectId, active, onSelect }: RailSessionProps) {
   const status = useSessionStatus(session.id)
   const unread = useSessionUnread(session.id)
   const agent = useSessionAgent(session.id)
@@ -47,7 +49,7 @@ function RailSession({ session, projectPath, active, onSelect }: RailSessionProp
       >
         <SessionStatusIcon kind={agent ?? session.kind} status={status} unread={unread} />
       </TooltipTrigger>
-      <SessionTooltip session={session} path={projectPath} />
+      <SessionTooltip session={session} path={projectPath} projectId={projectId} />
     </Tooltip>
   )
 }
@@ -140,6 +142,7 @@ export function SidebarRail({ onExpand }: SidebarRailProps) {
                 key={session.id}
                 session={session}
                 projectPath={path}
+                projectId={projectId}
                 active={session.id === activeId}
                 onSelect={() => select(session.id)}
               />

--- a/frontend/src/components/sidebar/session-tooltip-sandbox.test.tsx
+++ b/frontend/src/components/sidebar/session-tooltip-sandbox.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+//
+// The sandbox block of a session's tooltip, mounted for real: what it says is
+// the whole of what the card's shield means, and the node-only gate cannot tell
+// a sentence that changed from one that never rendered.
+//
+// The harness is imported first for the reason render-budget.test.tsx names: it
+// has to hook react-dom before anything else reaches it.
+import { mountBudget } from "@/test/render-budget"
+import { createElement } from "react"
+import { expect, test, vi } from "vitest"
+import type { Session } from "@/lib/session/sessions"
+import { Tooltip } from "@/components/ui/tooltip"
+import { SessionTooltip } from "./SessionTooltip"
+
+vi.mock("@/lib/app-events", () => ({ onAppEvent: () => () => {}, dispatchEnvelope: () => {} }))
+
+// The rung each project is on, as the settings store would answer it. Keyed by
+// project so every test owns its own answer: the rung store asks once per
+// (provider, project) and keeps what it got, which is the point of it.
+const rungs = vi.hoisted(() => new Map<string, string>())
+
+// Everything but the two calls the sandbox readout makes hangs, so the git
+// status and the pull request stay at their loading branch and nothing else
+// lands mid-assertion.
+vi.mock("@/lib/rpc", () => {
+  const never = () => new Promise<never>(() => {})
+  const hangs = new Proxy({}, { get: () => never })
+  return {
+    endpoint: () => ({ base: "http://localhost", token: "token" }),
+    Terminal: hangs,
+    DropService: hangs,
+    ProjectService: hangs,
+    Git: hangs,
+    Pulls: hangs,
+    Fonts: hangs,
+    AgentPlugin: hangs,
+    AppUpdate: hangs,
+    PatchNotes: hangs,
+    Providers: hangs,
+    Quota: hangs,
+    Themes: hangs,
+    Store: {
+      GetSetting: (_key: string, projectID: string) =>
+        Promise.resolve(projectID ? (rungs.get(projectID) ?? "") : ""),
+    },
+    System: { SandboxBackend: () => Promise.resolve("bubblewrap") },
+  }
+})
+
+function tooltip(session: Session, projectId: string) {
+  return createElement(
+    Tooltip,
+    { open: true },
+    createElement(SessionTooltip, { session, path: "/repo", projectId }),
+  )
+}
+
+const text = () => document.querySelector('[data-slot="tooltip-content"]')?.textContent ?? ""
+
+function session(patch: Partial<Session>): Session {
+  return { id: "s1", label: "claude", kind: "claude", ...patch }
+}
+
+const MOVED = "Opened before the sandbox setting changed; reopen the session to apply it."
+
+test("a confined session on a rung that still confines reads as it always did", async () => {
+  rungs.set("p-agrees-on", "everywhere")
+  const mounted = await mountBudget(tooltip(session({ sandboxed: true }), "p-agrees-on"))
+  expect(text()).toContain("Sandboxed")
+  expect(text()).toContain("Set when the session opened; reopen it to change.")
+  expect(text()).not.toContain(MOVED)
+  await mounted.unmount()
+})
+
+// The rung the session opened on is the rung it is still on, so its lack of a
+// shield is not news and the block stays off the tooltip entirely.
+test("an unconfined session on a rung that confines nothing says nothing", async () => {
+  rungs.set("p-agrees-off", "off")
+  const mounted = await mountBudget(tooltip(session({}), "p-agrees-off"))
+  expect(text()).not.toContain("Sandboxed")
+  expect(text()).not.toContain(MOVED)
+  await mounted.unmount()
+})
+
+test("a session the rung would confine today says why it is not", async () => {
+  rungs.set("p-moved-on", "everywhere")
+  const mounted = await mountBudget(tooltip(session({}), "p-moved-on"))
+  expect(text()).toContain("Not sandboxed")
+  expect(text()).toContain(MOVED)
+  await mounted.unmount()
+})
+
+// The other direction of the same move: the shield on the card is accurate, and
+// the sentence is what says the ladder no longer agrees with it.
+test("a confined session the rung would now leave out says so too", async () => {
+  rungs.set("p-moved-off", "off")
+  const mounted = await mountBudget(tooltip(session({ sandboxed: true }), "p-moved-off"))
+  expect(text()).toContain("Sandboxed")
+  expect(text()).toContain(MOVED)
+  await mounted.unmount()
+})

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -13,6 +13,7 @@ import {
   resolveImplicitSessionKind,
   resolveProjectDefaultProvider,
   sandboxDefaultFor,
+  sandboxDrift,
   sandboxKey,
   sandboxLevel,
   skipLevel,
@@ -593,6 +594,36 @@ describe("sandbox rung", () => {
     ]
     for (const [level, worktree, want] of cases) {
       expect(sandboxDefaultFor(level, worktree)).toBe(want)
+    }
+  })
+
+  // The card compares the answer frozen on its row against the rung the project
+  // is on now. Agreement is silence in both directions; the two disagreements
+  // are what the shield never said.
+  it("names which way a card and its rung disagree", () => {
+    const cases: [SandboxLevel, boolean, boolean, string][] = [
+      ["everywhere", false, true, ""],
+      ["off", false, false, ""],
+      ["worktrees", true, true, ""],
+      ["worktrees", false, false, ""],
+      ["everywhere", false, false, "would-confine"],
+      ["worktrees", true, false, "would-confine"],
+      ["off", false, true, "would-release"],
+      ["worktrees", false, true, "would-release"],
+    ]
+    for (const [level, worktree, confined, want] of cases) {
+      expect(sandboxDrift(level, worktree, confined)).toBe(want)
+    }
+  })
+
+  // "Ask" hands the decision to whoever opened the session, so a ticked box is
+  // not a card out of step with the ladder — there is no ladder answer to be
+  // out of step with.
+  it("never claims drift on the rung that asks", () => {
+    for (const worktree of [false, true]) {
+      for (const confined of [false, true]) {
+        expect(sandboxDrift("ask", worktree, confined)).toBe("")
+      }
     }
   })
 })

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -156,6 +156,33 @@ export function sandboxDefaultFor(level: SandboxLevel, worktree: boolean): boole
   return level === "worktrees" && worktree
 }
 
+// What a card's frozen answer reads as against the rung its project is on now.
+// "" is agreement — and the answer for everything that cannot be compared at
+// all, which is what keeps a mark off a card lich has nothing to say about.
+export type SandboxDrift = "" | "would-confine" | "would-release"
+
+// sandboxDrift compares the answer a session opened with against the one the
+// rung would give it today. The spawn freezes its answer on the row, so moving
+// the ladder never reaches a card already open (internal/terminal/sandbox.go) —
+// this is how the card says which side of that move it is on.
+//
+// "Ask" never drifts: it hands the decision to whoever opened the session, so
+// there is no rung answer to disagree with — only the box that was ticked.
+export function sandboxDrift(
+  level: SandboxLevel,
+  worktree: boolean,
+  confined: boolean,
+): SandboxDrift {
+  if (level === "ask") {
+    return ""
+  }
+  const now = sandboxDefaultFor(level, worktree)
+  if (now === confined) {
+    return ""
+  }
+  return now ? "would-confine" : "would-release"
+}
+
 // readEnabled interprets the stored flag: Claude is enabled by default (it was
 // always offered before the providers feature), every other provider is opt-in.
 // An explicit "1"/"0" overrides the default.

--- a/frontend/src/lib/use-sandbox-rung.ts
+++ b/frontend/src/lib/use-sandbox-rung.ts
@@ -1,0 +1,65 @@
+import { useEffect } from "react"
+import { createKeyedStore } from "@/lib/keyed-store"
+import { sandboxKey, sandboxLevel, type SandboxLevel } from "@/lib/providers-store"
+import { Store, System } from "@/lib/rpc"
+import { useKeyedStore } from "@/lib/use-keyed-store"
+
+// The rung a provider is on in one project, as the sidebar reads it. It lives
+// out here rather than in a card's own state because the card is what has to
+// notice the rung moving: Settings takes the screen while the sidebar stays
+// mounted (App.tsx), so a value read once at mount would never move again.
+//
+// null is "no rung to compare against", which covers three cases the card must
+// treat alike: nothing read yet, a lookup that failed, and a machine with no
+// sandbox backend at all. A stored "everywhere" on a machine that cannot
+// confine would otherwise mark every card as one the sandbox missed.
+const rungs = createKeyedStore<SandboxLevel | null>(null)
+
+// Keys already asked for. Never cleared: a machine that cannot confine answers
+// null forever, and re-reading it on every card mount would be a round trip per
+// card for an answer that is not going to change.
+const asked = new Set<string>()
+
+// A shell is not a provider — the rung is keyed by provider and `shell` is not
+// one, so a terminal session has no rung to disagree with.
+function rungKey(providerId: string, projectId: string): string {
+  return providerId && providerId !== "shell" ? `${providerId}\n${projectId}` : ""
+}
+
+function load(key: string): void {
+  const [providerId, projectId] = key.split("\n")
+  void Promise.all([
+    System.SandboxBackend(),
+    // The project's rung wins over the global one, the order store.SandboxLevel
+    // reads in.
+    projectId ? Store.GetSetting(sandboxKey(providerId), projectId) : Promise.resolve(""),
+    Store.GetSetting(sandboxKey(providerId), ""),
+  ])
+    .then(([backend, scoped, global]) => {
+      rungs.set(key, backend === "" ? null : sandboxLevel(scoped || global))
+    })
+    .catch(() => undefined)
+}
+
+/** Re-read every rung a card is comparing against. Called by the pane that
+ * writes one: the whole point of the readout is that a card notices the ladder
+ * moving, and nothing else on the settings screen reaches back here. */
+export function refreshSandboxRungs(): void {
+  for (const key of asked) {
+    load(key)
+  }
+}
+
+/** The rung this provider is on in this project, or null while there is nothing
+ * to compare against (see the store above). */
+export function useSandboxRung(providerId: string, projectId: string): SandboxLevel | null {
+  const key = rungKey(providerId, projectId)
+  useEffect(() => {
+    if (!key || asked.has(key)) {
+      return
+    }
+    asked.add(key)
+    load(key)
+  }, [key])
+  return useKeyedStore(rungs, key)
+}


### PR DESCRIPTION
Deletes one `docs/ceilings.md` bullet by fixing it: **A confined session is frozen at the answer it opened with**.

The decision stands — the row wins over the rung, and moving the ladder never changes a card already open. What was missing is that the card could not say which side of that move it was on: the shield said confined or not, never why, so a card with no shield beside a rung set to `Everywhere` was a session opened before the rung moved and nothing on screen said it.

## What the card says now

The sidebar reads the rung its project is on (`provider.<id>.sandbox`, project scope winning over global) and compares it against the answer frozen on the session row.

| Row | Rung today | Card |
| --- | --- | --- |
| confined | would confine | `Shield` — exactly as before |
| unconfined | would not confine | nothing — exactly as before |
| unconfined | **would confine** | `ShieldOff`, dimmer than the shield |
| confined | **would not confine** | `Shield`, tooltip carries the rest |

Either disagreement puts one sentence in the session tooltip: *Opened before the sandbox setting changed; reopen the session to apply it.* The crossed shield is drawn at `text-muted-foreground/60` and negated for the one thing it must never be read as — a confined session.

Three cases never claim drift, because there is nothing to compare:

- **`Ask`** hands the decision to whoever opened the session, so the rung has no answer of its own (`store.SandboxDefault` returns false there on purpose).
- **A terminal session**, whose `shell` kind is not a provider the rung is keyed by.
- **A machine with no sandbox backend**, where a stored `everywhere` would otherwise mark every card.

## Data path

Frontend only — no Go field, no new JSON tag, so `api-types.ts` does not move. The pure comparison is `sandboxDrift` beside `sandboxDefaultFor` in `providers-store.ts`.

The rung lives in a module-level `createKeyedStore` (`lib/use-sandbox-rung.ts`) rather than a card's own state: Settings takes the screen while the sidebar stays mounted, so a value read at mount would never move again. The Sandbox pane calls `refreshSandboxRungs()` after each write, which is what makes a card notice the ladder moving without a reload.

`projectId` is threaded to `SessionCard` and `SessionTooltip` because the rung is read in the project's scope. The rail gets it too — collapsed, that tooltip is the only text a session has, so it cannot be the half that stops explaining.

## Test plan

- [x] `src/lib/providers-store.test.ts` — `sandboxDrift` over all eight (rung, checkout, row) combinations, plus `Ask` never drifting.
- [x] `src/components/sidebar/session-tooltip-sandbox.test.tsx` — the tooltip mounted for real (jsdom) in four states: agree confined, agree unconfined, and both directions of disagreement carrying the sentence.
- [x] `./node_modules/.bin/biome ci .` exit 0 (17 standing a11y warnings unchanged).
- [x] `vitest run` — 133 files, 1578 tests green, render budgets included.
- [x] `tsc -b --noEmit` and `vite build`.
- [ ] Smoke in `task dev`: open a session on `Off`, move the rung to `Everywhere`, confirm the crossed shield appears on the open card without a reload.