### PR TITLE
fix: present the Windows window without DirectComposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The window no longer opens white on some Windows machines.** Chromium presents
+  its frames through DirectComposition on Windows, and a graphics driver that
+  cannot leaves lich rendering into a window that never shows anything: the page
+  loads, the processes live, the screen stays blank (measured on Intel UHD,
+  driver 31.0.101.2141). lich's own window now presents through the classic swap
+  chain there, which costs it the video overlays a window with no video never
+  used, and keeps GPU rasterisation and the terminal's WebGL renderer.
+
 ## [0.48.0] - 2026-09-09
 
 ### Changed

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -507,7 +507,10 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   runner only (`release.yml` opens the window and reads a page over CDP), never on a desk, so the taskbar
   icon and AppUserModelID grouping on Windows, the Dock tile, Cmd-Tab and menu bar name on macOS, and the
   graceful close on restart on both are designed, not seen; what the macOS runner did measure is that the
-  subprocesses hold no Dock tile of their own and the page renders (`release.yml`, the `mac` job).
+  subprocesses hold no Dock tile of their own and the page renders (`release.yml`, the `mac` job). A page
+  read over CDP is not a pixel either: a window that renders every frame and presents none reads as green, and
+  that is exactly what an Intel UHD driver did on Windows until `shell/src/main.rs` turned DirectComposition
+  off there. No runner here can look at its own screen, so presentation is only ever proven on a desk.
 - **A Linux install whose window is missing or dies at startup opens a system browser instead**
   (`internal/chromium.Run`): `go run`, a bare binary copied out of the tarball, a package missing
   `lib/lich/shell` — each falls through to the ladder below with one `Warn` line; a window that exits with

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -202,6 +202,17 @@ fn main() {
     {
         app = app.credential_storage(kurogane::CredentialStorage::Basic);
     }
+    // Chromium presents its frames through DirectComposition on Windows, and
+    // an Intel UHD driver that cannot (31.0.101.2141, measured) leaves every
+    // frame rendered and never shown: five live processes, the page loaded on
+    // CDP, a white window. The classic swap chain costs the video overlays a
+    // window with no video has no use for; --use-angle=gl and
+    // --disable-gpu-compositing also clear it, but each swaps a whole backend
+    // out, and the terminal's WebGL renderer rides on this one.
+    #[cfg(windows)]
+    {
+        app = app.chromium_flag("disable-direct-composition");
+    }
     if let Some(class) = launch.class {
         app = app.window_class(class);
     }


### PR DESCRIPTION
0.48.0 opens a white window on Windows: the page loads, the five CEF processes live, and nothing is ever painted. Reported on Intel UHD, driver 31.0.101.2141.

## What it is

Chromium presents its frames through DirectComposition on Windows. A driver that cannot leaves lich rendering into a window that never shows anything. `--disable-gpu`, `--use-angle=gl` and `--disable-gpu-compositing` all clear it as well, but each swaps a whole backend out; `--disable-direct-composition` touches presentation alone, so GPU rasterisation and the terminal's WebGL renderer stay.

The switch goes in before the user's own, so `lich -- --use-angle=gl` still wins.

## Why CI was green

The Windows job in `release.yml` opens the window and reads the page over CDP. A window that renders every frame and presents none passes that. No runner here can look at its own screen, so presentation is only ever proven on a desk. Written down in `docs/ceilings.md`, in the bullet that already says the Windows and macOS windows are runner-tested only.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --release --all-targets -- -D warnings`, `cargo test --release` (Linux)
- [ ] The `shell` job builds the `cfg(windows)` block on windows-latest
- [ ] The window paints on the reporting machine after this build