### PR TITLE
fix: remember the plugin rows on Settings › Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Settings › Updates no longer blanks its plugin rows on the way in.** The
+  per-provider list waited on a fresh read of every CLI on every visit, so
+  returning to the pane showed an empty block for a moment while the rest of
+  the screen was already painted. It now paints the last answer and re-reads
+  underneath, and "Check for updates" still says whether the check got through.
 - **oh-my-pi and opencode cards name the MCP tool, not the server that carries
   it.** Both harnesses spell an MCP tool with a single underscore between the
   server and the tool, which a card could not divide, so it spent its width on

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -844,12 +844,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   seen, and the ones who have not will read the binary they install. A wrong headline is a patch release. The
   update toast reads nothing from the release but its tag, on purpose: the toast says a release exists, and
   the dialog is where it speaks.
-- **`agentplugin.Status` is the one settings read that is not remembered** (`UpdatesSettings.tsx`): it costs
-  ~180 ms and its rows blank on every visit to Updates, while every other read on the screen paints from the
-  last answer. It is not an oversight — `PluginSetting` awaits that read for its *outcome*, telling "Checked."
-  from "Check failed — are you online?", and `useRemoteResource`'s `refresh` is fire-and-forget with the
-  failure folded into state, so there is nothing to await. Caching it means rewiring both of that pane's flows
-  around a resource's `loading` and `error`, and that is the price, not a line of config.
 - **`useBinaryCheck` is deliberately not a `useRemoteResource` caller** (`frontend/src/lib/use-binary-check.ts`):
   it answers `null` until a verdict is in and debounces its input, because the value it checks arrives one
   keystroke at a time — and `useRemoteResource` has no debounce seam to hang that on. So the path verdicts on

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -769,6 +769,9 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   directory that is gone. The window is one round-trip (it re-reads on mount, on focus, and after this screen
   creates a checkout itself) and git refuses the wrong move anyway, which is why it is filed rather than left
   cold — but it is the one to think twice about before the next `cache` is added to something a button reads.
+  The plugin rows on Settings › Updates (`PluginSetting`) are the second case: a plugin installed or removed
+  from a terminal while the user was elsewhere is painted as it was on the way back in, so the row offers an
+  Install that has already happened, or withholds one that has not, until that visit's read lands.
 - **Unsent prose on the pull request screen lives in memory, and nothing collects it**
   (`frontend/src/lib/pulls/draft-store.ts`): a description, a comment and every thread reply survive each
   unmount the screen can produce, and none of them survives a reload — unlike the pending review beside them,

--- a/frontend/src/components/settings/PluginSetting.test.tsx
+++ b/frontend/src/components/settings/PluginSetting.test.tsx
@@ -105,6 +105,9 @@ describe("the plugin pane", () => {
 
     expect(text()).toContain("Check failed — are you online?")
     expect(text()).not.toContain("Checked.")
+    // Beside the rows, not in place of them: a check that could not be made
+    // says nothing about the answer already on the pane.
+    expect(text()).toContain("Claude Code")
     await mounted.unmount()
   })
 

