### PR TITLE
fix: name the MCP tool on an Antigravity card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An Antigravity card now names the MCP tool it is running.** Every MCP call
+  there is the same internal step, so a card that opened a session read
+  `call_mcp_tool` followed by `lich/open_session`, spending the line on the step
+  and crowding the tool worth reading off the end of it. It now draws the server
+  and the tool the way every other provider's card does: `lich · open_session`.
 - **An agent reached through a custom binary path now counts as installed.**
   Detection only ever scanned `$PATH`, so a machine whose only agent is the one
   you pointed lich at in Settings › Providers read as a machine with nothing on

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -474,13 +474,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   arrives there only once that repo cuts a release and the user reinstalls the plugin, and until they do it is
   missing from that session's list while it is in every other. `lich rename` works there like anywhere else; it is
   discovery that lags, which is the whole reason the tools exist.
-- **An Antigravity card names the step, not the MCP tool** (`frontend/src/lib/session/tool-label.ts`): every MCP
-  call there is the one step `call_mcp_tool`, with the server and the tool in `args.ServerName` / `args.ToolName`
-  (measured on 1.1.19). Nothing in that name can be split, so the fix was never here — the plugin reads those two
-  arguments and sends them as the report's `detail`, and the card draws `call_mcp_tool · lich/open_session` where a
-  Claude Code card draws `lich · open_session`. The trap is reaching for `tool-label.ts` when that line looks
-  wrong: the tool's identity arrives in a different field on this provider, and a plugin older than the release
-  that added it sends `call_mcp_tool` with no detail at all.
 - **Only Claude Code says what a session is waiting for; the others say less or nothing**
   (`frontend/src/components/sidebar/SessionCard.tsx`, table in `docs/hooks/session-state.md`): its
   `Notification` carries a `message` written for a human, so the card reads "Claude needs your permission to

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -165,7 +165,7 @@ part worth reading starts:
 |-------------------|---------------------------|-----------------------------------|
 | Claude Code       | `mcp__lich__open_session` | `lich · open_session`             |
 | Codex             | `mcp__srv__tool`          | `srv · tool`                      |
-| Antigravity       | `call_mcp_tool`           | `call_mcp_tool · lich/open_session` |
+| Antigravity       | `call_mcp_tool`           | `lich · open_session`             |
 | oh-my-pi          | `mcp__lich_list_sessions` | `lich · list_sessions`            |
 | opencode          | `lichprobe_list_sessions` | `lichprobe · list_sessions`       |
 
@@ -177,8 +177,11 @@ hook payload.
 **Antigravity is the one harness whose tool name is not the tool.** Every MCP
 call there is the single step `call_mcp_tool`, and which server and which tool
 are two of its arguments (`args.ServerName`, `args.ToolName`) — so the client
-reads them and sends them as `detail`, which is why that row is the only one
-whose card line is made of both fields.
+reads them and sends them as `detail`, spelled `<server>/<tool>`. That row is
+the only one whose card line is split out of the *other* field: the label takes
+the detail whole and nothing is drawn beside it. A `detail` shaped any other
+way, and a plugin too old to send one at all, leaves the step name on the card
+the way any name that cannot be split is left.
 
 Of the names that *are* the tool, only the doubled underscore divides on the
 string alone: `mcp__lich_list_sessions` reads as `lich` + `list_sessions` or

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -42,7 +42,7 @@ import { useSessionRelay } from "@/lib/session/use-session-relay"
 import { useSessionInbox } from "@/lib/session/use-session-inbox"
 import { useSessionTool } from "@/lib/session/use-session-tool"
 import { toolGlyph } from "@/lib/session/tool-glyph"
-import { toolLabel } from "@/lib/session/tool-label"
+import { toolLine } from "@/lib/session/tool-label"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { baseReadout } from "@/lib/git/base-status"
 import { usePullRequest } from "@/lib/pulls/use-pull-request"
