### PR TITLE
fix: set the sandbox helper Chromium actually reads setuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   combining accent underlined the wrong columns. The match now runs over the
   whole logical line and maps back to the cells the characters really occupy.
 
+- **The window opens on Ubuntu instead of dying at launch.** Where the desktop
+  denies unprivileged user namespaces, which is Ubuntu's AppArmor policy,
+  Chromium confines the window through its setuid sandbox helper. The deb, rpm
+  and AUR packages installed that helper root-owned and 4755 beside the
+  window's binary, but Chromium reads the copy beside its own library, found it
+  without the setuid bit and aborted: no window, and `trace/breakpoint trap` in
+  lich's log. The packages now set the mode on the copy Chromium reads;
+  installing the release over the previous one is enough.
+
 ## [0.49.0] - 2026-09-09
 
 > [!WARNING]

--- a/build/linux/aur/PKGBUILD.tpl
+++ b/build/linux/aur/PKGBUILD.tpl
@@ -32,11 +32,9 @@ package() {
   # /usr/bin/lich looks for it: /usr/lib/lich/shell.
   install -d "${pkgdir}/usr/lib/lich"
   cp -a shell "${pkgdir}/usr/lib/lich/shell"
-  # Chromium's setuid sandbox helper, at the only path its zygote reads:
-  # beside lich-shell, root-owned (install under fakeroot) and 4755. Without
-  # it a desktop that denies unprivileged user namespaces opens the window
-  # with --no-sandbox. The tarball's own copy under cef/ is read by nothing.
-  install -m4755 shell/cef/chrome-sandbox "${pkgdir}/usr/lib/lich/shell/chrome-sandbox"
+  # Chromium reads its setuid sandbox helper from cef/, beside libcef.so, and
+  # aborts the window when the one there is not root-owned (fakeroot) and 4755.
+  chmod 4755 "${pkgdir}/usr/lib/lich/shell/cef/chrome-sandbox"
   install -Dm644 "lich-${pkgver}.desktop" "${pkgdir}/usr/share/applications/lich.desktop"
   install -Dm644 "lich-${pkgver}.png" "${pkgdir}/usr/share/icons/hicolor/128x128/apps/lich.png"
 }

--- a/build/linux/nfpm/nfpm.yaml
+++ b/build/linux/nfpm/nfpm.yaml
@@ -21,22 +21,12 @@ contents:
   - src: "./bin/lich"
     dst: "/usr/local/bin/lich"
   # The window, where /usr/local/bin/lich looks for it: the lib directory
-  # sibling to its bin (internal/chromium/shell.go).
+  # sibling to its bin (internal/chromium/shell.go). Its cef/chrome-sandbox gets
+  # 4755 from the install scripts: a second entry for it collides with the tree,
+  # and the archlinux packager drops a setuid bit read from the source file.
   - src: "./bin/shell"
     dst: "/usr/local/lib/lich/shell"
     type: tree
-  # Chromium's setuid sandbox helper, at the only path its zygote reads —
-  # beside the executable, root-owned and 4755 (shell/src/main.rs). Without it
-  # a desktop that denies unprivileged user namespaces, which is Ubuntu's
-  # AppArmor policy, opens the window with --no-sandbox. Copied rather than
-  # moved: the tree above carries the same binary under cef/, where the
-  # tarball keeps it and nothing reads it.
-  - src: "./bin/shell/cef/chrome-sandbox"
-    dst: "/usr/local/lib/lich/shell/chrome-sandbox"
-    file_info:
-      mode: 0o4755
-      owner: root
-      group: root
   - src: "./build/appicon.png"
     dst: "/usr/share/icons/hicolor/128x128/apps/lich.png"
   - src: "./build/linux/lich.desktop"
@@ -147,3 +137,9 @@ rpm:
 
 scripts:
   postinstall: "./build/linux/nfpm/scripts/postinstall.sh"
+
+# pacman runs post_install on the first install only, and every upgrade rewrites
+# the sandbox helper with the package's own mode.
+archlinux:
+  scripts:
+    postupgrade: "./build/linux/nfpm/scripts/postinstall.sh"

