### PR TITLE
fix: announce a scheduled prompt that lands late, and say when one is lost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a dotfiles repository was simply absent inside a confined session, with
   nothing saying so. The shield's tooltip lists them: "Not mounted (symlinks):
   .gitconfig, .ssh/known_hosts". The policy has not changed — only the silence.
+=======
+- **A scheduled prompt now says when it is late, and a lost one says so on
+  screen.** A prompt that could not be typed at its time — the session was
+  mid-setup, mid-sentence, without a terminal, or lich was closed — arrives with
+  one line in front of it naming the time it was scheduled for and how late it
+  is, so neither the agent nor you reads a reminder from three days ago as one
+  written now. A prompt on time still arrives exactly as you wrote it. And
+  deleting a session for good takes the only copy of the prompt parked on it,
+  which used to happen in silence: now a notice names the session and what it
+  was going to say — on screen, and as a desktop notification, so a session an
+  agent closed while you were away still reaches you.
 
 ### Fixed
 

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -302,16 +302,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   events rather than bytes, the bracketed paste markers do not survive, and every provider TUI then guesses at where
   a paste ends from timing alone. A target that repaints on a timer of its own never goes quiet and gets its Enter
   at `defaultSettleLimit` regardless, which is the case this cannot tell from a paste still arriving.
