### PR TITLE
fix: name the login a token-only session spends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `call_mcp_tool` followed by `lich/open_session`, spending the line on the step
   and crowding the tool worth reading off the end of it. It now draws the server
   and the tool the way every other provider's card does: `lich · open_session`.
+- **The plan gauge now says when a login has no name to show.** A
+  `claude setup-token` session drew its windows under the provider's name with
+  the account line blank, exactly like a provider that names nobody; it now
+  reads "Token login", and the blank is left to the providers that have nobody
+  to name.
 - **An agent reached through a custom binary path now counts as installed.**
   Detection only ever scanned `$PATH`, so a machine whose only agent is the one
   you pointed lich at in Settings › Providers read as a machine with nothing on

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -517,12 +517,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   the API rejects an OAuth token without it — the same coupling as the user agent, and it fails closed, as a
   failed reading. Headers carry the two account-wide windows and no plan name, so such a session shows no
   model-scoped weekly cap and no "Max 5x" badge.
-- **A token-only login has a gauge and no name** (`internal/quota/claude.go`): the same
-  `claude setup-token` scope that keeps the usage route out of reach keeps `/api/oauth/profile` out of reach —
-  it wants `user:profile`, and `user:inference` is all that token has — so the profile route is not asked at
-  all on that path rather than asked once per cache window for a 403. Such a session shows its windows under
-  the provider's name with no account line, which is the same thing a session on a provider that names nobody
-  shows, and nothing on screen tells the two apart.
 - **Only two providers name the account a session spends, and the reasons the other six do not are not one
   reason** (`internal/quota`, `Plan.Account`): Claude Code answers a profile route with the credentials token,
   and Codex carries an `email` claim in the OIDC id token beside its access token (read unverified, and

--- a/frontend/src/components/PlanQuota.tsx
+++ b/frontend/src/components/PlanQuota.tsx
@@ -1,6 +1,6 @@
 import type { QuotaPlan } from "@/lib/api-types"
 import { Gauge } from "lucide-react"
-import { hottestWindow, shortWindow } from "@/lib/quota/quota-format"
+import { accountLine, hottestWindow, shortWindow } from "@/lib/quota/quota-format"
 import { useNow } from "@/lib/use-now"
 import { QuotaGauge } from "./QuotaGauge"
 import { usageColor } from "./ContextRing"
@@ -35,6 +35,7 @@ export function PlanQuota({ plan }: PlanQuotaProps) {
 
 function PlanDetails({ plan }: PlanQuotaProps) {
   const now = useNow()
+  const account = accountLine(plan)
   return (
     <div className="flex min-w-52 flex-col gap-2.5">
       {(plan.windows ?? []).map((window) => (
@@ -43,9 +44,9 @@ function PlanDetails({ plan }: PlanQuotaProps) {
           {window.lockedReason && <p className="text-xs text-destructive">{window.lockedReason}</p>}
         </div>
       ))}
-      {plan.account && (
+      {account && (
         <span className="break-all border-t border-border pt-2 font-mono text-[0.6875rem] text-muted-foreground">
-          {plan.account}
+          {account}
         </span>
       )}
     </div>

--- a/frontend/src/components/settings/PlanUsageSetting.tsx
+++ b/frontend/src/components/settings/PlanUsageSetting.tsx
@@ -1,4 +1,5 @@
 import type { QuotaPlan } from "@/lib/api-types"
+import { accountLine } from "@/lib/quota/quota-format"
 import { usePlanQuotaFor } from "@/lib/quota/use-plan-quota"
 import { useNow } from "@/lib/use-now"
 import { QuotaGauge, gaugeGrid } from "@/components/QuotaGauge"
@@ -77,9 +78,9 @@ function PlanBody({ plan, now }: { plan: QuotaPlan; now: Date }) {
       ))}
       {/* The login this reading was taken against. Settings asks the machine-wide
           question, so this is lich's own — never a session's wrapper binary. */}
-      {plan.account && (
+      {accountLine(plan) && (
         <span className="break-all font-mono text-[0.6875rem] text-muted-foreground">
-          {plan.account}
+          {accountLine(plan)}
         </span>
       )}
     </div>

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -580,6 +580,10 @@ export interface QuotaPlan {
   /** The login the windows were read against, where the provider names one —
    * absent is an unnamed account, never a failed reading. */
   account?: string
+  /** Why `account` is absent, for the one absence that has a reason worth
+   * reading: the session's login is a long-lived OAuth token lich may not ask
+   * the profile route about. Absent for a provider that simply names nobody. */
+  noAccount?: "token-login"
   windows?: QuotaWindow[]
   status: "ok" | "signed-out" | "error" | "unknown"
 }

--- a/frontend/src/lib/quota/quota-format.test.ts
+++ b/frontend/src/lib/quota/quota-format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { QuotaPlan } from "@/lib/api-types"
-import { formatWindow, hottestWindow, shortWindow, timeLeft } from "./quota-format"
+import { accountLine, formatWindow, hottestWindow, shortWindow, timeLeft } from "./quota-format"
 
 const plan = (
   ...windows: Array<{ label: string; percent: number; active?: boolean }>
@@ -90,5 +90,23 @@ describe("timeLeft", () => {
     expect(timeLeft(undefined, now)).toBe("")
     expect(timeLeft("", now)).toBe("")
     expect(timeLeft("whenever", now)).toBe("")
+  })
+})
+
+describe("accountLine", () => {
+  const reading = (fields: Partial<QuotaPlan>): QuotaPlan => ({ ...plan(), ...fields })
+
+  it("names the account the provider named", () => {
+    expect(accountLine(reading({ account: "dev@example.com" }))).toBe("dev@example.com")
+  })
+
+  // The two blanks this used to draw as one: a login lich may not ask about,
+  // and a provider with nobody to name.
+  it("says a token login is why there is no name", () => {
+    expect(accountLine(reading({ noAccount: "token-login" }))).toBe("Token login")
+  })
+
+  it("stays empty for a provider that names nobody", () => {
+    expect(accountLine(reading({}))).toBe("")
   })
 })

--- a/frontend/src/lib/quota/quota-format.ts
+++ b/frontend/src/lib/quota/quota-format.ts
@@ -25,6 +25,18 @@ export function hottestWindow(plan: QuotaPlan): QuotaWindow | null {
   return hottest
 }
 
+// accountLine is what the gauge prints where the account's name goes. An
+// unnamed account is not one state but two, and the blank they used to share
+// said neither: a provider that names nobody has nothing to print, while a
+// `claude setup-token` login has a name lich is not allowed to ask for, which
+// is worth a word rather than a gap.
+export function accountLine(plan: QuotaPlan): string {
+  if (plan.account) {
+    return plan.account
+  }
+  return plan.noAccount === "token-login" ? "Token login" : ""
+}
+
 // shortWindow names a window's length in the width a status bar has: "5h",
 // "wk", "30d". Empty when the provider did not report a length.
 export function shortWindow(seconds: number): string {

--- a/internal/quota/claude.go
+++ b/internal/quota/claude.go
@@ -180,7 +180,9 @@ func (s *Service) claudeAccount(token string) string {
 // claudeProbe measures a token that can only infer: it sends the probe request
 // and reads the windows off the response headers. The plan name and the account
 // both stay empty — the headers carry the spend, never the subscription it is
-// spent against nor whose it is.
+// spent against nor whose it is. The reading says which of those it is, so the
+// gauge can name the absence rather than draw the blank a provider that names
+// nobody draws.
 func (s *Service) claudeProbe(p Plan, token string) Plan {
 	resp, authOK, err := s.send(http.MethodPost, s.probeURL, token, claudeProbeBody, map[string]string{
 		"anthropic-beta":    claudeBetaHeader,
@@ -202,6 +204,7 @@ func (s *Service) claudeProbe(p Plan, token string) Plan {
 	if len(p.Windows) == 0 {
 		return failed(p)
 	}
+	p.NoAccount = NoAccountTokenLogin
 	return p
 }
 

--- a/internal/quota/identity_test.go
+++ b/internal/quota/identity_test.go
@@ -161,8 +161,33 @@ func TestClaudeProbeAsksTheProfileRouteNothing(t *testing.T) {
 	if got.Account != "" {
 		t.Errorf("account = %q, want none", got.Account)
 	}
+	// The reason travels with the reading: without it the gauge cannot tell
+	// this blank from the one a provider that names nobody reports.
+	if got.NoAccount != NoAccountTokenLogin {
+		t.Errorf("noAccount = %q, want %q", got.NoAccount, NoAccountTokenLogin)
+	}
 	if len(got.Windows) != 2 {
 		t.Errorf("windows = %+v, want the two the headers carry", got.Windows)
+	}
+}
+
+// The credentials path names its account, so it has no reason to carry: only a
+// token login may not be asked, and a reading that names nobody for any other
+// cause must not borrow that label.
+func TestClaudeCredentialsLoginCarriesNoReasonForAnUnnamedAccount(t *testing.T) {
+	writeCreds(t, claudeCredsJSON, "")
+	usage := serveRoutes(t, map[string]string{"/usage": claudeLimitsBody})
+	profile := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer profile.Close()
+	svc := newService(usage.URL+"/usage", "", time.Now())
+	svc.profileURL = profile.URL
+
+	got := svc.claudePlan(lichEnv())
+
+	if got.NoAccount != "" {
+		t.Errorf("noAccount = %q, want none on the credentials path", got.NoAccount)
 	}
 }
 

--- a/internal/quota/quota.go
+++ b/internal/quota/quota.go
@@ -130,14 +130,26 @@ type Window struct {
 // environment does not name. It is empty whenever the provider will not say
 // which, which is a reading without a name and never an error: a gauge that
 // cannot name its account is exactly what lich drew before this field existed.
+//
+// NoAccount carries why it is empty, for the one absence a reader can act on.
+// Left empty, an unnamed account is drawn the same whether the provider names
+// nobody or the session's own login is one lich may not ask about, and nothing
+// on the gauge told the two apart.
 type Plan struct {
-	Provider string   `json:"provider"`
-	Name     string   `json:"name"`
-	Plan     string   `json:"plan,omitempty"`
-	Account  string   `json:"account,omitempty"`
-	Windows  []Window `json:"windows,omitempty"`
-	Status   string   `json:"status"`
+	Provider  string   `json:"provider"`
+	Name      string   `json:"name"`
+	Plan      string   `json:"plan,omitempty"`
+	Account   string   `json:"account,omitempty"`
+	NoAccount string   `json:"noAccount,omitempty"`
+	Windows   []Window `json:"windows,omitempty"`
+	Status    string   `json:"status"`
 }
+
+// NoAccountTokenLogin is the one reason an empty Account has a name: the
+// session's login is a long-lived OAuth token, whose scope keeps the profile
+// route out of reach, so lich never asks who it belongs to. Every other unnamed
+// account is a provider that names nobody, which needs no reason of its own.
+const NoAccountTokenLogin = "token-login"
 
 // Account is what a lich session's own process says about the account it
 // spends. Env is that process's environment — where a wrapper binary puts a


### PR DESCRIPTION
## What

A `claude setup-token` login carries `user:inference` alone, so `/api/oauth/profile` is never asked and `Plan.Account` comes back empty. The gauge drew that as a blank account line — which is exactly what a provider that names nobody draws. Nothing on screen told the two apart.

The reading now carries the reason: `Plan.NoAccount` is `"token-login"` on the probe path and empty everywhere else (mirrored in `frontend/src/lib/api-types.ts`, which is hand-owned). One helper, `accountLine`, turns that into the line both the footer gauge and Settings › Plan usage print: `"Token login"` for a token login, still empty for a provider with nobody to name.

No toggle, no setting — the absence just says which absence it is.

`docs/ceilings.md` loses the bullet that named the trap.

## Test plan

- [x] Go: the probe path carries the reason; the credentials path (profile route refused) carries none, so a failed name lookup cannot borrow the label
- [x] Frontend: `accountLine` over the three cases — named account, token login, nobody to name
- [x] `gofmt -l .`, `go vet ./...`, `go test ./...`
- [x] `./node_modules/.bin/biome ci .` exit 0, `pnpm test` (1624 passed), `pnpm build`