### PR TITLE
fix: end the window with the lich that opened it, so a relaunch opens one window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Relaunching after a killed lich opens one window, not two.** A lich that
+  died without closing its window (a kill, an out-of-memory, a crash) left the
+  window running, and the next launch found it: the new window was handed to
+  the old one and exited, which lich read as its own window failing to open, so
+  it opened a system browser beside it. The window now ends with the lich that
+  opened it, and the relaunch opens its own. The notice that the previous run
+  ended unexpectedly still shows, once, in that window.
 - **A session's quota gauge now follows that session's own login on macOS and
   Windows.** Which account a card spends was read from its process, and only
   Linux answered, so a session running a binary you configured lost its gauge

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ lives in the code, `docs/` and `CHANGELOG.md` — never restate any of it here.
 
 - Go 1.27, pure Go: `CGO_ENABLED=0` and a fully static binary are a constraint, not a default. The Linux
   window is a *separate* binary, `shell/` (Rust on CEF via a kurogane fork), launched with the same argv as a
-  system browser — nothing about it reaches the Go build (`docs/chromium-shell.md`).
+  system browser plus one switch of its own — nothing about it reaches the Go build (`docs/chromium-shell.md`).
 - OS-specific code is selected by build tags behind small seams, never by runtime checks — the PTY is the model
   (`internal/terminal`).
 - Service shapes are hand-owned in `frontend/src/lib/api-types.ts`: touch a Go struct's JSON tags and that mirror

--- a/build/linux/shell/README.md
+++ b/build/linux/shell/README.md
@@ -2,8 +2,10 @@
 
 `shell/` is the window lich opens on Linux: an embedded Chromium (CEF), a thin
 Rust crate over [kurogane](https://github.com/0x48piraj/kurogane). The Go
-backend launches it exactly the way it launches a system browser — same
-`internal/chromium.Args` argv — so nothing about it reaches the pure-Go build.
+backend launches it the way it launches a system browser — the same
+`internal/chromium.Args` argv, plus `--exit-on-stdin-eof` and the pipe behind
+it that ends the window with the lich that opened it — so nothing about it
+reaches the pure-Go build.
 
 ## The kurogane fork
 

--- a/docs/chromium-shell.md
+++ b/docs/chromium-shell.md
@@ -149,8 +149,12 @@ CGO) was never taken. The window is a **separate binary**, `shell/`, a Rust
 crate on [kurogane](https://github.com/0x48piraj/kurogane) (cef-rs
 underneath), and the Go binary launches it exactly the way it launches a
 system browser — the same `internal/chromium.Args` argv, `--app=<url>`,
-`--class`, `--user-data-dir`, the user's `--` switches. Nothing in the Go
-side knows which one it got; `CGO_ENABLED=0` and the static binary stand.
+`--class`, `--user-data-dir`, the user's `--` switches — plus one switch of
+its own, `--exit-on-stdin-eof`: lich holds the write end of a pipe on the
+window's stdin for as long as it lives, and the window ends on the EOF, so a
+lich killed outright takes its window with it instead of leaving an orphan
+for the next launch to be forwarded to. `CGO_ENABLED=0` and the static binary
+stand.
 The migration path really was "swap who provides the window": one new rung
 in the resolution ladder, above the desktop's default and below the pin.
 

--- a/internal/chromium/chromium.go
+++ b/internal/chromium/chromium.go
@@ -228,9 +228,29 @@ func launch(browser Result, url, dataDir, class string, extra []string, onStart 
 		}
 	}
 	argv := append(append([]string{}, browser.Prefix...), Args(url, dataDir, class, extra)...)
+	if browser.Step == stepShell {
+		argv = append(argv, exitOnStdinEOF)
+	}
 	cmd := exec.Command(browser.Path, argv...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	if browser.Step == stepShell {
+		// The bundled window's life is tied to this process by a pipe it reads
+		// for EOF: a lich that dies without closing its window (a kill, an
+		// out-of-memory, a crash) closes the write end with it, and the window
+		// goes. Left running, it was the orphan the next launch's window was
+		// forwarded to by CEF's process singleton, and that duplicate's exit 1
+		// read as the bundled window failing to open — a system browser opened
+		// beside the raised orphan. Only the write end is held here; Go marks
+		// both ends close-on-exec, so no session inherits it.
+		r, w, err := os.Pipe()
+		if err != nil {
+			return fmt.Errorf("launch %s: %w", browser.Path, err)
+		}
+		defer w.Close()
+		defer r.Close()
+		cmd.Stdin = r
+	}
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("launch %s: %w", browser.Path, err)
 	}

