### PR TITLE
fix: say so where lich quietly declines to act

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **What you type while a message is being relayed into your session no longer
+  goes out with it.** A relayed message is pasted at the prompt and an Enter is
+  sent behind it, and anything typed between the two was submitted as part of
+  it. Those keystrokes are now held for the length of that window and written at
+  the prompt the message leaves behind, where they were being typed.
+
+- **A handoff that is waiting for a prompt says so on the card it is waiting
+  for.** Handing a pull request's conflicts or an issue to a session writes at
+  its prompt once there is one, and a session still installing its dependencies
+  — or one you left half a sentence at — can hold that for minutes with nothing
+  on screen to show for it. The card now carries a line saying something is
+  waiting for that prompt until it lands.
+
+- **A turn whose snapshot lich dropped reads as a turn, not as a card that never
+  had one.** Every snapshot in the app runs on one worker, and a busy enough
+  queue drops a job, leaving the Review panel's "Last turn" with nothing to
+  show. It said "No last turn recorded", the same words a fresh session gets;
+  it now says the record was lost and that the next turn is recorded as usual.
+
 - **A session name that wrapped, or followed a wide character, stopped being a
   link.** The terminal looked for other sessions' names one screen row at a
   time and counted one character per column, so a long name broken across two

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -164,8 +164,11 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   disagree about which files exist), so a turn that only touched ignored files reports itself as having
   changed nothing. Every snapshot in the app runs on one FIFO worker, because git refuses a second `add`
   against an index another holds — so one session's first snapshot of a large checkout delays the next
-  session's, and a queue past `snapQueueDepth` drops a job, costing that turn its record with only the log
-  saying so. A checkout whose *first* snapshot fails is dropped outright and never asked again — the
+  session's, and a queue past `snapQueueDepth` drops a job, costing that turn its record — the panel reads
+  "lost" for it, which is a turn that ran and cannot be shown, never the "no last turn recorded" of a card
+  that has not had one. It says so for that turn alone: the next one to close files a record like any other,
+  and nothing carries the gap into the workspace database, so a lich relaunched between the two answers
+  "unrecorded" for a turn it lost before the restart. A checkout whose *first* snapshot fails is dropped outright and never asked again — the
   ordinary reason is a session opened outside a repository, but a transient failure at spawn reads the same
   and leaves that card with no last turn until it respawns. A pair read back at launch names loose objects
   no ref reaches, so a `git gc --prune` in that checkout between one run and the next leaves the panel
@@ -278,16 +281,22 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   holds the delivery back while the user has unsent input there. What it counts is printable input since the last
   Enter, escape sequences skipped — it cannot see the line, so an edit that leaves it empty by another route
   (Ctrl+W, a click into the middle of it) reads as a draft that is still there, and a delivery waits out
-  `draftIdle` for nothing. The stale-draft release is what keeps that a delay instead of a wedged relay. Two gaps
-  stay open: input arriving between the paste and its Enter still rides along — a window that is `defaultSubmitDelay`
-  at best and lasts until the target's PTY goes quiet at worst (`internal/relay`, `awaitSettled`) — and a provider
-  that takes keystrokes through anything other than this PTY is invisible here. The pull request and issue handoffs
-  wait on the same answer (`frontend/src/lib/terminal/write-at-prompt.ts`) with no Enter of their own to justify it:
-  hand a conflict to a session you left half a sentence in, and nothing appears at that prompt until the draft goes
-  stale.
+  `draftIdle` for nothing. The stale-draft release is what keeps that a delay instead of a wedged relay, and the
+  wait says so where it is happening: the pull request and issue handoffs
+  (`frontend/src/lib/terminal/write-at-prompt.ts`) wait on the same answer with no Enter of their own to justify
+  it, so while one is held its target's card carries a rung saying something is waiting for that prompt — hand a
+  conflict to a session you left half a sentence in and the card says where it went, rather than the click reading
+  as having done nothing. The mark lives in the page that is waiting, so it is only ever on the window that started
+  the handoff, and the relay's own hold is not drawn at all: a delivery held there answers to its sender, through
+  the ticket. What stays open is the provider that takes keystrokes through anything other than this PTY, which is
+  invisible to every part of this.
 - **A relayed Enter is timed against silence, not against the target** (`internal/relay`, `awaitSettled`): lich
   presses Enter once the target's PTY has been quiet for `defaultSubmitDelay`, because nothing here can read a TUI's
-  screen to know it has taken the paste in. On Windows that quiet is the whole instrument — ConPTY hands a child key
+  screen to know it has taken the paste in. The window that opens on the target's own keyboard is closed rather
+  than lived with: from the paste to the Enter its keystrokes are held and written at the prompt the Enter leaves
+  behind (`terminal.HoldInput`), so what a person types there is late by the length of the window instead of
+  submitted inside somebody else's message. Held, not dropped — but held is still not typed: an interrupt reached
+  for in that window lands after the delivery, on the turn the delivery started. On Windows that quiet is the whole instrument — ConPTY hands a child key
   events rather than bytes, the bracketed paste markers do not survive, and every provider TUI then guesses at where
   a paste ends from timing alone. A target that repaints on a timer of its own never goes quiet and gets its Enter
   at `defaultSettleLimit` regardless, which is the case this cannot tell from a paste still arriving.

