### PR TITLE
fix: key the window's Chromium profile by the browser that opens it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Each browser now gets its own window profile.** lich kept one Chromium
+  profile for whichever browser it opened, so installing a second one, changing
+  the desktop default or pinning `--browser` handed one browser's profile to
+  another — silently on a small version gap, and on a wide one as a window that
+  never opened and a dialog that could only say `exit status 1`. The profile is
+  now keyed by the browser, under `<config>/lich/chromium-profile/`, and the one
+  you already have moves under its key on the first launch so your settings come
+  with it.
 - **oh-my-pi and opencode cards name the MCP tool, not the server that carries
   it.** Both harnesses spell an MCP tool with a single underscore between the
   server and the tool, which a card could not divide, so it spent its width on

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -873,16 +873,15 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   pull request's file on the next one's tree. The re-read is held in state and never in a ref, for the replay
   reason `use-remote-resource.ts` documents, and `use-active-file.test.tsx` pins it by moving the pull
   request on a live component — a probe that remounted instead would call the ref version green.
-- **One Chromium profile serves whichever browser resolution picked**
-  (`internal/chromium/resolve.go`): `<config>/lich/chromium-profile` is not keyed by browser, so the ladder's
-  answer moving — a second Chromium-family browser installed, a new desktop default — hands one browser's
-  profile to another. Only a machine with *several* of them can move at all: with one installed, the default
-  rung and the scan land on the same binary. Measured across a patch-level gap (a profile written by Chromium
-  151.0.7922.169, opened by Helium's 151.0.7922.137): the fork adopts it in silence, the window opens, the UI
-  preferences in its localStorage survive, and the profile's recorded version is rewritten *downwards* — the
-  benign case, and the common one. A wide version gap meets Chromium's own guard against a profile from a
-  newer build instead, which refuses to start; lich then dies on a browser exit code and its dialog can only
-  say `exit status 1`, naming nothing. `LICH_BROWSER` pins the answer; nothing else does.
+- **A profile belongs to one browser, so changing browsers opens lich at its defaults**
+  (`internal/chromium/profiledir.go`): each browser gets `<config>/lich/chromium-profile/<name>-<digest>/`,
+  keyed by the command the ladder resolved, and the page's localStorage — every `lich.*` UI setting — lives
+  inside one of them. Nothing copies between them. Pin a different browser with `--browser`, or watch the
+  bundled window die at startup and fall back to a system one, and lich comes up looking factory-fresh; the
+  settings are still there, under the other key, and going back reaches them. The key is the resolved path
+  and *not* what its symlinks point at, so a store-style install (Nix, snap) keeps one profile across
+  updates through its stable launcher — but a browser pinned at a path carrying its own version, an
+  AppImage among them, is a new browser to this and starts empty on each update.
 - **On Linux, Windows and Apple Silicon the window is lich's own; on an Intel Mac it is the system
   browser's** (`internal/chromium/shell.go`, `shell/`): the Linux packages, the Windows installer and the
   arm64 `Lich.app` ship an embedded Chromium (CEF through kurogane) beside the binary, and the ladder takes
@@ -927,12 +926,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   Windows and macOS run with `no_sandbox` and the same bar everywhere: the Windows sandbox needs
   `cef_sandbox` linked into the executable and the macOS one a helper app initialising it, and neither is
   wired.
-- **The bundled window and a pinned browser share one profile directory** (`shell/src/main.rs`,
-  `internal/chromium.Run`): the shell is told `cache_dir` = the `--user-data-dir` lich hands every browser,
-  so CEF writes `<config>/lich/chromium-profile` as its own Chromium profile. Pin a browser with `--browser`
-  and that profile is handed to a different Chromium — the bullet above, now with the window on one side
-  of it. The prefs write is skipped for the window: it has no account chooser or translate bubble to hold
-  down, and the file would be dead weight in a profile CEF owns.
 - **Under Wayland the window is native Wayland, whatever the GPU** (`shell/src/main.rs`): kurogane forces
   `--ozone-platform=x11` on NVIDIA, on its own reading of NVIDIA's EGL, and 0.45.0 shipped that default.
   It cost file drops: a Wayland file manager dropping on an XWayland window goes through the compositor's

--- a/docs/chromium-shell.md
+++ b/docs/chromium-shell.md
@@ -61,7 +61,8 @@ Migration progress:
 2. **Chromium shell** — DONE (phase 2): `LICH_SHELL=chromium ./lich` serves
    the embedded frontend on the loopback listener (public mount; RPC/WS stay
    token-gated) and opens the system Chromium via `internal/chromium` on a
-   persistent profile (`~/.config/lich/chromium-profile` — localStorage lives
+   persistent profile, one per browser
+   (`~/.config/lich/chromium-profile/<name>-<digest>` — localStorage lives
    there, so the listener port is pinned to 47821, `LICH_LISTEN_PORT`
    overrides; NOT `LICH_PORT`, which is the per-session hook variable).
    Window closed = app exit. Extra flags: `lich -- --ozone-platform=wayland`.

--- a/internal/chromium/chromium.go
+++ b/internal/chromium/chromium.go
@@ -126,6 +126,14 @@ const startupGrace = 30 * time.Second
 // system browser, or ErrNoBrowser and the tab that answers it.
 func Run(url, dataDir, class string, extra []string, onStart func(*os.Process)) error {
 	start := func(browser Result) error {
+		// Here and not in launch: Focus resolves the same directory against a
+		// lich that has already done this, and renaming a profile a running
+		// browser holds open is not a migration.
+		if err := migrateProfile(browser.relocate(dataDir), browser.profileKey()); err != nil {
+			// The profile is only the user's settings; a launch that could not
+			// carry them over still opens a window.
+			slog.Warn("chromium profile migration", "err", err)
+		}
 		return launch(browser, url, dataDir, class, extra, onStart)
 	}
 	return run(RealEnv(), start, notifyDesktop)

--- a/internal/chromium/profiledir.go
+++ b/internal/chromium/profiledir.go
@@ -1,0 +1,122 @@
+package chromium
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// keyLen is how many hex characters of the digest name a profile directory. The
+// set being keyed is the Chromium-family browsers installed on one machine — a
+// handful — so 32 bits is already far more than the collision needs, and the
+// rest of the digest would only lengthen a name a human has to read in their
+// config directory.
+const keyLen = 8
+
+// migratingSuffix names the old profile while it is being moved. The move
+// cannot be a single rename — a directory will not go inside itself — so it
+// steps out to this sibling first, and a launch that finds one left behind
+// finishes the move instead of opening on an empty profile.
+const migratingSuffix = ".moving"
+
+// profileKey names the profile directory this resolution owns: the browser's
+// own name, so the config directory still reads, and a short digest of the
+// exact command behind it, so no two browsers ever share a profile. The whole
+// command and not the path alone, because every Chromium-family Flatpak runs
+// through the same `flatpak` binary.
+//
+// The path is cleaned and deliberately *not* resolved through its symlinks. On
+// Nix, and on any store-style install, the real executable sits under a path
+// carrying its version, so keying on that would hand the user a brand new
+// profile — an empty UI, every `lich.*` setting gone — on each browser update.
+// The launcher the ladder resolved is the stable name for the same browser.
+func (r Result) profileKey() string {
+	exe := filepath.Clean(r.Path)
+	command := strings.Join(append([]string{exe}, r.Prefix...), " ")
+	sum := sha256.Sum256([]byte(command))
+	return browserName(exe) + "-" + hex.EncodeToString(sum[:])[:keyLen]
+}
+
+// browserName reduces the executable's name to what is a directory name
+// everywhere lich runs: lowercased, without Windows' suffix, everything outside
+// [a-z0-9] folded to a dash ("Google Chrome.app/Contents/MacOS/Google Chrome"
+// is a macOS candidate, spaces and all).
+func browserName(exe string) string {
+	base := strings.ToLower(strings.TrimSuffix(filepath.Base(exe), ".exe"))
+	return strings.Trim(strings.Map(func(r rune) rune {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			return r
+		}
+		return '-'
+	}, base), "-")
+}
+
+// relocate is dir where this browser can actually write: only a sandboxed one
+// moves, and it keeps the directory's name so the dev shell still gets a tree
+// of its own.
+//
+// Slashes, not filepath: a ProfileRoot is only ever set by the Flatpak rung,
+// and a Flatpak path is a Linux path whatever this binary was built for.
+// filepath here would follow the *build* OS and hand a Linux sandbox a
+// backslash-joined directory — the same trap the two candidate builders in
+// chromium.go join by hand to stay out of.
+func (r Result) relocate(dir string) string {
+	if r.ProfileRoot == "" {
+		return dir
+	}
+	return r.ProfileRoot + "/" + path.Base(dir)
+}
+
+// ProfileDir is where this browser's profile goes, given the directory lich
+// would use: one keyed subdirectory per browser. A Chromium profile is a
+// particular build's own state, so handing one browser's to another is a silent
+// adoption at best, and at worst a browser that refuses to start on a profile a
+// newer one wrote.
+func (r Result) ProfileDir(dir string) string {
+	if r.ProfileRoot != "" {
+		return r.relocate(dir) + "/" + r.profileKey()
+	}
+	return filepath.Join(dir, r.profileKey())
+}
+
+// migrateProfile moves the single unkeyed profile older lich versions kept
+// directly under root into the subdirectory the browser resolved at this launch
+// now owns. It happens once: afterwards root holds keyed directories alone and
+// the check below finds nothing to move. What is being carried over is the
+// page's localStorage — every `lich.*` UI setting lives in that profile — so
+// skipping it would be a window that came back factory-fresh after an update.
+func migrateProfile(root, key string) error {
+	target := filepath.Join(root, key)
+	moving := root + migratingSuffix
+	if _, err := os.Stat(target); err == nil {
+		return nil
+	}
+	if _, err := os.Stat(moving); err != nil {
+		if !unkeyedProfile(root) {
+			return nil
+		}
+		if err := os.Rename(root, moving); err != nil {
+			return err
+		}
+	}
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		return err
+	}
+	return os.Rename(moving, target)
+}
+
+// unkeyedProfile reports whether root is itself a Chromium profile rather than
+// the directory of profiles it is now. `Local State` is the file every Chromium
+// writes into its user-data-dir and `Default` the profile directory lich names
+// on the command line (Args); the keyed layout has neither at its root.
+func unkeyedProfile(root string) bool {
+	for _, name := range []string{"Local State", profileName} {
+		if _, err := os.Stat(filepath.Join(root, name)); err == nil {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/chromium/profiledir_test.go
+++ b/internal/chromium/profiledir_test.go
@@ -1,0 +1,230 @@
+package chromium
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestProfileKeyIsOnePerBrowser is the whole point of the key: two browsers on
+// one machine never land on the same profile, and one browser lands on the same
+// profile every time — including across an update, which is why the path is not
+// resolved through its symlinks.
+func TestProfileKeyIsOnePerBrowser(t *testing.T) {
+	keys := map[string]string{}
+	for _, exe := range []string{
+		"/usr/bin/chromium",
+		"/usr/bin/helium-browser",
+		"/usr/lib/lich/shell/lich-shell",
+		"/run/current-system/sw/bin/chromium",
+	} {
+		key := (Result{Path: exe}).profileKey()
+		if other, clash := keys[key]; clash {
+			t.Fatalf("%s and %s share the profile key %q", exe, other, key)
+		}
+		keys[key] = exe
+	}
+	first := (Result{Path: "/usr/bin/chromium"}).profileKey()
+	if again := (Result{Path: "/usr/bin/chromium"}).profileKey(); again != first {
+		t.Fatalf("profileKey = %q then %q for the same browser", first, again)
+	}
+	if cleaned := (Result{Path: "/usr/bin//chromium"}).profileKey(); cleaned != first {
+		t.Fatalf("profileKey = %q for an uncleaned path, want %q", cleaned, first)
+	}
+}
+
+// TestProfileKeyDividesFlatpaks pins the reason the key is the whole command
+// and not the executable: every Chromium-family Flatpak is launched through the
+// same `flatpak` binary, so keying on the path alone would put all of them back
+// on one profile.
+func TestProfileKeyDividesFlatpaks(t *testing.T) {
+	chromium := Result{Path: "/usr/bin/flatpak", Prefix: []string{"run", "org.chromium.Chromium"}}
+	brave := Result{Path: "/usr/bin/flatpak", Prefix: []string{"run", "com.brave.Browser"}}
+	if chromium.profileKey() == brave.profileKey() {
+		t.Fatalf("two Flatpak browsers share the profile key %q", chromium.profileKey())
+	}
+}
+
+// TestProfileKeyNamesTheBrowser keeps the directory readable: whoever opens
+// their config directory should be able to tell which profile is whose, in
+// every spelling of an executable the candidate lists hold — Windows' suffix
+// and the spaces in a macOS bundle among them. Splitting a Windows path is
+// filepath's own job and only its Windows build does it, so the case here is
+// the suffix alone.
+func TestProfileKeyNamesTheBrowser(t *testing.T) {
+	cases := map[string]string{
+		"/usr/bin/chromium": "chromium-",
+		filepath.FromSlash("/Google/Chrome/Application/chrome.exe"):                        "chrome-",
+		filepath.FromSlash("/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"): "google-chrome-",
+	}
+	for exe, want := range cases {
+		if key := (Result{Path: exe}).profileKey(); !strings.HasPrefix(key, want) {
+			t.Errorf("profileKey(%s) = %q, want the %q prefix", exe, key, want)
+		}
+	}
+}
+
+// TestProfileDirKeysTheDirectory covers both shapes: the directory lich chose,
+// and the one a Flatpak's sandbox can actually write.
+func TestProfileDirKeysTheDirectory(t *testing.T) {
+	dir := filepath.FromSlash("/home/u/.config/lich/chromium-profile")
+	browser := Result{Path: "/usr/bin/chromium"}
+	want := filepath.Join(dir, browser.profileKey())
+	if got := browser.ProfileDir(dir); got != want {
+		t.Fatalf("ProfileDir = %q, want %q", got, want)
+	}
+
+	flatpak := Result{
+		Path:        "/usr/bin/flatpak",
+		Prefix:      []string{"run", "com.vivaldi.Vivaldi"},
+		ProfileRoot: "/home/u/.var/app/com.vivaldi.Vivaldi/config",
+	}
+	// Slashes even when this test runs on Windows: a Flatpak path is a Linux
+	// path whatever the binary was built for.
+	wantFlatpak := "/home/u/.var/app/com.vivaldi.Vivaldi/config/chromium-profile-dev/" + flatpak.profileKey()
+	if got := flatpak.ProfileDir("/home/u/.config/lich/chromium-profile-dev"); got != wantFlatpak {
+		t.Fatalf("ProfileDir = %q, want %q", got, wantFlatpak)
+	}
+}
+
+// unkeyed lays out the profile older lich versions kept directly under the
+// root, with a file only its localStorage would have, and returns the root.
+func unkeyed(t *testing.T) string {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "chromium-profile")
+	if err := os.MkdirAll(filepath.Join(root, profileName, "Local Storage"), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "Local State"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := os.WriteFile(settings(root), []byte("lich.theme"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return root
+}
+
+// settings names the file standing in for the page's localStorage, relative to
+// whichever root it is under.
+func settings(root string) string {
+	return filepath.Join(root, profileName, "Local Storage", "leveldb")
+}
+
+// TestMigrateProfileCarriesTheSettingsOver is the update path: the one profile
+// every browser shared becomes the profile of the browser that resolved, with
+// the `lich.*` settings in it intact.
+func TestMigrateProfileCarriesTheSettingsOver(t *testing.T) {
+	root := unkeyed(t)
+	key := (Result{Path: "/usr/bin/chromium"}).profileKey()
+	if err := migrateProfile(root, key); err != nil {
+		t.Fatalf("migrateProfile: %v", err)
+	}
+	if _, err := os.Stat(settings(filepath.Join(root, key))); err != nil {
+		t.Fatalf("settings did not survive the move: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "Local State")); err == nil {
+		t.Fatal("the unkeyed profile is still at the root of the directory")
+	}
+	if _, err := os.Stat(root + migratingSuffix); err == nil {
+		t.Fatal("the half-moved directory was left behind")
+	}
+}
+
+// TestMigrateProfileRunsOnce proves the second launch is a no-op rather than a
+// second move: by then the root holds keyed directories alone, and one of them
+// is a live profile.
+func TestMigrateProfileRunsOnce(t *testing.T) {
+	root := unkeyed(t)
+	key := (Result{Path: "/usr/bin/chromium"}).profileKey()
+	if err := migrateProfile(root, key); err != nil {
+		t.Fatalf("first migrateProfile: %v", err)
+	}
+	if err := migrateProfile(root, key); err != nil {
+		t.Fatalf("second migrateProfile: %v", err)
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("read root: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Name() != key {
+		t.Fatalf("root holds %v, want the one keyed profile %q", entries, key)
+	}
+}
+
+// TestMigrateProfileSkipsWhenTheTargetExists: a profile the browser is already
+// using is never overwritten by an older one somebody left at the root.
+func TestMigrateProfileSkipsWhenTheTargetExists(t *testing.T) {
+	root := unkeyed(t)
+	key := (Result{Path: "/usr/bin/chromium"}).profileKey()
+	target := filepath.Join(root, key)
+	if err := os.MkdirAll(target, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := migrateProfile(root, key); err != nil {
+		t.Fatalf("migrateProfile: %v", err)
+	}
+	if entries, err := os.ReadDir(target); err != nil || len(entries) != 0 {
+		t.Fatalf("target = %v (err %v), want the existing profile untouched", entries, err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "Local State")); err != nil {
+		t.Fatalf("the unkeyed profile was moved anyway: %v", err)
+	}
+}
+
+// TestMigrateProfileFinishesAnInterruptedMove: the move is two renames, so a
+// launch that finds the directory parked in between finishes it instead of
+// opening on an empty profile and orphaning the settings.
+func TestMigrateProfileFinishesAnInterruptedMove(t *testing.T) {
+	root := unkeyed(t)
+	key := (Result{Path: "/usr/bin/chromium"}).profileKey()
+	if err := os.Rename(root, root+migratingSuffix); err != nil {
+		t.Fatalf("park: %v", err)
+	}
+	if err := migrateProfile(root, key); err != nil {
+		t.Fatalf("migrateProfile: %v", err)
+	}
+	if _, err := os.Stat(settings(filepath.Join(root, key))); err != nil {
+		t.Fatalf("settings did not survive the interrupted move: %v", err)
+	}
+}
+
+// TestMigrateProfileIgnoresAFreshInstall: nothing to move is not an error, and
+// a machine that never had the unkeyed profile must not have a directory made
+// for it.
+func TestMigrateProfileIgnoresAFreshInstall(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "chromium-profile")
+	if err := migrateProfile(root, "chromium-0badc0de"); err != nil {
+		t.Fatalf("migrateProfile: %v", err)
+	}
+	if _, err := os.Stat(root); err == nil {
+		t.Fatal("migrateProfile created the profile directory on a fresh install")
+	}
+}
+
+// TestFocusFindsTheDirectoryRunUsed is the duplicate-launch path: focusing a
+// running lich hands the URL to a second browser process that Chromium's
+// profile lock forwards to the first, which only works if both processes
+// resolved the same profile directory. Two halves: resolution is a pure
+// function of the machine, and the directory Run migrates into is the one
+// launch opens.
+func TestFocusFindsTheDirectoryRunUsed(t *testing.T) {
+	dir := filepath.FromSlash("/home/u/.config/lich/chromium-profile")
+	machine := fakeEnv{installed: map[string]bool{"chromium": true, "vivaldi": true}}
+
+	run, err := Resolve(machine.env())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	focus, err := Resolve(machine.env())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if run.ProfileDir(dir) != focus.ProfileDir(dir) {
+		t.Fatalf("Focus would open %q, Run opened %q", focus.ProfileDir(dir), run.ProfileDir(dir))
+	}
+	// What Run migrates into (chromium.go) against what launch opens.
+	if got := filepath.Join(run.relocate(dir), run.profileKey()); got != run.ProfileDir(dir) {
+		t.Fatalf("migration target %q is not the profile directory %q", got, run.ProfileDir(dir))
+	}
+}

--- a/internal/chromium/resolve.go
+++ b/internal/chromium/resolve.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -101,22 +100,6 @@ type Result struct {
 func (r Result) Describe() string {
 	command := strings.Join(append([]string{r.Path}, r.Prefix...), " ")
 	return fmt.Sprintf("%s (%s)", command, r.Step)
-}
-
-// ProfileDir is where this browser's profile goes, given the directory lich
-// would use. Only a sandboxed browser moves it, and it keeps the directory's
-// name so the dev shell still gets a profile of its own.
-//
-// Slashes, not filepath: a ProfileRoot is only ever set by the Flatpak rung,
-// and a Flatpak path is a Linux path whatever this binary was built for.
-// filepath here would follow the *build* OS and hand a Linux sandbox a
-// backslash-joined directory — the same trap the two candidate builders in
-// chromium.go join by hand to stay out of.
-func (r Result) ProfileDir(dir string) string {
-	if r.ProfileRoot == "" {
-		return dir
-	}
-	return r.ProfileRoot + "/" + path.Base(dir)
 }
 
 // chromiumNames are the Chromium-family executables lich knows, in preference

--- a/internal/chromium/resolve_test.go
+++ b/internal/chromium/resolve_test.go
@@ -194,10 +194,11 @@ func TestResolveFlatpak(t *testing.T) {
 		t.Fatalf("Resolve = %q %v, want a flatpak run of the installed browser", got.Path, got.Prefix)
 	}
 	// The profile has to land inside the sandbox's own directory, and keep the
-	// name it had so the dev shell still gets a profile of its own.
+	// name it had so the dev shell still gets a profile of its own. The
+	// per-browser subdirectory under it is profiledir_test.go's.
 	want := "/home/u/.var/app/com.vivaldi.Vivaldi/config/chromium-profile-dev"
-	if dir := got.ProfileDir("/home/u/.config/lich/chromium-profile-dev"); dir != want {
-		t.Fatalf("ProfileDir = %q, want %q", dir, want)
+	if dir := got.relocate("/home/u/.config/lich/chromium-profile-dev"); dir != want {
+		t.Fatalf("relocate = %q, want %q", dir, want)
 	}
 }
 
@@ -222,12 +223,12 @@ func TestResolveNoBrowser(t *testing.T) {
 	}
 }
 
-// TestProfileDirUnchanged proves the relocation is Flatpak's alone: every other
+// TestRelocateUnchanged proves the relocation is Flatpak's alone: every other
 // browser reads the directory lich chose.
-func TestProfileDirUnchanged(t *testing.T) {
+func TestRelocateUnchanged(t *testing.T) {
 	dir := "/home/u/.config/lich/chromium-profile"
-	if got := (Result{Path: "/usr/bin/chromium"}).ProfileDir(dir); got != dir {
-		t.Fatalf("ProfileDir = %q, want %q", got, dir)
+	if got := (Result{Path: "/usr/bin/chromium"}).relocate(dir); got != dir {
+		t.Fatalf("relocate = %q, want %q", got, dir)
 	}
 }
 


### PR DESCRIPTION
lich kept one profile directory, `<config>/lich/chromium-profile`, for whichever browser the resolution ladder picked. A second Chromium-family browser installed, a new desktop default, or `--browser` pinning one is the ladder answering differently, and the profile a different Chromium wrote is then handed to it. Across a patch-level gap the adoption is silent; across a wide one it meets Chromium's own guard against a profile from a newer build, which refuses to start, and lich dies on a dialog that can only say `exit status 1`. The bundled window is on one side of that trade too: CEF is told the same directory as its `cache_dir`, so pinning a browser hands it the window's own profile.

## The key

Each resolution now owns a subdirectory under that path, `<name>-<digest>`, named for the browser and keyed by a short digest of the command behind it. Three decisions in it:

- **The whole command, not the executable.** Every Chromium-family Flatpak runs through the same `flatpak` binary, so keying on the path alone would put all of them back on one profile.
- **The resolved path, never what its symlinks point at.** On Nix and on any store-style install the real executable sits under a path carrying its version, so resolving symlinks would hand the user an empty profile on each browser update. The launcher the ladder found is the stable name for the same browser.
- **`Focus` resolves the same ladder as `Run`**, and therefore the same directory. That is what Chromium's profile lock needs in order to forward a duplicate launch to the running instance instead of opening a second lich.

## The migration

The profile already on disk moves under the key of the browser that resolves at the first launch after the update, once, so the page's localStorage (every `lich.*` UI setting) goes with it and nobody comes back to a window at its defaults. It is two renames, since a directory will not go inside itself, and a launch that finds one parked in between finishes the move rather than starting empty.

`Run` does the migration and `Focus` does not: the instance `Focus` hands over to has already done it, and renaming a profile a running browser holds open is not a migration.

## Unchanged

The Chromium flags, and the prefs write still skipped for the bundled window: it has no account chooser or translate bubble to hold down, and the file would be dead weight in a profile CEF owns.

## Ceilings

Two bullets go, both fixed: "One Chromium profile serves whichever browser resolution picked" and "The bundled window and a pinned browser share one profile directory". One replaces them, for the limit the fix creates rather than the fix itself: a profile now belongs to one browser, so changing browsers (a `--browser` pin, or the bundled window dying at startup and falling back to a system one) opens lich at its defaults, with the old settings still there under the other key. It also names the one path shape that still starts empty on every update, a browser pinned at a versioned path such as an AppImage.

`docs/chromium-shell.md` gains the new layout where it described the old one, and `CHANGELOG.md` gains one line under Fixed.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` green; `go test -race -count=3 ./internal/chromium/` green
- [x] `for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done` clean (this package has OS seams)
- [x] New tests cover the key derivation (one per browser, stable across updates, Flatpaks divided, the directory readable on each platform's spelling), the migration (carries the settings, runs once, skips when the target exists, finishes an interrupted move, no-ops on a fresh install), and that Focus resolves the directory Run used. Every new function is at 100% except `migrateProfile` at 83%, the two rename-failure branches.
- [ ] Not run on a machine with two Chromium-family browsers installed and a real profile to migrate; the migration is covered by tests over a laid-out directory only.