-
-- **A scheduled prompt is late or gone, never on time** (`internal/relay/later.go`, `deliverDue`): due prompts
-  are looked for every `scheduleTick`, and one whose session is not at a prompt — mid-setup, a draft on the
-  line, no terminal opened, a card parked and not yet resumed, is left for the next pass, so it lands
-  whenever that session next has somewhere to type, hours later if that is when. That covers lich having been
-  closed at the time: the first pass after launch types a prompt that came due days ago, unannounced. Gone is
-  the session removed for good rather than parked (deleted, forgotten, purged with its worktree, or taken by
-  a deleted project): the row is the only copy of the prompt, so it goes with the row, and all that says so is
-  one Warn in a log nobody is watching (`internal/store`, `noteForfeitedSchedules`).
-
 - **A lich-spawned Kiro session runs lich's agent, not the user's** (`internal/agentplugin/kiro.go`,
   `internal/terminal/command.go`, `agentArgs`): Kiro keeps its hooks inside an *agent config*, and its built-in
   `kiro_default` cannot be shadowed — a `kiro_default.json` in the agents directory is ignored outright (measured

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -90,6 +90,13 @@ export const USAGE_EVENT = "session-usage"
 // wrote; this is what the clock did.
 export const SCHEDULE_EVENT = "session-schedule"
 
+// Global event the backend emits when a scheduled prompt was lost with the
+// session it was parked on — deleted, forgotten, purged with its worktree, or
+// taken by a deleted project (see store.ScheduleForfeitEventName). Payload:
+// { label, at, prompt }. It carries no session id because there is no row left
+// to route to: the label is the only name that session ever had.
+export const SCHEDULE_FORFEIT_EVENT = "session-schedule-forfeited"
+
 // Global event the backend emits while one session has a request open with
 // another (see relay.RelayEventName). Payload: { id, peer, direction, ticket } —
 // the session whose card changes, the label at the other end, which way the
@@ -248,6 +255,22 @@ export function isIdEvent(data: unknown): data is { id: string } {
 
 export function isScheduleEvent(data: unknown): data is { id: string; at: number } {
   return isIdEvent(data) && typeof (data as { at?: unknown }).at === "number"
+}
+
+// session-schedule-forfeited names a session that is already gone, so the label
+// stands where every other event carries an id.
+export function isForfeitedScheduleEvent(
+  data: unknown,
+): data is { label: string; at: number; prompt: string } {
+  if (typeof data !== "object" || data === null) {
+    return false
+  }
+  const event = data as { label?: unknown; at?: unknown; prompt?: unknown }
+  return (
+    typeof event.label === "string" &&
+    typeof event.at === "number" &&
+    typeof event.prompt === "string"
+  )
 }
 
 // skippedLinks is optional rather than required: a nil list marshals as null,

--- a/frontend/src/providers/projects.tsx
+++ b/frontend/src/providers/projects.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { ReactNode } from "react"
 import { toast } from "sonner"
-import { Bell, Folder, MessageSquareDashed } from "lucide-react"
+import { AlarmClockOff, Bell, Folder, MessageSquareDashed } from "lucide-react"
 import { useMatch, useNavigate } from "react-router-dom"
 import type { ClosedSession, Project, RecentProject } from "@/lib/api-types"
 import type { StoredProject as StoreProject, StoredSession } from "@/lib/api-types"
@@ -50,10 +50,12 @@ import {
   MCP_EVENT,
   SANDBOX_EVENT,
   SCHEDULE_EVENT,
+  SCHEDULE_FORFEIT_EVENT,
   STATUS_EVENT,
   TITLE_EVENT,
   TOUCHED_EVENT,
   decideStatusNotice,
+  isForfeitedScheduleEvent,
   isIdEvent,
   isRelayStalledEvent,
   isMCPEvent,
@@ -113,6 +115,11 @@ const FIRST_LABEL = "Session 1"
 const FIRST_NEXT_SEQ = 2
 
 const ATTENTION_TOAST_MS = 10_000
+
+// How long the notice of a lost scheduled prompt stays up. Longer than the rest:
+// it carries the only remaining copy of what the user wrote, and once it goes
+// there is nowhere left to read it.
+const FORFEIT_TOAST_MS = 30_000
 
 // How long the undo stays on offer after a close. Long enough to notice the card
 // is gone and reach the button, short enough that it is not still there when the
@@ -281,6 +288,31 @@ export function ProjectsProvider({ children }: { children: ReactNode }) {
       if (next !== sessionsRef.current) {
         commit(next)
       }
+    })
+    return () => off()
+  }, [])
+
+  // A prompt parked on a session that was deleted for good is gone with the row
+  // — the row was the only copy of it. The toast is the whole of the amends: it
+  // says which session it was parked on and what it said, so the words can be
+  // read off the screen and parked somewhere else. No route to open, because
+  // there is nothing left to open.
+  useEffect(() => {
+    const off = onAppEvent(SCHEDULE_FORFEIT_EVENT, (data) => {
+      if (!isForfeitedScheduleEvent(data)) {
+        return
+      }
+      toast(
+        <div className="flex min-w-0 flex-col">
+          <span>Scheduled prompt lost with {data.label}</span>
+          {/* Clamped rather than cut: a prompt is capped at 8 KB, and the
+              toast's job is to name it, not to hold the whole of it. */}
+          <span className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+            Due {scheduledFor(data.at, new Date())}: {data.prompt}
+          </span>
+        </div>,
+        { duration: FORFEIT_TOAST_MS, icon: <AlarmClockOff className="size-4 text-amber-500" /> },
+      )
     })
     return () => off()
   }, [])

--- a/internal/relay/later.go
+++ b/internal/relay/later.go
@@ -1,6 +1,7 @@
 package relay
 
 import (
+	"fmt"
 	"log/slog"
 	"time"
 )
