### PR TITLE
fix: find a parked session by its branch, and say when the page was cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The palette's History tab now finds a parked session by its branch, and says
+  when it held back rows.** The search ran over a session's name, its project and
+  its path while the branch was read from git afterwards, so a row showing
+  `feat/relay-inbox` could not be found by typing that - the one thing on the row
+  most people go looking by. The branch is now recorded when a session is parked
+  and searched with the rest, and a term matching more parked sessions than one
+  page holds says `100 of 143` over the group instead of presenting the page as
+  the whole answer. Sessions parked before this version carry no branch until
+  they are parked again.
 - **A split's dragged pane sizes now come back when the grid does.** How many
   panes sit across follows the window, so collapsing the sidebar, opening the
   dock or moving to another monitor reshapes the wall - and the sizes you had

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -626,15 +626,10 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   cask's `depends_on` and the bundle's `LSMinimumSystemVersion` say 13.0 because the compiler does —
   both move with the next Go bump, and a machine below the floor is refused by Homebrew rather than
   by a crash.
-- **The History tab searches names, and the branch on every row is not one** (`internal/store/store.go`,
-  `frontend/src/lib/session/use-history-search.ts`): the search runs in the store, which holds a parked
-  session's name, its project's and its path — the branch is read out of git afterwards, for the rows the
-  search already kept. So a row that shows `feat/relay-inbox` cannot be found by typing that, and the tab
-  answers a branch the user is reading off the screen with nothing at all. A term that matches more than a
-  hundred parked sessions is cut to the hundred closed most recently, and nothing says the list was cut.
 - **The history's branch is read live, so a row whose checkout is gone has none** (`internal/project.BranchesOf`):
