### PR TITLE
fix: read a session's recap from where the last read stopped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wrong answer that looks right. Linux and macOS; Windows has no foreground
   process group to read it from.
 
+- **The Review panel's recap band no longer goes blank behind a large tool
+  result, and says when its words are the previous turn's.** The band read a
+  bounded tail of the conversation, so a turn whose closing words ended up
+  behind more than 4 MB of tool output showed nothing at all, exactly like a
+  turn that ended on a tool call. It now reads each session's transcript from
+  where the last read stopped, so a turn is read whole however large it is;
+  while a turn is running the band is labelled "from the previous turn", which
+  is whose words they are beside a diff that has no window to draw yet.
 - **On Windows, lich's own window no longer opens a stray console window beside
   it, or gives up and reopens in Chrome.** The window was built for the console
   subsystem, so Windows allocated a console for it and for each of Chromium's

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -47,7 +47,7 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   | Crush | cost only | `sessions.cost` per conversation; no window recorded with it |
   | Kiro CLI | context only | a window and a per-request percentage; spend is metered in credits, not dollars |
   | Antigravity | nothing | conversation filed as SQLite lich has no reader for |
-  | Cursor CLI | nothing | chat filed as SQLite lich has no reader for, search included |
+  | Cursor CLI | nothing | chat filed as SQLite lich has no reader for, search and recap included |
 
   **Kiro CLI is the mirror image of the cost-only rung, and the only provider on its own one.** It records
   `context_usage_percentage` against a `context_window_tokens` (`internal/terminal/usage_kiro.go`), so the ring
@@ -175,24 +175,9 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   no ref reaches, so a `git gc --prune` in that checkout between one run and the next leaves the panel
   reporting a failure rather than an absent turn. And the boundary is the session-state contract, so
   **Crush and Cursor CLI have no last turn at all**: neither reports a state
-  (`docs/hooks/session-state.md`), so nothing ever opens or closes a window there and the switch is never
-  drawn — a rule read off the session's own reports, not a list of providers, so it corrects itself the day
-  either one starts reporting.
-- **The recap beside that diff answers to a different clock, and to a different set of providers**
-  (`internal/terminal/said.go`): the band reads the last thing the agent *said* out of the provider's own
-  transcript, where the diff beside it brackets the window a turn ran in. The two agree once a turn has
-  finished — which is the only time a diff is offered — but mid-turn the band still shows the previous
-  turn's words with no date on them, beside a diff that reads "unavailable"; nothing in the panel says
-  which turn is speaking, and only the card's spinner does. The read is a bounded tail for the reason the
-  transcript search's is (`searchTailBytes`), so a turn whose closing words sit behind more than 4 MB of
-  tool output shows none — the band simply does not appear, which is also what a turn that ended on a tool
-  call looks like. And its provider list is *not* the one the switch above it is drawn from: seven of the
-  eight are read, and the one that is not — Cursor CLI — is also one of the two with no last turn to begin
-  with, so that gap is invisible today. Crush is the other, and its gap is not: its words are read and never
-  drawn, because nothing above it ever opens a window to draw them in. Both would surface the moment either
-  started reporting a state. Kiro CLI was on that list and silent in practice until the palette's search
-  reused the same reader: its block payloads are typed per block kind, and declaring one as a string failed
-  every line where the agent thought before it spoke — which is nearly all of them.
+  (`docs/hooks/session-state.md`), so nothing ever opens or closes a window there, and neither the switch nor
+  the recap band beside it is ever drawn — a rule read off the session's own reports, not a list of providers,
+  so it corrects itself the day either one starts reporting.
 - **A finished turn is unread until its own card is watched** (`frontend/src/lib/session/session-status-store.ts`,
   `frontend/src/providers/projects.tsx`): the solid emerald ring means "back from the agent, not read yet", and it
   fades only for the session whose terminal is on screen **while the window has focus**. A card left focused in a

--- a/frontend/src/components/diff/ReviewPanel.tsx
+++ b/frontend/src/components/diff/ReviewPanel.tsx
@@ -6,13 +6,13 @@ import type { LastSaid, LastTurn } from "@/lib/api-types"
 import { onAppEvent } from "@/lib/app-events"
 import { readDiffSource, writeDiffSource, type DiffSource } from "@/lib/dock-prefs"
 import { discardTargets, parseDiff, type DiffFile } from "@/lib/git/diff"
