### PR TITLE
fix: say what a shortcut costs the terminal underneath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   way — it is what each sender would have been told alone — and the worker is
   asked at its prompt to name the ticket. One open request behaves as before on
   both paths.
+- **The shortcut recorder now says what a chord costs the terminal.** A bound
+  chord is caught before the session sees it, so rebinding one to `Ctrl+R` took
+  the shell's history search with nothing on screen connecting the two. The row
+  now names what the chord already does down there — the shell's own control
+  codes, the terminal's search, the image paste the agent reads — and still
+  records it.
 - **The sandbox's "Ask each time" rung now reaches every session.** It only ever
   asked in the New worktree dialog, so a session started from the New session
   menu, by another session, or through the MCP tool quietly ran on the machine.

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -287,10 +287,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   no confirmation on the way. It is not a new privilege — the agent already runs as you, in a shell that can read
   the same disk — but it is new visibility, and a card it opens there is a card with a PTY in it.
 
-- **A hotkey is taken from the agent, and a rebind is checked against nothing** (`frontend/src/lib/use-hotkey.ts`,
-  `hotkeys.ts`): every bound combo is caught in the window capture phase and stopped there, so the chord never
-  reaches the PTY. The defaults spend chords no TUI can bind, but nothing holds a rebind to that, and recording
-  `Ctrl+R` silently costs the shell its history search with nothing on screen connecting the two.
 - **lich's own window offers the page every primary-modifier chord before Chromium runs it**
   (`shell/src/main.rs`): a CEF keyboard handler marks each Ctrl chord (Cmd on macOS) a keyboard shortcut, which
   is the only way a page can claim one of Chromium's *reserved* accelerators. Ctrl+T, Ctrl+W, Ctrl+Shift+T and

--- a/frontend/src/components/settings/HotkeysSettings.test.tsx
+++ b/frontend/src/components/settings/HotkeysSettings.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+//
+// The recorder saying what a rebind costs the terminal. A bound chord is
+// stopped in the window capture phase and never reaches the PTY, so recording
+// Ctrl+R takes the shell's history search — the pane has to connect the two,
+// and only a real mount says whether the line reached the row.
+//
+// The harness is imported first for the reason render-budget.test.tsx names.
+import { mountBudget } from "@/test/render-budget"
+import { createElement } from "react"
+import { expect, test, vi } from "vitest"
+import { DEFAULT_HOTKEYS, UNASSIGNED, type Hotkeys } from "@/lib/hotkeys"
+import { HotkeysSettings } from "./HotkeysSettings"
+
+const bindings = vi.hoisted(() => ({ hotkeys: {} as Hotkeys }))
+
+vi.mock("@/providers/settings", () => ({
+  useSettings: () => ({
+    hotkeys: bindings.hotkeys,
+    setHotkey: () => {},
+    resetHotkey: () => {},
+  }),
+}))
+
+test("says what a chord the terminal spends will cost, and nothing for one it does not", async () => {
+  // Every other action unbound, so the count below is these two rows and
+  // nothing the defaults happen to spend.
+  bindings.hotkeys = {
+    ...(Object.fromEntries(Object.keys(DEFAULT_HOTKEYS).map((id) => [id, UNASSIGNED])) as Hotkeys),
+    // The shell's history search, taken by a rebind.
+    settings: { mod: true, shift: false, alt: false, key: "r" },
+    // Ctrl+Shift+letter reaches no TUI at all, so it costs nothing.
+    newSession: { mod: true, shift: true, alt: false, key: "r" },
+  }
+
+  const mounted = await mountBudget(createElement(HotkeysSettings))
+  const text = document.body.textContent ?? ""
+
+  expect(text).toContain("Ctrl+R is the shell's history search; sessions will no longer see it.")
+  expect(text.match(/sessions will no longer see it/g)).toHaveLength(1)
+  await mounted.unmount()
+})