-  the branch is not stored — a worktree keeps the name it was created with while an agent moves the branch
-  inside it, so the directory cannot answer and only git can. The batch runs once per settled search, which
+  the branch a row shows is not the one it stores — a worktree keeps the name it was created with while an
+  agent moves the branch inside it, so the stored snapshot dates the close and only git can say what the
+  checkout is on now, which is what the row draws. The batch runs once per settled search, which
   also means a branch that moved while the palette is up is stale until the query changes or the palette is
   reopened. A checkout removed behind lich's back has no branch to read and no session to resume: that row
   says `checkout gone` and offers to forget

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -93,7 +93,7 @@ export function CommandPalette() {
 
   // The parked sessions are searched in the store rather than filtered here, so
   // the History tab reaches a session parked further back than one page of it.
-  const { rows: history, forget: dropParked } = useHistorySearch(query, open)
+  const { rows: history, total: historyTotal, forget: dropParked } = useHistorySearch(query, open)
 
   // Forgetting drops the row from the list in place rather than closing the
   // palette: the whole point of the action is that there are usually several of
@@ -126,7 +126,10 @@ export function CommandPalette() {
   // the name-matched groups (it is a disk read behind a debounce), so it is
   // listed last and never moves a row the user is already aiming at.
   const messages = useTranscriptSearch(query, all, open)
-  const groups = useMemo(() => paletteGroups(tab, results, messages), [tab, results, messages])
+  const groups = useMemo(
+    () => paletteGroups(tab, results, messages, historyTotal),
+    [tab, results, messages, historyTotal],
+  )
   const counts = useMemo(
     () => PALETTE_TABS.map((t) => paletteTabCount(t, results, messages)),
     [results, messages],

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -358,8 +358,7 @@ export interface StoredSession {
 
 /** internal/store.ClosedSession — one parked session offered for resuming. What
  * identifies it in a list somebody is browsing: the project rides along because
- * history spans every project at once, closed ones included. No branch — it
- * lives in git and the window reads it off the checkout (ProjectService.Branches). */
+ * history spans every project at once, closed ones included. */
 export interface ClosedSession {
   id: string
   projectId: string
@@ -370,9 +369,23 @@ export interface ClosedSession {
   label: string
   kind: string
   path: string
+  /** The branch the checkout was on when the session was parked, "" for a row
+   * parked before lich recorded one. It is the searchable snapshot — the store
+   * matches it in SQL — and never what the row shows: the branch on screen is
+   * read live off the checkout (ProjectService.BranchesOf), because a branch
+   * moves inside a worktree while the directory keeps its name. */
+  parkedBranch: string
   /** Unix seconds; 0 for a row parked before lich recorded the close, which
    * sorts last and is drawn as no date rather than as 1970. */
   closedAt: number
+}
+
+/** internal/store.ClosedHistory — one page of parked sessions and the size of
+ * the match it was cut from, so a list holding the store's cap can say so
+ * instead of presenting it as the whole answer. */
+export interface ClosedHistory {
+  sessions: ClosedSession[]
+  total: number
 }
 
 /** internal/terminal.TranscriptMatch — a session whose conversation mentions a

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -11,7 +11,7 @@ import type {
   BaseStatus,
   BinaryCheck,
   BranchRules,
-  ClosedSession,
+  ClosedHistory,
   LastSaid,
   LastTurn,
   Branches,
@@ -403,10 +403,12 @@ export const Store = {
   ReopenWorktreeSession: (projectID: string, path: string, newSessionID: string) =>
     call<StoredSession | null>("store.ReopenWorktreeSession", [projectID, path, newSessionID]),
   /** The parked sessions matching `term`, last closed first — the history the
-   * palette browses. Every word of the term must appear in the session's name,
-   * its project's name or its path; an empty term is the plain history. The
-   * search runs in the query, so it reaches past the page this answers with. */
-  ClosedSessions: (term: string) => call<ClosedSession[] | null>("store.ClosedSessions", [term]),
+   * palette browses — with how many matched in all, so a page cut at the store's
+   * cap can say so. Every word of the term must appear in the session's name,
+   * its project's name, its path or the branch it was parked on; an empty term
+   * is the plain history. The search runs in the query, so it reaches past the
+   * page this answers with. */
+  ClosedSessions: (term: string) => call<ClosedHistory | null>("store.ClosedSessions", [term]),
   /** Resume one parked session by its own id, or null when it is no longer
    * parked — another window resumed it, or its worktree was removed. */
   ReopenSession: (sessionID: string, newSessionID: string) =>

--- a/frontend/src/lib/session/command-palette.test.ts
+++ b/frontend/src/lib/session/command-palette.test.ts
@@ -277,6 +277,7 @@ const parked: ClosedSession[] = [
     label: "Wire the relay inbox",
     kind: "claude",
     path: "/home/u/wt/lich/relay-inbox",
+    parkedBranch: "feat/relay-inbox",
     closedAt: 1_700_000_200,
   },
   {
@@ -287,6 +288,9 @@ const parked: ClosedSession[] = [
     label: "Conpty handle recycling",
     kind: "claude",
     path: "/home/u/wt/lich/conpty",
+    // Parked on one branch, sitting on another now: the checkout moved on after
+    // the close, which is the disagreement the two fields exist to hold.
+    parkedBranch: "fix/conpty-first-try",
     closedAt: 1_700_000_100,
   },
   {
@@ -297,6 +301,7 @@ const parked: ClosedSession[] = [
     label: "vitest --ui",
     kind: "shell",
     path: "/home/u/wt/revu/gone",
+    parkedBranch: "chore/vitest-ui",
     closedAt: 1_700_000_000,
   },
 ]
@@ -334,6 +339,16 @@ describe("history search", () => {
   it("narrows on the branch, which the path cannot stand in for", () => {
     const hit = filterPalette("conpty-handle", [], [], [], rows).history
     expect(hit.map((h) => h.id)).toEqual(["h2"])
+  })
+
+  it("narrows on the parked branch too, which is the one the store matched", () => {
+    // h2's checkout has moved since it was parked, so the term the store found
+    // it by is not the branch on screen — and the filter must not drop the row
+    // the store just answered with.
+    expect(filterPalette("first-try", [], [], [], rows).history.map((h) => h.id)).toEqual(["h2"])
+    // h3's checkout is gone, so git names no branch at all and the snapshot is
+    // the only branch that row has.
+    expect(filterPalette("vitest-ui", [], [], [], rows).history.map((h) => h.id)).toEqual(["h3"])
   })
 
   it("narrows on the label, the project and the path too", () => {
@@ -378,6 +393,21 @@ describe("the History tab", () => {
   it("draws no group at all when nothing has ever been closed", () => {
     const none = filterPalette("", [], projects, closed, [])
     expect(paletteGroups("History", none, [])).toEqual([])
+  })
+
+  it("says how many matched when the store cut the page", () => {
+    // The rows in hand are one page; the number beside them is the whole match,
+    // which is what the header turns into "3 of 143".
+    const group = paletteGroups("History", results, [], 143)[0]
+    expect(group?.rows).toHaveLength(3)
+    expect(group?.total).toBe(143)
+  })
+
+  it("reports its own rows when nothing was cut", () => {
+    // total === rows.length is what the header reads as "not cut" — and a count
+    // that arrived stale, behind the rows, must never claim less than is drawn.
+    expect(paletteGroups("History", results, [], 3)[0]?.total).toBe(3)
+    expect(paletteGroups("History", results, [], 0)[0]?.total).toBe(3)
   })
 })
 

--- a/frontend/src/lib/session/command-palette.ts
+++ b/frontend/src/lib/session/command-palette.ts
@@ -57,9 +57,11 @@ export function matchesQuery(haystack: string, query: string): boolean {
 }
 
 // PaletteHistory is one parked session as the History tab lists it: the store's
-// row plus the branch its checkout is on, which lives in git and not in the row
-// (internal/store.ClosedSession). Both are "" for a checkout that is gone —
-// which is also the row that cannot be resumed, so one absence explains both.
+// row plus the branch its checkout is on *now*, read from git. That is not the
+// row's `parkedBranch`, which is the snapshot the close recorded for the search
+// to match — a branch moves inside a checkout, so only git can say what the row
+// shows. `branch` is "" for a checkout that is gone, which is also the row that
+// cannot be resumed, so one absence explains both.
 export interface PaletteHistory extends ClosedSession {
   branch: string
   /** The checkout is no longer on disk: this row forgets rather than resumes. */
@@ -106,12 +108,12 @@ export function filterPalette(
     ),
     projects: projects.filter((p) => matchesQuery(`${p.name} ${p.path}`, query)),
     closed: closed.filter((p) => matchesQuery(`${p.name} ${p.path}`, query)),
-    // The branch is in the haystack because it is what a user remembers a piece
-    // of work by, and it is the one part of the row the path cannot stand in
-    // for: a worktree keeps the name it was created with while the branch moves
-    // on (lib/git/checkout-label.ts).
+    // Both branches are in the haystack because they can disagree: the store
+    // matched the one it recorded at the close, and the row shows the one git
+    // reads now. Filtering on either alone would drop a row the other half of
+    // the search kept.
     history: history.filter((h) =>
-      matchesQuery(`${h.label} ${h.projectName} ${h.branch} ${h.path}`, query),
+      matchesQuery(`${h.label} ${h.projectName} ${h.branch} ${h.parkedBranch} ${h.path}`, query),
     ),
   }
 }
@@ -232,10 +234,15 @@ function group(label: string, rows: PaletteRow[], cap: number): PaletteGroup {
   return { label, rows: cap > 0 ? rows.slice(0, cap) : rows, total: rows.length }
 }
 
+// historyTotal is how many parked sessions matched the query in the store, which
+// is more than `results.history` holds whenever the store's page cut it. It
+// defaults to 0 for the callers that do not ask the store at all — the tests and
+// the tabs that list nothing parked — and the group falls back to its own rows.
 export function paletteGroups(
   tab: PaletteTab,
   results: PaletteResults,
   messages: readonly PaletteMessage[],
+  historyTotal = 0,
 ): PaletteGroup[] {
   const sessions = results.sessions.map((session): PaletteRow => ({ kind: "session", session }))
   const open = results.projects.map((project): PaletteRow => ({ kind: "project", project }))
@@ -252,7 +259,14 @@ export function paletteGroups(
       case "Messages":
         return [group("Messages", said, 0)]
       case "History":
-        return [group("Closed sessions", history, 0)]
+        // The cut this header reports happened in the store, not in the slice
+        // above: the query matched more parked sessions than one page carries.
+        return [
+          {
+            ...group("Closed sessions", history, 0),
+            total: Math.max(historyTotal, history.length),
+          },
+        ]
       // No closed projects or closed sessions here: bringing one back is not
       // what the palette is reached for mid-work, and the rows it costs are
       // rows the sessions and the open projects are cut to make room for. Their

--- a/frontend/src/lib/session/use-history-search.test.tsx
+++ b/frontend/src/lib/session/use-history-search.test.tsx
@@ -26,21 +26,27 @@ function row(id: string, label: string): ClosedSession {
     label,
     kind: "claude",
     path: `/wt/${id}`,
+    parkedBranch: `parked/${id}`,
     closedAt: 1_700_000_000,
   }
 }
 
 // The fake store searches by name so the test can tell a backend search from a
 // window filter: only "old" is answered for a term, and it is never in the list
-// the empty term returns.
+// the empty term returns. Its totals are larger than its pages, which is the
+// shape the real store answers a term matching more than one page in.
 vi.mock("@/lib/rpc", () => ({
   Store: {
     ClosedSessions: (term: string) => {
       terms.push(term)
       if (term === "") {
-        return Promise.resolve([row("s1", "recent work")])
+        return Promise.resolve({ sessions: [row("s1", "recent work")], total: 7 })
       }
-      return Promise.resolve(term.includes("old") ? [row("old", "the oldest work")] : [])
+      const hit = term.includes("old")
+      return Promise.resolve({
+        sessions: hit ? [row("old", "the oldest work")] : [],
+        total: hit ? 42 : 0,
+      })
     },
   },
   ProjectService: {
@@ -64,11 +70,16 @@ function last<T>(frames: T[]): T | undefined {
   return frames[frames.length - 1]
 }
 
-function probe(frames: PaletteHistory[][], forgets: ((id: string) => void)[]) {
+function probe(
+  frames: PaletteHistory[][],
+  forgets: ((id: string) => void)[],
+  totals: number[] = [],
+) {
   return function Probe({ query, enabled }: { query: string; enabled: boolean }) {
-    const { rows, forget } = useHistorySearch(query, enabled)
+    const { rows, total, forget } = useHistorySearch(query, enabled)
     useLayoutEffect(() => {
       frames.push(rows)
+      totals.push(total)
       forgets.push(forget)
     })
     return null
@@ -154,17 +165,64 @@ describe("useHistorySearch", () => {
   it("drops a forgotten row without asking the store again", async () => {
     const frames: PaletteHistory[][] = []
     const forgets: ((id: string) => void)[] = []
-    const Probe = probe(frames, forgets)
+    const totals: number[] = []
+    const Probe = probe(frames, forgets, totals)
     const budget = await mountBudget(
       createElement(StrictMode, null, createElement(Probe, { query: "", enabled: true })),
     )
     await budget.act(settled)
+    expect(last(totals)).toBe(7)
 
     await budget.act(() => {
       last(forgets)?.("s1")
     })
     expect(last(frames)).toEqual([])
     expect(terms).toEqual([""])
+    // The count comes down with the row, so a page that was never cut does not
+    // start claiming it was.
+    expect(last(totals)).toBe(6)
+    await budget.unmount()
+  })
+
+  it("carries the whole match count beside the page it got", async () => {
+    const frames: PaletteHistory[][] = []
+    const totals: number[] = []
+    const Probe = probe(frames, [], totals)
+    const budget = await mountBudget(
+      createElement(StrictMode, null, createElement(Probe, { query: "old", enabled: true })),
+    )
+    await budget.act(settled)
+
+    // One row in hand, 42 matched: without the second number the list would
+    // present its page as the whole answer.
+    expect((last(frames) ?? []).map((r) => r.id)).toEqual(["old"])
+    expect(last(totals)).toBe(42)
+    await budget.unmount()
+  })
+
+  it("counts nothing while the palette is closed", async () => {
+    const totals: number[] = []
+    const Probe = probe([], [], totals)
+    const budget = await mountBudget(
+      createElement(StrictMode, null, createElement(Probe, { query: "old", enabled: false })),
+    )
+    await budget.act(settled)
+
+    expect(last(totals)).toBe(0)
+    await budget.unmount()
+  })
+
+  it("keeps the branch the store matched on the row, beside the one git named", async () => {
+    const frames: PaletteHistory[][] = []
+    const Probe = probe(frames, [])
+    const budget = await mountBudget(
+      createElement(StrictMode, null, createElement(Probe, { query: "", enabled: true })),
+    )
+    await budget.act(settled)
+
+    const rows = last(frames) ?? []
+    expect(rows[0].branch).toBe("branch/wt/s1")
+    expect(rows[0].parkedBranch).toBe("parked/s1")
     await budget.unmount()
   })
 })

--- a/frontend/src/lib/session/use-history-search.ts
+++ b/frontend/src/lib/session/use-history-search.ts
@@ -12,11 +12,14 @@ const DEBOUNCE_MS = 200
 // joins them to what git and the filesystem say about their checkouts. Idle —
 // no rows, no calls — while the palette is closed.
 //
-// The term goes to the backend rather than filtering rows already in hand: the
-// store answers with one page, so a session parked further back than that page
-// is only reachable if the match happens in the query. The palette's own filter
-// still runs over what comes back, which is what narrows by branch — the one
-// part of a row that is not in the database.
+// `total` is how many sessions matched in all, which is not how many came back:
+// the store answers with one page, and the list needs the number to say it was
+// cut rather than present the page as the whole answer.
+//
+// The term goes to the backend rather than filtering rows already in hand, for
+// that same page: a session parked further back than it is only reachable if the
+// match happens in the query. The palette's own filter still runs over what
+// comes back.
 //
 // An empty query skips the debounce: it is the list the palette opens with, and
 // nothing was typed to wait out. Every effect run supersedes the one before it,
@@ -25,25 +28,28 @@ const DEBOUNCE_MS = 200
 export function useHistorySearch(
   query: string,
   enabled: boolean,
-): { rows: PaletteHistory[]; forget: (sessionID: string) => void } {
+): { rows: PaletteHistory[]; total: number; forget: (sessionID: string) => void } {
   const [parked, setParked] = useState<readonly ClosedSession[]>([])
+  const [total, setTotal] = useState(0)
   const [branches, setBranches] = useState<Readonly<Record<string, string>>>({})
   const [missing, setMissing] = useState<ReadonlySet<string>>(new Set())
 
   useEffect(() => {
     if (!enabled) {
       setParked([])
+      setTotal(0)
       return
     }
     let live = true
     const timer = window.setTimeout(
       () => {
-        void Store.ClosedSessions(query).then((parkedRows) => {
-          const history = parkedRows ?? []
+        void Store.ClosedSessions(query).then((answer) => {
+          const history = answer?.sessions ?? []
           if (!live) {
             return
           }
           setParked(history)
+          setTotal(answer?.total ?? 0)
           // Asked for after the rows are up: what git and the filesystem say is
           // what a row says about itself, and a failed check must not cost the
           // palette its entries.
@@ -75,12 +81,15 @@ export function useHistorySearch(
 
   // Forgetting drops the row in place rather than refetching: the list stays up
   // while several stale rows are cleared, which is how they are usually left.
+  // The match count comes down with it, or a page that was never cut would start
+  // claiming it was after a few rows were dropped from it.
   const forget = useCallback((sessionID: string) => {
     setParked((rows) => rows.filter((row) => row.id !== sessionID))
+    setTotal((matched) => Math.max(0, matched - 1))
   }, [])
 
   // Memoised because the rows are a dependency of the palette's own filter:
   // a fresh array every render would re-filter every group on every keystroke.
   const rows = useMemo(() => historyRows(parked, branches, missing), [parked, branches, missing])
-  return { rows, forget }
+  return { rows, total, forget }
 }

--- a/internal/spawn/park_test.go
+++ b/internal/spawn/park_test.go
@@ -82,11 +82,11 @@ func listed(t *testing.T, rows *store.Service, id string) (open, history bool) {
 			}
 		}
 	}
-	closed, err := rows.ClosedSessions("")
+	parked, err := rows.ClosedSessions("")
 	if err != nil {
 		t.Fatalf("ClosedSessions: %v", err)
 	}
-	for _, sess := range closed {
+	for _, sess := range parked.Sessions {
 		if sess.ID == id {
 			history = true
 		}
@@ -171,10 +171,11 @@ func TestAParkedSessionIsFoundInTheHistoryWithItsName(t *testing.T) {
 		t.Fatalf("Close alone: %v", err)
 	}
 
-	closed, err := rows.ClosedSessions("")
+	history, err := rows.ClosedSessions("")
 	if err != nil {
 		t.Fatalf("ClosedSessions: %v", err)
 	}
+	closed := history.Sessions
 	found := map[string]store.ClosedSession{}
 	for _, sess := range closed {
 		found[sess.ID] = sess

--- a/internal/store/history_test.go
+++ b/internal/store/history_test.go
@@ -32,10 +32,7 @@ func TestClosedSessionsOrdersByCloseNotByInsert(t *testing.T) {
 	atClock(t, time.Unix(1_700_000_100, 0), func() { _ = svc.CloseSession("p1", "second", "keep") })
 	atClock(t, time.Unix(1_700_000_200, 0), func() { _ = svc.CloseSession("p1", "first", "keep") })
 
-	closed, err := svc.ClosedSessions("")
-	if err != nil {
-		t.Fatalf("ClosedSessions: %v", err)
-	}
+	closed := mustClosed(t, svc, "")
 	if len(closed) != 2 {
 		t.Fatalf("got %d closed sessions, want 2", len(closed))
 	}
@@ -57,7 +54,7 @@ func TestClosedSessionsIdentifiesEachRow(t *testing.T) {
 	_ = svc.AddSession("p1", "gone", "Wire the relay inbox", "shell", "/wt/relay", 3, "")
 	atClock(t, time.Unix(1_700_000_000, 0), func() { _ = svc.CloseSession("p1", "gone", "keep") })
 
-	closed, _ := svc.ClosedSessions("")
+	closed := mustClosed(t, svc, "")
 	if len(closed) != 1 {
 		t.Fatalf("got %d closed sessions, want 1", len(closed))
 	}
@@ -80,10 +77,7 @@ func TestClosedSessionsSkipsOpenOnes(t *testing.T) {
 	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
 	_ = svc.AddSession("p1", "live", "Session 1", "claude", "", 2, "")
 
-	closed, err := svc.ClosedSessions("")
-	if err != nil {
-		t.Fatalf("ClosedSessions: %v", err)
-	}
+	closed := mustClosed(t, svc, "")
 	if len(closed) != 0 {
 		t.Errorf("closed = %+v, want none while the only session is open", closed)
 	}
@@ -100,7 +94,7 @@ func TestClosedSessionsIncludesClosedProjects(t *testing.T) {
 	_ = svc.CloseSession("p1", "old", "keep")
 	_ = svc.CloseProject("p1")
 
-	closed, _ := svc.ClosedSessions("")
+	closed := mustClosed(t, svc, "")
 	if len(closed) != 1 || closed[0].ProjectName != "alpha" {
 		t.Errorf("closed = %+v, want the session of the closed project, named", closed)
 	}
@@ -121,7 +115,7 @@ func TestClosedSessionsCapsTheList(t *testing.T) {
 		})
 	}
 
-	closed, _ := svc.ClosedSessions("")
+	closed := mustClosed(t, svc, "")
 	if len(closed) != 100 {
 		t.Errorf("got %d closed sessions, want the list capped at 100", len(closed))
 	}
@@ -162,7 +156,7 @@ func TestReopenSessionRestoresByID(t *testing.T) {
 	if len(projects) != 1 || len(projects[0].Sessions) != 2 {
 		t.Fatalf("sessions after resume = %+v, want the kept one and the resumed one", projects)
 	}
-	closed, _ := svc.ClosedSessions("")
+	closed := mustClosed(t, svc, "")
 	if len(closed) != 0 {
 		t.Errorf("closed = %+v, want the resumed row out of the history", closed)
 	}
@@ -255,7 +249,7 @@ func TestReopenWorktreeSessionRefusesTheEmptyPath(t *testing.T) {
 		t.Errorf("ReopenWorktreeSession(path: \"\") = %+v, want nil", restored)
 	}
 	// And the parked root session is still there for its own door.
-	closed, _ := svc.ClosedSessions("")
+	closed := mustClosed(t, svc, "")
 	if len(closed) != 1 || closed[0].ID != "root" {
 		t.Errorf("closed = %+v, want the root session still parked", closed)
 	}
@@ -275,7 +269,7 @@ func TestForgetSessionRemovesOneParkedRow(t *testing.T) {
 	if err := svc.ForgetSession("dead"); err != nil {
 		t.Fatalf("ForgetSession: %v", err)
 	}
-	closed, _ := svc.ClosedSessions("")
+	closed := mustClosed(t, svc, "")
 	if len(closed) != 0 {
 		t.Errorf("closed = %+v, want the forgotten row gone", closed)
 	}
@@ -350,12 +344,8 @@ func TestClosedSessionsSearchesByName(t *testing.T) {
 	svc := searchStore(t)
 
 	for _, term := range []string{"relay", "RELAY", "ReLaY"} {
-		closed, err := svc.ClosedSessions(term)
-		if err != nil {
-			t.Fatalf("ClosedSessions(%q): %v", term, err)
-		}
 		// Newest first, the same order the unfiltered list is in.
-		if got := ids(closed); len(got) != 2 || got[0] != "s2" || got[1] != "s1" {
+		if got := ids(mustClosed(t, svc, term)); len(got) != 2 || got[0] != "s2" || got[1] != "s1" {
 			t.Errorf("ClosedSessions(%q) = %v, want [s2 s1]", term, got)
 		}
 	}
@@ -470,11 +460,121 @@ func TestEscapeLike(t *testing.T) {
 	}
 }
 
+// mustClosed is the history's rows alone, for the tests that are about the rows
+// and not about the count beside them.
 func mustClosed(t *testing.T, svc *Service, term string) []ClosedSession {
 	t.Helper()
-	closed, err := svc.ClosedSessions(term)
+	history, err := svc.ClosedSessions(term)
 	if err != nil {
 		t.Fatalf("ClosedSessions(%q): %v", term, err)
 	}
-	return closed
+	return history.Sessions
+}
+
+// TestCloseSessionRecordsTheBranch is what makes a branch searchable at all: the
+// history query runs in SQL over the row, so a branch nothing wrote down at the
+// close cannot be typed to find the row showing it.
+func TestCloseSessionRecordsTheBranch(t *testing.T) {
+	svc := newTestStore(t)
+	svc.SetBranchOf(func(path string) string {
+		return map[string]string{
+			"/wt/relay":  "feat/relay-inbox",
+			"/tmp/alpha": "main",
+		}[path]
+	})
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 1, "")
+	_ = svc.AddSession("p1", "wt", "worktree work", "claude", "/wt/relay", 2, "")
+	// No path of its own: this one runs in the project's directory, which is the
+	// checkout whose branch it is parked on.
+	_ = svc.AddSession("p1", "root", "root work", "claude", "", 3, "")
+	_ = svc.CloseSession("p1", "wt", "keep")
+	_ = svc.CloseSession("p1", "root", "keep")
+
+	branches := map[string]string{}
+	for _, row := range mustClosed(t, svc, "") {
+		branches[row.ID] = row.ParkedBranch
+	}
+	if branches["wt"] != "feat/relay-inbox" {
+		t.Errorf("worktree row branch = %q, want the checkout's own", branches["wt"])
+	}
+	if branches["root"] != "main" {
+		t.Errorf("project-root row branch = %q, want the project's", branches["root"])
+	}
+}
+
+// TestCloseSessionWithoutBranchWiringStillParks: reading the branch is a
+// convenience for the search, never a condition of parking. A store with no
+// seam — every test but the one above, and a lich whose wiring has not run —
+// parks the row with an empty branch and loses nothing else.
+func TestCloseSessionWithoutBranchWiringStillParks(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 1, "")
+	_ = svc.AddSession("p1", "wt", "work", "claude", "/wt/relay", 2, "")
+	if err := svc.CloseSession("p1", "wt", "keep"); err != nil {
+		t.Fatalf("CloseSession: %v", err)
+	}
+
+	closed := mustClosed(t, svc, "")
+	if len(closed) != 1 || closed[0].ParkedBranch != "" {
+		t.Errorf("closed = %+v, want the row parked with no branch", closed)
+	}
+}
+
+// TestClosedSessionsSearchesByBranch is the ceiling this column closed: the
+// branch is on screen and was the one part of a row no term could reach.
+func TestClosedSessionsSearchesByBranch(t *testing.T) {
+	svc := newTestStore(t)
+	svc.SetBranchOf(func(path string) string {
+		return map[string]string{"/wt/s1": "feat/relay-inbox", "/wt/s2": "fix/split-groups"}[path]
+	})
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 1, "")
+	park(t, svc, "s1", "one", 1_700_000_100)
+	park(t, svc, "s2", "two", 1_700_000_200)
+
+	// Nothing but the branch says "relay" — not the label, not the path.
+	if got := ids(mustClosed(t, svc, "relay-inbox")); len(got) != 1 || got[0] != "s1" {
+		t.Errorf(`ClosedSessions("relay-inbox") = %v, want [s1] by branch`, got)
+	}
+	// And the branch joins the rest of the haystack rather than replacing it.
+	if got := ids(mustClosed(t, svc, "split two")); len(got) != 1 || got[0] != "s2" {
+		t.Errorf(`ClosedSessions("split two") = %v, want [s2] by branch and label`, got)
+	}
+}
+
+// TestClosedSessionsCountsTheWholeMatch is what lets the list say it was cut: a
+// page of closedSessionLimit rows is otherwise indistinguishable from a match
+// that happened to be exactly that big.
+func TestClosedSessionsCountsTheWholeMatch(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "keep", "Session 1", "claude", "", 1, "")
+	for i := range closedSessionLimit + 5 {
+		park(t, svc, fmt.Sprintf("s%d", i), "work", int64(1_700_000_000+i))
+	}
+	park(t, svc, "odd", "something else", 1_700_100_000)
+
+	history, err := svc.ClosedSessions("work")
+	if err != nil {
+		t.Fatalf("ClosedSessions: %v", err)
+	}
+	if len(history.Sessions) != closedSessionLimit {
+		t.Errorf("rows = %d, want the page capped at %d", len(history.Sessions), closedSessionLimit)
+	}
+	if history.Total != closedSessionLimit+5 {
+		t.Errorf("Total = %d, want the whole match behind the page", history.Total)
+	}
+
+	// A match that fits reports itself, so the list has nothing to say was cut.
+	fits, _ := svc.ClosedSessions("something")
+	if len(fits.Sessions) != 1 || fits.Total != 1 {
+		t.Errorf("small match = %d rows, Total %d; want 1 and 1", len(fits.Sessions), fits.Total)
+	}
+	// And an empty history counts nothing rather than the page it did not fill.
+	none, _ := svc.ClosedSessions("nothing-matches-this")
+	if len(none.Sessions) != 0 || none.Total != 0 {
+		t.Errorf("empty match = %d rows, Total %d; want 0 and 0", len(none.Sessions), none.Total)
+	}
 }

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -226,17 +226,49 @@ func (s *Service) DeleteSession(projectID, sessionID, activeID string) error {
 //
 // closed_at is stamped in the same statement rather than after it: it is what
 // orders the history the parked row exists to appear in, and a row parked
-// without one sorts as if it had been closed before everything else.
+// without one sorts as if it had been closed before everything else. The branch
+// is stamped with it, and this is the only place it ever is — the history search
+// runs in SQL, so a branch nothing wrote down cannot be typed to find the row
+// showing it.
+//
+// git is asked before the transaction opens: the store holds a single
+// connection, and a subprocess run under the write lock stalls every other
+// caller for as long as git takes.
 func (s *Service) CloseSession(projectID, sessionID, activeID string) error {
+	branch := s.parkedBranch(sessionID)
 	return s.tx(func(tx *sql.Tx) error {
 		if _, err := tx.Exec(
-			`UPDATE sessions SET is_open = 0, closed_at = ? WHERE id = ?`,
-			now().Unix(), sessionID,
+			`UPDATE sessions SET is_open = 0, closed_at = ?, parked_branch = ? WHERE id = ?`,
+			now().Unix(), branch, sessionID,
 		); err != nil {
 			return fmt.Errorf("close session %q: %w", sessionID, err)
 		}
 		return setActiveSession(tx, projectID, activeID)
 	})
+}
+
+// parkedBranch names the branch of the checkout a session is running in, for the
+// row about to be parked. A session with no path of its own runs in its
+// project's directory, which is then the checkout to ask about.
+//
+// Every failure answers "": a store without the wiring, a session id nothing
+// matches, a directory git cannot name a branch for. None of them is worth
+// refusing a close over — the row loses the branch as a search term and keeps
+// everything else.
+func (s *Service) parkedBranch(sessionID string) string {
+	if s.branchOf == nil {
+		return ""
+	}
+	var path string
+	if err := s.db.QueryRow(
+		`SELECT CASE WHEN s.path <> '' THEN s.path ELSE p.path END
+		   FROM sessions s JOIN projects p ON p.id = s.project_id
+		  WHERE s.id = ?`,
+		sessionID,
+	).Scan(&path); err != nil || path == "" {
+		return ""
+	}
+	return s.branchOf(path)
 }
 
 // ForgetSession deletes one parked session for good. It is the way out for the

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -95,7 +95,15 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- provider's own config documents and this session's directory to reach, and
     -- the window needs it to divide a tool name two harnesses spell with a single
     -- underscore. Empty for a row nothing has spawned yet.
-    mcp_servers         TEXT NOT NULL DEFAULT ''
+    mcp_servers         TEXT NOT NULL DEFAULT '',
+    -- The branch this session's checkout was on when it was parked; empty while
+    -- it is open, and on a row parked before the column existed. It exists to be
+    -- searched: the history query runs in SQL over the row, and git is only
+    -- asked about the rows that query already kept. It is a snapshot of the
+    -- close and never a reading of now — the window still draws git's answer,
+    -- because a branch moves inside a checkout while the worktree keeps the name
+    -- it was created with.
+    parked_branch       TEXT NOT NULL DEFAULT ''
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
 
@@ -155,6 +163,8 @@ type Service struct {
 	// sessionGone, when set, is told the id of every session whose row is
 	// deleted for good. See SetSessionGone.
 	sessionGone func(sessionID string)
+	// branchOf, when set, names the git branch of a checkout. See SetBranchOf.
+	branchOf func(path string) string
 }
 
 // SetSessionGone registers what to run when a session's row is deleted for
@@ -179,6 +189,16 @@ func (s *Service) sessionIsGone(sessionIDs ...string) {
 	for _, id := range sessionIDs {
 		s.sessionGone(id)
 	}
+}
+
+// SetBranchOf registers how to read a checkout's git branch (project.Branch).
+// CloseSession stamps the answer on the row it parks, which is what makes the
+// branch searchable in the history query.
+//
+// It is startup wiring, called before anything serves. Without it a park records
+// no branch, which costs that row nothing but the branch as a search term.
+func (s *Service) SetBranchOf(fn func(path string) string) {
+	s.branchOf = fn
 }
 
 // Session is a persisted terminal session (metadata only). Kind selects what
@@ -308,6 +328,7 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN scheduled_prompt TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN unread INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN mcp_servers TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN parked_branch TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN closed_seq INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE session_costs ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0`,
@@ -470,11 +491,12 @@ func (s *Service) RecentProjects() ([]Recent, error) {
 // ones included, and the project name is what tells two sessions of the same
 // name apart.
 //
-// No branch: it lives in git, and a worktree's directory stops agreeing with it
-// the moment an agent branches inside the checkout, which is the ordinary way
-// to work in one (frontend/src/lib/git/checkout-label.ts). The window reads it
-// off the checkout instead, and a row whose checkout is gone has none to show —
-// which is the same row that cannot be resumed anyway.
+// Two answers about the branch, and they are different questions: ParkedBranch
+// is the snapshot this row was closed on, which is what the search matches, and
+// what the window draws is read live off the checkout, because a worktree's
+// directory stops agreeing with its branch the moment an agent branches inside
+// it (frontend/src/lib/git/checkout-label.ts). A row whose checkout is gone has
+// nothing live to show — which is the same row that cannot be resumed anyway.
 type ClosedSession struct {
 	ID          string `json:"id"`
 	ProjectID   string `json:"projectId"`
@@ -486,9 +508,20 @@ type ClosedSession struct {
 	Label       string `json:"label"`
 	Kind        string `json:"kind"`
 	Path        string `json:"path"`
+	// The branch the checkout was on at the close, empty for a row parked before
+	// lich recorded one. Searchable, not drawn.
+	ParkedBranch string `json:"parkedBranch"`
 	// Unix seconds, 0 for a row parked before closed_at existed — which sorts
 	// last and is drawn as no date rather than as 1970.
 	ClosedAt int64 `json:"closedAt"`
+}
+
+// ClosedHistory is one page of the parked-session history and the size of the
+// match it was cut from. Total is what lets the list say it was cut instead of
+// presenting closedSessionLimit rows as the whole answer.
+type ClosedHistory struct {
+	Sessions []ClosedSession `json:"sessions"`
+	Total    int             `json:"total"`
 }
 
 // closedSessionLimit caps the history handed to the window — how many rows one
@@ -519,25 +552,35 @@ func escapeLike(term string) string {
 // The term is matched here rather than in the window because the window only
 // ever sees one page of rows, and a session parked further back than that page
 // would be unfindable by name. Every whitespace-separated word must appear
-// somewhere in the name, the project's name or the path — the same reading the
-// palette's own filter gives a query, so narrowing here never drops a row that
-// filter would have kept. LIKE is case-insensitive for ASCII in SQLite, which
-// is what makes this a search and not a prefix test.
+// somewhere in the name, the project's name, the path or the branch the session
+// was parked on — the same reading the palette's own filter gives a query, so
+// narrowing here never drops a row that filter would have kept. LIKE is
+// case-insensitive for ASCII in SQLite, which is what makes this a search and
+// not a prefix test.
+//
+// Total counts the whole match, not the page: without it a term matching more
+// parked sessions than fit would answer with closedSessionLimit rows and no way
+// for the list to say so.
 //
 // rowid is the tiebreak, not the order, for RecentProjects' reason twice over:
 // it dates the insert, and a resumed session is reinserted — so rows parked
 // before closed_at existed all carry 0 and fall back to it together.
-func (s *Service) ClosedSessions(term string) ([]ClosedSession, error) {
+func (s *Service) ClosedSessions(term string) (ClosedHistory, error) {
 	where := "WHERE s.is_open = 0"
 	args := []any{}
 	for _, word := range strings.Fields(term) {
-		where += " AND (s.label || ' ' || p.name || ' ' || s.path) LIKE ? ESCAPE '" + likeEscape + "'"
+		where += " AND (s.label || ' ' || p.name || ' ' || s.path || ' ' || s.parked_branch)" +
+			" LIKE ? ESCAPE '" + likeEscape + "'"
 		args = append(args, "%"+escapeLike(word)+"%")
 	}
 	args = append(args, closedSessionLimit)
 
+	// COUNT(*) OVER () rides along on every row rather than costing a second
+	// query: a window function is computed before LIMIT, so it counts the match
+	// and not the page.
 	rows, err := s.db.Query(
-		`SELECT s.id, s.project_id, p.name, p.path, s.label, s.kind, s.path, s.closed_at
+		`SELECT s.id, s.project_id, p.name, p.path, s.label, s.kind, s.path,
+		        s.parked_branch, s.closed_at, COUNT(*) OVER ()
 		   FROM sessions s JOIN projects p ON p.id = s.project_id
 		   `+where+`
 		  ORDER BY s.closed_at DESC, s.rowid DESC
@@ -545,25 +588,25 @@ func (s *Service) ClosedSessions(term string) ([]ClosedSession, error) {
 		args...,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("query closed sessions: %w", err)
+		return ClosedHistory{}, fmt.Errorf("query closed sessions: %w", err)
 	}
 	defer rows.Close()
 
-	closed := []ClosedSession{}
+	history := ClosedHistory{Sessions: []ClosedSession{}}
 	for rows.Next() {
 		var c ClosedSession
 		if err := rows.Scan(
 			&c.ID, &c.ProjectID, &c.ProjectName, &c.ProjectPath,
-			&c.Label, &c.Kind, &c.Path, &c.ClosedAt,
+			&c.Label, &c.Kind, &c.Path, &c.ParkedBranch, &c.ClosedAt, &history.Total,
 		); err != nil {
-			return nil, fmt.Errorf("scan closed session: %w", err)
+			return ClosedHistory{}, fmt.Errorf("scan closed session: %w", err)
 		}
-		closed = append(closed, c)
+		history.Sessions = append(history.Sessions, c)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterate closed sessions: %w", err)
+		return ClosedHistory{}, fmt.Errorf("iterate closed sessions: %w", err)
 	}
-	return closed, nil
+	return history, nil
 }
 
 // ProjectPath returns the directory of the project with this id, or "" when

--- a/main.go
+++ b/main.go
@@ -142,6 +142,9 @@ func main() {
 	// Relocating a project is the one flow that can point two rows at the same
 	// directory, so it validates the picked one against the workspace.
 	proj.SetProjects(db.ProjectAt)
+	// Parking a session records the branch its checkout was on, so the history
+	// search can match a branch the row is showing (store.SetBranchOf).
+	db.SetBranchOf(proj.Branch)
 
 	// Every service the frontend uses goes through the loopback RPC
 	// (internal/rpc). store.Close manages the DB lifecycle and stays Go-only.
@@ -267,16 +270,18 @@ func main() {
 //     life of the process and starts a second loop racing the first for every
 //     due prompt.
 //   - relay.SetPlugins, project.SetAccounts, project.SetProjects,
-//     quota.SetSessions, store.SetSessionGone and terminal.SetDropDir are
-//     startup wiring. Called with [null] they silently nil what they wired
-//     (encoding/json leaves a func or pointer alone on null), and the write
-//     races the readers already serving — nilling SetProjects also disarms the
-//     guard that keeps two projects off the same directory, and SetDropDir
-//     points the sandbox's read-only bind wherever the caller likes.
+//     quota.SetSessions, store.SetSessionGone, store.SetBranchOf and
+//     terminal.SetDropDir are startup wiring. Called with [null] they silently
+//     nil what they wired (encoding/json leaves a func or pointer alone on
+//     null), and the write races the readers already serving — nilling
+//     SetProjects also disarms the guard that keeps two projects off the same
+//     directory, and SetDropDir points the sandbox's read-only bind wherever
+//     the caller likes.
 func denyInternal(d *rpc.Handler) {
 	for _, method := range []string{
 		"store.Close",
 		"store.SetSessionGone",
+		"store.SetBranchOf",
 		"drop.Upload",
 		"drop.Save",
 		"drop.Purge",


### PR DESCRIPTION
Closes the `docs/ceilings.md` bullet **"The History tab searches names, and the branch on every row is not one"** — both traps in it.

## The traps

The History tab's search ran in the store, over a parked session's name, its project's and its path. The branch was read out of git *afterwards*, for the rows the search had already kept — so a row showing `feat/relay-inbox` could not be found by typing that, which is the one thing on a row people go looking by. And a term matching more parked sessions than one page holds was answered with the hundred closed most recently, with nothing saying the list had been cut.

## What changed

**The branch is recorded at the park.** `sessions.parked_branch` (plain `ALTER TABLE` migration, the existing idempotent pattern) is stamped by `CloseSession`, which reads git through the store's new `SetBranchOf` seam — wired to `project.Branch` in `main.go` beside `SetSessionGone`, and denied on `/rpc/` with the rest of the startup wiring. A session with no path of its own is parked on its project's directory's branch. git is asked *before* the transaction opens: the store holds one connection, and a subprocess under the write lock stalls every other caller.

The history query matches that column with the rest of the haystack. The branch a row **draws** is still git's — a branch moves inside a checkout while the worktree keeps the name it was created with, which is what the neighbouring ceiling says — so the stored one is the searchable snapshot and the shown one is now. A comment at the column and at `ClosedSession` says exactly that. The palette's own filter searches both, because they can disagree and dropping either would lose a row the other half of the search kept.

**The count comes back with the page.** `ClosedSessions` now answers a `ClosedHistory{sessions, total}`, with `total` from a `COUNT(*) OVER ()` riding on the same query — a window function runs before `LIMIT`, so it counts the match rather than the page, and no second query repeats the search. The History group's header already knew how to say `100 of 143`; it now gets the number that makes it true.

## Not done, on purpose

Rows parked before this version carry no branch until they are parked again. A launch-time backfill would walk every parked checkout and fork git once per row before the workspace is up — on a machine with hundreds of parked sessions that is hundreds of subprocesses against a gap that closes itself the next time each session is parked. The `CHANGELOG` entry says so to the user.

## Ceilings

The target bullet is deleted outright. The neighbouring **"The history's branch is read live"** bullet stays — its trap is real and untouched (a row whose checkout is gone still shows no branch, and a branch that moves while the palette is up is stale until the query changes) — but its opening clause said "the branch is not stored", which this PR makes false. It now says the branch a row *shows* is not the one it stores, and why.

## Tests

- Go: the branch is recorded on park for a worktree session and for a project-root one; a store with no seam still parks; a term matching only the branch finds the row; `Total` counts the whole match past the cap, equals the rows when nothing was cut, and is 0 for an empty match.
- Frontend: the hook carries `total` beside its page, zeroes it while the palette is closed, decrements it with a forgotten row, and keeps both branches on the row; the palette filter narrows on the parked branch (including on a row whose checkout is gone, where it is the only branch there is); the History group reports the store's count when cut and its own rows when not.

## Local gate

`gofmt -l .` clean · `go vet ./...` clean · `go test ./...` green · `biome ci .` **exit 0** · `pnpm test` 1639 passed · `pnpm build` green · cross-compile loop (linux/darwin/windows build + vet) clean.