### PR TITLE
fix: resize the dock from its whole edge while a file is open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   combining accent underlined the wrong columns. The match now runs over the
   whole logical line and maps back to the cells the characters really occupy.
 
+- **The dock resizes from its whole edge while a file is open.** Opening a file
+  in the Code tab laid its preview over the panel's drag handle, so only the
+  strip beside the tabs still resized the dock. The handle now sits above the
+  preview.
+
 ## [0.49.0] - 2026-09-09
 
 > [!WARNING]

--- a/frontend/src/components/common/ResizeHandle.tsx
+++ b/frontend/src/components/common/ResizeHandle.tsx
@@ -10,7 +10,9 @@ interface ResizeHandleProps {
 }
 
 // The drag strip along a resizable panel's edge: a 6px hit area, invisible
-// until hovered. The panel must be `relative` for it to land on the edge.
+// until hovered. The panel must be `relative` for it to land on the edge, and
+// the handle must come after the panel's content: z-10 ties with the layers a
+// panel raises over itself (the dock's file preview), and tree order wins it.
 export function ResizeHandle({ edge, label, handleProps }: ResizeHandleProps) {
   return (
     <div
@@ -19,7 +21,7 @@ export function ResizeHandle({ edge, label, handleProps }: ResizeHandleProps) {
       aria-label={label}
       {...handleProps}
       className={cn(
-        "absolute top-0 h-full w-1.5 cursor-col-resize touch-none transition-colors hover:bg-accent",
+        "absolute top-0 z-10 h-full w-1.5 cursor-col-resize touch-none transition-colors hover:bg-accent",
         edge === "right" ? "right-0" : "left-0",
       )}
     />


### PR DESCRIPTION
With a file open in the Code tab, the dock only resized from the strip beside its tabs. The preview is an `absolute inset-0 z-10` layer over the file tree (`FilesPanel`), and the shared `ResizeHandle` had no z-index, so from the preview's own header down the edge belonged to the file view: the path row and CodeMirror's gutter took the pointer. It shipped with the preview overlay in #238 (v0.30.0).

`ResizeHandle` now carries `z-10`, the layer the pane seams already use. It ties with the preview and wins on tree order, since every caller renders the handle after the panel's content; the component's comment names that as the precondition. The Review tab never had the problem: its sticky file headers sit inside the panel's padding and do not reach the edge.

## Test plan

- [x] `biome ci .` exit 0, `vitest run` (1773), `tsc` and `vite build`
- [x] Headless rig against the real app (isolated backend, Vite, CDP), dock open on a file preview:
  - before: `elementFromPoint` on the left edge hits the handle only beside the tabs (1 of 5 heights); below that, the preview header and the CodeMirror gutter
  - after: the handle at all 5 heights, and a pointer drag from the middle of the edge widens the dock from 448px to 568px
  - Review tab: at a sticky file header's height, the handle is the top element on the edge
- [x] Go untouched, so the backend gate was not run
