### PR TITLE
fix: update pre-window and Scoop Windows installs the right way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it, and Appearance drew a hairline between the Footer row and its layout
   editor, leaving the Left and Right headings pressed against a line that
   belonged to the setting above.
+- **A Windows install from before the window now gets the window when it
+  updates.** lich only recognised an installed lich by the window beside it,
+  so an install made by the installer of 0.45 or earlier updated the way a
+  portable exe does: the exe was swapped, the Start Menu shortcut and the
+  "Installed apps" entry stayed at the old version, and lich kept opening in a
+  system browser. Such an install is now recognised by its uninstaller and
+  updates by running the release installer, which upgrades it in place and
+  brings the window, the shortcut and the entry up with it.
+- **A Scoop install no longer updates through the installer.** Since 0.46 the
+  Scoop layout carries the window, which is what lich took as the mark of an
+  installer install, so the update button would have run the release installer
+  into Scoop's directory and registered a second lich in "Installed apps". A
+  Scoop install is now Scoop's, like a Homebrew one: the button opens a shell
+  with `scoop update lich` and a restart pasted, never run.
 
 ## [0.48.1] - 2026-09-09
 

--- a/docs/chromium-shell.md
+++ b/docs/chromium-shell.md
@@ -176,8 +176,15 @@ through CEF itself). The patch is upstream as
 Windows ships the same window, flat beside `lich.exe` as `shell\` the way
 CEF lays itself out there, inside the installer (`build/windows/lich.iss`)
 and as a zip beside the portable exe. The update button downloads the release's
-installer when this window is present, checks its SHA-256 against the release
-checksums, and runs it silently after closing lich. The per-user installer updates
+installer when this window is present or when Inno Setup's `unins000.exe` sits
+beside `lich.exe` (an installer install from before the window, v0.10.0 to
+v0.45.x, carries only that mark), checks its SHA-256 against the release
+checksums, and runs it silently after closing lich; the same AppId means the
+setup upgrades that install in place, bringing the window, the Start Menu
+shortcut and the "Installed apps" entry up with the exe. A Scoop install
+(`apps\lich\current`) carries the window too, but Scoop owns it: the button
+offers `scoop update lich` followed by a `/restart` spelled for PowerShell,
+and never runs the installer into Scoop's directory. The per-user installer updates
 the same directory without elevation and reopens lich on its previous port. A
 failed installation shows its error; `.lich-update-setup.log` beside `lich.exe`
 records the install. The last downloaded installer is retained there as

--- a/internal/appupdate/appupdate.go
+++ b/internal/appupdate/appupdate.go
@@ -44,6 +44,15 @@ const (
 	// rendered into the pasted text — it stays a shell env reference expanded at
 	// run time, not a literal baked into scrollback.
 	restartChain = ` && curl -fsS --max-time 5 -X POST "http://127.0.0.1:$LICH_PORT/restart?token=$LICH_TOKEN"`
+	// scoopPackage is the manifest name a Scoop install updates through; Scoop
+	// owns its copy under apps\lich\current, so lich never swaps it itself.
+	scoopPackage = "lich"
+	// restartChainPwsh is restartChain for the PowerShell a Windows session runs:
+	// `;` because Windows PowerShell 5.1 has no `&&`, and the env references in
+	// its own syntax. Scoop keeps the old version's directory until `scoop
+	// cleanup`, so the update lands while lich runs and the restart picks it up
+	// through the repointed junction.
+	restartChainPwsh = `; Invoke-RestMethod -Method Post "http://127.0.0.1:$env:LICH_PORT/restart?token=$env:LICH_TOKEN"`
 	// defaultOSRelease is where the distro identity lives; a Service field points
 	// tests elsewhere.
 	defaultOSRelease = "/etc/os-release"
