### PR TITLE
feat: search opencode and Crush conversations from the palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The palette's Messages tab now searches opencode and Crush sessions.** Both
+  keep their conversation in a SQLite database rather than in a transcript file,
+  so searching what was said skipped them in silence: a session that had talked
+  about the thing you typed simply never appeared. They are queried directly now,
+  counted and quoted like every other provider, and Cursor CLI is the only one
+  still unsearchable — it files a chat as encrypted, content-addressed blobs.
+
 ### Changed
 
 - **The sandbox's "Ask each time" rung now reaches every session.** It only ever

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -64,6 +64,7 @@ tool.
 | `internal/terminal/resume.go` | whether a resume can be offered | a `ResumeAvailable` case answering from what that provider left on disk |
 | `internal/terminal/transcript.go`, `sessiondb.go` | where that state lives | the path resolver the case above calls |
 | `internal/terminal/usage.go` | the footer's session readout | a `usageSourceFor` arm, plus a `sessionCost` arm reading whatever that provider records about spend — and a `contextUsageFor` arm only if it also records the model's context window. Which rung that lands the provider on is a row in `docs/ceilings.md`, in the same PR |
+| `internal/terminal/said.go`, `search.go` | the recap beside a diff and the palette's Messages tab | an arm in `transcriptReaderFor` with a line reader for a provider that files its conversation as JSONL, or the `said` and `search` queries in `sessiondb.go` for one that keeps it in a database of its own — a provider in neither is simply never listed, which is what every other miss in that search looks like |
 | `internal/sandbox/sandbox.go` | what a confined session can still reach | a `stateDirs` case — a provider missing here confines to a home with no credentials, which is a session that opens and cannot log in |
 | `internal/agentplugin/` | the companion plugin | a `<provider>.go` with install / installed-version, plus the four switches and the `supported` list in `agentplugin.go` |
 | `internal/cli/mcp.go` | the `open_session` tool schema | the new id in the `kind` description |

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -50,7 +50,7 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   | Crush | cost only | `sessions.cost` per conversation; no window recorded with it |
   | Kiro CLI | context only | a window and a per-request percentage; spend is metered in credits, not dollars |
   | Antigravity | nothing | conversation filed as SQLite lich has no reader for |
-  | Cursor CLI | nothing | chat filed as SQLite lich has no reader for |
+  | Cursor CLI | nothing | chat filed as SQLite lich has no reader for, search included |
 
   **Kiro CLI is the mirror image of the cost-only rung, and the only provider on its own one.** It records
   `context_usage_percentage` against a `context_window_tokens` (`internal/terminal/usage_kiro.go`), so the ring
@@ -217,14 +217,13 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   which turn is speaking, and only the card's spinner does. The read is a bounded tail for the reason the
   transcript search's is (`searchTailBytes`), so a turn whose closing words sit behind more than 4 MB of
   tool output shows none — the band simply does not appear, which is also what a turn that ended on a tool
-  call looks like. And its provider list is *not* the one the switch above it is drawn from: six of the
-  eight are read (Claude Code, Codex, Antigravity, opencode, oh-my-pi, Kiro CLI), and the two that are not
-  are the two with no last turn to begin with, so the gap is invisible today and would surface the moment
-  Crush or Cursor CLI started reporting a state. Kiro CLI was on that list and silent in practice until the
-  palette's search reused the same reader: its block payloads are typed per block kind, and declaring one as
-  a string failed every line where the agent thought before it spoke — which is nearly all of them. Crush is a query away — its `parts` column carries the
-  same `{type,text}` shape opencode's does — and Cursor CLI is not: it files a chat as content-addressed
-  blobs ordered by a protobuf index, with a `blobEncryptionKey` sitting in its own metadata.
+  call looks like. And its provider list is *not* the one the switch above it is drawn from: seven of the
+  eight are read, and the one that is not — Cursor CLI — is also one of the two with no last turn to begin
+  with, so that gap is invisible today. Crush is the other, and its gap is not: its words are read and never
+  drawn, because nothing above it ever opens a window to draw them in. Both would surface the moment either
+  started reporting a state. Kiro CLI was on that list and silent in practice until the palette's search
+  reused the same reader: its block payloads are typed per block kind, and declaring one as a string failed
+  every line where the agent thought before it spoke — which is nearly all of them.
 - **A finished turn is unread until its own card is watched** (`frontend/src/lib/session/session-status-store.ts`,
   `frontend/src/providers/projects.tsx`): the solid emerald ring means "back from the agent, not read yet", and it
   fades only for the session whose terminal is on screen **while the window has focus**. A card left focused in a
