### PR TITLE
docs: move provider facts out of ceilings into docs/providers

### DIFF
--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -6,8 +6,8 @@ about a dozen files across two repositories. This is the map — written after
 Antigravity, so it names what that change actually touched rather than what it
 should have. Cursor CLI came later and needed no plugin install at all — it runs
 every Claude Code hook on the machine, which is a shape the plugin table below
-does not have; [`ceilings.md`](ceilings.md) carries what that buys and what it
-costs.
+does not have; [`providers/cursor.md`](providers/cursor.md) carries what that
+buys and what it costs.
 
 Two rules govern the whole exercise, and both are in
 [`../CLAUDE.md`](../CLAUDE.md):
@@ -147,6 +147,10 @@ Not optional, and all in the same PR:
 - **`docs/hooks/fixtures/session-start.jsonl`** — the accepted-provider line
   above, which is what unblocks the plugin's own suite.
 - **`docs/ceilings.md`** — a bullet per gap, naming the mechanism and the file.
+- **`docs/providers/<id>.md`** — the reference page for the new harness: what it
+  is, its binary, its config directory and transcript, then a section per
+  subject in the order every other page uses. [`providers/`](providers/) is one
+  page per registry id, and a missing one is a provider nobody wrote down.
 - **`docs/cli.md`** — the `--kind` list, the MCP registration table, and the
   `doctor` sample output.
 - **`CHANGELOG.md`** — under `[Unreleased]`, written for someone who runs the

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -2,7 +2,8 @@
 
 Deliberate limits and shortcuts, and the traps they set. A bullet earns its place by naming something that breaks
 work when nobody knows it and that the call site never shows. The mechanism and the history stay in the code and
-`CHANGELOG.md`; this file is the trap alone.
+`CHANGELOG.md`; this file is the trap alone. Provider-specific behaviour is reference, not a trap, and lives in
+[`providers/`](providers/).
 
 - **A project's gh account governs gh, not git**: `vcs.account` (`internal/project/ghaccount.go`) puts one
   account's token in `GH_TOKEN` for every gh call lich makes for that project. A push still rides the remote's
@@ -205,11 +206,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
 - **The worktree setup script answers to the main checkout, never the new branch**
   (`internal/project/setup.go`): improve `.lich/setup-worktree.sh` on a feature branch and fresh worktrees keep
   running the old one until the change reaches the checkout the project points at.
-- **opencode files a fork under the parent's directory, not the new checkout's** (measured on 1.18.23): the
-  copied session's `directory` column is the one the original ran in, and its `parent_id` is left empty, so
-  opencode's own session list places a fork in the checkout it came from and records no lineage. lich's own
-  card is right — it carries the worktree it was opened in, and `origin_session_id` names the parent — but the
-  two disagree, and only lich's side is visible in lich.
 - **git status is polled** — one shared poller per repository path (`frontend/src/lib/git/git-status-store.ts`); the
   lich plugin's `session-touched` hook nudges an immediate refresh.
 - **The status badge has a single source** (`internal/project/status.go`): the branch, the HEAD commit and the
@@ -264,12 +260,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   fallback there would open lich a second time, in a system browser, on the profile the window owns — so a
   lich already running in the fallback browser is not focused by it either, and what a system browser does
   with the forwarded command line is its own.
-- **lich appends to the agent's system prompt, for two providers only**
-  (`internal/terminal/command.go`, `briefingFlags` → `relay.SpawnBriefing`): Claude Code and oh-my-pi are spawned
-  with `--append-system-prompt` carrying lich's own briefing, so text the user never wrote is in every session's
-  prompt and in `/proc/<pid>/cmdline`. Codex, Antigravity, opencode, Crush and Cursor CLI get nothing there — none
-  has a per-spawn append flag, so for those five the point exists only in lich's MCP instructions, and behaviour
-  between providers differs by that much.
 - **A prompt in use is recognised from the bytes going in, never from the line itself**
   (`internal/terminal/draft.go`): a relayed message pastes at the prompt and sends an Enter behind it, so lich
   holds the delivery back while the user has unsent input there. What it counts is printable input since the last
@@ -288,65 +278,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   events rather than bytes, the bracketed paste markers do not survive, and every provider TUI then guesses at where
   a paste ends from timing alone. A target that repaints on a timer of its own never goes quiet and gets its Enter
   at `defaultSettleLimit` regardless, which is the case this cannot tell from a paste still arriving.