--- a/build/linux/nfpm/scripts/postinstall.sh
+++ b/build/linux/nfpm/scripts/postinstall.sh
@@ -18,4 +18,8 @@ else
   echo "Warning: update-mime-database command not found. Custom URL schemes may not be immediately recognized." >&2
 fi
 
+# Chromium reads its setuid sandbox helper from cef/ and aborts the window when
+# it is not root-owned 4755; nfpm.yaml says why the package cannot set the mode.
+chmod 4755 /usr/local/lib/lich/shell/cef/chrome-sandbox
+
 exit 0

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -574,7 +574,11 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   `lich doctor` names the window a launch would open.
 - **The window's own sandbox needs an install a package manager made** (`shell/src/main.rs`, the kurogane
   fork's `no_sandbox`): Chromium confines the window's subprocesses in a user namespace, or through the
-  setuid helper beside `lich-shell`. Where it has neither, the browser process would abort at its zygote, so
+  setuid helper in `cef/`, beside `libcef.so` (not beside `lich-shell`: a helper there that is not root-owned
+  4755 aborts the browser process whatever sits elsewhere). The packages nfpm builds (deb, rpm, archlinux) set
+  that mode from their install script, since nfpm cannot mark one file of the window's tree setuid, so `rpm -V`
+  and `pacman -Qkk` report a mode mismatch on it; the AUR package carries the mode itself. Where it has
+  neither, the browser process would abort at its zygote, so
   the shell asks first, the way Chromium does (a fork trying `CLONE_NEWUSER`, the helper checked for root and
   4755, never as root; the `CHROME_DEVEL_SANDBOX` helper Chromium also accepts for a binary the user owns is
   not asked) and opens with `--no-sandbox`. Only a package can own that helper root: a tarball unpacked as

--- a/docs/chromium-shell.md
+++ b/docs/chromium-shell.md
@@ -205,7 +205,7 @@ taskbar group the running window under the pinned icon. The sandbox stays
 off there, as kurogane runs it, so the binary is a plain exe rather than CEF's
 `bootstrap.exe` loading a DLL; Linux is the one platform whose window runs
 sandboxed — from a package, where the deb, rpm and AUR install Chromium's
-setuid helper root-owned 4755 beside `lich-shell` for the desktops that deny
+setuid helper root-owned 4755 beside `libcef.so` for the desktops that deny
 unprivileged user namespaces (`docs/ceilings.md`). Built and smoke-tested on
 the CI runner only.
 

