### PR TITLE
fix: say why the window died, in the log and the dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lich's log. The packages now set the mode on the copy Chromium reads;
   installing the release over the previous one is enough.
 
+- **A window that fails to open says why.** When lich's window died on start,
+  the error dialog and `lich.log` named only the signal it died of, such as
+  "trace/breakpoint trap", while the reason the window printed went to a
+  terminal that a launch from the app menu does not have. The dialog now shows
+  the line the window died on, and the log keeps the last lines it wrote, so a
+  `lich rage` bundle carries them too. A second launch that fails to bring the
+  open window forward logs them the same way.
+
 ## [0.49.0] - 2026-09-09
 
 > [!WARNING]

--- a/docs/ceilings.md
+++ b/docs/ceilings.md
@@ -572,6 +572,16 @@ work when nobody knows it and that the call site never shows. The mechanism and 
   no window, and an Apple Silicon window that exits with an error inside `startupGrace` (30 s, because a
   segfault is reported only after its core dump is written) hands the URL to the default browser instead.
   `lich doctor` names the window a launch would open.
+- **Only a window that exits with an error leaves its stderr in the log** (`internal/chromium/stderr.go`): the
+  window's stderr still reaches lich's own, and a failed exit, of the window or of the launch that focuses it,
+  carries its last 20 lines into `lich.log`, with the first three FATAL or "Check failed" lines kept ahead of
+  them once they scroll out; the dialog shows only those lines, or the last three. Nothing is logged as it
+  comes, because a healthy start already writes Fontconfig, GPU and D-Bus warnings, so a window that misbehaves
+  and keeps running leaves nothing behind. The stream is a pipe the window's subprocesses inherit, and a clean
+  close waits up to `stderrDrain` (2 s) for them to let go of it (10 ms, measured on Linux). Windows takes the
+  same path unmeasured: whether Chromium writes its FATAL lines to stderr there, rather than only to its own
+  debug log, has not been seen, so the tail may hold no more than `lich-shell` prints itself;
+  `lich -- --enable-logging=stderr` asks Chromium for them.
 - **The window's own sandbox needs an install a package manager made** (`shell/src/main.rs`, the kurogane
   fork's `no_sandbox`): Chromium confines the window's subprocesses in a user namespace, or through the
   setuid helper in `cef/`, beside `libcef.so` (not beside `lich-shell`: a helper there that is not root-owned

--- a/internal/chromium/chromium.go
+++ b/internal/chromium/chromium.go
@@ -106,7 +106,9 @@ func fallsBack(step string, err error, elapsed time.Duration) bool {
 	return step == stepShell && err != nil && elapsed < startupGrace
 }
 
-// launch starts the resolved window on the profile and waits for it to exit.
+// launch starts the resolved window on the profile and waits for it to exit. A
+// window that exits with an error comes back as an ExitError, with the end of
+// what it wrote to stderr.
 func launch(window Result, url, dataDir, class string, extra []string, onStart func(*os.Process)) error {
 	dataDir = window.ProfileDir(dataDir)
 	if err := os.MkdirAll(dataDir, 0o700); err != nil {
@@ -114,7 +116,9 @@ func launch(window Result, url, dataDir, class string, extra []string, onStart f
 	}
 	cmd := exec.Command(window.Path, Args(url, dataDir, class, extra)...)
 	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	tail := &stderrTail{mirror: os.Stderr}
+	cmd.Stderr = tail
+	cmd.WaitDelay = stderrDrain
 	// The window's life is tied to this process by a pipe it reads for EOF: a
 	// lich that dies without closing its window (a kill, an out-of-memory, a
 	// crash) closes the write end with it, and the window goes. Left running,
@@ -134,5 +138,5 @@ func launch(window Result, url, dataDir, class string, extra []string, onStart f
 	if onStart != nil {
 		onStart(cmd.Process)
 	}
-	return cmd.Wait()
+	return tail.exit(cmd.Wait())
 }

--- a/internal/chromium/launch_unix_test.go
+++ b/internal/chromium/launch_unix_test.go
@@ -3,9 +3,11 @@
 package chromium
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -30,6 +32,27 @@ func TestFocusLaunchesThePinnedWindowOnItsProfile(t *testing.T) {
 	keyed := filepath.Join(profile, (Result{Path: exe}).profileKey())
 	if info, err := os.Stat(keyed); err != nil || !info.IsDir() {
 		t.Fatalf("profile directory %q not created: %v", keyed, err)
+	}
+}
+
+// A window that dies at launch says why: its stderr comes back on the exit,
+// which is what main.go logs and shows.
+func TestFocusReportsWhatTheWindowWroteBeforeItDied(t *testing.T) {
+	fatal := "[1:1:0911/1:FATAL:setuid_sandbox_host.cc:166] The SUID sandbox helper binary was found"
+	exe := filepath.Join(t.TempDir(), "lich-shell")
+	script := "#!/bin/sh\necho 'Fontconfig warning' >&2\necho '" + fatal + "' >&2\nexit 5\n"
+	if err := os.WriteFile(exe, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(OverrideEnv, exe)
+	err := Focus("http://127.0.0.1:1/", filepath.Join(t.TempDir(), "chromium-profile"), "lichtest")
+	var exit *ExitError
+	var code *exec.ExitError
+	if !errors.As(err, &exit) || !errors.As(err, &code) || code.ExitCode() != 5 {
+		t.Fatalf("Focus = %v, want an ExitError on exit status 5", err)
+	}
+	if want := []string{"Fontconfig warning", fatal}; !slices.Equal(exit.Stderr, want) {
+		t.Fatalf("Stderr = %q, want %q", exit.Stderr, want)
 	}
 }
 

--- a/internal/chromium/stderr.go
+++ b/internal/chromium/stderr.go
@@ -1,0 +1,154 @@
+package chromium
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os/exec"
+	"slices"
+	"strings"
+	"time"
+)
+
+// A healthy window already writes Fontconfig, GPU and D-Bus warnings, and
+// lich.log is rotated at 5 MiB, so the window's stderr is never logged as it
+// comes: only a launch that fails reports it, and only this much.
+const (
+	// tailLines is how much of the end of the stream a failed launch logs.
+	tailLines = 20
+	// lineBytes cuts a line that never ends, so a tail stays the size its line
+	// count promises.
+	lineBytes = 1024
+	// whyLines bounds the lines that say why the window died: the FATAL lines
+	// kept once they scroll out of the tail, and what Why hands a dialog.
+	whyLines = 3
+)
+
+// stderrDrain bounds how long Wait holds on to the window's stderr after the
+// window has exited: its subprocesses inherit the pipe, and Wait returns only
+// once they let go of it. Measured, they did within 10 ms of both a clean exit
+// and a FATAL one.
+const stderrDrain = 2 * time.Second
+
+// gap stands where a tail dropped lines between two it kept.
+const gap = "..."
+
+// stderrTail passes the window's stderr through to lich's own and keeps the
+// end of it. Only exec's copying goroutine writes, and Lines is read after
+// Wait has joined that goroutine, so there is no lock.
+type stderrTail struct {
+	mirror  io.Writer
+	partial []byte
+	// head holds the FATAL lines that scrolled out of lines, first ones first,
+	// with a gap wherever lines between them were dropped.
+	head  []string
+	fatal int
+	lines []string
+}
+
+func (t *stderrTail) Write(p []byte) (int, error) {
+	// A terminal that is not there (a launcher start, the windowsgui build)
+	// must not fail the copy: exec would report a window that closed cleanly
+	// as one that failed.
+	_, _ = t.mirror.Write(p)
+	n := len(p)
+	for {
+		i := bytes.IndexByte(p, '\n')
+		if i < 0 {
+			t.buffer(p)
+			return n, nil
+		}
+		t.buffer(p[:i])
+		t.push(string(t.partial))
+		t.partial = t.partial[:0]
+		p = p[i+1:]
+	}
+}
+
+func (t *stderrTail) buffer(b []byte) {
+	room := max(lineBytes-len(t.partial), 0)
+	t.partial = append(t.partial, b[:min(len(b), room)]...)
+}
+
+func (t *stderrTail) push(line string) {
+	line = strings.TrimRight(line, "\r")
+	if line == "" {
+		return
+	}
+	t.lines = append(t.lines, line)
+	if len(t.lines) <= tailLines {
+		return
+	}
+	t.drop(t.lines[0])
+	t.lines = t.lines[1:]
+}
+
+// drop keeps a FATAL line leaving the tail while there is room for one: the
+// browser aborts on its first, so that one is the cause, and what follows it
+// is the consequence (subprocesses dying, a crash dump) that would otherwise
+// push it out.
+func (t *stderrTail) drop(line string) {
+	if isFatal(line) && t.fatal < whyLines {
+		t.head = append(t.head, line)
+		t.fatal++
+		return
+	}
+	if len(t.head) > 0 && t.head[len(t.head)-1] == gap {
+		return
+	}
+	t.head = append(t.head, gap)
+}
+
+// exit is the window's exit as launch reports it: nil for a window that closed
+// cleanly, the exit and the tail otherwise. Wait reports a drain that ran out
+// only after a clean exit, so ErrWaitDelay is a closed window with a subprocess
+// that held the pipe past stderrDrain.
+func (t *stderrTail) exit(err error) error {
+	if err == nil || errors.Is(err, exec.ErrWaitDelay) {
+		return nil
+	}
+	return &ExitError{Err: err, Stderr: t.Lines()}
+}
+
+// Lines is what the window wrote to stderr, as far as the tail kept it.
+func (t *stderrTail) Lines() []string {
+	lines := append(slices.Clone(t.head), t.lines...)
+	if last := strings.TrimRight(string(t.partial), "\r"); last != "" {
+		lines = append(lines, last)
+	}
+	return lines
+}
+
+// isFatal is a line Chromium logs before it aborts. A failed CHECK is logged
+// at FATAL too; "Check failed" also catches one printed without the prefix.
+func isFatal(line string) bool {
+	return strings.Contains(line, ":FATAL:") || strings.Contains(line, "Check failed")
+}
+
+// ExitError is the window exiting with an error, with the end of what it wrote
+// to stderr: a launcher start has no terminal, so without it the log holds the
+// signal the window died of and never the reason.
+type ExitError struct {
+	Err    error
+	Stderr []string
+}
+
+func (e *ExitError) Error() string {
+	return strings.Join(append([]string{e.Err.Error()}, e.Stderr...), "\n")
+}
+
+func (e *ExitError) Unwrap() error { return e.Err }
+
+// Why is err short enough for a dialog: an ExitError keeps only the lines that
+// say why, its FATAL lines when it has any and its last lines otherwise.
+func Why(err error) string {
+	var exit *ExitError
+	if !errors.As(err, &exit) {
+		return err.Error()
+	}
+	why := slices.DeleteFunc(slices.Clone(exit.Stderr), func(line string) bool { return !isFatal(line) })
+	if len(why) == 0 {
+		why = exit.Stderr[max(len(exit.Stderr)-whyLines, 0):]
+	}
+	return strings.Join(append([]string{exit.Err.Error()}, why[:min(len(why), whyLines)]...), "\n")
+}

--- a/internal/chromium/stderr_test.go
+++ b/internal/chromium/stderr_test.go
@@ -1,0 +1,151 @@
+package chromium
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// noTerminal records what it is handed and fails every write, the stderr of a
+// launcher start.
+type noTerminal struct{ got []byte }
+
+func (n *noTerminal) Write(p []byte) (int, error) {
+	n.got = append(n.got, p...)
+	return 0, errors.New("no terminal")
+}
+
+func write(t *testing.T, tail *stderrTail, chunks ...string) {
+	t.Helper()
+	for _, chunk := range chunks {
+		if n, err := tail.Write([]byte(chunk)); n != len(chunk) || err != nil {
+			t.Fatalf("Write(%q) = %d, %v; want %d, nil", chunk, n, err, len(chunk))
+		}
+	}
+}
+
+func numbered(prefix string, from, to int) []string {
+	var lines []string
+	for i := from; i <= to; i++ {
+		lines = append(lines, fmt.Sprintf("%s %d", prefix, i))
+	}
+	return lines
+}
+
+// The copy never fails on the terminal: exec would report a window that closed
+// cleanly as one that failed.
+func TestStderrTailMirrorsEverythingAndNeverFails(t *testing.T) {
+	mirror := &noTerminal{}
+	tail := &stderrTail{mirror: mirror}
+	write(t, tail, "one\n", "tw", "o\r\n\n", "three")
+	if got := string(mirror.got); got != "one\ntwo\r\n\nthree" {
+		t.Fatalf("mirror got %q", got)
+	}
+	if got, want := tail.Lines(), []string{"one", "two", "three"}; !slices.Equal(got, want) {
+		t.Fatalf("Lines = %q, want %q", got, want)
+	}
+}
+
+func TestStderrTailKeepsTheLastTwentyLines(t *testing.T) {
+	tail := &stderrTail{mirror: io.Discard}
+	for _, line := range numbered("noise", 1, 25) {
+		write(t, tail, line+"\n")
+	}
+	want := append([]string{"..."}, numbered("noise", 6, 25)...)
+	if got := tail.Lines(); !slices.Equal(got, want) {
+		t.Fatalf("Lines = %q, want %q", got, want)
+	}
+}
+
+// The first FATAL lines survive what follows them, with a gap wherever lines
+// around them were dropped.
+func TestStderrTailKeepsTheFirstFatalLinesThatScrollOut(t *testing.T) {
+	tail := &stderrTail{mirror: io.Discard}
+	before := []string{
+		"Failed to connect to the bus",
+		"[1:1:0911/1:FATAL:zygote_host_impl_linux.cc:127] first",
+		"Check failed: second",
+		"Fontconfig warning",
+		"[1:1:0911/1:FATAL:gpu.cc:3] third",
+		"[1:1:0911/1:FATAL:gpu.cc:4] fourth",
+	}
+	write(t, tail, strings.Join(before, "\n")+"\n")
+	for _, line := range numbered("after", 1, 20) {
+		write(t, tail, line+"\n")
+	}
+	want := append([]string{"...", before[1], before[2], "...", before[4], "..."}, numbered("after", 1, 20)...)
+	if got := tail.Lines(); !slices.Equal(got, want) {
+		t.Fatalf("Lines = %q, want %q", got, want)
+	}
+}
+
+func TestStderrTailCutsALineThatNeverEnds(t *testing.T) {
+	tail := &stderrTail{mirror: io.Discard}
+	write(t, tail, strings.Repeat("x", 1000), strings.Repeat("y", 1000), "\nnext")
+	got := tail.Lines()
+	if want := strings.Repeat("x", 1000) + strings.Repeat("y", 24); len(got) != 2 || got[0] != want || got[1] != "next" {
+		t.Fatalf("Lines = %d lines, first %d bytes; want a 1024-byte line then next", len(got), len(got[0]))
+	}
+}
+
+func TestStderrTailExit(t *testing.T) {
+	tail := &stderrTail{mirror: io.Discard}
+	write(t, tail, "lich-shell: gone\n")
+	if err := tail.exit(nil); err != nil {
+		t.Fatalf("clean exit = %v, want nil", err)
+	}
+	// A subprocess holding the pipe past the drain is still a window the user closed.
+	if err := tail.exit(fmt.Errorf("wait: %w", exec.ErrWaitDelay)); err != nil {
+		t.Fatalf("drain overrun = %v, want nil", err)
+	}
+	died := errors.New("signal: trace/breakpoint trap (core dumped)")
+	var exit *ExitError
+	if err := tail.exit(died); !errors.As(err, &exit) || !errors.Is(err, died) {
+		t.Fatalf("failed exit = %#v, want an ExitError wrapping the exit", err)
+	}
+	if want := []string{"lich-shell: gone"}; !slices.Equal(exit.Stderr, want) {
+		t.Fatalf("Stderr = %q, want %q", exit.Stderr, want)
+	}
+	if got, want := exit.Error(), "signal: trace/breakpoint trap (core dumped)\nlich-shell: gone"; got != want {
+		t.Fatalf("Error = %q, want %q", got, want)
+	}
+}
+
+func TestWhy(t *testing.T) {
+	died := errors.New("signal: trace/breakpoint trap (core dumped)")
+	sandbox := "[1:1:0911/1:FATAL:setuid_sandbox_host.cc:166] The SUID sandbox helper binary was found"
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"not the window's exit", errors.New("launch lich-shell: permission denied"), "launch lich-shell: permission denied"},
+		{"nothing on stderr", &ExitError{Err: died}, died.Error()},
+		{
+			"the FATAL line over the noise around it",
+			fmt.Errorf("focus: %w", &ExitError{Err: died, Stderr: []string{"Fontconfig warning", sandbox, "[2:2:0911/1:ERROR:bus.cc:407] Failed"}}),
+			died.Error() + "\n" + sandbox,
+		},
+		{
+			"the first three FATAL lines",
+			&ExitError{Err: died, Stderr: []string{"...", ":FATAL: a", "Check failed: b", "noise", ":FATAL: c", ":FATAL: d"}},
+			died.Error() + "\n:FATAL: a\nCheck failed: b\n:FATAL: c",
+		},
+		{
+			"the last three lines when nothing was fatal",
+			&ExitError{Err: died, Stderr: numbered("line", 1, 5)},
+			died.Error() + "\nline 3\nline 4\nline 5",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Why(tt.err); got != tt.want {
+				t.Fatalf("Why = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -407,8 +407,8 @@ func runChromium(term *terminal.Service, configDir string, extra []string, coord
 		// doing nothing (#409). Best effort — where no dialog backend answers,
 		// the log line above still has the story.
 		_ = zenity.Error(fmt.Sprintf(
-			"lich could not open its window.\n\n%v\n\nLog: %s",
-			err, logging.Path(filepath.Join(configDir, "lich"))),
+			"lich could not open its window.\n\n%s\n\nLog: %s",
+			chromium.Why(err), logging.Path(filepath.Join(configDir, "lich"))),
 			zenity.Title("lich"))
 		os.Exit(1)
 	}


### PR DESCRIPTION
A lich 0.49.0 on Ubuntu opened no window, and `lich.log` held only `chromium shell err="signal: trace/breakpoint trap (core dumped)"`, then the same signal for `focus existing window`. The reason was one Chromium FATAL on the window's stderr (the sandbox helper under `cef/`, fixed in #587), and `launch` handed that stream straight to lich's own stderr, which a launcher start does not have. `lich rage` bundles the log, so it had nothing either.

## What changes

`launch` is where every window starts: `Run`, `Focus`, the macOS tab fallback inside `startupGrace`, and Windows, which has no launch path of its own. So the fix is there and covers all four. The window's stderr now goes through `stderrTail`, which passes every byte on to lich's stderr as before and keeps the end of it. A window that exits with an error comes back as `chromium.ExitError`, whose message is the exit followed by the tail, so each existing log site (`chromium shell`, `focus existing window`, `bundled window died at startup, opening a tab instead`) records it without a change at the call site. The dialog in `main.go` shows `chromium.Why(err)`: the exit and only the lines that say why.

Measured against the installed 0.49.0 `lich-shell`, headless (`--ozone-platform=headless`), with `--disable-namespace-sandbox` to reach the same helper check:

- the crash writes exactly one line, `[..:FATAL:sandbox/linux/suid/client/setuid_sandbox_host.cc:166] The SUID sandbox helper binary was found, but is not configured correctly...`, and exits on SIGTRAP with a core dump
- a healthy headless start writes one Fontconfig warning
- the stderr pipe reached EOF within 10 ms of the process exit, clean or FATAL

## Bounds, and why FATAL lines win the space

Nothing is logged while the window runs: `lich.log` rotates at 5 MiB and a healthy window is chatty. A failed exit logs its last 20 lines, each cut at 1 KiB. The first three FATAL or `Check failed` lines are kept ahead of the tail once they scroll out of it, with `...` wherever lines around them were dropped. Chromium aborts on its first FATAL, so that line is the cause, and what follows it is consequence: subprocesses losing the browser and saying so, a crash dump, a GPU process restarting. In the crash measured here the FATAL line was the last one, so a plain tail would have caught it; the rule is for the crash whose cause is followed by more than 20 lines of fallout. First ones rather than last, because later FATALs are the cascade.

The dialog gets those FATAL lines, at most three, or the last three lines when there are none. The whole tail in a dialog reads as a wall of warnings.

## The pipe

`os.Stderr` was a file the child inherited. A writer that is not a file makes exec copy through a pipe, and `Wait` then returns only once every holder of the write end has closed it, the window's subprocesses included. `WaitDelay` (2 s) bounds that after the window exits, and the `ErrWaitDelay` it reports, only ever after a clean exit, maps back to nil: the window closed as asked. The mirror swallows its own write errors for the same reason, since exec reports a copy error after a clean exit as the command failing, and the windowsgui build has no stderr to write to.

## Not covered

- Windows takes the same path, unmeasured: whether Chromium writes its FATAL lines to stderr there, rather than only to its own debug log, has not been seen, so the tail may carry only what `lich-shell` prints itself. Written down in `docs/ceilings.md`, with `lich -- --enable-logging=stderr` as the switch that asks for them.
- A window that misbehaves and keeps running leaves nothing in the log, by design.

## Test plan

- [x] `gofmt -l .` and `go vet ./...` clean
- [x] `go test ./...`, plus `-race` on `internal/chromium` (package coverage 92.7%, `stderr.go` 100%)
- [x] Cross-compile loop for linux, darwin and windows
- [x] New: the tail mirrors every byte and never fails the copy on a missing terminal; keeps the last 20 lines; keeps the first three FATAL lines that scroll out, with gaps; cuts a line at 1 KiB; a clean exit and a drain overrun are nil and a failed exit is an `ExitError` wrapping it; `Why` picks FATAL lines over the noise, caps them at three and falls back to the last three lines; `Focus` on a stand-in window that writes a FATAL line and exits 5 returns that line
- [x] Mutants of `tailLines`, `lineBytes` and `whyLines`, one either side, each fail the suite
- [x] Reproduced the reported crash headless against the installed `lich-shell` and read the stderr and pipe timings above
- [x] Rebased onto main after #587 merged; kept both CHANGELOG Fixed entries, gate rerun green
- [ ] On a desk: launch a broken install from the app menu and read the dialog and `lich.log`
