### PR TITLE
fix: size the git dialog's buttons alike and unstick the footer headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Two settings surfaces that were a pixel out.** The dialog a machine without
+  git opens sized its Check again button one step smaller than the two beside
+  it, and Appearance drew a hairline between the Footer row and its layout
+  editor, leaving the Left and Right headings pressed against a line that
+  belonged to the setting above.
+
 ## [0.48.1] - 2026-09-09
 
 ### Fixed

--- a/frontend/src/components/GitMissingGate.tsx
+++ b/frontend/src/components/GitMissingGate.tsx
@@ -50,7 +50,7 @@ export function GitMissingGate() {
           <Button variant="ghost" onClick={() => setDismissed(true)}>
             Not now
           </Button>
-          <CheckAgainButton />
+          <CheckAgainButton size="default" />
           <Button
             onClick={() => {
               void System.OpenExternal(GIT.url)

--- a/frontend/src/components/settings/FooterSettings.tsx
+++ b/frontend/src/components/settings/FooterSettings.tsx
@@ -36,34 +36,39 @@ export function FooterSettings() {
   }
   return (
     <>
-      {/* The row names the setting and holds the one control that is not a
-          drag; the editor below it is always open, because it is the thing the
-          row is about and hiding it behind a click buys nothing. */}
-      <SettingRow
-        title="Footer"
-        description={
-          !ready
-            ? "Loading saved choices…"
-            : saving
-              ? "Saving…"
-              : "Drag an item between the sides, or out to hide it. Applies to every project."
-        }
-      >
-        <Button
-          variant="ghost"
-          size="xs"
-          disabled={!ready || saving}
-          onClick={() => void change(DEFAULT_FOOTER_LAYOUT)}
+      {/* Row, editor and preview are one setting, so they are one child of the
+          section's divide-y: as separate children the hairline lands between
+          the row and the editor, drawn tight against the zone headings. */}
+      <div>
+        {/* The row names the setting and holds the one control that is not a
+            drag; the editor below it is always open, because it is the thing the
+            row is about and hiding it behind a click buys nothing. */}
+        <SettingRow
+          title="Footer"
+          description={
+            !ready
+              ? "Loading saved choices…"
+              : saving
+                ? "Saving…"
+                : "Drag an item between the sides, or out to hide it. Applies to every project."
+          }
         >
-          Restore default
-        </Button>
-      </SettingRow>
-      <FooterLayoutEditor
-        layout={layout}
-        disabled={!ready || saving}
-        onChange={(next) => void change(next)}
-      />
-      <FooterLayoutPreview layout={layout} />
+          <Button
+            variant="ghost"
+            size="xs"
+            disabled={!ready || saving}
+            onClick={() => void change(DEFAULT_FOOTER_LAYOUT)}
+          >
+            Restore default
+          </Button>
+        </SettingRow>
+        <FooterLayoutEditor
+          layout={layout}
+          disabled={!ready || saving}
+          onChange={(next) => void change(next)}
+        />
+        <FooterLayoutPreview layout={layout} />
+      </div>
       {hasFooterItem(layout, "cost") && <SpendCeiling />}
     </>
   )


### PR DESCRIPTION
Two spacing bugs a user reported from the screen.

## The git dialog

`GitMissingGate` puts three buttons in its footer. Two are `Button` at the
default size; the third is `CheckAgainButton`, whose own default is `sm`, so
Check again rendered a step shorter than Not now and Install git. It now passes
`size="default"`, which is what `ProviderSetupDialog` — the other dialog using
that button — already did. The inline uses (`ToolMissing`, `VcsToolsSetting`,
`ProvidersPane`) keep `sm`: their neighbours are `sm` too.

## The footer layout editor

The settings pane wraps a section's children in `divide-y` (`Settings.tsx:320`),
so every top-level child of a settings component gets a hairline above it.
`FooterSettings` returned a fragment of four: the row, the editor, the preview
and the spend ceiling. The hairline therefore landed between the row and the
editor, and the editor's root has no padding of its own — the Left and Right
zone headings were drawn tight against a line that belonged to the setting
above them.

Row, editor and preview are one setting, so they are one child now. The border
falls where the setting ends, and `SettingRow`'s `py-3` gives the headings their
space back. `first:border-t-0` still holds: the row is the wrapper's first
child, and the wrapper takes the divider.

## Test plan

- [x] `pnpm exec biome ci` on both files, exit 0
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm vitest run src/components/FooterSession.test.tsx` — 29 passed
- [ ] Settings › Appearance › Footer: no hairline between the row and the editor
- [ ] Rename `git` on PATH and relaunch: the three dialog buttons are one height