--- a/frontend/src/components/settings/PluginSetting.test.tsx
+++ b/frontend/src/components/settings/PluginSetting.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+//
+// The plugin pane, mounted for real. What it is about happens between two
+// visits to Updates — the rows have to come back painted rather than blank —
+// and the outcome of a check is read off the resource the refresh left behind
+// rather than awaited, which is a claim about a render and not about a value.
+//
+// The harness is imported before anything that reaches react-dom, for the
+// reason render-budget.test.tsx names.
+import { mountBudget } from "@/test/render-budget"
+import { createElement } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { clearRemoteCache } from "@/lib/remote-cache"
+import type { PluginStatus } from "@/lib/api-types"
+import { PluginSetting } from "./PluginSetting"
+
+const NOT_INSTALLED: PluginStatus = {
+  provider: "claude",
+  name: "Claude Code",
+  available: true,
+  installed: false,
+  installedVersion: "",
+  latestVersion: "0.9.0",
+  updateAvailable: false,
+}
+
+const INSTALLED: PluginStatus = {
+  ...NOT_INSTALLED,
+  installed: true,
+  installedVersion: "0.9.0",
+}
+
+/** What the next Status() call answers. Swapped per test, and mid-test. */
+let status: () => Promise<PluginStatus[]> = () => Promise.resolve([NOT_INSTALLED])
+const installs: string[] = []
+/** A read that never lands, so whatever is on screen came from the cache. */
+const pending = () => new Promise<PluginStatus[]>(() => {})
+
+vi.mock("@/lib/rpc", () => ({
+  AgentPlugin: {
+    Status: () => status(),
+    Install: (provider: string) => {
+      installs.push(provider)
+      return Promise.resolve(null)
+    },
+    Update: () => Promise.resolve(null),
+  },
+}))
+
+const text = () => document.body.textContent ?? ""
+
+function click(label: string): void {
+  const button = [...document.querySelectorAll("button")].find(
+    (element) => element.textContent?.trim() === label,
+  )
+  if (!button) {
+    throw new Error(`no "${label}" button on screen: ${text()}`)
+  }
+  button.click()
+}
+
+beforeEach(() => {
+  clearRemoteCache()
+  installs.length = 0
+  status = () => Promise.resolve([NOT_INSTALLED])
+})
+
+describe("the plugin pane", () => {
+  it("paints the filed rows on the next visit, before the refetch answers", async () => {
+    const first = await mountBudget(createElement(PluginSetting))
+    await first.act(() => {})
+    expect(text()).toContain("Claude Code")
+    await first.unmount()
+
+    // The read this mount runs never lands, so a row on screen is the filed
+    // answer and nothing else — which is the blank this pane used to show.
+    status = pending
+    const second = await mountBudget(createElement(PluginSetting))
+
+    expect(text()).toContain("Claude Code")
+    await second.unmount()
+  })
+
+  it("says the check was made once the refresh has landed", async () => {
+    const mounted = await mountBudget(createElement(PluginSetting))
+    await mounted.act(() => {})
+    expect(text()).not.toContain("Checked.")
+
+    await mounted.act(() => click("Check for updates"))
+
+    expect(text()).toContain("Checked.")
+    await mounted.unmount()
+  })
+
+  // The outcome is the resource's `error`, not a rejection: refresh folds the
+  // failure into state, so nothing is thrown for a catch to read.
+  it("says the check failed when the read did", async () => {
+    const mounted = await mountBudget(createElement(PluginSetting))
+    await mounted.act(() => {})
+    // Broken after the pane was painted, so the outcome is this refresh's and
+    // not something the mount left behind.
+    status = () => Promise.reject(new Error("connection refused"))
+
+    await mounted.act(() => click("Check for updates"))
+
+    expect(text()).toContain("Check failed — are you online?")
+    expect(text()).not.toContain("Checked.")
+    await mounted.unmount()
+  })
+
+  it("re-reads after an install and files what it read", async () => {
+    const mounted = await mountBudget(createElement(PluginSetting))
+    await mounted.act(() => {})
+    status = () => Promise.resolve([INSTALLED])
+
+    await mounted.act(() => click("Install"))
+
+    expect(installs).toEqual(["claude"])
+    expect(text()).toContain("v0.9.0")
+    expect(text()).not.toContain("Plugin not installed")
+    await mounted.unmount()
+
+    // The filed answer moved with it, so the next visit does not offer an
+    // install that has already happened.
+    status = pending
+    const second = await mountBudget(createElement(PluginSetting))
+
+    expect(text()).toContain("v0.9.0")
+    expect(text()).not.toContain("Plugin not installed")
+    await second.unmount()
+  })
+})

--- a/frontend/src/components/settings/PluginSetting.tsx
+++ b/frontend/src/components/settings/PluginSetting.tsx
@@ -12,42 +12,51 @@ import {
   RESTART_HINT,
 } from "@/lib/update/plugin-gate"
 import { runWithToast } from "@/lib/toast-async"
+import { useRemoteResource } from "@/lib/use-remote-resource"
 import type { PluginStatus } from "@/lib/api-types"
