### PR TITLE
fix: keep terminals alive when a render throw takes the stage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A render bug in the terminal area no longer blanks the window.** The stage
+  and every pane in it are now caught: the pane that stopped rendering says so
+  by name, its neighbours keep painting, and a retry puts it back. The terminals
+  themselves survive it — the same xterm, the same scrollback, the same
+  selection and modes, and output that arrived meanwhile is still there — so
+  recovering no longer means reloading the window over sessions that never
+  stopped running.
 - **A closed project is now findable by name, however long ago it was closed.**
   Only the twenty-five most recent closes were ever offered back, so an older
   project was reachable only by hunting its directory in the folder picker, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **A render bug in the terminal area no longer blanks the window.** The stage
   and every pane in it are now caught: the pane that stopped rendering says so
-  by name, its neighbours keep painting, and a retry puts it back. The terminals
+  by name, its neighbours keep painting, and a retry puts it back — or, when a
+  second try throws too, offers the reload rather than the same button. The terminals
   themselves survive it — the same xterm, the same scrollback, the same
   selection and modes, and output that arrived meanwhile is still there — so
   recovering no longer means reloading the window over sessions that never

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -137,15 +137,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   for one terminal. The budget suite pins that adding a pane mounts one terminal and remounts none
   (`frontend/src/components/render-budget.test.tsx`); it cannot measure the cadence, because jsdom has
   no canvas to paint.
-- **The terminals are outside every error boundary, so a throw in one still takes the window**
-  (`frontend/src/components/common/ErrorBoundary.tsx`, `App.tsx`): the boundaries wrap the screens over
-  the stage and the right dock's panels, and deliberately not `TerminalHost` — catching there means
-  unmounting it, which destroys every session's xterm instance and its DOM, and no remount brings those
-  scrollbacks back. Recovering the window would cost more than the blank one it replaced. So a render
-  throw anywhere under `TerminalHost` — a pane, a terminal's own chrome, the stage's grid — is still
-  the whole tree going, and the only way back is a reload, while the sessions keep running behind it.
-  The trap is reading "lich has error boundaries" as "a render bug can no longer blank the window": the
-  one subtree that owns the most state is the one nothing catches.
 - **A dropped file has no path, so lich guesses it** (`internal/drop`): a file under neither the session directory
   nor home is *copied*, so an agent told to edit it edits the copy — and that copy is deleted 3 days on, so a path
   pasted into a prompt eventually stops resolving.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -120,12 +120,19 @@ function Layout() {
           {/* relative: RightDock overlays this area when in full screen. */}
           <div className="relative flex flex-1 overflow-hidden">
             <div className="relative flex-1 overflow-hidden">
-              {/* TerminalHost is outside on purpose — unmounting it destroys
-                  every session's xterm, and no remount brings those back
-                  (docs/ceilings.md). The screens over it are what is caught:
-                  the fallback takes the same overlay they do, and the route
-                  resets it, so navigating away from a blown screen is enough. */}
-              <TerminalHost />
+              {/* The stage's own chrome — the grid, the seams, the dialogs it
+                  owns. A pane's throw is caught closer, inside TerminalHost,
+                  so this fallback is for the layout around them. Retrying
+                  remounts the host, and every terminal re-attaches from the
+                  registry with its scrollback. A throw inside xterm's own
+                  render loop is not a React render, so nothing here sees it. */}
+              <ErrorBoundary
+                label="The stage"
+                retry="Reload the stage"
+                className="absolute inset-0"
+              >
+                <TerminalHost />
+              </ErrorBoundary>
               <ErrorBoundary
                 label="This screen"
                 resetKey={location.pathname}

--- a/frontend/src/components/TerminalHost.tsx
+++ b/frontend/src/components/TerminalHost.tsx
@@ -5,6 +5,7 @@ import { TerminalView } from "./TerminalView"
 import { ResumeSessionDialog } from "./ResumeSessionDialog"
 import { ProviderIcon } from "./ProviderIcon"
 import { CloseButton } from "./common/CloseButton"
+import { ErrorBoundary } from "./common/ErrorBoundary"
 import { WorktreeCloseDialogs } from "./sidebar/WorktreeCloseDialogs"
 import { useWorktreeClose } from "./sidebar/useWorktreeClose"
 import { Terminal as TerminalService } from "@/lib/rpc"
@@ -17,6 +18,7 @@ import { cellAt, grid, offsetOf, rowLength, rowTracks } from "@/lib/session/pane
 import { paneTracks } from "@/lib/session/panes"
 import { usePanes } from "@/lib/session/use-panes"
 import { useStageSize } from "@/lib/session/use-stage-size"
+import { spawnedSessions } from "@/lib/terminal/terminal-registry"
 import { cn } from "@/lib/utils"
 import type { Session } from "@/lib/session/sessions"
 
@@ -178,8 +180,11 @@ export function TerminalHost() {
 
   // Session ids that have been viewed at least once, which keeps a terminal
   // mounted after the user navigates away. A session that leaves the workspace
-  // is pruned from it (see below), not left behind as a dead entry.
-  const [spawned, setSpawned] = useState<Set<string>>(() => new Set())
+  // is pruned from it (see below), not left behind as a dead entry. Seeded from
+  // the registry rather than empty: a host that remounted — the stage's error
+  // boundary retrying — must not walk sessions that never stopped running back
+  // through the gate and ask again about a conversation already resumed.
+  const [spawned, setSpawned] = useState<Set<string>>(() => new Set(spawnedSessions()))
   // The session whose resume prompt is on screen, if any; its spawn waits here.
   const [asking, setAsking] = useState<Session | null>(null)
   // The Claude session each spawned session was told to resume, keyed by session
@@ -315,34 +320,40 @@ export function TerminalHost() {
               // a selection: clicking a terminal is how you focus its pane.
               onPointerDownCapture={visible && !focused ? () => stage.focusCell(index) : undefined}
             >
-              {split && visible && (
-                <PaneHeader
-                  session={session}
-                  index={index}
-                  focused={focused}
-                  drag={paneDrag}
-                  onDrag={setPaneDrag}
-                  onFocus={stage.focusCell}
-                  onSwap={stage.swap}
-                  onDrop={stage.drop}
-                />
-              )}
-              <div className="relative min-h-0 flex-1">
-                <TerminalView
-                  sessionId={session.id}
-                  projectId={project.id}
-                  cwd={session.path || project.path}
-                  kind={session.kind}
-                  resume={resuming[session.id] ?? ""}
-                  roster={roster}
-                  visible={visible}
-                  focused={focused}
-                  sandboxed={session.sandboxed ?? false}
-                  label={session.label}
-                  onClose={() => worktreeClose.requestClose(session)}
-                  stillInWorkspace={() => hasSession(sessionsRef.current, session.id)}
-                />
-              </div>
+              {/* Per pane, so the fallback names the session that stopped
+                  rendering and the panes beside it carry on. The terminal
+                  detaches rather than dying with the subtree, so retrying
+                  re-attaches the very same one (lib/terminal/terminal-registry). */}
+              <ErrorBoundary label={`The ${session.label} pane`}>
+                {split && visible && (
+                  <PaneHeader
+                    session={session}
+                    index={index}
+                    focused={focused}
+                    drag={paneDrag}
+                    onDrag={setPaneDrag}
+                    onFocus={stage.focusCell}
+                    onSwap={stage.swap}
+                    onDrop={stage.drop}
+                  />
+                )}
+                <div className="relative min-h-0 flex-1">
+                  <TerminalView
+                    sessionId={session.id}
+                    projectId={project.id}
+                    cwd={session.path || project.path}
+                    kind={session.kind}
+                    resume={resuming[session.id] ?? ""}
+                    roster={roster}
+                    visible={visible}
+                    focused={focused}
+                    sandboxed={session.sandboxed ?? false}
+                    label={session.label}
+                    onClose={() => worktreeClose.requestClose(session)}
+                    stillInWorkspace={() => hasSession(sessionsRef.current, session.id)}
+                  />
+                </div>
+              </ErrorBoundary>
             </div>
           )
         })

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -11,34 +11,30 @@ import { errorText } from "@/lib/utils"
 import { onAppEvent } from "@/lib/app-events"
 import { ensureTransport, onSessionData, sendInput } from "@/lib/terminal/term-transport"
 import { chordSequence, isSearchOpenChord } from "@/lib/terminal/term-keys"