@@ -217,16 +226,38 @@ func canSelfApply(goos, exePath string) bool {
 	if exePath == "" {
 		return false
 	}
-	if brewOwned(exePath) || bundled(exePath) {
+	if brewOwned(exePath) || bundled(exePath) || scoopOwned(exePath) {
 		return false
 	}
 	return dirWritable(filepath.Dir(exePath))
 }
 
-// windowed recognizes the Windows installer layout.
-func windowed(exePath string) bool {
-	_, err := os.Stat(filepath.Join(filepath.Dir(exePath), "shell", "lich-shell.exe"))
-	return err == nil
+// scoopOwned reports whether exePath is a Scoop install: <root>\apps\lich\
+// <version or current>\lich.exe, whichever way the junction was resolved. The
+// directory is writable and, since the manifest ships the window, carries
+// shell\, so the checks above would send it to the Inno Setup installer —
+// which would register a second lich in "Installed apps" and write into the
+// version directory Scoop tracks.
+func scoopOwned(exePath string) bool {
+	segments := strings.Split(filepath.ToSlash(exePath), "/")
+	n := len(segments)
+	return n >= 4 && strings.EqualFold(segments[n-4], "apps") && strings.EqualFold(segments[n-3], scoopPackage)
+}
+
+// installerOwned recognizes the Windows installer layout by either mark it
+// leaves beside the exe: the window under shell\, or the uninstaller Inno Setup
+// writes to every install. The uninstaller is the only mark an install from
+// before the window carries (v0.10.0 to v0.45.x); swapping the bare exe there
+// left a lich that opened a system browser, with the shortcut and the
+// "Installed apps" entry stuck at the old version.
+func installerOwned(exePath string) bool {
+	dir := filepath.Dir(exePath)
+	for _, mark := range []string{filepath.Join("shell", "lich-shell.exe"), "unins000.exe"} {
+		if _, err := os.Stat(filepath.Join(dir, mark)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // brewOwned reports whether exePath is a Homebrew formula install. The Cellar
@@ -254,6 +285,8 @@ func bundled(exePath string) bool {
 
 // installCommand is the shell command the UI pastes to update this install, or
 // "" on the self-apply platforms (they swap the binary through the button).
+// A Scoop install is package-manager owned like Arch's, and its restart is
+// spelled for PowerShell.
 // Arch goes through its AUR helper plus an explicit restart — yay knows nothing
 // about lich's /restart — while every other distro uses install.sh, which
 // restarts itself. A Homebrew install is package-manager owned like Arch's, on
@@ -264,6 +297,9 @@ func (s *Service) installCommand() string {
 	}
 	if brewOwned(s.exePath) {
 		return "brew upgrade " + brewPackage + restartChain
+	}
+	if scoopOwned(s.exePath) {
+		return "scoop update " + scoopPackage + restartChainPwsh
 	}
 	if s.goos != "linux" {
 		return ""

--- a/internal/appupdate/appupdate_test.go
+++ b/internal/appupdate/appupdate_test.go
@@ -69,6 +69,7 @@ func TestCanSelfApply(t *testing.T) {
 		{"homebrew cellar is brew's", "darwin", cellarExe(t), false},
 		{"app bundle keeps its signature", "darwin", bundleExe(t), false},
 		{"installer layout carries the window", "windows", windowedExe(t), true},
+		{"scoop install is scoop's", "windows", scoopExe(t), false},
 	}
 	for _, tc := range tests {
 		if got := canSelfApply(tc.goos, tc.exePath); got != tc.want {
@@ -87,6 +88,21 @@ func windowedExe(t *testing.T) string {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(shell, "lich-shell.exe"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(dir, "lich.exe")
+}
+
+// scoopExe returns a writable path shaped like a Scoop install
+// (<root>\apps\lich\current\lich.exe) with the window beside it, the way the
+// manifest lays it out.
+func scoopExe(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "Scoop", "apps", "lich", "current")
+	if err := os.MkdirAll(filepath.Join(dir, "shell"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "shell", "lich-shell.exe"), nil, 0o644); err != nil {
 		t.Fatal(err)
 	}
 	return filepath.Join(dir, "lich.exe")
@@ -241,6 +257,8 @@ func TestInstallCommand(t *testing.T) {
 		{"darwin self-apply", "darwin", "", "", ""},
 		{"homebrew install", "darwin", cellarExe(t), "", brew},
 		{"cask install", "darwin", bundleExe(t), "", cask},
+		{"scoop install", "windows", scoopExe(t), "", "scoop update lich" + restartChainPwsh},
+		{"scoop version dir", "windows", filepath.Join("C:", "scoop", "apps", "lich", "0.47.0", "lich.exe"), "", "scoop update lich" + restartChainPwsh},
 		{"arch by ID", "linux", "", "ID=arch\n", arch},
 		{"arch quoted ID", "linux", "", "ID=\"arch\"\n", arch},
 		{"arch derivative via ID_LIKE", "linux", "", "ID=manjaro\nID_LIKE=arch\n", arch},

--- a/internal/appupdate/installer.go
+++ b/internal/appupdate/installer.go
@@ -13,7 +13,7 @@ import (
 const installerLimit = 1 << 30
 
 func (s *Service) installerUpdate() bool {
-	return s.goos == "windows" && windowed(s.exePath)
+	return s.goos == "windows" && installerOwned(s.exePath) && !scoopOwned(s.exePath)
 }
 
 func (s *Service) assetName(version string) string {

--- a/internal/appupdate/installer_test.go
+++ b/internal/appupdate/installer_test.go
@@ -13,12 +13,17 @@ import (
 )
 
 func TestWindowsApplyAsset(t *testing.T) {
-	for _, window := range []bool{false, true} {
-		t.Run(fmt.Sprint(window), func(t *testing.T) {
-			exe := filepath.Join(t.TempDir(), "lich.exe")
+	layouts := map[string]func(*testing.T) string{
+		"portable": func(t *testing.T) string { return filepath.Join(t.TempDir(), "lich.exe") },
+		"windowed": windowedExe,
+		"legacy":   legacyInstallExe,
+	}
+	for name, layout := range layouts {
+		t.Run(name, func(t *testing.T) {
+			window := name != "portable"
+			exe := layout(t)
 			asset := "lich-v0.8.0-windows-amd64.exe"
 			if window {
-				exe = windowedExe(t)
 				asset = "lich-v0.8.0-windows-amd64-setup.exe"
 			}
 			body := "verified release asset"
@@ -72,6 +77,9 @@ func windowsReleaseFixture(t *testing.T, asset, body string) *httptest.Server {
 func TestInstallerVerificationAndFailures(t *testing.T) {
 	body := "installer"
 	sum := sha256.Sum256([]byte(body))
+	if (&Service{goos: "windows", exePath: scoopExe(t)}).installerUpdate() {
+		t.Fatal("a Scoop install must not run the Inno Setup installer")
+	}
 	s := &Service{exePath: windowedExe(t)}
 	if err := s.applyInstaller(strings.NewReader(body), sum[:]); err == nil {
 		t.Fatal("missing installer callback must fail")
@@ -98,6 +106,18 @@ func TestInstallerVerificationAndFailures(t *testing.T) {
 	if err := stageInstaller(failingReader{}, sum[:], filepath.Join(t.TempDir(), "setup.exe")); err != io.ErrUnexpectedEOF {
 		t.Fatalf("read error = %v", err)
 	}
+}
+
+// legacyInstallExe returns a path laid out like an installer install from
+// before the window shipped: the Inno Setup uninstaller beside the exe and no
+// shell\ directory.
+func legacyInstallExe(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "unins000.exe"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(dir, "lich.exe")
 }
 
 type failingReader struct{}


### PR DESCRIPTION
## Summary

- A Windows install made by the installer of 0.45 or earlier has no `shell\` beside `lich.exe`, so the update button treated it as a portable exe: swapped the binary, left the Start Menu shortcut and the "Installed apps" entry at the old version, and lich kept opening in a system browser. `installerOwned` now also recognises Inno Setup's `unins000.exe` beside the exe; the same AppId since #21 means the release installer upgrades that install in place, bringing the window, the shortcut and the entry with it.
- A Scoop install (`apps\lich\current`) carries the window since 0.46, which was the only mark of an installer install, so the button would have run the installer into Scoop's directory and registered a second lich. `scoopOwned` makes it package-manager owned like Homebrew: `canSelfApply` is false and the UI pastes `scoop update lich` followed by a `/restart` spelled for PowerShell (`;` instead of `&&`, `$env:` references), never run.

Docs in `docs/chromium-shell.md`, entries under `[Unreleased]`.

## Test plan

- [x] `go test ./internal/appupdate/ ./internal/restart/` with the new legacy and Scoop layouts (`TestWindowsApplyAsset`, `TestCanSelfApply`, `TestInstallCommand`, `TestInstallerVerificationAndFailures`)
- [x] `gofmt`, `go vet`, cross-compile linux/darwin/windows
- [ ] On a Windows machine with a 0.45 installer install: Update runs the setup, `shell\` appears, lich reopens in its own window, "Installed apps" shows the new version
- [ ] On a Scoop install: Update opens a shell with the pasted command; running it updates and relaunches lich