@@ -700,21 +699,11 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   are unreachable either way — a resume comes back under a fresh id, so the old copies directory can never be
   addressed again — but they now sit on disk for up to three days rather than going at the close.
 - **The History tab searches names, never what was said** (`internal/terminal/search.go`): the Messages tab
-  reads a 4 MB tail per session per keystroke, and it is pointed at the sessions the palette can route to —
+  reads a 4 MB tail or a query per session per keystroke, and it is pointed at the sessions the palette can route to —
   the open ones. History is the long list, so widening the transcript search to it would put a hundred disk
   reads behind every character typed, on a machine that can hold hundreds of transcripts and a single one
   of 169 MB. The parked row keeps its `provider_session_id`, so the transcript is still there to be searched
   by whatever does it later; the fix when it bites is a query, not a bigger tail.
-- **The Messages tab reads five of the eight providers, and the three it misses are the ones with no
-  transcript to walk** (`transcriptReaderFor`, `internal/terminal/said.go`): the search and the last-turn
-  recap share one reader per provider, so both reach Claude Code, Codex, oh-my-pi, Kiro CLI and Antigravity —
-  every provider that files its conversation as JSONL. opencode keeps its messages in SQLite and is a `LIKE`
-  away, but a `LIKE` is a second mechanism (a query that counts and windows its own snippet) rather than a
-  sixth reader, and it is unwritten until somebody asks for it; Crush is the same query against its `parts`
-  column. Cursor CLI is the one that is not a query: it files a chat as content-addressed blobs ordered by a
-  protobuf index, with a `blobEncryptionKey` in its own metadata. A session on any of the three contributes
-  no rows and says nothing about it — the group simply does not list it, which is what every other miss in
-  that search looks like too.
 - **A filed backend answer outlives the screen that asked, under a key its caller writes by hand**
   (`frontend/src/lib/remote-cache.ts`): a `useRemoteResource` caller that passes `cache` has its answers kept
   in module memory until the page reloads, under exactly the string it composed. Two callers that compose the

--- a/internal/terminal/said.go
+++ b/internal/terminal/said.go
@@ -1,10 +1,8 @@
 package terminal
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
-	"os"
 	"slices"
 	"strings"
 