-import { makeReplayBuffer } from "@/lib/terminal/replay-buffer"
 import { takePaste } from "@/lib/terminal/paste-queue"
 import { takeFork } from "@/lib/terminal/fork-queue"
 import { takeSetup } from "@/lib/terminal/setup-queue"
 import type { PaletteSession } from "@/lib/session/command-palette"
 import { onTerminalFocusRequest } from "@/lib/terminal/focus-request"
-import { recordChunk } from "@/lib/terminal/term-perf"
 import { copyToastMessage, COPY_TOAST_DURATION_MS } from "@/lib/terminal/copy-toast"
 import { decodeBase64 } from "@/lib/terminal/term-frame"
 import {
-  cursorHidden,
-  cursorShape,
-  ensureFontLoaded,
-  fitTerminal,
-  mouseEncoding,
-  TERMINAL_PADDING_LEFT,
-} from "@/lib/terminal/term-view"
+  attachTerminal,
+  detachTerminal,
+  disposeTerminal,
+  feedEntry,
+  hideEntry,
+  type LiveTerminal,
+  showEntry,
+  terminalEntry,
+} from "@/lib/terminal/terminal-registry"
+import { ensureFontLoaded, fitTerminal, TERMINAL_PADDING_LEFT } from "@/lib/terminal/term-view"
 import { exitMarker, readSessionExit, type SessionExit } from "@/lib/terminal/session-exit"
 import { TerminalExitBanner } from "./TerminalExitBanner"
 import { TerminalDropHint } from "./TerminalDropHint"
 import { TerminalSearchBar, type SearchResults } from "./TerminalSearchBar"
 import { useTerminalDrop } from "./useTerminalDrop"
-import {
-  cursorShapeSequence,
-  cursorVisibilitySequence,
-  linkClickIsOurs,
-  mouseEncodingSequence,
-} from "@/lib/terminal/term-modes"
+import { linkClickIsOurs } from "@/lib/terminal/term-modes"
 import { createSessionLinkProvider } from "@/lib/terminal/session-link-provider"
 import { sessionLinkTargets } from "@/lib/terminal/session-links"
 import { useSettings } from "@/providers/settings"
@@ -53,8 +49,13 @@ import "@xterm/xterm/css/xterm.css"
 // Hidden sessions follow the waveterm model: the xterm instance is serialized
 // and destroyed (no buffer, no canvas, no renderer), PTY output queues in a
 // capped replay buffer, and showing the session recreates the terminal from
-// the serialized snapshot plus the queued tail. The component itself stays
-// mounted — its lifecycle is the PTY's (unmount closes the session).
+// the serialized snapshot plus the queued tail.
+//
+// The terminal itself is not this component's. It lives in the session's
+// registry entry (terminal-registry.ts), which this draws a container for and
+// attaches the host node into; unmounting detaches it and leaves everything
+// running, so an error boundary over the stage costs no scrollback. Only the
+// session leaving the workspace closes the PTY and disposes the terminal.
 
 // Event name prefixes mirror the backend (internal/terminal); the concrete
 // event carries the session ID as a suffix.
@@ -127,13 +128,6 @@ export interface TerminalViewProps {
   stillInWorkspace: () => boolean
 }
 
