### PR TITLE
fix: announce a dropped file's copy at the prompt, and keep it as long as its session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **A file lich had to copy now says so at the prompt, and the copy lives as
+  long as its session.** A path pasted for a file the session cannot reach
+  (dragged onto the terminal or chosen with the attach button) is followed by
+  one line naming the original, so the agent reads what the user reads instead
+  of editing a copy and reporting the file as changed. Dropping a folder the
+  session cannot reach says so too, rather than doing nothing. The copies are
+  deleted with the session they were dropped into; the three-day sweep now only
+  clears the ones an unclean exit orphaned, so a path pasted a week ago still
+  resolves.
+
 ### Fixed
 
 - **On Windows, lich's own window no longer opens a stray console window beside

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -137,9 +137,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   for one terminal. The budget suite pins that adding a pane mounts one terminal and remounts none
   (`frontend/src/components/render-budget.test.tsx`); it cannot measure the cadence, because jsdom has
   no canvas to paint.
-- **A dropped file has no path, so lich guesses it** (`internal/drop`): a file under neither the session directory
-  nor home is *copied*, so an agent told to edit it edits the copy — and that copy is deleted 3 days on, so a path
-  pasted into a prompt eventually stops resolving.
 - **An interrupted turn is read off the keystrokes, not from the provider** (`internal/terminal/draft.go`,
   `hookstate.go`, `Service.noteInterrupt`): Claude Code, Codex and oh-my-pi all skip the hook that ends a turn
   when the user stops one, so lich publishes `interrupted` itself when a lone Ctrl+C or Escape reaches a session
@@ -571,16 +568,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   and gh's keyring live outside it, so a confined macOS session never lost either and the switches change
   nothing there — they are inert rather than hidden, and there is no macOS hardware here to prove it further.
   Windows has no sandbox backend, so neither switch exists.
-- **A file handed to a confined session arrives as a copy** (`internal/drop`): the session's home is empty,
-  so lich does not look there for a dropped file at all — anything outside its checkout is copied and the
-  copy's path is what lands at the prompt, for a drag and for the footer's attach button alike. The agent may read it and not write back: an edit lands on the
-  copy, the user's own file is untouched, and nothing on screen distinguishes the two paths afterwards. A
-  dropped *folder* from outside the checkout yields nothing, there being no copy to make of a tree. The
-  copies live one directory per session and only that session's directory is mounted, so one confined
-  session cannot read what was dropped into the one beside it; the directory goes when the session's row is
-  deleted (parking a worktree session keeps it, as a resume still wants those paths). A lich that dies
-  without deleting a row leaves copies behind, and the three-day age rule is what clears them — which also
-  means a copy is the one part of a confined session that outlives the sandbox.
 - **A symlink in the home is not mounted into the sandbox** (`internal/sandbox`): every path lich binds is
   taken as it is on disk, and a link is skipped — following one would let a dotfile manager point the
   private home at whatever it likes, and binding one fails the spawn outright when a parent directory is

--- a/frontend/src/components/FooterBar.tsx
+++ b/frontend/src/components/FooterBar.tsx
@@ -6,7 +6,6 @@ import { Code, FileText, Paperclip, Diff, GitPullRequestArrow } from "lucide-rea
 import { DropService, Terminal as TerminalService } from "@/lib/rpc"
 import type { DockTab } from "@/components/dock/RightDock"
 import { useActiveSession } from "@/lib/session/use-active-session"
-import { baseName } from "@/lib/paths"
 import { isWindows } from "@/lib/platform"
 import { composeDroppedPaths } from "@/lib/terminal/drop-files"
 import { useGitStatus } from "@/lib/git/use-git-status"
@@ -88,19 +87,15 @@ export function FooterBar({ dock, onDock }: FooterBarProps) {
       return
     }
     try {
-      const { path: file, copied } = await DropService.Attach(sessionId, checkout, sandboxed)
+      const { path: file, notice } = await DropService.Attach(sessionId, checkout, sandboxed)
       if (!file) {
         return
       }
       // Composed the way a drop is: quoted, so a path with a space stays one
-      // argument, and bracketed, so the prompt takes it unsent.
-      void TerminalService.Write(sessionId, composeDroppedPaths([file], isWindows))
-      if (copied) {
-        toast.info(`Attached as a copy: ${baseName(file)}`, {
-          description:
-            "This session is sandboxed, so a file outside its checkout is attached as a copy: edits land on the copy, not on your file, and the copy is deleted when the session closes.",
-        })
-      }
+      // argument, bracketed, so the prompt takes it unsent, and carrying the
+      // backend's line when the path is a copy's.
+      const paste = composeDroppedPaths([file], isWindows, notice ? [notice] : [])
+      void TerminalService.Write(sessionId, paste)
     } catch (err) {
       // The backend's own sentence when it has one — it names the ceiling a
       // file was refused for, which nothing here could reconstruct.

--- a/frontend/src/components/useTerminalDrop.ts
+++ b/frontend/src/components/useTerminalDrop.ts
@@ -5,21 +5,9 @@ import { isWindows } from "@/lib/platform"
 import {
   composeDroppedPaths,
   type DropTarget,
-  KEEP_DROPPED_DAYS,
   readDroppedFiles,
   resolveDroppedFiles,
 } from "@/lib/terminal/drop-files"
-
-// copyNotice is what a pasted copy costs. A confined session cannot see the
-// user's file at all (internal/sandbox), so the copy is the normal outcome
-// there rather than a fallback, and it dies with the session instead of ageing
-// out.
-function copyNotice(confined: boolean): string {
-  if (confined) {
-    return "This session is sandboxed, so a file outside its checkout is attached as a copy: edits land on the copy, not on your file, and the copy is deleted when the session closes."
-  }
-  return `Not found under this session or your home, so edits land on the copy, not on your file — and the copy is deleted after ${KEEP_DROPPED_DAYS} days.`
-}
 
 // carriesFiles tells a file drag from text dragged out of the app's own UI —
 // a selection, a link — which the terminal leaves alone.
@@ -62,21 +50,17 @@ export function useTerminalDrop(
       return
     }
     void (async () => {
-      const { paths, skipped, copied } = await resolveDroppedFiles(target, dropped)
-      const paste = composeDroppedPaths(paths, isWindows)
+      const { paths, skipped, notices } = await resolveDroppedFiles(target, dropped)
+      // The notices ride in the paste rather than in a toast: a copy's path is
+      // read by the agent, which never sees one, and a toast is gone by the
+      // time anyone acts on the path.
+      const paste = composeDroppedPaths(paths, isWindows, notices)
       if (paste !== "") {
         write(paste)
         focus()
       }
       if (skipped.length > 0) {
         toast.error(`Not attached: ${skipped.join(", ")}`)
-      }
-      // Nothing failed here — the path pasted is simply a copy's, and the two
-      // read alike at the prompt.
-      if (copied.length > 0) {
-        toast.info(`Pasted as a copy: ${copied.join(", ")}`, {
-          description: copyNotice(target.confined),
-        })
       }
     })()
   }

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -465,12 +465,13 @@ export interface DropItem {
   dir: boolean
 }
 