--- a/frontend/src/components/diff/ReviewPanel.tsx
+++ b/frontend/src/components/diff/ReviewPanel.tsx
@@ -361,10 +361,11 @@ function PanelBody({
     return <Notice>Loading…</Notice>
   }
   if (source === "turn") {
-    // A turn that changed nothing and a turn nobody recorded are different
-    // answers, and each says which one it is. Conflating them would have the
-    // panel report "nothing happened" for a snapshot it simply lost, which is
-    // why the weighing is pure and tested (lastTurnNotice).
+    // A turn that changed nothing, a turn nobody recorded and a turn whose
+    // record lich lost are three different answers, and each says which one it
+    // is. Conflating them would have the panel report "nothing happened" — or
+    // "nothing ran" — for a snapshot it simply lost, which is why the weighing
+    // is pure and tested (lastTurnNotice).
     const notice = lastTurnNotice(turnState, files.length)
     if (notice === "empty") {
       return (
@@ -379,6 +380,14 @@ function PanelBody({
         <Notice>
           <span className="block text-foreground">No last turn recorded.</span>
           This fills in when a turn ends here.
+        </Notice>
+      )
+    }
+    if (notice === "lost") {
+      return (
+        <Notice>
+          <span className="block text-foreground">This turn’s record was lost.</span>A turn ended
+          here and lich could not snapshot the checkout for it. The next one is recorded as usual.
         </Notice>
       )
     }

--- a/frontend/src/components/sidebar/SessionCard.tsx
+++ b/frontend/src/components/sidebar/SessionCard.tsx
@@ -12,6 +12,7 @@ import {
   FolderOpen,
   GitBranch,
   GitPullRequestArrow,
+  Hourglass,
   Inbox,
   ListChecks,
   Pencil,
@@ -42,6 +43,7 @@ import { useSessionRelay } from "@/lib/session/use-session-relay"
 import { useSessionInbox } from "@/lib/session/use-session-inbox"
 import { useSessionTool } from "@/lib/session/use-session-tool"
 import { useSessionTodo } from "@/lib/session/use-session-todo"
+import { useHandoffHeld } from "@/lib/terminal/handoff-store"
 import { toolGlyph } from "@/lib/session/tool-glyph"
 import { toolLine } from "@/lib/session/tool-label"
 import { useGitStatus } from "@/lib/git/use-git-status"
@@ -202,6 +204,11 @@ export function SessionCard({
   // a message lands in a PTY and cleared when it is answered. null the rest of
   // the time, which is nearly always.
   const relay = useSessionRelay(session.id)
+  // Text handed to this session — a pull request's conflict, the issue a
+  // worktree was named after — still waiting for a prompt free enough to take
+  // it. The wait can be minutes, and until it ends the card looks exactly like
+  // one nothing was handed to (write-at-prompt.ts).
+  const handoffHeld = useHandoffHeld(session.id)
   // How many results this session has waiting in the relay's inbox: results of
   // tasks it delegated, uncollected. Zero — the usual case — draws nothing.
   const inbox = useSessionInbox(session.id)
@@ -463,8 +470,9 @@ export function SessionCard({
                   </span>
                 </span>
               )}
-              {/* One line, seven rungs: an open request, then a session blocked
-                  on the user, then results waiting to be collected, then how far
+              {/* One line, eight rungs: an open request, then a session blocked
+                  on the user, then a handoff waiting for this prompt, then
+                  results waiting to be collected, then how far
                   a quiet card got through its task list, then the
                   tool, then a prompt scheduled for later, then where the session
                   came from. A request in flight
@@ -473,7 +481,10 @@ export function SessionCard({
                   elsewhere in the list. A block outranks the rest for the
                   reason it needs words at all: the amber ring differs from the
                   emerald one by hue alone, so nothing else on the card says the
-                  session wants an answer. The inbox sits under those and over
+                  session wants an answer. A held handoff sits under the block
+                  and over the rest: text was handed to this session and is not
+                  at its prompt, which without a rung is indistinguishable from a
+                  click that did nothing. The inbox sits under those and over
                   the tool: mid-turn the live tool is the news, and the count
                   takes the rung when the card goes quiet — the same rule the
                   relay's own nudge follows. Task-list progress answers to that
@@ -519,6 +530,11 @@ export function SessionCard({
                   <span className="truncate font-medium text-amber-500">
                     {waitingReason || "Waiting on you"}
                   </span>
+                </span>
+              ) : handoffHeld ? (
+                <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">
+                  <Hourglass className="size-3 shrink-0" />
+                  <span className="truncate">Something is waiting for this prompt</span>
                 </span>
               ) : status !== "busy" && inbox > 0 ? (
                 <span className="flex w-full min-w-0 items-center gap-1 text-xs text-muted-foreground">

--- a/frontend/src/lib/api-types.ts
+++ b/frontend/src/lib/api-types.ts
@@ -633,12 +633,12 @@ export interface QuotaPlan {
  * reads it) and is present only for "ok"; `endedAt` is unix ms and present only
  * when there is a window to date.
  *
- * The three states are kept apart on purpose: "empty" is a turn that ran and
- * changed nothing, "unavailable" is no turn on record at all — no turn has
- * finished here yet, or its snapshot was lost. The panel must never show one as
- * the other. */
+ * The four states are kept apart on purpose: "empty" is a turn that ran and
+ * changed nothing, "unavailable" is no turn on record at all — none has
+ * finished here yet — and "lost" is a turn that ran and whose snapshot lich
+ * dropped. The panel must never show one as another. */
 export interface LastTurn {
-  state: "ok" | "empty" | "unavailable"
+  state: "ok" | "empty" | "unavailable" | "lost"
   diff?: string
   endedAt?: number
   /** The snapshot tree the diff's new side stands at — the revision the panel

--- a/frontend/src/lib/git/last-turn.test.ts
+++ b/frontend/src/lib/git/last-turn.test.ts
@@ -13,6 +13,13 @@ describe("lastTurnNotice", () => {
     expect(lastTurnNotice("unavailable", 0)).toBe("unrecorded")
   })
 
+  // The turn ran, and the snapshot that would have shown it was dropped. Read
+  // as unrecorded it would claim the card has never had a turn; read as empty
+  // it would claim the agent changed nothing.
+  it("keeps a turn whose record was lost apart from both", () => {
+    expect(lastTurnNotice("lost", 0)).toBe("lost")
+  })
+
   // Before the first read lands, and for a session whose provider never
   // reported: neither is an empty turn.
   it("reads no answer at all as unrecorded", () => {

--- a/frontend/src/lib/git/last-turn.ts
+++ b/frontend/src/lib/git/last-turn.ts
@@ -1,12 +1,13 @@
 import type { LastTurn } from "@/lib/api-types"
 import type { SessionStatus } from "@/lib/session/session-events"
 
-// What the Review panel draws for the session's last finished turn. The three
+// What the Review panel draws for the session's last finished turn. The four
 // answers are kept apart because conflating them is the one mistake this
-// feature can make: a turn that ran and changed nothing is a real answer, and
+// feature can make: a turn that ran and changed nothing is a real answer,
 // "nobody recorded a turn here" is the absence of one — reported as the first,
-// it reads as "the agent did nothing".
-export type LastTurnNotice = "diff" | "empty" | "unrecorded"
+// it reads as "the agent did nothing" — and a turn whose snapshot lich dropped
+// is a gap it has to own rather than a card that has never had a turn.
+export type LastTurnNotice = "diff" | "empty" | "unrecorded" | "lost"
 
 // lastTurnNotice weighs the backend's own state against what parseDiff could
 // make of the text. An "ok" carrying nothing a file list can be built from is
@@ -15,6 +16,9 @@ export type LastTurnNotice = "diff" | "empty" | "unrecorded"
 export function lastTurnNotice(state: LastTurn["state"] | null, fileCount: number): LastTurnNotice {
   if (state === "empty") {
     return "empty"
+  }
+  if (state === "lost") {
+    return "lost"
   }
   if (state === "ok" && fileCount > 0) {
     return "diff"

--- a/frontend/src/lib/terminal/handoff-store.ts
+++ b/frontend/src/lib/terminal/handoff-store.ts
@@ -1,0 +1,19 @@
+import { createKeyedStore } from "@/lib/keyed-store"
+import { useKeyedStore } from "@/lib/use-keyed-store"
+
+// Which sessions have text waiting for a prompt that is not free yet
+// (write-at-prompt.ts). A handoff is written into a session and left there for
+// the user to read and send — so when the prompt is busy, nothing appears and
+// nothing failed: the click reads as having done nothing at all, which is how
+// the pull request handoff was first reported.
+//
+// Not fed by an event like the other per-session stores: the wait happens in
+// this page, in the loop that polls for the prompt, so the only thing that
+// knows about it is the caller.
+export const handoffHolds = createKeyedStore<boolean>(false)
+
+// useHandoffHeld is whether this session has a handoff waiting for its prompt.
+// False for nearly every card, nearly always.
+export function useHandoffHeld(id: string): boolean {
+  return useKeyedStore(handoffHolds, id)
+}

--- a/frontend/src/lib/terminal/write-at-prompt.test.ts
+++ b/frontend/src/lib/terminal/write-at-prompt.test.ts
@@ -2,6 +2,7 @@
 // session that has no prompt yet. So both calls are stubbed and what is asserted
 // is that the write did not happen until Ready said so.
 import { describe, expect, it, vi } from "vitest"
+import { handoffHolds } from "./handoff-store"
 import { writeAtPrompt } from "./write-at-prompt"
 
 const ready = vi.fn()
@@ -22,6 +23,43 @@ describe("writeAtPrompt", () => {
 
     expect(ready).toHaveBeenCalledTimes(3)
     expect(write).toHaveBeenCalledWith("s1", "resolve the conflicts")
+  })
+
+  // The wait is minutes long at its worst and looks exactly like a click that
+  // did nothing, so the card it is waiting on says so for as long as it lasts
+  // (handoff-store).
+  it("marks the session it is waiting on, and clears the mark when it lands", async () => {
+    ready.mockReset()
+    write.mockReset()
+    let held: boolean | null = null
+    ready.mockImplementationOnce(() => {
+      return Promise.resolve(false)
+    })
+    ready.mockImplementationOnce(() => {
+      held = handoffHolds.get("s3")
+      return Promise.resolve(true)
+    })
+
+    await writeAtPrompt("s3", "resolve the conflicts")
+
+    expect(held).toBe(true)
+    expect(handoffHolds.get("s3")).toBe(false)
+  })
+
+  // A handoff that never reached a prompt is not waiting for one either: the
+  // caller words what was lost, and the card goes back to normal.
+  it("clears the mark when the wait runs out", async () => {
+    ready.mockReset()
+    write.mockReset()
+    ready.mockResolvedValue(false)
+    vi.useFakeTimers()
+    const wait = writeAtPrompt("s4", "fix CI").catch((err: unknown) => err)
+    await vi.advanceTimersByTimeAsync(6 * 60 * 1000)
+    vi.useRealTimers()
+
+    expect(await wait).toBeInstanceOf(Error)
+    expect(handoffHolds.get("s4")).toBe(false)
+    expect(write).not.toHaveBeenCalled()
   })
 
   it("writes straight away when the session is already at a prompt", async () => {

--- a/frontend/src/lib/terminal/write-at-prompt.ts
+++ b/frontend/src/lib/terminal/write-at-prompt.ts
@@ -1,4 +1,5 @@
 import { Terminal } from "@/lib/rpc"
+import { handoffHolds } from "./handoff-store"
 
 // Text written into a session the moment its card exists lands wherever that
 // PTY has got to — the checkout's setup script, a provider still taking the tty
@@ -19,6 +20,10 @@ import { Terminal } from "@/lib/rpc"
 // the worse of the two, and the draft releases itself (`internal/terminal`,
 // draftIdle).
 //
+// Whatever the reason, the wait says so on the card it is waiting for
+// (handoff-store): a handoff that is held looks exactly like one that never
+// happened, and a minute of that is long enough to go looking for the bug.
+//
 // Polled from here rather than waited on in Go: the wait can be minutes, and a
 // request held open for that long is one of the browser's handful of
 // connections to this backend. A short call every quarter second is the cheaper
@@ -38,11 +43,18 @@ const LIMIT_MS = 5 * 60 * 1000
  */
 export async function writeAtPrompt(sessionId: string, text: string): Promise<void> {
   const deadline = Date.now() + LIMIT_MS
-  while (!(await Terminal.Ready(sessionId))) {
-    if (Date.now() >= deadline) {
-      throw new Error("the session never reached a prompt")
+  try {
+    while (!(await Terminal.Ready(sessionId))) {
+      handoffHolds.set(sessionId, true)
+      if (Date.now() >= deadline) {
+        throw new Error("the session never reached a prompt")
+      }
+      await new Promise((resolve) => setTimeout(resolve, POLL_MS))
     }
-    await new Promise((resolve) => setTimeout(resolve, POLL_MS))
+    await Terminal.Write(sessionId, text)
+  } finally {
+    // Whatever became of it: the mark is about text still waiting, and a
+    // handoff that landed, failed or timed out is not waiting anymore.
+    handoffHolds.set(sessionId, false)
   }
-  await Terminal.Write(sessionId, text)
 }

--- a/internal/cli/wire_test.go
+++ b/internal/cli/wire_test.go
@@ -52,6 +52,9 @@ func (*wiredTerminal) QuietFor(string) time.Duration { return time.Hour }
 // derives — which is the one the wiring under test addresses.
 func (*wiredTerminal) AgentName(string) string { return "" }
 
+// Nobody is typing at these sessions, so the hold has nothing to keep back.
+func (*wiredTerminal) HoldInput(string) func() { return func() {} }
+
 func (w *wiredTerminal) Write(_, data string) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/internal/relay/deliver.go
+++ b/internal/relay/deliver.go
@@ -15,6 +15,10 @@ func (s *Service) deliver(sessionID, message string) error {
 	if err := s.awaitFree(sessionID); err != nil {
 		return err
 	}
+	// From here to the Enter, the prompt is this message's. Anything typed at it
+	// in between would be submitted as part of the message, so it is held and
+	// handed back at the prompt the Enter leaves behind (terminal.HoldInput).
+	defer s.term.HoldInput(sessionID)()
 	if err := s.term.Write(sessionID, paste(message)); err != nil {
 		return err
 	}

--- a/internal/relay/relay.go
+++ b/internal/relay/relay.go
@@ -200,6 +200,11 @@ type Terminal interface {
 	// peer roster, read out of the provider's own record. Empty when there is
 	// none, which is what leaves the roster on the derived name.
 	AgentName(id string) string
+	// HoldInput keeps what the person at that session types out of the
+	// submission this delivery is making, and hands it back at the prompt
+	// afterwards. The returned release is called once the Enter is through
+	// (see deliver).
+	HoldInput(id string) func()
 }
 
 // Peer is one session a caller may address: the label it is addressed by, the

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -55,6 +55,11 @@ type fakeTerminal struct {
 	// transcript the terminal service reads. Empty for a session nobody renamed,
 	// which is what puts the roster back on the derived name.
 	names map[string]string
+	// holding is whether a hold is open on that session right now, and inHold
+	// collects the writes that landed inside one — which is how a test asks
+	// whether the whole paste-to-Enter window was covered.
+	holding map[string]bool
+	inHold  map[string][]string
 }
 
 func newFakeTerminal(live ...string) *fakeTerminal {
@@ -62,7 +67,8 @@ func newFakeTerminal(live ...string) *fakeTerminal {
 		live: map[string]bool{}, writes: map[string][]string{},
 		settingUp: map[string]bool{}, typing: map[string]bool{},
 		noisy: map[string]int{}, drained: map[string]int{},
-		names: map[string]string{},
+		names:   map[string]string{},
+		holding: map[string]bool{}, inHold: map[string][]string{},
 	}
 	for _, id := range live {
 		t.live[id] = true
@@ -152,6 +158,9 @@ func (f *fakeTerminal) Write(id, data string) error {
 		f.refused++
 	} else {
 		f.writes[id] = append(f.writes[id], data)
+		if f.holding[id] {
+			f.inHold[id] = append(f.inHold[id], data)
+		}
 	}
 	hook := f.onWrite
 	f.mu.Unlock()
@@ -189,6 +198,35 @@ func (f *fakeTerminal) writesTo(id string) []string {
 
 func (f *fakeTerminal) written(id string) string {
 	return strings.Join(f.writesTo(id), "")
+}
+
+// HoldInput stands in for the terminal service keeping the user's keystrokes
+// out of a delivery's own submission (terminal.HoldInput). The fake has no
+// keyboard, so what it records is the window itself: which writes happened
+// while the hold was open.
+func (f *fakeTerminal) HoldInput(id string) func() {
+	f.mu.Lock()
+	f.holding[id] = true
+	f.mu.Unlock()
+	return func() {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		f.holding[id] = false
+	}
+}
+
+// holdOpen is whether a delivery still has that session's keyboard.
+func (f *fakeTerminal) holdOpen(id string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.holding[id]
+}
+
+// heldWrites is what a session was written while a delivery held its prompt.
+func (f *fakeTerminal) heldWrites(id string) []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.inHold[id]...)
 }
 
 // fakeEvents records what the relay announced to the window, in order.
@@ -456,6 +494,31 @@ func TestTheEnterWaitsForTheTargetToFinishTakingThePasteIn(t *testing.T) {
 	writes := term.written("s2")
 	if !strings.HasSuffix(writes, submit) {
 		t.Errorf("last write = %q, want the Enter behind the paste", writes)
+	}
+}
+
+// The paste and the Enter behind it are one submission, and the target's own
+// keyboard is held for the whole of it: anything typed in that window would be
+// sent as part of a message the person at that prompt never wrote
+// (terminal.HoldInput). The window opens before the paste and closes after the
+// Enter, which is what this reads off the fake.
+func TestTheTargetsKeyboardIsHeldForTheWholeSubmission(t *testing.T) {
+	term := newFakeTerminal("s1", "s2")
+	svc := newRelay(workspace(), term, nil)
+	svc.submitDelay = time.Millisecond
+	term.noise("s2", 3)
+
+	go svc.Send("s1", "docs", "", "run the tests", 1)
+
+	if !awaitWritten(term, "s2", submit) {
+		t.Fatal("the Enter never arrived")
+	}
+	held := term.heldWrites("s2")
+	if len(held) != 2 || !strings.HasPrefix(held[0], "\x1b[200~") || held[1] != submit {
+		t.Errorf("held writes = %q, want the paste and the Enter both inside the hold", held)
+	}
+	if term.holdOpen("s2") {
+		t.Error("the hold outlived the delivery: the prompt is the user's again")
 	}
 }
 

--- a/internal/terminal/draft.go
+++ b/internal/terminal/draft.go
@@ -2,6 +2,7 @@ package terminal
 
 import (
 	"bytes"
+	"log/slog"
 	"time"
 )
 
@@ -27,6 +28,11 @@ const (
 	// budget a held-back delivery has to wait it out (relay's deliveryLimit).
 	draftIdle = time.Minute
 
+	// holdLimit bounds what HoldInput keeps back. The window is seconds and a
+	// keyboard fills nothing in that time, so anything near this is a paste —
+	// and a paste that big is being dropped by the TUI at the other end anyway.
+	holdLimit = 1 << 20
+
 	esc   = 0x1b
 	ctrlC = 0x03
 	// maxEscape bounds what is held waiting for the rest of a sequence. The
@@ -44,6 +50,79 @@ var (
 	pasteStart = []byte("\x1b[200~")
 	pasteEnd   = []byte("\x1b[201~")
 )
+
+// HoldInput keeps the person at this session's keyboard out of a submission
+// that is not theirs, and returns the release that hands their keystrokes back.
+//
+// A relayed delivery is two writes a beat apart — the paste, then the Enter
+// that sends it (internal/relay, deliver) — and everything typed in between
+// lands on the same line and is submitted as part of the relayed message.
+// Unlike a delivery that waits out a draft, this is not an omission: it is the
+// user's own text going somewhere they never sent it, and the window is theirs
+// to lose from the moment the paste lands until the target's PTY goes quiet.
+//
+// So the keystrokes are held rather than dropped, and written the moment the
+// Enter is gone: they land on the fresh prompt the relayed message left behind,
+// which is where the user was typing them. Unknown sessions hand back a release
+// that does nothing.
+//
+// Holds count rather than latch, because two senders can deliver into one
+// target at the same time and the first Enter through must not hand the second
+// delivery's window back to the keyboard. Each release is to be called once.
+func (s *Service) HoldInput(id string) func() {
+	s.mu.Lock()
+	sess, ok := s.sessions[id]
+	if ok {
+		sess.holds++
+	}
+	s.mu.Unlock()
+	if !ok {
+		return func() {}
+	}
+	return func() { s.releaseInput(id) }
+}
+
+// releaseInput ends one hold and, once it was the last, replays what was typed
+// under them in the order it arrived. The replay goes through the ordinary
+// input path — the draft clock and the interrupt reading both answer to when
+// the keys reach the PTY, not to when the window took them.
+func (s *Service) releaseInput(id string) {
+	s.mu.Lock()
+	sess, ok := s.sessions[id]
+	if !ok {
+		s.mu.Unlock()
+		return
+	}
+	sess.holds--
+	if sess.holds > 0 {
+		s.mu.Unlock()
+		return
+	}
+	held := sess.held
+	sess.held, sess.holds = nil, 0
+	s.mu.Unlock()
+	if len(held) > 0 {
+		s.onInput(id, held)
+	}
+}
+
+// holdKeys files this write against the hold, and reports whether it took it.
+// Called before anything else looks at the bytes: a keystroke that is being
+// held has not happened yet as far as the rest of this file is concerned.
+func (s *Service) holdKeys(id string, data []byte) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	sess, ok := s.sessions[id]
+	if !ok || sess.holds == 0 {
+		return false
+	}
+	if len(sess.held)+len(data) > holdLimit {
+		slog.Warn("terminal: too much typed during a delivery, dropping the rest", "session", id)
+		return true
+	}
+	sess.held = append(sess.held, data...)
+	return true
+}
 
 // noteInput records whether the user is composing something at this session's
 // prompt right now, so a relayed message is not pasted into the middle of it

--- a/internal/terminal/draft_test.go
+++ b/internal/terminal/draft_test.go
@@ -1,6 +1,7 @@
 package terminal
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -176,5 +177,70 @@ func TestInterruptForAnUnknownSessionIsANoOp(t *testing.T) {
 	svc, _ := settled(t)
 	if svc.noteInput("nobody", []byte{ctrlC}) {
 		t.Fatal("a keystroke for a session lich does not run read as an interrupt")
+	}
+}
+
+// The window between a relayed paste and the Enter behind it. What the person
+// at that keyboard types inside it would be submitted as part of a message they
+// never sent, so it is held and written at the prompt the Enter leaves behind.
+func TestKeystrokesDuringADeliveryLandAfterIt(t *testing.T) {
+	svc, sess := settled(t)
+	pty := &shortWritePTY{chunk: 4096}
+	svc.mu.Lock()
+	sess.pty = pty
+	svc.mu.Unlock()
+
+	release := svc.HoldInput("s1")
+	if err := svc.Write("s1", "\x1b[200~relayed\x1b[201~"); err != nil {
+		t.Fatalf("the paste was refused: %v", err)
+	}
+	svc.onInput("s1", []byte("mine"))
+	if strings.Contains(pty.received.String(), "mine") {
+		t.Fatal("what the user typed went in with the relayed message")
+	}
+	if err := svc.Write("s1", "\r"); err != nil {
+		t.Fatalf("the Enter was refused: %v", err)
+	}
+	release()
+
+	want := "\x1b[200~relayed\x1b[201~\rmine"
+	if got := pty.received.String(); got != want {
+		t.Errorf("the PTY received %q, want %q", got, want)
+	}
+	// Handed back through the ordinary input path, so it is a draft at the new
+	// prompt like anything else typed there: the next delivery waits for it.
+	if svc.Ready("s1") {
+		t.Error("the handed-back keystrokes left the prompt free")
+	}
+}
+
+// A hold on a session that has gone leaves nothing behind, and its release is
+// safe to call: a delivery races the PTY exiting under it like any other write.
+func TestHoldingAGoneSessionIsHarmless(t *testing.T) {
+	svc, _ := settled(t)
+	svc.HoldInput("gone")()
+}
+
+// Two senders can deliver into the same target at once. The first Enter through
+// must not hand the keyboard back while the second delivery is still between
+// its own paste and Enter, or the keystrokes ride along with that one instead.
+func TestOverlappingDeliveriesKeepTheKeyboardHeld(t *testing.T) {
+	svc, sess := settled(t)
+	pty := &shortWritePTY{chunk: 4096}
+	svc.mu.Lock()
+	sess.pty = pty
+	svc.mu.Unlock()
+
+	first := svc.HoldInput("s1")
+	second := svc.HoldInput("s1")
+	svc.onInput("s1", []byte("mine"))
+
+	first()
+	if strings.Contains(pty.received.String(), "mine") {
+		t.Fatal("the first delivery's release handed the keys to the second one's submission")
+	}
+	second()
+	if !strings.Contains(pty.received.String(), "mine") {
+		t.Error("the keystrokes were never handed back")
 	}
 }

--- a/internal/terminal/terminal.go
+++ b/internal/terminal/terminal.go
@@ -190,6 +190,12 @@ type session struct {
 	draftAt    time.Time
 	escPending []byte
 	pasting    bool
+	// holds is how many relayed deliveries own this prompt until the Enter each
+	// sends behind its paste is through, and held is what the user typed while
+	// they did — replayed at the fresh prompt rather than submitted with
+	// somebody else's message. Both guarded by the service's mu. See HoldInput.
+	holds int
+	held  []byte
 	// confined records whether this PTY was spawned inside the sandbox, so Start
 	// can report it once the spawn is out of the lock. sandboxLinks rides with
 	// it: what that sandbox skipped for being a symlink, resolved by the same
@@ -413,6 +419,12 @@ func New(store Store, env []string, hub *events.Hub) *Service {
 // pasted through Write is that session's work, not this one's.
 func (s *Service) onInput(id string, data []byte) {
 	s.beatHandsOn(id, 0)
+	// Held first, and before the beat is spent on nothing: a delivery in flight
+	// owns this prompt until its Enter is through, and what was typed at it
+	// reaches the PTY from releaseInput instead (see HoldInput).
+	if s.holdKeys(id, data) {
+		return
+	}
 	if s.noteInput(id, data) {
 		s.noteInterrupt(id)
 	}

--- a/internal/terminal/turnsnap.go
+++ b/internal/terminal/turnsnap.go
@@ -17,18 +17,22 @@ import (
 // diff is a panel that says so, where a stalled hook is an agent that stops.
 const snapQueueDepth = 32
 
-// The three answers LastTurnDiff can give, kept apart on the wire because the
+// The four answers LastTurnDiff can give, kept apart on the wire because the
 // panel must never dress one as another: a turn that changed nothing is a real
-// answer, and no turn on record is the absence of one.
+// answer, no turn on record is the absence of one, and a turn whose snapshot
+// lich lost is neither — it happened, and only the panel saying so tells it
+// from a turn that has yet to run.
 const (
 	turnDiffOK          = "ok"
 	turnDiffEmpty       = "empty"
 	turnDiffUnavailable = "unavailable"
+	turnDiffLost        = "lost"
 )
 
 // LastTurn is what the Review panel's "Last turn" mode reads. Diff is empty for
 // every state but "ok", and EndedAt (unix ms) is set only when there is a window
-// to date — its absence is the second signal that nothing is on record.
+// to date — its absence is the second signal that nothing is on record. "lost"
+// is the one state with a turn behind it and nothing to show for it.
 type LastTurn struct {
 	State   string `json:"state"`
 	Diff    string `json:"diff,omitempty"`
@@ -51,6 +55,9 @@ type turnPair struct {
 // snapState is one session's snapshot accounting. seq numbers the turns so a
 // snapshot landing late is filed against the turn it was taken for and no other;
 // before is the opening tree of turn seq, still empty while its job is queued.
+// lost is set by the turn that closed without leaving a record — the queue
+// dropped a job, or git refused one — and cleared by the next turn that files
+// one, so the panel can say a turn ran here rather than that none did.
 type snapState struct {
 	dir    string
 	index  string
@@ -58,6 +65,7 @@ type snapState struct {
 	open   bool
 	before string
 	last   *turnPair
+	lost   bool
 }
 
 // turnSnaps records what each session's last finished turn changed on disk, by
@@ -228,7 +236,7 @@ func (t *turnSnaps) closeTurn(id string) {
 	seq, dir, index := state.seq, state.dir, state.index
 	t.mu.Unlock()
 
-	t.submit(func() {
+	if !t.submit(func() {
 		oid, err := project.SnapshotTree(dir, index)
 		if err != nil {
 			slog.Warn("turnsnap: closing snapshot failed", "session", id, "err", err)
@@ -237,6 +245,13 @@ func (t *turnSnaps) closeTurn(id string) {
 		state, ok := t.sessions[id]
 		if ok && state.seq == seq && err == nil && state.before != "" {
 			state.last = &turnPair{before: state.before, after: oid, endedAt: time.Now()}
+		}
+		// Whichever half went missing — this snapshot, or the opening one the
+		// queue dropped — the turn ran and lich cannot show it. Saying that is
+		// the difference between a panel that reports a gap and one that reads
+		// like a session which has never had a turn.
+		if ok && state.seq == seq {
+			state.lost = state.last == nil
 		}
 		// The same seq guard the record itself answers to: a session re-tracked
 		// while this job was queued is no longer the one that asked for it, and
@@ -266,7 +281,28 @@ func (t *turnSnaps) closeTurn(id string) {
 		if filed != nil {
 			filed(id)
 		}
-	})
+	}) {
+		// The queue was full, so the job above never runs and nothing else will
+		// speak for this turn. Marked here for the same reason the record is
+		// cleared here: a dropped job leaves no goroutine behind to do it.
+		t.markLost(id, seq)
+	}
+}
+
+// markLost records that the turn numbered seq ended with no record, and tells
+// the panel to ask again. A session re-tracked since is left alone, the same
+// guard every late write in this file answers to.
+func (t *turnSnaps) markLost(id string, seq uint64) {
+	t.mu.Lock()
+	state, ok := t.sessions[id]
+	if ok && state.seq == seq {
+		state.lost = true
+	}
+	filed := t.filed
+	t.mu.Unlock()
+	if ok && filed != nil {
+		filed(id)
+	}
 }
 
 // dropTurn abandons a turn nothing will close — the CLI left mid-run. The last
@@ -295,7 +331,8 @@ func (t *turnSnaps) forget(id string) {
 
 // pair answers with the session's last closed turn and the checkout to render it
 // against. ok is false when there is nothing on record — no turn has finished
-// here, or the one that did lost a snapshot.
+// here, or the one that did lost a snapshot (see lostTurn, which tells those
+// two apart).
 func (t *turnSnaps) pair(id string) (turnPair, string, bool) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -306,10 +343,22 @@ func (t *turnSnaps) pair(id string) (turnPair, string, bool) {
 	return *state.last, state.dir, true
 }
 
-// submit hands one snapshot to the worker, starting it on first use. A full
-// queue drops the job: the turn it belonged to then reads as unavailable, which
-// is the honest answer and not the one that says nothing changed.
-func (t *turnSnaps) submit(job func()) {
+// lostTurn is whether the last turn to close here ended without a record. Only
+// asked once pair has said there is none, which is the one moment the two are
+// worth telling apart.
+func (t *turnSnaps) lostTurn(id string) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	state, ok := t.sessions[id]
+	return ok && state.lost
+}
+
+// submit hands one snapshot to the worker, starting it on first use, and
+// reports whether it was taken. A full queue drops the job, and the caller is
+// the only one left that can say so: the turn it belonged to then reads as
+// lost, which is neither the answer that says nothing changed nor the one that
+// says nothing ran.
+func (t *turnSnaps) submit(job func()) bool {
 	t.mu.Lock()
 	if t.jobs == nil {
 		t.jobs = make(chan func(), snapQueueDepth)
@@ -324,8 +373,10 @@ func (t *turnSnaps) submit(job func()) {
 
 	select {
 	case jobs <- job:
+		return true
 	default:
 		slog.Warn("turnsnap: snapshot queue full, dropping a turn's snapshot")
+		return false
 	}
 }
 
@@ -361,6 +412,9 @@ func (t *turnSnaps) indexPath(id string) (string, error) {
 func (s *Service) LastTurnDiff(id string) (LastTurn, error) {
 	pair, dir, ok := s.snaps.pair(id)
 	if !ok {
+		if s.snaps.lostTurn(id) {
+			return LastTurn{State: turnDiffLost}, nil
+		}
 		return LastTurn{State: turnDiffUnavailable}, nil
 	}
 	ended := pair.endedAt.UnixMilli()

--- a/internal/terminal/turnsnap_test.go
+++ b/internal/terminal/turnsnap_test.go
@@ -185,8 +185,9 @@ func TestAQuietTurnDoesNotFallBackToTheOneBefore(t *testing.T) {
 
 // The same rule against a lost snapshot rather than a quiet turn: a turn whose
 // opening tree never landed — a dropped job, a git that failed — clears the
-// record instead of leaving the previous turn standing as if it were this one.
-func TestATurnWithNoOpeningSnapshotClearsTheRecord(t *testing.T) {
+// record instead of leaving the previous turn standing as if it were this one,
+// and says a turn ran here rather than that none did.
+func TestATurnWithNoOpeningSnapshotReadsAsLost(t *testing.T) {
 	svc, repo := snapRepo(t)
 	svc.snaps.track("s1", repo)
 
@@ -202,7 +203,48 @@ func TestATurnWithNoOpeningSnapshotClearsTheRecord(t *testing.T) {
 	svc.snaps.sessions["s1"].before = ""
 	svc.snaps.mu.Unlock()
 
-	closeAndWait(t, svc, "s1", turnDiffUnavailable)
+	closeAndWait(t, svc, "s1", turnDiffLost)
+}
+
+// The bullet this state exists for: the snapshot worker is busy and the queue
+// behind it is full, so the closing job is refused and nothing is ever recorded
+// for a turn that ran and changed files. It has to read as a turn whose record
+// was lost — never as a session that has not had one.
+func TestASnapshotTheQueueDroppedReadsAsLost(t *testing.T) {
+	svc, repo := snapRepo(t)
+	svc.snaps.track("s1", repo)
+
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "a.txt", "work with nothing to show for it\n")
+
+	// One job on the worker and snapQueueDepth behind it: the next submit is
+	// dropped rather than queued.
+	held := make(chan struct{})
+	svc.snaps.submit(func() { <-held })
+	for range snapQueueDepth {
+		svc.snaps.submit(func() {})
+	}
+
+	// Read straight after the report: a dropped job leaves nothing running to
+	// wait for, which is the whole problem.
+	svc.snaps.note("s1", statusDone)
+	turn, err := svc.LastTurnDiff("s1")
+	if err != nil {
+		t.Fatalf("LastTurnDiff: %v", err)
+	}
+	if turn.State != turnDiffLost {
+		t.Errorf("a dropped snapshot reads as %q, want %q", turn.State, turnDiffLost)
+	}
+
+	// And the next turn that files a record takes the mark back down. The
+	// backlog has to clear first: a drain submitted into a queue still full is
+	// dropped like anything else.
+	close(held)
+	waitFor(t, func() bool { return len(svc.snaps.jobs) == 0 }, "the backlog to clear")
+	drainSnaps(t, svc)
+	openAndWait(t, svc, "s1")
+	writeIn(t, repo, "a.txt", "recorded like any other\n")
+	closeAndWait(t, svc, "s1", turnDiffOK)
 }
 
 // A session whose first turn is still running has nothing to show, and a
@@ -566,7 +608,7 @@ func TestARetractedTurnIsNotRestored(t *testing.T) {
 	svc.snaps.sessions["s1"].seq++
 	svc.snaps.sessions["s1"].before = ""
 	svc.snaps.mu.Unlock()
-	closeAndWait(t, svc, "s1", turnDiffUnavailable)
+	closeAndWait(t, svc, "s1", turnDiffLost)
 	drainSnaps(t, svc)
 
 	next := relaunch(t, db)


### PR DESCRIPTION
Closes #578.

Three bullets in `docs/ceilings.md` shared one shape: lich declines to act, the decision is right for the case it was designed against, and nothing on screen says it happened. None of the underlying limits move here; each site says so instead.

## A dropped turn snapshot costs that turn its record

`submit` now reports whether the worker's queue took the job, and a turn that closes without leaving a pair marks itself lost, whichever half went missing: the job the queue refused, an opening snapshot that never landed, a git that failed. `LastTurnDiff` answers `lost` for it, which the Review panel draws as "This turn's record was lost" rather than the "No last turn recorded" a session that has never had a turn gets. The next turn to file a record takes the mark back down.

Nothing writes the mark to the workspace database, so a lich relaunched between the lost turn and the next one reads "unrecorded" for it again. That is in the ceiling.

## A handoff to a session with a stale draft never appears

The pull request and issue handoffs poll for a free prompt from the page (`writeAtPrompt`), and the wait runs minutes on a fresh checkout or on a prompt somebody left half a sentence at. While it lasts, the target's card carries a rung saying something is waiting for that prompt; it clears when the text lands, when the write fails and when the wait runs out.

The mark lives in the page that is waiting, so it is only on the window that started the handoff. The relay's own held delivery is still not drawn: that one answers to its sender, through the ticket.

## Keystrokes typed between the paste and its Enter ride along

`terminal.HoldInput` keeps the person at the target's keyboard out of a submission that is not theirs. The relay opens the hold before the paste and releases it after the Enter, and what was typed in between is written at the prompt the Enter leaves behind rather than dropped. Holds count rather than latch, so two senders delivering into one target do not hand each other's window back to the keyboard.

Held is still not typed: an interrupt reached for inside that window lands after the delivery, on the turn the delivery just started.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test ./...`, plus `-race` on `internal/terminal` and `internal/relay`
- [x] `pnpm exec biome ci .` exit 0, `pnpm test` (1753), `pnpm build`
- [x] Cross-compile loop for linux, darwin and windows
- [x] New: a snapshot the queue dropped reads as lost and the next turn clears it; keystrokes during a delivery land after it; overlapping deliveries keep the keyboard held; the hold covers the whole paste-to-Enter window; the handoff mark rises while waiting and clears however the wait ends
- [x] Changed: the two tests that asserted `unavailable` for a turn that closed with no opening snapshot now assert `lost`. The contract changed: that state is a turn whose record was lost, and both were passing on the transient window before the closing job landed
