### PR TITLE
feat: remove a worktree lich did not create, behind a confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A worktree you made by hand can now be removed through lich.** Closing the
+  last session in one only ever parked it, so cleaning up meant walking to a
+  terminal for `git worktree remove`. The close dialog now offers the removal
+  behind a confirmation naming the checkout's absolute path and saying lich did
+  not create it; uncommitted work still takes the same second confirmation it
+  always did. Agents are the exception — `close_session` has nobody to ask, so
+  it still refuses and says why.
+
 - **A relayed answer is no longer matched to a task by guesswork.** Nothing in
   an answer says which request it belongs to, so `lich reply "<answer>"` and
   `reply_to_session` without a ticket closed the oldest request delivered to

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -618,14 +618,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   says `checkout gone` and offers to forget
   itself, which is the only way such a row is ever collected — `PurgeWorktreeSessions` never ran for it,
   because the removal never went through the app.
-- **A worktree lich did not create can never be removed through lich** (`internal/project.WorktreeAdopted`):
-  `git worktree list` hands back every checkout of a repository, so one the user made by hand appears in the
-  picker and hosts a session like any other — and nothing but its path tells the two apart. Everything lich
-  creates lives under the worktrees root (`reserveWorktreePath`); a canonical path outside it is adopted, and
-  `RemoveWorktree` refuses it whether or not force was asked for. What that costs is the cleanup: a hand-made
-  checkout is parked, never collected, and removing it is a `git worktree remove` the user runs themselves.
-  The test is the path and only the path — a worktree lich created and the user then moved out of the data dir
-  reads as adopted, and one made by hand inside it reads as lich's own.
 - **The History tab searches names, never what was said** (`internal/terminal/search.go`): the Messages tab
   reads a 4 MB tail or a query per session per keystroke, and it is pointed at the sessions the palette can route to —
   the open ones. History is the long list, so widening the transcript search to it would put a hundred disk

--- a/frontend/src/components/pulls/Pulls.tsx
+++ b/frontend/src/components/pulls/Pulls.tsx
@@ -201,11 +201,13 @@ export function Pulls({ list = false }: PullsProps) {
       toast.error("Worktree has a pinned session — unpin it first.")
       return
     }