-- **A lich-spawned Kiro session runs lich's agent, not the user's** (`internal/agentplugin/kiro.go`,
-  `internal/terminal/command.go`, `agentArgs`): Kiro keeps its hooks inside an *agent config*, and its built-in
-  `kiro_default` cannot be shadowed — a `kiro_default.json` in the agents directory is ignored outright (measured
-  on 2.21.0). So the only place a hook can be registered is an agent lich writes itself, which the spawn then
-  names with `--agent lich`. Two things follow, and neither is visible on the card. The agent lich writes carries
-  no `prompt`, so a session loses the paragraph `kiro_default` adds about subagents, the planner and LSP — the
-  model still has every tool, it is just not told about those. And a default the user set with
-  `kiro-cli agent set-default` is **not** what a lich session runs; their own agent applies to Kiro started from a
-  terminal and not to Kiro started from a card. Deleting `~/.kiro/agents/lich.json` puts the session back on
-  `kiro_default` and silently ends every report with it: the spawn stops naming an agent it cannot find, which is
-  the one case where that costs a warning line rather than the reports.
-- **Kiro enforces no hook timeout, and blocks the turn behind one**
-  (`internal/agentplugin/kiro.go`): its TUI draws "0 of 1 hooks finished" while a report runs, and a hook that
-  slept four seconds ran to completion under both `timeout_ms: 1000` and `timeout: 1` (2.21.0). So lich writes no
-  timeout into the agent — a field that bounds nothing is a promise the file does not keep — and what actually
-  bounds a report is the request timeout inside the script itself. A lich whose listener has gone away costs a
-  Kiro turn that wait on every hook it fires, where the other harnesses cut it off themselves.
-- **Kiro's skip-permissions flag still stops once** (`internal/terminal/command.go`, `skipPermissionFlags`): with
-  the switch on, lich passes `--trust-all-tools`, and Kiro's TUI opens on a full-screen confirmation
-  ("No, exit / Yes, I accept / Yes, and don't ask again") that has to be answered before the session starts. The
-  flag is real and every tool afterwards runs unconfirmed; it is the *first* screen that is not skipped, which is
-  the one thing a user who ticked the box does not expect. Kiro's own `chat.disableTrustAllConfirmation` setting
-  turns it off for good, and lich does not write it — that setting disables a safety confirmation for every Kiro
-  on the machine, including the ones lich never spawned.
-- **A Kiro session never reports `waiting` or `idle`** (`docs/hooks/`): its five events are
-  `agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse` and `stop`, so lich closes session-start,
-  session-state's busy/tool/done rows and session-touched, and nothing else. A Kiro session sitting on a
-  permission prompt reads as `busy` — true, but it does not say what it is waiting for — and the card keeps the
-  provider's mark until the PTY itself goes, because there is no session-end event to clear it.
-- **A Cursor CLI session reports through Claude Code's plugin, or not at all** (`internal/agentplugin`,
-  `internal/terminal/start.go`, `providerKind`): lich installs no plugin into Cursor, and it does not have to —
-  the CLI executes every Claude Code hook on the machine, the user's own and each installed plugin's (measured on
-  2026.08.11: `hookSource: claude-user` and `claude-plugin`, with `${CLAUDE_PLUGIN_ROOT}` expanded). So on a
-  machine where the lich plugin is installed in Claude Code, a Cursor session reports the chat id it is running
-  and the files it touches, with nothing installed there — and on a machine without it, that session reports
-  nothing at all. Nothing on the card says which of the two it is.
-  **What never arrives is the turn.** Of the nine events the plugin registers, Cursor delivers four —
-  `SessionStart`, `PreToolUse`, `PostToolUse`, `SessionEnd` — and no `UserPromptSubmit` or `Stop`, measured
-  against hooks in Cursor's own format and in Claude Code's alike. So a turn that calls no tool never begins and
-  one that does never ends, which is why `terminal.closableState` drops every state but `idle` from a Cursor
-  session rather than pinning a spinner to the card for the rest of it: no spinner, no bell, no auto-title, and
-  no `waiting` either (`Notification` maps to nothing there). That is the Crush row of the table below, arrived
-  at from the other direction — lich does not own the registration here, so it filters what it cannot close.
-  The reports are also all that route carries: Cursor takes no MCP server on its command line and reads none from
-  a Claude Code plugin, so lich's own tools come from an `mcpServers` document its install writes under
-  `~/.cursor` — which is why installing for Cursor refuses while Claude Code has no plugin, why its version is
-  Claude Code's, and why its row offers no update of its own: the update is the Claude Code row's, one line up
-  the same screen. A Cursor session gets no briefing either — the CLI has no append flag — so what it knows about
-  lich is its tool list. One last edge: the plugin's script reports `claude`, the argument Claude Code's own
-  registration passes it, and lich drops that name for a card whose provider it chose itself — but a **shell**
-  session running `cursor-agent` by hand has only the report to go on and wears Claude's mark.
-- **Cursor keeps its state in two directories and its chats per checkout** (`internal/sandbox/sandbox.go`,
-  `internal/terminal/transcript.go`): its config dir is `$CURSOR_CONFIG_DIR` ‖ `$XDG_CONFIG_HOME/cursor` ‖
-  `~/.cursor` — not xdg-basedir, the fallback is the home directly — and it holds the credentials and the chats.
-  But `~/.cursor` is resolved off the home with no variable in the way at all, and that is where `mcp.json`, the
-  per-project transcripts and the CLI state live. On a machine with `XDG_CONFIG_HOME` set the two are different
-  directories and a sandbox binding only one is a session that cannot see its own MCP servers. The chat itself is
-  at `chats/<md5 of the resolved cwd>/<chatId>/store.db`, so a resume asked without the session's own working
-  directory answers "conversation gone" — the same shape as Crush.
 - **An install started from `go run` registers the lich on PATH, not itself** (`internal/agentplugin/crush.go`,
   `resolveLichBinary`): Crush's, oh-my-pi's and Cursor's registrations name the absolute path of the lich that
   wrote them, and under `go run` — `task dev` — that path is the binary the toolchain built into its cache and
@@ -357,45 +288,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   session reaches the lich its PTY's coordinates name, but not what the file appears to say. With no lich on
   PATH at all, a dev install registers nothing: Crush and oh-my-pi still get their hooks, and Cursor's install
   refuses outright.