-/** internal/drop.Attachment — the path the picker produced, and whether it is a
- * copy's (a confined session cannot open a file outside its checkout). Both
- * empty for a cancelled dialog. */
+/** internal/drop.Attachment: the path the picker produced, and the line that
+ * goes under it when the path is a copy's (a confined session cannot open a
+ * file outside its checkout); the notice is empty otherwise, and both are for a
+ * cancelled dialog. */
 export interface Attachment {
   path: string
-  copied: boolean
+  notice: string
 }
 
 /** internal/themes.Theme — a color theme for the UI tokens and xterm. */

--- a/frontend/src/lib/terminal/drop-files.test.ts
+++ b/frontend/src/lib/terminal/drop-files.test.ts
@@ -8,7 +8,7 @@ import {
 
 // The backend is the boundary: the lookup is an RPC and the upload its own
 // endpoint, so both are stubbed and the test asserts which branch each entry
-// took — the whole point of the copied list.
+// took, which is the whole point of the notices.
 const resolve = vi.fn()
 vi.mock("@/lib/rpc", () => ({
   DropService: {
@@ -47,6 +47,22 @@ describe("composeDroppedPaths", () => {
     const paste = composeDroppedPaths(["/home/u/a.ts", "/home/u/b.ts"])
 
     expect(paste).toBe(`${PASTE_START}/home/u/a.ts /home/u/b.ts ${PASTE_END}`)
+  })
+
+  // The notice is what tells a copy's path from the user's own, and it belongs
+  // in the prompt rather than in a toast: the agent reads the prompt. The
+  // trailing space gives way to a newline, so what is typed next lands under
+  // the line instead of on it.
+  it("writes the copy's line under the path, in the same paste", () => {
+    const paste = composeDroppedPaths(["/cfg/dropped/b.png"], false, ["[lich] copy of b.png; …"])
+
+    expect(paste).toBe(`${PASTE_START}/cfg/dropped/b.png\n[lich] copy of b.png; …\n${PASTE_END}`)
+  })
+
+  it("keeps one line per copy in a mixed drop", () => {
+    const paste = composeDroppedPaths(["/home/u/a.ts", "/cfg/dropped/b.png"], false, ["copy of b"])
+
+    expect(paste).toBe(`${PASTE_START}/home/u/a.ts /cfg/dropped/b.png\ncopy of b\n${PASTE_END}`)
   })
 
   // A path with a space is one argument or it is two files that do not exist.
@@ -91,7 +107,7 @@ describe("resolveDroppedFiles", () => {
     upload.mockReset()
     upload.mockResolvedValue({
       ok: true,
-      json: async () => ({ path: "/cfg/lich/dropped/b.png" }),
+      json: async () => ({ path: "/cfg/lich/dropped/b.png", notice: "[lich] copy of b.png; …" }),
     })
     vi.stubGlobal("fetch", upload)
   })
@@ -105,12 +121,13 @@ describe("resolveDroppedFiles", () => {
 
     const result = await resolveDroppedFiles(target(), [file("a.ts")])
 
-    expect(result).toEqual({ paths: ["/home/u/a.ts"], skipped: [], copied: [] })
+    expect(result).toEqual({ paths: ["/home/u/a.ts"], skipped: [], notices: [] })
     expect(upload).not.toHaveBeenCalled()
   })
 
-  // The path pasted for b.png is a copy's, and only this list says so.
-  it("names the entries pasted as a copy", async () => {
+  // The path pasted for b.png is a copy's, and the backend's line is what says
+  // so at the prompt; the file found in the tree brings none.
+  it("carries the backend's line for the entries pasted as a copy", async () => {
     resolve.mockResolvedValue(["/home/u/a.ts", ""])
 
     const result = await resolveDroppedFiles(target(), [file("a.ts"), file("b.png")])
@@ -118,7 +135,7 @@ describe("resolveDroppedFiles", () => {
     expect(result).toEqual({
       paths: ["/home/u/a.ts", "/cfg/lich/dropped/b.png"],
       skipped: [],
-      copied: ["b.png"],
+      notices: ["[lich] copy of b.png; …"],
     })
   })
 
@@ -129,7 +146,7 @@ describe("resolveDroppedFiles", () => {
 
     const result = await resolveDroppedFiles(target(), [file("b.png")])
 
-    expect(result).toEqual({ paths: [], skipped: ["b.png"], copied: [] })
+    expect(result).toEqual({ paths: [], skipped: ["b.png"], notices: [] })
   })
 
   // A directory has no bytes to copy, so it is skipped, never listed as one.
@@ -139,7 +156,7 @@ describe("resolveDroppedFiles", () => {
 
     const result = await resolveDroppedFiles(target(), [folder])
 
-    expect(result.copied).toEqual([])
+    expect(result.notices).toEqual([])
     expect(result.skipped).toHaveLength(1)
     expect(upload).not.toHaveBeenCalled()
   })
@@ -159,7 +176,7 @@ describe("resolveDroppedFiles", () => {
     const result = await resolveDroppedFiles(target(), [huge])
 
     expect(result.paths).toEqual([])
-    expect(result.copied).toEqual([])
+    expect(result.notices).toEqual([])
     expect(result.skipped).toEqual(["core.dump (over 32MB)"])
     expect(upload).not.toHaveBeenCalled()
   })
@@ -184,25 +201,30 @@ describe("resolveDroppedFiles", () => {
     const result = await resolveDroppedFiles(target(true), [file("b.png")])
 
     expect(resolve).toHaveBeenCalledWith("/home/u", expect.anything(), true)
-    expect(result.copied).toEqual(["b.png"])
+    expect(result.notices).toEqual(["[lich] copy of b.png; …"])
   })
 
-  // The reason a folder yielded no path names the search that ran: a confined
-  // session's home was never looked at.
-  it("does not blame a home a confined session never searched", async () => {
+  // A folder is the one drop with no answer: no path, and no copy to make of a
+  // tree, so the refusal has to be said out loud rather than left as a drop
+  // that did nothing. Same sentence confined or not: what the session can reach
+  // is its checkout either way.
+  it.each([false, true])("says a folder cannot be handed over (confined: %s)", async (confined) => {
     resolve.mockResolvedValue([""])
     const folder: DroppedFile = { name: "docs", size: 0, mtime: 1, dir: true, blob: null }
 
-    const result = await resolveDroppedFiles(target(true), [folder])
+    const result = await resolveDroppedFiles(target(confined), [folder])
 
-    expect(result.skipped).toEqual(["docs (folder outside this sandboxed session's checkout)"])
+    expect(result.skipped).toEqual([
+      "docs (folders outside the checkout cannot be handed over; drop files)",
+    ])
+    expect(result.paths).toEqual([])
   })
 
   it("answers an empty drop without touching the backend", async () => {
     expect(await resolveDroppedFiles(target(), [])).toEqual({
       paths: [],
       skipped: [],
-      copied: [],
+      notices: [],
     })
     expect(resolve).not.toHaveBeenCalled()
   })

--- a/frontend/src/lib/terminal/drop-files.ts
+++ b/frontend/src/lib/terminal/drop-files.ts
@@ -12,6 +12,10 @@
 // it at all, and everything outside its checkout arrives as a copy — which is
 // the one thing lich writes where such a session can still read it.
 //
+// A copy's path never lands at the prompt alone: the backend writes the line
+// that goes under it (internal/drop.copyNotice), and it is pasted with the
+// path, where the agent and the user read the same sentence.
+//
 // The provider on the other end does the rest — a pasted image path is
 // attached as an image, any other path is read as a path.
 
@@ -22,10 +26,6 @@ import { bracketedPaste } from "./bracketed-paste"
 // Matches internal/drop's maxUpload: bigger than a screenshot or a log is a
 // mis-drag, and the backend refuses it anyway.
 const MAX_UPLOAD_BYTES = 32 << 20
-
-// Matches internal/drop's keepDropped: how long a copy outlives its drop, which
-// is the half of the notice the user cannot find out any other way.
-export const KEEP_DROPPED_DAYS = 3
 
 /** One dropped entry: what the page can say about it, plus its bytes. */
 export interface DroppedFile extends DropItem {
@@ -78,11 +78,11 @@ export interface DropResult {
   /** Names of entries that yielded no path, with why. */
   skipped: string[]
   /**
-   * Names of entries neither tree held, whose path is a copy's — an edit there
-   * never reaches the user's file, and the copy expires. Nothing else in the UI
-   * distinguishes those paths from the real ones.
+   * One line per entry neither tree held, as the backend wrote it: the path
+   * pasted for it is a copy's, and nothing about the path itself says so.
+   * Pasted under the paths (composeDroppedPaths).
    */
-  copied: string[]
+  notices: string[]
 }
 
 /**
@@ -95,9 +95,9 @@ export async function resolveDroppedFiles(
 ): Promise<DropResult> {
   const paths: string[] = []
   const skipped: string[] = []
-  const copied: string[] = []
+  const notices: string[] = []
   if (dropped.length === 0) {
-    return { paths, skipped, copied }
+    return { paths, skipped, notices }
   }
   const items = dropped.map(({ name, size, mtime, dir }) => ({ name, size, mtime, dir }))
   const found = await DropService.Resolve(target.cwd, items, target.confined)
@@ -108,9 +108,10 @@ export async function resolveDroppedFiles(
       continue
     }
     // Nothing to fall back to: a directory cannot be uploaded, and copying one
-    // to paste the copy's path is not the drop the user made.
+    // to paste the copy's path is not the drop the user made. Saying so is the
+    // whole answer for a folder: it is the one drop that yields no path at all.
     if (entry.dir || !entry.blob) {
-      skipped.push(`${entry.name} (${missingFolder(target.confined)})`)
+      skipped.push(`${entry.name} (${FOLDER_REFUSED})`)
       continue
     }
     if (entry.blob.size > MAX_UPLOAD_BYTES) {
@@ -118,28 +119,31 @@ export async function resolveDroppedFiles(
       continue
     }
     try {
-      paths.push(await uploadDroppedFile(target.sessionId, entry.name, entry.blob))
-      copied.push(entry.name)
+      const copy = await uploadDroppedFile(target.sessionId, entry.name, entry.blob)
+      paths.push(copy.path)
+      notices.push(copy.notice)
     } catch {
       skipped.push(entry.name)
     }
   }
-  return { paths, skipped, copied }
+  return { paths, skipped, notices }
 }
 
-// missingFolder is why a dropped folder yielded no path, which is a different
-// sentence for a confined session: its home was never searched, so "not found
-// under your home" would name a search that did not happen.
-function missingFolder(confined: boolean): string {
-  return confined
-    ? "folder outside this sandboxed session's checkout"
-    : "folder not found under this session or your home"
-}
+// FOLDER_REFUSED is why a dropped folder yields no path. Copying a tree to
+// paste the copy's path is not the drop the user made, and a folder the session
+// cannot reach is the one drop lich has no answer for, so it says so instead
+// of dropping the entry on the floor.
+const FOLDER_REFUSED = "folders outside the checkout cannot be handed over; drop files"
 
 // uploadDroppedFile stores one file's bytes on the backend and answers with the
-// path of the copy. Its own endpoint, not the RPC: the body is the file. The
-// session id rides along because the copy is kept under it and deleted with it.
-async function uploadDroppedFile(sessionId: string, name: string, blob: Blob): Promise<string> {
+// path of the copy and the line that goes under it. Its own endpoint, not the
+// RPC: the body is the file. The session id rides along because the copy is
+// kept under it and deleted with it.
+async function uploadDroppedFile(
+  sessionId: string,
+  name: string,
+  blob: Blob,
+): Promise<{ path: string; notice: string }> {
   const { base, token } = endpoint()
   const query = `token=${token}&session=${encodeURIComponent(sessionId)}`
   const url = `${base}/drop?${query}&name=${encodeURIComponent(name)}`
@@ -147,11 +151,11 @@ async function uploadDroppedFile(sessionId: string, name: string, blob: Blob): P
   if (!response.ok) {
     throw new Error(`drop upload: HTTP ${response.status}`)
   }
-  const body = (await response.json()) as { path?: string }
+  const body = (await response.json()) as { path?: string; notice?: string }
   if (!body.path) {
     throw new Error("drop upload: no path in response")
   }
-  return body.path
+  return { path: body.path, notice: body.notice ?? "" }
 }
 
 /**
@@ -159,12 +163,26 @@ async function uploadDroppedFile(sessionId: string, name: string, blob: Blob): P
  * terminal emulator pastes a drop — with a trailing space, so what the user
  * types next does not run into the last path. Empty for an empty drop, which
  * the caller must not write.
+ *
+ * `notices` is what the backend said about the paths that are copies': they go
+ * on their own lines under the paths, inside the same paste, so the prompt
+ * carries them unsent for the agent and the user to read together. The trailing
+ * space gives way to a newline there: what is typed next belongs under the
+ * notice, not on it.
  */
-export function composeDroppedPaths(paths: readonly string[], isWindows = false): string {
+export function composeDroppedPaths(
+  paths: readonly string[],
+  isWindows = false,
+  notices: readonly string[] = [],
+): string {
   if (paths.length === 0) {
     return ""
   }
-  return bracketedPaste(`${paths.map((path) => quotePath(path, isWindows)).join(" ")} `)
+  const line = paths.map((path) => quotePath(path, isWindows)).join(" ")
+  if (notices.length === 0) {
+    return bracketedPaste(`${line} `)
+  }
+  return bracketedPaste(`${line}\n${notices.join("\n")}\n`)
 }
 
 // quotePath keeps a path with spaces — or anything else a shell would act on —

--- a/internal/drop/drop.go
+++ b/internal/drop/drop.go
@@ -12,7 +12,8 @@
 //     on the user's file.
 //   - Upload: for anything neither tree holds, keep a copy under the config dir
 //     and paste the copy's path. Reading it works; editing it edits the copy —
-//     which is why Resolve is tried first. The copies expire (see Prune).
+//     which is why Resolve is tried first, and why the copy's path never lands
+//     at a prompt without the line that says so (copyNotice).
 //
 // A confined session takes the second way far more often, and has to: its home
 // is an empty private one (internal/sandbox), so a path found under the real
@@ -24,7 +25,8 @@
 // The copies are kept one directory per session, and that is the unit they are
 // deleted in: a confined session sees its own directory mounted and not the one
 // beside it, and every copy a session was dropped goes when its row does
-// (Purge).
+// (Purge): a copy lives exactly as long as the session it was dropped into,
+// and the clock only ever collects the orphans (Prune).
 //
 // A dropped directory only ever takes the first path: the page can walk one,
 // but copying a tree to paste a path to the copy is not what the drop meant.
@@ -80,10 +82,11 @@ const mtimeSlackMs = 2_000
 // than collisions, and the drop is refused rather than overwriting.
 const maxCopies = 999
 
-// keepDropped is how long a copy outlives its drop. Long enough that a path
-// pasted into a prompt still resolves after a weekend of it sitting unsent,
-// and short enough that the directory cannot grow without bound, which is the
-// only reason it is deleted at all.
+// keepDropped is how long an orphaned copy outlives its drop: one whose
+// session row is already gone, which only a lich that died without deleting it
+// leaves behind. A copy whose session still exists is not aged out at all
+// (prune), so this is the bound on what a crash leaks, not on what a drop
+// lasts.
 const keepDropped = 3 * 24 * time.Hour
 
 // skipDirs are trees a dropped file is never meaningfully found in, and the
@@ -110,6 +113,9 @@ type Service struct {
 	dir string
 	// pick opens the host's file chooser. See SetPicker.
 	pick func(title string) (string, error)
+	// live reports whether a session's row is still there, open or parked. See
+	// New.
+	live func(sessionID string) bool
 }
 
 // SetPicker wires the host's file picker (internal/project), which is what the
@@ -133,12 +139,17 @@ func Dir(configDir string) string {
 // whose source is not there yet is skipped: the first file dropped into a
 // session that opened before the directory existed would land where that
 // session cannot read it.
-func New(configDir string) *Service {
+//
+// live answers whether a session's row still exists, open or parked
+// (store.SessionExists): it is what keeps the age rule off the copies of a
+// session that is still around. A nil one makes every copy an orphan, which is
+// what the tests want and never what a running lich does.
+func New(configDir string, live func(sessionID string) bool) *Service {
 	dir := Dir(configDir)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		slog.Warn("drop: could not create the copies dir", "dir", dir, "err", err)
 	}
-	return &Service{dir: dir}
+	return &Service{dir: dir, live: live}
 }
 
 // Resolve maps each item to its absolute path, or "" when neither the
@@ -330,9 +341,23 @@ func (s *Service) Upload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(map[string]string{"path": path}); err != nil {
+	body := map[string]string{"path": path, "notice": copyNotice(name)}
+	if err := json.NewEncoder(w).Encode(body); err != nil {
 		slog.Warn("drop: encode response", "path", path, "err", err)
 	}
+}
+
+// copyNotice is the line that lands at the prompt under a copy's path, for a
+// drag and for the attach button alike. Nothing about the path itself says it
+// is a copy, so without it an agent told to edit the file edits the copy and
+// reports back as if it had edited the original, and the user reads a path
+// they cannot tell from their own. It is one line of plain text because both
+// of them read the same prompt.
+func copyNotice(name string) string {
+	return fmt.Sprintf(
+		"[lich] copy of %s; the original is not reachable from this session, edits stay in the copy.",
+		name,
+	)
 }
 
 // attachTitle is the file chooser's own title, which is all the dialog says
@@ -340,11 +365,12 @@ func (s *Service) Upload(w http.ResponseWriter, r *http.Request) {
 const attachTitle = "Attach File"
 
 // Attachment is what the picker produced: the path to write at the prompt, and
-// whether that path is a copy's — the caller says so, because nothing about the
-// path itself does. Both empty for a cancelled dialog.
+// the line that goes under it when that path is a copy's (copyNotice), empty
+// when the session opens the file where it lies. Both empty for a cancelled
+// dialog.
 type Attachment struct {
 	Path   string `json:"path"`
-	Copied bool   `json:"copied"`
+	Notice string `json:"notice"`
 }
 
 // Attach opens the file chooser and answers with a path the session can
@@ -383,7 +409,7 @@ func (s *Service) Attach(sessionID, root string, confined bool) (Attachment, err
 	if err != nil {
 		return Attachment{}, err
 	}
-	return Attachment{Path: copied, Copied: true}, nil
+	return Attachment{Path: copied, Notice: copyNotice(filepath.Base(path))}, nil
 }
 
 // under reports whether path is inside root. Both are cleaned but neither is
@@ -493,9 +519,10 @@ func (s *Service) Purge(sessionID string) {
 	}
 }
 
-// Prune deletes copies older than keepDropped. Called after each new copy —
-// which is the only thing that grows the directory — so a lich left running
-// for weeks still clears what earlier drops left behind.
+// Prune deletes the copies of sessions that are gone and older than
+// keepDropped. Called after each new copy, the only thing that grows the
+// directory, so a lich left running for weeks still clears what earlier drops
+// left behind.
 //
 // Age is the backstop, not the rule: a session that ends takes its copies with
 // it (Purge), and what this catches is the session lich never saw end — a
@@ -531,6 +558,13 @@ func (s *Service) prune(empty bool) {
 		path := filepath.Join(s.dir, entry.Name())
 		if !entry.IsDir() {
 			pruneExpired(path, entry, deadline)
+			continue
+		}
+		// A copy is deleted by its session's row, not by the clock: the row
+		// still being there (open or parked) means its paths can still be
+		// pasted, however long ago the file was dropped. Only an orphan ages
+		// out.
+		if s.live != nil && s.live(entry.Name()) {
 			continue
 		}
 		s.pruneSession(path, deadline, empty)

--- a/internal/drop/drop_test.go
+++ b/internal/drop/drop_test.go
@@ -29,7 +29,7 @@ func homeAt(t *testing.T, home string) *Service {
 	previous := homeDir
 	homeDir = func() (string, error) { return home, nil }
 	t.Cleanup(func() { homeDir = previous })
-	return New(t.TempDir())
+	return New(t.TempDir(), nil)
 }
 
 // writeFile creates path with size bytes and a known modification time,
@@ -349,7 +349,7 @@ func TestResolveSearchesHomeWhereNothingConfines(t *testing.T) {
 func TestUploadAnswersPreflight(t *testing.T) {
 	recorder := httptest.NewRecorder()
 
-	New(t.TempDir()).Upload(recorder, httptest.NewRequest(http.MethodOptions, "/drop", nil))
+	New(t.TempDir(), nil).Upload(recorder, httptest.NewRequest(http.MethodOptions, "/drop", nil))
 
 	if recorder.Code != http.StatusNoContent {
 		t.Fatalf("preflight = %d, want %d", recorder.Code, http.StatusNoContent)
@@ -367,7 +367,7 @@ func TestUploadRefusesOtherMethods(t *testing.T) {
 			recorder := httptest.NewRecorder()
 
 			target := "/drop?name=shot.png&session=s1"
-			New(t.TempDir()).Upload(recorder, httptest.NewRequest(method, target, nil))
+			New(t.TempDir(), nil).Upload(recorder, httptest.NewRequest(method, target, nil))
 
 			if recorder.Code != http.StatusMethodNotAllowed {
 				t.Fatalf("%s = %d, want %d", method, recorder.Code, http.StatusMethodNotAllowed)
@@ -386,7 +386,7 @@ func TestUploadStoresBytes(t *testing.T) {
 	target := "/drop?name=shot.png&session=s1"
 	request := httptest.NewRequest(http.MethodPost, target, strings.NewReader("bytes"))
 
-	New(dir).Upload(recorder, request)
+	New(dir, nil).Upload(recorder, request)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("upload = %d (%s), want %d", recorder.Code, recorder.Body, http.StatusOK)
@@ -408,6 +408,41 @@ func TestUploadStoresBytes(t *testing.T) {
 	}
 }
 
+// TestCopyNoticeAnnouncesTheCopy pins the line itself, word for word: it is
+// the only thing at the prompt that tells a copy's path from the user's own,
+// and both readers act on it: the agent decides whether an edit is worth
+// making, the user whether the path is the file they meant. Derived from
+// nothing, so rewording it is a decision and not a passing test.
+func TestCopyNoticeAnnouncesTheCopy(t *testing.T) {
+	want := "[lich] copy of shot.png; the original is not reachable from this session, " +
+		"edits stay in the copy."
+
+	if got := copyNotice("shot.png"); got != want {
+		t.Fatalf("copyNotice = %q, want %q", got, want)
+	}
+}
+
+// TestUploadAnswersWithTheNotice: a dropped file is uploaded by the page, so
+// the line has to come back with the path or the drag would paste a bare copy's
+// path while the attach button announces its own.
+func TestUploadAnswersWithTheNotice(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	target := "/drop?name=shot.png&session=s1"
+	request := httptest.NewRequest(http.MethodPost, target, strings.NewReader("bytes"))
+
+	New(t.TempDir(), nil).Upload(recorder, request)
+
+	var answer struct {
+		Notice string `json:"notice"`
+	}
+	if err := json.Unmarshal(recorder.Body.Bytes(), &answer); err != nil {
+		t.Fatalf("decode %s: %v", recorder.Body, err)
+	}
+	if want := copyNotice("shot.png"); answer.Notice != want {
+		t.Fatalf("notice = %q, want %q", answer.Notice, want)
+	}
+}
+
 // TestUploadRejectsBadName keeps a dropped name from steering the write out of
 // the copies directory — the name is attacker-shaped input in the sense that
 // nothing about a drop guarantees its shape.
@@ -419,7 +454,7 @@ func TestUploadRejectsBadName(t *testing.T) {
 			target := "/drop?session=s1&name=" + url.QueryEscape(name)
 			request := httptest.NewRequest(http.MethodPost, target, strings.NewReader("x"))
 
-			New(dir).Upload(recorder, request)
+			New(dir, nil).Upload(recorder, request)
 
 			if name == "../../etc/passwd" || name == "/etc/passwd" {
 				// Base() reduces a traversal to its last element, which is a
@@ -469,7 +504,7 @@ func agedCopy(t *testing.T, service *Service, session, name string, age time.Dur
 // the constant moves with it, and would stay green for a window widened to a
 // week or a month.
 func TestPruneDeletesOnlyExpiredCopies(t *testing.T) {
-	service := New(t.TempDir())
+	service := New(t.TempDir(), nil)
 	expired := agedCopy(t, service, "s1", "old.png", 4*24*time.Hour)
 	kept := agedCopy(t, service, "s1", "recent.png", 2*24*time.Hour)
 
@@ -483,11 +518,47 @@ func TestPruneDeletesOnlyExpiredCopies(t *testing.T) {
 	}
 }
 
+// TestPruneKeepsTheCopiesOfALiveSession: the row is what deletes a copy
+// (Purge), so the clock may only ever collect what no row owns. A copy older
+// than any deadline still resolves while its session is there to paste it
+// into, parked included, since a resume wants those paths back.
+func TestPruneKeepsTheCopiesOfALiveSession(t *testing.T) {
+	service := New(t.TempDir(), func(sessionID string) bool { return sessionID == "live" })
+	kept := agedCopy(t, service, "live", "old.png", 30*24*time.Hour)
+	orphan := agedCopy(t, service, "gone", "old.png", 4*24*time.Hour)
+
+	service.Prune()
+	// Startup's pass is the other caller, and it may remove a session directory
+	// outright: a live row's must survive that too.
+	service.PruneStale()
+
+	if _, err := os.Stat(kept); err != nil {
+		t.Fatalf("a live session's copy was aged out: %v", err)
+	}
+	if _, err := os.Stat(orphan); !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("the orphaned copy is still there (%v)", err)
+	}
+}
+
+// TestPruneKeepsAnOrphanInsideTheWindow: a row that is gone is what puts a copy
+// on the clock, and the clock is still a window: a lich that died a minute ago
+// leaves paths that were pasted a minute before that.
+func TestPruneKeepsAnOrphanInsideTheWindow(t *testing.T) {
+	service := New(t.TempDir(), func(string) bool { return false })
+	kept := agedCopy(t, service, "gone", "recent.png", 2*24*time.Hour)
+
+	service.Prune()
+
+	if _, err := os.Stat(kept); err != nil {
+		t.Fatalf("an orphan inside the window was deleted: %v", err)
+	}
+}
+
 // TestSavePrunes is the trigger that matters most: a lich left running for
 // weeks never restarts, so the copy that grows the directory is what has to
 // clear the ones before it.
 func TestSavePrunes(t *testing.T) {
-	service := New(t.TempDir())
+	service := New(t.TempDir(), nil)
 	expired := agedCopy(t, service, "s1", "old.png", 4*24*time.Hour)
 
 	fresh, err := service.Save("s1", "new.png", strings.NewReader("bytes"))
@@ -519,7 +590,7 @@ func (r *failingReader) Read(p []byte) (int, error) {
 // no path was ever pasted — a truncated file under that name would be waste
 // the next drop of the same file has to route around.
 func TestSaveLeavesNothingBehindOnFailure(t *testing.T) {
-	service := New(t.TempDir())
+	service := New(t.TempDir(), nil)
 
 	if _, err := service.Save("s1", "shot.png", &failingReader{}); err == nil {
 		t.Fatal("Save reported success on a body that failed")
@@ -538,7 +609,7 @@ func TestSaveLeavesNothingBehindOnFailure(t *testing.T) {
 // user cleared it, or the config directory is on a volume that went away. Not
 // a fault, and not something a prune may report as one.
 func TestPruneWithoutCopiesDir(t *testing.T) {
-	service := New(t.TempDir())
+	service := New(t.TempDir(), nil)
 	if err := os.RemoveAll(service.dir); err != nil {
 		t.Fatalf("remove copies dir: %v", err)
 	}
@@ -550,7 +621,7 @@ func TestPruneWithoutCopiesDir(t *testing.T) {
 // TestSaveKeepsEarlierDrops pins the no-overwrite rule: the first copy's path
 // may still be sitting unsent in a prompt when the second file lands.
 func TestSaveKeepsEarlierDrops(t *testing.T) {
-	service := New(t.TempDir())
+	service := New(t.TempDir(), nil)
 
 	first, err := service.Save("s1", "shot.png", strings.NewReader("one"))
 	if err != nil {
@@ -581,7 +652,7 @@ func TestSaveKeepsEarlierDrops(t *testing.T) {
 // written as literals — deriving them from maxCopies would follow the constant
 // wherever it moved and never fail.
 func TestSaveRefusesAnExhaustedName(t *testing.T) {
-	service := New(t.TempDir())
+	service := New(t.TempDir(), nil)
 	dir := filepath.Join(service.dir, "s1")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -612,7 +683,7 @@ func TestSaveRefusesAnExhaustedName(t *testing.T) {
 func TestNewCreatesTheCopiesDir(t *testing.T) {
 	config := t.TempDir()
 
-	service := New(config)
+	service := New(config, nil)
 
 	info, err := os.Stat(service.dir)
 	if err != nil || !info.IsDir() {
@@ -630,7 +701,7 @@ func TestUploadRejectsAMissingSession(t *testing.T) {
 			target := "/drop?name=shot.png&session=" + url.QueryEscape(session)
 			request := httptest.NewRequest(http.MethodPost, target, strings.NewReader("x"))
 
-			New(t.TempDir()).Upload(recorder, request)
+			New(t.TempDir(), nil).Upload(recorder, request)
 
 			if recorder.Code != http.StatusBadRequest {
 				t.Fatalf("upload = %d, want %d", recorder.Code, http.StatusBadRequest)
@@ -648,7 +719,7 @@ func TestUploadKeepsATraversingSessionInside(t *testing.T) {
 	target := "/drop?name=shot.png&session=" + url.QueryEscape("../../evil")
 	request := httptest.NewRequest(http.MethodPost, target, strings.NewReader("x"))
 
-	New(config).Upload(recorder, request)
+	New(config, nil).Upload(recorder, request)
 
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("upload = %d (%s), want %d", recorder.Code, recorder.Body, http.StatusOK)
@@ -668,7 +739,7 @@ func TestUploadKeepsATraversingSessionInside(t *testing.T) {
 // copies exist for the conversation they were dropped into, and the session
 // closing is what ends them — with the copies of every other session untouched.
 func TestPurgeDeletesOneSessionsCopies(t *testing.T) {
-	service := New(t.TempDir())
+	service := New(t.TempDir(), nil)
 	gone := agedCopy(t, service, "s1", "shot.png", time.Minute)
 	kept := agedCopy(t, service, "s2", "shot.png", time.Minute)
 
@@ -685,7 +756,7 @@ func TestPurgeDeletesOneSessionsCopies(t *testing.T) {
 // TestPurgeRefusesToLeaveTheCopiesDir: Purge is handed a session id, and the
 // one thing it may never do is take a path out of the tree it owns.
 func TestPurgeRefusesToLeaveTheCopiesDir(t *testing.T) {
-	service := New(t.TempDir())
+	service := New(t.TempDir(), nil)
 	kept := agedCopy(t, service, "s1", "shot.png", time.Minute)
 
 	for _, session := range []string{"", ".", "..", "../"} {
@@ -705,7 +776,7 @@ func TestPurgeRefusesToLeaveTheCopiesDir(t *testing.T) {
 // under a live session would leave every later copy of that session invisible
 // inside the sandbox. A drop by another session must not do that.
 func TestPruneKeepsAnEmptySessionDir(t *testing.T) {
-	service := New(t.TempDir())
+	service := New(t.TempDir(), nil)
 	expired := agedCopy(t, service, "s1", "old.png", 4*24*time.Hour)
 	dir := filepath.Dir(expired)
 
@@ -723,7 +794,7 @@ func TestPruneKeepsAnEmptySessionDir(t *testing.T) {
 // spawned yet, so a directory with nothing left in it belongs to a session that
 // is over — the crash that never reported one gone.
 func TestPruneStaleRemovesEmptySessionDirs(t *testing.T) {
-	service := New(t.TempDir())
+	service := New(t.TempDir(), nil)
 	expired := agedCopy(t, service, "s1", "old.png", 4*24*time.Hour)
 	kept := agedCopy(t, service, "s2", "recent.png", time.Minute)
 
@@ -758,7 +829,7 @@ func TestAttachKeepsAPathTheSessionCanOpen(t *testing.T) {
 	root := t.TempDir()
 	want := filepath.Join(root, "src", "app.ts")
 	writeFile(t, want, 12, time.Now())
-	service := New(t.TempDir())
+	service := New(t.TempDir(), nil)
 	pick, _ := pickerAt(want, nil)
 	service.SetPicker(pick)
 
@@ -767,8 +838,8 @@ func TestAttachKeepsAPathTheSessionCanOpen(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Attach: %v", err)
 	}
-	if got.Path != want || got.Copied {
-		t.Fatalf("Attach = %+v, want the file's own path", got)
+	if got.Path != want || got.Notice != "" {
+		t.Fatalf("Attach = %+v, want the file's own path and nothing to announce", got)
 	}
 }
 
@@ -781,7 +852,7 @@ func TestAttachCopiesForAConfinedSession(t *testing.T) {
 	if err := os.WriteFile(elsewhere, []byte("bytes"), 0o644); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	service := New(t.TempDir())
+	service := New(t.TempDir(), nil)
 	pick, _ := pickerAt(elsewhere, nil)
 	service.SetPicker(pick)
 
@@ -790,8 +861,14 @@ func TestAttachCopiesForAConfinedSession(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Attach: %v", err)
 	}
-	if want := filepath.Join(service.dir, "s1", "spec.pdf"); got.Path != want || !got.Copied {
+	if want := filepath.Join(service.dir, "s1", "spec.pdf"); got.Path != want {
 		t.Fatalf("Attach = %+v, want a copy at %s", got, want)
+	}
+	// The copy is announced by the name the user picked, not by the copy's own:
+	// a second attachment of the same name lands as spec-2.pdf, which says
+	// nothing to whoever chose spec.pdf in the dialog.
+	if want := copyNotice("spec.pdf"); got.Notice != want {
+		t.Fatalf("Attach notice = %q, want %q", got.Notice, want)
 	}
 	if bytes, err := os.ReadFile(got.Path); err != nil || string(bytes) != "bytes" {
 		t.Fatalf("copy = %q (%v), want %q", bytes, err, "bytes")
@@ -815,7 +892,7 @@ func TestAttachLeavesAnUnconfinedSessionAlone(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			canConfine(t, tt.backend)
-			service := New(t.TempDir())
+			service := New(t.TempDir(), nil)
 			pick, _ := pickerAt(elsewhere, nil)
 			service.SetPicker(pick)
 
@@ -824,7 +901,7 @@ func TestAttachLeavesAnUnconfinedSessionAlone(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Attach: %v", err)
 			}
-			if got.Path != elsewhere || got.Copied {
+			if got.Path != elsewhere || got.Notice != "" {
 				t.Fatalf("Attach = %+v, want %q uncopied", got, elsewhere)
 			}
 		})
@@ -834,13 +911,13 @@ func TestAttachLeavesAnUnconfinedSessionAlone(t *testing.T) {
 // A cancelled dialog is the user changing their mind, not a failure to report.
 func TestAttachAnswersACancelledDialog(t *testing.T) {
 	canConfine(t, true)
-	service := New(t.TempDir())
+	service := New(t.TempDir(), nil)
 	pick, _ := pickerAt("", nil)
 	service.SetPicker(pick)
 
 	got, err := service.Attach("s1", t.TempDir(), true)
 
-	if err != nil || got.Path != "" || got.Copied {
+	if err != nil || got.Path != "" || got.Notice != "" {
 		t.Fatalf("Attach = %+v (%v), want an empty answer", got, err)
 	}
 }
@@ -866,7 +943,7 @@ func TestAttachRefusesWhatItCannotCopy(t *testing.T) {
 		{"no session to keep it under", huge, ""},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			service := New(t.TempDir())
+			service := New(t.TempDir(), nil)
 			pick, _ := pickerAt(tt.path, nil)
 			service.SetPicker(pick)
 
@@ -880,7 +957,7 @@ func TestAttachRefusesWhatItCannotCopy(t *testing.T) {
 // TestAttachWithoutAPicker: the wiring is startup's, and a service without it
 // has no dialog to open — which must not read as a cancelled one.
 func TestAttachWithoutAPicker(t *testing.T) {
-	if _, err := New(t.TempDir()).Attach("s1", t.TempDir(), true); err == nil {
+	if _, err := New(t.TempDir(), nil).Attach("s1", t.TempDir(), true); err == nil {
 		t.Fatal("Attach reported success with no picker wired")
 	}
 }
@@ -888,7 +965,7 @@ func TestAttachWithoutAPicker(t *testing.T) {
 // TestAttachReportsAFailedDialog keeps the picker's own failure from arriving as
 // a path nobody chose.
 func TestAttachReportsAFailedDialog(t *testing.T) {
-	service := New(t.TempDir())
+	service := New(t.TempDir(), nil)
 	pick, calls := pickerAt("/some/file", errors.New("no display"))
 	service.SetPicker(pick)
 

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -716,6 +716,25 @@ func (s *Service) SessionSandbox(sessionID string) string {
 	return sandbox.String
 }
 
+// SessionExists reports whether a session's row is still there, open or
+// parked, the two states a row can be in; only a delete removes it. It is what
+// tells lich's dropped-file copies apart from the ones an unclean exit
+// orphaned (internal/drop): the copies of a session that still exists are
+// still worth keeping, whatever their age.
+//
+// A read that failed answers true: the row not being readable is not the row
+// being gone, and the caller deletes on a false.
+func (s *Service) SessionExists(sessionID string) bool {
+	var exists bool
+	if err := s.db.QueryRow(
+		`SELECT EXISTS (SELECT 1 FROM sessions WHERE id = ?)`, sessionID,
+	).Scan(&exists); err != nil {
+		slog.Warn("session exists", "session", sessionID, "err", err)
+		return true
+	}
+	return exists
+}
+
 // SetProviderSession records the provider conversation id running inside a lich
 // session's PTY, reported by the provider's session-start hook. A session whose
 // row does not exist yet (the hook racing session persistence) matches nothing

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -23,6 +23,39 @@ func newTestStore(t *testing.T) *Service {
 	return svc
 }
 
+// TestSessionExistsSpansParkedRows: the answer is what internal/drop asks
+// before ageing a dropped-file copy out, and a parked session is one a resume
+// walks straight back into, so its copies are still worth keeping and parking
+// must not read as gone. Only the delete does.
+func TestSessionExistsSpansParkedRows(t *testing.T) {
+	svc := newTestStore(t)
+	if err := svc.AddProject("p1", "alpha", "/tmp/alpha"); err != nil {
+		t.Fatalf("AddProject: %v", err)
+	}
+	if err := svc.AddSession("p1", "s1", "one", providers.Claude, "", 0, ""); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+
+	if !svc.SessionExists("s1") {
+		t.Error("an open session reads as gone")
+	}
+	if err := svc.CloseSession("p1", "s1", ""); err != nil {
+		t.Fatalf("CloseSession: %v", err)
+	}
+	if !svc.SessionExists("s1") {
+		t.Error("a parked session reads as gone")
+	}
+	if err := svc.DeleteSession("p1", "s1", ""); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+	if svc.SessionExists("s1") {
+		t.Error("a deleted session still reads as there")
+	}
+	if svc.SessionExists("never-existed") {
+		t.Error("an unknown id reads as there")
+	}
+}
+
 func TestLoadStateRestoresOpenProjectsAndSessions(t *testing.T) {
 	svc := newTestStore(t)
 

--- a/main.go
+++ b/main.go
@@ -156,7 +156,9 @@ func main() {
 	// Every service the frontend uses goes through the loopback RPC
 	// (internal/rpc). store.Close manages the DB lifecycle and stays Go-only.
 	dispatcher := rpc.New()
-	drops := drop.New(configDir)
+	// db.SessionExists is what keeps the age rule off a live session's copies:
+	// they are deleted by the session's row going away, not by the clock.
+	drops := drop.New(configDir, db.SessionExists)
 	// The other prune runs after each new copy; this one is what clears the
 	// last of them for a lich that is never dropped on again — and the only one
 	// that may remove a session's directory outright, no session having spawned


### PR DESCRIPTION
Closes two `docs/ceilings.md` bullets by fixing what they described: **A dropped file has no path, so lich guesses it** and **A file handed to a confined session arrives as a copy**. Both are deleted, not reworded.

## The copy announces itself

A file the session cannot reach is copied, and the copy's path is what lands at the prompt. Nothing said so: an agent told to edit that file edited the copy and reported the file as changed, and the toast that explained it was gone by the time anyone acted on the path.

`internal/drop.copyNotice` now writes one line, and both entry points answer with it: `/drop` beside the path it stored, `Attach` in place of its `Copied` flag (named by the file the user picked in the dialog, not by the copy, which a collision renames). The frontend pastes the path and the line together, bracketed and unsent:

```
/home/u/.config/lich/dropped/s1/spec.pdf
[lich] copy of spec.pdf; the original is not reachable from this session, edits stay in the copy.
```

Drag and attach button alike, confined or not. The two copy toasts go with it: the agent never sees a toast, and the line is in the prompt for as long as the prompt is.

## A folder says why

A folder from outside the checkout has no path and no copy to make of a tree. It used to be reported as a search that missed ("folder not found under this session or your home"), which named a search a confined session never ran. It now names the refusal, the same sentence either way: `docs (folders outside the checkout cannot be handed over; drop files)`.

## A copy dies with its session, not with the clock

`Purge` already deleted a session's copies when its row went. The three-day sweep ran regardless, so a path pasted last week stopped resolving inside a session that was still open. It now skips any session whose row still exists, open or parked (`store.SessionExists`, which answers true on a read failure: an unreadable row is not a deleted one). The age rule is the orphan rule now, for the copies of a session lich never saw end.

## Tests

- `TestPruneKeepsTheCopiesOfALiveSession`, `TestPruneKeepsAnOrphanInsideTheWindow`: the live row's copy survives `Prune` and `PruneStale` at 30 days, the orphan's goes at 4, and an orphan inside the window stays.
- `TestCopyNoticeAnnouncesTheCopy` pins the sentence word for word, `TestUploadAnswersWithTheNotice` and the `Attach` tests pin that both paths carry it.
- `TestSessionExistsSpansParkedRows`: open, parked, deleted, unknown.
- Frontend: the line is pasted under the path in the same paste (single and mixed drops), and the folder message is asserted confined and not.

## Gate

`gofmt -l .` clean, `go vet ./...` and `go test ./...` green, cross-compile loop green for linux/darwin/windows; `biome ci .` exit 0, `pnpm test` 1684 green, `pnpm build` clean.