### PR TITLE
fix: keep unsent pull request prose across a reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returning to the pane showed an empty block for a moment while the rest of
   the screen was already painted. It now paints the last answer and re-reads
   underneath, and "Check for updates" still says whether the check got through.
+- **Unsent prose on the pull request screen now survives a reload.** A
+  description being rewritten, a comment being composed and every reply typed
+  into a review thread are kept the way a pending review already was, so an app
+  update or a closed window no longer costs what was written. They are retired
+  when they are sent, when the box is emptied, when their pull request stops
+  being open, and after 30 days, so nothing abandoned is kept forever.
 - **oh-my-pi and opencode cards name the MCP tool, not the server that carries
   it.** Both harnesses spell an MCP tool with a single underscore between the
   server and the tool, which a card could not divide, so it spent its width on

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -772,12 +772,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   The plugin rows on Settings › Updates (`PluginSetting`) are the second case: a plugin installed or removed
   from a terminal while the user was elsewhere is painted as it was on the way back in, so the row offers an
   Install that has already happened, or withholds one that has not, until that visit's read lands.
-- **Unsent prose on the pull request screen lives in memory, and nothing collects it**
-  (`frontend/src/lib/pulls/draft-store.ts`): a description, a comment and every thread reply survive each
-  unmount the screen can produce, and none of them survives a reload — unlike the pending review beside them,
-  which is mirrored to localStorage. Persisting these is the same argument that one already won, and the reason
-  it has not been taken is the other half: a filed review clears itself on submit, while an abandoned reply on
-  a thread nobody returns to would sit in storage forever with no one to collect it.
 - **The dock's remembered browse is module memory, keyed by a path and never swept**
   (`frontend/src/lib/file-browse.ts`): every checkout the Code tab has ever browsed keeps its filter,
   folds, preview and marked row until the page reloads — a few strings per checkout, deliberately not

--- a/frontend/src/components/diff/ReviewSlots.tsx
+++ b/frontend/src/components/diff/ReviewSlots.tsx
@@ -1,5 +1,6 @@
 import type { DraftReviewComment, ReviewThread as Thread } from "@/lib/api-types"
 import type { NewLineRange } from "@/lib/git/diff"
+import type { DraftScope } from "@/lib/pulls/draft-store"
 import { COMPOSER_KEY, draftSlotKey, isThreadSlot, threadSlotKey } from "@/lib/pulls/review-slots"
 import { CommentBox } from "@/components/pulls/CommentBox"
 import { PendingComments, ReviewThread, type ThreadActions } from "@/components/pulls/ReviewThread"