-- **Installing the plugin writes into four harnesses' own directories** (`internal/agentplugin`): Claude Code and
-  Codex are driven through their plugin CLI, but opencode, oh-my-pi and Crush have none, so lich writes the
-  released files itself. None of them records what is installed, so the version lives in a marker line lich wrote —
-  edit the file by hand and lich reads it as not installed. Crush below 0.88.0 ignores those lines in silence,
-  which is why the install asks its version first. Crush's block and omp's `mcp.json` register lich's MCP server by
-  the absolute path of the binary that installed it, and omp's is a JSON document lich rewrites rather than appends
-  to: every key survives, the user's formatting does not.
-- **Antigravity has a plugin CLI and lich installs around it** (`internal/agentplugin/antigravity.go`): `agy
-  plugin install` takes a directory, and its only remote form clones that repository's default branch — while lich
-  installs a *release*, whose version is what a card reports and what the next update compares against. So lich
-  writes the customization directory itself (`~/.gemini/config/plugins/lich/`), with three consequences. The
-  installed version lives in the manifest lich writes rather than in a marker line, since the directory is lich's
-  outright — and a copy the user installed through `agy plugin install` carries no version, so it reads as not
-  installed. The registration's commands are relative, resolved against the directory holding `hooks.json`
-  (Antigravity runs a hook through `sh -c` from there and sets no plugin-root variable of its own, both measured on
-  1.1.19), so moving that directory by hand breaks every report until the next install. And lich writes the hooks
-  and their scripts only: the plugin's skills come with `agy plugin install`, not with this, which is the same
-  thing already true of opencode, oh-my-pi and Crush.
-- **A new MCP tool reaches opencode a release later than everyone else** (`internal/cli/mcp.go`, `mcpTools`; the
-  registration table in `docs/cli.md`): every other harness is handed lich's own server, so a tool added here is in
-  that session's list on the next spawn. opencode cannot register an MCP server from a plugin, so its plugin
-  defines each tool itself in the companion repo (`omartelo/lich-plugin`, `opencode/lich.js`) — which means a tool
-  arrives there only once that repo cuts a release and the user reinstalls the plugin, and until they do it is
-  missing from that session's list while it is in every other. `lich rename` works there like anywhere else; it is
-  discovery that lags, which is the whole reason the tools exist.
-- **Only Claude Code says what a session is waiting for; the others say less or nothing**
-  (`frontend/src/components/sidebar/SessionCard.tsx`, table in `docs/hooks/session-state.md`): its
-  `Notification` carries a `message` written for a human, so the card reads "Claude needs your permission to
-  use Bash". Codex's `PermissionRequest` and opencode's `.asked` events carry only the thing being asked
-  about — `tool_name`, `permission`, `action` — so those cards read a bare `Bash` or `edit`, which says which
-  card to open and not what it will ask. **Antigravity, oh-my-pi, Crush and Cursor CLI send no reason at all** and keep the
-  generic "Waiting on you": none of the four reports `waiting` in the first place (Antigravity's permission
-  prompt raises no lifecycle event that has been measured; omp declares an approval event no run was ever seen
-  emitting; Crush reports no state), so there is nothing to hang a reason on. The trap is reading a bare card as
-  "nothing to say" — on those three it means the harness never spoke, not that the block is trivial.
-- **omp's state directory answers to two variables, and the profile wins** (`internal/agentplugin/omp.go`,
-  `internal/terminal/transcript.go`, resolving it independently as the Claude Code pair do): `OMP_PROFILE` moves
-  the whole directory and beats an explicit `PI_CODING_AGENT_DIR`. Get it backwards and the install lands where omp
-  is not reading and every restored card silently starts fresh.
 - **The plan gauge answers to two undocumented endpoints, and only two providers have one**
   (`internal/quota`): Claude Code's and Codex's usage routes are what their own CLIs poll, not published API. A
   field renamed upstream drops the window it fed rather than raising anything — an entry lich has no name for is
@@ -439,20 +331,6 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   the API rejects an OAuth token without it — the same coupling as the user agent, and it fails closed, as a
   failed reading. Headers carry the two account-wide windows and no plan name, so such a session shows no
   model-scoped weekly cap and no "Max 5x" badge.
