### PR TITLE
fix: name a Kiro card from the title Kiro files itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was going to say — on screen, and as a desktop notification, so a session an
   agent closed while you were away still reaches you.
 
+- **A terminal entrypoint now runs the same way on every OS, and agent cards say
+  why they cannot take one.** On Windows the command was run after your
+  PowerShell `$PROFILE`, which Linux and macOS never load, so an entrypoint that
+  leaned on an alias worked on one machine and silently did nothing on the next;
+  no profile or rc file is loaded now, on any OS. And *Entrypoint…* is no longer
+  missing from an agent card's menu — it is there, greyed, saying entrypoints run
+  in terminal sessions.
+
 ### Fixed
 
 - **Relaunching after a killed lich opens one window, not two.** A lich that
@@ -95,16 +103,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subprocesses; closing that console killed the window, and lich read the death
   as a window that could not open and fell back to the system browser after a
   long wait. It is a GUI binary now, like Chrome's own.
-
-### Changed
-
-- **A terminal entrypoint now runs the same way on every OS, and agent cards say
-  why they cannot take one.** On Windows the command was run after your
-  PowerShell `$PROFILE`, which Linux and macOS never load, so an entrypoint that
-  leaned on an alias worked on one machine and silently did nothing on the next;
-  no profile or rc file is loaded now, on any OS. And *Entrypoint…* is no longer
-  missing from an agent card's menu — it is there, greyed, saying entrypoints run
-  in terminal sessions.
 
 ## [0.47.1] - 2026-09-08
 
@@ -2371,10 +2369,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Delegate types a delegation, not a question.** Picking a session in
-  "Delegate to session…" used to put `Ask the "docs" session to ` at the
+  "Delegate to session…" used to put `Ask the "docs" session to` at the
   prompt, and whatever you typed next had to bend into "to <verb>" — a
   question or pasted context read wrong, and "Ask" was not even the button's
-  word. It now types `Delegate to the "docs" session: `, and anything can
+  word. It now types `Delegate to the "docs" session:`, and anything can
   follow the colon: an order, a question, a dump of context.
 
 - **A worker's answer no longer floods the orchestrator's prompt — it is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A Kiro session now names its own card.** Kiro hands its hooks no transcript
+  to read a title from, so a Kiro card kept the name lich gave it (`Session 3`)
+  however long the conversation ran. lich now reads the title Kiro writes for
+  itself and applies it when the turn ends, like every other provider's. A
+  session you renamed keeps your name, as before.
 - **Relaunching after a killed lich opens one window, not two.** A lich that
   died without closing its window (a kill, an out-of-memory, a crash) left the
   window running, and the next launch found it: the new window was handed to

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -324,13 +324,11 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   the one thing a user who ticked the box does not expect. Kiro's own `chat.disableTrustAllConfirmation` setting
   turns it off for good, and lich does not write it — that setting disables a safety confirmation for every Kiro
   on the machine, including the ones lich never spawned.
-- **A Kiro session never reports `waiting`, `idle`, or a title** (`docs/hooks/`): its five events are
+- **A Kiro session never reports `waiting` or `idle`** (`docs/hooks/`): its five events are
   `agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse` and `stop`, so lich closes session-start,
   session-state's busy/tool/done rows and session-touched, and nothing else. A Kiro session sitting on a
   permission prompt reads as `busy` — true, but it does not say what it is waiting for — and the card keeps the
