### PR TITLE
fix: say what the two sandbox grants hand over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The two sandbox grants say what they hand over.** In Settings › Sandbox, the
+  SSH agent switch now names the whole of it — every identity in your agent,
+  against any host, for as long as the session runs — and the GitHub token switch
+  says the agent can read the token out of its environment and spend it outside
+  this repository. The list of loaded keys is also re-read whenever the window
+  regains focus, so a key added with `ssh-add` after the pane was opened is no
+  longer handed over by a switch that never named it.
+
 ### Fixed
 
 - **A session name that wrapped, or followed a wide character, stopped being a

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -367,31 +367,35 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   X11 socket and its cookie instead, the wider of the two — X clients are not isolated from one another —
   and macOS gets neither, its pasteboard being a mach service rather than a socket, so a confined session
   there has no clipboard at all. macOS has no hardware here — its profile is unit-tested and has never run.
-- **The two sandbox grants hand over more than what they are read as** (`internal/store/settings.go`,
-  `internal/sandbox`, `internal/terminal/sandbox.go`): a confined session reaches the network as the user only
-  where the project turned one of them on, and each is all-or-nothing. The ssh agent is handed over as a socket,
-  so nothing private enters the sandbox — but the session signs with **every** identity loaded in that agent,
-  against any host it can reach, for as long as it runs. OpenSSH can pin a key to one destination, and only when
-  the key is added on the host (`ssh-add -h`); lich is given a socket that is already populated and can only
-  pass it on whole. The socket does not travel alone: `~/.ssh/known_hosts` is mounted read-only beside it,
-  because without it ssh cannot verify github.com, has no tty to ask on, and fails with "Host key
-  verification failed" before the key is ever offered — the grant would hand over the credential and not the
-  push. That file is public host keys, never a secret; what a confined session learns from it is the list of
-  machines the user connects to. Read-only, so a host the user has never connected to *outside* the sandbox
-  still fails inside it and cannot be learned there — blind trust-on-first-use is not a thing to grant an
-  unattended agent. And a `known_hosts` symlinked out of a dotfiles repository is dropped like every other
-  link in the home (`internal/sandbox`'s `existing`), which takes the whole grant down with it. That is why Settings lists what is in the agent — and the list is read when the pane opens,
-  so a key added afterwards is handed over by a switch that never named it. The GitHub token is one account's,
-  the project's own (`vcs.account`), and it rides in the session's environment: the agent can read it back out
-  of its own environment and spend it on anything that account's scopes allow, this repository or not. Neither
-  grant is keyed by provider — a grant describes what is inside the sandbox, not who runs in it — so turning
-  one on turns it on for every provider confined in that project. It is
+- **The two sandbox grants are all-or-nothing** (`internal/store/settings.go`, `internal/sandbox`,
+  `internal/terminal/sandbox.go`): a confined session reaches the network as the user only where the project
+  turned one of them on, and each is all-or-nothing. The ssh agent is handed over as a socket, so nothing
+  private enters the sandbox — but the session signs with **every** identity loaded in that agent, against any
+  host it can reach, for as long as it runs. OpenSSH can pin a key to one destination, and only when the key
+  is added on the host (`ssh-add -h`); lich is given a socket that is already populated and can only pass it
+  on whole. The socket does not travel alone: `~/.ssh/known_hosts` is mounted read-only beside it, because
+  without it ssh cannot verify github.com, has no tty to ask on, and fails with "Host key verification failed"
+  before the key is ever offered — the grant would hand over the credential and not the push. That file is
+  public host keys, never a secret; what a confined session learns from it is the list of machines the user
+  connects to. Read-only, so a host the user has never connected to *outside* the sandbox still fails inside
+  it and cannot be learned there — blind trust-on-first-use is not a thing to grant an unattended agent. And a
+  `known_hosts` symlinked out of a dotfiles repository is dropped like every other link in the home
+  (`internal/sandbox`'s `existing`), which takes the whole grant down with it. That is why Settings lists what
+  is in the agent, and re-reads the list every time the window regains focus: `ssh-add` is run in a terminal
+  outside lich, so the tab back is the frame where a key loaded a moment ago has to already be named by the
+  switch that hands it over. The GitHub token is one account's, the project's own (`vcs.account`), and it
+  rides in the session's environment: the agent can read it back out of its own environment and spend it on
+  anything that account's scopes allow, this repository or not. Both switches say that much in the sentence
+  under them — a grant is decided in a settings pane beside a sandbox whose whole promise is that the user's
+  credentials are not in there, and a switch read as "let it push with my GitHub key" is read as a smaller
+  promise than it makes. Neither grant is keyed by provider — a grant describes what is inside the sandbox,
+  not who runs in it — so turning one on turns it on for every provider confined in that project. It is
   resolved once per spawn, so a token gh rotates mid-session goes stale with nothing saying so, and a `gh auth
   token` that fails leaves the session with no token rather than failing the spawn. Both are off by default,
-  and both are Linux in practice: the macOS profile denies reads *inside* the home while a launchd agent socket
-  and gh's keyring live outside it, so a confined macOS session never lost either and the switches change
-  nothing there — they are inert rather than hidden, and there is no macOS hardware here to prove it further.
-  Windows has no sandbox backend, so neither switch exists.
+  and both are Linux in practice: the macOS profile denies reads *inside* the home while a launchd agent
+  socket and gh's keyring live outside it, so a confined macOS session never lost either and the switches
+  change nothing there — they are inert rather than hidden, and there is no macOS hardware here to prove it
+  further. Windows has no sandbox backend, so neither switch exists.
 - **The macOS floor is the toolchain's, not lich's** (`build/darwin/Info.plist.tpl`,
   `build/darwin/homebrew/lich.rb.tpl`): nothing in lich needs macOS 13, but Go 1.27 dropped every
   release before Ventura, so a binary built from this module cannot run on Big Sur or Monterey. The

--- a/frontend/src/components/settings/SandboxSettings.test.tsx
+++ b/frontend/src/components/settings/SandboxSettings.test.tsx
@@ -11,10 +11,13 @@ import { createElement } from "react"
 import { expect, test, vi } from "vitest"
 import { SandboxSettings } from "./SandboxSettings"
 
+// What the agent holds, swapped between reads so a second one is visible.
+let agentKeys: string[] = []
+
 vi.mock("@/lib/rpc", () => ({
   System: {
     SandboxBackend: () => Promise.resolve("bubblewrap"),
-    SSHAgentKeys: () => Promise.resolve([]),
+    SSHAgentKeys: () => Promise.resolve(agentKeys),
   },
   Store: { GetSetting: () => Promise.resolve("") },
   Providers: {
@@ -32,5 +35,40 @@ test("says the sandbox never confines a terminal", async () => {
   expect(document.body.textContent).toContain(
     "Terminals are never confined; the sandbox is for agents working unattended.",
   )
+  await mounted.unmount()
+})
+
+// The two grants are the credentials a confined session gets back, and each is
+// read as a smaller promise than it makes — the whole point of the sentence is
+// the half after the first full stop.
+test("each grant says what it hands over", async () => {
+  const mounted = await mountBudget(createElement(SandboxSettings))
+  await mounted.act(() => {})
+
+  expect(document.body.textContent).toContain(
+    "Signs with every identity in your agent, against any host, for as long as the session runs.",
+  )
+  expect(document.body.textContent).toContain(
+    "The agent can read the token out of its environment and spend it outside this repository.",
+  )
+  await mounted.unmount()
+})
+
+// ssh-add is run in a terminal outside this window, so the tab back is when the
+// list has to stop being the one read at pane open.
+test("re-reads the agent when the window comes back", async () => {
+  agentKeys = []
+  const mounted = await mountBudget(createElement(SandboxSettings))
+  await mounted.act(() => {})
+  expect(document.body.textContent).toContain("Nothing loaded.")
+
+  agentKeys = ["me@example.com (ED25519 256)"]
+  await mounted.act(() => {
+    window.dispatchEvent(new Event("focus"))
+  })
+  await mounted.act(() => {})
+
+  expect(document.body.textContent).toContain("Loaded: me@example.com (ED25519 256)")
+  agentKeys = []
   await mounted.unmount()
 })

--- a/frontend/src/components/settings/SandboxSettings.tsx
+++ b/frontend/src/components/settings/SandboxSettings.tsx
@@ -68,19 +68,21 @@ function useSandboxBackend() {
   })
 }
 
-// useAgentKeys lists what is loaded in the user's ssh agent, read when the pane
-// opens. It is the sentence the switch below it cannot say on its own: that
-// switch is read as "let it push with my GitHub key", and it hands over every
-// identity in this list. A key added after this read is handed over by a control
-// that never named it — reopening the pane refetches, which is the cheap answer
-// to that, and the filed list is only what stands on screen while it does.
+// useAgentKeys lists what is loaded in the user's ssh agent. It is the sentence
+// the switch below it cannot say on its own: that switch is read as "let it push
+// with my GitHub key", and it hands over every identity in this list.
+//
+// Re-read on focus, because `ssh-add` is run in a terminal outside this window
+// and the tab back is the frame where the list has to be right: read once at
+// pane open, a key loaded a moment ago is handed over by a control that never
+// named it. The filed list is what stands on screen while the re-read runs.
 function useAgentKeys(): string[] {
   const { data } = useRemoteResource(
     "ssh-agent-keys",
     // Folded rather than trusted: a machine with no agent answers null, not [],
     // and this list is read for a length.
     () => System.SSHAgentKeys().then((keys) => keys ?? NO_KEYS),
-    { empty: NO_KEYS, cache: "settings.sshAgentKeys" },
+    { empty: NO_KEYS, refetchOnFocus: true, cache: "settings.sshAgentKeys" },
   )
   return data
 }
@@ -156,14 +158,14 @@ export function SandboxSettings({ projectId }: { projectId?: string }) {
       <SettingBlock title="What a confined session may carry in">
         <Grant
           title="SSH agent"
-          description="git push works inside. Signs with every identity in your agent, for any host."
+          description="git push works inside. Signs with every identity in your agent, against any host, for as long as the session runs."
           detail={agentKeys.length > 0 ? `Loaded: ${agentKeys.join(" · ")}` : "Nothing loaded."}
           checked={sshAgent === "true"}
           onChange={(next) => setSSHAgent(String(next))}
         />
         <Grant
           title="GitHub token"
-          description="gh works inside. The agent can read the token out of its environment."
+          description="gh works inside. The agent can read the token out of its environment and spend it outside this repository."
           detail={accountLine(account)}
           checked={ghToken === "true"}
           onChange={(next) => setGHToken(String(next))}
@@ -275,9 +277,11 @@ function StatusStrip({ backend }: { backend: string }) {
 }
 
 // Grant is one credential handed back to a confined session. The description
-// carries the half nobody assumes — every identity, any host; a token the agent
-// can read straight out of its environment — because without it each switch reads
-// as a smaller promise than it makes.
+// carries the half nobody assumes — every identity, any host, for the whole life
+// of the session; a token the agent can read straight out of its environment and
+// spend anywhere that account reaches — because without it each switch reads as a
+// smaller promise than it makes, next to a sandbox whose whole pitch is that the
+// user's credentials are not in there.
 function Grant({
   title,
   description,


### PR DESCRIPTION
Closes #579.

`docs/ceilings.md` recorded what each grant in Project Settings actually passes into a confined session; neither switch's copy said it. The gap is that it was written in a contributor file while the decision is taken in a settings pane, beside a sandbox whose whole promise is that your credentials are not in there.

## What changed

- **SSH agent** now names the duration as well as the reach: *Signs with every identity in your agent, against any host, for as long as the session runs.*
- **GitHub token** now says what the agent can do with it, not just that it can see it: *The agent can read the token out of its environment and spend it outside this repository.*
- **The key list re-reads on window focus** instead of being read once when the pane opens. `ssh-add` is run in a terminal outside lich, so the tab back is the frame where a key loaded a moment ago has to already be named by the switch that hands it over. The filed list stands on screen while the re-read runs, so nothing flashes.

`refetchOnFocus` is the same option `useRemoteResource` already gives the checkouts and pull request screens; no new machinery.

`docs/ceilings.md` moves in the same PR: the bullet's headline was "hand over more than what they are read as", which is no longer the ceiling — what remains is that each grant is all-or-nothing and not keyed by provider.

## Test plan

- [x] `frontend` — new checks in `SandboxSettings.test.tsx`: each grant's sentence reaches the pane, and a key added between reads shows up after a `focus` event. Verified the second one fails with `refetchOnFocus` removed.
- [x] `pnpm test` (1752), `biome ci` exit 0, `pnpm build`
- [x] `gofmt -l .`, `go vet ./...`, `go test ./...`