-- **Only two providers name the account a session spends, and the reasons the other six do not are not one
-  reason** (`internal/quota`, `Plan.Account`): Claude Code answers a profile route with the credentials token,
-  and Codex carries an `email` claim in the OIDC id token beside its access token (read unverified, and
-  discarded once its `exp` has passed — the CLI can rotate the access token without rewriting the id one, and a
-  gauge under a login the user has left is worse than one under no name). opencode, Crush and oh-my-pi run on
-  the user's own API keys: there is no plan account to name, which is the same reason they have no gauge.
-  Antigravity's `~/.gemini/oauth_creds.json` *does* carry the same `email` claim and it is deliberately not
-  read: there is no `antigravityPlan`, so a `Plan` naming an account with no window in it renders nothing at
-  all (`PlanQuota` draws only a reading with a window) — the name arrives with the gauge or not at all. Cursor
-  CLI and Kiro CLI were measured on 2026-09-04 and carry no such claim: Cursor's `~/.config/cursor/auth.json`
-  token is a JWT whose `sub` is an opaque `github|user_…` and whose claims contain no email, and Kiro's login
-  is a row in `~/.local/share/kiro-cli/data.sqlite3` holding an opaque `aoa…` token, a `github` provider label
-  and an AWS profile ARN — nothing a person recognises as their account. Naming either would take a network
-  call against an unmeasured route, for a provider that has no gauge to hang the name under.
 - **The sandbox confines a working agent, not hostile code** (`internal/sandbox`): namespaces and mounts on
   Linux, a path policy on macOS, and nothing else — no seccomp filter, no Landlock ruleset. The network is
   never cut (the agent needs its API and the plugin's hooks report over loopback), so anything readable
@@ -670,10 +548,8 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   lich stays up with a notification and nothing on screen. Only a machine missing the opener itself reaches
   the dialog that carries the URL.
 - **Keep-awake follows the session-state report, and only that** (`internal/awake`, `turnLog.onOpen`): the
-  machine is held out of idle sleep while a hook says a turn is open. Crush reports no state at all, so a
-  Crush session left working behind a locked screen sleeps as it always did, and no card says so. Kiro's
-  permission prompt reads as `busy` (docs/hooks/session-state.md), so a Kiro session blocked on a human keeps
-  the machine awake until someone answers. Linux holds it through `systemd-inhibit --what=idle`: a distro
+  machine is held out of idle sleep while a hook says a turn is open, so what a provider reports decides whether
+  the machine stays up at all (`docs/providers/`). Linux holds it through `systemd-inhibit --what=idle`: a distro
   without systemd logs one warning per burst of work and sleeps, and a desktop that ignores logind idle
   inhibitors sleeps silently. The hold was measured on Linux only; on Windows and macOS CI proves the request
   is registered (`powercfg /requests`, `pmset -g assertions`), not that the machine stays up.

--- a/docs/hooks/README.md
+++ b/docs/hooks/README.md
@@ -23,7 +23,9 @@ way to end: without `Stop` a `busy` never becomes `done`, so
 `terminal.closableState` keeps everything but `idle` off a Cursor card. Reports
 also arrive naming `claude`, the argument Claude Code's own registration passes;
 lich answers from the kind it spawned instead (`terminal.providerKind`).
-`../ceilings.md` carries what all of that costs.
+[`../providers/cursor.md`](../providers/cursor.md) carries what all of that
+costs, and [`../providers/`](../providers/) holds the same page for every other
+harness.
 
 This directory is the **canonical, contract-first source** for those hooks:
 

--- a/docs/hooks/session-state.md
+++ b/docs/hooks/session-state.md
@@ -55,7 +55,7 @@ Both sides test against the payloads in
 permission event, so a Kiro session waiting on a confirmation reads as `busy`
 rather than `waiting` — the card says it is working, which is true, and does not
 say what it is waiting for. It has no session-end event either, so the card keeps
-the provider's mark until the PTY itself goes (docs/ceilings.md).
+the provider's mark until the PTY itself goes (docs/providers/kiro.md).
 
 Kiro is also the one harness that reads a hook's **stdout back into the
 conversation as context** — that is what its hooks are for. Every report script

--- a/docs/providers/antigravity.md
+++ b/docs/providers/antigravity.md
@@ -1,0 +1,58 @@
+# Antigravity
+
+`agy` (`internal/providers.Registry`). Its state lives under `~/.gemini`, read off the home alone: 1.1.19 falls
+back to a hardcoded `.gemini` when it cannot resolve the home and honours no environment variable of its own.
+The OAuth credentials sit at that root, the customizations under `config/`, and a conversation is SQLite at
+`antigravity-cli/conversations/<id>.db` with its JSONL beside it under
+`antigravity-cli/brain/<id>/.system_generated/logs/`. The limits these sit under are in
+[`../ceilings.md`](../ceilings.md).
+
+## Spawn
+
+lich appends nothing to the agent's system prompt (`internal/terminal/command.go`, `briefingFlags`): Antigravity
+has no per-spawn append flag, so the point the briefing makes exists only in lich's MCP instructions.
+
+## Hooks
+
+An Antigravity card sends no reason with a `waiting` and keeps the generic "Waiting on you"
+(`frontend/src/components/sidebar/SessionCard.tsx`; the mapping table is in
+[`../hooks/session-state.md`](../hooks/session-state.md)). It does not report `waiting` in the first place: its
+permission prompt raises no lifecycle event that has been measured, so there is nothing to hang a reason on. A
+bare card there means the harness never spoke, not that the block is trivial.
+
+## Transcript & cost
+
+Nothing provider-specific.
+
+## Plugin install
+
+Antigravity has a plugin CLI and lich installs around it (`internal/agentplugin/antigravity.go`): `agy plugin
+install` takes a directory, and its only remote form clones that repository's default branch, while lich
+installs a *release*, whose version is what a card reports and what the next update compares against. So lich
+writes the customization directory itself (`~/.gemini/config/plugins/lich/`), with three consequences. The
+installed version lives in the manifest lich writes rather than in a marker line, since the directory is lich's
+outright, and a copy the user installed through `agy plugin install` carries no version, so it reads as not
+installed. The registration's commands are relative, resolved against the directory holding `hooks.json`
+(Antigravity runs a hook through `sh -c` from there and sets no plugin-root variable of its own, both measured
+on 1.1.19), so moving that directory by hand breaks every report until the next install. And lich writes the
+hooks and their scripts only: the plugin's skills come with `agy plugin install`, not with this, which is the
+same thing already true of opencode, oh-my-pi and Crush.
+
+## MCP
+
+Nothing provider-specific.
+
+## Account
+
+`~/.gemini/oauth_creds.json` carries the same `email` claim Codex's id token does, and it is deliberately not
+read (`internal/quota`, `Plan.Account`): there is no `antigravityPlan`, so a `Plan` naming an account with no
+window in it renders nothing at all (`PlanQuota` draws only a reading with a window). The name arrives with the
+gauge or not at all.
+
+## Sandbox
+
+Nothing provider-specific.
+
+## Known limits
+
+Nothing provider-specific.

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -1,0 +1,46 @@
+# Claude Code
+
+`claude` (`internal/providers.Registry`), the default provider and the companion plugin's home. Its config
+directory is `$CLAUDE_CONFIG_DIR`, else `~/.claude`, with the account in `~/.claude.json` beside it. A
+conversation is one JSONL at `projects/<slug>/<id>.jsonl`, and a sub-agent's is a file of its own under
+`projects/<slug>/<id>/subagents/`. The limits these sit under are in [`../ceilings.md`](../ceilings.md).
+
+## Spawn
+
+lich appends to the agent's system prompt (`internal/terminal/command.go`, `briefingFlags` →
+`relay.SpawnBriefing`): a session is spawned with `--append-system-prompt` carrying lich's own briefing, so text
+the user never wrote is in every session's prompt and in `/proc/<pid>/cmdline`.
+
+## Hooks
+
+Claude Code is the only provider that says what a session is waiting for
+(`frontend/src/components/sidebar/SessionCard.tsx`; the mapping table is in
+[`../hooks/session-state.md`](../hooks/session-state.md)). Its `Notification` carries a `message` written for a
+human, so the card reads "Claude needs your permission to use Bash".
+
+## Transcript & cost
+
+Nothing provider-specific.
+
+## Plugin install
+
+Driven through Claude Code's own plugin CLI (`internal/agentplugin`), so lich writes none of the files itself
+and does not track the installed version in a marker line of its own.
+
+## MCP
+
+The session is handed lich's own MCP server on its command line (`--mcp-config`,
+`providers.AcceptsMCPServer`), so a tool added here is in that session's list on the next spawn.
+
+## Account
+
+The plan gauge names the account a session spends (`internal/quota`, `Plan.Account`): lich answers Claude
+Code's profile route with the credentials token.
+
+## Sandbox
+
+Nothing provider-specific.
+
+## Known limits
+
+Nothing provider-specific.

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -1,0 +1,46 @@
+# Codex
+
+`codex` (`internal/providers.Registry`). Its config directory is `$CODEX_HOME`, else `~/.codex`, and it files a
+rollout by the date it started: `sessions/<yyyy>/<mm>/<dd>/rollout-<timestamp>-<id>.jsonl`. The limits these sit
+under are in [`../ceilings.md`](../ceilings.md).
+
+## Spawn
+
+lich appends nothing to the agent's system prompt (`internal/terminal/command.go`, `briefingFlags`): Codex has
+no per-spawn append flag, so the point the briefing makes exists only in lich's MCP instructions.
+
+## Hooks
+
+Codex's `PermissionRequest` carries only the thing being asked about (`tool_name`, `tool_input`) and no message
+of its own, so a waiting card reads a bare `Bash` (`frontend/src/components/sidebar/SessionCard.tsx`; the
+mapping table is in [`../hooks/session-state.md`](../hooks/session-state.md)). That says which card to open and
+not what it will ask.
+
+## Transcript & cost
+
+Nothing provider-specific.
+
+## Plugin install
+
+Driven through Codex's own plugin CLI (`internal/agentplugin`), so lich writes none of the files itself and does
+not track the installed version in a marker line of its own.
+
+## MCP
+
+The session is handed lich's own MCP server on its command line (`-c` overrides for its `mcp_servers` table,
+`providers.AcceptsMCPServer`), so a tool added here is in that session's list on the next spawn.
+
+## Account
+
+The plan gauge names the account a session spends (`internal/quota`, `Plan.Account`): Codex carries an `email`
+claim in the OIDC id token beside its access token. It is read unverified, and discarded once its `exp` has
+passed, because the CLI can rotate the access token without rewriting the id one and a gauge under a login the
+user has left is worse than one under no name.
+
+## Sandbox
+
+Nothing provider-specific.
+
+## Known limits
+
+Nothing provider-specific.

