### PR TITLE
fix: run a terminal entrypoint without any rc, on every OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   as a window that could not open and fell back to the system browser after a
   long wait. It is a GUI binary now, like Chrome's own.
 
+### Changed
+
+- **A terminal entrypoint now runs the same way on every OS, and agent cards say
+  why they cannot take one.** On Windows the command was run after your
+  PowerShell `$PROFILE`, which Linux and macOS never load, so an entrypoint that
+  leaned on an alias worked on one machine and silently did nothing on the next;
+  no profile or rc file is loaded now, on any OS. And *Entrypoint…* is no longer
+  missing from an agent card's menu — it is there, greyed, saying entrypoints run
+  in terminal sessions.
+
 ## [0.47.1] - 2026-09-08
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ lich lets you:
 - **Keep a real terminal.** PTY-backed shells, several per project, rendered on
   the GPU — searchable scrollback that survives a full page reload. Give one an
   entrypoint — `lazygit`, `k9s`, `pnpm dev` — and it opens straight into that
-  tool every time; write your dev server into `.lich/run-worktree.sh` and every
+  tool every time, on Linux, macOS and Windows alike: no shell rc or PowerShell
+  profile is loaded first, so an entrypoint that works for you works for whoever
+  you share it with; write your dev server into `.lich/run-worktree.sh` and every
   checkout gets a **Run** card for it, on the port lich reserved for that
   worktree. The footer follows `cd` and names the branch — and, for a
   Claude Code or Codex session, the model, the context window in use and how

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -228,12 +228,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   (Git Bash, a POSIX-ish shell reached through PATH), that path still runs over a pipe, so an rc guarded the
   same way is skipped there exactly as it was everywhere before this fix, with no ConPTY wired in to close the
   gap.
-- **A terminal entrypoint reaches shell sessions only, and reads a different rc on each OS**
-  (`internal/terminal/entrypoint.go`): the menu item is absent on a provider card. On Linux and macOS the command
-  runs through the shell's `-c`, which loads no interactive rc: an alias defined in `.zshrc` is not a command that
-  can be an entrypoint, though `$PATH` is intact (`internal/terminal/shellenv.go`). On Windows it runs through
-  PowerShell's `-EncodedCommand`, which *does* load `$PROFILE` first — so the same alias works there, and an
-  entrypoint one user shares is not necessarily one the next can run.
 - **The worktree setup script answers to the main checkout, never the new branch, and never runs on Windows**
   (`internal/project/setup.go`, `internal/terminal/setup.go`): improve `.lich/setup-worktree.sh` on a feature
   branch and fresh worktrees keep running the old one until the change reaches the checkout the project points

