### PR TITLE
fix: keep a wall's dragged pane sizes per grid shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A split's dragged pane sizes now come back when the grid does.** How many
+  panes sit across follows the window, so collapsing the sidebar, opening the
+  dock or moving to another monitor reshapes the wall - and the sizes you had
+  dragged were kept for one shape only, which read as a resize being forgotten.
+  A wall now remembers what it was dragged to on each shape, so the layout you
+  made at four columns is waiting the next time four columns come back.
 - **An Antigravity card now names the MCP tool it is running.** Every MCP call
   there is the same internal step, so a card that opened a session read
   `call_mcp_tool` followed by `lich/open_session`, spending the line on the step

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -146,13 +146,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   the whole tree going, and the only way back is a reload, while the sessions keep running behind it.
   The trap is reading "lich has error boundaries" as "a render bug can no longer blank the window": the
   one subtree that owns the most state is the one nothing catches.
-- **The grid follows the window, so the layout you dragged is not always the one you get back**
-  (`frontend/src/lib/session/panes.ts`, `tracks`): how many panes sit across is computed from the
-  stage's measured width, so collapsing the sidebar, opening the dock or moving the window to another
-  monitor can reshape the wall under you. Track sizes are stored for the grid they were dragged on and
-  fall back to equal shares whenever the shape no longer matches — which reads as a resize being
-  silently forgotten, and is the alternative to restoring a four-column layout onto three columns. The
-  cells themselves and their order always survive; only the sizes do not.
 - **A dropped file has no path, so lich guesses it** (`internal/drop`): a file under neither the session directory
   nor home is *copied*, so an agent told to edit it edits the copy — and that copy is deleted 3 days on, so a path
   pasted into a prompt eventually stops resolving.

--- a/frontend/src/components/TerminalHost.tsx
+++ b/frontend/src/components/TerminalHost.tsx
@@ -13,7 +13,8 @@ import { activeSessionId, hasSession, resumableSession, sessionsOf } from "@/lib
 import { paletteSessions } from "@/lib/session/command-palette"
 import { spawnDecision, type SpawnProbe } from "@/lib/session/spawn-gate"
 import { PaneSeams } from "./PaneSeams"
-import { cellAt, grid, offsetOf, rowLength, rowTracks, tracks } from "@/lib/session/pane-grid"
+import { cellAt, grid, offsetOf, rowLength, rowTracks } from "@/lib/session/pane-grid"
+import { paneTracks } from "@/lib/session/panes"
 import { usePanes } from "@/lib/session/use-panes"
 import { useStageSize } from "@/lib/session/use-stage-size"
 import { cn } from "@/lib/utils"
