### PR TITLE
chore: cut 0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.47.0] - 2026-09-08
+
+> [!IMPORTANT]
+> **Search what a closed session said, not only what it was called.** Parking
+> a session files its conversation into a full-text index, so a phrase you
+> remember typing finds the closed session it was said in and shows the
+> sentence under the row. Sessions closed before this release are indexed in
+> the background the first time you search.
+
 ### Added
 
 - **The palette's History tab now searches what closed sessions said, not just
@@ -4482,7 +4491,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.46.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.47.0...HEAD
+[0.47.0]: https://github.com/omartelo/lich/compare/v0.46.0...v0.47.0
 [0.46.0]: https://github.com/omartelo/lich/compare/v0.45.0...v0.46.0
 [0.45.0]: https://github.com/omartelo/lich/compare/v0.44.0...v0.45.0
 [0.44.0]: https://github.com/omartelo/lich/compare/v0.43.1...v0.44.0


### PR DESCRIPTION
## Summary

Cuts `[Unreleased]` into `## [0.47.0] - 2026-09-08`, the Keep a Changelog way: the section moves whole (Added, Changed, Fixed, in that order), `[Unreleased]` stays at the top emptied, and the compare links are refreshed, `[Unreleased]` included.

The release carries one `> [!IMPORTANT]` headline, for the History tab searching what closed sessions said — the one feature that changes what somebody does with the palette. No `WARNING` or `NOTE`: nothing in the section asks the reader to do or avoid anything.

## Test plan

- [x] `grep '^## \[0.47.0\]' CHANGELOG.md` matches once, so the release job finds its notes
- [x] One `[!IMPORTANT]` block under the heading, before the first `###`
- [x] Compare links: `[Unreleased]` → `v0.47.0...HEAD`, `[0.47.0]` → `v0.46.0...v0.47.0`
- [ ] After merge: push `v0.47.0`, then read the What's new dialog and the release page
