### PR TITLE
fix: say on Windows what the worktree scripts skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was going to say — on screen, and as a desktop notification, so a session an
   agent closed while you were away still reaches you.
 
+- **A terminal entrypoint now runs the same way on every OS, and agent cards say
+  why they cannot take one.** On Windows the command was run after your
+  PowerShell `$PROFILE`, which Linux and macOS never load, so an entrypoint that
+  leaned on an alias worked on one machine and silently did nothing on the next;
+  no profile or rc file is loaded now, on any OS. And *Entrypoint…* is no longer
+  missing from an agent card's menu — it is there, greyed, saying entrypoints run
+  in terminal sessions.
+
 ### Fixed
 
 - **Relaunching after a killed lich opens one window, not two.** A lich that
@@ -95,16 +103,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subprocesses; closing that console killed the window, and lich read the death
   as a window that could not open and fell back to the system browser after a
   long wait. It is a GUI binary now, like Chrome's own.
-
-### Changed
-
-- **A terminal entrypoint now runs the same way on every OS, and agent cards say
-  why they cannot take one.** On Windows the command was run after your
-  PowerShell `$PROFILE`, which Linux and macOS never load, so an entrypoint that
-  leaned on an alias worked on one machine and silently did nothing on the next;
-  no profile or rc file is loaded now, on any OS. And *Entrypoint…* is no longer
-  missing from an agent card's menu — it is there, greyed, saying entrypoints run
-  in terminal sessions.
 
 ## [0.47.1] - 2026-09-08
 
@@ -2371,10 +2369,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Delegate types a delegation, not a question.** Picking a session in
-  "Delegate to session…" used to put `Ask the "docs" session to ` at the
+  "Delegate to session…" used to put `Ask the "docs" session to` at the
   prompt, and whatever you typed next had to bend into "to <verb>" — a
   question or pasted context read wrong, and "Ask" was not even the button's
-  word. It now types `Delegate to the "docs" session: `, and anything can
+  word. It now types `Delegate to the "docs" session:`, and anything can
   follow the colon: an order, a question, a dump of context.
 
 - **A worker's answer no longer floods the orchestrator's prompt — it is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Windows now says what it skipped instead of skipping it in silence.** Both
+  worktree scripts are sh, and a session there runs PowerShell. A fresh worktree
+  whose project ships `.lich/setup-worktree.sh` now opens with one line in the
+  card naming the setup it did not run, rather than a checkout whose
+  dependencies are quietly missing; and the Run item stays in the menu, dead
+  under the same reason, so it can no longer be mistaken for an offer the
+  project never made.
 - **A file lich had to copy now says so at the prompt, and the copy lives as
   long as its session.** A path pasted for a file the session cannot reach
   (dragged onto the terminal or chosen with the attach button) is followed by

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -14,13 +14,11 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   checkout owns, nothing binds it, and anything on the machine can take the port before the dev server starts. A
   Run card shortens that window rather than closing it — the process it starts is what binds the port, and
   whether the script even mentions the variable is the project's own business.
-- **The Run card is never started for you, and never on Windows** (`frontend/src/components/sidebar/SessionSidebar.tsx`):
-  a fresh worktree's setup script is still installing dependencies in the agent's card when the checkout appears,
-  and lich has no "setup finished" signal to hang an automatic start on — `terminal.Ready` answers a different
+- **The Run card is never started for you** (`frontend/src/components/sidebar/SessionSidebar.tsx`): a fresh
+  worktree's setup script is still installing dependencies in the agent's card when the checkout appears, and
+  lich has no "setup finished" signal to hang an automatic start on — `terminal.Ready` answers a different
   question, going false again for every turn the agent takes. So the card is one gesture, which is also what
-  keeps eight worktrees from meaning eight dev servers. On Windows the menu item is absent for the setup script's
-  reason: `.lich/run-worktree.sh` holds sh, and a session there runs PowerShell, where `$LICH_WORKTREE_PORT`
-  expands to nothing in silence.
+  keeps eight worktrees from meaning eight dev servers.
 - **The cost readout bills per `(session, transcript)`** (`internal/pricing`, `internal/terminal/usage_cost.go`): a
   conversation forked inside the PTY bills its copied history twice — lich's own resume continues the same
   transcript and is unaffected — and each sub-agent's own transcript is counted in, so one unreadable or
@@ -205,12 +203,9 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   (Git Bash, a POSIX-ish shell reached through PATH), that path still runs over a pipe, so an rc guarded the
   same way is skipped there exactly as it was everywhere before this fix, with no ConPTY wired in to close the
   gap.
