### PR TITLE
fix: stop billing a fork for the history it inherits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A forked session is no longer billed for the history it was branched from.**
+  The copy is a conversation of its own carrying every token of the original, so
+  the two cards together reported roughly twice what one conversation had spent,
+  in the footer readout and in `lich cost` alike. A fork now records what the
+  conversation it branched had cost at that moment and nets it back off its own
+  number, so the pair adds up to what was actually spent. Forks of forks count
+  the same way, and opencode is unchanged: it starts a forked session's cost at
+  zero on its own.
+
 - **A closed project is now findable by name, however long ago it was closed.**
   Only the twenty-five most recent closes were ever offered back, so an older
   project was reachable only by hunting its directory in the folder picker, and

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -254,11 +254,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   opencode's own session list places a fork in the checkout it came from and records no lineage. lich's own
   card is right — it carries the worktree it was opened in, and `origin_session_id` names the parent — but the
   two disagree, and only lich's side is visible in lich.
-- **A fork is billed as a second conversation from its first turn** (`internal/pricing`,
-  `internal/terminal/usage_cost.go`): the copy is a transcript of its own carrying every token of the history
-  it was branched from, so the pair reports roughly twice what one conversation spent. It is the same
-  arithmetic as the `(session, transcript)` bullet above, arrived at deliberately rather than by accident —
-  a lich-driven fork makes that path ordinary.
 - **git status is polled** — one shared poller per repository path (`frontend/src/lib/git/git-status-store.ts`); the
   lich plugin's `session-touched` hook nudges an immediate refresh.
 - **The status badge has a single source** (`internal/project/status.go`): the branch, the HEAD commit and the

--- a/internal/store/cost.go
+++ b/internal/store/cost.go
@@ -118,19 +118,54 @@ func restoreCostLedgers(tx *sql.Tx, sessionID string, ledgers []costRow) error {
 	return nil
 }
 
+// SaveForkCostOffset records, on a session just forked from the conversation
+// forkedFrom, what lich had counted that conversation to cost at this moment —
+// which is the stretch the fork's own transcript carries a copy of and the
+// ledger is about to count a second time. SessionCost and CostTotals take it
+// back off, so the pair adds up to what was actually spent.
+//
+// The offset is a snapshot in dollars, not in tokens, because the ledger it is
+// read out of is one: a counted stretch is never re-priced (scanTranscriptCost
+// resumes past it), so the parent's own figure does not move when a price
+// refresh lands either, and a token offset re-priced later would drift away from
+// the number the parent still shows.
+//
+// It is the raw ledger row rather than the parent's readout, which is what makes
+// a fork of a fork right: the parent's row holds the gross cost of its own
+// transcript, history included, and that whole stretch is what the copy repeats.
+// A conversation lich has counted nothing for offsets nothing.
+func (s *Service) SaveForkCostOffset(sessionID, forkedFrom string) error {
+	_, err := s.db.Exec(
+		`UPDATE sessions SET fork_cost_offset = COALESCE(
+		     (SELECT SUM(cost_usd) FROM session_costs WHERE transcript_id = ?), 0)
+		 WHERE id = ?`,
+		forkedFrom, sessionID,
+	)
+	if err != nil {
+		return fmt.Errorf("save fork cost offset for %q: %w", sessionID, err)
+	}
+	return nil
+}
+
 // SessionCost is what a session has cost so far: the sum of every transcript it
-// has run through. Zero for a session that has counted nothing yet — whether
-// that zero is worth showing is the caller's call, since an unpriced model must
-// read as "no number", never as free.
+// has run through, less what a fork inherited from the conversation it was
+// branched from (SaveForkCostOffset). Zero for a session that has counted
+// nothing yet — whether that zero is worth showing is the caller's call, since
+// an unpriced model must read as "no number", never as free.
+//
+// The subtraction is floored at zero: a fork whose ledger has not caught up with
+// its inherited history yet would otherwise report money back.
 func (s *Service) SessionCost(sessionID string) (float64, error) {
-	var cost sql.NullFloat64
+	var cost, offset sql.NullFloat64
 	err := s.db.QueryRow(
-		`SELECT SUM(cost_usd) FROM session_costs WHERE session_id = ?`, sessionID,
-	).Scan(&cost)
+		`SELECT (SELECT SUM(cost_usd) FROM session_costs WHERE session_id = ?),
+		        (SELECT fork_cost_offset FROM sessions WHERE id = ?)`,
+		sessionID, sessionID,
+	).Scan(&cost, &offset)
 	if err != nil {
 		return 0, fmt.Errorf("read session cost for %q: %w", sessionID, err)
 	}