-    // A checkout the user made by hand is theirs: lich lists it and works in it,
-    // but it is not lich's to delete. Refused here rather than at the call,
-    // which is past the point where the sessions have already been discarded.
+    // A checkout the user made by hand is theirs, so deleting it takes a
+    // confirmation naming the directory — which this screen has nowhere to put.
+    // Routed to the sidebar's close dialog, the way a dirty one is. Refused here
+    // rather than at the call, which is past the point where the sessions have
+    // already been discarded.
     if (await ProjectService.WorktreeAdopted(wtPath).catch(() => true)) {
-      toast.error("lich did not create this worktree — remove the checkout yourself.")
+      toast.error("lich did not create this worktree — remove it from the sidebar.")
       return
     }
     if (await ProjectService.WorktreeDirty(wtPath).catch(() => false)) {
@@ -226,7 +228,7 @@ export function Pulls({ list = false }: PullsProps) {
       navigate(`/projects/${projectId}`)
     }
     try {
-      await ProjectService.RemoveWorktree(projectPath, wtPath, false)
+      await ProjectService.RemoveWorktree(projectPath, wtPath, false, false)
       toast.success(`Removed ${baseName(wtPath)}`)
     } catch (err: unknown) {
       toast.error(`Failed to remove worktree: ${errorText(err)}`)

--- a/frontend/src/components/sidebar/WorktreeCloseDialogs.tsx
+++ b/frontend/src/components/sidebar/WorktreeCloseDialogs.tsx
@@ -50,10 +50,11 @@ interface CloseWorktreeDialogProps {
 // in: keep it on disk (it reappears in the new-worktree picker) or remove the
 // checkout via git. The branch is never deleted either way.
 //
-// A checkout lich adopted has only the one answer. The directory is the user's,
-// made outside lich and only listed by it, so the removal is refused by the
-// backend whatever this offers — and the description says so, or the missing
-// button reads as a bug rather than as the rule it is.
+// A checkout lich adopted is removable too, but the directory is the user's own
+// — made outside lich and only listed by it — so the wording names the absolute
+// path and says lich did not make it. That sentence is the acknowledgement the
+// backend asks for (project.RemoveWorktree): without it a caller that never
+// showed the path is refused.
 function CloseWorktreeDialog({
   session,
   adopted,
@@ -70,8 +71,8 @@ function CloseWorktreeDialog({
       description={
         adopted ? (
           <>
-            lich did not create the worktree at {path}, so it will not delete it. Closing parks the
-            session — the checkout stays exactly where it is.
+            lich did not create the worktree at {path}. Keep it, or remove the checkout? Removing
+            deletes that directory but keeps its branch.
           </>
         ) : (
           <>
@@ -82,13 +83,11 @@ function CloseWorktreeDialog({
       }
     >
       <Button variant="outline" onClick={onKeep}>
-        {adopted ? "Close session" : "Keep worktree"}
+        Keep worktree
       </Button>
-      {!adopted && (
-        <Button variant="destructive" onClick={onRemove}>
-          Remove worktree
-        </Button>
-      )}
+      <Button variant="destructive" onClick={onRemove}>
+        Remove worktree
+      </Button>
     </ConfirmDialog>
   )
 }

--- a/frontend/src/components/sidebar/useWorktreeClose.ts
+++ b/frontend/src/components/sidebar/useWorktreeClose.ts
@@ -18,8 +18,9 @@ export interface WorktreeClose {
   pendingClose: Session | null
   /**
    * Whether that checkout is one lich adopted rather than created, in which case
-   * it is the user's directory and removal is not on offer. True until the
-   * backend says otherwise, so the destructive answer never appears on a guess.
+   * the confirmation says whose directory it is before offering to delete it.
+   * True until the backend says otherwise, so the plainer wording never goes up
+   * on a guess.
    */
   pendingAdopted: boolean
   /** The dirty worktree waiting on a --force confirmation, or null. */
@@ -65,9 +66,13 @@ export function useWorktreeClose(
     // The checkout is going away, so no parked row for it may linger — one would
     // otherwise resurface a resume against a worktree that no longer exists.
     void Store.PurgeWorktreeSessions(projectId, session.path ?? "")
-    ProjectService.RemoveWorktree(projectPath, session.path ?? "", force).catch((err: unknown) => {
-      toast.error(`Failed to remove worktree: ${errorText(err)}`)
-    })
+    // Acknowledged: every path into here has gone through a dialog naming the
+    // directory, and for an adopted one that dialog says lich did not make it.
+    ProjectService.RemoveWorktree(projectPath, session.path ?? "", force, true).catch(
+      (err: unknown) => {
+        toast.error(`Failed to remove worktree: ${errorText(err)}`)
+      },
+    )
   }
 
   // Each step of the close, taken as closeIntent decides it. The card hides
@@ -81,10 +86,10 @@ export function useWorktreeClose(
         setPendingRunning(session)
         return
       case "ask-worktree": {
-        // Asked as the dialog opens rather than at the click on Remove: an
-        // adopted checkout has no removal to offer, and a button that only ever
-        // ends in a refusal is worse than the one that is not there. A failed
-        // check reads as adopted — the safe half of the answer.
+        // Asked as the dialog opens rather than at the click on Remove: what it
+        // decides is the wording, and a directory the user made by hand has to
+        // be named as theirs before the button that deletes it. A failed check
+        // reads as adopted — the half of the answer that says more.
         setPendingAdopted(true)
         setPendingClose(session)
         const sequence = ++adoptedProbe.current

--- a/frontend/src/components/sidebar/worktree-close-adopted.test.tsx
+++ b/frontend/src/components/sidebar/worktree-close-adopted.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+//
+// The keep-or-remove confirmation, mounted for real: removing a checkout lich
+// did not create is allowed, and the only thing standing between the user and
+// their own directory is what this dialog says. The node-only gate cannot read a
+// sentence, and the sentence is the whole safeguard.
+//
+// The harness is imported first for the reason render-budget.test.tsx names: it
+// has to hook react-dom before anything else reaches it.
+import { mountBudget } from "@/test/render-budget"
+import { createElement } from "react"
+import { expect, test } from "vitest"
+import type { Session } from "@/lib/session/sessions"
+import { WorktreeCloseDialogs } from "./WorktreeCloseDialogs"
+import type { WorktreeClose } from "./useWorktreeClose"
+
+const PATH = "/home/dev/checkouts/by-hand"
+
+const session: Session = { id: "s1", label: "by-hand", kind: "claude", path: PATH }
+
+function dialogs(adopted: boolean, onRemove: () => void = () => {}) {
+  const close: WorktreeClose = {
+    requestClose: () => {},
+    pendingRunning: null,
+    closeAnyway: () => {},
+    pendingClose: session,
+    pendingAdopted: adopted,
+    pendingForce: null,
+    cancel: () => {},
+    keep: () => {},
+    remove: onRemove,
+    forceRemove: () => {},
+  }
+  return createElement(WorktreeCloseDialogs, { close })
+}
+
+const removeButton = () =>
+  [...document.querySelectorAll("button")].find((b) => b.textContent === "Remove worktree")
+
+test("an adopted checkout names its absolute path and says lich did not make it", async () => {
+  const mounted = await mountBudget(dialogs(true))
+
+  const text = document.body.textContent ?? ""
+  expect(text).toContain(PATH)
+  expect(text).toContain("lich did not create the worktree at")
+  // The reversal: the removal is on offer, behind that sentence.
+  expect(removeButton()).toBeDefined()
+  await mounted.unmount()
+})
+
+test("a checkout lich created is named too, without the whose-directory sentence", async () => {
+  const mounted = await mountBudget(dialogs(false))
+
+  const text = document.body.textContent ?? ""
+  expect(text).toContain(PATH)
+  expect(text).not.toContain("lich did not create")
+  expect(removeButton()).toBeDefined()
+  await mounted.unmount()
+})
+
+test("Remove worktree hands the click to the flow, adopted or not", async () => {
+  const clicks: boolean[] = []
+  const mounted = await mountBudget(dialogs(true, () => clicks.push(true)))
+
+  const button = removeButton()
+  if (!button) {
+    throw new Error("Remove worktree button not rendered")
+  }
+  await mounted.act(() => button.click())
+  expect(clicks).toEqual([true])
+  await mounted.unmount()
+})

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -343,8 +343,13 @@ export const ProjectService = {
   /** Check a pull request's head branch out into its own worktree; rejects a fork PR. */
   CreateWorktreeFromPR: (projectPath: string, projectID: string, number: number) =>
     call<Worktree | null>("project.CreateWorktreeFromPR", [projectPath, projectID, number]),
-  RemoveWorktree: (projectPath: string, wtPath: string, force: boolean) =>
-    call<null>("project.RemoveWorktree", [projectPath, wtPath, force]),
+  /**
+   * Remove a worktree checkout. `adoptedAck` is the caller saying it has named
+   * the absolute path to the user and been told to go ahead, which is what one
+   * lich did not create needs on top of the usual answers.
+   */
+  RemoveWorktree: (projectPath: string, wtPath: string, force: boolean, adoptedAck: boolean) =>
+    call<null>("project.RemoveWorktree", [projectPath, wtPath, force, adoptedAck]),
   WorktreeDirty: (wtPath: string) => call<boolean>("project.WorktreeDirty", [wtPath]),
   WorktreeAdopted: (wtPath: string) => call<boolean>("project.WorktreeAdopted", [wtPath]),
 }

--- a/internal/cli/mcp.go
+++ b/internal/cli/mcp.go
@@ -439,7 +439,9 @@ var mcpTools = []mcpTool{
 			"argument: keep it on disk (the session is parked, and opening a session on " +
 			"that branch again resumes its conversation) or remove it. A checkout with " +
 			"uncommitted work is only removed with force, because what that discards is in " +
-			"no commit and on no remote. You cannot close the session you are running in.",
+			"no commit and on no remote. A checkout lich did not create is removed from the " +
+			"window only, so \"remove\" on one is refused here. You cannot close the session " +
+			"you are running in.",
 		Schema: schema(map[string]any{
 			"session": property("string",
 				"The session to close, by the label on its card or the name it answers to."),

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -233,7 +233,7 @@ func (*spawnGit) CreateWorktree(_, _, _, _ string, _ bool) (*project.Worktree, e
 
 func (g *spawnGit) ListCheckouts(string) ([]project.Worktree, error) { return g.checkouts, nil }
 
-func (g *spawnGit) RemoveWorktree(_, path string, force bool) error {
+func (g *spawnGit) RemoveWorktree(_, path string, force, _ bool) error {
 	g.removed, g.forced = path, force
 	return nil
 }

--- a/internal/project/worktree.go
+++ b/internal/project/worktree.go
@@ -394,11 +394,11 @@ func (s *Service) CreateWorktreeFromPR(projectPath, projectID string, number int
 // session like any other, and nothing but its path tells the two apart.
 // Everything lich creates lives under the worktrees root reserveWorktreePath
 // builds its paths in; anything outside it is the user's own directory, which
-// lich may forget but never delete.
+// lich deletes only once the user has been shown that path and said yes.
 //
 // Both sides go through canonicalPath, and an unresolvable root reads as
 // adopted: the answer gates a deletion, so the unknown case has to be the one
-// that keeps the checkout.
+// that asks first.
 func (s *Service) WorktreeAdopted(wtPath string) bool {
 	root, err := worktreesRoot()
 	if err != nil {
@@ -418,13 +418,14 @@ func (s *Service) WorktreeAdopted(wtPath string) bool {
 // relies on; force discards uncommitted changes after the user has confirmed.
 // The branch is never deleted either way.
 //
-// An adopted checkout is refused outright, force or not: the directory is the
-// user's, made outside lich and only listed by it, and --force would take
-// uncommitted work with it. Callers ask WorktreeAdopted before they take a
-// session apart, so this is the invariant behind them rather than the message
-// anyone reads — but it is the one that holds when a caller forgets.
-func (s *Service) RemoveWorktree(projectPath, wtPath string, force bool) error {
-	if s.WorktreeAdopted(wtPath) {
+// An adopted checkout is the user's own directory, made outside lich and only
+// listed by it, so deleting one needs adoptedAck on top of the usual answers:
+// the caller has put the absolute path in front of the user and been told to go
+// ahead. Without it the removal is refused, force or not — which is the answer
+// for a caller that has nobody to ask (the MCP close_session tool) and the one
+// that holds when a caller forgets.
+func (s *Service) RemoveWorktree(projectPath, wtPath string, force, adoptedAck bool) error {
+	if !adoptedAck && s.WorktreeAdopted(wtPath) {
 		return fmt.Errorf("The worktree at %s was not created by lich, so lich will not delete it.", wtPath)
 	}
 	args := []string{"worktree", "remove"}

--- a/internal/project/worktree_test.go
+++ b/internal/project/worktree_test.go
@@ -401,7 +401,7 @@ func TestRemoveWorktree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateWorktree: %v", err)
 	}
-	if err := svc.RemoveWorktree(repo, wt.Path, false); err != nil {
+	if err := svc.RemoveWorktree(repo, wt.Path, false, false); err != nil {
 		t.Fatalf("RemoveWorktree(clean): %v", err)
 	}
 	if _, err := os.Stat(wt.Path); !os.IsNotExist(err) {
@@ -415,13 +415,13 @@ func TestRemoveWorktree(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dirty.Path, "a.txt"), []byte("changed\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := svc.RemoveWorktree(repo, dirty.Path, false); err == nil {
+	if err := svc.RemoveWorktree(repo, dirty.Path, false, false); err == nil {
 		t.Error("RemoveWorktree(dirty) = nil error, want refusal")
 	}
 	if _, err := os.Stat(dirty.Path); err != nil {
 		t.Errorf("dirty worktree should remain on disk: %v", err)
 	}
-	if err := svc.RemoveWorktree(repo, dirty.Path, true); err != nil {
+	if err := svc.RemoveWorktree(repo, dirty.Path, true, false); err != nil {
 		t.Fatalf("RemoveWorktree(dirty, force): %v", err)
 	}
 	if _, err := os.Stat(dirty.Path); !os.IsNotExist(err) {
@@ -457,11 +457,12 @@ func TestWorktreeAdopted(t *testing.T) {
 	}
 }
 
-// TestRemoveWorktreeRefusesAnAdoptedCheckout proves a worktree the user made by
-// hand is never handed to `git worktree remove` — not even with force, which is
+// TestRemoveWorktreeRefusesAnAdoptedCheckoutUnacknowledged proves a worktree the
+// user made by hand is never handed to `git worktree remove` on the say-so of a
+// caller that has not shown its path to anyone — not even with force, which is
 // the call that would take uncommitted work with it. git lists it like any
-// other, so nothing but its path outside the data dir tells lich to keep away.
-func TestRemoveWorktreeRefusesAnAdoptedCheckout(t *testing.T) {
+// other, so nothing but its path outside the data dir tells lich to ask first.
+func TestRemoveWorktreeRefusesAnAdoptedCheckoutUnacknowledged(t *testing.T) {
 	t.Setenv("XDG_DATA_HOME", t.TempDir())
 	repo, git := initRepo(t)
 	adopted := filepath.Join(t.TempDir(), "by-hand")
@@ -469,7 +470,7 @@ func TestRemoveWorktreeRefusesAnAdoptedCheckout(t *testing.T) {
 
 	svc := New(nil)
 	for _, force := range []bool{false, true} {
-		if err := svc.RemoveWorktree(repo, adopted, force); err == nil {
+		if err := svc.RemoveWorktree(repo, adopted, force, false); err == nil {
 			t.Fatalf("RemoveWorktree(force=%v) = nil, want a refusal", force)
 		}
 	}
@@ -477,13 +478,59 @@ func TestRemoveWorktreeRefusesAnAdoptedCheckout(t *testing.T) {
 		t.Errorf("the user's checkout is gone: %v", err)
 	}
 	// Still registered: no `git worktree remove` ran, so the picker keeps
-	// offering it — adoption costs the removal, never the session.
+	// offering it — the refusal costs the removal, never the session.
 	branches, err := svc.ListBranches(repo)
 	if err != nil {
 		t.Fatalf("ListBranches: %v", err)
 	}
 	if !slices.ContainsFunc(branches.Worktrees, func(w Worktree) bool { return w.Name == "by-hand" }) {
 		t.Errorf("worktrees = %+v, want the adopted checkout still listed", branches.Worktrees)
+	}
+}
+
+// TestRemoveWorktreeAcknowledgedAdoptedCheckout proves the acknowledgement is
+// the whole difference: a caller that has named the absolute path to the user
+// gets the same removal any other checkout gets — and the uncommitted-work rule
+// is untouched by it, so a dirty one still needs force on top.
+func TestRemoveWorktreeAcknowledgedAdoptedCheckout(t *testing.T) {
+	t.Setenv("XDG_DATA_HOME", t.TempDir())
+	repo, git := initRepo(t)
+	svc := New(nil)
+
+	dirty := filepath.Join(t.TempDir(), "by-hand-dirty")
+	git("worktree", "add", "-b", "by-hand-dirty", dirty, "main")
+	if err := os.WriteFile(filepath.Join(dirty, "a.txt"), []byte("changed\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.RemoveWorktree(repo, dirty, false, true); err == nil {
+		t.Error("RemoveWorktree(adopted, dirty) = nil error, want git's refusal")
+	}
+	if _, err := os.Stat(dirty); err != nil {
+		t.Errorf("dirty checkout should remain on disk: %v", err)
+	}
+	if err := svc.RemoveWorktree(repo, dirty, true, true); err != nil {
+		t.Fatalf("RemoveWorktree(adopted, dirty, force): %v", err)
+	}
+	if _, err := os.Stat(dirty); !os.IsNotExist(err) {
+		t.Error("dirty adopted checkout still exists after a forced remove")
+	}
+
+	clean := filepath.Join(t.TempDir(), "by-hand")
+	git("worktree", "add", "-b", "by-hand", clean, "main")
+	if err := svc.RemoveWorktree(repo, clean, false, true); err != nil {
+		t.Fatalf("RemoveWorktree(adopted, clean): %v", err)
+	}
+	if _, err := os.Stat(clean); !os.IsNotExist(err) {
+		t.Error("adopted checkout still exists after an acknowledged remove")
+	}
+	// Collected, not just deleted: the picker stops offering a checkout that is
+	// gone, which is the point of removing it through lich at all.
+	branches, err := svc.ListBranches(repo)
+	if err != nil {
+		t.Fatalf("ListBranches: %v", err)
+	}
+	if slices.ContainsFunc(branches.Worktrees, func(w Worktree) bool { return w.Name == "by-hand" }) {
+		t.Errorf("worktrees = %+v, want the removed checkout gone", branches.Worktrees)
 	}
 }
 

--- a/internal/spawn/close.go
+++ b/internal/spawn/close.go
@@ -124,14 +124,17 @@ func (s *Service) Close(fromID, target, projectName, worktree string, force bool
 // the checkout does — one left behind would offer a resume into a directory that
 // no longer exists.
 func (s *Service) removeCheckout(found located, active string, force bool) error {
+	// The window offers this removal behind a confirmation naming the directory;
+	// here there is nobody to show it to, so an adopted checkout stays the user's.
 	// Asked before anything is taken apart, not after: the removal itself is
-	// refused for an adopted checkout (project.RemoveWorktree), but by then the
-	// terminal is closed and the rows are gone, and the session would be lost to
-	// keep a directory that was never at risk.
+	// refused too (project.RemoveWorktree), but by then the terminal is closed
+	// and the rows are gone, and the session would be lost to keep a directory
+	// that was never at risk.
 	if s.worktrees.WorktreeAdopted(found.session.Path) {
 		return fmt.Errorf(
 			"the worktree %s was not created by lich, so closing this session cannot delete it: "+
-				"say %q instead, which parks the session and leaves the checkout where it is",
+				"say %q instead, which parks the session and leaves the checkout where it is, "+
+				"or remove it from the window, which asks first",
 			found.session.Path, KeepWorktree,
 		)
 	}
@@ -156,7 +159,7 @@ func (s *Service) removeCheckout(found located, active string, force bool) error
 	if err := s.sessions.PurgeWorktreeSessions(found.project.ID, found.session.Path); err != nil {
 		return err
 	}
-	return s.worktrees.RemoveWorktree(found.project.Path, found.session.Path, force)
+	return s.worktrees.RemoveWorktree(found.project.Path, found.session.Path, force, false)
 }
 
 // finish takes down the PTY and the card. The terminal close is repeated for

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -98,7 +98,7 @@ type Worktrees interface {
 	ListBranches(path string) (project.Branches, error)
 	ListCheckouts(path string) ([]project.Worktree, error)
 	CreateWorktree(projectPath, projectID, name, base string, baseIsRemote bool) (*project.Worktree, error)
-	RemoveWorktree(projectPath, wtPath string, force bool) error
+	RemoveWorktree(projectPath, wtPath string, force, adoptedAck bool) error
 	WorktreeDirty(wtPath string) (bool, error)
 	WorktreeAdopted(wtPath string) bool
 }

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -216,7 +216,7 @@ func (f *fakeWorktrees) WorktreeDirty(path string) (bool, error) {
 
 func (f *fakeWorktrees) WorktreeAdopted(path string) bool { return f.adopted[path] }
 
-func (f *fakeWorktrees) RemoveWorktree(_, path string, force bool) error {
+func (f *fakeWorktrees) RemoveWorktree(_, path string, force, _ bool) error {
 	f.removed = append(f.removed, removedWorktree{path, force})
 	return f.removeErr
 }


### PR DESCRIPTION
## What

A worktree lich did not create can now be removed through lich. `git worktree list` hands back every checkout, so one the user made by hand shows up in the picker and hosts a session like any other — but `RemoveWorktree` refused to delete it, force or not. The checkout was parked, never collected, and cleaning it up meant walking to a terminal for `git worktree remove`.

The refusal is now the caller's to lift. `RemoveWorktree` takes an `adoptedAck` flag, which a caller passes only after putting the checkout's absolute path in front of the user and being told to go ahead. The close dialog does that, in the same place it used to explain why the removal was not on offer:

> lich did not create the worktree at `/home/dev/checkouts/by-hand`. Keep it, or remove the checkout? Removing deletes that directory but keeps its branch.

`WorktreeAdopted` stays exactly what it was — the path test, and now the test for the wording.

## What did not change

- **Uncommitted work.** A dirty checkout still refuses a plain remove and still asks a second time before `--force`, adopted or not.
- **`close_session` (MCP).** It has nobody to show a path to, so `worktree: "remove"` on an adopted checkout is still refused with the reason in the error, and the tool description now says an adopted checkout is removed from the window only.
- **The Pulls screen's post-merge cleanup.** It has no confirmation to put a path in, so an adopted checkout is routed to the sidebar — the way a dirty one already was.

Parked rows are collected either way: both removal paths call `PurgeWorktreeSessions` before git, so an adopted checkout removed through lich leaves no row offering a resume into a directory that is gone.

`docs/ceilings.md` loses the bullet outright.

## Test plan

- [x] `TestRemoveWorktreeRefusesAnAdoptedCheckoutUnacknowledged` — refused without the flag, force or not, and the checkout stays listed.
- [x] `TestRemoveWorktreeAcknowledgedAdoptedCheckout` — removed with the flag; dirty still needs `--force` on top; the picker stops offering it afterwards.
- [x] `TestCloseRefusesToRemoveAnAdoptedCheckout` — MCP still refuses, and nothing is taken apart for it.
- [x] `worktree-close-adopted.test.tsx` (jsdom) — the confirmation names the absolute path, says lich did not create it, and offers the removal.
- [x] Local gate: `gofmt -l .`, `go vet ./...`, `go test ./...`, `biome ci .` (exit 0), `pnpm test` (1665 passed), `pnpm build`.
- [x] Cross-compile loop for linux / darwin / windows.