-- **The worktree setup script answers to the main checkout, never the new branch, and never runs on Windows**
-  (`internal/project/setup.go`, `internal/terminal/setup.go`): improve `.lich/setup-worktree.sh` on a feature
-  branch and fresh worktrees keep running the old one until the change reaches the checkout the project points
-  at. And `.lich/setup-worktree.sh` is one file, versioned and shared by every checkout, holding sh — so a
-  Windows session skips it rather than feeding it to PowerShell, which would run the leading words of every line
-  as commands. A worktree opens there with its setup silently not done.
+- **The worktree setup script answers to the main checkout, never the new branch**
+  (`internal/project/setup.go`): improve `.lich/setup-worktree.sh` on a feature branch and fresh worktrees keep
+  running the old one until the change reaches the checkout the project points at.
 - **opencode files a fork under the parent's directory, not the new checkout's** (measured on 1.18.23): the
   copied session's `directory` column is the one the original ran in, and its `parent_id` is left empty, so
   opencode's own session list places a fork in the checkout it came from and records no lineage. lich's own

--- a/frontend/src/components/sidebar/SessionLaunchMenuItems.tsx
+++ b/frontend/src/components/sidebar/SessionLaunchMenuItems.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu"
+import { isWindows } from "@/lib/platform"
 import type { ProviderState } from "@/lib/providers-store"
 import { sandboxDefaultFor } from "@/lib/providers-store"
 import { CONFINED_MEANS } from "@/lib/sandbox-copy"
