### PR TITLE
fix: make the Files tab browsable in a plain folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Files tab is browsable in a plain folder.** A directory that is not a
+  repository has no `.gitignore` for lich to obey, so the tree listed
+  `node_modules`, `target`, `dist` and their kind like any other folder, stopped
+  at 20,000 files without saying so, and only re-read when you left the panel
+  and came back. Those directories are now skipped by name, a listing that hit
+  the cap says so under the rows, and the tree re-reads on the same cadence a
+  repository's does, so a file the agent just wrote shows up while you watch.
+
 - **Each browser now gets its own window profile.** lich kept one Chromium
   profile for whichever browser it opened, so installing a second one, changing
   the desktop default or pinning `--browser` handed one browser's profile to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,9 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repository has no `.gitignore` for lich to obey, so the tree listed
   `node_modules`, `target`, `dist` and their kind like any other folder, stopped
   at 20,000 files without saying so, and only re-read when you left the panel
-  and came back. Those directories are now skipped by name, a listing that hit
-  the cap says so under the rows, and the tree re-reads on the same cadence a
-  repository's does, so a file the agent just wrote shows up while you watch.
+  and came back. Those directories are now skipped by name, and the line under
+  the rows says which ones this folder had ("Hidden: build, node_modules") and
+  whether the listing hit the cap, so a folder keeping its own source under one
+  of those names tells you why it is missing. The tree also re-reads on the same
+  cadence a repository's does, so a file the agent just wrote shows up while you
+  watch.
 
 - **Each browser now gets its own window profile.** lich kept one Chromium
   profile for whichever browser it opened, so installing a second one, changing

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -284,13 +284,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   `frontend/src/lib/session/peer-name.ts`) for the relay to resolve against, and the derived string goes stale the
   moment anyone renames — it then addresses a session that no longer answers to it. Nothing reads the real name
   back, so `/list-agents` inside the session is the only place it is true.
-- **The file tree outside a repository is unfiltered and capped**
-  (`internal/project/tree.go`, `walkFiles`): a plain folder has no `.gitignore`
-  for lich to obey, so the Files tab lists dependency and build directories like
-  any other, and stops at `walkLimit` files with nothing on screen saying the
-  listing was cut. It also has no git status to poll, so the tree there refreshes
-  only when the panel is reopened — a file the agent just wrote shows up on the
-  next visit, not while you watch.
 - **A missing tool is answered from the launch's `PATH`** (`frontend/src/lib/vcs-tools.ts`): the git and gh
   checks resolve through the `PATH` lich pinned at startup (`terminal.PinPath`), so installing either one
   while lich is open leaves every surface still calling it missing until a restart. Each of them says so; a

