### PR TITLE
fix: verify a filed answer before a click acts on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plugin row offered an update for a plugin that was no longer installed. The
   rows still paint at once from what was read last, but the click re-asks first
   and acts on the answer: a missing checkout is created with the same gesture,
-  and a plugin that changed underneath gets the action it actually needs.
+  and a plugin that changed underneath gets the action it actually needs. The
+  "Remove worktree" a merge offers reads the same way, and now says the checkout
+  was already removed rather than reporting a failure to remove it.
 - **A split's dragged pane sizes now come back when the grid does.** How many
   panes sit across follows the window, so collapsing the sidebar, opening the
   dock or moving to another monitor reshapes the wall - and the sizes you had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   page holds says `100 of 143` over the group instead of presenting the page as
   the whole answer. Sessions parked before this version carry no branch until
   they are parked again.
+- **A button on a pull request or plugin row now checks before it acts.** Both
+  screens paint from the answer of their last visit, so a checkout removed from
+  a terminal still offered "Go to session" for a directory that was gone, and a
+  plugin row offered an update for a plugin that was no longer installed. The
+  rows still paint at once from what was read last, but the click re-asks first
+  and acts on the answer: a missing checkout is created with the same gesture,
+  and a plugin that changed underneath gets the action it actually needs.
 - **A split's dragged pane sizes now come back when the grid does.** How many
   panes sit across follows the window, so collapsing the sidebar, opening the
   dock or moving to another monitor reshapes the wall - and the sizes you had

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -667,17 +667,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   (a remount initialises the marker and never exercises the replay), and it must record frames from a layout
   effect rather than from the render body (the body sees passes that were never committed, which reads a
   correct hook as an oscillation). A probe missing either one calls the ref version green.
-- **One filed answer drives an action rather than a readout** (`frontend/src/lib/git/use-checkouts.ts`): every
-  other `cache` on this screen decides what is *shown*, and a value one round-trip old is only ever a stale
-  label. This one decides what a button *does* — `Pulls.tsx` asks it whether the pull request's head branch is
-  already checked out, and the answer picks between reusing a session and creating a worktree. A checkout
-  removed from a terminal while the user was on another screen therefore offers "Go to session" for a
-  directory that is gone. The window is one round-trip (it re-reads on mount, on focus, and after this screen
-  creates a checkout itself) and git refuses the wrong move anyway, which is why it is filed rather than left
-  cold — but it is the one to think twice about before the next `cache` is added to something a button reads.
-  The plugin rows on Settings › Updates (`PluginSetting`) are the second case: a plugin installed or removed
-  from a terminal while the user was elsewhere is painted as it was on the way back in, so the row offers an
-  Install that has already happened, or withholds one that has not, until that visit's read lands.
 - **The dock's remembered browse is module memory, keyed by a path and never swept**
   (`frontend/src/lib/file-browse.ts`): every checkout the Code tab has ever browsed keeps its filter,
   folds, preview and marked row until the page reloads — a few strings per checkout, deliberately not

--- a/frontend/src/components/pulls/Pulls.tsx
+++ b/frontend/src/components/pulls/Pulls.tsx
@@ -221,7 +221,7 @@ export function Pulls({ list = false }: PullsProps) {
     } catch (err: unknown) {
       toast.error(`Failed to remove worktree: ${errorText(err)}`)
     }