@@ -62,7 +63,8 @@ func (s *Service) RunSchedules() {
 //
 // A prompt that came due while lich was closed is delivered late, on the first
 // pass after launch. Late is what this feature promises; silently dropping the
-// only copy of what the user wrote is not.
+// only copy of what the user wrote is not — and one that lands late says so at
+// the prompt it lands on (lateNotice).
 func (s *Service) deliverDue() {
 	projects, err := s.sessions.LoadState()
 	if err != nil {
@@ -90,9 +92,49 @@ func (s *Service) deliverDue() {
 			if s.events != nil {
 				s.events.Emit(ScheduleEventName, ScheduleEvent{ID: sess.ID})
 			}
-			if err := s.deliver(sess.ID, sess.ScheduledPrompt); err != nil {
+			text := lateNotice(sess.ScheduledAt, now) + sess.ScheduledPrompt
+			if err := s.deliver(sess.ID, text); err != nil {
 				slog.Warn("relay: scheduled prompt not delivered", "session", sess.Label, "err", err)
 			}
 		}
+	}
+}
+
+// scheduleClock is how the notice spells the moment a prompt was parked for:
+// local time, to the minute, with the date — an overdue prompt is often days
+// old, and a clock alone would say nothing about which day it was meant for.
+const scheduleClock = "2006-01-02 15:04"
+
+// lateNotice is the line put in front of a prompt that missed its time, and ""
+// for one that did not. Everything reading the card reads it: the agent, which
+// would otherwise act on a reminder from three days ago as if it were now, and
+// the person, for whom a prompt typing itself at a session is otherwise
+// indistinguishable from one typed on time.
+//
+// The threshold is scheduleTick, because that is the resolution the whole
+// feature has: a prompt found on the very next pass is on time by every measure
+// this package can take, and announcing that second would put a notice in front
+// of every prompt lich ever delivers.
+func lateNotice(at, now int64) string {
+	late := time.Duration(now-at) * time.Second
+	if late <= scheduleTick {
+		return ""
+	}
+	return fmt.Sprintf("[lich] Scheduled for %s, delivered %s late.\n\n",
+		time.Unix(at, 0).Format(scheduleClock), lateBy(late))
+}
+
+// lateBy words how far past its time a prompt is, in one unit — "45m", "3h",
+// "2d". The same three rungs the card counts down on (frontend, timeUntil): the
+// reader wants the scale, and a prompt that is two days late is not helped by
+// the minutes on the end of it.
+func lateBy(d time.Duration) string {
+	switch {
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Round(time.Minute)/time.Minute))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Round(time.Hour)/time.Hour))
+	default:
+		return fmt.Sprintf("%dd", int(d.Round(24*time.Hour)/(24*time.Hour)))
 	}
 }

--- a/internal/relay/later_test.go
+++ b/internal/relay/later_test.go
@@ -106,7 +106,8 @@ func TestDeliverDueLeavesAPromptThatIsNotDueYet(t *testing.T) {
 }
 
 // Overdue is delivered, not dropped: this is the prompt that came due while
