### PR TITLE
fix: stop the Windows window from popping a console and quitting on it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,15 @@ jobs:
           if grep -qi 'VCRUNTIME\|MSVCP' "$RUNNER_TEMP/deps.txt"; then
             echo "::error::lich-shell.exe depends on the Visual C++ runtime"; cat "$RUNNER_TEMP/deps.txt"; exit 1
           fi
+          # GUI subsystem, not console: a console-subsystem window gets its own
+          # console window allocated (lich.exe is -H=windowsgui and has none to
+          # lend), and closing that console kills the window. Invisible to the
+          # run below, which inherits this shell's console.
+          dumpbin /HEADERS "$app/shell/lich-shell.exe" > "$RUNNER_TEMP/headers.txt"
+          grep -q 'subsystem (Windows GUI)' "$RUNNER_TEMP/headers.txt" || {
+            echo "::error::lich-shell.exe is not a GUI-subsystem binary; it will pop a console window"
+            grep -i subsystem "$RUNNER_TEMP/headers.txt"; exit 1
+          }
           export APPDATA="$RUNNER_TEMP/appdata" LICH_LISTEN_PORT=47899
           mkdir -p "$APPDATA"
           "$app/lich.exe" -- --remote-debugging-port=9334 &

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **On Windows, lich's own window no longer opens a stray console window beside
+  it, or gives up and reopens in Chrome.** The window was built for the console
+  subsystem, so Windows allocated a console for it and for each of Chromium's
+  subprocesses; closing that console killed the window, and lich read the death
+  as a window that could not open and fell back to the system browser after a
+  long wait. It is a GUI binary now, like Chrome's own.
+
 ## [0.47.1] - 2026-09-08
 
 ### Fixed

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -4,6 +4,12 @@
 //! `--class=<name>` names the window for the window manager,
 //! `--user-data-dir=<dir>` is where the profile lives, and every other
 //! `--switch[=value]` is a Chromium switch to honour (`lich -- --ozone-platform=wayland`).
+// Rust defaults to the console subsystem and lich.exe is built for the GUI one
+// (-H=windowsgui), so there is no console to inherit: Windows allocated a fresh
+// one per process, for the window and for every CEF subprocess. Closing it sent
+// CTRL_CLOSE_EVENT to the group and killed the window with 0xc000013a inside the
+// startup grace, which lich reads as a window that could not open.
+#![windows_subsystem = "windows"]
 use cef::rc::Rc as _;
 use cef::sys::cef_event_flags_t;
 use cef::{


### PR DESCRIPTION
A user's log shows lich on Windows opening a stray console window beside its own
window, sitting there, and then giving up and reopening in Chrome:

```
17:16:01 browser resolved browser="...\lich\shell\lich-shell.exe (the bundled window)"
17:16:24 bundled window died at startup, opening a system browser instead err="exit status 0xc000013a"
```

Four times in the same session, always the same exit code.

## What happens

`lich-shell.exe` is built for the **console** subsystem: Rust's default, and
`shell/src/main.rs` never declared otherwise. `lich.exe` is built for the GUI one
(`-H=windowsgui`, `Taskfile.yml:112`), so it has no console to lend, and Windows
allocates a fresh console window for any console-subsystem child. One for the
window, and one for each renderer, GPU and utility process CEF re-execs out of
the same binary.

That console is not only noise. It takes focus, it ships with QuickEdit on (a
click inside it blocks the process on its next write), and closing it sends
`CTRL_CLOSE_EVENT` to the whole process group: the window dies with
`STATUS_CONTROL_C_EXIT`, which is `0xc000013a` above. The death lands inside the
30s `startupGrace`, so `fallsBack` (`internal/chromium/chromium.go:203`) reads
lich's own console being closed as a window that could not open, and walks the
ladder down to the system browser.

`internal/winexec` exists for exactly this and every other console tool goes
through it (git, gh, the agent plugin), but `chromium.launch` uses a bare
`exec.Command`. Fixing the binary covers both sides at once, including the CEF
subprocesses, which a `CREATE_NO_WINDOW` on the Go side would not reach.

## Why CI was green

The release smoke test launches `"$app/lich.exe" &` from the runner's bash,
which **has** a console. The child inherits it, no console is allocated, and the
whole failure mode is invisible.

## The change

- `#![windows_subsystem = "windows"]` in `shell/src/main.rs`. This is how
  Chromium ships its own binaries; the attribute is ignored on Linux and macOS.
- The Windows smoke test now reads the subsystem out of the PE header with
  `dumpbin /HEADERS`, next to the Visual C++ runtime check it already runs. That
  is the check that would have caught this.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --release --all-targets -- -D warnings`,
      `cargo test --release` (9 passed) on the shell crate.
- [x] No Go or frontend file changed, so `gofmt`, `go vet` and both suites are
      untouched by this diff.
- [ ] The release job's Windows smoke test proves the assertion on a real runner;
      the console itself only shows on a desktop launch (Start Menu shortcut),
      which no runner performs.
