### PR TITLE
feat: draw the update download as a bar with percent and bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The update toast shows the download.** Pressing Update & install used to
+  leave one spinner turning until the whole thing was over, a minute or more
+  where the Windows installer is the asset. The toast now draws a bar with the
+  percent and the megabytes received of the total while the release downloads,
+  then a spinner naming the install, and says on Windows that lich closes and
+  reopens on its own. A failure says which of the two it died in and how far
+  the download got, and offers Retry.
+
 ### Fixed
 
 - **Two settings surfaces that were a pixel out.** The dialog a machine without

--- a/frontend/src/components/AppUpdateGate.tsx
+++ b/frontend/src/components/AppUpdateGate.tsx
@@ -11,6 +11,10 @@ import { AppUpdate, System } from "@/lib/rpc"
 import { useProjects } from "@/providers/projects"
 import { queuePaste } from "@/lib/terminal/paste-queue"
 import { readPref, writePref } from "@/lib/prefs"
+import { onAppEvent } from "@/lib/app-events"
+import type { AppUpdateProgress } from "@/lib/api-types"
+import { UpdateProgressToast } from "@/components/UpdateProgressToast"
+import { failureText, isUpdateProgress, UPDATE_PROGRESS_EVENT } from "@/lib/update/update-progress"
 import { registerUpdateChecker } from "@/lib/update/update-check"
 import { errorText } from "@/lib/utils"
 
