### PR TITLE
fix: say what the shell printed when its environment is unreadable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A failure to read the login shell's environment now says what the shell
+  printed.** The dump was discarded on a failed parse, so the log could only
+  report that no environment came back, never why the shell stopped before the
+  sentinel. The rc file's own words go to the log now, bounded to three lines,
+  with any assignment among them reported by its key alone: a dump that failed
+  to parse was never recognised as an environment, so its values are not ours to
+  log.
+
 ## [0.47.0] - 2026-09-08
 
 > [!IMPORTANT]

--- a/internal/terminal/shellenv.go
+++ b/internal/terminal/shellenv.go
@@ -126,9 +126,46 @@ func ReresolveShellEnv(base []string) ([]string, error) {
 		if err == nil {
 			err = errors.New("the shell printed no environment")
 		}
-		return nil, fmt.Errorf("%s: %w", shell, err)
+		return nil, fmt.Errorf("%s: %w (%s)", shell, err, shellDumpDigest(out))
 	}
 	return mergeEnv(base, extra), nil
+}
+
+// shellDumpDigestLines and shellDumpDigestWidth bound what a failed dump puts in
+// the log: enough of the shell's own words to say why it never reached the
+// sentinel, never the whole rc chatter.
+const (
+	shellDumpDigestLines = 3
+	shellDumpDigestWidth = 120
+)
+
+// shellDumpDigest describes a dump the parse did not recognise, and is the only
+// place its content is ever read for a human. A dump that failed to parse was
+// never recognised as an environment, so a line that assigns one is reported by
+// its key alone — its value was never ours to log. What is left is the rc file's
+// own output: the error, greeting or prompt that says where the shell stopped.
+func shellDumpDigest(out string) string {
+	var lines []string
+	for line := range strings.SplitSeq(out, "\n") {
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
+		if line == "" {
+			continue
+		}
+		if key, _, ok := strings.Cut(line, "="); ok && validEnvKey(key) {
+			line = key + "=..."
+		}
+		if len(line) > shellDumpDigestWidth {
+			line = line[:shellDumpDigestWidth] + "..."
+		}
+		lines = append(lines, line)
+		if len(lines) == shellDumpDigestLines {
+			break
+		}
+	}
+	if len(lines) == 0 {
+		return "printed nothing"
+	}
+	return fmt.Sprintf("%d bytes, starting: %s", len(out), strings.Join(lines, " | "))
 }
 
 // parseShellEnvDump returns the KEY=VALUE lines env printed after the last

--- a/internal/terminal/shellenv_test.go
+++ b/internal/terminal/shellenv_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -245,5 +246,36 @@ func TestReresolveShellEnvWithoutShellRepinsLaunchPATH(t *testing.T) {
 	}
 	if !slices.Equal(got, base) {
 		t.Fatalf("ReresolveShellEnv without SHELL = %v, want %v", got, base)
+	}
+}
+
+func TestShellDumpDigestRedactsAssignments(t *testing.T) {
+	got := shellDumpDigest("zsh: no such file\nAWS_SECRET_ACCESS_KEY=hunter2\n")
+	if strings.Contains(got, "hunter2") {
+		t.Fatalf("digest leaked a value: %q", got)
+	}
+	if !strings.Contains(got, "AWS_SECRET_ACCESS_KEY=...") {
+		t.Errorf("digest dropped the key: %q", got)
+	}
+	// The rc file's own words are the whole point: they say where it stopped.
+	if !strings.Contains(got, "zsh: no such file") {
+		t.Errorf("digest dropped the shell's message: %q", got)
+	}
+}
+
+func TestShellDumpDigestBounds(t *testing.T) {
+	if got := shellDumpDigest(""); got != "printed nothing" {
+		t.Errorf("empty dump = %q", got)
+	}
+	if got := shellDumpDigest("\n \r\n"); got != "printed nothing" {
+		t.Errorf("blank dump = %q", got)
+	}
+	many := shellDumpDigest(strings.Repeat("line\n", 10))
+	if strings.Count(many, "line") != shellDumpDigestLines {
+		t.Errorf("digest kept more than %d lines: %q", shellDumpDigestLines, many)
+	}
+	long := shellDumpDigest(strings.Repeat("x", shellDumpDigestWidth+50))
+	if !strings.Contains(long, "...") || len(long) > shellDumpDigestWidth+80 {
+		t.Errorf("digest did not truncate a long line: %q", long)
 	}
 }


### PR DESCRIPTION
Follow-up to #541, using the log that PR unblocked.

## What the log said

The reporter's Mac, opened from the Dock:

```
level=WARN source=internal/terminal/shellenv.go:80
  msg="terminal: shell env resolution yielded nothing, using launch env"
  err="/bin/zsh: the shell printed no environment"
level=WARN msg="gh failed" err="exec: \"gh\": executable file not found in $PATH"
level=WARN msg="rpc: call failed" method=terminal.Start
  err="... exec: \"claude\": executable file not found in $PATH"
```

That message is reached on exactly one path: `runShellDump` returned **no error** and the parse found no sentinel. So the shell started, ran to a clean EOF, and never executed `echo <sentinel>; env`. It rules out the timeout, the quiet window and a failing `pty.Start` — all three surface as an error.

What it does not say is *why*, because the parse discards the dump on failure. Measured against that: on the reporter's Mac the same `zsh -l -i -c 'echo …; env'` on a pty returns the full PATH in 72ms, and a 0×0 pty (what `pty.Start` creates, against `pty.StartWithSize` everywhere else in `internal/terminal`) reproduces nothing here — the sentinel comes through with 71 variables. The difference is in that rc file, and only its output can name it.

## The change

The dump goes into the error, bounded to three lines of at most 120 characters. An assignment among them is reported by its key alone — a dump the parse did not recognise was never recognised as an environment, so its values are not ours to write to a file bug reports get attached from. `AWS_SECRET_ACCESS_KEY=hunter2` logs as `AWS_SECRET_ACCESS_KEY=...`; `zsh: no such file` logs verbatim, which is the part that says where the shell stopped.

## Test plan

- [x] `gofmt -l .`, `go vet ./...`, `go test ./...`
- [x] Cross-compile loop over linux/darwin/windows
- [x] `TestShellDumpDigestRedactsAssignments` — a value never reaches the digest, the key and the shell's own message do
- [x] `TestShellDumpDigestBounds` — empty and blank-only dumps, the line cap, the width cap
- [ ] On the reporter's Mac: open `Lich.app` from the Dock, read `lich.log` for the digest

Frontend untouched.