@@ -215,6 +215,10 @@ export function SessionCard({
   // tasks it delegated, uncollected. Zero — the usual case — draws nothing.
   const inbox = useSessionInbox(session.id)
   const ToolGlyph = tool && toolGlyph(tool.name)
+  // The two halves of the line, which are not always the two fields the report
+  // sent: on Antigravity the tool's identity arrives in the detail, and drawing
+  // it takes the whole line (tool-label.ts).
+  const line = tool && toolLine(tool, session.mcpServers)
   // The prompt parked on this card, and how far off it is. Read at render
   // rather than counted down on a timer of its own: a card redraws often enough
   // that "in 3h" is never wrong by anything a person reads, and a clock ticking
@@ -533,11 +537,11 @@ export function SessionCard({
                       The separator travels inside the detail so it leaves with it,
                       instead of dangling after a truncated name. */}
                   <span className="min-w-0 truncate font-medium text-foreground">
-                    {toolLabel(tool.name, session.mcpServers)}
+                    {line?.label}
                   </span>
-                  {tool.detail && (
+                  {line?.detail && (
                     <span className="min-w-0 shrink-[9999] truncate font-mono">
-                      <span className="opacity-50">·</span> {tool.detail}
+                      <span className="opacity-50">·</span> {line.detail}
                     </span>
                   )}
                 </span>

--- a/frontend/src/lib/session/tool-label.test.ts
+++ b/frontend/src/lib/session/tool-label.test.ts
@@ -1,62 +1,105 @@
 import { describe, expect, it } from "vitest"
-import { toolLabel } from "./tool-label"
+import { toolLine } from "./tool-label"
 
 // The names a session's provider reports its servers under (providers.Detect).
 const SERVERS = ["lich", "ai-memory"]
 
-describe("toolLabel", () => {
+// Most of what this file pins is the name half alone: a tool whose detail is
+// its own words about the call, which the line carries through untouched.
+const label = (name: string, servers: readonly string[] = []) =>
+  toolLine({ name, detail: "" }, servers).label
+
+describe("toolLine", () => {
   it("drops the mcp machinery and keeps the server and the tool", () => {
-    expect(toolLabel("mcp__ai-memory__memory_write_page")).toBe("ai-memory · memory_write_page")
-    expect(toolLabel("mcp__lich__open_session")).toBe("lich · open_session")
+    expect(label("mcp__ai-memory__memory_write_page")).toBe("ai-memory · memory_write_page")
+    expect(label("mcp__lich__open_session")).toBe("lich · open_session")
   })
 
   // The server ends at the first `__` after the prefix, so a tool whose own
   // name carries one keeps it whole rather than losing its tail to the split.
   it("splits on the first separator, not the last", () => {
-    expect(toolLabel("mcp__srv__do__the__thing")).toBe("srv · do__the__thing")
+    expect(label("mcp__srv__do__the__thing")).toBe("srv · do__the__thing")
   })
 
   // Measured against omp 17.3.7: a single underscore between the server and the
   // tool, which only the list of registered servers can divide.
   it("splits omp's single-underscore form against the servers", () => {
-    expect(toolLabel("mcp__lich_list_sessions", SERVERS)).toBe("lich · list_sessions")
-    expect(toolLabel("mcp__ai-memory_memory_query", SERVERS)).toBe("ai-memory · memory_query")
+    expect(label("mcp__lich_list_sessions", SERVERS)).toBe("lich · list_sessions")
+    expect(label("mcp__ai-memory_memory_query", SERVERS)).toBe("ai-memory · memory_query")
   })
 
   // Measured against opencode 1.18.18: no prefix at all, so the servers are the
   // whole of what says where the name divides.
   it("splits opencode's bare form against the servers", () => {
-    expect(toolLabel("lich_open_session", SERVERS)).toBe("lich · open_session")
+    expect(label("lich_open_session", SERVERS)).toBe("lich · open_session")
   })
 
   // Two servers could claim the same name; the longer one is the one that read
   // the whole prefix rather than stopping inside it.
   it("takes the longest server that matches", () => {
-    expect(toolLabel("lich_relay_send", ["lich", "lich_relay"])).toBe("lich_relay · send")
+    expect(label("lich_relay_send", ["lich", "lich_relay"])).toBe("lich_relay · send")
   })
 
   // A server name is not a word boundary: `lichen_pick` is not lich's.
   it("matches a whole server name, not a prefix of one", () => {
-    expect(toolLabel("lichen_pick", SERVERS)).toBe("lichen_pick")
+    expect(label("lichen_pick", SERVERS)).toBe("lichen_pick")
   })
 
   it("leaves a name no server claims exactly as it arrived", () => {
-    expect(toolLabel("lichprobe_list_sessions", SERVERS)).toBe("lichprobe_list_sessions")
-    expect(toolLabel("mcp__other_list_sessions", SERVERS)).toBe("other_list_sessions")
-    expect(toolLabel("mcp__lich_list_sessions")).toBe("lich_list_sessions")
+    expect(label("lichprobe_list_sessions", SERVERS)).toBe("lichprobe_list_sessions")
+    expect(label("mcp__other_list_sessions", SERVERS)).toBe("other_list_sessions")
+    expect(label("mcp__lich_list_sessions")).toBe("lich_list_sessions")
   })
 
   it("shows a name that is not an MCP tool's exactly as it arrived", () => {
-    expect(toolLabel("Bash", SERVERS)).toBe("Bash")
-    expect(toolLabel("apply_patch", SERVERS)).toBe("apply_patch")
-    expect(toolLabel("", SERVERS)).toBe("")
+    expect(label("Bash", SERVERS)).toBe("Bash")
+    expect(label("apply_patch", SERVERS)).toBe("apply_patch")
+    expect(label("", SERVERS)).toBe("")
   })
 
   // Half a prefix is not an MCP name, and neither half is a server or a tool.
   it("still strips the prefix off a name it cannot split", () => {
-    expect(toolLabel("mcp__lich", SERVERS)).toBe("lich")
-    expect(toolLabel("mcp____tool", SERVERS)).toBe("__tool")
+    expect(label("mcp__lich", SERVERS)).toBe("lich")
+    expect(label("mcp____tool", SERVERS)).toBe("__tool")
     // A server with nothing after it draws no separator.
-    expect(toolLabel("lich_", SERVERS)).toBe("lich_")
+    expect(label("lich_", SERVERS)).toBe("lich_")
+  })
+
+  it("keeps the detail the harness sent beside the name", () => {
+    expect(toolLine({ name: "Bash", detail: "pnpm test" }, SERVERS)).toEqual({
+      label: "Bash",
+      detail: "pnpm test",
+    })
+  })
+
+  // Measured against Antigravity 1.1.19: the step is the same for every MCP
+  // call, and the plugin sends the tool it stands for as the detail. Splitting
+  // that is what makes the line read like every other provider's.
+  it("splits Antigravity's step against its detail", () => {
+    expect(toolLine({ name: "call_mcp_tool", detail: "lich/open_session" }, SERVERS)).toEqual({
+      label: "lich · open_session",
+      detail: "",
+    })
+  })
+
+  // A plugin older than the release that added the detail sends the step alone.
+  it("draws the step whole when it carries no detail", () => {
+    expect(toolLine({ name: "call_mcp_tool", detail: "" }, SERVERS)).toEqual({
+      label: "call_mcp_tool",
+      detail: "",
+    })
+  })
+
+  // Not every detail is an identity: one that does not spell `<server>/<tool>`
+  // is the harness's own words, and both halves stay as they arrived.
+  it("leaves a detail that is not a server and a tool alone", () => {
+    expect(toolLine({ name: "call_mcp_tool", detail: "open_session" }, SERVERS)).toEqual({
+      label: "call_mcp_tool",
+      detail: "open_session",
+    })
+    expect(toolLine({ name: "call_mcp_tool", detail: "lich/" }, SERVERS)).toEqual({
+      label: "call_mcp_tool",
+      detail: "lich/",
+    })
   })
 })

--- a/frontend/src/lib/session/tool-label.ts
+++ b/frontend/src/lib/session/tool-label.ts
@@ -1,3 +1,5 @@
+import type { SessionTool } from "./session-events"
+
 // The harnesses spell an MCP tool three different ways, all measured against the
 // real CLIs rather than read off their docs (docs/hooks/session-state.md):
 //
@@ -10,6 +12,19 @@
 // its narrowest.
 const MCP_DOUBLE = /^mcp__(.+?)__(.+)$/
 const MCP_PREFIX = "mcp__"
+
+// Antigravity is the one harness whose tool name is not the tool: every MCP call
+// there is the single step `call_mcp_tool`, and which server and which tool are
+// two of its arguments, which the plugin reads and sends as the report's detail
+// (`<server>/<tool>`). So the identity to split is in the other field, and a
+// server name never carries a slash.
+const MCP_STEP = "call_mcp_tool"
+const MCP_STEP_DETAIL = /^([^/]+)\/(.+)$/
+
+export interface ToolLine {
+  label: string
+  detail: string
+}
 
 // toolLabel shortens what it can prove and leaves the rest alone, drawing an MCP
 // tool as "<server> · <tool>".
@@ -25,7 +40,7 @@ const MCP_PREFIX = "mcp__"
 // A name matching no server keeps whatever survives the prefix, which is also
 // what any name that is not an MCP tool's gets, and what every name got before
 // a session had a list.
-export function toolLabel(name: string, servers: readonly string[] = []): string {
+function toolLabel(name: string, servers: readonly string[] = []): string {
   const parts = MCP_DOUBLE.exec(name)
   if (parts) {
     return `${parts[1]} · ${parts[2]}`
@@ -33,6 +48,24 @@ export function toolLabel(name: string, servers: readonly string[] = []): string
   const rest = name.startsWith(MCP_PREFIX) ? name.slice(MCP_PREFIX.length) : name
   const server = longestServer(rest, servers)
   return server ? `${server} · ${rest.slice(server.length + 1)}` : rest
+}
+
+// toolLine is the two halves a card draws for the tool a turn is running: the
+// label, and whatever the harness sent to identify the call beside it. The
+// single entry point on purpose: a card that reached for the label alone drew
+// Antigravity's step name with the tool it stands for repeated after it
+// (`call_mcp_tool · lich/open_session`), where every other provider drew
+// `lich · open_session`.
+//
+// A step whose detail is not `<server>/<tool>` keeps both halves as they
+// arrived, which is also what a plugin too old to send that detail gets: the
+// step name whole, the way any tool that cannot be split already looks.
+export function toolLine(tool: SessionTool, servers: readonly string[] = []): ToolLine {
+  const step = tool.name === MCP_STEP ? MCP_STEP_DETAIL.exec(tool.detail) : null
+  if (step) {
+    return { label: `${step[1]} · ${step[2]}`, detail: "" }
+  }
+  return { label: toolLabel(tool.name, servers), detail: tool.detail }
 }
 
 // longestServer is the longest name in servers that rest spells as `<name>_`,


### PR DESCRIPTION
Closes the `docs/ceilings.md` bullet "An Antigravity card names the step, not the MCP tool" by fixing it, so the line reads the same on every provider.

## What was wrong

Every MCP call on Antigravity is the one step `call_mcp_tool`, and which server and which tool are two of its arguments, which the plugin reads and sends as the report's `detail` (`lich/open_session`). The card drew the name and the detail as its two halves, so it read `call_mcp_tool · lich/open_session`: the step's name spent the line and the tool worth reading was crowded off the end of a 12rem card, where a Claude Code card read `lich · open_session`.

## What changed

- `frontend/src/lib/session/tool-label.ts` now exports `toolLine`, the single entry point for the two halves a card draws. On the step with a `<server>/<tool>` detail it splits that detail into the label, exactly as the doubled-underscore forms are split, and leaves nothing to draw beside it. Everything else keeps the label `toolLabel` already produced and the detail as it arrived.
- A detail shaped any other way, and a plugin older than the release that added it, leave the step name whole, which is what any unsplittable tool already looks like. That is what makes the old-plugin case need no bullet of its own.
- `SessionCard` reads the pair instead of reaching for the label alone, so there is one way to draw a tool line and it answers for every provider.
- `docs/hooks/session-state.md`: the Antigravity row of the MCP table now reads `lich · open_session`, and the paragraph under it says the detail's spelling and what an unsplittable one falls back to.
- `docs/ceilings.md`: bullet deleted, no trap left in its place.

## Test plan

- [x] `frontend/src/lib/session/tool-label.test.ts`: the step with a detail, without one, and with a detail that is not `<server>/<tool>` shaped (no slash, and an empty tool half). The existing name-splitting cases are unchanged, read through a `label` helper.
- [x] `./node_modules/.bin/biome ci .` exits 0
- [x] `pnpm test` (1625 passed, render budgets included)
- [x] `pnpm build`