@@ -90,10 +88,10 @@ func (s *Service) LastTurnSaid(id string) (LastSaid, error) {
 // provider's conversation, and both readers of one go through it: the last-turn
 // recap below, and the palette's transcript search (search.go).
 //
-// false for the two providers with no JSONL to walk. opencode keeps its messages
-// in SQLite, which each caller queries for what it needs; Cursor CLI files a
-// chat as a content-addressed blob store whose order lives in a protobuf index,
-// so nothing here reaches it at all (docs/ceilings.md).
+// false for the three providers with no JSONL to walk. opencode and Crush keep
+// their messages in SQLite, read by query instead (sessiondb.go); Cursor CLI
+// files a chat as a content-addressed blob store whose order lives in a protobuf
+// index, so neither mechanism reaches it at all (docs/ceilings.md).
 func transcriptReaderFor(src usageSource) (string, turnReader, bool) {
 	switch src.kind {
 	case providers.Claude:
@@ -113,16 +111,17 @@ func transcriptReaderFor(src usageSource) (string, turnReader, bool) {
 }
 
 // saidFor reads one conversation's closing words out of whatever the provider
-// files them in. Empty for every miss, and for the two providers that reach here
-// with nothing to read — Cursor CLI files its chat as a content-addressed blob
-// store, and neither it nor Crush reports a turn boundary, so neither is ever
-// offered the panel this feeds (docs/ceilings.md).
+// files them in: a line reader for the transcripts, and a query for the two
+// providers that keep their messages in a database of their own instead
+// (sessiondb.go). Empty for every miss, and for Cursor CLI, which reaches here
+// with nothing either can read — a chat filed as a content-addressed blob store
+// (docs/ceilings.md).
 func saidFor(src usageSource) string {
 	if path, read, ok := transcriptReaderFor(src); ok {
 		return lastSaidInTail(path, read)
 	}
-	if src.kind == providers.OpenCode {
-		return sessionDBSaid(src.path, opencodeSaidQuery, src.id)
+	if texts := sessionDBTexts(src.path, queriesFor(src.kind).said, src.id); len(texts) > 0 {
+		return strings.TrimSpace(texts[0])
 	}
 	return ""
 }
@@ -322,49 +321,6 @@ func joinText(blocks []textBlock, want ...string) (string, bool) {
 		return "", false
 	}
 	return strings.Join(parts, "\n"), true
-}
-
-// opencodeSaidQuery is the newest text part of the newest assistant message in
-// one opencode conversation. opencode splits a message across `part` rows and
-// keeps the role on the `message` row, so the join is what tells an assistant's
-// own words from a tool result written beside them.
-//
-// Sub-agents are left out on purpose, where the cost query walks down into them:
-// opencode files each as a session of its own, and what a sub-agent said last is
-// not what the session said last.
-const opencodeSaidQuery = `SELECT p.data FROM part p JOIN message m ON m.id = p.message_id
-	WHERE p.session_id = ? AND json_extract(m.data, '$.role') = 'assistant'
-	AND json_extract(p.data, '$.type') = 'text'
-	ORDER BY p.time_created DESC LIMIT 1`
-
-// sessionDBSaid reads one conversation's closing words out of a provider's own
-// SQLite database. Read-only and opened per call, for the reasons sessionDBCost
-// gives: lich must never write into a database another tool owns.
-func sessionDBSaid(path, query, id string) string {
-	if id == "" {
-		return ""
-	}
-	if _, err := os.Stat(path); err != nil {
-		return ""
-	}
-	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=busy_timeout(%d)", path, sessionDBBusyMS)
-	db, err := sql.Open("sqlite", dsn)
-	if err != nil {
-		return ""
-	}
-	defer func() { _ = db.Close() }()
-
-	var data string
-	if err := db.QueryRow(query, id).Scan(&data); err != nil {
-		return ""
-	}
-	var part struct {
-		Text string `json:"text"`
-	}
-	if err := json.Unmarshal([]byte(data), &part); err != nil {
-		return ""
-	}
-	return strings.TrimSpace(part.Text)
 }
 
 // capRunes trims the middle out of an over-long answer, keeping two thirds of

--- a/internal/terminal/said_test.go
+++ b/internal/terminal/said_test.go
@@ -240,15 +240,12 @@ func TestSaidForReadsTheOpenCodeDatabase(t *testing.T) {
 	}
 }
 
-// TestSaidForIsEmptyForProvidersWithNoLastTurn pins the deliberate gap: neither
-// Crush nor Cursor CLI reports a turn boundary, so neither is ever offered the
-// panel this feeds, and reading their stores would be answering a question
-// nobody can ask (docs/ceilings.md).
-func TestSaidForIsEmptyForProvidersWithNoLastTurn(t *testing.T) {
-	for _, kind := range []string{providers.Crush, providers.Cursor} {
-		if got := saidFor(usageSource{kind: kind, path: "/nope", id: "x"}); got != "" {
-			t.Errorf("saidFor(%s) = %q, want empty", kind, got)
-		}
+// TestSaidForIsEmptyForCursor pins the one provider neither mechanism reaches:
+// a chat filed as content-addressed blobs is not a transcript to walk and not a
+// query to run, so the read is empty rather than wrong (docs/ceilings.md).
+func TestSaidForIsEmptyForCursor(t *testing.T) {
+	if got := saidFor(usageSource{kind: providers.Cursor, path: "/nope", id: "x"}); got != "" {
+		t.Errorf("saidFor(cursor) = %q, want empty", got)
 	}
 }
 

--- a/internal/terminal/search.go
+++ b/internal/terminal/search.go
@@ -47,8 +47,8 @@ type TranscriptMatch struct {
 //
 // Every miss is silent and simply contributes no match — a session with no
 // provider id yet (a shell, or a provider that reports none), a provider whose
-// conversation lich cannot walk (transcriptReaderFor), a transcript that is
-// gone, a half-written line.
+// conversation lich can read by neither mechanism (searchSource), a transcript
+// that is gone, a half-written line.
 func (s *Service) SearchTranscripts(ids []string, query string) []TranscriptMatch {
 	q := strings.ToLower(strings.TrimSpace(query))
 	if utf8.RuneCountInString(q) < minSearchQuery {
@@ -68,15 +68,7 @@ func (s *Service) SearchTranscripts(ids []string, query string) []TranscriptMatc
 		if !ok {
 			continue
 		}
-		path, read, ok := transcriptReaderFor(src)
-		if !ok {
-			continue
-		}
-		tail, ok := readTail(path, searchTailBytes)
-		if !ok {
-			continue
-		}
-		match, ok := searchTranscript(tail, q, read)
+		match, ok := searchSource(src, q)
 		if !ok {
 			continue
 		}
@@ -84,6 +76,43 @@ func (s *Service) SearchTranscripts(ids []string, query string) []TranscriptMatc
 		matches = append(matches, match)
 	}
 	return matches
+}
+
+// searchSource asks one conversation about q, by whichever of the two mechanisms
+// its provider is read through: a bounded tail walked by the provider's own line
+// reader, or — for the two that keep their messages in a database of their own —
+// a query for the prose of that conversation (sessiondb.go). Both count the
+// messages that mention q and keep the newest as the snippet; false when neither
+// finds one, which is also what a provider read by neither answers.
+func searchSource(src usageSource, q string) (TranscriptMatch, bool) {
+	if path, read, ok := transcriptReaderFor(src); ok {
+		tail, ok := readTail(path, searchTailBytes)
+		if !ok {
+			return TranscriptMatch{}, false
+		}
+		return searchTranscript(tail, q, read)
+	}
+	return searchSessionRows(sessionDBTexts(src.path, queriesFor(src.kind).search, src.id), q)
+}
+
+// searchSessionRows is searchTranscript's other half: the same count and the
+// same newest-wins snippet, over messages a query already separated from the
+// tool calls around them, so there is no line to parse and nothing to reject.
+//
+// The rows are matched here rather than by a `LIKE` in the query: SQLite's is
+// case-insensitive over ASCII alone, and a palette that found "worktree" in one
+// provider and not "Wörter" in another would be answering two questions.
+func searchSessionRows(texts []string, q string) (TranscriptMatch, bool) {
+	var match TranscriptMatch
+	for _, text := range texts {
+		snippet, ok := snippetAround(text, q)
+		if !ok {
+			continue
+		}
+		match.Snippet = snippet
+		match.Count++
+	}
+	return match, match.Count > 0
 }
 
 // searchTranscript counts the messages in a transcript tail that mention q

--- a/internal/terminal/sessiondb.go
+++ b/internal/terminal/sessiondb.go
@@ -63,21 +63,12 @@ func crushSessionDB(cwd string) (string, bool) {
 // sessionRowExists reports whether table in the SQLite database at path holds a
 // row with this id. False for every failure — a missing file, a database held
 // exclusively, a table that is not there any more.
-//
-// The connection is read-only so lich can never write into a database another
-// tool owns, and it is opened per call rather than pooled: this runs once when a
-// restored card is first opened, and holding a handle on a file the provider is
-// migrating would be the more expensive mistake.
 func sessionRowExists(path, table, id string) bool {
 	if id == "" {
 		return false
 	}
-	if _, err := os.Stat(path); err != nil {
-		return false
-	}
-	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=busy_timeout(%d)", path, sessionDBBusyMS)
-	db, err := sql.Open("sqlite", dsn)
-	if err != nil {
+	db, ok := openSessionDB(path)
+	if !ok {
 		return false
 	}
 	defer func() { _ = db.Close() }()
@@ -113,37 +104,109 @@ const (
 	crushCostQuery = `SELECT cost FROM sessions WHERE id = ?`
 )
 
-// costQueryFor is the query above for a provider id, and "" for a provider that
-// keeps no such database. sessionDBCost refuses the empty one, so a kind that
-// reaches here by mistake reads as "nothing to show" rather than as free.
-func costQueryFor(kind string) string {
+// The SQL each database provider answers "what was said here" with. This is the
+// second mechanism the two providers with no JSONL to walk are read through: a
+// query in place of a line reader (transcriptReaderFor), returning the prose of
+// one conversation and nothing else — no tool call, no thinking, no result
+// written beside it.
+//
+// The two schemas differ in where a message keeps its parts. opencode splits one
+// across `part` rows keyed by `session_id`, with the role on the `message` row
+// beside them; Crush keeps every part of a message as a JSON array in the
+// `messages.parts` column, with the role on the row itself, and puts a part's
+// prose under `data.text` rather than beside its type. Both are measured
+// behaviour of another tool's schema (opencode 1.18.23, Crush 0.88.0), so a
+// column that moves reads as a conversation with nothing in it, never as an
+// error at the card — the same direction the cost reads fail in.
+//
+// Every one of these asks for a single session id, where the cost query walks
+// down into a conversation's sub-agents: opencode files each as a session of its
+// own (`parent_id`) and Crush dispatches one under a session of its own too, and
+// what a sub-agent said is not what this session said — its last word is not
+// this one's, and a search hit in it points at a message the session never
+// showed.
+const (
+	// The closing words: the newest text part of the newest assistant message.
+	opencodeSaidQuery = `SELECT json_extract(p.data, '$.text') FROM part p
+		JOIN message m ON m.id = p.message_id
+		WHERE p.session_id = ? AND json_extract(m.data, '$.role') = 'assistant'
+		AND json_extract(p.data, '$.type') = 'text'
+		ORDER BY p.time_created DESC LIMIT 1`
+
+	crushSaidQuery = `SELECT json_extract(part.value, '$.data.text')
+		FROM messages, json_each(messages.parts) AS part
+		WHERE messages.session_id = ? AND messages.role = 'assistant'
+		AND json_extract(part.value, '$.type') = 'text'
+		ORDER BY messages.created_at DESC, part.key DESC LIMIT 1`
+
+	// Everything said in one conversation, oldest first, so the caller counts
+	// the mentions and keeps the newest as its snippet. Both sides are returned:
+	// a search is asked what was talked about, not who said it.
+	opencodeSearchQuery = `SELECT json_extract(data, '$.text') FROM part
+		WHERE session_id = ? AND json_extract(data, '$.type') = 'text'
+		ORDER BY time_created`
+
+	crushSearchQuery = `SELECT json_extract(part.value, '$.data.text')
+		FROM messages, json_each(messages.parts) AS part
+		WHERE messages.session_id = ? AND json_extract(part.value, '$.type') = 'text'
+		ORDER BY messages.created_at, part.key`
+)
+
+// sessionDBQueries is the SQL one database provider answers with. Every field is
+// "" for a kind that keeps no such database, and every reader below refuses the
+// empty one — so a kind that reaches here by mistake reads as "nothing to show"
+// rather than as free, or as silent.
+type sessionDBQueries struct {
+	cost   string
+	said   string
+	search string
+}
+
+func queriesFor(kind string) sessionDBQueries {
 	switch kind {
 	case providers.OpenCode:
-		return opencodeCostQuery
+		return sessionDBQueries{
+			cost:   opencodeCostQuery,
+			said:   opencodeSaidQuery,
+			search: opencodeSearchQuery,
+		}
 	case providers.Crush:
-		return crushCostQuery
+		return sessionDBQueries{
+			cost:   crushCostQuery,
+			said:   crushSaidQuery,
+			search: crushSearchQuery,
+		}
 	}
-	return ""
+	return sessionDBQueries{}
+}
+
+// openSessionDB opens a provider's own database, or false when there is nothing
+// to open. Read-only so lich can never write into a database another tool owns,
+// and opened per call rather than pooled: these run on a card being restored, a
+// turn ending and a key being typed, and holding a handle on a file the provider
+// is migrating would be the more expensive mistake.
+func openSessionDB(path string) (*sql.DB, bool) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, false
+	}
+	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=busy_timeout(%d)", path, sessionDBBusyMS)
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, false
+	}
+	return db, true
 }
 
 // sessionDBCost reads what one conversation cost out of a provider's own
 // database. False for every failure and for a total the database cannot produce
 // — a missing file, a row that is not there, a schema that moved, a NULL sum —
 // which is the same "keep the last figure" the transcript readers answer with.
-//
-// Read-only and opened per call, for the reasons sessionRowExists gives: lich
-// must never write into a database another tool owns, and holding a handle on
-// one being migrated would be the more expensive mistake.
 func sessionDBCost(path, query, id string) (float64, bool) {
 	if id == "" || query == "" {
 		return 0, false
 	}
-	if _, err := os.Stat(path); err != nil {
-		return 0, false
-	}
-	dsn := fmt.Sprintf("file:%s?mode=ro&_pragma=busy_timeout(%d)", path, sessionDBBusyMS)
-	db, err := sql.Open("sqlite", dsn)
-	if err != nil {
+	db, ok := openSessionDB(path)
+	if !ok {
 		return 0, false
 	}
 	defer func() { _ = db.Close() }()
@@ -153,4 +216,41 @@ func sessionDBCost(path, query, id string) (float64, bool) {
 		return 0, false
 	}
 	return cost.Float64, true
+}
+
+// sessionDBTexts is the prose one conversation holds, in the order query asks
+// for it. Nil for every failure and for a schema that no longer matches: a
+// column that moved makes the query itself fail, which reads as a conversation
+// with nothing in it rather than as an error at the card.
+func sessionDBTexts(path, query, id string) []string {
+	if id == "" || query == "" {
+		return nil
+	}
+	db, ok := openSessionDB(path)
+	if !ok {
+		return nil
+	}
+	defer func() { _ = db.Close() }()
+
+	rows, err := db.Query(query, id)
+	if err != nil {
+		return nil
+	}
+	defer func() { _ = rows.Close() }()
+	var texts []string
+	for rows.Next() {
+		// NULL where the shape changed under the extract, which is a row with
+		// nothing said in it rather than a read that failed.
+		var text sql.NullString
+		if err := rows.Scan(&text); err != nil {
+			return nil
+		}
+		if text.String != "" {
+			texts = append(texts, text.String)
+		}
+	}
+	if rows.Err() != nil {
+		return nil
+	}
+	return texts
 }

--- a/internal/terminal/sessiondb_text_test.go
+++ b/internal/terminal/sessiondb_text_test.go
@@ -1,0 +1,155 @@
+package terminal
+
+import (
+	"database/sql"
+	"path/filepath"
+	"testing"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// writeMessageDB plants a throwaway database and runs stmts against it, closing
+// it before the path is handed back: the readers open their own read-only
+// connection, and a writer still holding the file is not what they meet in
+// practice.
+func writeMessageDB(t *testing.T, stmts ...string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "provider.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			_ = db.Close()
+			t.Fatalf("%s: %v", stmt, err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// opencodeMessageDB is opencode's own shape: the role on a `message` row, every
+// stretch of prose a `part` row beside it keyed by the session it belongs to.
+// The child session is what a `task` call files its sub-agent under — a session
+// of its own, linked by `parent_id` — and its words are here to prove they are
+// left out of the parent's.
+func opencodeMessageDB(t *testing.T) string {
+	t.Helper()
+	return writeMessageDB(t,
+		`CREATE TABLE session (id TEXT PRIMARY KEY, parent_id TEXT)`,
+		`CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT)`,
+		`CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT)`,
+		`INSERT INTO session VALUES ('ses_1', NULL)`,
+		`INSERT INTO session VALUES ('ses_child', 'ses_1')`,
+		`INSERT INTO message VALUES ('m1','ses_1',1,'{"role":"user"}')`,
+		`INSERT INTO message VALUES ('m2','ses_1',2,'{"role":"assistant"}')`,
+		`INSERT INTO message VALUES ('m3','ses_child',3,'{"role":"assistant"}')`,
+		`INSERT INTO part VALUES ('p1','m1','ses_1',1,'{"type":"text","text":"port the worktree hash"}')`,
+		`INSERT INTO part VALUES ('p2','m2','ses_1',2,'{"type":"text","text":"An earlier worktree answer."}')`,
+		`INSERT INTO part VALUES ('p3','m2','ses_1',3,'{"type":"text","text":"The worktree port is a hash."}')`,
+		`INSERT INTO part VALUES ('p4','m2','ses_1',4,'{"type":"tool","tool":"bash","state":{"input":"grep worktree"}}')`,
+		`INSERT INTO part VALUES ('p5','m3','ses_child',5,'{"type":"text","text":"a sub-agent worktree line"}')`,
+	)
+}
+
+// crushMessageDB is Crush's own shape, which is not opencode's: one `messages`
+// row per message with the role on it and every part of that message as a JSON
+// array in `parts`, where a part's prose sits under `data.text` rather than
+// beside its type (measured against 0.88.0). The reasoning and tool_call parts
+// are here because they are what a reader matching on the row alone would
+// surface instead.
+func crushMessageDB(t *testing.T) string {
+	t.Helper()
+	return writeMessageDB(t,
+		`CREATE TABLE messages (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, role TEXT NOT NULL,
+			parts TEXT NOT NULL DEFAULT '[]', created_at INTEGER NOT NULL)`,
+		`INSERT INTO messages VALUES ('m1','crush-1','user',
+			'[{"type":"text","data":{"text":"port the worktree hash"}}]',1)`,
+		`INSERT INTO messages VALUES ('m2','crush-1','assistant',
+			'[{"type":"reasoning","data":{"thinking":"the worktree port, then"}},
+			  {"type":"text","data":{"text":"An earlier worktree answer."}},
+			  {"type":"finish","data":{"reason":"end_turn"}}]',2)`,
+		`INSERT INTO messages VALUES ('m3','crush-1','assistant',
+			'[{"type":"text","data":{"text":"The worktree port is a hash."}},
+			  {"type":"tool_call","data":{"name":"bash","input":"grep worktree"}}]',3)`,
+		`INSERT INTO messages VALUES ('m4','crush-other','assistant',
+			'[{"type":"text","data":{"text":"another worktree session"}}]',4)`,
+	)
+}
+
+// TestSaidForReadsTheCrushDatabase covers the second provider whose conversation
+// is a database rather than a file. The answer is the newest text part of the
+// newest assistant message: the thinking that preceded it is not something the
+// agent said, and another conversation's closing words are not this one's.
+func TestSaidForReadsTheCrushDatabase(t *testing.T) {
+	src := usageSource{kind: providers.Crush, path: crushMessageDB(t), id: "crush-1"}
+	if got := saidFor(src); got != "The worktree port is a hash." {
+		t.Errorf("saidFor = %q, want the newest assistant text part", got)
+	}
+}
+
+// TestSearchSourceCountsAndWindowsADatabase is the search's half of the same
+// mechanism: both sides of the conversation are counted, a mention that is only
+// in a tool's arguments is not, and the newest match is what the palette row
+// shows.
+func TestSearchSourceCountsAndWindowsADatabase(t *testing.T) {
+	for _, tc := range []struct {
+		kind string
+		path string
+		id   string
+	}{
+		{providers.OpenCode, opencodeMessageDB(t), "ses_1"},
+		{providers.Crush, crushMessageDB(t), "crush-1"},
+	} {
+		t.Run(tc.kind, func(t *testing.T) {
+			got, ok := searchSource(usageSource{kind: tc.kind, path: tc.path, id: tc.id}, "worktree")
+			if !ok {
+				t.Fatal("searchSource: want a match")
+			}
+			want := TranscriptMatch{Snippet: "The worktree port is a hash.", Count: 3}
+			if got != want {
+				t.Errorf("searchSource = %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+// TestSearchSourceLeavesOpenCodeSubAgentsOut pins the rule the cost read makes in
+// reverse: opencode files each sub-agent as a session of its own, and a hit in
+// one points at a message this session never showed.
+func TestSearchSourceLeavesOpenCodeSubAgentsOut(t *testing.T) {
+	path := opencodeMessageDB(t)
+	parent, ok := searchSource(usageSource{kind: providers.OpenCode, path: path, id: "ses_1"}, "worktree")
+	if !ok || parent.Count != 3 {
+		t.Fatalf("searchSource(parent) = %+v, want the parent's three mentions alone", parent)
+	}
+	child, ok := searchSource(usageSource{kind: providers.OpenCode, path: path, id: "ses_child"}, "worktree")
+	if !ok || child.Snippet != "a sub-agent worktree line" {
+		t.Fatalf("searchSource(child) = %+v, want the sub-agent's own line", child)
+	}
+}
+
+// TestSessionDBTextsIsSilentForASchemaThatMoved is the direction both readers
+// have to fail in: the queries are measured behaviour of another tool's schema,
+// so a table or column that moves under them reads as a conversation with
+// nothing in it — never as an error at the card, which is what the cost readers
+// promise too.
+func TestSessionDBTextsIsSilentForASchemaThatMoved(t *testing.T) {
+	path := writeMessageDB(t, `CREATE TABLE messages_v2 (id TEXT PRIMARY KEY, prose TEXT)`,
+		`INSERT INTO messages_v2 VALUES ('m1','a worktree line nothing here can reach')`)
+	for _, kind := range []string{providers.OpenCode, providers.Crush} {
+		src := usageSource{kind: kind, path: path, id: "any"}
+		if got := saidFor(src); got != "" {
+			t.Errorf("saidFor(%s) = %q, want empty for a schema that moved", kind, got)
+		}
+		if got, ok := searchSource(src, "worktree"); ok {
+			t.Errorf("searchSource(%s) = %+v, want no match for a schema that moved", kind, got)
+		}
+	}
+	if got := sessionDBTexts(filepath.Join(t.TempDir(), "gone.db"), crushSearchQuery, "x"); got != nil {
+		t.Errorf("sessionDBTexts = %v, want nil for a database that is not there", got)
+	}
+}

--- a/internal/terminal/usage.go
+++ b/internal/terminal/usage.go
@@ -251,7 +251,7 @@ func (s *Service) wholeCost(src usageSource) (float64, costMiss, bool) {
 	case providers.OMP:
 		return ompTranscriptCost(src.path)
 	}
-	cost, ok := sessionDBCost(src.path, costQueryFor(src.kind), src.id)
+	cost, ok := sessionDBCost(src.path, queriesFor(src.kind).cost, src.id)
 	if !ok {
 		return 0, costMissUnread, false
 	}

--- a/internal/terminal/usage_tokenonly_test.go
+++ b/internal/terminal/usage_tokenonly_test.go
@@ -285,7 +285,7 @@ func TestSessionDBCostMisses(t *testing.T) {
 		name, path, query, id string
 	}{
 		{"no conversation id", path, crushCostQuery, ""},
-		{"a provider with no such database", path, costQueryFor(providers.Claude), "crush-1"},
+		{"a provider with no such database", path, queriesFor(providers.Claude).cost, "crush-1"},
 		{"a database that is not there", filepath.Join(t.TempDir(), "crush.db"), crushCostQuery, "crush-1"},
 		{"a row that is not there", path, crushCostQuery, "crush-gone"},
 		{"a table that moved", path, `SELECT cost FROM nowhere WHERE id = ?`, "crush-1"},


### PR DESCRIPTION
## What

The palette's Messages tab and the Review panel's last-turn recap shared one mechanism: a line reader per provider (`transcriptReaderFor`) over a JSONL transcript. opencode and Crush keep their conversation in a SQLite database instead, so both were skipped in silence — a session that had talked about the thing you typed simply never appeared in the palette.

They are read by a **second mechanism** now, as `docs/ceilings.md` said they would be: a query for the prose of one conversation, run against the same file and the same read-only open their cost readers already use.

## How

- `internal/terminal/sessiondb.go` gains a `said` and a `search` query per database provider, beside the cost ones, routed through a single `queriesFor(kind)` in place of the old `costQueryFor`. The read-only open is now one helper (`openSessionDB`) instead of three copies of the same DSN.
- `saidFor` and a new `searchSource` pick the mechanism: line reader where there is a transcript, query where there is a database.
- `searchSessionRows` counts and windows the snippet the way `searchTranscript` does — matching in Go rather than with a SQL `LIKE`, because SQLite's `LIKE` is case-insensitive over ASCII alone and the palette must answer the same question for every provider.

### Measured, not assumed

The schemas differ, and `docs/ceilings.md` had one of them wrong. opencode splits a message across `part` rows keyed by `session_id`, with the role on the `message` row beside them. Crush keeps every part of a message as a JSON array in `messages.parts`, with the role on the row itself, and puts a part's prose under **`data.text`** — not beside its type, which is the `{type,text}` shape the doc claimed it shared with opencode. Measured against opencode 1.18.23 and Crush 0.88.0.

Every query asks for a single session id, so a sub-agent filed as a session of its own is left out — the rule the recap already made, now stated once for both queries. A schema that no longer matches makes the query itself fail, which reads as a conversation with nothing in it rather than as an error at the card: the direction the cost readers already fail in.

Cursor CLI stays out. A chat filed as encrypted, content-addressed blobs ordered by a protobuf index is neither a transcript to walk nor a query to run.

## Docs

- The **Messages tab** bullet is deleted whole — the gap it named is closed.
- The **recap** bullet loses its Crush/Cursor clause and its provider count is corrected to seven of eight. It keeps the trap that remains: Crush's words are read and never drawn, because it reports no session state and nothing above the band ever opens a window for them.
- The **session-readout rung** table's Cursor row now says its absence covers search too.
- `docs/adding-a-provider.md` gains the row that map was missing: what a new provider adds to `said.go` / `search.go`, by either mechanism.

## Test plan

`internal/terminal/sessiondb_text_test.go`, against throwaway databases in each provider's real shape:

- [x] Crush last-said — newest text part of the newest assistant message, ignoring `reasoning`, `tool_call` and another session's rows
- [x] search count and snippet for both providers — both sides of the conversation counted, a mention that only appears in a tool's arguments not
- [x] opencode sub-agent exclusion — the parent's count is its own; the child answers for itself
- [x] a schema that moved → empty and no error, for `saidFor`, `searchSource` and `sessionDBTexts`

Gate: `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green, cross-compiled and vetted for linux/darwin/windows. `CGO_ENABLED=0` untouched — the queries run on `modernc.org/sqlite`, which the cost readers already use. No frontend change: the palette does not group by reader.