### PR TITLE
fix: put the sandbox's Ask rung to every caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The sandbox's "Ask each time" rung now reaches every session.** It only ever
+  asked in the New worktree dialog, so a session started from the New session
+  menu, by another session, or through the MCP tool quietly ran on the machine.
+  The New session menu now puts the question before the card opens, and a
+  session nobody can be asked about — one opened by an agent through
+  `open_session` or `lich open` — is confined, which that call now says.
 - **A session card now says when the sandbox setting moved past it.** A session
   is confined by the answer it opened with, so changing the rung in Settings
   never reaches a card already open, and the card's shield said confined or not

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -686,10 +686,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   binaries are the exception: their symlink chains are walked and the *directory* of every hop is mounted
   (`BinaryDirs`), which is what makes an agent installed the usual way — a link on `PATH` into a versioned
   store — runnable at all.
-- **Only the New worktree dialog asks** (`frontend/src/lib/use-sandbox-choice.ts`): the `Ask each time` rung
-  has one place to put the question, so a session opened from the New Session menu, by a delegation, or
-  through the MCP tool is not confined on that rung — it takes the answer closing the dialog would give.
-  `Worktrees only` and `Everywhere` reach every caller; `Ask` reaches one.
 - **A terminal session is never confined by a rung** (`internal/store/settings.go`): the rung is keyed by
   provider, and `shell` is not one — the sandbox exists to confine an agent working unattended, not the
   user's own prompt. A terminal opened in a project whose provider is on `Everywhere` still runs on the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -289,6 +289,13 @@ It answers to "auth-fix" and to "auth-fix-9f8e". Its agent may still be starting
   branch off a typo that names a revision, leaving a checkout nobody asked for.
   It is **ignored when `--worktree` names a branch that already exists**: a base
   says where a branch starts, and that one already started.
+- **Confinement is the rung's own answer**, and the output says so when the
+  answer is yes. Nobody is at this end to answer `Ask each time` — the rung that
+  puts the question in the New session menu and the New worktree dialog — so a
+  session opened here takes its confined side, the same as `Everywhere` and as
+  `Worktrees only` on a worktree. What that costs the session is in
+  Settings › Sandbox; there is no flag to override it, because the rung is the
+  user's answer and this end is the agent's.
 - `--model` is the model the session's provider starts on. The value is whatever
   that provider's own `--model` takes — an alias, a full name, a
   `provider/model` pair — and lich passes it through unchecked: the accepted

--- a/frontend/src/components/settings/SandboxSettings.tsx
+++ b/frontend/src/components/settings/SandboxSettings.tsx
@@ -49,7 +49,7 @@ const RUNGS: { level: SandboxLevel; label: string }[] = [
 // ever reads.
 const EXPOSES: Partial<Record<SandboxLevel, string>> = {
   off: "Every session runs on the machine.",
-  ask: "Nothing is confined unless you tick the box in the New worktree dialog.",
+  ask: "A session whose box you untick runs on the machine.",
   worktrees: "Sessions in the project directory run on the machine.",
 }
 
@@ -147,7 +147,9 @@ export function SandboxSettings({ projectId }: { projectId?: string }) {
           />
         ))}
         <p className="mt-2 max-w-prose text-xs text-muted-foreground">
-          Ask reaches the New worktree dialog only.
+          Ask puts the question in the New session menu and the New worktree dialog. A session
+          opened where nobody can answer — by another session, or through the MCP tool — is
+          confined.
         </p>
       </SettingBlock>
 

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -186,13 +186,14 @@ export function SessionGroup({
           collapsed={collapsed}
           isDragging={group.isDragging}
           providers={providers}
+          projectId={projectId}
           activatorRef={group.setActivatorNodeRef}
           // A fixed block is never dragged, and dnd-kit answers a disabled
           // sortable with aria-disabled + aria-roledescription="draggable" —
           // which would announce a working collapse button as a dead handle.
           activatorProps={fixed ? {} : { ...group.attributes, ...group.listeners }}
           onToggle={toggle}
-          onNewSession={(kind) => newSession(projectId, kind, path)}
+          onNewSession={(kind, sandbox) => newSession(projectId, kind, path, sandbox)}
           onRun={onRun}
         />
       )}

--- a/frontend/src/components/sidebar/SessionGroupHeader.tsx
+++ b/frontend/src/components/sidebar/SessionGroupHeader.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/dropdown-menu"
 import type { ProviderState } from "@/lib/providers-store"
 import type { ProviderKind } from "@/lib/session/sessions"
+import type { SandboxAnswer } from "@/lib/use-sandbox-choice"
 import { cn } from "@/lib/utils"
 import { SessionLaunchMenuItems } from "./SessionLaunchMenuItems"
 
@@ -28,10 +29,13 @@ interface SessionGroupHeaderProps {
   collapsed: boolean
   isDragging: boolean
   providers: ProviderState[]
+  // The project the launch menu opens into: it scopes the sandbox rung the menu
+  // reads before it puts the confinement question.
+  projectId: string
   activatorRef: (element: HTMLElement | null) => void
   activatorProps: ComponentPropsWithoutRef<"button">
   onToggle: () => void
-  onNewSession: (kind: ProviderKind | "shell") => void
+  onNewSession: (kind: ProviderKind | "shell", sandbox: SandboxAnswer) => void
   // Open this checkout's Run card. Absent when the project ships no run script.
   onRun?: () => void
 }