-    refreshCheckouts()
+    void refreshCheckouts()
   }
 
   const onMerged = () => {
@@ -248,32 +248,38 @@ export function Pulls({ list = false }: PullsProps) {
   // it is reused rather than recreated — and that includes the project's own
   // directory, which is where a branch usually is.
   //
+  // Which of the two it is comes from a fresh read, never from the filed answer
+  // the button was drawn from: a checkout removed from a terminal while the user
+  // was on another screen would otherwise send this to a directory that is gone.
+  // Verify before acting, never before showing — the label goes on painting from
+  // the cache, and only the click pays the round trip.
+  //
   // It answers with the session the work lands in, so a caller with something to
   // hand that session knows where to write; "" when nothing was opened.
   const openInSession = async (): Promise<string> => {
     if (!projectId || !detail) {
       return ""
     }
-    const existing = checkedOut
-    if (existing) {
-      const live = sessionsOf(sessions, projectId).find((s) => s.path === existing.path)
-      let target: string
-      if (live) {
-        activateSession(projectId, live.id)
-        target = live.id
-      } else if (existing.path === projectPath) {
-        // The project's own checkout is not a worktree: it has no parked
-        // session to resume and must never be handed to the worktree flows.
-        target = newSession(projectId)
-      } else {
-        target = await reopenWorktreeSession(projectId, existing)
-      }
-      openPulls(existing.path)
-      navigate(`/projects/${projectId}`)
-      return target
-    }
     setOpening(true)
     try {
+      const existing = (await refreshCheckouts()).find((c) => c.name === detail.headRefName)
+      if (existing) {
+        const live = sessionsOf(sessions, projectId).find((s) => s.path === existing.path)
+        let target: string
+        if (live) {
+          activateSession(projectId, live.id)
+          target = live.id
+        } else if (existing.path === projectPath) {
+          // The project's own checkout is not a worktree: it has no parked
+          // session to resume and must never be handed to the worktree flows.
+          target = newSession(projectId)
+        } else {
+          target = await reopenWorktreeSession(projectId, existing)
+        }
+        openPulls(existing.path)
+        navigate(`/projects/${projectId}`)
+        return target
+      }
       const wt = await ProjectService.CreateWorktreeFromPR(projectPath, projectId, detail.number)
       if (!wt) {
         return ""
@@ -283,7 +289,7 @@ export function Pulls({ list = false }: PullsProps) {
       const target = newWorktreeSession(projectId, wt)
       queueSetup(target)
       openPulls(wt.path)
-      refreshCheckouts()
+      void refreshCheckouts()
       navigate(`/projects/${projectId}`)
       return target
     } catch (err: unknown) {

--- a/frontend/src/components/pulls/Pulls.tsx
+++ b/frontend/src/components/pulls/Pulls.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom"
 import { GitPullRequestArrow } from "lucide-react"
 import { toast } from "sonner"
 import { ProjectService, Store } from "@/lib/rpc"
+import type { Worktree } from "@/lib/api-types"
 import { useProjects } from "@/providers/projects"
 import { baseName } from "@/lib/paths"
 import { Notice } from "@/components/common/Notice"
@@ -180,8 +181,17 @@ export function Pulls({ list = false }: PullsProps) {
   // otherwise walk back to the sidebar for. Refuse a dirty worktree: whatever
   // was never committed lives only there, and the sidebar's flow is the one that
   // knows how to confirm discarding it.
-  const removeWorktree = async (wtPath: string) => {
+  //
+  // The offer is drawn from the filed checkout list and the toast it rides
+  // outlives the merge by ten seconds, so the click re-reads too: a checkout
+  // already gone is what the offer was asking for, not a failure to report.
+  const removeWorktree = async (wt: Worktree) => {
     if (!projectId) {
+      return
+    }
+    const wtPath = wt.path
+    if (!(await refreshCheckouts()).some((c) => c.path === wtPath)) {
+      toast.success(`${baseName(wtPath)} was already removed`)
       return
     }
     const occupants = sessionsOf(sessions, projectId).filter((s) => s.path === wtPath)
@@ -239,7 +249,7 @@ export function Pulls({ list = false }: PullsProps) {
     }
     toast.success(merged, {
       duration: CLEANUP_TOAST_MS,
-      action: { label: "Remove worktree", onClick: () => void removeWorktree(wt.path) },
+      action: { label: "Remove worktree", onClick: () => void removeWorktree(wt) },
     })
   }
 

--- a/frontend/src/components/pulls/pulls-open-session.test.tsx
+++ b/frontend/src/components/pulls/pulls-open-session.test.tsx
@@ -48,6 +48,20 @@ const calls = vi.hoisted(() => ({
   created: [] as number[],
   reopened: [] as string[],
   activated: [] as string[],
+  removed: [] as string[],
+  /** Every toast raised, newest last, with the action a cleanup offer carries. */
+  toasts: [] as Array<{ message: string; action?: () => void }>,
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: (message: string, options?: { action?: { onClick: () => void } }) => {
+      calls.toasts.push({ message, action: options?.action?.onClick })
+    },
+    error: (message: string) => {
+      calls.toasts.push({ message })
+    },
+  },
 }))
 
 /** A read that never lands, so what is on screen came from the filed answer. */
@@ -62,6 +76,12 @@ vi.mock("@/lib/rpc", () => ({
     CreateWorktreeFromPR: (_path: string, _projectId: string, number: number) => {
       calls.created.push(number)
       return Promise.resolve(WORKTREE)
+    },
+    WorktreeAdopted: () => Promise.resolve(false),
+    WorktreeDirty: () => Promise.resolve(false),
+    RemoveWorktree: (_projectPath: string, wtPath: string) => {
+      calls.removed.push(wtPath)
+      return Promise.resolve(null)
     },
   },
   Store: { PurgeWorktreeSessions: () => Promise.resolve(null) },
@@ -112,16 +132,29 @@ vi.mock("@/lib/git/use-git-status", () => ({
   useGitStatus: () => ({ branch: "main", head: "abc123" }),
 }))
 
-// The pull request itself is not what this is about — only the button Pulls
-// hands it, with the label Pulls decided and the run Pulls wired.
+// The pull request itself is not what this is about — only what Pulls hands it:
+// the session button, with the label Pulls decided and the run Pulls wired, and
+// the merge that raises Pulls' own cleanup offer.
 vi.mock("./PullRequestView", () => ({
-  PullRequestView: ({ session }: { session: SessionAction }) =>
-    createElement("button", { type: "button", onClick: session.run }, session.label),
+  PullRequestView: ({ session, onMerged }: { session: SessionAction; onMerged: () => void }) => [
+    createElement("button", { key: "s", type: "button", onClick: session.run }, session.label),
+    createElement("button", { key: "m", type: "button", onClick: onMerged }, "Merge"),
+  ],
 }))
 
 const text = () => document.body.textContent ?? ""
 
-function clickSessionButton(): void {
+function click(label: string): void {
+  const button = [...document.querySelectorAll("button")].find(
+    (element) => element.textContent?.trim() === label,
+  )
+  if (!button) {
+    throw new Error(`no "${label}" button on screen: ${text()}`)
+  }
+  button.click()
+}
+
+const clickSessionButton = (): void => {
   const button = document.querySelector("button")
   if (!button) {
     throw new Error(`no session button on screen: ${text()}`)
@@ -129,12 +162,16 @@ function clickSessionButton(): void {
   button.click()
 }
 
+const lastToast = () => calls.toasts[calls.toasts.length - 1]
+
 beforeEach(() => {
   clearRemoteCache()
   calls.list = () => Promise.resolve([])
   calls.created = []
   calls.reopened = []
   calls.activated = []
+  calls.removed = []
+  calls.toasts = []
 })
 
 // The trap: the filed list still holds a checkout git no longer has, so the
@@ -161,6 +198,28 @@ it("creates a worktree when the filed checkout is gone by the time it is clicked
   expect(calls.activated).toEqual([])
   expect(calls.reopened).toEqual([])
   await second.unmount()
+})
+
+// The merge toast carries the same filed answer for ten seconds, which is long
+// enough for the checkout to go away under it — from the sidebar, or from a
+// terminal. A remove that has already happened is what the offer was asking
+// for, so it is said in the toast's own voice rather than reported as a failure.
+it("says the worktree was already removed instead of failing the cleanup", async () => {
+  calls.list = () => Promise.resolve([WORKTREE])
+  const mounted = await mountBudget(createElement(Pulls))
+  await mounted.act(() => {})
+
+  await mounted.act(() => click("Merge"))
+  const offer = lastToast()
+  expect(offer?.action).toBeDefined()
+
+  // Removed under the toast, answered to the offer's own read.
+  calls.list = () => Promise.resolve([])
+  await mounted.act(() => offer?.action?.())
+
+  expect(calls.removed).toEqual([])
+  expect(lastToast()?.message).toBe("feature was already removed")
+  await mounted.unmount()
 })
 
 // The other half of the same read: a checkout that is still there is reused,

--- a/frontend/src/components/pulls/pulls-open-session.test.tsx
+++ b/frontend/src/components/pulls/pulls-open-session.test.tsx
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+//
+// What the pull request screen's session button *does*, as opposed to what it
+// says. The label is drawn from the filed checkout list, which can be a round
+// trip behind a worktree removed from a terminal; the click re-reads before it
+// picks a path, so the two can disagree and the action still lands.
+//
+// The harness is imported before anything that reaches react-dom, for the
+// reason render-budget.test.tsx names.
+import { mountBudget } from "@/test/render-budget"
+import { createElement } from "react"
+import { beforeEach, expect, it, vi } from "vitest"
+import { clearRemoteCache } from "@/lib/remote-cache"
+import type { PullRequestDetail, Worktree } from "@/lib/api-types"
+import type { SessionAction } from "./PullRequestView"
+import { Pulls } from "./Pulls"
+
+const PROJECT_ID = "p1"
+const PROJECT_PATH = "/repo"
+const WORKTREE: Worktree = { name: "feature", path: "/checkouts/feature" }
+const LIVE_SESSION = "s-live"
+
+const DETAIL: PullRequestDetail = {
+  number: 7,
+  url: "https://example.invalid/pull/7",
+  title: "A pull request",
+  body: "",
+  author: "someone",
+  state: "OPEN",
+  isDraft: false,
+  mergeable: "MERGEABLE",
+  mergeStateStatus: "CLEAN",
+  reviewDecision: "",
+  reviewers: null,
+  baseRefName: "main",
+  headRefName: "feature",
+  changedFiles: 1,
+  isCrossRepository: false,
+  maintainerCanModify: false,
+  checks: { passed: 0, failed: 0, pending: 0, total: 0 },
+  checkRuns: null,
+  commits: null,
+}
+
+const calls = vi.hoisted(() => ({
+  /** What the next ListCheckouts answers. Swapped per test, and mid-test. */
+  list: () => Promise.resolve([] as Worktree[]),
+  created: [] as number[],
+  reopened: [] as string[],
+  activated: [] as string[],
+}))
+
+/** A read that never lands, so what is on screen came from the filed answer. */
+const pending = () => new Promise<Worktree[]>(() => {})
+
+vi.mock("@/lib/rpc", () => ({
+  ProjectService: {
+    ListCheckouts: () => calls.list(),
+    PullRequestDetail: () => Promise.resolve(DETAIL),
+    PullRequestConversation: () => Promise.resolve(null),
+    ListPullRequests: () => Promise.resolve([]),
+    CreateWorktreeFromPR: (_path: string, _projectId: string, number: number) => {
+      calls.created.push(number)
+      return Promise.resolve(WORKTREE)
+    },
+  },
+  Store: { PurgeWorktreeSessions: () => Promise.resolve(null) },
+  Terminal: { Write: () => Promise.resolve(null) },
+}))
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => () => {},
+  useParams: () => ({ projectId: PROJECT_ID }),
+}))
+
+// A session already living in the worktree, which is what makes the button read
+// "Go to session" rather than offering to open one.
+vi.mock("@/providers/projects", () => ({
+  useProjects: () => ({
+    projects: [{ id: PROJECT_ID, path: PROJECT_PATH }],
+    sessions: {
+      [PROJECT_ID]: {
+        sessions: [{ id: LIVE_SESSION, path: WORKTREE.path }],
+        activeId: LIVE_SESSION,
+        nextSeq: 2,
+      },
+    },
+    discardSession: () => {},
+    newSession: () => "s-new",
+    newWorktreeSession: () => "s-worktree",
+    reopenWorktreeSession: (_projectId: string, wt: Worktree) => {
+      calls.reopened.push(wt.path)
+      return Promise.resolve("s-reopened")
+    },
+    activateSession: (_projectId: string, id: string) => {
+      calls.activated.push(id)
+    },
+  }),
+}))
+
+// gh is answered at once: the screen draws nothing at all until it has.
+vi.mock("@/lib/use-binary-check", () => ({
+  NO_SETTLE: 0,
+  useBinaryCheck: () => ({ path: "/usr/bin/gh", status: "ok" }),
+}))
+
+vi.mock("@/lib/session/use-active-session", () => ({
+  useActiveSession: () => ({ sessionId: "s1", path: PROJECT_PATH, checkout: PROJECT_PATH }),
+}))
+
+vi.mock("@/lib/git/use-git-status", () => ({
+  useGitStatus: () => ({ branch: "main", head: "abc123" }),
+}))
+
+// The pull request itself is not what this is about — only the button Pulls
+// hands it, with the label Pulls decided and the run Pulls wired.
+vi.mock("./PullRequestView", () => ({
+  PullRequestView: ({ session }: { session: SessionAction }) =>
+    createElement("button", { type: "button", onClick: session.run }, session.label),
+}))
+
+const text = () => document.body.textContent ?? ""
+
+function clickSessionButton(): void {
+  const button = document.querySelector("button")
+  if (!button) {
+    throw new Error(`no session button on screen: ${text()}`)
+  }
+  button.click()
+}
+
+beforeEach(() => {
+  clearRemoteCache()
+  calls.list = () => Promise.resolve([])
+  calls.created = []
+  calls.reopened = []
+  calls.activated = []
+})
+
+// The trap: the filed list still holds a checkout git no longer has, so the
+// button offers to go to a session in a directory that is gone. Acting on the
+// filed answer hands that path to the session flows; acting on a fresh read
+// falls through to creating the checkout, with the same gesture.
+it("creates a worktree when the filed checkout is gone by the time it is clicked", async () => {
+  calls.list = () => Promise.resolve([WORKTREE])
+  const first = await mountBudget(createElement(Pulls))
+  await first.act(() => {})
+  await first.unmount()
+
+  // This visit's read never lands, so the button on screen is the filed answer
+  // and nothing else — the one frame the cache exists for.
+  calls.list = pending
+  const second = await mountBudget(createElement(Pulls))
+  expect(text()).toContain("Go to session")
+
+  // Removed from a terminal in the meantime, answered to the click's own read.
+  calls.list = () => Promise.resolve([])
+  await second.act(() => clickSessionButton())
+
+  expect(calls.created).toEqual([DETAIL.number])
+  expect(calls.activated).toEqual([])
+  expect(calls.reopened).toEqual([])
+  await second.unmount()
+})
+
+// The other half of the same read: a checkout that is still there is reused,
+// which is the whole reason the screen asks before it creates one.
+it("goes to the session when the checkout is still there", async () => {
+  calls.list = () => Promise.resolve([WORKTREE])
+  const mounted = await mountBudget(createElement(Pulls))
+  await mounted.act(() => {})
+  expect(text()).toContain("Go to session")
+
+  await mounted.act(() => clickSessionButton())
+
+  expect(calls.activated).toEqual([LIVE_SESSION])
+  expect(calls.created).toEqual([])
+  await mounted.unmount()
+})

--- a/frontend/src/components/settings/PluginSetting.test.tsx
+++ b/frontend/src/components/settings/PluginSetting.test.tsx
@@ -30,20 +30,36 @@ const INSTALLED: PluginStatus = {
   installedVersion: "0.9.0",
 }
 
+// An installed plugin one version behind, which is the row that draws a button
+// while claiming the plugin is already there.
+const OUTDATED: PluginStatus = {
+  ...INSTALLED,
+  installedVersion: "0.8.0",
+  updateAvailable: true,
+}
+
 /** What the next Status() call answers. Swapped per test, and mid-test. */
 let status: () => Promise<PluginStatus[]> = () => Promise.resolve([NOT_INSTALLED])
 const installs: string[] = []
 /** A read that never lands, so whatever is on screen came from the cache. */
 const pending = () => new Promise<PluginStatus[]>(() => {})
 
+const updates: string[] = []
+/** What the machine looks like once an install has run. Swapped per test. */
+let installed: () => void = () => {}
+
 vi.mock("@/lib/rpc", () => ({
   AgentPlugin: {
     Status: () => status(),
     Install: (provider: string) => {
       installs.push(provider)
+      installed()
       return Promise.resolve(null)
     },
-    Update: () => Promise.resolve(null),
+    Update: (provider: string) => {
+      updates.push(provider)
+      return Promise.resolve(null)
+    },
   },
 }))
 
@@ -62,6 +78,8 @@ function click(label: string): void {
 beforeEach(() => {
   clearRemoteCache()
   installs.length = 0
+  updates.length = 0
+  installed = () => {}
   status = () => Promise.resolve([NOT_INSTALLED])
 })
 
@@ -111,10 +129,41 @@ describe("the plugin pane", () => {
     await mounted.unmount()
   })
 
+  // The filed answer draws the row, so the button can be offering something
+  // that has already happened — or, here, something that cannot: the plugin was
+  // removed from a terminal, and the cached row still offers its update. The
+  // click re-asks before it acts, and installs what the fresh row is missing.
+  it("acts on the fresh row, not the filed one the button was drawn from", async () => {
+    status = () => Promise.resolve([OUTDATED])
+    const first = await mountBudget(createElement(PluginSetting))
+    await first.act(() => {})
+    await first.unmount()
+
+    // This visit's read never lands, so the row on screen is the filed one and
+    // the button under the pointer is the one the cache drew.
+    status = pending
+    const second = await mountBudget(createElement(PluginSetting))
+    expect(text()).toContain("Update to v0.9.0")
+
+    // What the terminal did in the meantime, answered to the click's own read.
+    status = () => Promise.resolve([NOT_INSTALLED])
+    await second.act(() => click("Update to v0.9.0"))
+
+    expect(installs).toEqual(["claude"])
+    expect(updates).toEqual([])
+    expect(text()).toContain("Install")
+    await second.unmount()
+  })
+
   it("re-reads after an install and files what it read", async () => {
     const mounted = await mountBudget(createElement(PluginSetting))
     await mounted.act(() => {})
-    status = () => Promise.resolve([INSTALLED])
+    // Turned by the install itself rather than before the click: the click
+    // re-reads first, and a machine that already had the plugin is the case
+    // above — not the one where installing is what put it there.
+    installed = () => {
+      status = () => Promise.resolve([INSTALLED])
+    }
 
     await mounted.act(() => click("Install"))
 

--- a/frontend/src/components/settings/PluginSetting.tsx
+++ b/frontend/src/components/settings/PluginSetting.tsx
@@ -39,11 +39,37 @@ export function PluginSetting() {
   })
 
   const run = async (call: () => Promise<null>, progress: string, done: string, failed: string) => {
-    setBusy(true)
     if (await runWithToast(progress, call, done, failed)) {
       // The filed answer is replaced by this read, so the next visit shows what
-      // the install just changed rather than the rows it changed away from.
+      // the action just changed rather than the rows it changed away from.
       await refresh()
+    }
+  }
+
+  // What the button under the pointer is really for. The row is drawn from a
+  // filed answer, so a plugin installed or removed from a terminal while the
+  // user was elsewhere offers the wrong thing until this visit's read lands:
+  // the click re-asks first and acts on the row that comes back, so an Update
+  // on a plugin since removed installs it instead, and an Install of one that
+  // is already there only repaints. Verify before acting, never before showing
+  // — the rows go on painting from the cache, and only the click pays a read.
+  const act = async (provider: string, name: string) => {
+    setBusy(true)
+    const fresh = (await refresh())?.find((row) => row.provider === provider)
+    if (fresh?.available && !fresh.installed) {
+      await run(
+        () => AgentPlugin.Install(provider),
+        `Installing lich plugin for ${name}…`,
+        `Plugin installed — ${RESTART_HINT}`,
+        "Install failed",
+      )
+    } else if (fresh?.installed && fresh.updateAvailable) {
+      await run(
+        () => AgentPlugin.Update(provider),
+        `Updating lich plugin for ${name}…`,
+        `Plugin updated — ${RESTART_HINT}`,
+        "Update failed",
+      )
     }
     setBusy(false)
   }
@@ -86,14 +112,7 @@ export function PluginSetting() {
             {status.available && !status.installed && (
               <Button
                 size="sm"
-                onClick={() =>
-                  void run(
-                    () => AgentPlugin.Install(status.provider),
-                    `Installing lich plugin for ${status.name}…`,
-                    `Plugin installed — ${RESTART_HINT}`,
-                    "Install failed",
-                  )
-                }
+                onClick={() => void act(status.provider, status.name)}
                 disabled={busy}
               >
                 {busy ? spinner : null}
@@ -104,14 +123,7 @@ export function PluginSetting() {
               <Button
                 size="sm"
                 variant="outline"
-                onClick={() =>
-                  void run(
-                    () => AgentPlugin.Update(status.provider),
-                    `Updating lich plugin for ${status.name}…`,
-                    `Plugin updated — ${RESTART_HINT}`,
-                    "Update failed",
-                  )
-                }
+                onClick={() => void act(status.provider, status.name)}
                 disabled={busy}
               >
                 {busy ? spinner : null}

--- a/frontend/src/lib/git/use-checkouts.ts
+++ b/frontend/src/lib/git/use-checkouts.ts
@@ -16,9 +16,14 @@ const NO_CHECKOUTS: Worktree[] = []
 // through refresh() right after this screen creates one itself. An error yields
 // an empty list: the worst it costs is a checkout attempt that gh refuses with
 // its own message, which is why the error itself is dropped here.
+//
+// refresh answers with the list it read, and that is what an action must use.
+// The filed answer paints the button, so it may be a round trip behind a
+// checkout removed from a terminal; deciding what the click *does* on a fresh
+// read is what keeps "Go to session" from pointing at a directory that is gone.
 export function useCheckouts(projectPath: string): {
   checkouts: Worktree[]
-  refresh: () => void
+  refresh: () => Promise<Worktree[]>
 } {
   const { data, refresh } = useRemoteResource(
     projectPath,

--- a/frontend/src/lib/use-remote-resource.test.tsx
+++ b/frontend/src/lib/use-remote-resource.test.tsx
@@ -249,7 +249,7 @@ describe("refresh", () => {
     const frames: Frame[] = []
     let land: (value: string) => void = () => {}
     let failing = false
-    let again: () => Promise<void> = () => Promise.resolve()
+    let again: () => Promise<string> = () => Promise.resolve("")
 
     function Probe() {
       const load = () =>
@@ -268,23 +268,31 @@ describe("refresh", () => {
 
     const mounted = await mountBudget(createElement(StrictMode, null, createElement(Probe)))
 
-    let settled = false
-    const asked = again().then(() => {
-      settled = true
+    let settled = ""
+    const asked = again().then((value) => {
+      settled = value
     })
     await mounted.act(() => {})
     // Still out: the promise stands for the round trip, not for the call.
-    expect(settled).toBe(false)
+    expect(settled).toBe("")
     await mounted.act(() => land("answer"))
     await asked
-    expect(settled).toBe(true)
+    // What it read, not just that it read: an action decides on this value
+    // rather than on the `data` its own render closed over.
+    expect(settled).toBe("answer")
 
     failing = true
     // Deliberately not caught. A refresh that rejected would fail the run here,
     // and the caller waiting to read `error` would never run at all.
-    await mounted.act(async () => await again())
+    let onFailure = "unset"
+    await mounted.act(async () => {
+      onFailure = await again()
+    })
 
     expect(frames[frames.length - 1]?.error).toContain("offline")
+    // The same fallback the failure put on screen, so a click still has
+    // something to act on rather than a thrown call it has to guard.
+    expect(onFailure).toBe("")
     await mounted.unmount()
   })
 })

--- a/frontend/src/lib/use-remote-resource.ts
+++ b/frontend/src/lib/use-remote-resource.ts
@@ -8,12 +8,18 @@ export interface RemoteResource<T> {
   data: T
   loading: boolean
   error: string | null
-  /** Run the lookup again. The promise settles once the answer is in `data` or
-   * the failure in `error`, and never rejects — a caller that only wants the
-   * refetch ignores it, and one that reports an outcome ("Checked." against
-   * "Check failed") awaits it and then reads `error`, which is where the
-   * failure went. */
-  refresh: () => Promise<void>
+  /** Run the lookup again, answering with what it read. The promise settles
+   * once that answer is in `data` or the failure in `error`, and never rejects
+   * — a caller that only wants the refetch ignores it, and one that reports an
+   * outcome ("Checked." against "Check failed") awaits it and then reads
+   * `error`, which is where the failure went.
+   *
+   * The value is what makes a *click* safe on a screen painted from a filed
+   * answer: the render goes on drawing the cached one, and the action re-asks
+   * here and decides on what comes back rather than on what is on screen. A
+   * failed read answers with the same fallback it puts in `data`, so there is
+   * always something to act on. */
+  refresh: () => Promise<T>
 }
 
 export interface RemoteResourceOptions<T> {
@@ -87,13 +93,13 @@ export function useRemoteResource<T>(
   const emptyRef = useRef(empty)
   emptyRef.current = empty
 
-  const refresh = useCallback((): Promise<void> => {
+  const refresh = useCallback((): Promise<T> => {
     if (!key) {
       seq.current++
       setData(emptyRef.current)
       setError(null)
       setLoading(false)
-      return Promise.resolve()
+      return Promise.resolve(emptyRef.current)
     }
     const mine = ++seq.current
     // A request whose last answer is in hand revalidates underneath: the screen
@@ -113,20 +119,25 @@ export function useRemoteResource<T>(
         if (cache) {
           writeRemoteCache(cache, result)
         }
-        if (mine !== seq.current) return
+        if (mine !== seq.current) return result
         setData(result)
         setError(null)
+        return result
       })
-      .catch((err: unknown) => {
-        if (mine !== seq.current) return
+      .catch((err: unknown): T => {
         // The filed answer is left standing, on the screen as well as in the
         // cache: a lookup that failed says nothing about the last one that
         // worked, and a caller that keeps its answers would otherwise blank a
         // pane it is about to paint again on the next visit. Everyone else
         // falls back to empty, where a stale readout has nothing to stand on.
+        // It is also what the caller is handed back, superseded or not: an
+        // action that asked for this read still has to be given an answer.
         const filed = cache ? readRemoteCache<T>(cache) : undefined
-        setData(filed ?? emptyRef.current)
+        const fallback = filed ?? emptyRef.current
+        if (mine !== seq.current) return fallback
+        setData(fallback)
         setError(errorText(err))
+        return fallback
       })
       .finally(() => {
         if (mine === seq.current) setLoading(false)


### PR DESCRIPTION
Every other `cache` on these screens decides what is *shown*, where a value one round trip old is only ever a stale label. Two of them decided what a button *does*:

- `Pulls.tsx` asked the filed checkout list whether the pull request's head branch was already checked out, and the answer picked between reusing a session and creating a worktree. A checkout removed from a terminal while the user was on another screen therefore offered "Go to session" for a directory that was gone.
- `PluginSetting`'s cached row on Settings › Updates offered an Install that had already happened, or an Update for a plugin no longer installed, until that visit's read landed.

## The fix

`useRemoteResource`'s `refresh` now answers with what it read. That value is the one thing a click needs and a render never has: the row keeps painting from the filed answer, and the action re-asks and decides on what comes back. A failed read answers with the same fallback it puts in `data`, so there is always something to act on.

**Verify before acting, never before showing.** A gone checkout falls through to the create-worktree path with the same gesture; a plugin row that changed underneath takes the action it actually needs. Every other `cache`-driven action reaches for the same promise, so the next one added to a button has a path.

## Tests

- `pulls-open-session.test.tsx` (new): a cached "checked out" whose checkout is gone, with the mount's read still in flight, creates a worktree on click and never reaches the session flows; the checkout that is still there is still reused. Both fail against the old `checkedOut` read.
- `PluginSetting.test.tsx`: a cached installed row against a fresh not-installed one installs on click rather than updating. The existing "re-reads after an install" case now turns the machine's state from the install itself, since the click re-reads first.
- `use-remote-resource.test.tsx`: `refresh` settles on the answer it read, and on the fallback when the read failed.

Existing tests for the cached paint stay as they were.

`docs/ceilings.md` loses the bullet outright.

## Gate

`biome ci .` exit 0 · `vitest run` 138 files / 1636 tests green · `tsc -b` and `vite build` clean. No Go touched.