--- a/docs/providers/crush.md
+++ b/docs/providers/crush.md
@@ -1,0 +1,48 @@
+# Crush
+
+`crush` (`internal/providers.Registry`). It is xdg-basedir: config under `$XDG_CONFIG_HOME/crush` and data under
+`$XDG_DATA_HOME/crush`. Its conversations are not there but in the checkout it was started in, as a database at
+`.crush/crush.db`, so the same id proves nothing about another checkout. The limits these sit under are in
+[`../ceilings.md`](../ceilings.md).
+
+## Spawn
+
+lich appends nothing to the agent's system prompt (`internal/terminal/command.go`, `briefingFlags`): Crush has no
+per-spawn append flag, so the point the briefing makes exists only in lich's MCP instructions.
+
+## Hooks
+
+Crush reports no session state at all (the mapping table is in
+[`../hooks/session-state.md`](../hooks/session-state.md)), so no turn ever opens or closes there. Two things
+follow. A waiting card sends no reason and keeps the generic "Waiting on you"
+(`frontend/src/components/sidebar/SessionCard.tsx`), which means the harness never spoke and not that the block
+is trivial. And keep-awake has nothing to listen to (`internal/awake`, `turnLog.onOpen`): a Crush session left
+working behind a locked screen sleeps as it always did, and no card says so.
+
+## Transcript & cost
+
+Nothing provider-specific.
+
+## Plugin install
+
+Crush has no plugin CLI, so lich writes the released files itself (`internal/agentplugin`). Crush records nothing
+about what is installed, so the version lives in a marker line lich wrote: edit the file by hand and lich reads
+it as not installed. Crush below 0.88.0 ignores those lines in silence, which is why the install asks its version
+first.
+
+## MCP
+
+Crush's config block registers lich's MCP server by the absolute path of the binary that installed it.
+
+## Account
+
+Crush runs on the user's own API keys, so there is no plan account to name (`internal/quota`, `Plan.Account`),
+which is the same reason it has no gauge.
+
+## Sandbox
+
+Nothing provider-specific.
+
+## Known limits
+
+Nothing provider-specific.

--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -1,0 +1,66 @@
+# Cursor CLI
+
+`cursor-agent` (`internal/providers.Registry`). Cursor keeps its state in two directories. Its config dir is
+`$CURSOR_CONFIG_DIR` ‖ `$XDG_CONFIG_HOME/cursor` ‖ `~/.cursor`, not xdg-basedir, the fallback being the home
+directly, and it holds the credentials and the chats. But `~/.cursor` is resolved off the home with no variable
+in the way at all, and that is where `mcp.json`, the per-project transcripts and the CLI state live. The chat
+itself is SQLite at `chats/<md5 of the resolved cwd>/<chatId>/store.db`. The limits these sit under are in
+[`../ceilings.md`](../ceilings.md).
+
+## Spawn
+
+lich appends nothing to the agent's system prompt (`internal/terminal/command.go`, `briefingFlags`): the CLI has
+no append flag, so what a Cursor session knows about lich is its tool list.
+
+## Hooks
+
+A Cursor CLI session reports through Claude Code's plugin, or not at all (`internal/agentplugin`,
+`internal/terminal/start.go`, `providerKind`). lich installs no plugin into Cursor, and it does not have to: the
+CLI executes every Claude Code hook on the machine, the user's own and each installed plugin's (measured on
+2026.08.11: `hookSource: claude-user` and `claude-plugin`, with `${CLAUDE_PLUGIN_ROOT}` expanded). So on a
+machine where the lich plugin is installed in Claude Code, a Cursor session reports the chat id it is running and
+the files it touches, with nothing installed there, and on a machine without it that session reports nothing at
+all. Nothing on the card says which of the two it is.
+
+**What never arrives is the turn.** Of the nine events the plugin registers, Cursor delivers four,
+`SessionStart`, `PreToolUse`, `PostToolUse` and `SessionEnd`, and no `UserPromptSubmit` or `Stop`, measured
+against hooks in Cursor's own format and in Claude Code's alike. So a turn that calls no tool never begins and
+one that does never ends, which is why `terminal.closableState` drops every state but `idle` from a Cursor
+session rather than pinning a spinner to the card for the rest of it: no spinner, no bell, no auto-title, and no
+`waiting` either (`Notification` maps to nothing there). That is the Crush row of
+[`../hooks/session-state.md`](../hooks/session-state.md)'s table arrived at from the other direction, since lich
+does not own the registration here and so filters what it cannot close.
+
+## Transcript & cost
+
+Cursor keeps its chats per checkout, so a resume asked without the session's own working directory answers
+"conversation gone" (`internal/terminal/transcript.go`), the same shape as Crush.
+
+## Plugin install
+
+lich installs nothing into Cursor. Installing for Cursor refuses while Claude Code has no plugin, its version is
+Claude Code's, and its row offers no update of its own: the update is the Claude Code row's, one line up the same
+screen.
+
+## MCP
+
+Cursor takes no MCP server on its command line and reads none from a Claude Code plugin, so lich's own tools come
+from an `mcpServers` document its install writes under `~/.cursor`.
+
+## Account
+
+Cursor CLI carries no claim naming the account, measured on 2026-09-04 (`internal/quota`, `Plan.Account`):
+`~/.config/cursor/auth.json`'s token is a JWT whose `sub` is an opaque `github|user_…` and whose claims contain
+no email, so there is nothing a person recognises as their account. Naming it would take a network call against
+an unmeasured route, for a provider that has no gauge to hang the name under.
+
+## Sandbox
+
+The two directories above are two mounts (`internal/sandbox/sandbox.go`). On a machine with `XDG_CONFIG_HOME` set
+they are different directories, and a sandbox binding only one is a session that cannot see its own MCP servers.
+
+## Known limits
+
+The plugin's script reports `claude`, the argument Claude Code's own registration passes it, and lich drops that
+name for a card whose provider it chose itself. A **shell** session running `cursor-agent` by hand has only the
+report to go on and wears Claude's mark.