--- a/shell/src/main.rs
+++ b/shell/src/main.rs
@@ -279,12 +279,12 @@ fn wait_for_eof(mut stdin: impl Read) -> bool {
 
 /// Whether Chromium can confine its subprocesses here, decided the way
 /// Chromium decides it at its zygote (content/browser/zygote_host): never as
-/// root; otherwise a user namespace, or the setuid helper beside the executable.
+/// root; otherwise a user namespace, or the setuid helper beside libcef.so.
 /// With neither the browser process aborts at startup, and Chromium's own
 /// advice is --no-sandbox; Ubuntu denies unprivileged user namespaces through
-/// AppArmor, and the packages do not ship the helper setuid, so that is every
-/// Ubuntu desktop. The "stability and security will suffer" bar Chrome draws
-/// over the switch is then the truth about that machine.
+/// AppArmor, so there only a package, which can own the helper root, keeps the
+/// sandbox. The "stability and security will suffer" bar Chrome draws over the
+/// switch is then the truth about that machine.
 #[cfg(target_os = "linux")]
 fn sandbox_available() -> bool {
     // SAFETY: geteuid has no preconditions.
@@ -296,7 +296,7 @@ fn sandbox_available() -> bool {
     }
     std::env::current_exe()
         .ok()
-        .and_then(|exe| exe.with_file_name("chrome-sandbox").metadata().ok())
+        .and_then(|exe| helper_path(&exe).metadata().ok())
         .is_some_and(|meta| {
             use std::os::unix::fs::MetadataExt;
             helper_usable(meta.uid(), meta.mode())
@@ -308,6 +308,13 @@ fn sandbox_available() -> bool {
 #[cfg(target_os = "linux")]
 fn helper_usable(uid: u32, mode: u32) -> bool {
     uid == 0 && mode & libc::S_ISUID != 0 && mode & libc::S_IXOTH != 0
+}
+
+/// Chromium looks for the helper beside libcef.so, not beside this executable:
+/// its FATAL names cef/chrome-sandbox even with a usable copy next to lich-shell.
+#[cfg(target_os = "linux")]
+fn helper_path(exe: &std::path::Path) -> std::path::PathBuf {
+    exe.with_file_name("cef").join("chrome-sandbox")
 }
 
 /// Chromium's own probe (sandbox::Credentials::CanCreateProcessInNewUserNS):
@@ -487,6 +494,15 @@ mod tests {
         assert!(!helper_usable(1000, 0o104755), "not root");
         assert!(!helper_usable(0, 0o100755), "no setuid bit");
         assert!(!helper_usable(0, 0o104750), "not executable by others");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn looks_for_the_helper_beside_libcef_where_chromium_does() {
+        assert_eq!(
+            helper_path(std::path::Path::new("/usr/lib/lich/shell/lich-shell")),
+            std::path::Path::new("/usr/lib/lich/shell/cef/chrome-sandbox")
+        );
     }
 
     #[test]


### PR DESCRIPTION
A user's lich 0.49.0 on Ubuntu opened no window: every launch ended in `signal: trace/breakpoint trap (core dumped)` about a second in. Chromium looks for its setuid sandbox helper in `cef/`, beside `libcef.so`, not beside `lich-shell`. The deb, rpm and AUR packages installed a root-owned 4755 copy beside `lich-shell` and left the one in `cef/` at 755, so on a desktop that denies unprivileged user namespaces (Ubuntu's AppArmor policy) Chromium fell back to the helper, found it unusable and aborted. `chmod 4755` on `cef/chrome-sandbox` is what got that user's window open.

## Which file Chromium reads

Measured without AppArmor by forcing the fallback: `lich-shell --ozone-platform=headless --disable-namespace-sandbox` on the installed AUR package exits 133, and the FATAL reads "You need to make sure that /usr/lib/lich/shell/cef/chrome-sandbox is owned by root and has mode 4755", with a root 4755 copy sitting beside `lich-shell` the whole time.

## Packaging

nfpm cannot mark one file of the window's tree setuid: a second `contents` entry for `cef/chrome-sandbox` fails with `content collision`, and the archlinux packager drops a setuid bit read from the source file (it writes `int64(fs.FileMode)`, and Go keeps setuid outside the Unix permission bits). The mode now comes from `postinstall.sh`; pacman runs that only on a first install, so it is wired to `archlinux.scripts.postupgrade` as well. The stray copy is gone from all three formats, and the package managers remove it on upgrade. The trade-off, written into the ceiling: `rpm -V` and `pacman -Qkk` report a mode mismatch on the helper.

The AUR `package()` chmods the copy in `cef/` instead of installing a second one.

## lich-shell

`sandbox_available()` checked the helper beside the executable, so it could count a machine as sandboxed when its only usable helper was one Chromium never reads. It now checks `cef/chrome-sandbox`, pinned by a test.

Not in this PR, each on its own branch: the user-namespace probe only tries `unshare`, which Ubuntu's AppArmor allows before denying the id maps, so a tarball install on Ubuntu still skips `--no-sandbox`; and the window's stderr, where this FATAL was printed, never reaches `lich.log` or `lich rage`.

## Test plan

- [x] `cargo fmt --check`, `cargo clippy --release --all-targets -- -D warnings` and `cargo test --release` (13 passed) in `shell/`
- [x] No Go or frontend code touched
- [x] Packages built with nfpm from `main` and from this branch around stub binaries, installed in containers with dpkg (Debian 12), rpm (Fedora 42) and pacman (Arch). `main`: `chrome-sandbox` 4755 and `cef/chrome-sandbox` 755. Upgrade to this branch: stray copy removed, `cef/chrome-sandbox` 4755 root. Fresh install: 4755 root
- [x] The PKGBUILD `package()` under fakeroot: `cef/chrome-sandbox` is `-rwsr-xr-x root root` in the archive
- [x] `install.sh` on clean Debian 12, Fedora 42 and Arch containers installs the v0.49.0 window and `lich doctor` finds it
- [ ] The next release's deb opens its window on an Ubuntu desktop with AppArmor