-
-interface PluginSettingProps {
-  /** One entry per provider that can run the plugin; null until Status answers. */
-  statuses: PluginStatus[] | null
-  /** Re-read Status after a mutation, so the rows show what just changed. */
-  onRefresh: () => Promise<void>
-}
 
 // PluginSetting is the plugin's row per provider CLI: its installed version, the
 // action that closes the gap, and — for a CLI the machine does not have — the
 // plain reason there is nothing to do.
-export function PluginSetting({ statuses, onRefresh }: PluginSettingProps) {
+export function PluginSetting() {
   const [busy, setBusy] = useState(false)
-  const [result, setResult] = useState("")
+  // Whether the user has asked for a check since this pane was mounted. The
+  // outcome itself is not stored: it is whatever the refresh left in `error`,
+  // read at render, so a later failure cannot sit under an older "Checked.".
+  const [checked, setChecked] = useState(false)
+  // One entry per provider that can run the plugin; null until Status answers.
+  // That read costs ~180 ms and every row here is drawn from it, so it is filed
+  // like the reads above it: coming back to Updates paints the last answer and
+  // revalidates underneath. The call takes no arguments, so the caller's own
+  // name is the whole of what identifies the answer it files.
+  const {
+    data: statuses,
+    error,
+    refresh,
+  } = useRemoteResource<PluginStatus[] | null>("agent-plugin-status", () => AgentPlugin.Status(), {
+    empty: null,
+    cache: "settings.pluginStatus",
+  })
 
   const run = async (call: () => Promise<null>, progress: string, done: string, failed: string) => {
     setBusy(true)
     if (await runWithToast(progress, call, done, failed)) {
-      await onRefresh()
+      // The filed answer is replaced by this read, so the next visit shows what
+      // the install just changed rather than the rows it changed away from.
+      await refresh()
     }
     setBusy(false)
   }
 
   const check = async () => {
     setBusy(true)
-    setResult("")
-    try {
-      await onRefresh()
-      setResult("Checked.")
-    } catch {
-      setResult("Check failed — are you online?")
-    } finally {
-      setBusy(false)
-    }
+    setChecked(false)
+    await refresh()
+    setChecked(true)
+    setBusy(false)
   }
+
+  const outcome = checked && (error ? "Check failed — are you online?" : "Checked.")
 
   const spinner = <LoaderCircle className="size-4 animate-spin" />
   const showTrustHint = statuses?.some((s) => s.provider === "codex" && s.installed)
@@ -130,7 +139,7 @@ export function PluginSetting({ statuses, onRefresh }: PluginSettingProps) {
           <Button size="sm" variant="outline" onClick={() => void check()} disabled={busy}>
             Check for updates
           </Button>
-          {result && <span className="text-xs text-muted-foreground">{result}</span>}
+          {outcome && <span className="text-xs text-muted-foreground">{outcome}</span>}
         </div>
       </div>
     </SettingBlock>

--- a/frontend/src/components/settings/UpdatesSettings.tsx
+++ b/frontend/src/components/settings/UpdatesSettings.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import { LoaderCircle, RefreshCw, Sparkles } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { SettingBlock } from "./SettingBlock"
 import { PatchNotesDialog } from "@/components/PatchNotesDialog"
 import { PluginSetting } from "./PluginSetting"
-import { AgentPlugin, PatchNotes } from "@/lib/rpc"
+import { PatchNotes } from "@/lib/rpc"
 import { runUpdateCheck } from "@/lib/update/update-check"
 import { useRemoteResource } from "@/lib/use-remote-resource"
-import type { PatchNotes as PatchNotesData, PluginStatus } from "@/lib/api-types"
+import type { PatchNotes as PatchNotesData } from "@/lib/api-types"
 
 export function UpdatesSettings() {
   const [notesOpen, setNotesOpen] = useState(false)
@@ -18,22 +18,6 @@ export function UpdatesSettings() {
     () => PatchNotes.Current(),
     { empty: null, cache: "settings.patchNotes" },
   )
-  // Deliberately not a remembered lookup, unlike the patch notes above it.
-  // PluginSetting awaits this for its *outcome* — "Checked." against "Check
-  // failed — are you online?" — and useRemoteResource's refresh is
-  // fire-and-forget with the failure folded into state, so there is nothing to
-  // await. The rows blank for one read on the way back in; the alternative was
-  // rewiring both of that pane's flows around a resource's loading and error.
-  const [plugin, setPlugin] = useState<PluginStatus[] | null>(null)
-
-  const refreshPlugin = async () => {
-    setPlugin(await AgentPlugin.Status())
-  }
-
-  useEffect(() => {
-    void refreshPlugin()
-  }, [])
-
   const checkApp = async () => {
     setChecking(true)
     setCheckResult("")
@@ -89,7 +73,7 @@ export function UpdatesSettings() {
         )}
       </SettingBlock>
 
-      <PluginSetting statuses={plugin} onRefresh={refreshPlugin} />
+      <PluginSetting />
     </>
   )
 }

--- a/frontend/src/lib/use-remote-resource.test.tsx
+++ b/frontend/src/lib/use-remote-resource.test.tsx
@@ -227,7 +227,9 @@ describe("a remembered lookup", () => {
     frames.length = 0
     const second = await mountBudget(probe(frames, fail, CACHE))
     await second.act(() => {})
-    expect(frames[frames.length - 1]?.error).toContain("not found")
+    // On the screen too, not only in the cache: the failure is reported beside
+    // the rows the last answer painted, never in place of them.
+    expect(states(frames)).toEqual([ANSWERED, '"answer" loading=false error=gh: not found'])
     await second.unmount()
 
     frames.length = 0

--- a/frontend/src/lib/use-remote-resource.test.tsx
+++ b/frontend/src/lib/use-remote-resource.test.tsx
@@ -238,3 +238,51 @@ describe("a remembered lookup", () => {
     await third.unmount()
   })
 })
+
+// The promise refresh hands back, which is what lets a caller report an outcome
+// — "Checked." against "Check failed — are you online?" — from `error` once the
+// call is done, instead of from a rejection it is never given.
+describe("refresh", () => {
+  it("settles on the answer, and on a failure without rejecting", async () => {
+    const frames: Frame[] = []
+    let land: (value: string) => void = () => {}
+    let failing = false
+    let again: () => Promise<void> = () => Promise.resolve()
+
+    function Probe() {
+      const load = () =>
+        failing
+          ? Promise.reject(new Error("offline"))
+          : new Promise<string>((resolve) => {
+              land = resolve
+            })
+      const r = useRemoteResource(KEY, load, { empty: "" })
+      again = r.refresh
+      useLayoutEffect(() => {
+        frames.push({ data: r.data, loading: r.loading, error: r.error })
+      })
+      return null
+    }
+
+    const mounted = await mountBudget(createElement(StrictMode, null, createElement(Probe)))
+
+    let settled = false
+    const asked = again().then(() => {
+      settled = true
+    })
+    await mounted.act(() => {})
+    // Still out: the promise stands for the round trip, not for the call.
+    expect(settled).toBe(false)
+    await mounted.act(() => land("answer"))
+    await asked
+    expect(settled).toBe(true)
+
+    failing = true
+    // Deliberately not caught. A refresh that rejected would fail the run here,
+    // and the caller waiting to read `error` would never run at all.
+    await mounted.act(async () => await again())
+
+    expect(frames[frames.length - 1]?.error).toContain("offline")
+    await mounted.unmount()
+  })
+})

--- a/frontend/src/lib/use-remote-resource.ts
+++ b/frontend/src/lib/use-remote-resource.ts
@@ -8,7 +8,12 @@ export interface RemoteResource<T> {
   data: T
   loading: boolean
   error: string | null
-  refresh: () => void
+  /** Run the lookup again. The promise settles once the answer is in `data` or
+   * the failure in `error`, and never rejects — a caller that only wants the
+   * refetch ignores it, and one that reports an outcome ("Checked." against
+   * "Check failed") awaits it and then reads `error`, which is where the
+   * failure went. */
+  refresh: () => Promise<void>
 }
 
 export interface RemoteResourceOptions<T> {
@@ -82,13 +87,13 @@ export function useRemoteResource<T>(
   const emptyRef = useRef(empty)
   emptyRef.current = empty
 
-  const refresh = useCallback(() => {
+  const refresh = useCallback((): Promise<void> => {
     if (!key) {
       seq.current++
       setData(emptyRef.current)
       setError(null)
       setLoading(false)
-      return
+      return Promise.resolve()
     }
     const mine = ++seq.current
     // A request whose last answer is in hand revalidates underneath: the screen
@@ -99,7 +104,7 @@ export function useRemoteResource<T>(
     if (!cache || readRemoteCache(cache) === undefined) {
       setLoading(true)
     }
-    loadRef
+    return loadRef
       .current()
       .then((result) => {
         // Filed before the sequence check: the key is this closure's own, so a
@@ -133,7 +138,7 @@ export function useRemoteResource<T>(
   }
 
   useEffect(() => {
-    refresh()
+    void refresh()
     if (refetchOnFocus) {
       window.addEventListener("focus", refresh)
     }

--- a/frontend/src/lib/use-remote-resource.ts
+++ b/frontend/src/lib/use-remote-resource.ts
@@ -119,9 +119,13 @@ export function useRemoteResource<T>(
       })
       .catch((err: unknown) => {
         if (mine !== seq.current) return
-        // The filed answer is left standing: a lookup that failed says nothing
-        // about the last one that worked, and the next success replaces it.
-        setData(emptyRef.current)
+        // The filed answer is left standing, on the screen as well as in the
+        // cache: a lookup that failed says nothing about the last one that
+        // worked, and a caller that keeps its answers would otherwise blank a
+        // pane it is about to paint again on the next visit. Everyone else
+        // falls back to empty, where a stale readout has nothing to stand on.
+        const filed = cache ? readRemoteCache<T>(cache) : undefined
+        setData(filed ?? emptyRef.current)
         setError(errorText(err))
       })
       .finally(() => {


### PR DESCRIPTION
## What

`agentplugin.Status` was the one read on Settings › Updates not filed in `remote-cache`: its per-provider rows blanked for ~180 ms on every visit, while the patch notes right above them painted from the last answer. This closes that, and deletes the `docs/ceilings.md` bullet that recorded it.

## Why it was left

`PluginSetting` awaited the read for its *outcome* — "Checked." against "Check failed — are you online?" — and `useRemoteResource`'s `refresh` was fire-and-forget with the failure folded into state, so there was nothing to await.

## How

- `refresh` now returns the call's own promise: it settles once the answer is in `data` or the failure in `error`, and never rejects. Every existing caller ignores the value and is untouched (`() => Promise<void>` is still assignable where `() => void` was declared).
- A failed lookup no longer resets `data` to `empty` where the cache holds an answer — the rows stay on screen and the failure is reported beside them, which is what the pane did before it was cached. Callers without a `cache` are unchanged.
- `PluginSetting` owns the read through `useRemoteResource` with `cache: "settings.pluginStatus"` — the call takes no arguments, so the caller's own name is the whole of what identifies the answer it files. The two props it took are gone.
- The outcome is derived at render from `checked && error`, so a later failure can never sit under an older "Checked.".
- Install and update still re-read after the mutation, which is what replaces the filed answer.

## Ceilings

The bullet this closes is deleted. The plugin rows are a second case of the bullet already there for `use-checkouts` — a filed answer a button reads rather than a label — so that bullet gains a clause naming them: a plugin installed or removed from a terminal is painted as it was until the visit's read lands.

## Tests

- `frontend/src/components/settings/PluginSetting.test.tsx` (new, jsdom): rows paint from the cache on a remount whose read never lands; "Checked." after a good refresh; "Check failed — are you online?" after a broken one, with the rows still standing; an install re-reads and the next visit no longer offers it.
- `frontend/src/lib/use-remote-resource.test.tsx`: `refresh` settles on the round trip, not on the call, and folds a failure into `error` without rejecting; a failed refetch now pins the filed answer on screen as well as in the cache.

## Gate

`biome ci .` exit 0 · `vitest run` 1591 passed (135 files) · `tsc -b` clean · `vite build` clean · `gofmt -l .` clean (no Go touched).