-  provider's mark until the PTY itself goes, because there is no session-end event to clear it. The title report
-  needs a transcript path off the hook payload, which Kiro passes on none of the five; it does write a `title`
-  into its session metadata, so closing that gap later means lich reading the file rather than another hook.
+  provider's mark until the PTY itself goes, because there is no session-end event to clear it.
 - **A Cursor CLI session reports through Claude Code's plugin, or not at all** (`internal/agentplugin`,
   `internal/terminal/start.go`, `providerKind`): lich installs no plugin into Cursor, and it does not have to —
   the CLI executes every Claude Code hook on the machine, the user's own and each installed plugin's (measured on

--- a/docs/hooks/session-title.md
+++ b/docs/hooks/session-title.md
@@ -30,15 +30,21 @@ Both sides test against the payloads in
 
 | Claude Code hook          | Codex hook                | Antigravity hook          | opencode event    | oh-my-pi event                | Crush hook | Cursor CLI hook | Kiro CLI hook | action                                           |
 |---------------------------|---------------------------|---------------------------|-------------------|-------------------------------|------------|-----------------|---------------|--------------------------------------------------|
-| `PostToolUse` + `Stop`    | `PostToolUse` + `Stop`    | `PreInvocation` + `Stop`  | `session.updated` | `session_stop` + `turn_start` | —          | —               | —             | set the session label to `title` (if still auto) |
+| `PostToolUse` + `Stop`    | `PostToolUse` + `Stop`    | `PreInvocation` + `Stop`  | `session.updated` | `session_stop` + `turn_start` | —          | —               | `stop`†        | set the session label to `title` (if still auto) |
 
-**Kiro registers no title report**, and the reason is not that it has no title:
-it writes one into its session metadata (`title`, derived from the first
-prompt). The report is a *script that reads a transcript path off the hook's own
-stdin*, and Kiro passes no path on any of its five events — its payloads carry
-`cwd`, `session_id` and the event's own fields and nothing else (measured on
-2.21.0). Closing it would mean lich resolving that file itself, which is a
-different mechanism from this contract rather than another column in it.
+† **Kiro registers no title report, and lich reads its title instead.** The
+report is a *script that reads a transcript path off the hook's own stdin*, and
+Kiro passes no path on any of its five events: its payloads carry `cwd`,
+`session_id` and the event's own fields and nothing else (measured on 2.21.0).
+But it does write a `title`, derived from the first prompt, into its session
+metadata, so lich resolves that file itself: on the `stop` report a Kiro session
+does send (the `done` row of [session-state.md](session-state.md)), it reads
+`title` out of `~/.kiro/sessions/cli/<session_id>.json`, the same file the
+context readout is taken from, and applies it through the guarded write below
+(`internal/terminal/title_kiro.go`). A missing file, one caught mid-write and a
+metadata carrying no title are all silence: the card keeps the name lich gave
+it. No hook client is involved, which is why the column is marked rather than
+filled: nothing is POSTed to this endpoint from a Kiro session.
 
 The `ai-title` is an internal Haiku summary of the first prompt. It does not
 exist at `SessionStart`, but it lands long before the turn it belongs to ends:
@@ -137,6 +143,9 @@ being debugged.
   `UPDATE sessions SET label = ? WHERE id = ? AND label_auto = 1`. A user
   `RenameSession` clears `label_auto`, so a manual name is never stomped.
   Returns whether the label actually changed.
+- **Kiro's own read**: `internal/terminal/title_kiro.go`, `Service.kiroTitle`,
+  the one title lich reads rather than receives (see the footnote above), taken
+  off the `done` report and handed to the same guarded write.
 - **Live update** — `internal/terminal/terminal.go`: when the label changed,
   emits the global app event `session-title` (`{id, label}`);
   `frontend/src/providers/projects.tsx` mirrors it into session state so the card
@@ -157,6 +166,13 @@ being debugged.
   was `1+1 is?` keeps the name lich gave it, correctly, since the prompt would
   fit on the card anyway. Absence there is the CLI's behaviour, not a broken
   hook, and it is the first thing to rule out before debugging one.
+- **A Kiro card is named at the turn's end, never during it.** Every other
+  harness reports in-turn, which is what stops a ten-minute first turn showing
+  `Session 3` for all ten minutes; Kiro's title is read off the `stop` report,
+  because reading it on each `busy` would cost a file read per tool call to
+  learn the same name. So a Kiro card wears the name lich gave it for the whole
+  of its first turn, where the other harnesses rename it seconds in, and a first
+  turn that never reaches a `stop` never renames it at all.
 - **Reacts to the first prompt, not later pivots reliably.** Claude Code may or
   may not refresh the `ai-title` mid-session; lich applies whatever the hook
   last sent while the label is still auto.

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -463,6 +463,13 @@ func (s *Service) onHookState(req hookRequest) {
 	if req.State != statusIdle {
 		go s.emitUsage(req.SessionID)
 	}
+	// A Kiro session's name is read here rather than reported, because Kiro
+	// hands its hooks no transcript path to read one from while it does file
+	// a title of its own (title_kiro.go). `done` is the turn end it raises,
+	// and the read is off-thread for the same reason the usage one is.
+	if req.State == statusDone {
+		go s.applyKiroTitle(req.SessionID)
+	}
 }
 
 // noteUnread persists whether this session's card is holding a finished turn