-// lich was closed.
+// lich was closed. It arrives announced, because a reminder from three days ago
+// read as one written now is the trap being closed here.
 func TestDeliverDueTypesAnOverduePrompt(t *testing.T) {
 	term := newFakeTerminal("s1")
 	svc := newRelay(scheduled(1000, "the overdue one", &scheduleWriter{}), term, nil)
@@ -114,8 +115,62 @@ func TestDeliverDueTypesAnOverduePrompt(t *testing.T) {
 
 	svc.deliverDue()
 
-	if !strings.Contains(term.written("s1"), "the overdue one") {
-		t.Fatalf("typed at s1 = %q, want the overdue prompt", term.written("s1"))
+	written := term.written("s1")
+	if !strings.Contains(written, "the overdue one") {
+		t.Fatalf("typed at s1 = %q, want the overdue prompt", written)
+	}
+	if !strings.Contains(written, "delivered 3d late") {
+		t.Fatalf("typed at s1 = %q, want it announced as three days late", written)
+	}
+	if !strings.Contains(written, "Scheduled for "+time.Unix(1000, 0).Format(scheduleClock)) {
+		t.Fatalf("typed at s1 = %q, want the time it was scheduled for", written)
+	}
+}
+
+// A prompt found within one pass of its time is on time by every measure this
+// package can take, so it arrives as the user wrote it and nothing else.
+func TestDeliverDueTypesAnOnTimePromptBare(t *testing.T) {
+	for name, now := range map[string]int64{
+		"to the second": 1000,
+		"within a tick": 1000 + int64(scheduleTick/time.Second),
+	} {
+		t.Run(name, func(t *testing.T) {
+			term := newFakeTerminal("s1")
+			svc := newRelay(scheduled(1000, "ship it", &scheduleWriter{}), term, nil)
+			svc.now = at(now)
+
+			svc.deliverDue()
+
+			if got := term.written("s1"); strings.Contains(got, "[lich]") {
+				t.Fatalf("typed at s1 = %q, want the prompt with no notice on it", got)
+			}
+		})
+	}
+}
+
+// The notice says the scale the reader acts on, one unit at a time: minutes for
+// a prompt that just missed its pass, hours for one held over a working day,
+// days for one that waited out a closed lich.
+func TestLateNoticeWordsTheDelay(t *testing.T) {
+	cases := map[string]struct {
+		late int64
+		want string
+	}{
+		"a minute past the tick": {late: 91, want: "2m"},
+		"most of an hour":        {late: 45 * 60, want: "45m"},
+		"three hours":            {late: 3 * 60 * 60, want: "3h"},
+		"two days":               {late: 2 * 24 * 60 * 60, want: "2d"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := lateNotice(1000, 1000+tc.late)
+			if !strings.Contains(got, "delivered "+tc.want+" late.") {
+				t.Fatalf("lateNotice = %q, want it %s late", got, tc.want)
+			}
+			if !strings.HasSuffix(got, "\n\n") {
+				t.Fatalf("lateNotice = %q, want the prompt on its own line under it", got)
+			}
+		})
 	}
 }
 

--- a/internal/store/mutations.go
+++ b/internal/store/mutations.go
@@ -168,14 +168,19 @@ func (s *Service) addSession(
 	})
 }
 
-// noteForfeitedSchedules logs every prompt still parked on a session about to be
-// deleted for good. A close parks the row and the schedule comes back with the
-// card (see reopen); a delete is the one exit where the prompt is lost rather
-// than delayed, and the row is the only copy of what the user wrote, so this
-// line is the last place it exists. Read before the delete, because after it
+// noteForfeitedSchedules reports every prompt still parked on a session about to
+// be deleted for good. A close parks the row and the schedule comes back with
+// the card (see reopen); a delete is the one exit where the prompt is lost
+// rather than delayed, and the row is the only copy of what the user wrote, so
+// this is the last place it exists. Read before the delete, because after it
 // there is nothing left to read.
 //
-// A failed read costs the log, never the delete: nothing here is allowed to
+// It reports twice, and neither is the other's fallback: the log line is the
+// record, and whatever SetScheduleForfeited wired is what puts it in front of
+// the person who parked the prompt — the card's menu is the only way to park
+// one, so that person is the user at the window.
+//
+// A failed read costs the report, never the delete: nothing here is allowed to
 // stand between the user and removing a session.
 func (s *Service) noteForfeitedSchedules(where string, args ...any) {
 	rows, err := s.db.Query(
@@ -197,6 +202,9 @@ func (s *Service) noteForfeitedSchedules(where string, args ...any) {
 		}
 		slog.Warn("scheduled prompt forfeited with deleted session",
 			"session", label, "due", time.Unix(at, 0).Format(time.RFC3339), "prompt", prompt)
+		if s.scheduleForfeited != nil {
+			s.scheduleForfeited(ForfeitedSchedule{Label: label, At: at, Prompt: prompt})
+		}
 	}
 }
 