-interface LiveTerminal {
-  term: Terminal
-  serialize: SerializeAddon
-  search: SearchAddon
-  dispose(): void
-}
-
 export function TerminalView({
   sessionId,
   projectId,
@@ -153,21 +147,10 @@ export function TerminalView({
   const { activateSession } = useProjects()
   const navigate = useNavigate()
   const containerRef = useRef<HTMLDivElement | null>(null)
-  const liveRef = useRef<LiveTerminal | null>(null)
-  // False until the mount effect's async setup builds the first terminal.
-  // The visibility effect must not create one before that: on first mount it
-  // runs while the font load is still in flight, and an unguarded show would
-  // plant an orphan, unwired terminal in the container — the real one then
-  // stacks below it (a black dead canvas on top, the prompt clipped at the
-  // bottom of the window).
-  const startedRef = useRef(false)
-  // Snapshot + queued output of a hidden (destroyed) terminal.
-  const serializedRef = useRef<string | null>(null)
-  // The modes the snapshot cannot carry (term-modes.ts). Kept apart from it
-  // because they survive the overflow path, where the snapshot is dropped:
-  // they describe the app, not the buffer.
-  const carriedModesRef = useRef("")
-  const replayRef = useRef(makeReplayBuffer())
+  // The session's terminal, its buffer and its PTY subscriptions. Looked up
+  // rather than held: this component is one of possibly several that will draw
+  // the same terminal over the session's life.
+  const entry = terminalEntry(sessionId)
   const visibleRef = useRef(visible)
   const focusedRef = useRef(focused)
   const stillInWorkspaceRef = useRef(stillInWorkspace)
@@ -185,26 +168,26 @@ export function TerminalView({
   // through a ref because xterm calls provideLinks straight from its own
   // render loop, well outside React's.
   const linkTargets = useMemo(() => sessionLinkTargets(roster, sessionId), [roster, sessionId])
-  const linkTargetsRef = useRef(linkTargets)
-  linkTargetsRef.current = linkTargets
+  entry.linkTargets.current = linkTargets
 
-  // In-terminal search (Ctrl+F). The open flag mirrors into a ref so the
-  // terminal's key handler — wired once at creation — reads the live value.
   // Set once this session's process is gone, and the whole of the card's
   // terminal state: the scrollback stays on screen, the banner below offers the
-  // two ways out of it.
-  const [exited, setExited] = useState<SessionExit | null>(null)
+  // two ways out of it. Seeded from the entry, because an exit can land while
+  // no view is mounted — the stage sitting in a boundary's fallback.
+  const [exited, setExited] = useState<SessionExit | null>(entry.exit)
 
   const [searchOpen, setSearchOpen] = useState(false)
   const [searchQuery, setSearchQuery] = useState("")
   const [searchResults, setSearchResults] = useState<SearchResults | null>(null)
+  // In-terminal search (Ctrl+F). The open flag mirrors into a ref so the
+  // terminal's key handler — wired once at creation — reads the live value.
   const searchOpenRef = useRef(searchOpen)
   searchOpenRef.current = searchOpen
 
   // runSearch jumps to the next/previous match; incremental keeps the current
   // match under the cursor while the query is still being typed.
   const runSearch = (query: string, direction: "next" | "prev", incremental = false) => {
-    const search = liveRef.current?.search
+    const search = entry.live?.search
     if (!search || query === "") {
       setSearchResults(null)
       return
@@ -222,7 +205,7 @@ export function TerminalView({
     setSearchOpen(false)
     setSearchQuery("")
     setSearchResults(null)
-    const live = liveRef.current
+    const live = entry.live
     if (live) {
       live.search.clearDecorations()
       live.term.clearSelection()
@@ -243,7 +226,7 @@ export function TerminalView({
   // would reopen whatever the provider last saved rather than what is on screen.
   // The scrollback is left alone — it is the evidence of what happened.
   const restart = () => {
-    const live = liveRef.current
+    const live = entry.live
     // The band raising this is inside a terminal that is on screen, so there is
     // always one to measure: a hidden layer is visibility:hidden and takes no
     // click at all. Guarded rather than asserted because the size is the only
@@ -263,8 +246,9 @@ export function TerminalView({
       live.term.rows,
     )
       .then(() => {
+        entry.exit = null
         setExited(null)
-        liveRef.current?.term.focus()
+        entry.live?.term.focus()
       })
       .catch((error: unknown) => {
         toast.error(`Session failed to restart: ${errorText(error)}`)
@@ -280,9 +264,23 @@ export function TerminalView({
     activateSession(target.projectId, target.sessionId)
   }
 
-  // createTerminal builds a live terminal in the container, wired for input,
-  // resize and copy-on-select. Shared by mount and every show-after-hide.
-  const createTerminal = (container: HTMLDivElement): LiveTerminal => {
+  // xterm's handlers are wired once, when the terminal is built, and that
+  // terminal outlives the component that built it — so they call the view that
+  // is mounted now through the entry, never the closure they were born in. No
+  // dependencies: every commit republishes them.
+  useEffect(() => {
+    entry.handlers = {
+      searchOpen: () => searchOpenRef.current,
+      closeSearch,
+      searchResults: (index, count) => setSearchResults({ index, count }),
+      activateLink,
+      exited: setExited,
+    }
+  })
+
+  // createTerminal builds a live terminal in the session's host node, wired for
+  // input, resize and copy-on-select. Shared by mount and every show-after-hide.
+  const createTerminal = (host: HTMLDivElement): LiveTerminal => {
     // Tracks the pointer sitting on a link, so the mousedown listener below only
     // swallows a click the link layer is about to serve.
     let linkHovered = false
@@ -320,9 +318,11 @@ export function TerminalView({
     // one already claimed the cells. A session called "docs" printed inside
     // https://docs.example.com must not swallow the URL.
     const sessionLinks = term.registerLinkProvider(
-      createSessionLinkProvider(term, linkTargetsRef, activateLink),
+      createSessionLinkProvider(term, entry.linkTargets, (target) =>
+        entry.handlers?.activateLink(target),
+      ),
     )
-    term.open(container)
+    term.open(host)
 
     // A link click must not also reach the PTY: an app that reads the mouse and
     // opens the links it prints (Claude Code does) would open the same URL a
@@ -345,7 +345,7 @@ export function TerminalView({
     const search = new SearchAddon()
     term.loadAddon(search)
     const searchResults = search.onDidChangeResults(({ resultIndex, resultCount }) =>
-      setSearchResults({ index: resultIndex, count: resultCount }),
+      entry.handlers?.searchResults(resultIndex, resultCount),
     )
 
     // WebGL is the renderer; context loss falls back to xterm's DOM renderer.
@@ -355,7 +355,11 @@ export function TerminalView({
       webgl.dispose()
     })
     term.loadAddon(webgl)
-    fitTerminal(term, container)
+    // Against the React container, not the host: the left gutter is padding on
+    // the container, and the fit subtracts it (term-view.ts). A terminal built
+    // while nothing is mounted has no container to measure and no size worth
+    // measuring — the next visibility pass refits it.
+    fitTerminal(term, containerRef.current ?? host)
 
     // Chords xterm encodes differently from what our TUIs expect go straight
     // to the PTY (see term-keys.ts). Returning false makes xterm skip the
@@ -369,9 +373,9 @@ export function TerminalView({
       // (Ctrl+F) is caught by a window capture-phase listener in the mount
       // effect — that is what beats Chromium's own Find accelerator in --app
       // mode; xterm's handler here is too late (the accelerator already fired).
-      if (searchOpenRef.current && event.key === "Escape") {
+      if (entry.handlers?.searchOpen() && event.key === "Escape") {
         event.preventDefault()
-        closeSearch()
+        entry.handlers.closeSearch()
         return false
       }
       // Platform-dependent because Claude Code's clipboard-image-paste chord is
@@ -398,7 +402,7 @@ export function TerminalView({
     // must not hijack the clipboard or raise a toast on every step.
     let copyTimer = 0
     const selection = term.onSelectionChange(() => {
-      if (searchOpenRef.current) {
+      if (entry.handlers?.searchOpen()) {
         return
       }
       window.clearTimeout(copyTimer)
@@ -433,7 +437,7 @@ export function TerminalView({
         // enough to start killing live renderers (a frozen terminal for the 3s
         // xterm waits for a restore, then a permanent fall back to the slower
         // DOM renderer). Hand the context back here instead.
-        const canvases = [...container.querySelectorAll("canvas")]
+        const canvases = [...host.querySelectorAll("canvas")]
         term.dispose()
         for (const canvas of canvases) {
           canvas.getContext("webgl2")?.getExtension("WEBGL_lose_context")?.loseContext()
@@ -442,70 +446,24 @@ export function TerminalView({
     }
   }
 
-  // hide serializes the live terminal and destroys it; output then queues in
-  // the replay buffer until show.
-  const hideTerminal = () => {
-    const live = liveRef.current
-    if (!live) {
-      return
-    }
-    serializedRef.current = live.serialize.serialize()
-    carriedModesRef.current =
-      mouseEncodingSequence(mouseEncoding(live.term)) +
-      cursorVisibilitySequence(cursorHidden(live.term)) +
-      cursorShapeSequence(cursorShape(live.term))
-    live.dispose()
-    liveRef.current = null
-  }
-
-  // show rebuilds the terminal from the snapshot plus the queued tail.
-  const showTerminal = () => {
-    const container = containerRef.current
-    if (liveRef.current || !container) {
-      return
-    }
-    const live = createTerminal(container)
-    if (replayRef.current.truncated()) {
-      // The queue overflowed while hidden; the head of what remains may be a
-      // partial ANSI sequence. The snapshot is stale relative to it either
-      // way, so start clean from the tail.
-      serializedRef.current = null
-      live.term.clear()
-    }
-    if (serializedRef.current) {
-      live.term.write(serializedRef.current)
-    }
-    // Between the snapshot and the queued tail: the tail is newer output, so
-    // anything the app changed there still wins.
-    if (carriedModesRef.current) {
-      live.term.write(carriedModesRef.current)
-    }
-    for (const chunk of replayRef.current.drain()) {
-      live.term.write(chunk)
-    }
-    serializedRef.current = null
-    carriedModesRef.current = ""
-    liveRef.current = live
-  }
-
   // Files dropped on the terminal land at the prompt as paths (useTerminalDrop).
   const { dropping, onDrop, onDragEnter, onDragOver, onDragLeave } = useTerminalDrop(
     { cwd, sessionId, confined: sandboxed },
     writeInput,
-    () => liveRef.current?.term.focus(),
+    () => entry.live?.term.focus(),
   )
 
-  // Create the terminal and its PTY session once per session id. The session
-  // runs in the background regardless of visibility and is only torn down
-  // when it is closed (this component unmounts) — never on navigation.
+  // Attach the session's terminal, and build it and its PTY on the first mount
+  // that ever draws the session. The session runs in the background regardless
+  // of visibility and is only torn down when it is closed — never on
+  // navigation, and never because this component went away.
   useEffect(() => {
     const container = containerRef.current
     if (!container) {
       return
     }
 
-    let disposed = false
-    const cleanups: Array<() => void> = []
+    attachTerminal(entry, container)
 
     // Ctrl+F must be caught in the window capture phase to beat Chromium's Find
     // accelerator in --app mode (the same pattern the zoom hotkeys use in
@@ -526,29 +484,59 @@ export function TerminalView({
       setSearchOpen(true)
     }
     window.addEventListener("keydown", onSearchKey, true)
-    cleanups.push(() => window.removeEventListener("keydown", onSearchKey, true))
 
-    // Output sink: the live terminal when one exists, the replay buffer
-    // while the session is hidden and the terminal destroyed.
-    const feed = (bytes: Uint8Array, decodeMs: number) => {
-      const live = liveRef.current
-      if (live) {
-        const t0 = performance.now()
-        live.term.write(bytes, () => recordChunk(decodeMs, performance.now() - t0, bytes.length))
-        return
+    // The refit follows the container, which is this component's: the pane it
+    // sits in is what changes size.
+    let refitTimer = 0
+    const resizeObserver = new ResizeObserver(() => {
+      window.clearTimeout(refitTimer)
+      refitTimer = window.setTimeout(() => {
+        if (visibleRef.current && entry.live) {
+          fitTerminal(entry.live.term, container)
+        }
+      }, REFIT_DEBOUNCE_MS)
+    })
+    resizeObserver.observe(container)
+
+    const teardown = () => {
+      window.removeEventListener("keydown", onSearchKey, true)
+      window.clearTimeout(refitTimer)
+      resizeObserver.disconnect()
+      detachTerminal(entry)
+      // The PTY and the terminal die with the session, never with this
+      // component. React unmounts for reasons that are not a close — StrictMode
+      // mounts every component twice in dev, a hot reload tears the tree down,
+      // an error boundary over the stage catches a throw — and a terminal
+      // closed for one of those takes the running agent and its scrollback with
+      // it. That was invisible while every session's PTY was born on this very
+      // mount; a session opened through the CLI or its MCP tools is already
+      // running when the card is first viewed, and the double mount killed the
+      // conversation the user came to read.
+      if (!stillInWorkspaceRef.current()) {
+        void Service.Close(sessionId)
+        disposeTerminal(sessionId)
       }
-      replayRef.current.push(bytes)
     }
+
+    if (entry.setup) {
+      // Remounted onto a terminal that outlived us: its buffer, its modes and
+      // its PTY subscriptions all belong to the entry, so re-attaching the node
+      // was the whole of the work — the visibility effect below refits it.
+      return teardown
+    }
+    entry.setup = true
 
     void (async () => {
       await ensureFontLoaded(fontRef.current)
-      if (disposed) {
+      if (entry.disposed) {
         return
       }
 
-      const live = createTerminal(container)
-      liveRef.current = live
-      startedRef.current = true
+      showEntry(entry, createTerminal)
+      const live = entry.live
+      if (!live) {
+        return
+      }
       ensureTransport()
 
       // Reseed scrollback from the backend tail. A full page reload discards the
@@ -561,43 +549,34 @@ export function TerminalView({
       // brand-new session.
       try {
         const tail = await Service.Replay(sessionId)
-        if (disposed) {
+        if (entry.disposed) {
           return
         }
-        if (tail && liveRef.current === live) {
+        if (tail && entry.live === live) {
           live.term.write(decodeBase64(tail))
         }
       } catch {
         // No tail is fine — the terminal just starts from live output.
       }
 
-      const offData = onAppEvent(DATA_EVENT_PREFIX + sessionId, (data) => {
-        const t0 = performance.now()
-        const bytes = decodeBase64(data as string)
-        feed(bytes, performance.now() - t0)
-      })
-      const offWsData = onSessionData(sessionId, (payload) => feed(payload, 0))
-      const offExit = onAppEvent(EXIT_EVENT_PREFIX + sessionId, (data) => {
-        const exit = readSessionExit(data)
-        feed(new TextEncoder().encode(exitMarker(exit)), 0)
-        setExited(exit)
-      })
-      cleanups.push(offData, offWsData, offExit)
-
-      let refitTimer = 0
-      const resizeObserver = new ResizeObserver(() => {
-        window.clearTimeout(refitTimer)
-        refitTimer = window.setTimeout(() => {
-          if (visibleRef.current && liveRef.current) {
-            fitTerminal(liveRef.current.term, container)
-          }
-        }, REFIT_DEBOUNCE_MS)
-      })
-      resizeObserver.observe(container)
-      cleanups.push(() => {
-        window.clearTimeout(refitTimer)
-        resizeObserver.disconnect()
-      })
+      // The session's subscriptions, not this component's: they feed the entry,
+      // so output that arrives while no view is mounted — the stage sitting in
+      // a boundary's fallback — still lands in the terminal instead of leaving
+      // a hole in the scrollback. They come off with the session (dispose).
+      entry.subscriptions.push(
+        onAppEvent(DATA_EVENT_PREFIX + sessionId, (data) => {
+          const t0 = performance.now()
+          const bytes = decodeBase64(data as string)
+          feedEntry(entry, bytes, performance.now() - t0)
+        }),
+        onSessionData(sessionId, (payload) => feedEntry(entry, payload, 0)),
+        onAppEvent(EXIT_EVENT_PREFIX + sessionId, (data) => {
+          const exit = readSessionExit(data)
+          feedEntry(entry, new TextEncoder().encode(exitMarker(exit)), 0)
+          entry.exit = exit
+          entry.handlers?.exited(exit)
+        }),
+      )
 
       // A queued fork carries the conversation to branch, which stands in for
       // the resume id this spawn would otherwise have had: a card born of a
@@ -624,15 +603,14 @@ export function TerminalView({
         toast.error(`Session failed to start: ${errorText(error)}`)
         return
       }
-      if (disposed) {
-        // Unmounted during the Start round-trip. If the session went with it,
-        // the cleanup's Close raced ahead of the spawn, so close again now
-        // that the PTY exists; if the session is still in the workspace this
-        // was React remounting us and the PTY is the one the next mount
-        // attaches to. The queued paste stays put either way.
-        if (!stillInWorkspaceRef.current()) {
-          void Service.Close(sessionId)
-        }
+      if (!stillInWorkspaceRef.current()) {
+        // The session was closed during the Start round-trip, so the teardown's
+        // Close raced ahead of the spawn: close the PTY that now exists. An
+        // unmount that was not a close needs none of this — the terminal is
+        // still the entry's, and the next mount attaches to it. The queued
+        // paste stays put either way.
+        void Service.Close(sessionId)
+        disposeTerminal(sessionId)
         return
       }
       // Start is a no-op for a session that was already running — one an agent
@@ -656,53 +634,38 @@ export function TerminalView({
       } else {
         // Navigated away while the font load was in flight: enter the hidden
         // state (serialize + destroy) and demote the backend session.
-        hideTerminal()
+        hideEntry(entry)
         void Service.SetVisible(sessionId, false)
       }
     })()
 
-    return () => {
-      disposed = true
-      for (const cleanup of cleanups) {
-        cleanup()
-      }
-      // The PTY dies with the session, never with this component. React
-      // unmounts for reasons that are not a close — StrictMode mounts every
-      // component twice in dev, a hot reload tears the tree down — and a PTY
-      // closed for one of those takes the running agent and its scrollback
-      // with it. That was invisible while every session's PTY was born on
-      // this very mount; a session opened through the CLI or its MCP tools is
-      // already running when the card is first viewed, and the double mount
-      // killed the conversation the user came to read.
-      if (!stillInWorkspaceRef.current()) {
-        void Service.Close(sessionId)
-      }
-      liveRef.current?.dispose()
-      liveRef.current = null
-    }
-  }, [sessionId, projectId, cwd, kind])
+    return teardown
+  }, [sessionId, projectId, cwd, kind, entry])
 
   // Visibility is the terminal's lifecycle: hidden destroys it (state lives
   // in the snapshot + replay buffer + backend), visible rebuilds it, refits,
   // syncs the PTY size and focuses.
   useEffect(() => {
-    if (!startedRef.current) {
-      // First mount: the async setup owns terminal creation and reads
-      // visibleRef when it finishes.
+    if (!entry.opened) {
+      // First mount: the async setup owns terminal creation, because xterm
+      // measures its cell against whatever face is loaded when it opens and the
+      // font is still in flight. An unguarded show here would plant an orphan,
+      // unwired terminal in the host — the real one then stacks below it (a
+      // black dead canvas on top, the prompt clipped at the bottom).
       return
     }
     if (!visible) {
-      if (liveRef.current) {
+      if (entry.live) {
         if (searchOpenRef.current) {
           closeSearch()
         }
-        hideTerminal()
+        hideEntry(entry)
         void Service.SetVisible(sessionId, false)
       }
       return
     }
-    showTerminal()
-    const live = liveRef.current
+    showEntry(entry, createTerminal)
+    const live = entry.live
     if (!live) {
       return
     }
@@ -714,7 +677,7 @@ export function TerminalView({
     if (focusedRef.current) {
       live.term.focus()
     }
-  }, [visible, sessionId])
+  }, [visible, sessionId, entry])
 
   // Focus on its own, because it now moves without visibility: switching panes
   // leaves both terminals painting and only changes which one has the cursor.
@@ -723,16 +686,16 @@ export function TerminalView({
   // terminal nobody can see.
   useEffect(() => {
     if (focused && visible) {
-      liveRef.current?.term.focus()
+      entry.live?.term.focus()
     }
-  }, [focused, visible])
+  }, [focused, visible, entry])
 
   // The sidebar writes a delegate request at this session's prompt and then
   // asks for the cursor back, so the user carries on typing where they already
   // were.
   useEffect(
-    () => onTerminalFocusRequest(sessionId, () => liveRef.current?.term.focus()),
-    [sessionId],
+    () => onTerminalFocusRequest(sessionId, () => entry.live?.term.focus()),
+    [sessionId, entry],
   )
 
   // Font family and size need no live-update path: changing them means being
@@ -740,11 +703,11 @@ export function TerminalView({
   // recreation reads the refs. The theme can flip with a terminal on screen
   // (OS scheme under "system").
   useEffect(() => {
-    const live = liveRef.current
+    const live = entry.live
     if (live) {
       live.term.options.theme = resolvedTheme.terminal
     }
-  }, [resolvedTheme])
+  }, [resolvedTheme, entry])
 
   // The container carries the terminal's own background: the sub-cell
   // remainder of the grid fit and the ruler gutter then blend into the

--- a/frontend/src/components/common/ErrorBoundary.test.tsx
+++ b/frontend/src/components/common/ErrorBoundary.test.tsx
@@ -4,15 +4,26 @@
 // component throws while rendering, nothing catches it, and React unmounts the
 // whole tree — in lich's case the window, sidebar and terminals included. So
 // the assertions are about what is left standing, not about the boundary's own
-// state: the sibling subtree, and a child that renders again after a retry.
+// state: the sibling subtree, a child that renders again after a retry, and the
+// terminal a caught stage hands back.
 //
 // The harness has to be imported before anything that reaches react-dom, which
 // is why it is first here (see @/test/render-budget).
 import { mountBudget } from "@/test/render-budget"
+import { useEffect, useReducer, useRef } from "react"
 import { afterEach, beforeEach, expect, test, vi } from "vitest"
+import {
+  attachTerminal,
+  detachTerminal,
+  disposeTerminal,
+  type LiveTerminal,
+  terminalEntry,
+} from "@/lib/terminal/terminal-registry"
 import { ErrorBoundary } from "./ErrorBoundary"
 
 const MESSAGE = "files.map is not a function"
+const SESSION = "s1"
+const SCROLLBACK = "the conversation so far"
 
 // Read at render time rather than taken as a prop: the boundary is showing its
 // fallback when the flag flips, so nothing it holds would be re-read until the
@@ -37,9 +48,42 @@ function tree() {
   )
 }
 
-function retryButton(): HTMLButtonElement {
+// A pane, drawn the way the stage draws one: a container this component owns,
+// with the session's host node attached into it and detached again on unmount.
+// xterm needs a canvas and a measured font, so the terminal itself stands in —
+// which object comes back is what the test is about.
+function Pane() {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const entry = terminalEntry(SESSION)
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) {
+      return
+    }
+    attachTerminal(entry, container)
+    return () => detachTerminal(entry)
+  }, [entry])
+  return <div ref={containerRef} />
+}
+
+// Re-renders the boundary's children from outside it, which is what turns a
+// healthy stage into a throwing one.
+let repaint = () => {}
+
+function Stage() {
+  const [, bump] = useReducer((count: number) => count + 1, 0)
+  repaint = bump
+  return (
+    <ErrorBoundary label="The stage" retry="Reload the stage">
+      <Panel />
+      <Pane />
+    </ErrorBoundary>
+  )
+}
+
+function retryButton(label = "Try again"): HTMLButtonElement {
   const button = [...document.querySelectorAll("button")].find(
-    (candidate) => candidate.textContent?.trim() === "Try again",
+    (candidate) => candidate.textContent?.trim() === label,
   )
   if (!button) {
     throw new Error("the fallback offers no retry")
@@ -59,6 +103,7 @@ beforeEach(() => {
 afterEach(() => {
   window.removeEventListener("error", swallow)
   crash = true
+  disposeTerminal(SESSION)
   vi.restoreAllMocks()
 })
 
@@ -82,6 +127,45 @@ test("a throwing child leaves its siblings alive, and retry re-renders it", asyn
   expect(document.body.textContent).toContain("panel content")
   expect(document.body.textContent).not.toContain("The panel stopped rendering")
   expect(document.body.textContent).toContain("the sidebar")
+
+  await mounted.unmount()
+})
+
+test("a throw over the stage keeps the terminal it unmounts, and gives it back", async () => {
+  vi.spyOn(console, "error").mockImplementation(() => {})
+  crash = false
+
+  const entry = terminalEntry(SESSION)
+  const live = {
+    term: { rows: 24, refresh: vi.fn() },
+    dispose: vi.fn(),
+  } as unknown as LiveTerminal
+  entry.live = live
+
+  const mounted = await mountBudget(<Stage />)
+  entry.host.textContent = SCROLLBACK
+  expect(document.body.textContent).toContain(SCROLLBACK)
+
+  await mounted.act(() => {
+    crash = true
+    repaint()
+  })
+  // The stage is gone and says so; the terminal it took down with it is not.
+  expect(document.body.textContent).toContain("The stage stopped rendering")
+  expect(document.body.textContent).not.toContain(SCROLLBACK)
+  expect(entry.live).toBe(live)
+  expect(live.dispose).not.toHaveBeenCalled()
+
+  crash = false
+  await mounted.act(() => {
+    retryButton("Reload the stage").click()
+  })
+  // The same terminal, in the same node, with what was in it — no snapshot and
+  // no round trip through the backend.
+  expect(entry.live).toBe(live)
+  expect(entry.host.textContent).toBe(SCROLLBACK)
+  expect(document.body.contains(entry.host)).toBe(true)
+  expect(document.body.textContent).not.toContain("The stage stopped rendering")
 
   await mounted.unmount()
 })

--- a/frontend/src/components/common/ErrorBoundary.test.tsx
+++ b/frontend/src/components/common/ErrorBoundary.test.tsx
@@ -131,6 +131,34 @@ test("a throwing child leaves its siblings alive, and retry re-renders it", asyn
   await mounted.unmount()
 })
 
+test("a retry that throws again offers the reload instead of another retry", async () => {
+  vi.spyOn(console, "error").mockImplementation(() => {})
+  const reload = vi.fn()
+  vi.spyOn(window, "location", "get").mockReturnValue({
+    ...window.location,
+    reload,
+  } as unknown as Location)
+
+  const mounted = await mountBudget(tree())
+  expect(retryButton().textContent).toContain("Try again")
+
+  // The retry lands on a subtree that is still broken, which is the loop this
+  // exists to end: the offer changes rather than repeating.
+  await mounted.act(() => {
+    retryButton().click()
+  })
+  expect(document.body.textContent).toContain("The panel stopped rendering")
+  expect(document.body.textContent).toContain(MESSAGE)
+  expect(() => retryButton()).toThrow()
+
+  await mounted.act(() => {
+    retryButton("Reload the window").click()
+  })
+  expect(reload).toHaveBeenCalledTimes(1)
+
+  await mounted.unmount()
+})
+
 test("a throw over the stage keeps the terminal it unmounts, and gives it back", async () => {
   vi.spyOn(console, "error").mockImplementation(() => {})
   crash = false

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -10,6 +10,8 @@ interface ErrorBoundaryProps {
   children: ReactNode
   /** Clears the error when it changes: the subtree swapped in is not the one that threw. */
   resetKey?: string
+  /** What the retry offers to do, where "try again" undersells it. */
+  retry?: string
   /** Positioning for the fallback, whose default is to fill whatever it is handed. */
   className?: string
 }
@@ -24,7 +26,9 @@ interface ErrorBoundaryState {
 // while the sessions themselves keep running with nothing on screen saying so.
 // A class is not a style choice here — React offers no hook that catches.
 //
-// Deliberately never around TerminalHost; docs/ceilings.md says what that costs.
+// The stage is caught too. Unmounting it used to destroy every session's xterm;
+// the terminals now outlive their components (lib/terminal/terminal-registry.ts),
+// so the fallback costs a repaint and nothing else.
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   state: ErrorBoundaryState = { error: null }
 
@@ -63,7 +67,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         </Notice>
         <Button variant="ghost" size="sm" onClick={() => this.setState({ error: null })}>
           <RotateCcw data-icon="inline-start" />
-          Try again
+          {this.props.retry ?? "Try again"}
         </Button>
       </div>
     )

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -18,7 +18,13 @@ interface ErrorBoundaryProps {
 
 interface ErrorBoundaryState {
   error: Error | null
+  /** Throws since the last subtree that rendered. Two means retrying is not it. */
+  throws: number
 }
+
+// After this many consecutive throws the retry has answered the question: the
+// subtree is not coming back, and offering it again is a loop on a fallback.
+const RETRIES_BEFORE_RELOAD = 2
 
 // The one thing standing between a render throw and a blank window. Nothing
 // catching means React unmounts at the root, and lich's root is the window: the
@@ -30,27 +36,37 @@ interface ErrorBoundaryState {
 // the terminals now outlive their components (lib/terminal/terminal-registry.ts),
 // so the fallback costs a repaint and nothing else.
 export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
-  state: ErrorBoundaryState = { error: null }
+  state: ErrorBoundaryState = { error: null, throws: 0 }
 
-  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+  static getDerivedStateFromError(error: Error): Pick<ErrorBoundaryState, "error"> {
     return { error }
   }
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error(`${this.props.label} failed to render`, error, info.componentStack)
+    // Counted here rather than beside the error, because getDerivedStateFromError
+    // is handed no previous state to add to.
+    this.setState((previous) => ({ throws: previous.throws + 1 }))
   }
 
   componentDidUpdate(previous: ErrorBoundaryProps) {
     if (this.state.error !== null && previous.resetKey !== this.props.resetKey) {
-      this.setState({ error: null })
+      this.setState({ error: null, throws: 0 })
+      return
+    }
+    // Reached with no error is the children having committed, so whatever the
+    // count was, the retry worked and the next throw starts over.
+    if (this.state.error === null && this.state.throws > 0) {
+      this.setState({ throws: 0 })
     }
   }
 
   render() {
-    const { error } = this.state
+    const { error, throws } = this.state
     if (error === null) {
       return this.props.children
     }
+    const exhausted = throws >= RETRIES_BEFORE_RELOAD
     return (
       <div
         className={cn(
@@ -65,9 +81,16 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         <Notice className="max-w-md py-0 font-mono break-words">
           {error.message || String(error)}
         </Notice>
-        <Button variant="ghost" size="sm" onClick={() => this.setState({ error: null })}>
+        {/* The same retry that just failed is a loop, so past the second throw
+            the only offer left is the one that always works. The sessions keep
+            running through it — a reload costs the page, not the PTYs. */}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => (exhausted ? window.location.reload() : this.setState({ error: null }))}
+        >
           <RotateCcw data-icon="inline-start" />
-          {this.props.retry ?? "Try again"}
+          {exhausted ? "Reload the window" : (this.props.retry ?? "Try again")}
         </Button>
       </div>
     )

--- a/frontend/src/components/render-budget.test.tsx
+++ b/frontend/src/components/render-budget.test.tsx
@@ -331,12 +331,14 @@ test("switching project re-renders the mounted terminals but never remounts one"
 
   // Two commits: the route moves, then p2's session clears its spawn gate and
   // mounts. Three TerminalView renders across them — s1 in both, s4 in the
-  // second — because nothing under TerminalHost is memoized.
+  // second — because nothing under TerminalHost is memoized. Each pane wears an
+  // ErrorBoundary of its own, so it repaints alongside the view it wraps.
   await budget.act(() => navigate("/projects/p2"))
   expect(budget.take()).toEqual({
     HashRouter: 1,
     Router: 1,
     TerminalHost: 2,
+    ErrorBoundary: 3,
     TerminalView: 3,
     ResumeSessionDialog: 2,
     WorktreeCloseDialogs: 2,
@@ -358,6 +360,7 @@ test("switching project re-renders the mounted terminals but never remounts one"
     HashRouter: 1,
     Router: 1,
     TerminalHost: 1,
+    ErrorBoundary: 2,
     TerminalView: 2,
     ResumeSessionDialog: 1,
     WorktreeCloseDialogs: 1,

--- a/frontend/src/lib/terminal/terminal-registry.test.ts
+++ b/frontend/src/lib/terminal/terminal-registry.test.ts
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+//
+// The registry's whole job is outliving React, so what is asserted here is what
+// survives a detach and what does not survive a dispose. xterm itself needs a
+// canvas and a measured font, neither of which jsdom has, so the terminal is a
+// stand-in — its identity is the point, not its rendering.
+
+import { afterEach, expect, test, vi } from "vitest"
+import {
+  attachTerminal,
+  detachTerminal,
+  disposeTerminal,
+  feedEntry,
+  hideEntry,
+  type LiveTerminal,
+  showEntry,
+  spawnedSessions,
+  terminalEntry,
+} from "./terminal-registry"
+
+const SESSION = "s1"
+
+function fakeLive() {
+  const written: string[] = []
+  const live = {
+    term: {
+      rows: 24,
+      refresh: vi.fn(),
+      write: (data: string | Uint8Array) =>
+        written.push(typeof data === "string" ? data : new TextDecoder().decode(data)),
+      clear: vi.fn(),
+    },
+    serialize: { serialize: () => "SNAPSHOT" },
+    search: {},
+    dispose: vi.fn(),
+  }
+  return { live: live as unknown as LiveTerminal, written, dispose: live.dispose }
+}
+
+afterEach(() => {
+  disposeTerminal(SESSION)
+})
+
+test("the entry, its host and its terminal are the session's, not the caller's", () => {
+  const entry = terminalEntry(SESSION)
+  expect(terminalEntry(SESSION)).toBe(entry)
+  expect(terminalEntry(SESSION).host).toBe(entry.host)
+})
+
+test("detaching keeps the terminal and re-attaching brings its buffer back", () => {
+  const entry = terminalEntry(SESSION)
+  const { live, dispose } = fakeLive()
+  entry.live = live
+  const first = document.createElement("div")
+  attachTerminal(entry, first)
+  entry.host.textContent = "the scrollback"
+
+  detachTerminal(entry)
+  expect(entry.host.parentElement).toBeNull()
+  expect(entry.live).toBe(live)
+  expect(dispose).not.toHaveBeenCalled()
+
+  // A different container, because the component that mounts next is a
+  // different component: what comes back is the node, with what was in it.
+  const second = document.createElement("div")
+  attachTerminal(entry, second)
+  expect(second.firstChild).toBe(entry.host)
+  expect(second.textContent).toBe("the scrollback")
+  expect(entry.live).toBe(live)
+})
+
+test("output while nothing is attached lands in the terminal, not on the floor", () => {
+  const entry = terminalEntry(SESSION)
+  const { live, written } = fakeLive()
+  entry.live = live
+  detachTerminal(entry)
+
+  feedEntry(entry, new TextEncoder().encode("still running"), 0)
+  expect(written).toEqual(["still running"])
+})
+
+test("output while the terminal is destroyed queues until it is rebuilt", () => {
+  const entry = terminalEntry(SESSION)
+  const built = fakeLive()
+  entry.live = built.live
+  hideEntry(entry)
+  expect(entry.live).toBeNull()
+  expect(built.dispose).toHaveBeenCalled()
+
+  feedEntry(entry, new TextEncoder().encode("queued"), 0)
+  const rebuilt = fakeLive()
+  showEntry(entry, () => rebuilt.live)
+  expect(rebuilt.written).toEqual(["SNAPSHOT", "queued"])
+  expect(entry.opened).toBe(true)
+})
+
+test("a session whose terminal is running is reported as already spawned", () => {
+  const entry = terminalEntry(SESSION)
+  // A host that remounts asks this before sending anything back through the
+  // spawn gate: the answer is no until the setup has actually run.
+  expect(spawnedSessions()).not.toContain(SESSION)
+  entry.setup = true
+  expect(spawnedSessions()).toContain(SESSION)
+  disposeTerminal(SESSION)
+  expect(spawnedSessions()).not.toContain(SESSION)
+})
+
+test("disposing ends the terminal and forgets the session", () => {
+  const entry = terminalEntry(SESSION)
+  const { live, dispose } = fakeLive()
+  entry.live = live
+  const off = vi.fn()
+  entry.subscriptions.push(off)
+  attachTerminal(entry, document.createElement("div"))
+
+  disposeTerminal(SESSION)
+  expect(dispose).toHaveBeenCalled()
+  expect(off).toHaveBeenCalled()
+  expect(entry.host.parentElement).toBeNull()
+  expect(entry.disposed).toBe(true)
+  // A session id that comes back — an undone close — starts from nothing.
+  expect(terminalEntry(SESSION)).not.toBe(entry)
+})

--- a/frontend/src/lib/terminal/terminal-registry.ts
+++ b/frontend/src/lib/terminal/terminal-registry.ts
@@ -1,0 +1,207 @@
+// Where a session's terminal actually lives.
+//
+// The xterm instance, its DOM and its scrollback belong to the session, not to
+// the React component that draws it. TerminalView attaches the host node below
+// into a container it owns and detaches it again on unmount, so an error
+// boundary over the stage can throw the whole tree away and put it back with
+// every terminal still running and every scrollback intact — no serialize round
+// trip, and the same Terminal object on the other side.
+//
+// Disposing is the session closing and nothing else. A *hidden* session still
+// follows the waveterm model (serialize, destroy, queue output here) because
+// that frees a WebGL renderer; an unmount frees nothing worth a scrollback.
+//
+// A throw inside xterm's own render loop is not a React render, so no boundary
+// sees it — that one still reaches the window as a broken terminal.
+
+import type { SearchAddon } from "@xterm/addon-search"
+import type { SerializeAddon } from "@xterm/addon-serialize"
+import type { Terminal } from "@xterm/xterm"
+import type { PaletteSession } from "@/lib/session/command-palette"
+import { makeReplayBuffer, type ReplayBuffer } from "./replay-buffer"
+import type { SessionExit } from "./session-exit"
+import type { SessionLinkTargets } from "./session-links"
+import { cursorShapeSequence, cursorVisibilitySequence, mouseEncodingSequence } from "./term-modes"
+import { recordChunk } from "./term-perf"
+import { cursorHidden, cursorShape, mouseEncoding } from "./term-view"
+
+export interface LiveTerminal {
+  term: Terminal
+  serialize: SerializeAddon
+  search: SearchAddon
+  dispose(): void
+}
+
+/**
+ * The mounted view's live callbacks. xterm's own handlers are wired once, when
+ * the terminal is built, and that terminal outlives the component that built it
+ * — so they reach whichever view is mounted *now* through here rather than
+ * through the closure they were created in.
+ */
+export interface TerminalHandlers {
+  searchOpen(): boolean
+  closeSearch(): void
+  searchResults(index: number, count: number): void
+  activateLink(target: PaletteSession): void
+  exited(exit: SessionExit): void
+}
+
+export interface TerminalEntry {
+  readonly sessionId: string
+  /** xterm's parent element, owned here: React moves it, never destroys it. */
+  readonly host: HTMLDivElement
+  live: LiveTerminal | null
+  /** Snapshot of a hidden (destroyed) terminal, replayed by showEntry. */
+  serialized: string | null
+  /** The modes the snapshot cannot carry (term-modes.ts). */
+  carriedModes: string
+  readonly replay: ReplayBuffer
+  /** Read by the link provider, which xterm calls from its own render loop. */
+  readonly linkTargets: { current: SessionLinkTargets }
+  handlers: TerminalHandlers | null
+  /** True once the PTY setup has been run for this session; it runs once. */
+  setup: boolean
+  /**
+   * True once a terminal has been built. Nothing may open one before then:
+   * the first one waits on the font, because xterm measures its cell against
+   * whatever face is loaded when it opens.
+   */
+  opened: boolean
+  /** PTY subscriptions — the session's lifetime, not the component's. */
+  readonly subscriptions: Array<() => void>
+  exit: SessionExit | null
+  /** Set when the session closes, so a setup still in flight lets go. */
+  disposed: boolean
+}
+
+const entries = new Map<string, TerminalEntry>()
+
+function createHost(): HTMLDivElement {
+  const host = document.createElement("div")
+  host.style.height = "100%"
+  host.style.width = "100%"
+  return host
+}
+
+/** The session's entry, created on first use. Idempotent by session id. */
+export function terminalEntry(sessionId: string): TerminalEntry {
+  const existing = entries.get(sessionId)
+  if (existing) {
+    return existing
+  }
+  const entry: TerminalEntry = {
+    sessionId,
+    host: createHost(),
+    live: null,
+    serialized: null,
+    carriedModes: "",
+    replay: makeReplayBuffer(),
+    linkTargets: { current: { pattern: null, byLabel: new Map() } },
+    handlers: null,
+    setup: false,
+    opened: false,
+    subscriptions: [],
+    exit: null,
+    disposed: false,
+  }
+  entries.set(sessionId, entry)
+  return entry
+}
+
+/** The sessions whose terminal is already built and running. */
+export function spawnedSessions(): string[] {
+  return [...entries.values()].filter((entry) => entry.setup).map((entry) => entry.sessionId)
+}
+
+export function attachTerminal(entry: TerminalEntry, container: HTMLElement): void {
+  if (entry.host.parentElement === container) {
+    return
+  }
+  container.appendChild(entry.host)
+  // Time spent outside the document leaves the renderer's canvas holding
+  // nothing the compositor kept: re-attaching restores the element, not the
+  // pixels, so the buffer xterm still has is drawn again.
+  entry.live?.term.refresh(0, entry.live.term.rows - 1)
+}
+
+/** Takes the terminal out of the tree and leaves it running. */
+export function detachTerminal(entry: TerminalEntry): void {
+  entry.host.remove()
+}
+
+/** Ends the session's terminal for good. Only a closed session gets here. */
+export function disposeTerminal(sessionId: string): void {
+  const entry = entries.get(sessionId)
+  if (!entry) {
+    return
+  }
+  entry.disposed = true
+  entries.delete(sessionId)
+  for (const off of entry.subscriptions) {
+    off()
+  }
+  entry.subscriptions.length = 0
+  entry.handlers = null
+  entry.live?.dispose()
+  entry.live = null
+  entry.host.remove()
+}
+
+/** Output sink: the live terminal, or the replay queue while it is destroyed. */
+export function feedEntry(entry: TerminalEntry, bytes: Uint8Array, decodeMs: number): void {
+  const live = entry.live
+  if (!live) {
+    entry.replay.push(bytes)
+    return
+  }
+  const t0 = performance.now()
+  live.term.write(bytes, () => recordChunk(decodeMs, performance.now() - t0, bytes.length))
+}
+
+/** Serializes the live terminal and destroys it; output then queues until show. */
+export function hideEntry(entry: TerminalEntry): void {
+  const live = entry.live
+  if (!live) {
+    return
+  }
+  entry.serialized = live.serialize.serialize()
+  entry.carriedModes =
+    mouseEncodingSequence(mouseEncoding(live.term)) +
+    cursorVisibilitySequence(cursorHidden(live.term)) +
+    cursorShapeSequence(cursorShape(live.term))
+  live.dispose()
+  entry.live = null
+}
+
+/** Rebuilds the terminal from the snapshot plus the queued tail. */
+export function showEntry(
+  entry: TerminalEntry,
+  create: (host: HTMLDivElement) => LiveTerminal,
+): void {
+  if (entry.live) {
+    return
+  }
+  const live = create(entry.host)
+  if (entry.replay.truncated()) {
+    // The queue overflowed while hidden; the head of what remains may be a
+    // partial ANSI sequence. The snapshot is stale relative to it either way,
+    // so start clean from the tail.
+    entry.serialized = null
+    live.term.clear()
+  }
+  if (entry.serialized) {
+    live.term.write(entry.serialized)
+  }
+  // Between the snapshot and the queued tail: the tail is newer output, so
+  // anything the app changed there still wins.
+  if (entry.carriedModes) {
+    live.term.write(entry.carriedModes)
+  }
+  for (const chunk of entry.replay.drain()) {
+    live.term.write(chunk)
+  }
+  entry.serialized = null
+  entry.carriedModes = ""
+  entry.opened = true
+  entry.live = live
+}


### PR DESCRIPTION
## What

`docs/ceilings.md` said the terminals sat outside every error boundary, so a render throw anywhere under the stage took the whole window and the only way back was a reload over sessions that were still running. That bullet is gone, because the reason for it is.

A terminal no longer belongs to the component that draws it. Each session's xterm instance, its host element, its snapshot/replay state and its PTY subscriptions live in a module-level registry keyed by session id (`frontend/src/lib/terminal/terminal-registry.ts`). `TerminalView` attaches the host node into a container it owns and detaches it again on unmount; only the session leaving the workspace closes the PTY and disposes the terminal.

Two consequences worth naming:

- The subscriptions are the session's, not the component's, so output that arrives while nothing is mounted — the stage sitting in a fallback — still lands in the terminal instead of leaving a hole in the scrollback.
- xterm's own handlers are wired once, at creation, and that terminal outlives the component that built it. They now reach whichever view is mounted through the entry (`TerminalHandlers`) rather than the closure they were born in, so search, links and the exit banner keep working after a recovery.

With that safe, each pane gets an `ErrorBoundary` that names its session — its neighbours keep painting — and the stage gets one for the grid, the seams and the dialogs around them, retrying with "Reload the stage". `TerminalHost` seeds its `spawned` set from the registry so a stage retry does not walk running sessions back through the spawn gate and re-ask about a conversation already resumed.

A throw inside xterm's own render loop is not a React render and stays outside all of this; that is one comment in `App.tsx`, not a ceiling.

## Tests

- `ErrorBoundary.test.tsx` throws over a stage that has a pane attached: the fallback shows, and the retry gives back the same terminal object, in the same node, with what was in it.
- `terminal-registry.test.ts` covers detach vs dispose, feeding a detached terminal, the hide/show snapshot round trip and `spawnedSessions`.
- The render budgets gain one `ErrorBoundary` per pane — the tree really did grow one — and the remount counts the suite exists for are unchanged.

## Gate

`biome ci .` exit 0 · `pnpm test` 1669 passed · `pnpm build` · `gofmt -l .`, `go vet ./...`, `go test ./...` clean.