### PR TITLE
fix: show a truncated theme name in a tooltip, and draw the Settings seam as a separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A theme whose name does not fit its card can be read in full.** The theme
+  picker cuts long names and repository captions to the width of the card, and
+  nothing showed the rest. Hovering a card now shows both in a tooltip.
+
+- **The line above Version Control in Settings is a straight rule.** It was the
+  top border of the entry itself, so it bent at the entry's rounded corners and
+  the highlight of the open section filled the gap above it. It is a separator
+  of its own now.
+
 ## [0.50.0] - 2026-09-11
 
 ### Added

--- a/frontend/src/components/settings/Settings.tsx
+++ b/frontend/src/components/settings/Settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { Fragment, useEffect, useMemo, useState } from "react"
 import type { ComponentType, KeyboardEvent, ReactNode } from "react"
 import { useParams } from "react-router-dom"
 import {
@@ -21,6 +21,7 @@ import { VcsToolsSetting } from "./VcsToolsSetting"
 import { UpdatesSettings } from "./UpdatesSettings"
 import { HelpSettings } from "./HelpSettings"
 import { SearchInput } from "@/components/common/SearchInput"
+import { Separator } from "@/components/ui/separator"
 import {
   readSettingsProvider,
   readSettingsQuery,
@@ -206,23 +207,24 @@ export function Settings() {
   const providerName = providers.find((provider) => provider.id === openProvider)?.name ?? ""
 
   const navButton = (section: Section) => (
-    <button
-      key={section.id}
-      type="button"
-      onClick={() => openSection(section.id)}
-      className={cn(
-        "flex items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-accent-foreground",
-        section.seam && "mt-2 border-t border-border pt-3",
-        current.id === section.id && "bg-accent text-accent-foreground",
-      )}
-    >
-      <section.icon className="size-4 shrink-0" />
-      {sectionLabel(section.id)}
-      {/* Where you are, when the pane goes a level deeper than the nav does. */}
-      {section.id === "providers" && current.id === "providers" && providerName && (
-        <span className="ml-auto truncate text-xs opacity-70">{providerName}</span>
-      )}
-    </button>
+    <Fragment key={section.id}>
+      {section.seam && <Separator className="my-1.5" />}
+      <button
+        type="button"
+        onClick={() => openSection(section.id)}
+        className={cn(
+          "flex items-center gap-2 rounded-md px-3 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-accent/50 hover:text-accent-foreground",
+          current.id === section.id && "bg-accent text-accent-foreground",
+        )}
+      >
+        <section.icon className="size-4 shrink-0" />
+        {sectionLabel(section.id)}
+        {/* Where you are, when the pane goes a level deeper than the nav does. */}
+        {section.id === "providers" && current.id === "providers" && providerName && (
+          <span className="ml-auto truncate text-xs opacity-70">{providerName}</span>
+        )}
+      </button>
+    </Fragment>
   )
 
   return (

--- a/frontend/src/components/settings/ThemePicker.tsx
+++ b/frontend/src/components/settings/ThemePicker.tsx
@@ -238,31 +238,34 @@ interface ThemeCardProps {
 function ThemeCard({ name, caption, selected, preview, onSelect, actions }: ThemeCardProps) {
   return (
     <div className="group relative w-[9.5rem] shrink-0">
-      <button
-        type="button"
-        onClick={onSelect}
-        aria-current={selected}
-        className={cn(
-          "block w-full rounded-md text-left outline-none",
-          "focus-visible:ring-2 focus-visible:ring-ring",
-        )}
-      >
-        {/* The ring belongs to the interface, not to the theme being previewed,
-            so it is drawn on the padding around the miniature and in the
-            interface's own foreground. Over the miniature and in --ring it
-            vanished on any theme whose ring is close to its own background,
-            which is most of them. The padding is always there, so selecting a
-            card never resizes it. */}
-        <span
-          className={cn("block rounded-lg p-1", selected && "ring-2 ring-inset ring-foreground/70")}
+      <Tooltip>
+        <TooltipTrigger
+          type="button"
+          onClick={onSelect}
+          aria-current={selected}
+          className={cn(
+            "block w-full rounded-md text-left outline-none",
+            "focus-visible:ring-2 focus-visible:ring-ring",
+          )}
         >
-          <span className="block overflow-hidden rounded-md">{preview}</span>
-        </span>
-        <span className="mt-1.5 flex items-baseline gap-1.5">
-          <span className="truncate text-xs font-medium text-foreground">{name}</span>
-          <span className="truncate text-[0.6875rem] text-muted-foreground">{caption}</span>
-        </span>
-      </button>
+          <span
+            className={cn(
+              "block rounded-lg p-1",
+              selected && "ring-2 ring-inset ring-foreground/70",
+            )}
+          >
+            <span className="block overflow-hidden rounded-md">{preview}</span>
+          </span>
+          <span className="mt-1.5 flex items-baseline gap-1.5">
+            <span className="truncate text-xs font-medium text-foreground">{name}</span>
+            <span className="truncate text-[0.6875rem] text-muted-foreground">{caption}</span>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom">
+          {name}
+          <span className="opacity-70">{caption}</span>
+        </TooltipContent>
+      </Tooltip>
       {/* Update and remove ride the card rather than a row of their own: they
           belong to one theme, and only an imported theme has them. */}
       {actions && (


### PR DESCRIPTION
## Summary

- **Theme names can be read in full.** The theme picker cards are 9.5rem wide and truncate both the name and the repository caption, with nothing showing the rest. The card is now the trigger of a tooltip that shows the name and caption below it.
- **The seam above Version Control is a separator.** It was `border-t` on the nav button itself, so the line bent with the button's `rounded-md` and the active fill covered the `pt-3` above the label. A section marked `seam` now gets a `Separator` rendered before its button, which is styled like every other entry.
- Dropped the six-line comment on the theme card's selection ring: it told the story of the fix that put the ring on the padding, and that story lives in git.

## Test plan

- [x] `biome ci .` exit 0, `tsc -b`, `vite build`, `vitest run` (1773 passed)
- [x] Headless rig (isolated backend, Vite and Chromium over CDP): hovering the Dark card shows "Dark / bundled" below it; the Settings nav has a 1px `data-slot="separator"` before Version Control and that button's `border-top-width` is `0px`; no console errors
- [ ] In `task dev`, hover an imported theme with a long name and repository and check the tooltip wraps inside `max-w-xs`