@@ -89,6 +93,7 @@ export function SessionGroupHeader({
   collapsed,
   isDragging,
   providers,
+  projectId,
   activatorRef,
   activatorProps,
   onToggle,
@@ -155,6 +160,7 @@ export function SessionGroupHeader({
             <SessionLaunchMenuItems
               providers={providers}
               terminalLabel="New Terminal"
+              projectId={projectId}
               onNewSession={onNewSession}
               onRun={onRun}
             />

--- a/frontend/src/components/sidebar/SessionLaunchMenuItems.tsx
+++ b/frontend/src/components/sidebar/SessionLaunchMenuItems.tsx
@@ -1,12 +1,19 @@
-import { GitBranch, Play, Terminal } from "lucide-react"
+import { useState } from "react"
+import { ChevronLeft, GitBranch, Play, Terminal } from "lucide-react"
 import { ProviderIcon } from "@/components/ProviderIcon"
 import {
+  DropdownMenuCheckboxItem,
   DropdownMenuGroup,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu"
 import type { ProviderState } from "@/lib/providers-store"
+import { sandboxDefaultFor } from "@/lib/providers-store"
+import { CONFINED_MEANS } from "@/lib/sandbox-copy"
 import type { ProviderKind } from "@/lib/session/sessions"
+import type { SandboxAnswer } from "@/lib/use-sandbox-choice"
+import { useSandboxAsk } from "@/lib/use-sandbox-rung"
 
 interface WorktreeMenuAction {
   disabled: boolean
@@ -16,25 +23,114 @@ interface WorktreeMenuAction {
 interface SessionLaunchMenuItemsProps {
   providers: ProviderState[]
   terminalLabel: "Terminal" | "New Terminal"
-  onNewSession: (kind: ProviderKind | "shell") => void
+  /** The project whose sandbox rung the confinement question is read from. */
+  projectId: string
+  /** sandbox is the confinement answer for the new session — "on"/"off" when
+   * the rung asked for one, "" when it answered by itself. */
+  onNewSession: (kind: ProviderKind | "shell", sandbox: SandboxAnswer) => void
   worktree?: WorktreeMenuAction
   /** Open the checkout's Run card. Absent when the project ships no
    * .lich/run-worktree.sh — there would be no command to run. */
   onRun?: () => void
 }
 
+interface SandboxStepProps {
+  provider: ProviderState
+  onOpen: (sandbox: SandboxAnswer) => void
+  onBack: () => void
+}
+
+// SandboxStep is the "Ask each time" rung's question, put where the session is
+// being opened from rather than in a dialog over it: the menu that was going to
+// open the card holds the choice instead, and the item that opens it is one row
+// below the box.
+//
+// A menu-native checkbox rather than the dialog's — the same question, the same
+// wording — because a plain input inside a base-ui popup takes no part in the
+// menu's roving focus, and a question only a mouse can answer is not one.
+//
+// It stands per provider because the rung does (store.sandboxKey): a menu
+// listing Claude on Ask beside Codex on Everywhere cannot carry one box that
+// means both.
+function SandboxStep({ provider, onOpen, onBack }: SandboxStepProps) {
+  // The rung's own answer, which for "ask" is the confined side and does not
+  // depend on the checkout — so the side this session lands on is not asked
+  // here (store.SandboxDefault).
+  const [confined, setConfined] = useState(() => sandboxDefaultFor("ask", false))
+  return (
+    <>
+      <DropdownMenuGroup>
+        <DropdownMenuLabel className="flex items-center gap-2">
+          <ProviderIcon kind={provider.id} />
+          {provider.name}
+        </DropdownMenuLabel>
+        <DropdownMenuCheckboxItem checked={confined} onCheckedChange={setConfined}>
+          Run confined
+        </DropdownMenuCheckboxItem>
+        <p className="px-2 pt-0.5 pb-1.5 text-xs text-muted-foreground">{CONFINED_MEANS}</p>
+      </DropdownMenuGroup>
+      <DropdownMenuSeparator />
+      <DropdownMenuGroup>
+        <DropdownMenuItem onClick={() => onOpen(confined ? "on" : "off")}>
+          <ProviderIcon kind={provider.id} />
+          Open session
+        </DropdownMenuItem>
+        {/* Back stays in the menu — closing it is what Escape and the trigger
+            already do, and a "Back" that dismisses the whole thing is a click
+            nobody gets a second try at. */}
+        <DropdownMenuItem closeOnClick={false} onClick={onBack}>
+          <ChevronLeft />
+          Back
+        </DropdownMenuItem>
+      </DropdownMenuGroup>
+    </>
+  )
+}
+
 export function SessionLaunchMenuItems({
   providers,
   terminalLabel,
+  projectId,
   onNewSession,
   worktree,
   onRun,
 }: SessionLaunchMenuItemsProps) {
+  const asking = useSandboxAsk(
+    providers.map((provider) => provider.id),
+    projectId,
+  )
+  // The provider whose confinement is being asked about, null while the menu is
+  // its usual list. Every other rung answers for itself, so its item opens the
+  // card on the click as it always has.
+  const [pending, setPending] = useState<ProviderState | null>(null)
+
+  if (pending) {
+    return (
+      <SandboxStep
+        provider={pending}
+        // Put back before the card opens, rather than left to the popup
+        // unmounting with the menu: the next click on this menu has to be a
+        // provider list, never last time's half-answered question.
+        onOpen={(sandbox) => {
+          setPending(null)
+          onNewSession(pending.id, sandbox)
+        }}
+        onBack={() => setPending(null)}
+      />
+    )
+  }
+
   return (
     <>
       <DropdownMenuGroup>
         {providers.map((provider) => (
-          <DropdownMenuItem key={provider.id} onClick={() => onNewSession(provider.id)}>
+          <DropdownMenuItem
+            key={provider.id}
+            closeOnClick={!asking.has(provider.id)}
+            onClick={() =>
+              asking.has(provider.id) ? setPending(provider) : onNewSession(provider.id, "")
+            }
+          >
             <ProviderIcon kind={provider.id} />
             {provider.name}
           </DropdownMenuItem>
@@ -42,7 +138,7 @@ export function SessionLaunchMenuItems({
       </DropdownMenuGroup>
       <DropdownMenuSeparator />
       <DropdownMenuGroup>
-        <DropdownMenuItem onClick={() => onNewSession("shell")}>
+        <DropdownMenuItem onClick={() => onNewSession("shell", "")}>
           <Terminal />
           {terminalLabel}
         </DropdownMenuItem>

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -434,7 +434,8 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
             <SessionLaunchMenuItems
               providers={enabled}
               terminalLabel="Terminal"
-              onNewSession={(kind) => newSession(projectId, kind)}
+              projectId={projectId}
+              onNewSession={(kind, sandbox) => newSession(projectId, kind, "", sandbox)}
               worktree={{
                 disabled: !git?.branch,
                 onSelect: () => {

--- a/frontend/src/components/sidebar/WorktreeSandboxRow.tsx
+++ b/frontend/src/components/sidebar/WorktreeSandboxRow.tsx
@@ -1,5 +1,6 @@
 import { Checkbox } from "@/components/ui/checkbox"
 import { Label } from "@/components/ui/label"
+import { CONFINED_MEANS } from "@/lib/sandbox-copy"
 import type { SandboxChoice } from "@/lib/use-sandbox-choice"
 
 // WorktreeSandboxRow is the New-worktree dialog's confinement line: whether the
@@ -26,10 +27,7 @@ export function WorktreeSandboxRow({ choice }: { choice: SandboxChoice }) {
         <Label htmlFor="worktree-sandbox" className="text-sm font-medium">
           Run confined
         </Label>
-        <span className="text-xs text-muted-foreground">
-          An empty home holding only the agent's own state, the machine read-only, and writes only
-          inside this worktree. The network stays on.
-        </span>
+        <span className="text-xs text-muted-foreground">{CONFINED_MEANS}</span>
       </div>
     </div>
   )

--- a/frontend/src/components/sidebar/session-launch-sandbox.test.tsx
+++ b/frontend/src/components/sidebar/session-launch-sandbox.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+//
+// The New session menu putting the "Ask each time" rung's question, mounted for
+// real: the answer is what the menu does on a click, and the node-only gate
+// cannot tell an extra step from a card that opened.
+//
+// The harness is imported first for the reason render-budget.test.tsx names: it
+// has to hook react-dom before anything else reaches it.
+import { mountBudget } from "@/test/render-budget"
+import { createElement } from "react"
+import { beforeEach, expect, test, vi } from "vitest"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import type { ProviderState } from "@/lib/providers-store"
+import type { SandboxAnswer } from "@/lib/use-sandbox-choice"
+import { SessionLaunchMenuItems } from "./SessionLaunchMenuItems"
+
+const store = vi.hoisted(() => ({ backend: "bubblewrap", rungs: {} as Record<string, string> }))
+
+vi.mock("@/lib/rpc", () => ({
+  System: { SandboxBackend: () => Promise.resolve(store.backend) },
+  Store: { GetSetting: (key: string) => Promise.resolve(store.rungs[key] ?? "") },
+}))
+
+beforeEach(() => {
+  store.backend = "bubblewrap"
+  store.rungs = {}
+})
+
+const claude: ProviderState = {
+  id: "claude",
+  name: "Claude Code",
+  binary: "claude",
+  installed: true,
+  enabled: true,
+  docs: "",
+}
+
+type Opened = [string, SandboxAnswer]
+
+// A project of its own per test: the rung store caches by (provider, project)
+// and never clears — the same cache a card reads, so two tests sharing a
+// project would share the first one's answer.
+function menu(opened: Opened[], projectId: string) {
+  return createElement(
+    DropdownMenu,
+    { open: true },
+    createElement(DropdownMenuTrigger, null, "+"),
+    createElement(
+      DropdownMenuContent,
+      null,
+      createElement(SessionLaunchMenuItems, {
+        providers: [claude],
+        terminalLabel: "Terminal" as const,
+        projectId,
+        onNewSession: (kind, sandbox) => opened.push([kind, sandbox]),
+      }),
+    ),
+  )
+}
+
+const item = (label: string) =>
+  [...document.querySelectorAll('[role="menuitem"],[role="menuitemcheckbox"]')].find(
+    (element) => element.textContent === label,
+  ) as HTMLElement | undefined
+
+test("the Ask rung puts the question before the card, and the answer opens with it", async () => {
+  store.rungs["provider.claude.sandbox"] = "ask"
+  const opened: Opened[] = []
+  const mounted = await mountBudget(menu(opened, "asks"))
+
+  const provider = item("Claude Code")
+  if (!provider) {
+    throw new Error("provider item not rendered")
+  }
+  await mounted.act(() => provider.click())
+  expect(opened).toEqual([])
+  expect(document.body.textContent).toContain("Run confined")
+
+  // The rung's own answer is the confined one, so the box the user leaves
+  // untouched is the one the unattended callers would have taken.
+  const open = item("Open session")
+  if (!open) {
+    throw new Error("open item not rendered")
+  }
+  await mounted.act(() => open.click())
+  expect(opened).toEqual([["claude", "on"]])
+  await mounted.unmount()
+})
+
+test("unticking the box is what opens the session on the machine", async () => {
+  store.rungs["provider.claude.sandbox"] = "ask"
+  const opened: Opened[] = []
+  const mounted = await mountBudget(menu(opened, "unticks"))
+
+  await mounted.act(() => item("Claude Code")?.click())
+  await mounted.act(() => item("Run confined")?.click())
+  await mounted.act(() => item("Open session")?.click())
+
+  expect(opened).toEqual([["claude", "off"]])
+  await mounted.unmount()
+})
+
+// Back leaves the menu standing on its list, so the question can be reached
+// again — and the answer to it never opens a card by itself.
+test("Back puts the menu on its list without opening anything", async () => {
+  store.rungs["provider.claude.sandbox"] = "ask"
+  const opened: Opened[] = []
+  const mounted = await mountBudget(menu(opened, "back"))
+
+  await mounted.act(() => item("Claude Code")?.click())
+  await mounted.act(() => item("Back")?.click())
+
+  expect(opened).toEqual([])
+  expect(item("Claude Code")).toBeDefined()
+  expect(item("Terminal")).toBeDefined()
+  await mounted.unmount()
+})
+
+// Every other rung answers for itself, in the store, on the spawn. Asking there
+// would be a step with one honest answer.
+test.each(["", "off", "worktrees", "everywhere"])(
+  "the %s rung opens on the click",
+  async (rung) => {
+    store.rungs["provider.claude.sandbox"] = rung
+    const opened: Opened[] = []
+    const mounted = await mountBudget(menu(opened, `rung-${rung}`))
+
+    await mounted.act(() => item("Claude Code")?.click())
+
+    expect(opened).toEqual([["claude", ""]])
+    expect(document.body.textContent).not.toContain("Run confined")
+    await mounted.unmount()
+  },
+)
+
+// A rung is a question about confinement, and a machine that cannot confine has
+// nothing to ask about: the menu opens the card and the spawn leaves it alone.
+test("a machine with no sandbox backend is never asked", async () => {
+  store.backend = ""
+  store.rungs["provider.claude.sandbox"] = "ask"
+  const opened: Opened[] = []
+  const mounted = await mountBudget(menu(opened, "no-backend"))
+
+  await mounted.act(() => item("Claude Code")?.click())
+
+  expect(opened).toEqual([["claude", ""]])
+  await mounted.unmount()
+})

--- a/frontend/src/components/sidebar/worktree-run.test.tsx
+++ b/frontend/src/components/sidebar/worktree-run.test.tsx
@@ -58,6 +58,7 @@ function menu(onRun?: () => void) {
       createElement(SessionLaunchMenuItems, {
         providers: [],
         terminalLabel: "New Terminal" as const,
+        projectId: "p1",
         onNewSession: () => {},
         onRun,
       }),

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -585,8 +585,11 @@ describe("sandbox rung", () => {
     const cases: [SandboxLevel, boolean, boolean][] = [
       ["off", false, false],
       ["off", true, false],
-      ["ask", false, false],
-      ["ask", true, false],
+      // Contract change: "ask" confines on either checkout, matching the Go
+      // side. It is the rung where nobody being asked confines the session, so
+      // the box that does the asking opens on that side.
+      ["ask", false, true],
+      ["ask", true, true],
       ["worktrees", false, false],
       ["worktrees", true, true],
       ["everywhere", false, true],

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -125,8 +125,8 @@ export const SSH_AGENT_KEY = "sandbox.ssh-agent"
 export const GH_TOKEN_KEY = "sandbox.gh-token"
 
 // Which sessions of a provider run confined, as one ladder ordered by how much
-// of the machine a session can reach. "ask" sits second because a session
-// nobody answered for runs unconfined, exactly like "off" — it moves who
+// of the machine a session can reach. "ask" sits second because it is the rung
+// a user can answer their way to "off" on, one session at a time — it moves who
 // decides, not what the sandbox is. Mirrors the Sandbox* constants in Go.
 export type SandboxLevel = "off" | "ask" | "worktrees" | "everywhere"
 
@@ -146,13 +146,17 @@ export function sandboxLevel(value: string): SandboxLevel {
 // the gate already knows the risk of.
 export const SANDBOX_RISK_ORDER: readonly SandboxLevel[] = [...SANDBOX_LEVELS].reverse()
 
-// sandboxDefaultFor is what the new-session dialog arrives showing: the rung
-// applied to the checkout the session will start in. It is the frontend's copy
-// of store.SandboxDefault in Go — the dialog has to show the same answer the
-// spawn would reach on its own, or the box the user leaves untouched means
-// something other than what it shows.
+// sandboxDefaultFor is what a confinement box arrives showing: the rung applied
+// to the checkout the session will start in. It is the frontend's copy of
+// store.SandboxDefault in Go — the box has to show the same answer the spawn
+// would reach on its own, or the one the user leaves untouched means something
+// other than what it shows.
+//
+// "ask" answers true on either checkout, as the Go side does: it is the rung
+// where nobody being asked confines the session, so the box that is asking
+// opens on that side.
 export function sandboxDefaultFor(level: SandboxLevel, worktree: boolean): boolean {
-  if (level === "everywhere") return true
+  if (level === "everywhere" || level === "ask") return true
   return level === "worktrees" && worktree
 }
 

--- a/frontend/src/lib/sandbox-copy.ts
+++ b/frontend/src/lib/sandbox-copy.ts
@@ -30,3 +30,10 @@ export function cannotConfineCopy(platform: SandboxPlatform): CannotConfineCopy 
     advice: "Install bubblewrap and reopen lich. Until then every session runs on the machine.",
   }
 }
+
+// What confinement costs a session, in the one wording every surface that puts
+// the question uses: the New worktree dialog's row and the New session menu's
+// item. "Its checkout" rather than "this worktree" because the menu also opens
+// sessions in the project's own directory.
+export const CONFINED_MEANS =
+  "An empty home holding only the agent's own state, the machine read-only, and writes only inside its checkout. The network stays on."

--- a/frontend/src/lib/use-sandbox-choice.ts
+++ b/frontend/src/lib/use-sandbox-choice.ts
@@ -59,8 +59,9 @@ export function useSandboxChoice(
       setAvailable(canConfine)
       setChoice(sandboxDefaultFor(sandboxLevel(scoped || global), worktree))
     }
-    // A settings read that fails leaves the row absent and the session
-    // unconfined, which is what lich did before the sandbox existed.
+    // A settings read that fails leaves the row absent, which hands the session
+    // back to the rung's own answer at spawn time (store.SandboxDefault) rather
+    // than to a box that never loaded.
     void load().catch(() => undefined)
     return () => {
       stale = true

--- a/frontend/src/lib/use-sandbox-rung.ts
+++ b/frontend/src/lib/use-sandbox-rung.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react"
 import { createKeyedStore } from "@/lib/keyed-store"
 import { sandboxKey, sandboxLevel, type SandboxLevel } from "@/lib/providers-store"
 import { Store, System } from "@/lib/rpc"
@@ -62,4 +62,60 @@ export function useSandboxRung(providerId: string, projectId: string): SandboxLe
     load(key)
   }, [key])
   return useKeyedStore(rungs, key)
+}
+
+/** The providers in this project whose rung is "Ask each time": the ones a menu
+ * has to put the confinement question to before it opens a card, since that
+ * rung has no answer of its own. Every other rung, and a machine that cannot
+ * confine, is absent — the menu opens the card on the click as it always has.
+ *
+ * Reads the same store useSandboxRung does, so a card comparing a provider's
+ * rung and a menu asking about it cost one round trip between them, and the
+ * pane that writes a rung refreshes both. */
+export function useSandboxAsk(
+  providerIds: readonly string[],
+  projectId: string,
+): ReadonlySet<string> {
+  // The array is rebuilt on every render of the menu; its contents are not.
+  const ids = providerIds.join(" ")
+  const keys = useMemo(
+    () =>
+      ids
+        .split(" ")
+        .filter(Boolean)
+        .map((id) => rungKey(id, projectId))
+        .filter(Boolean),
+    [ids, projectId],
+  )
+
+  useEffect(() => {
+    for (const key of keys) {
+      if (!asked.has(key)) {
+        asked.add(key)
+        load(key)
+      }
+    }
+  }, [keys])
+
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      const offs = keys.map((key) => rungs.subscribe(key, onChange))
+      return () => {
+        for (const off of offs) {
+          off()
+        }
+      }
+    },
+    [keys],
+  )
+  // Snapshotted as a joined string rather than a Set: useSyncExternalStore
+  // compares snapshots by identity, and a collection rebuilt on every read is a
+  // new one every render.
+  const asking = useSyncExternalStore(subscribe, () =>
+    keys
+      .filter((key) => rungs.get(key) === "ask")
+      .map((key) => key.split("\n")[0])
+      .join(" "),
+  )
+  return useMemo(() => new Set(asking.split(" ").filter(Boolean)), [asking])
 }

--- a/frontend/src/providers/projects-context.ts
+++ b/frontend/src/providers/projects-context.ts
@@ -1,6 +1,7 @@
 import { createContext, useContext } from "react"
 import type { ClosedSession, Project, RecentProject } from "@/lib/api-types"
 import type { Session, SessionKind, SessionState } from "@/lib/session/sessions"
+import type { SandboxAnswer } from "@/lib/use-sandbox-choice"
 
 export interface ProjectsValue {
   projects: Project[]
@@ -21,7 +22,12 @@ export interface ProjectsValue {
   closeProject: (id: string) => void
   /** Open a new session in a project and focus it, returning its id. Kind
    * defaults to the project's provider choice; path to its own directory. */
-  newSession: (projectId: string, kind?: SessionKind, path?: string) => string
+  newSession: (
+    projectId: string,
+    kind?: SessionKind,
+    path?: string,
+    sandbox?: SandboxAnswer,
+  ) => string
   /** Open a project-default session rooted at a git worktree, labeled after it,
    * returning its id. sandbox is the dialog's confinement answer ("on"/"off"),
    * "" to follow the provider's rung. from is the session being forked into this

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -73,6 +73,7 @@ import { NotificationsOptIn } from "@/components/NotificationsOptIn"
 import { refreshGitStatus } from "@/lib/git/use-git-status"
 import { markSessionSeen, restoreSessionUnread } from "@/lib/session/use-session-status"
 import { useHotkey } from "@/lib/use-hotkey"
+import type { SandboxAnswer } from "@/lib/use-sandbox-choice"
 import { neighborProjectId } from "@/lib/project-order"
 import { requestTerminalFocus } from "@/lib/terminal/focus-request"
 import { useSettings } from "./settings"
@@ -436,16 +437,31 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
     [projects, activeProjectId, navigate],
   )
 
-  const newSession = useCallback((projectId: string, kind?: SessionKind, path = "") => {
-    const sessionId = newSessionId()
-    const resolvedKind = resolveNewSessionKind(kind, projectNewSessionKind(projectId))
-    const next = addSession(sessionsRef.current, projectId, sessionId, resolvedKind, path)
-    const project = next[projectId]
-    const created = project.sessions[project.sessions.length - 1]
-    commit(next)
-    void Store.AddSession(projectId, sessionId, created.label, resolvedKind, path, project.nextSeq)
-    return sessionId
-  }, [])
+  // sandbox is the confinement answer the launch menu collected on the "Ask
+  // each time" rung — "" from every caller with nowhere to put the question,
+  // which hands the session to the rung's own answer at spawn time
+  // (store.SandboxDefault).
+  const newSession = useCallback(
+    (projectId: string, kind?: SessionKind, path = "", sandbox: SandboxAnswer = "") => {
+      const sessionId = newSessionId()
+      const resolvedKind = resolveNewSessionKind(kind, projectNewSessionKind(projectId))
+      const next = addSession(sessionsRef.current, projectId, sessionId, resolvedKind, path)
+      const project = next[projectId]
+      const created = project.sessions[project.sessions.length - 1]
+      commit(next)
+      void Store.AddSession(
+        projectId,
+        sessionId,
+        created.label,
+        resolvedKind,
+        path,
+        project.nextSeq,
+        sandbox,
+      )
+      return sessionId
+    },
+    [],
+  )
 
   // sandbox is the answer the new-worktree dialog collected: "on", "off", or ""
   // when the machine cannot confine anything and nothing was asked.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -415,17 +415,27 @@ func (c *client) deliver(opened spawn.Session, prompt string) (relay.Result, err
 // minutes, and no instruction to "give it a moment" survives that. Sending is
 // what waits now (relay.awaitReady), so the honest thing to say is that the
 // message will be held.
+//
+// The confinement clause is only there when the session is confined: it changes
+// what the session can do — an empty home, no credentials it was not granted,
+// writes only inside its checkout — and a caller that discovers that from a
+// failure inside the session has to diagnose it from the far end.
 func openedText(opened spawn.Session) string {
 	where := fmt.Sprintf("project %q", opened.Project)
 	if opened.Path != "" {
 		where = fmt.Sprintf("%s, in worktree %s", where, opened.Path)
 	}
+	confined := ""
+	if opened.Confined {
+		confined = " It runs confined: an empty home holding only its agent's own state, the " +
+			"machine read-only, and writes only inside its checkout."
+	}
 	return fmt.Sprintf(
-		"Opened session %q (%s) in %s.\n"+
+		"Opened session %q (%s) in %s.%s\n"+
 			"It answers to %q and to %q. Its agent may still be starting — a fresh "+
 			"worktree runs the project's setup script first — so a task you send it "+
 			"is held until the agent is up rather than lost.\n",
-		opened.Label, opened.Kind, where, opened.Label, opened.Name,
+		opened.Label, opened.Kind, where, confined, opened.Label, opened.Name,
 	)
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1071,3 +1071,27 @@ func TestWorktreesSaysWhenThereAreNone(t *testing.T) {
 		t.Errorf("json = %q, want [] — a script should not have to handle null", jsonOut)
 	}
 }
+
+// The session's confinement is only in the text when there is one: an unconfined
+// session is what lich did before the sandbox existed, and a line about it on
+// every open is a line nobody reads by the third one.
+func TestOpenSaysWhenTheSessionRunsConfined(t *testing.T) {
+	unconfined := newFakeLich(t, openedBody)
+	_, plain, _ := run(t, unconfined, "open", "--worktree", "auth-fix")
+	if strings.Contains(plain, "confined") {
+		t.Errorf("an unconfined session was described as one:\n%s", plain)
+	}
+
+	f := newFakeLich(t, strings.TrimSuffix(openedBody, "}")+`,"confined":true}`)
+	code, stdout, stderr := run(t, f, "open", "--worktree", "auth-fix")
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %q", code, stderr)
+	}
+	// What the confinement costs the caller, not the word alone: nobody was here
+	// to answer the rung, so the session's limits have to arrive with it.
+	for _, phrase := range []string{"runs confined", "empty home", "read-only", "its checkout"} {
+		if !strings.Contains(stdout, phrase) {
+			t.Errorf("output is missing %q:\n%s", phrase, stdout)
+		}
+	}
+}

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -385,9 +385,11 @@ var mcpTools = []mcpTool{
 			"first and roots the new session in it, which is how you give a task its own " +
 			"checkout instead of sharing yours — and optionally hands it the task in the same " +
 			"call, so fanning work out costs one call per worker instead of two. Returns the " +
-			"names the new session is addressed by, and, when a task came with it, that task's " +
-			"outcome: the answer if it was quick, otherwise a ticket to carry on from, exactly " +
-			"as send_to_session returns one.",
+			"names the new session is addressed by, whether it runs confined — nobody is here " +
+			"to answer the sandbox's \"ask each time\" rung, so a session opened this way takes " +
+			"the confined side of it — and, when a task came with it, that task's outcome: the " +
+			"answer if it was quick, otherwise a ticket to carry on from, exactly as " +
+			"send_to_session returns one.",
 		Schema: schema(map[string]any{
 			"project": property("string",
 				"Project to open the session in: the name of one already open, or the "+

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -151,6 +151,8 @@ type spawnStore struct {
 	model string
 	// renamed is the session id and label the last rename wrote.
 	renamed [2]string
+	// confines is what the sandbox rung answers a caller with nobody to ask.
+	confines bool
 }
 
 func (*spawnStore) LoadState() ([]store.Project, error) {
@@ -175,6 +177,12 @@ func (s *spawnStore) SetSessionModel(_, model string) error {
 }
 
 func (s *spawnStore) SetSessionEntrypoint(_, _ string) error { return nil }
+
+func (s *spawnStore) SandboxDefault(_, _, _ string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.confines
+}
 
 func (s *spawnStore) DeleteSession(_, _, _ string) error {
 	s.mu.Lock()

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -83,6 +83,7 @@ type Sessions interface {
 	AddSessionFrom(
 		projectID, sessionID, label, kind, path string, nextSeq int, originID, originLabel string,
 	) error
+	SandboxDefault(providerID, projectID, cwd string) bool
 	SetSessionModel(sessionID, model string) error
 	SetSessionEntrypoint(sessionID, entrypoint string) error
 	RenameSession(sessionID, label string) error
@@ -128,6 +129,10 @@ type Events interface {
 // the store's own spelling. NextSeq is the project's label counter after this
 // session took its number. OriginSessionID and OriginLabel name the session that
 // asked for this one — empty when the caller was not a session at all.
+// Confined is whether the session opened inside the sandbox. Nobody is at this
+// end to be asked, so it is the rung's own answer (store.SandboxDefault), and
+// saying it is what keeps a caller from discovering the empty home and the
+// read-only machine by running into them.
 type Session struct {
 	ID              string `json:"id"`
 	ProjectID       string `json:"projectId"`
@@ -139,6 +144,7 @@ type Session struct {
 	NextSeq         int    `json:"nextSeq"`
 	OriginSessionID string `json:"originSessionId"`
 	OriginLabel     string `json:"originLabel"`
+	Confined        bool   `json:"confined"`
 }
 
 // Service opens sessions on behalf of a caller outside the window.
@@ -248,6 +254,7 @@ func (s *Service) Open(fromID, projectName, kind, worktree, base, model string) 
 		NextSeq:         target.NextSeq + 1,
 		OriginSessionID: originID,
 		OriginLabel:     originLabel,
+		Confined:        s.sessions.SandboxDefault(kind, target.ID, cwd),
 	}
 	if err := s.sessions.AddSessionFrom(
 		target.ID, id, label, kind, stored, opened.NextSeq, originID, originLabel,

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -49,6 +49,11 @@ type fakeSessions struct {
 	// renameErr is the write refusing.
 	renamed   map[string]string
 	renameErr error
+	// confines is the rung's own answer for a caller with nobody to ask, and
+	// sandboxAsked records the (provider, project, cwd) each Open resolved it
+	// for — the trio the real store scopes the rung by.
+	confines     bool
+	sandboxAsked [][3]string
 }
 
 // closedRow is one session the store was asked to take out of the workspace.
@@ -141,6 +146,11 @@ func (f *fakeSessions) AddSessionFrom(
 		}
 	}
 	return nil
+}
+
+func (f *fakeSessions) SandboxDefault(providerID, projectID, cwd string) bool {
+	f.sandboxAsked = append(f.sandboxAsked, [3]string{providerID, projectID, cwd})
+	return f.confines
 }
 
 func (f *fakeSessions) SetSessionModel(sessionID, model string) error {
@@ -842,5 +852,47 @@ func TestSessionIDsDoNotRepeat(t *testing.T) {
 	}
 	if sessions.rows[0].sessionID == sessions.rows[1].sessionID {
 		t.Fatal("two sessions took the same id — the second would overwrite the first's row")
+	}
+}
+
+// Nobody is at this end of an open_session or a `lich open` to answer the
+// sandbox's "ask each time" rung, so the store resolves it and the caller is
+// told which side it landed on — the empty home and the read-only machine are
+// not something to discover from a failure inside the session.
+func TestOpenReportsTheConfinementTheRungResolvedTo(t *testing.T) {
+	svc, sessions, _, _, events := newService(t)
+	sessions.confines = true
+
+	opened, err := svc.Open("s1", "", "", "auth-fix", "", "")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+
+	if !opened.Confined {
+		t.Error("the rung confined the session and the caller was not told")
+	}
+	// Scoped by the trio the rung is keyed on, and by the checkout the session
+	// actually starts in rather than the project's own directory: a worktree is
+	// the side "Worktrees only" confines.
+	if got := sessions.sandboxAsked; len(got) != 1 || got[0] != [3]string{"codex", "p1", "/wt/auth-fix"} {
+		t.Errorf("resolved the rung for %v, want the new session's provider, project and checkout", got)
+	}
+	// The window draws the card from this payload, so a confinement the caller
+	// was told about has to be in it too.
+	if len(events.events) != 1 || events.events[0].data != any(opened) {
+		t.Errorf("the window was told %+v, the caller %+v", events.events, opened)
+	}
+}
+
+func TestOpenReportsNoConfinementWhenTheRungLeavesTheSessionOut(t *testing.T) {
+	svc, sessions, _, _, _ := newService(t)
+	sessions.confines = false
+
+	opened, err := svc.Open("s1", "", "", "", "", "")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if opened.Confined {
+		t.Error("reported a confinement no rung asked for")
 	}
 }

--- a/internal/store/sandbox_test.go
+++ b/internal/store/sandbox_test.go
@@ -65,10 +65,13 @@ func TestSandboxDefaultPerRungAndCheckout(t *testing.T) {
 	}{
 		{SandboxOff, root, false},
 		{SandboxOff, "/work/wt", false},
-		{SandboxAsk, root, false},
-		// Ask hands the decision to whoever opens the session. A caller with
-		// nowhere to ask gets the answer closing the dialog would give.
-		{SandboxAsk, "/work/wt", false},
+		// Contract change: Ask hands the decision to whoever opens the session,
+		// and this function is only reached for it by a caller with nobody to
+		// ask — an MCP open_session, `lich open`, a respawn. That caller is the
+		// unattended agent the rung exists for, so it takes the confined side,
+		// on either checkout.
+		{SandboxAsk, root, true},
+		{SandboxAsk, "/work/wt", true},
 		{SandboxWorktrees, root, false},
 		{SandboxWorktrees, root + "/", false},
 		{SandboxWorktrees, "/work/wt", true},

--- a/internal/store/settings.go
+++ b/internal/store/settings.go
@@ -155,8 +155,9 @@ func (s *Service) SkipPermissions(providerID, projectID, cwd string) bool {
 const (
 	// SandboxOff runs sessions straight on the machine. The default.
 	SandboxOff = "off"
-	// SandboxAsk leaves the answer to the session about to open: the dialog
-	// carries the choice, and a session opened any other way is not confined.
+	// SandboxAsk leaves the answer to whoever opens the session — the New
+	// worktree dialog and the New session menu both put the question — and
+	// confines the session where there is nobody to put it to.
 	SandboxAsk = "ask"
 	// SandboxWorktrees confines sessions in a worktree and leaves the project's
 	// own checkout alone — a worktree is the throwaway one, which is the split
@@ -244,13 +245,16 @@ func (s *Service) SandboxGHToken(projectID string) bool {
 // SkipPermissions does: anything but the project's own directory is a worktree,
 // and a project whose path cannot be read falls back to the main checkout.
 //
-// SandboxAsk answers false here on purpose. It is the rung that hands the
-// decision to whoever opens the session, and every caller that cannot ask —
-// a respawn, an MCP tool, a delegation — has to be left with the answer the
-// user would get by closing the dialog rather than with one nobody chose.
+// SandboxAsk answers true here, and does so whichever checkout the session
+// starts in. It is the rung that hands the decision to whoever opens the
+// session, so this function is only reached for it when there was nobody to
+// hand it to — an MCP open_session, `lich open`, a respawn of a row nothing
+// ever recorded an answer on. The rung exists to confine agents working
+// unattended, and a session no human is opening is the unattended case exactly,
+// so the answer nobody chose is the confined one.
 func (s *Service) SandboxDefault(providerID, projectID, cwd string) bool {
 	switch s.SandboxLevel(providerID, projectID) {
-	case SandboxEverywhere:
+	case SandboxEverywhere, SandboxAsk:
 		return true
 	case SandboxWorktrees:
 		root := s.ProjectPath(projectID)


### PR DESCRIPTION
Deletes the `Only the New worktree dialog asks` ceiling by closing it.

## The trap

`Ask each time` had one place to put its question. A session opened from
the New session menu, by another session, or through the MCP tool never
saw it and took the unconfined answer — the one closing the dialog would
have given. `Worktrees only` and `Everywhere` reached every caller; `Ask`
reached one.

## Where the question goes now

**The New session menu asks, inline.** A provider on `Ask` swaps the menu
for the confinement choice instead of opening the card: the same wording
the dialog's row carries (`lib/sandbox-copy.ts` now holds it once), as a
menu-native checkbox — a plain input inside a base-ui popup takes no part
in the menu's roving focus, and a question only a mouse can answer is not
one. The answer rides the row insert, so the spawn reads it. Every other
rung opens on the click as before, and a machine with no sandbox backend
is never asked.

The step is per provider because the rung is (`store.sandboxKey`): a menu
listing Claude on `Ask` beside Codex on `Everywhere` cannot carry one box
that means both. The rungs are read when the menu opens, not on the
click, so a click never waits on a settings read to know whether it opens
a card or a question — and they are read through `use-sandbox-rung.ts`,
the store #511 landed for the card's drift shield, so a card comparing a
provider's rung and a menu asking about it cost one round trip between
them and the settings pane refreshes both.

**Where nobody can be asked, the rung resolves to confined.**
`store.SandboxDefault` is only reached for `Ask` by a caller with nobody
to ask — `open_session`, `lich open`, a respawn of a row nothing ever
recorded an answer on. That caller is the unattended agent the rung
exists for, so it takes the confined side, on either checkout. The
`open_session` tool description says so, and `spawn.Session` carries the
answer so the call's own result says it for the session it opened.

## Notes

- `sandboxDefaultFor` moves with the Go side, so the worktree dialog now
  arrives on `Ask` with the box ticked — the box has to show the answer
  the spawn would reach on its own.
- `sandboxDrift` is untouched: #511 already excludes `Ask` from the card's
  crossed shield, because that rung's answer is the box that was ticked
  rather than the rung.
- Two tests change because the contract did, both named in the diff:
  `TestSandboxDefaultPerRungAndCheckout` and the `sandboxDefaultFor`
  mirror test.
- `docs/ceilings.md` loses the bullet outright. Settings › Sandbox and
  `docs/cli.md` no longer name the dialog as the only asker.

## What still resolves rather than asks

The one-click entry points have no surface to put a question on and take
the documented default: the rail's `+`, `Ctrl+Shift+T`, the empty-project
button, and Pulls' hand-off to a new session. On `Ask` those now open
confined with the card's shield showing it, where before they opened on
the machine saying nothing. `Ctrl+Shift+T` is why the documented default
is load-bearing rather than a stopgap — a hotkey has nowhere to ask.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green
- [x] `biome ci .` exit 0, `vitest run` 1586 passed, `tsc -b` + `vite build` clean
- [x] New: `session-launch-sandbox.test.tsx` — the menu asks on `Ask`, opens on
      the click for `off`/`worktrees`/`everywhere`/unset, never asks without a
      backend, records both answers, and `Back` returns to the list
- [x] New: `TestOpenReportsTheConfinementTheRungResolvedTo`,
      `TestOpenReportsNoConfinementWhenTheRungLeavesTheSessionOut`,
      `TestOpenSaysWhenTheSessionRunsConfined`
- [ ] Smoke the menu in `task dev` — the frontend gate renders it, but the
      base-ui popup is worth one look on real hardware