--- a/frontend/src/components/dock/FilesPanel.test.tsx
+++ b/frontend/src/components/dock/FilesPanel.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+//
+// The two halves of the plain-folder tree the gate's node environment cannot
+// see: the line a cut listing owes the reader, and the tick that re-reads a
+// folder git has no status for. Both are render paths — the panel's other
+// suites are pure logic — so this one opts into jsdom the way the render
+// budgets do.
+//
+// The harness has to be imported before anything that reaches react-dom (see
+// @/test/render-budget), which is why it is first.
+import { mountBudget } from "@/test/render-budget"
+import { createElement } from "react"
+import { afterEach, beforeEach, expect, test, vi } from "vitest"
+import { buildTree } from "@/lib/git/file-tree"
+import type { DiffFile } from "@/lib/git/diff"
+import { GIT_POLL } from "@/lib/git/use-git-status"
+import { TreeBody, usePlainFolderTick } from "./FilesPanel"
+
+const NO_STATS = new Map<string, DiffFile>()
+
+function body(cut: boolean, files: string[] = ["a.txt", "src/main.go"]) {
+  return createElement(TreeBody, {
+    tree: buildTree(files),
+    query: "",
+    active: "",
+    toggled: new Set<string>(),
+    onToggled: () => {},
+    stats: NO_STATS,
+    cut,
+    loading: false,
+    failed: false,
+    onOpen: () => {},
+    onEditor: () => {},
+  })
+}
+
+const CUT_LINE = "This folder has more files than the tree can list."
+
+test("a cut listing says so under the rows", async () => {
+  const budget = await mountBudget(body(true))
+  const text = document.body.textContent ?? ""
+  expect(text).toContain(CUT_LINE)
+  // Under the tree, not instead of it: the rows the walk did reach still show.
+  expect(text.indexOf("a.txt")).toBeLessThan(text.indexOf(CUT_LINE))
+  await budget.unmount()
+})
+
+test("a listing that reached the end says nothing", async () => {
+  const budget = await mountBudget(body(false))
+  expect(document.body.textContent ?? "").not.toContain(CUT_LINE)
+  await budget.unmount()
+})
+
+// The empty branch is where the line matters most: a filter that matched
+// nothing in a listing that was cut has not searched the folder, and saying only
+// "No file matches" would report that as a finished answer.
+test("an empty tree still admits the listing was cut", async () => {
+  const budget = await mountBudget(body(true, []))
+  const text = document.body.textContent ?? ""
+  expect(text).toContain("No files here")
+  expect(text).toContain(CUT_LINE)
+  await budget.unmount()
+})
+
+function probe(on: boolean) {
+  return createElement(function Probe() {
+    return createElement("span", null, `tick ${usePlainFolderTick(on)}`)
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+test("a plain folder re-reads on the git poller's idle cadence", async () => {
+  const budget = await mountBudget(probe(true))
+  expect(document.body.textContent).toContain("tick 0")
+  await budget.act(() => {
+    vi.advanceTimersByTime(GIT_POLL.slowMs)
+  })
+  expect(document.body.textContent).toContain("tick 1")
+  await budget.act(() => {
+    vi.advanceTimersByTime(GIT_POLL.slowMs * 2)
+  })
+  expect(document.body.textContent).toContain("tick 3")
+  await budget.unmount()
+})
+
+// A repository keys its tree off the git status it already polls, so a second
+// timer on the same path would be one walk per tick for nothing.
+test("a repository is left to its git status", async () => {
+  const budget = await mountBudget(probe(false))
+  await budget.act(() => {
+    vi.advanceTimersByTime(GIT_POLL.slowMs * 5)
+  })
+  expect(document.body.textContent).toContain("tick 0")
+  await budget.unmount()
+})

--- a/frontend/src/components/dock/FilesPanel.test.tsx
+++ b/frontend/src/components/dock/FilesPanel.test.tsx
@@ -1,10 +1,10 @@
 // @vitest-environment jsdom
 //
 // The two halves of the plain-folder tree the gate's node environment cannot
-// see: the line a cut listing owes the reader, and the tick that re-reads a
-// folder git has no status for. Both are render paths — the panel's other
-// suites are pure logic — so this one opts into jsdom the way the render
-// budgets do.
+// see: the footnote a partial listing owes the reader, and the tick that
+// re-reads a folder git has no status for. Both are render paths (the panel's
+// other suites are pure logic), so this one opts into jsdom the way the render
+// budgets do. The footnote's own wording is pinned next to treeFootnote.
 //
 // The harness has to be imported before anything that reaches react-dom (see
 // @/test/render-budget), which is why it is first.
@@ -18,7 +18,13 @@ import { TreeBody, usePlainFolderTick } from "./FilesPanel"
 
 const NO_STATS = new Map<string, DiffFile>()
 
-function body(cut: boolean, files: string[] = ["a.txt", "src/main.go"]) {
+interface BodyOptions {
+  cut?: boolean
+  hidden?: string[]
+  files?: string[]
+}
+
+function body({ cut = false, hidden = [], files = ["a.txt", "src/main.go"] }: BodyOptions) {
   return createElement(TreeBody, {
     tree: buildTree(files),
     query: "",
@@ -27,6 +33,7 @@ function body(cut: boolean, files: string[] = ["a.txt", "src/main.go"]) {
     onToggled: () => {},
     stats: NO_STATS,
     cut,
+    hidden,
     loading: false,
     failed: false,
     onOpen: () => {},
@@ -35,9 +42,10 @@ function body(cut: boolean, files: string[] = ["a.txt", "src/main.go"]) {
 }
 
 const CUT_LINE = "This folder has more files than the tree can list."
+const HIDDEN_LINE = "Hidden: build, node_modules."
 
 test("a cut listing says so under the rows", async () => {
-  const budget = await mountBudget(body(true))
+  const budget = await mountBudget(body({ cut: true }))
   const text = document.body.textContent ?? ""
   expect(text).toContain(CUT_LINE)
   // Under the tree, not instead of it: the rows the walk did reach still show.
@@ -45,19 +53,33 @@ test("a cut listing says so under the rows", async () => {
   await budget.unmount()
 })
 
-test("a listing that reached the end says nothing", async () => {
-  const budget = await mountBudget(body(false))
-  expect(document.body.textContent ?? "").not.toContain(CUT_LINE)
+// The judgement call the ignore set makes is answered on screen: a folder that
+// keeps its own source under build/ is one line away from the reason.
+test("a filtered listing names the directories it stepped over", async () => {
+  const budget = await mountBudget(body({ hidden: ["build", "node_modules"] }))
+  const text = document.body.textContent ?? ""
+  expect(text).toContain(HIDDEN_LINE)
+  expect(text).not.toContain(CUT_LINE)
+  expect(text.indexOf("a.txt")).toBeLessThan(text.indexOf(HIDDEN_LINE))
+  await budget.unmount()
+})
+
+test("a listing that reached the end and hid nothing says nothing", async () => {
+  const budget = await mountBudget(body({}))
+  const text = document.body.textContent ?? ""
+  expect(text).not.toContain(CUT_LINE)
+  expect(text).not.toContain("Hidden:")
   await budget.unmount()
 })
 
 // The empty branch is where the line matters most: a filter that matched
 // nothing in a listing that was cut has not searched the folder, and saying only
 // "No file matches" would report that as a finished answer.
-test("an empty tree still admits the listing was cut", async () => {
-  const budget = await mountBudget(body(true, []))
+test("an empty tree still admits what it left out", async () => {
+  const budget = await mountBudget(body({ cut: true, hidden: ["build"], files: [] }))
   const text = document.body.textContent ?? ""
   expect(text).toContain("No files here")
+  expect(text).toContain("Hidden: build.")
   expect(text).toContain(CUT_LINE)
   await budget.unmount()
 })

--- a/frontend/src/components/dock/FilesPanel.tsx
+++ b/frontend/src/components/dock/FilesPanel.tsx
@@ -9,7 +9,7 @@ import { type Composer, ReviewSlot } from "@/components/diff/ReviewSlots"
 import { FileTree } from "@/components/FileTree"
 import { threadSlots, type SlotElements } from "@/lib/codemirror-threads"
 import { formatLineRef, parseDiff, type DiffFile } from "@/lib/git/diff"
-import { buildTree, type TreeNode } from "@/lib/git/file-tree"
+import { buildTree, treeFootnote, type TreeNode } from "@/lib/git/file-tree"
 import { updateFileBrowse, useFileBrowse } from "@/lib/file-browse"
 import { COMPOSER_KEY } from "@/lib/pulls/review-slots"
 import { matchesQuery } from "@/lib/session/command-palette"
@@ -66,6 +66,7 @@ export function FilesPanel() {
       return {
         files: listing.files ?? [],
         cut: listing.cut,
+        hidden: listing.hidden ?? [],
         stats: diffStatsByPath(parseDiff(diffText)),
       }
     },
@@ -131,6 +132,7 @@ export function FilesPanel() {
             onToggled={(toggled) => updateFileBrowse(path, { toggled })}
             stats={data.stats}
             cut={data.cut}
+            hidden={data.hidden}
             loading={loading}
             failed={error !== null}
             onOpen={(rel) => updateFileBrowse(path, { open: rel, selected: rel })}
@@ -158,9 +160,15 @@ export function FilesPanel() {
 
 // What the tree holds before its first answer, and after a failed lookup. A
 // module-level constant because useRemoteResource compares it by identity.
-const NO_TREE: { files: string[]; cut: boolean; stats: Map<string, DiffFile> } = {
+const NO_TREE: {
+  files: string[]
+  cut: boolean
+  hidden: string[]
+  stats: Map<string, DiffFile>
+} = {
   files: [],
   cut: false,
+  hidden: [],
   stats: new Map(),
 }
 
@@ -208,6 +216,9 @@ interface TreeBodyProps {
   /** The listing stopped at the walk's cap, so the tree is only part of the
    * folder. Only a plain folder can set it: git's listing is never cut. */
   cut: boolean
+  /** Directory names the walk stepped over, for the same reason. Empty in a
+   * repository, where .gitignore filters and lich names nothing. */
+  hidden: string[]
   /** A read with nothing on screen yet. False through a refetch that has last
    * time's tree to stand on, which is what keeps a poll tick from flashing. */
   loading: boolean
@@ -227,12 +238,14 @@ export function TreeBody({
   onToggled,
   stats,
   cut,
+  hidden,
   loading,
   failed,
   onOpen,
   onEditor,
 }: TreeBodyProps) {
   const filtering = query.trim() !== ""
+  const footnote = treeFootnote(cut, hidden)
   if (failed) {
     return <Notice>Could not read this folder</Notice>
   }
@@ -258,14 +271,12 @@ export function TreeBody({
           onSelect={onOpen}
         />
       )}
-      {/* A cut listing has to say so, and it says so under the rows rather than
-          over them: it is a footnote to the tree, not a state of the panel. It
-          outlives the empty branch on purpose: "No file matches" is a lie when
-          the listing the filter ran over was only part of the folder. */}
-      {cut && (
-        <Notice className="shrink-0 border-t border-border py-2">
-          This folder has more files than the tree can list.
-        </Notice>
+      {/* A listing that left something out has to say so, under the rows rather
+          than over them: it is a footnote to the tree, not a state of the panel.
+          It outlives the empty branch on purpose: "No file matches" is a lie
+          when the listing the filter ran over was only part of the folder. */}
+      {footnote !== "" && (
+        <Notice className="shrink-0 border-t border-border py-2">{footnote}</Notice>
       )}
     </>
   )

--- a/frontend/src/components/dock/FilesPanel.tsx
+++ b/frontend/src/components/dock/FilesPanel.tsx
@@ -18,7 +18,7 @@ import { queuePaste } from "@/lib/terminal/paste-queue"
 import { useProjects } from "@/providers/projects"
 import { ProjectService, System } from "@/lib/rpc"
 import { useActiveSession } from "@/lib/session/use-active-session"
-import { useGitStatus } from "@/lib/git/use-git-status"
+import { GIT_POLL, useGitStatus } from "@/lib/git/use-git-status"
 import { useInject } from "@/lib/use-inject"
 import { useRemoteResource } from "@/lib/use-remote-resource"
 import { useFileEditor } from "./useFileEditor"
@@ -44,22 +44,30 @@ export function FilesPanel() {
   // one worktree's browse off another's tree, which the panel used to do by
   // clearing on a path change.
   const browse = useFileBrowse(path)
+  // A plain folder answers no git status, so the key below would never move and
+  // the tree would only ever re-read on a remount. This tick is what replaces
+  // the status for it, on the cadence an idle repository's poll settles at.
+  const tick = usePlainFolderTick(path !== "" && status === null)
   // Same invalidation as the diff panel: the git-status poll doubles as the
   // signal, so a new or removed file shows up without a watcher. It rides the
   // key rather than an effect, because the key is what stands for the request.
   const key = path
-    ? `${path} ${status?.files ?? 0} ${status?.added ?? 0} ${status?.deleted ?? 0}`
+    ? `${path} ${status?.files ?? 0} ${status?.added ?? 0} ${status?.deleted ?? 0} ${tick}`
     : ""
   const { data, loading, error } = useRemoteResource(
     key,
     async () => {
       // The diff feeds each row its +/- badge; a diff failure (nothing to diff)
       // just means no badges, never a broken tree — hence the swallowed catch.
-      const [files, diffText] = await Promise.all([
+      const [listing, diffText] = await Promise.all([
         ProjectService.Tree(path),
         ProjectService.DiffText(path).catch(() => ""),
       ])
-      return { files: files ?? [], stats: diffStatsByPath(parseDiff(diffText)) }
+      return {
+        files: listing.files ?? [],
+        cut: listing.cut,
+        stats: diffStatsByPath(parseDiff(diffText)),
+      }
     },
     // resetOn is the path and not the key: a moved file count refreshes the
     // tree in place, while a worktree switch with no answer on file must drop
@@ -122,6 +130,7 @@ export function FilesPanel() {
             toggled={browse.toggled}
             onToggled={(toggled) => updateFileBrowse(path, { toggled })}
             stats={data.stats}
+            cut={data.cut}
             loading={loading}
             failed={error !== null}
             onOpen={(rel) => updateFileBrowse(path, { open: rel, selected: rel })}
@@ -149,9 +158,28 @@ export function FilesPanel() {
 
 // What the tree holds before its first answer, and after a failed lookup. A
 // module-level constant because useRemoteResource compares it by identity.
-const NO_TREE: { files: string[]; stats: Map<string, DiffFile> } = {
+const NO_TREE: { files: string[]; cut: boolean; stats: Map<string, DiffFile> } = {
   files: [],
+  cut: false,
   stats: new Map(),
+}
+
+// usePlainFolderTick advances a counter on the git poller's idle cadence while
+// `on`, so a caller keyed off it re-reads on the same rhythm a repository's
+// tree does. Only the plain-folder case turns it on: there is no git status
+// there to notice a file the agent just wrote, and a walk is cheap next to the
+// several git subprocesses the poller runs on the same path anyway. Exported
+// for tests.
+export function usePlainFolderTick(on: boolean): number {
+  const [tick, setTick] = useState(0)
+  useEffect(() => {
+    if (!on) {
+      return
+    }
+    const id = setInterval(() => setTick((n) => n + 1), GIT_POLL.slowMs)
+    return () => clearInterval(id)
+  }, [on])
+  return tick
 }
 
 // diffStatsByPath keys each changed file's +/- counts by its current path so a
@@ -177,6 +205,9 @@ interface TreeBodyProps {
   toggled: ReadonlySet<string>
   onToggled: (toggled: ReadonlySet<string>) => void
   stats: Map<string, DiffFile>
+  /** The listing stopped at the walk's cap, so the tree is only part of the
+   * folder. Only a plain folder can set it: git's listing is never cut. */
+  cut: boolean
   /** A read with nothing on screen yet. False through a refetch that has last
    * time's tree to stand on, which is what keeps a poll tick from flashing. */
   loading: boolean
@@ -185,13 +216,17 @@ interface TreeBodyProps {
   onEditor: (rel: string) => void
 }
 
-function TreeBody({
+// Exported for tests: the gate cannot stand FilesPanel up whole (it hangs off
+// the projects provider and a live session), and the tree's states are what the
+// panel is read on.
+export function TreeBody({
   tree,
   query,
   active,
   toggled,
   onToggled,
   stats,
+  cut,
   loading,
   failed,
   onOpen,
@@ -204,23 +239,35 @@ function TreeBody({
   if (loading) {
     return <Notice>Loading…</Notice>
   }
-  if (tree.length === 0) {
-    return <Notice>{filtering ? "No file matches" : "No files here"}</Notice>
-  }
   return (
-    <FileTree
-      tree={tree}
-      active={active}
-      // Suspended, not replaced: clearing the filter gives back the folders the
-      // browse had open rather than a tree collapsed to the root.
-      expandAll={filtering}
-      toggled={toggled}
-      onToggled={onToggled}
-      stats={stats}
-      onEditor={onEditor}
-      className="h-full"
-      onSelect={onOpen}
-    />
+    <>
+      {tree.length === 0 ? (
+        <Notice>{filtering ? "No file matches" : "No files here"}</Notice>
+      ) : (
+        <FileTree
+          tree={tree}
+          active={active}
+          // Suspended, not replaced: clearing the filter gives back the folders
+          // the browse had open rather than a tree collapsed to the root.
+          expandAll={filtering}
+          toggled={toggled}
+          onToggled={onToggled}
+          stats={stats}
+          onEditor={onEditor}
+          className="min-h-0 flex-1"
+          onSelect={onOpen}
+        />
+      )}
+      {/* A cut listing has to say so, and it says so under the rows rather than
+          over them: it is a footnote to the tree, not a state of the panel. It
+          outlives the empty branch on purpose: "No file matches" is a lie when
+          the listing the filter ran over was only part of the folder. */}
+      {cut && (
+        <Notice className="shrink-0 border-t border-border py-2">
+          This folder has more files than the tree can list.
+        </Notice>
+      )}
+    </>
   )
 }
 

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -259,6 +259,15 @@ export interface DraftReviewComment {
 /** The verdict a submitted review carries. */
 export type ReviewEvent = "approve" | "comment" | "request_changes"
 
+/** internal/project.FileListing: one listing of a checkout's files for the
+ * Files panel. In a repository it is git's own list and `cut` is never set;
+ * in a plain folder it is a bounded walk, and `cut` says the walk stopped at
+ * its cap with files still unread. */
+export interface FileListing {
+  files: string[] | null
+  cut: boolean
+}
+
 /** internal/project.Worktree — a git worktree checkout: branch and path. */
 export interface Worktree {
   name: string

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -260,12 +260,17 @@ export interface DraftReviewComment {
 export type ReviewEvent = "approve" | "comment" | "request_changes"
 
 /** internal/project.FileListing: one listing of a checkout's files for the
- * Files panel. In a repository it is git's own list and `cut` is never set;
- * in a plain folder it is a bounded walk, and `cut` says the walk stopped at
- * its cap with files still unread. */
+ * Files panel, plus what the panel owes the reader about how they were
+ * gathered. In a repository it is git's own list, and neither `cut` nor
+ * `hidden` is ever set; in a plain folder it is a bounded walk that says where
+ * it stopped and which directories it stepped over. */
 export interface FileListing {
   files: string[] | null
   cut: boolean
+  /** The ignored directory names this folder actually had (`node_modules`,
+   * `build`, …), sorted and deduped. Always empty in a repository, where
+   * .gitignore does the filtering and lich names nothing. */
+  hidden: string[] | null
 }
 
 /** internal/project.Worktree — a git worktree checkout: branch and path. */

--- a/frontend/src/lib/git/file-tree.test.ts
+++ b/frontend/src/lib/git/file-tree.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { buildTree, type TreeNode } from "./file-tree"
+import { buildTree, treeFootnote, type TreeNode } from "./file-tree"
 
 // names flattens a node list to "type:path" strings in order, so a test reads
 // the whole shape and ordering in one assertion.
@@ -66,5 +66,26 @@ describe("buildTree", () => {
   it("ignores empty and malformed segments", () => {
     expect(buildTree([""])).toEqual([])
     expect(names(buildTree(["a//b"]))).toEqual(["dir:a", "file:a/b"])
+  })
+})
+
+describe("treeFootnote", () => {
+  it("a repository owes the reader nothing", () => {
+    expect(treeFootnote(false, [])).toBe("")
+  })
+
+  it("names the directories the walk stepped over", () => {
+    expect(treeFootnote(false, ["build", "node_modules"])).toBe("Hidden: build, node_modules.")
+  })
+
+  it("says a listing stopped short", () => {
+    expect(treeFootnote(true, [])).toBe("This folder has more files than the tree can list.")
+  })
+
+  // Both, and the names first: they are the half a reader can act on.
+  it("puts the names ahead of the cap", () => {
+    expect(treeFootnote(true, ["vendor"])).toBe(
+      "Hidden: vendor. This folder has more files than the tree can list.",
+    )
   })
 })

--- a/frontend/src/lib/git/file-tree.ts
+++ b/frontend/src/lib/git/file-tree.ts
@@ -70,3 +70,20 @@ function sortTree(nodes: TreeNode[]): void {
     sortTree(node.children)
   }
 }
+
+// treeFootnote is the one line a listing owes the reader when it is not the
+// whole folder: which directories the walk stepped over, and whether it ran out
+// of room before the end. The names come first because they are the actionable
+// half: somebody whose source lives under build/ reads why it is missing
+// instead of concluding the panel is broken. Empty string when there is nothing
+// to admit, which is every repository (git filters, and lich names nothing).
+export function treeFootnote(cut: boolean, hidden: string[]): string {
+  const parts: string[] = []
+  if (hidden.length > 0) {
+    parts.push(`Hidden: ${hidden.join(", ")}.`)
+  }
+  if (cut) {
+    parts.push("This folder has more files than the tree can list.")
+  }
+  return parts.join(" ")
+}

--- a/frontend/src/lib/git/use-git-status.ts
+++ b/frontend/src/lib/git/use-git-status.ts
@@ -8,7 +8,11 @@ export type { GitStatus }
 // up while the agent is still typing; after five quiet reads it falls back to
 // the old 3s, which is what an idle project costs today. The plugin's
 // session-touched hook still nudges an immediate read on top of this.
-const GIT_POLL: PollCadence = { fastMs: 1_000, slowMs: 3_000, idleTicks: 5 }
+//
+// Exported for the Files panel: a plain folder has no git status to key its
+// tree off, so it re-walks on this same cadence rather than inventing a second
+// one for the user to notice the difference in.
+export const GIT_POLL: PollCadence = { fastMs: 1_000, slowMs: 3_000, idleTicks: 5 }
 
 // Two calls, not three: Diff carries the branch, because the one git status it
 // runs already reports it alongside the head and the dirty entries.

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -22,6 +22,7 @@ import type {
   DraftReviewComment,
   Attachment,
   DropItem,
+  FileListing,
   Issue,
   MergeMethod,
   PatchNotes as PatchNotesData,
@@ -213,8 +214,10 @@ export const ProjectService = {
    * collide on. null when the repository has no origin to measure against. */
   BaseStatus: (path: string) => call<BaseStatus | null>("project.BaseStatus", [path]),
   DiffText: (path: string) => call<string>("project.DiffText", [path]),
-  /** Tracked files, repo-relative and slash-separated, sorted (git ls-files). */
-  Tree: (path: string) => call<string[] | null>("project.Tree", [path]),
+  /** The checkout's files, repo-relative and slash-separated, sorted: git
+   * ls-files in a repository, a bounded walk in a plain folder, where `cut`
+   * reports the walk stopped at its cap. */
+  Tree: (path: string) => call<FileListing>("project.Tree", [path]),
   ReadFile: (path: string, rel: string) => call<string>("project.ReadFile", [path, rel]),
   /** Lines from..to (1-based, inclusive) of one file for the diff's context
    * expander. ref is the revision the diff's new side stands at: "" for the

--- a/internal/project/tree.go
+++ b/internal/project/tree.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -33,15 +34,19 @@ func isBinary(data []byte) bool {
 	return bytes.IndexByte(data[:min(len(data), binarySniffBytes)], 0) >= 0
 }
 
-// FileListing is one listing of a directory's files: the paths, and whether the
-// listing is the whole directory or only as much of it as the walk was allowed
-// to read. Cut is what the Files panel says out loud: a tree that silently
-// stops short reads as a folder with fewer files in it than it has.
+// FileListing is one listing of a directory's files: the paths, plus the two
+// things the Files panel has to say out loud about how they were gathered. A
+// tree that silently stops short, or silently leaves a directory out, reads as
+// a folder with fewer files in it than it has.
 type FileListing struct {
 	Files []string `json:"files"`
 	// Cut reports a listing that stopped at walkLimit. Only a plain-folder walk
 	// can set it; git's own listing is never capped.
 	Cut bool `json:"cut"`
+	// Hidden names the walkIgnore directories this folder actually had, sorted
+	// and deduped: the panel names them, so somebody keeping source under a
+	// build/ or vendor/ reads why it is missing instead of guessing.
+	Hidden []string `json:"hidden"`
 }
 
 // Tree lists a directory's files as root-relative, slash-separated paths,
@@ -113,13 +118,14 @@ var walkIgnore = map[string]bool{
 // walkFiles lists a plain directory's regular files, root-relative and
 // slash-separated, stopping at limit files (walkLimit; a parameter so the cap
 // is testable without laying down 20k files) and reporting whether it stopped
-// there. Symlinks are skipped (nothing here resolves one, and a link
-// to a directory is a walk that may not terminate), walkIgnore directories are
-// skipped whole, and an unreadable subdirectory costs its own subtree rather
-// than the answer.
+// there and which ignored directories it passed. Symlinks are skipped (nothing
+// here resolves one, and a link to a directory is a walk that may not
+// terminate), walkIgnore directories are skipped whole, and an unreadable
+// subdirectory costs its own subtree rather than the answer.
 func walkFiles(root string, limit int) (FileListing, error) {
 	var files []string
 	cut := false
+	hidden := map[string]bool{}
 	err := filepath.WalkDir(root, func(full string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			if full == root {
@@ -132,6 +138,7 @@ func walkFiles(root string, limit int) (FileListing, error) {
 		}
 		if entry.IsDir() {
 			if full != root && walkIgnore[entry.Name()] {
+				hidden[entry.Name()] = true
 				return fs.SkipDir
 			}
 			return nil
@@ -154,7 +161,7 @@ func walkFiles(root string, limit int) (FileListing, error) {
 		return FileListing{}, fmt.Errorf("list %s: %w", root, err)
 	}
 	slices.Sort(files)
-	return FileListing{Files: files, Cut: cut}, nil
+	return FileListing{Files: files, Cut: cut, Hidden: slices.Sorted(maps.Keys(hidden))}, nil
 }
 
 // lsFiles runs `git ls-files -z` with the given selectors and splits its

--- a/internal/project/tree.go
+++ b/internal/project/tree.go
@@ -33,6 +33,17 @@ func isBinary(data []byte) bool {
 	return bytes.IndexByte(data[:min(len(data), binarySniffBytes)], 0) >= 0
 }
 
+// FileListing is one listing of a directory's files: the paths, and whether the
+// listing is the whole directory or only as much of it as the walk was allowed
+// to read. Cut is what the Files panel says out loud: a tree that silently
+// stops short reads as a folder with fewer files in it than it has.
+type FileListing struct {
+	Files []string `json:"files"`
+	// Cut reports a listing that stopped at walkLimit. Only a plain-folder walk
+	// can set it; git's own listing is never capped.
+	Cut bool `json:"cut"`
+}
+
 // Tree lists a directory's files as root-relative, slash-separated paths,
 // sorted. Inside a repository it merges tracked files with
 // untracked-but-not-ignored ones (`ls-files --cached --others
@@ -42,7 +53,7 @@ func isBinary(data []byte) bool {
 // build output leak in. Anywhere else — a plain folder, a machine without git —
 // it falls back to walking the directory: browsing a project's files is not a
 // git feature, and only the diff panel beside it is.
-func (s *Service) Tree(path string) ([]string, error) {
+func (s *Service) Tree(path string) (FileListing, error) {
 	// Asked before anything is listed, and quietly: a plain directory is not a
 	// failure to report, and routing its refreshes through runGit would file a
 	// warning per poll for a folder that is behaving exactly as it should. A
@@ -53,11 +64,11 @@ func (s *Service) Tree(path string) ([]string, error) {
 	}
 	present, err := lsFiles(path, "--cached", "--others", "--exclude-standard")
 	if err != nil {
-		return nil, err
+		return FileListing{}, err
 	}
 	deleted, err := lsFiles(path, "--deleted")
 	if err != nil {
-		return nil, err
+		return FileListing{}, err
 	}
 	gone := make(map[string]struct{}, len(deleted))
 	for _, rel := range deleted {
@@ -71,22 +82,44 @@ func (s *Service) Tree(path string) ([]string, error) {
 	}
 	// The --cached/--others merge is not globally sorted; the tree wants one order.
 	slices.Sort(files)
-	return files, nil
+	return FileListing{Files: files}, nil
 }
 
-// walkLimit caps a non-repository walk. Without git there is no .gitignore to
-// obey, so the walk has no way to leave a dependency or build directory out;
-// the cap is what keeps a home directory or a node_modules from arriving as one
-// RPC answer the tree then has to render.
+// walkLimit caps a non-repository walk. walkIgnore keeps the usual dependency
+// and build trees out, but it is a name list and not a .gitignore: a folder can
+// still hold more files than the tree has any business rendering, so the cap
+// stays as the backstop, and a walk that hits it says so (FileListing.Cut).
 const walkLimit = 20000
+
+// walkIgnore is the directory names a plain-folder walk skips at any depth.
+// Without git there is no .gitignore to obey, and these are the trees nobody
+// opens the Files panel to browse: a machine-written dependency, cache or
+// build directory. Deliberately a short list matched by name alone: the
+// alternative is a per-project ignore setting for a panel that is a file
+// browser, not a build tool.
+var walkIgnore = map[string]bool{
+	".cache":       true,
+	".git":         true,
+	".venv":        true,
+	"__pycache__":  true,
+	"build":        true,
+	"dist":         true,
+	"node_modules": true,
+	"target":       true,
+	"vendor":       true,
+	"venv":         true,
+}
 
 // walkFiles lists a plain directory's regular files, root-relative and
 // slash-separated, stopping at limit files (walkLimit; a parameter so the cap
-// is testable without laying down 20k files). Symlinks are skipped (nothing here resolves one, and a link
-// to a directory is a walk that may not terminate), .git is skipped whole, and
-// an unreadable subdirectory costs its own subtree rather than the answer.
-func walkFiles(root string, limit int) ([]string, error) {
+// is testable without laying down 20k files) and reporting whether it stopped
+// there. Symlinks are skipped (nothing here resolves one, and a link
+// to a directory is a walk that may not terminate), walkIgnore directories are
+// skipped whole, and an unreadable subdirectory costs its own subtree rather
+// than the answer.
+func walkFiles(root string, limit int) (FileListing, error) {
 	var files []string
+	cut := false
 	err := filepath.WalkDir(root, func(full string, entry fs.DirEntry, err error) error {
 		if err != nil {
 			if full == root {
@@ -98,7 +131,7 @@ func walkFiles(root string, limit int) ([]string, error) {
 			return fs.SkipDir
 		}
 		if entry.IsDir() {
-			if full != root && entry.Name() == ".git" {
+			if full != root && walkIgnore[entry.Name()] {
 				return fs.SkipDir
 			}
 			return nil
@@ -112,15 +145,16 @@ func walkFiles(root string, limit int) ([]string, error) {
 		}
 		files = append(files, filepath.ToSlash(rel))
 		if len(files) >= limit {
+			cut = true
 			return fs.SkipAll
 		}
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("list %s: %w", root, err)
+		return FileListing{}, fmt.Errorf("list %s: %w", root, err)
 	}
 	slices.Sort(files)
-	return files, nil
+	return FileListing{Files: files, Cut: cut}, nil
 }
 
 // lsFiles runs `git ls-files -z` with the given selectors and splits its

--- a/internal/project/tree_test.go
+++ b/internal/project/tree_test.go
@@ -75,6 +75,9 @@ func TestTreeWalksNonRepo(t *testing.T) {
 	if tree.Cut {
 		t.Error("Tree.Cut = true on a walk that reached the end, want false")
 	}
+	if got := strings.Join(tree.Hidden, ","); got != ".git" {
+		t.Errorf("Tree.Hidden = %q, want %q", got, ".git")
+	}
 }
 
 // TestTreeReportsBrokenRepo proves the gate only routes a path away from git
@@ -150,6 +153,40 @@ func TestWalkIgnoresDependencyDirs(t *testing.T) {
 	want := "build-tools/run.sh,dist.txt,main.go"
 	if got := strings.Join(tree.Files, ","); got != want {
 		t.Errorf("walkFiles = %q, want %q", got, want)
+	}
+	// Every ignored name this folder actually had, once each: node_modules sat
+	// at two depths, and .git was not here at all.
+	wantHidden := ".cache,.venv,__pycache__,build,dist,node_modules,target,vendor,venv"
+	if got := strings.Join(tree.Hidden, ","); got != wantHidden {
+		t.Errorf("walkFiles.Hidden = %q, want %q", got, wantHidden)
+	}
+}
+
+// TestWalkHiddenNamesOnlyWhatIsThere proves Hidden is the folder's own answer
+// and not the ignore set recited back: it is what the panel prints, so a name
+// in it that is not on disk sends the reader looking for a directory that was
+// never there.
+func TestWalkHiddenNamesOnlyWhatIsThere(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "main.go", "package main\n")
+	write(t, dir, "dist/out.js", "x")
+
+	tree, err := walkFiles(dir, walkLimit)
+	if err != nil {
+		t.Fatalf("walkFiles: %v", err)
+	}
+	if got := strings.Join(tree.Hidden, ","); got != "dist" {
+		t.Errorf("walkFiles.Hidden = %q, want %q", got, "dist")
+	}
+
+	clean := t.TempDir()
+	write(t, clean, "main.go", "package main\n")
+	bare, err := walkFiles(clean, walkLimit)
+	if err != nil {
+		t.Fatalf("walkFiles: %v", err)
+	}
+	if len(bare.Hidden) != 0 {
+		t.Errorf("walkFiles.Hidden = %v on a folder with nothing to skip, want empty", bare.Hidden)
 	}
 }
 

--- a/internal/project/tree_test.go
+++ b/internal/project/tree_test.go
@@ -3,6 +3,7 @@ package project
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -28,11 +29,11 @@ func TestTree(t *testing.T) {
 	git("add", ".gitignore")
 	git("commit", "-m", "gitignore")
 
-	files, err := New(nil).Tree(repo)
+	tree, err := New(nil).Tree(repo)
 	if err != nil {
 		t.Fatalf("Tree: %v", err)
 	}
-	got := strings.Join(files, ",")
+	got := strings.Join(tree.Files, ",")
 	want := ".gitignore,a.txt,internal/rpc/rpc.go,untracked.txt,z.txt"
 	if got != want {
 		t.Errorf("Tree = %q, want %q", got, want)
@@ -46,12 +47,12 @@ func TestTreeDropsDeleted(t *testing.T) {
 	if err := os.Remove(filepath.Join(repo, "a.txt")); err != nil {
 		t.Fatal(err)
 	}
-	files, err := New(nil).Tree(repo)
+	tree, err := New(nil).Tree(repo)
 	if err != nil {
 		t.Fatalf("Tree: %v", err)
 	}
-	if slices.Contains(files, "a.txt") {
-		t.Errorf("Tree = %v, want a.txt dropped", files)
+	if slices.Contains(tree.Files, "a.txt") {
+		t.Errorf("Tree = %v, want a.txt dropped", tree.Files)
 	}
 }
 
@@ -64,12 +65,15 @@ func TestTreeWalksNonRepo(t *testing.T) {
 	write(t, dir, "b.txt", "b\n")
 	write(t, dir, "src/main.go", "package main\n")
 	write(t, dir, ".git/config", "[core]\n")
-	files, err := New(nil).Tree(dir)
+	tree, err := New(nil).Tree(dir)
 	if err != nil {
 		t.Fatalf("Tree: %v", err)
 	}
-	if got, want := strings.Join(files, ","), "b.txt,src/main.go"; got != want {
+	if got, want := strings.Join(tree.Files, ","), "b.txt,src/main.go"; got != want {
 		t.Errorf("Tree = %q, want %q", got, want)
+	}
+	if tree.Cut {
+		t.Error("Tree.Cut = true on a walk that reached the end, want false")
 	}
 }
 
@@ -80,9 +84,9 @@ func TestTreeWalksNonRepo(t *testing.T) {
 func TestTreeReportsBrokenRepo(t *testing.T) {
 	repo, _ := initRepo(t)
 	write(t, repo, ".git/index", "not an index")
-	files, err := New(nil).Tree(repo)
+	tree, err := New(nil).Tree(repo)
 	if err == nil {
-		t.Fatalf("Tree on a corrupt index = %v, want an error", files)
+		t.Fatalf("Tree on a corrupt index = %v, want an error", tree.Files)
 	}
 }
 
@@ -94,10 +98,11 @@ func TestTreeMissingDir(t *testing.T) {
 	}
 }
 
-// TestWalkFilesStopsAtLimit proves the walk is bounded: without .gitignore
-// nothing else keeps a dependency directory out of one RPC answer. walkLimit's
-// own value is pinned as a literal — deriving it would make the test follow the
-// constant instead of pinning it.
+// TestWalkFilesStopsAtLimit proves the walk is bounded and says so: walkIgnore
+// is a name list, not a .gitignore, so the cap is still what stands between a
+// huge folder and one RPC answer, and Cut is what lets the panel admit the
+// listing is partial. walkLimit's own value is pinned as a literal (deriving
+// it would make the test follow the constant instead of pinning it).
 func TestWalkFilesStopsAtLimit(t *testing.T) {
 	if walkLimit != 20000 {
 		t.Errorf("walkLimit = %d, want 20000", walkLimit)
@@ -106,12 +111,60 @@ func TestWalkFilesStopsAtLimit(t *testing.T) {
 	for i := range 12 {
 		write(t, dir, fmt.Sprintf("f%02d.txt", i), "x")
 	}
-	files, err := walkFiles(dir, 10)
+	tree, err := walkFiles(dir, 10)
 	if err != nil {
 		t.Fatalf("walkFiles: %v", err)
 	}
-	if len(files) != 10 {
-		t.Errorf("walkFiles = %d files, want 10", len(files))
+	if len(tree.Files) != 10 {
+		t.Errorf("walkFiles = %d files, want 10", len(tree.Files))
+	}
+	if !tree.Cut {
+		t.Error("walkFiles.Cut = false on a listing that stopped at the cap, want true")
+	}
+}
+
+// TestWalkIgnoresDependencyDirs proves the plain-folder walk leaves the
+// machine-written trees out at any depth, and only those: a file whose *own*
+// name matches an ignored directory is a file, and a directory whose name only
+// contains one is not the one being skipped.
+func TestWalkIgnoresDependencyDirs(t *testing.T) {
+	dir := t.TempDir()
+	write(t, dir, "main.go", "package main\n")
+	write(t, dir, "node_modules/left-pad/index.js", "x")
+	write(t, dir, "src/node_modules/dep/index.js", "x")
+	write(t, dir, "src/app/dist/bundle.js", "x")
+	write(t, dir, "api/__pycache__/mod.pyc", "x")
+	write(t, dir, "web/.venv/lib/site.py", "x")
+	write(t, dir, "go/vendor/dep/dep.go", "x")
+	write(t, dir, "rs/target/debug/bin", "x")
+	write(t, dir, "cc/build/out.o", "x")
+	write(t, dir, "py/venv/bin/python", "x")
+	write(t, dir, "app/.cache/blob", "x")
+	write(t, dir, "dist.txt", "not a directory")
+	write(t, dir, "build-tools/run.sh", "not build/")
+
+	tree, err := walkFiles(dir, walkLimit)
+	if err != nil {
+		t.Fatalf("walkFiles: %v", err)
+	}
+	want := "build-tools/run.sh,dist.txt,main.go"
+	if got := strings.Join(tree.Files, ","); got != want {
+		t.Errorf("walkFiles = %q, want %q", got, want)
+	}
+}
+
+// TestWalkIgnoreNames pins the set itself. The walk is the only filter a plain
+// folder gets, so a name silently dropped from here is a dependency tree back
+// in the panel, and a name silently added is a directory of somebody's source
+// gone from it.
+func TestWalkIgnoreNames(t *testing.T) {
+	want := []string{
+		".cache", ".git", ".venv", "__pycache__", "build",
+		"dist", "node_modules", "target", "vendor", "venv",
+	}
+	got := slices.Sorted(maps.Keys(walkIgnore))
+	if !slices.Equal(got, want) {
+		t.Errorf("walkIgnore = %v, want %v", got, want)
 	}
 }
 


### PR DESCRIPTION
Closes the whole `docs/ceilings.md` bullet on the non-repository file tree, which set three traps at once: an unfiltered walk, a silent cap, and no refresh.

## What changed

**The walk skips the machine-written trees, and names what it skipped.** `walkIgnore` (`internal/project/tree.go`) holds ten directory names skipped by name at any depth: `.cache`, `.git`, `.venv`, `__pycache__`, `build`, `dist`, `node_modules`, `target`, `vendor`, `venv`. It absorbs the `.git` case the walk already special-cased. Matched by name only, on purpose: the alternative is a per-project ignore setting for a panel that is a file browser, not a build tool.

That set makes a judgement call for the reader, so the reader gets told. `FileListing.Hidden` carries the ignored names this folder *actually had*, sorted and deduped, and it is the folder's own answer rather than the set recited back: a name in it that is not on disk would send somebody looking for a directory that was never there.

**A partial listing says so, in one line.** `Tree` now answers `FileListing {files, cut, hidden}` (mirrored in `frontend/src/lib/api-types.ts`, wired in `rpc.ts`). `treeFootnote` composes the line and the Files panel renders it under the rows in the panel's `Notice` idiom:

- `Hidden: build, node_modules.`
- `This folder has more files than the tree can list.`
- both, names first, because the names are the half a reader can act on.

Neither is ever set in a repository: git filters there, and lich names nothing. The footnote deliberately survives the empty branch too, since "No file matches" is a false answer when the filter only ran over part of the folder.

**The tree refreshes on its own.** A plain folder answers no git status, so the panel's request key never moved and the tree only re-read on a remount. `usePlainFolderTick` advances that key on `GIT_POLL.slowMs`, the cadence a repository's poller settles at once it is idle, and only while the panel is mounted with no git status on the path.

## The measurement behind the cadence

`walkFiles` on real folders, warm, on this machine:

| root | files | walk |
|---|---|---|
| a JS project (2 498 files before the ignore set) | 41 | **0.2 ms** |
| `~/try` (hits the cap) | 20 000 | **90-110 ms** |
| `$HOME` (hits the cap) | 20 000 | **59-67 ms** |

Cold reads on the capped folders were 180-290 ms. The ignore set is what moves the common case: the JS project drops from 2 498 files to 41, and from 5-6 ms to 0.2 ms. A poll at the git cadence costs that, not the capped figure, for any folder somebody actually opens as a project. The cap stays as the backstop for the rest, and a folder that hits it now says so instead of quietly showing 20 000 of its files.

## Tests

- Go: `TestWalkIgnoresDependencyDirs` (skipped at any depth, only directories, and the `Hidden` list it produces), `TestWalkHiddenNamesOnlyWhatIsThere` (both directions: one present name, and empty on a folder with nothing to skip), `TestWalkIgnoreNames` (pins the set itself), `TestWalkFilesStopsAtLimit` (pins `Cut`), `TestTreeWalksNonRepo` (pins `Cut` false and `Hidden` on a complete walk).
- Frontend, node env: `treeFootnote` in `file-tree.test.ts`, all four wordings.
- Frontend, jsdom: `FilesPanel.test.tsx` for the line landing under the rows, its absence on a complete listing, its survival through the empty branch, and the tick firing on `GIT_POLL.slowMs` for a plain folder and never for a repository.

## Gate

`gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green, `biome ci .` exit 0, `pnpm test` 1617 passing, `pnpm build` green. `shell/` untouched.
