### PR TITLE
fix: keep the last binary verdict while a check re-runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which always names the latest release. A lich installed from the old
   raw-file URL needs a one-time `scoop uninstall lich` and install from the new
   one.
+- **A binary check no longer blinks through "unknown" on the way back.** The
+  path verdicts on Settings › Version Control and under every provider's binary
+  field answered nothing at all until a fresh check came back, so reopening the
+  pane, or switching to a provider you had already looked at, painted a blank
+  where the verdict had been and filled it in a moment later. The last verdict
+  for a value is kept and shown while the check runs again behind it; a value
+  never checked still says nothing, and re-reading `$PATH` with "Check again"
+  still asks every question over.
 
 ## [0.46.0] - 2026-09-07
 

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -804,12 +804,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   seen, and the ones who have not will read the binary they install. A wrong headline is a patch release. The
   update toast reads nothing from the release but its tag, on purpose: the toast says a release exists, and
   the dialog is where it speaks.
-- **`useBinaryCheck` is deliberately not a `useRemoteResource` caller** (`frontend/src/lib/use-binary-check.ts`):
-  it answers `null` until a verdict is in and debounces its input, because the value it checks arrives one
-  keystroke at a time — and `useRemoteResource` has no debounce seam to hang that on. So the path verdicts on
-  Settings › Version Control and every provider's binary block still blink through "unknown" on the way back
-  to the screen. Measured at 1–3 ms per check (`providers.Verify` is a `LookPath`), which is why closing it
-  was not worth widening a hook the whole app reads through.
 - **The Files changed tab remembers which file, never where in it**
   (`frontend/src/lib/pulls/use-active-file.ts`): the changed-files tree's mark comes back with the tab, but
   the diff pane reopens at the top. Nothing in this codebase restores a scroll offset, and the one that would

--- a/frontend/src/lib/use-binary-check.test.tsx
+++ b/frontend/src/lib/use-binary-check.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+//
+// What a surface paints while a check is in flight. The hook is rendered rather
+// than left to a pure half because the whole behaviour is a frame: the verdict
+// on screen on the way back in, before anything has answered.
+//
+// The harness has to be imported before anything that reaches react-dom, which
+// is why it is first here (see @/test/render-budget).
+import { mountBudget } from "@/test/render-budget"
+import { createElement } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { refreshPath } from "@/lib/path-refresh"
+import { Providers } from "@/lib/rpc"
+import { NO_SETTLE, useBinaryCheck } from "@/lib/use-binary-check"
+import type { BinaryCheck } from "@/lib/api-types"
+
+vi.mock("@/lib/rpc", () => ({
+  Providers: {
+    Verify: vi.fn(),
+    RefreshPath: vi.fn(),
+  },
+}))
+
+const verify = vi.mocked(Providers.Verify)
+const refreshRPC = vi.mocked(Providers.RefreshPath)
+
+const found = (path: string): BinaryCheck => ({ path, status: "ok" })
+
+const last = (frames: (BinaryCheck | null)[]) => frames[frames.length - 1]
+
+// Every value each render answered with, in order, so a null frame between two
+// verdicts is visible rather than averaged away.
+async function paint(bin: string): Promise<{ frames: (BinaryCheck | null)[] }> {
+  const frames: (BinaryCheck | null)[] = []
+  function Probe() {
+    frames.push(useBinaryCheck(bin, NO_SETTLE))
+    return null
+  }
+  const mounted = await mountBudget(createElement(Probe))
+  // The settle is a timer even at zero, so the answer lands a macrotask later.
+  await mounted.act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
+  await mounted.unmount()
+  return { frames }
+}
+
+beforeEach(() => {
+  verify.mockReset()
+  refreshRPC.mockReset()
+})
+
+describe("useBinaryCheck", () => {
+  // Each test names its own binary: the verdicts are module-level, which is the
+  // point of them, so a shared name would let one test answer the next.
+  it("answers null for a value it has never checked", async () => {
+    verify.mockResolvedValue(found("/usr/bin/first"))
+
+    const { frames } = await paint("first")
+
+    expect(frames[0]).toBeNull()
+    expect(last(frames)).toEqual(found("/usr/bin/first"))
+  })
+
+  it("paints the last verdict on a remount, with no null frame", async () => {
+    verify.mockResolvedValue(found("/usr/bin/second"))
+    await paint("second")
+
+    const { frames } = await paint("second")
+
+    expect(frames).not.toContain(null)
+    expect(frames[0]).toEqual(found("/usr/bin/second"))
+    // And it is still re-checked behind what is on screen.
+    expect(verify).toHaveBeenCalledTimes(2)
+  })
+
+  it("starts a value it has not seen at null, however many it has", async () => {
+    verify.mockResolvedValue(found("/usr/bin/third"))
+    await paint("third")
+    verify.mockResolvedValue(found("/opt/fourth"))
+
+    const { frames } = await paint("fourth")
+
+    expect(frames[0]).toBeNull()
+    expect(last(frames)).toEqual(found("/opt/fourth"))
+  })
+
+  // A verdict is resolved through the pinned $PATH, so a re-read makes every one
+  // of them a fresh question rather than a repeat of the answer already filed.
+  it("re-checks when the pinned PATH moves", async () => {
+    verify.mockResolvedValue(found("/usr/bin/fifth"))
+    await paint("fifth")
+    refreshRPC.mockResolvedValue(null)
+    await refreshPath()
+    verify.mockResolvedValue(found("/opt/fifth"))
+
+    const { frames } = await paint("fifth")
+
+    expect(verify).toHaveBeenCalledTimes(2)
+    expect(frames[0]).toBeNull()
+    expect(last(frames)).toEqual(found("/opt/fifth"))
+  })
+})

