### PR TITLE
feat: show how far a quiet card got through its agent's task list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reopens on its own. A failure says which of the two it died in and how far
   the download got, and offers Retry.
 
+- **A finished card says how much its agent stopped short of.** When a Claude
+  Code session ends a turn with an unfinished task list of its own, its card
+  reads "3 of 7 done" on the line that already carries what the session is up
+  to. It draws only while the card is quiet, so nothing takes the line from the
+  tool a running turn is in, and it goes away when the list is finished. No
+  other provider writes a list lich can read, so no other card grows a line.
+
 ### Changed
 
 - **Two baked prices corrected.** An offline install billed Claude 3 Haiku's

--- a/frontend/src/components/render-budget.test.tsx
+++ b/frontend/src/components/render-budget.test.tsx
@@ -34,7 +34,7 @@ import { createElement, useEffect } from "react"
 import { HashRouter } from "react-router-dom"
 import { afterEach, beforeEach, expect, test, vi } from "vitest"
 import { ProjectsContext, type ProjectsValue } from "@/providers/projects-context"
-import { STATUS_EVENT, USAGE_EVENT } from "@/lib/session/session-events"
+import { STATUS_EVENT, TODO_EVENT, USAGE_EVENT } from "@/lib/session/session-events"
 
 // The /events channel, as the app sees it: the stores subscribe at import, and a
 // test publishes to the same registry the backend socket would. Mocked rather
