### PR TITLE
fix: say whose arithmetic each dollar in a cost total is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`lich cost` now says whose arithmetic each dollar is.** A new `source`
+  column, carried in `--json` and `--csv` too, marks a row `priced` where lich
+  derived the money from Claude Code's and Codex's token counts and `reported`
+  where oh-my-pi, opencode or Crush handed over the figure they computed
+  themselves. A project that ran both reads `mixed`, and a total that mixes them
+  gains a line splitting the sessions between the two.
 - **A session card now says why it cannot be forked.** "Fork to worktree…" used
   to be missing altogether on Antigravity, oh-my-pi, Crush, Cursor CLI and Kiro
   CLI cards, so the offer looked lost rather than withheld. The item is there

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -112,14 +112,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   it at all and falls back on its own life: parked, it is dated by the close; open, it is dated *now*, so it
   is unpriced in every window ending today. Slicing money by day would need a second ledger keyed by day, and
   there is none.
-- **A `lich cost` total adds lich's own arithmetic to three other tools'** (`store.CostTotals`): five providers
-  write to the same ledger, but only Claude Code and Codex are priced here. oh-my-pi, opencode and Crush each
-  hand over a figure they computed themselves, carrying the omission their own accounting has — the rungs above
-  name one per provider — and the sum says nothing about the difference. A dollar lich derived from token
-  counts and a dollar Crush reported read identically in the table, in `--json` and in `--csv`, so how close a
-  project's number is depends on which providers ran under it, with nothing on any of those surfaces saying
-  which did. The `unpriced` count answers the other question — what is missing outright — and cannot answer
-  this one.
 - **Hands-on time is read off three signals, and one of them is not universal**
   (`internal/terminal/handson.go`, `noteOutput`, `closableState`): the figure beside the cost
   counts the gap between consecutive signs of life in a session — any hook report naming it, a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -425,10 +425,11 @@ What the sessions lich still remembers have cost, at API prices, one row per
 project and a total under them:
 
 ```
-project	sessions	unpriced	cost
-lich	12	2	$4.31
-revu	3	0	$0.88
-total	15	2	$5.19
+project	sessions	unpriced	source	cost
+lich	12	2	mixed	$4.31
+revu	3	0	priced	$0.88
+total	15	2	mixed	$5.19
+9 priced by lich, 4 reported by their provider.
 Lower bound: 2 unpriced of 15 sessions — their spend is not in this total.
 ```
 
@@ -446,12 +447,16 @@ unreadable transcript, an unpriced model, a provider lich has no reader for
 (Antigravity and Cursor CLI), or a session that ran while the readout was off
 all land in the same count.
 
-The money it *does* carry comes from two kinds of accounting, and the report
-does not separate them: lich prices Claude Code and Codex itself from their
-token counts, while oh-my-pi, opencode and Crush each report a figure they
-computed themselves, with the omission their own accounting has. How close a
-project's total is therefore depends on which providers ran under it —
-`docs/ceilings.md` has the rung each is on and what each one leaves out.
+**The `source` column is the other half of that contract.** The money comes
+from two kinds of accounting and reads identically either way: `priced` is
+lich's own arithmetic over the token counts Claude Code and Codex write down,
+`reported` is the figure oh-my-pi, opencode or Crush computed themselves and
+handed over, with the omission their own accounting has. A row that ran both
+reads `mixed`, and a total that mixes them adds the line above the last one,
+splitting the counted sessions between the two. A row with no money to
+attribute — every session in it unpriced, or its spend earned by a provider CLI
+started by hand inside a shell session — reads `—` and claims no rung.
+`docs/ceilings.md` has what each rung's own figure leaves out.
 
 With the cost readout switched off, no transcript is ever summed and every
 session is unpriced, so the total can only be `$0.00`. That case adds a second
@@ -479,14 +484,19 @@ The filters:
 columns, `unpriced` included, so the bound survives the export:
 
 ```
-project,sessions,unpriced,cost_usd
-lich,12,2,4.312500
-revu,3,0,0.880000
+project,sessions,unpriced,source,cost_usd
+lich,12,2,mixed,4.312500
+revu,3,0,priced,0.880000
 ```
 
