### PR TITLE
fix: count a configured binary as installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   you pointed lich at in Settings › Providers read as a machine with nothing on
   it: every implicit new session — the empty screen's button, the hotkey, a new
   worktree — opened a terminal instead. Detection now resolves that setting the
-  way the spawn does, the provider row says the binary came from a custom path,
+  way the spawn does, a binary set for one project alone counts for that
+  project's sessions, the provider row says the binary came from a custom path,
   and the empty screen that does still open a terminal says why.
 - **"Check again" now finds a tool installed after lich started.** lich read the
   login shell's `$PATH` once, at launch, so an agent, git or gh installed into a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An agent reached through a custom binary path now counts as installed.**
+  Detection only ever scanned `$PATH`, so a machine whose only agent is the one
+  you pointed lich at in Settings › Providers read as a machine with nothing on
+  it: every implicit new session — the empty screen's button, the hotkey, a new
+  worktree — opened a terminal instead. Detection now resolves that setting the
+  way the spawn does, the provider row says the binary came from a custom path,
+  and the empty screen that does still open a terminal says why.
 - **"Check again" now finds a tool installed after lich started.** lich read the
   login shell's `$PATH` once, at launch, so an agent, git or gh installed into a
   directory that `$PATH` did not already carry stayed missing on every surface

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -276,13 +276,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   it was branched from, so the pair reports roughly twice what one conversation spent. It is the same
   arithmetic as the `(session, transcript)` bullet above, arrived at deliberately rather than by accident —
   a lich-driven fork makes that path ordinary.
-- **A machine with no agent on PATH opens terminals, and a custom binary path looks like one**
-  (`frontend/src/lib/providers-store.ts`, `resolveImplicitSessionKind`): with nothing installed, every implicit
-  new session — the empty screen's button, the hotkey, a new worktree — spawns a shell, because the provider
-  fallback still resolves to Claude and that card would die on `claude: command not found`. Detection only ever
-  scans `PATH`, so a user whose only agent is reached through a `provider.<id>.bin` override reads as that same
-  bare machine and gets a terminal they did not want. Their agent is still one click away in the New Session
-  menu, which is filtered by the enabled flag and not by install state.
 - **git status is polled** — one shared poller per repository path (`frontend/src/lib/git/git-status-store.ts`); the
   lich plugin's `session-touched` hook nudges an immediate refresh.
 - **The status badge has a single source** (`internal/project/status.go`): the branch, the HEAD commit and the

--- a/frontend/src/components/EmptySessions.tsx
+++ b/frontend/src/components/EmptySessions.tsx
@@ -3,7 +3,7 @@ import { useParams } from "react-router-dom"
 import { EmptyScreen } from "@/components/common/EmptyScreen"
 import { Button } from "@/components/ui/button"
 import { useProjects } from "@/providers/projects"
-import { NO_AGENT_REASON, useNoProviderInstalled } from "@/lib/providers-store"
+import { NO_AGENT_REASON, useProjectSessionKind } from "@/lib/providers-store"
 import { sessionsOf } from "@/lib/session/sessions"
 
 // A sessionless project is a legal state: the user is asked for a session rather