-import { lastTurnNotice, turnSwitchable } from "@/lib/git/last-turn"
+import { lastTurnNotice, saidNote, turnSwitchable } from "@/lib/git/last-turn"
 import { addReviewComment } from "@/lib/review-comments"
 import { ProjectService, Terminal } from "@/lib/rpc"
 import { useActiveSession } from "@/lib/session/use-active-session"
 import { formatAge, subscribeAge } from "@/lib/session/session-age"
 import { isIdEvent, TURN_EVENT } from "@/lib/session/session-events"
-import { useSessionEverReported } from "@/lib/session/use-session-status"
+import { useSessionEverReported, useSessionStatus } from "@/lib/session/use-session-status"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { useInject } from "@/lib/use-inject"
 import { errorText } from "@/lib/utils"
@@ -52,6 +52,10 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
   // state and holds no record has no turn to bracket, so it is offered the
   // working tree alone (turnSwitchable).
   const reported = useSessionEverReported(sessionId)
+  // The recap band reads the last thing the agent said, which mid-turn is the
+  // previous turn's, and the band says so rather than leaving the reader to the
+  // card's spinner (saidNote).
+  const sessionStatus = useSessionStatus(sessionId)
   const switchable = turnSwitchable(reported, hasLastTurn)
   // The source the reviewer picked, read back on every mount because the dock
   // has no shortage of them: it is a ternary between two component types, so
