### PR TITLE
chore: pin the window to the fork's lich-next, upstream master plus the open PRs

### DIFF
--- a/build/linux/shell/README.md
+++ b/build/linux/shell/README.md
@@ -19,9 +19,9 @@ hands the page Chromium's reserved chords) as
 `NSApplication` kept to the browser process as
 [0x48piraj/kurogane#14](https://github.com/0x48piraj/kurogane/pull/14), and
 the macOS bundle layout (the framework resolved from `Contents/Frameworks`,
-the subprocesses run as the bundle's helper app), which upstream carries on
-its `seal-of-approval/distribution` branch
-([53d51ba](https://github.com/0x48piraj/kurogane/commit/53d51ba7d234161f8709109dcb8d6395f38c7bb4));
+the subprocesses run as the bundle's helper app), which upstream ships on
+master since
+[53d51ba](https://github.com/0x48piraj/kurogane/commit/53d51ba7d234161f8709109dcb8d6395f38c7bb4);
 lich's own PRs for that layout, #13 and #15, were closed as covered. One more
 fix is the fork's alone so far: a second launch on the profile makes CEF
 ask the running browser what to do with it, and kurogane answered nothing,
@@ -33,7 +33,7 @@ for Linux, where Chromium needs nothing of the binary to confine its
 subprocesses, and `shell/src/main.rs` passes `--no-sandbox` on the machines
 that cannot (Ubuntu's AppArmor policy, root). All of it is carried meanwhile
 on the fork `shell/Cargo.toml` pins:
-`omartelo/kurogane`, branch `lich`, on top of upstream `eedaedc`.
+`omartelo/kurogane`, branch `lich-next`, on top of upstream `fda6cb6`.
 One wrinkle the patch works around: cef-rs hands CEF a *borrowed* string when
 it writes an out-parameter struct back, so a `wm_class_class` built from `&str`
 arrives empty — the fork allocates those through CEF's own

--- a/docs/chromium-shell.md
+++ b/docs/chromium-shell.md
@@ -217,10 +217,9 @@ dies at startup falls back to. `lich-shell` sits beside `lich` in
 `Contents/MacOS`, because macOS reads a process's bundle off its executable's
 path and only a process inside the bundle is `Lich.app` to the Dock, to
 Cmd-Tab and to the menu bar; the framework goes to `Contents/Frameworks`,
-where kurogane looks for it (upstream's `seal-of-approval/distribution`
-branch, commit
-[53d51ba](https://github.com/0x48piraj/kurogane/commit/53d51ba7d234161f8709109dcb8d6395f38c7bb4),
-carried on the fork meanwhile; lich's #13 was closed as covered). CEF's
+where kurogane looks for it (upstream master since
+[53d51ba](https://github.com/0x48piraj/kurogane/commit/53d51ba7d234161f8709109dcb8d6395f38c7bb4);
+lich's #13 was closed as covered). CEF's
 subprocesses run as the five helper apps beside the framework (`Lich
 Helper` and the Renderer, GPU, Plugin and Alerts variants, each a copy of
 the binary under an `LSUIElement` plist), the way CEF's own samples lay

--- a/shell/Cargo.lock
+++ b/shell/Cargo.lock
@@ -695,7 +695,7 @@ dependencies = [
 [[package]]
 name = "kurogane"
 version = "0.0.4"
-source = "git+https://github.com/omartelo/kurogane?rev=bb274847fc3bd517358f1bd41cc56ab69bfd7dd9#bb274847fc3bd517358f1bd41cc56ab69bfd7dd9"
+source = "git+https://github.com/omartelo/kurogane?rev=445638402d8e5afe565812e0f378d7910f3f21b0#445638402d8e5afe565812e0f378d7910f3f21b0"
 dependencies = [
  "cef",
  "ctrlc",
@@ -712,7 +712,7 @@ dependencies = [
 [[package]]
 name = "kurogane-layout"
 version = "0.0.4"
-source = "git+https://github.com/omartelo/kurogane?rev=bb274847fc3bd517358f1bd41cc56ab69bfd7dd9#bb274847fc3bd517358f1bd41cc56ab69bfd7dd9"
+source = "git+https://github.com/omartelo/kurogane?rev=445638402d8e5afe565812e0f378d7910f3f21b0#445638402d8e5afe565812e0f378d7910f3f21b0"
 dependencies = [
  "dirs",
  "serde",

--- a/shell/Cargo.toml
+++ b/shell/Cargo.toml
@@ -7,16 +7,14 @@ description = "lich's window: an embedded Chromium (CEF) launched by the Go back
 license = "AGPL-3.0-only"
 
 [dependencies]
-# The fork's `lich` branch: upstream eedaedc plus window_class / window_title /
-# window_icon / cache_dir (kurogane#11), the client handlers a browser delegate
-# supplies (kurogane#12), the NSApplication kept to the browser process
-# (kurogane#14), and the macOS bundle layout (framework in Contents/Frameworks,
-# subprocesses as the bundle's helper app) that upstream carries on its
-# seal-of-approval/distribution branch (53d51ba), and a relaunch on the
-# profile raising the window it already has (451bd7c) and the Linux sandbox
-# left on (bb27484); move back to 0x48piraj/kurogane once they land
-# (build/linux/shell/README.md).
-kurogane = { git = "https://github.com/omartelo/kurogane", rev = "bb274847fc3bd517358f1bd41cc56ab69bfd7dd9" }
+# The fork's `lich-next` branch: upstream master (fda6cb6, which ships the
+# macOS bundle layout) plus window_class / window_title / window_icon /
+# cache_dir (kurogane#11), the client handlers a browser delegate supplies
+# (kurogane#12), the NSApplication kept to the browser process (kurogane#14),
+# a relaunch on the profile raising the window it already has (451bd7c) and
+# the Linux sandbox left on (bb27484); move back to 0x48piraj/kurogane once
+# they land (build/linux/shell/README.md).
+kurogane = { git = "https://github.com/omartelo/kurogane", rev = "445638402d8e5afe565812e0f378d7910f3f21b0" }
 
 # The CEF handler types a delegate returns (main.rs). Pinned to the revision
 # kurogane's own workspace pins: two cef crates in one binary are two different


### PR DESCRIPTION
kurogane's master now ships the macOS bundle layout the fork carried (framework in `Contents/Frameworks`, subprocesses as the bundle's helper app, commit 53d51ba), so the pin moves from `lich` (upstream eedaedc plus seven patches) to `lich-next`: upstream master `fda6cb6` plus what is still ours, #11 (window identity), #12 (client handlers), #14 (`NSApplication` in the browser process only), the relaunch raise (451bd7c) and the Linux sandbox (bb27484). #13 and #15 are closed as covered. Nothing in `shell/src` changes: the `App` API lich uses is the same.

Verified: the three open PRs rebased clean on the new master and pass fmt, clippy and the suites; `lich-next` is green on the fork's CI on the three OSes; `lich-shell` builds and passes its 12 tests against it. `release.yml` dispatched on this branch runs the window end to end on Linux, Windows and macOS before merge.

Docs: `shell/Cargo.toml` comment, `build/linux/shell/README.md` fork section and the macOS paragraph of `docs/chromium-shell.md` now say the layout is upstream master's, not a branch's.