### PR TITLE
fix: refuse a ticketless answer when two errands are open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **An answer that names no ticket no longer guesses which task it belongs to.**
+  `lich reply "<answer>"` and `reply_to_session` without a ticket used to close
+  the oldest request delivered to that session, so a session working two relayed
+  tasks that answered the second one first sent it home as the answer to the
+  first — and both senders read a confident report of work nobody did. With two
+  or more requests open the answer is now refused, listing every open ticket
+  with the opening of what it asked, so the retry names the right one. One open
+  request is answered as before.
 - **The sandbox's "Ask each time" rung now reaches every session.** It only ever
   asked in the New worktree dialog, so a session started from the New session
   menu, by another session, or through the MCP tool quietly ran on the machine.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   confident report of work nobody did. With two or more requests open the answer
   is now refused, listing every open ticket with the opening of what it asked so
   the retry names the right one. The same guess ran one step later, when a turn
-  ended with no answer at all: that ending is now reported to neither sender,
-  and the worker is asked at its prompt to name the ticket. One open request
-  behaves as before on both paths.
+  ended with no answer at all and the oldest request was reported as answered
+  somewhere else: every request that turn could have been is now reported that
+  way — it is what each sender would have been told alone — and the worker is
+  asked at its prompt to name the ticket. One open request behaves as before on
+  both paths.
 - **The sandbox's "Ask each time" rung now reaches every session.** It only ever
   asked in the New worktree dialog, so a session started from the New session
   menu, by another session, or through the MCP tool quietly ran on the machine.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,14 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **An answer that names no ticket no longer guesses which task it belongs to.**
-  `lich reply "<answer>"` and `reply_to_session` without a ticket used to close
-  the oldest request delivered to that session, so a session working two relayed
-  tasks that answered the second one first sent it home as the answer to the
-  first — and both senders read a confident report of work nobody did. With two
-  or more requests open the answer is now refused, listing every open ticket
-  with the opening of what it asked, so the retry names the right one. One open
-  request is answered as before.
+- **A relayed answer is no longer matched to a task by guesswork.** Nothing in
+  an answer says which request it belongs to, so `lich reply "<answer>"` and
+  `reply_to_session` without a ticket closed the oldest request delivered to
+  that session: a session working two relayed tasks that answered the second one
+  first sent it home as the answer to the first, and both senders read a
+  confident report of work nobody did. With two or more requests open the answer
+  is now refused, listing every open ticket with the opening of what it asked so
+  the retry names the right one. The same guess ran one step later, when a turn
+  ended with no answer at all: that ending is now reported to neither sender,
+  and the worker is asked at its prompt to name the ticket. One open request
+  behaves as before on both paths.
 - **The sandbox's "Ask each time" rung now reaches every session.** It only ever
   asked in the New worktree dialog, so a session started from the New session
   menu, by another session, or through the MCP tool quietly ran on the machine.

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -371,15 +371,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   a deleted project): the row is the only copy of the prompt, so it goes with the row, and all that says so is
   one Warn in a log nobody is watching (`internal/store`, `noteForfeitedSchedules`).
 
-- **A turn that ends with two errands open reports neither** (`internal/relay/observe.go`,
-  `turnCandidates`): a state report says a turn ended, never which task it was, and the target's screen is the
-  one thing lich does not read. With a single errand open that ending is its own and the sender is told the
-  target finished without answering; with two, no sender is told anything at all, and the worker is asked at
-  its prompt to name the ticket instead. That note is typed once per errand — it is itself a turn at that
-  prompt, so re-sending it on every turn end would nudge a session forever — which leaves an agent that
-  ignores it with two senders waiting out their full wait and then the ticket's hour. A message delivered
-  mid-turn is not part of the ambiguity: the turn was already running, so its ending is attributed as before.
-
 - **A lich-spawned Kiro session runs lich's agent, not the user's** (`internal/agentplugin/kiro.go`,
   `internal/terminal/command.go`, `agentArgs`): Kiro keeps its hooks inside an *agent config*, and its built-in
   `kiro_default` cannot be shadowed — a `kiro_default.json` in the agents directory is ignored outright (measured

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -371,6 +371,15 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   a deleted project): the row is the only copy of the prompt, so it goes with the row, and all that says so is
   one Warn in a log nobody is watching (`internal/store`, `noteForfeitedSchedules`).
 
+- **A turn that ends with two errands open reports neither** (`internal/relay/observe.go`,
+  `turnCandidates`): a state report says a turn ended, never which task it was, and the target's screen is the
+  one thing lich does not read. With a single errand open that ending is its own and the sender is told the
+  target finished without answering; with two, no sender is told anything at all, and the worker is asked at
+  its prompt to name the ticket instead. That note is typed once per errand — it is itself a turn at that
+  prompt, so re-sending it on every turn end would nudge a session forever — which leaves an agent that
+  ignores it with two senders waiting out their full wait and then the ticket's hour. A message delivered
+  mid-turn is not part of the ambiguity: the turn was already running, so its ending is attributed as before.
+
 - **A lich-spawned Kiro session runs lich's agent, not the user's** (`internal/agentplugin/kiro.go`,
   `internal/terminal/command.go`, `agentArgs`): Kiro keeps its hooks inside an *agent config*, and its built-in
   `kiro_default` cannot be shadowed — a `kiro_default.json` in the agents directory is ignored outright (measured

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -371,13 +371,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   a deleted project): the row is the only copy of the prompt, so it goes with the row, and all that says so is
   one Warn in a log nobody is watching (`internal/store`, `noteForfeitedSchedules`).
 