--- a/internal/terminal/title_kiro.go
+++ b/internal/terminal/title_kiro.go
@@ -1,0 +1,70 @@
+package terminal
+
+import (
+	"encoding/json"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// The Kiro CLI side of the session title, and the one provider lich reads a
+// title for itself. The report every other harness sends is a hook script
+// reading a transcript path off its own stdin, and Kiro passes one on none of
+// its five events (docs/hooks/session-title.md). It does file a `title`,
+// derived from the first prompt, into the session metadata transcript.go
+// resolves (kiroSessionPath): the same `.json` the context readout is read
+// from. So the turn's end is where lich goes and reads it.
+
+// kiroMetadataTitle reads the title Kiro filed for one conversation. ok is
+// false for every absence (no file yet, a file caught mid-write, metadata
+// carrying no title), because a session whose name lich cannot read keeps the
+// name lich gave it, which is silence rather than a failure.
+func kiroMetadataTitle(path string) (string, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	var meta struct {
+		Title string `json:"title"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return "", false
+	}
+	// Trimmed like the reported one is (parseSessionTitle), so both doors
+	// apply the same string.
+	title := strings.TrimSpace(meta.Title)
+	return title, title != ""
+}
+
+// kiroTitle resolves the title Kiro filed for the conversation running in
+// session id. ok is false when the session runs something else, when no
+// conversation is linked to it yet, and on every absence above.
+func (s *Service) kiroTitle(id string) (string, bool) {
+	if s.kindOf(id) != providers.Kiro {
+		return "", false
+	}
+	providerSessionID, err := s.store.ProviderSession(id)
+	if err != nil || providerSessionID == "" {
+		return "", false
+	}
+	path, ok := kiroSessionPath(providerSessionID)
+	if !ok {
+		return "", false
+	}
+	return kiroMetadataTitle(path)
+}
+
+// applyKiroTitle publishes that title down the same path a reported one takes
+// (onTitle): the store's guarded write, which leaves a session the user renamed
+// alone, and the event the card redraws on.
+func (s *Service) applyKiroTitle(id string) {
+	title, ok := s.kiroTitle(id)
+	if !ok {
+		return
+	}
+	if err := s.onTitle(id, title); err != nil {
+		slog.Warn("terminal: apply kiro title", "session", id, "err", err)
+	}
+}

--- a/internal/terminal/title_kiro_test.go
+++ b/internal/terminal/title_kiro_test.go
@@ -1,0 +1,54 @@
+package terminal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestKiroMetadataTitle proves the name is taken from the `title` Kiro files
+// beside the rest of a conversation's metadata, and that every way it can be
+// absent reads as silence (a card keeping the name lich gave it) rather than as
+// a title of "".
+func TestKiroMetadataTitle(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			"the title Kiro derived from the first prompt",
+			`{"session_id":"s1","cwd":"/w","title":"Fix the flaky PTY test","session_state":{}}`,
+			"Fix the flaky PTY test",
+		},
+		{"metadata written before the title", `{"session_id":"s1","cwd":"/w"}`, ""},
+		{"a title Kiro filed empty", `{"title":""}`, ""},
+		{"a title that is only spaces", `{"title":"   "}`, ""},
+		{"surrounding space is trimmed", `{"title":"  Name it  "}`, "Name it"},
+		// The file is written by another process, so a read can land mid-write.
+		{"caught half-written", `{"session_id":"s1","tit`, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "session.json")
+			if err := os.WriteFile(path, []byte(tt.body), 0o600); err != nil {
+				t.Fatalf("write session file: %v", err)
+			}
+			got, ok := kiroMetadataTitle(path)
+			if ok != (tt.want != "") {
+				t.Fatalf("kiroMetadataTitle = %q, %v, want ok=%v", got, ok, tt.want != "")
+			}
+			if got != tt.want {
+				t.Errorf("kiroMetadataTitle = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// A conversation whose metadata file is not there yet, or was pruned, is the
+// common absence, and it must not reach the card as an error.
+func TestKiroMetadataTitleAbsentFile(t *testing.T) {
+	if got, ok := kiroMetadataTitle(filepath.Join(t.TempDir(), "absent.json")); ok {
+		t.Errorf("kiroMetadataTitle(absent) = %q, true, want a miss", got)
+	}
+}

--- a/internal/terminal/title_kiro_wiring_test.go
+++ b/internal/terminal/title_kiro_wiring_test.go
@@ -1,0 +1,119 @@
+// These cover the read wired into the Service, which needs the suite's Store
+// stub, and that stub lives in terminal_test.go, which is Unix-only for its
+// real PTY spawns. Nothing here spawns anything; the tag is the stub's, not
+// this file's. The read's own logic is in title_kiro_test.go and runs on every
+// OS.
+//go:build !windows
+
+package terminal
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/omartelo/lich/internal/events"
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// titleStore records what reached the guarded write, which is the last thing
+// lich does with a title before the card redraws.
+type titleStore struct {
+	stubBins
+	titles chan string
+}
+
+func (s *titleStore) SetSessionTitle(_, title string) (bool, error) {
+	s.titles <- title
+	return true, nil
+}
+
+// plantKiroSession writes one conversation's metadata where kiroSessionPath
+// looks for it, under a throwaway home.
+func plantKiroSession(t *testing.T, providerSessionID, body string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	dir := filepath.Join(home, ".kiro", "sessions", "cli")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, providerSessionID+".json"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestKiroTitlePublishedOnStop is the whole feature: Kiro reports no title, so
+// the turn's end is where lich reads the one Kiro filed itself and sends it
+// down the same path a reported title takes.
+func TestKiroTitlePublishedOnStop(t *testing.T) {
+	const id = "kiro-uuid"
+	plantKiroSession(t, id, `{"session_id":"`+id+`","title":"Port the PTY seam to Windows"}`)
+	store := &titleStore{stubBins: stubBins{providerSession: id}, titles: make(chan string, 1)}
+	svc := New(store, nil, events.New())
+	svc.spawns.Store("s1", spawn{kind: providers.Kiro})
+
+	svc.onHookState(hookRequest{SessionID: "s1", State: statusDone})
+
+	select {
+	case got := <-store.titles:
+		if got != "Port the PTY seam to Windows" {
+			t.Errorf("title = %q, want %q", got, "Port the PTY seam to Windows")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the turn ended and no title reached the store")
+	}
+}
+
+// A tool call is not the turn's end. Kiro reports `busy` once per tool, and
+// reading the metadata on each of them would buy a name lich already has at
+// the cost of a file read per tool call.
+func TestKiroTitleNotReadMidTurn(t *testing.T) {
+	const id = "kiro-uuid"
+	plantKiroSession(t, id, `{"session_id":"`+id+`","title":"Port the PTY seam to Windows"}`)
+	store := &titleStore{stubBins: stubBins{providerSession: id}, titles: make(chan string, 1)}
+	svc := New(store, nil, events.New())
+	svc.spawns.Store("s1", spawn{kind: providers.Kiro})
+
+	svc.onHookState(hookRequest{SessionID: "s1", State: statusBusy})
+
+	select {
+	case got := <-store.titles:
+		t.Errorf("a mid-turn report titled the card %q", got)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+// The resolution every other session must miss on: the file is Kiro's, and a
+// session with no conversation linked to it yet has no file to name.
+func TestKiroTitleResolution(t *testing.T) {
+	const id = "kiro-uuid"
+	plantKiroSession(t, id, `{"session_id":"`+id+`","title":"Port the PTY seam to Windows"}`)
+	tests := []struct {
+		name            string
+		kind            string
+		providerSession string
+		want            string
+	}{
+		{"a Kiro session naming its conversation", providers.Kiro, id, "Port the PTY seam to Windows"},
+		{"another provider's session", providers.Claude, id, ""},
+		{"a shell", KindShell, id, ""},
+		{"before session-start linked a conversation", providers.Kiro, "", ""},
+		{"a conversation whose file was pruned", providers.Kiro, "gone-uuid", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := New(stubBins{providerSession: tt.providerSession}, nil, events.New())
+			svc.spawns.Store("s1", spawn{kind: tt.kind})
+			got, ok := svc.kiroTitle("s1")
+			if ok != (tt.want != "") {
+				t.Fatalf("kiroTitle = %q, %v, want ok=%v", got, ok, tt.want != "")
+			}
+			if got != tt.want {
+				t.Errorf("kiroTitle = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

A Kiro session never auto-titled its card: it kept `Session 3` for the whole conversation. Kiro registers no title report because the report is a hook script that reads a transcript path off its own stdin, and Kiro passes one on none of its five events. It does write a `title`, derived from the first prompt, into its session metadata, so lich reads that file rather than waiting for another hook.

## How

- `internal/terminal/title_kiro.go`: `kiroMetadataTitle` reads `title` out of the session metadata file, and `Service.kiroTitle` resolves that file through the same `kiroSessionPath` the context readout uses (so it honours the same `~/.kiro` resolution). `applyKiroTitle` publishes it through `onTitle`, the same guarded write and `session-title` event a reported title takes, so a session the user renamed keeps its name.
- `internal/terminal/terminal.go`: the read runs off the `done` report, which is the turn end Kiro does raise, and off-thread like the usage read beside it. Not on `busy`: that fires once per tool call and would cost a file read each time to learn the same name.
- A missing file, one caught mid-write and a metadata carrying no title are all silence, never an error.

## Docs

- `docs/ceilings.md`: the bullet is now "A Kiro session never reports `waiting` or `idle`"; the title sentences are gone.
- `docs/hooks/session-title.md`: the Kiro column is marked `stop` with a footnote explaining that no hook client is involved, plus a server-side bullet and a new known ceiling (a Kiro card is named at the turn's end, never during it).
- `CHANGELOG.md` `[Unreleased]` > Fixed: one user-facing line.

## Test plan

- [x] `gofmt -l .` clean, `go vet ./...` clean (with a `frontend/dist` placeholder, which the embed needs and the build artifact is gitignored).
- [x] `go test ./...` green; `go test -race ./internal/terminal -run Kiro -count=3` green.
- [x] Cross-compile loop green for linux, darwin and windows (build + vet).
- [x] New tests: the read (present, absent, malformed, empty and whitespace-only title), the resolution (another provider, a shell, no conversation linked, a pruned file), and the publish on `stop` (with a proof it does not fire mid-turn). The publish test fails without the wiring.