--- a/internal/store/schedule_test.go
+++ b/internal/store/schedule_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestSetSessionScheduleParksOnePromptPerSession pins the shape the card is
@@ -142,6 +143,88 @@ func TestDeletingASessionLogsTheForfeitedSchedule(t *testing.T) {
 			if !strings.Contains(got, "forfeited") || !strings.Contains(got, "worker") ||
 				!strings.Contains(got, "run the release checklist") {
 				t.Fatalf("log = %q, want the forfeited prompt named with its session", got)
+			}
+		})
+	}
+}
+
+// The log is the record; this is the half the user sees. Every door that
+// removes a row for good has to reach the person who parked the prompt, because
+// the row was the only copy of it.
+func TestDeletingASessionReportsTheForfeitedSchedule(t *testing.T) {
+	for name, remove := range map[string]func(*Service) error{
+		"delete":  func(svc *Service) error { return svc.DeleteSession("p1", "wt1", "base") },
+		"forget":  func(svc *Service) error { _ = svc.CloseSession("p1", "wt1", "base"); return svc.ForgetSession("wt1") },
+		"purge":   func(svc *Service) error { return svc.PurgeWorktreeSessions("p1", "/wt/foo") },
+		"project": func(svc *Service) error { return svc.DeleteProject("p1") },
+	} {
+		t.Run(name, func(t *testing.T) {
+			svc := newTestStore(t)
+			var lost []ForfeitedSchedule
+			svc.SetScheduleForfeited(func(f ForfeitedSchedule) { lost = append(lost, f) })
+			_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+			_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2, "")
+			_ = svc.AddSession("p1", "wt1", "worker", "claude", "/wt/foo", 3, "")
+			_ = svc.SetSessionSchedule("wt1", 1700000000, "run the release checklist")
+
+			if err := remove(svc); err != nil {
+				t.Fatalf("remove: %v", err)
+			}
+			if len(lost) != 1 {
+				t.Fatalf("reported = %+v, want the one forfeited prompt", lost)
+			}
+			if lost[0].Label != "worker" || lost[0].At != 1700000000 ||
+				lost[0].Prompt != "run the release checklist" {
+				t.Fatalf("reported = %+v, want the session, its time and its prompt", lost[0])
+			}
+		})
+	}
+}
+
+// The desktop channel is what reaches a forfeit nobody was at the window for,
+// and it has two lines to say it in (internal/system, Notify): the session in
+// the headline, the prompt and its time under it.
+func TestForfeitedScheduleNotice(t *testing.T) {
+	summary, detail := ForfeitedSchedule{
+		Label: "worker", At: 1700000000, Prompt: "run the release checklist",
+	}.Notice()
+
+	if !strings.Contains(summary, `"worker"`) {
+		t.Fatalf("summary = %q, want the session named", summary)
+	}
+	if !strings.Contains(detail, "run the release checklist") {
+		t.Fatalf("detail = %q, want the prompt that was lost", detail)
+	}
+	if want := time.Unix(1700000000, 0).Format(forfeitClock); !strings.Contains(detail, want) {
+		t.Fatalf("detail = %q, want the time it was due (%s)", detail, want)
+	}
+}
+
+// A session with nothing parked on it is removed in silence, and so is a park:
+// the row comes back with the card, prompt and all.
+func TestClosingOrDeletingWithoutAScheduleReportsNothing(t *testing.T) {
+	for name, remove := range map[string]func(*Service) error{
+		"nothing parked": func(svc *Service) error {
+			return svc.DeleteSession("p1", "wt1", "base")
+		},
+		"parked, not deleted": func(svc *Service) error {
+			_ = svc.SetSessionSchedule("wt1", 1700000000, "run the release checklist")
+			return svc.CloseSession("p1", "wt1", "base")
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			svc := newTestStore(t)
+			reported := 0
+			svc.SetScheduleForfeited(func(ForfeitedSchedule) { reported++ })
+			_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+			_ = svc.AddSession("p1", "base", "Session 1", "claude", "", 2, "")
+			_ = svc.AddSession("p1", "wt1", "worker", "claude", "/wt/foo", 3, "")
+
+			if err := remove(svc); err != nil {
+				t.Fatalf("remove: %v", err)
+			}
+			if reported != 0 {
+				t.Fatalf("reported %d forfeits, want none", reported)
 			}
 		})
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	_ "modernc.org/sqlite"
 )