-	return cost.Float64, nil
+	return max(0, cost.Float64-offset.Float64), nil
 }
 
 // CostSourceMixed labels a total whose money came off both rungs — some of it
@@ -282,13 +317,18 @@ func (s *Service) CostTotals(project, provider string, since int64) (CostReport,
 // one row per project. The kind is in the grouping because whose arithmetic a
 // session's dollars are is a fact of the provider that spent them
 // (providers.CostSourceOf) and the ledger itself records nothing about it.
+//
+// A forked session's money is netted the same way the live readout nets it
+// (SessionCost), per session and floored at zero — MAX over a NULL cost is NULL,
+// so a session with nothing counted stays uncounted rather than becoming a zero
+// the sum would swallow.
 func (s *Service) costRows(project, provider string, since int64) ([]*projectRow, error) {
 	rows, err := s.db.Query(
 		`SELECT p.name,
 		        s.kind,
 		        COUNT(*),
 		        SUM(CASE WHEN c.cost IS NULL THEN 1 ELSE 0 END),
-		        COALESCE(SUM(c.cost), 0)
+		        COALESCE(SUM(MAX(c.cost - s.fork_cost_offset, 0)), 0)
 		   FROM sessions s
 		   JOIN projects p ON p.id = s.project_id
 		   LEFT JOIN (SELECT session_id, SUM(cost_usd) AS cost, MAX(updated_at) AS seen

--- a/internal/store/cost_test.go
+++ b/internal/store/cost_test.go
@@ -192,3 +192,127 @@ func TestCostReadoutIsOffUntilAskedFor(t *testing.T) {
 		t.Error("CostReadout = false after it was turned on")
 	}
 }
+
+// TestAForkIsNotBilledForTheHistoryItInherits is the whole point of the offset:
+// the copy's own transcript carries the parent's turns, so the ledger counts
+// them again and the session readout takes them back off. The parent is left
+// alone — it spent that money once and still reports it.
+func TestAForkIsNotBilledForTheHistoryItInherits(t *testing.T) {
+	svc := newCostSession(t)
+	if err := svc.SaveCostLedger("s1", "uuid-a", 100, "m1", 1.25); err != nil {
+		t.Fatalf("SaveCostLedger: %v", err)
+	}
+	if err := svc.AddSession("p1", "s2", "Session 2", "", "", 3, ""); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+	if err := svc.SaveForkCostOffset("s2", "uuid-a"); err != nil {
+		t.Fatalf("SaveForkCostOffset: %v", err)
+	}
+	// The fork's own transcript: the parent's 1.25 of history, plus 0.5 of its
+	// own.
+	if err := svc.SaveCostLedger("s2", "uuid-b", 200, "m2", 1.75); err != nil {
+		t.Fatalf("SaveCostLedger: %v", err)
+	}
+
+	fork, err := svc.SessionCost("s2")
+	if err != nil {
+		t.Fatalf("SessionCost: %v", err)
+	}
+	parent, err := svc.SessionCost("s1")
+	if err != nil {
+		t.Fatalf("SessionCost: %v", err)
+	}
+
+	if fork != 0.5 {
+		t.Errorf("fork cost = %v, want the 0.5 it spent itself", fork)
+	}
+	if parent != 1.25 {
+		t.Errorf("parent cost = %v, want its own 1.25 untouched", parent)
+	}
+}
+
+// TestAForkOfAForkOffsetsItsOwnParent: the offset is the parent's raw ledger
+// row, history included, and never its netted readout — which is what keeps a
+// chain of forks adding up to one conversation's spend instead of subtracting
+// the same history twice.
+func TestAForkOfAForkOffsetsItsOwnParent(t *testing.T) {
+	svc := newCostSession(t)
+	if err := svc.SaveCostLedger("s1", "uuid-a", 100, "m1", 1.25); err != nil {
+		t.Fatalf("SaveCostLedger: %v", err)
+	}
+	for _, id := range []string{"s2", "s3"} {
+		if err := svc.AddSession("p1", id, id, "", "", 3, ""); err != nil {
+			t.Fatalf("AddSession: %v", err)
+		}
+	}
+	// s2 forks s1's conversation and spends 0.5 of its own on top of it.
+	if err := svc.SaveForkCostOffset("s2", "uuid-a"); err != nil {
+		t.Fatalf("SaveForkCostOffset: %v", err)
+	}
+	if err := svc.SaveCostLedger("s2", "uuid-b", 200, "m2", 1.75); err != nil {
+		t.Fatalf("SaveCostLedger: %v", err)
+	}
+	// s3 forks s2's, and spends 0.25.
+	if err := svc.SaveForkCostOffset("s3", "uuid-b"); err != nil {
+		t.Fatalf("SaveForkCostOffset: %v", err)
+	}
+	if err := svc.SaveCostLedger("s3", "uuid-c", 300, "m3", 2.0); err != nil {
+		t.Fatalf("SaveCostLedger: %v", err)
+	}
+
+	cost, err := svc.SessionCost("s3")
+
+	if err != nil {
+		t.Fatalf("SessionCost: %v", err)
+	}
+	if cost != 0.25 {
+		t.Errorf("fork of a fork = %v, want the 0.25 it spent itself", cost)
+	}
+}
+
+// TestAForkNeverReportsMoneyBack: the offset is a snapshot of a conversation the
+// fork's own ledger has not caught up with yet, and a negative dollar figure on
+// a card is worse than a low one.
+func TestAForkNeverReportsMoneyBack(t *testing.T) {
+	svc := newCostSession(t)
+	if err := svc.SaveCostLedger("s1", "uuid-a", 100, "m1", 1.25); err != nil {
+		t.Fatalf("SaveCostLedger: %v", err)
+	}
+	if err := svc.AddSession("p1", "s2", "Session 2", "", "", 3, ""); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+	if err := svc.SaveForkCostOffset("s2", "uuid-a"); err != nil {
+		t.Fatalf("SaveForkCostOffset: %v", err)
+	}
+
+	cost, err := svc.SessionCost("s2")
+
+	if err != nil {
+		t.Fatalf("SessionCost: %v", err)
+	}
+	if cost != 0 {
+		t.Errorf("SessionCost = %v, want 0 rather than a negative total", cost)
+	}
+}
+
+// TestForkingAnUncountedConversationOffsetsNothing: a conversation lich never
+// priced — the readout off while it ran, a model with no rate — has no money to
+// give back, and inventing one would bill the fork below what it spent.
+func TestForkingAnUncountedConversationOffsetsNothing(t *testing.T) {
+	svc := newCostSession(t)
+	if err := svc.SaveForkCostOffset("s1", "uuid-never-counted"); err != nil {
+		t.Fatalf("SaveForkCostOffset: %v", err)
+	}
+	if err := svc.SaveCostLedger("s1", "uuid-b", 200, "m2", 0.75); err != nil {
+		t.Fatalf("SaveCostLedger: %v", err)
+	}
+
+	cost, err := svc.SessionCost("s1")
+
+	if err != nil {
+		t.Fatalf("SessionCost: %v", err)
+	}
+	if cost != 0.75 {
+		t.Errorf("SessionCost = %v, want the whole 0.75 counted", cost)
+	}
+}

--- a/internal/store/cost_totals_test.go
+++ b/internal/store/cost_totals_test.go
@@ -315,3 +315,51 @@ func TestCostTotalsAttributesNoRungItCannotName(t *testing.T) {
 		t.Errorf("total = %v, want the shell session's 3.00 counted", report.CostUSD)
 	}
 }
+
+// TestCostTotalsNetsAForksInheritedHistory: the ledger the report sums holds the
+// fork's gross number, history included, so `lich cost` has to net it the same
+// way the live readout does — or the pair reads as twice what was spent.
+func TestCostTotalsNetsAForksInheritedHistory(t *testing.T) {
+	svc := costWorkspace(t)
+	bill(t, svc, "p1", "s1", "claude", 1.25)
+	// The fork's own transcript carries s1's 1.25 of history and 0.5 of its own.
+	bill(t, svc, "p1", "s2", "claude", 1.75)
+	if err := svc.SaveForkCostOffset("s2", "uuid-s1"); err != nil {
+		t.Fatalf("SaveForkCostOffset: %v", err)
+	}
+
+	report, err := svc.CostTotals("", "", 0)
+
+	if err != nil {
+		t.Fatalf("CostTotals: %v", err)
+	}
+	if report.CostUSD != 1.75 {
+		t.Errorf("total = %v, want the 1.75 the pair actually spent", report.CostUSD)
+	}
+	if report.Sessions != 2 || report.Unpriced != 0 {
+		t.Errorf("counts = %d sessions, %d unpriced, want both sessions counted",
+			report.Sessions, report.Unpriced)
+	}
+}
+
+// TestAForkedSessionUnderItsOffsetCountsAsZero, never as money back: a fork
+// whose ledger has not caught up with the history it inherited would otherwise
+// take a project's total below what its other sessions spent.
+func TestAForkedSessionUnderItsOffsetCountsAsZero(t *testing.T) {
+	svc := costWorkspace(t)
+	bill(t, svc, "p1", "s1", "claude", 1.25)
+	bill(t, svc, "p1", "s2", "claude", 0)
+	if err := svc.SaveForkCostOffset("s2", "uuid-s1"); err != nil {
+		t.Fatalf("SaveForkCostOffset: %v", err)
+	}
+
+	report, err := svc.CostTotals("", "", 0)
+
+	if err != nil {
+		t.Fatalf("CostTotals: %v", err)
+	}
+	if report.CostUSD != 1.25 {
+		t.Errorf("total = %v, want the parent's 1.25 with nothing subtracted from it",
+			report.CostUSD)
+	}
+}

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -354,21 +354,26 @@ func (s *Service) reopen(newSessionID, where string, args ...any) (*Session, err
 		// parked is typed on the resumed card's first free prompt, exactly like
 		// one that came due while lich was closed (internal/relay, deliverDue).
 		//
+		// The fork cost offset rides along with the ledgers it nets: the copied
+		// history is still in this session's transcript after a resume, so a row
+		// that came back without it would bill the fork for its parent again.
+		//
 		// project_id is read rather than passed: reopening by id knows only the
 		// session, and the row is what says where it belongs.
 		var labelAuto int
 		var projectID, model, entrypoint, sandbox string
+		var forkOffset float64
 		row := tx.QueryRow(
 			`SELECT id, project_id, label, kind, path, provider_session_id, label_auto,
 			        model, entrypoint, sandbox, pinned, origin_session_id, origin_label,
-			        scheduled_at, scheduled_prompt
+			        scheduled_at, scheduled_prompt, fork_cost_offset
 			   FROM sessions `+where,
 			args...,
 		)
 		if err := row.Scan(
 			&old.ID, &projectID, &old.Label, &old.Kind, &old.Path, &old.ProviderSessionID,
 			&labelAuto, &model, &entrypoint, &sandbox, &old.Pinned, &old.OriginSessionID, &old.OriginLabel,
-			&old.ScheduledAt, &old.ScheduledPrompt,
+			&old.ScheduledAt, &old.ScheduledPrompt, &forkOffset,
 		); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return nil // nothing parked; caller creates a new session
@@ -403,11 +408,11 @@ func (s *Service) reopen(newSessionID, where string, args ...any) (*Session, err
 			`INSERT INTO sessions
 			   (id, project_id, label, kind, path, provider_session_id, label_auto,
 			    model, entrypoint, sandbox, pinned, origin_session_id, origin_label,
-			    scheduled_at, scheduled_prompt, position)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
+			    scheduled_at, scheduled_prompt, fork_cost_offset, position)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
 			newSessionID, projectID, old.Label, old.Kind, old.Path, old.ProviderSessionID, labelAuto,
 			model, entrypoint, sandbox, old.Pinned, old.OriginSessionID, old.OriginLabel,
-			old.ScheduledAt, old.ScheduledPrompt, projectID,
+			old.ScheduledAt, old.ScheduledPrompt, forkOffset, projectID,
 		); err != nil {
 			return fmt.Errorf("reinsert session %q: %w", newSessionID, err)
 		}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -109,7 +109,15 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- close and never a reading of now — the window still draws git's answer,
     -- because a branch moves inside a checkout while the worktree keeps the name
     -- it was created with.
-    parked_branch       TEXT NOT NULL DEFAULT ''
+    parked_branch       TEXT NOT NULL DEFAULT '',
+    -- What the conversation this session was forked from had already cost when
+    -- the fork was spawned, in USD, and 0 for every session that is not one. A
+    -- fork's own transcript carries the history it was branched from, so the
+    -- ledger counts that stretch a second time; this is what is taken back off
+    -- (SaveForkCostOffset). It stays out of session_costs because it belongs to
+    -- the session, not to any one transcript it has run: the fork keeps owing it
+    -- after a /clear starts a second conversation under the same card.
+    fork_cost_offset    REAL NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_id);
 