--- a/internal/chromium/shell.go
+++ b/internal/chromium/shell.go
@@ -7,13 +7,18 @@ import (
 
 // shellName is the window binary `task build:shell` produces out of shell/, a
 // Rust crate on CEF: lich's own Chromium, launched with the same arguments as
-// any browser on the ladder (Args), so nothing about the launch knows which
-// one it got. The executable suffix is the only thing about it Windows changes
+// any browser on the ladder (Args) plus exitOnStdinEOF, the one switch that is
+// its own. The executable suffix is the only thing about it Windows changes
 // (shell_name_windows.go).
 const shellName = "lich-shell" + shellExt
 
 // stepShell names the rung the bundled window answers on.
 const stepShell = "the bundled window"
+
+// exitOnStdinEOF is the switch that tells the bundled window to end when its
+// stdin does (shell/src/main.rs). Passed to it alone: a system browser has no
+// such switch, and lich holds no pipe to one.
+const exitOnStdinEOF = "--exit-on-stdin-eof"
 
 // shellPaths lists where the bundled window sits relative to the lich
 // executable: under shell/ beside it (a tarball, bin/ after `task build`),

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -17,6 +17,7 @@ use cef::{
     wrap_keyboard_handler,
 };
 use kurogane::{App, ClientAppBrowserDelegate};
+use std::io::Read;
 use std::os::raw::c_int;
 
 /// The title the window carries. The page title is never used for it.
@@ -39,6 +40,8 @@ struct Launch {
     url: Option<String>,
     class: Option<String>,
     profile_dir: Option<String>,
+    /// lich's own switch (internal/chromium/launch): end when stdin does.
+    exit_on_stdin_eof: bool,
     switches: Vec<(String, Option<String>)>,
 }
 
@@ -67,6 +70,7 @@ fn parse<I: IntoIterator<Item = String>>(args: I) -> Launch {
             "app" => launch.url = value,
             "class" => launch.class = value,
             "user-data-dir" => launch.profile_dir = value,
+            "exit-on-stdin-eof" => launch.exit_on_stdin_eof = true,
             // Feature lists stay in argv, where CEF reads them and unions them
             // with the features it disables itself. Pushed through kurogane
             // they would land as a plain switch write after that union and
@@ -228,7 +232,27 @@ fn main() {
             None => app.chromium_flag(name),
         };
     }
+    // Last, after the fork in sandbox_available: that one must be the only
+    // thread. Reached only from lich, whose end is what ends this window; a
+    // shell launched by hand keeps whatever stdin it was given.
+    if launch.exit_on_stdin_eof {
+        std::thread::spawn(|| {
+            wait_for_eof(std::io::stdin());
+            std::process::exit(0);
+        });
+    }
     app.run_or_exit();
+}
+
+/// Blocks until stdin ends. lich holds the write end of the pipe it hands the
+/// window for as long as it lives and never writes to it, so EOF here is lich
+/// gone — killed, crashed, out of memory — and the window it opened goes with
+/// it. Left running, the window was the orphan the next launch's window was
+/// forwarded to by CEF's process singleton; that duplicate's exit read as the
+/// window failing to open, and lich opened a system browser beside it.
+fn wait_for_eof(mut stdin: impl Read) {
+    let mut byte = [0u8; 1];
+    while matches!(stdin.read(&mut byte), Ok(1..)) {}
 }
 
 /// Whether Chromium can confine its subprocesses here, decided the way
@@ -339,6 +363,7 @@ mod tests {
             "--class=lich",
             "--no-first-run",
             "--disable-features=Translate",
+            "--exit-on-stdin-eof",
         ]));
         assert_eq!(
             launch,
@@ -346,6 +371,7 @@ mod tests {
                 url: Some("http://127.0.0.1:47821/?token=x".into()),
                 class: Some("lich".into()),
                 profile_dir: Some("/home/u/.config/lich/chromium-profile".into()),
+                exit_on_stdin_eof: true,
                 switches: vec![
                     ("profile-directory".into(), Some("Default".into())),
                     ("no-first-run".into(), None),
@@ -365,6 +391,12 @@ mod tests {
             launch.switches,
             vec![("ozone-platform".into(), Some("wayland".into()))]
         );
+    }
+
+    #[test]
+    fn returns_once_stdin_ends_whatever_was_written() {
+        wait_for_eof(std::io::Cursor::new(b"noise"));
+        wait_for_eof(std::io::empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A lich killed outright (kill, OOM, crash) left `lich-shell` running on the profile. The next launch's window was forwarded to that orphan by CEF's process singleton and exited 1 within `startupGrace`, which `run` read as the bundled window failing to open: a system browser opened beside the raised orphan — two windows for one lich, and the "previous run ended unexpectedly" notice showing in the wrong one.

`launch` now hands the bundled window a pipe on stdin whose write end only lich holds, with `--exit-on-stdin-eof`; the shell reads it for EOF and exits. One mechanism on Linux, macOS and Windows, so no per-OS parent-death signal or job object and nothing new in `docs/ceilings.md`. A shell launched by hand, without the switch, keeps whatever stdin it was given.

## Test plan

- [x] Isolated rig (own `XDG_CONFIG_HOME`, port 47899): `kill -9` on lich, relaunch. Before: orphan `lich-shell` + `/usr/lib/chromium --app=…` and "bundled window died at startup, opening a system browser instead" in the log. After: shell ends with lich, relaunch opens a single window, no fallback line.
- [x] SIGTERM on the window (the restart flow's close) still exits lich 0 and removes `runtime.json`.
- [x] `gofmt`, `go vet`, cross-compile loop (linux/darwin/windows), `go test ./...`.
- [x] `cargo fmt --check`, `cargo clippy --release --all-targets -- -D warnings`, `cargo test --release`.
- [ ] Windows and macOS e2e in CI (the duplicate-instance step) stay green.