@@ -155,8 +156,9 @@ export function TerminalHost() {
   const [liveRows, setLiveRows] = useState<number[] | null>(null)
   // The shares belong to the wall being drawn, not to the window: arranging one
   // group 60/40 must not carry into the next one the user opens.
-  const cols = liveCols ?? tracks(stage.current?.cols ?? [], layout.cols)
-  const rows = liveRows ?? tracks(stage.current?.rows ?? [], layout.rows)
+  const shares = paneTracks(stage.current, layout)
+  const cols = liveCols ?? shares.cols
+  const rows = liveRows ?? shares.rows
 
   // The pane a dragged one is hovering over, for the drop hint. The drag itself
   // is a pointer gesture on the label rather than HTML5 drag-and-drop, which the
@@ -366,7 +368,7 @@ export function TerminalHost() {
               onCommit={(next) => {
                 setLiveCols(null)
                 if (stage.current) {
-                  stage.setTracks(stage.current.id, { cols: next })
+                  stage.setTracks(stage.current.id, layout, { cols: next })
                 }
               }}
             />
@@ -381,7 +383,7 @@ export function TerminalHost() {
           onCommit={(next) => {
             setLiveRows(null)
             if (stage.current) {
-              stage.setTracks(stage.current.id, { rows: next })
+              stage.setTracks(stage.current.id, layout, { rows: next })
             }
           }}
         />

--- a/frontend/src/components/render-budget.test.tsx
+++ b/frontend/src/components/render-budget.test.tsx
@@ -395,7 +395,7 @@ test("adding a pane mounts its terminal and never remounts the ones already up",
   const before = { ...terminalMounts.counts }
 
   await budget.act(() =>
-    writeGroups("p1", [{ id: "g1", name: "wall", cells: ["s1", "s2"], cols: [], rows: [] }]),
+    writeGroups("p1", [{ id: "g1", name: "wall", cells: ["s1", "s2"], tracks: {} }]),
   )
 
   // The second pane's terminal is born once, and the first pane's is not thrown

--- a/frontend/src/lib/session/panes-store.test.ts
+++ b/frontend/src/lib/session/panes-store.test.ts
@@ -19,7 +19,7 @@ beforeEach(() => {
   stored.clear()
 })
 
-const group = { id: "g1", name: "wall", cells: ["s1", "s2"], cols: [], rows: [] }
+const group = { id: "g1", name: "wall", cells: ["s1", "s2"], tracks: {} }
 
 describe("storedGroups", () => {
   it("answers an identity-stable empty array for a project with nothing stored", () => {

--- a/frontend/src/lib/session/panes.test.ts
+++ b/frontend/src/lib/session/panes.test.ts
@@ -6,14 +6,18 @@ import {
   focusAfterRemove,
   formatGroups,
   groupOf,
+  MAX_TRACK_SHAPES,
   movingFrom,
   nextCandidate,
   type PaneGroup,
+  paneTracks,
   parseGroups,
   planAdd,
   removeFromGroups,
   reorderCells,
   resolveGroups,
+  setTracks,
+  shapeKey,
   stageAction,
   swapCells,
   updateGroup,
@@ -27,13 +31,24 @@ const group = (id: string, cells: string[], name = id): PaneGroup => ({
   id,
   name,
   cells,
-  cols: [],
-  rows: [],
+  tracks: {},
 })
 
 describe("parseGroups", () => {
   it("reads what formatGroups wrote", () => {
     const groups = [group("g1", ["a", "b"], "orchestrator"), group("g2", ["c"])]
+    expect(parseGroups(formatGroups(groups))).toEqual(groups)
+  })
+
+  it("reads a wall's dragged sizes back for every shape it holds", () => {
+    const groups = setTracks(
+      [group("g1", ["a", "b"])],
+      "g1",
+      { cols: 2, rows: 1 },
+      {
+        cols: [0.6, 0.4],
+      },
+    )
     expect(parseGroups(formatGroups(groups))).toEqual(groups)
   })
 
@@ -48,7 +63,7 @@ describe("parseGroups", () => {
 
   it("drops entries that are not groups and keeps the ones that are", () => {
     expect(parseGroups('[{"nope":1},{"id":"g1","cells":["a"]}]')).toEqual([
-      { id: "g1", name: "", cells: ["a"], cols: [], rows: [] },
+      { id: "g1", name: "", cells: ["a"], tracks: {} },
     ])
   })
 })
@@ -168,6 +183,75 @@ describe("updateGroup / dissolveGroup", () => {
     expect(dissolveGroup([group("g1", ["a"]), group("g2", ["b"])], "g1").map((g) => g.id)).toEqual([
       "g2",
     ])
+  })
+})
+
+// A wall is reshaped by the window, not by the user: the sidebar collapsing,
+// the dock opening, a second monitor. So the same wall is dragged at four
+// columns and met again at three. Both layouts are the user's, and a shape they
+// have never dragged is a first layout rather than a forgotten one.
+describe("setTracks / paneTracks", () => {
+  const wall = group("g1", ["a", "b", "c", "d"])
+  const wide = { cols: 4, rows: 1 }
+  const narrow = { cols: 3, rows: 2 }
+  const wideCols = [0.4, 0.2, 0.2, 0.2]
+  const narrowCols = [0.5, 0.25, 0.25]
+
+  it("gives a shape never dragged equal shares", () => {
+    expect(paneTracks(wall, wide).cols).toEqual([0.25, 0.25, 0.25, 0.25])
+    expect(paneTracks(null, narrow).rows).toEqual([0.5, 0.5])
+  })
+
+  it("restores a drag when its shape comes back", () => {
+    const groups = setTracks([wall], "g1", wide, { cols: wideCols })
+    expect(paneTracks(groups[0], wide).cols).toEqual(wideCols)
+    expect(paneTracks(groups[0], narrow).cols).toEqual([1 / 3, 1 / 3, 1 / 3])
+    expect(paneTracks(groups[0], wide).cols).toEqual(wideCols)
+  })
+
+  it("keeps one wall's layout for every shape it was dragged on", () => {
+    let groups = setTracks([wall], "g1", wide, { cols: wideCols })
+    groups = setTracks(groups, "g1", narrow, { cols: narrowCols, rows: [0.7, 0.3] })
+    expect(paneTracks(groups[0], wide).cols).toEqual(wideCols)
+    expect(paneTracks(groups[0], wide).rows).toEqual([1])
+    expect(paneTracks(groups[0], narrow).cols).toEqual(narrowCols)
+    expect(paneTracks(groups[0], narrow).rows).toEqual([0.7, 0.3])
+  })
+
+  it("leaves the other walls alone, and a group that is gone", () => {
+    const groups = setTracks([wall, group("g2", ["e", "f"])], "g1", wide, { cols: wideCols })
+    expect(groups[1].tracks).toEqual({})
+    expect(setTracks(groups, "gone", wide, { cols: wideCols })).toEqual(groups)
+  })
+
+  // Shapes are minted by the window, so a map that grew with every width the
+  // stage has ever had is one nobody prunes.
+  it("forgets the shape dragged longest ago once there are too many", () => {
+    const shapes = Array.from({ length: MAX_TRACK_SHAPES + 1 }, (_, i) => ({
+      cols: i + 2,
+      rows: 1,
+    }))
+    let groups = [wall]
+    for (const shape of shapes) {
+      groups = setTracks(groups, "g1", shape, {
+        cols: Array.from({ length: shape.cols }, () => 1 / shape.cols),
+      })
+    }
+    expect(Object.keys(groups[0].tracks)).toHaveLength(MAX_TRACK_SHAPES)
+    expect(groups[0].tracks[shapeKey(shapes[0])]).toBeUndefined()
+    expect(groups[0].tracks[shapeKey(shapes[shapes.length - 1])]).toBeDefined()
+  })
+
+  it("counts a re-drag as use, so a shape in daily rotation is never the one dropped", () => {
+    let groups = [wall]
+    const shapes = Array.from({ length: MAX_TRACK_SHAPES }, (_, i) => ({ cols: i + 2, rows: 1 }))
+    for (const shape of shapes) {
+      groups = setTracks(groups, "g1", shape, { cols: [] })
+    }
+    groups = setTracks(groups, "g1", shapes[0], { cols: wideCols })
+    groups = setTracks(groups, "g1", { cols: 20, rows: 1 }, { cols: [] })
+    expect(groups[0].tracks[shapeKey(shapes[0])]).toEqual({ cols: wideCols, rows: [] })
+    expect(groups[0].tracks[shapeKey(shapes[1])]).toBeUndefined()
   })
 })
 

--- a/frontend/src/lib/session/panes.ts
+++ b/frontend/src/lib/session/panes.ts
@@ -28,8 +28,20 @@
 // its cell is wherever that id sits in the group, so focus is read rather than
 // stored and a stale one cannot outlive the cell it named.
 import { applyOrder } from "@/lib/reorder"
-import { fits } from "./pane-grid"
+import { fits, type Grid, tracks } from "./pane-grid"
 import type { Session } from "./sessions"
+
+/** The shares of each axis a wall was dragged to, on one grid shape. */
+export interface TrackSizes {
+  cols: number[]
+  rows: number[]
+}
+
+// How many shapes one wall remembers having been dragged on. A window reshapes
+// a wall a handful of ways (the sidebar collapsing, the dock opening, a second
+// monitor), and past that the shape dragged longest ago is one the user is not
+// coming back to.
+export const MAX_TRACK_SHAPES = 6
 
 export interface PaneGroup {
   /** Stable across renames and reorders: the sidebar keys its block, its fold
@@ -38,16 +50,29 @@ export interface PaneGroup {
   name: string
   /** Session ids, in the order they are laid out. */
   cells: string[]
-  /** Column and row shares, belonging to the group rather than to the window:
-   * arranging one wall 60/40 must not carry into the next one. */
-  cols: number[]
-  rows: number[]
+  /** Column and row shares per grid shape, belonging to the group rather than
+   * to the window: arranging one wall 60/40 must not carry into the next one.
+   * Keyed by shape because the grid reshapes under the user: a wall dragged at
+   * four columns has to come back the next time four columns do. */
+  tracks: Record<string, TrackSizes>
 }
 
 export const groupsKey = (projectId: string): string => `lich.panes.${projectId}`
 
 function numbers(value: unknown): number[] {
   return Array.isArray(value) ? value.filter((n): n is number => typeof n === "number") : []
+}
+
+function trackMap(value: unknown): Record<string, TrackSizes> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {}
+  }
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([shape, sizes]) => {
+      const stored = sizes as Partial<TrackSizes> | undefined
+      return [shape, { cols: numbers(stored?.cols), rows: numbers(stored?.rows) }]
+    }),
+  )
 }
 
 // parseGroups reads the stored value, and answers "no groups" for anything it
@@ -73,8 +98,7 @@ export function parseGroups(raw: string | null): PaneGroup[] {
           id: group.id,
           name: typeof group.name === "string" ? group.name : "",
           cells: group.cells.filter((id): id is string => typeof id === "string"),
-          cols: numbers(group.cols),
-          rows: numbers(group.rows),
+          tracks: trackMap(group.tracks),
         },
       ]
     })
@@ -191,6 +215,43 @@ export function updateGroup(
   change: Partial<Omit<PaneGroup, "id">>,
 ): PaneGroup[] {
   return groups.map((group) => (group.id === groupId ? { ...group, ...change } : group))
+}
+
+/** The key a grid shape's dragged shares are stored under. */
+export function shapeKey({ cols, rows }: Grid): string {
+  return `${cols}x${rows}`
+}
+
+// paneTracks is what the stage draws: the shares dragged on this shape, or equal
+// ones for a shape never dragged, which is a first layout, not a forgotten one.
+export function paneTracks(group: PaneGroup | null, shape: Grid): TrackSizes {
+  const stored = group?.tracks[shapeKey(shape)]
+  return {
+    cols: tracks(stored?.cols ?? [], shape.cols),
+    rows: tracks(stored?.rows ?? [], shape.rows),
+  }
+}
+
+// setTracks writes a drag against the shape it was dragged on, so the wall the
+// user arranged at four columns is still that wall when four columns come back.
+// The map is capped: shapes are minted by the window, not by the user, and a
+// pref that grows with every width the stage has ever had is one nobody prunes.
+export function setTracks(
+  groups: readonly PaneGroup[],
+  groupId: string,
+  shape: Grid,
+  change: Partial<TrackSizes>,
+): PaneGroup[] {
+  const group = groups.find((candidate) => candidate.id === groupId)
+  if (!group) {
+    return [...groups]
+  }
+  const key = shapeKey(shape)
+  const sizes = { ...(group.tracks[key] ?? { cols: [], rows: [] }), ...change }
+  const others = Object.entries(group.tracks).filter(([at]) => at !== key)
+  // Most recently dragged last, so what the slice drops is the oldest shape.
+  const kept = [...others.slice(-(MAX_TRACK_SHAPES - 1)), [key, sizes] as const]
+  return updateGroup(groups, groupId, { tracks: Object.fromEntries(kept) })
 }
 
 export function dissolveGroup(groups: readonly PaneGroup[], groupId: string): PaneGroup[] {

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -367,7 +367,7 @@ describe("delegatesOf", () => {
 describe("sidebarGroups", () => {
   const ids = (groups: ReturnType<typeof sidebarGroups>) =>
     groups.map((group) => [group.key, group.sessions.map((s) => s.id)])
-  const wall = (id: string, cells: string[]) => ({ id, name: id, cells, cols: [], rows: [] })
+  const wall = (id: string, cells: string[]) => ({ id, name: id, cells, tracks: {} })
 
   it("draws one block per worktree when nothing is pinned", () => {
     let state = addSession({}, P, "s1")
@@ -954,7 +954,7 @@ describe("dragOrder", () => {
     kind: "shell",
     ...extra,
   })
-  const wall = (id: string, cells: string[]) => ({ id, name: id, cells, cols: [], rows: [] })
+  const wall = (id: string, cells: string[]) => ({ id, name: id, cells, tracks: {} })
 
   it("moves a wall past a checkout's block, carrying its cards", () => {
     const stored = [s("a1", { path: "/wt/a" }), s("r1"), s("r2")]

--- a/frontend/src/lib/session/use-panes.ts
+++ b/frontend/src/lib/session/use-panes.ts
@@ -11,10 +11,12 @@ import {
   removeFromGroups,
   reorderCells,
   resolveGroups,
+  setTracks as setGroupTracks,
   swapCells,
+  type TrackSizes,
   updateGroup,
 } from "./panes"
-import { fits } from "./pane-grid"
+import { fits, type Grid } from "./pane-grid"
 import { stageSize, useStoredGroups, writeGroups } from "./panes-store"
 
 export interface Panes {
@@ -55,8 +57,10 @@ export interface Panes {
   groupWith: (sessionId: string, delegateIds: readonly string[]) => number
   rename: (groupId: string, name: string) => void
   dissolve: (groupId: string) => void
-  /** Persist a wall's dragged column or row shares. */
-  setTracks: (groupId: string, change: { cols?: number[]; rows?: number[] }) => void
+  /** Persist a wall's dragged column or row shares, against the grid shape they
+   * were dragged on: the same wall gets its own layout at four columns and at
+   * three, and a shape never dragged still opens on equal shares. */
+  setTracks: (groupId: string, shape: Grid, change: Partial<TrackSizes>) => void
 }
 
 // The one definition of what the walls do, shared by the terminals that draw one
@@ -139,8 +143,7 @@ export function usePanes(projectId: string): Panes {
         id: newGroupId(),
         name: defaultName(list, plan.around),
         cells: [plan.around, plan.sessionId],
-        cols: [],
-        rows: [],
+        tracks: {},
       }
       commit([...removeFromGroups(groups, plan.sessionId), born])
       return true
@@ -169,8 +172,7 @@ export function usePanes(projectId: string): Panes {
         id: newGroupId(),
         name: defaultName(list, sessionId),
         cells: [sessionId, ...shown],
-        cols: [],
-        rows: [],
+        tracks: {},
       }
       // The session this was asked of leaves whatever wall it was on: it is the
       // subject of the action, not a bystander moved by it.
@@ -188,8 +190,8 @@ export function usePanes(projectId: string): Panes {
     dissolve(groupId) {
       commit(dissolveGroup(groups, groupId))
     },
-    setTracks(groupId, change) {
-      commit(updateGroup(groups, groupId, change))
+    setTracks(groupId, shape, change) {
+      commit(setGroupTracks(groups, groupId, shape, change))
     },
   }
 }


### PR DESCRIPTION
## What

A split group stored one set of column and row shares. The grid, however, is computed from the stage's measured width, so collapsing the sidebar, opening the dock or moving the window to another monitor reshapes the wall: the stored vector no longer described the grid, `tracks` fell back to equal shares, and a layout the user had dragged read as silently forgotten.

A group now keeps its shares in a map keyed by the grid's shape (`"<cols>x<rows>"`). A wall dragged at four columns and again at three restores each when that shape comes back, and a shape never dragged still opens on equal shares, which is a first layout rather than a loss.

## How

- `PaneGroup.cols` / `.rows` become `tracks: Record<string, TrackSizes>`, parsed with the same tolerance as the rest of the pref: anything unreadable costs the arrangement and nothing else.
- `paneTracks(group, shape)` is the one read the stage does; `setTracks(groups, id, shape, change)` is the one write a seam commits, merging columns and rows for the same shape.
- The map is capped at `MAX_TRACK_SHAPES` (6) and evicts the shape dragged longest ago, so a pref cannot grow with every width the stage has ever had. A re-drag counts as use.
- Sizes stay where they already lived: the page's localStorage, via `panes-store` and `prefs` (the hybrid-persistence rule in `docs/ceilings.md`).

Storage stays localStorage and the shape of a stored group changed, so one arrangement's sizes are dropped on the first launch after this. Cells and their order survive, as they always did.

## Ceilings

`docs/ceilings.md` loses the bullet "The grid follows the window, so the layout you dragged is not always the one you get back": the trap it named is gone, so the bullet goes rather than getting a sentence about the fix.

## Test plan

`frontend/src/lib/session/panes.test.ts` covers the round trip:

- drag at 4 columns, restored at 4;
- reshape to 3, equal shares there;
- back to 4, the drag is still there;
- both shapes dragged, both kept, columns and rows;
- cap eviction: the oldest shape drops, a re-dragged one stays.

Gate, run in this worktree: `./node_modules/.bin/biome ci .` exit 0, `pnpm test` 1628 passed (render budgets included), `pnpm build` clean. No Go changed.