@@ -206,7 +210,7 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
   return (
     <div className="flex h-full flex-col">
       {switchable && <SourceRow source={source} onSource={changeSource} endedAt={endedAt} />}
-      {source === "turn" && said !== "" && <SaidBand text={said} />}
+      {source === "turn" && said !== "" && <SaidBand text={said} note={saidNote(sessionStatus)} />}
       <div className="flex-1 overflow-y-auto">
         <PanelBody
           source={source}
@@ -234,19 +238,25 @@ export function ReviewPanel({ bulk }: { bulk: DiffBulk }) {
 }
 
 // SaidBand is the agent's own closing words for the shown turn, above the files
-// it changed. A band rather than a card: it shares the panel's edges and is set
-// apart by its ground alone, because the diff below is the object that carries
-// the hierarchy.
+// it changed, under a label naming which turn spoke them whenever that is not
+// the turn below (see saidNote). A band rather than a card: it shares the
+// panel's edges and is set apart by its ground alone, because the diff below is
+// the object that carries the hierarchy.
 //
 // It sits outside the scrolling body and scrolls in its own right, so a turn
 // that ended in a long report cannot push the file list off screen. The text is
 // rendered as text — the agent writes markdown, and a panel that parsed it would
 // be claiming to know which provider's flavour this is.
-function SaidBand({ text }: { text: string }) {
+function SaidBand({ text, note }: { text: string; note: string }) {
   return (
     <div className="flex shrink-0 flex-col gap-1 border-b border-border bg-muted px-2.5 pt-2 pb-2.5">
-      <span className="text-2xs font-medium tracking-wider text-muted-foreground uppercase">
-        Said
+      <span className="flex items-baseline gap-1.5">
+        <span className="text-2xs font-medium tracking-wider text-muted-foreground uppercase">
+          Said
+        </span>
+        {/* Which turn is speaking: the one thing the words themselves cannot
+            say, and the diff beside them has no window to date while it runs. */}
+        {note !== "" && <span className="text-2xs text-muted-foreground">{note}</span>}
       </span>
       <p className="max-h-32 overflow-y-auto whitespace-pre-wrap text-xs">{text}</p>
     </div>

--- a/frontend/src/lib/git/last-turn.test.ts
+++ b/frontend/src/lib/git/last-turn.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { lastTurnNotice, turnSwitchable } from "./last-turn"
+import { lastTurnNotice, saidNote, turnSwitchable } from "./last-turn"
 
 describe("lastTurnNotice", () => {
   it("draws the diff only when there is one to draw", () => {
@@ -45,5 +45,26 @@ describe("turnSwitchable", () => {
   // on record there is none to show: the working tree alone.
   it("withholds the switch from a session with neither", () => {
     expect(turnSwitchable(false, false)).toBe(false)
+  })
+})
+
+describe("saidNote", () => {
+  // Mid-turn the band is the only thing on the panel that can say which turn is
+  // speaking: the diff beside it has no window to draw yet.
+  it("names the previous turn while the agent is running", () => {
+    expect(saidNote("busy")).toBe("from the previous turn")
+  })
+
+  // Once the turn closes the words and the diff are the same turn's, and a
+  // label repeating that would sit on every card at rest.
+  it("drops the label once the turn is over", () => {
+    expect(saidNote("done")).toBe("")
+    expect(saidNote(null)).toBe("")
+  })
+
+  // "waiting" is reported both mid-turn and at an idle prompt, so it cannot
+  // name a turn without being wrong half the time.
+  it("says nothing for a state that could be either turn", () => {
+    expect(saidNote("waiting")).toBe("")
   })
 })

--- a/frontend/src/lib/git/last-turn.ts
+++ b/frontend/src/lib/git/last-turn.ts
@@ -1,4 +1,5 @@
 import type { LastTurn } from "@/lib/api-types"
+import type { SessionStatus } from "@/lib/session/session-events"
 
 // What the Review panel draws for the session's last finished turn. The three
 // answers are kept apart because conflating them is the one mistake this
@@ -32,4 +33,16 @@ export function lastTurnNotice(state: LastTurn["state"] | null, fileCount: numbe
 // offered the working tree alone, which is the whole point of the gate.
 export function turnSwitchable(everReported: boolean, hasLastTurn: boolean): boolean {
   return everReported || hasLastTurn
+}
+
+// saidNote is what the recap band says about whose words it is showing. The
+// band reads the last thing the agent said, which is not always the turn the
+// diff beside it brackets: while a turn is running those are still the previous
+// turn's words, next to a diff that reads "unavailable" until the window closes.
+//
+// "" for every other state, and deliberately including "waiting": that report
+// covers both a session blocked mid-turn and one sitting at its prompt with the
+// turn already over, and a label naming the wrong turn is worse than none.
+export function saidNote(status: SessionStatus | null): string {
+  return status === "busy" ? "from the previous turn" : ""
 }

--- a/internal/terminal/said.go
+++ b/internal/terminal/said.go
@@ -1,10 +1,14 @@
 package terminal
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/omartelo/lich/internal/providers"
 )
@@ -66,8 +70,8 @@ type textBlock struct {
 // It is the last message on record, not the last message of the turn the diff
 // brackets. The two agree whenever a turn has finished, which is the only time
 // the panel offers a diff at all; mid-turn this is still the previous turn's
-// words while the diff reads "unavailable", and the card's own spinner is what
-// says why.
+// words while the diff reads "unavailable", which is why the band labels them
+// as such while the card is busy (saidNote, frontend/src/lib/git/last-turn.ts).
 func (s *Service) LastTurnSaid(id string) (LastSaid, error) {
 	providerSessionID, err := s.store.ProviderSession(id)
 	if err != nil {
@@ -80,7 +84,7 @@ func (s *Service) LastTurnSaid(id string) (LastSaid, error) {
 	if !ok {
 		return LastSaid{}, nil
 	}
-	return LastSaid{Text: capRunes(saidFor(src), saidRuneCap)}, nil
+	return LastSaid{Text: capRunes(s.recap.said(id, src), saidRuneCap)}, nil
 }
 
 // transcriptReaderFor pairs a conversation's JSONL transcript with the reader
@@ -110,15 +114,40 @@ func transcriptReaderFor(src usageSource) (string, turnReader, bool) {
 	return "", nil, false
 }
 
-// saidFor reads one conversation's closing words out of whatever the provider
-// files them in: a line reader for the transcripts, and a query for the two
-// providers that keep their messages in a database of their own instead
-// (sessiondb.go). Empty for every miss, and for Cursor CLI, which reaches here
-// with nothing either can read — a chat filed as a content-addressed blob store
-// (docs/ceilings.md).
-func saidFor(src usageSource) string {
+// saidCursors is where each session's transcript was last read to. A transcript
+// is append-only, so remembering the offset one read ended at turns the next
+// into a walk of what has been written since, and a turn is then read whole
+// however large it is, where a bounded tail re-read every poll (searchTailBytes,
+// still what the palette's search does) loses the turn whose closing words fall
+// behind more tool output than the bound holds.
+//
+// In memory, per run of lich: what the cursor saves is the reading, never the
+// answer, so a session restored at launch simply seeds itself again.
+type saidCursors struct {
+	mu sync.Mutex
+	at map[string]*saidCursor
+}
+
+// saidCursor is one session's place in one transcript: the file's identity, how
+// far it has been read, and the last prose found there. The identity is what
+// tells an ordinary append apart from a file this cursor no longer belongs to
+// (a forked conversation, or a rewritten one), where the offset would otherwise
+// count into bytes nobody read.
+type saidCursor struct {
+	info   os.FileInfo
+	offset int64
+	text   string
+}
+
+// said reads one conversation's closing words out of whatever the provider files
+// them in: a walk of the transcript for the providers that write JSONL, and a
+// query for the two that keep their messages in a database of their own
+// (sessiondb.go), which have no tail to bound and so no cursor to keep. Empty
+// for every miss, and for Cursor CLI, which reaches here with nothing either can
+// read: a chat filed as a content-addressed blob store (docs/ceilings.md).
+func (c *saidCursors) said(id string, src usageSource) string {
 	if path, read, ok := transcriptReaderFor(src); ok {
-		return lastSaidInTail(path, read)
+		return c.walk(id, path, read)
 	}
 	if texts := sessionDBTexts(src.path, queriesFor(src.kind).said, src.id); len(texts) > 0 {
 		return strings.TrimSpace(texts[0])
@@ -126,32 +155,102 @@ func saidFor(src usageSource) string {
 	return ""
 }
 
-// lastSaidInTail walks a JSONL transcript's tail and keeps the last thing the
-// agent said in it. The tail is bounded for the reason the transcript search
-// bounds its own (searchTailBytes): a long conversation runs to tens of
-// megabytes of tool output, and this is re-read while the panel is open.
-//
-// Ceiling: a turn whose closing words fall outside that tail reads as no words
-// at all. It takes a single tool result larger than the bound to do it, and the
-// honest answer then is the empty one — the alternative is showing an older
-// turn's words under this turn's heading.
-func lastSaidInTail(path string, read turnReader) string {
-	if path == "" {
+// walk reads whatever the transcript has grown since this session was last
+// asked, and keeps the newest thing the agent said in it. The answer already on
+// record stands when those new bytes hold no prose, which is what a poll
+// landing in the middle of a turn's tool output reads, and what used to be an
+// empty band indistinguishable from a turn that ended on a tool call.
+func (c *saidCursors) walk(id, path string, read turnReader) string {
+	f, err := os.Open(path)
+	if err != nil {
 		return ""
 	}
-	tail, ok := readTail(path, searchTailBytes)
-	if !ok {
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
 		return ""
 	}
+	// The lock spans the read: its only contenders are two polls of the same
+	// panel, which would be reading the same bytes anyway.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cur, fresh := c.cursor(id, info)
+	lines, end := readLines(f, cur.offset, info.Size())
+	text, found := lastSaid(lines, read)
+	// A tail holding no prose at all is the one case worth a full walk: it takes
+	// a single tool result larger than the bound, and the words behind it are
+	// exactly the turn the band exists to catch up on. Once per session: the
+	// cursor lands at the end of the file either way.
+	if !found && fresh && cur.offset > 0 {
+		lines, end = readLines(f, 0, info.Size())
+		text, found = lastSaid(lines, read)
+	}
+	cur.info, cur.offset = info, end
+	if found {
+		cur.text = text
+	}
+	return cur.text
+}
+
+// cursor answers with this session's place in info, seeding a new one at the
+// file's tail: a conversation running for hours is tens of MB, and a first read
+// is paying for a panel somebody just opened. fresh says the cursor was made
+// here: nothing read before this, or a file the previous read's offset does
+// not
+// belong to (see saidCursor).
+func (c *saidCursors) cursor(id string, info os.FileInfo) (*saidCursor, bool) {
+	if cur, ok := c.at[id]; ok && os.SameFile(cur.info, info) && info.Size() >= cur.offset {
+		return cur, false
+	}
+	if c.at == nil {
+		c.at = make(map[string]*saidCursor)
+	}
+	cur := &saidCursor{offset: max(0, info.Size()-searchTailBytes)}
+	c.at[id] = cur
+	return cur, true
+}
+
+// forget drops a closed session's cursor. Nothing will ask about its transcript
+// again, and a card is closed far more often than lich is.
+func (c *saidCursors) forget(id string) {
+	c.mu.Lock()
+	delete(c.at, id)
+	c.mu.Unlock()
+}
+
+// readLines returns the complete lines between start and the end of an open
+// transcript, and the offset the last of them ended at. A transcript caught
+// mid-write leaves its half line behind rather than consuming it: the next read
+// starts at that line and reads it whole.
+func readLines(f *os.File, start, size int64) ([]byte, int64) {
+	if size <= start {
+		return nil, start
+	}
+	buf := make([]byte, size-start)
+	if _, err := f.ReadAt(buf, start); err != nil && err != io.EOF {
+		return nil, start
+	}
+	cut := bytes.LastIndexByte(buf, '\n')
+	if cut < 0 {
+		return nil, start
+	}
+	return buf[:cut+1], start + int64(cut) + 1
+}
+
+// lastSaid keeps the last thing the agent said in a run of transcript lines.
+// false when they hold none, which for a continuing read means nothing new was
+// said rather than that nothing was.
+func lastSaid(lines []byte, read turnReader) (string, bool) {
 	var last string
-	for _, line := range strings.Split(string(tail), "\n") {
-		// A tail cut mid-line fails to parse like any malformed one, which is
-		// why nothing here distinguishes the two.
+	var found bool
+	for _, line := range strings.Split(string(lines), "\n") {
+		// A line the reader rejects is a tool call, a meta line, or one a seed
+		// tail cut in half, and nothing here distinguishes them.
 		if t, ok := read([]byte(line)); ok && t.role == roleAssistant {
-			last = t.text
+			last, found = t.text, true
 		}
 	}
-	return strings.TrimSpace(last)
+	return strings.TrimSpace(last), found
 }
 
 // claudeTurn reads a Claude transcript line. Sidechain lines — a sub-agent's own

--- a/internal/terminal/said_test.go
+++ b/internal/terminal/said_test.go
@@ -132,32 +132,32 @@ func TestSaidReadersPickTheLastProse(t *testing.T) {
 			if err := os.WriteFile(path, []byte(strings.Join(tc.body, "\n")+"\n"), 0o644); err != nil {
 				t.Fatal(err)
 			}
-			if got := lastSaidInTail(path, tc.read); got != tc.want {
-				t.Errorf("lastSaidInTail = %q, want %q", got, tc.want)
+			if got := new(saidCursors).walk("s1", path, tc.read); got != tc.want {
+				t.Errorf("walk = %q, want %q", got, tc.want)
 			}
 		})
 	}
 }
 
-// TestLastSaidInTailSkipsAHalfLine pins that a tail cut mid-line — the ordinary
-// state of a bounded read — costs the cut line and nothing else.
-func TestLastSaidInTailSkipsAHalfLine(t *testing.T) {
+// TestSaidWalkSkipsAHalfLine pins that a line the seed tail cut in half costs
+// the cut line and nothing else.
+func TestSaidWalkSkipsAHalfLine(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "transcript.jsonl")
 	body := `ontent":[{"type":"text","text":"cut in half"}]}}` + "\n" +
 		`{"type":"assistant","message":{"content":[{"type":"text","text":"whole line"}]}}` + "\n"
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if got := lastSaidInTail(path, claudeTurn); got != "whole line" {
-		t.Errorf("lastSaidInTail = %q, want the whole line", got)
+	if got := new(saidCursors).walk("s1", path, claudeTurn); got != "whole line" {
+		t.Errorf("walk = %q, want the whole line", got)
 	}
 }
 
-// TestSaidForRoutesByProvider walks the dispatch itself: the same source struct
+// TestSaidRoutesByProvider walks the dispatch itself: the same source struct
 // with a different kind must reach a reader that understands that provider's
 // format, and Kiro must reach the `.jsonl` rather than the `.json` its source
 // carries — the one arm that transforms the path it is given.
-func TestSaidForRoutesByProvider(t *testing.T) {
+func TestSaidRoutesByProvider(t *testing.T) {
 	tests := []struct {
 		kind string
 		// name of the file to plant; the source's path is `file` unless the
@@ -197,18 +197,18 @@ func TestSaidForRoutesByProvider(t *testing.T) {
 			}
 			src := usageSource{kind: tc.kind, path: filepath.Join(dir, tc.path), id: "x"}
 			want := tc.kind + " here"
-			if got := saidFor(src); got != want {
-				t.Errorf("saidFor(%s) = %q, want %q", tc.kind, got, want)
+			if got := new(saidCursors).said("s1", src); got != want {
+				t.Errorf("said(%s) = %q, want %q", tc.kind, got, want)
 			}
 		})
 	}
 }
 
-// TestSaidForReadsTheOpenCodeDatabase covers the one provider whose conversation
+// TestSaidReadsTheOpenCodeDatabase covers the one provider whose conversation
 // is a database rather than a file, against the schema opencode writes: the role
 // lives on the message row and the text on a part row beside it, so the join is
 // what keeps a tool result from being read as the agent's own words.
-func TestSaidForReadsTheOpenCodeDatabase(t *testing.T) {
+func TestSaidReadsTheOpenCodeDatabase(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "opencode.db")
 	db, err := sql.Open("sqlite", path)
 	if err != nil {
@@ -235,17 +235,18 @@ func TestSaidForReadsTheOpenCodeDatabase(t *testing.T) {
 	}
 
 	src := usageSource{kind: providers.OpenCode, path: path, id: "ses_1"}
-	if got := saidFor(src); got != "Shipped." {
-		t.Errorf("saidFor = %q, want the newest assistant text part", got)
+	if got := new(saidCursors).said("s1", src); got != "Shipped." {
+		t.Errorf("said = %q, want the newest assistant text part", got)
 	}
 }
 
-// TestSaidForIsEmptyForCursor pins the one provider neither mechanism reaches:
+// TestSaidIsEmptyForCursor pins the one provider neither mechanism reaches:
 // a chat filed as content-addressed blobs is not a transcript to walk and not a
 // query to run, so the read is empty rather than wrong (docs/ceilings.md).
-func TestSaidForIsEmptyForCursor(t *testing.T) {
-	if got := saidFor(usageSource{kind: providers.Cursor, path: "/nope", id: "x"}); got != "" {
-		t.Errorf("saidFor(cursor) = %q, want empty", got)
+func TestSaidIsEmptyForCursor(t *testing.T) {
+	src := usageSource{kind: providers.Cursor, path: "/nope", id: "x"}
+	if got := new(saidCursors).said("s1", src); got != "" {
+		t.Errorf("said(cursor) = %q, want empty", got)
 	}
 }
 
@@ -279,5 +280,117 @@ func TestCapRunesKeepsBothEnds(t *testing.T) {
 	}
 	if short := capRunes("short", 30); short != "short" {
 		t.Errorf("capRunes cut a text under the cap: %q", short)
+	}
+}
+
+// TestSaidCursorContinuesWhereItStopped is the read the band rides on once a
+// session is open: the first walk seeds itself, and every walk after it covers
+// only what was appended. So the answer stands while a turn buries it under
+// tool output (the band used to go empty there, which is what a turn that
+// ended on a tool call looks like), and a new turn's words replace it.
+func TestSaidCursorContinuesWhereItStopped(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "t.jsonl")
+	writeLines(t, path, saidLine("First turn."))
+	var cursors saidCursors
+
+	if got := cursors.walk("s1", path, claudeTurn); got != "First turn." {
+		t.Fatalf("first walk = %q, want the seeded answer", got)
+	}
+	appendLines(t, path, saidPad(64<<10))
+	if got := cursors.walk("s1", path, claudeTurn); got != "First turn." {
+		t.Errorf("walk over tool output = %q, want the answer to stand", got)
+	}
+	appendLines(t, path, saidLine("Second turn."))
+	if got := cursors.walk("s1", path, claudeTurn); got != "Second turn." {
+		t.Errorf("walk = %q, want the newest turn's words", got)
+	}
+}
+
+// TestSaidCursorKeepsWordsBehindTheTailBound is the bound itself gone. A turn
+// whose closing words end up behind more tool output than a tail read holds
+// (one tool result is enough) used to leave the band empty, which is what a turn
+// that ended on a tool call looks like. The cursor walks what was appended and
+// keeps the words it already read.
+func TestSaidCursorKeepsWordsBehindTheTailBound(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "t.jsonl")
+	writeLines(t, path, saidLine("Three failures."))
+	var cursors saidCursors
+	if got := cursors.walk("s1", path, claudeTurn); got != "Three failures." {
+		t.Fatalf("first walk = %q", got)
+	}
+
+	appendLines(t, path, saidPad(searchTailBytes+(1<<20)))
+	if got := cursors.walk("s1", path, claudeTurn); got != "Three failures." {
+		t.Errorf("walk = %q, want the words the tool output buried", got)
+	}
+}
+
+// TestSaidCursorSeedsPastAHugeToolResult covers the same bound on the one read
+// that has no cursor to continue from. A first walk starts at the tail, and a
+// tail holding no prose at all (one tool result larger than it) is walked
+// again from the start rather than answered empty.
+func TestSaidCursorSeedsPastAHugeToolResult(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "t.jsonl")
+	writeLines(t, path, saidLine("Behind the wall."), saidPad(searchTailBytes+(1<<20)))
+
+	if got := new(saidCursors).walk("s1", path, claudeTurn); got != "Behind the wall." {
+		t.Errorf("walk = %q, want the words behind the tool output", got)
+	}
+}
+
+// TestSaidCursorResetsOnANewTranscript pins the two states an offset must never
+// be trusted in: a file that shrank under it, and a file it was never counted
+// against: a conversation forked or rewritten (see saidCursor).
+func TestSaidCursorResetsOnANewTranscript(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "t.jsonl")
+	writeLines(t, path, saidLine("Long conversation."), saidPad(16<<10))
+	var cursors saidCursors
+	if got := cursors.walk("s1", path, claudeTurn); got != "Long conversation." {
+		t.Fatalf("first walk = %q", got)
+	}
+
+	writeLines(t, path, saidLine("Rewritten."))
+	if got := cursors.walk("s1", path, claudeTurn); got != "Rewritten." {
+		t.Errorf("walk after a shrink = %q, want the rewritten file's words", got)
+	}
+
+	forked := filepath.Join(dir, "fork.jsonl")
+	writeLines(t, forked, saidLine("Forked."))
+	if got := cursors.walk("s1", forked, claudeTurn); got != "Forked." {
+		t.Errorf("walk after a fork = %q, want the new transcript's words", got)
+	}
+}
+
+// saidLine is one Claude assistant turn saying text.
+func saidLine(text string) string {
+	return `{"type":"assistant","message":{"content":[{"type":"text","text":"` + text + `"}]}}`
+}
+
+// saidPad is at least n bytes of the lines every reader rejects: the tool
+// output a real conversation buries its prose under.
+func saidPad(n int) string {
+	line := `{"type":"progress","data":"` + strings.Repeat("x", 1024) + `"}`
+	return strings.TrimSuffix(strings.Repeat(line+"\n", n/len(line)+1), "\n")
+}
+
+func writeLines(t *testing.T, path string, lines ...string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func appendLines(t *testing.T, path string, lines ...string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(strings.Join(lines, "\n") + "\n"); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/terminal/sessiondb_text_test.go
+++ b/internal/terminal/sessiondb_text_test.go
@@ -84,14 +84,14 @@ func crushMessageDB(t *testing.T) string {
 	)
 }
 
-// TestSaidForReadsTheCrushDatabase covers the second provider whose conversation
+// TestSaidReadsTheCrushDatabase covers the second provider whose conversation
 // is a database rather than a file. The answer is the newest text part of the
 // newest assistant message: the thinking that preceded it is not something the
 // agent said, and another conversation's closing words are not this one's.
-func TestSaidForReadsTheCrushDatabase(t *testing.T) {
+func TestSaidReadsTheCrushDatabase(t *testing.T) {
 	src := usageSource{kind: providers.Crush, path: crushMessageDB(t), id: "crush-1"}
-	if got := saidFor(src); got != "The worktree port is a hash." {
-		t.Errorf("saidFor = %q, want the newest assistant text part", got)
+	if got := new(saidCursors).said("s1", src); got != "The worktree port is a hash." {
+		t.Errorf("said = %q, want the newest assistant text part", got)
 	}
 }
 
@@ -146,8 +146,8 @@ func TestSessionDBTextsIsSilentForASchemaThatMoved(t *testing.T) {
 		`INSERT INTO messages_v2 VALUES ('m1','a worktree line nothing here can reach')`)
 	for _, kind := range []string{providers.OpenCode, providers.Crush} {
 		src := usageSource{kind: kind, path: path, id: "any"}
-		if got := saidFor(src); got != "" {
-			t.Errorf("saidFor(%s) = %q, want empty for a schema that moved", kind, got)
+		if got := new(saidCursors).said("s1", src); got != "" {
+			t.Errorf("said(%s) = %q, want empty for a schema that moved", kind, got)
 		}
 		if got, ok := searchSource(src, "worktree"); ok {
 			t.Errorf("searchSource(%s) = %+v, want no match for a schema that moved", kind, got)

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -295,6 +295,10 @@ type Service struct {
 	// output while the agent is busy (see handsOn). It carries its own lock for
 	// the reason turns does: a hook must never queue behind a PTY spawn.
 	hands handsOn
+	// recap is where each session's provider transcript was last read to, so
+	// the Review panel's band walks what has been appended since rather than
+	// re-reading a bounded tail every poll (see saidCursors).
+	recap saidCursors
 	// snaps brackets each session's turn with a tree snapshot of its checkout,
 	// which is what the Review panel's "Last turn" mode diffs (see turnSnaps).
 	// It reads the same boundary turns does and carries its own lock for the
@@ -706,6 +710,7 @@ func (s *Service) Close(id string) error {
 	// last turn changed — and its snapshot index would otherwise outlive it on
 	// disk for the rest of the machine's life.
 	s.snaps.forget(id)
+	s.recap.forget(id)
 	// Synchronously, and before the row that the window is about to delete goes:
 	// a write that loses that race is dropped silently (store.AddHandsOn), and
 	// this is the last chance a closed card gets to keep what it was worked.


### PR DESCRIPTION
Closes the `docs/ceilings.md` bullet "The recap beside that diff answers to a different clock, and to a different set of providers".

## The bound

The Review panel's recap band read a bounded 4 MB tail of the provider transcript (`searchTailBytes`), re-read on every poll. A turn whose closing words ended up behind a single tool result larger than that bound showed nothing at all, which is exactly what a turn that ended on a tool call looks like: the band simply does not appear, and nothing says why.

A transcript is append-only, so the read now keeps a per-session cursor (`saidCursors`): the byte offset the last read ended at. Each read walks from there to the end of the file, so a turn is read whole however large it is, and the answer already on record stands while a turn buries it under tool output. The cursor is seeded from a tail on the first read, because a first read is paying for a panel somebody just opened; a seed tail that holds no prose at all is walked again from the start, once, rather than answered empty. It resets when the file shrinks or its identity changes, which is a forked or rewritten conversation, so an offset is never counted into bytes nobody read. It lives in memory and is dropped when the session closes: what it saves is the reading, never the answer.

The two providers that file their messages in a database of their own (opencode, Crush) query it and have no tail to bound, so they keep no cursor.

## Which turn is speaking

Mid-turn the band showed the previous turn's words with no label, beside a diff reading "unavailable", and only the card's spinner said why. The band now carries "from the previous turn" while the card is busy, and drops the label once the turn closes. `waiting` is deliberately unlabelled: it covers both a session blocked mid-turn and one sitting at its prompt, so a label there would name the wrong turn half the time.

## Crush and Cursor

Their absence is the session-state contract, already named in the rung table and in the "Last turn" ceiling. Cursor CLI's row now reads "search and recap included", and the "Last turn" bullet says that neither the switch nor the recap band beside it is drawn for a provider that reports no state. Both correct themselves the day either one starts reporting.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test ./...` green, `-race` on `internal/terminal`
- [x] `internal/terminal` coverage 94.2%
- [x] `pnpm exec biome ci .` exit 0
- [x] `pnpm test` green (144 files, 1684 tests) and `pnpm build` succeeds
- [x] New backend tests cover the cursor continuing where it stopped, words kept behind the old tail bound, a seed past a huge tool result, and the reset on a shrink and on a fork
- [x] `saidNote` covered for `busy`, `done`, `null` and `waiting`