### PR TITLE
docs: name the glibc floor in the README install table

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ curl -fsSL https://raw.githubusercontent.com/omartelo/lich/main/install.sh | sh
 
 | Platform | Get it | Needs at runtime |
 | --- | --- | --- |
-| **Linux** | `install.sh` above, or AUR [`lich-bin`](https://aur.archlinux.org/packages/lich-bin) (`yay -S lich-bin`) | `zenity` — the window ships in the package |
+| **Linux** | `install.sh` above, or AUR [`lich-bin`](https://aur.archlinux.org/packages/lich-bin) (`yay -S lich-bin`) | `zenity`, plus glibc 2.34 or newer for the window that ships in the package (Debian 12, Ubuntu 22.04, RHEL 9 and up) |
 | **macOS** *(experimental)* | `brew install --cask omartelo/tap/lich` | nothing on Apple Silicon — the window ships in the app; Intel opens lich as a tab in your default browser |
 | **Windows** *(experimental)* | installer from [Releases](https://github.com/omartelo/lich/releases), or Scoop: `scoop install https://github.com/omartelo/lich/releases/latest/download/lich.json` | nothing — the window ships with both |
 


### PR DESCRIPTION
The Linux packages already refuse an install below glibc 2.34 (`build/linux/nfpm/nfpm.yaml` declares `libc6 (>= 2.34)` on the deb and `libc.so.6(GLIBC_2.34)` on the rpm), and `INSTALL.md` states the floor. The README's own install table did not, so a reader who follows the one-line installer on Debian 11 or RHEL 8 meets it as an apt or dnf dependency error and has to work out why.

The table's runtime column now names it, and ties it to the window rather than to lich, which is what actually carries the requirement.

No CHANGELOG entry: nothing a user of a published version lived changed here.