@@ -267,6 +267,35 @@ test("a status event repaints that session's card and nothing else", async () =>
   // s2 is a background card: the sidebar, the two cards beside it and the footer
   // are all absent, which is the invariant.
   expect(budget.take()).toEqual({ "SessionCard#s2": 1, ...CARD_CHROME })
+  await budget.unmount()
+})
+
+test("a todo event repaints that session's card and nothing else", async () => {
+  const budget = await mountSidebar()
+  await budget.act(() => bus.emit(TODO_EVENT, { id: "s2", done: 3, total: 7 }))
+  expect(budget.take()).toEqual({ "SessionCard#s2": 1, ...CARD_CHROME })
+  await budget.unmount()
+})
+
+// Not a budget: the rung itself. The count draws on a card that has gone quiet
+// and never on one mid-turn, where the tool line is what says the session is
+// moving, and this file is where a card is mounted for real (the rest of the
+// gate is node-only, so a throw in that branch would pass everywhere else).
+test("the task list draws on a quiet card and never on a busy one", async () => {
+  const budget = await mountSidebar()
+  await budget.act(() => {
+    bus.emit(STATUS_EVENT, { id: "s2", state: "busy", tool: "Edit", detail: "SessionCard.tsx" })
+    bus.emit(TODO_EVENT, { id: "s2", done: 3, total: 7 })
+  })
+  expect(document.body.textContent).toContain("Edit")
+  expect(document.body.textContent).not.toContain("3 of 7")
+
+  await budget.act(() => bus.emit(STATUS_EVENT, { id: "s2", state: "done" }))
+  expect(document.body.textContent).toContain("3 of 7 done")
+
+  // A finished list is an answer, not news.
+  await budget.act(() => bus.emit(TODO_EVENT, { id: "s2", done: 7, total: 7 }))
+  expect(document.body.textContent).not.toContain("7 of 7")
   await budget.unmount()
 })
 

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -13,6 +13,7 @@ import {
   GitBranch,
   GitPullRequestArrow,
   Inbox,
+  ListChecks,
   Pencil,
   Columns2,
   Pin,
@@ -40,6 +41,7 @@ import { useSessionAgent } from "@/lib/session/use-session-agent"
 import { useSessionRelay } from "@/lib/session/use-session-relay"
 import { useSessionInbox } from "@/lib/session/use-session-inbox"
 import { useSessionTool } from "@/lib/session/use-session-tool"
+import { useSessionTodo } from "@/lib/session/use-session-todo"
 import { toolGlyph } from "@/lib/session/tool-glyph"
 import { toolLine } from "@/lib/session/tool-label"
 import { useGitStatus } from "@/lib/git/use-git-status"
@@ -203,6 +205,10 @@ export function SessionCard({
   // How many results this session has waiting in the relay's inbox: results of
   // tasks it delegated, uncollected. Zero — the usual case — draws nothing.
   const inbox = useSessionInbox(session.id)
+  // How far the agent got through the task list it wrote for itself. null for
+  // most sessions: no list, a finished one, or a provider whose list lich
+  // cannot read (terminal.todoReaderFor).
+  const todo = useSessionTodo(session.id)
   const ToolGlyph = tool && toolGlyph(tool.name)
   // The two halves of the line, which are not always the two fields the report
   // sent: on Antigravity the tool's identity arrives in the detail, and drawing
@@ -457,8 +463,9 @@ export function SessionCard({
                   </span>
                 </span>
               )}
-              {/* One line, six rungs: an open request, then a session blocked
-                  on the user, then results waiting to be collected, then the
+              {/* One line, seven rungs: an open request, then a session blocked
+                  on the user, then results waiting to be collected, then how far
+                  a quiet card got through its task list, then the
                   tool, then a prompt scheduled for later, then where the session
                   came from. A request in flight
                   explains the whole turn — a card working because another
@@ -469,7 +476,12 @@ export function SessionCard({
                   session wants an answer. The inbox sits under those and over
                   the tool: mid-turn the live tool is the news, and the count
                   takes the rung when the card goes quiet — the same rule the
-                  relay's own nudge follows. The origin is last precisely
+                  relay's own nudge follows. Task-list progress answers to that
+                  rule for a reason of its own: the tool changes at every step
+                  and is how a card proves it is moving, while a count can sit
+                  still for minutes, so it waits for the turn to end and then
+                  answers the question a finished card leaves open, which is how
+                  much the agent stopped short of. The origin is last precisely
                   because it is never news: it says something that has been true
                   since the card was created, so it surfaces only once the card
                   is quiet, which is when somebody scanning the sidebar is
@@ -513,6 +525,16 @@ export function SessionCard({
                   <Inbox className="size-3 shrink-0" />
                   <span className="truncate font-medium text-foreground">
                     {inbox === 1 ? "1 result ready" : `${inbox} results ready`}
+                  </span>
+                </span>
+              ) : status !== "busy" && todo ? (
+                <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">
+                  <ListChecks className="size-3 shrink-0" />
+                  <span className="truncate">
+                    <span className="font-medium tabular-nums text-foreground">
+                      {`${todo.done} of ${todo.total}`}
+                    </span>
+                    {" done"}
                   </span>
                 </span>
               ) : tool ? (

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -246,6 +246,41 @@ export function toInboxCount(data: unknown): number {
   return Math.floor(count)
 }
 
+// Global event the backend emits when a session's agent moved through the task
+// list it wrote for itself (see terminal.todoEventName). Payload:
+// { id, done, total }, the whole list either way, so the rule for what is worth
+// drawing lives on the card rather than in the backend.
+//
+// Only Claude Code writes a list lich can read (terminal.todoReaderFor names
+// what every other provider does instead), and it carries what the agent last
+// wrote rather than what is true: a list abandoned unfinished keeps its count.
+export const TODO_EVENT = "session-todo"
+
+// A session's progress through its agent's task list.
+export interface SessionTodo {
+  done: number
+  total: number
+}
+
+// toSessionTodo narrows a todo payload to a list worth drawing, or null for
+// everything else: a malformed payload, a shape from another build, a list of
+// one (an agent that writes a single item is narrating, not planning), and a
+// finished list, whose count is over and would otherwise sit on the card as
+// news forever.
+export function toSessionTodo(data: unknown): SessionTodo | null {
+  const { done, total } = (data ?? {}) as { done?: unknown; total?: unknown }
+  if (typeof done !== "number" || typeof total !== "number") {
+    return null
+  }
+  if (!Number.isFinite(done) || !Number.isFinite(total)) {
+    return null
+  }
+  if (total < 2 || done < 0 || done >= total) {
+    return null
+  }
+  return { done: Math.floor(done), total: Math.floor(total) }
+}
+
 // session-touched carries only a session id.
 export function isIdEvent(data: unknown): data is { id: string } {
   return (

--- a/frontend/src/lib/session/session-events.ts
+++ b/frontend/src/lib/session/session-events.ts
@@ -262,11 +262,14 @@ export interface SessionTodo {
   total: number
 }
 
+// The shortest list worth a line on the card. An agent that writes a single
+// item is narrating what it is doing, which the tool line already says.
+const MIN_TODO_ITEMS = 2
+
 // toSessionTodo narrows a todo payload to a list worth drawing, or null for
-// everything else: a malformed payload, a shape from another build, a list of
-// one (an agent that writes a single item is narrating, not planning), and a
-// finished list, whose count is over and would otherwise sit on the card as
-// news forever.
+// everything else: a malformed payload, a shape from another build, a list too
+// short to be a plan, and a finished list, whose count is over and would
+// otherwise sit on the card as news forever.
 export function toSessionTodo(data: unknown): SessionTodo | null {
   const { done, total } = (data ?? {}) as { done?: unknown; total?: unknown }
   if (typeof done !== "number" || typeof total !== "number") {
@@ -275,7 +278,7 @@ export function toSessionTodo(data: unknown): SessionTodo | null {
   if (!Number.isFinite(done) || !Number.isFinite(total)) {
     return null
   }
-  if (total < 2 || done < 0 || done >= total) {
+  if (total < MIN_TODO_ITEMS || done < 0 || done >= total) {
     return null
   }
   return { done: Math.floor(done), total: Math.floor(total) }

--- a/frontend/src/lib/session/session-todo-store.test.ts
+++ b/frontend/src/lib/session/session-todo-store.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest"
+import { createSessionTodoStore } from "./session-todo-store"
+
+// harness wires a store to a hand-driven pair of sources.
+function harness() {
+  let onTodo: (data: unknown) => void = () => {}
+  let onStatus: (data: unknown) => void = () => {}
+  const store = createSessionTodoStore(
+    (h) => {
+      onTodo = h
+      return () => {}
+    },
+    (h) => {
+      onStatus = h
+      return () => {}
+    },
+  )
+  return {
+    store,
+    todo: (data: unknown) => onTodo(data),
+    status: (data: unknown) => onStatus(data),
+  }
+}
+
+describe("createSessionTodoStore", () => {
+  it("has no progress for a session nothing has reported", () => {
+    const { store } = harness()
+    expect(store.get("s1")).toBeNull()
+  })
+
+  it("takes the counts a report carries", () => {
+    const { store, todo } = harness()
+    todo({ id: "s1", done: 3, total: 7 })
+    expect(store.get("s1")).toEqual({ done: 3, total: 7 })
+  })
+
+  // The count is over: keeping it would leave a card reading "7 of 7" as news
+  // for the rest of the session.
+  it("clears when the list is finished", () => {
+    const { store, todo } = harness()
+    todo({ id: "s1", done: 3, total: 7 })
+    todo({ id: "s1", done: 7, total: 7 })
+    expect(store.get("s1")).toBeNull()
+  })
+
+  // An agent that writes a single item is narrating, not planning.
+  it("draws nothing for a list of one", () => {
+    const { store, todo } = harness()
+    todo({ id: "s1", done: 0, total: 1 })
+    expect(store.get("s1")).toBeNull()
+  })
+
+  it("ignores a payload from another build", () => {
+    const { store, todo } = harness()
+    todo({ id: "s1", done: 2, total: 5 })
+    todo({ id: "s1", count: 4 })
+    expect(store.get("s1")).toBeNull()
+  })
+
+  it("keeps sessions apart", () => {
+    const { store, todo } = harness()
+    todo({ id: "s1", done: 1, total: 4 })
+    todo({ id: "s2", done: 3, total: 4 })
+    expect(store.get("s1")).toEqual({ done: 1, total: 4 })
+    expect(store.get("s2")).toEqual({ done: 3, total: 4 })
+  })
+
+  // The store builds a new object per event; a repeat must not hand
+  // useSyncExternalStore a new reference and re-render the card for nothing.
+  it("holds the same reference for a repeated report", () => {
+    const { store, todo } = harness()
+    todo({ id: "s1", done: 2, total: 6 })
+    const first = store.get("s1")
+    todo({ id: "s1", done: 2, total: 6 })
+    expect(store.get("s1")).toBe(first)
+  })
+
+  // SessionEnd: the provider's CLI left, so the count would sit on a card whose
+  // agent is gone.
+  it("clears when the session goes idle", () => {
+    const { store, todo, status } = harness()
+    todo({ id: "s1", done: 2, total: 6 })
+    status({ id: "s1", state: "idle" })
+    expect(store.get("s1")).toBeNull()
+  })
+
+  it("survives every other state report", () => {
+    const { store, todo, status } = harness()
+    todo({ id: "s1", done: 2, total: 6 })
+    status({ id: "s1", state: "busy", tool: "Edit" })
+    status({ id: "s1", state: "done" })
+    expect(store.get("s1")).toEqual({ done: 2, total: 6 })
+  })
+})

--- a/frontend/src/lib/session/session-todo-store.ts
+++ b/frontend/src/lib/session/session-todo-store.ts
@@ -1,0 +1,47 @@
+import { createKeyedStore, type ReadableKeyedStore } from "@/lib/keyed-store"
+import {
+  isIdEvent,
+  isIdleEvent,
+  toSessionTodo,
+  type SessionEventSource,
+  type SessionTodo,
+} from "./session-events"
+
+// Two payloads name the same progress when both counts match. The store builds
+// a new object per event, so without this a repeat would hand
+// useSyncExternalStore a new reference and re-render the card for nothing.
+function sameTodo(a: SessionTodo | null, b: SessionTodo | null): boolean {
+  if (a === null || b === null) {
+    return a === b
+  }
+  return a.done === b.done && a.total === b.total
+}
+
+// createSessionTodoStore keeps how far each session's agent got through the
+// task list it wrote for itself, keyed by session id (see
+// terminal.todoEventName). A payload that is not worth drawing clears the
+// entry: a list of one, or a finished one, is an answer, not an absence.
+//
+// It clears on "idle" for the reason the tool line does: SessionEnd means the
+// provider's CLI left, and the count would otherwise sit on a card whose agent
+// is gone.
+export function createSessionTodoStore(
+  todoSource: SessionEventSource,
+  statusSource: SessionEventSource,
+): ReadableKeyedStore<SessionTodo | null> {
+  const store = createKeyedStore<SessionTodo | null>(null, sameTodo)
+
+  todoSource((data) => {
+    if (isIdEvent(data)) {
+      store.set(data.id, toSessionTodo(data))
+    }
+  })
+
+  statusSource((data) => {
+    if (isIdleEvent(data)) {
+      store.set(data.id, null)
+    }
+  })
+
+  return store
+}

--- a/frontend/src/lib/session/use-session-todo.ts
+++ b/frontend/src/lib/session/use-session-todo.ts
@@ -1,0 +1,20 @@
+import { onAppEvent } from "@/lib/app-events"
+import { STATUS_EVENT, TODO_EVENT, type SessionTodo } from "./session-events"
+import { createSessionTodoStore } from "./session-todo-store"
+import { useKeyedStore } from "@/lib/use-keyed-store"
+
+// Subscribed at import rather than on first use: that opens the /events socket
+// at page load, so progress reported before any card mounts still lands.
+const store = createSessionTodoStore(
+  (handler) => onAppEvent(TODO_EVENT, handler),
+  (handler) => onAppEvent(STATUS_EVENT, handler),
+)
+
+// useSessionTodo reads how far a session's agent got through the task list it
+// wrote for itself (see session-todo-store), which retains it across the card's
+// unmount. Null whenever there is no list worth drawing, which is most
+// sessions: the agent wrote none, its provider writes none lich can read, or
+// the one it wrote is finished.
+export function useSessionTodo(sessionId: string): SessionTodo | null {
+  return useKeyedStore(store, sessionId)
+}

--- a/internal/terminal/said.go
+++ b/internal/terminal/said.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"slices"
 	"strings"
-	"sync"
 
 	"github.com/omartelo/lich/internal/providers"
 )
@@ -114,29 +113,13 @@ func transcriptReaderFor(src usageSource) (string, turnReader, bool) {
 	return "", nil, false
 }
 
-// saidCursors is where each session's transcript was last read to. A transcript
-// is append-only, so remembering the offset one read ended at turns the next
-// into a walk of what has been written since, and a turn is then read whole
-// however large it is, where a bounded tail re-read every poll (searchTailBytes,
-// still what the palette's search does) loses the turn whose closing words fall
+// saidCursors is where each session's transcript was last read to for the
+// closing words of a turn (see transcriptCursors). A turn is read whole however
+// large it is, where a bounded tail re-read every poll (searchTailBytes, still
+// what the palette's search does) loses the turn whose closing words fall
 // behind more tool output than the bound holds.
-//
-// In memory, per run of lich: what the cursor saves is the reading, never the
-// answer, so a session restored at launch simply seeds itself again.
 type saidCursors struct {
-	mu sync.Mutex
-	at map[string]*saidCursor
-}
-
-// saidCursor is one session's place in one transcript: the file's identity, how
-// far it has been read, and the last prose found there. The identity is what
-// tells an ordinary append apart from a file this cursor no longer belongs to
-// (a forked conversation, or a rewritten one), where the offset would otherwise
-// count into bytes nobody read.
-type saidCursor struct {
-	info   os.FileInfo
-	offset int64
-	text   string
+	cursors transcriptCursors[string]
 }
 
 // said reads one conversation's closing words out of whatever the provider files
@@ -170,51 +153,26 @@ func (c *saidCursors) walk(id, path string, read turnReader) string {
 	if err != nil {
 		return ""
 	}
-	// The lock spans the read: its only contenders are two polls of the same
-	// panel, which would be reading the same bytes anyway.
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	cur, fresh := c.cursor(id, info)
-	lines, end := readLines(f, cur.offset, info.Size())
-	text, found := lastSaid(lines, read)
-	// A tail holding no prose at all is the one case worth a full walk: it takes
-	// a single tool result larger than the bound, and the words behind it are
-	// exactly the turn the band exists to catch up on. Once per session: the
-	// cursor lands at the end of the file either way.
-	if !found && fresh && cur.offset > 0 {
-		lines, end = readLines(f, 0, info.Size())
-		text, found = lastSaid(lines, read)
-	}
-	cur.info, cur.offset = info, end
-	if found {
-		cur.text = text
-	}
-	return cur.text
-}
-
-// cursor answers with this session's place in info, seeding a new one at the
-// file's tail: a conversation running for hours is tens of MB, and a first read
-// is paying for a panel somebody just opened. fresh says the cursor was made
-// here: nothing read before this, or a file the previous read's offset does not
-// belong to (see saidCursor).
-func (c *saidCursors) cursor(id string, info os.FileInfo) (*saidCursor, bool) {
-	if cur, ok := c.at[id]; ok && os.SameFile(cur.info, info) && info.Size() >= cur.offset {
-		return cur, false
-	}
-	if c.at == nil {
-		c.at = make(map[string]*saidCursor)
-	}
-	cur := &saidCursor{offset: max(0, info.Size()-searchTailBytes)}
-	c.at[id] = cur
-	return cur, true
-}
-
-// forget drops a closed session's cursor. Nothing will ask about its transcript
-// again, and a card is closed far more often than lich is.
-func (c *saidCursors) forget(id string) {
-	c.mu.Lock()
-	delete(c.at, id)
-	c.mu.Unlock()
+	var answer string
+	c.cursors.under(id, info, func(cur *transcriptCursor[string], fresh bool) {
+		lines, end := readLines(f, cur.offset, info.Size())
+		text, found := lastSaid(lines, read)
+		// A tail holding no prose at all is the one case worth a full walk: it
+		// takes a single tool result larger than the bound, and the words behind
+		// it are exactly the turn the band exists to catch up on. Once per
+		// session: the cursor lands at the end of the file either way, and the
+		// panel this pays for is one somebody just opened.
+		if !found && fresh && cur.offset > 0 {
+			lines, end = readLines(f, 0, info.Size())
+			text, found = lastSaid(lines, read)
+		}
+		cur.info, cur.offset = info, end
+		if found {
+			cur.value = text
+		}
+		answer = cur.value
+	})
+	return answer
 }
 
 // readLines returns the complete lines between start and the end of an open

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -297,6 +297,10 @@ type Service struct {
 	// the Review panel's band walks what has been appended since rather than
 	// re-reading a bounded tail every poll (see saidCursors).
 	recap saidCursors
+	// todos is the same reading for the task list an agent writes for itself,
+	// kept apart from recap because the two are read on different clocks (see
+	// todoCursors).
+	todos todoCursors
 	// snaps brackets each session's turn with a tree snapshot of its checkout,
 	// which is what the Review panel's "Last turn" mode diffs (see turnSnaps).
 	// It reads the same boundary turns does and carries its own lock for the
@@ -462,6 +466,11 @@ func (s *Service) onHookState(req hookRequest) {
 	// idle (SessionEnd): the session is ending, nothing new to read.
 	if req.State != statusIdle {
 		go s.emitUsage(req.SessionID)
+		// The same read, for the list the agent wrote itself: a `TodoWrite`
+		// lands mid-turn like a usage line, and the card that draws the count
+		// is looking at a session that has gone quiet, so the read has to have
+		// happened before the turn ends.
+		go s.emitTodo(req.SessionID)
 	}
 	// A Kiro session's name is read here rather than reported, because Kiro
 	// hands its hooks no transcript path to read one from while it does file
@@ -595,8 +604,10 @@ func (s *Service) noteInterrupt(id string) {
 	}
 	// An interrupted turn spent tokens like any other, and it may be the last
 	// one for a while: refresh the context readout off the transcript, off the
-	// caller's thread the way the hook path does.
+	// caller's thread the way the hook path does. The task list goes with it:
+	// an interrupted turn is exactly the one whose progress is worth reading.
 	go s.emitUsage(id)
+	go s.emitTodo(id)
 }
 
 // SetSessionState wires fn to every session-state report the hooks deliver.
@@ -716,6 +727,7 @@ func (s *Service) Close(id string) error {
 	// disk for the rest of the machine's life.
 	s.snaps.forget(id)
 	s.recap.forget(id)
+	s.todos.forget(id)
 	// Synchronously, and before the row that the window is about to delete goes:
 	// a write that loses that race is dropped silently (store.AddHandsOn), and
 	// this is the last chance a closed card gets to keep what it was worked.

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -299,8 +299,11 @@ type Service struct {
 	recap saidCursors
 	// todos is the same reading for the task list an agent writes for itself,
 	// kept apart from recap because the two are read on different clocks (see
-	// todoCursors).
-	todos todoCursors
+	// todoCursors). todoEmit orders what comes out of it: that event is emitted
+	// only when the count moves, so two reports landing out of order would
+	// leave the older count on the card (see emitTodo).
+	todos    todoCursors
+	todoEmit sync.Mutex
 	// snaps brackets each session's turn with a tree snapshot of its checkout,
 	// which is what the Review panel's "Last turn" mode diffs (see turnSnaps).
 	// It reads the same boundary turns does and carries its own lock for the
@@ -465,12 +468,12 @@ func (s *Service) onHookState(req hookRequest) {
 	// off-thread so a stalled emit never blocks the hook's response. Skip
 	// idle (SessionEnd): the session is ending, nothing new to read.
 	if req.State != statusIdle {
-		go s.emitUsage(req.SessionID)
-		// The same read, for the list the agent wrote itself: a `TodoWrite`
-		// lands mid-turn like a usage line, and the card that draws the count
-		// is looking at a session that has gone quiet, so the read has to have
-		// happened before the turn ends.
-		go s.emitTodo(req.SessionID)
+		// Both readouts taken off the transcript go out together, on one
+		// resolution of it: the context window, and the list the agent wrote
+		// itself. A `TodoWrite` lands mid-turn like a usage line, and the card
+		// that draws the count is looking at a session that has gone quiet, so
+		// the read has to have happened before the turn ends.
+		go s.emitReadouts(req.SessionID)
 	}
 	// A Kiro session's name is read here rather than reported, because Kiro
 	// hands its hooks no transcript path to read one from while it does file
@@ -603,11 +606,11 @@ func (s *Service) noteInterrupt(id string) {
 		watch(id, statusInterrupted)
 	}
 	// An interrupted turn spent tokens like any other, and it may be the last
-	// one for a while: refresh the context readout off the transcript, off the
-	// caller's thread the way the hook path does. The task list goes with it:
-	// an interrupted turn is exactly the one whose progress is worth reading.
-	go s.emitUsage(id)
-	go s.emitTodo(id)
+	// one for a while: refresh the readouts off the transcript, off the
+	// caller's thread the way the hook path does. The task list goes with the
+	// context window: an interrupted turn is exactly the one whose progress is
+	// worth reading.
+	go s.emitReadouts(id)
 }
 
 // SetSessionState wires fn to every session-state report the hooks deliver.
@@ -726,8 +729,8 @@ func (s *Service) Close(id string) error {
 	// last turn changed — and its snapshot index would otherwise outlive it on
 	// disk for the rest of the machine's life.
 	s.snaps.forget(id)
-	s.recap.forget(id)
-	s.todos.forget(id)
+	s.recap.cursors.forget(id)
+	s.todos.cursors.forget(id)
 	// Synchronously, and before the row that the window is about to delete goes:
 	// a write that loses that race is dropped silently (store.AddHandsOn), and
 	// this is the last chance a closed card gets to keep what it was worked.

--- a/internal/terminal/transcriptcursor.go
+++ b/internal/terminal/transcriptcursor.go
@@ -1,0 +1,68 @@
+package terminal
+
+import (
+	"os"
+	"sync"
+)
+
+// transcriptCursors is where each session's provider transcript was last read
+// to, for one kind of answer. A transcript is append-only, so remembering the
+// offset a read ended at turns the next one into a walk of what has been
+// written since, where a bounded tail re-read every time loses whatever falls
+// behind the bound.
+//
+// It holds the bookkeeping the readers share and none of their policy: what
+// counts as an answer, and what to do when a walk finds none, belongs to the
+// reader (said.go keeps the last thing the agent said, turntodo.go the last
+// task list it wrote).
+//
+// In memory, per run of lich: what a cursor saves is the reading, never the
+// answer, so a session restored at launch simply seeds itself again.
+//
+// The zero value is ready to use.
+type transcriptCursors[T any] struct {
+	mu sync.Mutex
+	at map[string]*transcriptCursor[T]
+}
+
+// transcriptCursor is one session's place in one transcript: the file's
+// identity, how far it has been read, and the last answer found there. The
+// identity is what tells an ordinary append apart from a file this cursor no
+// longer belongs to (a forked conversation, or a rewritten one), where the
+// offset would otherwise count into bytes nobody read.
+type transcriptCursor[T any] struct {
+	info   os.FileInfo
+	offset int64
+	value  T
+}
+
+// under runs fn with this session's cursor, holding the lock for as long as it
+// takes: a reader mutates the cursor it was handed, and the only contenders are
+// two reads of the same session, which would be reading the same bytes anyway.
+//
+// fresh says the cursor was made here: nothing read before this, or a file the
+// previous read's offset does not belong to. A new cursor is seeded at the
+// file's tail, since a conversation running for hours is tens of MB and a first
+// read is paying for something with a person or an agent waiting on it.
+func (c *transcriptCursors[T]) under(id string, info os.FileInfo, fn func(cur *transcriptCursor[T], fresh bool)) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if cur, ok := c.at[id]; ok && os.SameFile(cur.info, info) && info.Size() >= cur.offset {
+		fn(cur, false)
+		return
+	}
+	if c.at == nil {
+		c.at = make(map[string]*transcriptCursor[T])
+	}
+	cur := &transcriptCursor[T]{offset: max(0, info.Size()-searchTailBytes)}
+	c.at[id] = cur
+	fn(cur, true)
+}
+
+// forget drops a closed session's cursor. Nothing will ask about its transcript
+// again, and a card is closed far more often than lich is.
+func (c *transcriptCursors[T]) forget(id string) {
+	c.mu.Lock()
+	delete(c.at, id)
+	c.mu.Unlock()
+}

--- a/internal/terminal/turntodo.go
+++ b/internal/terminal/turntodo.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"os"
 	"strings"
-	"sync"
 
 	"github.com/omartelo/lich/internal/providers"
 )
@@ -148,37 +147,28 @@ func countTodos(raw json.RawMessage) (todoList, bool) {
 const todoStatusDone = "completed"
 
 // todoCursors is where each session's transcript was last read to for a task
-// list, on the same reasoning saidCursors keeps its own place: a transcript is
-// append-only, so remembering the offset turns every read after the first into
-// a walk of what has been written since.
+// list (see transcriptCursors).
 //
 // Kept apart from the recap's cursor because the two are read on different
 // clocks: this one runs off the state hook on every report, the recap only
 // while a panel is open, and a shared offset would let either consume the lines
 // the other has not read yet.
-//
-// In memory, per run of lich: what the cursor saves is the reading, never the
-// answer. A window reloaded mid-turn draws no progress until the session's next
-// report, which for a running agent is its next tool call.
 type todoCursors struct {
-	mu sync.Mutex
-	at map[string]*todoCursor
-}
-
-// todoCursor is one session's place in one transcript: the file's identity, how
-// far it has been read, and the last list found there. The identity is what
-// tells an ordinary append apart from a file this cursor no longer belongs to
-// (a forked conversation, or a rewritten one).
-type todoCursor struct {
-	info   os.FileInfo
-	offset int64
-	list   todoList
+	cursors transcriptCursors[todoList]
 }
 
 // read answers with the task list this session's agent last wrote, and whether
 // that pair just changed. Only a change is worth an event: a report lands on
 // every tool call, and re-emitting the same two numbers would re-render the
 // card through a whole turn to say nothing.
+//
+// A list further back than the tail a new cursor is seeded at is not looked
+// for. The recap pays a walk of the whole file in that case, but this read
+// happens on the first report of every session rather than on a panel somebody
+// opened, and a session that never writes a list is exactly the one that would
+// never find anything: transcripts here run to 168MB, and the tail is 4MB of
+// conversation. What it costs is a resumed session drawing no progress until
+// its agent writes the list again, which the per-run cursor gives up on anyway.
 func (c *todoCursors) read(id string, src usageSource) (todoList, bool) {
 	path, reader, ok := todoReaderFor(src)
 	if !ok {
@@ -193,52 +183,19 @@ func (c *todoCursors) read(id string, src usageSource) (todoList, bool) {
 	if err != nil {
 		return todoList{}, false
 	}
-	// The lock spans the read: its only contenders are two reports of the same
-	// session, which would be reading the same bytes anyway.
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	cur, fresh := c.cursor(id, info)
-	lines, end := readLines(f, cur.offset, info.Size())
-	list, found := lastTodo(lines, reader)
-	// A seeded tail holding no list is the case worth a full walk: a list
-	// written before the tail begins is the one a session resumed at launch
-	// would otherwise never show. Once per session, since the cursor lands at
-	// the end of the file either way.
-	if !found && fresh && cur.offset > 0 {
-		lines, end = readLines(f, 0, info.Size())
-		list, found = lastTodo(lines, reader)
-	}
-	cur.info, cur.offset = info, end
-	if !found {
-		return cur.list, false
-	}
-	changed := list != cur.list
-	cur.list = list
+	var list todoList
+	var changed bool
+	c.cursors.under(id, info, func(cur *transcriptCursor[todoList], _ bool) {
+		lines, end := readLines(f, cur.offset, info.Size())
+		found, ok := lastTodo(lines, reader)
+		cur.info, cur.offset = info, end
+		if ok {
+			changed = found != cur.value
+			cur.value = found
+		}
+		list = cur.value
+	})
 	return list, changed
-}
-
-// cursor answers with this session's place in info, seeding a new one at the
-// file's tail: a conversation running for hours is tens of MB, and the first
-// read is paying for a report that has an agent waiting on it. fresh says the
-// cursor was made here.
-func (c *todoCursors) cursor(id string, info os.FileInfo) (*todoCursor, bool) {
-	if cur, ok := c.at[id]; ok && os.SameFile(cur.info, info) && info.Size() >= cur.offset {
-		return cur, false
-	}
-	if c.at == nil {
-		c.at = make(map[string]*todoCursor)
-	}
-	cur := &todoCursor{offset: max(0, info.Size()-searchTailBytes)}
-	c.at[id] = cur
-	return cur, true
-}
-
-// forget drops a closed session's cursor. Nothing will ask about its transcript
-// again, and a card is closed far more often than lich is.
-func (c *todoCursors) forget(id string) {
-	c.mu.Lock()
-	delete(c.at, id)
-	c.mu.Unlock()
 }
 
 // lastTodo keeps the last task list written in a run of transcript lines. false
@@ -255,22 +212,31 @@ func lastTodo(lines []byte, read todoReader) (todoList, bool) {
 	return last, found
 }
 
-// emitTodo reads the task list of the conversation running in session id and
-// pushes it to the frontend when it has moved. Called off the status hook next
-// to emitUsage, and silent on every miss (no provider id yet, no transcript, a
-// provider that writes no list) so the card keeps the count it has.
-func (s *Service) emitTodo(id string) {
-	providerSessionID, err := s.store.ProviderSession(id)
-	if err != nil || providerSessionID == "" {
-		return
-	}
-	src, ok := usageSourceFor(providerSessionID, s.spawnOf(id).cwd)
-	if !ok {
-		return
-	}
+// sessionTodo resolves the event emitTodo would push for session id, and
+// whether the pair moved since the last read. Split from the emit so the
+// reading is testable without a connected window, the way sessionUsage is.
+func (s *Service) sessionTodo(id string, src usageSource) (todoEvent, bool) {
 	list, changed := s.todos.read(id, src)
 	if !changed {
-		return
+		return todoEvent{}, false
 	}
-	s.hub.Emit(todoEventName, todoEvent{ID: id, Done: list.done, Total: list.total})
+	return todoEvent{ID: id, Done: list.done, Total: list.total}, true
+}
+
+// emitTodo reads the task list of the conversation running in session id and
+// pushes it to the frontend when it has moved. Silent on every miss (a provider
+// that writes no list, an unreadable transcript, a list that has not changed),
+// so the card keeps the count it has.
+//
+// The lock spans the read and the push, which is what keeps two reports of the
+// same session from landing out of order: this event is emitted only when the
+// pair moves, so an older count arriving last would sit on the card until the
+// list changes again. The contended window is one Emit, and every read here is
+// already serialised by the cursor behind it.
+func (s *Service) emitTodo(id string, src usageSource) {
+	s.todoEmit.Lock()
+	defer s.todoEmit.Unlock()
+	if event, ok := s.sessionTodo(id, src); ok {
+		s.hub.Emit(todoEventName, event)
+	}
 }

--- a/internal/terminal/turntodo.go
+++ b/internal/terminal/turntodo.go
@@ -1,0 +1,276 @@
+package terminal
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// todoEventName carries how far a session got through the task list its agent
+// wrote for itself ({id, done, total}), emitted whenever that pair changes.
+// Global like the other session events: the card that reads it is only mounted
+// while its project is active, so a per-session name could not reach it.
+//
+// The pair is what the agent last wrote, not what is true: an agent that
+// abandons a list without closing its items leaves the card reporting the
+// count it was abandoned at, until it writes another one.
+const todoEventName = "session-todo"
+
+// todoEvent is the payload of todoEventName. Both counts are the whole list the
+// agent last wrote, so a card can decide for itself whether a list is worth
+// drawing (a finished one is not, and neither is a list of one).
+type todoEvent struct {
+	ID    string `json:"id"`
+	Done  int    `json:"done"`
+	Total int    `json:"total"`
+}
+
+// todoList is one task list as the sidebar reads it: how many of its items are
+// finished, and how many there are. The items themselves stay in the terminal,
+// where the agent wrote them.
+type todoList struct {
+	done  int
+	total int
+}
+
+// todoReader reads one line of a provider's JSONL transcript, answering with
+// the task list it writes. false for every line that writes none, which is
+// almost all of them.
+type todoReader func(line []byte) (todoList, bool)
+
+// todoReaderFor pairs a conversation's transcript with the reader that finds a
+// task list in it, and is the whole of what lich knows about reading one.
+//
+// Only Claude Code, and this is a limit of the harnesses rather than of lich.
+// What each one was measured to do, so the next reader is not re-derived:
+//
+//   - Claude Code files `TodoWrite` as an ordinary tool call, with the list in
+//     its input. Read here.
+//   - Codex has `update_plan`, but its rollout never records it as a tool call
+//     of its own: the plan arrives inside the JavaScript source of an `exec`
+//     call (`await tools.update_plan({plan:[{step:"...",status:"..."}]})`),
+//     where the object is not even JSON (measured 2026.09.09 against every
+//     `update_plan` in ~/.codex/sessions). Reading it means parsing JS with a
+//     regexp, which is a reader that breaks on a line break.
+//   - oh-my-pi, Antigravity and Kiro write no task list at all, so there is
+//     nothing to find in transcripts lich already walks.
+//   - opencode and Crush keep their messages in SQLite (sessiondb.go) and
+//     Cursor CLI in a blob store lich cannot order (docs/ceilings.md), so they
+//     have no line to read either way.
+//
+// A session whose provider is absent here simply draws no progress, which is
+// the same thing a session whose agent never wrote a list draws.
+func todoReaderFor(src usageSource) (string, todoReader, bool) {
+	if src.kind == providers.Claude {
+		return src.path, claudeTodo, true
+	}
+	return "", nil, false
+}
+
+// claudeTodo reads a `TodoWrite` call out of a Claude transcript line.
+//
+// `todos` is taken both as the array it reads as and as a string holding that
+// array, because Claude Code files it as a string (measured against 2.1.212 and
+// 2.1.216); an array is what the tool's own schema describes, so a version that
+// stops encoding it twice keeps working here.
+//
+// Sidechain lines are skipped for the reason claudeTurn skips them: a sub-agent
+// keeps a list of its own, and its progress is not the session's.
+func claudeTodo(line []byte) (todoList, bool) {
+	var entry struct {
+		Type        string `json:"type"`
+		IsSidechain bool   `json:"isSidechain"`
+		Message     struct {
+			Content []struct {
+				Type  string `json:"type"`
+				Name  string `json:"name"`
+				Input struct {
+					Todos json.RawMessage `json:"todos"`
+				} `json:"input"`
+			} `json:"content"`
+		} `json:"message"`
+	}
+	if err := json.Unmarshal(line, &entry); err != nil {
+		return todoList{}, false
+	}
+	if entry.IsSidechain || entry.Type != roleAssistant {
+		return todoList{}, false
+	}
+	for _, block := range entry.Message.Content {
+		if block.Type != "tool_use" || block.Name != "TodoWrite" {
+			continue
+		}
+		if list, ok := countTodos(block.Input.Todos); ok {
+			return list, true
+		}
+	}
+	return todoList{}, false
+}
+
+// todoItem is the one field of a written task the count needs.
+type todoItem struct {
+	Status string `json:"status"`
+}
+
+// countTodos counts a written list, whether it arrives as an array or as a
+// string holding one. An empty list is not a list: it is what a `TodoWrite`
+// clearing the board writes, and a card drawing "0 of 0" would be reporting
+// work nobody planned.
+func countTodos(raw json.RawMessage) (todoList, bool) {
+	var items []todoItem
+	if err := json.Unmarshal(raw, &items); err != nil {
+		var encoded string
+		if err := json.Unmarshal(raw, &encoded); err != nil {
+			return todoList{}, false
+		}
+		if err := json.Unmarshal([]byte(encoded), &items); err != nil {
+			return todoList{}, false
+		}
+	}
+	if len(items) == 0 {
+		return todoList{}, false
+	}
+	list := todoList{total: len(items)}
+	for _, item := range items {
+		if item.Status == todoStatusDone {
+			list.done++
+		}
+	}
+	return list, true
+}
+
+// The one status worth counting. The other two Claude Code writes (`pending`
+// and `in_progress`) are both work left to do, and a status this reader has
+// never seen counts as work left too.
+const todoStatusDone = "completed"
+
+// todoCursors is where each session's transcript was last read to for a task
+// list, on the same reasoning saidCursors keeps its own place: a transcript is
+// append-only, so remembering the offset turns every read after the first into
+// a walk of what has been written since.
+//
+// Kept apart from the recap's cursor because the two are read on different
+// clocks: this one runs off the state hook on every report, the recap only
+// while a panel is open, and a shared offset would let either consume the lines
+// the other has not read yet.
+//
+// In memory, per run of lich: what the cursor saves is the reading, never the
+// answer. A window reloaded mid-turn draws no progress until the session's next
+// report, which for a running agent is its next tool call.
+type todoCursors struct {
+	mu sync.Mutex
+	at map[string]*todoCursor
+}
+
+// todoCursor is one session's place in one transcript: the file's identity, how
+// far it has been read, and the last list found there. The identity is what
+// tells an ordinary append apart from a file this cursor no longer belongs to
+// (a forked conversation, or a rewritten one).
+type todoCursor struct {
+	info   os.FileInfo
+	offset int64
+	list   todoList
+}
+
+// read answers with the task list this session's agent last wrote, and whether
+// that pair just changed. Only a change is worth an event: a report lands on
+// every tool call, and re-emitting the same two numbers would re-render the
+// card through a whole turn to say nothing.
+func (c *todoCursors) read(id string, src usageSource) (todoList, bool) {
+	path, reader, ok := todoReaderFor(src)
+	if !ok {
+		return todoList{}, false
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return todoList{}, false
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		return todoList{}, false
+	}
+	// The lock spans the read: its only contenders are two reports of the same
+	// session, which would be reading the same bytes anyway.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	cur, fresh := c.cursor(id, info)
+	lines, end := readLines(f, cur.offset, info.Size())
+	list, found := lastTodo(lines, reader)
+	// A seeded tail holding no list is the case worth a full walk: a list
+	// written before the tail begins is the one a session resumed at launch
+	// would otherwise never show. Once per session, since the cursor lands at
+	// the end of the file either way.
+	if !found && fresh && cur.offset > 0 {
+		lines, end = readLines(f, 0, info.Size())
+		list, found = lastTodo(lines, reader)
+	}
+	cur.info, cur.offset = info, end
+	if !found {
+		return cur.list, false
+	}
+	changed := list != cur.list
+	cur.list = list
+	return list, changed
+}
+
+// cursor answers with this session's place in info, seeding a new one at the
+// file's tail: a conversation running for hours is tens of MB, and the first
+// read is paying for a report that has an agent waiting on it. fresh says the
+// cursor was made here.
+func (c *todoCursors) cursor(id string, info os.FileInfo) (*todoCursor, bool) {
+	if cur, ok := c.at[id]; ok && os.SameFile(cur.info, info) && info.Size() >= cur.offset {
+		return cur, false
+	}
+	if c.at == nil {
+		c.at = make(map[string]*todoCursor)
+	}
+	cur := &todoCursor{offset: max(0, info.Size()-searchTailBytes)}
+	c.at[id] = cur
+	return cur, true
+}
+
+// forget drops a closed session's cursor. Nothing will ask about its transcript
+// again, and a card is closed far more often than lich is.
+func (c *todoCursors) forget(id string) {
+	c.mu.Lock()
+	delete(c.at, id)
+	c.mu.Unlock()
+}
+
+// lastTodo keeps the last task list written in a run of transcript lines. false
+// when they hold none, which for a continuing read means no list was written
+// since the last one rather than that none ever was.
+func lastTodo(lines []byte, read todoReader) (todoList, bool) {
+	var last todoList
+	var found bool
+	for _, line := range strings.Split(string(lines), "\n") {
+		if list, ok := read([]byte(line)); ok {
+			last, found = list, true
+		}
+	}
+	return last, found
+}
+
+// emitTodo reads the task list of the conversation running in session id and
+// pushes it to the frontend when it has moved. Called off the status hook next
+// to emitUsage, and silent on every miss (no provider id yet, no transcript, a
+// provider that writes no list) so the card keeps the count it has.
+func (s *Service) emitTodo(id string) {
+	providerSessionID, err := s.store.ProviderSession(id)
+	if err != nil || providerSessionID == "" {
+		return
+	}
+	src, ok := usageSourceFor(providerSessionID, s.spawnOf(id).cwd)
+	if !ok {
+		return
+	}
+	list, changed := s.todos.read(id, src)
+	if !changed {
+		return
+	}
+	s.hub.Emit(todoEventName, todoEvent{ID: id, Done: list.done, Total: list.total})
+}

--- a/internal/terminal/turntodo_test.go
+++ b/internal/terminal/turntodo_test.go
@@ -1,0 +1,211 @@
+package terminal
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/omartelo/lich/internal/providers"
+)
+
+// A `TodoWrite` line as Claude Code files one, with the list encoded the way it
+// was measured to encode it: a string holding the array.
+func todoLine(items ...string) string {
+	inner := strings.Join(items, ",")
+	encoded := strings.ReplaceAll("["+inner+"]", `"`, `\"`)
+	return `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TodoWrite",` +
+		`"input":{"todos":"` + encoded + `"}}]}}`
+}
+
+func todoItemJSON(status string) string {
+	return `{"content":"a task","status":"` + status + `","activeForm":"doing a task"}`
+}
+
+// TestClaudeTodoReadsBothEncodings pins the pair of shapes the reader takes:
+// the array the tool's schema describes, and the string Claude Code actually
+// writes. A version that stops double-encoding must not stop the count.
+func TestClaudeTodoReadsBothEncodings(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+		want todoList
+		ok   bool
+	}{
+		{
+			name: "list encoded as a string",
+			line: todoLine(todoItemJSON("completed"), todoItemJSON("completed"), todoItemJSON("pending")),
+			want: todoList{done: 2, total: 3},
+			ok:   true,
+		},
+		{
+			name: "list as a plain array",
+			line: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TodoWrite",` +
+				`"input":{"todos":[{"status":"completed"},{"status":"in_progress"}]}}]}}`,
+			want: todoList{done: 1, total: 2},
+			ok:   true,
+		},
+		{
+			name: "a status the reader has never seen is work left to do",
+			line: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TodoWrite",` +
+				`"input":{"todos":[{"status":"blocked"},{"status":"completed"}]}}]}}`,
+			want: todoList{done: 1, total: 2},
+			ok:   true,
+		},
+		{
+			name: "a sub-agent's list is not the session's",
+			line: `{"type":"assistant","isSidechain":true,"message":{"content":[{"type":"tool_use",` +
+				`"name":"TodoWrite","input":{"todos":[{"status":"completed"}]}}]}}`,
+			ok: false,
+		},
+		{
+			name: "another tool writes no list",
+			line: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit",` +
+				`"input":{"file_path":"a.go"}}]}}`,
+			ok: false,
+		},
+		{
+			name: "a cleared board is not a list",
+			line: `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"TodoWrite",` +
+				`"input":{"todos":[]}}]}}`,
+			ok: false,
+		},
+		{
+			name: "a user turn carrying a bare string content",
+			line: `{"type":"user","message":{"content":"write the tests"}}`,
+			ok:   false,
+		},
+		{
+			name: "a line cut in half",
+			line: `ontent":[{"type":"tool_use","name":"TodoWrite"`,
+			ok:   false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := claudeTodo([]byte(tc.line))
+			if ok != tc.ok {
+				t.Fatalf("claudeTodo ok = %v, want %v", ok, tc.ok)
+			}
+			if ok && got != tc.want {
+				t.Errorf("claudeTodo = %+v, want %+v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTodoReaderForClaudeOnly pins the provider table: only Claude Code files a
+// task list lich can read, and every other provider answers with nothing rather
+// than with a reader that finds nothing.
+func TestTodoReaderForClaudeOnly(t *testing.T) {
+	if _, _, ok := todoReaderFor(usageSource{kind: providers.Claude, path: "/t.jsonl"}); !ok {
+		t.Error("Claude should have a reader")
+	}
+	for _, kind := range []string{
+		providers.Codex, providers.OMP, providers.Antigravity,
+		providers.Kiro, providers.OpenCode, providers.Crush, providers.Cursor,
+	} {
+		if _, _, ok := todoReaderFor(usageSource{kind: kind, path: "/t.jsonl"}); ok {
+			t.Errorf("%s should have no reader", kind)
+		}
+	}
+}
+
+// TestTodoReadReportsOnlyChanges pins what the event is worth emitting for: the
+// first list, then a moved count, and nothing at all for a re-read that found
+// no new line. A report lands on every tool call, so a re-emitted pair would
+// re-render the card through a whole turn to say nothing.
+func TestTodoReadReportsOnlyChanges(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	write := func(lines ...string) {
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+		if _, err := f.WriteString(strings.Join(lines, "\n") + "\n"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	src := usageSource{kind: providers.Claude, path: path, id: "x"}
+	var cursors todoCursors
+
+	write(todoLine(todoItemJSON("pending"), todoItemJSON("pending")))
+	if list, changed := cursors.read("s1", src); !changed || list != (todoList{done: 0, total: 2}) {
+		t.Fatalf("first read = %+v, changed %v; want 0 of 2, changed", list, changed)
+	}
+	if list, changed := cursors.read("s1", src); changed || list != (todoList{done: 0, total: 2}) {
+		t.Errorf("re-read = %+v, changed %v; want the same pair, unchanged", list, changed)
+	}
+
+	// A turn's other tool calls move nothing, and the count has to survive them:
+	// the reader answers with the list on record, not with an empty one.
+	write(`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Edit","input":{}}]}}`)
+	if list, changed := cursors.read("s1", src); changed || list != (todoList{done: 0, total: 2}) {
+		t.Errorf("after an unrelated tool = %+v, changed %v; want the same pair, unchanged", list, changed)
+	}
+
+	write(todoLine(todoItemJSON("completed"), todoItemJSON("pending")))
+	if list, changed := cursors.read("s1", src); !changed || list != (todoList{done: 1, total: 2}) {
+		t.Errorf("after progress = %+v, changed %v; want 1 of 2, changed", list, changed)
+	}
+}
+
+// TestTodoReadWalksTheWholeFileOnce pins the seed: a list written further back
+// than the tail the cursor starts at is still found, which is what a session
+// resumed at launch depends on.
+func TestTodoReadWalksTheWholeFileOnce(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+	filler := strings.Repeat(
+		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{}}]}}`+"\n",
+		searchTailBytes/90+40,
+	)
+	body := todoLine(todoItemJSON("completed"), todoItemJSON("pending"), todoItemJSON("pending")) + "\n" + filler
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src := usageSource{kind: providers.Claude, path: path, id: "x"}
+	list, changed := new(todoCursors).read("s1", src)
+	if !changed || list != (todoList{done: 1, total: 3}) {
+		t.Errorf("read = %+v, changed %v; want 1 of 3, changed", list, changed)
+	}
+}
+
+// TestTodoReadRereadsAReplacedTranscript pins that a cursor whose file is no
+// longer the file it was made against starts over instead of counting into
+// bytes nobody read. Both ways that happens are here: the transcript swapped
+// for another file (a forked conversation), and the same file rewritten shorter
+// than the cursor had already reached.
+func TestTodoReadRereadsAReplacedTranscript(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "transcript.jsonl")
+	src := usageSource{kind: providers.Claude, path: path, id: "x"}
+	var cursors todoCursors
+
+	first := todoLine(todoItemJSON("completed"), todoItemJSON("completed"), todoItemJSON("pending"))
+	if err := os.WriteFile(path, []byte(first+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, changed := cursors.read("s1", src); !changed {
+		t.Fatal("first read should report a change")
+	}
+
+	forked := filepath.Join(dir, "forked.jsonl")
+	body := todoLine(todoItemJSON("pending"), todoItemJSON("pending")) + "\n"
+	if err := os.WriteFile(forked, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(forked, path); err != nil {
+		t.Fatal(err)
+	}
+	if list, changed := cursors.read("s1", src); !changed || list != (todoList{done: 0, total: 2}) {
+		t.Fatalf("after a fork = %+v, changed %v; want 0 of 2, changed", list, changed)
+	}
+
+	if err := os.WriteFile(path, []byte(todoLine(todoItemJSON("completed"))+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if list, changed := cursors.read("s1", src); !changed || list != (todoList{done: 1, total: 1}) {
+		t.Errorf("after a shorter rewrite = %+v, changed %v; want 1 of 1, changed", list, changed)
+	}
+}

--- a/internal/terminal/turntodo_test.go
+++ b/internal/terminal/turntodo_test.go
@@ -151,24 +151,41 @@ func TestTodoReadReportsOnlyChanges(t *testing.T) {
 	}
 }
 
-// TestTodoReadWalksTheWholeFileOnce pins the seed: a list written further back
-// than the tail the cursor starts at is still found, which is what a session
-// resumed at launch depends on.
-func TestTodoReadWalksTheWholeFileOnce(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "transcript.jsonl")
+// TestTodoReadLooksNoFurtherBackThanTheTail pins the bound this read is worth:
+// a list inside the tail a new cursor seeds at is found, and one behind it is
+// not looked for. The recap walks the whole file in that case; this read
+// happens on the first report of every session instead of on a panel somebody
+// opened, and the transcripts it would walk run to hundreds of MB.
+func TestTodoReadLooksNoFurtherBackThanTheTail(t *testing.T) {
 	filler := strings.Repeat(
 		`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Read","input":{}}]}}`+"\n",
 		searchTailBytes/90+40,
 	)
-	body := todoLine(todoItemJSON("completed"), todoItemJSON("pending"), todoItemJSON("pending")) + "\n" + filler
-	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	src := usageSource{kind: providers.Claude, path: path, id: "x"}
-	list, changed := new(todoCursors).read("s1", src)
-	if !changed || list != (todoList{done: 1, total: 3}) {
-		t.Errorf("read = %+v, changed %v; want 1 of 3, changed", list, changed)
-	}
+	list := todoLine(todoItemJSON("completed"), todoItemJSON("pending"), todoItemJSON("pending"))
+
+	t.Run("inside the tail", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "transcript.jsonl")
+		if err := os.WriteFile(path, []byte(filler+list+"\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		src := usageSource{kind: providers.Claude, path: path, id: "x"}
+		got, changed := new(todoCursors).read("s1", src)
+		if !changed || got != (todoList{done: 1, total: 3}) {
+			t.Errorf("read = %+v, changed %v; want 1 of 3, changed", got, changed)
+		}
+	})
+
+	t.Run("behind the tail", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "transcript.jsonl")
+		if err := os.WriteFile(path, []byte(list+"\n"+filler), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		src := usageSource{kind: providers.Claude, path: path, id: "s1"}
+		got, changed := new(todoCursors).read("s1", src)
+		if changed || got != (todoList{}) {
+			t.Errorf("read = %+v, changed %v; want no list, unchanged", got, changed)
+		}
+	})
 }
 
 // TestTodoReadRereadsAReplacedTranscript pins that a cursor whose file is no

--- a/internal/terminal/turntodo_unix_test.go
+++ b/internal/terminal/turntodo_unix_test.go
@@ -1,0 +1,81 @@
+// The suite reuses stubBins and writeTranscript from the Unix-tagged files, so
+// it carries the same tag and the package still builds on Windows. Nothing here
+// is platform-specific: the reader itself is covered in turntodo_test.go, which
+// runs everywhere.
+//go:build !windows
+
+package terminal
+
+import (
+	"testing"
+
+	"github.com/omartelo/lich/internal/events"
+)
+
+// TestSessionTodoReportsTheWrittenList proves the whole read the card's count
+// rides on: session id, recorded provider session, transcript, the event.
+func TestSessionTodoReportsTheWrittenList(t *testing.T) {
+	writeTranscript(t, "uuid-abc", todoLine(
+		todoItemJSON("completed"), todoItemJSON("in_progress"), todoItemJSON("pending"),
+	)+"\n")
+	svc := New(stubBins{providerSession: "uuid-abc"}, nil, events.New())
+	src, ok := svc.transcriptSource("s1")
+	if !ok {
+		t.Fatal("transcriptSource: want ok, got false")
+	}
+
+	got, ok := svc.sessionTodo("s1", src)
+	if !ok {
+		t.Fatal("sessionTodo: want ok, got false")
+	}
+	if want := (todoEvent{ID: "s1", Done: 1, Total: 3}); got != want {
+		t.Errorf("sessionTodo = %+v, want %+v", got, want)
+	}
+
+	// The second read of an unchanged transcript is the common case, once per
+	// tool call: there is nothing to push.
+	if _, ok := svc.sessionTodo("s1", src); ok {
+		t.Error("sessionTodo: want no event for an unchanged list")
+	}
+}
+
+// TestSessionTodoIsSilentWithoutAList pins the two misses that reach here on
+// every report of most sessions: an agent that wrote no list, and a provider
+// whose transcript holds none lich can read.
+func TestSessionTodoIsSilentWithoutAList(t *testing.T) {
+	t.Run("claude session with no list", func(t *testing.T) {
+		writeTranscript(t, "uuid-abc", `{"type":"assistant","message":{"content":`+
+			`[{"type":"text","text":"Done."}]}}`+"\n")
+		svc := New(stubBins{providerSession: "uuid-abc"}, nil, events.New())
+		src, ok := svc.transcriptSource("s1")
+		if !ok {
+			t.Fatal("transcriptSource: want ok, got false")
+		}
+		if _, ok := svc.sessionTodo("s1", src); ok {
+			t.Error("sessionTodo: want no event for a session with no list")
+		}
+	})
+
+	t.Run("provider that writes none", func(t *testing.T) {
+		writeCodexTranscript(t, "uuid-codex", `{"type":"response_item","payload":`+
+			`{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Done."}]}}`+"\n")
+		svc := New(stubBins{providerSession: "uuid-codex"}, nil, events.New())
+		src, ok := svc.transcriptSource("s1")
+		if !ok {
+			t.Fatal("transcriptSource: want ok, got false")
+		}
+		if _, ok := svc.sessionTodo("s1", src); ok {
+			t.Error("sessionTodo: want no event for a provider with no list to read")
+		}
+	})
+}
+
+// TestTranscriptSourceIsSilentWithoutAProviderSession pins the miss both
+// readouts share: a session whose provider has not reported its conversation
+// yet, which is every session until its first hook lands.
+func TestTranscriptSourceIsSilentWithoutAProviderSession(t *testing.T) {
+	svc := New(stubBins{}, nil, events.New())
+	if _, ok := svc.transcriptSource("s1"); ok {
+		t.Error("transcriptSource: want false without a provider session")
+	}
+}

--- a/internal/terminal/usage.go
+++ b/internal/terminal/usage.go
@@ -52,27 +52,64 @@ type usageEvent struct {
 // transcript, an unreadable or half-written file — so the readout keeps its last
 // value instead of flickering.
 func (s *Service) emitUsage(id string) {
-	if event, ok := s.sessionUsage(id); ok {
+	if src, ok := s.transcriptSource(id); ok {
+		s.emitUsageFrom(id, src)
+	}
+}
+
+// emitUsageFrom is emitUsage once the transcript behind it is known.
+func (s *Service) emitUsageFrom(id string, src usageSource) {
+	if event, ok := s.usageFrom(id, src); ok {
 		s.hub.Emit(usageEventName, event)
 	}
+}
+
+// emitReadouts pushes both readouts a state report refreshes, off one
+// resolution of the transcript they are read from: the context window and cost,
+// then the agent's own task list. Called on the hook's own path (in a goroutine
+// of its own, since a stalled emit must never hold the agent's next step up),
+// and silent on every miss so a readout keeps its last value rather than
+// flickering.
+func (s *Service) emitReadouts(id string) {
+	src, ok := s.transcriptSource(id)
+	if !ok {
+		return
+	}
+	s.emitUsageFrom(id, src)
+	s.emitTodo(id, src)
 }
 
 // sessionUsage resolves the event emitUsage would push for session id, or
 // ok=false for every miss the doc above lists. Split from the emit so the
 // resolution is testable without a connected window — pollCwd's pattern.
 func (s *Service) sessionUsage(id string) (usageEvent, bool) {
-	providerSessionID, err := s.store.ProviderSession(id)
-	if err != nil {
-		slog.Warn("terminal: read provider session", "session", id, "err", err)
-		return usageEvent{}, false
-	}
-	if providerSessionID == "" {
-		return usageEvent{}, false
-	}
-	src, ok := usageSourceFor(providerSessionID, s.spawnOf(id).cwd)
+	src, ok := s.transcriptSource(id)
 	if !ok {
 		return usageEvent{}, false
 	}
+	return s.usageFrom(id, src)
+}
+
+// transcriptSource resolves the conversation a session is running: its recorded
+// provider session, then the file that provider files it in. false for a
+// session with no provider id yet and for a provider lich cannot read.
+//
+// Every readout taken off a transcript goes through here, so a report that
+// feeds two of them resolves once rather than once each (see emitReadouts).
+func (s *Service) transcriptSource(id string) (usageSource, bool) {
+	providerSessionID, err := s.store.ProviderSession(id)
+	if err != nil {
+		slog.Warn("terminal: read provider session", "session", id, "err", err)
+		return usageSource{}, false
+	}
+	if providerSessionID == "" {
+		return usageSource{}, false
+	}
+	return usageSourceFor(providerSessionID, s.spawnOf(id).cwd)
+}
+
+// usageFrom is sessionUsage once the transcript behind it is known.
+func (s *Service) usageFrom(id string, src usageSource) (usageEvent, bool) {
 	u, ok, supported := contextUsageFor(src)
 	// A provider whose window lich can read but has not read yet — a transcript
 	// still being written, a conversation before its first assistant line — keeps


### PR DESCRIPTION
A card that has gone quiet says what its session is up to but never how much of the work it planned is left. Claude Code writes that list itself (`TodoWrite`), and lich already walks the transcript it writes it in, so the count is a read of something already on disk.

Borrowed from EasyMint's `TodoStrip`, cut down to what fits a 15rem sidebar.

## On the card

A seventh rung on the second line, between the inbox and the tool:

```
 3 of 7 done
```

It draws only while the card is **not** busy. Mid-turn the tool line is what proves the session is moving, changing at every step, and a count that can sit still for minutes would take the line from it. Once the turn ends the tool line is cleared anyway, and the count answers the question a finished card leaves open: how much the agent stopped short of.

Two lists draw nothing: a finished one (its count is over, and it would sit there as news for the rest of the session) and a list of one item (an agent writing a single task is narrating, not planning). Both rules live in the frontend narrowing, so the event carries the fact and the card decides.

## Reading it

`internal/terminal/turntodo.go` is a sibling of the recap reader in `said.go`: same transcript, same walk of what has been appended since the last read. It keeps a cursor of its own because the two are read on different clocks. The recap is read only while the Review panel is open; this one is read on every state report, and a shared offset would let either consume the lines the other has not seen.

The event is emitted only when the pair moves. A report lands on every tool call, so re-emitting the same two numbers would re-render the card through a whole turn to say nothing.

## Which providers

`todoReaderFor` is the table, and it carries what each harness was measured to do so the next reader is not re-derived:

| Provider | What it writes | Read |
|---|---|---|
| Claude Code | `TodoWrite`, an ordinary tool call | yes |
| Codex | `update_plan`, but only inside the JavaScript source of an `exec` call, where the object is not even JSON | no |
| oh-my-pi, Antigravity, Kiro | no task list at all | no |
| opencode, Crush | messages in SQLite, no line to read | no |
| Cursor CLI | a blob store lich cannot order | no |

A session whose provider is absent there draws no progress, which is what a session whose agent never wrote a list draws too. That is a limit of the harnesses rather than one of lich, so it is documented where the reader is, not in `docs/ceilings.md`.

Two smaller limits, both in the code: the pair is what the agent last **wrote**, not what is true, so a list abandoned unfinished keeps its count until another one is written; and the cursor is per run of lich, so a window reloaded mid-turn draws no progress until the session's next report.

## Test plan

- [x] `gofmt -l ./internal ./main.go` and `go vet ./...` clean
- [x] `go test ./...` green, including the new `turntodo_test.go`: both encodings of `todos` (Claude Code files the list as a string holding the array, measured against 2.1.212 and 2.1.216), a sub-agent's list skipped, an emptied board, changes reported once, the whole-file walk that seeds a resumed session, and a transcript replaced under the cursor
- [x] Cross-compile loop for linux, darwin and windows
- [x] `pnpm exec biome ci .` exit 0
- [x] `pnpm exec vitest run` green (1723), including the 9 store tests
- [x] `pnpm build`
- [x] Reader run against the two real transcripts on this machine that hold a `TodoWrite`: both lists read whole (15 items and 6)
