### PR TITLE
fix: say the cwd is unknown when the shell runs somewhere unreadable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A session whose shell runs inside tmux, over ssh or in a container now says
+  its directory is unknown instead of naming a local one.** The card, its
+  tooltip and the footer read "cwd unknown · inside tmux": the directory those
+  hosts sit in is real and is not where the user is typing, which is the one
+  wrong answer that looks right. Linux and macOS; Windows has no foreground
+  process group to read it from.
+
 - **On Windows, lich's own window no longer opens a stray console window beside
   it, or gives up and reopens in Chrome.** The window was built for the console
   subsystem, so Windows allocated a console for it and for each of Chromium's

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -4,9 +4,6 @@ Deliberate limits and shortcuts, and the traps they set. A bullet earns its plac
 work when nobody knows it and that the call site never shows. The mechanism and the history stay in the code and
 `CHANGELOG.md`; this file is the trap alone.
 
-- **Session cwd is polled** from the terminal's foreground process group (`internal/terminal/cwd.go`): a shell
-  hosted elsewhere — tmux, ssh, a container — is beyond every reader, and the readout goes on naming a real
-  local directory that is not where the user is, with nothing on screen saying so.
 - **A project's gh account governs gh, not git**: `vcs.account` (`internal/project/ghaccount.go`) puts one
   account's token in `GH_TOKEN` for every gh call lich makes for that project. A push still rides the remote's
   ssh key and signs with the global `user.email`, so a PR can be *read* by one account and its commits *land*

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -75,7 +75,7 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
   const { footerLayout, footerVisibility, showContextUsage } = useSettings()
   const showCost = useCostReadout()
   const layout = resolveFooterLayout(footerLayout, footerVisibility, showContextUsage, showCost)
-  const { projectId, sessionId, path, checkout, kind, sandboxed } = useActiveSession()
+  const { projectId, sessionId, path, cwdHost, checkout, kind, sandboxed } = useActiveSession()
   const status = useGitStatus(path)
   const pr = usePullRequest(path, status?.branch ?? "", status?.head ?? "")
   // The picker runs on the backend (DropService.Attach), not through
@@ -153,7 +153,9 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
       </FooterButton>
     ),
     checkout: path && <FooterCheckout path={path} branch={status?.branch ?? ""} />,