@@ -234,6 +235,9 @@ type Service struct {
 	// sessionGone, when set, is told the id of every session whose row is
 	// deleted for good. See SetSessionGone.
 	sessionGone func(sessionID string)
+	// scheduleForfeited, when set, is told about every scheduled prompt lost
+	// with the session it was parked on. See SetScheduleForfeited.
+	scheduleForfeited func(ForfeitedSchedule)
 	// branchOf, when set, names the git branch of a checkout. See SetBranchOf.
 	branchOf func(path string) string
 	// transcriptOf, when set, reads a conversation as searchable prose and says
@@ -273,6 +277,46 @@ func (s *Service) sessionIsGone(sessionIDs ...string) {
 	for _, id := range sessionIDs {
 		s.sessionGone(id)
 	}
+}
+
+// ScheduleForfeitEventName is emitted when a scheduled prompt was lost with the
+// session it was parked on, so the person who parked it is told rather than left
+// to find out at a time that never comes. Payload: ForfeitedSchedule.
+const ScheduleForfeitEventName = "session-schedule-forfeited"
+
+// ForfeitedSchedule is one scheduled prompt that went with a deleted session:
+// what that session was called, when the prompt was due, and the prompt itself.
+// It carries no session id — the row is gone, so there is nothing left to route
+// to, and the label is the only name the user ever knew it by.
+type ForfeitedSchedule struct {
+	Label  string `json:"label"`
+	At     int64  `json:"at"`
+	Prompt string `json:"prompt"`
+}
+
+// forfeitClock is how a forfeit notice spells the time the prompt was due:
+// local, to the minute, with the date. The log line beside it keeps RFC3339 —
+// that one is read by whoever is grepping, this one by whoever is at the desk.
+const forfeitClock = "2006-01-02 15:04"
+
+// Notice words one forfeit for a desktop notification: the headline names the
+// session, the second line what the prompt was going to say and when. Both are
+// bounded by the notifier itself (internal/system, notifyLimit), which is why
+// the prompt goes in whole rather than cut to some length chosen here.
+func (f ForfeitedSchedule) Notice() (summary, detail string) {
+	return fmt.Sprintf("Scheduled prompt lost with %q", f.Label),
+		fmt.Sprintf("Due %s: %s", time.Unix(f.At, 0).Format(forfeitClock), f.Prompt)
+}
+
+// SetScheduleForfeited registers what to run for each scheduled prompt lost to a
+// delete — DeleteSession, ForgetSession, PurgeWorktreeSessions and
+// DeleteProject, never CloseSession, which parks the row and brings the schedule
+// back with the card.
+//
+// It is startup wiring, called before anything serves. Without it a forfeit
+// costs nothing but the notice: the log line is written either way.
+func (s *Service) SetScheduleForfeited(fn func(ForfeitedSchedule)) {
+	s.scheduleForfeited = fn
 }
 
 // SetBranchOf registers how to read a checkout's git branch (project.Branch).

--- a/main.go
+++ b/main.go
@@ -188,6 +188,19 @@ func main() {
 	uncleanExit := singleton.UncleanExit(configDir, os.Getenv(restart.WaitEnv))
 	sys := system.New(env, logPath, version, uncleanExit)
 	dispatcher.Register("system", sys)
+	// Deleting a session for good takes any prompt parked on it, and the row is
+	// the only copy of what the user wrote. Both channels are used, and neither
+	// is the other's fallback: the toast is what the user reading the card sees,
+	// and the desktop notification is what reaches a forfeit nobody was at the
+	// window for — an agent closing a session under --no-window, where an event
+	// with no client connected is dropped.
+	db.SetScheduleForfeited(func(lost store.ForfeitedSchedule) {
+		hub.Emit(store.ScheduleForfeitEventName, lost)
+		summary, detail := lost.Notice()
+		if err := sys.Notify(summary, detail); err != nil {
+			slog.Warn("notify forfeited schedule", "session", lost.Label, "err", err)
+		}
+	})
 	providerSvc := providers.New()
 	// One resolution, three readers: the process PATH exec.LookPath resolves a
 	// binary through, what a new session inherits, and the editor lookup. They
@@ -279,8 +292,8 @@ func main() {
 //     life of the process and starts a second loop racing the first for every
 //     due prompt.
 //   - relay.SetPlugins, project.SetAccounts, project.SetProjects,
-//     quota.SetSessions, store.SetSessionGone, store.SetBranchOf,
-//     store.SetTranscriptOf and terminal.SetDropDir are startup wiring. Called with [null] they silently
+//     quota.SetSessions, store.SetSessionGone, store.SetScheduleForfeited,
+//     store.SetBranchOf, store.SetTranscriptOf and terminal.SetDropDir are startup wiring. Called with [null] they silently
 //     nil what they wired (encoding/json leaves a func or pointer alone on
 //     null), and the write races the readers already serving — nilling
 //     SetProjects also disarms the guard that keeps two projects off the same
@@ -290,6 +303,7 @@ func denyInternal(d *rpc.Handler) {
 	for _, method := range []string{
 		"store.Close",
 		"store.SetSessionGone",
+		"store.SetScheduleForfeited",
 		"store.SetBranchOf",
 		"store.SetTranscriptOf",
 		"drop.Upload",


### PR DESCRIPTION
Deletes the `docs/ceilings.md` bullet **"A scheduled prompt is late or gone, never on time"** by closing both of its traps on screen.

### Late is announced

A due prompt whose session is not at a prompt is left for the next pass — mid-setup, a draft on the line, no terminal, a card not yet resumed — so it lands whenever that session next has somewhere to type, including the first pass after a launch for one that came due days ago. That part is the feature. What it cost was that the prompt then arrived indistinguishable from one typed on time.

`deliverDue` now puts one line in front of a prompt that is more than a `scheduleTick` late:

```
[lich] Scheduled for 2026-09-05 09:00, delivered 3d late.

run the release checklist
```

On time stays bare — a prompt found on the very next pass is on time by every measure this package can take, and announcing that second would put a notice in front of every prompt lich ever delivers. The delay is worded in one unit, the same three rungs the card counts down on: `45m`, `3h`, `2d`.

### A forfeit reaches the person who parked it

A session removed for good takes the prompt with it — the row was the only copy — and all that said so was a Warn in a log nobody watches. `noteForfeitedSchedules` now reports each one through a new `store.SetScheduleForfeited` hook as well as logging it, and `main` wires that to both channels lich already has:

- the `/events` socket, where the window raises a toast naming the session, the time it was due and what it was going to say, clamped to two lines;
- the desktop notifier (`system.Notify`), which is what reaches a forfeit nobody was at the window for — an agent closing a session under `--no-window`, where an event with no client connected is dropped.

All four doors report: `DeleteSession`, `ForgetSession`, `PurgeWorktreeSessions` and `DeleteProject`. `CloseSession` reports nothing — a park brings the schedule back with the card.

The card's **Schedule a prompt…** menu is the only surface that can park one (there is no `lich later` and no MCP tool for it), so the person owed the news is always the user: `docs/cli.md` documents no scheduling and is untouched.

### Tests

- `internal/relay`: on time → no notice; three days late → the notice with the right duration and the scheduled time; and `lateNotice` worded across minutes, hours and days.
- `internal/store`: the forfeit reported once, with label, time and prompt, on each of the four delete doors; nothing reported for a session with no schedule or for a park; and the two lines the desktop notice is worded into.

### Gate

`gofmt -l .` clean, `go vet ./...` clean, `go test ./...` green with `-race` on `internal/relay` and `internal/store`; `biome ci .` exit 0, `pnpm test` (1692) and `pnpm build` green.