### PR TITLE
fix: name the dotfiles a sandboxed session's home did not get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clears the ones an unclean exit orphaned, so a path pasted a week ago still
   resolves.
 
+- **A sandboxed session's tooltip now names the dotfiles its private home did
+  not get.** Every path lich binds into the sandbox is taken as it is on disk
+  and a symlink is skipped, so a `~/.gitconfig` or `~/.ssh/known_hosts` kept in
+  a dotfiles repository was simply absent inside a confined session, with
+  nothing saying so. The shield's tooltip lists them: "Not mounted (symlinks):
+  .gitconfig, .ssh/known_hosts". The policy has not changed — only the silence.
+
 ### Fixed
 
 - **A session whose shell runs inside tmux, over ssh or in a container now says

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -547,7 +547,7 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   machines the user connects to. Read-only, so a host the user has never connected to *outside* the sandbox
   still fails inside it and cannot be learned there — blind trust-on-first-use is not a thing to grant an
   unattended agent. And a `known_hosts` symlinked out of a dotfiles repository is dropped like every other
-  link in the home (below), which takes the whole grant down with it and says nothing. That is why Settings lists what is in the agent — and the list is read when the pane opens,
+  link in the home (`internal/sandbox`'s `existing`), which takes the whole grant down with it. That is why Settings lists what is in the agent — and the list is read when the pane opens,
   so a key added afterwards is handed over by a switch that never named it. The GitHub token is one account's,
   the project's own (`vcs.account`), and it rides in the session's environment: the agent can read it back out
   of its own environment and spend it on anything that account's scopes allow, this repository or not. Neither
@@ -559,14 +559,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   and gh's keyring live outside it, so a confined macOS session never lost either and the switches change
   nothing there — they are inert rather than hidden, and there is no macOS hardware here to prove it further.
   Windows has no sandbox backend, so neither switch exists.
-- **A symlink in the home is not mounted into the sandbox** (`internal/sandbox`): every path lich binds is
-  taken as it is on disk, and a link is skipped — following one would let a dotfile manager point the
-  private home at whatever it likes, and binding one fails the spawn outright when a parent directory is
-  already mounted (bubblewrap resolves a mount destination through symlinks). So a `~/.gitconfig` symlinked
-  out of a dotfiles repository is absent inside a confined session, with nothing on screen saying so. The
-  binaries are the exception: their symlink chains are walked and the *directory* of every hop is mounted
-  (`BinaryDirs`), which is what makes an agent installed the usual way — a link on `PATH` into a versioned
-  store — runnable at all.
 - **The macOS floor is the toolchain's, not lich's** (`build/darwin/Info.plist.tpl`,
   `build/darwin/homebrew/lich.rb.tpl`): nothing in lich needs macOS 13, but Go 1.27 dropped every
   release before Ventura, so a binary built from this module cannot run on Big Sur or Monterey. The

--- a/frontend/src/components/sidebar/SessionTooltip.tsx
+++ b/frontend/src/components/sidebar/SessionTooltip.tsx
@@ -56,6 +56,7 @@ export function SessionTooltip({ session, path, projectId }: SessionTooltipProps
   const base = baseReadout(git?.base ?? null)
   const rung = useSandboxRung(session.kind, projectId)
   const confined = session.sandboxed ?? false
+  const skippedLinks = session.sandboxSkippedLinks ?? []
   const drift = rung === null ? "" : sandboxDrift(rung, !!session.path, confined)
   return (
     <TooltipContent side="right" className="max-w-xs border border-border bg-card text-foreground">
@@ -133,7 +134,14 @@ export function SessionTooltip({ session, path, projectId }: SessionTooltipProps
             not move this card.
 
             An unconfined session is silent here unless the rung has since moved
-            past it, which is the one time its lack of a shield is news. */}
+            past it, which is the one time its lack of a shield is news.
+
+            The last line names what the sandbox left out of the private home
+            for being a symlink. Every path it binds is taken as it is on disk
+            and a link is skipped, so a ~/.gitconfig kept in a dotfiles
+            repository is not in there — an absence the session would otherwise
+            only meet as a command that behaves differently inside the sandbox
+            than outside it. Nothing skipped draws nothing. */}
         {(confined || drift) && (
           <span className="flex flex-col gap-0.5">
             <span className="flex items-center gap-1.5">
@@ -152,6 +160,11 @@ export function SessionTooltip({ session, path, projectId }: SessionTooltipProps
                 ? "Opened before the sandbox setting changed; reopen the session to apply it."
                 : "Set when the session opened; reopen it to change."}
             </span>
+            {skippedLinks.length > 0 && (
+              <span className="text-muted-foreground">
+                Not mounted (symlinks): {skippedLinks.join(", ")}
+              </span>
+            )}
           </span>
         )}
         {git?.branch && (

--- a/frontend/src/components/sidebar/session-tooltip-sandbox.test.tsx
+++ b/frontend/src/components/sidebar/session-tooltip-sandbox.test.tsx
@@ -100,3 +100,27 @@ test("a confined session the rung would now leave out says so too", async () => 
   expect(text()).toContain(MOVED)
   await mounted.unmount()
 })
+
+// What the whole change exists for: the dotfiles the private home did not get,
+// named on the card instead of discovered as a git that has forgotten who you
+// are.
+test("a confined session names what the sandbox skipped for being a symlink", async () => {
+  rungs.set("p-links", "everywhere")
+  const mounted = await mountBudget(
+    tooltip(
+      session({ sandboxed: true, sandboxSkippedLinks: [".gitconfig", ".ssh/known_hosts"] }),
+      "p-links",
+    ),
+  )
+  expect(text()).toContain("Not mounted (symlinks): .gitconfig, .ssh/known_hosts")
+  await mounted.unmount()
+})
+
+// Nothing skipped is nothing to say: the line is absent rather than empty.
+test("a confined session that skipped nothing draws no line", async () => {
+  rungs.set("p-no-links", "everywhere")
+  const mounted = await mountBudget(tooltip(session({ sandboxed: true }), "p-no-links"))
+  expect(text()).toContain("Sandboxed")
+  expect(text()).not.toContain("Not mounted")
+  await mounted.unmount()
+})

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -354,6 +354,11 @@ export interface StoredSession {
    * what the card divides a tool name carrying no separator of its own against.
    * null for a row nothing has spawned yet. */
   mcpServers: string[] | null
+  /** The paths under the home this session's sandbox skipped for being
+   * symlinks, home-relative (".gitconfig", ".ssh/known_hosts") — what the
+   * tooltip names as not mounted. null for an unconfined session and for one
+   * whose sandbox skipped nothing. */
+  sandboxSkippedLinks: string[] | null
 }
 
 /** internal/store.ClosedSession — one parked session offered for resuming. What

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -51,10 +51,12 @@ export const CWD_EVENT = "session-cwd"
 export const AGENT_EVENT = "session-agent"
 
 // Global event the backend emits on every spawn with whether that PTY runs
-// inside the sandbox (see terminal.sandboxEventName). Payload: { id, confined }.
-// The verdict is the spawn's — it resolves the provider's rung, the checkout and
-// any per-session override — and it is persisted with the row too, which is what
-// a page reload hydrates from.
+// inside the sandbox (see terminal.sandboxEventName). Payload:
+// { id, confined, skippedLinks } — the last being the home paths that sandbox
+// left out for being symlinks, which is the one absence a confined session has
+// no other way of learning about. The verdict is the spawn's — it resolves the
+// provider's rung, the checkout and any per-session override — and both are
+// persisted with the row too, which is what a page reload hydrates from.
 export const SANDBOX_EVENT = "session-sandbox"
 
 // Global event the backend emits on every spawn with the MCP servers that
@@ -248,8 +250,20 @@ export function isScheduleEvent(data: unknown): data is { id: string; at: number
   return isIdEvent(data) && typeof (data as { at?: unknown }).at === "number"
 }
 
-export function isSandboxEvent(data: unknown): data is { id: string; confined: boolean } {
-  return isIdEvent(data) && typeof (data as { confined?: unknown }).confined === "boolean"
+// skippedLinks is optional rather than required: a nil list marshals as null,
+// and an event carrying no names must still land the confinement verdict.
+export function isSandboxEvent(
+  data: unknown,
+): data is { id: string; confined: boolean; skippedLinks?: string[] | null } {
+  if (!isIdEvent(data) || typeof (data as { confined?: unknown }).confined !== "boolean") {
+    return false
+  }
+  const links = (data as { skippedLinks?: unknown }).skippedLinks
+  return (
+    links === undefined ||
+    links === null ||
+    (Array.isArray(links) && links.every((name) => typeof name === "string"))
+  )
 }
 
 export function isMCPEvent(data: unknown): data is { id: string; servers: string[] } {

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -55,6 +55,11 @@ export interface Session {
   // the checkout and any per-session override, and reports the verdict back;
   // the card never re-derives it.
   sandboxed?: boolean
+  // The home paths that sandbox skipped for being symlinks, home-relative —
+  // what a confined session will not find where it expects it. Absent means
+  // none were skipped. Written by the same spawn report as sandboxed and read
+  // back on hydration.
+  sandboxSkippedLinks?: string[]
   // Kept at the head of the project's list and refused a close until unpinned.
   pinned?: boolean
   // The session that asked for this one, when it was opened by delegation:
@@ -274,19 +279,24 @@ export function renameSession(
   }
 }
 
-// setSessionSandboxed records whether a session's PTY runs confined, as the
-// spawn reported it. Unknown ids leave the state untouched, and a value that
+// setSessionSandboxed records whether a session's PTY runs confined and what
+// that sandbox left out of the private home for being a symlink, as the spawn
+// reported both. Unknown ids leave the state untouched, and a report that
 // already matches returns the same object — the event fires on every spawn, and
 // a re-render per respawn of an unchanged card is a card that flickers.
 export function setSessionSandboxed(
   state: SessionState,
   sessionId: string,
   sandboxed: boolean,
+  skippedLinks: string[] = [],
 ): SessionState {
   const projectId = projectOfSession(state, sessionId)
   const current = projectId ? state[projectId] : undefined
   const session = current?.sessions.find((s) => s.id === sessionId)
-  if (!projectId || !current || !session || (session.sandboxed ?? false) === sandboxed) {
+  const same =
+    (session?.sandboxed ?? false) === sandboxed &&
+    sameNames(session?.sandboxSkippedLinks, skippedLinks)
+  if (!projectId || !current || !session || same) {
     return state
   }
   return {
@@ -299,8 +309,9 @@ export function setSessionSandboxed(
         }
         // Dropped rather than set to undefined, so an unconfined session carries
         // no key at all — the shape the two hydration paths produce.
-        const { sandboxed: _was, ...rest } = s
-        return sandboxed ? { ...rest, sandboxed: true } : rest
+        const { sandboxed: _was, sandboxSkippedLinks: _links, ...rest } = s
+        const next = sandboxed ? { ...rest, sandboxed: true } : rest
+        return skippedLinks.length > 0 ? { ...next, sandboxSkippedLinks: skippedLinks } : next
       }),
     },
   }
@@ -318,7 +329,7 @@ export function setSessionMCPServers(
   const projectId = projectOfSession(state, sessionId)
   const current = projectId ? state[projectId] : undefined
   const session = current?.sessions.find((s) => s.id === sessionId)
-  if (!projectId || !current || !session || sameServers(session.mcpServers, servers)) {
+  if (!projectId || !current || !session || sameNames(session.mcpServers, servers)) {
     return state
   }
   return {
@@ -338,7 +349,10 @@ export function setSessionMCPServers(
   }
 }
 
-function sameServers(a: string[] | undefined, b: string[]): boolean {
+// Two spawn-reported lists read the same, in order. Shared by both reports that
+// carry one: an event fires on every spawn, and a list that has not moved must
+// not be a state change.
+function sameNames(a: string[] | undefined, b: string[]): boolean {
   return (a ?? []).length === b.length && (a ?? []).every((name, i) => name === b[i])
 }
 

--- a/frontend/src/providers/project-workspace.test.ts
+++ b/frontend/src/providers/project-workspace.test.ts
@@ -20,6 +20,7 @@ const storedSession = (overrides: Partial<StoredSession> = {}): StoredSession =>
   hasLastTurn: false,
   unread: false,
   mcpServers: null,
+  sandboxSkippedLinks: null,
   ...overrides,
 })
 
@@ -190,6 +191,31 @@ describe("MCP servers on hydration", () => {
       ])
       const session = state.p1?.sessions[0]
       expect(session && "mcpServers" in session).toBe(false)
+    }
+  })
+})
+
+// The same route, for the paths the sandbox skipped: the tooltip is redrawn on
+// every reload and the spawn that resolved them is long gone.
+describe("skipped sandbox links on hydration", () => {
+  it("carries the links the spawn recorded", () => {
+    const state = buildSessionState([
+      storedProject({
+        sessions: [storedSession({ id: "s1", sandboxSkippedLinks: [".gitconfig"] })],
+      }),
+    ])
+    expect(state.p1?.sessions[0]?.sandboxSkippedLinks).toEqual([".gitconfig"])
+  })
+
+  // An unconfined session and one whose sandbox skipped nothing both draw no
+  // line, so neither carries the key.
+  it("leaves no key for a row that skipped none", () => {
+    for (const sandboxSkippedLinks of [null, []]) {
+      const state = buildSessionState([
+        storedProject({ sessions: [storedSession({ id: "s1", sandboxSkippedLinks })] }),
+      ])
+      const session = state.p1?.sessions[0]
+      expect(session && "sandboxSkippedLinks" in session).toBe(false)
     }
   })
 })

--- a/frontend/src/providers/project-workspace.ts
+++ b/frontend/src/providers/project-workspace.ts
@@ -25,6 +25,9 @@ export function buildSessionState(loaded: StoredProject[]): SessionState {
         : {}),
       ...(session.hasLastTurn ? { hasLastTurn: true } : {}),
       ...(session.mcpServers?.length ? { mcpServers: session.mcpServers } : {}),
+      ...(session.sandboxSkippedLinks?.length
+        ? { sandboxSkippedLinks: session.sandboxSkippedLinks }
+        : {}),
     }))
     state[project.id] = {
       sessions,

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -102,6 +102,9 @@ const cardFromStored = (restored: StoredSession): Session => ({
     ? { scheduledAt: restored.scheduledAt, scheduledPrompt: restored.scheduledPrompt }
     : {}),
   ...(restored.mcpServers?.length ? { mcpServers: restored.mcpServers } : {}),
+  ...(restored.sandboxSkippedLinks?.length
+    ? { sandboxSkippedLinks: restored.sandboxSkippedLinks }
+    : {}),
 })
 
 // The first session of any project is always "Session 1"; the counter then
@@ -236,7 +239,12 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       if (!isSandboxEvent(data)) {
         return
       }
-      const next = setSessionSandboxed(sessionsRef.current, data.id, data.confined)
+      const next = setSessionSandboxed(
+        sessionsRef.current,
+        data.id,
+        data.confined,
+        data.skippedLinks ?? [],
+      )
       if (next !== sessionsRef.current) {
         commit(next)
       }

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/omartelo/lich/internal/providers"
 )
@@ -50,6 +51,12 @@ type Spec struct {
 	// Read is every path bound read-only: configuration, installed toolchains,
 	// and the binaries the session runs.
 	Read []string
+	// SkippedLinks names the paths under Home that were dropped for being
+	// symlinks, relative to Home (".gitconfig", ".ssh/known_hosts"). It is not a
+	// mount list: it is what the session will not find where it expects it, so
+	// the window can say so rather than leave the absence to be discovered by a
+	// command that fails inside the sandbox and works outside it.
+	SkippedLinks []string
 }
 
 // stateDirs is where each provider keeps the state a confined session still
@@ -226,13 +233,55 @@ var readableToolchain = []string{
 // without Rust has no ~/.cargo, and that is not an error.
 func Describe(providerID, home, cwd, gitCommon string, extraRead []string, sshAgent bool) Spec {
 	spec := Spec{Home: home, Cwd: cwd, GitCommon: gitCommon}
-	spec.Write = existing(append(stateDirs(providerID, home), under(home, writableCaches)...))
+	write := append(stateDirs(providerID, home), under(home, writableCaches)...)
 	read := append(under(home, readableToolchain), displaySockets(home)...)
 	if sshAgent {
 		read = append(read, AgentSocket(), knownHosts(home))
 	}
+	// Over this package's own two lists and not extraRead: the binaries are the
+	// exception to the symlink rule (BinaryDirs walks their chains), so naming
+	// one would report a link that is in fact mounted.
+	spec.SkippedLinks = skippedLinks(home, write, read)
+	spec.Write = existing(write)
 	spec.Read = existing(append(read, extraRead...))
 	return spec
+}
+
+// skippedLinks names the paths existing is about to drop for being symlinks,
+// relative to home — the dotfiles a confined session will not find where it
+// expects them, so the card can say which ones rather than leave a
+// ~/.gitconfig quietly absent.
+//
+// Only paths under home are named. Everything else in a Spec is either not a
+// link by construction (the display socket and the ssh agent are checked as
+// sockets) or is one on purpose, and a path outside the home has no short name
+// a person reading a tooltip would recognise.
+//
+// A path that is not there at all says nothing: a machine without Rust has no
+// ~/.cargo, and its absence is not news. Duplicates are dropped and order is
+// kept, so the line reads in the order the profile lists them.
+func skippedLinks(home string, lists ...[]string) []string {
+	prefix := home + string(filepath.Separator)
+	seen := make(map[string]bool)
+	var out []string
+	for _, list := range lists {
+		for _, path := range list {
+			if !strings.HasPrefix(path, prefix) {
+				continue
+			}
+			name := path[len(prefix):]
+			if seen[name] {
+				continue
+			}
+			info, err := os.Lstat(path)
+			if err != nil || info.Mode()&os.ModeSymlink == 0 {
+				continue
+			}
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	return out
 }
 
 // Backend names what confines a session on this machine, or "" when nothing can.
@@ -364,7 +413,8 @@ func under(base string, names []string) []string {
 // whatever the user's dotfile manager happens to point at.
 //
 // The cost is real and deliberate: a `~/.gitconfig` symlinked out of a dotfiles
-// repository is not in a confined session, and nothing on screen says so. The
+// repository is not in a confined session. What it is not is silent — the same
+// pass names them (skippedLinks) and the card says which ones are missing. The
 // binaries the session runs are the exception, and they are handled by mounting
 // directories instead (BinaryDirs).
 func existing(paths []string) []string {

--- a/internal/sandbox/skippedlinks_unix_test.go
+++ b/internal/sandbox/skippedlinks_unix_test.go
@@ -1,0 +1,97 @@
+//go:build !windows
+
+package sandbox
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// link creates name under home pointing at a real file elsewhere, the shape a
+// dotfile manager leaves behind.
+func link(t *testing.T, home, name string) {
+	t.Helper()
+	target := filepath.Join(t.TempDir(), filepath.Base(name))
+	if err := os.WriteFile(target, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write link target: %v", err)
+	}
+	path := filepath.Join(home, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(target, path); err != nil {
+		t.Fatalf("symlink %s: %v", name, err)
+	}
+}
+
+// A dotfile the profile lists and the home answers with a link: skipped from
+// the mounts, and named — the whole point of the field.
+func TestDescribeNamesSkippedLinks(t *testing.T) {
+	clearHarnessEnv(t)
+	home := t.TempDir()
+	link(t, home, ".gitconfig")
+
+	spec := Describe(providers.Claude, home, filepath.Join(home, "checkout"), "", nil, false)
+
+	if slices.Contains(spec.Read, filepath.Join(home, ".gitconfig")) {
+		t.Errorf("a symlinked dotfile was mounted: %v", spec.Read)
+	}
+	if !slices.Contains(spec.SkippedLinks, ".gitconfig") {
+		t.Errorf("SkippedLinks = %v, want it to name .gitconfig", spec.SkippedLinks)
+	}
+}
+
+// The grant's own file is the same trap: without known_hosts the ssh agent
+// signs nothing, so a link there takes the whole grant down and has to say so.
+func TestDescribeNamesSkippedKnownHosts(t *testing.T) {
+	clearHarnessEnv(t)
+	home := t.TempDir()
+	link(t, home, filepath.Join(".ssh", "known_hosts"))
+
+	spec := Describe(providers.Claude, home, filepath.Join(home, "checkout"), "", nil, true)
+
+	want := filepath.Join(".ssh", "known_hosts")
+	if !slices.Contains(spec.SkippedLinks, want) {
+		t.Errorf("SkippedLinks = %v, want it to name %s", spec.SkippedLinks, want)
+	}
+}
+
+// A real file is mounted, and a real file is not news: naming one would put a
+// line on the card about a path the session can read.
+func TestDescribeLeavesRealFilesUnnamed(t *testing.T) {
+	clearHarnessEnv(t)
+	home := t.TempDir()
+	if err := os.WriteFile(filepath.Join(home, ".gitconfig"), []byte("[user]\n"), 0o600); err != nil {
+		t.Fatalf("write .gitconfig: %v", err)
+	}
+
+	spec := Describe(providers.Claude, home, filepath.Join(home, "checkout"), "", nil, false)
+
+	if !slices.Contains(spec.Read, filepath.Join(home, ".gitconfig")) {
+		t.Errorf("a real dotfile was not mounted: %v", spec.Read)
+	}
+	if len(spec.SkippedLinks) != 0 {
+		t.Errorf("SkippedLinks = %v, want none", spec.SkippedLinks)
+	}
+}
+
+// The binaries are the exception the whole policy is written around: their
+// symlink chains are walked and every hop's directory is mounted (BinaryDirs),
+// so nothing the caller hands in as an extra read is a path the session is
+// missing. Fed a link among them, the list still names none of it.
+func TestDescribeLeavesBinaryDirsUnnamed(t *testing.T) {
+	clearHarnessEnv(t)
+	home := t.TempDir()
+	link(t, home, ".tools")
+
+	spec := Describe(providers.Claude, home, filepath.Join(home, "checkout"), "",
+		[]string{filepath.Join(home, ".tools")}, false)
+
+	if slices.Contains(spec.SkippedLinks, ".tools") {
+		t.Errorf("a binary directory was named as skipped: %v", spec.SkippedLinks)
+	}
+}

--- a/internal/store/mcpservers_test.go
+++ b/internal/store/mcpservers_test.go
@@ -68,8 +68,38 @@ func TestSessionMCPServersClearsOnAnEmptyList(t *testing.T) {
 // and not a guess: it reads as no servers, which is what an unspawned row says.
 func TestDecodeMCPServersRefusesWhatItCannotRead(t *testing.T) {
 	for _, encoded := range []string{"", "not json", `{"lich":true}`} {
-		if got := decodeMCPServers(encoded); got != nil {
-			t.Errorf("decodeMCPServers(%q) = %v, want none", encoded, got)
+		if got := decodeStrings(encoded); got != nil {
+			t.Errorf("decodeStrings(%q) = %v, want none", encoded, got)
 		}
+	}
+}
+
+// The same round trip for the sandbox's skipped links, which ride the row for
+// the same reason: the spawn is the only thing that resolves them, and the
+// tooltip that names them is redrawn on every reload.
+func TestSessionSandboxLinksRoundTrip(t *testing.T) {
+	svc := sandboxProject(t, "/work/alpha")
+	if err := svc.AddSession("p1", "s1", "one", providers.Claude, "", 0, ""); err != nil {
+		t.Fatalf("AddSession: %v", err)
+	}
+	if got := sessionOf(t, svc, "s1").SandboxSkippedLinks; got != nil {
+		t.Errorf("an unspawned session = %v, want none", got)
+	}
+
+	want := []string{".gitconfig", ".ssh/known_hosts"}
+	if err := svc.SetSessionSandboxLinks("s1", want); err != nil {
+		t.Fatalf("SetSessionSandboxLinks: %v", err)
+	}
+	if got := sessionOf(t, svc, "s1").SandboxSkippedLinks; !slices.Equal(got, want) {
+		t.Errorf("SandboxSkippedLinks = %v, want %v", got, want)
+	}
+
+	// An unconfined respawn of the same card clears it, so the line does not
+	// outlive the sandbox that put it there.
+	if err := svc.SetSessionSandboxLinks("s1", nil); err != nil {
+		t.Fatalf("SetSessionSandboxLinks(nil): %v", err)
+	}
+	if got := sessionOf(t, svc, "s1").SandboxSkippedLinks; got != nil {
+		t.Errorf("SandboxSkippedLinks = %v, want none", got)
 	}
 }

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -837,31 +837,48 @@ func (s *Service) tx(fn func(*sql.Tx) error) error {
 // nothing and a session nobody has spawned read the same way, and both mean the
 // card shows a tool name whole.
 func (s *Service) SetSessionMCPServers(sessionID string, servers []string) error {
+	return s.setSessionList(sessionID, "mcp_servers", servers)
+}
+
+// SetSessionSandboxLinks records the home paths this session's sandbox skipped
+// for being symlinks, home-relative — what the card names as not mounted, so a
+// ~/.gitconfig symlinked out of a dotfiles repository is an absence the session
+// is told about rather than one it discovers by failing. Written by the spawn
+// that resolved them, and read back on hydration for the reason above: the PTY
+// outlives the page.
+func (s *Service) SetSessionSandboxLinks(sessionID string, links []string) error {
+	return s.setSessionList(sessionID, "sandbox_links", links)
+}
+
+// setSessionList writes a JSON array into one of the session's list columns.
+// column is a literal from the two callers above and never anything a caller
+// outside this file names.
+func (s *Service) setSessionList(sessionID, column string, values []string) error {
 	encoded := ""
-	if len(servers) > 0 {
-		body, err := json.Marshal(servers)
+	if len(values) > 0 {
+		body, err := json.Marshal(values)
 		if err != nil {
-			return fmt.Errorf("encode MCP servers for %q: %w", sessionID, err)
+			return fmt.Errorf("encode %s for %q: %w", column, sessionID, err)
 		}
 		encoded = string(body)
 	}
 	if _, err := s.db.Exec(
-		`UPDATE sessions SET mcp_servers = ? WHERE id = ?`, encoded, sessionID,
+		fmt.Sprintf(`UPDATE sessions SET %s = ? WHERE id = ?`, column), encoded, sessionID,
 	); err != nil {
-		return fmt.Errorf("set MCP servers on %q: %w", sessionID, err)
+		return fmt.Errorf("set %s on %q: %w", column, sessionID, err)
 	}
 	return nil
 }
 
-// decodeMCPServers reads back what SetSessionMCPServers wrote. A row lich cannot
-// parse answers nil, which is the same answer an unspawned row gives.
-func decodeMCPServers(encoded string) []string {
+// decodeStrings reads back what setSessionList wrote. A row lich cannot parse
+// answers nil, which is the same answer an unspawned row gives.
+func decodeStrings(encoded string) []string {
 	if encoded == "" {
 		return nil
 	}
-	var servers []string
-	if err := json.Unmarshal([]byte(encoded), &servers); err != nil {
+	var values []string
+	if err := json.Unmarshal([]byte(encoded), &values); err != nil {
 		return nil
 	}
-	return servers
+	return values
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -80,6 +80,13 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- to say "nobody decided this one" — a session opened before the user picked
     -- a rung, or by a caller with nowhere to ask.
     sandbox             TEXT NOT NULL DEFAULT '',
+    -- The paths under the user's home this session's sandbox skipped for being
+    -- symlinks, home-relative, as a JSON array. Written by the spawn because
+    -- only the spawn resolves them, and read back so the card can go on naming
+    -- what a confined session will not find where it expects it — a ~/.gitconfig
+    -- symlinked out of a dotfiles repository, above all. Empty for an
+    -- unconfined session and for one that skipped nothing.
+    sandbox_links       TEXT NOT NULL DEFAULT '',
     -- When this session was parked, in unix seconds; 0 while it is open, and on
     -- a row parked before the column existed. rowid cannot stand in for it: it
     -- dates the insert, not the close, and a resume reinserts the row under a
@@ -332,6 +339,12 @@ type Session struct {
 	// session's directory — and a page reload has to come back to the same
 	// answer without re-deriving it. Nil for a row nothing has spawned yet.
 	MCPServers []string `json:"mcpServers"`
+	// SandboxSkippedLinks names the paths under the user's home this session's
+	// sandbox left out for being symlinks, relative to that home. It rides the
+	// row for the reason MCPServers does — the spawn is what resolved it, and a
+	// page reload has to come back to the same answer. Nil for an unconfined
+	// session and for one whose sandbox skipped nothing.
+	SandboxSkippedLinks []string `json:"sandboxSkippedLinks"`
 }
 
 // Project is a persisted project together with its restorable session state.
@@ -407,6 +420,7 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN mcp_servers TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN parked_branch TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN fork_cost_offset REAL NOT NULL DEFAULT 0`,
+		`ALTER TABLE sessions ADD COLUMN sandbox_links TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN closed_seq INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE session_costs ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0`,
@@ -651,7 +665,7 @@ func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	rows, err := s.db.Query(
 		`SELECT id, label, kind, path, provider_session_id, entrypoint, sandbox, pinned,
 		        origin_session_id, origin_label, scheduled_at, scheduled_prompt, unread,
-		        mcp_servers,
+		        mcp_servers, sandbox_links,
 		        EXISTS (SELECT 1 FROM session_last_turn WHERE session_id = sessions.id)
 		   FROM sessions WHERE project_id = ? AND is_open = 1 ORDER BY position, rowid`,
 		projectID,
@@ -664,15 +678,17 @@ func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	sessions := []Session{}
 	for rows.Next() {
 		var sess Session
-		var servers string
+		var servers, links string
 		if err := rows.Scan(
 			&sess.ID, &sess.Label, &sess.Kind, &sess.Path, &sess.ProviderSessionID,
 			&sess.Entrypoint, &sess.Sandbox, &sess.Pinned, &sess.OriginSessionID, &sess.OriginLabel,
-			&sess.ScheduledAt, &sess.ScheduledPrompt, &sess.Unread, &servers, &sess.HasLastTurn,
+			&sess.ScheduledAt, &sess.ScheduledPrompt, &sess.Unread, &servers, &links,
+			&sess.HasLastTurn,
 		); err != nil {
 			return nil, fmt.Errorf("scan session: %w", err)
 		}
-		sess.MCPServers = decodeMCPServers(servers)
+		sess.MCPServers = decodeStrings(servers)
+		sess.SandboxSkippedLinks = decodeStrings(links)
 		sessions = append(sessions, sess)
 	}
 	if err := rows.Err(); err != nil {

--- a/internal/terminal/sandbox.go
+++ b/internal/terminal/sandbox.go
@@ -27,9 +27,16 @@ import (
 // dropDir is where this session's dropped-file copies live (sessionDropDir),
 // bound read-only so a file dragged onto a confined terminal is a file the
 // agent can actually open. Empty leaves it out.
-func wrapSandbox(spec ptySpec, kind, home, dropDir string, confined bool, creds sandboxCreds) ptySpec {
+//
+// The second return is what the sandbox skipped for being a symlink, home-
+// relative (sandbox.Spec's SkippedLinks). It rides back with the spawn because
+// this is the only moment anything resolves it, and a session that cannot find
+// its own ~/.gitconfig is owed the reason.
+func wrapSandbox(
+	spec ptySpec, kind, home, dropDir string, confined bool, creds sandboxCreds,
+) (ptySpec, []string) {
 	if !confined || home == "" || !sandbox.Available() {
-		return spec
+		return spec, nil
 	}
 	read := append(executables(spec.bin), dropDir)
 	sb := sandbox.Describe(kind, home, spec.dir, project.GitCommonDir(spec.dir), read, creds.sshAgent)
@@ -40,7 +47,7 @@ func wrapSandbox(spec ptySpec, kind, home, dropDir string, confined bool, creds 
 	if creds.ghToken != "" {
 		spec.env = append(spec.env, "GH_TOKEN="+creds.ghToken)
 	}
-	return spec
+	return spec, sb.SkippedLinks
 }
 
 // sandboxCreds is what a confined session is handed to act on the network as the

--- a/internal/terminal/sandbox_test.go
+++ b/internal/terminal/sandbox_test.go
@@ -72,7 +72,7 @@ func TestWrapSandboxLeavesAnUnconfinedSpawnAlone(t *testing.T) {
 		{"not confined", "/home/u", false},
 		{"no home to empty", "", true},
 	} {
-		got := wrapSandbox(baseSpec(), providers.Claude, tt.home, "", tt.confined, sandboxCreds{})
+		got, _ := wrapSandbox(baseSpec(), providers.Claude, tt.home, "", tt.confined, sandboxCreds{})
 		if got.bin != original.bin || !slices.Equal(got.args, original.args) {
 			t.Errorf("%s: spawn rewritten to %q %v", tt.name, got.bin, got.args)
 		}
@@ -84,7 +84,7 @@ func TestWrapSandboxKeepsTheCommandAndItsArguments(t *testing.T) {
 		t.Skip("no sandbox backend on this machine")
 	}
 	original := baseSpec()
-	got := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), "", true, sandboxCreds{})
+	got, _ := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), "", true, sandboxCreds{})
 	if got.bin == original.bin {
 		t.Fatalf("the spawn was not confined: still %q", got.bin)
 	}
@@ -201,7 +201,7 @@ func TestWrapSandboxMountsTheSessionsCopies(t *testing.T) {
 	}
 	copies := sessionDropDir(t.TempDir(), "s1", true)
 
-	got := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), copies, true, sandboxCreds{})
+	got, _ := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), copies, true, sandboxCreds{})
 
 	// Substring, not an argv element: the two backends spell a mounted path in
 	// their own vocabulary — bubblewrap takes it as its own argument
@@ -221,7 +221,7 @@ func TestWrapSandboxKeepsTheTokenOutOfTheArguments(t *testing.T) {
 		t.Skip("bubblewrap is not installed")
 	}
 	const token = "gho_secret_probe_value"
-	got := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), "", true, sandboxCreds{ghToken: token})
+	got, _ := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), "", true, sandboxCreds{ghToken: token})
 
 	if !slices.Contains(got.env, "GH_TOKEN="+token) {
 		t.Errorf("GH_TOKEN missing from the child environment: %v", got.env)
@@ -237,7 +237,7 @@ func TestWrapSandboxAddsNoTokenWithoutOne(t *testing.T) {
 	if _, err := exec.LookPath("bwrap"); err != nil {
 		t.Skip("bubblewrap is not installed")
 	}
-	got := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), "", true, sandboxCreds{})
+	got, _ := wrapSandbox(baseSpec(), providers.Claude, t.TempDir(), "", true, sandboxCreds{})
 	if slices.ContainsFunc(got.env, func(kv string) bool { return strings.HasPrefix(kv, "GH_TOKEN=") }) {
 		t.Errorf("GH_TOKEN set without the flag: %v", got.env)
 	}

--- a/internal/terminal/start.go
+++ b/internal/terminal/start.go
@@ -81,7 +81,7 @@ func (s *Service) Start(
 	// overwrites whatever the previous PTY left in the frontend's stores.
 	s.hub.Emit(cwdEventName, cwdEvent{ID: id, Cwd: cwd})
 	s.hub.Emit(agentEventName, agentEvent{ID: id, Agent: ""})
-	s.hub.Emit(sandboxEventName, sandboxEvent{ID: id, Confined: sess.confined})
+	s.reportSandbox(id, sess.confined, sess.sandboxLinks)
 	s.reportMCPServers(id, kind, cwd)
 	// Bound to the effective cwd rather than the requested one, and outside
 	// s.mu: track queues a warm-up of this checkout's snapshot index, and the
@@ -150,7 +150,9 @@ func (s *Service) spawnSession(
 	// session they run in front of.
 	inSandbox := confined(s.store, id, kind, projectID, cwd)
 	creds := s.sandboxCredentials(projectID, cwd, inSandbox)
-	spec = wrapSandbox(spec, kind, userHome(), sessionDropDir(s.dropDir, id, inSandbox), inSandbox, creds)
+	spec, skippedLinks := wrapSandbox(
+		spec, kind, userHome(), sessionDropDir(s.dropDir, id, inSandbox), inSandbox, creds,
+	)
 	p, err := startPTY(spec)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to start pty for %q: %w", id, err)
@@ -173,8 +175,9 @@ func (s *Service) spawnSession(
 		// Timed from the spawn, so a program that never writes anything still
 		// becomes ready once: quiet is the signal, and silence from the start
 		// is quiet too.
-		lastOut:  time.Now(),
-		confined: inSandbox,
+		lastOut:      time.Now(),
+		confined:     inSandbox,
+		sandboxLinks: skippedLinks,
 	}
 	s.sessions[id] = sess
 	// Outside mu's protection by design (see Service.spawns), and stored with the
@@ -239,6 +242,22 @@ func closableState(kind, state string) bool {
 		return true
 	}
 	return state == statusIdle
+}
+
+// reportSandbox records and announces how this spawn was confined: the verdict,
+// and the home paths the sandbox skipped for being symlinks. The verdict is
+// already on the row (confined writes it); the skipped links are written here,
+// because only the spawn resolves them and the PTY outlives the page — a reload
+// has no second spawn to hear them from.
+//
+// A failed write is logged and nothing else, for the reason reportMCPServers
+// gives: it costs the card a line at the next reload, and refusing to spawn a
+// session over what its tooltip says would be the worse trade.
+func (s *Service) reportSandbox(id string, confined bool, links []string) {
+	if err := s.store.SetSessionSandboxLinks(id, links); err != nil {
+		slog.Warn("record sandbox skipped links", "session", id, "error", err)
+	}
+	s.hub.Emit(sandboxEventName, sandboxEvent{ID: id, Confined: confined, SkippedLinks: links})
 }
 
 // reportMCPServers records and announces the MCP servers this spawn's provider

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -56,11 +56,14 @@ const (
 	// clear so a respawned session never wears a dead agent's icon.
 	agentEventName = "session-agent"
 	// sandboxEventName carries whether a session's PTY runs confined ({id,
-	// confined}), emitted by every spawn. The card marks a confined session, and
-	// the answer is the spawn's own — it takes the provider's rung, the checkout
-	// and a per-session override to reach, so the window is told rather than
-	// asked to work it out again. Persisted with the row too (store.Session's
-	// Sandbox), which is what a page reload hydrates from.
+	// confined, skippedLinks}), emitted by every spawn. The card marks a confined
+	// session, and the answer is the spawn's own — it takes the provider's rung,
+	// the checkout and a per-session override to reach, so the window is told
+	// rather than asked to work it out again. skippedLinks is what that sandbox
+	// left out of the private home for being a symlink, which is the one absence
+	// a session has no other way of learning about. Both persisted with the row
+	// (store.Session's Sandbox and SandboxSkippedLinks), which is what a page
+	// reload hydrates from.
 	sandboxEventName = "session-sandbox"
 	// mcpEventName carries the MCP servers a session's provider could reach at
 	// its spawn ({id, servers}), emitted by every spawn. The card divides a tool
@@ -129,11 +132,14 @@ type agentEvent struct {
 	Agent string `json:"agent"`
 }
 
-// sandboxEvent is the payload of sandboxEventName: the session and whether its
-// PTY is confined.
+// sandboxEvent is the payload of sandboxEventName: the session, whether its PTY
+// is confined, and the home paths that sandbox skipped for being symlinks,
+// relative to the home (nil for an unconfined spawn and for one that skipped
+// none).
 type sandboxEvent struct {
-	ID       string `json:"id"`
-	Confined bool   `json:"confined"`
+	ID           string   `json:"id"`
+	Confined     bool     `json:"confined"`
+	SkippedLinks []string `json:"skippedLinks"`
 }
 
 // mcpEvent is the payload of mcpEventName: the session and the MCP servers its
@@ -185,8 +191,11 @@ type session struct {
 	escPending []byte
 	pasting    bool
 	// confined records whether this PTY was spawned inside the sandbox, so Start
-	// can report it once the spawn is out of the lock.
-	confined bool
+	// can report it once the spawn is out of the lock. sandboxLinks rides with
+	// it: what that sandbox skipped for being a symlink, resolved by the same
+	// call and reported in the same event.
+	confined     bool
+	sandboxLinks []string
 }
 
 // Store is the persistence the terminal service depends on: the binary to spawn
@@ -212,6 +221,7 @@ type Store interface {
 	SessionSandbox(sessionID string) string
 	SetSessionSandbox(sessionID, sandbox string) error
 	SetSessionMCPServers(sessionID string, servers []string) error
+	SetSessionSandboxLinks(sessionID string, links []string) error
 	SandboxDefault(providerID, projectID, cwd string) bool
 	SandboxSSHAgent(projectID string) bool
 	SandboxGHToken(projectID string) bool

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -61,6 +61,10 @@ type stubBins struct {
 	// The MCP servers the spawn recorded per session, the shape
 	// store.SetSessionMCPServers writes. Nil until a test cares.
 	mcpServers map[string][]string
+	// The home paths the spawn's sandbox skipped for being symlinks, per
+	// session, the shape store.SetSessionSandboxLinks writes. Nil until a test
+	// cares.
+	sandboxLinks map[string][]string
 	// What each session inherited from the conversation it was forked from, the
 	// shape store.SaveForkCostOffset writes. Nil until a test cares.
 	forkOffsets map[string]float64
@@ -114,6 +118,13 @@ func (s stubBins) SetSessionSandbox(_, _ string) error { return nil }
 func (s stubBins) SetSessionMCPServers(id string, servers []string) error {
 	if s.mcpServers != nil {
 		s.mcpServers[id] = servers
+	}
+	return nil
+}
+
+func (s stubBins) SetSessionSandboxLinks(id string, links []string) error {
+	if s.sandboxLinks != nil {
+		s.sandboxLinks[id] = links
 	}
 	return nil
 }


### PR DESCRIPTION
## What

Closes the silence behind a documented sandbox trap, and deletes its `docs/ceilings.md` bullet.

Every path lich binds into a confined session's private home is taken as it is on disk, and a symlink is skipped — following one would let a dotfile manager point the private home anywhere, and binding one fails the spawn outright when a parent directory is already mounted. **That policy has not changed.** What has changed is that it no longer happens quietly: a `~/.gitconfig` kept in a dotfiles repository was simply absent inside a confined session, and a `~/.ssh/known_hosts` symlinked the same way took the whole ssh-agent grant down with it, with nothing on screen saying so.

## How

- `sandbox.Describe` now records what it skipped: `Spec.SkippedLinks`, home-relative (`.gitconfig`, `.ssh/known_hosts`). Only over this package's own two lists — the binaries are the exception the policy is written around (`BinaryDirs` walks their chains and mounts each hop's *directory*), so nothing a caller hands in as an extra read is ever named.
- The spawn carries it back (`wrapSandbox`'s second return), reports it on `session-sandbox` beside the confinement verdict, and persists it on the row (`sessions.sandbox_links`) — the PTY outlives the page, so a reload has no second spawn to hear it from. `SetSessionMCPServers` and the new `SetSessionSandboxLinks` now share one `setSessionList` writer and one `decodeStrings` reader.
- The shield tooltip #511 already made speak adds one line: `Not mounted (symlinks): .gitconfig, .ssh/known_hosts`. An empty list draws nothing.
- `docs/ceilings.md`: the "A symlink in the home is not mounted into the sandbox" bullet is gone, not rewritten. The grants bullet stays — it is about the grant — with its `known_hosts` clause losing only the words "and says nothing", and its now-dangling `(below)` pointed at the code instead.

## Tests

- Go (`internal/sandbox/skippedlinks_unix_test.go`): a link skipped and named, the grant's own `known_hosts` named, a real file mounted and not named, an extra-read link not named.
- Go (`internal/store`): the row round-trips and clears on an unconfined respawn.
- Frontend: the tooltip draws the line and the names, and draws nothing when nothing was skipped; both hydration paths carry the list back across a reload.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green
- [x] cross-compile loop green for linux, darwin, windows
- [x] `biome ci .` exit 0, `pnpm test` (1685 passing), `pnpm build`
- [ ] Smoke in `task dev`: open a confined session on a machine with a symlinked `~/.gitconfig` and read the shield tooltip