-    path: path && <FooterCheckout path={path} branch={status?.branch ?? ""} display="path" />,
+    path: path && (
+      <FooterCheckout path={path} branch={status?.branch ?? ""} display="path" host={cwdHost} />
+    ),
   }
   return (
     <footer className="flex min-h-9 min-w-0 shrink-0 flex-wrap items-center justify-between gap-x-4 gap-y-1 border-t border-border bg-sidebar px-3 py-1 text-xs text-muted-foreground">

--- a/frontend/src/components/FooterCheckout.tsx
+++ b/frontend/src/components/FooterCheckout.tsx
@@ -1,20 +1,33 @@
 import { Folder, GitBranch } from "lucide-react"
-import { baseName, displayPath } from "@/lib/paths"
+import { baseName, displayPath, unknownCwd } from "@/lib/paths"
 
 interface FooterCheckoutProps {
   path: string
   branch: string
   display?: "branch" | "path"
+  /** Set when the session's shell runs somewhere lich cannot read into: the
+   * readout says so rather than naming the checkout, which is a directory the
+   * user has left. Passed to the path readout only — the branch beside it is a
+   * fact about the checkout and stays true wherever the shell went. */
+  host?: string
 }
 
-export function FooterCheckout({ path, branch, display = "branch" }: FooterCheckoutProps) {
+export function FooterCheckout({
+  path,
+  branch,
+  display = "branch",
+  host = "",
+}: FooterCheckoutProps) {
   const showBranch = display === "branch" && branch
-  const label =
-    display === "path" ? displayPath(path) : branch || baseName(path) || displayPath(path)
+  const label = host
+    ? unknownCwd(host)
+    : display === "path"
+      ? displayPath(path)
+      : branch || baseName(path) || displayPath(path)
   const Icon = showBranch ? GitBranch : Folder
   return (
     <span
-      title={display === "path" ? path : label}
+      title={host || display !== "path" ? label : path}
       className="flex min-w-0 max-w-56 items-center gap-1.5 select-text"
     >
       <Icon className="size-3.5 shrink-0" aria-hidden="true" />

--- a/frontend/src/components/FooterSession.test.tsx
+++ b/frontend/src/components/FooterSession.test.tsx
@@ -31,6 +31,7 @@ vi.mock("@/lib/session/use-active-session", () => ({
     projectId: "p1",
     sessionId: "s1",
     path: "/repo",
+    cwdHost: "",
     checkout: "/repo",
     kind: state.agent ?? "",
     sandboxed: false,
@@ -233,6 +234,39 @@ test.each(["path", "branch"] as const)(
     )
   },
 )
+
+test("a hosted shell says the cwd is unknown instead of naming the checkout", async () => {
+  await act(async () =>
+    root.render(
+      createElement(FooterCheckout, {
+        path: "/project/.worktrees/a-long-worktree",
+        branch: "feature/footer",
+        display: "path",
+        host: "tmux",
+      }),
+    ),
+  )
+  expect(container.textContent).toBe("cwd unknown · inside tmux")
+  // The path must not survive as the tooltip either: it is a directory the user
+  // is not standing in, and a hover would hand it over as though it were.
+  expect(container.querySelector("[title]")?.getAttribute("title")).toBe(
+    "cwd unknown · inside tmux",
+  )
+})
+
+test("the branch readout keeps speaking for the checkout while the shell is hosted", async () => {
+  // The branch is a fact about the checkout, true wherever the shell went, so
+  // only the path readout is passed a host (FooterBar).
+  await act(async () =>
+    root.render(
+      createElement(FooterCheckout, {
+        path: "/project/.worktrees/a-long-worktree",
+        branch: "feature/footer",
+      }),
+    ),
+  )
+  expect(container.textContent).toBe("feature/footer")
+})
 
 test.each(["signed-out", "error", "unknown"] as const)(
   "%s never shows quota as zero",

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -28,7 +28,7 @@ import { useSortable } from "@dnd-kit/sortable"
 import { toast } from "sonner"
 import { cn, errorText } from "@/lib/utils"
 import { dragStyle } from "@/lib/use-sortable-list"
-import { displayPath } from "@/lib/paths"
+import { displayPath, unknownCwd } from "@/lib/paths"
 import type { Session } from "@/lib/session/sessions"
 import {
   useSessionStatus,
@@ -226,7 +226,12 @@ export function SessionCard({
   // session's static start path — a worktree session lives in its own checkout,
   // so that path (not the project's) is the fallback. Git status and the PR
   // badge follow whatever is shown, so they reflect the directory's repo.
-  const liveCwd = useSessionCwd(session.id)
+  //
+  // cwdHost is the shell the watcher could not read into (tmux, ssh, a
+  // container). Only the path line answers to it: git and the PR still speak
+  // for the checkout, which is a repository whether or not the user is standing
+  // in it — the line is what would otherwise claim to know where they are.
+  const { cwd: liveCwd, host: cwdHost } = useSessionCwd(session.id)
   const shownPath = liveCwd || session.path || path
   const git = useGitStatus(shownPath)
   const pr = usePullRequest(shownPath, git?.branch ?? "", git?.head ?? "")
@@ -571,7 +576,7 @@ export function SessionCard({
                     "[mask-image:linear-gradient(to_right,transparent,black_1.25rem)]",
                 )}
               >
-                {`\u200e${displayPath(shownPath)}`}
+                {`\u200e${cwdHost ? unknownCwd(cwdHost) : displayPath(shownPath)}`}
               </span>
               {git?.branch && (
                 <span className="flex w-full items-center justify-between gap-2 text-xs text-muted-foreground">

--- a/frontend/src/components/sidebar/SessionTooltip.tsx
+++ b/frontend/src/components/sidebar/SessionTooltip.tsx
@@ -9,6 +9,7 @@ import {
   ShieldOff,
   TriangleAlert,
 } from "lucide-react"
+import { unknownCwd } from "@/lib/paths"
 import { sandboxDrift } from "@/lib/providers-store"
 import type { Session } from "@/lib/session/sessions"
 import { useSandboxRung } from "@/lib/use-sandbox-rung"
@@ -47,7 +48,7 @@ interface SessionTooltipProps {
 // behind them are keyed by path and shared (one git poller per repository), so
 // the second reader costs a subscription, not a second poll.
 export function SessionTooltip({ session, path, projectId }: SessionTooltipProps) {
-  const liveCwd = useSessionCwd(session.id)
+  const { cwd: liveCwd, host: cwdHost } = useSessionCwd(session.id)
   const relay = useSessionRelay(session.id)
   const shownPath = liveCwd || session.path || path
   const git = useGitStatus(shownPath)
@@ -60,7 +61,9 @@ export function SessionTooltip({ session, path, projectId }: SessionTooltipProps
     <TooltipContent side="right" className="max-w-xs border border-border bg-card text-foreground">
       <div className="flex flex-col gap-1.5">
         <span className="font-medium">{session.label}</span>
-        <span className="break-all font-mono text-muted-foreground">{shownPath}</span>
+        <span className="break-all font-mono text-muted-foreground">
+          {cwdHost ? unknownCwd(cwdHost) : shownPath}
+        </span>
         {/* The open request, and the ticket it runs on. The card already draws
             the arrow and the peer; the number is the part that exists nowhere
             else a person can read it — it is typed once, into the target's

--- a/frontend/src/lib/paths.test.ts
+++ b/frontend/src/lib/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { baseName, displayPath } from "./paths"
+import { baseName, displayPath, unknownCwd } from "./paths"
 
 describe("displayPath", () => {
   it("collapses a POSIX home prefix to ~", () => {
@@ -37,5 +37,19 @@ describe("baseName", () => {
   it("returns empty for a root or empty path", () => {
     expect(baseName("/")).toBe("")
     expect(baseName("")).toBe("")
+  })
+})
+
+describe("unknownCwd", () => {
+  it("names what stands between the readout and a directory", () => {
+    expect(unknownCwd("tmux")).toBe("cwd unknown · inside tmux")
+    expect(unknownCwd("ssh")).toBe("cwd unknown · inside ssh")
+    expect(unknownCwd("distrobox-enter")).toBe("cwd unknown · inside distrobox-enter")
+  })
+
+  it("says it does not know before it says what is in the way", () => {
+    // The line is read at a glance beside real paths, so "cwd unknown" leads:
+    // a reader who takes in nothing else must not come away with a location.
+    expect(unknownCwd("tmux").startsWith("cwd unknown")).toBe(true)
   })
 })

--- a/frontend/src/lib/paths.ts
+++ b/frontend/src/lib/paths.ts
@@ -13,3 +13,12 @@ export function baseName(path: string): string {
   const segments = path.split(/[/\\]+/).filter(Boolean)
   return segments[segments.length - 1] ?? ""
 }
+
+// unknownCwd is what a path readout says when the backend reported a host
+// instead of a directory: the session's shell runs inside tmux, over ssh or in
+// a container, and the last local path it knew is a real directory the user is
+// not in. Saying nothing would read as "still there" — the readout has to say
+// it does not know, and what is in the way.
+export function unknownCwd(host: string): string {
+  return `cwd unknown · inside ${host}`
+}

--- a/frontend/src/lib/session/session-cwd-store.test.ts
+++ b/frontend/src/lib/session/session-cwd-store.test.ts
@@ -12,17 +12,17 @@ function harness() {
 }
 
 describe("createSessionCwdStore", () => {
-  it("returns empty while nothing has been reported", () => {
+  it("returns nothing while nothing has been reported", () => {
     const { store } = harness()
-    expect(store.get("s1")).toBe("")
+    expect(store.get("s1")).toEqual({ cwd: "", host: "" })
   })
 
   it("keeps the last reported cwd per session", () => {
     const { store, emit } = harness()
-    emit({ id: "s1", cwd: "/home/user/project" })
-    emit({ id: "s2", cwd: "/tmp" })
-    expect(store.get("s1")).toBe("/home/user/project")
-    expect(store.get("s2")).toBe("/tmp")
+    emit({ id: "s1", cwd: "/home/user/project", host: "" })
+    emit({ id: "s2", cwd: "/tmp", host: "" })
+    expect(store.get("s1")).toEqual({ cwd: "/home/user/project", host: "" })
+    expect(store.get("s2")).toEqual({ cwd: "/tmp", host: "" })
   })
 
   it("notifies only the session's subscribers on change", () => {
@@ -31,7 +31,7 @@ describe("createSessionCwdStore", () => {
     let s2 = 0
     store.subscribe("s1", () => s1++)
     store.subscribe("s2", () => s2++)
-    emit({ id: "s1", cwd: "/a" })
+    emit({ id: "s1", cwd: "/a", host: "" })
     expect(s1).toBe(1)
     expect(s2).toBe(0)
   })
@@ -40,31 +40,51 @@ describe("createSessionCwdStore", () => {
     const { store, emit } = harness()
     let calls = 0
     store.subscribe("s1", () => calls++)
-    emit({ id: "s1", cwd: "/a" })
-    emit({ id: "s1", cwd: "/a" })
+    emit({ id: "s1", cwd: "/a", host: "" })
+    emit({ id: "s1", cwd: "/a", host: "" })
     expect(calls).toBe(1)
   })
 
   it("retains the cwd across an unsubscribe, like a card unmount", () => {
     const { store, emit } = harness()
     const off = store.subscribe("s1", () => {})
-    emit({ id: "s1", cwd: "/a" })
+    emit({ id: "s1", cwd: "/a", host: "" })
     off()
-    expect(store.get("s1")).toBe("/a")
+    expect(store.get("s1")).toEqual({ cwd: "/a", host: "" })
   })
 
   it("ignores malformed payloads", () => {
     const { store, emit } = harness()
     emit({ id: "s1" })
     emit({ cwd: "/a" })
+    emit({ id: "s1", cwd: "/a", host: 3 })
     emit(null)
-    expect(store.get("s1")).toBe("")
+    expect(store.get("s1")).toEqual({ cwd: "", host: "" })
   })
 
   it("overwrites a stale cwd when the backend re-reports on respawn", () => {
     const { store, emit } = harness()
-    emit({ id: "s1", cwd: "/somewhere/deep" })
-    emit({ id: "s1", cwd: "/home/user/project" })
-    expect(store.get("s1")).toBe("/home/user/project")
+    emit({ id: "s1", cwd: "/somewhere/deep", host: "" })
+    emit({ id: "s1", cwd: "/home/user/project", host: "" })
+    expect(store.get("s1")).toEqual({ cwd: "/home/user/project", host: "" })
+  })
+
+  it("drops the path it knew when the shell moves out of reach", () => {
+    const { store, emit } = harness()
+    emit({ id: "s1", cwd: "/home/user/project", host: "" })
+    emit({ id: "s1", cwd: "", host: "tmux" })
+    // The old path must not survive as a fallback: it is a real directory, and
+    // the card would draw it as though the session were still standing there.
+    expect(store.get("s1")).toEqual({ cwd: "", host: "tmux" })
+  })
+
+  it("notifies when only the host changes", () => {
+    const { store, emit } = harness()
+    let calls = 0
+    store.subscribe("s1", () => calls++)
+    emit({ id: "s1", cwd: "", host: "tmux" })
+    emit({ id: "s1", cwd: "", host: "ssh" })
+    expect(calls).toBe(2)
+    expect(store.get("s1")).toEqual({ cwd: "", host: "ssh" })
   })
 })

--- a/frontend/src/lib/session/session-cwd-store.ts
+++ b/frontend/src/lib/session/session-cwd-store.ts
@@ -1,17 +1,33 @@
 import { createKeyedStore, type ReadableKeyedStore } from "@/lib/keyed-store"
 import { isCwdEvent, type SessionEventSource } from "./session-events"
 
-// createSessionCwdStore keeps the last reported working directory of every
-// session, keyed by session id, fed by one subscription taken at creation —
-// before any card mounts. get() answers "" until the backend reports one, and
+// Where a session is, as far as the backend can tell. At most one side is set:
+// a host means the shell runs somewhere no local reader follows (tmux, ssh, a
+// container), so there is no directory to report rather than a stale one.
+export interface SessionCwd {
+  cwd: string
+  host: string
+}
+
+const NOWHERE: SessionCwd = { cwd: "", host: "" }
+
+// createSessionCwdStore keeps the last reported location of every session,
+// keyed by session id, fed by one subscription taken at creation — before any
+// card mounts. get() answers an empty pair until the backend reports one, and
 // the card falls back to the session's static path. The backend re-reports the
 // start directory on every PTY spawn, so a respawn overwrites whatever the
 // previous shell left here.
-export function createSessionCwdStore(source: SessionEventSource): ReadableKeyedStore<string> {
-  const store = createKeyedStore("")
+//
+// The value is an object rebuilt on every report, so the store is given its own
+// comparison: without it every poll would re-render the card (see keyed-store).
+export function createSessionCwdStore(source: SessionEventSource): ReadableKeyedStore<SessionCwd> {
+  const store = createKeyedStore<SessionCwd>(
+    NOWHERE,
+    (a, b) => a.cwd === b.cwd && a.host === b.host,
+  )
   source((data) => {
     if (isCwdEvent(data)) {
-      store.set(data.id, data.cwd)
+      store.set(data.id, { cwd: data.cwd, host: data.host ?? "" })
     }
   })
   return store

--- a/frontend/src/lib/session/session-events.test.ts
+++ b/frontend/src/lib/session/session-events.test.ts
@@ -136,12 +136,15 @@ describe("isTitleEvent", () => {
 describe("isCwdEvent", () => {
   it("accepts a payload carrying a string id and cwd", () => {
     expect(isCwdEvent({ id: "s1", cwd: "/home/user" })).toBe(true)
+    expect(isCwdEvent({ id: "s1", cwd: "/home/user", host: "" })).toBe(true)
+    expect(isCwdEvent({ id: "s1", cwd: "", host: "tmux" })).toBe(true)
   })
 
   it("rejects a payload missing either half", () => {
     expect(isCwdEvent({ id: "s1" })).toBe(false)
     expect(isCwdEvent({ cwd: "/home/user" })).toBe(false)
     expect(isCwdEvent({ id: "s1", cwd: 2 })).toBe(false)
+    expect(isCwdEvent({ id: "s1", cwd: "/home/user", host: 2 })).toBe(false)
     expect(isCwdEvent(null)).toBe(false)
   })
 })

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -40,7 +40,9 @@ export const TURN_EVENT = "session-turn"
 
 // Global event the backend emits with a session's live working directory (see
 // terminal.cwdEventName): once with the directory the PTY starts in, then on
-// every change the cwd watcher observes. Payload: { id, cwd }.
+// every change the cwd watcher observes. Payload: { id, cwd, host } — a
+// non-empty host names the foreground process the directory cannot be read
+// through (tmux, ssh, a container) and arrives with an empty cwd.
 export const CWD_EVENT = "session-cwd"
 
 // Global event the backend emits when a provider CLI starts inside a session's
@@ -409,8 +411,12 @@ export function isTitleEvent(data: unknown): data is { id: string; label: string
   return isIdEvent(data) && typeof (data as { label?: unknown }).label === "string"
 }
 
-export function isCwdEvent(data: unknown): data is { id: string; cwd: string } {
-  return isIdEvent(data) && typeof (data as { cwd?: unknown }).cwd === "string"
+export function isCwdEvent(data: unknown): data is { id: string; cwd: string; host?: string } {
+  if (!isIdEvent(data) || typeof (data as { cwd?: unknown }).cwd !== "string") {
+    return false
+  }
+  const host = (data as { host?: unknown }).host
+  return host === undefined || typeof host === "string"
 }
 
 export function isAgentEvent(data: unknown): data is { id: string; agent: string } {

--- a/frontend/src/lib/session/use-active-session.ts
+++ b/frontend/src/lib/session/use-active-session.ts
@@ -23,6 +23,9 @@ export function useActiveSession(): {
   projectId: string | null
   sessionId: string
   path: string
+  /** The foreground process hosting the session's shell out of reach — tmux,
+   * ssh, a container — "" whenever the path above is the real one. */
+  cwdHost: string
   /** The session's static checkout — what the sidebar keys a worktree's pull
    * request card on, so a `cd` cannot open a card no group can show. */
   checkout: string
@@ -39,11 +42,12 @@ export function useActiveSession(): {
   const projectId = match?.params.projectId ?? null
   const projectPath = projects.find((p) => p.id === projectId)?.path ?? ""
   const target = activeTarget(sessions, projectId, projectPath)
-  const cwd = useSessionCwd(target.sessionId)
+  const { cwd, host } = useSessionCwd(target.sessionId)
   return {
     projectId,
     sessionId: target.sessionId,
     path: cwd || target.path,
+    cwdHost: host,
     checkout: target.path,
     kind: target.kind,
     sandboxed: target.sandboxed,

--- a/frontend/src/lib/session/use-session-cwd.ts
+++ b/frontend/src/lib/session/use-session-cwd.ts
@@ -1,15 +1,15 @@
 import { onAppEvent } from "@/lib/app-events"
 import { CWD_EVENT } from "./session-events"
-import { createSessionCwdStore } from "./session-cwd-store"
+import { createSessionCwdStore, type SessionCwd } from "./session-cwd-store"
 import { useKeyedStore } from "@/lib/use-keyed-store"
 
 // Subscribed at import rather than on first use: that opens the /events socket
 // at page load, so a cwd reported before any card mounts still lands.
 const store = createSessionCwdStore((handler) => onAppEvent(CWD_EVENT, handler))
 
-// useSessionCwd reads a session's live working directory from the shared store
-// (see session-cwd-store), which retains it across the card's unmount. Returns
-// "" while the backend has reported nothing for the session.
-export function useSessionCwd(sessionId: string): string {
+// useSessionCwd reads where a session is from the shared store (see
+// session-cwd-store), which retains it across the card's unmount. Both fields
+// are "" while the backend has reported nothing for the session.
+export function useSessionCwd(sessionId: string): SessionCwd {
   return useKeyedStore(store, sessionId)
 }

--- a/internal/terminal/cwd.go
+++ b/internal/terminal/cwd.go
@@ -3,21 +3,26 @@ package terminal
 import (
 	"bytes"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/omartelo/lich/internal/events"
 )
 
-// cwdEventName carries a session's live working directory ({id, cwd}), emitted
-// once with the directory the PTY starts in and again whenever the child
-// process moves (the user runs `cd`). Global like the other session events:
-// its consumer (the session card's path line) may be unmounted when it fires.
+// cwdEventName carries a session's live working directory ({id, cwd, host}),
+// emitted once with the directory the PTY starts in and again whenever the
+// child process moves (the user runs `cd`). A non-empty host names a
+// foreground process the directory cannot be read through (see shellHosts) and
+// comes with an empty cwd: the session is somewhere, but not somewhere this
+// machine can name. Global like the other session events: its consumer (the
+// session card's path line) may be unmounted when it fires.
 const cwdEventName = "session-cwd"
 
 // cwdEvent is the payload of cwdEventName.
 type cwdEvent struct {
-	ID  string `json:"id"`
-	Cwd string `json:"cwd"`
+	ID   string `json:"id"`
+	Cwd  string `json:"cwd"`
+	Host string `json:"host"`
 }
 
 // cwdPollInterval is how often a session's child working directory is read.
@@ -25,6 +30,46 @@ type cwdEvent struct {
 // (readlink on Linux, proc_pidinfo on macOS, a PEB walk on Windows) and emits
 // only on change, so a static directory costs nothing to re-render.
 const cwdPollInterval = 300 * time.Millisecond
+
+// shellHosts are foreground commands that put the user's shell somewhere no
+// local reader can follow: another machine (ssh, mosh), another namespace
+// (docker, podman, nsenter, distrobox, toolbox, flatpak) or another terminal
+// multiplexer whose panes are processes of their own (tmux, screen). Their own
+// working directory is a real local path, which is exactly the danger — the
+// readout would keep naming a directory the user is not in, and look right
+// doing it.
+//
+// A named list rather than a test, because nothing a process exposes says "the
+// shell you are watching is not mine": the pane, the container and the remote
+// host are all invisible from here. A wrapper nobody listed still reads as an
+// ordinary job.
+var shellHosts = map[string]bool{
+	"tmux":            true,
+	"screen":          true,
+	"ssh":             true,
+	"mosh-client":     true,
+	"docker":          true,
+	"podman":          true,
+	"nsenter":         true,
+	"distrobox-enter": true,
+	"toolbox":         true,
+	"flatpak":         true,
+}
+
+// shellHost returns the name to publish when comm belongs to shellHosts, and
+// "" for every ordinary foreground job. tmux writes its role into its own comm
+// ("tmux: client"), so the match is on the command ahead of the colon; Linux
+// truncates comm to 15 bytes, which every name above fits inside.
+func shellHost(comm string) string {
+	name := strings.TrimSpace(comm)
+	if i := strings.IndexByte(name, ':'); i >= 0 {
+		name = strings.TrimSpace(name[:i])
+	}
+	if !shellHosts[name] {
+		return ""
+	}
+	return name
+}
 
 // dosPathRunes is how many UTF-16 code units a DosPath of n bytes holds, and 0
 // when n is not a length a UTF-16 buffer can have. n comes out of the child's
@@ -72,27 +117,41 @@ func watchCwd(id string, pid int, initial string, done <-chan struct{}, hub *eve
 	}
 	ticker := time.NewTicker(cwdPollInterval)
 	defer ticker.Stop()
-	pollCwd(pid, initial, ticker.C, done, func(cwd string) {
-		hub.Emit(cwdEventName, cwdEvent{ID: id, Cwd: cwd})
+	read := func() (string, string) { return processCwd(pid) }
+	pollCwd(initial, ticker.C, done, read, func(cwd, host string) {
+		hub.Emit(cwdEventName, cwdEvent{ID: id, Cwd: cwd, Host: host})
 	})
 }
 
-// pollCwd reads pid's working directory on every tick and calls emit when it
-// differs from the last seen value, returning when done closes. An unreadable
-// directory (the process just died, done is about to close) is skipped rather
-// than reported. Split from watchCwd so tests drive the ticks.
-func pollCwd(pid int, last string, tick <-chan time.Time, done <-chan struct{}, emit func(string)) {
+// pollCwd reads the session's location on every tick and calls emit whenever
+// it differs from the last published one, returning when done closes. A read
+// answering neither a directory nor a host (the process just died, done is
+// about to close) is skipped rather than reported; a host arriving or clearing
+// is a change even when the directory beside it does not move, because that is
+// the moment the readout stops — or starts — being true. read is a parameter,
+// like tick, so tests drive both without a process to point at.
+func pollCwd(
+	last string,
+	tick <-chan time.Time,
+	done <-chan struct{},
+	read func() (string, string),
+	emit func(cwd, host string),
+) {
+	lastHost := ""
 	for {
 		select {
 		case <-done:
 			return
 		case <-tick:
-			cwd := processCwd(pid)
-			if cwd == "" || cwd == last {
+			cwd, host := read()
+			if cwd == "" && host == "" {
 				continue
 			}
-			last = cwd
-			emit(cwd)
+			if cwd == last && host == lastHost {
+				continue
+			}
+			last, lastHost = cwd, host
+			emit(cwd, host)
 		}
 	}
 }

--- a/internal/terminal/cwd_darwin.go
+++ b/internal/terminal/cwd_darwin.go
@@ -80,3 +80,18 @@ func readCwd(pid int) string {
 	}
 	return string(path)
 }
+
+// readComm returns pid's command name — p_comm, the executable's basename
+// truncated to 16 bytes — or "" when the process cannot be read. The same
+// sysctl foregroundPgrp uses, answering what Linux reads out of /proc/<pid>/comm.
+func readComm(pid int) string {
+	proc, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		return ""
+	}
+	comm := proc.Proc.P_comm[:]
+	if i := bytes.IndexByte(comm, 0); i >= 0 {
+		comm = comm[:i]
+	}
+	return string(comm)
+}

--- a/internal/terminal/cwd_foreground_test.go
+++ b/internal/terminal/cwd_foreground_test.go
@@ -4,7 +4,10 @@ package terminal
 
 import (
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -52,12 +55,12 @@ func TestProcessCwdFollowsForegroundJob(t *testing.T) {
 	pid := cmd.Process.Pid
 	deadline := time.Now().Add(20 * time.Second)
 	for {
-		got := processCwd(pid)
-		if got == inner {
+		got, host := processCwd(pid)
+		if got == inner && host == "" {
 			break
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("processCwd(%d) = %q, want the nested shell's %q", pid, got, inner)
+			t.Fatalf("processCwd(%d) = (%q, %q), want the nested shell's %q", pid, got, host, inner)
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
@@ -65,5 +68,33 @@ func TestProcessCwdFollowsForegroundJob(t *testing.T) {
 	// be a run where both reads happen to agree on the same directory.
 	if got := readCwd(pid); got != outer {
 		t.Fatalf("readCwd(%d) = %q, want the unmoved child's %q", pid, got, outer)
+	}
+}
+
+// TestReadCommNamesTheProcess proves the comm read this seam matches against
+// resolves a live process — exercised against the test binary itself, whose
+// name both platforms truncate (15 bytes on Linux, 16 on macOS) rather than
+// refuse. And that an ordinary command is not mistaken for a shell host, which
+// is the half of shellHost no list of names can assert on its own.
+func TestReadCommNamesTheProcess(t *testing.T) {
+	comm := readComm(os.Getpid())
+	if comm == "" {
+		t.Fatal(`readComm(self) = "", want the test binary's name`)
+	}
+	if base := filepath.Base(os.Args[0]); !strings.HasPrefix(base, comm) {
+		t.Errorf("readComm(self) = %q, want a prefix of %q", comm, base)
+	}
+	if host := shellHost(comm); host != "" {
+		t.Errorf("shellHost(%q) = %q, want no host for an ordinary process", comm, host)
+	}
+}
+
+// TestReadCommOfDeadPidIsEmpty proves an unresolvable process yields no name,
+// so processCwd falls through to the directory read rather than matching the
+// empty string against the host list.
+func TestReadCommOfDeadPidIsEmpty(t *testing.T) {
+	// Far beyond any real PID space (Linux pid_max < 2^22, macOS ~1e5).
+	if got := readComm(1 << 30); got != "" {
+		t.Errorf("readComm(dead) = %q, want empty", got)
 	}
 }

--- a/internal/terminal/cwd_linux.go
+++ b/internal/terminal/cwd_linux.go
@@ -3,6 +3,7 @@
 package terminal
 
 import (
+	"bytes"
 	"os"
 	"strconv"
 )
@@ -33,4 +34,16 @@ func foregroundPgrp(pid int) int {
 		return 0
 	}
 	return parseTpgid(stat)
+}
+
+// readComm returns pid's command name — /proc/<pid>/comm, the executable's
+// basename truncated to 15 bytes — or "" when it cannot be read. Read rather
+// than /proc/<pid>/cmdline because a process is free to rewrite its own argv
+// (tmux does), while comm answers what was executed.
+func readComm(pid int) string {
+	comm, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/comm")
+	if err != nil {
+		return ""
+	}
+	return string(bytes.TrimSpace(comm))
 }

--- a/internal/terminal/cwd_other.go
+++ b/internal/terminal/cwd_other.go
@@ -6,4 +6,4 @@ package terminal
 // directory the session started in.
 const cwdTracked = false
 
-func processCwd(int) string { return "" }
+func processCwd(int) (string, string) { return "", "" }

--- a/internal/terminal/cwd_track_test.go
+++ b/internal/terminal/cwd_track_test.go
@@ -26,15 +26,22 @@ func physical(t *testing.T, path string) string {
 	return resolved
 }
 
-// waitEmit receives one emitted cwd or fails the test after a grace period.
-func waitEmit(t *testing.T, emits <-chan string) string {
+// emitted is one pollCwd publish: the directory it read, and the host standing
+// in the way of reading one.
+type emitted struct {
+	cwd  string
+	host string
+}
+
+// waitEmit receives one publish or fails the test after a grace period.
+func waitEmit(t *testing.T, emits <-chan emitted) emitted {
 	t.Helper()
 	select {
-	case cwd := <-emits:
-		return cwd
+	case e := <-emits:
+		return e
 	case <-time.After(5 * time.Second):
 		t.Fatal("pollCwd emitted nothing")
-		return ""
+		return emitted{}
 	}
 }
 
@@ -92,8 +99,12 @@ func TestProcessCwdReadsSelf(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Getwd: %v", err)
 	}
-	if got := processCwd(os.Getpid()); physical(t, got) != physical(t, wd) {
+	got, host := processCwd(os.Getpid())
+	if physical(t, got) != physical(t, wd) {
 		t.Errorf("processCwd(self) = %q, want %q", got, wd)
+	}
+	if host != "" {
+		t.Errorf("processCwd(self) host = %q, want none for an ordinary process", host)
 	}
 }
 
@@ -102,8 +113,8 @@ func TestProcessCwdReadsSelf(t *testing.T) {
 func TestProcessCwdOfDeadPidIsEmpty(t *testing.T) {
 	// Far beyond any real PID space (Linux pid_max < 2^22, macOS ~1e5); Windows
 	// simply finds no such process to open.
-	if got := processCwd(1 << 30); got != "" {
-		t.Errorf("processCwd(dead) = %q, want empty", got)
+	if got, host := processCwd(1 << 30); got != "" || host != "" {
+		t.Errorf("processCwd(dead) = (%q, %q), want both empty", got, host)
 	}
 }
 
@@ -118,11 +129,14 @@ func TestPollCwdEmitsOnlyOnChange(t *testing.T) {
 
 	tick := make(chan time.Time)
 	done := make(chan struct{})
-	emits := make(chan string, 8)
+	emits := make(chan emitted, 8)
 	finished := make(chan struct{})
+	self := func() (string, string) { return processCwd(os.Getpid()) }
 	go func() {
 		defer close(finished)
-		pollCwd(os.Getpid(), start, tick, done, func(cwd string) { emits <- cwd })
+		pollCwd(start, tick, done, self, func(cwd, host string) {
+			emits <- emitted{cwd, host}
+		})
 	}()
 
 	// Unchanged directory: the tick is consumed without an emit. tick is
@@ -137,16 +151,16 @@ func TestPollCwdEmitsOnlyOnChange(t *testing.T) {
 		t.Fatalf("Getwd: %v", err)
 	}
 	tick <- time.Time{}
-	if got := waitEmit(t, emits); physical(t, got) != physical(t, moved) {
-		t.Errorf("emitted %q, want %q", got, moved)
+	if got := waitEmit(t, emits); physical(t, got.cwd) != physical(t, moved) {
+		t.Errorf("emitted %q, want %q", got.cwd, moved)
 	}
 
 	// Same directory again: accepting this tick proves the change above
 	// emitted exactly once.
 	tick <- time.Time{}
 	select {
-	case cwd := <-emits:
-		t.Errorf("unexpected emit %q for unchanged cwd", cwd)
+	case e := <-emits:
+		t.Errorf("unexpected emit %q for unchanged cwd", e.cwd)
 	default:
 	}
 
@@ -155,5 +169,84 @@ func TestPollCwdEmitsOnlyOnChange(t *testing.T) {
 	case <-finished:
 	case <-time.After(5 * time.Second):
 		t.Fatal("pollCwd did not stop after done closed")
+	}
+}
+
+// TestPollCwdPublishesTheHostInsteadOfAPath proves the readout goes unknown the
+// moment the shell moves somewhere no reader follows, and comes back when it
+// returns. The last local directory must not be published again on the way in:
+// it is a real path, and naming it is the whole failure this seam exists to
+// end. Driven off a hand-fed read, because the alternative is starting a tmux.
+func TestPollCwdPublishesTheHostInsteadOfAPath(t *testing.T) {
+	readings := make(chan emitted, 8)
+	tick := make(chan time.Time)
+	done := make(chan struct{})
+	emits := make(chan emitted, 8)
+	go pollCwd("/repo", tick, done,
+		func() (string, string) { r := <-readings; return r.cwd, r.host },
+		func(cwd, host string) { emits <- emitted{cwd, host} })
+	t.Cleanup(func() { close(done) })
+
+	// Entering tmux: no directory, a host, and a publish that overwrites /repo.
+	readings <- emitted{"", "tmux"}
+	tick <- time.Time{}
+	if got := waitEmit(t, emits); got != (emitted{"", "tmux"}) {
+		t.Errorf("entering tmux emitted %+v, want an empty cwd hosted by tmux", got)
+	}
+
+	// Still inside it: the host is not news twice over.
+	readings <- emitted{"", "tmux"}
+	tick <- time.Time{}
+	readings <- emitted{"", "tmux"}
+	tick <- time.Time{}
+	select {
+	case e := <-emits:
+		t.Errorf("unexpected emit %+v while the host had not changed", e)
+	default:
+	}
+
+	// Back at the shell's prompt, in the very directory tmux was started from:
+	// a change, because the readout was unknown a tick ago.
+	readings <- emitted{"/repo", ""}
+	tick <- time.Time{}
+	if got := waitEmit(t, emits); got != (emitted{"/repo", ""}) {
+		t.Errorf("leaving tmux emitted %+v, want /repo with no host", got)
+	}
+}
+
+// TestShellHostNamesOnlyKnownHosts pins the list itself: every name on it is
+// answered with, an ordinary foreground job is not, and tmux's own comm — which
+// carries its role after a colon — still matches.
+func TestShellHostNamesOnlyKnownHosts(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"tmux", "tmux"},
+		{"tmux: client", "tmux"},
+		{"tmux: server", "tmux"},
+		{"screen", "screen"},
+		{"ssh", "ssh"},
+		{"mosh-client", "mosh-client"},
+		{"docker", "docker"},
+		{"podman", "podman"},
+		{"nsenter", "nsenter"},
+		{"distrobox-enter", "distrobox-enter"},
+		{"toolbox", "toolbox"},
+		{"flatpak", "flatpak"},
+		// /proc/<pid>/comm comes back with its newline attached.
+		{"ssh\n", "ssh"},
+		{"zsh", ""},
+		{"", ""},
+		{"vim", ""},
+		// A prefix is not a match: these run right here.
+		{"sshd", ""},
+		{"dockerd", ""},
+		{"tmuxinator", ""},
+	}
+	for _, tc := range cases {
+		if got := shellHost(tc.in); got != tc.want {
+			t.Errorf("shellHost(%q) = %q, want %q", tc.in, got, tc.want)
+		}
 	}
 }

--- a/internal/terminal/cwd_unix.go
+++ b/internal/terminal/cwd_unix.go
@@ -17,17 +17,26 @@ import "golang.org/x/sys/unix"
 // through a `cd /tmp && …` the agent runs — which is why the foreground group
 // is read and not the deepest descendant of the process tree.
 //
-// Each OS brings foregroundPgrp and readCwd (see the cwd_* files). Both are
-// allowed to fail: an unreadable foreground group (a root shell under `sudo`,
-// a leader that just exited) falls back to the direct child, so the readout is
-// never worse than tracking the child alone.
-func processCwd(pid int) string {
+// A foreground job that is itself hosting the shell — tmux, ssh, a container
+// runtime (shellHosts) — answers with its own name and no directory instead.
+// Its cwd is readable and wrong: the shell the user types into lives in a pane,
+// on another machine or in another namespace, and none of them are on this
+// filesystem. Second return is that host's name, "" when there is none.
+//
+// Each OS brings foregroundPgrp, readCwd and readComm (see the cwd_* files).
+// All three are allowed to fail: an unreadable foreground group (a root shell
+// under `sudo`, a leader that just exited) falls back to the direct child, so
+// the readout is never worse than tracking the child alone.
+func processCwd(pid int) (string, string) {
 	if fg := foregroundPgrp(pid); fg > 0 && fg != pid && ownsTerminal(pid) {
+		if host := shellHost(readComm(fg)); host != "" {
+			return "", host
+		}
 		if cwd := readCwd(fg); cwd != "" {
-			return cwd
+			return cwd, ""
 		}
 	}
-	return readCwd(pid)
+	return readCwd(pid), ""
 }
 
 // ownsTerminal reports whether pid leads its own terminal session, which every

--- a/internal/terminal/cwd_windows.go
+++ b/internal/terminal/cwd_windows.go
@@ -9,7 +9,19 @@ import (
 
 const cwdTracked = true
 
-// processCwd returns pid's current working directory, or "" when it cannot be
+// processCwd returns pid's current working directory, and a second value the
+// unix readers use to name a foreground process hosting a shell they cannot
+// follow (tmux, ssh, a container). Windows has no foreground process group to
+// read that from — a console hands its input to whatever holds it, and nothing
+// records which process that is — so this side never has a host to report and
+// the readout can still name a directory the user has left. Kept as is
+// deliberately: the whole detection would have to be rebuilt on a different
+// mechanism, and there is no Windows hardware here to build it against.
+func processCwd(pid int) (string, string) {
+	return readCwd(pid), ""
+}
+
+// readCwd returns pid's current working directory, or "" when it cannot be
 // read (the process exited, or was never ours to inspect). Windows keeps a
 // process's cwd in its PEB (ProcessParameters.CurrentDirectory), so the read
 // is a pointer walk through the child's memory: NtQueryInformationProcess for
@@ -17,7 +29,7 @@ const cwdTracked = true
 // and finally the path buffer. Assumes the child matches our architecture (a
 // 32-bit child's PEB has a different layout) — there the walk dereferences
 // garbage and fails, degrading to "" like any dead process.
-func processCwd(pid int) string {
+func readCwd(pid int) string {
 	h, err := windows.OpenProcess(
 		windows.PROCESS_QUERY_INFORMATION|windows.PROCESS_VM_READ,
 		false,


### PR DESCRIPTION
## The trap

`docs/ceilings.md` carried this:

> **Session cwd is polled** from the terminal's foreground process group (`internal/terminal/cwd.go`): a shell hosted elsewhere — tmux, ssh, a container — is beyond every reader, and the readout goes on naming a real local directory that is not where the user is, with nothing on screen saying so.

A readable and wrong path is the one failure mode that looks right. The bullet is deleted, not rewritten.

## What changed

**Backend** (`internal/terminal/`) — the foreground process's `comm` is read beside its directory (`/proc/<pid>/comm` on Linux, `p_comm` through the sysctl `foregroundPgrp` already calls on macOS) and matched against a named list: `tmux`, `screen`, `ssh`, `mosh-client`, `docker`, `podman`, `nsenter`, `distrobox-enter`, `toolbox`, `flatpak`. A match publishes the host name with an **empty** cwd, so the stale path does not survive as a fallback. `session-cwd` grows a `host` field; `pollCwd` treats a host arriving or clearing as a change, since that is the moment the readout stops — or starts — being true.

A named list rather than a test, because nothing a process exposes says "the shell you are watching is not mine".

**Frontend** — `useSessionCwd` returns `{ cwd, host }`. The session card's path line, its tooltip and the footer path readout draw `cwd unknown · inside tmux` (one helper, `unknownCwd`, so all three agree). Git status, the PR badge and the branch readout still follow the checkout: that is a repository whether or not the user is standing in it, and only the path line was claiming to know where they are.

**Windows** is unchanged and says so in a comment: there is no foreground process group to read a host from, so the whole detection would have to be rebuilt on a different mechanism, with no hardware here to build it against.

## Tests

- `TestShellHostNamesOnlyKnownHosts` — the list, tmux's `tmux: client` comm, the trailing newline `/proc` returns, and that `sshd` / `dockerd` / `tmuxinator` are not matched by prefix.
- `TestReadCommNamesTheProcess` / `…OfDeadPidIsEmpty` — the per-platform comm read, against the test binary itself.
- `TestPollCwdPublishesTheHostInsteadOfAPath` — entering a host publishes unknown, staying inside it is silent, leaving republishes the directory.
- Frontend: the store drops the path it knew on a host, notifies when only the host changes, rejects a non-string `host`; `unknownCwd` leads with "cwd unknown"; `FooterCheckout` renders the line and drops the path from its `title` too, while the branch readout keeps the checkout's branch.

## Still open

A wrapper nobody named still reads as an ordinary foreground job and still lies. Whether an unknown comm whose directory never moves while the user types deserves the same treatment is a separate call — raised with the requester, not decided here, so no bullet was left behind for it.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green
- [x] `for os in linux darwin windows; do GOOS=$os go build ./... && GOOS=$os go vet ./...; done`
- [x] `biome ci .` exit 0, `pnpm test` (1687 passed), `pnpm build`
- [ ] By hand in `task dev`: run `tmux` in a session and watch the card, the tooltip and the footer go unknown, then `exit` and watch the path come back