--- a/docs/providers/kiro.md
+++ b/docs/providers/kiro.md
@@ -1,0 +1,78 @@
+# Kiro CLI
+
+`kiro-cli` (`internal/providers.Registry`), spawned as `kiro-cli chat`, since `--model` and `--trust-all-tools`
+are the `chat` subcommand's while `--agent` and `--resume-id` are the root's. `~/.kiro` hangs off the home alone,
+with no environment variable to honour (2.21.0 resolves `$HOME/.kiro`), and holds the agents, the settings and
+the conversations; the login token is a row in the SQLite store under `$XDG_DATA_HOME/kiro-cli/data.sqlite3`. A
+conversation's metadata is `~/.kiro/sessions/cli/<id>.json` with its turns in the `.jsonl` beside it. The limits
+these sit under are in [`../ceilings.md`](../ceilings.md).
+
+## Spawn
+
+**A lich-spawned Kiro session runs lich's agent, not the user's** (`internal/agentplugin/kiro.go`,
+`internal/terminal/command.go`, `agentArgs`). Kiro keeps its hooks inside an *agent config*, and its built-in
+`kiro_default` cannot be shadowed: a `kiro_default.json` in the agents directory is ignored outright (measured on
+2.21.0). So the only place a hook can be registered is an agent lich writes itself, which the spawn then names
+with `--agent lich`. Two things follow, and neither is visible on the card. The agent lich writes carries no
+`prompt`, so a session loses the paragraph `kiro_default` adds about subagents, the planner and LSP: the model
+still has every tool, it is just not told about those. And a default the user set with
+`kiro-cli agent set-default` is **not** what a lich session runs; their own agent applies to Kiro started from a
+terminal and not to Kiro started from a card. Deleting `~/.kiro/agents/lich.json` puts the session back on `kiro_default` and
+silently ends every report with it: the spawn stops naming an agent it cannot find, which is the one case where
+that costs a warning line rather than the reports.
+
+Kiro's skip-permissions flag still stops once (`internal/terminal/command.go`, `skipPermissionFlags`). With the
+switch on, lich passes `--trust-all-tools`, and Kiro's TUI opens on a full-screen confirmation ("No, exit / Yes,
+I accept / Yes, and don't ask again") that has to be answered before the session starts. The flag is real and
+every tool afterwards runs unconfirmed; it is the *first* screen that is not skipped, which is the one thing a
+user who ticked the box does not expect. Kiro's own `chat.disableTrustAllConfirmation` setting turns it off for
+good, and lich does not write it: that setting disables a safety confirmation for every Kiro on the machine,
+including the ones lich never spawned.
+
+lich appends nothing to the agent's system prompt (`internal/terminal/command.go`, `briefingFlags` has no entry
+for Kiro), so the point the briefing makes exists only in lich's MCP instructions.
+
+## Hooks
+
+**Kiro enforces no hook timeout, and blocks the turn behind one** (`internal/agentplugin/kiro.go`): its TUI draws
+"0 of 1 hooks finished" while a report runs, and a hook that slept four seconds ran to completion under both
+`timeout_ms: 1000` and `timeout: 1` (2.21.0). So lich writes no timeout into the agent, a field that bounds
+nothing being a promise the file does not keep, and what actually bounds a report is the request timeout inside
+the script itself. A lich whose listener has gone away costs a Kiro turn that wait on every hook it fires, where
+the other harnesses cut it off themselves.
+
+**A Kiro session never reports `waiting` or `idle`** ([`../hooks/`](../hooks/)). Its five events are `agentSpawn`,
+`userPromptSubmit`, `preToolUse`, `postToolUse` and `stop`, so lich closes session-start, session-state's
+busy/tool/done rows and session-touched, and nothing else. A Kiro session sitting on a permission prompt reads as
+`busy`, true, but it does not say what it is waiting for, and the card keeps the provider's mark until the PTY
+itself goes, because there is no session-end event to clear it. That `busy` also holds the machine awake
+(`internal/awake`, `turnLog.onOpen`): a Kiro session blocked on a human keeps it out of idle sleep until someone
+answers.
+
+## Transcript & cost
+
+Nothing provider-specific.
+
+## Plugin install
+
+The hooks are the agent config named under Spawn, and there is nothing else to install: Kiro has no plugin
+system, so the version lives in that file's `description` rather than in a marker line.
+
+## MCP
+
+Nothing provider-specific.
+
+## Account
+
+Kiro CLI carries no claim naming the account, measured on 2026-09-04 (`internal/quota`, `Plan.Account`): its
+login is a row in `~/.local/share/kiro-cli/data.sqlite3` holding an opaque `aoa…` token, a `github` provider
+label and an AWS profile ARN, nothing a person recognises as their account. Naming it would take a network call
+against an unmeasured route, for a provider that has no gauge to hang the name under.
+
+## Sandbox
+
+Nothing provider-specific.
+
+## Known limits
+
+Nothing provider-specific.

