### PR TITLE
fix: cut a history snippet's window in the query, not out of the whole conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   where the last read stopped, so a turn is read whole however large it is;
   while a turn is running the band is labelled "from the previous turn", which
   is whose words they are beside a diff that has no window to draw yet.
+
+- **Searching a large history no longer reads whole conversations to show one
+  sentence.** Every row a search matched on its conversation had its indexed
+  body read out whole: megabytes each, a page of a hundred rows, once per
+  settled keystroke. The stretch the snippet is cut from is now cut by the query
+  itself, so the page reads kilobytes whatever the conversations behind it hold.
+
 - **On Windows, lich's own window no longer opens a stray console window beside
   it, or gives up and reopens in Chrome.** The window was built for the console
   subsystem, so Windows allocated a console for it and for each of Chromium's

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -559,13 +559,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   says `checkout gone` and offers to forget
   itself, which is the only way such a row is ever collected — `PurgeWorktreeSessions` never ran for it,
   because the removal never went through the app.
-- **A history snippet costs the whole conversation it is cut from** (`internal/store/transcripts.go`,
-  `conversationBodies`): the rows a search matched on their conversation have their indexed body read out of
-  the store whole — up to 8 MB each, one page of up to a hundred rows, once per settled keystroke — and the
-  window is cut in Go rather than in the query, because FTS5's own `snippet()` walks every instance of the
-  term and a conversation that says "session" three thousand times costs a tenth of a second per row. Prose
-  is a low single-digit percentage of a transcript, so the page a real workspace hands back is tens of
-  megabytes at the very worst; the fix when it bites is an `instr`/`substr` window in SQL, not a smaller cap.
 - **A filed backend answer outlives the screen that asked, under a key its caller writes by hand**
   (`frontend/src/lib/remote-cache.ts`): a `useRemoteResource` caller that passes `cache` has its answers kept
   in module memory until the page reloads, under exactly the string it composed. Two callers that compose the

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // newTestStore opens a throwaway database under the test's temp directory.
-func newTestStore(t *testing.T) *Service {
+func newTestStore(t testing.TB) *Service {
 	t.Helper()
 	svc, err := open(filepath.Join(t.TempDir(), "test.db"))
 	if err != nil {

--- a/internal/store/transcripts.go
+++ b/internal/store/transcripts.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"time"
 	"unicode"
-	"unicode/utf8"
 
 	"github.com/omartelo/lich/internal/snippet"
 )
@@ -59,107 +58,108 @@ func (s *Service) indexTranscript(sessionID string) {
 
 // attachSnippets fills in the words that made each of these rows a hit, for the
 // ids the search matched on their conversation. It runs over the page and not
-// over the match: a snippet costs reading the conversation it is cut out of, and
-// a term can match more sessions than one page carries.
+// over the match: a snippet costs reading part of the conversation it is cut out
+// of, and a term can match more sessions than one page carries.
 //
-// The window is cut here rather than by the index's own snippet(): that function
-// walks every instance of the term in the document, which on a conversation that
-// says "session" three thousand times is a tenth of a second per row. A row
-// whose conversation cannot be read, or whose hit is a fold of the index's own
-// (accents are folded, so "ción" is indexed as "cion" and found by either),
-// keeps its place in the list with no snippet under it.
+// One query per word of the term, over the rows still without a snippet: a term
+// is almost always one word, and a session is windowed on the first of them its
+// conversation mentions, which is the word the snippet is then centred on. A row
+// whose conversation mentions none of them (a hit the index found by a fold of
+// its own, since accents are folded and "ción" is indexed as "cion") keeps its
+// place in the list with no snippet under it.
 func (s *Service) attachSnippets(sessions []ClosedSession, ids []string, term string) {
 	if len(ids) == 0 {
 		return
 	}
-	bodies := s.conversationBodies(ids)
+	row := make(map[string]int, len(sessions))
+	for i := range sessions {
+		row[sessions[i].ID] = i
+	}
 	// Split the way the index was asked (ftsQuery): "worktree/port" matched the
 	// conversation as two words, and is two words here or no snippet is found.
-	words := searchWords(strings.ToLower(term))
-	for i := range sessions {
-		body, ok := bodies[sessions[i].ID]
-		if !ok {
-			continue
+	pending := ids
+	for _, word := range searchWords(strings.ToLower(term)) {
+		if len(pending) == 0 {
+			return
 		}
-		for _, word := range words {
-			if cut, ok := snippet.Around(around(body, word), word); ok {
-				sessions[i].Snippet = cut
-				break
+		windows := s.conversationWindows(pending, word)
+		var missed []string
+		for _, id := range pending {
+			i, ok := row[id]
+			if !ok {
+				continue
 			}
+			cut, ok := snippet.Around(windows[id], word)
+			if !ok {
+				missed = append(missed, id)
+				continue
+			}
+			sessions[i].Snippet = cut
 		}
+		pending = missed
 	}
 }
 
-// windowBytes is how much of a conversation the snippet is cut out of, centred
-// on a first, approximate reading of where the word is. Wide enough that the
-// exact cut has the whole sentence around the hit to work with, and narrow
-// enough that a two-megabyte conversation is not walked rune by rune once per
-// row on screen.
-const windowBytes = 4096
+// windowChars is how much of a conversation the snippet is cut out of, centred
+// on the first mention of the word. Wide enough that the exact cut has the whole
+// sentence around the hit to work with even after collapsing the whitespace a
+// transcript is written with, and narrow enough that a page of a hundred rows is
+// hundreds of kilobytes rather than the hundreds of megabytes the conversations
+// behind it hold.
+const windowChars = 4096
 
-// around is that first reading: the stretch of body near the first mention of
-// word, found by one case-folded scan and sliced out of the original. The offset
-// is approximate, because folding is not length-preserving, and it does not need
-// to be exact: it only has to land the mention inside a window the real cut then
-// searches properly. Empty when the body does not mention the word at all, which
-// is a hit the index found by a fold the plain text does not have.
-func around(body, word string) string {
-	// The plain scan first: word is already lowercased and a conversation is
-	// mostly lowercase prose, so the copy the fold below needs is one this
-	// almost always avoids. On a page of megabyte conversations that copy is the
-	// larger half of the whole search.
-	at := strings.Index(body, word)
-	if at < 0 {
-		at = strings.Index(strings.ToLower(body), word)
-	}
-	if at < 0 {
-		return ""
-	}
-	start := max(at-windowBytes/2, 0)
-	end := min(at+windowBytes/2, len(body))
-	// Sliced off a byte offset, so either edge can fall inside a rune. A
-	// half rune left at one would be drawn as a replacement character.
-	for start < end && !utf8.RuneStart(body[start]) {
-		start++
-	}
-	for end > start {
-		if r, size := utf8.DecodeLastRuneInString(body[start:end]); r != utf8.RuneError || size > 1 {
-			break
-		}
-		end--
-	}
-	return body[start:end]
-}
+// firstMention is where a body first mentions the bound word, as SQL: one
+// position, or 0 for a body that does not mention it at all. Characters, not
+// bytes: instr and substr both count in characters, so a window cut off this
+// offset never opens or closes inside a rune.
+//
+// The plain scan first, because coalesce stops at the first argument that is not
+// null: a conversation is mostly lowercase prose and the word is already
+// lowercased, so the folded copy of a multi-megabyte body is one this almost
+// always avoids. The fold itself is SQLite's, which is ASCII: a body that shouts
+// an accented word in capitals is a hit with no snippet, the same answer the
+// index's own accent fold already gives.
+const firstMention = `coalesce(nullif(instr(body, ?), 0), instr(lower(body), ?))`
 
-// conversationBodies reads the indexed conversations of these sessions, keyed by
-// session id. A body that is not there is simply absent from the answer, which
-// is a row with no snippet rather than a search that failed.
-func (s *Service) conversationBodies(ids []string) map[string]string {
-	query := `SELECT session_id, body FROM session_texts WHERE session_id IN (?` +
-		strings.Repeat(",?", len(ids)-1) + `)`
-	args := make([]any, len(ids))
-	for i, id := range ids {
-		args[i] = id
+// conversationWindows cuts, in the query, the stretch of each of these
+// conversations around its first mention of word, keyed by session id. A body
+// that is not indexed or does not mention the word is simply absent from the
+// answer, which is a row with no snippet rather than a search that failed.
+//
+// The window is what keeps a search off the size of the conversations it
+// searches: the rows are matched on bodies of up to eight megabytes each and the
+// answer carries windowChars characters of each, so the page a settled keystroke
+// reads is bounded by the page's own length.
+func (s *Service) conversationWindows(ids []string, word string) map[string]string {
+	query := `SELECT session_id, substr(body, max(` + firstMention + ` - ?, 1), ?)
+	            FROM session_texts
+	           WHERE ` + firstMention + ` > 0
+	             AND session_id IN (?` + strings.Repeat(",?", len(ids)-1) + `)`
+	// Bound in the order the query names them: the window's own mention, its
+	// two bounds, the filter's mention, then the ids.
+	args := []any{word, word, windowChars / 2, windowChars, word, word}
+	for _, id := range ids {
+		args = append(args, id)
 	}
 	rows, err := s.db.Query(query, args...)
 	if err != nil {
-		slog.Warn("store: read indexed conversations", "err", err)
+		slog.Warn("store: window indexed conversations", "err", err)
 		return nil
 	}
 	defer rows.Close()
-	bodies := make(map[string]string, len(ids))
+	windows := make(map[string]string, len(ids))
 	for rows.Next() {
-		var id, body string
-		if err := rows.Scan(&id, &body); err != nil {
-			slog.Warn("store: scan indexed conversation", "err", err)
-			return bodies
+		var id, window string
+		if err := rows.Scan(&id, &window); err != nil {
+			slog.Warn("store: scan conversation window", "err", err)
+			return windows
 		}
-		bodies[id] = body
+		windows[id] = window
 	}
 	if err := rows.Err(); err != nil {
-		slog.Warn("store: iterate indexed conversations", "err", err)
+		slog.Warn("store: iterate conversation windows", "err", err)
 	}
-	return bodies
+	return windows
 }
 
 // indexTarget is what reading one session's conversation takes: the id its

--- a/internal/store/transcripts_test.go
+++ b/internal/store/transcripts_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,7 +12,7 @@ import (
 // indexed wires a store to a fixed set of conversations, keyed by the provider
 // session id a row carries. It stands in for terminal.TranscriptText, whose own
 // reading of a provider's transcript is tested where it lives.
-func indexed(t *testing.T, svc *Service, texts map[string]string) {
+func indexed(t testing.TB, svc *Service, texts map[string]string) {
 	t.Helper()
 	svc.SetTranscriptOf(func(providerSessionID, cwd string) (string, bool) {
 		return texts[providerSessionID], false
@@ -20,7 +21,7 @@ func indexed(t *testing.T, svc *Service, texts map[string]string) {
 
 // indexedAndCut is indexed for a conversation the cap dropped the oldest of,
 // which is the answer the row has to carry through to the window.
-func indexedAndCut(t *testing.T, svc *Service, texts map[string]string) {
+func indexedAndCut(t testing.TB, svc *Service, texts map[string]string) {
 	t.Helper()
 	svc.SetTranscriptOf(func(providerSessionID, cwd string) (string, bool) {
 		return texts[providerSessionID], true
@@ -29,7 +30,7 @@ func indexedAndCut(t *testing.T, svc *Service, texts map[string]string) {
 
 // parkWithConversation adds a session, records the provider id its conversation
 // is filed under and closes it, which is what writes the index.
-func parkWithConversation(t *testing.T, svc *Service, sessionID, label, providerSessionID string) {
+func parkWithConversation(t testing.TB, svc *Service, sessionID, label, providerSessionID string) {
 	t.Helper()
 	if err := svc.AddSession("p1", sessionID, label, "claude", "", 2, ""); err != nil {
 		t.Fatalf("AddSession(%q): %v", sessionID, err)
@@ -274,40 +275,107 @@ func indexRows(t *testing.T, svc *Service) int {
 	return n
 }
 
-// TestAroundWindowsTheConversation covers the first, cheap reading of where a
-// word is: it only has to land the mention inside a window, and it must never
-// hand back a half rune for the snippet to draw as a replacement character.
-func TestAroundWindowsTheConversation(t *testing.T) {
+// windowOf parks one conversation and asks the query for the stretch it cuts
+// around the first mention of word, which is what the snippet is cut out of.
+func windowOf(t *testing.T, body, word string) (string, bool) {
+	t.Helper()
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	indexed(t, svc, map[string]string{"uuid-a": body})
+	parkWithConversation(t, svc, "s-a", "Session 4", "uuid-a")
+
+	window, ok := svc.conversationWindows([]string{"s-a"}, word)["s-a"]
+	return window, ok
+}
+
+// TestConversationWindowsCutsAroundTheMention covers the window the query cuts:
+// it only has to land the mention inside a bounded stretch of the conversation,
+// wherever in it the mention falls, and it must never hand back a half rune for
+// the snippet to draw as a replacement character.
+func TestConversationWindowsCutsAroundTheMention(t *testing.T) {
+	filler := strings.Repeat("filler ", 2000)
+
 	t.Run("keeps the mention and its surroundings", func(t *testing.T) {
-		body := strings.Repeat("filler ", 2000) + "the ADOPTION guard " + strings.Repeat("tail ", 2000)
-		got := around(body, "adoption")
-		if !strings.Contains(got, "ADOPTION guard") {
-			t.Errorf("around = %.80q…, want the mention and what follows it", got)
+		window, ok := windowOf(t, filler+"the ADOPTION guard "+filler, "adoption")
+		if !ok {
+			t.Fatal("no window for a conversation that mentions the word")
 		}
-		if len(got) > windowBytes {
-			t.Errorf("window is %d bytes, want at most %d", len(got), windowBytes)
+		if !strings.Contains(window, "ADOPTION guard") {
+			t.Errorf("window = %.80q…, want the mention and what follows it", window)
+		}
+		if n := utf8.RuneCountInString(window); n > windowChars {
+			t.Errorf("window is %d characters, want at most %d", n, windowChars)
+		}
+	})
+
+	t.Run("windows a mention at either end of the conversation", func(t *testing.T) {
+		for name, body := range map[string]string{
+			"first words": "the adoption guard " + filler,
+			"last words":  filler + "the adoption guard",
+		} {
+			window, ok := windowOf(t, body, "adoption")
+			if !ok {
+				t.Fatalf("%s: no window", name)
+			}
+			if !strings.Contains(window, "adoption guard") {
+				t.Errorf("%s: window = %.80q…, want the mention", name, window)
+			}
 		}
 	})
 
 	t.Run("cuts on rune boundaries", func(t *testing.T) {
-		body := strings.Repeat("é", 4000) + "adoption" + strings.Repeat("é", 4000)
-		got := around(body, "adoption")
-		if strings.ContainsRune(got, '�') {
+		accents := strings.Repeat("é", 4000)
+		window, ok := windowOf(t, accents+"adoption"+accents, "adoption")
+		if !ok {
+			t.Fatal("no window for a conversation that mentions the word")
+		}
+		if strings.ContainsRune(window, '\uFFFD') {
 			t.Error("window holds a replacement character, so an edge fell inside a rune")
 		}
-		if !utf8.ValidString(got) {
+		if !utf8.ValidString(window) {
 			t.Error("window is not valid UTF-8")
+		}
+		if n := utf8.RuneCountInString(window); n != windowChars {
+			t.Errorf("window is %d characters, want the full %d", n, windowChars)
 		}
 	})
 
-	t.Run("is empty when the plain text does not hold the word", func(t *testing.T) {
+	t.Run("leaves out a conversation that does not mention the word", func(t *testing.T) {
 		// What an accent fold in the index looks like from here: the search
 		// matched "cion" against "ción", and the row keeps its place with no
 		// snippet under it.
-		if got := around("una decisión importante", "cion"); got != "" {
-			t.Errorf("around = %q, want empty", got)
+		if window, ok := windowOf(t, "una decisión importante", "cion"); ok {
+			t.Errorf("window = %q, want none", window)
 		}
 	})
+}
+
+// TestConversationWindowsBoundThePage is the cost the window exists for: the
+// rows of a page are matched on conversations of megabytes each, and what the
+// search reads out of them is the window per row and nothing more.
+func TestConversationWindowsBoundThePage(t *testing.T) {
+	const rows, size = 20, 512 * 1024
+	svc := newTestStore(t)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	parkConversations(t, svc, rows, conversationOfSize(size))
+
+	ids := make([]string, rows)
+	for i := range ids {
+		ids[i] = fmt.Sprintf("s-%d", i)
+	}
+	windows := svc.conversationWindows(ids, "session")
+
+	if len(windows) != rows {
+		t.Fatalf("windowed %d of %d conversations", len(windows), rows)
+	}
+	read := 0
+	for _, window := range windows {
+		read += len(window)
+	}
+	if want := rows * windowChars; read > want {
+		t.Errorf("page read %d bytes of %d indexed, want at most %d",
+			read, rows*size, want)
+	}
 }
 
 // TestTheCapCuttingReachesTheRow carries the flag the whole way: the reader
@@ -512,4 +580,48 @@ func ftsHits(t *testing.T, svc *Service, term string) int {
 		t.Fatalf("count index hits: %v", err)
 	}
 	return n
+}
+
+// conversationOfSize is the prose the cost measurements run on: a session that
+// talked about one thing all the way through, so the term is mentioned
+// thousands of times, which is the shape FTS5's own snippet() walks and the
+// shape the window has to cut cheaply.
+func conversationOfSize(size int) string {
+	const paragraph = "we traced the session through the worktree adoption guard " +
+		"and wrote down what the store said before parking the session again. "
+	var b strings.Builder
+	for b.Len() < size {
+		b.WriteString(paragraph)
+	}
+	return b.String()
+}
+
+// parkConversations parks n sessions holding the same conversation, which is the
+// synthetic workspace #539 measured its worst case on.
+func parkConversations(t testing.TB, svc *Service, n int, body string) {
+	t.Helper()
+	texts := make(map[string]string, n)
+	for i := range n {
+		texts[fmt.Sprintf("uuid-%d", i)] = body
+	}
+	indexed(t, svc, texts)
+	for i := range n {
+		parkWithConversation(t, svc, fmt.Sprintf("s-%d", i), "Session", fmt.Sprintf("uuid-%d", i))
+	}
+}
+
+// BenchmarkClosedSessionsSnippets is #539's synthetic worst case: two hundred
+// parked sessions of 434 KB with a term matching every one of them, answered as
+// one page of a hundred rows carrying a snippet each. What it measures is what
+// the page reads, which the allocation per search says better than the clock.
+func BenchmarkClosedSessionsSnippets(b *testing.B) {
+	svc := newTestStore(b)
+	_ = svc.AddProject("p1", "alpha", "/tmp/alpha")
+	parkConversations(b, svc, 200, conversationOfSize(434*1024))
+
+	for b.Loop() {
+		if _, err := svc.ClosedSessions("session"); err != nil {
+			b.Fatalf("ClosedSessions: %v", err)
+		}
+	}
 }


### PR DESCRIPTION
A history search that matched a parked session on its conversation read that
conversation out of the store whole, up to 8 MB a row and a page of up to a
hundred rows, once per settled keystroke, so that Go could slice 4 KB out of the
middle of it. `docs/ceilings.md` named the fix in the bullet describing the
trap, and loses the bullet outright.

## What lands

**The window is cut by the query.** `conversationWindows` asks for
`substr(body, max(<first mention> - 2048, 1), 4096)` and the rows come back as
kilobytes. `instr` and `substr` both count in characters rather than bytes, so
the cut never opens or closes inside a rune, which the Go slice had to walk the
edges to guarantee.

**The plain scan first, the fold only when it misses.**
`coalesce(nullif(instr(body, ?), 0), instr(lower(body), ?))` keeps #539's fourth
performance decision inside SQL: a conversation is mostly lowercase prose and
the word is already lowercased, so the folded copy of a multi-megabyte body is
almost never made. `coalesce` really does stop at its first non-null argument
here, checked against a second argument SQLite can only fail on if it evaluates
it.

**Per-word terms window on the first word that matches, as before.** One query
per word over the rows still without a snippet, and a term is almost always one
word. A row whose conversation mentions none of them keeps its place in the list
with no snippet under it, which is the answer a hit found by the index's accent
fold already got.

**`internal/snippet` stays.** It is what centres the palette line inside the
window and collapses the whitespace a transcript is written with, and the
Messages tab cuts its own snippets with it. The window feeds it 4 KB instead of
8 MB.

## Measured

200 parked sessions, a term matching every one of them, answered as one page of
a hundred rows carrying a snippet each. Paired runs alternating the two
implementations on the same machine, median of five (434 KB) and three
(3.46 MB); the clock moves with what else the machine is doing, the allocation
does not.

| 200 sessions of | | before | after |
|---|---|---|---|
| **434 KB** | conversation the page reads | 43.4 MB | 400 KB |
| | allocated per settled search | 50.0 MB | 9.0 MB |
| | wall clock | 34 ms | 33 ms |
| **3.46 MB** | conversation the page reads | 346 MB | 400 KB |
| | allocated per settled search | 368 MB | 9.0 MB |
| | wall clock | 224 ms | 153 ms |

The bound is the point: what the page reads is now the page's own length times
the window, whatever the conversations behind it hold. `BenchmarkClosedSessionsSnippets`
is the 434 KB case, kept in the tree; the 3.46 MB one is the same benchmark with
the size changed, and it wants 692 MB of temporary database, so it is not
committed.

## Known gap

The fold in SQL is SQLite's, which is ASCII. A conversation whose only mention
of the word shouts it in accented capitals ("SESSAO" with the tilde) is a hit
with no snippet, where the Go scan's Unicode fold would have found it. It is the
same answer the index's own accent fold already gives (`decision` matches
`decision` with the accent and shows nothing under it), and the row still says
it matched on its conversation, so no new bullet: the sentence-start case,
`Sessao` with the tilde, still folds, because only the accented letter itself
is out of ASCII's reach.

## Tests

Go: the window keeping the mention and its surroundings, a mention in the first
and the last words of a conversation, a body of accented runes cut on rune
boundaries and coming back valid UTF-8 at exactly the window's length, a word
the conversation does not mention leaving the row out of the answer, and the
page of twenty conversations of 512 KB reading at most the window per row. The
snippet tests around them (a term split on punctuation, a hit found by the
index's accent fold, the cap flag) are unchanged and still pass.

Local gate green: `gofmt -l .`, `go vet ./...`, `go test ./...`, and
`go test -race -count=3 ./internal/store/`. No frontend file is touched, so the
frontend gate has nothing to answer to.