### PR TITLE
fix: say on the Sandbox pane that a terminal is never confined

### DIFF
--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -641,10 +641,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   binaries are the exception: their symlink chains are walked and the *directory* of every hop is mounted
   (`BinaryDirs`), which is what makes an agent installed the usual way — a link on `PATH` into a versioned
   store — runnable at all.
-- **A terminal session is never confined by a rung** (`internal/store/settings.go`): the rung is keyed by
-  provider, and `shell` is not one — the sandbox exists to confine an agent working unattended, not the
-  user's own prompt. A terminal opened in a project whose provider is on `Everywhere` still runs on the
-  machine, and nothing says so.
 - **The macOS floor is the toolchain's, not lich's** (`build/darwin/Info.plist.tpl`,
   `build/darwin/homebrew/lich.rb.tpl`): nothing in lich needs macOS 13, but Go 1.27 dropped every
   release before Ventura, so a binary built from this module cannot run on Big Sur or Monterey. The

--- a/frontend/src/components/settings/SandboxSettings.test.tsx
+++ b/frontend/src/components/settings/SandboxSettings.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+//
+// The Sandbox pane, mounted for real. The rung is keyed by provider and `shell`
+// is not one, so a terminal in a project on Everywhere runs on the machine —
+// the ladder cannot say that with a row, and the node-only gate cannot tell a
+// sentence that renders from one that was written and never reached the pane.
+//
+// The harness is imported first for the reason render-budget.test.tsx names.
+import { mountBudget } from "@/test/render-budget"
+import { createElement } from "react"
+import { expect, test, vi } from "vitest"
+import { SandboxSettings } from "./SandboxSettings"
+
+vi.mock("@/lib/rpc", () => ({
+  System: {
+    SandboxBackend: () => Promise.resolve("bubblewrap"),
+    SSHAgentKeys: () => Promise.resolve([]),
+  },
+  Store: { GetSetting: () => Promise.resolve("") },
+  Providers: {
+    Detect: () =>
+      Promise.resolve([
+        { id: "claude", name: "Claude Code", binary: "claude", installed: true, source: "path" },
+      ]),
+  },
+}))
+
+test("says the sandbox never confines a terminal", async () => {
+  const mounted = await mountBudget(createElement(SandboxSettings))
+  await mounted.act(() => {})
+
+  expect(document.body.textContent).toContain(
+    "Terminals are never confined; the sandbox is for agents working unattended.",
+  )
+  await mounted.unmount()
+})

--- a/frontend/src/components/settings/SandboxSettings.tsx
+++ b/frontend/src/components/settings/SandboxSettings.tsx
@@ -149,7 +149,7 @@ export function SandboxSettings({ projectId }: { projectId?: string }) {
         <p className="mt-2 max-w-prose text-xs text-muted-foreground">
           Ask puts the question in the New session menu and the New worktree dialog. A session
           opened where nobody can answer — by another session, or through the MCP tool — is
-          confined.
+          confined. Terminals are never confined; the sandbox is for agents working unattended.
         </p>
       </SettingBlock>
 


### PR DESCRIPTION
## What

The sandbox rung is keyed by provider, and `shell` is not one. A terminal opened in a project whose provider sits on `Everywhere` still runs on the machine — the ladder has no row it could say that with, and nothing else on the pane said it either.

The note under the ladder now does, in one sentence:

> Terminals are never confined; the sandbox is for agents working unattended.

No toggle, no setting: the behaviour is deliberate and only its silence was the bug.

`docs/ceilings.md` loses the bullet that named the trap.

## Test plan

- [x] `SandboxSettings.test.tsx` mounts the pane and asserts the sentence renders — the node-only gate cannot tell copy that reaches the pane from copy that does not.
- [x] `./node_modules/.bin/biome ci .` exit 0
- [x] `pnpm test` (1622 passed), `pnpm build`