--- a/docs/providers/omp.md
+++ b/docs/providers/omp.md
@@ -1,0 +1,54 @@
+# oh-my-pi
+
+`omp` (`internal/providers.Registry`). Its state directory answers to two variables and the profile wins:
+`OMP_PROFILE` moves the whole directory to `~/.omp/profiles/<profile>/agent` and beats an explicit
+`PI_CODING_AGENT_DIR`, which otherwise names it, falling back to `~/.omp/agent`. One JSONL holds a conversation,
+in a directory named after the cwd it ran in: `sessions/<encoded cwd>/<timestamp>_<id>.jsonl`. The limits these
+sit under are in [`../ceilings.md`](../ceilings.md).
+
+## Spawn
+
+lich appends to the agent's system prompt (`internal/terminal/command.go`, `briefingFlags` →
+`relay.SpawnBriefing`): a session is spawned with `--append-system-prompt` carrying lich's own briefing, so text
+the user never wrote is in every session's prompt and in `/proc/<pid>/cmdline`.
+
+## Hooks
+
+An oh-my-pi card sends no reason with a `waiting` and keeps the generic "Waiting on you"
+(`frontend/src/components/sidebar/SessionCard.tsx`; the mapping table is in
+[`../hooks/session-state.md`](../hooks/session-state.md)). It does not report `waiting` in the first place: it
+declares an approval event no run was ever seen emitting, so there is nothing to hang a reason on. A bare card
+there means the harness never spoke, not that the block is trivial.
+
+## Transcript & cost
+
+Nothing provider-specific.
+
+## Plugin install
+
+oh-my-pi has no plugin CLI, so lich writes the released files itself (`internal/agentplugin`). omp records
+nothing about what is installed, so the version lives in a marker line lich wrote: edit the file by hand and lich
+reads it as not installed.
+
+Both halves land in the state directory above, resolved independently by the install and by the transcript
+reader (`internal/agentplugin/omp.go`, `internal/terminal/transcript.go`, as the Claude Code pair do). Get the
+precedence backwards and the install lands where omp is not reading and every restored card silently starts
+fresh.
+
+## MCP
+
+omp's `mcp.json` registers lich's MCP server by the absolute path of the binary that installed it, and it is a
+JSON document lich rewrites rather than appends to: every key survives, the user's formatting does not.
+
+## Account
+
+oh-my-pi runs on the user's own API keys, so there is no plan account to name (`internal/quota`, `Plan.Account`),
+which is the same reason it has no gauge.
+
+## Sandbox
+
+Nothing provider-specific.
+
+## Known limits
+
+Nothing provider-specific.

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -1,0 +1,56 @@
+# opencode
+
+`opencode` (`internal/providers.Registry`). It reads its directories through the xdg-basedir convention on every
+platform rather than the OS-native ones: config under `$XDG_CONFIG_HOME/opencode`, and every conversation in one
+database at `$XDG_DATA_HOME/opencode/opencode.db`. The limits these sit under are in
+[`../ceilings.md`](../ceilings.md).
+
+## Spawn
+
+lich appends nothing to the agent's system prompt (`internal/terminal/command.go`, `briefingFlags`): opencode has
+no per-spawn append flag, so the point the briefing makes exists only in lich's MCP instructions.
+
+opencode files a fork under the parent's directory, not the new checkout's (measured on 1.18.23): the copied
+session's `directory` column is the one the original ran in, and its `parent_id` is left empty, so opencode's own
+session list places a fork in the checkout it came from and records no lineage. lich's own card is right, since
+it carries the worktree it was opened in and `origin_session_id` names the parent, but the two disagree and only
+lich's side is visible in lich.
+
+## Hooks
+
+opencode's `.asked` events carry only the thing being asked about (`permission`, `action`), so a waiting card
+reads a bare `edit` (`frontend/src/components/sidebar/SessionCard.tsx`; the mapping table is in
+[`../hooks/session-state.md`](../hooks/session-state.md)). That says which card to open and not what it will ask.
+
+## Transcript & cost
+
+Nothing provider-specific.
+
+## Plugin install
+
+opencode has no plugin CLI, so lich writes the released files itself (`internal/agentplugin`). opencode records
+nothing about what is installed, so the version lives in a marker line lich wrote: edit the file by hand and lich
+reads it as not installed.
+
+## MCP
+
+A new MCP tool reaches opencode a release later than everyone else (`internal/cli/mcp.go`, `mcpTools`; the
+registration table in [`../cli.md`](../cli.md)). Every other harness is handed lich's own server, so a tool added
+there is in that session's list on the next spawn. opencode cannot register an MCP server from a plugin, so its
+plugin defines each tool itself in the companion repo (`omartelo/lich-plugin`, `opencode/lich.js`), which means a
+tool arrives there only once that repo cuts a release and the user reinstalls the plugin. Until they do it is
+missing from that session's list while it is in every other. `lich rename` works there like anywhere else; it is
+discovery that lags, which is the whole reason the tools exist.
+
+## Account
+
+opencode runs on the user's own API keys, so there is no plan account to name (`internal/quota`, `Plan.Account`),
+which is the same reason it has no gauge.
+
+## Sandbox
+
+Nothing provider-specific.
+
+## Known limits
+
+Nothing provider-specific.

--- a/frontend/src/lib/providers-store.test.ts
+++ b/frontend/src/lib/providers-store.test.ts
@@ -69,7 +69,8 @@ describe("provider setting keys", () => {
     expect(skipPermissionFlags.cursor).toBe("--force")
     // Kiro's is the one spelling here that does not fully deliver: with it on,
     // its TUI still opens on a confirmation the user accepts once
-    // (docs/ceilings.md). The switch is still offered, because the flag is real.
+    // (docs/providers/kiro.md). The switch is still offered, because the flag
+    // is real.
     expect(skipPermissionFlags.kiro).toBe("--trust-all-tools")
     expect(skipPermissionFlags.shell).toBeUndefined()
   })