@@ -93,23 +97,42 @@ export function AppUpdateGate() {
   const promptSelfApply = (version: string) => {
     toast(`lich ${version} is available`, {
       duration: Infinity,
-      action: { label: "Update & install", onClick: () => void runApply() },
+      action: { label: "Update & install", onClick: () => void runApply(version) },
       cancel: { label: "Later", onClick: () => dismiss(version) },
     })
   }
 
-  // Download + verify + swap, then a persistent toast whose Restart button
-  // relaunches lich in place. Kept persistent so the button stays available if
-  // the user doesn't restart right away.
-  const runApply = async () => {
-    const id = toast.loading("Downloading lich update…")
+  // Download + verify + swap, drawn step by step off the progress events Apply
+  // emits, then a persistent toast whose Restart button relaunches lich in
+  // place. Kept persistent so the button stays available if the user doesn't
+  // restart right away. A failure names the phase it died in and offers the
+  // whole thing again; there is no resume.
+  const runApply = async (version: string) => {
+    let last: AppUpdateProgress | null = null
+    const show = (progress: AppUpdateProgress | null, id?: string | number) =>
+      toast.custom(() => <UpdateProgressToast version={version} progress={progress} />, {
+        id,
+        duration: Infinity,
+      })
+    const id = show(null)
+    const unsubscribe = onAppEvent(UPDATE_PROGRESS_EVENT, (data) => {
+      if (!isUpdateProgress(data)) return
+      last = data
+      show(data, id)
+    })
     try {
       await AppUpdate.Apply()
     } catch (error) {
-      toast.error(`Update failed: ${errorText(error)}`, { id })
+      unsubscribe()
+      toast.error(failureText(last, errorText(error)), {
+        id,
+        duration: Infinity,
+        action: { label: "Retry", onClick: () => void runApply(version) },
+      })
       return
     }
-    toast.success("lich updated", {
+    unsubscribe()
+    toast.success(`lich updated to ${version}`, {
       id,
       duration: Infinity,
       action: { label: "Restart", onClick: () => void runRestart() },

--- a/frontend/src/components/UpdateProgressToast.tsx
+++ b/frontend/src/components/UpdateProgressToast.tsx
@@ -1,0 +1,54 @@
+import { LoaderCircle } from "lucide-react"
+import type { AppUpdateProgress } from "@/lib/api-types"
+import { downloadReading } from "@/lib/update/update-progress"
+
+// UpdateProgressToast is the body of the update toast while Apply runs: a bar
+// with percent and bytes during the download (indeterminate without a total),
+// then a spinner naming the phase that has no percentage. Rendered through
+// toast.custom on the popover surface, like the install prompt.
+export function UpdateProgressToast({
+  version,
+  progress,
+}: {
+  version: string
+  progress: AppUpdateProgress | null
+}) {
+  const downloading = progress === null || progress.phase === "download"
+  return (
+    <div className="flex w-full flex-col gap-2.5 rounded-md border bg-popover p-4 text-sm text-popover-foreground shadow-lg">
+      <div className="flex items-center gap-2">
+        {!downloading && <LoaderCircle className="size-4 shrink-0 animate-spin" />}
+        <span className="min-w-0 flex-1 truncate font-medium">
+          {downloading ? `Downloading lich ${version}` : `Installing lich ${version}…`}
+        </span>
+      </div>
+      {downloading && <DownloadBar progress={progress} />}
+      {progress?.phase === "installer" && (
+        <span className="text-xs text-muted-foreground">lich closes and reopens on its own.</span>
+      )}
+    </div>
+  )
+}
+
+function DownloadBar({ progress }: { progress: AppUpdateProgress | null }) {
+  const reading = progress ? downloadReading(progress) : null
+  const percent = reading?.percent ?? null
+  return (
+    <>
+      <span className="h-1.5 overflow-hidden rounded-full bg-muted">
+        {percent === null ? (
+          <span className="block h-full w-1/3 animate-update-indeterminate rounded-full bg-foreground motion-reduce:animate-none" />
+        ) : (
+          <span
+            className="block h-full rounded-full bg-foreground"
+            style={{ width: `${percent}%` }}
+          />
+        )}
+      </span>
+      <span className="flex justify-between text-xs text-muted-foreground tabular-nums">
+        <span>{percent === null ? "" : `${percent}%`}</span>
+        <span>{reading?.bytes ?? ""}</span>
+      </span>
+    </>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -27,6 +27,13 @@
     /* The one text rung below text-xs: the uppercase label that heads a group
        of rows (DESIGN.md). Font size only, as the arbitrary value it replaced. */
     --text-2xs: 0.65625rem;
+    /* The update toast's bar while the download has no total: a third of the
+       track sliding across, the way an indeterminate bar reads everywhere. */
+    --animate-update-indeterminate: update-indeterminate 1.4s ease-in-out infinite;
+    @keyframes update-indeterminate {
+        from { transform: translateX(-100%); }
+        to { transform: translateX(300%); }
+    }
     --font-heading: var(--font-sans);
     --font-sans: 'Geist Variable', sans-serif;
     --color-sidebar-ring: var(--sidebar-ring);

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -462,6 +462,18 @@ export interface AppUpdateStatus {
 }
 
 /**
+ * internal/appupdate.Progress — one step of Apply, on the "appupdate-progress"
+ * event: bytes of the download (total -1 without a Content-Length), then the
+ * phase with no percentage — install swaps the binary in place, installer
+ * hands over to the Windows installer and closes lich.
+ */
+export interface AppUpdateProgress {
+  phase: "download" | "install" | "installer"
+  received: number
+  total: number
+}
+
+/**
  * internal/drop.Item — one entry of a terminal file drop, described by the
  * only thing Chromium tells the page about a local file. mtime is
  * File.lastModified (milliseconds); size is 0 for a directory, whose reported

--- a/frontend/src/lib/update/update-progress.test.ts
+++ b/frontend/src/lib/update/update-progress.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+import { downloadReading, failureText, isUpdateProgress } from "./update-progress"
+
+describe("downloadReading", () => {
+  it("reads percent and bytes off a known total", () => {
+    expect(
+      downloadReading({ phase: "download", received: 44_900_000, total: 118_200_000 }),
+    ).toEqual({
+      percent: 37,
+      bytes: "44.9 MB of 118.2 MB",
+    })
+  })
+  it("caps at 100 and floors, never rounding past what arrived", () => {
+    expect(downloadReading({ phase: "download", received: 999, total: 1000 }).percent).toBe(99)
+    expect(downloadReading({ phase: "download", received: 1200, total: 1000 }).percent).toBe(100)
+  })
+  it("is indeterminate without a total", () => {
+    expect(downloadReading({ phase: "download", received: 5_000_000, total: -1 })).toEqual({
+      percent: null,
+      bytes: "5.0 MB",
+    })
+  })
+})
+
+describe("failureText", () => {
+  it("names the download and how far it got", () => {
+    expect(failureText({ phase: "download", received: 380, total: 1000 }, "connection reset")).toBe(
+      "Download failed at 38%: connection reset",
+    )
+    expect(failureText({ phase: "download", received: 380, total: -1 }, "reset")).toBe(
+      "Download failed: reset",
+    )
+  })
+  it("names the install once the download is over", () => {
+    expect(failureText({ phase: "install", received: 0, total: 0 }, "checksum mismatch")).toBe(
+      "Install failed: checksum mismatch",
+    )
+    expect(failureText({ phase: "installer", received: 0, total: 0 }, "x")).toBe(
+      "Install failed: x",
+    )
+  })
+  it("says only that the update failed before any step arrived", () => {
+    expect(failureText(null, "no release")).toBe("Update failed: no release")
+  })
+})
+
+describe("isUpdateProgress", () => {
+  it("accepts the three phases and rejects the rest", () => {
+    expect(isUpdateProgress({ phase: "download", received: 1, total: 2 })).toBe(true)
+    expect(isUpdateProgress({ phase: "installer", received: 0, total: 0 })).toBe(true)
+    expect(isUpdateProgress({ phase: "verify", received: 0, total: 0 })).toBe(false)
+    expect(isUpdateProgress({ phase: "download", received: "1", total: 2 })).toBe(false)
+    expect(isUpdateProgress(null)).toBe(false)
+  })
+})

--- a/frontend/src/lib/update/update-progress.ts
+++ b/frontend/src/lib/update/update-progress.ts
@@ -1,0 +1,50 @@
+// What the update toast shows for one progress step, kept pure (no toast, no
+// socket) so the arithmetic and the wording are testable. The component
+// renders these.
+
+import type { AppUpdateProgress } from "@/lib/api-types"
+
+/** internal/appupdate.ProgressEventName. */
+export const UPDATE_PROGRESS_EVENT = "appupdate-progress"
+
+const BYTES_PER_MB = 1_000_000
+
+export function isUpdateProgress(data: unknown): data is AppUpdateProgress {
+  if (typeof data !== "object" || data === null) return false
+  const p = data as Record<string, unknown>
+  return (
+    (p.phase === "download" || p.phase === "install" || p.phase === "installer") &&
+    typeof p.received === "number" &&
+    typeof p.total === "number"
+  )
+}
+
+/** Megabytes with one decimal: the assets run 10–120 MB, so no smaller unit. */
+export function formatMegabytes(bytes: number): string {
+  return `${(bytes / BYTES_PER_MB).toFixed(1)} MB`
+}
+
+/** DownloadReading is the bar and its caption: percent is null while the total
+ * is unknown, which draws the bar indeterminate. */
+export interface DownloadReading {
+  percent: number | null
+  bytes: string
+}
+
+export function downloadReading(p: AppUpdateProgress): DownloadReading {
+  if (p.total <= 0) {
+    return { percent: null, bytes: formatMegabytes(p.received) }
+  }
+  const percent = Math.min(100, Math.floor((p.received * 100) / p.total))
+  return { percent, bytes: `${formatMegabytes(p.received)} of ${formatMegabytes(p.total)}` }
+}
+
+/** failureText names the phase the update died in — there are two now — and,
+ * for a download, how far it got. */
+export function failureText(last: AppUpdateProgress | null, error: string): string {
+  if (last === null || last.phase !== "download") {
+    return last === null ? `Update failed: ${error}` : `Install failed: ${error}`
+  }
+  const { percent } = downloadReading(last)
+  return percent === null ? `Download failed: ${error}` : `Download failed at ${percent}%: ${error}`
+}

--- a/internal/appupdate/appupdate.go
+++ b/internal/appupdate/appupdate.go
@@ -64,6 +64,9 @@ const (
 type Service struct {
 	mu      sync.Mutex
 	install func(string) error
+	// emit publishes Apply's progress to the app's event hub (ProgressEventName);
+	// nil leaves the update working and silent.
+	emit func(name string, data any)
 
 	http *http.Client
 	// download carries the release-asset GET; separate from http so the short
@@ -92,11 +95,13 @@ type Service struct {
 }
 
 // New returns a service that reports version as the running build and polls
-// GitHub for the latest release.
-func New(version string, install func(string) error) *Service {
+// GitHub for the latest release. install runs a downloaded Windows installer;
+// emit is the app's event hub.
+func New(version string, install func(string) error, emit func(name string, data any)) *Service {
 	exe, _ := os.Executable() // "" if unresolved — canSelfApply then stays false.
 	return &Service{
 		install:       install,
+		emit:          emit,
 		http:          &http.Client{Timeout: httpTimeout},
 		download:      &http.Client{Timeout: downloadTimeout},
 		version:       version,
@@ -180,9 +185,10 @@ func (s *Service) Apply() error {
 		return fmt.Errorf("download %s: status %d", asset, resp.StatusCode)
 	}
 	if s.installerUpdate() {
-		return s.applyInstaller(resp.Body, sum)
+		return s.applyInstaller(s.progressReader(resp.Body, resp.ContentLength, phaseInstaller), sum)
 	}
-	if err := s.applyBinary(io.LimitReader(resp.Body, assetLimit), sum); err != nil {
+	body := s.progressReader(resp.Body, resp.ContentLength, phaseInstall)
+	if err := s.applyBinary(io.LimitReader(body, assetLimit), sum); err != nil {
 		return fmt.Errorf("apply update: %w", err)
 	}
 	return nil

--- a/internal/appupdate/appupdate_test.go
+++ b/internal/appupdate/appupdate_test.go
@@ -266,7 +266,7 @@ func TestInstallCommand(t *testing.T) {
 }
 
 func TestApplyRejectedWhenNotSelfApply(t *testing.T) {
-	s := New("0.7.0", nil)
+	s := New("0.7.0", nil, nil)
 	s.exePath = "" // forces canSelfApply false regardless of platform
 	if err := s.Apply(); err == nil {
 		t.Fatal("Apply() = nil, want an error when self-apply is unsupported")
@@ -300,6 +300,28 @@ func applyServer(t *testing.T, assetStatus int) *httptest.Server {
 
 // applyService is a Service pinned to darwin/arm64 — the self-apply path driven
 // off whatever host runs the suite.
+func TestApplyReportsProgress(t *testing.T) {
+	body := "verified release asset"
+	srv := windowsReleaseFixture(t, "lich-v0.8.0-darwin-arm64", body)
+	defer srv.Close()
+	s := applyService(t, srv, func(r io.Reader, _ []byte) error { _, err := io.ReadAll(r); return err })
+	s.downloadBase = srv.URL + "/"
+	var steps []Progress
+	s.emit = func(_ string, data any) { steps = append(steps, data.(Progress)) }
+	if err := s.Apply(); err != nil {
+		t.Fatal(err)
+	}
+	if len(steps) < 3 {
+		t.Fatalf("steps = %+v", steps)
+	}
+	if first := steps[0]; first != (Progress{Phase: phaseDownload, Received: 0, Total: int64(len(body))}) {
+		t.Errorf("first = %+v", first)
+	}
+	if last := steps[len(steps)-1]; last != (Progress{Phase: phaseInstall}) {
+		t.Errorf("last = %+v", last)
+	}
+}
+
 func applyService(t *testing.T, srv *httptest.Server, apply func(io.Reader, []byte) error) *Service {
 	t.Helper()
 	return &Service{
@@ -433,7 +455,7 @@ func TestFetchChecksum(t *testing.T) {
 }
 
 func TestNewResolvesExe(t *testing.T) {
-	s := New("0.7.0", nil)
+	s := New("0.7.0", nil, nil)
 	if s.version != "0.7.0" {
 		t.Fatalf("version = %q", s.version)
 	}

--- a/internal/appupdate/progress.go
+++ b/internal/appupdate/progress.go
@@ -1,0 +1,82 @@
+package appupdate
+
+import (
+	"io"
+	"time"
+)
+
+// ProgressEventName is the hub event Apply's phases ride on, for the toast.
+const ProgressEventName = "appupdate-progress"
+
+// Progress is one step of Apply: bytes received of total during the download
+// (total is -1 when the asset came without a Content-Length), then the phase
+// that has no percentage — "install" for the in-place swap, "installer" where
+// lich hands over to the Windows installer and closes.
+type Progress struct {
+	Phase    string `json:"phase"`
+	Received int64  `json:"received"`
+	Total    int64  `json:"total"`
+}
+
+const (
+	phaseDownload  = "download"
+	phaseInstall   = "install"
+	phaseInstaller = "installer"
+	// A download event per ~1% or per 250 ms, whichever comes first: enough for
+	// the bar to move on a slow link, and no repaint per chunk on a fast one.
+	progressStepPct  = 1
+	progressInterval = 250 * time.Millisecond
+)
+
+// progressReader counts the asset body as it passes and reports it, then
+// announces the phase that follows the download when the body ends.
+type progressReader struct {
+	r        io.Reader
+	total    int64
+	after    string
+	emit     func(Progress)
+	now      func() time.Time
+	received int64
+	lastN    int64
+	lastAt   time.Time
+}
+
+func (s *Service) progressReader(r io.Reader, total int64, after string) io.Reader {
+	p := &progressReader{r: r, total: total, after: after, emit: s.emitProgress, now: time.Now}
+	p.report()
+	return p
+}
+
+func (p *progressReader) Read(b []byte) (int, error) {
+	n, err := p.r.Read(b)
+	p.received += int64(n)
+	if err == io.EOF {
+		p.report()
+		p.emit(Progress{Phase: p.after})
+		return n, err
+	}
+	if p.due() {
+		p.report()
+	}
+	return n, err
+}
+
+func (p *progressReader) due() bool {
+	if p.total > 0 && (p.received-p.lastN)*100/p.total >= progressStepPct {
+		return true
+	}
+	return p.now().Sub(p.lastAt) >= progressInterval
+}
+
+func (p *progressReader) report() {
+	p.lastN, p.lastAt = p.received, p.now()
+	p.emit(Progress{Phase: phaseDownload, Received: p.received, Total: p.total})
+}
+
+// emitProgress hands one step to the hub; a Service built without one (tests,
+// a bare binary) updates in silence.
+func (s *Service) emitProgress(p Progress) {
+	if s.emit != nil {
+		s.emit(ProgressEventName, p)
+	}
+}

--- a/internal/appupdate/progress_test.go
+++ b/internal/appupdate/progress_test.go
@@ -1,0 +1,96 @@
+package appupdate
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"time"
+)
+
+// collectProgress returns a Service whose emit appends every step to the
+// returned slice.
+func collectProgress() (*Service, *[]Progress) {
+	steps := &[]Progress{}
+	s := &Service{emit: func(name string, data any) {
+		if name != ProgressEventName {
+			panic("unexpected event " + name)
+		}
+		*steps = append(*steps, data.(Progress))
+	}}
+	return s, steps
+}
+
+func TestProgressReaderStepsByPercent(t *testing.T) {
+	s, steps := collectProgress()
+	body := strings.Repeat("x", 1000)
+	r := s.progressReader(strings.NewReader(body), 1000, phaseInstall)
+	if got, err := io.ReadAll(iotest5(r)); err != nil || len(got) != 1000 {
+		t.Fatalf("read = %d bytes, %v", len(got), err)
+	}
+	// Announced at 0, then one step per 1% (every second 5-byte read), then
+	// the phase that follows the download.
+	first, last := (*steps)[0], (*steps)[len(*steps)-1]
+	if first != (Progress{Phase: phaseDownload, Received: 0, Total: 1000}) {
+		t.Errorf("first step = %+v", first)
+	}
+	if last != (Progress{Phase: phaseInstall}) {
+		t.Errorf("last step = %+v", last)
+	}
+	if done := (*steps)[len(*steps)-2]; done != (Progress{Phase: phaseDownload, Received: 1000, Total: 1000}) {
+		t.Errorf("final download step = %+v", done)
+	}
+	if n := len(*steps); n < 100 || n > 103 {
+		t.Errorf("steps = %d, want one per percent", n)
+	}
+}
+
+func TestProgressReaderUnknownTotalStepsByTime(t *testing.T) {
+	s, steps := collectProgress()
+	now := time.Unix(0, 0)
+	p := &progressReader{r: strings.NewReader(strings.Repeat("x", 30)), total: -1, after: phaseInstaller, emit: s.emitProgress, now: func() time.Time { return now }}
+	p.report()
+	buf := make([]byte, 10)
+	if _, err := p.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	if len(*steps) != 1 {
+		t.Fatalf("a read inside the interval must not report, steps = %+v", *steps)
+	}
+	now = now.Add(progressInterval)
+	if _, err := p.Read(buf); err != nil {
+		t.Fatal(err)
+	}
+	if got := (*steps)[1]; got != (Progress{Phase: phaseDownload, Received: 20, Total: -1}) {
+		t.Errorf("timed step = %+v", got)
+	}
+	if _, err := io.ReadAll(p); err != nil {
+		t.Fatal(err)
+	}
+	if last := (*steps)[len(*steps)-1]; last != (Progress{Phase: phaseInstaller}) {
+		t.Errorf("last step = %+v", last)
+	}
+}
+
+func TestProgressSilentWithoutHub(t *testing.T) {
+	s := &Service{}
+	r := s.progressReader(strings.NewReader("abc"), 3, phaseInstall)
+	if got, err := io.ReadAll(r); err != nil || string(got) != "abc" {
+		t.Fatalf("read = %q, %v", got, err)
+	}
+}
+
+// iotest5 reads its source five bytes at a time, so a percent of a
+// 1000-byte body takes two reads.
+func iotest5(r io.Reader) io.Reader { return &chunked{r: r, n: 5} }
+
+type chunked struct {
+	r io.Reader
+	n int
+}
+
+func (c *chunked) Read(b []byte) (int, error) {
+	if len(b) > c.n {
+		b = b[:c.n]
+	}
+	return c.r.Read(b)
+}

--- a/main.go
+++ b/main.go
@@ -189,7 +189,7 @@ func main() {
 		exe = ""
 	}
 	coord := restart.New(exe, os.Environ())
-	dispatcher.Register("appupdate", appupdate.New(version, coord.Install))
+	dispatcher.Register("appupdate", appupdate.New(version, coord.Install, hub.Emit))
 	dispatcher.Register("patchnotes", patchnotes.New(version, changelog))
 	dispatcher.Register("store", db)
 	// Read before runChromium writes this run's runtime file over the previous


### PR DESCRIPTION
## Summary

Approved mockup: https://claude.ai/code/artifact/4bef5c9e-54c2-4946-930b-140e2ec2c9b7

- **Backend** (`internal/appupdate/progress.go`): `Apply` wraps the asset body in a counting reader that emits `appupdate-progress` on the app hub, one step per ~1% or 250 ms (whichever first), announced at 0 and at the end, then the phase that follows the download: `install` for the in-place swap, `installer` where lich hands over to the Windows installer and closes. `total` is the `Content-Length`, -1 when absent. `New` takes the hub's `Emit`; nil keeps the update silent (tests, bare binary).
- **Frontend**: `UpdateProgressToast` draws the bar (QuotaGauge's track/fill, indeterminate without a total) with percent and "44.9 MB of 118.2 MB", then a spinner naming the install and, on the installer phase, the line that lich closes and reopens on its own. The gate subscribes to the event for the duration of `Apply`; a failure reads "Download failed at 38%: …" or "Install failed: …" with a Retry action. Pure arithmetic and wording live in `lib/update/update-progress.ts`.
- `AppUpdateProgress` mirrored in `api-types.ts`; CHANGELOG entry under Added.

Out of scope, on purpose (in the mockup notes): cancelling the download, speed/ETA, resuming a broken download.

## Test plan

- [x] `go test ./internal/...`, `go vet ./internal/...`, gofmt: progress reader steps by percent, by time without a total, ends on the following phase, silent without a hub; `Apply` reports download then install
- [x] `pnpm exec biome ci .` exit 0, `pnpm test` (1714), `pnpm build`
- [ ] macOS or portable Windows: the bar moves during the download, then "Installing…", then "lich updated to X" with Restart
- [ ] Windows installer install: the bar, then "Installing…" with the closes-and-reopens line, then lich reopens on its own
- [ ] Pull the network mid-download: "Download failed at N%: …" with Retry