@@ -8,6 +9,9 @@ import { PendingComments, ReviewThread, type ThreadActions } from "@/components/
 // working diff, which has no pull request behind it and therefore no threads,
 // no drafts and nothing to submit.
 export interface DiffReview {
+  /** The pull request being reviewed — what an unsent reply in one of these
+   * threads is filed under (draft-store). */
+  pull: DraftScope
   /** Threads anchored in this file. */
   threads: Thread[]
   /** Draft comments in this file, each with its index in the pending review —
@@ -104,7 +108,9 @@ export function ReviewSlot({
 
   if (isThreadSlot(slotKey)) {
     const thread = review.threads.find((held) => threadSlotKey(held) === slotKey)
-    return thread ? <ReviewThread thread={thread} actions={review.actions} /> : null
+    return thread ? (
+      <ReviewThread pull={review.pull} thread={thread} actions={review.actions} />
+    ) : null
   }
 
   const drafts = review.drafts.filter(({ comment }) => draftSlotKey(comment) === slotKey)

--- a/frontend/src/components/pulls/PullRequestView.tsx
+++ b/frontend/src/components/pulls/PullRequestView.tsx
@@ -86,6 +86,10 @@ function failingChecks(failed: number): string | undefined {
 
 interface PullRequestViewProps {
   path: string
+  /** Which project's screen this is. Only the unsent prose on it needs one —
+   * the drafts are filed per project, so the list column can retire the ones
+   * whose pull request has closed (draft-store). */
+  projectId: string
   /** The checkout's HEAD; changing it refetches the diff under the Files tab. */
   head: string
   detail: PullRequestDetail
@@ -112,6 +116,7 @@ interface PullRequestViewProps {
 // what a merge means for the worktree it lives in, stay the screen's.
 export function PullRequestView({
   path,
+  projectId,
   head,
   detail,
   session,
@@ -475,6 +480,7 @@ export function PullRequestView({
           <PullsFiles
             path={path}
             number={detail.number}
+            projectId={projectId}
             // The last commit is the head: gh lists them oldest first, and the
             // detail already carries them, so the expander costs no extra call.
             headOid={detail.commits?.[detail.commits.length - 1]?.oid ?? ""}
@@ -490,7 +496,7 @@ export function PullRequestView({
             {tab === "commits" && <PullsCommits commits={detail.commits} />}
             {tab === "conversation" && (
               <PullsConversation
-                pullRequest={detail.url}
+                pull={{ projectId, number: detail.number }}
                 conversation={conversation}
                 loading={conversationLoading}
                 actions={actions}
@@ -498,7 +504,12 @@ export function PullRequestView({
               />
             )}
             {tab === "overview" && (
-              <PullsOverview path={path} detail={detail} onRefresh={onRefresh} />
+              <PullsOverview
+                path={path}
+                projectId={projectId}
+                detail={detail}
+                onRefresh={onRefresh}
+              />
             )}
           </div>
         )}

--- a/frontend/src/components/pulls/Pulls.tsx
+++ b/frontend/src/components/pulls/Pulls.tsx
@@ -18,7 +18,8 @@ import { writeAtPrompt } from "@/lib/terminal/write-at-prompt"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { useCheckouts } from "@/lib/git/use-checkouts"
 import { invalidatePullRequests } from "@/lib/pulls/pull-request-lookup"
-import { parsePullsQuery } from "@/lib/pulls/pull-request-list"
+import { sweepDrafts } from "@/lib/pulls/draft-store"
+import { PULLS_PAGE_LIMIT, parsePullsQuery } from "@/lib/pulls/pull-request-list"
 import {
   readLastPull,
   readPullsQuery,
@@ -120,7 +121,8 @@ export function Pulls({ list = false }: PullsProps) {
   }
   // An empty path is the hook's own "nothing to look up", so the single pull
   // request screen never spends a gh call on a list it does not show.
-  const pulls = usePullRequests(list && hasGH ? projectPath || path : "", parsedQuery.state)
+  const listPath = list && hasGH ? projectPath || path : ""
+  const pulls = usePullRequests(listPath, parsedQuery.state)
   const { checkouts, refresh: refreshCheckouts } = useCheckouts(projectPath)
   // Where the pull request's own branch already lives, if anywhere. Every
   // "work on this PR" decision hangs off it: whether to create a checkout,
@@ -138,6 +140,31 @@ export function Pulls({ list = false }: PullsProps) {
       writeLastPull(projectId, selected)
     }
   }, [list, projectId, selected])
+
+  // Unsent prose outlives the screen it was typed on, so something has to
+  // retire it: this list is the only thing that knows a pull request has
+  // stopped being open (draft-store). An empty list is an answer like any
+  // other — a repository whose pull requests have all landed — which is why the
+  // guard is the path the lookup was given rather than the rows it came back
+  // with: no path is no answer at all, and sweeping against it would collect
+  // every draft in the project.
+  //
+  // Two more, each of which would otherwise take a draft that is still wanted:
+  // a query asking for merged or closed pull requests answers with a set that
+  // says nothing about the open ones, and an answer cut at the page limit is
+  // not the repository's whole list.
+  useEffect(() => {
+    if (!listPath || !projectId || pulls.loading || pulls.error) {
+      return
+    }
+    if (parsedQuery.state !== "open" || pulls.list.length >= PULLS_PAGE_LIMIT) {
+      return
+    }
+    sweepDrafts(
+      projectId,
+      pulls.list.map((pr) => pr.number),
+    )
+  }, [listPath, projectId, parsedQuery.state, pulls.list, pulls.loading, pulls.error])
 
   // This screen and the badges around it read the same pull request through two
   // separate lookups, so a change with HEAD standing still — a merge, a PR
@@ -318,6 +345,7 @@ export function Pulls({ list = false }: PullsProps) {
     body = (
       <PullRequestView
         path={path}
+        projectId={projectId ?? ""}
         head={head}
         detail={detail}
         session={session}

--- a/frontend/src/components/pulls/PullsConversation.tsx
+++ b/frontend/src/components/pulls/PullsConversation.tsx
@@ -5,6 +5,7 @@ import { Markdown } from "@/components/Markdown"
 import { Notice } from "@/components/common/Notice"
 import type { PullRequestConversation, PullRequestReview } from "@/lib/api-types"
 import { conversationTimeline } from "@/lib/pulls/conversation-timeline"
+import type { DraftScope } from "@/lib/pulls/draft-store"
 import { useDraft } from "@/lib/pulls/use-draft"
 import { errorText } from "@/lib/utils"
 import { Byline } from "./Byline"
@@ -12,9 +13,10 @@ import { CommentBox } from "./CommentBox"
 import { ReviewThread, type ThreadActions } from "./ReviewThread"
 
 interface PullsConversationProps {
-  /** The pull request this is about, by URL — what its unsent comment is filed
-   * under, so the box survives the tab strip above it (draft-store). */
-  pullRequest: string
+  /** The pull request this is about — what its unsent comment and every unsent
+   * reply below are filed under, so a box survives the tab strip above it, and
+   * so a merged pull request's leftovers can be found again (draft-store). */
+  pull: DraftScope
   conversation: PullRequestConversation | null
   loading: boolean
   actions: ThreadActions
@@ -30,11 +32,11 @@ interface PullsConversationProps {
 export function PullsConversation({
   conversation,
   loading,
-  pullRequest,
+  pull,
   actions,
   onComment,
 }: PullsConversationProps) {
-  const [draft, setDraft] = useDraft("comment", pullRequest)
+  const [draft, setDraft] = useDraft(pull, "comment")
   const [sending, setSending] = useState(false)
   const [showResolved, setShowResolved] = useState(false)
   const timeline = conversationTimeline(conversation)
@@ -77,7 +79,13 @@ export function PullsConversation({
           )
         }
         return (
-          <ReviewThread key={item.thread.id} thread={item.thread} actions={actions} standalone />
+          <ReviewThread
+            key={item.thread.id}
+            pull={pull}
+            thread={item.thread}
+            actions={actions}
+            standalone
+          />
         )
       })}
 
@@ -102,6 +110,7 @@ export function PullsConversation({
             timeline.resolved.map((thread) => (
               <ReviewThread
                 key={thread.id}
+                pull={pull}
                 thread={thread}
                 actions={actions}
                 standalone

--- a/frontend/src/components/pulls/PullsFiles.tsx
+++ b/frontend/src/components/pulls/PullsFiles.tsx
@@ -101,6 +101,9 @@ interface PullsFilesProps {
   path: string
   /** Which pull request's diff to fetch. */
   number: number
+  /** Which project's screen this is — an unsent reply in one of the threads
+   * below is filed under it (draft-store). */
+  projectId: string
   /** The commit the diff's new side stands at — the PR's head, which the
    * expander reads unchanged lines from. "" while the detail has no commit to
    * name, and then the diff shows what git printed and nothing more. */
@@ -127,6 +130,7 @@ interface PullsFilesProps {
 export function PullsFiles({
   path,
   number,
+  projectId,
   headOid,
   head,
   pullRequest,
@@ -178,10 +182,14 @@ export function PullsFiles({
   // in the review summary. Hence the drafts and not the whole review: only the
   // line comments are laid over the diff.
   const drafts = review.comments
+  // Rebuilt only when one of its two halves moves, because it rides the memo
+  // below into every mounted editor's decorations.
+  const pull = useMemo(() => ({ projectId, number }), [projectId, number])
   const reviews = useMemo(() => {
     const byPath = new Map<string, DiffReview>()
     for (const file of files ?? []) {
       byPath.set(file.newPath, {
+        pull,
         threads: (threads ?? []).filter((thread) => thread.path === file.newPath),
         drafts: [
           ...draftsOnFile(drafts, file.newPath, "RIGHT"),
@@ -194,7 +202,7 @@ export function PullsFiles({
       })
     }
     return byPath
-  }, [files, threads, drafts, actions, pullRequest])
+  }, [files, threads, drafts, actions, pull, pullRequest])
 
   if (error) {
     return <Notice className="px-4 py-6 text-sm">Couldn’t load the diff: {error}</Notice>

--- a/frontend/src/components/pulls/PullsOverview.tsx
+++ b/frontend/src/components/pulls/PullsOverview.tsx
@@ -27,7 +27,10 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { commentFieldClass } from "./CommentBox"
 
-interface PullsOverviewProps {
+// What the tab and the reviewer row under it both read. Split because only the
+// description is written here, and only what is written needs a project to be
+// filed under.
+interface PullRequestPaneProps {
   path: string
   detail: PullRequestDetail
   /** Re-read the pull request: an edit here lands on GitHub, and GitHub's
@@ -35,15 +38,21 @@ interface PullsOverviewProps {
   onRefresh: () => void
 }
 
+interface PullsOverviewProps extends PullRequestPaneProps {
+  /** Which project's screen this is — what an unsent description is filed
+   * under, and what retires it once the pull request closes (draft-store). */
+  projectId: string
+}
+
 // PullsOverview is the "Overview" tab: who opened the pull request, who is
 // reviewing it, and what it says. The description and the reviewers are both
 // editable here — they were the last two things about a pull request that sent
 // the reader out to github.com.
-export function PullsOverview({ path, detail, onRefresh }: PullsOverviewProps) {
+export function PullsOverview({ path, projectId, detail, onRefresh }: PullsOverviewProps) {
   // null is "not editing"; an empty string is a description being cleared, which
   // is a legitimate edit and must not read as the same thing. Owned outside the
   // tree, because the tab above this one unmounts it (draft-store).
-  const [draft, setDraft] = useDraft("body", detail.url)
+  const [draft, setDraft] = useDraft({ projectId, number: detail.number }, "body")
   const [saving, setSaving] = useState(false)
 
   const save = async () => {
@@ -128,7 +137,7 @@ export function PullsOverview({ path, detail, onRefresh }: PullsOverviewProps) {
 // The roster, and the one control that changes it. The picker is the only way a
 // reviewer is added or dropped — a second affordance on the chips would be two
 // ways to say the same thing, and the tick already reads as "asked".
-function Reviewers({ path, detail, onRefresh }: PullsOverviewProps) {
+function Reviewers({ path, detail, onRefresh }: PullRequestPaneProps) {
   // Read on first open rather than with the pull request: most readings of a
   // pull request never touch the roster, and this is a gh round-trip.
   const [candidates, setCandidates] = useState<ReviewCandidate[] | null>(null)

--- a/frontend/src/components/pulls/ReviewThread.tsx
+++ b/frontend/src/components/pulls/ReviewThread.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button"
 import { IconAction } from "@/components/common/IconAction"
 import type { DraftReviewComment, ReviewThread as Thread } from "@/lib/api-types"
 import { formatLineRef } from "@/lib/git/diff"
+import type { DraftScope } from "@/lib/pulls/draft-store"
 import { cn, errorText } from "@/lib/utils"
 import { Byline } from "./Byline"
 import { CommentBox } from "./CommentBox"
@@ -29,6 +30,9 @@ export interface ThreadActions {
 }
 
 interface ReviewThreadProps {
+  /** The pull request the thread hangs off — what an unsent reply is filed
+   * under, and what retires it once that pull request closes (draft-store). */
+  pull: DraftScope
   thread: Thread
   actions: ThreadActions
   /** Show the file and GitHub's own hunk above the comments — for the
@@ -53,6 +57,7 @@ function lineRef(thread: Thread): string {
 // opens under the line, and again in the Conversation tab for the threads no
 // line can hold (an outdated one, or a file this diff does not show).
 export function ReviewThread({
+  pull,
   thread,
   actions,
   standalone,
@@ -64,7 +69,7 @@ export function ReviewThread({
   // draft is filed. Owned outside the tree because three separate things destroy
   // this component — the tab strip, folding the file, and a diff refetch
   // rebuilding the CodeMirror widget this lives in (draft-store).
-  const [draft, setDraft] = useDraft("reply", thread.id)
+  const [draft, setDraft] = useDraft(pull, "reply", thread.id)
   const replying = draft !== null
   const [busy, setBusy] = useState(false)
   // Any thread folds, because any of them can be one you have already read and

--- a/frontend/src/lib/prefs.ts
+++ b/frontend/src/lib/prefs.ts
@@ -20,6 +20,20 @@ export function removePref(key: string): void {
   localStorage.removeItem(key)
 }
 
+/** Every stored key under a prefix — what a family of keys nobody can name in
+ * advance is read and collected through (pulls/draft-store, one key per box of
+ * unsent prose). Snapshotted, so a caller may remove keys while walking it. */
+export function prefKeys(prefix: string): string[] {
+  const keys: string[] = []
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i)
+    if (key?.startsWith(prefix)) {
+      keys.push(key)
+    }
+  }
+  return keys
+}
+
 /** One of a known set — a theme, a sort. Anything else is a value from another
  * build (or a hand-edited store) and reads as the fallback. */
 export function parseEnumPref<T extends string>(

--- a/frontend/src/lib/pulls/draft-store.test.ts
+++ b/frontend/src/lib/pulls/draft-store.test.ts
@@ -1,66 +1,100 @@
-import { beforeEach, describe, expect, it } from "vitest"
-import { draftKey, draftStore } from "./draft-store"
+// @vitest-environment jsdom
+//
+// jsdom for its localStorage alone, and nothing here renders. The store reads
+// storage as it loads — that is what a draft surviving a reload *is* — so a
+// stub installed by the test body would arrive too late, and enumerating the
+// keys is half of what the sweep does.
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  DRAFT_MAX_AGE_MS,
+  type DraftScope,
+  draftKey,
+  draftStore,
+  parseDraft,
+  setDraft,
+  sweepDrafts,
+} from "./draft-store"
 
-const PR = "https://github.com/omartelo/lich/pull/389"
-const OTHER = "https://github.com/omartelo/lich/pull/12"
+const PROJECT = "a1b2c3d4e5f6"
+const OTHER_PROJECT = "0f0f0f0f0f0f"
+const PR: DraftScope = { projectId: PROJECT, number: 389 }
+const OTHER: DraftScope = { projectId: PROJECT, number: 12 }
+const THREAD = "PRRT_kwDOabc"
 
-const KEYS = [
-  draftKey("body", PR),
-  draftKey("comment", PR),
-  draftKey("reply", PR),
-  draftKey("body", OTHER),
-  draftKey("comment", OTHER),
-  draftKey("reply", "PRRT_kwDOabc"),
-]
+// A page load: the module reads storage once as it evaluates, so a fresh copy
+// of it is the only honest way to ask what the next launch would restore.
+async function reload() {
+  vi.resetModules()
+  return await import("./draft-store")
+}
 
 beforeEach(() => {
-  for (const key of KEYS) {
-    draftStore.set(key, null)
+  localStorage.clear()
+  for (const key of [
+    draftKey(PR, "body"),
+    draftKey(PR, "comment"),
+    draftKey(PR, "reply", THREAD),
+    draftKey(OTHER, "comment"),
+  ]) {
+    setDraft(key, null)
   }
 })
+
+// A draft as an earlier page left it, at an age this one has to judge. Written
+// to storage rather than staged by moving the clock: the record is what the
+// cap reads, and the clock is not what these tests are about.
+function storeAged(key: string, text: string, age: number): void {
+  localStorage.setItem(key, JSON.stringify({ text, at: Date.now() - age }))
+}
 
 describe("a draft's key", () => {
   // The whole reason the kind is in the key: the description and the
   // conversation box are both about the same pull request, and typing in one
   // must not appear in the other.
   it("keeps two kinds about the same pull request apart", () => {
-    draftStore.set(draftKey("body", PR), "a rewritten description")
-    draftStore.set(draftKey("comment", PR), "a comment")
+    setDraft(draftKey(PR, "body"), "a rewritten description")
+    setDraft(draftKey(PR, "comment"), "a comment")
 
-    expect(draftStore.get(draftKey("body", PR))).toBe("a rewritten description")
-    expect(draftStore.get(draftKey("comment", PR))).toBe("a comment")
+    expect(draftStore.get(draftKey(PR, "body"))).toBe("a rewritten description")
+    expect(draftStore.get(draftKey(PR, "comment"))).toBe("a comment")
   })
 
   it("keeps one kind on two pull requests apart", () => {
-    draftStore.set(draftKey("comment", PR), "about 389")
-    draftStore.set(draftKey("comment", OTHER), "about 12")
+    setDraft(draftKey(PR, "comment"), "about 389")
+    setDraft(draftKey(OTHER, "comment"), "about 12")
 
-    expect(draftStore.get(draftKey("comment", PR))).toBe("about 389")
-    expect(draftStore.get(draftKey("comment", OTHER))).toBe("about 12")
+    expect(draftStore.get(draftKey(PR, "comment"))).toBe("about 389")
+    expect(draftStore.get(draftKey(OTHER, "comment"))).toBe("about 12")
   })
 
-  // A separator that could appear inside an id would let one id be written that
-  // lands on another kind's key. A newline appears in neither a URL nor a
-  // GitHub node id, and this is what says so out loud.
-  it("cannot be forged out of an id", () => {
-    expect(draftKey("body", PR)).not.toBe(draftKey("comment", PR))
-    expect(draftKey("reply", `${PR}\ncomment`)).not.toBe(draftKey("comment", PR))
+  it("keeps two projects reading the same numbers apart", () => {
+    setDraft(draftKey(PR, "comment"), "mine")
+    setDraft(draftKey({ projectId: OTHER_PROJECT, number: 389 }, "comment"), "theirs")
+
+    expect(draftStore.get(draftKey(PR, "comment"))).toBe("mine")
+  })
+
+  // A thread id rides the end of the key, so it must not be able to land on the
+  // description's or the comment's.
+  it("cannot be forged out of a thread id", () => {
+    expect(draftKey(PR, "reply", "body")).not.toBe(draftKey(PR, "body"))
+    expect(draftKey(PR, "reply", THREAD)).not.toBe(draftKey(PR, "comment"))
   })
 })
 
 describe("a draft that has not been written", () => {
   it("reads as no draft, not as an empty one", () => {
-    expect(draftStore.get(draftKey("reply", "PRRT_kwDOabc"))).toBeNull()
+    expect(draftStore.get(draftKey(PR, "reply", THREAD))).toBeNull()
   })
 
   // The distinction the reply box and the description both hang on: a box that
   // is open and empty is still open, and a description being cleared is a
   // legitimate edit. Collapsing the two would close a box under the user.
   it("is not the same as a draft that was emptied", () => {
-    draftStore.set(draftKey("body", PR), "")
+    setDraft(draftKey(PR, "body"), "")
 
-    expect(draftStore.get(draftKey("body", PR))).toBe("")
-    expect(draftStore.get(draftKey("body", PR))).not.toBeNull()
+    expect(draftStore.get(draftKey(PR, "body"))).toBe("")
+    expect(draftStore.get(draftKey(PR, "body"))).not.toBeNull()
   })
 })
 
@@ -68,14 +102,14 @@ describe("subscribers", () => {
   it("hear their own key and no other", () => {
     let body = 0
     let comment = 0
-    const offBody = draftStore.subscribe(draftKey("body", PR), () => {
+    const offBody = draftStore.subscribe(draftKey(PR, "body"), () => {
       body++
     })
-    const offComment = draftStore.subscribe(draftKey("comment", PR), () => {
+    const offComment = draftStore.subscribe(draftKey(PR, "comment"), () => {
       comment++
     })
 
-    draftStore.set(draftKey("body", PR), "typing")
+    setDraft(draftKey(PR, "body"), "typing")
 
     expect(body).toBe(1)
     expect(comment).toBe(0)
@@ -87,15 +121,146 @@ describe("subscribers", () => {
   // changed nothing must not re-render anything, since the reply box lives
   // inside a CodeMirror widget that redraws with it.
   it("are not woken by a write that changes nothing", () => {
-    draftStore.set(draftKey("body", PR), "same")
+    setDraft(draftKey(PR, "body"), "same")
     let woken = 0
-    const off = draftStore.subscribe(draftKey("body", PR), () => {
+    const off = draftStore.subscribe(draftKey(PR, "body"), () => {
       woken++
     })
 
-    draftStore.set(draftKey("body", PR), "same")
+    setDraft(draftKey(PR, "body"), "same")
 
     expect(woken).toBe(0)
     off()
+  })
+})
+
+describe("a draft across a reload", () => {
+  it("comes back as it was typed", async () => {
+    setDraft(draftKey(PR, "reply", THREAD), "half a reply")
+
+    const next = await reload()
+
+    expect(next.draftStore.get(next.draftKey(PR, "reply", THREAD))).toBe("half a reply")
+  })
+
+  it("is gone once it has been sent", async () => {
+    setDraft(draftKey(PR, "comment"), "a comment")
+    setDraft(draftKey(PR, "comment"), null)
+
+    const next = await reload()
+
+    expect(next.draftStore.get(next.draftKey(PR, "comment"))).toBeNull()
+    expect(localStorage.getItem(draftKey(PR, "comment"))).toBeNull()
+  })
+
+  // Emptying the box is the other way a draft ends. In memory "" and null stay
+  // apart — the box is still open — but neither is prose worth restoring.
+  it("is gone once the box has been emptied", async () => {
+    setDraft(draftKey(PR, "body"), "a rewritten description")
+    setDraft(draftKey(PR, "body"), "")
+
+    const next = await reload()
+
+    expect(next.draftStore.get(next.draftKey(PR, "body"))).toBeNull()
+    expect(localStorage.getItem(draftKey(PR, "body"))).toBeNull()
+  })
+
+  // A pref must never be able to break a launch: a record from another build,
+  // or a hand-edited one, restores nothing and is collected on the way past.
+  it("is dropped when the stored record cannot be read", async () => {
+    localStorage.setItem(draftKey(PR, "comment"), "{not json")
+
+    const next = await reload()
+
+    expect(next.draftStore.get(next.draftKey(PR, "comment"))).toBeNull()
+    expect(localStorage.getItem(draftKey(PR, "comment"))).toBeNull()
+  })
+})
+
+describe("the sweep against the open pull requests", () => {
+  it("collects a draft whose pull request is no longer open", async () => {
+    setDraft(draftKey(PR, "comment"), "about a merged one")
+    setDraft(draftKey(OTHER, "comment"), "about an open one")
+
+    sweepDrafts(PROJECT, [OTHER.number])
+
+    const next = await reload()
+    expect(next.draftStore.get(next.draftKey(PR, "comment"))).toBeNull()
+    expect(next.draftStore.get(next.draftKey(OTHER, "comment"))).toBe("about an open one")
+  })
+
+  it("collects every draft on that pull request, replies included", () => {
+    setDraft(draftKey(PR, "body"), "a description")
+    setDraft(draftKey(PR, "reply", THREAD), "a reply")
+
+    sweepDrafts(PROJECT, [])
+
+    expect(localStorage.getItem(draftKey(PR, "body"))).toBeNull()
+    expect(localStorage.getItem(draftKey(PR, "reply", THREAD))).toBeNull()
+  })
+
+  // The list is one project's. Another project's pull request numbering says
+  // nothing about this one's, and sweeping across them would collect drafts
+  // for pull requests that are open.
+  it("leaves another project's drafts alone", () => {
+    const theirs = draftKey({ projectId: OTHER_PROJECT, number: 389 }, "comment")
+    setDraft(theirs, "another project's")
+
+    sweepDrafts(PROJECT, [])
+
+    expect(localStorage.getItem(theirs)).not.toBeNull()
+  })
+
+  // The box on screen is not emptied under the user: a pull request merged
+  // while a reply was being written still has that reply in the page.
+  it("does not take what is still on screen", () => {
+    setDraft(draftKey(PR, "comment"), "still being typed")
+
+    sweepDrafts(PROJECT, [])
+
+    expect(draftStore.get(draftKey(PR, "comment"))).toBe("still being typed")
+  })
+})
+
+describe("the age cap", () => {
+  it("collects a draft nobody came back to", async () => {
+    storeAged(draftKey(PR, "comment"), "written a long time ago", DRAFT_MAX_AGE_MS + 1)
+
+    const next = await reload()
+
+    expect(next.draftStore.get(next.draftKey(PR, "comment"))).toBeNull()
+    expect(localStorage.getItem(draftKey(PR, "comment"))).toBeNull()
+  })
+
+  it("keeps one that is only nearly that old", async () => {
+    storeAged(draftKey(PR, "comment"), "written a while ago", DRAFT_MAX_AGE_MS - 60_000)
+
+    const next = await reload()
+
+    expect(next.draftStore.get(next.draftKey(PR, "comment"))).toBe("written a while ago")
+  })
+
+  // The sweep is the other place the cap is enforced: a project left open for
+  // weeks collects the leftovers of the ones nobody opens, which is the whole
+  // point of a backstop under a per-project list.
+  it("is enforced by the sweep too, across every project", () => {
+    const theirs = draftKey({ projectId: OTHER_PROJECT, number: 7 }, "comment")
+    storeAged(theirs, "another project's, and old", DRAFT_MAX_AGE_MS + 1)
+
+    sweepDrafts(PROJECT, [])
+
+    expect(localStorage.getItem(theirs)).toBeNull()
+  })
+})
+
+describe("a stored record", () => {
+  // A record with no timestamp cannot be aged, and a draft that cannot be aged
+  // is a draft nothing would ever collect.
+  it("that carries no time reads as expired", () => {
+    expect(parseDraft(JSON.stringify({ text: "orphaned" }), Date.now())).toBeNull()
+  })
+
+  it("that carries no prose reads as no draft", () => {
+    expect(parseDraft(JSON.stringify({ text: "", at: Date.now() }), Date.now())).toBeNull()
   })
 })

--- a/frontend/src/lib/pulls/draft-store.test.ts
+++ b/frontend/src/lib/pulls/draft-store.test.ts
@@ -20,6 +20,9 @@ const OTHER_PROJECT = "0f0f0f0f0f0f"
 const PR: DraftScope = { projectId: PROJECT, number: 389 }
 const OTHER: DraftScope = { projectId: PROJECT, number: 12 }
 const THREAD = "PRRT_kwDOabc"
+// The highest number a swept list carries: nothing above it can be judged
+// closed, so every sweep that means to collect something says it out loud.
+const NEWEST = 400
 
 // A page load: the module reads storage once as it evaluates, so a fresh copy
 // of it is the only honest way to ask what the next launch would restore.
@@ -182,7 +185,7 @@ describe("the sweep against the open pull requests", () => {
     setDraft(draftKey(PR, "comment"), "about a merged one")
     setDraft(draftKey(OTHER, "comment"), "about an open one")
 
-    sweepDrafts(PROJECT, [OTHER.number])
+    sweepDrafts(PROJECT, [OTHER.number, NEWEST])
 
     const next = await reload()
     expect(next.draftStore.get(next.draftKey(PR, "comment"))).toBeNull()
@@ -193,7 +196,7 @@ describe("the sweep against the open pull requests", () => {
     setDraft(draftKey(PR, "body"), "a description")
     setDraft(draftKey(PR, "reply", THREAD), "a reply")
 
-    sweepDrafts(PROJECT, [])
+    sweepDrafts(PROJECT, [NEWEST])
 
     expect(localStorage.getItem(draftKey(PR, "body"))).toBeNull()
     expect(localStorage.getItem(draftKey(PR, "reply", THREAD))).toBeNull()
@@ -206,7 +209,7 @@ describe("the sweep against the open pull requests", () => {
     const theirs = draftKey({ projectId: OTHER_PROJECT, number: 389 }, "comment")
     setDraft(theirs, "another project's")
 
-    sweepDrafts(PROJECT, [])
+    sweepDrafts(PROJECT, [NEWEST])
 
     expect(localStorage.getItem(theirs)).not.toBeNull()
   })
@@ -216,9 +219,35 @@ describe("the sweep against the open pull requests", () => {
   it("does not take what is still on screen", () => {
     setDraft(draftKey(PR, "comment"), "still being typed")
 
-    sweepDrafts(PROJECT, [])
+    sweepDrafts(PROJECT, [NEWEST])
 
     expect(draftStore.get(draftKey(PR, "comment"))).toBe("still being typed")
+  })
+})
+
+describe("the sweep against a list that is behind", () => {
+  // Numbers are monotonic, so a pull request opened after the list was read is
+  // above everything in it — and the screen can be painting from an answer
+  // minutes old. Its absence from the list is the list being stale, never the
+  // pull request having closed.
+  it("keeps a draft on a number the list could not have carried", () => {
+    const opened = draftKey({ projectId: PROJECT, number: NEWEST + 1 }, "comment")
+    setDraft(opened, "about one opened since")
+
+    sweepDrafts(PROJECT, [OTHER.number, NEWEST])
+
+    expect(localStorage.getItem(opened)).not.toBeNull()
+  })
+
+  // With no rows there is no ceiling, and so no evidence about any number: a
+  // stale empty answer must not read as "this repository has nothing open".
+  // Those drafts are the age cap's.
+  it("keeps everything when the list came back empty", () => {
+    setDraft(draftKey(PR, "comment"), "about something")
+
+    sweepDrafts(PROJECT, [])
+
+    expect(localStorage.getItem(draftKey(PR, "comment"))).not.toBeNull()
   })
 })
 

--- a/frontend/src/lib/pulls/draft-store.ts
+++ b/frontend/src/lib/pulls/draft-store.ts
@@ -1,4 +1,5 @@
-import { createKeyedStore } from "@/lib/keyed-store"
+import { createKeyedStore, type ReadableKeyedStore } from "@/lib/keyed-store"
+import { prefKeys, readPref, removePref, writePref } from "@/lib/prefs"
 
 // Prose typed into the pull request screen and not yet sent: a description
 // being rewritten, a comment being composed, a reply to a review thread.
@@ -20,24 +21,124 @@ import { createKeyedStore } from "@/lib/keyed-store"
 // That distinction was already PullsOverview's, and it now carries the reply
 // box's `replying` flag too, which is one state fewer to keep in step.
 //
-// In memory only. It survives every unmount this screen can produce, which is
-// what was being lost; it does not survive a reload. Persisting is the same
-// argument pending-review-store already won — GitHub has no record of an unsent
-// comment either — and the reason to hold off is that nothing here would ever
-// collect an abandoned reply, where a filed review clears itself on submit. Add
-// it when a draft lost to a reload survives to be reported, not before.
-export const draftStore = createKeyedStore<string | null>(null)
+// Mirrored into localStorage on every write, like the pending review beside it
+// (pending-review-store): GitHub has no record of an unsent comment either, and
+// an app update reloading the page is not an answer to "I was writing that".
+// What the review does not need is collection — a filed review clears itself on
+// submit, while a reply abandoned on a thread nobody returns to has nothing to
+// retire it. That is `sweepDrafts` below, and it is why the storage key carries
+// the project and the pull request number rather than a URL: the list column
+// already reads a project's open pull requests, and a number that is no longer
+// among them is a draft with nowhere to go.
+const KEY_PREFIX = "lich.pulls.draft."
 
-/** What a draft belongs to. The kind rides the key so two boxes about the same
- * pull request — its description and its conversation — never share one. */
+// The backstop under that sweep. A project the user closes, or a repository
+// nobody opens again, lands no list to sweep against, so its drafts would sit
+// in storage forever. Long enough that a review picked up after a holiday is
+// still there, short enough that "forever" is not the answer.
+export const DRAFT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
+
+const store = createKeyedStore<string | null>(null)
+
+/** The drafts, read side. Writing goes through `setDraft`, which is what keeps
+ * storage in step with memory. */
+export const draftStore: ReadableKeyedStore<string | null> = store
+
+/** What a draft belongs to: the project whose list retires it, and the pull
+ * request it is about. */
+export interface DraftScope {
+  projectId: string
+  number: number
+}
+
+/** What a draft is on. The kind rides the key so two boxes about the same pull
+ * request — its description and its conversation — never share one. */
 export type DraftKind = "body" | "comment" | "reply"
 
-/** `id` identifies what is being written about: the pull request's URL for a
- * description or a comment (unique across projects, like the viewed ticks and
- * the pending review beside them), and the thread's own id for a reply, which
- * GitHub already makes unique on its own. */
-export function draftKey(kind: DraftKind, id: string): string {
-  // A newline appears in neither a URL nor a GitHub node id, so no id can be
-  // written that lands on another kind's key.
-  return `${kind}\n${id}`
+/** The key one box's prose is filed under, in the store and in storage alike.
+ * `id` names the thread a reply answers; the description and the comment are
+ * about the pull request itself and take none. */
+export function draftKey(scope: DraftScope, kind: DraftKind, id = ""): string {
+  const target = id ? `${kind}.${id}` : kind
+  return `${KEY_PREFIX}${scope.projectId}.${scope.number}.${target}`
 }
+
+/** Write one box's prose. null (sent, or the box closed) and "" (emptied) are
+ * both drafts with nothing to keep, so both collect the stored copy — the
+ * distinction between them is the screen's, and stays in memory. */
+export function setDraft(key: string, text: string | null): void {
+  store.set(key, text)
+  if (text) {
+    writePref(key, JSON.stringify({ text, at: Date.now() }))
+  } else {
+    removePref(key)
+  }
+}
+
+/** Retire the stored drafts this project has no pull request for any more, and
+ * anything anywhere past the age cap. `open` is the project's open pull
+ * requests, as the list column read them.
+ *
+ * Storage only: a box still on screen keeps what was typed into it, because a
+ * pull request merged while its reply was being written is not a reason to
+ * empty the box under the user. */
+export function sweepDrafts(projectId: string, open: readonly number[]): void {
+  const keep = new Set(open)
+  const now = Date.now()
+  for (const key of prefKeys(KEY_PREFIX)) {
+    const scope = scopeOf(key)
+    const closed = scope !== null && scope.projectId === projectId && !keep.has(scope.number)
+    if (closed || parseDraft(readPref(key), now) === null) {
+      removePref(key)
+    }
+  }
+}
+
+// The project and pull request a stored key is about, or null for a key this
+// build cannot read as one — a key from another build, or a hand-edited one,
+// belongs to no project and so is swept by the age cap alone.
+function scopeOf(key: string): DraftScope | null {
+  const parts = key.slice(KEY_PREFIX.length).split(".")
+  const number = Number(parts[1])
+  if (parts.length < 3 || !parts[0] || !Number.isInteger(number) || number <= 0) {
+    return null
+  }
+  return { projectId: parts[0], number }
+}
+
+/** Narrow a stored value to the prose in it, or null — which is also what an
+ * expired draft reads as. Anything that does not parse is dropped rather than
+ * repaired, like the pending review beside it: half a comment restored into a
+ * box is worse than a box that is simply empty. */
+export function parseDraft(raw: string | null, now: number): string | null {
+  if (!raw) {
+    return null
+  }
+  try {
+    const held = JSON.parse(raw) as { text?: unknown; at?: unknown }
+    const text = typeof held.text === "string" ? held.text : ""
+    // A record with no timestamp cannot be aged, so it is treated as expired
+    // rather than kept forever — the one thing this file must not allow.
+    const at = typeof held.at === "number" ? held.at : 0
+    return text !== "" && now - at < DRAFT_MAX_AGE_MS ? text : null
+  } catch {
+    return null
+  }
+}
+
+// What an earlier page left behind, read once at load: the reload these drafts
+// used not to survive. Expired and unreadable records are collected on the way
+// past, so a store nobody sweeps still shrinks.
+function restoreDrafts(): void {
+  const now = Date.now()
+  for (const key of prefKeys(KEY_PREFIX)) {
+    const text = parseDraft(readPref(key), now)
+    if (text === null) {
+      removePref(key)
+    } else {
+      store.set(key, text)
+    }
+  }
+}
+
+restoreDrafts()

--- a/frontend/src/lib/pulls/draft-store.ts
+++ b/frontend/src/lib/pulls/draft-store.ts
@@ -84,10 +84,21 @@ export function setDraft(key: string, text: string | null): void {
  * empty the box under the user. */
 export function sweepDrafts(projectId: string, open: readonly number[]): void {
   const keep = new Set(open)
+  // A list says nothing about a number above its own highest. Numbers are
+  // monotonic, so a pull request opened after the list was read — and the
+  // screen paints from an answer that can be minutes old (remote-cache) — sits
+  // above everything in it, and would otherwise read as one that had closed.
+  // A list that came back empty carries no such ceiling and so retires
+  // nothing; that repository's drafts are the age cap's.
+  const ceiling = Math.max(0, ...open)
   const now = Date.now()
   for (const key of prefKeys(KEY_PREFIX)) {
     const scope = scopeOf(key)
-    const closed = scope !== null && scope.projectId === projectId && !keep.has(scope.number)
+    const closed =
+      scope !== null &&
+      scope.projectId === projectId &&
+      scope.number <= ceiling &&
+      !keep.has(scope.number)
     if (closed || parseDraft(readPref(key), now) === null) {
       removePref(key)
     }

--- a/frontend/src/lib/pulls/use-draft.test.tsx
+++ b/frontend/src/lib/pulls/use-draft.test.tsx
@@ -11,18 +11,18 @@
 import { mountBudget } from "@/test/render-budget"
 import { StrictMode, createElement, useLayoutEffect } from "react"
 import { beforeEach, describe, expect, it } from "vitest"
-import { draftKey, draftStore } from "./draft-store"
+import { type DraftScope, draftKey, setDraft } from "./draft-store"
 import { useDraft } from "./use-draft"
 
-const PR = "https://github.com/omartelo/lich/pull/389"
+const PR: DraftScope = { projectId: "a1b2c3d4e5f6", number: 389 }
 
 // Records what each commit saw, from a layout effect rather than the render
 // body: the body sees passes React never committed (use-remote-resource.test).
-function box(seen: (string | null)[], id = PR, kind: "body" | "comment" | "reply" = "comment") {
+function box(seen: (string | null)[], kind: "body" | "comment" | "reply" = "comment", id = "") {
   let type: (next: string | null) => void = () => {}
   function Box() {
-    const [draft, setDraft] = useDraft(kind, id)
-    type = setDraft
+    const [draft, write] = useDraft(PR, kind, id)
+    type = write
     useLayoutEffect(() => {
       seen.push(draft)
     })
@@ -35,8 +35,13 @@ function box(seen: (string | null)[], id = PR, kind: "body" | "comment" | "reply
 }
 
 beforeEach(() => {
-  for (const kind of ["body", "comment", "reply"] as const) {
-    draftStore.set(draftKey(kind, PR), null)
+  for (const key of [
+    draftKey(PR, "body"),
+    draftKey(PR, "comment"),
+    draftKey(PR, "reply", "PRRT_one"),
+    draftKey(PR, "reply", "PRRT_two"),
+  ]) {
+    setDraft(key, null)
   }
 })
 
@@ -80,8 +85,8 @@ describe("a draft being typed", () => {
   it("does not reach a box with another id", async () => {
     const mine: (string | null)[] = []
     const theirs: (string | null)[] = []
-    const first = box(mine, "PRRT_one", "reply")
-    const other = box(theirs, "PRRT_two", "reply")
+    const first = box(mine, "reply", "PRRT_one")
+    const other = box(theirs, "reply", "PRRT_two")
 
     const a = await mountBudget(first.element)
     const b = await mountBudget(other.element)
@@ -91,6 +96,6 @@ describe("a draft being typed", () => {
     expect(theirs[theirs.length - 1]).toBeNull()
     await a.unmount()
     await b.unmount()
-    draftStore.set(draftKey("reply", "PRRT_one"), null)
+    setDraft(draftKey(PR, "reply", "PRRT_one"), null)
   })
 })

--- a/frontend/src/lib/pulls/use-draft.ts
+++ b/frontend/src/lib/pulls/use-draft.ts
@@ -1,21 +1,26 @@
 import { useCallback } from "react"
 import { useKeyedStore } from "@/lib/use-keyed-store"
-import { draftStore, type DraftKind, draftKey } from "./draft-store"
+import { type DraftKind, type DraftScope, draftKey, draftStore, setDraft } from "./draft-store"
 
 /** One box of unsent prose, read and written like `useState` but owned outside
- * the tree (draft-store), so a tab switch, a collapsed file or a refetched diff
- * cannot take what was typed. null is "no draft": for the description and the
- * reply box, that is also what closes them. */
+ * the tree (draft-store), so a tab switch, a collapsed file, a refetched diff —
+ * or a reload — cannot take what was typed. null is "no draft": for the
+ * description and the reply box, that is also what closes them.
+ *
+ * A scope that has not resolved yet, or a reply with no thread behind it, is
+ * filed under no key at all rather than under one ending in nothing. */
 export function useDraft(
+  scope: DraftScope,
   kind: DraftKind,
-  id: string,
+  id = "",
 ): [string | null, (next: string | null) => void] {
-  const key = id ? draftKey(kind, id) : ""
+  const addressed = scope.projectId !== "" && scope.number > 0 && (kind !== "reply" || id !== "")
+  const key = addressed ? draftKey(scope, kind, id) : ""
   const draft = useKeyedStore(draftStore, key)
   const set = useCallback(
     (next: string | null) => {
       if (key) {
-        draftStore.set(key, next)
+        setDraft(key, next)
       }
     },
     [key],


### PR DESCRIPTION
## What

Unsent prose on the pull request screen — a description being rewritten, a comment being composed, a reply typed into a review thread — lived in memory alone. It survived every unmount the screen can produce and nothing else, so an app update, a closed window or any reload took what was written. The pending review beside it was already mirrored to localStorage, and the argument is the same: GitHub has no record of an unsent comment either.

What held it back was the other half — collection. A filed review clears itself on submit; an abandoned reply on a thread nobody returns to had nothing to retire it. Both halves close here, so `docs/ceilings.md` loses that bullet.

## How

- **Persisted** under `lich.pulls.draft.<project>.<number>.<target>`, one key per box (`body`, `comment`, `reply.<thread id>`), value `{ text, at }`. The store reads them once at load — that is the reload it now survives — and every write mirrors through `setDraft`.
- **Collected** three ways: when the draft is sent, when its box is emptied (`""` and `null` both drop the stored copy; in memory they stay apart, since an open empty box is still open), and when its pull request stops being open. The last one is the list column's answer: on each landing, `sweepDrafts` drops every stored draft for that project whose number the list does not carry.
- **`DRAFT_MAX_AGE_MS` (30 days)** is the backstop, enforced at load and by every sweep, for a project that lands no list again.

A list only proves what it can carry. Numbers are monotonic, so `sweepDrafts` never retires one above the highest in the list it is sweeping against: a pull request opened since the list was read — the screen can paint from an answer minutes old (`remote-cache`) — is above everything in it, and its absence is the list being stale rather than the pull request having closed. A list that came back empty carries no ceiling at all and so retires nothing; that repository's drafts are the age cap's.

The sweep is guarded on three more things that would otherwise collect a draft still wanted: no lookup path (no answer at all, as opposed to an empty one), a query asking for merged or closed pull requests, and an answer cut at `PULLS_PAGE_LIMIT`. It touches storage only — a pull request merged while its reply is being written does not empty the box under the user.

The key needs the project, so `projectId` is threaded to the four components that own a box, and `DiffReview` carries the pull request into the threads rendered inside the diff.

## Test plan

- [x] `frontend`: save/restore across a simulated reload (`vi.resetModules()` + re-import, which is the load path itself), the three clears, the sweep against a list (another project's drafts left alone; a number above the list's highest kept; an empty list retiring nothing), the age cap at load and in the sweep, and a record that carries no timestamp.
- [x] `./node_modules/.bin/biome ci .` exit 0
- [x] `pnpm test` — 1602 passed
- [x] `pnpm build`
- [x] `gofmt -l .` clean, `go vet ./...` clean (no Go changed)
- [ ] By hand in `task dev`: type into all three boxes, reload the window, confirm each comes back; merge a pull request and confirm the list landing retires its drafts.