### PR TITLE
fix: give a checkout one Run card and send the menu to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deleted with the session they were dropped into; the three-day sweep now only
   clears the ones an unclean exit orphaned, so a path pasted a week ago still
   resolves.
+- **A checkout gets one Run card, and the menu goes to it.** Asking to run a
+  checkout that is already running one opened a second card, whose only report
+  was the port it could not bind. The item now reads "Go to Run card" and takes
+  you to the card that is there, including one whose command has exited: the
+  shell left in it is the retry. Closing the card is what frees the slot.
 
 - **A sandboxed session's tooltip now names the dotfiles its private home did
   not get.** Every path lich binds into the sandbox is taken as it is on disk

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -14,12 +14,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   checkout owns, nothing binds it, and anything on the machine can take the port before the dev server starts. A
   Run card shortens that window rather than closing it — the process it starts is what binds the port, and
   whether the script even mentions the variable is the project's own business.
-- **A Run card is a terminal, not a supervisor** (`internal/spawn/run.go`, `.lich/run-worktree.sh`): lich starts
-  the command and stops caring. Nothing restarts it, nothing reports memory or CPU, and nothing dedupes — asking
-  twice opens two cards, and the second one's own `address already in use` is the whole of the report. When the
-  command exits the entrypoint wrapper leaves the user's shell in the same card with the error still on screen
-  (`internal/terminal/entrypoint.go`), which is the retry: ↑, Enter. The script is one command, so a project with
-  a web server and a worker beside it opens two cards or writes a script that backgrounds one of them.
 - **The Run card is never started for you, and never on Windows** (`frontend/src/components/sidebar/SessionSidebar.tsx`):
   a fresh worktree's setup script is still installing dependencies in the agent's card when the checkout appears,
   and lich has no "setup finished" signal to hang an automatic start on — `terminal.Ready` answers a different

--- a/frontend/src/components/sidebar/SessionGroup.tsx
+++ b/frontend/src/components/sidebar/SessionGroup.tsx
@@ -15,6 +15,7 @@ import { SessionCard } from "./SessionCard"
 import { PullRequestCard } from "./PullRequestCard"
 import { isPullsOpen, subscribePullsCard } from "@/lib/pulls-card-store"
 import { SessionGroupHeader } from "./SessionGroupHeader"