@@ -335,6 +343,7 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN unread INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN mcp_servers TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN parked_branch TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN fork_cost_offset REAL NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN closed_seq INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE session_costs ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0`,

--- a/internal/terminal/start.go
+++ b/internal/terminal/start.go
@@ -61,6 +61,9 @@ func (s *Service) Start(
 	if fork && resume == "" {
 		return fmt.Errorf("a fork needs the conversation to branch, and no resume id was given")
 	}
+	if fork {
+		s.recordForkCost(id, kind, resume)
+	}
 	// Resolved before the lock, because it reads a file: the conversation this
 	// spawn replaces is still on the row until its successor reports, so a name
 	// recorded there is the one this card answers to. Whatever is left is the

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -222,6 +222,7 @@ type Store interface {
 	CostLedger(sessionID, transcriptID string) (int64, string, float64, error)
 	SaveCostLedger(sessionID, transcriptID string, offset int64, lastMessage string, cost float64) error
 	SessionCost(sessionID string) (float64, error)
+	SaveForkCostOffset(sessionID, forkedFrom string) error
 	AddHandsOn(sessionID string, seconds int64) error
 	HandsOn(sessionID string) (int64, error)
 	SaveTurnRecord(sessionID string, rec store.TurnRecord) error

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -61,6 +61,9 @@ type stubBins struct {
 	// The MCP servers the spawn recorded per session, the shape
 	// store.SetSessionMCPServers writes. Nil until a test cares.
 	mcpServers map[string][]string
+	// What each session inherited from the conversation it was forked from, the
+	// shape store.SaveForkCostOffset writes. Nil until a test cares.
+	forkOffsets map[string]float64
 	// One field per cost method, because the three failures are three different
 	// stories: a ledger that cannot be read, one that cannot be written, and a
 	// total that cannot be summed. A single error field would let a test claim
@@ -161,6 +164,22 @@ func (s stubBins) SaveCostLedger(
 	return nil
 }
 
+// SaveForkCostOffset mirrors the store's own arithmetic: the offset is the raw
+// ledger cost of the conversation being forked, whichever session ran it.
+func (s stubBins) SaveForkCostOffset(sessionID, forkedFrom string) error {
+	if s.forkOffsets == nil {
+		return nil
+	}
+	offset := 0.0
+	for key, ledger := range s.ledgers {
+		if strings.HasSuffix(key, "\x00"+forkedFrom) {
+			offset += ledger.cost
+		}
+	}
+	s.forkOffsets[sessionID] = offset
+	return nil
+}
+
 func (s stubBins) SessionCost(sessionID string) (float64, error) {
 	if s.sessionCostErr != nil {
 		return 0, s.sessionCostErr
@@ -171,7 +190,7 @@ func (s stubBins) SessionCost(sessionID string) (float64, error) {
 			total += ledger.cost
 		}
 	}
-	return total, nil
+	return max(0, total-s.forkOffsets[sessionID]), nil
 }
 
 func (s stubBins) AddHandsOn(sessionID string, seconds int64) error {

--- a/internal/terminal/usage.go
+++ b/internal/terminal/usage.go
@@ -241,6 +241,32 @@ func (s *Service) sessionCost(id string, src usageSource) (float64, costMiss, bo
 	return total, costMissNone, true
 }
 
+// recordForkCost snapshots what the conversation being branched had already
+// cost, so the copy is not billed a second time for the history it inherits.
+// Called once, from the spawn that forks (Start): the offset is what was true at
+// the fork, and a stretch the ledger has already counted is never re-priced, so
+// it does not move again afterwards.
+//
+// Only the rung lich prices itself is offset, and that is the whole of the
+// difference between the three providers that fork. Claude Code's copy is a
+// transcript of its own carrying every assistant line of the parent's, and a
+// forked Codex rollout copies the parent's token_count records and carries its
+// running total forward — so lich's own scan counts that stretch twice (measured
+// on 2.1.263 and 0.153.4). opencode reports its own figure instead, and its fork
+// starts at zero: the copy inherits the parent's token counters but not its cost
+// (measured on 1.18.29), so subtracting there would hide what the fork spent.
+//
+// A failure is logged and dropped rather than failing the spawn: the user is
+// waiting on a session, and a readout that is too high is not worth losing it.
+func (s *Service) recordForkCost(id, kind, forkedFrom string) {
+	if providers.CostSourceOf(kind) != providers.CostSourcePriced {
+		return
+	}
+	if err := s.store.SaveForkCostOffset(id, forkedFrom); err != nil {
+		slog.Warn("terminal: save fork cost offset", "session", id, "err", err)
+	}
+}
+
 // wholeCost prices one conversation whole, for the providers that report a
 // running total rather than per-turn deltas: each reads its own store, and
 // the two database providers say only that the row could not be read.

--- a/internal/terminal/usage_cost_test.go
+++ b/internal/terminal/usage_cost_test.go
@@ -772,3 +772,68 @@ func TestAPricedSessionCarriesNoMissReason(t *testing.T) {
 		t.Errorf("CostMiss = %q, want empty beside a number", got.CostMiss)
 	}
 }
+
+// TestAForkRecordsWhatItsParentHadCost proves the offset is taken at the fork's
+// own spawn. The copy carries the history it was branched from, so the ledger is
+// about to count that stretch a second time, and what it had cost the first time
+// is what has to come back off.
+func TestAForkRecordsWhatItsParentHadCost(t *testing.T) {
+	store := newCostStore("")
+	store.bin = stayAliveBin(t)
+	store.forkOffsets = map[string]float64{}
+	store.ledgers["parent\x00abc-123"] = stubLedger{cost: 1.25}
+	svc := New(store, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("fork") })
+
+	err := svc.Start("fork", "p1", t.TempDir(), "claude", "abc-123", "", true, false, 80, 24)
+
+	if err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+	if got := store.forkOffsets["fork"]; got != 1.25 {
+		t.Errorf("fork offset = %v, want the 1.25 its parent had counted", got)
+	}
+}
+
+// TestAForkOfAProviderThatPricesItselfOffsetsNothing: opencode hands lich its
+// own figure and starts a forked session's at zero, so netting anything off it
+// would hide what the fork itself spent.
+func TestAForkOfAProviderThatPricesItselfOffsetsNothing(t *testing.T) {
+	store := newCostStore("")
+	store.bin = stayAliveBin(t)
+	store.forkOffsets = map[string]float64{}
+	store.ledgers["parent\x00abc-123"] = stubLedger{cost: 1.25}
+	svc := New(store, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("fork") })
+
+	err := svc.Start("fork", "p1", t.TempDir(), "opencode", "abc-123", "", true, false, 80, 24)
+
+	if err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+	if _, offset := store.forkOffsets["fork"]; offset {
+		t.Errorf("fork offset = %v, want none for a provider that prices its own turns",
+			store.forkOffsets["fork"])
+	}
+}
+
+// TestAResumeIsNotAFork: continuing a conversation counts it once, so a spawn
+// that only resumes must record no offset — one that did would bill the session
+// backwards for its own history.
+func TestAResumeIsNotAFork(t *testing.T) {
+	store := newCostStore("")
+	store.bin = stayAliveBin(t)
+	store.forkOffsets = map[string]float64{}
+	store.ledgers["parent\x00abc-123"] = stubLedger{cost: 1.25}
+	svc := New(store, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("s1") })
+
+	err := svc.Start("s1", "p1", t.TempDir(), "claude", "abc-123", "", false, false, 80, 24)
+
+	if err != nil {
+		t.Fatalf("Start = %v, want nil", err)
+	}
+	if _, offset := store.forkOffsets["s1"]; offset {
+		t.Errorf("resume recorded an offset of %v, want none", store.forkOffsets["s1"])
+	}
+}


### PR DESCRIPTION
Closes the `docs/ceilings.md` bullet **"A fork is billed as a second conversation from its first turn"** by fixing it: the bullet is deleted, not rewritten.

## The trap

A lich-driven fork asks the provider to copy a conversation. The copy is a transcript of its own carrying every token of the history it was branched from, so the cost scan counted that stretch again and the pair of cards reported roughly twice what one conversation spent — on the footer readout and in `lich cost` alike.

## The fix

The fork's own spawn (`terminal.Start`, the one place that knows both the new session and the conversation being branched) records what lich had counted that conversation to cost at that moment, on a new `sessions.fork_cost_offset` column. `SessionCost` and `CostTotals` net it back off, floored at zero.

Two decisions worth naming:

- **The snapshot is dollars, not tokens.** The ledger it is read out of is dollars, and a counted stretch is never re-priced — `scanTranscriptCost` resumes past it — so the parent's own figure does not move when a price refresh lands either. Token counts are not persisted per row, and a token offset re-priced later would drift away from the number the parent still shows. Written as a comment on `SaveForkCostOffset`.
- **The offset is the parent's raw ledger row, never its netted readout.** That is what makes a fork of a fork right: each link subtracts the gross cost of the transcript it copied, once.

## The three providers that fork, measured

| Provider | Forked session's own figure | Offset |
| --- | --- | --- |
| Claude Code 2.1.263 | the copy repeats every assistant line of the parent's, usage counters included | yes |
| Codex 0.153.4 | the forked rollout copies the parent's `token_count` records **and carries `total_token_usage` forward** — measured: a fork of a 22-turn session opens with the parent's final 764,616 input tokens already on it | yes |
| opencode 1.18.29 | the copy inherits the parent's token counters but **not** its `cost`, which stays 0 | no |

The opencode measurement was run against the build on this machine, in an isolated `XDG_DATA_HOME` holding a copy of the real database with the parent's `cost` seeded to `1.2345`: the forked row came back with the parent's `tokens_input`/`tokens_output` copied verbatim and `cost` at `0`. lich reads `cost` there, so subtracting anything would hide what the fork itself spent. The Codex measurement was a `codex exec fork` in an isolated `CODEX_HOME`.

The rung is selected by `providers.CostSourceOf` rather than a new predicate: the offset exists because lich re-prices tokens it reads, so it applies exactly to `CostSourcePriced`. The other five providers have no fork verb at all (`providers.SupportsFork`), which the neighbouring ceilings bullet still covers.

## Not touched

A fork made *inside* the PTY is not one lich sees; the `(session, transcript)` bullet above the deleted one already says so, and it stays.

## Tests

- `internal/terminal`: the offset is recorded at the fork's spawn; not recorded for opencode; not recorded for a plain resume.
- `internal/store`: subtracted in the session readout, subtracted in `CostTotals`, a fork of a fork, never negative on either path, and an uncounted parent offsetting nothing.
- Each new test was mutation-checked — reverting the production change fails it.
- The offset rides through the park/resume reinsert with the ledgers it nets (`ReopenWorktreeSession`).

## Gate

`gofmt -l ./internal ./main.go` clean, `go vet ./...` clean, `go test ./...` green, `-race` green on `internal/terminal` and `internal/store`, and the three-OS build/vet loop clean. No JSON tag moved, so the frontend mirror is untouched.

## One residual, for the record

The offset is only as good as what the ledger had counted when the fork was spawned. Fork a conversation while the cost readout is switched off and nothing has been counted for it, so the offset is zero and turning the readout on later bills the copied history on both cards. That is the readout's own kill switch rather than a fork trap, so it is not written up as a ceiling here.
