### PR TITLE
fix: keep every history hit on screen, and end a session's PTY when it leaves

### DIFF
--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -604,6 +604,13 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   says `checkout gone` and offers to forget
   itself, which is the only way such a row is ever collected — `PurgeWorktreeSessions` never ran for it,
   because the removal never went through the app.
+- **A history snippet costs the whole conversation it is cut from** (`internal/store/transcripts.go`,
+  `conversationBodies`): the rows a search matched on their conversation have their indexed body read out of
+  the store whole — up to 8 MB each, one page of up to a hundred rows, once per settled keystroke — and the
+  window is cut in Go rather than in the query, because FTS5's own `snippet()` walks every instance of the
+  term and a conversation that says "session" three thousand times costs a tenth of a second per row. Prose
+  is a low single-digit percentage of a transcript, so the page a real workspace hands back is tens of
+  megabytes at the very worst; the fix when it bites is an `instr`/`substr` window in SQL, not a smaller cap.
 - **A filed backend answer outlives the screen that asked, under a key its caller writes by hand**
   (`frontend/src/lib/remote-cache.ts`): a `useRemoteResource` caller that passes `cache` has its answers kept
   in module memory until the page reloads, under exactly the string it composed. Two callers that compose the

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,8 @@ import { parseBoolPref, readPref, writePref } from "@/lib/prefs"
 import { ProjectsProvider, useProjects } from "@/providers/projects"
 import { activeSessionId, sessionsOf } from "@/lib/session/sessions"
 import { usePanes } from "@/lib/session/use-panes"
