### PR TITLE
fix: link a session name that wraps or follows a wide character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A session name that wrapped, or followed a wide character, stopped being a
+  link.** The terminal looked for other sessions' names one screen row at a
+  time and counted one character per column, so a long name broken across two
+  rows was found on neither of them, and a name printed after CJK text or a
+  combining accent underlined the wrong columns. The match now runs over the
+  whole logical line and maps back to the cells the characters really occupy.
+
 ## [0.49.0] - 2026-09-09
 
 > [!WARNING]

--- a/frontend/src/lib/terminal/session-link-provider.test.ts
+++ b/frontend/src/lib/terminal/session-link-provider.test.ts
@@ -52,6 +52,56 @@ describe("createSessionLinkProvider", () => {
     expect(activated).toEqual([expect.objectContaining({ sessionId: "auth-1" })])
   })
 
+  it("finds a label that wrapped across two rows, from either of them", async () => {
+    // 20 columns puts "auth service" astride the wrap: "auth " ends row 1 and
+    // "service" opens row 2. Read a row at a time the label is on neither.
+    const term = new Terminal({ cols: 20, rows: 24 })
+    await writeLine(term, "waiting on the auth service")
+
+    const targets = sessionLinkTargets(
+      [session({ sessionId: "auth-1", label: "auth service" })],
+      "",
+    )
+    const provider = createSessionLinkProvider(term, { current: targets }, () => {})
+
+    const range = { start: { x: 16, y: 1 }, end: { x: 7, y: 2 } }
+    for (const row of [1, 2]) {
+      const links = await provideLinks(provider, row)
+      expect(links).toHaveLength(1)
+      expect((links as ILink[])[0].text).toBe("auth service")
+      expect((links as ILink[])[0].range).toEqual(range)
+    }
+  })
+
+  it("counts cells, not characters, when a wide char sits before the label", async () => {
+    // Each of the two wide chars is one character of the line's text and two
+    // columns of its buffer, so a match mapped by string offset would underline
+    // two cells to the left of the label.
+    const term = new Terminal({ cols: 80, rows: 24 })
+    await writeLine(term, "日本 auth done")
+
+    const targets = sessionLinkTargets([session({ sessionId: "auth-1", label: "auth" })], "")
+    const provider = createSessionLinkProvider(term, { current: targets }, () => {})
+
+    const links = await provideLinks(provider, 1)
+    expect(links).toHaveLength(1)
+    expect((links as ILink[])[0].range).toEqual({ start: { x: 6, y: 1 }, end: { x: 9, y: 1 } })
+  })
+
+  it("counts cells, not characters, when a combining mark sits before the label", async () => {
+    // "é" written as e + U+0301 is two characters in one cell, the mirror of the
+    // wide char above: mapping by string offset would run one cell too far right.
+    const term = new Terminal({ cols: 80, rows: 24 })
+    await writeLine(term, "cafe\u0301 auth done")
+
+    const targets = sessionLinkTargets([session({ sessionId: "auth-1", label: "auth" })], "")
+    const provider = createSessionLinkProvider(term, { current: targets }, () => {})
+
+    const links = await provideLinks(provider, 1)
+    expect(links).toHaveLength(1)
+    expect((links as ILink[])[0].range).toEqual({ start: { x: 6, y: 1 }, end: { x: 9, y: 1 } })
+  })
+
   it("reports no links on a line that mentions nothing open", async () => {
     const term = new Terminal({ cols: 80, rows: 24 })
     await writeLine(term, "nothing to see here")

--- a/frontend/src/lib/terminal/session-link-provider.ts
+++ b/frontend/src/lib/terminal/session-link-provider.ts
@@ -3,17 +3,88 @@
 // clickable jump to it — the same custom-link-provider mechanism
 // WebLinksAddon (TerminalView.tsx) uses for URLs, but xterm has none built in
 // for arbitrary text, so this is a small hand-written one.
-//
-// ponytail: matches are found one physical row at a time, one string
-// character costing exactly one cell — a label that wraps across two rows, or
-// carries a wide/combining character, is missed. Session labels are short,
-// mostly-ASCII, user-typed slugs in practice; if that ever stops holding,
-// @xterm/addon-web-links's internal LinkComputer shows the fuller wrapped-line
-// + cell-width walk to grow into.
 
 import type { ILink, ILinkProvider, Terminal } from "@xterm/xterm"
 import type { PaletteSession } from "@/lib/session/command-palette"
 import { findLabelMatches, type SessionLinkTargets } from "./session-links"
+
+// The match runs over the whole logical line, continuation rows included, so a
+// label that wrapped still links. The walk stops here in either direction: a
+// program printing megabytes without a newline must not turn every mouse move
+// into a scan of the scrollback.
+const MAX_WINDOW_CELLS = 2048
+
+// A logical line as one string, plus the cells each string index came from.
+// Neither direction is 1:1 — a wide char covers two cells, a combining mark
+// adds a char without adding a cell, and a wrap moves the next char to a row of
+// its own — so the mapping is recorded during the walk rather than computed
+// back from a string offset.
+interface WindowedLine {
+  text: string
+  /** Buffer row of the char at each string index. */
+  row: number[]
+  /** First cell of the char at each string index, 0-based. */
+  cellStart: number[]
+  /** Cell after the char at each string index, 0-based. */
+  cellEnd: number[]
+}
+
+// readWindow reads the whole logical line the given buffer row belongs to.
+// Continuation rows are the ones flagged isWrapped, which is what xterm sets
+// when the cursor auto-wrapped rather than met a newline.
+function readWindow(term: Terminal, lineIndex: number): WindowedLine | null {
+  const buf = term.buffer.active
+  if (!buf.getLine(lineIndex)) {
+    return null
+  }
+  let budget = MAX_WINDOW_CELLS
+  let top = lineIndex
+  while (budget > 0 && buf.getLine(top)?.isWrapped) {
+    const above = buf.getLine(top - 1)
+    if (!above) {
+      break
+    }
+    top--
+    budget -= above.length
+  }
+  budget = MAX_WINDOW_CELLS
+  let bottom = lineIndex
+  while (budget > 0) {
+    const below = buf.getLine(bottom + 1)
+    if (!below?.isWrapped) {
+      break
+    }
+    bottom++
+    budget -= below.length
+  }
+
+  const cell = buf.getNullCell()
+  const line: WindowedLine = { text: "", row: [], cellStart: [], cellEnd: [] }
+  for (let y = top; y <= bottom; y++) {
+    const row = buf.getLine(y)
+    if (!row) {
+      break
+    }
+    for (let x = 0; x < row.length; ) {
+      row.getCell(x, cell)
+      // A cell holding no codepoint still owns its column, and reads back as
+      // the space translateToString would have put there. Advancing by the
+      // width steps over the right half of a wide char, which carries no
+      // character of its own; the fallback of 1 is what keeps a zero-width
+      // cell from stalling the walk, the same guard xterm's own walk has.
+      const chars = cell.getChars() || " "
+      const next = x + (cell.getWidth() || 1)
+      line.text += chars
+      for (let i = 0; i < chars.length; i++) {
+        line.row.push(y)
+        line.cellStart.push(x)
+        line.cellEnd.push(next)
+      }
+      x = next
+    }
+  }
+  return line
+}
 
 export function createSessionLinkProvider(
   term: Terminal,
@@ -23,23 +94,27 @@ export function createSessionLinkProvider(
   return {
     provideLinks(bufferLineNumber, callback) {
       const targets = targetsRef.current
-      const line = targets.pattern ? term.buffer.active.getLine(bufferLineNumber - 1) : undefined
+      const line = targets.pattern ? readWindow(term, bufferLineNumber - 1) : null
       if (!line) {
         callback(undefined)
         return
       }
-      const text = line.translateToString(true)
-      const matches = findLabelMatches(text, targets)
+      const matches = findLabelMatches(line.text, targets)
       if (matches.length === 0) {
         callback(undefined)
         return
       }
       const links: ILink[] = matches.map(({ start, end, session }) => ({
+        // xterm's range is 1-based and includes its right edge, so the first
+        // cell shifts up by one while the exclusive end cell already names the
+        // last column. Taking the end from the match's last char, rather than
+        // from the one past it, is what keeps a label ending flush with the
+        // right margin from reporting column 0 of the row below.
         range: {
-          start: { x: start + 1, y: bufferLineNumber },
-          end: { x: end, y: bufferLineNumber },
+          start: { x: line.cellStart[start] + 1, y: line.row[start] + 1 },
+          end: { x: line.cellEnd[end - 1], y: line.row[end - 1] + 1 },
         },
-        text: text.slice(start, end),
+        text: line.text.slice(start, end),
         decorations: { pointerCursor: true, underline: true },
         activate: () => activate(session),
       }))


### PR DESCRIPTION
The terminal's session-name link provider carried a known ceiling: it matched one physical row at a time, with one string character costing exactly one cell. Two ways that showed:

- **A name broken across a wrap linked on neither row.** Each row was trimmed and matched alone, so `auth service` split into `auth ` and `service` was found in neither. lich's own cards are narrow and its AI-written titles are long, so this is the common case, not the exotic one.
- **A name after a wide or combining character underlined the wrong cells.** `日本 auth` put the link two columns left of `auth`; `cafe` + U+0301 put it one column right.

## What changed

`session-link-provider.ts` now reads the whole logical line the hovered row belongs to, walking up and down through the rows xterm flags `isWrapped`, and builds the string by walking cells rather than calling `translateToString`. Each string index records the row and the first and last cell its character occupies, so mapping a match back to a range is an array read instead of arithmetic that has to guess at widths.

Two details worth naming:

- **The window expands on `isWrapped` alone.** `@xterm/addon-web-links`'s own walk also stops at whitespace, which is sound for URLs and wrong here: session names contain spaces, and stopping at one truncates the window mid-name. The 2048-cell budget is the only bound left.
- **A link's right edge comes from its last character, not the one past it.** The addon reads the position after the match, which reports column 0 of the following row when a match ends flush with the right margin. Taking `cellEnd` of the last character keeps the range on the row the text is on.

`session-links.ts` is untouched: the matcher was never the problem.

## Test plan

- [x] Three tests added to `session-link-provider.test.ts`, driving a real xterm `Terminal`: a name astride a wrap read from either row, a name after two CJK characters, a name after a combining accent.
- [x] All three fail against the previous provider with exactly the wrong offsets described above (`x: 4` and `x: 7` where `x: 6` is right); the three existing tests pass unchanged, so no expectation was rewritten to fit.
- [x] `pnpm exec biome ci .` exit 0, `vitest run` 1750 passed, `pnpm build`, `gofmt -l .`, `go vet ./...`, `go test ./...`.
- [ ] Hover a wrapped session name in a narrow card in `task dev`.