@@ -40,6 +41,35 @@ interface SessionLaunchMenuItemsProps {
   /** The checkout's Run entry. Absent when the project ships no
    * .lich/run-worktree.sh — there would be no command to run. */
   run?: RunMenuAction
+}
+
+/** Why the Run item is dead on Windows: .lich/run-worktree.sh holds sh and a
+ * session there runs PowerShell, which would take its lines as commands of its
+ * own and expand $LICH_WORKTREE_PORT to nothing. */
+export const RUN_NOT_ON_WINDOWS = "Run scripts are sh; not run on Windows."
+
+// The checkout's Run row: live where the script can run, dead under the
+// sentence naming why on Windows — SessionForkItem's idiom. The row stays
+// either way, because a user who runs a card on Linux and finds nothing on
+// Windows has no way to learn that the offer was withheld rather than missing.
+function RunMenuItem({ run }: { run: RunMenuAction }) {
+  if (isWindows) {
+    return (
+      <DropdownMenuItem disabled>
+        <Play />
+        <span className="flex flex-col items-start">
+          Run
+          <span className="text-xs">{RUN_NOT_ON_WINDOWS}</span>
+        </span>
+      </DropdownMenuItem>
+    )
+  }
+  return (
+    <DropdownMenuItem onClick={run.onSelect}>
+      <Play />
+      {run.open ? "Go to Run card" : "Run"}
+    </DropdownMenuItem>
+  )
 }
 
 interface SandboxStepProps {
@@ -150,12 +180,7 @@ export function SessionLaunchMenuItems({
           <Terminal />
           {terminalLabel}
         </DropdownMenuItem>
-        {run && (
-          <DropdownMenuItem onClick={run.onSelect}>
-            <Play />
-            {run.open ? "Go to Run card" : "Run"}
-          </DropdownMenuItem>
-        )}
+        {run && <RunMenuItem run={run} />}
         {worktree && (
           <DropdownMenuItem disabled={worktree.disabled} onClick={worktree.onSelect}>
             <GitBranch />

--- a/frontend/src/components/sidebar/SessionSidebar.tsx
+++ b/frontend/src/components/sidebar/SessionSidebar.tsx
@@ -6,7 +6,6 @@ import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import { GitPullRequestArrow, PanelLeftClose, Plus, Search } from "lucide-react"
 import { toast } from "sonner"
 import { ProjectService, Spawn, Terminal as TerminalService } from "@/lib/rpc"
-import { isWindows } from "@/lib/platform"
 import { errorText } from "@/lib/utils"
 import { closeSettings, isSettingsOpen, subscribeSettingsCard } from "@/lib/settings-card-store"
 import { closePulls, openPulls } from "@/lib/pulls-card-store"
@@ -119,12 +118,12 @@ export function SessionSidebar({ onCollapse }: SessionSidebarProps) {
   // inside lich that writes the file; edited on disk it goes stale until the
   // project is reopened, exactly as the dialog's own reading of it does.
   //
-  // Never on Windows, for the setup script's reason: the file holds sh and a
-  // session there runs PowerShell, which would take its lines as commands of
-  // its own and expand $LICH_WORKTREE_PORT to nothing.
+  // Asked on Windows too, where the item is rendered dead under its reason
+  // (SessionLaunchMenuItems): whether the row can be clicked is that menu's
+  // call, and this one only knows whether there is a command at all.
   const [runnable, setRunnable] = useState(false)
   useEffect(() => {
-    if (!path || worktreeOpen || isWindows) {
+    if (!path || worktreeOpen) {
       return
     }
     let stale = false

--- a/frontend/src/components/sidebar/worktree-run.test.tsx
+++ b/frontend/src/components/sidebar/worktree-run.test.tsx
@@ -14,8 +14,22 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { SessionLaunchMenuItems } from "./SessionLaunchMenuItems"
+import { RUN_NOT_ON_WINDOWS, SessionLaunchMenuItems } from "./SessionLaunchMenuItems"
 import { WorktreeScriptRows } from "./WorktreeScriptRows"
+
+// The OS the menu reads, behind a getter so one file can mount both sides: the
+// component reads it per render, and vi.mock replaces the module for the whole
+// file.
+const os = vi.hoisted(() => ({ windows: false }))
+
+vi.mock("@/lib/platform", () => ({
+  get isWindows() {
+    return os.windows
+  },
+  get isMac() {
+    return false
+  },
+}))
 
 const setup = vi.hoisted(() => ({
   run: "",
@@ -40,6 +54,7 @@ vi.mock("@/lib/rpc", () => ({
 }))
 
 beforeEach(() => {
+  os.windows = false
   setup.run = ""
   setup.script = ""
   setup.saved = []
@@ -144,4 +159,44 @@ test("a configured run command is shown beside the setup script", async () => {
   expect(text()).toContain(".lich/setup-worktree.sh")
   expect(text()).toContain(".lich/run-worktree.sh")
   await rows.unmount()
+})
+
+// The run script is one file, versioned and shared by every checkout, and it
+// holds sh — so on Windows the row stays and says so, rather than going missing
+// with no way to tell a withheld offer from an absent one.
+test("the Run item is dead on Windows, naming why", async () => {
+  os.windows = true
+  const clicks: number[] = []
+  const mounted = await mountBudget(menu({ open: false, onSelect: () => clicks.push(1) }))
+
+  const row = [...document.querySelectorAll('[role="menuitem"]')].find((element) =>
+    element.textContent?.startsWith("Run"),
+  ) as HTMLElement | undefined
+  if (!row) {
+    throw new Error("Run row not rendered")
+  }
+  expect(row.getAttribute("data-disabled")).not.toBeNull()
+  expect(row.textContent).toContain(RUN_NOT_ON_WINDOWS)
+
+  await mounted.act(() => {
+    row.click()
+  })
+  expect(clicks).toEqual([])
+  await mounted.unmount()
+})
+
+test("the Run item is live everywhere else, with no reason to give", async () => {
+  const clicks: number[] = []
+  const mounted = await mountBudget(menu({ open: false, onSelect: () => clicks.push(1) }))
+
+  const row = menuItem("Run")
+  if (!row) {
+    throw new Error("Run row not rendered")
+  }
+  expect(row.getAttribute("data-disabled")).toBeNull()
+  await mounted.act(() => {
+    row.click()
+  })
+  expect(clicks).toEqual([1])
+  await mounted.unmount()
 })

--- a/internal/project/setup.go
+++ b/internal/project/setup.go
@@ -11,11 +11,13 @@ import (
 // the repository rather than lich's store so both are versioned and shared like
 // the code they bootstrap; an untracked copy works too.
 //
-// setupScriptPath runs once in a new worktree's terminal before its provider
-// starts. runScriptPath is the project's own app — the command a run card opens
-// into, in a checkout that already has its dependencies.
+// SetupScriptPath runs once in a new worktree's terminal before its provider
+// starts, and is exported because a session that skips it names the file on
+// screen (internal/terminal.setupSkippedNotice). runScriptPath is the project's
+// own app — the command a run card opens into, in a checkout that already has
+// its dependencies.
 const (
-	setupScriptPath = ".lich/setup-worktree.sh"
+	SetupScriptPath = ".lich/setup-worktree.sh"
 	runScriptPath   = ".lich/run-worktree.sh"
 )
 
@@ -24,7 +26,7 @@ const (
 // worktree being created: a worktree opened on somebody else's branch (the PR
 // flow) must not execute that branch's script.
 func SetupScript(projectPath string) string {
-	return readScript(projectPath, setupScriptPath)
+	return readScript(projectPath, SetupScriptPath)
 }
 
 // RunScript returns the project's run script, or "" when the repository ships
@@ -77,7 +79,7 @@ func (s *Service) WorktreeSetup(path string) WorktreeSetup {
 // user's call. Saving an empty script removes the file instead, returning the
 // dialog to the suggestion state rather than pinning an empty setup.
 func (s *Service) SaveWorktreeSetup(path, script string) error {
-	return writeScript(path, setupScriptPath, script)
+	return writeScript(path, SetupScriptPath, script)
 }
 
 // SaveWorktreeRun writes the run script into the project checkout, the same way

--- a/internal/terminal/setup.go
+++ b/internal/terminal/setup.go
@@ -3,6 +3,7 @@ package terminal
 import (
 	"strings"
 
+	"github.com/omartelo/lich/internal/project"
 	"github.com/omartelo/lich/internal/shquote"
 )
 
@@ -15,7 +16,7 @@ import (
 // decision stays pure and testable off-Windows (wrapArgv's pattern): Windows is
 // skipped, and not for the shell's sake — a Windows session runs PowerShell now
 // (windowsShells), which wrapEntrypoint composes for. What is skipped is the
-// script: setupScriptPath is `.lich/setup-worktree.sh`, one file, versioned in
+// script: project.SetupScriptPath is `.lich/setup-worktree.sh`, one file, versioned in
 // the repository and shared by everyone who checks it out, and its contents are
 // sh. Running that through PowerShell would not fail cleanly — it would run the
 // leading words of every line as commands.
@@ -60,3 +61,27 @@ const (
 	setupDone        = "\x1b]6969;lich-setup-done\x07"
 	setupDoneEscaped = "\\033]6969;lich-setup-done\\007"
 )
+
+// setupSkippedNotice is the line a Windows session prints in its card, and ""
+// wherever there is nothing to say. It answers the silence wrapSetup used to
+// leave: the checkout opens with its dependencies not installed, and the first
+// thing that fails is the agent's own command, for a reason only this file
+// knows.
+//
+// goos is wrapSetup's seam, and the two decide from the same pair — a script
+// wrapSetup refuses is exactly a script this announces.
+//
+// It is written into the session's output (Service.spawnSession) rather than
+// composed into the spawn, because there is no exec on Windows: printing the
+// line from PowerShell would leave PowerShell between lich and the provider for
+// the life of the session, and the pid the cwd poller reads is the one lich
+// spawned.
+func setupSkippedNotice(script, goos string) string {
+	if script == "" || goos != "windows" {
+		return ""
+	}
+	// CRLF because a PTY's own newline is one: the card would otherwise keep
+	// the column the line ended in and let the provider draw from there.
+	return "[lich] setup skipped: " + project.SetupScriptPath +
+		" is sh and this session runs PowerShell.\r\n"
+}

--- a/internal/terminal/setup_test.go
+++ b/internal/terminal/setup_test.go
@@ -3,6 +3,8 @@ package terminal
 import (
 	"strings"
 	"testing"
+
+	"github.com/omartelo/lich/internal/project"
 )
 
 // TestWrapSetup proves the wrap decision table: no script or Windows leaves
@@ -74,5 +76,45 @@ func TestSetupMarkerSpellingsAgree(t *testing.T) {
 	unescaped = strings.ReplaceAll(unescaped, `\007`, "\x07")
 	if unescaped != setupDone {
 		t.Errorf("printf writes %q, the service watches for %q", unescaped, setupDone)
+	}
+}
+
+// TestSetupSkippedNotice pins the line a Windows session gets in place of the
+// setup it will not run, and the pairing that makes it honest: the script
+// wrapSetup refuses is exactly the script this announces, so neither OS can end
+// up both skipping the setup and saying nothing about it.
+func TestSetupSkippedNotice(t *testing.T) {
+	for _, tt := range []struct{ script, goos string }{
+		{"pnpm i", "linux"},
+		{"pnpm i", "darwin"},
+		{"", "windows"},
+		{"", "linux"},
+	} {
+		if got := setupSkippedNotice(tt.script, tt.goos); got != "" {
+			t.Errorf("setupSkippedNotice(%q, %q) = %q, want silence", tt.script, tt.goos, got)
+		}
+	}
+
+	got := setupSkippedNotice("pnpm i", "windows")
+	for _, want := range []string{
+		"[lich] setup skipped:",
+		project.SetupScriptPath,
+		"PowerShell",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("notice %q is missing %q", got, want)
+		}
+	}
+	// A PTY's newline: without the carriage return the provider draws from the
+	// column the notice ended in.
+	if !strings.HasSuffix(got, "\r\n") {
+		t.Errorf("notice %q does not end a PTY line", got)
+	}
+
+	for _, goos := range []string{"linux", "darwin", "windows"} {
+		_, wrapped := wrapSetup(ptySpec{bin: "claude"}, "pnpm i", goos)
+		if wrapped == (setupSkippedNotice("pnpm i", goos) != "") {
+			t.Errorf("goos %q: wrapped=%v and the notice disagree about who speaks", goos, wrapped)
+		}
 	}
 }

--- a/internal/terminal/start.go
+++ b/internal/terminal/start.go
@@ -143,8 +143,11 @@ func (s *Service) spawnSession(
 	// project's setup script first, then the entrypoint, then the shell.
 	spec = wrapEntrypoint(spec, kind, s.store.SessionEntrypoint(id), runtime.GOOS)
 	settingUp := false
+	skipped := ""
 	if setup {
-		spec, settingUp = wrapSetup(spec, project.SetupScript(s.store.ProjectPath(projectID)), runtime.GOOS)
+		script := project.SetupScript(s.store.ProjectPath(projectID))
+		spec, settingUp = wrapSetup(spec, script, runtime.GOOS)
+		skipped = setupSkippedNotice(script, runtime.GOOS)
 	}
 	// Outermost, so the setup script and the entrypoint are confined with the
 	// session they run in front of.
@@ -183,6 +186,13 @@ func (s *Service) spawnSession(
 	// Outside mu's protection by design (see Service.spawns), and stored with the
 	// registration so no report can arrive for a session whose kind is unknown.
 	s.spawns.Store(id, spawn{kind: kind, cwd: cwd})
+	// Written the way stream writes the PTY's own bytes, and before the reader
+	// that would race it: into the replay so a reload still finds the line, and
+	// through the coalescer so an attached window has it now.
+	if skipped != "" {
+		sess.replay.append([]byte(skipped))
+		sess.out.Write([]byte(skipped))
+	}
 	go s.stream(id, sess)
 	return sess, cwd, nil
 }


### PR DESCRIPTION
Closes the Windows half of two `docs/ceilings.md` bullets by putting the skip on screen.

Both `.lich/setup-worktree.sh` and `.lich/run-worktree.sh` hold sh, and a Windows session runs PowerShell. lich skipped both there in silence, so a fresh worktree opened with its dependencies not installed and nothing saying so, and the Run item was simply absent — indistinguishable from an offer the project never made.

## What changed

- **The setup banner.** A Windows session whose project ships a setup script now gets one line in its card before the agent starts: `[lich] setup skipped: .lich/setup-worktree.sh is sh and this session runs PowerShell.` It is written into the session's output (`Service.spawnSession`), the way `stream` writes the PTY's own bytes, rather than composed into the spawn — PowerShell has no `exec`, so printing it from there would leave a shell between lich and the provider for the life of the session, and the pid the cwd poller reads is the one lich spawned. `setupSkippedNotice` takes `goos` as a parameter, `wrapSetup`'s seam, and the two decide from the same pair.
- **The Run item.** Present on Windows and disabled under `Run scripts are sh; not run on Windows.`, the idiom `SessionForkItem` and `SessionEntrypointItem` set. The sidebar now reads the project's run script on every OS; whether the row can be clicked is the menu's call. `isWindows` already existed in `frontend/src/lib/platform.ts`, so no payload or `api-types.ts` change was needed.
- **`docs/ceilings.md`.** Both bullets lose their Windows sentences and are retitled to the half that remains — the setup script still answers to the main checkout, and the Run card is still never started for you.
- **`CHANGELOG.md`** `[Unreleased]` › Changed gets the user-facing line.

## Tests

- `TestSetupSkippedNotice` (`internal/terminal/setup_test.go`): the line's content, its CRLF, and the pairing that makes it honest — a script `wrapSetup` refuses is exactly a script the notice announces, asserted across all three GOOS values, so no OS can end up both skipping the setup and saying nothing.
- `worktree-run.test.tsx`: the Run row mounted for real on both sides — disabled with its reason and swallowing the click on Windows, live and firing `onSelect` elsewhere. `@/lib/platform` is mocked behind getters so one file covers both.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean
- [x] `go test ./...` green
- [x] cross-compile loop green for linux, darwin, windows
- [x] `biome ci .` exit 0 (17 standing warnings, unchanged)
- [x] `pnpm test` green (145 files, 1707 tests)
- [x] `pnpm build` succeeds
- [ ] Windows os-tests job green on CI