--- a/frontend/src/components/settings/HotkeysSettings.tsx
+++ b/frontend/src/components/settings/HotkeysSettings.tsx
@@ -10,6 +10,7 @@ import {
   HOTKEY_ACTIONS,
   HOTKEY_GROUPS,
   sameCombo,
+  terminalCost,
   UNASSIGNED,
   type HotkeyAction,
   type HotkeyId,
@@ -50,6 +51,10 @@ function HotkeyRow({ action, conflicts }: { action: HotkeyAction; conflicts?: Ho
   const combo = hotkeys[action.id]
   const isDefault = sameCombo(combo, DEFAULT_HOTKEYS[action.id])
   const isUnassigned = !combo.key
+  // What this binding costs the terminal underneath. Said rather than refused:
+  // the chord is the user's to spend, and until now nothing connected the
+  // rebind to the shell command that stopped working.
+  const cost = terminalCost(combo)
 
   const onKeyDown = (event: React.KeyboardEvent) => {
     if (!recording) return
@@ -84,6 +89,7 @@ function HotkeyRow({ action, conflicts }: { action: HotkeyAction; conflicts?: Ho
             Also bound to {conflicts.map(hotkeyLabel).join(", ")}
           </span>
         )}
+        {cost && <span className="mt-0.5 text-xs text-muted-foreground">{cost}</span>}
       </div>
       <button
         type="button"

--- a/frontend/src/lib/hotkeys.ts
+++ b/frontend/src/lib/hotkeys.ts
@@ -337,6 +337,51 @@ export function hotkeyConflicts(hotkeys: Hotkeys): Partial<Record<HotkeyId, Hotk
   return conflicts
 }
 
+// What the terminal side already spends a chord on, keyed by the combo's key.
+// The list is Ctrl+letter and nothing else on purpose: xterm's control-code
+// mapping needs Shift up, so Ctrl+Shift+anything reaches no TUI at all and
+// costs nothing (measured in a live session against `cat -v`, and the reason
+// every default above is in that family).
+//
+// It is what the defaults' own note has always known and no rebind was ever
+// held to: a bound chord is caught in the window capture phase and stopped
+// there, so it never reaches the PTY. lich does not veto the user's choice —
+// the recorder only has to say what the choice costs.
+const TERMINAL_CHORDS: Record<string, string> = {
+  a: "the shell's move to the start of the line",
+  c: "the shell's interrupt",
+  d: "the shell's end of input",
+  e: "the shell's move to the end of the line",
+  k: "the shell's kill to the end of the line",
+  l: "the shell's clear screen",
+  q: "the shell's resume output",
+  r: "the shell's history search",
+  s: "the shell's stop output",
+  u: "the shell's kill to the start of the line",
+  w: "the shell's erase word",
+  z: "the shell's suspend",
+  // Not the shell's: the two the session terminal spends for itself, and the
+  // one a provider binds inside it (shortcuts.ts, terminal/term-keys.ts).
+  f: "the session terminal's own search",
+  v: "the image paste lich sends the agent",
+  Backspace: "the erase word lich sends the agent",
+}
+
+// terminalCost is the one line the recorder shows for a chord the terminal side
+// already spends, and "" for one the PTY never sees anyway.
+//
+// The chord is spelled Ctrl even on macOS, where formatCombo prints ⌘: what a
+// TUI reads is the control code, and matchesCombo folds Cmd and Ctrl into one
+// `mod`, so binding ⌘R there swallows ^R too. Naming ⌘ would point at the wrong
+// key — the same reason shortcuts.ts spells its rows out by hand.
+export function terminalCost(combo: Combo): string {
+  if (!combo.mod || combo.shift || combo.alt) {
+    return ""
+  }
+  const spent = TERMINAL_CHORDS[combo.key]
+  return spent ? `Ctrl+${formatKey(combo.key)} is ${spent}; sessions will no longer see it.` : ""
+}
+
 function formatKey(key: string): string {
   if (key === " ") return "Space"
   if (key.startsWith("Arrow")) return key.slice("Arrow".length)


### PR DESCRIPTION
## What

Every bound chord is caught in the window capture phase and stopped there, so it never reaches the PTY. The defaults were chosen against that; a rebind was held to nothing. Recording `Ctrl+R` silently cost the shell its history search, with nothing on screen connecting the two.

`hotkeys.ts` now names what the terminal side already spends — the shell's control codes (`Ctrl+C D Z L R A E U W K S Q`), the session terminal's own search, and the image paste and erase-word lich rewrites on the way to the agent — and the recorder shows one line for a chord on that list:

> Ctrl+R is the shell's history search; sessions will no longer see it.

It still records; it just says. No toggle, no setting, no veto — the chord is the user's to spend.

Two details worth reading:

- The list is `Ctrl`+key with Shift up, because `Ctrl+Shift+<letter>` reaches no TUI at all (xterm's control-code mapping needs Shift up) — which is why the defaults live in that family.
- The line spells `Ctrl` on macOS too, where `formatCombo` prints `⌘`: `matchesCombo` folds Cmd and Ctrl into one `mod`, so binding `⌘R` there swallows `^R` as well, and naming `⌘` would point at the wrong key. Same reason `shortcuts.ts` spells its rows out by hand.

One default is on the list and now says so: the command palette's `Ctrl+K` costs the shell its kill-to-end-of-line. That was already true and unsaid.

The `docs/ceilings.md` bullet naming the trap is deleted. The neighbouring bullet — lich's own window offering the page every primary-modifier chord — stays.

## Test plan

- [x] `HotkeysSettings.test.tsx` mounts the pane with one row on `Ctrl+R` and one on `Ctrl+Shift+R`, and asserts the line renders for the first and for nothing else
- [x] `./node_modules/.bin/biome ci .` exit 0
- [x] `pnpm test` (1622 passed), `pnpm build`