--- a/internal/agentplugin/kiro.go
+++ b/internal/agentplugin/kiro.go
@@ -25,9 +25,9 @@ import (
 //
 // Three of the four reports are registered. The title report is not: it reads an
 // `ai-title` out of a transcript path the harness hands it on stdin, and Kiro
-// passes no transcript path at all — see docs/ceilings.md, which also carries
-// what a lich-spawned Kiro session gives up by running this agent instead of
-// `kiro_default`.
+// passes no transcript path at all — see docs/providers/kiro.md, which also
+// carries what a lich-spawned Kiro session gives up by running this agent
+// instead of `kiro_default`.
 
 // kiroWriteTools are the tools whose use means a file may have changed, so the
 // touched report fires for them and not for a read. They are registered as one
@@ -71,7 +71,8 @@ var kiroHooks = []struct {
 // `timeout_ms: 1000` and `timeout: 1` (2.21.0, on `agentSpawn`). Neither
 // spelling bounds anything, and a field lich writes that does nothing is the
 // silent no-op this package exists to avoid. What actually bounds a report is
-// the script's own request timeout, which is where docs/ceilings.md points.
+// the script's own request timeout, which is where docs/providers/kiro.md
+// points.
 
 func (s *Service) kiroInstall() error {
 	version, err := s.releaseVersion()
@@ -141,7 +142,8 @@ func kiroScripts() []string {
 // `kiro_default` adds about subagents, the planner and LSP, and costs nothing
 // else. Copying that paragraph instead would freeze a snapshot of Kiro's own
 // default into a file lich never updates, which is a session drifting further
-// from stock Kiro with every release and saying nothing (docs/ceilings.md).
+// from stock Kiro with every release and saying nothing
+// (docs/providers/kiro.md).
 //
 // `resources` is the one thing worth carrying over from `kiro_default`, because
 // dropping it would silently stop a project's own context from loading.

--- a/internal/agentplugin/mcpservers.go
+++ b/internal/agentplugin/mcpservers.go
@@ -21,7 +21,7 @@ import (
 //
 // Every other provider is answered with lich's own name alone: their tool names
 // either carry the doubled underscore the card splits without help, or are not a
-// tool name at all (Antigravity's, docs/ceilings.md).
+// tool name at all (Antigravity's, docs/hooks/session-state.md).
 
 // opencodeMCPKey is the key opencode holds its servers under.
 const opencodeMCPKey = "mcp"

--- a/internal/providers/providers.go
+++ b/internal/providers/providers.go
@@ -47,7 +47,7 @@ type Provider struct {
 // conversation by id (terminal.resumeArgs); all but Cursor CLI also have the
 // companion plugin installed into them (agentplugin.supported) — Cursor runs it
 // anyway, because it executes every Claude Code hook on the machine, which
-// docs/ceilings.md names along with what that costs. What still differs per
+// docs/providers/cursor.md names along with what that costs. What still differs per
 // provider is spelled at each of those tables, and AcceptsMCPServer below is
 // the one split this file owns.
 var Registry = []Provider{

--- a/internal/terminal/terminal_test.go
+++ b/internal/terminal/terminal_test.go
@@ -883,7 +883,7 @@ func TestSkipPermissionArgs(t *testing.T) {
 		{"cursor on", "cursor", true, []string{"--force"}},
 		// Kiro's is the only one that is not a "dangerous"/"yolo"/"force" word,
 		// and it does not fully deliver: with it on, Kiro's TUI still opens on a
-		// confirmation the user has to accept once (docs/ceilings.md).
+		// confirmation the user has to accept once (docs/providers/kiro.md).
 		{"kiro off", "kiro", false, nil},
 		{"kiro on", "kiro", true, []string{"--trust-all-tools"}},
 		{"shell is never wired", KindShell, true, nil},


### PR DESCRIPTION
`docs/ceilings.md` says in its own header that it is "the trap alone", but a run of its bullets were measured provider behaviour instead: what a harness is spawned with, which lifecycle events it fires, how its plugin installs, whether it names the account a session spends. That is reference, and a reader hunting one of those facts was reading a file organised around something else.

## What moved

Fourteen bullets, into `docs/providers/<id>.md`, one page per `internal/providers.Registry` id (claude, codex, antigravity, opencode, omp, crush, cursor, kiro). Each page opens with what the harness is, its binary, its config directory and where its transcript lives, then holds the same eight sections in the same order so the eight can be read side by side: Spawn, Hooks, Transcript & cost, Plugin install, MCP, Account, Sandbox, Known limits. A section with nothing to say says so rather than standing empty.

Bullets that named several providers at once were split per provider: the plugin-install one, the waiting-reason one, the account-naming one and the system-prompt-append one now each land in the files they were about. Citations came along with the sentences.

The keep-awake bullet stays in ceilings with its Crush and Kiro halves moved to those files. What is left of it is `systemd-inhibit` and the Windows/macOS CI evidence, which is about the machine and not about a provider.

Bullet count in `docs/ceilings.md`: **66 before, 52 after**.

## Cross-links

- `ceilings.md`'s header gains one sentence pointing at `docs/providers/`.
- `docs/adding-a-provider.md` points its Cursor sentence at `providers/cursor.md`, and its paperwork checklist gains the new page as a required artifact for a ninth provider.
- `docs/hooks/README.md` points its Cursor paragraph at `providers/cursor.md` and the directory at `providers/`.
- `docs/hooks/session-state.md`'s Kiro pointer follows the fact to `providers/kiro.md`.

## Not done here

No Go changed, so a handful of code comments still point at `docs/ceilings.md` for facts that now live in `docs/providers/` (`internal/agentplugin/kiro.go`, `internal/providers/providers.go`, `internal/agentplugin/mcpservers.go`, two tests). Left deliberately: this PR is docs only.

## Test plan

- [x] `gofmt -l .` clean (no Go touched)
- [x] Every relative link in the new pages resolves
- [x] No em dashes in the new pages
- [ ] Read the eight pages once on GitHub