+import type { RunMenuAction } from "./SessionLaunchMenuItems"
 
 interface SessionGroupProps {
   projectId: string
@@ -63,9 +64,10 @@ interface SessionGroupProps {
   // Closing stays the sidebar's: the last session of a worktree raises the
   // keep-or-remove dialog it owns (useWorktreeClose).
   onClose: (session: Session) => void
-  // Open this checkout's Run card. Absent when the project ships no run script,
-  // and on the gathered blocks, which are not checkouts.
-  onRun?: () => void
+  // The checkout's Run entry: open its Run card, or go to the one it has.
+  // Absent when the project ships no run script, and on the gathered blocks,
+  // which are not checkouts.
+  run?: RunMenuAction
   // The worktree's pull-request entry: opens the Pulls screen for this branch.
   // pullsActive marks it when that screen is showing this group's PR. Rendered
   // only for worktree groups (a truthy path).
@@ -110,7 +112,7 @@ export function SessionGroup({
   sortable,
   onReorder,
   onClose,
-  onRun,
+  run,
   pullsActive,
   onPulls,
   onClosePulls,
@@ -194,7 +196,7 @@ export function SessionGroup({
           activatorProps={fixed ? {} : { ...group.attributes, ...group.listeners }}
           onToggle={toggle}
           onNewSession={(kind, sandbox) => newSession(projectId, kind, path, sandbox)}
-          onRun={onRun}
+          run={run}
         />
       )}
       <div

--- a/frontend/src/components/sidebar/SessionGroupHeader.tsx
+++ b/frontend/src/components/sidebar/SessionGroupHeader.tsx
@@ -12,7 +12,7 @@ import type { ProviderState } from "@/lib/providers-store"
 import type { ProviderKind } from "@/lib/session/sessions"
 import type { SandboxAnswer } from "@/lib/use-sandbox-choice"
 import { cn } from "@/lib/utils"
-import { SessionLaunchMenuItems } from "./SessionLaunchMenuItems"
+import { type RunMenuAction, SessionLaunchMenuItems } from "./SessionLaunchMenuItems"
 
 interface SessionGroupHeaderProps {
   name: string
@@ -36,8 +36,9 @@ interface SessionGroupHeaderProps {
   activatorProps: ComponentPropsWithoutRef<"button">
   onToggle: () => void
   onNewSession: (kind: ProviderKind | "shell", sandbox: SandboxAnswer) => void
-  // Open this checkout's Run card. Absent when the project ships no run script.
-  onRun?: () => void
+  // The checkout's Run entry: open its Run card, or go to the one it has.
+  // Absent when the project ships no run script.
+  run?: RunMenuAction
 }
 
 interface SessionGroupTitleButtonProps {
@@ -98,7 +99,7 @@ export function SessionGroupHeader({
   activatorProps,
   onToggle,
   onNewSession,
-  onRun,
+  run,
 }: SessionGroupHeaderProps) {
   const [editing, setEditing] = useState(false)
 
@@ -162,7 +163,7 @@ export function SessionGroupHeader({
               terminalLabel="New Terminal"
               projectId={projectId}
               onNewSession={onNewSession}
-              onRun={onRun}
+              run={run}
             />
           </DropdownMenuContent>
         </DropdownMenu>

--- a/frontend/src/components/sidebar/SessionLaunchMenuItems.tsx
+++ b/frontend/src/components/sidebar/SessionLaunchMenuItems.tsx
@@ -20,6 +20,14 @@ interface WorktreeMenuAction {
   onSelect: () => void
 }
 
+/** The checkout's Run entry. open is whether it already has a Run card (one per
+ * checkout, see internal/spawn.Run), which is what turns the item from opening
+ * one into going to the one that is there. */
+export interface RunMenuAction {
+  open: boolean
+  onSelect: () => void
+}
+
 interface SessionLaunchMenuItemsProps {
   providers: ProviderState[]
   terminalLabel: "Terminal" | "New Terminal"
@@ -29,9 +37,9 @@ interface SessionLaunchMenuItemsProps {
    * the rung asked for one, "" when it answered by itself. */
   onNewSession: (kind: ProviderKind | "shell", sandbox: SandboxAnswer) => void
   worktree?: WorktreeMenuAction
-  /** Open the checkout's Run card. Absent when the project ships no
+  /** The checkout's Run entry. Absent when the project ships no
    * .lich/run-worktree.sh — there would be no command to run. */
-  onRun?: () => void
+  run?: RunMenuAction
 }
 
 interface SandboxStepProps {
@@ -93,7 +101,7 @@ export function SessionLaunchMenuItems({
   projectId,
   onNewSession,
   worktree,
-  onRun,
+  run,
 }: SessionLaunchMenuItemsProps) {
   const asking = useSandboxAsk(
     providers.map((provider) => provider.id),
@@ -142,10 +150,10 @@ export function SessionLaunchMenuItems({
           <Terminal />
           {terminalLabel}
         </DropdownMenuItem>
-        {onRun && (
-          <DropdownMenuItem onClick={onRun}>
+        {run && (
+          <DropdownMenuItem onClick={run.onSelect}>
             <Play />
-            Run
+            {run.open ? "Go to Run card" : "Run"}
           </DropdownMenuItem>
         )}
         {worktree && (

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -42,6 +42,7 @@ import {
   dragOrder,
   reorderSubset,
   type Session,
+  runCardIn,
   sessionsOf,
   sidebarGroups,
   type SidebarGroup,
@@ -54,7 +55,7 @@ import { useWorktreeClose } from "./useWorktreeClose"
 import { useGitStatus } from "@/lib/git/use-git-status"
 import { usePanelWidth } from "@/lib/use-panel-width"
 import { useWorktreeDialogIntent } from "@/lib/use-sidebar-intent"
-import { SessionLaunchMenuItems } from "./SessionLaunchMenuItems"
+import { type RunMenuAction, SessionLaunchMenuItems } from "./SessionLaunchMenuItems"
 
 // Named here like every other `lich.*` pref rather than spelled at the call
 // site. The bounds go with it: wide enough for a session label and its branch,
@@ -339,6 +340,33 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
     setWorktreeOpen(false)
   }
 
+  // The checkout's Run entry. One checkout gets one Run card, so once it has one
+  // the item goes to that card rather than asking for a second, which the
+  // backend would answer with the same card anyway (internal/spawn.Run). A card
+  // whose command has exited still counts: the shell the wrapper left in it is
+  // the retry, and only closing the card frees the slot.
+  //
+  // Asked of the unfiltered list: a Run card the query hid is still the one this
+  // checkout has.
+  const runAction = (group: SidebarGroup): RunMenuAction => {
+    const card = runCardIn(list, group.path)
+    if (card) {
+      return {
+        open: true,
+        onSelect: () => {
+          activateSession(projectId, card.id)
+          navigate(`/projects/${projectId}`)
+        },
+      }
+    }
+    return {
+      open: false,
+      onSelect: () => {
+        Spawn.Run(projectId, group.path || path).catch((error) => toast.error(errorText(error)))
+      },
+    }
+  }
+
   // One block, rendered the same whichever drag list it belongs to.
   const renderGroup = (group: SidebarGroup) => {
     const groupActive = group.sessions.some((s) => s.id === realActiveId)
@@ -380,15 +408,7 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
         onClose={worktreeClose.requestClose}
         // Offered on a checkout's block alone: a wall and the pinned block
         // gather cards from everywhere and have no directory to run one in.
-        onRun={
-          runnable && !group.pinned && !group.stage
-            ? () => {
-                Spawn.Run(projectId, group.path || path).catch((error) =>
-                  toast.error(errorText(error)),
-                )
-              }
-            : undefined
-        }
+        run={runnable && !group.pinned && !group.stage ? runAction(group) : undefined}
         pullsActive={onPullsRoute && groupActive}
         onPulls={() => {
           openPulls(group.path || path)

--- a/frontend/src/components/sidebar/worktree-run.test.tsx
+++ b/frontend/src/components/sidebar/worktree-run.test.tsx
@@ -47,7 +47,7 @@ beforeEach(() => {
 
 const text = () => document.body.textContent ?? ""
 
-function menu(onRun?: () => void) {
+function menu(run?: { open: boolean; onSelect: () => void }) {
   return createElement(
     DropdownMenu,
     { open: true },
@@ -60,11 +60,17 @@ function menu(onRun?: () => void) {
         terminalLabel: "New Terminal" as const,
         projectId: "p1",
         onNewSession: () => {},
-        onRun,
+        run,
       }),
     ),
   )
 }
+
+// The item to click, by the label it is wearing.
+const menuItem = (label: string) =>
+  [...document.querySelectorAll('[role="menuitem"]')].find(
+    (element) => element.textContent === label,
+  ) as HTMLElement | undefined
 
 test("the launch menu offers Run only when the project ships a run script", async () => {
   const without = await mountBudget(menu())
@@ -73,20 +79,37 @@ test("the launch menu offers Run only when the project ships a run script", asyn
   await without.unmount()
 
   const clicks: number[] = []
-  const with_ = await mountBudget(menu(() => clicks.push(1)))
+  const with_ = await mountBudget(menu({ open: false, onSelect: () => clicks.push(1) }))
   expect(text()).toContain("Run")
+  expect(text()).not.toContain("Go to Run card")
 
-  const item = [...document.querySelectorAll('[role="menuitem"]')].find(
-    (element) => element.textContent === "Run",
-  )
+  const item = menuItem("Run")
   if (!item) {
     throw new Error("Run item not rendered")
   }
   await with_.act(() => {
-    ;(item as HTMLElement).click()
+    item.click()
   })
   expect(clicks).toEqual([1])
   await with_.unmount()
+})
+
+// One Run card per checkout (internal/spawn.Run): once the checkout has one, the
+// same item goes to that card instead of asking for a second.
+test("the item reads Go to Run card once the checkout has one", async () => {
+  const focused: number[] = []
+  const open = await mountBudget(menu({ open: true, onSelect: () => focused.push(1) }))
+  expect(text()).toContain("Go to Run card")
+
+  const item = menuItem("Go to Run card")
+  if (!item) {
+    throw new Error("Go to Run card item not rendered")
+  }
+  await open.act(() => {
+    item.click()
+  })
+  expect(focused).toEqual([1])
+  await open.unmount()
 })
 
 test("the dialog offers a run command when the repository ships none", async () => {

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -328,6 +328,10 @@ export interface StoredSession {
   providerSessionId: string
   /** The command a terminal session opens into; always "" for a provider one. */
   entrypoint: string
+  /** Whether this row is its checkout's Run card (internal/spawn.Run). The one
+   * per checkout: the Run menu item goes to this card instead of opening a
+   * second one, and only closing the card frees the slot. */
+  run: boolean
   /** Whether this session runs confined: "on", "off", or "" for a row nothing
    * has spawned yet. Written by the spawn, which is what resolves the rung. */
   sandbox: string

--- a/frontend/src/lib/rpc.ts
+++ b/frontend/src/lib/rpc.ts
@@ -565,7 +565,11 @@ export const Spawn = {
    * whose entrypoint is .lich/run-worktree.sh, its PTY started by the backend
    * so the app is up whether or not the card is ever looked at. Rejects a
    * project that ships no run script. The card arrives through session-opened,
-   * like every other session opened outside the window. */
+   * like every other session opened outside the window.
+   *
+   * One card per checkout: a checkout that already has one gets nothing new,
+   * and the window sends the menu item to that card instead of calling this
+   * (runCardIn). */
   Run: (projectId: string, cwd: string) => call<null>("spawn.Run", [projectId, cwd]),
 }
 

--- a/frontend/src/lib/session/session-events.test.ts
+++ b/frontend/src/lib/session/session-events.test.ts
@@ -343,9 +343,17 @@ describe("toOpenedSession", () => {
       kind: "claude",
       path: "/wt/auth-fix",
       nextSeq: 5,
+      run: false,
       originSessionId: "s1",
       originLabel: "planner",
     })
+  })
+
+  // The mark is what sends the next Run to this card instead of opening a second
+  // one, so it has to survive the narrowing (internal/spawn.Run).
+  it("keeps the run mark of a Run card", () => {
+    expect(toOpenedSession({ ...payload, run: true })?.run).toBe(true)
+    expect(toOpenedSession({ ...payload, run: "yes" })?.run).toBe(false)
   })
 
   // A session opened from the window, or by `lich open` from a plain shell, has

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -324,6 +324,11 @@ export interface OpenedSession {
   kind: SessionKind
   path: string
   nextSeq: number
+  // Whether the card is its checkout's Run card (internal/spawn.Run). It rides
+  // the event because the mark is what sends the next Run to this card: a card
+  // adopted without it would leave the menu offering a second one until the next
+  // reload read the row.
+  run: boolean
   // The session that asked for this one, and what it was called at the time.
   // Both "" when the opener was not a session — `lich open` from a plain shell.
   originSessionId: string
@@ -339,12 +344,13 @@ export function toOpenedSession(data: unknown): OpenedSession | null {
   if (!isIdEvent(data)) {
     return null
   }
-  const { projectId, label, kind, path, nextSeq, originSessionId, originLabel } = data as {
+  const { projectId, label, kind, path, nextSeq, run, originSessionId, originLabel } = data as {
     projectId?: unknown
     label?: unknown
     kind?: unknown
     path?: unknown
     nextSeq?: unknown
+    run?: unknown
     originSessionId?: unknown
     originLabel?: unknown
   }
@@ -361,6 +367,7 @@ export function toOpenedSession(data: unknown): OpenedSession | null {
     kind,
     path: typeof path === "string" ? path : "",
     nextSeq: typeof nextSeq === "number" ? nextSeq : 1,
+    run: run === true,
     originSessionId: typeof originSessionId === "string" ? originSessionId : "",
     originLabel: typeof originLabel === "string" ? originLabel : "",
   }

--- a/frontend/src/lib/session/sessions.test.ts
+++ b/frontend/src/lib/session/sessions.test.ts
@@ -24,6 +24,7 @@ import {
   reorderSubset,
   restoreSession,
   resumableSession,
+  runCardIn,
   sessionOrigin,
   sessionsOf,
   setActiveSession,
@@ -361,6 +362,41 @@ describe("delegatesOf", () => {
   it("answers nothing for a session nobody was delegated from", () => {
     expect(delegatesOf(buildState(2), P, "s1")).toEqual([])
     expect(delegatesOf(buildState(2), P, "")).toEqual([])
+  })
+})
+
+describe("runCardIn", () => {
+  const card = (id: string, extra: Partial<Session> = {}): Session => ({
+    id,
+    label: id,
+    kind: "shell",
+    ...extra,
+  })
+
+  it("names the checkout's Run card, and nothing for a checkout without one", () => {
+    const sessions = [card("s1"), card("run", { run: true, path: "/wt/a" })]
+    expect(runCardIn(sessions, "/wt/a")?.id).toBe("run")
+    expect(runCardIn(sessions, "")).toBeUndefined()
+    expect(runCardIn(sessions, "/wt/b")).toBeUndefined()
+  })
+
+  it("finds the project's own checkout under the empty path", () => {
+    expect(runCardIn([card("run", { run: true })], "")?.id).toBe("run")
+  })
+
+  // A Run card that has been pinned or dragged onto a wall is drawn in one of the
+  // gathered blocks, and still holds its checkout's one slot.
+  it("finds a Run card the sidebar draws in another block", () => {
+    const pinned = [card("run", { run: true, path: "/wt/a", pinned: true })]
+    expect(runCardIn(pinned, "/wt/a")?.id).toBe("run")
+  })
+
+  // The mark is the backend's; a terminal the user aimed at a command by hand is
+  // an ordinary card and holds no slot.
+  it("ignores a terminal that merely has an entrypoint", () => {
+    expect(
+      runCardIn([card("term", { entrypoint: "pnpm dev", path: "/wt/a" })], "/wt/a"),
+    ).toBeUndefined()
   })
 })
 

--- a/frontend/src/lib/session/sessions.ts
+++ b/frontend/src/lib/session/sessions.ts
@@ -50,6 +50,11 @@ export interface Session {
   // every provider session — the store refuses to record one against a card
   // whose PTY runs an agent.
   entrypoint?: string
+  // Whether this card is its checkout's Run card (internal/spawn.Run). Absent
+  // for every other session, including a terminal the user aimed at a command by
+  // hand: the mark is the backend's, and it is what holds the one Run card a
+  // checkout gets (runCardIn).
+  run?: boolean
   // Whether this session's PTY runs inside the sandbox (internal/sandbox).
   // Absent means it does not — the spawn decides it, from the provider's rung,
   // the checkout and any per-session override, and reports the verdict back;
@@ -513,6 +518,18 @@ export function sidebarGroups(
     }
   }
   return blocks
+}
+
+// runCardIn names the Run card of the checkout stored as `path` ("" for the
+// project's own directory), or undefined when it has none, which is what puts
+// the launch menu's item on "Run" rather than "Go to Run card".
+//
+// It reads the project's whole list rather than the block that checkout draws: a
+// Run card that has been pinned, or dragged onto a wall, is drawn in one of the
+// gathered blocks and still holds its checkout's slot, exactly as the backend
+// sees it (internal/spawn.runCardIn matches the row, not the block).
+export function runCardIn(sessions: Session[], path: string): Session | undefined {
+  return sessions.find((session) => session.run && (session.path ?? "") === path)
 }
 
 // reorderSubset returns the full id order that hands `ids` to the sessions the

--- a/frontend/src/providers/project-workspace.test.ts
+++ b/frontend/src/providers/project-workspace.test.ts
@@ -13,6 +13,7 @@ const storedSession = (overrides: Partial<StoredSession> = {}): StoredSession =>
   path: "",
   providerSessionId: "",
   entrypoint: "",
+  run: false,
   sandbox: "",
   pinned: false,
   originSessionId: "",

--- a/frontend/src/providers/project-workspace.ts
+++ b/frontend/src/providers/project-workspace.ts
@@ -15,6 +15,7 @@ export function buildSessionState(loaded: StoredProject[]): SessionState {
       ...(session.path ? { path: session.path } : {}),
       ...(session.providerSessionId ? { providerSessionId: session.providerSessionId } : {}),
       ...(session.entrypoint ? { entrypoint: session.entrypoint } : {}),
+      ...(session.run ? { run: true } : {}),
       ...(session.sandbox === "on" ? { sandboxed: true } : {}),
       ...(session.pinned ? { pinned: true } : {}),
       ...(session.originSessionId

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -94,6 +94,7 @@ const cardFromStored = (restored: StoredSession): Session => ({
   path: restored.path,
   ...(restored.providerSessionId ? { providerSessionId: restored.providerSessionId } : {}),
   ...(restored.entrypoint ? { entrypoint: restored.entrypoint } : {}),
+  ...(restored.run ? { run: true } : {}),
   ...(restored.sandbox === "on" ? { sandboxed: true } : {}),
   ...(restored.originSessionId
     ? { originSessionId: restored.originSessionId, originLabel: restored.originLabel }
@@ -323,6 +324,7 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
         label,
         kind,
         ...(path ? { path } : {}),
+        ...(opened.run ? { run: true } : {}),
         ...(originSessionId ? { originSessionId, originLabel } : {}),
       }
       const next = adoptSession(sessionsRef.current, projectId, session, nextSeq)

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -180,7 +180,7 @@ func (s *spawnStore) SetSessionModel(_, model string) error {
 	return nil
 }
 
-func (s *spawnStore) SetSessionEntrypoint(_, _ string) error { return nil }
+func (s *spawnStore) SetRunEntrypoint(_, _ string) error { return nil }
 
 func (s *spawnStore) SandboxDefault(_, _, _ string) bool {
 	s.mu.Lock()

--- a/internal/spawn/run.go
+++ b/internal/spawn/run.go
@@ -26,8 +26,12 @@ import (
 // same card, with the error still on screen (internal/terminal.wrapEntrypoint).
 //
 // cwd is any checkout of the project: a worktree, or the project's own
-// directory. Nothing here dedupes — asking twice opens two cards, and the
-// second one's own error is the honest report that the port is taken.
+// directory. One checkout gets one Run card: asking again hands back the card it
+// already has, since a second one could only report the port it cannot bind. A
+// card whose command has exited still holds that slot: the wrapper left the
+// user's shell in it and that shell is the retry, so only closing the card frees
+// it, which is what the loaded state already says by listing open rows alone
+// (store.sessionsOf).
 func (s *Service) Run(projectID, cwd string) (Session, error) {
 	if projectID == "" || cwd == "" {
 		return Session{}, fmt.Errorf("a run card needs a project and a checkout to open in")
@@ -46,6 +50,11 @@ func (s *Service) Run(projectID, cwd string) (Session, error) {
 	target, ok := projectByID(projects, projectID)
 	if !ok {
 		return Session{}, fmt.Errorf("no open project with id %q", projectID)
+	}
+	// Before the script is even read: the card this checkout already has is the
+	// answer whatever .lich/run-worktree.sh says now.
+	if live, ok := runCardIn(target, storedPath(target.Path, cwd)); ok {
+		return live, nil
 	}
 	script := project.RunScript(target.Path)
 	if script == "" {
@@ -70,6 +79,7 @@ func (s *Service) Run(projectID, cwd string) (Session, error) {
 		Kind:    terminal.KindShell,
 		Path:    storedPath(target.Path, cwd),
 		NextSeq: target.NextSeq + 1,
+		Run:     true,
 	}
 	if err := s.sessions.AddSessionFrom(
 		target.ID, id, opened.Label, opened.Kind, opened.Path, opened.NextSeq, "", "",
@@ -79,8 +89,9 @@ func (s *Service) Run(projectID, cwd string) (Session, error) {
 	// Before the spawn rather than after it: terminal.Start reads the entrypoint
 	// off the row, so a write that lands later opens a bare shell instead of the
 	// app. Both writes are this goroutine's, in order, which is what the window
-	// could not have promised had it made them over two RPC calls.
-	if err := s.sessions.SetSessionEntrypoint(id, script); err != nil {
+	// could not have promised had it made them over two RPC calls. It is also
+	// what marks the row a Run card, so the lookup above can find it.
+	if err := s.sessions.SetRunEntrypoint(id, script); err != nil {
 		return Session{}, fmt.Errorf("record the run command on session %q: %w", opened.Label, err)
 	}
 	// Announced before the spawn, and regardless of how it goes, for Open's
@@ -98,6 +109,33 @@ func (s *Service) Run(projectID, cwd string) (Session, error) {
 		return Session{}, fmt.Errorf("the run card was created but its terminal did not start: %w", err)
 	}
 	return opened, nil
+}
+
+// runCardIn finds a checkout's live Run card among a project's loaded sessions,
+// matched on the row's own mark rather than on its entrypoint: the script on
+// disk moves, and a card renamed or re-aimed by hand is still the run seat this
+// checkout spent.
+//
+// path is the store's spelling of the checkout (storedPath), which is what the
+// row holds and what the window groups by.
+func runCardIn(target store.Project, path string) (Session, bool) {
+	for _, sess := range target.Sessions {
+		if !sess.Run || sess.Path != path {
+			continue
+		}
+		return Session{
+			ID:        sess.ID,
+			ProjectID: target.ID,
+			Project:   target.Name,
+			Label:     sess.Label,
+			Kind:      sess.Kind,
+			Path:      sess.Path,
+			// The counter stands where it is: no label was taken this time.
+			NextSeq: target.NextSeq,
+			Run:     true,
+		}, true
+	}
+	return Session{}, false
 }
 
 // projectByID finds an open project by its id — what the window addresses a

--- a/internal/spawn/run_test.go
+++ b/internal/spawn/run_test.go
@@ -56,6 +56,11 @@ func TestRunOpensATerminalOnTheScript(t *testing.T) {
 	if got := sessions.entrypoints[opened.ID]; got != "pnpm dev --port $LICH_WORKTREE_PORT" {
 		t.Errorf("entrypoint = %q, want the script", got)
 	}
+	// The mark is what the window finds the card by, so a card opened without it
+	// is one the next Run would open a rival to.
+	if !opened.Run {
+		t.Error("opened card is not marked a run card")
+	}
 	// The PTY is started here rather than left to the window: that is the whole
 	// point — a run card nobody clicks still runs the app.
 	if len(term.spawns) != 1 {
@@ -140,5 +145,86 @@ func TestRunFailsWhenTheEntrypointCannotBeRecorded(t *testing.T) {
 	}
 	if len(term.spawns) != 0 {
 		t.Errorf("spawns = %d, want none — the shell would not run the app", len(term.spawns))
+	}
+}
+
+// One Run card per checkout: the second ask is answered with the first card,
+// because a rival could only report the port it cannot bind. Nothing is written,
+// nothing is spawned, and no session-opened is emitted: the card the window is
+// being sent to is one it already draws.
+func TestRunGoesToTheCheckoutsExistingCard(t *testing.T) {
+	svc, sessions, term, events, _ := runWorkspace(t, "task dev")
+	sessions.projects[0].Sessions = []store.Session{
+		{ID: "old", Label: "task dev", Kind: "shell", Path: "/wt/feature", Run: true},
+	}
+
+	opened, err := svc.Run("p1", "/wt/feature")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if opened.ID != "old" {
+		t.Errorf("id = %q, want the card the checkout already has", opened.ID)
+	}
+	if !opened.Run || opened.Project != "lich" || opened.ProjectID != "p1" {
+		t.Errorf("opened = %+v, want the existing card named in full", opened)
+	}
+	// The label counter did not move: no card took a number.
+	if opened.NextSeq != 4 {
+		t.Errorf("nextSeq = %d, want the counter left where it was", opened.NextSeq)
+	}
+	if len(sessions.rows) != 0 || len(term.spawns) != 0 || len(events.events) != 0 {
+		t.Errorf("rows = %d, spawns = %d, events = %d, want none of them",
+			len(sessions.rows), len(term.spawns), len(events.events))
+	}
+}
+
+// A Run card whose command has exited still holds the slot: the wrapper left the
+// user's shell in that card and it is the retry (↑, Enter). The store says so by
+// listing open rows alone, so the guard needs no liveness question of its own:
+// what frees the slot is closing the card, which takes the row out of the list.
+func TestRunOnlyCountsTheCardsTheWorkspaceStillHolds(t *testing.T) {
+	svc, sessions, term, _, _ := runWorkspace(t, "task dev")
+	// The closed card is simply not in the loaded state, exactly as
+	// store.sessionsOf hands it over.
+	sessions.projects[0].Sessions = nil
+
+	opened, err := svc.Run("p1", "/wt/feature")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if opened.ID == "" || len(term.spawns) != 1 {
+		t.Errorf("opened = %+v, spawns = %d, want a fresh card", opened, len(term.spawns))
+	}
+}
+
+// The slot is per checkout, and the mark is the backend's: a Run card in another
+// worktree, and a terminal the user aimed at a command by hand, both leave this
+// checkout's Run item opening a card.
+func TestRunIsDedupedPerCheckoutAndByTheMarkAlone(t *testing.T) {
+	svc, sessions, term, _, root := runWorkspace(t, "task dev")
+	sessions.projects[0].Sessions = []store.Session{
+		{ID: "other", Label: "task dev", Kind: "shell", Path: "/wt/other", Run: true},
+		{ID: "hand", Label: "lazygit", Kind: "shell", Path: "/wt/feature", Entrypoint: "lazygit"},
+		{ID: "main", Label: "task dev", Kind: "shell", Path: "", Run: true},
+	}
+
+	opened, err := svc.Run("p1", "/wt/feature")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if opened.ID == "other" || opened.ID == "hand" || opened.ID == "main" {
+		t.Errorf("id = %q, want a card of this checkout's own", opened.ID)
+	}
+	if len(term.spawns) != 1 {
+		t.Errorf("spawns = %d, want one", len(term.spawns))
+	}
+	// The project's own directory is a checkout like any other, and its card is
+	// the one stored under the empty path.
+	reused, err := svc.Run("p1", root)
+	if err != nil {
+		t.Fatalf("Run in the project directory: %v", err)
+	}
+	if reused.ID != "main" {
+		t.Errorf("id = %q, want the main checkout's existing card", reused.ID)
 	}
 }

--- a/internal/spawn/spawn.go
+++ b/internal/spawn/spawn.go
@@ -85,7 +85,7 @@ type Sessions interface {
 	) error
 	SandboxDefault(providerID, projectID, cwd string) bool
 	SetSessionModel(sessionID, model string) error
-	SetSessionEntrypoint(sessionID, entrypoint string) error
+	SetRunEntrypoint(sessionID, entrypoint string) error
 	RenameSession(sessionID, label string) error
 	DeleteSession(projectID, sessionID, activeID string) error
 	CloseSession(projectID, sessionID, activeID string) error
@@ -149,6 +149,10 @@ type Session struct {
 	OriginSessionID string `json:"originSessionId"`
 	OriginLabel     string `json:"originLabel"`
 	Confined        bool   `json:"confined"`
+	// Run marks a checkout's Run card, so the window can find it again and send
+	// the menu item to it rather than opening a second one (Run). Only Run sets
+	// it; every session opened any other way is a card of its own.
+	Run bool `json:"run"`
 }
 
 // Service opens sessions on behalf of a caller outside the window.

--- a/internal/spawn/spawn_test.go
+++ b/internal/spawn/spawn_test.go
@@ -37,7 +37,8 @@ type fakeSessions struct {
 	models   map[string]string
 	modelErr error
 	// entrypoints records the run command written on each session row, keyed by
-	// session id.
+	// session id. Only a Run card gets one from this service, so a row in here is
+	// also a row marked as one.
 	entrypoints   map[string]string
 	entrypointErr error
 	// deleted/parked/purged record what a close asked the store to do, and
@@ -164,7 +165,7 @@ func (f *fakeSessions) SetSessionModel(sessionID, model string) error {
 	return nil
 }
 
-func (f *fakeSessions) SetSessionEntrypoint(sessionID, entrypoint string) error {
+func (f *fakeSessions) SetRunEntrypoint(sessionID, entrypoint string) error {
 	if f.entrypointErr != nil {
 		return f.entrypointErr
 	}

--- a/internal/store/entrypoint_test.go
+++ b/internal/store/entrypoint_test.go
@@ -112,3 +112,73 @@ func TestReopenWorktreeSessionCarriesSpawnOverrides(t *testing.T) {
 		t.Errorf("restored = %+v, want the entrypoint reported to the window", restored)
 	}
 }
+
+// TestSetRunEntrypointMarksTheRunCard is the write behind the one Run card a
+// checkout gets (internal/spawn.Run): the command and the mark land together, so
+// the window can find that card again by the row rather than by guessing at an
+// entrypoint. A terminal the user aimed at a command by hand stays unmarked and
+// holds no slot.
+func TestSetRunEntrypointMarksTheRunCard(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "run", "task dev", "shell", "/wt/foo", 2, "")
+	_ = svc.AddSession("p1", "term", "Terminal 1", "shell", "", 3, "")
+	_ = svc.AddSession("p1", "agent", "Session 1", "claude", "", 4, "")
+
+	if err := svc.SetRunEntrypoint("run", "  task dev\n"); err != nil {
+		t.Fatalf("SetRunEntrypoint: %v", err)
+	}
+	if err := svc.SetRunEntrypoint("agent", "task dev"); err != nil {
+		t.Fatalf("SetRunEntrypoint on a provider session errored: %v", err)
+	}
+	_ = svc.SetSessionEntrypoint("term", "lazygit")
+
+	projects, err := svc.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	marks := map[string]bool{}
+	commands := map[string]string{}
+	for _, sess := range projects[0].Sessions {
+		marks[sess.ID] = sess.Run
+		commands[sess.ID] = sess.Entrypoint
+	}
+	if !marks["run"] || commands["run"] != "task dev" {
+		t.Errorf("run card = (%v, %q), want marked and trimmed", marks["run"], commands["run"])
+	}
+	if marks["term"] || commands["term"] != "lazygit" {
+		t.Errorf("hand-set terminal = (%v, %q), want the command without the mark",
+			marks["term"], commands["term"])
+	}
+	if marks["agent"] {
+		t.Error("provider session was marked a run card; the kind clause should refuse it")
+	}
+}
+
+// TestReopenCarriesTheRunMark: a resumed Run card is still its checkout's, or the
+// next Run would open a second one onto the same port.
+func TestReopenCarriesTheRunMark(t *testing.T) {
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2, "")
+	_ = svc.AddSession("p1", "run", "task dev", "shell", "/wt/foo", 3, "")
+	_ = svc.SetRunEntrypoint("run", "task dev")
+	_ = svc.CloseSession("p1", "run", "base")
+
+	restored, err := svc.ReopenWorktreeSession("p1", "/wt/foo", "run2")
+	if err != nil {
+		t.Fatalf("ReopenWorktreeSession: %v", err)
+	}
+	if restored == nil || !restored.Run {
+		t.Fatalf("restored = %+v, want the run mark reported to the window", restored)
+	}
+	projects, err := svc.LoadState()
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	for _, sess := range projects[0].Sessions {
+		if sess.ID == "run2" && !sess.Run {
+			t.Error("resumed row lost its run mark")
+		}
+	}
+}

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -354,6 +354,10 @@ func (s *Service) reopen(newSessionID, where string, args ...any) (*Session, err
 		// shell — silently, on the one path where the card keeps its identity but
 		// not its id.
 		//
+		// The run mark rides along with the entrypoint it belongs to: a resumed
+		// Run card that came back unmarked would leave its checkout's slot free,
+		// and the next Run would open a second card onto the same port.
+		//
 		// The scheduled prompt rides along because the row is the only copy of
 		// what the user parked there: parking a session is not cancelling its
 		// reminder, and a resume that dropped it forfeited the prompt with
@@ -369,17 +373,19 @@ func (s *Service) reopen(newSessionID, where string, args ...any) (*Session, err
 		// session, and the row is what says where it belongs.
 		var labelAuto int
 		var projectID, model, entrypoint, sandbox string
+		var run bool
 		var forkOffset float64
 		row := tx.QueryRow(
 			`SELECT id, project_id, label, kind, path, provider_session_id, label_auto,
-			        model, entrypoint, sandbox, pinned, origin_session_id, origin_label,
+			        model, entrypoint, run, sandbox, pinned, origin_session_id, origin_label,
 			        scheduled_at, scheduled_prompt, fork_cost_offset
 			   FROM sessions `+where,
 			args...,
 		)
 		if err := row.Scan(
 			&old.ID, &projectID, &old.Label, &old.Kind, &old.Path, &old.ProviderSessionID,
-			&labelAuto, &model, &entrypoint, &sandbox, &old.Pinned, &old.OriginSessionID, &old.OriginLabel,
+			&labelAuto, &model, &entrypoint, &run, &sandbox, &old.Pinned,
+			&old.OriginSessionID, &old.OriginLabel,
 			&old.ScheduledAt, &old.ScheduledPrompt, &forkOffset,
 		); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
@@ -414,11 +420,11 @@ func (s *Service) reopen(newSessionID, where string, args ...any) (*Session, err
 		if _, err := tx.Exec(
 			`INSERT INTO sessions
 			   (id, project_id, label, kind, path, provider_session_id, label_auto,
-			    model, entrypoint, sandbox, pinned, origin_session_id, origin_label,
+			    model, entrypoint, run, sandbox, pinned, origin_session_id, origin_label,
 			    scheduled_at, scheduled_prompt, fork_cost_offset, position)
-			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, `+nextSessionPosition+`)`,
 			newSessionID, projectID, old.Label, old.Kind, old.Path, old.ProviderSessionID, labelAuto,
-			model, entrypoint, sandbox, old.Pinned, old.OriginSessionID, old.OriginLabel,
+			model, entrypoint, run, sandbox, old.Pinned, old.OriginSessionID, old.OriginLabel,
 			old.ScheduledAt, old.ScheduledPrompt, forkOffset, projectID,
 		); err != nil {
 			return fmt.Errorf("reinsert session %q: %w", newSessionID, err)
@@ -439,6 +445,7 @@ func (s *Service) reopen(newSessionID, where string, args ...any) (*Session, err
 			Path:              old.Path,
 			ProviderSessionID: old.ProviderSessionID,
 			Entrypoint:        entrypoint,
+			Run:               run,
 			Sandbox:           sandbox,
 			Pinned:            old.Pinned,
 			OriginSessionID:   old.OriginSessionID,
@@ -622,6 +629,26 @@ func (s *Service) SetSessionEntrypoint(sessionID, entrypoint string) error {
 		strings.TrimSpace(entrypoint), sessionID,
 	); err != nil {
 		return fmt.Errorf("set entrypoint on %q: %w", sessionID, err)
+	}
+	return nil
+}
+
+// SetRunEntrypoint records the run script on a session row and marks that row as
+// the checkout's Run card, in one statement. The mark means "this card is what
+// .lich/run-worktree.sh opened into", and a row holding one half of that would
+// either be a run card nothing can find or a slot held by a bare shell.
+//
+// Only internal/spawn.Run calls it. A terminal the user aims at a command by
+// hand goes through SetSessionEntrypoint and stays an ordinary card, so it never
+// occupies the one Run card its checkout gets.
+//
+// The kind clause is SetSessionEntrypoint's, for the same reason.
+func (s *Service) SetRunEntrypoint(sessionID, entrypoint string) error {
+	if _, err := s.db.Exec(
+		`UPDATE sessions SET entrypoint = ?, run = 1 WHERE id = ? AND kind = 'shell'`,
+		strings.TrimSpace(entrypoint), sessionID,
+	); err != nil {
+		return fmt.Errorf("set run entrypoint on %q: %w", sessionID, err)
 	}
 	return nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -68,6 +68,13 @@ CREATE TABLE IF NOT EXISTS sessions (
     -- on a provider row the entrypoint is the provider, and a value parked there
     -- would be a setting nothing reads.
     entrypoint          TEXT NOT NULL DEFAULT '',
+    -- Whether this row is a checkout's Run card (internal/spawn.Run) rather than
+    -- a terminal somebody aimed at a command by hand. It is what holds the one
+    -- Run card a checkout gets: the menu finds the card by this flag and the
+    -- path beside it. Not derivable from entrypoint: the script on disk moves,
+    -- and a card renamed or re-aimed by hand is still the checkout's run seat
+    -- until it is closed.
+    run                 INTEGER NOT NULL DEFAULT 0,
     -- The session that asked for this one, when it was opened by delegation.
     -- Two columns rather than a foreign key: the id resolves to whatever the
     -- parent is called now, and the label is what it was called when the
@@ -308,6 +315,10 @@ type Session struct {
 	// a provider session. The window reads it to prefill its dialog and to say
 	// on the card what a renamed terminal actually runs.
 	Entrypoint string `json:"entrypoint"`
+	// Run marks the checkout's Run card (internal/spawn.Run): the one session per
+	// checkout that opens on .lich/run-worktree.sh. The window reads it to send
+	// the Run menu item to that card instead of opening a second one.
+	Run bool `json:"run"`
 	// Sandbox is whether this session runs confined: "on", "off", or empty for a
 	// row nothing has spawned yet. The spawn writes its own verdict here, so the
 	// window can mark a confined card without re-deriving a decision that took
@@ -421,6 +432,7 @@ func open(path string) (*Service, error) {
 		`ALTER TABLE sessions ADD COLUMN parked_branch TEXT NOT NULL DEFAULT ''`,
 		`ALTER TABLE sessions ADD COLUMN fork_cost_offset REAL NOT NULL DEFAULT 0`,
 		`ALTER TABLE sessions ADD COLUMN sandbox_links TEXT NOT NULL DEFAULT ''`,
+		`ALTER TABLE sessions ADD COLUMN run INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN position INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE projects ADD COLUMN closed_seq INTEGER NOT NULL DEFAULT 0`,
 		`ALTER TABLE session_costs ADD COLUMN updated_at INTEGER NOT NULL DEFAULT 0`,
@@ -663,7 +675,7 @@ func (s *Service) ProjectAt(path string) (string, string) {
 // the frontend would have no order left to put an unpinned card back into.
 func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 	rows, err := s.db.Query(
-		`SELECT id, label, kind, path, provider_session_id, entrypoint, sandbox, pinned,
+		`SELECT id, label, kind, path, provider_session_id, entrypoint, run, sandbox, pinned,
 		        origin_session_id, origin_label, scheduled_at, scheduled_prompt, unread,
 		        mcp_servers, sandbox_links,
 		        EXISTS (SELECT 1 FROM session_last_turn WHERE session_id = sessions.id)
@@ -681,7 +693,8 @@ func (s *Service) sessionsOf(projectID string) ([]Session, error) {
 		var servers, links string
 		if err := rows.Scan(
 			&sess.ID, &sess.Label, &sess.Kind, &sess.Path, &sess.ProviderSessionID,
-			&sess.Entrypoint, &sess.Sandbox, &sess.Pinned, &sess.OriginSessionID, &sess.OriginLabel,
+			&sess.Entrypoint, &sess.Run, &sess.Sandbox, &sess.Pinned,
+			&sess.OriginSessionID, &sess.OriginLabel,
 			&sess.ScheduledAt, &sess.ScheduledPrompt, &sess.Unread, &servers, &links,
 			&sess.HasLastTurn,
 		); err != nil {


### PR DESCRIPTION
## What

A checkout gets one Run card. Asking again goes to the card it already has, and
the launch menu says so.

Before: the Run item spawned a card every time it was clicked. The second one
started the same command in the same checkout, so its only output was the
`address already in use` of the port the first card had bound, and the user was
left with two cards and no way to tell which was serving.

## How

- The session row carries a `run` mark. `store.SetRunEntrypoint` writes it
  together with the entrypoint it means, in one statement: a row holding one
  half of that would either be a Run card nothing can find or a slot held by a
  bare shell. A terminal the user aims at a command by hand still goes through
  `SetSessionEntrypoint` and holds no slot.
- `spawn.Run` looks the checkout's card up in the state it already loads, and
  returns it instead of opening a rival. That is the shared guard, so any future
  caller inherits it; today there is none (no MCP tool or CLI command opens a
  Run card).
- The launch menu item reads "Go to Run card" when the checkout has one, and
  activating it is what it does. The lookup (`runCardIn`) runs over the
  project's whole session list rather than the block the checkout draws: a Run
  card that has been pinned, or dragged onto a wall, is drawn in one of the
  gathered blocks and still holds its checkout's slot. It also reads the
  unfiltered list, so a card the sidebar query hid is still found.
- A Run card whose command has exited still holds the slot: the wrapper left the
  user's shell in it and that shell is the retry. Only closing the card frees
  it, which the loaded state already says by listing open rows alone.
- The mark rides the park/resume cycle, for the same reason the entrypoint does,
  and rides `session-opened`, so a card adopted in this run is found without
  waiting for a reload.

`docs/ceilings.md`: the "A Run card is a terminal, not a supervisor" bullet is
deleted. What it named as the trap was the dedupe, which is now closed; the rest
of it (no supervisor, no metrics, the shell is the retry, one command per script)
is the design, and it lives in `internal/spawn/run.go`. The one consequence
worth naming is that a project wanting a second process must background it in
the script, and the menu shows that by refusing to open a second card in words
rather than silently, so it sets no trap. The neighbouring "never started for
you" bullet is untouched.

## Tests

- Go: the row mark and the lookup. `SetRunEntrypoint` marks a shell row and
  trims its command, is refused on a provider row, leaves a hand-set entrypoint
  unmarked, and survives park/resume. `spawn.Run` returns the checkout's
  existing card (no row, no spawn, no event, counter untouched), opens a fresh
  one when the workspace holds no card, and dedupes per checkout and by the mark
  alone.
- Frontend: the menu item switches between "Run" and "Go to Run card" and calls
  the action behind each, plus `runCardIn` over the checkout, the project's own
  directory, a pinned card and a bare entrypoint.

Local gate green: `gofmt -l .`, `go vet ./...`, `go test ./...`, `biome ci .`
exit 0, `vitest run` (1687 tests), `tsc` + `vite build`.
