### PR TITLE
fix: let a Windows session hear the Ctrl+C its close sends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a dotfiles repository was simply absent inside a confined session, with
   nothing saying so. The shield's tooltip lists them: "Not mounted (symlinks):
   .gitconfig, .ssh/known_hosts". The policy has not changed — only the silence.
-=======
+
 - **A scheduled prompt now says when it is late, and a lost one says so on
   screen.** A prompt that could not be typed at its time — the session was
   mid-setup, mid-sentence, without a terminal, or lich was closed — arrives with
@@ -53,6 +53,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   measured against that login instead of the one lich is signed in to. A session
   whose environment cannot be read at all shows no gauge on any platform now,
   which is what a card whose terminal is not yet up looks like until it is.
+
+- **Closing a session on Windows now asks the agent to leave before
+  terminating it.** The close sends the terminal's Ctrl+C and gives the agent a
+  moment to run its own exit path — hooks, transcripts, whatever it writes on
+  the way out — where it used to be killed outright. An agent whose TUI wants a
+  second Ctrl+C to quit is still terminated when that moment runs out.
 
 - **A session whose shell runs inside tmux, over ssh or in a container now says
   its directory is unknown instead of naming a local one.** The card, its

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -177,10 +177,14 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   fades only for the session whose terminal is on screen **while the window has focus**. A card left focused in a
   background window keeps its ring solid until the window is touched again, which is the point, but it also means
   a browser that reports focus oddly never fades one.
