### PR TITLE
chore: cut 0.47.1 in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.47.1] - 2026-09-08
+
 ### Fixed
 
 - **A failure to read the login shell's environment now says what the shell
@@ -4501,7 +4503,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   CPU, costing ~40ms per frame in a full-size window. Under Xwayland typing is
   stall-free at full frame rate.
 
-[Unreleased]: https://github.com/omartelo/lich/compare/v0.47.0...HEAD
+[Unreleased]: https://github.com/omartelo/lich/compare/v0.47.1...HEAD
+[0.47.1]: https://github.com/omartelo/lich/compare/v0.47.0...v0.47.1
 [0.47.0]: https://github.com/omartelo/lich/compare/v0.46.0...v0.47.0
 [0.46.0]: https://github.com/omartelo/lich/compare/v0.45.0...v0.46.0
 [0.45.0]: https://github.com/omartelo/lich/compare/v0.44.0...v0.45.0


### PR DESCRIPTION
Cuts the one entry sitting in `[Unreleased]` — #544, the login-shell dump digest — into a `0.47.1` section, so the release job has notes to read.

- `## [0.47.1] - 2026-09-08`, bracketed and ISO-dated with no `v`, which is what `.github/workflows/release.yml` greps for.
- `[Unreleased]` stays at the top, emptied.
- Compare links refreshed: `[Unreleased]` now spans from `v0.47.1`, and `[0.47.1]` from `v0.47.0`.
- No alert blocks: a patch carrying a single diagnostic fix has no headline to make.

CHANGELOG only, no code. The `v0.47.1` tag is yours to push once this lands.