@@ -16,7 +16,7 @@ export function EmptySessions() {
   // What the button will actually spawn is decided in the store, for every
   // implicit entry point at once. This only reads the same answer, so the label
   // cannot promise an agent the machine has not got.
-  const noAgent = useNoProviderInstalled()
+  const noAgent = useProjectSessionKind(projectId) === "shell"
 
   if (sessionsOf(sessions, projectId).length > 0) {
     return null

--- a/frontend/src/components/EmptySessions.tsx
+++ b/frontend/src/components/EmptySessions.tsx
@@ -3,7 +3,7 @@ import { useParams } from "react-router-dom"
 import { EmptyScreen } from "@/components/common/EmptyScreen"
 import { Button } from "@/components/ui/button"
 import { useProjects } from "@/providers/projects"
-import { useNoProviderInstalled } from "@/lib/providers-store"
+import { NO_AGENT_REASON, useNoProviderInstalled } from "@/lib/providers-store"
 import { sessionsOf } from "@/lib/session/sessions"
 
 // A sessionless project is a legal state: the user is asked for a session rather
@@ -26,11 +26,7 @@ export function EmptySessions() {
     <EmptyScreen
       icon={SquareTerminal}
       title="No session open"
-      description={
-        noAgent
-          ? "No coding agent is installed, so this opens a terminal — install one from Settings › Providers."
-          : "Open a session to start working in this project."
-      }
+      description={noAgent ? NO_AGENT_REASON : "Open a session to start working in this project."}
     >
       <Button onClick={() => newSession(projectId)}>
         {noAgent ? <SquareTerminal data-icon="inline-start" /> : <Plus data-icon="inline-start" />}

--- a/frontend/src/components/settings/ProviderToggleRow.tsx
+++ b/frontend/src/components/settings/ProviderToggleRow.tsx
@@ -1,5 +1,6 @@
 import { ProviderIcon } from "@/components/ProviderIcon"
 import { Switch } from "@/components/ui/switch"
+import { installSummary } from "@/lib/provider-summary"
 import { setProviderEnabled, type ProviderState } from "@/lib/providers-store"
 import { ProviderDocsLink } from "./ProviderDocsLink"
 
@@ -19,7 +20,7 @@ export function ProviderToggleRow({ provider }: { provider: ProviderState }) {
           <div className="text-sm font-medium text-foreground">{provider.name}</div>
           <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
             {provider.installed ? (
-              "Installed"
+              installSummary(provider)
             ) : (
               <>
                 <span>Not found on PATH</span>

--- a/frontend/src/components/sidebar/session-launch-sandbox.test.tsx
+++ b/frontend/src/components/sidebar/session-launch-sandbox.test.tsx
@@ -35,6 +35,7 @@ const claude: ProviderState = {
   name: "Claude Code",
   binary: "claude",
   installed: true,
+  source: "path",
   enabled: true,
   docs: "",
 }

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -522,6 +522,9 @@ export interface DetectedProvider {
   binary: string
   installed: boolean
   path: string
+  /** Which layer `path` came from: `"path"` for a $PATH hit, `"setting"` for the
+   * binary configured in Settings › Providers. Empty when nothing was found. */
+  source: "path" | "setting" | ""
   /** The page documenting how to install this CLI. Carried on every entry: the
    * row with somewhere to send the user is the one that found nothing. */
   docs: string

--- a/frontend/src/lib/provider-setup.test.ts
+++ b/frontend/src/lib/provider-setup.test.ts
@@ -7,6 +7,7 @@ const p = (id: string, installed: boolean): ProviderState => ({
   name: id,
   binary: id,
   installed,
+  source: installed ? "path" : "",
   enabled: false,
   docs: `https://example.test/${id}`,
 })

--- a/frontend/src/lib/provider-summary.test.ts
+++ b/frontend/src/lib/provider-summary.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { QuotaPlan } from "@/lib/api-types"
-import { countOpenSessions, planSummary } from "./provider-summary"
+import { countOpenSessions, installSummary, planSummary } from "./provider-summary"
 import type { SessionState } from "@/lib/session/sessions"
 
 function state(kinds: Record<string, string[]>): SessionState {
@@ -80,5 +80,14 @@ describe("the plan reading a row shows", () => {
     expect(planSummary(null)).toBe("")
     expect(planSummary(plan({ status: "error" }))).toBe("")
     expect(planSummary(plan({ windows: [] }))).toBe("")
+  })
+})
+
+describe("installSummary", () => {
+  // The row that says "Installed" on a machine with nothing on $PATH is the one
+  // that has to say where the binary came from, or the reading looks invented.
+  it("names the configured path, and leaves a $PATH hit plain", () => {
+    expect(installSummary({ source: "setting" })).toBe("Installed · custom path")
+    expect(installSummary({ source: "path" })).toBe("Installed")
   })
 })

--- a/frontend/src/lib/provider-summary.ts
+++ b/frontend/src/lib/provider-summary.ts
@@ -6,6 +6,14 @@ import type { QuotaPlan } from "@/lib/api-types"
 import { hottestWindow, formatWindow } from "@/lib/quota/quota-format"
 import type { SessionState } from "@/lib/session/sessions"
 
+/** What an installed provider's row says about where its binary came from. A
+ * configured path is worth naming: it is the one that answers when `which` does
+ * not, so a row reading a plain "Installed" on a machine with nothing on PATH
+ * would look like a detection lich cannot explain. */
+export function installSummary(provider: { source: string }): string {
+  return provider.source === "setting" ? "Installed · custom path" : "Installed"
+}
+
 /** How many open sessions across every project this provider is running. The
  * answer to "can I turn this off?", which is the question the switch beside it
  * raises. Counts the sessions on screen; a parked row is not one. */

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -9,6 +9,7 @@ import {
   enabledProviders,
   readEnabled,
   noProviderInstalled,
+  NO_AGENT_REASON,
   resolveDefaultProvider,
   resolveImplicitSessionKind,
   resolveProjectDefaultProvider,
@@ -163,6 +164,7 @@ describe("enabledProviders", () => {
     name: id,
     binary: id,
     installed,
+    source: installed ? "path" : "",
     enabled,
     docs: `https://example.test/${id}`,
   })
@@ -180,6 +182,7 @@ describe("resolveDefaultProvider", () => {
     name: id,
     binary: id,
     installed: true,
+    source: "path",
     enabled,
     docs: `https://example.test/${id}`,
   })
@@ -206,6 +209,7 @@ describe("resolveProjectDefaultProvider", () => {
     name: id,
     binary: id,
     installed: true,
+    source: "path",
     enabled,
     docs: `https://example.test/${id}`,
   })
@@ -230,11 +234,17 @@ describe("resolveProjectDefaultProvider", () => {
 // gate in front of them is what stops an implicit session opening on
 // `claude: command not found`.
 describe("noProviderInstalled / resolveImplicitSessionKind", () => {
-  const p = (id: string, installed: boolean, enabled: boolean): ProviderState => ({
+  const p = (
+    id: string,
+    installed: boolean,
+    enabled: boolean,
+    source: ProviderState["source"] = installed ? "path" : "",
+  ): ProviderState => ({
     id: id as ProviderState["id"],
     name: id,
     binary: id,
     installed,
+    source,
     enabled,
     docs: `https://example.test/${id}`,
   })
@@ -263,11 +273,31 @@ describe("noProviderInstalled / resolveImplicitSessionKind", () => {
     expect(resolveImplicitSessionKind(list, "codex", "")).toBe("codex")
   })
 
-  // A custom binary path leaves installed=false on every row, so this machine
-  // gets a terminal it did not need. Deliberate, and in docs/ceilings.md.
   it("still resolves the enabled provider once anything else is on PATH", () => {
     const list = [p("claude", false, true), p("crush", true, false)]
     expect(resolveImplicitSessionKind(list, "claude", "")).toBe("claude")
+  })
+
+  // The trap this gate used to set: nothing on PATH, one agent reached through
+  // the binary setting. Detection resolves that setting now (providers.Detect),
+  // so the row arrives installed and the implicit session is the agent — the
+  // terminal was the whole surprise.
+  it("spawns the agent a machine only knows about from its binary setting", () => {
+    const configured = [p("claude", true, true, "setting"), p("codex", false, false)]
+    expect(noProviderInstalled(configured)).toBe(false)
+    expect(resolveImplicitSessionKind(configured, "", "")).toBe("claude")
+    expect(resolveImplicitSessionKind(configured, "claude", "")).toBe("claude")
+  })
+})
+
+describe("NO_AGENT_REASON", () => {
+  // Pinned as a literal rather than read back off the export: this is the one
+  // sentence that explains a terminal the user did not ask for, and a test that
+  // compares the constant to itself would pass through any rewrite of it.
+  it("names both the reason and where the machine is told about an agent", () => {
+    expect(NO_AGENT_REASON).toBe(
+      "No agent found on PATH, so this opens a terminal — set one in Settings › Providers.",
+    )
   })
 })
 
@@ -279,6 +309,7 @@ describe("createProvidersStore", () => {
       binary: "claude",
       installed: true,
       path: "/usr/bin/claude",
+      source: "path",
       docs: "https://code.claude.com/docs/en/setup",
     },
     // A binary that is not the id, which is what antigravity ships as.
@@ -288,10 +319,19 @@ describe("createProvidersStore", () => {
       binary: "cdx",
       installed: false,
       path: "",
+      source: "",
       docs: "https://d/codex",
     },
     // unknown id
-    { id: "mystery", name: "Mystery", binary: "mystery", installed: true, path: "/x", docs: "" },
+    {
+      id: "mystery",
+      name: "Mystery",
+      binary: "mystery",
+      installed: true,
+      path: "/x",
+      source: "path",
+      docs: "",
+    },
   ]
 
   function build(enabledValues: Record<string, string> = {}, defaultValue = "") {
@@ -380,6 +420,7 @@ describe("createProvidersStore", () => {
         binary: "claude",
         installed: false,
         path: "",
+        source: "",
         docs: "d",
       },
     ]
@@ -403,6 +444,7 @@ describe("createProvidersStore", () => {
         binary: "claude",
         installed: true,
         path: "/usr/bin/claude",
+        source: "path",
         docs: "d",
       },
     ]

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest"
-import type { DetectedProvider } from "./api-types"
+import type { BinaryCheck, DetectedProvider } from "./api-types"
 import {
   binKey,
   binOffKey,
@@ -288,6 +288,35 @@ describe("noProviderInstalled / resolveImplicitSessionKind", () => {
     expect(resolveImplicitSessionKind(configured, "", "")).toBe("claude")
     expect(resolveImplicitSessionKind(configured, "claude", "")).toBe("claude")
   })
+
+  // The other half of the same trap: the override is in one project's scope, so
+  // detection — which answers for the machine and takes no project — cannot see
+  // it. The page composes it in.
+  it("spawns the provider a project's own binary setting points at", () => {
+    const bare = [p("claude", false, true), p("crush", false, true)]
+    expect(resolveImplicitSessionKind(bare, "", "", new Set(["crush"]))).toBe("crush")
+    // …and not the enabled-flag fallback, which on this machine names a binary
+    // that is not there. Claude is the stored default and still loses.
+    expect(resolveImplicitSessionKind(bare, "claude", "", new Set(["crush"]))).toBe("crush")
+    // The project default wins among the ones it can actually run.
+    expect(resolveImplicitSessionKind(bare, "", "claude", new Set(["claude", "crush"]))).toBe(
+      "claude",
+    )
+  })
+
+  it("keeps the shell for a project whose override is disabled or absent", () => {
+    const bare = [p("claude", false, true), p("crush", false, false)]
+    expect(resolveImplicitSessionKind(bare, "", "", new Set())).toBe("shell")
+    // crush is turned off, so a binary configured for it is one nothing offers.
+    expect(resolveImplicitSessionKind(bare, "", "", new Set(["crush"]))).toBe("shell")
+  })
+
+  // A machine with an agent of its own resolves exactly as it always did: the
+  // project layer is consulted only where it can change the answer.
+  it("ignores the project layer once anything is installed machine-wide", () => {
+    const list = [p("claude", true, true), p("crush", false, true)]
+    expect(resolveImplicitSessionKind(list, "claude", "", new Set(["crush"]))).toBe("claude")
+  })
 })
 
 describe("NO_AGENT_REASON", () => {
@@ -334,19 +363,36 @@ describe("createProvidersStore", () => {
     },
   ]
 
-  function build(enabledValues: Record<string, string> = {}, defaultValue = "") {
+  function build(
+    enabledValues: Record<string, string> = {},
+    defaultValue = "",
+    options: {
+      detected?: DetectedProvider[]
+      projectSettings?: Record<string, string>
+      runnable?: string[]
+    } = {},
+  ) {
     const persistEnabled = vi.fn()
     const persistDefault = vi.fn()
     const persistProjectDefault = vi.fn()
+    const verifyBin = vi.fn(
+      async (bin: string): Promise<BinaryCheck> =>
+        options.runnable?.includes(bin)
+          ? { path: bin, status: "ok" }
+          : { path: "", status: "not-found" },
+    )
     const store = createProvidersStore({
-      detect: async () => detected,
+      detect: async () => options.detected ?? detected,
       getEnabled: async (id) => enabledValues[id] ?? "",
+      getProjectSetting: async (key, projectId) =>
+        options.projectSettings?.[`${key}\n${projectId}`] ?? "",
+      verifyBin,
       persistEnabled,
       getDefault: async () => defaultValue,
       persistDefault,
       persistProjectDefault,
     })
-    return { store, persistEnabled, persistDefault, persistProjectDefault }
+    return { store, persistEnabled, persistDefault, persistProjectDefault, verifyBin }
   }
 
   it("loads only known providers with their install + default enabled state", async () => {
@@ -392,6 +438,8 @@ describe("createProvidersStore", () => {
       detect,
       getEnabled: async () => "",
       persistEnabled: vi.fn(),
+      getProjectSetting: async () => "",
+      verifyBin: async () => ({ path: "", status: "not-found" }) as const,
       getDefault: async () => "",
       persistDefault: vi.fn(),
       persistProjectDefault: vi.fn(),
@@ -428,6 +476,8 @@ describe("createProvidersStore", () => {
       detect: async () => probe,
       getEnabled: async () => "",
       persistEnabled: vi.fn(),
+      getProjectSetting: async () => "",
+      verifyBin: async () => ({ path: "", status: "not-found" }) as const,
       getDefault: async () => "",
       persistDefault: vi.fn(),
       persistProjectDefault: vi.fn(),
@@ -461,6 +511,8 @@ describe("createProvidersStore", () => {
       detect: async () => detected,
       getEnabled,
       persistEnabled: vi.fn(),
+      getProjectSetting: async () => "",
+      verifyBin: async () => ({ path: "", status: "not-found" }) as const,
       getDefault: async () => "codex",
       persistDefault: vi.fn(),
       persistProjectDefault: vi.fn(),
@@ -487,6 +539,76 @@ describe("createProvidersStore", () => {
     // codex is the only not-installed row; claude is on PATH, so a project with
     // no override gets the provider.
     expect(store.getProjectSessionKind("proj")).toBe("claude")
+  })
+
+  // End to end through the store: nothing on the machine, one project pointing
+  // crush at a wrapper it can run. The project's implicit session is crush, and
+  // every other project still gets the shell.
+  it("reads a project's binary override and spawns that provider", async () => {
+    const bare: DetectedProvider[] = [
+      {
+        id: "claude",
+        name: "Claude Code",
+        binary: "claude",
+        installed: false,
+        path: "",
+        source: "",
+        docs: "",
+      },
+      {
+        id: "crush",
+        name: "Crush",
+        binary: "crush",
+        installed: false,
+        path: "",
+        source: "",
+        docs: "",
+      },
+    ]
+    const { store, verifyBin } = build({ crush: "1" }, "", {
+      detected: bare,
+      projectSettings: { "provider.crush.bin\nproj": "/opt/agents/crush" },
+      runnable: ["/opt/agents/crush"],
+    })
+    await store.load()
+    store.hydrateProjectDefaults([{ id: "proj", defaultProvider: "" }])
+    await vi.waitFor(() => expect(store.getProjectSessionKind("proj")).toBe("crush"))
+    expect(store.getProjectSessionKind("other")).toBe("shell")
+    expect(verifyBin).toHaveBeenCalledWith("/opt/agents/crush")
+  })
+
+  // Mirrors store.ProviderBin in Go: the switch beside the path parks the layer,
+  // and a parked project layer resolves as if it were unset.
+  it("skips a project override whose layer is parked", async () => {
+    const bare: DetectedProvider[] = [
+      {
+        id: "claude",
+        name: "Claude Code",
+        binary: "claude",
+        installed: false,
+        path: "",
+        source: "",
+        docs: "",
+      },
+    ]
+    const { store } = build({}, "", {
+      detected: bare,
+      projectSettings: { "claude.bin\nproj": "/opt/agents/claude", "claude.bin.off\nproj": "true" },
+      runnable: ["/opt/agents/claude"],
+    })
+    await store.load()
+    store.hydrateProjectDefaults([{ id: "proj", defaultProvider: "" }])
+    await vi.waitFor(() => expect(store.getProjectSessionKind("proj")).toBe("shell"))
+  })
+
+  // The read costs a request per provider per project, so it is spent only where
+  // it can change an answer: a machine with an agent of its own never asks.
+  it("does not read project settings while anything is installed machine-wide", async () => {
+    const { store, verifyBin } = build({ claude: "1" })
+    await store.load()
+    store.hydrateProjectDefaults([{ id: "proj", defaultProvider: "" }])
+    expect(store.getProjectSessionKind("proj")).toBe("claude")
+    expect(verifyBin).not.toHaveBeenCalled()
   })
 
   it("loads the stored default provider", async () => {
@@ -534,6 +656,8 @@ describe("createProvidersStore", () => {
       detect,
       getEnabled: async () => "",
       persistEnabled: vi.fn(),
+      getProjectSetting: async () => "",
+      verifyBin: async () => ({ path: "", status: "not-found" }) as const,
       getDefault: async () => "claude",
       persistDefault: vi.fn(),
       persistProjectDefault: vi.fn(),
@@ -552,6 +676,8 @@ describe("createProvidersStore", () => {
       detect,
       getEnabled: async () => "",
       persistEnabled: vi.fn(),
+      getProjectSetting: async () => "",
+      verifyBin: async () => ({ path: "", status: "not-found" }) as const,
       getDefault: async () => "claude",
       persistDefault: vi.fn(),
       persistProjectDefault: vi.fn(),

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -8,7 +8,7 @@
 // is testable without React or the network, mirroring git-status-store. A module
 // singleton wires it to the real RPC, and useProviders is the React wrapper.
 import { useCallback, useEffect, useSyncExternalStore } from "react"
-import type { DetectedProvider } from "./api-types"
+import type { BinaryCheck, DetectedProvider } from "./api-types"
 import { Providers, Store } from "./rpc"
 import { errorText } from "./utils"
 import { PROVIDER_KINDS, type ProviderKind, type SessionKind } from "@/lib/session/sessions"
@@ -259,24 +259,41 @@ export function noProviderInstalled(list: ProviderState[]): boolean {
 export const NO_AGENT_REASON =
   "No agent found on PATH, so this opens a terminal — set one in Settings › Providers."
 
+// No project binaries known — a project nothing was read for, and every caller
+// asking the machine-wide question. Frozen and shared so the default argument is
+// one allocation rather than one per call.
+const NO_PROJECT_BINARIES: ReadonlySet<string> = new Set<string>()
+
 // resolveImplicitSessionKind is what a session nobody picked a kind for spawns:
 // the empty screen's button, the new-session hotkey, a new worktree. It is
 // resolveProjectDefaultProvider with one gate in front, because on a machine
 // with no agent installed every fallback below still lands on Claude — readEnabled
 // leaves Claude enabled by default, so the card opens on `claude: command not
 // found`. A shell spawns with zero providers, and it is where the install command
-// from the provider's docs link gets pasted. Detection resolves the binary
+// from the provider's docs link gets pasted. Detection resolves the global binary
 // setting too (providers.Detect), so an agent lich only knows about because the
 // user typed its path is an agent this gate lets through.
+//
+// projectBinaries names the providers this project points a working binary at in
+// its own scope, which detection cannot see: Detect answers for the machine and
+// takes no project. It is consulted only on the bare machine — where nothing is
+// installed, the enabled-flag fallback would name a binary that is not there, so
+// the choice is made among the ones this project can actually run.
 export function resolveImplicitSessionKind(
   list: ProviderState[],
   globalDefaultId: string,
   projectDefaultId: string,
+  projectBinaries: ReadonlySet<string> = NO_PROJECT_BINARIES,
 ): SessionKind {
-  if (noProviderInstalled(list)) {
+  if (!noProviderInstalled(list)) {
+    return resolveProjectDefaultProvider(list, globalDefaultId, projectDefaultId)
+  }
+  const usable = enabledProviders(list).filter((provider) => projectBinaries.has(provider.id))
+  if (usable.length === 0) {
     return "shell"
   }
-  return resolveProjectDefaultProvider(list, globalDefaultId, projectDefaultId)
+  const resolved = resolveProjectDefaultProvider(list, globalDefaultId, projectDefaultId)
+  return usable.find((provider) => provider.id === resolved)?.id ?? usable[0].id
 }
 
 function isProviderKind(id: string): id is ProviderKind {
@@ -292,6 +309,12 @@ function isDetectedKind(provider: DetectedProvider): boolean {
 export interface ProvidersDeps {
   detect: () => Promise<DetectedProvider[] | null>
   getEnabled: (id: string) => Promise<string>
+  /** One stored setting in one project's scope — the binary override and the
+   * switch that parks it, which is all this store reads per project. */
+  getProjectSetting: (key: string, projectId: string) => Promise<string>
+  /** Resolve a binary the way the spawn does. The same providers.Verify the
+   * Settings binary block asks, so the two cannot disagree about a path. */
+  verifyBin: (bin: string) => Promise<BinaryCheck>
   persistEnabled: (id: string, value: string) => void
   getDefault: () => Promise<string>
   persistDefault: (id: string) => void
@@ -323,6 +346,15 @@ class ProviderStoreImpl implements ProvidersStore {
   private providers: ProviderState[] = []
   private defaultId = ""
   private projectDefaultIds = new Map<string, string>()
+  // Per project, the providers its own binary setting points at something
+  // runnable. Read lazily and only on the bare machine (ensureProjectBinaries),
+  // because that is the only state in which the answer changes anything.
+  private projectBinaries = new Map<string, ReadonlySet<string>>()
+  private projectBinaryLoads = new Map<string, Promise<void>>()
+  // One verdict per path, so eight providers pointed at one wrapper cost one
+  // round trip. Dropped whole on a refresh: a re-read of $PATH restates every
+  // verdict on screen, and a stale one here would survive it.
+  private verdicts = new Map<string, boolean>()
   private state: "idle" | "loading" | "ready" = "idle"
   private providerLoad: Promise<void> | null = null
   private listeners = new Set<() => void>()
@@ -360,6 +392,9 @@ class ProviderStoreImpl implements ProvidersStore {
   // (lib/path-refresh).
   refresh = async (): Promise<void> => {
     const detected = (await this.deps.detect()) ?? []
+    this.projectBinaries.clear()
+    this.projectBinaryLoads.clear()
+    this.verdicts.clear()
     const enabled = new Map(this.providers.map((provider) => [provider.id, provider.enabled]))
     this.providers = detected.filter(isDetectedKind).map((provider) => ({
       id: provider.id as ProviderKind,
@@ -370,6 +405,7 @@ class ProviderStoreImpl implements ProvidersStore {
       docs: provider.docs,
       enabled: enabled.get(provider.id as ProviderKind) ?? readEnabled(provider.id, ""),
     }))
+    this.sweepProjectBinaries()
     this.emit()
   }
 
@@ -389,6 +425,7 @@ class ProviderStoreImpl implements ProvidersStore {
     for (const project of projects) {
       this.projectDefaultIds.set(project.id, project.defaultProvider)
     }
+    this.sweepProjectBinaries()
     this.emit()
   }
 
@@ -415,12 +452,84 @@ class ProviderStoreImpl implements ProvidersStore {
       this.defaultId,
       this.getProjectDefaultSnapshot(projectId),
     )
-  getProjectSessionKind = (projectId: string): SessionKind =>
-    resolveImplicitSessionKind(
+  getProjectSessionKind = (projectId: string): SessionKind => {
+    // Asked from render and from the spawn itself, so the read it may start is
+    // fire-and-forget: the answer below is the machine-wide one until it lands,
+    // and landing emits.
+    this.ensureProjectBinaries(projectId)
+    return resolveImplicitSessionKind(
       this.providers,
       this.defaultId,
       this.getProjectDefaultSnapshot(projectId),
+      this.projectBinaries.get(projectId) ?? NO_PROJECT_BINARIES,
     )
+  }
+
+  // sweepProjectBinaries reads every project lich already knows about. Called
+  // wherever the answer could have changed — detection landing, a refresh, a
+  // project arriving — and cheap everywhere else, because ensureProjectBinaries
+  // declines on any machine that has an agent of its own.
+  private sweepProjectBinaries(): void {
+    for (const projectId of this.projectDefaultIds.keys()) {
+      this.ensureProjectBinaries(projectId)
+    }
+  }
+
+  // ensureProjectBinaries reads a project's own binary overrides, once. It is
+  // gated on the bare machine because that is the only state where a project
+  // override decides anything: with an agent on $PATH the implicit kind is
+  // resolved by the enabled flags alone, and asking would spend a request per
+  // provider per project to change no answer.
+  private ensureProjectBinaries(projectId: string): void {
+    if (projectId === "" || !noProviderInstalled(this.providers)) {
+      return
+    }
+    if (this.projectBinaries.has(projectId) || this.projectBinaryLoads.has(projectId)) {
+      return
+    }
+    const load = this.readProjectBinaries(projectId)
+      .then((found) => {
+        this.projectBinaries.set(projectId, found)
+        this.emit()
+      })
+      // A failed read leaves the project unanswered rather than answered "none":
+      // a later sweep retries, and until then the machine-wide reading stands.
+      .catch(() => undefined)
+      .finally(() => {
+        this.projectBinaryLoads.delete(projectId)
+      })
+    this.projectBinaryLoads.set(projectId, load)
+  }
+
+  // readProjectBinaries mirrors store.ProviderBin's project layer in Go: the
+  // override counts unless the switch beside it parks the layer, and it counts
+  // only if the backend can run what it names.
+  private async readProjectBinaries(projectId: string): Promise<ReadonlySet<string>> {
+    const answers = await Promise.all(
+      this.providers.map(async (provider) => {
+        const bin = (await this.deps.getProjectSetting(binKey(provider.id), projectId)).trim()
+        if (bin === "") {
+          return null
+        }
+        const parked = await this.deps.getProjectSetting(binOffKey(provider.id), projectId)
+        if (parked === "true") {
+          return null
+        }
+        return (await this.verify(bin)) ? provider.id : null
+      }),
+    )
+    return new Set(answers.filter((id): id is ProviderKind => id !== null))
+  }
+
+  private async verify(bin: string): Promise<boolean> {
+    const cached = this.verdicts.get(bin)
+    if (cached !== undefined) {
+      return cached
+    }
+    const ok = (await this.deps.verifyBin(bin)).status === "ok"
+    this.verdicts.set(bin, ok)
+    return ok
+  }
 
   private async performLoad(): Promise<void> {
     const [detected, storedDefault] = await Promise.all([
@@ -440,6 +549,7 @@ class ProviderStoreImpl implements ProvidersStore {
     )
     this.defaultId = storedDefault
     this.state = "ready"
+    this.sweepProjectBinaries()
     this.emit()
   }
 
@@ -457,6 +567,8 @@ export function createProvidersStore(deps: ProvidersDeps): ProvidersStore {
 const store = createProvidersStore({
   detect: () => Providers.Detect(),
   getEnabled: (id) => Store.GetSetting(enabledKey(id), GLOBAL_SCOPE),
+  getProjectSetting: (key, projectId) => Store.GetSetting(key, projectId),
+  verifyBin: (bin) => Providers.Verify(bin),
   persistEnabled: (id, value) => {
     void Store.SetSetting(enabledKey(id), GLOBAL_SCOPE, value)
   },
@@ -548,12 +660,15 @@ export function useDefaultProvider(): ProviderKind {
   return resolveDefaultProvider(providers, defaultId)
 }
 
-// useNoProviderInstalled reports the machine with no agent on PATH, which is
-// what a surface offering an implicit session shows a terminal for.
-export function useNoProviderInstalled(): boolean {
-  const providers = useSyncExternalStore(store.subscribe, store.getSnapshot)
+// useProjectSessionKind is what this project's implicit new session will spawn —
+// the same answer projectNewSessionKind gives the button, read reactively. A
+// surface that says what the button is about to do reads it here rather than
+// re-deriving it, so the label cannot promise an agent the spawn has not got.
+export function useProjectSessionKind(projectId: string): SessionKind {
+  const getSnapshot = useCallback(() => store.getProjectSessionKind(projectId), [projectId])
+  const kind = useSyncExternalStore(store.subscribe, getSnapshot)
   useEffect(store.ensureLoaded, [])
-  return noProviderInstalled(providers)
+  return kind
 }
 
 // useStoredProjectDefaultProvider returns the unresolved project value. Empty

--- a/frontend/src/lib/providers-store.ts
+++ b/frontend/src/lib/providers-store.ts
@@ -203,6 +203,9 @@ export interface ProviderState {
   /** The executable a session spawns — a provider id is not its command. */
   binary: string
   installed: boolean
+  /** Which layer the binary was found at: "path" or "setting" (the binary
+   * configured in Settings › Providers). Empty when nothing was found. */
+  source: DetectedProvider["source"]
   enabled: boolean
   /** The page documenting how to install this CLI — offered on the rows that
    * found nothing, which are the only rows that need it. */
@@ -210,8 +213,9 @@ export interface ProviderState {
 }
 
 // enabledProviders are the ones offered in New Session. Not filtered by install
-// state on purpose: a Claude with a custom bin path (so "claude" is not on PATH)
-// must still appear — a genuinely missing binary surfaces as a PTY error.
+// state on purpose: a provider whose binary is configured in a single project's
+// scope is not one detection can see, and a genuinely missing binary surfaces as
+// a PTY error.
 export function enabledProviders(list: ProviderState[]): ProviderState[] {
   return list.filter((p) => p.enabled)
 }
@@ -242,11 +246,18 @@ export function resolveProjectDefaultProvider(
 
 // noProviderInstalled reports the one machine state in which spawning the
 // resolved default is guaranteed to fail: detection has answered and found no
-// binary at all. An empty list is detection not having answered yet — never
-// this, exactly as in decideProviderSetup.
+// binary at all, at any layer. An empty list is detection not having answered
+// yet — never this, exactly as in decideProviderSetup.
 export function noProviderInstalled(list: ProviderState[]): boolean {
   return list.length > 0 && !list.some((provider) => provider.installed)
 }
+
+// NO_AGENT_REASON is what the empty screen says when its own button will open a
+// terminal rather than an agent. A shell nobody asked for is the surprise this
+// sentence exists to remove, so it names both the reason and where the machine
+// is told about an agent lich could not find on its own.
+export const NO_AGENT_REASON =
+  "No agent found on PATH, so this opens a terminal — set one in Settings › Providers."
 
 // resolveImplicitSessionKind is what a session nobody picked a kind for spawns:
 // the empty screen's button, the new-session hotkey, a new worktree. It is
@@ -254,7 +265,9 @@ export function noProviderInstalled(list: ProviderState[]): boolean {
 // with no agent installed every fallback below still lands on Claude — readEnabled
 // leaves Claude enabled by default, so the card opens on `claude: command not
 // found`. A shell spawns with zero providers, and it is where the install command
-// from the provider's docs link gets pasted.
+// from the provider's docs link gets pasted. Detection resolves the binary
+// setting too (providers.Detect), so an agent lich only knows about because the
+// user typed its path is an agent this gate lets through.
 export function resolveImplicitSessionKind(
   list: ProviderState[],
   globalDefaultId: string,
@@ -353,6 +366,7 @@ class ProviderStoreImpl implements ProvidersStore {
       name: provider.name,
       binary: provider.binary,
       installed: provider.installed,
+      source: provider.source,
       docs: provider.docs,
       enabled: enabled.get(provider.id as ProviderKind) ?? readEnabled(provider.id, ""),
     }))
@@ -419,6 +433,7 @@ class ProviderStoreImpl implements ProvidersStore {
         name: provider.name,
         binary: provider.binary,
         installed: provider.installed,
+        source: provider.source,
         docs: provider.docs,
         enabled: readEnabled(provider.id, await this.deps.getEnabled(provider.id)),
       })),

--- a/frontend/src/lib/settings-prefs.test.ts
+++ b/frontend/src/lib/settings-prefs.test.ts
@@ -94,6 +94,7 @@ const provider = (id: string, enabled: boolean): ProviderState => ({
   name: id,
   binary: id,
   installed: true,
+  source: "path",
   enabled,
   docs: `https://example.test/${id}`,
 })

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -208,6 +208,12 @@ func (d *Doctor) checkBrowser() (Status, string) {
 
 // checkProviders counts the harnesses a session could spawn. None is not a
 // launch failure — the window opens on an empty workspace — so it warns.
+//
+// The scan is $PATH alone: a diagnosis will not open the workspace database
+// while a lich is running (checkStore), so the binaries configured in Settings ›
+// Providers — which the app itself resolves and counts as installed — are not
+// read here. The warning says so, or an app that spawns agents fine would be
+// read as contradicting its own doctor.
 func (d *Doctor) checkProviders() (Status, string) {
 	found := d.detect()
 	var installed []string
@@ -217,7 +223,7 @@ func (d *Doctor) checkProviders() (Status, string) {
 		}
 	}
 	if len(installed) == 0 {
-		return Warn, "none on PATH — lich opens, but no session can spawn"
+		return Warn, "none on PATH; Settings overrides not read"
 	}
 	return OK, fmt.Sprintf("%d of %d on PATH: %s",
 		len(installed), len(found), strings.Join(installed, ", "))

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -255,7 +255,10 @@ func TestAMissingBrowserStopsALaunchAndMissingProvidersDoNot(t *testing.T) {
 	if checks["providers"].Status != Warn {
 		t.Errorf("providers = %s, want warn — the window still opens", checks["providers"].Status)
 	}
-	if !strings.Contains(checks["providers"].Detail, "no session can spawn") {
+	// The contract moved: this scan is $PATH alone, and the app counts a binary
+	// configured in Settings as installed too. A warning that did not say so
+	// would read as a verdict on a machine that spawns agents fine.
+	if !strings.Contains(checks["providers"].Detail, "Settings overrides not read") {
 		t.Errorf("providers detail = %q", checks["providers"].Detail)
 	}
 }

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -2,8 +2,8 @@
 // a session (Claude Code, Codex, Antigravity, opencode, oh-my-pi, Crush, Cursor
 // CLI, Kiro CLI). A provider id doubles as the session kind that spawns it; the terminal
 // resolves the id to a binary, and the settings store keys per-provider
-// overrides on it. Detection is a PATH scan, mirroring internal/chromium's
-// browser detection.
+// overrides on it. Detection reads that override and then scans PATH, mirroring
+// internal/chromium's browser detection.
 package providers
 
 import (
@@ -141,18 +141,33 @@ func DefaultBinary(id string) string {
 	return ""
 }
 
-// Detected reports a provider and whether one of its binaries was found on PATH.
+// Where the binary a session would spawn was resolved from. A machine with an
+// agent only lich knows about — reached through the binary setting rather than
+// $PATH — is installed just as much as one that answers `which`, and the two are
+// told apart so Settings can caption the row with which layer won.
+const (
+	// SourcePath: one of the provider's own binaries answered on $PATH.
+	SourcePath = "path"
+	// SourceSetting: the binary configured in Settings › Providers, which is the
+	// one the spawn resolves first.
+	SourceSetting = "setting"
+)
+
+// Detected reports a provider and whether a binary a session could spawn was
+// found — on PATH, or at the path the user configured.
 // Binary is the executable name a session spawns (DefaultBinary), which the
 // settings screen needs even when nothing was found: a provider id is not its
 // command — Antigravity's is `agy`.
 // Docs is carried on every entry, installed or not: the row that has somewhere
 // to send the user is exactly the one that found nothing.
+// Source is SourcePath or SourceSetting, empty when nothing was found.
 type Detected struct {
 	ID        string `json:"id"`
 	Name      string `json:"name"`
 	Binary    string `json:"binary"`
 	Installed bool   `json:"installed"`
 	Path      string `json:"path"`
+	Source    string `json:"source"`
 	Docs      string `json:"docs"`
 }
 
@@ -169,6 +184,10 @@ type Service struct {
 	// change it — and RefreshPath is then the no-op that scans the same PATH
 	// again.
 	refreshPath func() error
+	// configuredBin answers a provider's binary setting, the global one. Also
+	// guarded by mu, and also nil outside the app: a Service built to read the
+	// machine has no workspace database behind it, so it scans PATH alone.
+	configuredBin func(id string) string
 }
 
 // New returns a Service that scans the real PATH.
@@ -184,6 +203,28 @@ func (s *Service) SetPathRefresh(fn func() error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.refreshPath = fn
+}
+
+// SetConfiguredBin wires where Detect reads a provider's binary setting from.
+// The settings store cannot be reached from here — it imports this package to
+// key those settings — so main.go hands the reader in, exactly as it does the
+// PATH refresh.
+func (s *Service) SetConfiguredBin(fn func(id string) string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.configuredBin = fn
+}
+
+// binSetting reads the configured binary for a provider, "" when nothing is
+// wired or nothing is set.
+func (s *Service) binSetting(id string) string {
+	s.mu.Lock()
+	read := s.configuredBin
+	s.mu.Unlock()
+	if read == nil {
+		return ""
+	}
+	return read(id)
 }
 
 // RefreshPath re-reads the login shell's environment and re-pins what it
@@ -207,21 +248,39 @@ func (s *Service) RefreshPath() error {
 }
 
 // Detect returns every known provider with its install state, resolving the
-// first candidate binary found on PATH. The list order matches Registry.
+// binary exactly as a spawn would: the configured one first, then the first
+// candidate found on PATH. The list order matches Registry.
+//
+// Reading the setting is what keeps a machine whose only agent lives at a path
+// the user typed from reading as a bare machine — the state the empty screen
+// answers with a terminal.
 func (s *Service) Detect() ([]Detected, error) {
 	out := make([]Detected, 0, len(Registry))
 	for _, p := range Registry {
 		d := Detected{ID: p.ID, Name: p.Name, Binary: DefaultBinary(p.ID), Docs: p.Docs}
-		for _, name := range p.Binaries {
-			if path, err := s.lookPath(name); err == nil {
-				d.Installed = true
-				d.Path = path
-				break
-			}
-		}
-		out = append(out, d)
+		out = append(out, s.resolve(d, p.Binaries))
 	}
 	return out, nil
+}
+
+// resolve fills in where the provider's binary was found. A configured binary
+// answers alone, whether or not it resolves: it is what the spawn will run, so
+// falling through to PATH would report a binary no session of this provider
+// would ever start.
+func (s *Service) resolve(d Detected, binaries []string) Detected {
+	if bin := s.binSetting(d.ID); bin != "" {
+		if check := s.Verify(bin); check.Status == CheckOK {
+			d.Installed, d.Path, d.Source = true, check.Path, SourceSetting
+		}
+		return d
+	}
+	for _, name := range binaries {
+		if path, err := s.lookPath(name); err == nil {
+			d.Installed, d.Path, d.Source = true, path, SourcePath
+			break
+		}
+	}
+	return d
 }
 
 // CostSource is whose arithmetic a session's dollars in the cost ledger are.

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -197,3 +197,123 @@ func TestCostSourceOfNamesEveryRung(t *testing.T) {
 		t.Errorf("CostSourceOf(shell) = %q, want no rung", got)
 	}
 }
+
+// TestDetectCountsAConfiguredBinary is the trap this reading exists to close: a
+// machine whose only agent is reached through the binary setting used to read as
+// a machine with nothing on it, so every implicit new session opened a terminal.
+// The three answers a setting can give are pinned together — accepted, rejected,
+// absent — because it is the same branch deciding all three.
+func TestDetectCountsAConfiguredBinary(t *testing.T) {
+	configured := map[string]string{
+		Claude: "/opt/agents/claude-wrapper",
+		Codex:  "/opt/agents/gone",
+	}
+	svc := &Service{
+		// Nothing at all on PATH: the bare machine the bullet described.
+		lookPath: func(name string) (string, error) {
+			if name == "/opt/agents/claude-wrapper" {
+				return name, nil
+			}
+			return "", exec.ErrNotFound
+		},
+		configuredBin: func(id string) string { return configured[id] },
+	}
+
+	got, err := svc.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if !got[0].Installed || got[0].Path != "/opt/agents/claude-wrapper" {
+		t.Errorf("claude = %+v, want installed at the configured path", got[0])
+	}
+	if got[0].Source != SourceSetting {
+		t.Errorf("claude source = %q, want %q", got[0].Source, SourceSetting)
+	}
+	// A configured binary that does not resolve is still the spawn's answer, so
+	// the provider is not installed — and it says nothing about where from.
+	if got[1].Installed || got[1].Source != "" {
+		t.Errorf("codex = %+v, want not installed with no source", got[1])
+	}
+	// Nothing configured and nothing on PATH is the machine it always was.
+	if got[2].Installed || got[2].Source != "" {
+		t.Errorf("antigravity = %+v, want not installed with no source", got[2])
+	}
+}
+
+// TestDetectPrefersTheConfiguredBinary pins the precedence against the spawn's:
+// terminal reads store.ProviderBin before falling back to the provider's own
+// command, so a configured binary decides even when $PATH has one — reporting
+// the $PATH hit would name a binary no session of this provider would run.
+func TestDetectPrefersTheConfiguredBinary(t *testing.T) {
+	svc := &Service{
+		lookPath: func(name string) (string, error) {
+			if name == "claude" {
+				return "/usr/bin/claude", nil
+			}
+			return "", exec.ErrNotFound
+		},
+		configuredBin: func(id string) string {
+			if id == Claude {
+				return "/nowhere/claude"
+			}
+			return ""
+		},
+	}
+
+	got, err := svc.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if got[0].Installed || got[0].Path != "" {
+		t.Errorf("claude = %+v, want the broken override to answer, not $PATH", got[0])
+	}
+}
+
+// TestDetectSourceIsPathWhenNothingIsConfigured keeps the new field honest for
+// the machine that has changed nothing: a $PATH hit says so, and a Service with
+// no settings reader behind it (`lich doctor`, `lich rage`) scans PATH alone.
+func TestDetectSourceIsPathWhenNothingIsConfigured(t *testing.T) {
+	svc := &Service{
+		lookPath: func(name string) (string, error) {
+			if name == "claude" {
+				return "/usr/bin/claude", nil
+			}
+			return "", exec.ErrNotFound
+		},
+	}
+
+	got, err := svc.Detect()
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if got[0].Source != SourcePath || got[0].Path != "/usr/bin/claude" {
+		t.Errorf("claude = %+v, want %q at /usr/bin/claude", got[0], SourcePath)
+	}
+	if got[1].Source != "" {
+		t.Errorf("codex source = %q, want empty when nothing was found", got[1].Source)
+	}
+}
+
+// TestSetConfiguredBinIsWhatDetectReads proves the seam main.go wires, rather
+// than the field a test can set directly: the settings store cannot be reached
+// from this package, so a Detect that stopped calling the injected reader would
+// pass every test above and ship the bug back.
+func TestSetConfiguredBinIsWhatDetectReads(t *testing.T) {
+	svc := &Service{lookPath: func(string) (string, error) { return "", exec.ErrNotFound }}
+	if got, _ := svc.Detect(); got[0].Installed {
+		t.Fatal("claude installed before any binary was configured")
+	}
+
+	svc.SetConfiguredBin(func(id string) string {
+		if id == Claude {
+			return "/usr/bin/claude"
+		}
+		return ""
+	})
+	svc.lookPath = func(name string) (string, error) { return name, nil }
+
+	got, _ := svc.Detect()
+	if !got[0].Installed || got[0].Source != SourceSetting {
+		t.Errorf("claude = %+v, want installed from the setting", got[0])
+	}
+}

--- a/internal/providers/providers_test.go
+++ b/internal/providers/providers_test.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"errors"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -204,14 +205,15 @@ func TestCostSourceOfNamesEveryRung(t *testing.T) {
 // The three answers a setting can give are pinned together — accepted, rejected,
 // absent — because it is the same branch deciding all three.
 func TestDetectCountsAConfiguredBinary(t *testing.T) {
+	wrapper := configuredPath(t, "claude-wrapper")
 	configured := map[string]string{
-		Claude: "/opt/agents/claude-wrapper",
-		Codex:  "/opt/agents/gone",
+		Claude: wrapper,
+		Codex:  configuredPath(t, "gone"),
 	}
 	svc := &Service{
 		// Nothing at all on PATH: the bare machine the bullet described.
 		lookPath: func(name string) (string, error) {
-			if name == "/opt/agents/claude-wrapper" {
+			if name == wrapper {
 				return name, nil
 			}
 			return "", exec.ErrNotFound
@@ -223,7 +225,7 @@ func TestDetectCountsAConfiguredBinary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Detect: %v", err)
 	}
-	if !got[0].Installed || got[0].Path != "/opt/agents/claude-wrapper" {
+	if !got[0].Installed || got[0].Path != wrapper {
 		t.Errorf("claude = %+v, want installed at the configured path", got[0])
 	}
 	if got[0].Source != SourceSetting {
@@ -245,6 +247,7 @@ func TestDetectCountsAConfiguredBinary(t *testing.T) {
 // command, so a configured binary decides even when $PATH has one — reporting
 // the $PATH hit would name a binary no session of this provider would run.
 func TestDetectPrefersTheConfiguredBinary(t *testing.T) {
+	missing := configuredPath(t, "gone")
 	svc := &Service{
 		lookPath: func(name string) (string, error) {
 			if name == "claude" {
@@ -254,7 +257,7 @@ func TestDetectPrefersTheConfiguredBinary(t *testing.T) {
 		},
 		configuredBin: func(id string) string {
 			if id == Claude {
-				return "/nowhere/claude"
+				return missing
 			}
 			return ""
 		},
@@ -304,9 +307,10 @@ func TestSetConfiguredBinIsWhatDetectReads(t *testing.T) {
 		t.Fatal("claude installed before any binary was configured")
 	}
 
+	wrapper := configuredPath(t, "claude")
 	svc.SetConfiguredBin(func(id string) string {
 		if id == Claude {
-			return "/usr/bin/claude"
+			return wrapper
 		}
 		return ""
 	})
@@ -316,4 +320,14 @@ func TestSetConfiguredBinIsWhatDetectReads(t *testing.T) {
 	if !got[0].Installed || got[0].Source != SourceSetting {
 		t.Errorf("claude = %+v, want installed from the setting", got[0])
 	}
+}
+
+// configuredPath spells what a user types into the binary setting, absolute for
+// the OS the test is running on. It matters: Verify answers CheckRelative for a
+// path that names a location without naming it from the root, and a POSIX path
+// is exactly that on Windows — no drive letter, so filepath.IsAbs says no. The
+// file is never created; every test above resolves it through a fake lookPath.
+func configuredPath(t *testing.T, name string) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), name)
 }

--- a/main.go
+++ b/main.go
@@ -191,6 +191,11 @@ func main() {
 		sys.SetEnv(next)
 		return nil
 	})
+	// Detection resolves a provider the way the spawn does, so an agent reached
+	// only through the binary setting counts as installed — otherwise a machine
+	// with one configured agent and nothing on PATH reads as bare, and every
+	// implicit new session opens a terminal instead.
+	providerSvc.SetConfiguredBin(func(id string) string { return db.ProviderBin(id, "") })
 	dispatcher.Register("providers", providerSvc)
 	// The quota reading is per session, not per machine: a session spawned from
 	// a binary the user configured can spend another account entirely, and the


### PR DESCRIPTION
## The trap

`providers.Detect` only ever scanned `$PATH`, so a machine whose only agent is reached through the `provider.<id>.bin` setting read as a machine with nothing on it. `resolveImplicitSessionKind` saw no installed provider and every implicit new session — the empty screen's button, the new-session hotkey, a new worktree — opened a terminal the user did not ask for. That was a `docs/ceilings.md` bullet; this PR deletes it by fixing it.

## The change

- **`internal/providers.Detect` resolves the binary the way the spawn does**: the configured one first, through `Verify` (so it counts only if it can actually be run), then the `$PATH` scan. A configured binary answers alone whether or not it resolves — it is what the spawn will run, so falling through to `$PATH` would report a binary no session of that provider would ever start.
- **New `source` field** on `Detected` (`"path"` | `"setting"`, empty when nothing was found), mirrored in `frontend/src/lib/api-types.ts` and carried through `providers-store`. Settings' provider row captions a setting-sourced hit with "Installed · custom path", so a reading on a machine with nothing on `$PATH` does not look invented.
- **`main.go` wires the reader** (`SetConfiguredBin`), the same seam shape as `SetPathRefresh` — `internal/store` imports `internal/providers` to key those settings, so the dependency only goes one way.
- **A project's own binary override counts for that project.** `Detect` answers for the machine and takes no project, so the per-project half is composed on the page rather than by redesigning it: the providers store reads the project's own binary layer (skipping a parked one, exactly as `store.ProviderBin` does in Go), asks the existing `providers.Verify` whether it can be run, caches the verdict per path, and hands the result to `resolveImplicitSessionKind`. The read is spent only on the bare machine — with an agent on `$PATH` the implicit kind is resolved by the enabled flags alone, so asking would cost a request per provider per project to change no answer — and is dropped on a refresh, so "Check again" re-resolves it. On that bare machine the choice is made among the providers the project can actually run, rather than by the enabled-flag fallback, which would name a binary that is not there.
- **The empty screen says why, and cannot disagree with its own button.** The remaining half is the only thing that can work there: a machine with truly nothing anywhere still opens a shell. `EmptySessions` now reads the resolved kind itself and shows one sentence when it is a terminal — "No agent found on PATH, so this opens a terminal — set one in Settings › Providers." The New Session menu still lists every enabled agent, as before.
- **`lich doctor` says what its scan does not cover**: `none on PATH; Settings overrides not read`. It will not open the workspace database while a lich is running (`checkStore`), so it cannot read the overrides the app resolves, and the old wording ("no session can spawn") would have read as a verdict on a machine that spawns agents fine.

Generic across the registry, so all eight providers are covered by the same branch.

## Tests

- Go: `Detect` with an override accepted, rejected and absent; the override beating a `$PATH` hit; `source` on a plain `$PATH` machine and on a `Service` with no settings reader (`lich doctor`, `lich rage`); and the injected seam itself, which is what `main.go` actually wires. Doctor's line pinned to the new wording.
- Frontend: `resolveImplicitSessionKind` with a setting-sourced provider and with a project-scoped one (picks that provider, beats the stored default, keeps the shell when the override is absent or its provider disabled, and is ignored entirely once anything is installed machine-wide); the store end to end — a project override read, verified and spawned, a parked layer skipped, and no project read at all while the machine has an agent; the empty-screen sentence pinned as a literal.
- Two existing tests changed because the contract changed, named in the diff: one asserted that a custom binary path leaves the machine reading as bare and cited the ceiling; the other pinned doctor's old wording.

## Gate

`gofmt -l .` clean · `go vet ./...` clean · `go test ./...` green · `biome ci .` exit 0 · `pnpm test` 1621 passed · `pnpm build` ok.