+A row with no rung leaves the `source` cell empty rather than carrying the
+table's dash: to a script a blank is the absence, and the dash is a thing to
+print.
+
 `--json` is the whole report on one line — `projects`, the summed `sessions`,
-`unpriced` and `costUsd`, and `readout` for whether anything is being counted
-at all.
+`unpriced` and `costUsd`, the total's own `source` with the `priced` and
+`reported` session counts behind it, and `readout` for whether anything is
+being counted at all.
 
 It is not registered as an MCP tool. Every tool definition is in the prompt of
 every session lich spawns whether or not it is used (see the ceiling below), and

--- a/internal/cli/cost.go
+++ b/internal/cli/cost.go
@@ -79,13 +79,42 @@ func (c *client) printCost(report store.CostReport) error {
 		fmt.Fprintln(c.stdout, "No sessions matched.")
 		return nil
 	}
-	fmt.Fprintln(c.stdout, "project\tsessions\tunpriced\tcost")
+	fmt.Fprintln(c.stdout, "project\tsessions\tunpriced\tsource\tcost")
 	for _, row := range report.Projects {
-		fmt.Fprintf(c.stdout, "%s\t%d\t%d\t%s\n", row.Project, row.Sessions, row.Unpriced, money(row.CostUSD))
+		fmt.Fprintf(c.stdout, "%s\t%d\t%d\t%s\t%s\n",
+			row.Project, row.Sessions, row.Unpriced, source(row.Source), money(row.CostUSD))
 	}
-	fmt.Fprintf(c.stdout, "total\t%d\t%d\t%s\n", report.Sessions, report.Unpriced, money(report.CostUSD))
+	fmt.Fprintf(c.stdout, "total\t%d\t%d\t%s\t%s\n",
+		report.Sessions, report.Unpriced, source(report.Source), money(report.CostUSD))
+	if line := arithmetic(report); line != "" {
+		fmt.Fprintln(c.stdout, line)
+	}
 	fmt.Fprintln(c.stdout, exclusion(report))
 	return nil
+}
+
+// source is a row's rung as a table cell. A row with nothing to attribute — no
+// money counted in it at all — reads as the absence it is rather than as a gap
+// in the column.
+func source(rung string) string {
+	if rung == "" {
+		return "—"
+	}
+	return rung
+}
+
+// arithmetic names the split when a total spans both rungs. A dollar lich
+// derived from token counts and a dollar the provider reported are the same
+// figure in the money column, and the sum is the one place that difference
+// disappears — the source column has already said which is which per row, so a
+// total on a single rung needs no line at all.
+func arithmetic(report store.CostReport) string {
+	if report.Priced == 0 || report.Reported == 0 {
+		return ""
+	}
+	return fmt.Sprintf(
+		"%d priced by lich, %d reported by their provider.", report.Priced, report.Reported,
+	)
 }
 
 // exclusion words what the total does not cover. Off readout gets its own
@@ -115,15 +144,19 @@ func money(usd float64) string {
 }
 
 // emitCSV writes the per-project rows and no total: a total is the sum of the
