### PR TITLE
docs: drop the cost --since bullet the flag and docs/cli.md already state

### DIFF
--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -103,15 +103,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   moving an unrelated item. The editor waits for that setting before migrating old visibility choices.
   Hiding a reading hides its warning too. An item without data can occupy an editor slot while drawing
   nothing in the live footer — a PR on a branch without one, or an unsupported provider reading.
-- **`lich cost --since` windows on sessions, never on days** (`store.CostTotals`): the ledger is a running
-  total per `(session, transcript)` with no per-turn history behind it, so the only date a session's spend
-  carries is when it was last counted. A window therefore selects *sessions active in it* and counts each one
-  whole — a session that ran through the boundary brings every dollar of its life into the window, and one
-  idle since before it brings none. Reading a windowed total as "what was spent that week" overstates a
-  long-lived card by however long it has been running. A session with nothing counted has no ledger to date
-  it at all and falls back on its own life: parked, it is dated by the close; open, it is dated *now*, so it
-  is unpriced in every window ending today. Slicing money by day would need a second ledger keyed by day, and
-  there is none.
 - **Hands-on time is read off three signals, and one of them is not universal**
   (`internal/terminal/handson.go`, `noteOutput`, `closableState`): the figure beside the cost
   counts the gap between consecutive signs of life in a session — any hook report naming it, a

--- a/internal/cli/cost.go
+++ b/internal/cli/cost.go
@@ -14,7 +14,7 @@ func (c *client) cost(args []string) error {
 	flags := newFlagSet("cost")
 	project := flags.String("project", "", "only this project, by name")
 	provider := flags.String("provider", "", "only sessions running this provider")
-	since := flags.String("since", "", "only sessions active within this window, e.g. 7d or 12h")
+	since := flags.String("since", "", "only sessions active within this window, counted whole, e.g. 7d or 12h")
 	asJSON := flags.Bool("json", false, "print the whole report as JSON")
 	asCSV := flags.Bool("csv", false, "print the per-project rows as CSV")
 	if err := c.parse(flags, args); err != nil {


### PR DESCRIPTION
`--since` selecting sessions active in the window and counting each one whole is the flag's documented semantics (docs/cli.md, `lich help cost`), not a trap the call site hides. The bullet restated that and promised a per-day ledger nobody wants. The flag's usage string now says `counted whole` too. Doc and help text only.