### PR TITLE
chore: generate the baked price floor instead of copying it by hand

### DIFF
--- a/.github/workflows/pricing.yml
+++ b/.github/workflows/pricing.yml
@@ -1,0 +1,75 @@
+name: pricing
+
+# The baked price floor (internal/pricing/prices.json) is what an offline install
+# bills with, so it drifts from the day it ships and nothing in a normal run
+# notices. This reprices it from LiteLLM once a month and opens a pull request
+# when a rate actually moved — never a gate, so a rate change upstream cannot
+# turn somebody else's pull request red.
+on:
+  schedule:
+    # 06:00 UTC on the 1st. Cadence is generous on purpose: published rates move
+    # rarely, and the pull request is a review, not an alert.
+    - cron: "0 6 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+
+      # genfloor is a //go:build ignore program: it needs no frontend/dist,
+      # because it never imports the package that embeds it.
+      - name: Reprice the floor
+        run: go run internal/pricing/genfloor.go
+
+      - name: Stop when nothing moved
+        id: diff
+        run: git diff --quiet internal/pricing/prices.json && echo "changed=false" >> "$GITHUB_OUTPUT" || echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      # The suite reads the floor, so a table that arrived malformed enough to
+      # survive the parser is caught here rather than in the pull request.
+      - name: Backend pricing suite
+        if: steps.diff.outputs.changed == 'true'
+        run: go test ./internal/pricing/
+
+      - name: Open the pull request
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          branch="pricing/refresh"
+          git switch -c "$branch"
+          git add internal/pricing/prices.json
+          git commit -m "chore: reprice the baked floor from LiteLLM"
+          # Force: the branch is a rolling snapshot of the current table, not a
+          # history. A month with no review leaves one branch, not twelve.
+          git push -f origin "$branch"
+          # A pull request already open on this branch has just been updated by
+          # that push; opening a second one would fail the job for no reason.
+          if [ -n "$(gh pr list --head "$branch" --state open --json number --jq '.[].number')" ]; then
+            exit 0
+          fi
+          cat > /tmp/pr-body.md <<'BODY'
+          `task pricing:refresh`, run on a schedule. The floor is what an install with
+          no network bills with, so what changed here is what an offline session was
+          charging at the wrong rate.
+
+          Read the diff as prices, not as a bump: a rate that moved is a user-visible
+          change, and its `CHANGELOG.md` entry is yours to write before this merges.
+          BODY
+          gh pr create --head "$branch" \
+            --title "chore: reprice the baked floor from LiteLLM" \
+            --body-file /tmp/pr-body.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Two baked prices corrected.** An offline install billed Claude 3 Haiku's
+  hour-long cache writes at 12x Anthropic's rate, and had no price at all for
+  Claude 3 Opus's — which withheld that session's whole cost rather than
+  under-report it. The floor is now repriced from LiteLLM's table by
+  `task pricing:refresh` instead of by hand.
+
 - **An Intel Mac opens lich as a tab in the default browser.** It is the one
   build with no window of its own, and it no longer looks for Chrome, Chromium,
   Edge, Brave or Vivaldi to open a window in: lich serves itself, hands the URL

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -178,6 +178,14 @@ tasks:
       - cmd: cd frontend && pnpm test
       - task: test:shell
 
+  pricing:refresh:
+    desc: Reprice internal/pricing/prices.json from LiteLLM — run it when cutting a release
+    cmds:
+      # The baked floor is what an offline install prices with, so it drifts from
+      # the day it ships. This only reprices the ids already in the file; which
+      # models the floor carries stays a hand-picked list.
+      - cmd: go run internal/pricing/genfloor.go
+
   mutation:
     desc: Mutation tests via gremlins — .gremlins.yaml, scope with -- ./internal/pkg/
     preconditions:

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -70,10 +70,14 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   neither schema is a contract anybody promised to keep.
   The Codex window in that table is 95% of the rollout's default or configured `model_context_window`, and
   Codex is the one rung lich prices itself. `internal/pricing/prices.json` bakes a fixed slice of OpenAI rates
-  beside the Claude ones, copied by hand from the same LiteLLM table the refresh reads, so an offline Codex
+  beside the Claude ones, read from the same LiteLLM table the refresh reads, so an offline Codex
   session shows a cost at the rate that shipped — **stale by however long it has been since the release**,