-- **An answer that names no ticket is matched by delivery order** (`internal/relay/answer.go`,
-  `errandOfLocked`): `lich reply "<answer>"` and `reply_to_session` without a ticket close the oldest message
-  delivered to that session and still open, because nothing in an answer itself says which request it belongs to.
-  A session working two relayed tasks at once that answers the second one first sends it home as the answer to the
-  first, and both senders read a confident wrong report — nothing anywhere reports the mismatch. Naming the ticket
-  is still the only exact route, which is why every relayed message spells it and why the card's tooltip shows it.
-
 - **A lich-spawned Kiro session runs lich's agent, not the user's** (`internal/agentplugin/kiro.go`,
   `internal/terminal/command.go`, `agentArgs`): Kiro keeps its hooks inside an *agent config*, and its built-in
   `kiro_default` cannot be shadowed — a `kiro_default.json` in the agents directory is ignored outright (measured

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -228,15 +228,26 @@ This is what a relayed message asks the receiving agent to run. An answer is
 capped at 64 KiB. Replying twice to one ticket is an error — the first answer
 already went home.
 
-Called with the answer alone it hands it to the request open against the
-calling session: the oldest message actually delivered there and still
-unanswered. The ticket is written down in one place only — the message typed at
-the target's prompt — so an agent whose context was compacted past that message
-would otherwise be holding an answer with no route home. With several requests
-open the oldest delivery is closed first, the order every provider hands queued
-tasks to its agent in; a task still queued for a prompt that has not received it
-is never picked. Outside a session, or with nothing open, it is an error rather
-than a guess, and the ticket is still the way to name a specific errand.
+Called with the answer alone it hands it to the one request open against the
+calling session: a message actually delivered there and still unanswered. The
+ticket is written down in one place only — the message typed at the target's
+prompt — so an agent whose context was compacted past that message would
+otherwise be holding an answer with no route home. A task still queued for a
+prompt that has not received it is never picked.
+
+With two or more open it is refused, because nothing in an answer says which
+request it belongs to and closing the wrong one sends both senders a confident
+report of work they never asked for. The refusal lists every open ticket with
+the opening of what it asked, so the retry names the right one:
+
+```
+lich: 2 requests are open against this session, and an answer that names no ticket would close the wrong one. Name the ticket the answer belongs to:
+  lich reply 1a2b3c4d "<answer>"   — run the tests and report the failures
+  lich reply 5e6f7a8b "<answer>"   — build the docs
+```
+
+Outside a session, or with nothing open, it is an error rather than a guess, and
+the ticket is still the way to name a specific errand.
 
 ### `lich open [--project <name-or-path>] [--kind <provider>] [--worktree <branch>] [--base <branch>] [--model <model>] [--prompt <task>]`
 
@@ -530,7 +541,7 @@ at lich.
 | `list_sessions` | The live sessions that can be given work, as JSON — each with the state it last reported, `waiting` among them. |
 | `send_to_session` | `session`, `prompt`, optional `project` and `timeout_seconds`. |
 | `wait_for_answer` | optional `ticket` and `timeout_seconds` — with a ticket, `lich wait <ticket>`; without one, the collect: everything ready at once. |
-| `reply_to_session` | `answer`, optional `ticket` — what a relayed message asks for; without a ticket, the request open against the calling session. |
+| `reply_to_session` | `answer`, optional `ticket` — what a relayed message asks for; without a ticket, the one request open against the calling session, and a refusal naming each open ticket when there are two. |
 | `open_session` | optional `project` (a name, or an absolute directory path, which is opened as a project first), `kind`, `worktree`, `base`, `model` — `lich open` — plus optional `prompt` — `lich open --prompt`, the same hand-off in the same call. |
 | `close_session` | `session`, optional `project`, `worktree` (`keep`/`remove`), `force`. |
 | `rename_session` | `label`, optional `session` (omitted renames the caller's own) and `project` — `lich rename`. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -180,7 +180,11 @@ Types `<prompt>` at `<session>`'s prompt, submits it, and waits.
   there. The window raises a toast that opens the card. A sender that had
   already stopped waiting is told at its own prompt instead, the same way an
   answer would arrive — a pending result promises that prompt news, and a stall
-  is that news.
+  is that news. A turn ending only reports this way when it belongs to one
+  errand: a session working two at once ends a turn that says nothing about
+  which task it was, so neither sender is told anything and the worker is asked
+  at its own prompt to name the ticket, in the words `lich reply` refuses a
+  ticketless answer with.
 
 ```
 docs is still working. The errand is open — a message that session was not ready

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -180,11 +180,12 @@ Types `<prompt>` at `<session>`'s prompt, submits it, and waits.
   there. The window raises a toast that opens the card. A sender that had
   already stopped waiting is told at its own prompt instead, the same way an
   answer would arrive — a pending result promises that prompt news, and a stall
-  is that news. A turn ending only reports this way when it belongs to one
-  errand: a session working two at once ends a turn that says nothing about
-  which task it was, so neither sender is told anything and the worker is asked
-  at its own prompt to name the ticket, in the words `lich reply` refuses a
-  ticketless answer with.
+  is that news. A session working two requests at once ends a turn that says
+  this about both — it finished a turn and answered neither here — so both
+  senders are told it, which is what each would have been told alone. Which of
+  the two that turn actually was is the part nothing outside that session can
+  say, so it is not decided: the worker is asked at its own prompt to name the
+  ticket, in the words `lich reply` refuses a ticketless answer with.
 
 ```
 docs is still working. The errand is open — a message that session was not ready

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -184,8 +184,9 @@ Types `<prompt>` at `<session>`'s prompt, submits it, and waits.
   this about both — it finished a turn and answered neither here — so both
   senders are told it, which is what each would have been told alone. Which of
   the two that turn actually was is the part nothing outside that session can
-  say, so it is not decided: the worker is asked at its own prompt to name the
-  ticket, in the words `lich reply` refuses a ticketless answer with.
+  say, so it is not decided: a note at the worker's own prompt names the
+  requests that went home unanswered, and says the next one it answers has to
+  name its ticket.
 
 ```
 docs is still working. The errand is open — a message that session was not ready

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -436,6 +436,35 @@ func TestReplyWithoutATicketSendsTheSessionsOwnErrandHome(t *testing.T) {
 	}
 }
 
+// A ticketless answer with two requests open is refused by the app, and the
+// refusal is the only thing that tells the agent which tickets it has to choose
+// between — so it has to reach the terminal whole, list and newlines included.
+func TestTheRefusalOfATicketlessAnswerReachesTheAgent(t *testing.T) {
+	refusal := "2 requests are open against this session, and an answer that names no ticket " +
+		"would close the wrong one. Name the ticket the answer belongs to:\n" +
+		"  lich reply a1b2c3d4 \"<answer>\"   — run the tests\n" +
+		"  lich reply 5e6f7a8b \"<answer>\"   — build the docs"
+	body, err := json.Marshal(map[string]string{"error": refusal})
+	if err != nil {
+		t.Fatalf("encode the refusal: %v", err)
+	}
+	f := newFakeLich(t, string(body))
+	f.status = http.StatusInternalServerError
+
+	code, _, stderr := run(t, f, "reply", "3 failures in foo_test")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	for _, want := range []string{"a1b2c3d4", "5e6f7a8b", "run the tests", "build the docs"} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr is missing %q:\n%s", want, stderr)
+		}
+	}
+	if strings.Count(stderr, "lich reply ") != 2 {
+		t.Errorf("the list of open errands did not survive:\n%s", stderr)
+	}
+}
+
 func TestWrongArgumentCountsFailWithUsage(t *testing.T) {
 	f := newFakeLich(t, `null`)
 

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -46,8 +46,10 @@ var commands = []command{
 		args: "[<ticket>] <answer>",
 		about: "Send <answer> back to whoever is waiting on <ticket>. This is what a\n" +
 			"relayed message asks you to run when you are done. Without a ticket it\n" +
-			"answers the request open against this session, for when the message\n" +
-			"carrying the number is no longer in reach.",
+			"answers the one request open against this session, for when the message\n" +
+			"carrying the number is no longer in reach; with two open it is refused,\n" +
+			"naming each ticket and what it asked, because nothing in an answer says\n" +
+			"which request it belongs to.",
 	},
 	{
 		name: "open",

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -522,8 +522,10 @@ var mcpTools = []mcpTool{
 			"waiting on the ticket and reading nothing else.",
 		Schema: schema(map[string]any{
 			"ticket": property("string", "The ticket from the message you were given. "+
-				"Leave it out only if that message is no longer in your context — then the "+
-				"request open against this session is answered."),
+				"Leave it out only if that message is no longer in your context — then the one "+
+				"request open against this session is answered. With two open the call is "+
+				"refused, naming each ticket and what it asked, because nothing in an answer "+
+				"says which request it belongs to: retry with the ticket you mean."),
 			"answer": property("string", "Your answer, in full — nothing else is sent back."),
 		}, "answer"),
 		Run: func(c *client, args mcpArgs) (string, error) {

--- a/internal/cli/mcp_test.go
+++ b/internal/cli/mcp_test.go
@@ -412,6 +412,35 @@ func TestMCPReplyToSession(t *testing.T) {
 	}
 }
 
+// The same refusal on the tool surface: an agent that left the ticket out is
+// told which requests are open and what each asked, or it has nothing to retry
+// with.
+func TestMCPReplyWithoutATicketCarriesTheRefusal(t *testing.T) {
+	refusal := "2 requests are open against this session, and an answer that names no ticket " +
+		"would close the wrong one. Name the ticket the answer belongs to:\n" +
+		"  lich reply a1b2c3d4 \"<answer>\"   — run the tests\n" +
+		"  lich reply 5e6f7a8b \"<answer>\"   — build the docs"
+	body, err := json.Marshal(map[string]string{"error": refusal})
+	if err != nil {
+		t.Fatalf("encode the refusal: %v", err)
+	}
+	f := newFakeLich(t, string(body))
+	f.status = 500
+
+	replies := speak(t, f, `{"jsonrpc":"2.0","id":1,"method":"tools/call","params":
+		{"name":"reply_to_session","arguments":{"answer":"docs are built"}}}`)
+
+	text, failed := textOf(t, replies[0])
+	if !failed {
+		t.Error("the refused answer was not marked isError")
+	}
+	for _, want := range []string{"a1b2c3d4", "5e6f7a8b", "run the tests", "build the docs"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("text is missing %q:\n%s", want, text)
+		}
+	}
+}
+
 func TestMCPAFailedCallIsAToolErrorNotAProtocolError(t *testing.T) {
 	f := newFakeLich(t, `{"error":"no live session named \"ghost\""}`)
 	f.status = 500

--- a/internal/relay/answer.go
+++ b/internal/relay/answer.go
@@ -1,7 +1,6 @@
 package relay
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -122,16 +121,34 @@ func (s *Service) errandOfLocked(replierID string) (string, error) {
 	sort.Slice(open, func(i, j int) bool {
 		return s.tickets[open[i]].deliverySeq < s.tickets[open[j]].deliverySeq
 	})
-	return "", errors.New(pickTicketNotice(len(open), openErrands(s.tickets, open)))
+	return "", fmt.Errorf(
+		"%d requests are open against this session, and an answer that names no ticket "+
+			"would close the wrong one. Name the ticket the answer belongs to:\n%s",
+		len(open), openErrands(s.tickets, open),
+	)
 }
 
 // openErrands lists the errands a ticketless answer was refused with: the reply
 // command for each, and the line it asked for beside it, so the agent picks the
 // ticket by what the task was rather than by a number it cannot tell apart.
 func openErrands(tickets map[string]*ticket, ids []string) string {
+	return errandLines(tickets, ids, "  lich reply ", " \"<answer>\"")
+}
+
+// namedErrands lists the same errands as history rather than as somewhere to
+// reply: the ticket and what it asked, no command. It is what a session is
+// shown about errands that are already over — an invitation to answer one of
+// those is an invitation to run something that fails.
+func namedErrands(tickets map[string]*ticket, ids []string) string {
+	return errandLines(tickets, ids, "  ", "")
+}
+
+// errandLines renders one line per errand: the ticket between lead and tail,
+// and the opening of what it asked beside it.
+func errandLines(tickets map[string]*ticket, ids []string, lead, tail string) string {
 	var b strings.Builder
 	for _, id := range ids {
-		fmt.Fprintf(&b, "  lich reply %s \"<answer>\"", id)
+		b.WriteString(lead + id + tail)
 		if asked := tickets[id].asked; asked != "" {
 			fmt.Fprintf(&b, "   — %s", asked)
 		}

--- a/internal/relay/answer.go
+++ b/internal/relay/answer.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -121,11 +122,7 @@ func (s *Service) errandOfLocked(replierID string) (string, error) {
 	sort.Slice(open, func(i, j int) bool {
 		return s.tickets[open[i]].deliverySeq < s.tickets[open[j]].deliverySeq
 	})
-	return "", fmt.Errorf(
-		"%d requests are open against this session, and an answer that names no ticket "+
-			"would close the wrong one. Name the ticket the answer belongs to:\n%s",
-		len(open), openErrands(s.tickets, open),
-	)
+	return "", errors.New(pickTicketNotice(len(open), openErrands(s.tickets, open)))
 }
 
 // openErrands lists the errands a ticketless answer was refused with: the reply

--- a/internal/relay/answer.go
+++ b/internal/relay/answer.go
@@ -2,6 +2,7 @@ package relay
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -33,12 +34,12 @@ func (s *Service) Wait(ticketID string, waitSeconds int) (Result, error) {
 // Reply hands an answer back to whoever is waiting on ticketID. It is what the
 // message composed by Send asks the receiving agent to run.
 //
-// An empty ticketID answers the errand open against replierID instead, the way
-// an empty ticket collects everything waiting for a sender (see Collect). The
+// An empty ticketID answers the one errand open against replierID, the way an
+// empty ticket collects everything waiting for a sender (see Collect). The
 // ticket is written down in one place only — the message typed at the target's
 // prompt — so an agent whose context no longer reaches that message would
 // otherwise be holding an answer with no route home, and the sender blocked on
-// a ticket nobody can name.
+// a ticket nobody can name. With two open it is refused: see errandOfLocked.
 func (s *Service) Reply(replierID, ticketID, answer string) error {
 	answer = sanitize(answer)
 	if len(answer) > answerLimit {
@@ -85,36 +86,77 @@ func (s *Service) Reply(replierID, ticketID, answer string) error {
 }
 
 // errandOfLocked is the errand an answer that named no ticket belongs to: the
-// first message actually delivered to this session that is still open — first
-// by hand-off order (deliverySeq), which is the order itself and not a clock
-// reading of it. Called under s.mu.
+// single message delivered to this session and still open. Called under s.mu.
 //
-// Oldest-delivered is the same rule turnErrand closes a turn by, and for the
-// same reason: every provider queues typed input, so a session handed several
-// tasks works through them in the order they arrived. It is a guess all the
-// same — an agent that answers its second task first pays it back on the third
-// — which is why the ticket is still named everywhere it is known, and why the
-// window now shows it. A queued task nobody has read yet is never picked: it is
-// not at that prompt, so no answer at that prompt can be about it.
+// Nothing in an answer itself says which request it belongs to, so with two
+// errands open there is no way to tell them apart — and the guess this used to
+// make (the oldest delivery) sent a session's answer to its second task home as
+// the answer to its first, which both senders then read as a confident report of
+// work they never asked for. So it is refused instead, naming every open ticket
+// with the line it asked for, and the agent retries with the one it means. One
+// open errand needs no guess, and none is still the error it always was.
+//
+// A queued task nobody has read yet is never listed: it is not at that prompt,
+// so no answer at that prompt can be about it.
 func (s *Service) errandOfLocked(replierID string) (string, error) {
 	if replierID == "" {
 		return "", fmt.Errorf(
 			"answering without a ticket needs a session of your own — name it instead: lich reply <ticket> \"<answer>\"")
 	}
-	var oldestID string
-	var oldest *ticket
+	open := make([]string, 0, len(s.tickets))
 	for id, t := range s.tickets {
 		if t.targetID != replierID || t.delivered.IsZero() {
 			continue
 		}
-		if oldest == nil || t.deliverySeq < oldest.deliverySeq {
-			oldestID, oldest = id, t
-		}
+		open = append(open, id)
 	}
-	if oldest == nil {
+	switch len(open) {
+	case 0:
 		return "", fmt.Errorf("no open request to answer — nobody is waiting on this session")
+	case 1:
+		return open[0], nil
 	}
-	return oldestID, nil
+	// Hand-off order, so the list reads the way the tasks arrived rather than the
+	// way Go happened to walk the map.
+	sort.Slice(open, func(i, j int) bool {
+		return s.tickets[open[i]].deliverySeq < s.tickets[open[j]].deliverySeq
+	})
+	return "", fmt.Errorf(
+		"%d requests are open against this session, and an answer that names no ticket "+
+			"would close the wrong one. Name the ticket the answer belongs to:\n%s",
+		len(open), openErrands(s.tickets, open),
+	)
+}
+
+// openErrands lists the errands a ticketless answer was refused with: the reply
+// command for each, and the line it asked for beside it, so the agent picks the
+// ticket by what the task was rather than by a number it cannot tell apart.
+func openErrands(tickets map[string]*ticket, ids []string) string {
+	var b strings.Builder
+	for _, id := range ids {
+		fmt.Fprintf(&b, "  lich reply %s \"<answer>\"", id)
+		if asked := tickets[id].asked; asked != "" {
+			fmt.Fprintf(&b, "   — %s", asked)
+		}
+		b.WriteString("\n")
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// askedLimit is how much of a prompt an errand is named by. Long enough to tell
+// two tasks apart, short enough that a session holding several still reads as a
+// list rather than as the prompts all over again.
+const askedLimit = 72
+
+// askedExcerpt is the opening of a prompt on one line. The cut is in bytes and
+// can land inside a rune, which is a replacement character in the middle of the
+// one line that identifies an errand.
+func askedExcerpt(prompt string) string {
+	line := strings.Join(strings.Fields(prompt), " ")
+	if len(line) <= askedLimit {
+		return line
+	}
+	return strings.ToValidUTF8(line[:askedLimit], "") + "…"
 }
 
 // await blocks on one ticket until it is answered or the wait runs out. It only

--- a/internal/relay/compose.go
+++ b/internal/relay/compose.go
@@ -92,27 +92,21 @@ func replyInstruction(hasTools bool, ticketID string) string {
 		"and the detail is in your commits and files anyway."
 }
 
-// pickTicketNotice is what a session with more than one errand open is told,
-// and it is one text because it answers one question from two sides: the
-// refusal a ticketless answer gets (errandOfLocked), and the note typed at a
-// worker whose turn ended without an answer to any of them. The agent reading
-// both is the same agent, and two spellings of one instruction is one more
-// thing to guess between. errands is the list openErrands renders.
-func pickTicketNotice(count int, errands string) string {
+// pickTicketNudge is what a worker is told at its own prompt after a turn that
+// ended with none of its errands answered. Those errands are over by the time it
+// reads this — every one the turn could have been went home unanswered, which is
+// the same true thing about each of them — so they are named as history and not
+// as somewhere to reply: a ticket the relay has closed answers "unknown ticket",
+// and a note that invites that is worse than no note. What it asks for is the
+// next answer, which is the one that can still name its ticket.
+func pickTicketNudge(count int, errands string) string {
 	return fmt.Sprintf(
-		"%d requests are open against this session, and an answer that names no ticket "+
-			"would close the wrong one. Name the ticket the answer belongs to:\n%s",
+		"[lich] Your turn ended with no answer sent, so %d requests went back to their senders "+
+			"unanswered:\n%s\nNothing outside this session can say which of them that turn was, "+
+			"which is why none of them could be answered for you. The next request you answer has "+
+			"to name its ticket: lich reply <ticket> \"<answer>\".",
 		count, errands,
 	)
-}
-
-// pickTicketNudge is that notice typed at the worker's own prompt, after a turn
-// that ended with none of its errands answered and nothing here able to say
-// which one it was. No sender is told anything on that path — a report picked
-// out of two is the wrong report half the time — so this note is the whole of
-// what happens, and an agent that never reads it leaves both senders waiting.
-func pickTicketNudge(count int, errands string) string {
-	return "[lich] Your turn ended with no answer sent. " + pickTicketNotice(count, errands)
 }
 
 // nudgeNotice is the one line typed at a sender's prompt when results are

--- a/internal/relay/compose.go
+++ b/internal/relay/compose.go
@@ -92,6 +92,29 @@ func replyInstruction(hasTools bool, ticketID string) string {
 		"and the detail is in your commits and files anyway."
 }
 
+// pickTicketNotice is what a session with more than one errand open is told,
+// and it is one text because it answers one question from two sides: the
+// refusal a ticketless answer gets (errandOfLocked), and the note typed at a
+// worker whose turn ended without an answer to any of them. The agent reading
+// both is the same agent, and two spellings of one instruction is one more
+// thing to guess between. errands is the list openErrands renders.
+func pickTicketNotice(count int, errands string) string {
+	return fmt.Sprintf(
+		"%d requests are open against this session, and an answer that names no ticket "+
+			"would close the wrong one. Name the ticket the answer belongs to:\n%s",
+		count, errands,
+	)
+}
+
+// pickTicketNudge is that notice typed at the worker's own prompt, after a turn
+// that ended with none of its errands answered and nothing here able to say
+// which one it was. No sender is told anything on that path — a report picked
+// out of two is the wrong report half the time — so this note is the whole of
+// what happens, and an agent that never reads it leaves both senders waiting.
+func pickTicketNudge(count int, errands string) string {
+	return "[lich] Your turn ended with no answer sent. " + pickTicketNotice(count, errands)
+}
+
 // nudgeNotice is the one line typed at a sender's prompt when results are
 // waiting and nobody is holding the line for them. It replaces typing the
 // results themselves: N results landing as N prompt submissions each restart

--- a/internal/relay/observe.go
+++ b/internal/relay/observe.go
@@ -21,7 +21,7 @@ import (
 func (s *Service) Observe(sessionID, state string) {
 	s.mu.Lock()
 	s.recordState(sessionID, state)
-	ended, notice, nudged := s.endedErrands(sessionID, state)
+	ended, notice := s.endedErrands(sessionID, state)
 	// A waiter still holding the line carries the news out through its own
 	// select; an errand nobody is attending is stashed for the sender instead,
 	// the way an answer would be. Without it the promise a pending result makes
@@ -46,31 +46,14 @@ func (s *Service) Observe(sessionID, state string) {
 		s.stash(e.id, e.t, StatusUnanswered, "")
 	}
 	if notice != "" {
-		s.askForATicket(sessionID, notice, nudged)
+		if err := s.deliver(sessionID, notice); err != nil {
+			slog.Warn("relay: ticket request not delivered", "session", sessionID, "err", err)
+		}
 	}
 	// This session as a sender: its turn ending frees its prompt, which is what
 	// a nudge held back during the turn was waiting for.
 	if state == stateDone {
 		s.flushNudge(sessionID)
-	}
-}
-
-// askForATicket types the notice at the worker's own prompt and gives the marks
-// back if it never got there. The notice is the whole of what happens to an
-// ambiguous turn — no sender is told anything — so one that failed to arrive has
-// to be sendable again, the same bookkeeping flushNudge does for the inbox.
-func (s *Service) askForATicket(sessionID, notice string, nudged []string) {
-	err := s.deliver(sessionID, notice)
-	if err == nil {
-		return
-	}
-	slog.Warn("relay: ticket request not delivered", "session", sessionID, "err", err)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for _, id := range nudged {
-		if t, ok := s.tickets[id]; ok {
-			t.nudged = false
-		}
 	}
 }
 
@@ -124,12 +107,12 @@ func (s *Service) recordState(sessionID, state string) {
 // stall channel, for Observe to announce outside the lock. Called with s.mu
 // held.
 //
-// It returns two more things for the turn nothing can attribute: the notice to
-// type at the worker's prompt, and the tickets it was marked against, so a
-// notice that never arrived can be sent again.
-func (s *Service) endedErrands(sessionID, state string) ([]endedErrand, string, []string) {
+// It returns one more thing for a turn that could have been either of two
+// errands: the notice asking the worker to name the ticket next time, for
+// Observe to type outside the lock.
+func (s *Service) endedErrands(sessionID, state string) ([]endedErrand, string) {
 	var ended []endedErrand
-	notice, nudged := "", []string(nil)
+	notice := ""
 	switch state {
 	case stateBusy:
 		for _, t := range s.tickets {
@@ -153,40 +136,27 @@ func (s *Service) endedErrands(sessionID, state string) ([]endedErrand, string, 
 		}
 	case stateDone:
 		candidates := s.turnCandidates(sessionID)
-		if len(candidates) == 1 {
-			id := candidates[0]
+		// Worded before the tickets go, because it is read off them — and only
+		// where the turn could have been either: with one candidate there is
+		// nothing to pick between.
+		if len(candidates) > 1 {
+			notice = pickTicketNudge(len(candidates), openErrands(s.tickets, candidates))
+		}
+		// What the ending says is the same thing about every errand it could
+		// have been — the target finished a turn and did not answer this one —
+		// and that is true of each of them whichever one it worked on. So they
+		// all take the path a single one takes: no sender hears anything the
+		// others could not also have been told. Naming which one that turn *was*
+		// is the part nothing here can do, and the notice above is what asks the
+		// worker for it.
+		for _, id := range candidates {
 			t := s.tickets[id]
 			delete(s.tickets, id)
 			close(t.stalled)
 			ended = append(ended, endedErrand{id, t})
-			break
-		}
-		if len(candidates) > 1 {
-			notice, nudged = s.askTicketNoticeLocked(candidates)
 		}
 	}
-	return ended, notice, nudged
-}
-
-// askTicketNoticeLocked words the notice for a turn that ended with more than
-// one errand it could have been, and marks the errands it names. Empty when
-// every one of them has been asked about already: the notice is typed at the
-// worker's prompt and starts a turn of its own, so nudging on every turn end
-// would nudge that session forever. A task that arrives later is unmarked and
-// asks again, which is the rule the inbox nudge follows for the same reason.
-// Called under s.mu.
-func (s *Service) askTicketNoticeLocked(candidates []string) (string, []string) {
-	var fresh []string
-	for _, id := range candidates {
-		if t := s.tickets[id]; !t.nudged {
-			t.nudged = true
-			fresh = append(fresh, id)
-		}
-	}
-	if len(fresh) == 0 {
-		return "", nil
-	}
-	return pickTicketNudge(len(candidates), openErrands(s.tickets, candidates)), fresh
+	return ended, notice
 }
 
 // turnCandidates is every errand of a target's the turn that just ended could

--- a/internal/relay/observe.go
+++ b/internal/relay/observe.go
@@ -1,6 +1,9 @@
 package relay
 
-import ()
+import (
+	"log/slog"
+	"sort"
+)
 
 // Observe takes one session-state report from the hooks the provider already
 // runs (docs/hooks/session-state.md). It exists for one case: a target that
@@ -18,7 +21,7 @@ import ()
 func (s *Service) Observe(sessionID, state string) {
 	s.mu.Lock()
 	s.recordState(sessionID, state)
-	ended := s.endedErrands(sessionID, state)
+	ended, notice, nudged := s.endedErrands(sessionID, state)
 	// A waiter still holding the line carries the news out through its own
 	// select; an errand nobody is attending is stashed for the sender instead,
 	// the way an answer would be. Without it the promise a pending result makes
@@ -42,10 +45,32 @@ func (s *Service) Observe(sessionID, state string) {
 	for _, e := range quiet {
 		s.stash(e.id, e.t, StatusUnanswered, "")
 	}
+	if notice != "" {
+		s.askForATicket(sessionID, notice, nudged)
+	}
 	// This session as a sender: its turn ending frees its prompt, which is what
 	// a nudge held back during the turn was waiting for.
 	if state == stateDone {
 		s.flushNudge(sessionID)
+	}
+}
+
+// askForATicket types the notice at the worker's own prompt and gives the marks
+// back if it never got there. The notice is the whole of what happens to an
+// ambiguous turn — no sender is told anything — so one that failed to arrive has
+// to be sendable again, the same bookkeeping flushNudge does for the inbox.
+func (s *Service) askForATicket(sessionID, notice string, nudged []string) {
+	err := s.deliver(sessionID, notice)
+	if err == nil {
+		return
+	}
+	slog.Warn("relay: ticket request not delivered", "session", sessionID, "err", err)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, id := range nudged {
+		if t, ok := s.tickets[id]; ok {
+			t.nudged = false
+		}
 	}
 }
 
@@ -95,11 +120,16 @@ func (s *Service) recordState(sessionID, state string) {
 
 }
 
-// endedErrands takes every ticket the report ends off the table and closes
-// its stall channel, for Observe to announce outside the lock. Called with
-// s.mu held.
-func (s *Service) endedErrands(sessionID, state string) []endedErrand {
+// endedErrands takes every ticket the report ends off the table and closes its
+// stall channel, for Observe to announce outside the lock. Called with s.mu
+// held.
+//
+// It returns two more things for the turn nothing can attribute: the notice to
+// type at the worker's prompt, and the tickets it was marked against, so a
+// notice that never arrived can be sent again.
+func (s *Service) endedErrands(sessionID, state string) ([]endedErrand, string, []string) {
 	var ended []endedErrand
+	notice, nudged := "", []string(nil)
 	switch state {
 	case stateBusy:
 		for _, t := range s.tickets {
@@ -122,25 +152,65 @@ func (s *Service) endedErrands(sessionID, state string) []endedErrand {
 			}
 		}
 	case stateDone:
-		if id, t := s.turnErrand(sessionID); t != nil {
+		candidates := s.turnCandidates(sessionID)
+		if len(candidates) == 1 {
+			id := candidates[0]
+			t := s.tickets[id]
 			delete(s.tickets, id)
 			close(t.stalled)
 			ended = append(ended, endedErrand{id, t})
+			break
+		}
+		if len(candidates) > 1 {
+			notice, nudged = s.askTicketNoticeLocked(candidates)
 		}
 	}
-	return ended
+	return ended, notice, nudged
 }
 
-// turnErrand decides which of a target's errands the turn that just ended
-// belongs to, and returns it — nil when the turn was nobody's. A turn answers
-// for at most one errand: every provider queues typed input, so two messages
-// delivered to one session run as two turns, and a single done closing both
-// would report "answered elsewhere" about a request the target had not read
-// yet. The oldest delivery owns the turn; the rest wait for their own, their
-// busy marks reset so the next turn starts clean. Called under s.mu.
-func (s *Service) turnErrand(sessionID string) (string, *ticket) {
-	var oldestID string
-	var oldest *ticket
+// askTicketNoticeLocked words the notice for a turn that ended with more than
+// one errand it could have been, and marks the errands it names. Empty when
+// every one of them has been asked about already: the notice is typed at the
+// worker's prompt and starts a turn of its own, so nudging on every turn end
+// would nudge that session forever. A task that arrives later is unmarked and
+// asks again, which is the rule the inbox nudge follows for the same reason.
+// Called under s.mu.
+func (s *Service) askTicketNoticeLocked(candidates []string) (string, []string) {
+	var fresh []string
+	for _, id := range candidates {
+		if t := s.tickets[id]; !t.nudged {
+			t.nudged = true
+			fresh = append(fresh, id)
+		}
+	}
+	if len(fresh) == 0 {
+		return "", nil
+	}
+	return pickTicketNudge(len(candidates), openErrands(s.tickets, candidates)), fresh
+}
+
+// turnCandidates is every errand of a target's the turn that just ended could
+// have been, oldest delivery first. A turn answers for at most one errand:
+// every provider queues typed input, so two messages delivered to one session
+// run as two turns, and a single done closing both would report "answered
+// elsewhere" about a request the target had not read yet.
+//
+// One candidate is that turn's errand and nothing else's. Two are a turn
+// nothing here can attribute — the target's screen is the only place that says
+// which task it worked on, and reading it is the one thing this feature does
+// not do — so the caller closes neither and asks the worker to name the ticket
+// instead. Picking the oldest, which this used to do, closed a stranger's
+// errand on a guess and told its sender the work was over.
+//
+// A message delivered mid-turn is not a candidate for that turn's end: the turn
+// was already running, so its ending says nothing about the task pasted into
+// it. That is what skipTurns counts, and it is why the case a second task
+// arrives inside the first's turn is attributable rather than ambiguous.
+//
+// Called under s.mu. It consumes the skip counts and clears the busy marks, so
+// one turn ending is read exactly once and the next starts clean.
+func (s *Service) turnCandidates(sessionID string) []string {
+	var candidates []string
 	for id, t := range s.tickets {
 		if t.targetID != sessionID || t.delivered.IsZero() {
 			continue
@@ -155,16 +225,17 @@ func (s *Service) turnErrand(sessionID string) (string, *ticket) {
 		if !t.sawBusy {
 			continue
 		}
-		if oldest == nil || t.deliverySeq < oldest.deliverySeq {
-			oldestID, oldest = id, t
-		}
+		candidates = append(candidates, id)
 	}
 	for _, t := range s.tickets {
-		if t.targetID == sessionID && t != oldest {
+		if t.targetID == sessionID {
 			t.sawBusy = false
 		}
 	}
-	return oldestID, oldest
+	sort.Slice(candidates, func(i, j int) bool {
+		return s.tickets[candidates[i]].deliverySeq < s.tickets[candidates[j]].deliverySeq
+	})
+	return candidates
 }
 
 // announce raises or clears one session's mark. Called outside s.mu on every

--- a/internal/relay/observe.go
+++ b/internal/relay/observe.go
@@ -140,7 +140,7 @@ func (s *Service) endedErrands(sessionID, state string) ([]endedErrand, string) 
 		// where the turn could have been either: with one candidate there is
 		// nothing to pick between.
 		if len(candidates) > 1 {
-			notice = pickTicketNudge(len(candidates), openErrands(s.tickets, candidates))
+			notice = pickTicketNudge(len(candidates), namedErrands(s.tickets, candidates))
 		}
 		// What the ending says is the same thing about every errand it could
 		// have been — the target finished a turn and did not answer this one —

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -260,8 +260,14 @@ type ticket struct {
 	// wrong errand about one time in ten. A counter is the order itself rather
 	// than a reading of it, so no clock's resolution can flatten it.
 	deliverySeq uint64
-	done        chan struct{}
-	answer      string
+	// asked is the opening of the prompt this errand carried, on one line. It is
+	// what names an errand to the agent working it: a session with more than one
+	// open request has to be shown which is which before it can pick the ticket
+	// its answer belongs to (see errandOfLocked). The whole prompt is not kept —
+	// it runs to promptLimit, and what a reader needs is the line they recognise.
+	asked  string
+	done   chan struct{}
+	answer string
 
 	// attended is how many callers are blocked on this ticket right now. An
 	// answer that lands while nobody is waiting has nowhere to be returned, so
@@ -456,6 +462,7 @@ func (s *Service) Send(fromID, target, project, prompt string, waitSeconds int) 
 		targetID:    dest.ID,
 		target:      dest.Peer.Label,
 		created:     s.now(),
+		asked:       askedExcerpt(prompt),
 		done:        make(chan struct{}),
 		stalled:     make(chan struct{}),
 		unread:      make(chan struct{}),

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -286,6 +286,10 @@ type ticket struct {
 	// unread closes when the target never reacted to the task at all. See
 	// watchReceipt.
 	unread chan struct{}
+	// nudged is whether the worker has already been asked to name this errand's
+	// ticket, which is what bounds that notice at one per errand (see
+	// askTicketNoticeLocked).
+	nudged bool
 	// redelivered is whether the task was already typed in a second time, which
 	// is what bounds watchReceipt's retry at one.
 	redelivered bool

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -286,10 +286,6 @@ type ticket struct {
 	// unread closes when the target never reacted to the task at all. See
 	// watchReceipt.
 	unread chan struct{}
-	// nudged is whether the worker has already been asked to name this errand's
-	// ticket, which is what bounds that notice at one per errand (see
-	// askTicketNoticeLocked).
-	nudged bool
 	// redelivered is whether the task was already typed in a second time, which
 	// is what bounds watchReceipt's retry at one.
 	redelivered bool

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -1467,13 +1467,48 @@ func TestReplyRefusesUnknownAndRepeatedTickets(t *testing.T) {
 // reaches the ticket answers its own session's open request, and with several
 // open the oldest delivery is closed first — the order every provider hands
 // queued tasks to its agent in.
-func TestReplyWithoutATicketAnswersTheOldestErrandDelivered(t *testing.T) {
+// TestReplyWithoutATicketAnswersTheOneOpenErrand is the case the shorthand
+// exists for: an agent whose context was compacted past the message can still
+// send its answer home, because one open request needs no guessing.
+func TestReplyWithoutATicketAnswersTheOneOpenErrand(t *testing.T) {
+	events := &fakeEvents{}
+	svc := newRelay(workspace(), newFakeTerminal("s1", "s2"), events)
+
+	only := make(chan Result, 1)
+	go func() {
+		got, _ := svc.Send("s1", "docs", "", "run the tests", 30)
+		only <- got
+	}()
+	if !events.awaitMark("s1", DirectionOut) {
+		t.Fatal("the message was never delivered")
+	}
+
+	if err := svc.Reply("s2", "", "3 failures in foo_test"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	select {
+	case got := <-only:
+		if got.Answer != "3 failures in foo_test" {
+			t.Errorf("answer = %q", got.Answer)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("the open errand was never answered")
+	}
+}
+
+// TestReplyWithoutATicketIsRefusedWithTwoErrandsOpen pins the refusal that
+// replaced the guess. Nothing in an answer says which request it belongs to, so
+// a session working two tasks that answers the second one first used to send it
+// home as the answer to the first — two senders reading a confident report of
+// work nobody did. The refusal has to name both tickets and what each asked, or
+// the agent has nothing to retry with.
+func TestReplyWithoutATicketIsRefusedWithTwoErrandsOpen(t *testing.T) {
 	events := &fakeEvents{}
 	svc := newRelay(workspace(), newFakeTerminal("s1", "s2", "s3"), events)
 
 	first := make(chan Result, 1)
 	go func() {
-		got, _ := svc.Send("s1", "docs", "", "run the tests", 30)
+		got, _ := svc.Send("s1", "docs", "", "run the tests and report the failures", 30)
 		first <- got
 	}()
 	if !events.awaitMark("s1", DirectionOut) {
@@ -1488,30 +1523,58 @@ func TestReplyWithoutATicketAnswersTheOldestErrandDelivered(t *testing.T) {
 		t.Fatal("the second message was never delivered")
 	}
 
-	if err := svc.Reply("s2", "", "3 failures in foo_test"); err != nil {
-		t.Fatalf("Reply: %v", err)
+	err := svc.Reply("s2", "", "docs are built")
+	if err == nil {
+		t.Fatal("a ticketless answer was accepted with two errands open")
 	}
-	select {
-	case got := <-first:
-		if got.Answer != "3 failures in foo_test" {
-			t.Errorf("answer = %q", got.Answer)
+	svc.mu.Lock()
+	ids := make([]string, 0, len(svc.tickets))
+	for id := range svc.tickets {
+		ids = append(ids, id)
+	}
+	svc.mu.Unlock()
+	if len(ids) != 2 {
+		t.Fatalf("open tickets = %v, want the two that were sent", ids)
+	}
+	for _, id := range ids {
+		if !strings.Contains(err.Error(), id) {
+			t.Errorf("the refusal does not name ticket %q:\n%s", id, err)
 		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("the oldest errand was not the one answered")
 	}
-	select {
-	case got := <-second:
-		t.Fatalf("the second errand was closed by the same answer: %+v", got)
-	default:
+	for _, asked := range []string{"run the tests and report the failures", "build the docs"} {
+		if !strings.Contains(err.Error(), asked) {
+			t.Errorf("the refusal does not say what %q asked:\n%s", asked, err)
+		}
 	}
 
-	// The next answer takes the next errand, which is what makes this usable
-	// twice over rather than only for a session with exactly one request open.
-	if err := svc.Reply("s2", "", "docs are built"); err != nil {
-		t.Fatalf("Reply: %v", err)
+	// Neither errand was closed by the refused answer, and naming the ticket is
+	// the retry the message asked for all along.
+	select {
+	case got := <-first:
+		t.Fatalf("the refused answer closed an errand anyway: %+v", got)
+	case got := <-second:
+		t.Fatalf("the refused answer closed an errand anyway: %+v", got)
+	default:
 	}
-	if got := <-second; got.Answer != "docs are built" {
-		t.Errorf("second answer = %q", got.Answer)
+	if err := svc.Reply("s2", ids[0], "answered by name"); err != nil {
+		t.Fatalf("Reply with a ticket: %v", err)
+	}
+}
+
+// TestAnErrandIsNamedByTheOpeningOfItsPrompt covers the line the refusal reads
+// by: whitespace collapsed onto one line, and a long prompt cut on a rune
+// boundary — the cut is in bytes, and half a rune is a replacement character in
+// the middle of the one line that tells two errands apart.
+func TestAnErrandIsNamedByTheOpeningOfItsPrompt(t *testing.T) {
+	if got := askedExcerpt("run the tests\n\nthen  report"); got != "run the tests then report" {
+		t.Errorf("excerpt = %q", got)
+	}
+	long := askedExcerpt(strings.Repeat("é", 200))
+	if !strings.HasSuffix(long, "…") {
+		t.Errorf("a prompt over the limit was not cut: %q", long)
+	}
+	if !utf8.ValidString(long) {
+		t.Errorf("the cut landed inside a rune: %q", long)
 	}
 }
 
@@ -1523,22 +1586,20 @@ func TestReplyWithoutATicketAnswersTheOldestErrandDelivered(t *testing.T) {
 //
 // The two tickets here share a delivered time exactly, which is the case the
 // runner hits by accident: any ordering that reads the clock has nothing left
-// to choose by, and only the hand-off counter still answers.
+// to choose by, and only the hand-off counter still answers. A turn ending is
+// where that choice is still made — a ticketless answer refuses to make it.
 func TestErrandOrderSurvivesAClockThatCannotTellThemApart(t *testing.T) {
 	svc := newRelay(workspace(), newFakeTerminal("s1", "s2", "s3"), &fakeEvents{})
 	tick := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
-	svc.tickets = map[string]*ticket{
-		"second": {fromID: "s3", targetID: "s2", delivered: tick, deliverySeq: 2},
-		"first":  {fromID: "s1", targetID: "s2", delivered: tick, deliverySeq: 1},
-	}
 
 	// Run it more than once: one pass can pick the right entry out of a map by
 	// luck, and luck is the thing being tested away.
 	for i := 0; i < 50; i++ {
-		got, err := svc.errandOfLocked("s2")
-		if err != nil {
-			t.Fatalf("errandOfLocked: %v", err)
+		svc.tickets = map[string]*ticket{
+			"second": {fromID: "s3", targetID: "s2", delivered: tick, deliverySeq: 2, sawBusy: true},
+			"first":  {fromID: "s1", targetID: "s2", delivered: tick, deliverySeq: 1, sawBusy: true},
 		}
+		got, _ := svc.turnErrand("s2")
 		if got != "first" {
 			t.Fatalf("errand = %q, want the first delivered", got)
 		}

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -1045,15 +1045,21 @@ func TestADoneWithTwoErrandsOpenStallsBothAndAsksForTheTicket(t *testing.T) {
 	notice := strings.Join(term.writesTo("s2")[delivery:], "")
 	for _, want := range []string{
 		"[lich]", "run the tests and report the failures", "build the docs",
-		"Name the ticket the answer belongs to",
+		"went back to their senders unanswered", "The next request you answer has to name its ticket",
 	} {
 		if !strings.Contains(notice, want) {
 			t.Errorf("the notice is missing %q:\n%s", want, notice)
 		}
 	}
+	// The tickets are named as what happened, never as somewhere to reply: the
+	// stall closed them, so a worker that ran a reply command out of this note
+	// would be told the ticket is unknown.
 	for _, id := range tickets {
 		if !strings.Contains(notice, id) {
 			t.Errorf("the notice does not name ticket %q:\n%s", id, notice)
+		}
+		if strings.Contains(notice, "lich reply "+id) {
+			t.Errorf("the notice invites a reply to closed ticket %q:\n%s", id, notice)
 		}
 	}
 }

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -994,45 +994,115 @@ func awaitDelivered(t *testing.T, svc *Service, n int) {
 	t.Fatalf("never saw %d delivered tickets", n)
 }
 
-// TestADoneClosesOnlyTheTurnsOwnErrand proves a turn answers for one errand.
-// Two messages delivered back to back — inside the second or two before the
-// target's busy report lands — queue as two turns; the first turn's end must
-// not report the second errand as answered elsewhere while its message is
-// still queued, unread.
-func TestADoneClosesOnlyTheTurnsOwnErrand(t *testing.T) {
-	svc := newRelay(workspace(), newFakeTerminal("s1", "s2", "s3"), nil)
+// TestADoneWithTwoErrandsOpenClosesNeitherAndAsksForTheTicket proves a turn
+// nothing can attribute closes nothing. Two messages delivered back to back —
+// inside the second or two before the target's busy report lands — queue as two
+// turns, and the end of the first says only that a turn ended: the target's
+// screen is the only place that says which task it worked on. Closing the
+// oldest, which this used to do, reported a stranger's errand as over on a
+// guess. What happens instead is a note at the worker's own prompt naming both
+// tickets and what each asked, and nothing at all at either sender's.
+func TestADoneWithTwoErrandsOpenClosesNeitherAndAsksForTheTicket(t *testing.T) {
+	term := newFakeTerminal("s1", "s2", "s3")
+	events := &fakeEvents{}
+	svc := newRelay(workspace(), term, events)
 
 	first := make(chan Result, 1)
 	go func() {
-		got, _ := svc.Send("s1", "docs", "", "task one", 5)
+		got, _ := svc.Send("s1", "docs", "", "run the tests and report the failures", 5)
 		first <- got
 	}()
 	awaitDelivered(t, svc, 1)
 	second := make(chan Result, 1)
 	go func() {
-		got, _ := svc.Send("s3", "docs", "", "task two", 5)
+		got, _ := svc.Send("s3", "docs", "", "build the docs", 5)
 		second <- got
 	}()
 	awaitDelivered(t, svc, 2)
+	delivery := len(term.writesTo("s2"))
 
-	// The target picks the first task up and ends that turn without replying.
 	svc.Observe("s2", "busy")
 	svc.Observe("s2", "done")
-	if got := <-first; got.Status != StatusUnanswered {
-		t.Fatalf("first errand = %q, want %q", got.Status, StatusUnanswered)
-	}
+
 	select {
+	case got := <-first:
+		t.Fatalf("a turn nothing can attribute closed an errand: %+v", got)
 	case got := <-second:
-		t.Fatalf("the first turn's end closed the second errand too: %+v", got)
-	case <-time.After(50 * time.Millisecond):
+		t.Fatalf("a turn nothing can attribute closed an errand: %+v", got)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if halts := events.stalled(); len(halts) != 0 {
+		t.Errorf("a sender was told its errand was over: %+v", halts)
+	}
+	svc.mu.Lock()
+	ids := make([]string, 0, len(svc.tickets))
+	for id := range svc.tickets {
+		ids = append(ids, id)
+	}
+	inbox := len(svc.ready)
+	svc.mu.Unlock()
+	if len(ids) != 2 || inbox != 0 {
+		t.Fatalf("open tickets = %v, inbox = %d, want both still open and nothing stashed", ids, inbox)
 	}
 
-	// The queued second task runs as its own turn.
+	if !awaitWrites(term, "s2", delivery+2) {
+		t.Fatal("the worker was never asked to name the ticket")
+	}
+	notice := strings.Join(term.writesTo("s2")[delivery:], "")
+	for _, want := range []string{
+		"[lich]", "run the tests and report the failures", "build the docs",
+		"Name the ticket the answer belongs to",
+	} {
+		if !strings.Contains(notice, want) {
+			t.Errorf("the notice is missing %q:\n%s", want, notice)
+		}
+	}
+	for _, id := range ids {
+		if !strings.Contains(notice, id) {
+			t.Errorf("the notice does not name ticket %q:\n%s", id, notice)
+		}
+	}
+
+	// One note per errand. The note is typed at that prompt and runs as a turn
+	// of its own, so a second ending must not produce a second one — that is a
+	// session nudged forever.
 	svc.Observe("s2", "busy")
 	svc.Observe("s2", "done")
-	if got := <-second; got.Status != StatusUnanswered {
-		t.Fatalf("second errand = %q, want %q", got.Status, StatusUnanswered)
+	time.Sleep(50 * time.Millisecond)
+	if got := len(term.writesTo("s2")); got != delivery+2 {
+		t.Errorf("writes = %d, want the one notice: a turn end nudged the worker again", got)
 	}
+
+	// Naming the ticket still works, and the errand left behind is unambiguous
+	// again: the next turn that ends without an answer is its own.
+	if err := svc.Reply("s2", ids[0], "answered by name"); err != nil {
+		t.Fatalf("Reply: %v", err)
+	}
+	svc.Observe("s2", "busy")
+	svc.Observe("s2", "done")
+	for i := 0; i < 2; i++ {
+		select {
+		case got := <-first:
+			assertClosed(t, got)
+		case got := <-second:
+			assertClosed(t, got)
+		case <-time.After(2 * time.Second):
+			t.Fatal("the one errand left was not closed by its own turn")
+		}
+	}
+}
+
+// assertClosed is either end of the pair above: the errand answered by name,
+// and the one the turn after it closed unanswered.
+func assertClosed(t *testing.T, got Result) {
+	t.Helper()
+	if got.Status == StatusAnswered && got.Answer == "answered by name" {
+		return
+	}
+	if got.Status == StatusUnanswered {
+		return
+	}
+	t.Fatalf("result = %+v, want the named answer or an unanswered errand", got)
 }
 
 // TestASecondErrandQueuedMidTurnSurvivesTheFirstsEnd is the same guarantee with
@@ -1586,8 +1656,10 @@ func TestAnErrandIsNamedByTheOpeningOfItsPrompt(t *testing.T) {
 //
 // The two tickets here share a delivered time exactly, which is the case the
 // runner hits by accident: any ordering that reads the clock has nothing left
-// to choose by, and only the hand-off counter still answers. A turn ending is
-// where that choice is still made — a ticketless answer refuses to make it.
+// to choose by, and only the hand-off counter still answers. Nothing picks one
+// of two candidates anymore, but the order they are listed in is what a worker
+// reads to tell them apart, and a list that shuffles between two runs is one it
+// cannot.
 func TestErrandOrderSurvivesAClockThatCannotTellThemApart(t *testing.T) {
 	svc := newRelay(workspace(), newFakeTerminal("s1", "s2", "s3"), &fakeEvents{})
 	tick := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
@@ -1599,9 +1671,9 @@ func TestErrandOrderSurvivesAClockThatCannotTellThemApart(t *testing.T) {
 			"second": {fromID: "s3", targetID: "s2", delivered: tick, deliverySeq: 2, sawBusy: true},
 			"first":  {fromID: "s1", targetID: "s2", delivered: tick, deliverySeq: 1, sawBusy: true},
 		}
-		got, _ := svc.turnErrand("s2")
-		if got != "first" {
-			t.Fatalf("errand = %q, want the first delivered", got)
+		got := svc.turnCandidates("s2")
+		if len(got) != 2 || got[0] != "first" {
+			t.Fatalf("candidates = %v, want the first delivered at the front", got)
 		}
 	}
 }

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -994,15 +994,16 @@ func awaitDelivered(t *testing.T, svc *Service, n int) {
 	t.Fatalf("never saw %d delivered tickets", n)
 }
 
-// TestADoneWithTwoErrandsOpenClosesNeitherAndAsksForTheTicket proves a turn
-// nothing can attribute closes nothing. Two messages delivered back to back —
+// TestADoneWithTwoErrandsOpenStallsBothAndAsksForTheTicket proves what a turn
+// ending says, and what it does not. Two messages delivered back to back —
 // inside the second or two before the target's busy report lands — queue as two
-// turns, and the end of the first says only that a turn ended: the target's
-// screen is the only place that says which task it worked on. Closing the
-// oldest, which this used to do, reported a stranger's errand as over on a
-// guess. What happens instead is a note at the worker's own prompt naming both
-// tickets and what each asked, and nothing at all at either sender's.
-func TestADoneWithTwoErrandsOpenClosesNeitherAndAsksForTheTicket(t *testing.T) {
+// turns, and the end of the first says only that a turn ended without an answer
+// here. That is the same true thing about every errand it could have been, so
+// every one of them takes the stall path a single errand takes and every sender
+// hears what it would have heard alone. What nothing here can say is which of
+// them that turn was — so the answer is not put on one of them by delivery
+// order, and the worker is asked at its own prompt to name the ticket.
+func TestADoneWithTwoErrandsOpenStallsBothAndAsksForTheTicket(t *testing.T) {
 	term := newFakeTerminal("s1", "s2", "s3")
 	events := &fakeEvents{}
 	svc := newRelay(workspace(), term, events)
@@ -1020,29 +1021,22 @@ func TestADoneWithTwoErrandsOpenClosesNeitherAndAsksForTheTicket(t *testing.T) {
 	}()
 	awaitDelivered(t, svc, 2)
 	delivery := len(term.writesTo("s2"))
+	tickets := openTickets(svc)
 
 	svc.Observe("s2", "busy")
 	svc.Observe("s2", "done")
 
-	select {
-	case got := <-first:
-		t.Fatalf("a turn nothing can attribute closed an errand: %+v", got)
-	case got := <-second:
-		t.Fatalf("a turn nothing can attribute closed an errand: %+v", got)
-	case <-time.After(100 * time.Millisecond):
+	for _, got := range []Result{<-first, <-second} {
+		if got.Status != StatusUnanswered {
+			t.Errorf("status = %q, want %q for both errands the turn could have been",
+				got.Status, StatusUnanswered)
+		}
 	}
-	if halts := events.stalled(); len(halts) != 0 {
-		t.Errorf("a sender was told its errand was over: %+v", halts)
+	if halts := events.stalled(); len(halts) != 2 {
+		t.Errorf("stall events = %d, want one per sender", len(halts))
 	}
-	svc.mu.Lock()
-	ids := make([]string, 0, len(svc.tickets))
-	for id := range svc.tickets {
-		ids = append(ids, id)
-	}
-	inbox := len(svc.ready)
-	svc.mu.Unlock()
-	if len(ids) != 2 || inbox != 0 {
-		t.Fatalf("open tickets = %v, inbox = %d, want both still open and nothing stashed", ids, inbox)
+	if left := openTickets(svc); len(left) != 0 {
+		t.Errorf("open tickets = %v, want both closed by the turn that ended", left)
 	}
 
 	if !awaitWrites(term, "s2", delivery+2) {
@@ -1057,52 +1051,49 @@ func TestADoneWithTwoErrandsOpenClosesNeitherAndAsksForTheTicket(t *testing.T) {
 			t.Errorf("the notice is missing %q:\n%s", want, notice)
 		}
 	}
-	for _, id := range ids {
+	for _, id := range tickets {
 		if !strings.Contains(notice, id) {
 			t.Errorf("the notice does not name ticket %q:\n%s", id, notice)
 		}
 	}
+}
 
-	// One note per errand. The note is typed at that prompt and runs as a turn
-	// of its own, so a second ending must not produce a second one — that is a
-	// session nudged forever.
+// A single errand is the case there is nothing to pick between: it is stalled
+// on its own, and the worker is not asked to name anything.
+func TestADoneWithOneErrandOpenStallsItWithoutANotice(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, &fakeEvents{})
+
+	only := make(chan Result, 1)
+	go func() {
+		got, _ := svc.Send("s1", "docs", "", "run the tests", 5)
+		only <- got
+	}()
+	awaitDelivered(t, svc, 1)
+	delivery := len(term.writesTo("s2"))
+
 	svc.Observe("s2", "busy")
 	svc.Observe("s2", "done")
+
+	if got := <-only; got.Status != StatusUnanswered {
+		t.Fatalf("status = %q, want %q", got.Status, StatusUnanswered)
+	}
 	time.Sleep(50 * time.Millisecond)
-	if got := len(term.writesTo("s2")); got != delivery+2 {
-		t.Errorf("writes = %d, want the one notice: a turn end nudged the worker again", got)
-	}
-
-	// Naming the ticket still works, and the errand left behind is unambiguous
-	// again: the next turn that ends without an answer is its own.
-	if err := svc.Reply("s2", ids[0], "answered by name"); err != nil {
-		t.Fatalf("Reply: %v", err)
-	}
-	svc.Observe("s2", "busy")
-	svc.Observe("s2", "done")
-	for i := 0; i < 2; i++ {
-		select {
-		case got := <-first:
-			assertClosed(t, got)
-		case got := <-second:
-			assertClosed(t, got)
-		case <-time.After(2 * time.Second):
-			t.Fatal("the one errand left was not closed by its own turn")
-		}
+	if got := len(term.writesTo("s2")); got != delivery {
+		t.Errorf("writes = %d, want no notice: there was only one errand to be", got)
 	}
 }
 
-// assertClosed is either end of the pair above: the errand answered by name,
-// and the one the turn after it closed unanswered.
-func assertClosed(t *testing.T, got Result) {
-	t.Helper()
-	if got.Status == StatusAnswered && got.Answer == "answered by name" {
-		return
+// openTickets is every errand still on the table, for a test that has to know
+// what was closed and what the worker was told about.
+func openTickets(svc *Service) []string {
+	svc.mu.Lock()
+	defer svc.mu.Unlock()
+	ids := make([]string, 0, len(svc.tickets))
+	for id := range svc.tickets {
+		ids = append(ids, id)
 	}
-	if got.Status == StatusUnanswered {
-		return
-	}
-	t.Fatalf("result = %+v, want the named answer or an unanswered errand", got)
+	return ids
 }
 
 // TestASecondErrandQueuedMidTurnSurvivesTheFirstsEnd is the same guarantee with
@@ -1597,12 +1588,7 @@ func TestReplyWithoutATicketIsRefusedWithTwoErrandsOpen(t *testing.T) {
 	if err == nil {
 		t.Fatal("a ticketless answer was accepted with two errands open")
 	}
-	svc.mu.Lock()
-	ids := make([]string, 0, len(svc.tickets))
-	for id := range svc.tickets {
-		ids = append(ids, id)
-	}
-	svc.mu.Unlock()
+	ids := openTickets(svc)
 	if len(ids) != 2 {
 		t.Fatalf("open tickets = %v, want the two that were sent", ids)
 	}


### PR DESCRIPTION
## What

`lich reply "<answer>"` and `reply_to_session` without a ticket closed the oldest message delivered to that session and still open. Nothing in an answer says which request it belongs to, so a session working two relayed tasks that answered the second one first sent it home as the answer to the first — and both senders read a confident report of work nobody did.

With two or more requests open the answer is now refused, listing every open ticket with the opening of what it asked:

```
lich: 2 requests are open against this session, and an answer that names no ticket would close the wrong one. Name the ticket the answer belongs to:
  lich reply 1a2b3c4d "<answer>"   — run the tests and report the failures
  lich reply 5e6f7a8b "<answer>"   — build the docs
```

One open errand is answered as before; none is still the error it always was. A task still queued for a prompt that never received it is never listed.

## Where

- `internal/relay/answer.go` — `errandOfLocked` refuses instead of guessing; `askedExcerpt` names an errand by the opening of its prompt.
- `internal/relay/relay.go` — the ticket carries that one line (`asked`), taken at `Send`.
- `internal/cli/mcp.go`, `internal/cli/help.go` — the `reply_to_session` description and `lich help reply` say it in the same words.
- `docs/ceilings.md` — the bullet this closes is gone. `docs/cli.md` and `CHANGELOG.md` [Unreleased] › Changed updated.

`turnErrand` still owns the oldest-delivery rule for deciding which errand a finished turn belongs to — a different question, unchanged here, and the tie-break regression test moved onto it.

## Test plan

- [x] `go test ./internal/relay/ -race` — one open (accepted), two open (refused, both tickets and both prompts named, neither errand closed, the retry by ticket works), none open, and the excerpt's rune-boundary cut.
- [x] `go test ./internal/cli/ -race` — CLI stderr and the MCP tool result carry the refusal whole, list and newlines included.
- [x] `gofmt -l .`, `go vet ./...`, `go test ./...` clean. No frontend files touched.