--- a/frontend/src/components/sidebar/EntrypointDialog.tsx
+++ b/frontend/src/components/sidebar/EntrypointDialog.tsx
@@ -71,7 +71,8 @@ export function EntrypointDialog({
             className="font-mono"
           />
           <p className="text-xs text-muted-foreground">
-            Runs in <span className="font-mono">{cwd}</span>. Leave empty for a plain shell.
+            Runs in <span className="font-mono">{cwd}</span> without loading your shell&rsquo;s rc
+            file, so an alias is not a command. Leave empty for a plain shell.
           </p>
         </div>
         <DialogFooter>

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -17,7 +17,6 @@ import {
   Columns2,
   Pin,
   PinOff,
-  Play,
   Shield,
   ShieldOff,
   Terminal,
@@ -48,6 +47,7 @@ import { baseReadout } from "@/lib/git/base-status"
 import { usePullRequest } from "@/lib/pulls/use-pull-request"
 import { CloseButton } from "@/components/common/CloseButton"
 import { DiffStat } from "@/components/DiffStat"
+import { SessionEntrypointItem } from "./SessionEntrypointItem"
 import { SessionForkItem } from "./SessionForkItem"
 import { SessionStatusIcon } from "./SessionStatusIcon"
 import { SessionTooltip } from "./SessionTooltip"
@@ -117,8 +117,7 @@ interface SessionCardProps {
   // hand — but the id is what lets a terminal editor be launched in it.
   onOpenTerminal: (cwd: string) => string
   // Record the command this terminal opens into, "" to clear it back to a plain
-  // shell. Offered on shell sessions alone: on a provider card the entrypoint is
-  // the provider, and the store refuses one there anyway.
+  // shell. Only a terminal card can take one (SessionEntrypointItem).
   onSetEntrypoint: (entrypoint: string) => void
   // Open the Pulls screen for this session's worktree, parking its PR card.
   onPulls: () => void
@@ -659,12 +658,7 @@ export function SessionCard({
             {pinned ? <PinOff /> : <Pin />}
             {pinned ? "Unpin" : "Pin"}
           </ContextMenuItem>
-          {session.kind === "shell" && (
-            <ContextMenuItem onClick={() => setEntrypointOpen(true)}>
-              <Play />
-              Entrypoint…
-            </ContextMenuItem>
-          )}
+          <SessionEntrypointItem session={session} onOpen={() => setEntrypointOpen(true)} />
           {!active && (
             <ContextMenuItem onClick={onStageToggle}>
               <Columns2 />

--- a/frontend/src/components/sidebar/SessionEntrypointItem.tsx
+++ b/frontend/src/components/sidebar/SessionEntrypointItem.tsx
@@ -1,0 +1,34 @@
+import { Play } from "lucide-react"
+import { ContextMenuItem } from "@/components/ui/context-menu"
+import type { Session } from "@/lib/session/sessions"
+
+interface SessionEntrypointItemProps {
+  session: Session
+  onOpen: () => void
+}
+
+// "Entrypoint…" on a session card: live on a terminal, dead under the sentence
+// naming why on an agent card, the idiom SessionForkItem sets. The row stays
+// either way, because a user who gave one terminal an entrypoint and finds
+// nothing on their Claude Code card has no way to learn that the offer was
+// withheld rather than missing — on a provider card the entrypoint *is* the
+// provider, and the store refuses one there anyway.
+export function SessionEntrypointItem({ session, onOpen }: SessionEntrypointItemProps) {
+  if (session.kind !== "shell") {
+    return (
+      <ContextMenuItem disabled>
+        <Play />
+        <span className="flex flex-col items-start">
+          Entrypoint…
+          <span className="text-xs">Entrypoints run in terminal sessions.</span>
+        </span>
+      </ContextMenuItem>
+    )
+  }
+  return (
+    <ContextMenuItem onClick={onOpen}>
+      <Play />
+      Entrypoint…
+    </ContextMenuItem>
+  )
+}

--- a/frontend/src/components/sidebar/session-entrypoint-item.test.tsx
+++ b/frontend/src/components/sidebar/session-entrypoint-item.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+//
+// The Entrypoint row of a session card, mounted for real: the node-only gate
+// cannot tell a disabled item carrying its reason from an item that never
+// rendered, and the reason is the whole point of the row.
+//
+// The harness is imported first for the reason render-budget.test.tsx names: it
+// has to hook react-dom before anything else reaches it.
+import { mountBudget } from "@/test/render-budget"
+import { createElement } from "react"
+import { expect, test } from "vitest"
+import { ContextMenu, ContextMenuContent, ContextMenuTrigger } from "@/components/ui/context-menu"
+import type { Session } from "@/lib/session/sessions"
+import { SessionEntrypointItem } from "./SessionEntrypointItem"
+
+function menu(session: Session, onOpen: () => void = () => {}) {
+  return createElement(
+    ContextMenu,
+    { open: true },
+    createElement(ContextMenuTrigger, null, "card"),
+    createElement(
+      ContextMenuContent,
+      null,
+      createElement(SessionEntrypointItem, { session, onOpen }),
+    ),
+  )
+}
+
+const item = () =>
+  [...document.querySelectorAll('[role="menuitem"]')].find((element) =>
+    element.textContent?.startsWith("Entrypoint"),
+  )
+
+test("an agent card gets the row disabled, naming why", async () => {
+  const mounted = await mountBudget(menu({ id: "s1", label: "claude", kind: "claude" }))
+
+  const row = item()
+  if (!row) {
+    throw new Error("Entrypoint row not rendered")
+  }
+  expect(row.getAttribute("data-disabled")).not.toBeNull()
+  expect(row.textContent).toContain("Entrypoints run in terminal sessions.")
+  await mounted.unmount()
+})
+
+test("a terminal card gets the row live, with no reason to give", async () => {
+  const opened: number[] = []
+  const mounted = await mountBudget(
+    menu({ id: "s1", label: "term", kind: "shell" }, () => opened.push(1)),
+  )
+
+  const row = item()
+  if (!row) {
+    throw new Error("Entrypoint row not rendered")
+  }
+  expect(row.getAttribute("data-disabled")).toBeNull()
+  expect(row.textContent).toBe("Entrypoint…")
+
+  await mounted.act(() => {
+    ;(row as HTMLElement).click()
+  })
+  expect(opened).toEqual([1])
+  await mounted.unmount()
+})

--- a/internal/terminal/entrypoint.go
+++ b/internal/terminal/entrypoint.go
@@ -45,11 +45,12 @@ func wrapEntrypoint(spec ptySpec, kind, entrypoint, goos string) ptySpec {
 		return spec
 	}
 	if goos == "windows" {
-		// No -NoProfile: the profile is the user's own rc, this is their own
-		// shell, and PowerShell loads it before running the command — so an
-		// alias defined in $PROFILE can be an entrypoint, the one thing the
-		// POSIX branch cannot offer.
-		spec.args = []string{"-NoExit", "-EncodedCommand", encodePwshCommand(entrypoint)}
+		// -NoProfile is what makes an entrypoint mean the same thing on both
+		// OSes: the POSIX branch's -c loads no interactive rc, and PowerShell
+		// would load $PROFILE before the command unless told not to. A command
+		// that only runs where its author's rc defined it is not one a user can
+		// share, and nothing on screen would say which half was missing.
+		spec.args = []string{"-NoProfile", "-NoExit", "-EncodedCommand", encodePwshCommand(entrypoint)}
 		return spec
 	}
 	// The newline is load-bearing: a command ending in a comment or an unclosed

--- a/internal/terminal/entrypoint_test.go
+++ b/internal/terminal/entrypoint_test.go
@@ -122,6 +122,11 @@ func TestWrapEntrypointComposesWithSetup(t *testing.T) {
 // the command, so the shell they land in is the process lich spawned rather than
 // a second one exec'd over it. A regression that composed a chain instead would
 // leave the working-directory poll (cwd.go) watching a parent that never moves.
+//
+// -NoProfile is the other half, and the one a reader is likeliest to drop as
+// noise: it is what makes an entrypoint mean the same thing on both OSes, since
+// the POSIX branch loads no rc either. What that costs is proved on a real
+// shell by entrypoint_windows_test.go.
 func TestWrapEntrypointOnWindowsKeepsOneProcess(t *testing.T) {
 	spec := entrypointSpec()
 	spec.bin = `C:\Program Files\PowerShell\7\pwsh.exe`
@@ -131,10 +136,11 @@ func TestWrapEntrypointOnWindowsKeepsOneProcess(t *testing.T) {
 	if got.bin != spec.bin {
 		t.Errorf("bin = %q, want the session's own shell %q", got.bin, spec.bin)
 	}
-	if len(got.args) != 3 || got.args[0] != "-NoExit" || got.args[1] != "-EncodedCommand" {
-		t.Fatalf("args = %v, want -NoExit -EncodedCommand <script>", got.args)
+	if len(got.args) != 4 || got.args[0] != "-NoProfile" || got.args[1] != "-NoExit" ||
+		got.args[2] != "-EncodedCommand" {
+		t.Fatalf("args = %v, want -NoProfile -NoExit -EncodedCommand <script>", got.args)
 	}
-	if command := decodePwshCommand(t, got.args[2]); command != "lazygit" {
+	if command := decodePwshCommand(t, got.args[3]); command != "lazygit" {
 		t.Errorf("encoded command = %q, want the trimmed entrypoint", command)
 	}
 	if got.dir != spec.dir || got.cols != spec.cols || got.rows != spec.rows {

--- a/internal/terminal/entrypoint_windows_test.go
+++ b/internal/terminal/entrypoint_windows_test.go
@@ -1,0 +1,94 @@
+//go:build windows
+
+package terminal
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	entrypointMarker = "lich-entrypoint-ran"
+	profileMarker    = "lich-profile-ran"
+)
+
+// TestWrapEntrypointLoadsNoProfileOnARealShell is the half only a Windows runner
+// can answer. wrapEntrypoint's own test pins the argv; that -NoProfile in it
+// actually keeps $PROFILE out of the command's way is PowerShell's behaviour,
+// and the parity this feature promises rests on it.
+//
+// The control run is the load-bearing part: the same argv without -NoProfile
+// has to show the profile running. Without it, a profile written to the wrong
+// path — PowerShell resolves it per host and per major version — would look
+// exactly like a profile correctly skipped, and the test would pass forever
+// while proving nothing.
+func TestWrapEntrypointLoadsNoProfileOnARealShell(t *testing.T) {
+	shell := userShell()
+	if shell == "" {
+		t.Skip("no PowerShell on $PATH")
+	}
+	installProfile(t, shell)
+
+	args := wrapEntrypoint(ptySpec{bin: shell}, KindShell, `Write-Output "`+entrypointMarker+`"`, "windows").args
+
+	control := runShell(t, shell, args[1:])
+	if !strings.Contains(control, profileMarker) || !strings.Contains(control, entrypointMarker) {
+		t.Fatalf("control run reached neither the profile nor the command, so this test proves nothing: %q", control)
+	}
+
+	out := runShell(t, shell, args)
+	if !strings.Contains(out, entrypointMarker) {
+		t.Errorf("the entrypoint did not run: %q", out)
+	}
+	if strings.Contains(out, profileMarker) {
+		t.Errorf("$PROFILE ran despite -NoProfile: %q", out)
+	}
+}
+
+// installProfile writes a profile at the path this very shell reports, and takes
+// it away again. It skips rather than overwrite one that is already there: this
+// suite runs on a developer's own machine as readily as on a runner, and their
+// PowerShell profile is not ours to clobber.
+func installProfile(t *testing.T, shell string) {
+	t.Helper()
+	path := strings.TrimSpace(runShell(t, shell, []string{"-NoProfile", "-Command", "$PROFILE.CurrentUserCurrentHost"}))
+	if path == "" {
+		t.Skip("this PowerShell reports no per-user profile path")
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Skip("a PowerShell profile is already installed here; not overwriting it")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("create profile directory: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(`Write-Output "`+profileMarker+"\"\n"), 0o644); err != nil {
+		t.Fatalf("write profile: %v", err)
+	}
+	t.Cleanup(func() { os.Remove(path) })
+}
+
+// runShell runs the shell to completion and answers with everything it printed.
+// stdin is the null device, which is what ends the prompt -NoExit leaves behind;
+// the deadline is the backstop for a PowerShell that reads it differently, and
+// the output is returned either way because the markers are the answer, not the
+// exit status.
+func runShell(t *testing.T, shell string, args []string) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	var out bytes.Buffer
+	cmd := exec.CommandContext(ctx, shell, args...)
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil && ctx.Err() == nil {
+		t.Fatalf("run %s %v: %v (output: %q)", shell, args, err, out.String())
+	}
+	return out.String()
+}


### PR DESCRIPTION
Closes one `docs/ceilings.md` bullet by removing what it described, rather than rewording it.

## The trap

`wrapEntrypoint` composed two different contracts. On Linux and macOS the command goes through the shell's `-c`, which loads no interactive rc. On Windows it went through PowerShell's `-EncodedCommand`, which loads `$PROFILE` first — so an entrypoint leaning on an alias worked on its author's machine and silently did nothing on the next one, with nothing on screen saying which half was missing. And the *Entrypoint…* menu item was simply absent from an agent card, which answers no question a user has.

## The fix

- **`-NoProfile` on the Windows argv.** No rc, no profile, either side. One comment says why, since a reader is likelier to drop the flag as noise than to reinstate it.
- **`internal/terminal/entrypoint_windows_test.go`** (build-tagged, so only the Windows runner runs it) proves the flag does what the parity rests on: it installs a profile at the path PowerShell itself reports, then runs lich's own argv twice. The control run without `-NoProfile` **has to** show the profile running — otherwise a profile written where that shell never looks would be indistinguishable from one correctly skipped, and the test would pass forever proving nothing. It skips rather than overwrite a profile that is already installed, so it is safe on a developer's own Windows box.
- **`SessionEntrypointItem`** replaces the `session.kind === "shell" &&` gate in `SessionCard`: the row is there on every card, disabled under "Entrypoints run in terminal sessions." on an agent one. Same idiom as `SessionForkItem` (#509), same jsdom test shape.
- The entrypoint dialog and the README both say the rc is not loaded, where the person typing the command reads it.

## Local Gate

`gofmt -l .` clean · `go vet ./...` clean · `go test ./...` green · cross-compile loop (linux/darwin/windows) green · `biome ci .` exit 0 · `pnpm test` 1683 green · `pnpm build` green. `shell/` untouched.

## Note

The Windows half is proven only by the `os-tests` job on this PR — there is no hardware here for it.