-  until the refresh (`internal/pricing/pricing.go`) lands and overrides it. Nothing regenerates that slice, so
-  what is left
+  until the refresh (`internal/pricing/pricing.go`) lands and overrides it. `task pricing:refresh` reprices
+  the slice from that table, and a monthly job (`.github/workflows/pricing.yml`) runs it and opens a pull
+  request when a rate moved — deliberately not a gate, since an upstream price change is nobody's pull
+  request to fix. A hand-copied `cacheWrite1h` sat 12x over Anthropic's rate until the first run of that
+  task found it. What the job cannot notice is a model the floor never carried: that list is hand-picked,
+  so what is left
   with no price at all is a model newer than the build, or one LiteLLM never priced — and with no network
   the refresh that would settle it never runs. A Codex conversation that ran `/model` has no cost from that
   turn on (`codexCostScan.mixed`): the one running total spans both models and the rollout never splits it,

--- a/internal/pricing/genfloor.go
+++ b/internal/pricing/genfloor.go
@@ -1,0 +1,120 @@
+//go:build ignore
+
+// Command genfloor rewrites prices.json from LiteLLM's table — the same source
+// the runtime refresh reads, so the baked floor and a refreshed install price a
+// model the same way. Run it when cutting a release:
+//
+//	task pricing:refresh
+//
+// Which models the floor carries stays a hand-curated decision: this only
+// reprices the ids already in the file, and reports one that the table has
+// stopped publishing rather than dropping it. The field names below mirror
+// remoteEntry in pricing.go; that file is the one that decides what a price is.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"time"
+)
+
+const (
+	remoteURL = "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json"
+	floorPath = "internal/pricing/prices.json"
+	bodyLimit = 16 << 20
+)
+
+// remote is LiteLLM's shape; rate is lich's. omitempty keeps an unpublished
+// price absent rather than writing a zero, which is what the runtime reads as
+// "this model has no price for that" (see Rate.Cost).
+type remote struct {
+	Input        float64 `json:"input_cost_per_token"`
+	Output       float64 `json:"output_cost_per_token"`
+	CacheRead    float64 `json:"cache_read_input_token_cost"`
+	CacheWrite   float64 `json:"cache_creation_input_token_cost"`
+	CacheWrite1h float64 `json:"cache_creation_input_token_cost_above_1hr"`
+}
+
+type rate struct {
+	Input        float64 `json:"input,omitempty"`
+	Output       float64 `json:"output,omitempty"`
+	CacheRead    float64 `json:"cacheRead,omitempty"`
+	CacheWrite   float64 `json:"cacheWrite,omitempty"`
+	CacheWrite1h float64 `json:"cacheWrite1h,omitempty"`
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "genfloor:", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	floor := map[string]rate{}
+	current, err := os.ReadFile(floorPath)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(current, &floor); err != nil {
+		return err
+	}
+
+	table, err := fetch()
+	if err != nil {
+		return err
+	}
+
+	stale := []string{}
+	for model := range floor {
+		entry, ok := table[model]
+		if !ok {
+			stale = append(stale, model)
+			continue
+		}
+		if entry.Input == 0 && entry.Output == 0 {
+			stale = append(stale, model)
+			continue
+		}
+		floor[model] = rate(entry)
+	}
+	sort.Strings(stale)
+	for _, model := range stale {
+		fmt.Fprintf(os.Stderr, "genfloor: %s is no longer priced upstream — kept at its baked rate\n", model)
+	}
+
+	out, err := json.MarshalIndent(floor, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(floorPath, append(out, '\n'), 0o644); err != nil {
+		return err
+	}
+	fmt.Printf("genfloor: repriced %d of %d models\n", len(floor)-len(stale), len(floor))
+	return nil
+}
+
+func fetch() (map[string]remote, error) {
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(remoteURL)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: %s", remoteURL, resp.Status)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, bodyLimit))
+	if err != nil {
+		return nil, err
+	}
+	var table map[string]remote
+	if err := json.Unmarshal(data, &table); err != nil {
+		return nil, err
+	}
+	return table, nil
+}

--- a/internal/pricing/prices.json
+++ b/internal/pricing/prices.json
@@ -1,325 +1,326 @@
 {
   "claude-3-7-sonnet-20250219": {
-    "input": 3e-06,
-    "output": 1.5e-05,
-    "cacheRead": 3e-07,
-    "cacheWrite": 3.75e-06,
-    "cacheWrite1h": 6e-06
+    "input": 0.000003,
+    "output": 0.000015,
+    "cacheRead": 3e-7,
+    "cacheWrite": 0.00000375,
+    "cacheWrite1h": 0.000006
   },
   "claude-3-haiku-20240307": {
-    "input": 2.5e-07,
-    "output": 1.25e-06,
-    "cacheRead": 3e-08,
-    "cacheWrite": 3e-07,
-    "cacheWrite1h": 6e-06
+    "input": 2.5e-7,
+    "output": 0.00000125,
+    "cacheRead": 3e-8,
+    "cacheWrite": 3e-7,
+    "cacheWrite1h": 5e-7
   },
   "claude-3-opus-20240229": {
-    "input": 1.5e-05,
-    "output": 7.5e-05,
-    "cacheRead": 1.5e-06,
-    "cacheWrite": 1.875e-05
+    "input": 0.000015,
+    "output": 0.000075,
+    "cacheRead": 0.0000015,
+    "cacheWrite": 0.00001875,
+    "cacheWrite1h": 0.00003
   },
   "claude-4-opus-20250514": {
-    "input": 1.5e-05,
-    "output": 7.5e-05,
-    "cacheRead": 1.5e-06,
-    "cacheWrite": 1.875e-05
+    "input": 0.000015,
+    "output": 0.000075,
+    "cacheRead": 0.0000015,
+    "cacheWrite": 0.00001875
   },
   "claude-4-sonnet-20250514": {
-    "input": 3e-06,
-    "output": 1.5e-05,
-    "cacheRead": 3e-07,
-    "cacheWrite": 3.75e-06
+    "input": 0.000003,
+    "output": 0.000015,
+    "cacheRead": 3e-7,
+    "cacheWrite": 0.00000375
   },
   "claude-fable-5": {
-    "input": 1e-05,
-    "output": 5e-05,
-    "cacheRead": 1e-06,
-    "cacheWrite": 1.25e-05,
-    "cacheWrite1h": 2e-05
+    "input": 0.00001,
+    "output": 0.00005,
+    "cacheRead": 0.000001,
+    "cacheWrite": 0.0000125,
+    "cacheWrite1h": 0.00002
   },
   "claude-haiku-4-5": {
-    "input": 1e-06,
-    "output": 5e-06,
-    "cacheRead": 1e-07,
-    "cacheWrite": 1.25e-06,
-    "cacheWrite1h": 2e-06
+    "input": 0.000001,
+    "output": 0.000005,
+    "cacheRead": 1e-7,
+    "cacheWrite": 0.00000125,
+    "cacheWrite1h": 0.000002
   },
   "claude-haiku-4-5-20251001": {
-    "input": 1e-06,
-    "output": 5e-06,
-    "cacheRead": 1e-07,
-    "cacheWrite": 1.25e-06,
-    "cacheWrite1h": 2e-06
+    "input": 0.000001,
+    "output": 0.000005,
+    "cacheRead": 1e-7,
+    "cacheWrite": 0.00000125,
+    "cacheWrite1h": 0.000002
   },
   "claude-opus-4-1": {
-    "input": 1.5e-05,
-    "output": 7.5e-05,
-    "cacheRead": 1.5e-06,
-    "cacheWrite": 1.875e-05,
-    "cacheWrite1h": 3e-05
+    "input": 0.000015,
+    "output": 0.000075,
+    "cacheRead": 0.0000015,
+    "cacheWrite": 0.00001875,
+    "cacheWrite1h": 0.00003
   },
   "claude-opus-4-1-20250805": {
-    "input": 1.5e-05,
-    "output": 7.5e-05,
-    "cacheRead": 1.5e-06,
-    "cacheWrite": 1.875e-05,
-    "cacheWrite1h": 3e-05
+    "input": 0.000015,
+    "output": 0.000075,
+    "cacheRead": 0.0000015,
+    "cacheWrite": 0.00001875,
+    "cacheWrite1h": 0.00003
   },
   "claude-opus-4-20250514": {
-    "input": 1.5e-05,
-    "output": 7.5e-05,
-    "cacheRead": 1.5e-06,
-    "cacheWrite": 1.875e-05,
-    "cacheWrite1h": 3e-05
+    "input": 0.000015,
+    "output": 0.000075,
+    "cacheRead": 0.0000015,
+    "cacheWrite": 0.00001875,
+    "cacheWrite1h": 0.00003
   },
   "claude-opus-4-5": {
-    "input": 5e-06,
-    "output": 2.5e-05,
-    "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06,
-    "cacheWrite1h": 1e-05
+    "input": 0.000005,
+    "output": 0.000025,
+    "cacheRead": 5e-7,
+    "cacheWrite": 0.00000625,
+    "cacheWrite1h": 0.00001
   },
   "claude-opus-4-5-20251101": {
-    "input": 5e-06,
-    "output": 2.5e-05,
-    "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06,
-    "cacheWrite1h": 1e-05
+    "input": 0.000005,
+    "output": 0.000025,
+    "cacheRead": 5e-7,
+    "cacheWrite": 0.00000625,
+    "cacheWrite1h": 0.00001
   },
   "claude-opus-4-6": {
-    "input": 5e-06,
-    "output": 2.5e-05,
-    "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06,
-    "cacheWrite1h": 1e-05
+    "input": 0.000005,
+    "output": 0.000025,
+    "cacheRead": 5e-7,
+    "cacheWrite": 0.00000625,
+    "cacheWrite1h": 0.00001
   },
   "claude-opus-4-6-20260205": {
-    "input": 5e-06,
-    "output": 2.5e-05,
-    "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06,
-    "cacheWrite1h": 1e-05
+    "input": 0.000005,
+    "output": 0.000025,
+    "cacheRead": 5e-7,
+    "cacheWrite": 0.00000625,
+    "cacheWrite1h": 0.00001
   },
   "claude-opus-4-7": {
-    "input": 5e-06,
-    "output": 2.5e-05,
-    "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06,
-    "cacheWrite1h": 1e-05
+    "input": 0.000005,
+    "output": 0.000025,
+    "cacheRead": 5e-7,
+    "cacheWrite": 0.00000625,
+    "cacheWrite1h": 0.00001
   },
   "claude-opus-4-7-20260416": {
-    "input": 5e-06,
-    "output": 2.5e-05,
-    "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06,
-    "cacheWrite1h": 1e-05
+    "input": 0.000005,
+    "output": 0.000025,
+    "cacheRead": 5e-7,
+    "cacheWrite": 0.00000625,
+    "cacheWrite1h": 0.00001
   },
   "claude-opus-4-8": {
-    "input": 5e-06,
-    "output": 2.5e-05,
-    "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06,
-    "cacheWrite1h": 1e-05
+    "input": 0.000005,
+    "output": 0.000025,
+    "cacheRead": 5e-7,
+    "cacheWrite": 0.00000625,
+    "cacheWrite1h": 0.00001
   },
   "claude-opus-5": {
-    "input": 5e-06,
-    "output": 2.5e-05,
-    "cacheRead": 5e-07,
-    "cacheWrite": 6.25e-06,
-    "cacheWrite1h": 1e-05
+    "input": 0.000005,
+    "output": 0.000025,
+    "cacheRead": 5e-7,
+    "cacheWrite": 0.00000625,
+    "cacheWrite1h": 0.00001
   },
   "claude-sonnet-4-20250514": {
-    "input": 3e-06,
-    "output": 1.5e-05,
-    "cacheRead": 3e-07,
-    "cacheWrite": 3.75e-06,
-    "cacheWrite1h": 6e-06
+    "input": 0.000003,
+    "output": 0.000015,
+    "cacheRead": 3e-7,
+    "cacheWrite": 0.00000375,
+    "cacheWrite1h": 0.000006
   },
   "claude-sonnet-4-5": {
-    "input": 3e-06,
-    "output": 1.5e-05,
-    "cacheRead": 3e-07,
-    "cacheWrite": 3.75e-06,
-    "cacheWrite1h": 6e-06
+    "input": 0.000003,
+    "output": 0.000015,
+    "cacheRead": 3e-7,
+    "cacheWrite": 0.00000375,
+    "cacheWrite1h": 0.000006
   },
   "claude-sonnet-4-5-20250929": {
-    "input": 3e-06,
-    "output": 1.5e-05,
-    "cacheRead": 3e-07,
-    "cacheWrite": 3.75e-06,
-    "cacheWrite1h": 6e-06
+    "input": 0.000003,
+    "output": 0.000015,
+    "cacheRead": 3e-7,
+    "cacheWrite": 0.00000375,
+    "cacheWrite1h": 0.000006
   },
   "claude-sonnet-4-6": {
-    "input": 3e-06,
-    "output": 1.5e-05,
-    "cacheRead": 3e-07,
-    "cacheWrite": 3.75e-06,
-    "cacheWrite1h": 6e-06
+    "input": 0.000003,
+    "output": 0.000015,
+    "cacheRead": 3e-7,
+    "cacheWrite": 0.00000375,
+    "cacheWrite1h": 0.000006
   },
   "claude-sonnet-5": {
-    "input": 2e-06,
-    "output": 1e-05,
-    "cacheRead": 2e-07,
-    "cacheWrite": 2.5e-06,
-    "cacheWrite1h": 4e-06
+    "input": 0.000002,
+    "output": 0.00001,
+    "cacheRead": 2e-7,
+    "cacheWrite": 0.0000025,
+    "cacheWrite1h": 0.000004
   },
   "codex-mini-latest": {
-    "input": 1.5e-06,
-    "output": 6e-06,
-    "cacheRead": 3.75e-07
+    "input": 0.0000015,
+    "output": 0.000006,
+    "cacheRead": 3.75e-7
   },
   "gpt-5": {
-    "input": 1.25e-06,
-    "output": 1e-05,
-    "cacheRead": 1.25e-07
+    "input": 0.00000125,
+    "output": 0.00001,
+    "cacheRead": 1.25e-7
   },
   "gpt-5-chat": {
-    "input": 1.25e-06,
-    "output": 1e-05,
-    "cacheRead": 1.25e-07
+    "input": 0.00000125,
+    "output": 0.00001,
+    "cacheRead": 1.25e-7
   },
   "gpt-5-chat-latest": {
-    "input": 1.25e-06,
-    "output": 1e-05,
-    "cacheRead": 1.25e-07
+    "input": 0.00000125,
+    "output": 0.00001,
+    "cacheRead": 1.25e-7
   },
   "gpt-5-codex": {
-    "input": 1.25e-06,
-    "output": 1e-05,
-    "cacheRead": 1.25e-07
+    "input": 0.00000125,
+    "output": 0.00001,
+    "cacheRead": 1.25e-7
   },
   "gpt-5-mini": {
-    "input": 2.5e-07,
-    "output": 2e-06,
-    "cacheRead": 2.5e-08
+    "input": 2.5e-7,
+    "output": 0.000002,
+    "cacheRead": 2.5e-8
   },
   "gpt-5-nano": {
-    "input": 5e-08,
-    "output": 4e-07,
-    "cacheRead": 5e-09
+    "input": 5e-8,
+    "output": 4e-7,
+    "cacheRead": 5e-9
   },
   "gpt-5-pro": {
-    "input": 1.5e-05,
+    "input": 0.000015,
     "output": 0.00012
   },
   "gpt-5-search-api": {
-    "input": 1.25e-06,
-    "output": 1e-05,
-    "cacheRead": 1.25e-07
+    "input": 0.00000125,
+    "output": 0.00001,
+    "cacheRead": 1.25e-7
   },
   "gpt-5.1": {
-    "input": 1.25e-06,
-    "output": 1e-05,
-    "cacheRead": 1.25e-07
+    "input": 0.00000125,
+    "output": 0.00001,
+    "cacheRead": 1.25e-7
   },
   "gpt-5.1-chat-latest": {
-    "input": 1.25e-06,
-    "output": 1e-05,
-    "cacheRead": 1.25e-07
+    "input": 0.00000125,
+    "output": 0.00001,
+    "cacheRead": 1.25e-7
   },
   "gpt-5.1-codex": {
-    "input": 1.25e-06,
-    "output": 1e-05,
-    "cacheRead": 1.25e-07
+    "input": 0.00000125,
+    "output": 0.00001,
+    "cacheRead": 1.25e-7
   },
   "gpt-5.1-codex-max": {
-    "input": 1.25e-06,
-    "output": 1e-05,
-    "cacheRead": 1.25e-07
+    "input": 0.00000125,
+    "output": 0.00001,
+    "cacheRead": 1.25e-7
   },
   "gpt-5.1-codex-mini": {
-    "input": 2.5e-07,
-    "output": 2e-06,
-    "cacheRead": 2.5e-08
+    "input": 2.5e-7,
+    "output": 0.000002,
+    "cacheRead": 2.5e-8
   },
   "gpt-5.2": {
-    "input": 1.75e-06,
-    "output": 1.4e-05,
-    "cacheRead": 1.75e-07
+    "input": 0.00000175,
+    "output": 0.000014,
+    "cacheRead": 1.75e-7
   },
   "gpt-5.2-chat-latest": {
-    "input": 1.75e-06,
-    "output": 1.4e-05,
-    "cacheRead": 1.75e-07
+    "input": 0.00000175,
+    "output": 0.000014,
+    "cacheRead": 1.75e-7
   },
   "gpt-5.2-codex": {
-    "input": 1.75e-06,
-    "output": 1.4e-05,
-    "cacheRead": 1.75e-07
+    "input": 0.00000175,
+    "output": 0.000014,
+    "cacheRead": 1.75e-7
   },
   "gpt-5.2-pro": {
-    "input": 2.1e-05,
+    "input": 0.000021,
     "output": 0.000168
   },
   "gpt-5.3-chat-latest": {
-    "input": 1.75e-06,
-    "output": 1.4e-05,
-    "cacheRead": 1.75e-07
+    "input": 0.00000175,
+    "output": 0.000014,
+    "cacheRead": 1.75e-7
   },
   "gpt-5.3-codex": {
-    "input": 1.75e-06,
-    "output": 1.4e-05,
-    "cacheRead": 1.75e-07
+    "input": 0.00000175,
+    "output": 0.000014,
+    "cacheRead": 1.75e-7
   },
   "gpt-5.4": {
-    "input": 2.5e-06,
-    "output": 1.5e-05,
-    "cacheRead": 2.5e-07
+    "input": 0.0000025,
+    "output": 0.000015,
+    "cacheRead": 2.5e-7
   },
   "gpt-5.4-mini": {
-    "input": 7.5e-07,
-    "output": 4.5e-06,
-    "cacheRead": 7.5e-08
+    "input": 7.5e-7,
+    "output": 0.0000045,
+    "cacheRead": 7.5e-8
   },
   "gpt-5.4-nano": {
-    "input": 2e-07,
-    "output": 1.25e-06,
-    "cacheRead": 2e-08
+    "input": 2e-7,
+    "output": 0.00000125,
+    "cacheRead": 2e-8
   },
   "gpt-5.4-pro": {
-    "input": 3e-05,
+    "input": 0.00003,
     "output": 0.00018,
-    "cacheRead": 3e-06
+    "cacheRead": 0.000003
   },
   "gpt-5.5": {
-    "input": 5e-06,
-    "output": 3e-05,
-    "cacheRead": 5e-07
+    "input": 0.000005,
+    "output": 0.00003,
+    "cacheRead": 5e-7
   },
   "gpt-5.5-pro": {
-    "input": 3e-05,
+    "input": 0.00003,
     "output": 0.00018,
-    "cacheRead": 3e-06
+    "cacheRead": 0.000003
   },
   "gpt-5.6": {
-    "input": 4e-06,
-    "output": 2e-05,
-    "cacheRead": 4e-07,
-    "cacheWrite": 5e-06
+    "input": 0.000004,
+    "output": 0.00002,
+    "cacheRead": 4e-7,
+    "cacheWrite": 0.000005
   },
   "gpt-5.6-cyber": {
-    "input": 1.25e-05,
-    "output": 7.5e-05,
-    "cacheRead": 1.25e-06,
-    "cacheWrite": 1.5625e-05
+    "input": 0.0000125,
+    "output": 0.000075,
+    "cacheRead": 0.00000125,
+    "cacheWrite": 0.000015625
   },
   "gpt-5.6-luna": {
-    "input": 2e-07,
-    "output": 1.2e-06,
-    "cacheRead": 2e-08,
-    "cacheWrite": 2.5e-07
+    "input": 2e-7,
+    "output": 0.0000012,
+    "cacheRead": 2e-8,
+    "cacheWrite": 2.5e-7
   },
   "gpt-5.6-sol": {
-    "input": 4e-06,
-    "output": 2e-05,
-    "cacheRead": 4e-07,
-    "cacheWrite": 5e-06
+    "input": 0.000004,
+    "output": 0.00002,
+    "cacheRead": 4e-7,
+    "cacheWrite": 0.000005
   },
   "gpt-5.6-terra": {
-    "input": 2e-06,
-    "output": 1.2e-05,
-    "cacheRead": 2e-07,
-    "cacheWrite": 2.5e-06
+    "input": 0.000002,
+    "output": 0.000012,
+    "cacheRead": 2e-7,
+    "cacheWrite": 0.0000025
   }
 }


### PR DESCRIPTION
`internal/pricing/prices.json` is the floor an install with no network bills with, and
`docs/ceilings.md` said the quiet part already: it is copied by hand from LiteLLM's table
and *nothing regenerates that slice*. This is where that sentence stops being true.

## What was wrong

Measured against the live table, 53 of the 55 baked models agree. Two do not, both on the
hour-long cache write:

| model | baked | LiteLLM | effect |
| --- | --- | --- | --- |
| `claude-3-haiku-20240307` | `6e-06` | `5e-07` | billed at 12x the published rate |
| `claude-3-opus-20240229` | absent | `3e-05` | `Rate.Cost` returns `ok=false`, so the session shows **no cost at all** |

The second is the worse one: an absent price is the deliberate "withhold rather than
under-report" branch, so the user sees the `unpriced-model` marker and a tooltip that
blames a network which would not have helped.

## What changed

- `internal/pricing/genfloor.go` — `//go:build ignore`, so build, vet and test never see
  it. It reprices the ids already in the file from the same table
  `internal/pricing/pricing.go` refreshes from. Which models the floor carries stays a
  hand-picked list; a model the table stopped publishing is reported on stderr and kept at
  its baked rate rather than dropped.
- `task pricing:refresh` runs it.
- `.github/workflows/pricing.yml` runs it monthly and opens a pull request only when a rate
  actually moved.
- `prices.json` is the output of that run: the two fixes above, plus a one-time
  reformat — `encoding/json` writes `0.000003` where the hand-written file had `3e-06`.
  Verified value by value against `HEAD`: 55 models, exactly 2 changes, no precision lost.

## Two deliberate non-features

**The job is not a gate.** A rate moving upstream is nobody's pull request to fix, and a CI
that goes red on somebody else's frontend change because Anthropic repriced a model is the
kind of red people learn to ignore. It opens a pull request instead.

**The bot does not write the changelog.** A price that moved is user-visible, and the entry
belongs to whoever reviews the diff — the pull request body says so.

## Known ceiling

A pull request opened with `GITHUB_TOKEN` does not trigger workflows, so these will arrive
without CI. `go test ./internal/pricing/` runs inside the job instead. A PAT would fix it
and did not look worth the secret for a diff of one JSON file.

`docs/ceilings.md` moved with the change: the bullet now names the job, says why it is not
a gate, and keeps what the job still cannot notice — a model the floor never carried.

## Test plan

- [x] `gofmt -l ./internal ./main.go` clean, `go vet ./...` clean (with a `frontend/dist`
      placeholder), `go test ./...` green
- [x] `go run internal/pricing/genfloor.go` — "repriced 55 of 55 models"; rerun is a no-op
- [x] `prices.json` diffed against `HEAD` value by value: 2 changes, both intended
- [x] workflow YAML parses; the shell step passes `bash -n`
- [ ] the scheduled run itself — first exercise is `workflow_dispatch` after merge