+import { Terminal as TerminalService } from "@/lib/rpc"
+import { reapTerminals } from "@/lib/terminal/terminal-registry"
 import {
   requestSessionIntent,
   requestWorktreeDialog,
@@ -54,6 +56,14 @@ function Layout() {
   }
   const toggleSidebar = () => showSidebar(!sidebar)
   useHotkey(hotkeys.toggleSidebar, toggleSidebar)
+  // A session's PTY and terminal end when the session leaves the workspace,
+  // decided here and not in the view that drew it: that view is gone while
+  // the stage sits in an error boundary's fallback, and a close made from the
+  // sidebar meanwhile would otherwise leave the agent running unseen.
+  useEffect(() => {
+    const live = new Set(Object.values(sessions).flatMap((p) => p.sessions.map((s) => s.id)))
+    reapTerminals(live, (id) => void TerminalService.Close(id))
+  }, [sessions])
   // Both of these act on sidebar chrome — the worktree dialog, a card's rename
   // field — and the rail carries neither, so a collapsed sidebar is opened
   // first rather than letting the chord quietly do nothing. The request is a

--- a/frontend/src/components/TerminalHost.tsx
+++ b/frontend/src/components/TerminalHost.tsx
@@ -246,7 +246,8 @@ export function TerminalHost() {
 
   // A session that left the workspace leaves both maps with it. Its id can come
   // back — an undone close restores the very same one — and its terminal did
-  // not: the unmount closed the PTY. A leftover "spawned" entry would mount the
+  // not: leaving closed the PTY (App.tsx, reapTerminals). A leftover "spawned"
+  // entry would mount the
   // card straight into a fresh PTY, past the gate that asks about the
   // conversation, and a leftover resume id would then be answered for the user.
   useEffect(() => {

--- a/frontend/src/components/TerminalView.tsx
+++ b/frontend/src/components/TerminalView.tsx
@@ -502,20 +502,17 @@ export function TerminalView({
       window.removeEventListener("keydown", onSearchKey, true)
       window.clearTimeout(refitTimer)
       resizeObserver.disconnect()
+      // Detached, never closed: the PTY and the terminal die with the session
+      // (App.tsx, reapTerminals), never with this component. React unmounts for
+      // reasons that are not a close — StrictMode mounts every component twice
+      // in dev, a hot reload tears the tree down, an error boundary over the
+      // stage catches a throw — and a terminal closed for one of those takes
+      // the running agent and its scrollback with it. That was invisible while
+      // every session's PTY was born on this very mount; a session opened
+      // through the CLI or its MCP tools is already running when the card is
+      // first viewed, and the double mount killed the conversation the user
+      // came to read.
       detachTerminal(entry)
-      // The PTY and the terminal die with the session, never with this
-      // component. React unmounts for reasons that are not a close — StrictMode
-      // mounts every component twice in dev, a hot reload tears the tree down,
-      // an error boundary over the stage catches a throw — and a terminal
-      // closed for one of those takes the running agent and its scrollback with
-      // it. That was invisible while every session's PTY was born on this very
-      // mount; a session opened through the CLI or its MCP tools is already
-      // running when the card is first viewed, and the double mount killed the
-      // conversation the user came to read.
-      if (!stillInWorkspaceRef.current()) {
-        void Service.Close(sessionId)
-        disposeTerminal(sessionId)
-      }
     }
 
     if (entry.setup) {
@@ -604,7 +601,7 @@ export function TerminalView({
         return
       }
       if (!stillInWorkspaceRef.current()) {
-        // The session was closed during the Start round-trip, so the teardown's
+        // The session was closed during the Start round-trip, so the reaper's
         // Close raced ahead of the spawn: close the PTY that now exists. An
         // unmount that was not a close needs none of this — the terminal is
         // still the entry's, and the next mount attaches to it. The queued

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -378,9 +378,14 @@ export interface ClosedSession {
   /** Unix seconds; 0 for a row parked before lich recorded the close, which
    * sorts last and is drawn as no date rather than as 1970. */
   closedAt: number
-  /** The stretch of the parked conversation that matched the search, out of the
-   * index the close wrote. "" for a row matched by name alone, and for every row
-   * of an empty query, which matched nothing in particular. */
+  /** The search reached this row through its conversation, out of the index the
+   * close wrote. What keeps the row in the list, apart from the snippet: a hit
+   * the index found by folding an accent, or a term it split on punctuation, has
+   * nothing to show under the row and is still the answer. */
+  matchedConversation: boolean
+  /** The stretch of the parked conversation that matched the search. "" for a
+   * row matched by name alone, for one matched by a fold (above), and for every
+   * row of an empty query, which matched nothing in particular. */
   snippet: string
   /** The cap on one session's index dropped the oldest of this conversation, so
    * a search over it reaches only the newer part. The row says so, because a

--- a/frontend/src/lib/session/command-palette.test.ts
+++ b/frontend/src/lib/session/command-palette.test.ts
@@ -298,6 +298,7 @@ const parked: ClosedSession[] = [
     path: "/home/u/wt/lich/relay-inbox",
     parkedBranch: "feat/relay-inbox",
     closedAt: 1_700_000_200,
+    matchedConversation: false,
     snippet: "",
     truncated: false,
   },
@@ -313,6 +314,7 @@ const parked: ClosedSession[] = [
     // the close, which is the disagreement the two fields exist to hold.
     parkedBranch: "fix/conpty-first-try",
     closedAt: 1_700_000_100,
+    matchedConversation: false,
     snippet: "",
     truncated: false,
   },
@@ -326,6 +328,7 @@ const parked: ClosedSession[] = [
     path: "/home/u/wt/revu/gone",
     parkedBranch: "chore/vitest-ui",
     closedAt: 1_700_000_000,
+    matchedConversation: false,
     snippet: "",
     truncated: false,
   },
@@ -399,7 +402,13 @@ describe("history search", () => {
     // one window out of it. Nothing on the row carries the words, so re-testing
     // the query here would drop the row the search just answered with.
     const said = historyRows(
-      [{ ...(parked[1] as ClosedSession), snippet: "…the ConPTY handle was recycled…" }],
+      [
+        {
+          ...(parked[1] as ClosedSession),
+          matchedConversation: true,
+          snippet: "…the ConPTY handle was recycled…",
+        },
+      ],
       parkedBranches,
       new Set(),
     )
@@ -409,6 +418,18 @@ describe("history search", () => {
     expect(filterPalette("recycled zombie", [], [], [], said).history.map((h) => h.id)).toEqual([
       "h2",
     ])
+  })
+
+  it("keeps a conversation match that has no snippet to show", () => {
+    // The index folds accents, so "decision" found a session that said
+    // "decisión" and the plain text had nothing to cut. The flag is what the
+    // row is kept on; an empty snippet must not read as "matched by name".
+    const folded = historyRows(
+      [{ ...(parked[1] as ClosedSession), matchedConversation: true, snippet: "" }],
+      parkedBranches,
+      new Set(),
+    )
+    expect(filterPalette("decision", [], [], [], folded).history.map((h) => h.id)).toEqual(["h2"])
   })
 })
 

--- a/frontend/src/lib/session/command-palette.ts
+++ b/frontend/src/lib/session/command-palette.ts
@@ -57,8 +57,8 @@ export function matchesQuery(haystack: string, query: string): boolean {
 }
 
 // PaletteHistory is one parked session as the History tab lists it: the store's
-// row (its `snippet` carrying the words that matched, when the conversation is
-// what matched) plus the branch its checkout is on *now*, read from git. That is not the
+// row (`matchedConversation` and its `snippet` saying when and where the
+// conversation is what matched) plus the branch its checkout is on *now*, read from git. That is not the
 // row's `parkedBranch`, which is the snapshot the close recorded for the search
 // to match — a branch moves inside a checkout, so only git can say what the row
 // shows. `branch` is "" for a checkout that is gone, which is also the row that
@@ -118,13 +118,14 @@ export function filterPalette(
     // matched the one it recorded at the close, and the row shows the one git
     // reads now. Filtering on either alone would drop a row the other half of
     // the search kept.
-    // A row carrying a snippet was matched on its conversation in the store, and
-    // is kept without asking again: the snippet is one window onto a hit that
-    // may be a megabyte of prose, so re-testing the query against it would drop
-    // rows whose two words matched paragraphs apart.
+    // A row the store matched on its conversation is kept without asking again:
+    // the snippet is one window onto a hit that may be a megabyte of prose — or
+    // no window at all, for a hit the index found by folding an accent — so
+    // re-testing the query against the row would drop the answer the search
+    // just gave.
     history: history.filter(
       (h) =>
-        h.snippet !== "" ||
+        h.matchedConversation ||
         matchesQuery(`${h.label} ${h.projectName} ${h.branch} ${h.parkedBranch} ${h.path}`, query),
     ),
   }

--- a/frontend/src/lib/session/use-history-search.test.tsx
+++ b/frontend/src/lib/session/use-history-search.test.tsx
@@ -23,6 +23,7 @@ const backlog = { left: 0 }
 function row(id: string, label: string, snippet = ""): ClosedSession {
   return {
     id,
+    matchedConversation: snippet !== "",
     snippet,
     truncated: false,
     projectId: "p1",
@@ -259,6 +260,26 @@ describe("useHistorySearch", () => {
       () => new Promise((resolve) => setTimeout(resolve, POLL_MS + DEBOUNCE_MS + 60)),
     )
     expect(terms).toEqual(["old", "old", "old"])
+    await budget.unmount()
+  })
+
+  it("never polls behind an empty query, where nothing is being indexed", async () => {
+    // The store starts its backfill on a term alone, so the count it reports
+    // for the plain list never moves: a poll here is a query and a git read per
+    // row every second for as long as the palette stays open.
+    backlog.left = 2
+    const backlogs: number[] = []
+    const Probe = probe([], [], [], backlogs)
+    const budget = await mountBudget(
+      createElement(StrictMode, null, createElement(Probe, { query: "", enabled: true })),
+    )
+    await budget.act(settled)
+    expect(last(backlogs)).toBe(2)
+
+    await budget.act(
+      () => new Promise((resolve) => setTimeout(resolve, POLL_MS + DEBOUNCE_MS + 60)),
+    )
+    expect(terms).toEqual([""])
     await budget.unmount()
   })
 

--- a/frontend/src/lib/session/use-history-search.ts
+++ b/frontend/src/lib/session/use-history-search.ts
@@ -103,13 +103,18 @@ export function useHistorySearch(
   // Ask again while the backfill is working. The tick is state rather than an
   // interval so it chains off the answer that reported the count: a slow reply
   // never stacks a second request behind the first.
+  //
+  // Only behind a term: the store starts its backfill on a term and on nothing
+  // else, so with the palette open on the plain list the count never moves, and
+  // polling it is a query and a git read per row every second for as long as
+  // the palette stays up, reporting nothing.
   useEffect(() => {
-    if (!enabled || indexing === 0) {
+    if (!enabled || indexing === 0 || query.trim() === "") {
       return
     }
     const timer = window.setTimeout(() => setPoll((n) => n + 1), BACKFILL_POLL_MS)
     return () => window.clearTimeout(timer)
-  }, [enabled, indexing, poll])
+  }, [enabled, indexing, poll, query])
 
   // Forgetting drops the row in place rather than refetching: the list stays up
   // while several stale rows are cleared, which is how they are usually left.

--- a/frontend/src/lib/terminal/terminal-registry.test.ts
+++ b/frontend/src/lib/terminal/terminal-registry.test.ts
@@ -13,6 +13,7 @@ import {
   feedEntry,
   hideEntry,
   type LiveTerminal,
+  reapTerminals,
   showEntry,
   spawnedSessions,
   terminalEntry,
@@ -103,6 +104,22 @@ test("a session whose terminal is running is reported as already spawned", () =>
   expect(spawnedSessions()).toContain(SESSION)
   disposeTerminal(SESSION)
   expect(spawnedSessions()).not.toContain(SESSION)
+})
+
+test("reaping closes the sessions that left the workspace and keeps the rest", () => {
+  const gone = terminalEntry("s-gone")
+  const { live, dispose } = fakeLive()
+  gone.live = live
+  const kept = terminalEntry(SESSION)
+  const closed: string[] = []
+
+  reapTerminals(new Set([SESSION]), (id) => closed.push(id))
+
+  expect(closed).toEqual(["s-gone"])
+  expect(dispose).toHaveBeenCalled()
+  expect(gone.disposed).toBe(true)
+  expect(terminalEntry(SESSION)).toBe(kept)
+  expect(kept.disposed).toBe(false)
 })
 
 test("disposing ends the terminal and forgets the session", () => {

--- a/frontend/src/lib/terminal/terminal-registry.ts
+++ b/frontend/src/lib/terminal/terminal-registry.ts
@@ -129,6 +129,22 @@ export function detachTerminal(entry: TerminalEntry): void {
   entry.host.remove()
 }
 
+/**
+ * Ends the terminals of every session no longer in the workspace: closes its
+ * PTY through `close` and disposes the terminal. Run from above every error
+ * boundary, on each change to the workspace, because the view that drew a
+ * session is not there to notice its close while the stage sits in a fallback
+ * — and a terminal left here is an agent running with nothing on screen.
+ */
+export function reapTerminals(live: ReadonlySet<string>, close: (sessionId: string) => void): void {
+  for (const sessionId of [...entries.keys()]) {
+    if (!live.has(sessionId)) {
+      close(sessionId)
+      disposeTerminal(sessionId)
+    }
+  }
+}
+
 /** Ends the session's terminal for good. Only a closed session gets here. */
 export function disposeTerminal(sessionId: string): void {
   const entry = entries.get(sessionId)

--- a/internal/store/history.go
+++ b/internal/store/history.go
@@ -34,9 +34,14 @@ type ClosedSession struct {
 	// Unix seconds, 0 for a row parked before closed_at existed — which sorts
 	// last and is drawn as no date rather than as 1970.
 	ClosedAt int64 `json:"closedAt"`
+	// Whether the search reached this row through its conversation. It is what
+	// the window keeps the row on, apart from the snippet: a hit the index found
+	// by a fold the plain text does not have ("cion" against "ción"), or a term
+	// the index split on punctuation, has a snippet of nothing to show.
+	MatchedConversation bool `json:"matchedConversation"`
 	// The stretch of conversation that matched the search, empty for a row the
-	// search matched by name, and for every row of an empty query, which
-	// matched nothing in particular.
+	// search matched by name, for one matched by a fold (see above), and for
+	// every row of an empty query, which matched nothing in particular.
 	Snippet string `json:"snippet"`
 	// Whether the cap on one session's index dropped the oldest of this
 	// conversation. The row says so on screen: a search that reaches only part
@@ -104,16 +109,6 @@ func escapeLike(term string) string {
 // it dates the insert, and a resumed session is reinserted — so rows parked
 // before closed_at existed all carry 0 and fall back to it together.
 func (s *Service) ClosedSessions(term string) (ClosedHistory, error) {
-	where := "WHERE s.is_open = 0"
-	with, join, args := "", "", []any{}
-
-	// The match is MATERIALIZED, and not a subquery inlined into the join:
-	// without it SQLite runs the full-text search again for every parked row it
-	// walks, which on a workspace of two hundred sessions costs tens of seconds
-	// instead of tens of milliseconds.
-	//
-	// It is also written before the WHERE it feeds, so its argument is bound
-	// first: the one place the order of these two halves matters.
 	if strings.TrimSpace(term) != "" {
 		// Started on any term, not only one the index can be asked about: the
 		// count of what is still unindexed goes back with every answer, and a
@@ -121,29 +116,7 @@ func (s *Service) ClosedSessions(term string) (ClosedHistory, error) {
 		// reporting a backfill nothing had started.
 		s.backfill()
 	}
-	if match := ftsQuery(term); match != "" {
-		with = `WITH said AS MATERIALIZED (
-		          SELECT t.session_id FROM session_texts t
-		            JOIN session_texts_fts f ON f.rowid = t.rowid
-		           WHERE session_texts_fts MATCH ?)`
-		join = "LEFT JOIN said m ON m.session_id = s.id"
-		args = append(args, match)
-	}
-	if names := strings.Fields(term); len(names) > 0 {
-		clauses := make([]string, 0, len(names))
-		for _, word := range names {
-			clauses = append(clauses,
-				"(s.label || ' ' || p.name || ' ' || s.path || ' ' || s.parked_branch)"+
-					" LIKE ? ESCAPE '"+likeEscape+"'")
-			args = append(args, "%"+escapeLike(word)+"%")
-		}
-		matched := "(" + strings.Join(clauses, " AND ") + ")"
-		if join != "" {
-			matched += " OR m.session_id IS NOT NULL"
-		}
-		where += " AND (" + matched + ")"
-	}
-	args = append(args, closedSessionLimit)
+	match := closedSessionsMatch(term)
 
 	// Counted before the rows are asked for, never while they are being walked:
 	// the store holds a single connection, and a second query opened inside the
@@ -154,17 +127,17 @@ func (s *Service) ClosedSessions(term string) (ClosedHistory, error) {
 	// query: a window function is computed before LIMIT, so it counts the match
 	// and not the page.
 	rows, err := s.db.Query(
-		with+`
+		match.with+`
 		 SELECT s.id, s.project_id, p.name, p.path, s.label, s.kind, s.path,
-		        s.parked_branch, s.closed_at, `+saidColumn(join)+`,
+		        s.parked_branch, s.closed_at, `+match.said+`,
 		        COALESCE(x.truncated, 0), COUNT(*) OVER ()
 		   FROM sessions s JOIN projects p ON p.id = s.project_id
 		   LEFT JOIN session_texts x ON x.session_id = s.id
-		   `+join+`
-		   `+where+`
+		   `+match.join+`
+		   `+match.where+`
 		  ORDER BY s.closed_at DESC, s.rowid DESC
 		  LIMIT ?`,
-		args...,
+		append(match.args, closedSessionLimit)...,
 	)
 	if err != nil {
 		return ClosedHistory{}, fmt.Errorf("query closed sessions: %w", err)
@@ -175,15 +148,14 @@ func (s *Service) ClosedSessions(term string) (ClosedHistory, error) {
 	var said []string
 	for rows.Next() {
 		var c ClosedSession
-		var matchedConversation bool
 		if err := rows.Scan(
 			&c.ID, &c.ProjectID, &c.ProjectName, &c.ProjectPath,
 			&c.Label, &c.Kind, &c.Path, &c.ParkedBranch, &c.ClosedAt,
-			&matchedConversation, &c.Truncated, &history.Total,
+			&c.MatchedConversation, &c.Truncated, &history.Total,
 		); err != nil {
 			return ClosedHistory{}, fmt.Errorf("scan closed session: %w", err)
 		}
-		if matchedConversation {
+		if c.MatchedConversation {
 			said = append(said, c.ID)
 		}
 		history.Sessions = append(history.Sessions, c)
@@ -198,13 +170,52 @@ func (s *Service) ClosedSessions(term string) (ClosedHistory, error) {
 	return history, nil
 }
 
-// saidColumn is what the query reports into the snippet pass: whether this row
-// was matched on its conversation. A query with no match has no m to read, and a
-// term nothing could be searched for never gets one, so every row answers false
-// and no conversation is read at all.
-func saidColumn(join string) string {
-	if join == "" {
-		return "0"
+// sessionMatch is the SQL a term turns into, in the pieces ClosedSessions
+// splices around its SELECT. args are bound in the order the pieces name them:
+// the CTE's MATCH first, then one LIKE per word.
+type sessionMatch struct {
+	with, join, where string
+	// said is the column reporting whether a row was matched on its
+	// conversation. A term nothing could be searched for has no m to read, so
+	// it reads 0 and no conversation is opened for a snippet.
+	said string
+	args []any
+}
+
+// closedSessionsMatch is the OR the search is built around, as SQL: every word
+// in the name half, or the conversation in the index. An empty term is no
+// condition at all beyond the row being parked.
+//
+// The match is MATERIALIZED, and not a subquery inlined into the join: without
+// it SQLite runs the full-text search again for every parked row it walks,
+// which on a workspace of two hundred sessions costs tens of seconds instead of
+// tens of milliseconds.
+func closedSessionsMatch(term string) sessionMatch {
+	m := sessionMatch{where: "WHERE s.is_open = 0", said: "0", args: []any{}}
+	if fts := ftsQuery(term); fts != "" {
+		m.with = `WITH said AS MATERIALIZED (
+		          SELECT t.session_id FROM session_texts t
+		            JOIN session_texts_fts f ON f.rowid = t.rowid
+		           WHERE session_texts_fts MATCH ?)`
+		m.join = "LEFT JOIN said m ON m.session_id = s.id"
+		m.said = "m.session_id IS NOT NULL"
+		m.args = append(m.args, fts)
 	}
-	return "m.session_id IS NOT NULL"
+	names := strings.Fields(term)
+	if len(names) == 0 {
+		return m
+	}
+	clauses := make([]string, 0, len(names))
+	for _, word := range names {
+		clauses = append(clauses,
+			"(s.label || ' ' || p.name || ' ' || s.path || ' ' || s.parked_branch)"+
+				" LIKE ? ESCAPE '"+likeEscape+"'")
+		m.args = append(m.args, "%"+escapeLike(word)+"%")
+	}
+	matched := "(" + strings.Join(clauses, " AND ") + ")"
+	if m.join != "" {
+		matched += " OR m.session_id IS NOT NULL"
+	}
+	m.where += " AND (" + matched + ")"
+	return m
 }

--- a/internal/store/history_test.go
+++ b/internal/store/history_test.go
@@ -2,7 +2,9 @@ package store
 
 import (
 	"fmt"
+	"reflect"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 )
@@ -576,5 +578,45 @@ func TestClosedSessionsCountsTheWholeMatch(t *testing.T) {
 	none, _ := svc.ClosedSessions("nothing-matches-this")
 	if len(none.Sessions) != 0 || none.Total != 0 {
 		t.Errorf("empty match = %d rows, Total %d; want 0 and 0", len(none.Sessions), none.Total)
+	}
+}
+
+// TestClosedSessionsMatch pins the SQL a term turns into, and above all the
+// order its arguments are bound in: the CTE's MATCH is written before the WHERE
+// it feeds, so its argument has to come first, and a term with nothing for the
+// index binds no MATCH at all.
+func TestClosedSessionsMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		term     string
+		wantWith bool
+		wantArgs []any
+	}{
+		{name: "an empty term is the plain history", term: "", wantArgs: []any{}},
+		{
+			name: "a word asks the index first and the names second",
+			term: "adopt", wantWith: true, wantArgs: []any{`"adopt"*`, "%adopt%"},
+		},
+		{
+			name: "punctuation alone searches names alone",
+			term: "%_", wantArgs: []any{`%\%\_%`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := closedSessionsMatch(tt.term)
+			if got := m.with != ""; got != tt.wantWith {
+				t.Errorf("with = %q, want a CTE: %v", m.with, tt.wantWith)
+			}
+			if (m.join != "") != tt.wantWith || (m.said != "0") != tt.wantWith {
+				t.Errorf("join = %q, said = %q: the CTE and what reads it disagree", m.join, m.said)
+			}
+			if !reflect.DeepEqual(m.args, tt.wantArgs) {
+				t.Errorf("args = %#v, want %#v", m.args, tt.wantArgs)
+			}
+			if !strings.HasPrefix(m.where, "WHERE s.is_open = 0") {
+				t.Errorf("where = %q does not start from the parked rows", m.where)
+			}
+		})
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -163,16 +163,21 @@ CREATE TABLE IF NOT EXISTS session_hands_on (
 );
 
 -- What a parked session talked about, for the History tab's search. One row per
--- closed session, replaced by each close and deleted with the row, and written
--- even when it is empty, because an empty row is what says the session was
--- looked at and keeps the backfill from reading the same disk again on every
--- search (transcripts.go).
+-- closed session, replaced by each close and written even when it is empty,
+-- because an empty row is what says the session was looked at and keeps the
+-- backfill from reading the same disk again on every search (transcripts.go).
+--
+-- The CASCADE is the whole of its deletion: a resume reinserts the session under
+-- a new id and deletes the old row, and a forgotten project takes its sessions
+-- with it through the same clause above — neither passes through a code path
+-- that could drop the text by hand, and a body of up to eight megabytes left
+-- behind on every resume is the leak that clause closes.
 --
 -- The body is kept here, keyed, rather than inside the index: the row a search
 -- draws needs the words around its hit, and only a primary key can fetch one
 -- conversation out of hundreds without walking all of them.
 CREATE TABLE IF NOT EXISTS session_texts (
-    session_id TEXT NOT NULL PRIMARY KEY,
+    session_id TEXT NOT NULL PRIMARY KEY REFERENCES sessions(id) ON DELETE CASCADE,
     -- Whether the cap on what one session's index holds dropped the oldest of
     -- this conversation (terminal.indexTextBytes). It sits before the body and
     -- not after it because that is the only way to read it without walking a
@@ -231,7 +236,9 @@ type Service struct {
 	// while one is running starts nothing. See backfill.
 	backfilling atomic.Bool
 	// backfillDone and stopped are how Close waits a running backfill out
-	// rather than pulling the database from under it.
+	// rather than pulling the database from under it; backfillMu orders a
+	// backfill's start against that Close (backfill).
+	backfillMu   sync.Mutex
 	backfillDone sync.WaitGroup
 	stopped      chan struct{}
 	stopOnce     sync.Once
@@ -253,13 +260,11 @@ func (s *Service) SetSessionGone(fn func(sessionID string)) {
 // and nothing at all when the store runs without it — every test, and a lich
 // whose wiring has not run yet.
 func (s *Service) sessionIsGone(sessionIDs ...string) {
+	if s.sessionGone == nil {
+		return
+	}
 	for _, id := range sessionIDs {
-		// The one funnel every delete passes through, which is what keeps a
-		// forgotten session's conversation from outliving its row.
-		s.dropTranscript(id)
-		if s.sessionGone != nil {
-			s.sessionGone(id)
-		}
+		s.sessionGone(id)
 	}
 }
 
@@ -450,7 +455,9 @@ func databasePath() (string, error) {
 // goroutine writes through this same connection, and closing it under one is a
 // failed write logged as if the disk had gone.
 func (s *Service) Close() error {
+	s.backfillMu.Lock()
 	s.stopOnce.Do(func() { close(s.stopped) })
+	s.backfillMu.Unlock()
 	s.backfillDone.Wait()
 	return s.db.Close()
 }

--- a/internal/store/transcripts.go
+++ b/internal/store/transcripts.go
@@ -73,7 +73,9 @@ func (s *Service) attachSnippets(sessions []ClosedSession, ids []string, term st
 		return
 	}
 	bodies := s.conversationBodies(ids)
-	words := strings.Fields(strings.ToLower(term))
+	// Split the way the index was asked (ftsQuery): "worktree/port" matched the
+	// conversation as two words, and is two words here or no snippet is found.
+	words := searchWords(strings.ToLower(term))
 	for i := range sessions {
 		body, ok := bodies[sessions[i].ID]
 		if !ok {
@@ -178,15 +180,6 @@ func (s *Service) indexTarget(sessionID string) (providerSessionID, cwd string) 
 	return providerSessionID, cwd
 }
 
-// dropTranscript forgets one session's index. It rides on sessionIsGone, so
-// every path that deletes a row for good takes its conversation with it, while a
-// close, which parks the row for a later resume, keeps it.
-func (s *Service) dropTranscript(sessionID string) {
-	if _, err := s.db.Exec(`DELETE FROM session_texts WHERE session_id = ?`, sessionID); err != nil {
-		slog.Warn("store: drop transcript index", "session", sessionID, "err", err)
-	}
-}
-
 // unindexed counts the parked sessions with no index row: the ones parked before
 // lich wrote one, which is every row in a workspace meeting this version for the
 // first time. It is what the History tab's header reports while the
@@ -211,8 +204,23 @@ func (s *Service) unindexed() int {
 //
 // Only one runs at a time, and it stops when the store closes: every search
 // while it is working starts it again and the guard turns that into nothing.
+//
+// The start is taken under the same lock Close closes the store under, so a
+// backfill never begins after Close has started waiting: a WaitGroup added to
+// while it is being waited on at zero is the one thing the type forbids, and
+// the goroutine it would let through writes into a closed database.
 func (s *Service) backfill() {
-	if s.transcriptOf == nil || !s.backfilling.CompareAndSwap(false, true) {
+	if s.transcriptOf == nil {
+		return
+	}
+	s.backfillMu.Lock()
+	defer s.backfillMu.Unlock()
+	select {
+	case <-s.stopped:
+		return
+	default:
+	}
+	if !s.backfilling.CompareAndSwap(false, true) {
 		return
 	}
 	s.backfillDone.Add(1)
@@ -266,12 +274,20 @@ func (s *Service) nextUnindexed() (string, bool) {
 // substrings: a query that found "worktree" by name and not by conversation
 // would be answering two questions.
 func ftsQuery(term string) string {
-	words := strings.FieldsFunc(term, func(r rune) bool {
-		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
-	})
+	words := searchWords(term)
 	phrases := make([]string, 0, len(words))
 	for _, word := range words {
 		phrases = append(phrases, `"`+word+`"*`)
 	}
 	return strings.Join(phrases, " ")
+}
+
+// searchWords is a term cut the way FTS5's own tokenizer cuts the text it
+// indexes: on everything that is not a letter or a digit. Both halves of the
+// conversation search read the term through it, the query that asks the index
+// and the snippet that shows the hit, so they agree on what a word is.
+func searchWords(term string) []string {
+	return strings.FieldsFunc(term, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
 }

--- a/internal/store/transcripts_test.go
+++ b/internal/store/transcripts_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -348,4 +349,167 @@ func mustClosedRow(t *testing.T, svc *Service, term, sessionID string) ClosedSes
 	}
 	t.Fatalf("ClosedSessions(%q) returned no row %q", term, sessionID)
 	return ClosedSession{}
+}
+
+// TestClosedSessionsKeepsARowMatchedByAFold: the index folds accents, so
+// "decision" finds a conversation that says "decisión", and the plain text has
+// no snippet to cut for it. The row still answers, and says which half of the
+// search it answered on — that flag, not the snippet, is what the window keeps
+// it on.
+func TestClosedSessionsKeepsARowMatchedByAFold(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	indexed(t, svc, map[string]string{"uuid-a": "una decisión importante"})
+	parkWithConversation(t, svc, "s-a", "Session 4", "uuid-a")
+
+	row := mustClosedRow(t, svc, "decision", "s-a")
+
+	if !row.MatchedConversation {
+		t.Error("a row the index matched does not say so")
+	}
+	if row.Snippet != "" {
+		t.Errorf("Snippet = %q, want none for a hit the plain text does not hold", row.Snippet)
+	}
+	if named := mustClosedRow(t, svc, "Session", "s-a"); named.MatchedConversation {
+		t.Error("a row matched by name alone claims its conversation matched")
+	}
+}
+
+// TestClosedSessionsSnippetsATermSplitOnPunctuation pins the two halves of the
+// conversation search reading a term the same way: the index is asked for
+// "worktree/port" as two words, so the snippet has to look for two words too, or
+// the hit the index found shows nothing under it.
+func TestClosedSessionsSnippetsATermSplitOnPunctuation(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	indexed(t, svc, map[string]string{"uuid-a": "we traced the worktree port hash"})
+	parkWithConversation(t, svc, "s-a", "Session 4", "uuid-a")
+
+	row := mustClosedRow(t, svc, "worktree/port", "s-a")
+
+	if !strings.Contains(row.Snippet, "worktree") {
+		t.Errorf("Snippet = %q, want the matched stretch of the conversation", row.Snippet)
+	}
+}
+
+// TestResumingASessionDropsItsIndexRow: a resume reinserts the row under a new
+// id and deletes the old one, and the conversation has to go with it — a body
+// of up to eight megabytes left under an id nothing refers to is a leak that
+// grows by one on every resume, and a search still walks it.
+func TestResumingASessionDropsItsIndexRow(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	indexed(t, svc, map[string]string{"uuid-a": "we traced the worktree adoption guard"})
+	parkWithConversation(t, svc, "s-a", "Session 4", "uuid-a")
+
+	if _, err := svc.ReopenSession("s-a", "s-a2"); err != nil {
+		t.Fatalf("ReopenSession: %v", err)
+	}
+
+	if n := indexRows(t, svc); n != 0 {
+		t.Errorf("%d index rows for a session that is open again, want 0", n)
+	}
+	if n := ftsHits(t, svc, "adoption"); n != 0 {
+		t.Errorf("the index still answers %d hits for a conversation whose row is gone", n)
+	}
+	if err := svc.CloseSession("p1", "s-a2", ""); err != nil {
+		t.Fatalf("CloseSession: %v", err)
+	}
+	if n := indexRows(t, svc); n != 1 {
+		t.Errorf("%d index rows after the second park, want 1", n)
+	}
+}
+
+// TestForgettingAProjectForgetsItsConversations: the project's sessions go
+// through the schema's cascade and never through a code path, so the
+// conversations have to ride the same clause.
+func TestForgettingAProjectForgetsItsConversations(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	indexed(t, svc, map[string]string{"uuid-a": "we traced the worktree adoption guard"})
+	parkWithConversation(t, svc, "s-a", "Session 4", "uuid-a")
+
+	if err := svc.DeleteProject("p1"); err != nil {
+		t.Fatalf("DeleteProject: %v", err)
+	}
+
+	if n := indexRows(t, svc); n != 0 {
+		t.Errorf("%d index rows survived the project, want 0", n)
+	}
+	if n := ftsHits(t, svc, "adoption"); n != 0 {
+		t.Errorf("the index still answers %d hits for a project that is gone", n)
+	}
+}
+
+// TestCloseWaitsOutTheBackfill: the backfill writes through the store's one
+// connection, so Close has to wait for the session it is on rather than pull
+// the database from under it — and a backfill asked for after Close has begun
+// must start nothing at all.
+func TestCloseWaitsOutTheBackfill(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "test.db")
+	svc, err := open(path)
+	if err != nil {
+		t.Fatalf("open test store: %v", err)
+	}
+	t.Cleanup(func() { _ = svc.Close() })
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	parkWithConversation(t, svc, "s-a", "Session 4", "uuid-a")
+	reading, release := make(chan struct{}), make(chan struct{})
+	svc.SetTranscriptOf(func(string, string) (string, bool) {
+		close(reading)
+		<-release
+		return "we traced the worktree adoption guard", false
+	})
+	if _, err := svc.ClosedSessions("adoption"); err != nil {
+		t.Fatalf("ClosedSessions: %v", err)
+	}
+	<-reading
+
+	closed := make(chan error, 1)
+	go func() { closed <- svc.Close() }()
+	select {
+	case err := <-closed:
+		t.Fatalf("Close returned %v with a backfill mid-read", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case err := <-closed:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close never returned after the backfill let go")
+	}
+	// Read back through a second handle: the first is closed, and the write
+	// it waited for has to be on disk.
+	reopened, err := open(path)
+	if err != nil {
+		t.Fatalf("reopen test store: %v", err)
+	}
+	defer func() { _ = reopened.Close() }()
+	if n := indexRows(t, reopened); n != 1 {
+		t.Errorf("%d index rows after the store closed under a backfill, want the 1 it was writing", n)
+	}
+	// Started after Close: the guard has to turn it into nothing, or the
+	// WaitGroup is added to under a Wait that already returned.
+	svc.backfill()
+	if svc.backfilling.Load() {
+		t.Error("a backfill started after the store closed")
+	}
+}
+
+// ftsHits asks the index directly, past the join to sessions that hides an
+// orphan from the history list: it is the only way to see a body the triggers
+// left in the index after its row was gone.
+func ftsHits(t *testing.T, svc *Service, term string) int {
+	t.Helper()
+	var n int
+	if err := svc.db.QueryRow(
+		`SELECT COUNT(*) FROM session_texts_fts WHERE session_texts_fts MATCH ?`, ftsQuery(term),
+	).Scan(&n); err != nil {
+		t.Fatalf("count index hits: %v", err)
+	}
+	return n
 }

--- a/internal/terminal/index.go
+++ b/internal/terminal/index.go
@@ -91,16 +91,16 @@ func transcriptProse(path string, read turnReader) string {
 	}
 }
 
-// newestBytes keeps at most max bytes from the end of text, cut at a line break
+// newestBytes keeps at most limit bytes from the end of text, cut at a line break
 // so the index never holds half a sentence, and never inside a rune. The newest
 // end is the one kept: a search is asked about work somebody remembers doing,
 // and the closer to the close of a session it happened the likelier that is.
 // cut is whether anything was dropped at all.
-func newestBytes(text string, max int) (string, bool) {
-	if len(text) <= max {
+func newestBytes(text string, limit int) (string, bool) {
+	if len(text) <= limit {
 		return text, false
 	}
-	cut := text[len(text)-max:]
+	cut := text[len(text)-limit:]
 	if at := strings.IndexByte(cut, '\n'); at >= 0 {
 		cut = cut[at+1:]
 	}

--- a/internal/terminal/index_test.go
+++ b/internal/terminal/index_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // TestTranscriptTextReadsWhatWasSaid pins the extraction the history index is
@@ -130,7 +131,7 @@ func TestNewestBytesNeverCutsARune(t *testing.T) {
 	text := strings.Repeat("é", 40)
 	for max := 1; max <= len(text); max++ {
 		got, _ := newestBytes(text, max)
-		if !isValidUTF8(got) {
+		if !utf8.ValidString(got) {
 			t.Fatalf("newestBytes(%d) = %q, which is not valid UTF-8", max, got)
 		}
 		if !strings.HasSuffix(text, got) {
@@ -166,15 +167,6 @@ func copyFile(t *testing.T, from, to string) {
 	if err := os.WriteFile(to, body, 0o644); err != nil {
 		t.Fatal(err)
 	}
-}
-
-func isValidUTF8(s string) bool {
-	for _, r := range s {
-		if r == '�' {
-			return false
-		}
-	}
-	return true
 }
 
 // TestTranscriptTextReportsTheCapCutting is the flag a history row draws: a

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -64,11 +64,11 @@ type stubBins struct {
 	// What each session inherited from the conversation it was forked from, the
 	// shape store.SaveForkCostOffset writes. Nil until a test cares.
 	forkOffsets map[string]float64
-	// One field per cost method, because the three failures are three different
-	// stories: a ledger that cannot be read, one that cannot be written, and a
-	// total that cannot be summed. A single error field would let a test claim
-	// the path it never reached.
-	ledgerErr, saveLedgerErr, sessionCostErr error
+	// One field per cost method, because the four failures are four different
+	// stories: a ledger that cannot be read, one that cannot be written, a
+	// total that cannot be summed, and a fork's offset that cannot be recorded.
+	// A single error field would let a test claim the path it never reached.
+	ledgerErr, saveLedgerErr, sessionCostErr, forkOffsetErr error
 }
 
 // projectWithSetup is a project checkout shipping .lich/setup-worktree.sh —
@@ -167,6 +167,9 @@ func (s stubBins) SaveCostLedger(
 // SaveForkCostOffset mirrors the store's own arithmetic: the offset is the raw
 // ledger cost of the conversation being forked, whichever session ran it.
 func (s stubBins) SaveForkCostOffset(sessionID, forkedFrom string) error {
+	if s.forkOffsetErr != nil {
+		return s.forkOffsetErr
+	}
 	if s.forkOffsets == nil {
 		return nil
 	}

--- a/internal/terminal/usage_cost_test.go
+++ b/internal/terminal/usage_cost_test.go
@@ -6,6 +6,7 @@
 package terminal
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -835,5 +836,27 @@ func TestAResumeIsNotAFork(t *testing.T) {
 	}
 	if _, offset := store.forkOffsets["s1"]; offset {
 		t.Errorf("resume recorded an offset of %v, want none", store.forkOffsets["s1"])
+	}
+}
+
+// TestAForkWhoseOffsetCannotBeSavedStillStarts: the user is waiting on a
+// session, and a readout that is too high is not worth losing it, so the
+// failure is logged and the spawn goes ahead with no offset recorded.
+func TestAForkWhoseOffsetCannotBeSavedStillStarts(t *testing.T) {
+	store := newCostStore("")
+	store.bin = stayAliveBin(t)
+	store.forkOffsets = map[string]float64{}
+	store.forkOffsetErr = errors.New("disk full")
+	store.ledgers["parent\x00abc-123"] = stubLedger{cost: 1.25}
+	svc := New(store, nil, events.New())
+	t.Cleanup(func() { _ = svc.Close("fork") })
+
+	err := svc.Start("fork", "p1", t.TempDir(), "claude", "abc-123", "", true, false, 80, 24)
+
+	if err != nil {
+		t.Fatalf("Start = %v, want the spawn to survive a failed offset", err)
+	}
+	if _, offset := store.forkOffsets["fork"]; offset {
+		t.Errorf("an offset of %v was recorded through a store that refused it", store.forkOffsets["fork"])
 	}
 }


### PR DESCRIPTION
## Summary

Audit of the last five PRs (#537–#541), all on unreleased features. Ten findings applied; the four that a user would hit:

- **History polled the store every second behind an empty query.** The backfill only starts on a term, so with the palette open on the plain list the unindexed count never moved, and each poll was a `ClosedSessions` query plus `Missing`/`BranchesOf` (a git read per row). The poll now runs only behind a term.
- **A conversation hit with no snippet was dropped by the window.** An accent fold (`decision` against `decisión`) or a term the index split on punctuation (`worktree/port`) came back with an empty snippet, and `filterPalette` kept rows on the snippet alone. `ClosedSession` now carries `matchedConversation` (mirrored in `api-types.ts`), the window keeps rows on it, and the snippet splits the term the way `ftsQuery` does (`searchWords`).
- **`session_texts` leaked a row per resume.** It was the only per-session table without `REFERENCES sessions(id) ON DELETE CASCADE`: `reopen` deletes the row and reinserts under a new id, `DeleteProject` cascades sessions, and neither touched the text. The cascade covers both, so `dropTranscript` and the `sessionIsGone` detour are gone.
- **A session closed while its pane sat in a fallback kept its PTY running.** Only `TerminalView`'s teardown called `Terminal.Close`; with the stage or pane boundary showing its fallback (#538) no view is mounted to do it, and the registry entry (xterm, WebGL context, subscriptions) stayed forever. `reapTerminals` now runs from `Layout`, above every boundary, on each change to the workspace; the view's teardown only detaches.

The rest: the backfill's start is ordered against `Close` under one lock (a `WaitGroup.Add` could race the `Wait`); the history query's SQL is assembled in `closedSessionsMatch` with the argument order pinned; the fork-offset stub has an error field and a test for the logged path; `newestBytes` no longer shadows `max`; the test helper reimplementing `utf8.ValidString` is gone; the cost of cutting a snippet is a bullet in `docs/ceilings.md`.

No CHANGELOG entry: everything here fixes entries already under `[Unreleased]`.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test -race ./...`
- [x] `pnpm exec biome ci .` exit 0, `pnpm test` (1681), `pnpm build`
- [x] New tests: fold and punctuation hits kept (Go + TS), cascade on resume and project delete, `Close` waits out a backfill and refuses a late one, query builder args, empty-query never polls, `reapTerminals`, fork-offset save failure
- [ ] `task dev`: open the palette on a workspace with pre-index parked sessions, leave it on History with no term, confirm no repeated `ClosedSessions` in the log; close a session while a pane shows its fallback, confirm the PTY exits
