### PR TITLE
feat: self-update windowed Windows installs through the installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,3 +165,9 @@ jobs:
 
       - name: Backend tests
         run: bash .github/scripts/go-test-summary.sh ${{ matrix.os }}
+
+      - name: Windows installer self-update end to end
+        if: runner.os == 'Windows'
+        env:
+          CGO_ENABLED: "0"
+        run: go test -tags installer_e2e -run '^TestWindowsInstallerE2E$' -v -timeout 10m ./internal/appupdate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was going to say — on screen, and as a desktop notification, so a session an
   agent closed while you were away still reaches you.
 
+- **A terminal entrypoint now runs the same way on every OS, and agent cards say
+  why they cannot take one.** On Windows the command was run after your
+  PowerShell `$PROFILE`, which Linux and macOS never load, so an entrypoint that
+  leaned on an alias worked on one machine and silently did nothing on the next;
+  no profile or rc file is loaded now, on any OS. And *Entrypoint…* is no longer
+  missing from an agent card's menu — it is there, greyed, saying entrypoints run
+  in terminal sessions.
+
 ### Fixed
 
 - **Relaunching after a killed lich opens one window, not two.** A lich that
@@ -95,16 +103,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subprocesses; closing that console killed the window, and lich read the death
   as a window that could not open and fell back to the system browser after a
   long wait. It is a GUI binary now, like Chrome's own.
-
-### Changed
-
-- **A terminal entrypoint now runs the same way on every OS, and agent cards say
-  why they cannot take one.** On Windows the command was run after your
-  PowerShell `$PROFILE`, which Linux and macOS never load, so an entrypoint that
-  leaned on an alias worked on one machine and silently did nothing on the next;
-  no profile or rc file is loaded now, on any OS. And *Entrypoint…* is no longer
-  missing from an agent card's menu — it is there, greyed, saying entrypoints run
-  in terminal sessions.
 
 ## [0.47.1] - 2026-09-08
 
@@ -2371,10 +2369,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Delegate types a delegation, not a question.** Picking a session in
-  "Delegate to session…" used to put `Ask the "docs" session to ` at the
+  "Delegate to session…" used to put `Ask the "docs" session to` at the
   prompt, and whatever you typed next had to bend into "to <verb>" — a
   question or pasted context read wrong, and "Ask" was not even the button's
-  word. It now types `Delegate to the "docs" session: `, and anything can
+  word. It now types `Delegate to the "docs" session:`, and anything can
   follow the colon: an order, a question, a dump of context.
 
 - **A worker's answer no longer floods the orchestrator's prompt — it is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Windows installs with the bundled window now update lich and Chromium together through the installer and reopen automatically.
+
 - **Relaunching after a killed lich opens one window, not two.** A lich that
   died without closing its window (a kill, an out-of-memory, a crash) left the
   window running, and the next launch found it: the new window was handed to