-// columns, and the unpriced column travels beside the money, so what the number
-// leaves out survives the export rather than staying behind in lich.
+// columns, and the unpriced and source columns travel beside the money, so what
+// the number leaves out and whose arithmetic it is survive the export rather
+// than staying behind in lich.
 func (c *client) emitCSV(report store.CostReport) error {
-	rows := [][]string{{"project", "sessions", "unpriced", "cost_usd"}}
+	rows := [][]string{{"project", "sessions", "unpriced", "source", "cost_usd"}}
 	for _, row := range report.Projects {
 		rows = append(rows, []string{
 			row.Project,
 			strconv.Itoa(row.Sessions),
 			strconv.Itoa(row.Unpriced),
+			// Empty rather than the table's dash: a script reads a blank cell as
+			// "no rung", and the dash is a thing to print, not a value.
+			row.Source,
 			strconv.FormatFloat(row.CostUSD, 'f', 6, 64),
 		})
 	}

--- a/internal/cli/cost_test.go
+++ b/internal/cli/cost_test.go
@@ -7,11 +7,12 @@ import (
 )
 
 // costBody is a report the fake lich hands back: two projects, one session in
-// them that lich could not price.
+// them that lich could not price, and money off both rungs.
 const costBody = `{"projects":[` +
-	`{"project":"lich","sessions":3,"unpriced":1,"costUsd":4.3125},` +
-	`{"project":"revu","sessions":1,"unpriced":0,"costUsd":0.5}],` +
-	`"sessions":4,"unpriced":1,"costUsd":4.8125,"readout":true}`
+	`{"project":"lich","sessions":3,"unpriced":1,"source":"mixed","costUsd":4.3125},` +
+	`{"project":"revu","sessions":1,"unpriced":0,"source":"reported","costUsd":0.5}],` +
+	`"sessions":4,"unpriced":1,"priced":1,"reported":2,"source":"mixed",` +
+	`"costUsd":4.8125,"readout":true}`
 
 // TestCostPrintsTheTableAndWhatItLeavesOut is the contract of the whole
 // command: the money never appears without the count of what is missing from
@@ -26,10 +27,11 @@ func TestCostPrintsTheTableAndWhatItLeavesOut(t *testing.T) {
 		t.Fatalf("exit = %d (%s)", code, stderr)
 	}
 	for _, want := range []string{
-		"project\tsessions\tunpriced\tcost",
-		"lich\t3\t1\t$4.31",
-		"revu\t1\t0\t$0.50",
-		"total\t4\t1\t$4.81",
+		"project\tsessions\tunpriced\tsource\tcost",
+		"lich\t3\t1\tmixed\t$4.31",
+		"revu\t1\t0\treported\t$0.50",
+		"total\t4\t1\tmixed\t$4.81",
+		"1 priced by lich, 2 reported by their provider.",
 		"Lower bound: 1 unpriced of 4 sessions",
 	} {
 		if !strings.Contains(stdout, want) {
@@ -44,8 +46,8 @@ func TestCostPrintsTheTableAndWhatItLeavesOut(t *testing.T) {
 // A total with nothing missing says so rather than staying silent: "no warning"
 // and "nothing to warn about" are the two readings an empty line leaves open.
 func TestACompleteTotalSaysItIsComplete(t *testing.T) {
-	f := newFakeLich(t, `{"projects":[{"project":"lich","sessions":2,"unpriced":0,"costUsd":1}],`+
-		`"sessions":2,"unpriced":0,"costUsd":1,"readout":true}`)
+	f := newFakeLich(t, `{"projects":[{"project":"lich","sessions":2,"unpriced":0,"source":"priced","costUsd":1}],`+
+		`"sessions":2,"unpriced":0,"priced":2,"source":"priced","costUsd":1,"readout":true}`)
 
 	_, stdout, _ := run(t, f, "cost")
 
@@ -124,8 +126,9 @@ func TestCostRefusesAWindowItCannotRead(t *testing.T) {
 	}
 }
 
-// --json is the whole report, totals and readout flag included, so a script
-// piping this anywhere gets the exclusion with the money.
+// --json is the whole report — totals, the two rung tallies and the readout
+// flag included — so a script piping this anywhere gets the exclusion and the
+// arithmetic behind the money along with it.
 func TestCostEmitsJSON(t *testing.T) {
 	f := newFakeLich(t, costBody)
 
@@ -134,16 +137,19 @@ func TestCostEmitsJSON(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d", code)
 	}
-	for _, want := range []string{`"unpriced":1`, `"costUsd":4.8125`, `"readout":true`} {
+	for _, want := range []string{
+		`"unpriced":1`, `"priced":1`, `"reported":2`, `"source":"mixed"`,
+		`"costUsd":4.8125`, `"readout":true`,
+	} {
 		if !strings.Contains(stdout, want) {
 			t.Errorf("stdout = %q, want it to carry %q", stdout, want)
 		}
 	}
 }
 
-// --csv carries the unpriced column beside the money, which is how the bound
-// survives leaving lich. The exact figure goes out, not the two places the
-// table rounds to.
+// --csv carries the unpriced and source columns beside the money, which is how
+// the bound and whose arithmetic it is survive leaving lich. The exact figure
+// goes out, not the two places the table rounds to.
 func TestCostEmitsCSV(t *testing.T) {
 	f := newFakeLich(t, costBody)
 
@@ -152,7 +158,8 @@ func TestCostEmitsCSV(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d", code)
 	}
-	want := "project,sessions,unpriced,cost_usd\nlich,3,1,4.312500\nrevu,1,0,0.500000\n"
+	want := "project,sessions,unpriced,source,cost_usd\n" +
+		"lich,3,1,mixed,4.312500\nrevu,1,0,reported,0.500000\n"
 	if stdout != want {
 		t.Errorf("stdout = %q, want %q", stdout, want)
 	}
@@ -167,5 +174,35 @@ func TestCostRefusesTwoFormatsAtOnce(t *testing.T) {
 
 	if code != 1 || !strings.Contains(stderr, "usage: lich cost") {
 		t.Errorf("cost --json --csv = %d %q, want the usage line", code, stderr)
+	}
+}
+
+// A total on one rung says so in the source column and adds no line under the
+// table: the split line exists to warn that two kinds of arithmetic were summed,
+// and here they were not.
+func TestCostSplitsTheArithmeticOnlyWhenItIsMixed(t *testing.T) {
+	f := newFakeLich(t, `{"projects":[{"project":"lich","sessions":2,"unpriced":0,"source":"priced","costUsd":1}],`+
+		`"sessions":2,"unpriced":0,"priced":2,"source":"priced","costUsd":1,"readout":true}`)
+
+	_, stdout, _ := run(t, f, "cost")
+
+	if !strings.Contains(stdout, "lich\t2\t0\tpriced\t$1.00") {
+		t.Errorf("stdout = %q, want the row on the priced rung", stdout)
+	}
+	if strings.Contains(stdout, "reported by their provider") {
+		t.Errorf("stdout = %q, want no split line for a total on one rung", stdout)
+	}
+}
+
+// A row with no money to attribute reads as an absence, not as a blank cell a
+// reader has to guess at — and no rung is claimed for it.
+func TestCostMarksARowWithNoRung(t *testing.T) {
+	f := newFakeLich(t, `{"projects":[{"project":"lich","sessions":2,"unpriced":2,"costUsd":0}],`+
+		`"sessions":2,"unpriced":2,"costUsd":0,"readout":true}`)
+
+	_, stdout, _ := run(t, f, "cost")
+
+	if !strings.Contains(stdout, "lich\t2\t2\t—\t$0.00") {
+		t.Errorf("stdout = %q, want the row to mark its missing rung", stdout)
 	}
 }

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -89,7 +89,8 @@ var commands = []command{
 		about: "What the sessions lich remembers have cost, per project, at API prices.\n" +
 			"--since keeps the ones active in a window (7d, 24h, 90m). The total\n" +
 			"always says how many sessions it could not price: with any of those,\n" +
-			"it is a lower bound.",
+			"it is a lower bound. The source column says whose arithmetic a row's\n" +
+			"money is — priced here, or reported by the provider that spent it.",
 	},
 	{
 		name: "mcp",

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -183,3 +183,39 @@ func (s *Service) Detect() ([]Detected, error) {
 	}
 	return out, nil
 }
+
+// CostSource is whose arithmetic a session's dollars in the cost ledger are.
+// Five providers file a figure there and they reach it two ways, which any
+// report summing them has to be able to say: a dollar lich derived and a dollar
+// Crush reported are the same number on screen and not the same claim.
+type CostSource string
+
+const (
+	// CostSourceNone: no dollars at all. Antigravity and Cursor CLI file their
+	// conversations where lich has no reader, and Kiro CLI meters spend in
+	// credits, not money — and a session running the user's shell was never
+	// spawned as a provider, so whatever it ran by hand is on neither rung.
+	CostSourceNone CostSource = ""
+	// CostSourcePriced: lich prices the conversation itself, from the token
+	// counts the provider writes down (internal/pricing).
+	CostSourcePriced CostSource = "priced"
+	// CostSourceReported: the provider priced its own turns and lich files that
+	// figure unchanged — each bills models no table here knows, so a second
+	// opinion would only be a second, disagreeing number.
+	CostSourceReported CostSource = "reported"
+)
+
+// CostSourceOf says which of the two a provider's spend is, and it is the one
+// answer both the live readout and `lich cost` rely on. The rung is a fact of
+// the provider — what it writes down decides who can price it — so it is
+// answered from the id alone and never recorded per ledger row.
+// docs/ceilings.md carries what each rung's figure leaves out.
+func CostSourceOf(id string) CostSource {
+	switch id {
+	case Claude, Codex:
+		return CostSourcePriced
+	case OMP, OpenCode, Crush:
+		return CostSourceReported
+	}
+	return CostSourceNone
+}

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -166,3 +166,34 @@ func TestSupportsFork(t *testing.T) {
 		}
 	}
 }
+
+// TestCostSourceOfNamesEveryRung is the table `lich cost` and the footer both
+// read the split off. Every registered provider is in it: a new one lands on a
+// rung the moment lich can read its spend, and until somebody says which, the
+// report would silently file its dollars as nobody's arithmetic.
+func TestCostSourceOfNamesEveryRung(t *testing.T) {
+	want := map[string]CostSource{
+		Claude:      CostSourcePriced,
+		Codex:       CostSourcePriced,
+		OMP:         CostSourceReported,
+		OpenCode:    CostSourceReported,
+		Crush:       CostSourceReported,
+		Antigravity: CostSourceNone,
+		Cursor:      CostSourceNone,
+		Kiro:        CostSourceNone,
+	}
+	for _, p := range Registry {
+		rung, named := want[p.ID]
+		if !named {
+			t.Fatalf("%s is on no rung: name one for it, or the report files its money as nobody's", p.ID)
+		}
+		if got := CostSourceOf(p.ID); got != rung {
+			t.Errorf("CostSourceOf(%q) = %q, want %q", p.ID, got, rung)
+		}
+	}
+	// A session running the user's shell was spawned as no provider at all,
+	// whatever CLI the user started inside it.
+	if got := CostSourceOf("shell"); got != CostSourceNone {
+		t.Errorf("CostSourceOf(shell) = %q, want no rung", got)
+	}
+}

--- a/internal/store/cost.go
+++ b/internal/store/cost.go
@@ -4,6 +4,9 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
+
+	"github.com/omartelo/lich/internal/providers"
 )
 
 // CostLedger returns how far a session's cost accounting has read into one of
@@ -130,18 +133,32 @@ func (s *Service) SessionCost(sessionID string) (float64, error) {
 	return cost.Float64, nil
 }
 
+// CostSourceMixed labels a total whose money came off both rungs — some of it
+// priced here, some of it reported by the provider that spent it. It is a fact
+// of the sum rather than of any provider, which is why it is not one of
+// providers.CostSource's answers.
+const CostSourceMixed = "mixed"
+
 // CostTotal is what one project's sessions have cost. Sessions is every session
 // in the unit; Unpriced is how many of them carry no price at all, so the money
 // covers Sessions-Unpriced of them.
+//
+// Source is whose arithmetic that money is: providers.CostSourcePriced when
+// lich derived every dollar of it from token counts, providers.CostSourceReported
+// when the providers that spent it handed their own figures over, and
+// CostSourceMixed when the row spans both. Empty is a row with nothing to
+// attribute — every session in it unpriced, or its spend earned by a provider
+// CLI run by hand inside a shell session, which lich never spawned a rung for.
 type CostTotal struct {
 	Project  string  `json:"project"`
 	Sessions int     `json:"sessions"`
 	Unpriced int     `json:"unpriced"`
+	Source   string  `json:"source"`
 	CostUSD  float64 `json:"costUsd"`
 }
 
-// CostReport is CostTotals' answer: a row per project, and the same three
-// numbers summed across every row.
+// CostReport is CostTotals' answer: a row per project, and the same numbers
+// summed across every row.
 //
 // The money is a **lower bound** whenever Unpriced is not zero. A session lich
 // never priced holds no ledger row at all — its provider files its conversation
@@ -157,6 +174,10 @@ type CostTotal struct {
 // never persisted, so the ledger can only say that a session has no price —
 // not which of the reasons it was.
 //
+// Priced and Reported are how many counted sessions each rung contributed, and
+// they are what lets a reader weigh the total: the sum is the one place the
+// difference between the two is invisible, since both arrive as dollars.
+//
 // Readout is whether the cost readout is on at all. Off, no transcript is ever
 // summed, so every session is unpriced and the total can only be zero — which a
 // caller has to be able to say instead of printing a $0.00 that reads as free.
@@ -164,8 +185,48 @@ type CostReport struct {
 	Projects []CostTotal `json:"projects"`
 	Sessions int         `json:"sessions"`
 	Unpriced int         `json:"unpriced"`
+	Priced   int         `json:"priced"`
+	Reported int         `json:"reported"`
+	Source   string      `json:"source"`
 	CostUSD  float64     `json:"costUsd"`
 	Readout  bool        `json:"readout"`
+}
+
+// projectRow accumulates one project's groups while the query is walked. The
+// two tallies are session counts per rung, kept out of CostTotal because the
+// report publishes them summed once rather than per row.
+type projectRow struct {
+	CostTotal
+	priced   int
+	reported int
+}
+
+// count folds one (project, kind) group in. Only counted sessions land on a
+// rung: an unpriced one carries no money to attribute to anybody's arithmetic.
+func (r *projectRow) count(kind string, sessions, unpriced int, cost float64) {
+	r.Sessions += sessions
+	r.Unpriced += unpriced
+	r.CostUSD += cost
+	switch providers.CostSourceOf(kind) {
+	case providers.CostSourcePriced:
+		r.priced += sessions - unpriced
+	case providers.CostSourceReported:
+		r.reported += sessions - unpriced
+	}
+}
+
+// costSource labels a unit's money by the rungs that reached it. See CostTotal
+// for what each answer means, empty included.
+func costSource(priced, reported int) string {
+	switch {
+	case priced > 0 && reported > 0:
+		return CostSourceMixed
+	case priced > 0:
+		return string(providers.CostSourcePriced)
+	case reported > 0:
+		return string(providers.CostSourceReported)
+	}
+	return string(providers.CostSourceNone)
 }
 
 // CostTotals sums the ledger by project. project narrows it to one by name,
@@ -189,8 +250,42 @@ func (s *Service) CostTotals(project, provider string, since int64) (CostReport,
 	// second query while one is being walked waits on a connection its own
 	// caller is holding.
 	report := CostReport{Projects: []CostTotal{}, Readout: s.CostReadout()}
+	rows, err := s.costRows(project, provider, since)
+	if err != nil {
+		return CostReport{}, err
+	}
+	for _, row := range rows {
+		row.Source = costSource(row.priced, row.reported)
+		report.Projects = append(report.Projects, row.CostTotal)
+		report.Sessions += row.Sessions
+		report.Unpriced += row.Unpriced
+		report.CostUSD += row.CostUSD
+		report.Priced += row.priced
+		report.Reported += row.reported
+	}
+	report.Source = costSource(report.Priced, report.Reported)
+	// The expensive project reads first. A stable sort over rows the query
+	// ordered by name keeps the name as the tiebreak between equal spends.
+	sort.SliceStable(report.Projects, func(i, j int) bool {
+		return report.Projects[i].CostUSD > report.Projects[j].CostUSD
+	})
+	// A name that matched nothing is refused rather than answered with a zero:
+	// this is money, and a typo that reads as "that project cost nothing" is
+	// worse than no answer at all.
+	if project != "" && len(report.Projects) == 0 {
+		return CostReport{}, fmt.Errorf("no sessions in a project named %q", project)
+	}
+	return report, nil
+}
+
+// costRows reads the ledger grouped by project *and session kind*, folded into
+// one row per project. The kind is in the grouping because whose arithmetic a
+// session's dollars are is a fact of the provider that spent them
+// (providers.CostSourceOf) and the ledger itself records nothing about it.
+func (s *Service) costRows(project, provider string, since int64) ([]*projectRow, error) {
 	rows, err := s.db.Query(
 		`SELECT p.name,
+		        s.kind,
 		        COUNT(*),
 		        SUM(CASE WHEN c.cost IS NULL THEN 1 ELSE 0 END),
 		        COALESCE(SUM(c.cost), 0)
@@ -205,33 +300,36 @@ func (s *Service) CostTotals(project, provider string, since int64) (CostReport,
 		                    CASE WHEN s.is_open = 1
 		                         THEN CAST(strftime('%s', 'now') AS INTEGER)
 		                         ELSE s.closed_at END) >= ?)
-		  GROUP BY p.id, p.name
-		  ORDER BY COALESCE(SUM(c.cost), 0) DESC, p.name`,
+		  GROUP BY p.id, p.name, s.kind
+		  ORDER BY p.name`,
 		project, project, provider, provider, since, since,
 	)
 	if err != nil {
-		return CostReport{}, fmt.Errorf("read cost totals: %w", err)
+		return nil, fmt.Errorf("read cost totals: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 
+	var order []*projectRow
+	byName := map[string]*projectRow{}
 	for rows.Next() {
-		var row CostTotal
-		if err := rows.Scan(&row.Project, &row.Sessions, &row.Unpriced, &row.CostUSD); err != nil {
-			return CostReport{}, fmt.Errorf("scan cost total: %w", err)
+		var (
+			name, kind         string
+			sessions, unpriced int
+			cost               float64
+		)
+		if err := rows.Scan(&name, &kind, &sessions, &unpriced, &cost); err != nil {
+			return nil, fmt.Errorf("scan cost total: %w", err)
 		}
-		report.Projects = append(report.Projects, row)
-		report.Sessions += row.Sessions
-		report.Unpriced += row.Unpriced
-		report.CostUSD += row.CostUSD
+		row := byName[name]
+		if row == nil {
+			row = &projectRow{CostTotal: CostTotal{Project: name}}
+			byName[name] = row
+			order = append(order, row)
+		}
+		row.count(kind, sessions, unpriced, cost)
 	}
 	if err := rows.Err(); err != nil {
-		return CostReport{}, fmt.Errorf("iterate cost totals: %w", err)
+		return nil, fmt.Errorf("iterate cost totals: %w", err)
 	}
-	// A name that matched nothing is refused rather than answered with a zero:
-	// this is money, and a typo that reads as "that project cost nothing" is
-	// worse than no answer at all.
-	if project != "" && len(report.Projects) == 0 {
-		return CostReport{}, fmt.Errorf("no sessions in a project named %q", project)
-	}
-	return report, nil
+	return order, nil
 }

--- a/internal/store/cost_totals_test.go
+++ b/internal/store/cost_totals_test.go
@@ -3,6 +3,8 @@ package store
 import (
 	"testing"
 	"time"
+
+	"github.com/omartelo/lich/internal/providers"
 )
 
 // costWorkspace opens a store with two projects and the sessions named, so a
@@ -234,5 +236,82 @@ func TestSavingALedgerStampsIt(t *testing.T) {
 	}
 	if stamped < before || stamped > time.Now().Unix()+1 {
 		t.Errorf("stamp = %d, want it inside [%d, now]", stamped, before)
+	}
+}
+
+// TestCostTotalsNamesWhoseArithmeticEachRowIs: the money column reads the same
+// whether lich derived a dollar from token counts or a provider handed its own
+// figure over, so every row says which — and a project that ran both says so
+// too, rather than picking one of the two names.
+func TestCostTotalsNamesWhoseArithmeticEachRowIs(t *testing.T) {
+	svc := costWorkspace(t)
+	bill(t, svc, "p1", "s1", providers.Claude, 2.00)
+	bill(t, svc, "p1", "s2", providers.Crush, 1.00)
+	bill(t, svc, "p2", "s3", providers.OpenCode, 0.50)
+
+	report, err := svc.CostTotals("", "", 0)
+	if err != nil {
+		t.Fatalf("CostTotals: %v", err)
+	}
+	if got := report.Projects[0]; got.Project != "alpha" || got.Source != CostSourceMixed {
+		t.Errorf("alpha = %+v, want its two rungs named as %q", got, CostSourceMixed)
+	}
+	if got := report.Projects[1]; got.Source != string(providers.CostSourceReported) {
+		t.Errorf("beta = %+v, want the opencode row reported by its provider", got)
+	}
+	if report.Priced != 1 || report.Reported != 2 || report.Source != CostSourceMixed {
+		t.Errorf("total = %d priced, %d reported, %q, want 1, 2 and mixed",
+			report.Priced, report.Reported, report.Source)
+	}
+}
+
+// A row on one rung says that rung and nothing else: "mixed" on a project that
+// only ever ran Claude Code would be a warning about a difference that is not
+// there.
+func TestCostTotalsNamesASingleRungPlainly(t *testing.T) {
+	svc := costWorkspace(t)
+	bill(t, svc, "p1", "s1", providers.Claude, 1.00)
+	bill(t, svc, "p1", "s2", providers.Codex, 1.00)
+
+	report, err := svc.CostTotals("", "", 0)
+	if err != nil {
+		t.Fatalf("CostTotals: %v", err)
+	}
+	if got := report.Projects[0].Source; got != string(providers.CostSourcePriced) {
+		t.Errorf("source = %q, want both sessions priced here", got)
+	}
+	if report.Priced != 2 || report.Reported != 0 {
+		t.Errorf("tallies = %d priced, %d reported, want 2 and 0", report.Priced, report.Reported)
+	}
+}
+
+// Money with no rung under it is not attributed to one. A session with nothing
+// counted is on no rung because it carries no dollars; a provider CLI run by
+// hand inside a shell session carries them under a kind lich never spawned as a
+// provider, and guessing which arithmetic priced it is the one thing the column
+// must not do.
+func TestCostTotalsAttributesNoRungItCannotName(t *testing.T) {
+	svc := costWorkspace(t)
+	if err := svc.AddSession("p1", "s1", "unpriced", providers.Antigravity, "", 2, ""); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+	bill(t, svc, "p2", "s2", "shell", 3.00)
+
+	report, err := svc.CostTotals("", "", 0)
+	if err != nil {
+		t.Fatalf("CostTotals: %v", err)
+	}
+	for _, row := range report.Projects {
+		if row.Source != "" {
+			t.Errorf("%s = %+v, want no rung named", row.Project, row)
+		}
+	}
+	if report.Priced != 0 || report.Reported != 0 || report.Source != "" {
+		t.Errorf("total = %d priced, %d reported, %q, want nothing attributed",
+			report.Priced, report.Reported, report.Source)
+	}
+	// The money is still in the total: unattributed is not uncounted.
+	if report.CostUSD != 3.00 {
+		t.Errorf("total = %v, want the shell session's 3.00 counted", report.CostUSD)
 	}
 }


### PR DESCRIPTION
`lich cost` sums a ledger five providers write to, and only two of them are
priced here. Claude Code and Codex are lich's own arithmetic over their token
counts; oh-my-pi, opencode and Crush each hand over a figure they computed
themselves, carrying the omission their own accounting has. Both arrive as
dollars, so the table, `--json` and `--csv` read identically either way, and
nothing on any of those surfaces said which did which. The `unpriced` count
answers what is missing outright and cannot answer this.

## What changed

- `providers.CostSourceOf` is the seam: the rung is a fact of the provider, so
  it is answered from the id alone and nothing new is recorded per ledger row.
- `store.CostTotals` groups by session kind as well as project and folds the
  groups back into one row per project, tallying which rung each counted
  session's money came off. `CostTotal` gains `Source`; `CostReport` gains
  `Source` with the `Priced` and `Reported` session counts behind it.
- The table gains a `source` column (`priced`, `reported`, `mixed`, or `—` for
  a row with no money to attribute), `--csv` gains the same column, `--json`
  the fields, and a total that mixes both rungs gains one line above the
  exclusion: `N priced by lich, M reported by their provider.`
- The `unpriced` count and its line are untouched.

A row with nothing to attribute is one whose sessions are all unpriced, or one
whose spend was earned by a provider CLI started by hand inside a shell
session — a kind lich never spawned a rung for. It claims no rung rather than
guessing one, and its money is still in the total.

`docs/ceilings.md` loses the bullet outright; `docs/cli.md` documents the
column on all three surfaces, and `CHANGELOG.md` carries the user-facing line.

## Test plan

- [x] `internal/providers`: every registered provider is pinned to a rung, so a
      new one cannot land with its money filed as nobody's arithmetic.
- [x] `internal/store`: a mixed project, a single-rung project, and money on no
      rung at all (still counted, still unattributed).
- [x] `internal/cli`: the table column, the split line and its absence on a
      single-rung total, the dash for a row with no rung, `--json` fields and
      the `--csv` header and rows.
- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green.
- [x] Coverage: store 86.8%, cli 91.1%, providers 87.5%.