-- **A session close is a hang-up on Unix and a kill on Windows** (`internal/terminal/pty_unix.go`,
+- **A session close is a hang-up on Unix and a Ctrl+C on Windows** (`internal/terminal/pty_unix.go`,
   `pty_windows.go`): closing a card signals the agent and gives it `closeGrace` to leave, so its exit path runs —
-  hooks, transcripts, whatever it writes on the way out. A ConPTY has no signal to deliver, so the same close on
-  Windows is still abrupt: an agent that saves state on exit loses it there, and nothing on screen says so.
+  hooks, transcripts, whatever it writes on the way out. A ConPTY has no signal to deliver, so Windows sends the
+  terminal's own Ctrl+C instead, and that is a weaker ask: an agent whose TUI reads one Ctrl+C as "interrupt the
+  turn" and wants a second one to quit — Claude Code does — is still killed when the grace runs out, and nothing
+  on screen says so. That the byte arrives at all depends on `heedCtrlC`: a lich started by a service passes an
+  inherited "ignore Ctrl+C" to every agent it spawns, and clearing it before the first spawn is what the Windows
+  close rests on.
 - **The shell-env pty read is bounded by silence, not by the child's exit, and Windows never gets one**
   (`internal/terminal/shellenv_unix.go`, `runShellDump`): resolving PATH and friends runs the login shell on a
   pty rather than a pipe so an rc guarded on `[ -t 0 ]`/`tty -s` (nvm's and fnm's own init, among others) loads —

--- a/internal/terminal/pty.go
+++ b/internal/terminal/pty.go
@@ -3,7 +3,15 @@ package terminal
 import (
 	"path/filepath"
 	"strings"
+	"time"
 )
+
+// closeGrace is how long a close waits for the signalled child to leave on
+// its own before killing it. An agent killed outright never runs its own exit
+// path: Claude Code, for one, treats a session that dies within ten seconds of
+// its first frame as a fullscreen renderer that failed to start, and two of
+// those turn its fullscreen renderer off for every session on the machine.
+const closeGrace = time.Second
 
 // ptySpec describes the child process a session's PTY runs. It carries
 // everything the platform needs to spawn: ConPTY has no exec.Cmd (CreateProcess

--- a/internal/terminal/pty_unix.go
+++ b/internal/terminal/pty_unix.go
@@ -12,13 +12,6 @@ import (
 	"github.com/creack/pty"
 )
 
-// closeGrace is how long a hang-up waits for the signalled child to leave on
-// its own before killing it. An agent killed outright never runs its own exit
-// path: Claude Code, for one, treats a session that dies within ten seconds of
-// its first frame as a fullscreen renderer that failed to start, and two of
-// those turn its fullscreen renderer off for every session on the machine.
-const closeGrace = time.Second
-
 // startPTY starts spec's child attached to a fresh PTY sized cols x rows.
 func startPTY(spec ptySpec) (ptyHandle, error) {
 	cmd := exec.Command(spec.bin, spec.args...)

--- a/internal/terminal/pty_windows.go
+++ b/internal/terminal/pty_windows.go
@@ -5,6 +5,7 @@ package terminal
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os/exec"
 	"sync"
 
@@ -12,8 +13,27 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+// setConsoleCtrlHandler is not in x/sys/windows; the call below is the only
+// use lich has for it.
+var setConsoleCtrlHandler = windows.NewLazySystemDLL("kernel32.dll").NewProc("SetConsoleCtrlHandler")
+
+// heedCtrlC clears the "ignore Ctrl+C" attribute this process may carry, once.
+// A process started by a service — a scheduler, a CI runner — inherits that
+// attribute and hands it to every process it starts, and a child that ignores
+// Ctrl+C never sees the one a close sends: the close waits out closeGrace and
+// kills it anyway. A child inherits the attribute as it stands when it is
+// created, so clearing it before the first spawn covers every session after.
+// It is the process default otherwise, so this changes nothing for a lich
+// started from a desktop.
+var heedCtrlC = sync.OnceFunc(func() {
+	if ok, _, err := setConsoleCtrlHandler.Call(0, 0); ok == 0 {
+		slog.Warn("clear the inherited Ctrl+C ignore", "error", err)
+	}
+})
+
 // startPTY starts spec's child attached to a fresh ConPTY sized cols x rows.
 func startPTY(spec ptySpec) (ptyHandle, error) {
+	heedCtrlC()
 	line, err := commandLine(spec.bin, spec.args)
 	if err != nil {
 		return nil, err
@@ -83,10 +103,9 @@ func (p *windowsPTY) Wait() (int, error) {
 	return int(code), nil
 }
 
-// Close hangs up and terminates the child, once. The pending Wait is cancelled
-// before the lock is taken because it only returns when the child exits, and
-// the child exits because of this very call — conpty polls the process handle
-// on a one-second tick, so that is the longest a close waits for it.
+// Close sends Ctrl+C and kills the child only if it outstays closeGrace, once.
+// Cancel the pending Wait before taking its lock: conpty polls the process
+// handle on a one-second tick, so acquiring the lock can take another second.
 func (p *windowsPTY) Close() error {
 	p.cancelWait()
 	p.mu.Lock()
@@ -95,5 +114,14 @@ func (p *windowsPTY) Close() error {
 		return nil
 	}
 	p.closed = true
+	// Send the terminal's Ctrl+C key through ConPTY so the child's console
+	// handles it without attaching the backend to another session's console.
+	if _, err := p.Write([]byte{ctrlC}); err == nil {
+		ctx, cancel := context.WithTimeout(context.Background(), closeGrace)
+		defer cancel()
+		if _, err := p.ConPty.Wait(ctx); err != nil && ctx.Err() == nil {
+			slog.Warn("wait for Ctrl+C exit", "pid", p.Pid(), "error", err)
+		}
+	}
 	return p.ConPty.Close()
 }

--- a/internal/terminal/pty_windows_test.go
+++ b/internal/terminal/pty_windows_test.go
@@ -3,10 +3,115 @@
 package terminal
 
 import (
+	"bytes"
+	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 )
+
+// TestWindowsPTYCloseRunsExitHandler proves a session close reaches the child
+// as a console Ctrl+C: it leaves through its own interrupt handler, which a
+// kill would never let it run. The child does nothing to make itself hear that
+// signal — startPTY clearing the inherited "ignore Ctrl+C" (see heedCtrlC) is
+// what delivers it, and this test is red without that call, because a CI
+// runner is exactly the service whose children inherit the attribute.
+func TestWindowsPTYCloseRunsExitHandler(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "saved")
+	p, transcript := startWindowsCloseChild(t, path)
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if saved, err := os.ReadFile(path); err != nil || string(saved) != "saved on interrupt" {
+		t.Fatalf("exit handler's file after Close = %q, %v; the child said %q", saved, err, transcript())
+	}
+}
+
+// startWindowsCloseChild runs this test binary as a child that saves a file
+// when it is interrupted, and returns once that child says its handler is
+// armed — a Ctrl+C delivered before then would be answered by the default
+// disposition, and the test would be measuring the runtime instead of the
+// child. The second return reads back everything the child has said, which is
+// the only account of a close that went wrong on a machine nobody can attach
+// a debugger to.
+func startWindowsCloseChild(t *testing.T, path string) (ptyHandle, func() string) {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, err := startPTY(ptySpec{
+		bin: exe, args: []string{"-test.run=^TestWindowsPTYCloseChild$"},
+		// Not t.TempDir(): the child holds its working directory open for as
+		// long as it takes Windows to tear it down after the close, and the
+		// cleanup that cannot delete it fails the test for the wrong reason.
+		dir: os.TempDir(), env: append(os.Environ(), "LICH_TEST_CLOSE_FILE="+path),
+		cols: 80, rows: 24,
+	})
+	if err != nil {
+		t.Fatalf("startPTY: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Close() })
+
+	var mu sync.Mutex
+	var seen bytes.Buffer
+	transcript := func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return seen.String()
+	}
+	armed := make(chan struct{})
+	go func() {
+		said := false
+		buf := make([]byte, 256)
+		for {
+			n, err := p.Read(buf)
+			mu.Lock()
+			seen.Write(buf[:n])
+			hit := bytes.Contains(seen.Bytes(), []byte("armed"))
+			mu.Unlock()
+			if hit && !said {
+				said = true
+				close(armed)
+			}
+			if err != nil {
+				return
+			}
+		}
+	}()
+	select {
+	case <-armed:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("timed out waiting for the child to arm its Ctrl+C handler; it said %q", transcript())
+	}
+	return p, transcript
+}
+
+// TestWindowsPTYCloseChild is the child startWindowsCloseChild runs, and a
+// no-op in every other run of this binary.
+func TestWindowsPTYCloseChild(t *testing.T) {
+	path := os.Getenv("LICH_TEST_CLOSE_FILE")
+	if path == "" {
+		return
+	}
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
+	defer signal.Stop(interrupt)
+	fmt.Println("armed")
+
+	select {
+	case <-interrupt:
+	case <-time.After(30 * time.Second):
+		t.Fatal("no interrupt arrived")
+	}
+	if err := os.WriteFile(path, []byte("saved on interrupt"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
 
 // TestWindowsPTYCloseIsSingleShot pins the guard windowsPTY puts over conpty's
 // Close, which the service relies on: stream reaps a PTY the user-driven Close


### PR DESCRIPTION
Closing a Windows session used to kill its agent outright, so nothing it writes on the way out — hooks, transcripts, saved state — ever ran. The close now writes the terminal's own Ctrl+C into the ConPTY, waits the shared one-second `closeGrace`, then tears the console down. The single-close and Wait handle guards, the Unix close and its tests are untouched.

The first version of this looked right and was dead in the water: the Windows runner proved the child never saw the Ctrl+C. A 2x2 probe on that runner (clearing the inherited disposition x holding a console read pending) named the cause outright:

```
clear=false read=false: delivered=false
clear=false read=true:  delivered=false
clear=true  read=false: delivered=true
clear=true  read=true:  delivered=true
```

A process started by a service inherits "ignore Ctrl+C" and hands that attribute to every process it starts — a CI runner is one such service, and so is any lich launched from a scheduler. `heedCtrlC` clears it once before the first spawn, which is what makes the byte arrive; it is the process default otherwise, so a lich started from a desktop is unaffected. Child stdin mode measured `0x1f7` throughout: processed input was never the problem.

The regression test runs this binary as a child that arms `os.Interrupt` and saves a file when it fires. The child does nothing to help itself hear the signal, so the test is red the moment `heedCtrlC` goes away — and it was, three times, before that call existed.

The seam is shared by all eight providers. Ctrl+C is a weaker ask than the Unix hang-up, though: an agent whose TUI reads one Ctrl+C as "interrupt the turn" and wants a second to quit — Claude Code does — is still killed when the grace runs out. That is why the ceilings bullet is rewritten rather than deleted, and why the changelog line says the close asks rather than promises.

Validation: gofmt, `go vet`, backend tests; build and vet for linux/darwin/windows; the real Windows and macOS os-tests runners green on this head. No frontend change.