--- a/build/windows/lich.iss
+++ b/build/windows/lich.iss
@@ -35,6 +35,9 @@ UninstallDisplayIcon={app}\{#AppExe}
 WizardStyle=modern
 Compression=lzma2
 SolidCompression=yes
+CloseApplications=yes
+CloseApplicationsFilter=*
+RestartApplications=no
 
 [Files]
 Source: "..\..\bin\{#AppExe}"; DestDir: "{app}"; Flags: ignoreversion
@@ -50,3 +53,50 @@ Name: "{autoprograms}\{#AppName}"; Filename: "{app}\{#AppExe}"; AppUserModelID: 
 
 [Run]
 Filename: "{app}\{#AppExe}"; Description: "Launch {#AppName}"; Flags: nowait postinstall skipifsilent
+; Explicit update mode inherits lich's pinned port and restart marker. Ordinary
+; silent installs still do not launch an application on the user's desktop.
+Filename: "{app}\{#AppExe}"; Flags: nowait runascurrentuser; Check: IsUpdate
+
+[Code]
+const
+  SynchronizeAccess = $00100000;
+  WaitObject0 = 0;
+  ShutdownTimeout = 60000;
+
+function OpenProcess(Access: LongWord; Inherit: Boolean; PID: LongWord): THandle;
+  external 'OpenProcess@kernel32.dll stdcall';
+function WaitForSingleObject(Handle: THandle; Milliseconds: LongWord): LongWord;
+  external 'WaitForSingleObject@kernel32.dll stdcall';
+function CloseHandle(Handle: THandle): Boolean;
+  external 'CloseHandle@kernel32.dll stdcall';
+
+function IsUpdate: Boolean;
+begin
+  Result := ExpandConstant('{param:UPDATEPID|0}') <> '0';
+end;
+
+function InitializeSetup: Boolean;
+var
+  Process: THandle;
+  PID: Integer;
+begin
+  Result := True;
+  if not IsUpdate then Exit;
+  PID := StrToIntDef(ExpandConstant('{param:UPDATEPID|0}'), 0);
+  if PID <= 0 then begin
+    Result := False;
+    Exit;
+  end;
+  { lich closes its window and flushes its database before releasing its exe.
+    Restart Manager then handles any remaining Chromium file holders. }
+  Process := OpenProcess(SynchronizeAccess, False, PID);
+  if Process <> 0 then begin
+    Result := WaitForSingleObject(Process, ShutdownTimeout) = WaitObject0;
+    CloseHandle(Process);
+  end else
+    Result := DLLGetLastError = 87; { ERROR_INVALID_PARAMETER: already exited }
+  if Result then
+    Log('lich update: outgoing process exited before file replacement')
+  else
+    MsgBox('lich did not exit. Close lich and run the update again.', mbError, MB_OK);
+end;

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -648,11 +648,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   icon and AppUserModelID grouping on Windows, the Dock tile, Cmd-Tab and menu bar name on macOS, and the
   graceful close on restart on both are designed, not seen; what the macOS runner did measure is that the
   subprocesses hold no Dock tile of their own and the page renders (`release.yml`, the `mac` job).
-- **A Windows install with the window beside it does not self-update** (`internal/appupdate.windowed`):
-  the self-apply asset is the bare exe, and swapping it under a `shell\` directory would leave a third of
-  a gigabyte of Chromium at the installer's version. The update button sends that install to the release
-  page for the installer instead; the portable exe with no `shell\` beside it keeps self-applying, and
-  keeps opening a system browser.
 - **A Linux install whose window is missing or dies at startup opens a system browser instead**
   (`internal/chromium.Run`): `go run`, a bare binary copied out of the tarball, a package missing
   `lib/lich/shell` — each falls through to the ladder below with one `Warn` line; a window that exits with
@@ -686,10 +681,7 @@ work when nobody knows it and that the call site never shows. The mechanism and 
 - **Without a Chromium `--app` window there is no window lifecycle** (`main.go`, `openWithoutWindow`) —
   reached with no Chromium-family browser installed, or on purpose with `--no-window`/`LICH_NO_WINDOW`. lich
   opens a plain tab and then runs until it is signalled, because a tab it did not spawn cannot be waited on.
-  Closing the tab leaves lich serving, and `/restart` — which frees the pinned port by terminating "the
-  window" — is handed this process instead. On Windows that terminate is a `taskkill` WM_CLOSE against a
-  process that has no window, so an in-place update leaves the successor racing a port that never frees:
-  a `--no-window` launch now buys that trap on a machine that could have had a window.
+  Closing the tab leaves lich serving.
 - **The tab fallback cannot tell "opened" from "nothing happened"** (`internal/system.OpenURL`): `xdg-open`,
   `open` and `rundll32` are started and never waited on — waiting would block for the life of the browser they
   hand off to. A desktop with a URL handler installed but no browser behind it therefore looks like success:

--- a/docs/chromium-shell.md
+++ b/docs/chromium-shell.md
@@ -175,7 +175,16 @@ through CEF itself). The patch is upstream as
 
 Windows ships the same window, flat beside `lich.exe` as `shell\` the way
 CEF lays itself out there, inside the installer (`build/windows/lich.iss`)
-and as a zip beside the portable exe. Two things the Linux window gets from
+and as a zip beside the portable exe. The update button downloads the release's
+installer when this window is present, checks its SHA-256 against the release
+checksums, and runs it silently after closing lich. The per-user installer updates
+the same directory without elevation and reopens lich on its previous port. A
+failed installation shows its error; `.lich-update-setup.log` beside `lich.exe`
+records the install. The last downloaded installer is retained there as
+`.lich-update-setup.exe` for retry and replaced on the next update. The portable
+exe without `shell\lich-shell.exe` still swaps only itself and offers Restart.
+
+Two things the Linux window gets from
 its WM_CLASS come from elsewhere on Windows: the executable carries lich's
 icon and manifest as resources (`shell/build.rs`), and the process claims the
 AppUserModelID the Start Menu shortcut declares, which is what makes the

--- a/internal/appupdate/appupdate.go
+++ b/internal/appupdate/appupdate.go
@@ -16,6 +16,7 @@ import (
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/minio/selfupdate"
@@ -61,6 +62,9 @@ const (
 // Service reports lich's own update state and applies self-updates where the
 // binary is writable.
 type Service struct {
+	mu      sync.Mutex
+	install func(string) error
+
 	http *http.Client
 	// download carries the release-asset GET; separate from http so the short
 	// metadata timeout never applies to the body. Nil falls back to http
@@ -89,9 +93,10 @@ type Service struct {
 
 // New returns a service that reports version as the running build and polls
 // GitHub for the latest release.
-func New(version string) *Service {
+func New(version string, install func(string) error) *Service {
 	exe, _ := os.Executable() // "" if unresolved — canSelfApply then stays false.
 	return &Service{
+		install:       install,
 		http:          &http.Client{Timeout: httpTimeout},
 		download:      &http.Client{Timeout: downloadTimeout},
 		version:       version,
@@ -143,10 +148,12 @@ func (s *Service) Status() Status {
 	return st
 }
 
-// Apply downloads the latest release binary for this platform, verifies its
-// SHA-256 against the release checksums, and atomically swaps it over the
-// running executable. Only valid where CanSelfApply is true.
+// Apply verifies the latest release against its SHA-256 checksum, then swaps
+// the portable executable or hands a windowed Windows install to its installer.
+// The installer closes and relaunches lich. Only valid where CanSelfApply is true.
 func (s *Service) Apply() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if !canSelfApply(s.goos, s.exePath) {
 		return fmt.Errorf("self-apply not supported on this install")
 	}
@@ -154,7 +161,7 @@ func (s *Service) Apply() error {
 	if latest == "" {
 		return fmt.Errorf("could not resolve the latest release")
 	}
-	asset := assetName(s.goos, s.goarch, latest)
+	asset := s.assetName(latest)
 	if asset == "" {
 		return fmt.Errorf("no release asset for %s/%s", s.goos, s.goarch)
 	}
@@ -171,6 +178,9 @@ func (s *Service) Apply() error {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("download %s: status %d", asset, resp.StatusCode)
+	}
+	if s.installerUpdate() {
+		return s.applyInstaller(resp.Body, sum)
 	}
 	if err := s.applyBinary(io.LimitReader(resp.Body, assetLimit), sum); err != nil {
 		return fmt.Errorf("apply update: %w", err)
@@ -207,17 +217,13 @@ func canSelfApply(goos, exePath string) bool {
 	if exePath == "" {
 		return false
 	}
-	if brewOwned(exePath) || bundled(exePath) || windowed(exePath) {
+	if brewOwned(exePath) || bundled(exePath) {
 		return false
 	}
 	return dirWritable(filepath.Dir(exePath))
 }
 
-// windowed reports whether exePath has lich's own window installed beside it,
-// the Windows installer's layout (build/windows/lich.iss). The self-apply
-// asset is the bare exe, so swapping it would leave the window, a third of a
-// gigabyte of Chromium, at the version the installer put there; that install
-// updates through the installer.
+// windowed recognizes the Windows installer layout.
 func windowed(exePath string) bool {
 	_, err := os.Stat(filepath.Join(filepath.Dir(exePath), "shell", "lich-shell.exe"))
 	return err == nil

--- a/internal/appupdate/appupdate_test.go
+++ b/internal/appupdate/appupdate_test.go
@@ -68,7 +68,7 @@ func TestCanSelfApply(t *testing.T) {
 		{"unwritable dir", "darwin", filepath.Join("/nonexistent-abc123", "lich"), false},
 		{"homebrew cellar is brew's", "darwin", cellarExe(t), false},
 		{"app bundle keeps its signature", "darwin", bundleExe(t), false},
-		{"installer layout carries the window", "windows", windowedExe(t), false},
+		{"installer layout carries the window", "windows", windowedExe(t), true},
 	}
 	for _, tc := range tests {
 		if got := canSelfApply(tc.goos, tc.exePath); got != tc.want {
@@ -266,7 +266,7 @@ func TestInstallCommand(t *testing.T) {
 }
 
 func TestApplyRejectedWhenNotSelfApply(t *testing.T) {
-	s := New("0.7.0")
+	s := New("0.7.0", nil)
 	s.exePath = "" // forces canSelfApply false regardless of platform
 	if err := s.Apply(); err == nil {
 		t.Fatal("Apply() = nil, want an error when self-apply is unsupported")
@@ -433,7 +433,7 @@ func TestFetchChecksum(t *testing.T) {
 }
 
 func TestNewResolvesExe(t *testing.T) {
-	s := New("0.7.0")
+	s := New("0.7.0", nil)
 	if s.version != "0.7.0" {
 		t.Fatalf("version = %q", s.version)
 	}

--- a/internal/appupdate/installer.go
+++ b/internal/appupdate/installer.go
@@ -1,0 +1,60 @@
+package appupdate
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// The installer includes Chromium, several hundred MiB larger than the exe.
+const installerLimit = 1 << 30
+
+func (s *Service) installerUpdate() bool {
+	return s.goos == "windows" && windowed(s.exePath)
+}
+
+func (s *Service) assetName(version string) string {
+	if s.installerUpdate() && s.goarch == "amd64" {
+		return "lich-v" + version + "-windows-amd64-setup.exe"
+	}
+	return assetName(s.goos, s.goarch, version)
+}
+
+func (s *Service) applyInstaller(r io.Reader, checksum []byte) error {
+	if s.install == nil {
+		return fmt.Errorf("installer updates unavailable")
+	}
+	// One retained installer, replaced on the next update; no growing cache of CEF.
+	path := filepath.Join(filepath.Dir(s.exePath), ".lich-update-setup.exe")
+	if err := stageInstaller(r, checksum, path); err != nil {
+		return fmt.Errorf("verify installer: %w", err)
+	}
+	return s.install(path)
+}
+
+func stageInstaller(r io.Reader, checksum []byte, path string) error {
+	f, err := os.CreateTemp(filepath.Dir(path), ".lich-download-*.exe")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	hash := sha256.New()
+	n, copyErr := io.Copy(io.MultiWriter(f, hash), io.LimitReader(r, installerLimit+1))
+	closeErr := f.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if n > installerLimit {
+		return fmt.Errorf("installer exceeds %d bytes", installerLimit)
+	}
+	if !bytes.Equal(hash.Sum(nil), checksum) {
+		return fmt.Errorf("installer checksum mismatch")
+	}
+	return os.Rename(f.Name(), path)
+}

--- a/internal/appupdate/installer_e2e_windows_test.go
+++ b/internal/appupdate/installer_e2e_windows_test.go
@@ -1,0 +1,265 @@
+//go:build windows && installer_e2e
+
+package appupdate
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Runs the real backend and production Inno script. Only Chromium is a fixture:
+// a WinForms window with a child holding libcef.dll until a delayed clean close.
+func TestWindowsInstallerE2E(t *testing.T) {
+	root, err := filepath.Abs(filepath.Join("..", ".."))
+	if err != nil {
+		t.Fatal(err)
+	}
+	work := t.TempDir()
+	install := filepath.Join(work, "installed lich")
+	build := filepath.Join(work, "build", "windows")
+	bin := filepath.Join(work, "bin")
+	for _, dir := range []string{install, build, filepath.Join(bin, "shell")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, name := range []string{"lich.iss", "lich.ico"} {
+		copyFixture(t, filepath.Join(root, "build", "windows", name), filepath.Join(build, name))
+	}
+	csc := filepath.Join(os.Getenv("WINDIR"), "Microsoft.NET", "Framework64", "v4.0.30319", "csc.exe")
+	runFixture(t, root, csc, "/nologo", "/target:winexe", "/r:System.Windows.Forms.dll",
+		"/out:"+filepath.Join(bin, "shell", "lich-shell.exe"), filepath.Join(root, "internal", "appupdate", "testdata", "window.cs"))
+	asset := "lich-v0.8.0-windows-amd64-setup.exe"
+	installer := filepath.Join(bin, "lich-setup.exe")
+	srv := installerReleaseFixture(t, installer, asset)
+	defer srv.Close()
+	overlay := releaseOverlay(t, root, work, srv.URL)
+	oldExe := filepath.Join(install, "lich.exe")
+	runFixture(t, root, "go", "build", "-overlay", overlay, "-ldflags=-H=windowsgui -X main.version=0.7.0", "-o", oldExe, ".")
+	runFixture(t, root, "go", "build", "-overlay", overlay, "-ldflags=-H=windowsgui -X main.version=0.8.0", "-o", filepath.Join(bin, "lich.exe"), ".")
+	if err := os.CopyFS(filepath.Join(install, "shell"), os.DirFS(filepath.Join(bin, "shell"))); err != nil {
+		t.Fatal(err)
+	}
+	writeFixture(t, filepath.Join(install, "shell", "libcef.dll"), []byte("0.7.0"))
+	writeFixture(t, filepath.Join(bin, "shell", "libcef.dll"), []byte("0.8.0"))
+	t.Setenv("VERSION", "0.8.0")
+	iscc := filepath.Join(os.Getenv("ProgramFiles(x86)"), "Inno Setup 6", "ISCC.exe")
+	runFixture(t, root, iscc, "/Qp", filepath.Join(build, "lich.iss"))
+	runInstalledUpdate(t, install, bin, work)
+}
+
+func installerReleaseFixture(t *testing.T, installer, asset string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/latest":
+			fmt.Fprint(w, `{"tag_name":"v0.8.0"}`)
+		case "/v0.8.0/checksums.txt":
+			data, err := os.ReadFile(installer)
+			if err != nil {
+				http.Error(w, err.Error(), 500)
+				return
+			}
+			fmt.Fprintf(w, "%x  %s\n", sha256.Sum256(data), asset)
+		case "/v0.8.0/" + asset:
+			http.ServeFile(w, r, installer)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// An overlay changes only the release URLs in the test builds. Shipped binaries
+// have no environment switch allowing a local process to redirect their updates.
+func releaseOverlay(t *testing.T, root, work, url string) string {
+	t.Helper()
+	source := filepath.Join(root, "internal", "appupdate", "appupdate.go")
+	data, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := strings.Replace(string(data), `"https://api.github.com/repos/" + repo + "/releases/latest"`, fmt.Sprintf("%q", url+"/latest"), 1)
+	text = strings.Replace(text, `"https://github.com/" + repo + "/releases/download/"`, fmt.Sprintf("%q", url+"/"), 1)
+	patched := filepath.Join(work, "appupdate.go")
+	writeFixture(t, patched, []byte(text))
+	data, err = json.Marshal(map[string]any{"Replace": map[string]string{source: patched}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	overlay := filepath.Join(work, "overlay.json")
+	writeFixture(t, overlay, data)
+	return overlay
+}
+
+func runInstalledUpdate(t *testing.T, install, bin, work string) {
+	t.Helper()
+	t.Setenv("APPDATA", filepath.Join(work, "config"))
+	t.Setenv("LICH_LISTEN_PORT", "47983")
+	t.Setenv("LICH_UPDATE_EVENTS", filepath.Join(work, "events.txt"))
+	t.Setenv("LICH_BROWSER", "")
+	t.Setenv("LICH_NO_WINDOW", "")
+	t.Setenv("CGO_ENABLED", "0")
+	cmd := exec.Command(filepath.Join(install, "lich.exe"))
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { cleanupInstalledFixture(t, install, work, cmd.Process.Pid) })
+	waitFixture(t, func() bool {
+		return fixtureVersion(work) == "0.7.0" && strings.Contains(fixtureEvents(work), "window ready 0.7.0")
+	})
+	oldToken := fixtureToken(work)
+	resp, err := http.Post("http://127.0.0.1:47983/rpc/appupdate.Apply?token="+oldToken, "application/json", strings.NewReader("[]"))
+	// Closing the window may end the RPC connection before its response flushes.
+	if err == nil {
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("Apply status = %d", resp.StatusCode)
+		}
+	}
+	waitFixture(t, func() bool {
+		return fixtureVersion(work) == "0.8.0" && strings.Contains(fixtureEvents(work), "window ready 0.8.0")
+	})
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("old lich did not exit cleanly: %v", err)
+	}
+	if fixtureToken(work) == oldToken {
+		t.Fatal("successor did not take the port")
+	}
+	assertInstalledUpdate(t, install, bin, work)
+}
+
+func cleanupInstalledFixture(t *testing.T, install, work string, pid int) {
+	t.Helper()
+	if t.Failed() {
+		for _, path := range []string{filepath.Join(install, ".lich-update-setup.log"), filepath.Join(work, "config", "lich", "lich.log"), filepath.Join(work, "events.txt")} {
+			data, err := os.ReadFile(path)
+			t.Logf("%s: %v\n%s", path, err, data)
+		}
+	}
+	// Only this fixture's process tree; never match an installed lich by name.
+	if data, err := os.ReadFile(filepath.Join(work, "config", "lich", "runtime.json")); err == nil {
+		var runtime struct {
+			PID int `json:"pid"`
+		}
+		if json.Unmarshal(data, &runtime) == nil && runtime.PID > 0 {
+			_ = exec.Command("taskkill.exe", "/F", "/T", "/PID", fmt.Sprint(runtime.PID)).Run()
+		}
+	}
+	_ = exec.Command("taskkill.exe", "/F", "/T", "/PID", fmt.Sprint(pid)).Run()
+	_ = exec.Command(filepath.Join(install, "unins000.exe"), "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART").Run()
+}
+
+func assertInstalledUpdate(t *testing.T, install, bin, work string) {
+	t.Helper()
+	installed, err := os.ReadFile(filepath.Join(install, "lich.exe"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := os.ReadFile(filepath.Join(bin, "lich.exe"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sha256.Sum256(installed) != sha256.Sum256(want) {
+		t.Fatal("installed exe was not replaced")
+	}
+	events := fixtureEvents(work)
+	last := -1
+	for _, event := range []string{"window ready 0.7.0", "close requested 0.7.0", "locks released", "window closed 0.7.0", "window ready 0.8.0"} {
+		index := strings.Index(events, event)
+		if index <= last {
+			t.Fatalf("incorrect shutdown order for %q:\n%s", event, events)
+		}
+		last = index
+	}
+	log, err := os.ReadFile(filepath.Join(install, ".lich-update-setup.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Inno's log may be UTF-16; strip NULs for these ASCII assertions.
+	text := strings.ReplaceAll(string(log), "\x00", "")
+	if !strings.Contains(text, "outgoing process exited before file replacement") {
+		t.Fatalf("installer did not await lich:\n%s", text)
+	}
+	t.Logf("installer replaced exe and locked DLL; successor owns port 47983\n%s", events)
+}
+
+func fixtureToken(work string) string {
+	data, err := os.ReadFile(filepath.Join(work, "config", "lich", "runtime.json"))
+	if err != nil {
+		return ""
+	}
+	var runtime struct {
+		Token string `json:"token"`
+	}
+	if json.Unmarshal(data, &runtime) != nil {
+		return ""
+	}
+	return runtime.Token
+}
+
+func fixtureVersion(work string) string {
+	client := &http.Client{Timeout: time.Second}
+	resp, err := client.Post("http://127.0.0.1:47983/rpc/system.Diagnostics?token="+fixtureToken(work), "application/json", strings.NewReader("[]"))
+	if err != nil {
+		return ""
+	}
+	defer resp.Body.Close()
+	var info struct {
+		Version string `json:"version"`
+	}
+	if json.NewDecoder(resp.Body).Decode(&info) != nil {
+		return ""
+	}
+	return info.Version
+}
+
+func fixtureEvents(work string) string {
+	data, _ := os.ReadFile(filepath.Join(work, "events.txt"))
+	return string(data)
+}
+
+func waitFixture(t *testing.T, ready func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(deadline) {
+		if ready() {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for installed lich")
+}
+
+func runFixture(t *testing.T, dir, exe string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(exe, args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%s: %v\n%s", exe, err, out)
+	}
+}
+
+func copyFixture(t *testing.T, from, to string) {
+	t.Helper()
+	data, err := os.ReadFile(from)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeFixture(t, to, data)
+}
+
+func writeFixture(t *testing.T, path string, data []byte) {
+	t.Helper()
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/appupdate/installer_test.go
+++ b/internal/appupdate/installer_test.go
@@ -1,0 +1,105 @@
+package appupdate
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWindowsApplyAsset(t *testing.T) {
+	for _, window := range []bool{false, true} {
+		t.Run(fmt.Sprint(window), func(t *testing.T) {
+			exe := filepath.Join(t.TempDir(), "lich.exe")
+			asset := "lich-v0.8.0-windows-amd64.exe"
+			if window {
+				exe = windowedExe(t)
+				asset = "lich-v0.8.0-windows-amd64-setup.exe"
+			}
+			body := "verified release asset"
+			srv := windowsReleaseFixture(t, asset, body)
+			defer srv.Close()
+			s := applyService(t, srv, func(r io.Reader, checksum []byte) error {
+				if window {
+					t.Fatal("installer layout must not swap the bare exe")
+				}
+				return nil
+			})
+			s.goos, s.goarch, s.exePath = "windows", "amd64", exe
+			s.downloadBase = srv.URL + "/"
+			installed := false
+			s.install = func(path string) error {
+				data, err := os.ReadFile(path)
+				if err != nil || string(data) != body {
+					t.Fatalf("installer bytes = %q, %v", data, err)
+				}
+				installed = true
+				return nil
+			}
+			if err := s.Apply(); err != nil {
+				t.Fatal(err)
+			}
+			if installed != window {
+				t.Fatalf("installed = %v, window = %v", installed, window)
+			}
+		})
+	}
+}
+
+func windowsReleaseFixture(t *testing.T, asset, body string) *httptest.Server {
+	t.Helper()
+	sum := sha256.Sum256([]byte(body))
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/latest":
+			fmt.Fprint(w, `{"tag_name":"v0.8.0"}`)
+		case "/v0.8.0/checksums.txt":
+			fmt.Fprintf(w, "%x  %s\n", sum, asset)
+		case "/v0.8.0/" + asset:
+			fmt.Fprint(w, body)
+		default:
+			t.Errorf("unexpected asset request: %s", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func TestInstallerVerificationAndFailures(t *testing.T) {
+	body := "installer"
+	sum := sha256.Sum256([]byte(body))
+	s := &Service{exePath: windowedExe(t)}
+	if err := s.applyInstaller(strings.NewReader(body), sum[:]); err == nil {
+		t.Fatal("missing installer callback must fail")
+	}
+	launched := false
+	s.install = func(string) error { launched = true; return io.ErrClosedPipe }
+	if err := s.applyInstaller(strings.NewReader("corrupt"), sum[:]); err == nil || launched {
+		t.Fatalf("bad checksum: err=%v, launched=%v", err, launched)
+	}
+	if err := s.applyInstaller(strings.NewReader(body), sum[:]); err != io.ErrClosedPipe {
+		t.Fatalf("launch error = %v", err)
+	}
+	// A retry replaces the retained installer rather than accumulating downloads.
+	if err := s.applyInstaller(strings.NewReader(body), sum[:]); err != io.ErrClosedPipe {
+		t.Fatalf("retry error = %v", err)
+	}
+	files, err := filepath.Glob(filepath.Join(filepath.Dir(s.exePath), ".lich-*.exe"))
+	if err != nil || len(files) != 1 {
+		t.Fatalf("retained downloads = %v, %v", files, err)
+	}
+	if err := stageInstaller(strings.NewReader(body), sum[:], filepath.Join(t.TempDir(), "missing", "setup.exe")); err == nil {
+		t.Fatal("unwritable staging directory must fail")
+	}
+	if err := stageInstaller(failingReader{}, sum[:], filepath.Join(t.TempDir(), "setup.exe")); err != io.ErrUnexpectedEOF {
+		t.Fatalf("read error = %v", err)
+	}
+}
+
+type failingReader struct{}
+
+func (failingReader) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }

--- a/internal/appupdate/testdata/window.cs
+++ b/internal/appupdate/testdata/window.cs
@@ -1,0 +1,44 @@
+// A GUI lifecycle with a child holding a bundled DLL, without downloading CEF.
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Windows.Forms;
+
+class WindowFixture {
+    static void Record(string message) {
+        File.AppendAllText(Environment.GetEnvironmentVariable("LICH_UPDATE_EVENTS"), message + "\n");
+    }
+
+    [STAThread]
+    static void Main(string[] args) {
+        string resource = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "libcef.dll");
+        if (args.Length == 1 && args[0] == "hold") {
+            using (FileStream held = File.Open(resource, FileMode.Open, FileAccess.Read, FileShare.Read)) {
+                Console.WriteLine("locked");
+                Console.ReadLine();
+                Thread.Sleep(1000); // Children take time to release their loaded resources.
+            }
+            Record("locks released");
+            return;
+        }
+        string version = File.ReadAllText(resource).Trim();
+        using (Process child = Process.Start(new ProcessStartInfo(Application.ExecutablePath, "hold") {
+            UseShellExecute = false, RedirectStandardInput = true, RedirectStandardOutput = true
+        })) {
+            if (child.StandardOutput.ReadLine() != "locked") throw new Exception("child did not lock DLL");
+            using (Form window = new Form()) {
+                window.Text = "lich update fixture " + version;
+                window.Shown += delegate { Record("window ready " + version); };
+                window.FormClosing += delegate {
+                    Record("close requested " + version);
+                    child.StandardInput.WriteLine("close");
+                    child.StandardInput.Flush();
+                    if (!child.WaitForExit(10000)) throw new Exception("child retained DLL");
+                    Record("window closed " + version);
+                };
+                Application.Run(window);
+            }
+        }
+    }
+}

--- a/internal/restart/restart.go
+++ b/internal/restart/restart.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"sync"
 )
@@ -22,11 +23,12 @@ const WaitEnv = "LICH_RESTART_WAIT"
 type Coordinator struct {
 	mu      sync.Mutex
 	window  *os.Process
+	stop    func()
 	started bool
 	exePath string
 	env     []string
 	// seams for tests; default to the build-tagged process primitives.
-	spawn     func(exe string, env []string) error
+	spawn     func(exe string, env, args []string) error
 	terminate func(p *os.Process) error
 }
 
@@ -50,11 +52,35 @@ func (c *Coordinator) SetWindow(p *os.Process) {
 	c.mu.Unlock()
 }
 
+// SetStop supplies a clean exit when lich serves without a window. A Windows
+// WM_CLOSE cannot signal a backend with no GUI of its own.
+func (c *Coordinator) SetStop(stop func()) {
+	c.mu.Lock()
+	c.stop = stop
+	c.mu.Unlock()
+}
+
 // Do launches the successor and closes the window. Order matters: the successor
 // starts first and blocks retrying the pinned port; then the window dies, this
 // process exits, and the freed port lets the successor bind and open a fresh
 // window.
 func (c *Coordinator) Do() error {
+	return c.launch(c.exePath, nil)
+}
+
+// Install hands replacement and relaunch to Inno Setup. It waits for this PID
+// to exit before touching files, so the window and main's defers finish first.
+func (c *Coordinator) Install(installer string) error {
+	return c.launch(installer, installerArgs(filepath.Dir(c.exePath), os.Getpid()))
+}
+
+func installerArgs(dir string, pid int) []string {
+	return []string{"/SILENT", "/NORESTART", "/CLOSEAPPLICATIONS", "/NORESTARTAPPLICATIONS",
+		"/DIR=" + dir, "/UPDATEPID=" + strconv.Itoa(pid),
+		"/LOG=" + filepath.Join(dir, ".lich-update-setup.log")}
+}
+
+func (c *Coordinator) launch(exe string, args []string) error {
 	if c.exePath == "" {
 		return errors.New("restart: executable path unknown")
 	}
@@ -69,11 +95,13 @@ func (c *Coordinator) Do() error {
 	if c.started {
 		return nil
 	}
-	if err := c.spawn(c.exePath, successorEnv(c.env)); err != nil {
+	if err := c.spawn(exe, successorEnv(c.env), args); err != nil {
 		return fmt.Errorf("restart: launch successor: %w", err)
 	}
 	c.started = true
-	if c.window != nil {
+	if c.stop != nil {
+		c.stop()
+	} else if c.window != nil {
 		if err := c.terminate(c.window); err != nil {
 			return fmt.Errorf("restart: close window: %w", err)
 		}

--- a/internal/restart/restart_test.go
+++ b/internal/restart/restart_test.go
@@ -2,8 +2,11 @@ package restart
 
 import (
 	"errors"
+	"io"
 	"os"
+	"path/filepath"
 	"slices"
+	"strconv"
 	"testing"
 )
 
@@ -75,7 +78,7 @@ func TestDoSpawnsThenTerminates(t *testing.T) {
 	c := &Coordinator{
 		exePath: "/usr/local/bin/lich",
 		env:     []string{"PATH=/bin"},
-		spawn: func(_ string, env []string) error {
+		spawn: func(_ string, env, _ []string) error {
 			spawnedEnv = env
 			order = append(order, "spawn")
 			return nil
@@ -107,7 +110,7 @@ func TestDoIsIdempotent(t *testing.T) {
 	spawns, terminates := 0, 0
 	c := &Coordinator{
 		exePath:   "/usr/local/bin/lich",
-		spawn:     func(string, []string) error { spawns++; return nil },
+		spawn:     func(string, []string, []string) error { spawns++; return nil },
 		terminate: func(*os.Process) error { terminates++; return nil },
 	}
 	c.SetWindow(&os.Process{})
@@ -126,7 +129,7 @@ func TestDoWithoutWindowStillSpawns(t *testing.T) {
 	spawned := false
 	c := &Coordinator{
 		exePath:   "/usr/local/bin/lich",
-		spawn:     func(string, []string) error { spawned = true; return nil },
+		spawn:     func(string, []string, []string) error { spawned = true; return nil },
 		terminate: func(*os.Process) error { t.Fatal("terminate called with no window"); return nil },
 	}
 	if err := c.Do(); err != nil {
@@ -139,7 +142,7 @@ func TestDoWithoutWindowStillSpawns(t *testing.T) {
 
 func TestDoErrors(t *testing.T) {
 	t.Run("no exe path", func(t *testing.T) {
-		c := &Coordinator{spawn: func(string, []string) error { return nil }}
+		c := &Coordinator{spawn: func(string, []string, []string) error { return nil }}
 		if err := c.Do(); err == nil {
 			t.Fatal("Do() = nil, want error when exe path is unknown")
 		}
@@ -148,7 +151,7 @@ func TestDoErrors(t *testing.T) {
 	t.Run("spawn failure propagates", func(t *testing.T) {
 		c := &Coordinator{
 			exePath: "/usr/local/bin/lich",
-			spawn:   func(string, []string) error { return errors.New("boom") },
+			spawn:   func(string, []string, []string) error { return errors.New("boom") },
 		}
 		if err := c.Do(); err == nil {
 			t.Fatal("Do() = nil, want spawn error")
@@ -159,7 +162,7 @@ func TestDoErrors(t *testing.T) {
 		calls := 0
 		c := &Coordinator{
 			exePath: "/usr/local/bin/lich",
-			spawn: func(string, []string) error {
+			spawn: func(string, []string, []string) error {
 				calls++
 				if calls == 1 {
 					return errors.New("boom")
@@ -177,4 +180,60 @@ func TestDoErrors(t *testing.T) {
 			t.Fatalf("spawn calls = %d, want 2 (failure must not latch)", calls)
 		}
 	})
+}
+
+func TestInstallLaunchesBeforeShutdown(t *testing.T) {
+	var order []string
+	c := New(filepath.Join(t.TempDir(), "lich.exe"), []string{"LICH_LISTEN_PORT=47821"})
+	c.spawn = func(exe string, env, args []string) error {
+		if exe != "verified-setup.exe" {
+			t.Fatalf("spawned %q instead of installer", exe)
+		}
+		want := []string{"/SILENT", "/NORESTART", "/CLOSEAPPLICATIONS", "/NORESTARTAPPLICATIONS",
+			"/DIR=" + filepath.Dir(c.exePath), "/UPDATEPID=" + strconv.Itoa(os.Getpid()),
+			"/LOG=" + filepath.Join(filepath.Dir(c.exePath), ".lich-update-setup.log")}
+		if !slices.Equal(args, want) {
+			t.Fatalf("installer args = %v, want %v", args, want)
+		}
+		if !slices.Contains(env, "LICH_LISTEN_PORT=47821") || !slices.Contains(env, WaitEnv+"=1") {
+			t.Fatalf("installer lost restart environment: %v", env)
+		}
+		order = append(order, "launch")
+		return nil
+	}
+	c.terminate = func(*os.Process) error { order = append(order, "shutdown"); return nil }
+	c.SetWindow(&os.Process{})
+	if err := c.Install("verified-setup.exe"); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Do(); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(order, []string{"launch", "shutdown"}) {
+		t.Fatalf("shutdown order = %v", order)
+	}
+}
+
+func TestInstallerLaunchFailureKeepsWindow(t *testing.T) {
+	c := New("lich.exe", nil)
+	c.spawn = func(string, []string, []string) error { return io.ErrClosedPipe }
+	c.terminate = func(*os.Process) error { t.Fatal("closed window after launch failure"); return nil }
+	c.SetWindow(&os.Process{})
+	if err := c.Install("setup.exe"); !errors.Is(err, io.ErrClosedPipe) {
+		t.Fatalf("launch error = %v", err)
+	}
+}
+
+func TestInstallWithoutWindowExitsCleanly(t *testing.T) {
+	c := New("lich.exe", nil)
+	var order []string
+	c.spawn = func(string, []string, []string) error { order = append(order, "launch"); return nil }
+	c.terminate = func(*os.Process) error { t.Fatal("must not taskkill the backend"); return nil }
+	c.SetStop(func() { order = append(order, "stop") })
+	if err := c.Install("setup.exe"); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(order, []string{"launch", "stop"}) {
+		t.Fatalf("order = %v", order)
+	}
 }

--- a/internal/restart/restart_unix.go
+++ b/internal/restart/restart_unix.go
@@ -11,8 +11,8 @@ import (
 // startDetached launches exe in its own session (setsid) so it outlives this
 // process and the PTY that triggered the restart. stdio is left nil — the
 // successor logs to its own file (main's logging.Init), like any lich launch.
-func startDetached(exe string, env []string) error {
-	cmd := exec.Command(exe)
+func startDetached(exe string, env, args []string) error {
+	cmd := exec.Command(exe, args...)
 	cmd.Env = env
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
 	return cmd.Start()

--- a/internal/restart/restart_windows.go
+++ b/internal/restart/restart_windows.go
@@ -12,10 +12,10 @@ import (
 )
 
 // startDetached launches exe detached from this console and process group so it
-// outlives the restarting process. Windows installs self-apply through
-// internal/appupdate rather than this path, so this exists mainly to compile.
-func startDetached(exe string, env []string) error {
-	cmd := exec.Command(exe)
+// outlives the restarting process, including an installer that must wait for
+// this process to release its executable.
+func startDetached(exe string, env, args []string) error {
+	cmd := exec.Command(exe, args...)
 	cmd.Env = env
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		CreationFlags: windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP,

--- a/main.go
+++ b/main.go
@@ -179,7 +179,17 @@ func main() {
 	dispatcher.Register("project", proj)
 	plugins := agentplugin.New(db)
 	dispatcher.Register("agentplugin", plugins)
-	dispatcher.Register("appupdate", appupdate.New(version))
+	// In-place restart: the update flow (install.sh) POSTs /restart after
+	// replacing the binary. os.Environ() here carries the pinned LICH_LISTEN_PORT
+	// so the successor rebinds the same port. A missing executable path only
+	// disables restart; the app still runs.
+	exe, err := os.Executable()
+	if err != nil {
+		slog.Warn("resolve executable — restart disabled", "err", err)
+		exe = ""
+	}
+	coord := restart.New(exe, os.Environ())
+	dispatcher.Register("appupdate", appupdate.New(version, coord.Install))
 	dispatcher.Register("patchnotes", patchnotes.New(version, changelog))
 	dispatcher.Register("store", db)
 	// Read before runChromium writes this run's runtime file over the previous
@@ -254,16 +264,6 @@ func main() {
 	term.Mount("/drop", http.HandlerFunc(drops.Upload))
 	term.Mount("/events", hub)
 
-	// In-place restart: the update flow (install.sh) POSTs /restart after
-	// replacing the binary. os.Environ() here carries the pinned LICH_LISTEN_PORT
-	// so the successor rebinds the same port. A missing executable path only
-	// disables restart; the app still runs.
-	exe, err := os.Executable()
-	if err != nil {
-		slog.Warn("resolve executable — restart disabled", "err", err)
-		exe = ""
-	}
-	coord := restart.New(exe, os.Environ())
 	term.SetRestart(coord.Do)
 
 	runChromium(term, configDir, chromiumArgs, coord)
@@ -445,15 +445,10 @@ func openWithoutWindow(url, addr, configDir string, coord *restart.Coordinator, 
 			lost+": closing the tab leaves lich running.",
 		zenity.Title("lich"))
 
-	// The window's exit is the app lifecycle everywhere else, and /restart
-	// terminates that window to free the pinned port for its successor. With no
-	// window, this process is what has to go — so it is what the coordinator is
-	// handed, and the signal it sends is the one waited on here.
-	if self, err := os.FindProcess(os.Getpid()); err == nil {
-		coord.SetWindow(self)
-	}
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(stop)
+	coord.SetStop(func() { stop <- os.Interrupt })
 	slog.Info("serving without a window", "addr", addr)
 	<-stop
 	slog.Info("signal received, exiting")


### PR DESCRIPTION
Windows installs with `shell\lich-shell.exe` now download and verify the release installer, close lich cleanly, update the whole install, and reopen on the same port. Portable Windows executables keep the existing binary swap.

The detached `/SILENT /NORESTART /CLOSEAPPLICATIONS` handoff preserves the current directory and environment. Inno waits for the outgoing PID before replacing files, uses the existing per-user/no-UAC install, and relaunches only in update mode. Windowless launches now use a clean stop callback. The obsolete ceilings bullet is deleted; update docs and the Unreleased fix entry are included.

Validation: gofmt, go vet, full Go suite (2,580 passing; 85.9% coverage), frontend build/Biome/tests (1,705 passing; 97.73% coverage), and Linux/macOS/Windows build+vet. Added asset-choice, checksum/failure, argv, and shutdown-order tests. The Windows os-tests job builds the production Inno installer against a local release fixture, updates a running real backend with a GUI/child-process DLL-lock fixture, and checks both the installed binary and successor on the original port. This tests the Windows installer boundary with a window fixture, not real CEF on desktop hardware.

The existing installer-layout test changes because its contract changed: a writable windowed install now supports self-apply. Existing portable and package-manager contracts remain covered.

Windows CI passed on d39a0b5: [installer end-to-end and backend job](https://github.com/omartelo/lich/actions/runs/34360732159/job/102496734576). The recorded order was old window ready → close requested → child DLL lock released → old window closed → new window ready; the installed exe matched the new build and the successor owned port 47983. All other CI jobs, including the Windows shell, passed.
