### PR TITLE
fix: make every closed project searchable, not just the last 25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A closed project is now findable by name, however long ago it was closed.**
+  Only the twenty-five most recent closes were ever offered back, so an older
+  project was reachable only by hunting its directory in the folder picker, and
+  neither the reopen menu nor the palette said so. Typing in the command palette
+  now searches every closed project there has ever been, by name and by path,
+  and its Closed group says how many matches it is showing of how many it found.
+  The reopen menu still lists the newest five, with a line under them naming how
+  many more the palette can reach.
 - **A split's dragged pane sizes now come back when the grid does.** How many
   panes sit across follows the window, so collapsing the sidebar, opening the
   dock or moving to another monitor reshapes the wall - and the sizes you had

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -272,13 +272,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   and the base branch. The remote fetched from is the one whose URL matches the pull request's own, origin when
   none does — lich reads gh's base repository off that URL rather than asking gh again, so a clone whose remotes
   all name a different repository than the pull request lives on falls back to origin and fails there.
-- **Persistence is hybrid**: UI prefs in the page's localStorage (`lich.*` keys — the reason the listener port is
-  pinned at 47821; `LICH_LISTEN_PORT` overrides it, `LICH_PORT` is the distinct per-session hook variable), the
-  workspace in SQLite (`<config-dir>/lich/lich.db`, `internal/store`). Closing a session deletes its row; keeping a
-  worktree parks its session for a later resume; closing a project hides it, and reopening one whose directory is
-  gone relocates it instead, keeping the stored id its sessions and its worktree directory hang off. Only the 25
-  most recent closes are offered back (`recentLimit`, `internal/store/store.go`) — the row survives, but past that
-  a project is reachable only through the directory picker, and neither the menu nor the palette says so.
 - **A project opened from outside the window is matched by the spelling of its path**
   (`internal/project/project.go`, `Identify`; `internal/spawn/projects.go`): `lich open --project <dir>` normalizes
   what it is handed — `~` expanded, cleaned, refused unless absolute — and then matches that string against the

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -26,6 +26,7 @@ import {
   type PaletteSession,
   type PaletteTab,
 } from "@/lib/session/command-palette"
+import { useClosedProjects } from "@/lib/session/use-closed-projects"
 import { useHistorySearch } from "@/lib/session/use-history-search"
 import { useTranscriptSearch } from "@/lib/session/use-transcript-search"
 import { toast } from "sonner"
@@ -33,8 +34,8 @@ import { PickerDialog, PickerEmpty, PickerGroup, PickerRow } from "@/components/
 import { agoLabel } from "@/lib/ago"
 import { displayPath } from "@/lib/paths"
 import { isSessionKind } from "@/lib/session/sessions"
-import type { Project, RecentProject } from "@/lib/api-types"
-import { ProjectService, Store } from "@/lib/rpc"
+import type { Project } from "@/lib/api-types"
+import { Store } from "@/lib/rpc"
 import { cn, errorText } from "@/lib/utils"
 
 // CommandPalette is the app-wide quick switcher: one shortcut (Ctrl/Cmd+K by
@@ -54,9 +55,7 @@ export function CommandPalette() {
   const [query, setQuery] = useState("")
   const [tab, setTab] = useState<PaletteTab>("All")
   const [selected, setSelected] = useState(0)
-  const [closed, setClosed] = useState<RecentProject[]>([])
   const [running, setRunning] = useState<ReadonlySet<string>>(new Set())
-  const [missing, setMissing] = useState<ReadonlySet<string>>(new Set())
 
   useHotkey(hotkeys.commandPalette, () => {
     setOpen((v) => !v)
@@ -65,31 +64,12 @@ export function CommandPalette() {
     setSelected(0)
   })
 
-  // The closed projects live in the store, not in the workspace state, so they
-  // are fetched per opening — anything closed or reopened since the last one
-  // moves in or out of the list. Their directories are read with them: a project
-  // whose folder moved is relocated rather than reopened.
-  useEffect(() => {
-    if (!open) {
-      return
-    }
-    let live = true
-    void Store.RecentProjects().then((recentRows) => {
-      const recents = recentRows ?? []
-      if (!live) {
-        return
-      }
-      setClosed(recents)
-      void ProjectService.Missing(recents.map((row) => row.path)).then((gone) => {
-        if (live) {
-          setMissing(new Set(gone ?? []))
-        }
-      })
-    })
-    return () => {
-      live = false
-    }
-  }, [open])
+  // The closed projects live in the store, not in the workspace state, and they
+  // are searched there rather than filtered here: past one page of the reopen
+  // list the palette is the only way back to one, so a term that only matches an
+  // older close still has to find it. Their directories come back with them, so
+  // a project whose folder moved is relocated rather than reopened.
+  const { rows: closed, total: closedTotal, missing } = useClosedProjects(query, open)
 
   // The parked sessions are searched in the store rather than filtered here, so
   // the History tab reaches a session parked further back than one page of it.
@@ -119,8 +99,8 @@ export function CommandPalette() {
   }, [open])
   const all = useMemo(() => rankSessions(flat, running), [flat, running])
   const results = useMemo(
-    () => filterPalette(query, all, projects, closed, history),
-    [query, all, projects, closed, history],
+    () => filterPalette(query, all, projects, closed, history, closedTotal),
+    [query, all, projects, closed, history, closedTotal],
   )
   // What was said inside the sessions, not just their names. It arrives after
   // the name-matched groups (it is a disk read behind a debounce), so it is

--- a/frontend/src/components/tabs/OpenProjectMenu.tsx
+++ b/frontend/src/components/tabs/OpenProjectMenu.tsx
@@ -16,8 +16,8 @@ import { useProjects } from "@/providers/projects"
 
 // MENU_LIMIT is how many closed projects the menu offers. Five is what fits
 // above the picker entry without turning the menu into a second project list;
-// the store returns a longer list than this and the command palette searches
-// the rest of it.
+// the palette searches every closed project there has ever been, and the footer
+// line below says so once there are more than these.
 const MENU_LIMIT = 5
 
 // OpenProjectMenu is the top strip's "+": the projects closed earlier, newest
@@ -28,6 +28,9 @@ export function OpenProjectMenu() {
   const { projects, openProject, openRecent } = useProjects()
   const [recents, setRecents] = useState<RecentProject[]>([])
   const [missing, setMissing] = useState<ReadonlySet<string>>(new Set())
+  // The closed projects this menu does not list. They are not unreachable, but
+  // nothing here said where they went until this number did.
+  const [more, setMore] = useState(0)
 
   // The open projects are exactly what the recent ones are not, so the list is
   // refetched whenever they change: closing a tab adds one, opening removes it.
@@ -41,11 +44,17 @@ export function OpenProjectMenu() {
         return
       }
       setRecents(shown)
-      // Asked for after the list is up: the mark is what a row says about
-      // itself, and a failed check must not cost the menu its entries.
+      // Asked for after the list is up: the mark and the count are what the
+      // list says about itself, and a failed check must not cost the menu its
+      // entries.
       void ProjectService.Missing(shown.map((row) => row.path)).then((gone) => {
         if (live) {
           setMissing(new Set(gone ?? []))
+        }
+      })
+      void Store.ClosedProjectCount().then((count) => {
+        if (live) {
+          setMore(Math.max(0, count - shown.length))
         }
       })
     })
