### PR TITLE
fix: delete the terminal-theme selection nothing reads

### DIFF
--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -788,13 +788,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   pretending the setting is absent. Shortcuts and the panes themselves are indexed off `HOTKEY_ACTIONS` and
   `SETTING_SECTIONS`, so those two never fall behind.
 
-- **The old terminal-theme selection is left where it was written** (`appearance.terminalTheme` in the
-  workspace database, `lich.appearance.terminalTheme` in localStorage): one theme now colors both surfaces,
-  and nothing reads either key any more. They are not deleted on upgrade, because a migration that runs on
-  every launch to clear a value nobody reads costs more than the row it removes. The trap is for whoever
-  gives the terminal its own theme again: an install that used one before this version still holds the id it
-  had, so that feature must write a fresh key rather than adopting this one, which would silently restore a
-  choice the user made under different rules.
 - **The footer editor's sides wrap, and stop lining up when they do**
   (`FooterLayoutEditor.tsx`): each side is a tray of chips laid out with `flex-wrap`, so a user who turns on
   most of the twelve items gets two rows in one column and one in the other, and the two stop reading as the

--- a/frontend/src/providers/settings.test.tsx
+++ b/frontend/src/providers/settings.test.tsx
@@ -57,6 +57,19 @@ beforeEach(() => {
   localStorage.clear()
 })
 
+// The terminal kept its own theme until one theme took over both surfaces. The
+// key is pinned by hand here rather than imported: the point is the exact
+// string an old install still holds.
+describe("the terminal-theme leftover", () => {
+  it("drops the page's copy on load", async () => {
+    localStorage.setItem("lich.appearance.terminalTheme", "emerald")
+
+    await mountSettings()
+
+    expect(localStorage.getItem("lich.appearance.terminalTheme")).toBeNull()
+  })
+})
+
 describe("the hotkey bindings", () => {
   it("reads them from the workspace, without writing anything back", async () => {
     settings.set(`${HOTKEYS_SETTING_KEY}@`, rebound(MINE))

--- a/frontend/src/providers/settings.tsx
+++ b/frontend/src/providers/settings.tsx
@@ -45,6 +45,12 @@ const FONT_STORAGE_KEY = "lich.terminal.font"
 const TERMINAL_FONT_SIZE_STORAGE_KEY = "lich.terminal.fontSize"
 const THEME_STORAGE_KEY = "lich.appearance.theme"
 const ZOOM_STORAGE_KEY = "lich.appearance.zoom"
+// The terminal's own theme selection, from before one theme coloured both
+// surfaces. Nothing reads it, and it is dropped on every load rather than once:
+// a terminal theme that ever comes back needs a key of its own, because this one
+// would be cleared under it. Restoring a choice its user made when the two were
+// separate is what dropping it prevents.
+const LEGACY_TERMINAL_THEME_KEY = "lich.appearance.terminalTheme"
 const CONTEXT_USAGE_STORAGE_KEY = "lich.footer.contextUsage"
 const COST_BUDGET_STORAGE_KEY = "lich.footer.costBudget"
 const DESKTOP_NOTIFICATIONS_STORAGE_KEY = "lich.notifications.desktop"
@@ -254,6 +260,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       cancelled = true
     }
   }, [persistTheme])
+
+  useEffect(() => {
+    removePref(LEGACY_TERMINAL_THEME_KEY)
+  }, [])
 
   const persistHotkeys = useCallback((next: Hotkeys) => {
     hotkeysTouched.current = true

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -311,6 +311,13 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN closed_seq INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE session_costs ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0`,
+		// The terminal's own theme selection, from before one theme coloured both
+		// surfaces. Nothing reads it, and a row left standing would hand whoever
+		// gives the terminal a theme again a choice its user made under other
+		// rules. Unlike the ALTERs above this runs on every launch, so a terminal
+		// theme that ever comes back needs a key of its own: this one is cleared
+		// under it.
+		`DELETE FROM settings WHERE key = 'appearance.terminalTheme'`,
 	}
 	for _, stmt := range migrations {
 		if _, err := db.Exec(stmt); err != nil && !migrationApplied(err) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -829,6 +829,45 @@ CREATE TABLE sessions (
 	}
 }
 
+// TestOpenDropsTheTerminalThemeSetting: one theme colours both the app and the
+// terminal now, and the selection the terminal used to keep is read by nothing.
+// It is deleted on the way past so that whoever gives the terminal its own
+// theme again starts from the default, rather than silently restoring a choice
+// its user made when the two were separate.
+func TestOpenDropsTheTerminalThemeSetting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "themed.db")
+	before, err := open(path)
+	if err != nil {
+		t.Fatalf("open store: %v", err)
+	}
+	if err := before.SetSetting("appearance.terminalTheme", "", "emerald"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	// The same leftover under a project scope, and the live selection beside it.
+	_ = before.SetSetting("appearance.terminalTheme", "p1", "emerald")
+	_ = before.SetSetting("appearance.theme", "", "rose-pine")
+	_ = before.Close()
+
+	after, err := open(path)
+	if err != nil {
+		t.Fatalf("reopen store: %v", err)
+	}
+	defer after.Close()
+
+	for _, scope := range []string{"", "p1"} {
+		got, err := after.GetSetting("appearance.terminalTheme", scope)
+		if err != nil {
+			t.Fatalf("GetSetting(scope %q): %v", scope, err)
+		}
+		if got != "" {
+			t.Errorf("terminal theme in scope %q = %q, want it gone", scope, got)
+		}
+	}
+	if got, _ := after.GetSetting("appearance.theme", ""); got != "rose-pine" {
+		t.Errorf("app theme = %q, want it untouched", got)
+	}
+}
+
 // TestOpenRenamesClaudeSessionColumn proves the multi-provider rename carries
 // stored ids over instead of stranding them: a database still on the
 // claude_session_id column comes back with its values readable under


### PR DESCRIPTION
One theme colours both the app and the terminal, and neither key the old
terminal-only selection lived under has a reader left: `appearance.terminalTheme`
in the workspace database, `lich.appearance.terminalTheme` in the page's
localStorage. They were left in place because clearing them looked like it cost
more than the rows.

This is the cheap version of clearing them, one statement in each store where
that store is already opened:

- `internal/store`: a `DELETE FROM settings` beside the schema migrations, which
  run on every launch anyway.
- `frontend/src/providers/settings.tsx`: one `removePref` where the appearance
  prefs are read.

Both are unconditional, so a terminal theme that ever comes back needs a key of
its own instead of adopting this one. That is the trap the ceilings bullet
carried, and it now sits in the two comments, so the bullet goes.

No `CHANGELOG.md` entry: nothing a user can see changes.

## Test plan

- [x] `go test ./...` (`TestOpenDropsTheTerminalThemeSetting`: the row is gone
      after a reopen, in both scopes, and the live `appearance.theme` is not)
- [x] `pnpm test` (`settings.test.tsx`: the page's copy is gone once the
      provider has loaded)
- [x] Both tests fail without the fix
- [x] `gofmt -l .`, `go vet ./...`, `biome ci .` (exit 0), `pnpm build`