--- a/frontend/src/lib/use-binary-check.ts
+++ b/frontend/src/lib/use-binary-check.ts
@@ -13,24 +13,39 @@ const SETTLE_MS = 400
 // the tool it is about to shell out to exists.
 export const NO_SETTLE = 0
 
+// The last verdict for each input, filed the way remote-cache.ts files a backend
+// answer: module-level, never persisted, and never a source of truth. It is what
+// a surface paints while its own check is in flight, so a settings pane reopened
+// or a provider block remounted comes back with the verdict it had instead of
+// blinking through "unknown".
+//
+// The key carries the whole input, the $PATH pin included: a verdict is resolved
+// through the pin (path-refresh), so the same value asked before and after a
+// re-read are two different questions, and a key of the value alone would paint
+// the pre-move answer as if it still held.
+const verdicts = new Map<string, BinaryCheck>()
+
+const verdictKey = (bin: string, path: number): string => `${path} ${bin}`
+
 // useBinaryCheck resolves a configured binary through the backend, re-checking
-// whenever the value settles. Null while the first answer for a value is in
-// flight — the callers draw nothing rather than flashing a failure between
-// keystrokes.
+// whenever the value settles. Null for an input never checked, so the callers
+// draw nothing rather than flashing a failure between keystrokes.
 //
 // It re-checks on a re-read of the machine's $PATH too (lib/path-refresh): the
 // answer is resolved through the pin, so a moved pin makes every verdict on
 // screen stale at once, wherever the re-check was pressed.
 export function useBinaryCheck(bin: string, settleMs: number = SETTLE_MS): BinaryCheck | null {
-  const [check, setCheck] = useState<BinaryCheck | null>(null)
   const path = useSyncExternalStore(subscribePathRefresh, pathVersion)
+  const key = verdictKey(bin, path)
+  const [check, setCheck] = useState<BinaryCheck | null>(() => verdicts.get(key) ?? null)
 
   useEffect(() => {
     let live = true
-    setCheck(null)
+    setCheck(verdicts.get(key) ?? null)
     const timer = setTimeout(() => {
       Providers.Verify(bin)
         .then((next) => {
+          verdicts.set(key, next)
           if (live) {
             setCheck(next)
           }
@@ -43,7 +58,7 @@ export function useBinaryCheck(bin: string, settleMs: number = SETTLE_MS): Binar
       live = false
       clearTimeout(timer)
     }
-  }, [bin, settleMs, path])
+  }, [bin, settleMs, key])
 
   return check
 }


### PR DESCRIPTION
`useBinaryCheck` answers `null` until a verdict is in, so the path verdicts on
Settings › Version Control and under every provider's binary field blinked
through "unknown" on the way back to the screen: a remount had nothing to
paint, and the answer arrived a round trip later.

The last verdict for each input is now filed in a module-level map, the way
`remote-cache.ts` files a backend answer, and painted while the check runs
again behind it. The key carries the whole input, the `$PATH` pin included
(#519), so the re-check after "Check again" starts from nothing rather than
serving the pre-move answer as if it still held. The debounce is untouched, and
a value never checked still answers `null`.

It stays out of `useRemoteResource` for the reason the ceilings bullet gave (no
debounce seam), so that bullet's trap is closed and the bullet goes.

## Test plan

- [x] `pnpm test`, new `use-binary-check.test.tsx` (jsdom, the render-budget
      harness): a remount paints the last verdict with no null frame and still
      re-checks; a value never seen starts at null; a `$PATH` re-read re-checks
      and starts that question at null
- [x] The remount test is the one that fails against the current hook
- [x] `biome ci .` (exit 0), `pnpm build`
- [x] `CHANGELOG.md` [Unreleased] › Fixed