@@ -116,6 +125,11 @@ export function OpenProjectMenu() {
           <FolderOpen className="size-4 shrink-0 text-muted-foreground" />
           Open folder…
         </DropdownMenuItem>
+        {more > 0 && (
+          <div className="px-2 pt-1.5 text-xs text-muted-foreground">
+            {more} more closed project{more === 1 ? "" : "s"} — search the palette
+          </div>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/frontend/src/components/tabs/open-project-menu-more.test.tsx
+++ b/frontend/src/components/tabs/open-project-menu-more.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+//
+// The reopen menu lists five closed projects and the store keeps far more than
+// that. Nothing in the menu used to say so, which is the whole reason this line
+// exists, and the node-only gate cannot tell a line that renders from one that
+// never did.
+//
+// The harness is imported first for the reason render-budget.test.tsx names: it
+// has to hook react-dom before anything else reaches it.
+import { mountBudget } from "@/test/render-budget"
+import { createElement } from "react"
+import { beforeEach, expect, test, vi } from "vitest"
+import type { RecentProject } from "@/lib/api-types"
+import { OpenProjectMenu } from "./OpenProjectMenu"
+
+let closedCount = 0
+
+function project(id: string): RecentProject {
+  return { id, name: id, path: `/src/${id}` }
+}
+
+vi.mock("@/lib/rpc", () => ({
+  Store: {
+    RecentProjects: () =>
+      Promise.resolve(["p1", "p2", "p3", "p4", "p5", "p6"].map((id) => project(id))),
+    ClosedProjectCount: () => Promise.resolve(closedCount),
+  },
+  ProjectService: {
+    Missing: () => Promise.resolve([]),
+  },
+}))
+
+// One frozen value, not a fresh object per render: the menu refetches whenever
+// `projects` changes identity, and a new array each render is an endless loop.
+vi.mock("@/providers/projects", () => {
+  const value = { projects: [], openProject: () => {}, openRecent: () => {} }
+  return { useProjects: () => value }
+})
+
+// base-ui opens the menu on the trigger's click, so the test opens it the way a
+// user does rather than reaching for a prop the component does not take.
+async function openMenu(): Promise<void> {
+  const trigger = document.querySelector('[aria-label="Open project"]')
+  if (!(trigger instanceof HTMLElement)) {
+    throw new Error("menu trigger not rendered")
+  }
+  trigger.click()
+  await new Promise((resolve) => setTimeout(resolve, 30))
+}
+
+const menuText = (): string =>
+  [...document.querySelectorAll('[role="menu"]')].map((node) => node.textContent ?? "").join(" ")
+
+beforeEach(() => {
+  closedCount = 0
+})
+
+test("the menu points at the palette for the closed projects it does not list", async () => {
+  closedCount = 30
+  const mounted = await mountBudget(createElement(OpenProjectMenu))
+  await new Promise((resolve) => setTimeout(resolve, 30))
+  await openMenu()
+
+  // Five rows are listed of thirty closed, so twenty-five are only reachable
+  // through the palette.
+  expect(menuText()).toContain("25 more closed projects")
+  await mounted.unmount()
+})
+
+test("one project left over is named in the singular", async () => {
+  closedCount = 6
+  const mounted = await mountBudget(createElement(OpenProjectMenu))
+  await new Promise((resolve) => setTimeout(resolve, 30))
+  await openMenu()
+
+  expect(menuText()).toContain("1 more closed project ")
+  await mounted.unmount()
+})
+
+test("a menu that lists every closed project says nothing about the palette", async () => {
+  closedCount = 5
+  const mounted = await mountBudget(createElement(OpenProjectMenu))
+  await new Promise((resolve) => setTimeout(resolve, 30))
+  await openMenu()
+
+  // The menu is open, so an absent line is an absent line and not an unopened
+  // menu: the assertion below would pass either way.
+  expect(menuText()).toContain("Recent projects")
+  expect(menuText()).not.toContain("more closed project")
+  await mounted.unmount()
+})

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -354,8 +354,13 @@ export const Store = {
   AddProject: (id: string, name: string, path: string) =>
     call<null>("store.AddProject", [id, name, path]),
   CloseProject: (id: string) => call<null>("store.CloseProject", [id]),
-  /** The closed projects offered for reopening, newest first (capped backend-side). */
-  RecentProjects: () => call<RecentProject[] | null>("store.RecentProjects", []),
+  /** The closed projects matching `term` (every word in the name or the path),
+   * newest close first and capped backend-side. An empty term is the plain
+   * reopen list. */
+  RecentProjects: (term = "") => call<RecentProject[] | null>("store.RecentProjects", [term]),
+  /** How many closed projects `term` matches, page or no page: what a capped
+   * list says it is leaving out. */
+  ClosedProjectCount: (term = "") => call<number>("store.ClosedProjectCount", [term]),
   /** sandbox is whether this session runs confined ("on"/"off", "" to follow the
    * provider's rung). It rides the insert because the PTY reads it on the first
    * spawn — a second call would race the card this one puts on screen. */

--- a/frontend/src/lib/session/command-palette.test.ts
+++ b/frontend/src/lib/session/command-palette.test.ts
@@ -149,6 +149,24 @@ describe("paletteGroups", () => {
     expect(paletteGroups("Sessions", results, messages)[0]?.rows).toHaveLength(3)
   })
 
+  it("says how many closed projects the store matched past the page it sent", () => {
+    const cut = filterPalette("", all, projects, closed, [], 63)
+    const groups = paletteGroups("Projects", cut, messages)
+    const closedGroup = groups.find((g) => g.label === "Closed")
+    // The header reads "4 of 63": the cut happened in the store, so the rows in
+    // hand cannot report it on their own.
+    expect(closedGroup?.rows).toHaveLength(4)
+    expect(closedGroup?.total).toBe(63)
+  })
+
+  it("never reports a total under the rows it is showing", () => {
+    // A stale total from the query before this one must not read as a group
+    // that shrank below its own rows.
+    const stale = filterPalette("", all, projects, closed, [], 1)
+    const closedGroup = paletteGroups("Projects", stale, messages).find((g) => g.label === "Closed")
+    expect(closedGroup?.total).toBe(4)
+  })
+
   it("drops a group with no rows", () => {
     const empty = filterPalette("nothing-matches-this", all, projects, closed)
     expect(paletteGroups("All", empty, [])).toEqual([])

--- a/frontend/src/lib/session/command-palette.ts
+++ b/frontend/src/lib/session/command-palette.ts
@@ -85,9 +85,12 @@ export function historyRows(
 export interface PaletteResults {
   sessions: PaletteSession[]
   projects: Project[]
-  // The closed projects, which the reopen menu shows five of: past that the
-  // palette is the only way back to one.
+  // One page of the closed projects the store matched, which the reopen menu
+  // shows five of: past that the palette is the only way back to one.
   closed: Project[]
+  // Every closed project the term matched, so the group header can report a
+  // page that was cut instead of cutting it in silence.
+  closedTotal: number
   // The parked sessions — what the History tab lists, and the only group whose
   // rows are not in the workspace at all.
   history: PaletteHistory[]
@@ -99,8 +102,10 @@ export function filterPalette(
   projects: readonly Project[],
   closed: readonly Project[] = [],
   history: readonly PaletteHistory[] = [],
+  closedTotal = 0,
 ): PaletteResults {
   return {
+    closedTotal,
     sessions: allSessions.filter((s) =>
       matchesQuery(`${s.label} ${s.projectName} ${s.path}`, query),
     ),
@@ -227,9 +232,11 @@ export function historyAction(row: PaletteHistory): "resume" | "forget" {
   return row.gone ? "forget" : "resume"
 }
 
-// cap of 0 means no cap — the tab that names one kind lists all of it.
-function group(label: string, rows: PaletteRow[], cap: number): PaletteGroup {
-  return { label, rows: cap > 0 ? rows.slice(0, cap) : rows, total: rows.length }
+// cap of 0 means no cap: the tab that names one kind lists all of it. `total`
+// is how many rows the group stands for, which is the caller's to say when the
+// backend cut the list before it got here; never fewer than the rows on screen.
+function group(label: string, rows: PaletteRow[], cap: number, total = rows.length): PaletteGroup {
+  return { label, rows: cap > 0 ? rows.slice(0, cap) : rows, total: Math.max(total, rows.length) }
 }
 
 export function paletteGroups(
@@ -248,7 +255,7 @@ export function paletteGroups(
       case "Sessions":
         return [group("Sessions", sessions, 0)]
       case "Projects":
-        return [group("Open", open, 0), group("Closed", closed, 0)]
+        return [group("Open", open, 0), group("Closed", closed, 0, results.closedTotal)]
       case "Messages":
         return [group("Messages", said, 0)]
       case "History":

--- a/frontend/src/lib/session/use-closed-projects.test.tsx
+++ b/frontend/src/lib/session/use-closed-projects.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+//
+// The wiring the palette's Closed group is: the typed term has to reach the
+// store, because the store is the only place that can see past the page it
+// answers with. A test that filters rows in the window would pass against the
+// bug this hook exists to close.
+//
+// The harness has to be imported before anything that reaches react-dom, which
+// is why it is first here (see @/test/render-budget).
+import { mountBudget } from "@/test/render-budget"
+import { StrictMode, createElement, useLayoutEffect, useState } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { RecentProject } from "@/lib/api-types"
+import { useClosedProjects } from "@/lib/session/use-closed-projects"
+
+const terms: string[] = []
+const countTerms: string[] = []
+const missingPaths: string[][] = []
+
+function project(id: string, name: string): RecentProject {
+  return { id, name, path: `/src/${id}` }
+}
+
+// The fake store searches by name so the test can tell a backend search from a
+// window filter: only "old" is answered for a term, and it is never in the list
+// the empty term returns. The count runs past the page on purpose.
+vi.mock("@/lib/rpc", () => ({
+  Store: {
+    RecentProjects: (term: string) => {
+      terms.push(term)
+      if (term === "") {
+        return Promise.resolve([project("p1", "recent work")])
+      }
+      return Promise.resolve(term.includes("old") ? [project("old", "the oldest work")] : [])
+    },
+    ClosedProjectCount: (term: string) => {
+      countTerms.push(term)
+      return Promise.resolve(term === "" ? 63 : 1)
+    },
+  },
+  ProjectService: {
+    Missing: (paths: string[]) => {
+      missingPaths.push(paths)
+      return Promise.resolve(paths.filter((p) => p === "/src/old"))
+    },
+  },
+}))
+
+// The debounce is real, so the test waits it out rather than mocking the clock:
+// act() and fake timers fight over the same queue, and what is being asserted is
+// that a burst of keystrokes costs one call.
+const DEBOUNCE_MS = 200
+
+const settled = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, DEBOUNCE_MS + 60))
+
+// The newest frame, which is the one the palette would be painting.
+function last<T>(frames: T[]): T | undefined {
+  return frames[frames.length - 1]
+}
+
+interface Frame {
+  rows: RecentProject[]
+  total: number
+  missing: ReadonlySet<string>
+}
+
+function probe(frames: Frame[]) {
+  return function Probe({ query, enabled }: { query: string; enabled: boolean }) {
+    const closed = useClosedProjects(query, enabled)
+    useLayoutEffect(() => {
+      frames.push(closed)
+    })
+    return null
+  }
+}
+
+function typing(frames: Frame[], typers: ((q: string) => void)[]) {
+  return function Typing() {
+    const [query, setQuery] = useState("")
+    const closed = useClosedProjects(query, true)
+    useLayoutEffect(() => {
+      frames.push(closed)
+      typers.push(setQuery)
+    })
+    return null
+  }
+}
+
+beforeEach(() => {
+  terms.length = 0
+  countTerms.length = 0
+  missingPaths.length = 0
+})
+
+describe("useClosedProjects", () => {
+  it("asks the store for the plain reopen list when nothing is typed", async () => {
+    const frames: Frame[] = []
+    const Probe = probe(frames)
+    const mounted = await mountBudget(
+      createElement(StrictMode, null, createElement(Probe, { query: "", enabled: true })),
+    )
+    await settled()
+
+    expect(terms).toEqual([""])
+    expect(last(frames)?.rows.map((row) => row.id)).toEqual(["p1"])
+    await mounted.unmount()
+  })
+
+  it("sends the typed term to the store, so a project past the page is found", async () => {
+    const frames: Frame[] = []
+    const Probe = probe(frames)
+    const mounted = await mountBudget(
+      createElement(StrictMode, null, createElement(Probe, { query: "old", enabled: true })),
+    )
+    await settled()
+
+    expect(terms).toContain("old")
+    // "old" is not in the list the empty term answers with: a window-side filter
+    // could never have produced this row.
+    expect(last(frames)?.rows.map((row) => row.id)).toEqual(["old"])
+    expect(last(frames)?.missing.has("/src/old")).toBe(true)
+    expect(last(missingPaths)).toEqual(["/src/old"])
+    await mounted.unmount()
+  })
+
+  it("reports every match, not the page, so a cut list can say what it left out", async () => {
+    const frames: Frame[] = []
+    const Probe = probe(frames)
+    const mounted = await mountBudget(
+      createElement(StrictMode, null, createElement(Probe, { query: "", enabled: true })),
+    )
+    await settled()
+
+    expect(countTerms).toContain("")
+    expect(last(frames)?.total).toBe(63)
+    await mounted.unmount()
+  })
+
+  it("costs one search for a burst of keystrokes", async () => {
+    const frames: Frame[] = []
+    const typers: ((q: string) => void)[] = []
+    const Typing = typing(frames, typers)
+    const mounted = await mountBudget(createElement(Typing))
+    await settled()
+    terms.length = 0
+
+    for (const word of ["o", "ol", "old"]) {
+      last(typers)?.(word)
+    }
+    await settled()
+
+    expect(terms).toEqual(["old"])
+    expect(last(frames)?.rows.map((row) => row.id)).toEqual(["old"])
+    await mounted.unmount()
+  })
+
+  it("asks for nothing while the palette is closed", async () => {
+    const frames: Frame[] = []
+    const Probe = probe(frames)
+    const mounted = await mountBudget(createElement(Probe, { query: "old", enabled: false }))
+    await settled()
+
+    expect(terms).toEqual([])
+    expect(last(frames)?.rows).toEqual([])
+    expect(last(frames)?.total).toBe(0)
+    await mounted.unmount()
+  })
+})

--- a/frontend/src/lib/session/use-closed-projects.ts
+++ b/frontend/src/lib/session/use-closed-projects.ts
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react"
+import type { RecentProject } from "@/lib/api-types"
+import { ProjectService, Store } from "@/lib/rpc"
+
+// The closed projects are read per keystroke once the term reaches the store,
+// so the typing is waited out rather than fired on: the same bargain the parked
+// sessions and the transcript search make (use-history-search).
+const DEBOUNCE_MS = 200
+
+export interface ClosedProjects {
+  /** One page of matches, newest close first. */
+  rows: RecentProject[]
+  /** Every match, page or no page, so the group can say what it left out. */
+  total: number
+  /** The rows whose directory is gone: they relocate rather than reopen. */
+  missing: ReadonlySet<string>
+}
+
+// useClosedProjects asks the store for the closed projects matching `query` and
+// checks where their directories went. Idle (no rows, no calls) while the
+// palette is closed.
+//
+// The term goes to the backend rather than filtering rows already in hand: the
+// store answers with one page, so a project closed further back than that page
+// is only reachable if the match happens in the query. That page is what the
+// reopen menu lists too, which is why the count comes back with it.
+//
+// An empty query skips the debounce: it is the list the palette opens with, and
+// nothing was typed to wait out. Every effect run supersedes the one before it,
+// so a reply that lands after the query moved on is dropped rather than painted
+// over newer rows.
+export function useClosedProjects(query: string, enabled: boolean): ClosedProjects {
+  const [rows, setRows] = useState<RecentProject[]>([])
+  const [total, setTotal] = useState(0)
+  const [missing, setMissing] = useState<ReadonlySet<string>>(new Set())
+
+  useEffect(() => {
+    if (!enabled) {
+      setRows([])
+      setTotal(0)
+      return
+    }
+    let live = true
+    const timer = window.setTimeout(
+      () => {
+        void Store.RecentProjects(query).then((recentRows) => {
+          const recents = recentRows ?? []
+          if (!live) {
+            return
+          }
+          setRows(recents)
+          setTotal(recents.length)
+          // Asked for after the rows are up: what the count and the filesystem
+          // say is what a row says about itself, and a failed check must not
+          // cost the palette its entries.
+          void Store.ClosedProjectCount(query).then((count) => {
+            if (live) {
+              setTotal(count)
+            }
+          })
+          void ProjectService.Missing(recents.map((row) => row.path)).then((gone) => {
+            if (live) {
+              setMissing(new Set(gone ?? []))
+            }
+          })
+        })
+      },
+      query.trim() === "" ? 0 : DEBOUNCE_MS,
+    )
+    return () => {
+      live = false
+      window.clearTimeout(timer)
+    }
+  }, [query, enabled])
+
+  return { rows, total, missing }
+}

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -204,7 +204,7 @@ func (s *spawnStore) RenameSession(sessionID, label string) error {
 
 func (*spawnStore) CloseSession(_, _, _ string) error { return nil }
 
-func (*spawnStore) RecentProjects() ([]store.Recent, error) { return nil, nil }
+func (*spawnStore) RecentProjects(string) ([]store.Recent, error) { return nil, nil }
 
 // The wire tests never open a project: what they prove is the arguments a
 // command posts, and the workspace this fixture answers with is already open.

--- a/internal/spawn/projects.go
+++ b/internal/spawn/projects.go
@@ -51,7 +51,7 @@ func (s *Service) ensureProject(
 // answers with whichever of the two rows the query reached first.
 func (s *Service) adoptProject(identity *project.Project) ([]store.Project, store.Project, error) {
 	id, name := identity.ID, identity.Name
-	recents, err := s.sessions.RecentProjects()
+	recents, err := s.sessions.RecentProjects("")
 	if err != nil {
 		return nil, store.Project{}, fmt.Errorf("read the closed projects: %w", err)
 	}

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -78,7 +78,7 @@ const (
 // a later resume. The store implements it.
 type Sessions interface {
 	LoadState() ([]store.Project, error)
-	RecentProjects() ([]store.Recent, error)
+	RecentProjects(term string) ([]store.Recent, error)
 	AddProject(id, name, path string) error
 	AddSessionFrom(
 		projectID, sessionID, label, kind, path string, nextSeq int, originID, originLabel string,

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -93,7 +93,7 @@ func (f *fakeSessions) LoadState() ([]store.Project, error) {
 	return f.projects, f.loadErr
 }
 
-func (f *fakeSessions) RecentProjects() ([]store.Recent, error) {
+func (f *fakeSessions) RecentProjects(string) ([]store.Recent, error) {
 	if f.recentErr != nil {
 		return nil, f.recentErr
 	}

--- a/internal/store/closedprojects_test.go
+++ b/internal/store/closedprojects_test.go
@@ -1,0 +1,192 @@
+package store
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+)
+
+// closeProject opens a project and closes it again, which is the only way a row
+// reaches the reopen list: closed_seq is stamped by the close.
+func closeProject(t *testing.T, svc *Service, id, name, path string) {
+	t.Helper()
+	if err := svc.AddProject(id, name, path); err != nil {
+		t.Fatalf("AddProject(%s): %v", id, err)
+	}
+	if err := svc.CloseProject(id); err != nil {
+		t.Fatalf("CloseProject(%s): %v", id, err)
+	}
+}
+
+// searchIDs is the reopen list for one term, reduced to what the order is
+// asserted on.
+func searchIDs(t *testing.T, svc *Service, term string) []string {
+	t.Helper()
+	recents, err := svc.RecentProjects(term)
+	if err != nil {
+		t.Fatalf("RecentProjects(%q): %v", term, err)
+	}
+	ids := make([]string, len(recents))
+	for i, r := range recents {
+		ids[i] = r.ID
+	}
+	return ids
+}
+
+// TestRecentProjectsSearchesNameAndPath is the search itself: a term narrows the
+// list whatever its case, every word has to land, and the path is part of the
+// haystack because that is the half of a row a name does not say.
+func TestRecentProjectsSearchesNameAndPath(t *testing.T) {
+	svc := newTestStore(t)
+	closeProject(t, svc, "p1", "relay inbox", "/src/relay")
+	closeProject(t, svc, "p2", "relay tickets", "/src/relay-tickets")
+	closeProject(t, svc, "p3", "split groups", "/work/split")
+
+	for _, term := range []string{"relay", "RELAY", "ReLaY"} {
+		// Newest close first, the same order the unfiltered list is in.
+		if got := searchIDs(t, svc, term); !slices.Equal(got, []string{"p2", "p1"}) {
+			t.Errorf("RecentProjects(%q) = %v, want [p2 p1]", term, got)
+		}
+	}
+	if got := searchIDs(t, svc, "inbox relay"); !slices.Equal(got, []string{"p1"}) {
+		t.Errorf(`RecentProjects("inbox relay") = %v, want [p1] whatever the word order`, got)
+	}
+	if got := searchIDs(t, svc, "relay split"); len(got) != 0 {
+		t.Errorf(`RecentProjects("relay split") = %v, want none: no row carries both`, got)
+	}
+	if got := searchIDs(t, svc, "work split"); !slices.Equal(got, []string{"p3"}) {
+		t.Errorf(`RecentProjects("work split") = %v, want [p3] by path`, got)
+	}
+	if got := searchIDs(t, svc, ""); !slices.Equal(got, []string{"p3", "p2", "p1"}) {
+		t.Errorf(`RecentProjects("") = %v, want the whole list newest first`, got)
+	}
+}
+
+// TestRecentProjectsSearchSkipsOpenOnes pins the term against the flag: a
+// matching project that is on screen is not offered for reopening.
+func TestRecentProjectsSearchSkipsOpenOnes(t *testing.T) {
+	svc := newTestStore(t)
+	closeProject(t, svc, "p1", "relay inbox", "/src/relay")
+	if err := svc.AddProject("p2", "relay tickets", "/src/relay-tickets"); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+
+	if got := searchIDs(t, svc, "relay"); !slices.Equal(got, []string{"p1"}) {
+		t.Errorf(`RecentProjects("relay") = %v, want [p1]: p2 is open`, got)
+	}
+}
+
+// TestRecentProjectsSearchEscapesWildcards is why the term is escaped: LIKE
+// reads % and _ as patterns, so an unescaped name containing either would match
+// rows that have nothing to do with it.
+func TestRecentProjectsSearchEscapesWildcards(t *testing.T) {
+	svc := newTestStore(t)
+	closeProject(t, svc, "pct", "100% done", "/src/pct")
+	closeProject(t, svc, "und", "hand_off", "/src/und")
+	closeProject(t, svc, "esc", `back\slash`, "/src/esc")
+	// The decoys are what an unescaped term matches: % swallows the trailing
+	// zero, _ stands in for the X, and a bare backslash is an escape sequence
+	// SQLite refuses outright.
+	closeProject(t, svc, "wide", "1000 lines", "/src/wide")
+	closeProject(t, svc, "any", "handXoff", "/src/any")
+
+	cases := map[string]string{
+		"100%":       "pct",
+		"hand_off":   "und",
+		`back\slash`: "esc",
+	}
+	for term, want := range cases {
+		if got := searchIDs(t, svc, term); !slices.Equal(got, []string{want}) {
+			t.Errorf("RecentProjects(%q) = %v, want [%s] only", term, got, want)
+		}
+	}
+}
+
+// TestRecentProjectsSearchReachesPastTheCap is the ceiling this search closed: a
+// project closed further back than one page of the reopen list is still findable
+// by name, which is the whole point of matching in the query.
+func TestRecentProjectsSearchReachesPastTheCap(t *testing.T) {
+	svc := newTestStore(t)
+	closeProject(t, svc, "needle", "the oldest project", "/src/needle")
+	for i := range recentLimit + 5 {
+		id := fmt.Sprintf("p%d", i)
+		closeProject(t, svc, id, "newer project", "/src/"+id)
+	}
+
+	unfiltered := searchIDs(t, svc, "")
+	if len(unfiltered) != recentLimit {
+		t.Fatalf("unfiltered list = %d rows, want %d", len(unfiltered), recentLimit)
+	}
+	if slices.Contains(unfiltered, "needle") {
+		t.Fatal("the oldest row is inside the unfiltered page; the test proves nothing")
+	}
+	if got := searchIDs(t, svc, "oldest"); !slices.Equal(got, []string{"needle"}) {
+		t.Errorf(`RecentProjects("oldest") = %v, want [needle] from past the cap`, got)
+	}
+}
+
+// TestRecentProjectsSearchCapsMatches pins that the cap outlives the search: a
+// term matching everything is still one page, newest close first.
+func TestRecentProjectsSearchCapsMatches(t *testing.T) {
+	svc := newTestStore(t)
+	for i := range recentLimit + 5 {
+		id := fmt.Sprintf("p%d", i)
+		closeProject(t, svc, id, "project work", "/src/"+id)
+	}
+
+	got := searchIDs(t, svc, "work")
+	if len(got) != recentLimit {
+		t.Fatalf("got %d matches, want the list capped at %d", len(got), recentLimit)
+	}
+	if got[0] != fmt.Sprintf("p%d", recentLimit+4) {
+		t.Errorf("newest match = %q, want the last project closed", got[0])
+	}
+}
+
+// TestClosedProjectCountAnswersPastTheCap is what the cut is reported with: the
+// count is over every match, not over the page, so the menu and the palette can
+// say how many they are leaving out.
+func TestClosedProjectCountAnswersPastTheCap(t *testing.T) {
+	svc := newTestStore(t)
+	for i := range recentLimit + 5 {
+		id := fmt.Sprintf("p%d", i)
+		closeProject(t, svc, id, "project work", "/src/"+id)
+	}
+	closeProject(t, svc, "other", "unrelated", "/src/other")
+	if err := svc.AddProject("open", "project work open", "/src/open"); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+
+	cases := map[string]int{
+		"":         recentLimit + 6,
+		"work":     recentLimit + 5,
+		"unrelate": 1,
+		"nothing":  0,
+	}
+	for term, want := range cases {
+		got, err := svc.ClosedProjectCount(term)
+		if err != nil {
+			t.Fatalf("ClosedProjectCount(%q): %v", term, err)
+		}
+		if got != want {
+			t.Errorf("ClosedProjectCount(%q) = %d, want %d", term, got, want)
+		}
+	}
+}
+
+// TestClosedProjectCountEscapesWildcards holds the count to the same reading as
+// the list: they are one search, and a term that counted more than it listed
+// would report a cut that is not there.
+func TestClosedProjectCountEscapesWildcards(t *testing.T) {
+	svc := newTestStore(t)
+	closeProject(t, svc, "pct", "100% done", "/src/pct")
+	closeProject(t, svc, "wide", "1000 lines", "/src/wide")
+
+	got, err := svc.ClosedProjectCount("100%")
+	if err != nil {
+		t.Fatalf("ClosedProjectCount: %v", err)
+	}
+	if got != 1 {
+		t.Errorf(`ClosedProjectCount("100%%") = %d, want 1`, got)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,14 +2,20 @@
 // open projects, their terminal sessions and the settings scoped globally or to
 // one project — provider binaries and defaults, the permission and sandbox
 // rungs, the gh account. It never stores chat or terminal content — only the
-// metadata needed to restore the workspace after a restart.
+// metadata needed to restore the workspace after a restart. The file is
+// <config-dir>/lich/lich.db, or lich-dev.db under LICH_DEV so a rig never
+// touches an installed lich's workspace (databasePath).
 //
 // A UI preference stays in the frontend's localStorage by default: it needs
 // synchronous access on first paint and the backend never reads it. It moves
 // here when losing it costs more than reading it a frame late — the theme
 // selections and the "what's new" mark did, because Chromium recreates a
 // damaged profile from scratch and takes every `lich.*` key with it (the why is
-// at the setting keys in frontend/src/providers/settings.tsx).
+// at the setting keys in frontend/src/providers/settings.tsx). Those `lich.*`
+// keys are also why the listener port is pinned rather than picked: localStorage
+// is keyed by the origin the port forms, so moving it wipes the store
+// (internal/singleton.DefaultPort, which LICH_LISTEN_PORT overrides; not
+// LICH_PORT, the per-session hook variable).
 package store
 
 import (
@@ -425,25 +431,47 @@ type Recent struct {
 	Path string `json:"path"`
 }
 
-// recentLimit caps the reopen list. The reopen menu shows five of them and the
-// command palette searches all of them, so the number answers to the palette:
-// far enough back to cover the projects a workspace actually cycles through,
-// and still a bound — the alternative is a list that only grows and a query
-// that reads every closed project ever.
+// recentLimit caps how many closed projects one call answers with, not how far
+// back it looks: the search runs in the query, so a project closed long before
+// the newest twenty-five is still found by name. The alternative is a list that
+// only grows and a menu that reads every closed project ever.
 const recentLimit = 25
 
-// RecentProjects returns the closed projects (is_open = 0) offered for
-// reopening, the last one closed first, up to recentLimit of them.
+// closedProjectMatch is the WHERE clause and its arguments for the closed
+// projects (is_open = 0) matching term: every whitespace-separated word has to
+// appear somewhere in the name or the path, which is the same reading the
+// palette's own filter gives a query. An empty term matches all of them. LIKE
+// is case-insensitive for ASCII in SQLite, which is what makes this a search
+// and not a prefix test.
+func closedProjectMatch(term string) (string, []any) {
+	where := "WHERE is_open = 0"
+	args := []any{}
+	for _, word := range strings.Fields(term) {
+		where += " AND (name || ' ' || path) LIKE ? ESCAPE '" + likeEscape + "'"
+		args = append(args, "%"+escapeLike(word)+"%")
+	}
+	return where, args
+}
+
+// RecentProjects returns the closed projects matching term, the last one closed
+// first, up to recentLimit of them. An empty term is the plain reopen list: the
+// most recently closed, whatever they are named.
+//
+// The term is matched here rather than in the window for the reason
+// ClosedSessions matches its own: the window only ever sees one page of rows, so
+// a project closed further back than that page would be unreachable by name.
 //
 // rowid is the tiebreaker, not the order: it dates a project's first open, so
 // on its own it hid a long-standing project behind newer ones the moment it was
 // closed. Rows closed before closed_seq existed carry 0 and keep falling back
 // to it.
-func (s *Service) RecentProjects() ([]Recent, error) {
+func (s *Service) RecentProjects(term string) ([]Recent, error) {
+	where, args := closedProjectMatch(term)
+	args = append(args, recentLimit)
 	rows, err := s.db.Query(
-		`SELECT id, name, path FROM projects WHERE is_open = 0
+		`SELECT id, name, path FROM projects `+where+`
 		  ORDER BY closed_seq DESC, rowid DESC LIMIT ?`,
-		recentLimit,
+		args...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("query recent projects: %w", err)
@@ -462,6 +490,20 @@ func (s *Service) RecentProjects() ([]Recent, error) {
 		return nil, fmt.Errorf("iterate recent projects: %w", err)
 	}
 	return recents, nil
+}
+
+// ClosedProjectCount counts the closed projects matching term, which is how a
+// list capped at recentLimit says what it is leaving out: the reopen menu points
+// at the palette when there are more, and the palette's own group header reports
+// the matches it could not fit. A COUNT over one indexed flag is cheap enough to
+// ask for beside the list itself.
+func (s *Service) ClosedProjectCount(term string) (int, error) {
+	where, args := closedProjectMatch(term)
+	var count int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM projects `+where, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count closed projects: %w", err)
+	}
+	return count, nil
 }
 
 // ClosedSession is one parked session offered for resuming — what identifies it
@@ -498,8 +540,8 @@ type ClosedSession struct {
 // end of.
 const closedSessionLimit = 100
 
-// likeEscape is the ESCAPE character the history search declares, so a name
-// containing % or _ searches for those characters instead of matching anything.
+// likeEscape is the ESCAPE character the searches declare, so a name containing
+// % or _ searches for those characters instead of matching anything.
 const likeEscape = `\`
 
 // escapeLike neutralises the LIKE wildcards in a user's search term. The escape

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1109,7 +1109,7 @@ func TestRecentProjectsListsClosedOnesNewestFirst(t *testing.T) {
 		}
 	}
 
-	recents, err := svc.RecentProjects()
+	recents, err := svc.RecentProjects("")
 	if err != nil {
 		t.Fatalf("RecentProjects: %v", err)
 	}
@@ -1131,7 +1131,7 @@ func TestRecentProjectsListsClosedOnesNewestFirst(t *testing.T) {
 	}
 }
 
-// TestRecentProjectsStopAtTwentyFive pins the cap the palette searches within:
+// TestRecentProjectsStopAtTwentyFive pins the page the store answers with:
 // one project past it is closed, and the one that falls off is the oldest close,
 // never the newest. The number is written out rather than read from the constant
 // so moving the constant has to move this line too.
@@ -1169,7 +1169,7 @@ func TestRecentProjectsStopAtTwentyFive(t *testing.T) {
 // recentIDs is the reopen menu's list reduced to what its order is asserted on.
 func recentIDs(t *testing.T, svc *Service) []string {
 	t.Helper()
-	recents, err := svc.RecentProjects()
+	recents, err := svc.RecentProjects("")
 	if err != nil {
 		t.Fatalf("RecentProjects: %v", err)
 	}
@@ -1271,7 +1271,7 @@ func TestReopeningARecentProjectRestoresItsSessions(t *testing.T) {
 	if err := svc.AddProject("p1", "alpha", "/tmp/alpha"); err != nil {
 		t.Fatalf("AddProject (reopen): %v", err)
 	}
-	recents, err := svc.RecentProjects()
+	recents, err := svc.RecentProjects("")
 	if err != nil {
 		t.Fatalf("RecentProjects: %v", err)
 	}
@@ -1298,7 +1298,7 @@ func TestDeleteProjectRemovesItsSessions(t *testing.T) {
 	if err := svc.DeleteProject("p1"); err != nil {
 		t.Fatalf("DeleteProject: %v", err)
 	}
-	recents, err := svc.RecentProjects()
+	recents, err := svc.RecentProjects("")
 	if err != nil {
 		t.Fatalf("RecentProjects: %v", err)
 	}


### PR DESCRIPTION
## What

Only the twenty-five most recent closes were ever offered back. Past that a project was reachable only by hunting its directory in the folder picker, and neither the reopen menu nor the command palette said so.

## The fix

- `store.RecentProjects` now takes a search term and matches it in the query: LIKE over the name and the path, every whitespace-separated word, wildcards escaped, the same reading `ClosedSessions` already gave parked sessions (#505). The page it answers with caps the rows returned, never the reach; an empty term is still the plain reopen list.
- `store.ClosedProjectCount` answers how many closed projects a term matches, so a capped list can say what it left out.
- The palette's Closed group reads through a new `useClosedProjects` hook, debounced like the other palette searches, and its group header now reports "N of M" instead of cutting a search in silence.
- The reopen menu keeps its five newest and gains a line under them naming how many more the palette can reach.

## Docs

The `docs/ceilings.md` "Persistence is hybrid" bullet is deleted rather than rewritten: the trap it named is closed, and no sentence describing the fix is left behind. The mechanism it carried (the localStorage/SQLite split, the database file, why the listener port is pinned) now lives in the `internal/store` package doc, next to the pinned-port reason already recorded at `internal/singleton.DefaultPort`.

## Tests

- Go: the LIKE query (escape, per word, order, cap, a match found past the cap, open projects excluded) and the count (past the cap, term-aware, escaped).
- Frontend: `useClosedProjects` sends the typed term to the store and reports the full total, one search per keystroke burst, idle while the palette is closed; the Closed group header carries the store's total; the reopen menu renders the line and its singular, and stays silent when it lists everything.

## Gate

`gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green, cross-compiled and vetted for linux/darwin/windows. In `frontend/`: `biome ci .` exit 0, `pnpm test` 1643 passing, `pnpm build` succeeds.